### PR TITLE
feat: Add Gemini-inspired aurora recording indicator

### DIFF
--- a/Murmur.xcodeproj/project.pbxproj
+++ b/Murmur.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		A1000918 /* ReviewTrayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000908 /* ReviewTrayView.swift */; };
 		A1000919 /* FloatingPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000909 /* FloatingPanelView.swift */; };
 		A100091A /* FloatingPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100090A /* FloatingPanelController.swift */; };
+		A100091B /* AuroraRecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100090B /* AuroraRecordingView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -105,6 +106,7 @@
 		A1000908 /* ReviewTrayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTrayView.swift; sourceTree = "<group>"; };
 		A1000909 /* FloatingPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelView.swift; sourceTree = "<group>"; };
 		A100090A /* FloatingPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPanelController.swift; sourceTree = "<group>"; };
+		A100090B /* AuroraRecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuroraRecordingView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -206,6 +208,7 @@
 				A1000906 /* CelebrationViews.swift */,
 				A1000907 /* PillViews.swift */,
 				A1000908 /* ReviewTrayView.swift */,
+				A100090B /* AuroraRecordingView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -391,6 +394,7 @@
 				A1000918 /* ReviewTrayView.swift in Sources */,
 				A1000919 /* FloatingPanelView.swift in Sources */,
 				A100091A /* FloatingPanelController.swift in Sources */,
