### PR TITLE
feat: Simplify processing view UI

### DIFF
--- a/Murmur/Core/TranscriptionTaskManager.swift
+++ b/Murmur/Core/TranscriptionTaskManager.swift
@@ -47,11 +47,11 @@ enum DisplayStatus: Equatable {
         case .idle:
             return "Ready"
         case .gettingReady:
-            return "Getting ready..."
+            return "Preparing..."
         case .transcribing:
             return "Transcribing..."
         case .findingActionItems:
-            return "Finding action items..."
+            return "Finding tasks..."
         case .finishing:
             return "Almost done..."
         case .transcriptSaved:

--- a/Murmur/UI/FloatingPanel/Components/AuroraProcessingView.swift
+++ b/Murmur/UI/FloatingPanel/Components/AuroraProcessingView.swift
@@ -8,7 +8,6 @@ import SwiftUI
 @available(macOS 26.0, *)
 struct AuroraProcessingView: View {
     let status: DisplayStatus
-    let recordingDuration: TimeInterval
 
     @Environment(\.accessibilityReduceMotion) var reduceMotion
 
@@ -23,11 +22,6 @@ struct AuroraProcessingView: View {
     // Fixed expanded dimensions (no collapse for processing - users want to see status)
     private let width: CGFloat = 200
     private let height: CGFloat = 44
-
-    init(status: DisplayStatus, recordingDuration: TimeInterval = 0) {
-        self.status = status
-        self.recordingDuration = recordingDuration
-    }
 
     var body: some View {
         ZStack {
@@ -95,61 +89,20 @@ struct AuroraProcessingView: View {
     // MARK: - Content
 
     private var expandedContent: some View {
-        HStack(spacing: 0) {
-            // Duration display (left)
-            Text(formatDuration(recordingDuration))
-                .font(.system(size: 15, weight: .semibold, design: .monospaced))
+        VStack(spacing: 2) {
+            Text(status.statusText)
+                .font(.system(size: 14, weight: .medium))
                 .foregroundColor(.panelTextPrimary)
-                .frame(width: 60, alignment: .center)
+                .lineLimit(1)
 
-            Spacer()
-
-            // Status text (center)
-            VStack(spacing: 2) {
-                Text(status.statusText)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundColor(.panelTextPrimary)
+            // Warning text (if applicable)
+            if let warning = warningText {
+                Text(warning)
+                    .font(.system(size: 10, weight: .regular))
+                    .foregroundColor(.statusWarningMuted)
                     .lineLimit(1)
-
-                // Warning text (if applicable)
-                if let warning = warningText {
-                    Text(warning)
-                        .font(.system(size: 10, weight: .regular))
-                        .foregroundColor(.statusWarningMuted)
-                        .lineLimit(1)
-                }
-            }
-
-            Spacer()
-
-            // Estimated time (right) - optional
-            if let estimate = estimatedTimeRemaining {
-                Text(estimate)
-                    .font(.system(size: 11, weight: .regular))
-                    .foregroundColor(.panelTextMuted)
-                    .frame(width: 50, alignment: .center)
-            } else {
-                Spacer()
-                    .frame(width: 50)
             }
         }
-        .padding(.horizontal, 12)
-    }
-
-    // MARK: - Estimated Time
-
-    private var estimatedTimeRemaining: String? {
-        guard recordingDuration > 0 else { return nil }
-
-        // Rough estimate: processing takes ~10% of recording time
-        let estimatedTotal = recordingDuration * 0.1
-        let currentProgress = status.progress
-        let elapsedFraction = currentProgress
-        let estimatedRemaining = estimatedTotal * (1 - elapsedFraction)
-
-        if estimatedRemaining < 10 { return nil }  // Don't show if almost done
-        if estimatedRemaining < 60 { return "~\(Int(estimatedRemaining))s" }
-        return "~\(Int(estimatedRemaining / 60)) min"
     }
 
     // MARK: - Aurora Background
@@ -331,14 +284,6 @@ struct AuroraProcessingView: View {
         timerCancellable?.invalidate()
         timerCancellable = nil
     }
-
-    // MARK: - Format Helpers
-
-    private func formatDuration(_ duration: TimeInterval) -> String {
-        let minutes = Int(duration) / 60
-        let seconds = Int(duration) % 60
-        return String(format: "%02d:%02d", minutes, seconds)
-    }
 }
 
 // MARK: - Preview
@@ -350,10 +295,10 @@ struct AuroraProcessingView_Previews: PreviewProvider {
         ZStack {
             Color.black
             VStack(spacing: 20) {
-                AuroraProcessingView(status: .gettingReady, recordingDuration: 125)
-                AuroraProcessingView(status: .transcribing(progress: 0.45), recordingDuration: 125)
-                AuroraProcessingView(status: .findingActionItems, recordingDuration: 125)
-                AuroraProcessingView(status: .finishing, recordingDuration: 125)
+                AuroraProcessingView(status: .gettingReady)
+                AuroraProcessingView(status: .transcribing(progress: 0.45))
+                AuroraProcessingView(status: .findingActionItems)
+                AuroraProcessingView(status: .finishing)
             }
         }
         .frame(width: 400, height: 400)

--- a/Murmur/UI/FloatingPanel/Components/AuroraSuccessView.swift
+++ b/Murmur/UI/FloatingPanel/Components/AuroraSuccessView.swift
@@ -38,7 +38,7 @@ struct AuroraSuccessView: View {
                     .scaleEffect(checkScale)
                     .opacity(checkOpacity)
 
-                // Text content
+                // Text content - fixedSize prevents truncation
                 VStack(alignment: .leading, spacing: 2) {
                     Text(primaryText)
                         .font(.system(size: 14, weight: .semibold))
@@ -52,6 +52,7 @@ struct AuroraSuccessView: View {
                             .opacity(textOpacity)
                     }
                 }
+                .fixedSize(horizontal: true, vertical: false)
 
                 Spacer()
             }
@@ -70,7 +71,7 @@ struct AuroraSuccessView: View {
     private var primaryText: String {
         switch successType {
         case .transcriptSaved:
-            return "Transcription saved"
+            return "Saved"
         case .tasksAdded(let count):
             return "\(count) task\(count == 1 ? "" : "s") added"
         }
@@ -79,7 +80,7 @@ struct AuroraSuccessView: View {
     private var secondaryText: String? {
         switch successType {
         case .transcriptSaved:
-            return "No action items found"
+            return "No tasks found"
         case .tasksAdded:
             return nil
         }
@@ -146,9 +147,9 @@ struct AuroraSuccessView: View {
     private var accessibilityText: String {
         switch successType {
         case .transcriptSaved:
-            return "Transcript saved successfully. No action items found."
+            return "Transcript saved. No tasks found."
         case .tasksAdded(let count):
-            return "\(count) task\(count == 1 ? "" : "s") added successfully"
+            return "\(count) task\(count == 1 ? "" : "s") added"
         }
     }
 }

--- a/Murmur/UI/FloatingPanel/FloatingPanelView.swift
+++ b/Murmur/UI/FloatingPanel/FloatingPanelView.swift
@@ -119,10 +119,7 @@ struct FloatingPanelView: View {
             case .completed(let count):
                 AuroraSuccessView(successType: .tasksAdded(count: count))
             default:
-                AuroraProcessingView(
-                    status: taskManager.displayStatus,
-                    recordingDuration: audio.recordingDuration
-                )
+                AuroraProcessingView(status: taskManager.displayStatus)
             }
         case .reviewing:
             PillReviewingView(itemCount: taskManager.pendingReview?.totalCount ?? 0)


### PR DESCRIPTION
## Summary
- Remove timer display from post-recording processing view
- Center status text ("Preparing...", "Transcribing...", "Finding tasks...", "Almost done...")
- Shorten status text strings for better readability
- Remove estimated time display (rarely shown anyway)
- Update success view with shorter text ("Saved", "No tasks found")

## Before
```
[00:00] [Spacer] [Finding tasks...] [Spacer] [~12s]
```

## After
```
        [Finding tasks...]
        (centered in pill)
```

## Test plan
- [ ] Record a short clip and stop
- [ ] Verify processing states show centered text without timer
- [ ] Verify success view shows "Saved" / "No tasks found" correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)