### PR TITLE
feat: Thread-safety, hover-expand pill UI, and centralized date formatting

### DIFF
--- a/Murmur.xcodeproj/project.pbxproj
+++ b/Murmur.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		A1000600 /* ActionItemReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000601 /* ActionItemReviewView.swift */; };
 		A1000700 /* ServiceResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000701 /* ServiceResult.swift */; };
 		A1000800 /* FailedActionItemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000801 /* FailedActionItemManager.swift */; };
+		A1000803 /* DateFormattingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000802 /* DateFormattingHelper.swift */; };
 		A1000911 /* PillStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000901 /* PillStateManager.swift */; };
 		A1000912 /* WaveformViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000902 /* WaveformViews.swift */; };
 		A1000913 /* LawsComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000903 /* LawsComponents.swift */; };
@@ -91,6 +92,7 @@
 		A1000601 /* ActionItemReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionItemReviewView.swift; sourceTree = "<group>"; };
 		A1000701 /* ServiceResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceResult.swift; sourceTree = "<group>"; };
 		A1000801 /* FailedActionItemManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailedActionItemManager.swift; sourceTree = "<group>"; };
+		A1000802 /* DateFormattingHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormattingHelper.swift; sourceTree = "<group>"; };
 		A1000901 /* PillStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillStateManager.swift; sourceTree = "<group>"; };
 		A1000902 /* WaveformViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformViews.swift; sourceTree = "<group>"; };
 		A1000903 /* LawsComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LawsComponents.swift; sourceTree = "<group>"; };
@@ -165,6 +167,7 @@
 				A1000401 /* AudioPreprocessor.swift */,
 				A1000701 /* ServiceResult.swift */,
 				A1000801 /* FailedActionItemManager.swift */,
+				A1000802 /* DateFormattingHelper.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -373,6 +376,7 @@
 				A1000600 /* ActionItemReviewView.swift in Sources */,
 				A1000700 /* ServiceResult.swift in Sources */,
 				A1000800 /* FailedActionItemManager.swift in Sources */,
+				A1000803 /* DateFormattingHelper.swift in Sources */,
 				A1000911 /* PillStateManager.swift in Sources */,
 				A1000912 /* WaveformViews.swift in Sources */,
 				A1000913 /* LawsComponents.swift in Sources */,