+				A100091B /* AuroraRecordingView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Murmur/Design/DesignTokens.swift
+++ b/Murmur/Design/DesignTokens.swift
@@ -192,6 +192,20 @@ extension Color {
 
     /// Glass Background - ultra thin material equivalent
     static let glassBackground = Color.black.opacity(0.4)
+
+    // MARK: - Aurora Recording Indicator Colors
+
+    /// Aurora mic color - warm coral for microphone audio
+    static let auroraCoral = Color(hex: "#FF6B6B")
+
+    /// Aurora system color - cool teal for system audio
+    static let auroraTeal = Color(hex: "#4ECDC4")
+
+    /// Aurora mic secondary - lighter coral for gradients
+    static let auroraCoralLight = Color(hex: "#FFB3B3")
+
+    /// Aurora system secondary - lighter teal for gradients
+    static let auroraTealLight = Color(hex: "#A8E6E0")
 }
 
 // MARK: - Gradients
@@ -400,6 +414,22 @@ struct ShadowStyle {
     static let recordingGlow = ShadowStyle(
         color: Color.recordingCoral.opacity(0.5),
         radius: 12,
+        x: 0,
+        y: 0
+    )
+
+    /// Aurora mic glow - coral bloom effect
+    static let auroraMicGlow = ShadowStyle(
+        color: Color.auroraCoral.opacity(0.6),
+        radius: 16,
+        x: 0,
+        y: 0
+    )
+
+    /// Aurora system glow - teal bloom effect
+    static let auroraSystemGlow = ShadowStyle(
+        color: Color.auroraTeal.opacity(0.6),
+        radius: 16,
         x: 0,
         y: 0
     )

--- a/Murmur/UI/FloatingPanel/Components/AuroraRecordingView.swift
+++ b/Murmur/UI/FloatingPanel/Components/AuroraRecordingView.swift
@@ -1,0 +1,342 @@
+import SwiftUI
+
+// MARK: - Aurora Recording View
+/// A living aurora visualization that dances with your conversation
+/// Gemini-inspired: Soft, glowing fog that gently pulses with audio
+/// Uses layered radial gradients with heavy blur for diffuse, smoky effect
+
+@available(macOS 26.0, *)
+struct AuroraRecordingView: View {
+    @ObservedObject var audio: Audio
+    let onStop: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) var reduceMotion
+    @State private var isExpanded = false
+    @State private var isStopHovered = false
+
+    // Smoothed audio levels (prevents jitter)
+    @State private var smoothedMicLevel: CGFloat = 0
+    @State private var smoothedSystemLevel: CGFloat = 0
+
+    // Collapsed/expanded dimensions
+    private let collapsedWidth: CGFloat = 72
+    private let collapsedHeight: CGFloat = 36
+    private let expandedWidth: CGFloat = 200
+    private let expandedHeight: CGFloat = 44
+
+    // Animation smoothing factor (lower = smoother, slower response)
+    private let smoothingFactor: CGFloat = 0.08
+
+    var body: some View {
+        ZStack {
+            // Aurora background (always visible)
+            auroraBackground
+                .clipShape(Capsule())
+
+            // Expanded content (timer + stop button)
+            if isExpanded {
+                expandedContent
+                    .transition(.opacity.animation(.easeOut(duration: 0.1)))
+            }
+        }
+        .frame(
+            width: isExpanded ? expandedWidth : collapsedWidth,
+            height: isExpanded ? expandedHeight : collapsedHeight
+        )
+        .animation(.spring(response: 0.15, dampingFraction: 0.8), value: isExpanded)
+        .onHover { hovering in
+            isExpanded = hovering
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Recording in progress, \(formatDurationAccessible(audio.recordingDuration))")
+        .accessibilityHint("Hover to reveal controls")
+    }
+
+    // MARK: - Aurora Background (Gemini-style fog layers)
+
+    private var auroraBackground: some View {
+        ZStack {
+            // Base dark background
+            Color.panelCharcoal
+
+            // MIC FOG: Coral/warm tones, biased LEFT
+            fogLayer(
+                color: Color.auroraCoral,
+                secondaryColor: Color.auroraCoralLight,
+                blurRadius: 12,
+                opacity: 0.75,
+                orbCount: 2,
+                phaseOffset: 0,
+                isMicLevel: true,
+                positionBias: -0.8  // Bias left
+            )
+            .blendMode(.plusLighter)
+
+            // SYSTEM FOG: Teal/cool tones, biased RIGHT
+            fogLayer(
+                color: Color.auroraTeal,
+                secondaryColor: Color.auroraTealLight,
+                blurRadius: 10,
+                opacity: 0.7,
+                orbCount: 2,
+                phaseOffset: .pi / 3,
+                isMicLevel: false,
+                positionBias: 0.8  // Bias right
+            )
+            .blendMode(.plusLighter)
+        }
+        .overlay(
+            // Capsule border glow matches position bias (coral left, teal right)
+            Capsule()
+                .strokeBorder(
+                    LinearGradient(
+                        colors: [
+                            Color.auroraCoral.opacity(0.4),
+                            Color.auroraTeal.opacity(0.4)
+                        ],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    ),
+                    lineWidth: 1
+                )
+        )
+        // Outer glow shadows (coral left, teal right)
+        .shadow(color: Color.auroraCoral.opacity(0.3), radius: 20, x: -5, y: 0)
+        .shadow(color: Color.auroraTeal.opacity(0.25), radius: 20, x: 5, y: 0)
+    }
+
+    // MARK: - Fog Layer
+
+    private func fogLayer(
+        color: Color,
+        secondaryColor: Color,
+        blurRadius: CGFloat,
+        opacity: Double,
+        orbCount: Int,
+        phaseOffset: Double,
+        isMicLevel: Bool,
+        positionBias: CGFloat = 0  // -1 = left, 0 = center, 1 = right
+    ) -> some View {
+        TimelineView(.animation(minimumInterval: 1/30)) { timeline in
+            Canvas { context, size in
+                let time = timeline.date.timeIntervalSinceReferenceDate
+
+                // Update smoothed levels
+                let targetMic = CGFloat(audio.audioLevelHistory.last ?? 0)
+                let targetSystem = CGFloat(audio.systemAudioLevelHistory.last ?? 0)
+
+                // Use main actor dispatch for state updates (can't mutate @State in Canvas)
+                // Instead, compute smoothed values locally each frame
+                let effectiveSmoothing = reduceMotion ? 0.02 : smoothingFactor
+                let localSmoothedMic = smoothedMicLevel + (targetMic - smoothedMicLevel) * effectiveSmoothing
+                let localSmoothedSystem = smoothedSystemLevel + (targetSystem - smoothedSystemLevel) * effectiveSmoothing
+
+                // Select audio level based on layer type
+                let audioLevel = isMicLevel ? localSmoothedMic : localSmoothedSystem
+
+                // Draw fog orbs
+                drawFogOrbs(
+                    context: &context,
+                    size: size,
+                    time: time,
+                    audioLevel: audioLevel,
+                    color: color,
+                    secondaryColor: secondaryColor,
+                    orbCount: orbCount,
+                    phaseOffset: phaseOffset,
+                    opacity: opacity,
+                    positionBias: positionBias
+                )
+
+                // Update state for next frame (approximate - computed in body)
+                DispatchQueue.main.async {
+                    smoothedMicLevel = localSmoothedMic
+                    smoothedSystemLevel = localSmoothedSystem
+                }
+            }
+        }
+        .blur(radius: blurRadius)
+    }
+
+    // MARK: - Pseudo-noise Function
+
+    /// Creates organic, non-repeating motion by layering sine waves with prime-ratio frequencies
+    private func pseudoNoise(time: Double, phase: Double, seed: Double) -> Double {
+        let t = time + seed
+        let p = phase
+
+        // Layer multiple sine waves with incommensurate frequencies
+        let wave1 = sin(t * 1.0 + p)
+        let wave2 = sin(t * 1.7 + p * 2.3) * 0.5
+        let wave3 = sin(t * 0.3 + p * 0.7) * 0.3
+        let wave4 = sin(t * 2.3 + p * 1.1) * 0.2
+
+        // Sum and normalize (max amplitude ~2.0)
+        return (wave1 + wave2 + wave3 + wave4) / 2.0
+    }
+
+    // MARK: - Draw Fog Orbs
+
+    private func drawFogOrbs(
+        context: inout GraphicsContext,
+        size: CGSize,
+        time: Double,
+        audioLevel: CGFloat,
+        color: Color,
+        secondaryColor: Color,
+        orbCount: Int,
+        phaseOffset: Double,
+        opacity: Double,
+        positionBias: CGFloat = 0  // -1 = left, 0 = center, 1 = right
+    ) {
+        let width = size.width
+        let height = size.height
+        let centerY = height / 2
+
+        // Slow animation speed (0.15x for calm, organic feel)
+        let slowTime = reduceMotion ? 0 : time * 0.15
+
+        // Audio reactivity affects SIZE and BRIGHTNESS, not speed
+        // Base level of 0.6 ensures visibility even in silence, peaks at 1.8x with audio
+        let audioBoost = 0.6 + Double(audioLevel) * 1.5  // 0.6 to 2.1x
+
+        // Position bias shifts center point left or right
+        let biasOffset = positionBias * width * 0.15
+
+        for i in 0..<orbCount {
+            let orbPhase = Double(i) * (.pi * 2 / Double(orbCount)) + phaseOffset
+
+            // Organic movement using pseudo-noise
+            let xNoise = pseudoNoise(time: slowTime, phase: orbPhase, seed: 0)
+            let yNoise = pseudoNoise(time: slowTime * 0.8, phase: orbPhase * 1.3, seed: 100)
+
+            let xOffset = xNoise * (width * 0.18)
+            let yOffset = yNoise * (height * 0.15)
+
+            let orbCenterX = width / 2 + biasOffset + xOffset
+            let orbCenterY = centerY + yOffset
+
+            // Orb size varies with audio and subtle breathing
+            let breatheNoise = pseudoNoise(time: slowTime * 0.4, phase: orbPhase, seed: 200)
+            let breathe = 1.0 + breatheNoise * 0.12
+            let baseSize = max(width, height) * 0.8  // Larger orbs to fill the capsule
+            let orbSize = baseSize * audioBoost * breathe
+
+            // Draw radial gradient orb
+            let orbRect = CGRect(
+                x: orbCenterX - orbSize / 2,
+                y: orbCenterY - orbSize / 2,
+                width: orbSize,
+                height: orbSize
+            )
+
+            // Radial gradient: color center fading to transparent
+            let gradient = Gradient(stops: [
+                .init(color: color.opacity(opacity * audioBoost), location: 0),
+                .init(color: secondaryColor.opacity(opacity * 0.6), location: 0.4),
+                .init(color: color.opacity(opacity * 0.3), location: 0.7),
+                .init(color: Color.clear, location: 1.0)
+            ])
+
+            context.fill(
+                Path(ellipseIn: orbRect),
+                with: .radialGradient(
+                    gradient,
+                    center: CGPoint(x: orbCenterX, y: orbCenterY),
+                    startRadius: 0,
+                    endRadius: orbSize / 2
+                )
+            )
+        }
+    }
+
+    // MARK: - Expanded Content
+
+    private var expandedContent: some View {
+        HStack(spacing: 12) {
+            Spacer()
+
+            // Timer
+            Text(formatDuration(audio.recordingDuration))
+                .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                .foregroundColor(.panelTextPrimary)
+                .lineLimit(1)
+                .fixedSize()
+
+            // Stop button
+            Button(action: onStop) {
+                ZStack {
+                    Circle()
+                        .fill(isStopHovered ? Color.panelCharcoalSurface : Color.panelCharcoalElevated)
+                        .frame(width: 32, height: 32)
+
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Color.panelTextPrimary)
+                        .frame(width: 12, height: 12)
+                }
+                .scaleEffect(isStopHovered ? 1.1 : 1.0)
+            }
+            .buttonStyle(PlainButtonStyle())
+            .onHover { hovering in
+                withAnimation(.spring(response: 0.15, dampingFraction: 0.8)) {
+                    isStopHovered = hovering
+                }
+            }
+            .accessibilityLabel("Stop recording")
+
+            Spacer()
+                .frame(width: 8)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func formatDuration(_ duration: TimeInterval) -> String {
+        let minutes = Int(duration) / 60
+        let seconds = Int(duration) % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+
+    private func formatDurationAccessible(_ duration: TimeInterval) -> String {
+        let minutes = Int(duration) / 60
+        let seconds = Int(duration) % 60
+        if minutes > 0 {
+            return "\(minutes) minute\(minutes == 1 ? "" : "s") \(seconds) second\(seconds == 1 ? "" : "s")"
+        }
+        return "\(seconds) second\(seconds == 1 ? "" : "s")"
+    }
+}
+
+// MARK: - Aurora Dimensions
+
+struct AuroraDimensions {
+    /// Collapsed width - pure aurora
+    static let collapsedWidth: CGFloat = 72
+
+    /// Collapsed height
+    static let collapsedHeight: CGFloat = 36
+
+    /// Expanded width - aurora + timer + stop
+    static let expandedWidth: CGFloat = 200
+
+    /// Expanded height
+    static let expandedHeight: CGFloat = 44
+}
+
+// MARK: - Preview
+
+#if DEBUG
+@available(macOS 26.0, *)
+struct AuroraRecordingView_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            Color.black
+            // Note: Preview needs actual Audio instance
+            // AuroraRecordingView(audio: Audio(), onStop: {})
+            Text("Preview requires Audio instance")
+                .foregroundColor(.white)
+        }
+        .frame(width: 300, height: 200)
+    }
+}
+#endif

--- a/Murmur/UI/FloatingPanel/FloatingPanelView.swift
+++ b/Murmur/UI/FloatingPanel/FloatingPanelView.swift
@@ -18,6 +18,9 @@ struct FloatingPanelView: View {
     @ObservedObject var pillStateManager: PillStateManager
     @ObservedObject var failedTranscriptionManager: FailedTranscriptionManager
 
+    // User preference for aurora recording indicator
+    @AppStorage("useAuroraRecording") private var useAuroraRecording: Bool = false
+
     // Consolidated celebration state (replaces 3 separate @State vars)
     @State private var celebrationState: CelebrationState = .none
 
@@ -150,8 +153,14 @@ struct FloatingPanelView: View {
                 failedCount: failedTranscriptionManager.failedTranscriptions.count
             )
         case .recording:
-            PillRecordingView(audio: audio) {
-                audio.stop()
+            if useAuroraRecording {
+                AuroraRecordingView(audio: audio) {
+                    audio.stop()
+                }
+            } else {
+                PillRecordingView(audio: audio) {
+                    audio.stop()
+                }
             }
         case .processing:
             PillProcessingView(status: taskManager.displayStatus)

--- a/Murmur/UI/Settings.swift
+++ b/Murmur/UI/Settings.swift
@@ -32,6 +32,7 @@ struct SettingsView: View {
     @AppStorage("transcriptionProvider") private var transcriptionProvider: String = "deepgram"
     @AppStorage("deepgramAPIKey") private var deepgramAPIKey: String = ""
     @AppStorage("assemblyaiAPIKey") private var assemblyaiAPIKey: String = ""
+    @AppStorage("useAuroraRecording") private var useAuroraRecording: Bool = false
     @Environment(\.dismiss) private var dismiss
 
     // MARK: - Tab State
@@ -221,6 +222,23 @@ extension SettingsView {
                     Text("Used to identify you in transcripts and attribute action items.")
                         .font(.caption)
                         .foregroundColor(.textOnCreamMuted)
+                }
+            }
+
+            // Appearance Card
+            SettingsCard(title: "Appearance", icon: "paintbrush") {
+                VStack(alignment: .leading, spacing: Spacing.sm) {
+                    Toggle(isOn: $useAuroraRecording) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Aurora Recording Indicator")
+                                .font(.bodySmall)
+                                .foregroundColor(.textOnCream)
+                            Text("Flowing colors that dance with your conversation")
+                                .font(.caption)
+                                .foregroundColor(.textOnCreamMuted)
+                        }
+                    }
+                    .toggleStyle(.switch)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Adds a new audio-reactive recording visualization inspired by Gemini Live's voice mode
- Soft, glowing fog effect with mic audio (coral) on the left and system audio (teal) on the right
- Organic movement using pseudo-noise animation (multi-frequency sine waves)
- Optional via Settings → Recording → Appearance toggle

## Changes
| File | Description |
|------|-------------|
| `AuroraRecordingView.swift` | New component with Canvas-based fog rendering |
| `DesignTokens.swift` | Aurora color palette (coral, teal, light variants) |
| `FloatingPanelView.swift` | Conditional rendering based on user preference |
| `Settings.swift` | Toggle to switch between aurora and classic modes |

## Visual Design
- **Mic audio** → Coral fog, biased left
- **System audio** → Teal fog, biased right
- Heavy blur (10-12px) creates diffuse, smoky appearance
- Additive blend modes for natural glow overlap

## Test plan
- [ ] Enable aurora mode in Settings → Recording → Appearance
- [ ] Start recording and verify fog appears
- [ ] Speak into mic - coral (left side) should glow brighter
- [ ] Play system audio - teal (right side) should glow brighter
- [ ] Hover over pill to verify timer and stop button appear
- [ ] Toggle setting off and verify classic pill view returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)