--- a/Murmur/Core/Audio.swift
+++ b/Murmur/Core/Audio.swift
@@ -27,8 +27,21 @@ class Audio: ObservableObject {
     private var startTime: Date?
     private var timer: Timer?
 
-    // Device change watchdog
-    private var lastBufferTime: Date = Date()
+    // Device change watchdog - thread-safe access via lock
+    private var _lastBufferTime: Date = Date()
+    private let lastBufferTimeLock = NSLock()
+    private var lastBufferTime: Date {
+        get {
+            lastBufferTimeLock.lock()
+            defer { lastBufferTimeLock.unlock() }
+            return _lastBufferTime
+        }
+        set {
+            lastBufferTimeLock.lock()
+            defer { lastBufferTimeLock.unlock() }
+            _lastBufferTime = newValue
+        }
+    }
     private var watchdogTimer: Timer?
 
     // System audio capture
@@ -127,7 +140,7 @@ class Audio: ObservableObject {
         // Start system audio capture
         if let capture = systemAudioCapture as? SystemAudioCapture {
             let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-            let timestamp = formatTimestamp(Date())
+            let timestamp = DateFormattingHelper.formatFilenamePrecise(Date())
             let fileURL = documentsPath.appendingPathComponent("meeting_\(timestamp)_system.wav")
 
             DispatchQueue.main.async {
@@ -207,7 +220,7 @@ class Audio: ObservableObject {
         // Create mic audio file - ALWAYS save as mono for Speech framework compatibility
         do {
             let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-            let timestamp = formatTimestamp(Date())
+            let timestamp = DateFormattingHelper.formatFilenamePrecise(Date())
             let fileURL = documentsPath.appendingPathComponent("meeting_\(timestamp)_mic.wav")
 
             DispatchQueue.main.async {
@@ -311,18 +324,24 @@ class Audio: ObservableObject {
             capture.stop()
         }
 
-        // Close audio files
+        // Close audio files - wait for pending writes to complete first
         let finalMicURL = micAudioFileURL
         let finalSystemURL = systemAudioFileURL
 
-        if micAudioFile != nil {
-            micAudioFile = nil
-            print("✓ Mic audio file closed: \(finalMicURL?.lastPathComponent ?? "unknown")")
+        // Flush mic audio queue before closing file to prevent race condition
+        micAudioFileQueue.sync {
+            if self.micAudioFile != nil {
+                self.micAudioFile = nil
+                print("✓ Mic audio file closed: \(finalMicURL?.lastPathComponent ?? "unknown")")
+            }
         }
 
-        if systemAudioFile != nil {
-            systemAudioFile = nil
-            print("✓ System audio file closed: \(finalSystemURL?.lastPathComponent ?? "unknown")")
+        // Flush system audio queue before closing file
+        systemAudioFileQueue.sync {
+            if self.systemAudioFile != nil {
+                self.systemAudioFile = nil
+                print("✓ System audio file closed: \(finalSystemURL?.lastPathComponent ?? "unknown")")
+            }
         }
 
         DispatchQueue.main.async {
@@ -405,7 +424,7 @@ class Audio: ObservableObject {
 
             // Create new file segment as mono
             let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-            let timestamp = formatTimestamp(Date())
+            let timestamp = DateFormattingHelper.formatFilenamePrecise(Date())
             let fileURL = documentsPath.appendingPathComponent("meeting_\(timestamp)_mic_recovery.wav")
 
             do {
@@ -630,12 +649,6 @@ class Audio: ObservableObject {
             self.systemAudioLevelHistory.removeFirst()
             self.systemAudioLevelHistory.append(level)
         }
-    }
-
-    private func formatTimestamp(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss-SSS"
-        return formatter.string(from: date)
     }
 
     deinit {

--- a/Murmur/Core/CoreAudioUtils.swift
+++ b/Murmur/Core/CoreAudioUtils.swift
@@ -75,18 +75,6 @@ extension AudioObjectID {
         return processObject
     }
 
-    func readProcessBundleID() -> String? {
-        if let result = try? readString(kAudioProcessPropertyBundleID) {
-            result.isEmpty ? nil : result
-        } else {
-            nil
-        }
-    }
-
-    func readProcessIsRunning() -> Bool {
-        (try? readBool(kAudioProcessPropertyIsRunning)) ?? false
-    }
-
     /// Reads the value for `kAudioHardwarePropertyDefaultSystemOutputDevice`, should only be called on the system object.
     func readDefaultSystemOutputDevice() throws -> AudioDeviceID {
         try requireSystemObject()

--- a/Murmur/Core/DateFormattingHelper.swift
+++ b/Murmur/Core/DateFormattingHelper.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Centralized date formatting utilities with cached formatters for performance
+/// Eliminates duplicate DateFormatter initialization across the codebase
+enum DateFormattingHelper {
+
+    // MARK: - Cached Formatters (thread-safe, reused)
+
+    /// Filename format with milliseconds: "2024-01-15_14-30-45-123"
+    private static let filenamePreciseFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss-SSS"
+        return formatter
+    }()
+
+    /// Filename format without milliseconds: "2024-01-15_14-30-45"
+    private static let filenameFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
+        return formatter
+    }()
+
+    /// Display format: "Jan 15, 2024 at 2:30 PM"
+    private static let displayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    /// Time only: "14:30:45"
+    private static let timeOnlyFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter
+    }()
+
+    /// ISO date only: "2024-01-15"
+    private static let isoDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    // MARK: - Public API
+
+    /// Format for audio filenames with millisecond precision
+    /// Example: "2024-01-15_14-30-45-123"
+    static func formatFilenamePrecise(_ date: Date) -> String {
+        filenamePreciseFormatter.string(from: date)
+    }
+
+    /// Format for transcript filenames without milliseconds
+    /// Example: "2024-01-15_14-30-45"
+    static func formatFilename(_ date: Date) -> String {
+        filenameFormatter.string(from: date)
+    }
+
+    /// Format for user-facing display (medium date, short time)
+    /// Example: "Jan 15, 2024 at 2:30 PM"
+    static func formatDisplay(_ date: Date) -> String {
+        displayFormatter.string(from: date)
+    }
+
+    /// Format time only
+    /// Example: "14:30:45"
+    static func formatTimeOnly(_ date: Date) -> String {
+        timeOnlyFormatter.string(from: date)
+    }
+
+    /// Format ISO date only
+    /// Example: "2024-01-15"
+    static func formatISODate(_ date: Date) -> String {
+        isoDateFormatter.string(from: date)
+    }
+
+    /// Format a TimeInterval as MM:SS
+    /// Example: 125.0 -> "02:05"
+    static func formatDuration(_ interval: TimeInterval) -> String {
+        let minutes = Int(interval) / 60
+        let seconds = Int(interval) % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+
+    /// Format a TimeInterval as M:SS (no leading zero on minutes)
+    /// Example: 125.0 -> "2:05"
+    static func formatDurationCompact(_ interval: TimeInterval) -> String {
+        let minutes = Int(interval) / 60
+        let seconds = Int(interval) % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}

--- a/Murmur/Core/SystemAudioCapture.swift
+++ b/Murmur/Core/SystemAudioCapture.swift
@@ -16,10 +16,22 @@ class SystemAudioCapture: ObservableObject {
     private let queue = DispatchQueue(label: "SystemAudioCapture", qos: .userInitiated)
     private var bufferCallback: ((AVAudioPCMBuffer) -> Void)?
 
-    // Device change watchdog
-    private var lastBufferTime: Date = Date()
+    // Device change watchdog - thread-safe access via lock
+    private var _lastBufferTime: Date = Date()
+    private let lastBufferTimeLock = NSLock()
+    private var lastBufferTime: Date {
+        get {
+            lastBufferTimeLock.lock()
+            defer { lastBufferTimeLock.unlock() }
+            return _lastBufferTime
+        }
+        set {
+            lastBufferTimeLock.lock()
+            defer { lastBufferTimeLock.unlock() }
+            _lastBufferTime = newValue
+        }
+    }
     private var watchdogTimer: Timer?
-    private var audioFile: AVAudioFile?
 
     init() {}
 
@@ -45,11 +57,6 @@ class SystemAudioCapture: ObservableObject {
             errorMessage = errMsg
             throw error
         }
-    }
-
-    /// Sets the audio file reference for writing (called from Audio.swift)
-    func setAudioFile(_ file: AVAudioFile?) {
-        self.audioFile = file
     }
 
     /// Stops capturing system audio

--- a/Murmur/Core/TranscriptSaver.swift
+++ b/Murmur/Core/TranscriptSaver.swift
@@ -38,7 +38,7 @@ class TranscriptSaver {
         }
 
         // Generate filename with timestamp
-        let timestamp = formatTimestamp(Date())
+        let timestamp = DateFormattingHelper.formatFilename(Date())
         let filename = "Call_\(timestamp).md"
         let fileURL = saveDir.appendingPathComponent(filename)
 
@@ -60,20 +60,6 @@ class TranscriptSaver {
         }
     }
 
-
-    /// Format timestamp for filename (YYYY-MM-DD_HH-mm-ss)
-    private static func formatTimestamp(_ date: Date) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
-        return formatter.string(from: date)
-    }
-
-    /// Format TimeInterval as MM:SS
-    private static func formatTimeInterval(_ interval: TimeInterval) -> String {
-        let minutes = Int(interval) / 60
-        let seconds = Int(interval) % 60
-        return String(format: "%02d:%02d", minutes, seconds)
-    }
 
     /// Format source label for timeline display
     private static func formatSourceLabel(_ source: String) -> String {
@@ -99,7 +85,7 @@ class TranscriptSaver {
 
         **Duration:** \(durationString)
         **Words:** \(wordCount)
-        **Date:** \(formatTimestamp(date))
+        **Date:** \(DateFormattingHelper.formatDisplay(date))
 
         ---
 
@@ -131,7 +117,7 @@ class TranscriptSaver {
             return nil
         }
 
-        let timestamp = formatTimestamp(Date())
+        let timestamp = DateFormattingHelper.formatFilename(Date())
         let filename = "Call_\(timestamp)_AssemblyAI.md"
         let fileURL = saveDir.appendingPathComponent(filename)
 
@@ -348,7 +334,7 @@ class TranscriptSaver {
             return nil
         }
 
-        let timestamp = formatTimestamp(Date())
+        let timestamp = DateFormattingHelper.formatFilename(Date())
         let filename = "Call_\(timestamp).md"
         let fileURL = saveDir.appendingPathComponent(filename)
 
@@ -540,7 +526,7 @@ class TranscriptSaver {
 
             if totalUtterances > 0 {
                 let speakerName = speakerMappings[speakerId]?.displayName ?? "Speaker \(speakerId)"
-                let timeStr = formatTimeInterval(Double(totalTimeMs) / 1000.0)
+                let timeStr = DateFormattingHelper.formatDuration(Double(totalTimeMs) / 1000.0)
                 doc += "- **\(speakerName):** \(totalUtterances) utterances, ~\(totalWords) words, \(timeStr) speaking\n"
             }
         }

--- a/Murmur/Design/DesignTokens.swift
+++ b/Murmur/Design/DesignTokens.swift
@@ -847,6 +847,10 @@ struct PillDimensions {
     static let idleWidth: CGFloat = 40
     static let idleHeight: CGFloat = 20
 
+    /// Idle expanded state: hover to reveal Record/Files buttons
+    static let idleExpandedWidth: CGFloat = 120
+    static let idleExpandedHeight: CGFloat = 28
+
     /// Recording/Processing state: expanded with controls
     static let recordingWidth: CGFloat = 180
     static let recordingHeight: CGFloat = 40

--- a/Murmur/TranscriptedApp.swift
+++ b/Murmur/TranscriptedApp.swift
@@ -91,9 +91,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             audio: audio!
         )
         floatingPanel?.showWindow(nil)
-
-        // Permissions are now requested during onboarding
-        // requestPermissions() - no longer needed here
     }
 
     #if DEBUG
@@ -161,21 +158,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         settingsWindow?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-    }
-
-    func requestPermissions() {
-        // Pre-request Reminders access for smoother UX later
-        Task {
-            let store = EKEventStore()
-            do {
-                let granted = try await store.requestFullAccessToReminders()
-                print(granted ? "✓ Reminders access granted" : "⚠️ Reminders access denied")
-            } catch {
-                print("⚠️ Reminders permission error: \(error.localizedDescription)")
-            }
-        }
-
-        print("ℹ️ System audio permission will be requested on first capture attempt")
     }
 
     /// Handle recording completion - trigger transcription

--- a/Murmur/UI/FloatingPanel/Components/PillViews.swift
+++ b/Murmur/UI/FloatingPanel/Components/PillViews.swift
@@ -1,60 +1,159 @@
 import SwiftUI
 
-// MARK: - Pill Idle View (40x20px - Dynamic Island style)
+// MARK: - Pill Idle View (Hover-expand design)
 
-/// Minimal capsule shown when app is idle
-/// Frosted glass background, dormant waveform, tap to start recording
+/// Minimal capsule that expands on hover to reveal Record and Files buttons
+/// Collapsed: 40x20px with minimal waveform icon
+/// Expanded: 120x28px with two buttons side-by-side
 @available(macOS 14.0, *)
 struct PillIdleView: View {
-    let onTap: () -> Void
-    let failedCount: Int  // Badge for failed transcriptions
+    let onRecord: () -> Void
+    let onFiles: () -> Void
+    let failedCount: Int
 
-    @State private var isHovered = false
+    @Environment(\.accessibilityReduceMotion) var reduceMotion
+    @State private var isExpanded = false
+    @State private var hoveredButton: HoveredButton? = nil
 
-    init(onTap: @escaping () -> Void, failedCount: Int = 0) {
-        self.onTap = onTap
+    enum HoveredButton {
+        case record
+        case files
+    }
+
+    init(onRecord: @escaping () -> Void, onFiles: @escaping () -> Void, failedCount: Int = 0) {
+        self.onRecord = onRecord
+        self.onFiles = onFiles
         self.failedCount = failedCount
     }
 
+    private var currentWidth: CGFloat {
+        isExpanded ? PillDimensions.idleExpandedWidth : PillDimensions.idleWidth
+    }
+
+    private var currentHeight: CGFloat {
+        isExpanded ? PillDimensions.idleExpandedHeight : PillDimensions.idleHeight
+    }
+
     var body: some View {
-        Button(action: onTap) {
-            ZStack {
-                // Frosted glass capsule background
-                Capsule()
-                    .fill(.ultraThinMaterial)
-                    .overlay(
-                        Capsule()
-                            .strokeBorder(
-                                LinearGradient(
-                                    colors: [Color.white.opacity(0.3), Color.white.opacity(0.1)],
-                                    startPoint: .topLeading,
-                                    endPoint: .bottomTrailing
-                                ),
-                                lineWidth: 0.5
-                            )
-                    )
+        ZStack {
+            // Frosted glass capsule background
+            Capsule()
+                .fill(.ultraThinMaterial)
+                .overlay(
+                    Capsule()
+                        .strokeBorder(
+                            LinearGradient(
+                                colors: [Color.white.opacity(0.3), Color.white.opacity(0.1)],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            ),
+                            lineWidth: 0.5
+                        )
+                )
 
-                // Dormant waveform centered
-                DormantWaveformView()
+            // Content: collapsed icon or expanded buttons
+            if isExpanded {
+                expandedContent
+            } else {
+                collapsedContent
+            }
 
-                // Failed transcription badge (top-right)
-                if failedCount > 0 {
-                    FailedBadgeOverlay(count: failedCount)
-                        .offset(x: PillDimensions.idleWidth / 2 - 6, y: -PillDimensions.idleHeight / 2 + 4)
+            // Failed transcription badge (top-right) - only when collapsed
+            if failedCount > 0 && !isExpanded {
+                FailedBadgeOverlay(count: failedCount)
+                    .offset(x: currentWidth / 2 - 6, y: -currentHeight / 2 + 4)
+            }
+        }
+        .frame(width: currentWidth, height: currentHeight)
+        .animation(reduceMotion ? .none : .elegant, value: isExpanded)
+        .shadow(color: Color.black.opacity(0.15), radius: 4, y: 2)
+        .onHover { hovering in
+            withAnimation(reduceMotion ? .none : .elegant) {
+                isExpanded = hovering
+                if !hovering {
+                    hoveredButton = nil
                 }
             }
-            .frame(width: PillDimensions.idleWidth, height: PillDimensions.idleHeight)
-            .scaleEffect(isHovered ? 1.05 : 1.0)
-            .shadow(color: Color.black.opacity(0.15), radius: 4, y: 2)
         }
-        .buttonStyle(PlainButtonStyle())
-        .onHover { hovering in
-            withAnimation(.pillMorph) {
-                isHovered = hovering
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(isExpanded ? "Recording options" : "Transcripted - hover to expand")
+    }
+
+    // MARK: - Collapsed Content
+
+    private var collapsedContent: some View {
+        MinimalWaveformIcon()
+    }
+
+    // MARK: - Expanded Content
+
+    private var expandedContent: some View {
+        HStack(spacing: 0) {
+            // Record button - left side
+            ExpandedPillButton(
+                icon: "mic.fill",
+                label: "Record",
+                isHovered: hoveredButton == .record,
+                action: onRecord
+            )
+            .onHover { hovering in
+                hoveredButton = hovering ? .record : (hoveredButton == .record ? nil : hoveredButton)
+            }
+
+            // Subtle divider
+            Rectangle()
+                .fill(Color.white.opacity(0.15))
+                .frame(width: 1, height: 16)
+
+            // Files button - right side
+            ExpandedPillButton(
+                icon: "doc.text.fill",
+                label: "Files",
+                isHovered: hoveredButton == .files,
+                action: onFiles
+            )
+            .onHover { hovering in
+                hoveredButton = hovering ? .files : (hoveredButton == .files ? nil : hoveredButton)
             }
         }
-        .accessibilityLabel("Start recording")
-        .accessibilityHint("Double-tap to start recording audio")
+        .opacity(isExpanded ? 1 : 0)
+        .animation(reduceMotion ? .none : .easeOut(duration: 0.2).delay(0.1), value: isExpanded)
+    }
+}
+
+// MARK: - Expanded Pill Button
+
+/// Reusable button component for the expanded idle pill
+/// Shows icon + label with hover highlight effect
+@available(macOS 14.0, *)
+struct ExpandedPillButton: View {
+    let icon: String
+    let label: String
+    let isHovered: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.system(size: 10, weight: .medium))
+
+                Text(label)
+                    .font(.system(size: 10, weight: .medium))
+            }
+            .foregroundColor(isHovered ? .panelTextPrimary : .panelTextSecondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isHovered ? Color.white.opacity(0.1) : Color.clear)
+            )
+            .scaleEffect(isHovered ? 1.02 : 1.0)
+            .animation(.pillMorph, value: isHovered)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .accessibilityLabel(label)
+        .accessibilityHint(label == "Record" ? "Start recording audio" : "Open transcripts folder")
     }
 }
 

--- a/Murmur/UI/FloatingPanel/Components/WaveformViews.swift
+++ b/Murmur/UI/FloatingPanel/Components/WaveformViews.swift
@@ -183,3 +183,43 @@ struct DormantWaveformView: View {
         }
     }
 }
+
+// MARK: - Minimal Waveform Icon (Collapsed idle state)
+
+/// Simplified 3-bar waveform icon for the collapsed idle pill
+/// Static or very subtle breathing animation, respects reduce motion
+@available(macOS 14.0, *)
+struct MinimalWaveformIcon: View {
+    @Environment(\.accessibilityReduceMotion) var reduceMotion
+    @State private var breatheScale: CGFloat = 1.0
+
+    private let barWidth: CGFloat = 2
+    private let barSpacing: CGFloat = 2
+    // Symmetric heights: short, tall, short
+    private let barHeights: [CGFloat] = [4, 8, 4]
+
+    var body: some View {
+        HStack(spacing: barSpacing) {
+            ForEach(0..<3, id: \.self) { index in
+                RoundedRectangle(cornerRadius: 1)
+                    .fill(Color.terracotta.opacity(0.5))
+                    .frame(width: barWidth, height: barHeights[index] * breatheScale)
+            }
+        }
+        .onAppear {
+            if !reduceMotion {
+                startSubtleBreathing()
+            }
+        }
+    }
+
+    private func startSubtleBreathing() {
+        // Very slow, subtle breathing (5 second cycle, minimal scale change)
+        withAnimation(
+            .easeInOut(duration: 2.5)
+            .repeatForever(autoreverses: true)
+        ) {
+            breatheScale = 1.15
+        }
+    }
+}

--- a/Murmur/UI/FloatingPanel/FloatingPanelView.swift
+++ b/Murmur/UI/FloatingPanel/FloatingPanelView.swift
@@ -10,8 +10,6 @@ struct FloatingPanelView: View {
 
     @State private var showCompletionCheckmark = false
     @State private var checkmarkScale: CGFloat = 0.7
-    @State private var isRecordButtonHovered = false
-    @State private var isFileButtonHovered = false
 
     // Success celebration states (Peak-End Rule)
     @State private var showRecordingStoppedCelebration = false
@@ -24,28 +22,6 @@ struct FloatingPanelView: View {
     @State private var showSilencePrompt = false
     @State private var silencePromptDismissed = false  // Prevents re-showing after dismiss
     private let silenceThresholdSeconds: TimeInterval = 120  // 2 minutes
-
-    private let panelHeight: CGFloat = 110  // Increased to fit content (was 68)
-    private let panelWidth: CGFloat = 200  // Reduced width
-    private let baseNotificationHeight: CGFloat = 100  // Base space for celebrations
-    private let reviewNotificationHeight: CGFloat = 280  // Expanded height for review UI
-    private let totalWindowWidth: CGFloat = 320  // Wide enough for notifications
-    private let maxWindowHeight: CGFloat = 390  // Max window size (controller uses this)
-
-    // Dynamic notification height based on review state
-    private var notificationHeight: CGFloat {
-        taskManager.pendingReview != nil ? reviewNotificationHeight : baseNotificationHeight
-    }
-
-    // Dynamic total height for content area (matches controller's window)
-    private var totalWindowHeight: CGFloat {
-        maxWindowHeight
-    }
-
-    // Whether we have pending action items to review
-    private var hasPendingReview: Bool {
-        taskManager.pendingReview != nil
-    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -167,7 +143,8 @@ struct FloatingPanelView: View {
         switch pillStateManager.state {
         case .idle:
             PillIdleView(
-                onTap: { audio.start() },
+                onRecord: { audio.start() },
+                onFiles: { openTranscriptsFolder() },
                 failedCount: 0  // TODO: Wire to FailedTranscriptionManager
             )
         case .recording:
@@ -178,186 +155,6 @@ struct FloatingPanelView: View {
             PillProcessingView(status: taskManager.displayStatus)
         case .reviewing:
             PillReviewingView(itemCount: taskManager.pendingReview?.totalCount ?? 0)
-        }
-    }
-
-    // MARK: - Full Panel Content (Laws of UX Warm Minimalism) - DEPRECATED
-
-    private var fullPanelContent: some View {
-        VStack(spacing: 10) {
-            // Status Display Area (Laws of UX card style)
-            ZStack {
-                RoundedRectangle(cornerRadius: Radius.lawsButton, style: .continuous)
-                    .fill(Color.surfaceCard)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: Radius.lawsButton, style: .continuous)
-                            .stroke(Color.accentBlue.opacity(0.1), lineWidth: 1)
-                    )
-
-                HStack(spacing: 8) {
-                    // Left side: Status display with priority logic
-                    if audio.isRecording {
-                        // Recording indicator dot with glow pulse
-                        Circle()
-                            .fill(Color.recordingCoral)
-                            .frame(width: 8, height: 8)
-                            .shadow(color: .recordingCoral.opacity(0.5), radius: 2)
-                            .pulse(when: true, minScale: 0.9, maxScale: 1.1)
-
-                        if showSilencePrompt {
-                            // Silence warning during recording
-                            Text("Silence: \(Int(audio.silenceDuration / 60))m")
-                                .font(.system(size: 12, weight: .medium))
-                                .foregroundColor(.statusWarningMuted)
-                        } else {
-                            // Timer display (monospace for retro feel)
-                            Text(formatDuration(audio.recordingDuration))
-                                .font(.system(size: 14, weight: .bold, design: .monospaced))
-                                .foregroundColor(.textOnCream)
-                        }
-                    } else {
-                        // Status display with celebration overlays
-                        ZStack {
-                            LawsStatusTextView(status: taskManager.displayStatus)
-
-                            // Recording stopped celebration (blue ring)
-                            RecordingStoppedCelebration(isVisible: showRecordingStoppedCelebration)
-                        }
-                    }
-
-                    Spacer()
-
-                    // Right side: Mini waveform only when recording (shows both mic & system audio)
-                    if audio.isRecording {
-                        WaveformMiniView(
-                            levels: Array(audio.audioLevelHistory.suffix(8)),
-                            systemLevels: Array(audio.systemAudioLevelHistory.suffix(8)),
-                            maxHeight: 20
-                        )
-                        .frame(height: 20)
-                    }
-                }
-                .padding(.horizontal, 10)
-            }
-            .frame(height: 28)
-
-            // Controls (Laws of UX style buttons)
-            HStack(spacing: 10) {
-                LawsButton(
-                    iconName: audio.isRecording ? "stop.fill" : "record.circle",
-                    label: audio.isRecording ? "Stop" : "Record",
-                    color: audio.isRecording ? .textOnCreamSecondary : .recordingCoral,
-                    isActive: audio.isRecording
-                ) {
-                    if audio.isRecording {
-                        audio.stop()
-                    } else {
-                        audio.start()
-                    }
-                }
-
-                LawsButton(
-                    iconName: "folder.fill",
-                    label: "Files",
-                    color: .accentBlue,
-                    isActive: false
-                ) {
-                    openTranscriptsFolder()
-                }
-            }
-        }
-        .padding(12)
-    }
-
-    // MARK: - Panel Background (Laws of UX Warm Minimalism)
-
-    private var panelBackground: some View {
-        ZStack {
-            // Warm cream base with vibrancy
-            VisualEffectBlur(material: .hudWindow, blendingMode: .behindWindow)
-
-            // Eggshell tint overlay
-            Color.surfaceEggshell.opacity(0.85)
-
-            // Recording state: Add red glow border
-            if audio.isRecording {
-                RoundedRectangle(cornerRadius: Radius.lawsCard, style: .continuous)
-                    .stroke(Color.recordingCoral.opacity(0.5), lineWidth: 2)
-            }
-
-            // Subtle border (Laws of UX style)
-            RoundedRectangle(cornerRadius: Radius.lawsCard, style: .continuous)
-                .stroke(Color.accentBlue.opacity(0.15), lineWidth: 1)
-        }
-        // Laws of UX shadow
-        .shadow(
-            color: CardStyle.shadowCard.color,
-            radius: CardStyle.shadowCard.radius,
-            x: CardStyle.shadowCard.x,
-            y: CardStyle.shadowCard.y
-        )
-    }
-
-    // MARK: - Error Overlay (Contextual with recovery actions)
-
-    private var errorOverlay: some View {
-        Group {
-            if let errorMessage = audio.error {
-                let contextualError = ContextualError.from(message: errorMessage)
-
-                VStack {
-                    Spacer()
-                    ContextualErrorBanner(
-                        error: contextualError,
-                        onTap: errorTapAction(for: contextualError)
-                    )
-                    .padding(.horizontal, 8)
-                    .padding(.bottom, 8)
-                }
-                .transition(.asymmetric(
-                    insertion: .move(edge: .bottom).combined(with: .opacity),
-                    removal: .opacity
-                ))
-            }
-        }
-    }
-
-    /// Returns the appropriate action for tapping on an error banner
-    private func errorTapAction(for error: ContextualError) -> (() -> Void)? {
-        switch error {
-        case .transcriptionFailed:
-            // Could trigger retry - for now, just open settings
-            return {
-                if let url = URL(string: "x-apple.systempreferences:") {
-                    NSWorkspace.shared.open(url)
-                }
-            }
-        case .microphoneError, .permissionDenied:
-            // Open System Settings > Privacy > Microphone
-            return {
-                if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
-                    NSWorkspace.shared.open(url)
-                }
-            }
-        case .invalidAPIKey:
-            // Could open app settings - for now just dismiss
-            return nil
-        case .storageFull:
-            // Open About This Mac > Storage
-            return {
-                if let url = URL(string: "x-apple.systempreferences:com.apple.preference.storagemanagement") {
-                    NSWorkspace.shared.open(url)
-                }
-            }
-        case .networkError:
-            // Open Network preferences
-            return {
-                if let url = URL(string: "x-apple.systempreferences:com.apple.preference.network") {
-                    NSWorkspace.shared.open(url)
-                }
-            }
-        case .unknown:
-            return nil
         }
     }
 


### PR DESCRIPTION
## Summary

- **Thread-safety improvements**: Add NSLock wrappers to prevent race conditions during device changes while recording
- **New hover-expand idle pill UX**: Redesigned minimal pill that expands on hover to reveal Record/Files buttons
- **Centralized date formatting**: New `DateFormattingHelper` with cached formatters, eliminating duplicate initialization
- **Code cleanup**: Remove ~180 lines of deprecated code and unused methods

## Changes

### Thread Safety
- Add NSLock wrapper for `lastBufferTime` in `Audio.swift` and `SystemAudioCapture.swift`
- Fix race condition in audio file closure by using `queue.sync` before closing files

### New Hover-Expand Idle Pill
| State | Size | Content |
|-------|------|---------|
| Collapsed | 40×20px | Minimal 3-bar waveform icon with subtle breathing |
| Expanded | 120×28px | Record + Files buttons with hover highlights |

- Respects `accessibilityReduceMotion` preference
- New `MinimalWaveformIcon` and `ExpandedPillButton` components

### DateFormattingHelper
Cached formatters for consistent date handling:
- `formatFilenamePrecise()` — with milliseconds for audio files
- `formatFilename()` — for transcript filenames  
- `formatDisplay()` — user-facing format
- `formatDuration()` — TimeInterval → "MM:SS"

### Cleanup
- Remove `requestPermissions()` from AppDelegate (now in onboarding)
- Remove unused CoreAudioUtils methods
- Remove deprecated FloatingPanelView code

## Test plan

- [x] Build succeeds with no errors
- [x] App launches and displays floating pill
- [x] 5-minute recording test completed successfully
- [x] Transcript saved with correct formatting
- [ ] Verify hover-expand animation on idle pill
- [ ] Verify Record button starts recording
- [ ] Verify Files button opens transcripts folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)