### PR TITLE
docs: fix stale documentation across 6 files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,13 +95,12 @@ The app uses **FluidAudio** for 100% local transcription — no cloud API, no in
 
 ```
 TranscriptedApp.swift (AppDelegate)
-├── Audio                    → Recording state, audio levels
-├── TranscriptionTaskManager → Background transcription queue, progress tracking
+├── Audio                      → Recording state, audio levels
+├── TranscriptionTaskManager   → Background transcription queue, progress tracking
 ├── FailedTranscriptionManager → Retry queue with persistent storage
-├── RecordingValidator       → Pre-recording system checks
-├── StatsService             → Recording statistics and streak tracking
-├── StatsDatabase            → SQLite persistence for stats
-└── FloatingPanelController  → UI coordination
+├── FloatingPanelController    → UI coordination
+├── SettingsWindowController   → Settings window
+└── OnboardingWindowController → Onboarding flow
 ```
 
 ### UI Components
@@ -121,6 +120,7 @@ FloatingPanel/
 │   ├── AttentionPromptView.swift   # Notification prompts (silence warning)
 │   ├── TranscriptTrayView.swift    # Recent transcripts tray with copy-to-clipboard
 │   ├── TranscriptDetailView.swift  # Transcript detail with chat bubbles
+│   ├── SpeakerNamingView.swift     # Speaker identification and naming UI
 │   ├── AuroraIdleView.swift        # Aurora animation for idle state
 │   ├── AuroraRecordingView.swift   # Aurora animation for recording state
 │   ├── AuroraProcessingView.swift  # Aurora animation for processing state
@@ -133,15 +133,11 @@ Settings window (`Murmur/UI/Settings/`):
 ```
 Settings/
 ├── SettingsWindowController.swift          # NSWindowController, 800x600 fixed window
-├── SettingsContainerView.swift             # Sidebar + content layout
+├── SettingsContainerView.swift             # Single-page scrolling layout (stats, speakers, preferences)
 ├── SettingsSidebarView.swift               # Left sidebar navigation
 ├── Models/
-│   └── SettingsNavigationState.swift       # Tab state (Dashboard, Preferences)
-├── Tabs/
-│   ├── DashboardView.swift                 # Stats, recent transcripts
-│   └── PreferencesView.swift               # Storage, model status, task service, appearance
+│   └── SettingsNavigationState.swift       # Tab state (Dashboard, Speakers, Preferences)
 └── Components/
-    ├── RecentTranscriptsView.swift          # Recent transcript list
     └── SettingsSectionCard.swift            # Reusable card component
 ```
 
@@ -184,6 +180,7 @@ User settings stored in `UserDefaults`:
 | `hasCompletedOnboarding` | Onboarding completion flag |
 | `enableUISounds` | Enable/disable recording sounds |
 | `useAuroraRecording` | Enable aurora animation |
+| `enableQwenSpeakerInference` | Enable Qwen-based speaker name inference |
 | `floatingPanelX` | Saved pill X position |
 | `floatingPanelY` | Saved pill Y position |
 
@@ -270,7 +267,10 @@ Murmur/
 │   ├── ParakeetService.swift      # Local STT via FluidAudio (Parakeet TDT V3)
 │   ├── SortformerService.swift    # Local speaker diarization via FluidAudio
 │   ├── SpeakerDatabase.swift      # Persistent voice fingerprints (SQLite + 256-dim embeddings)
-│   └── AudioResampler.swift       # Audio resampling (48kHz → 16kHz) and WAV loading
+│   ├── AudioResampler.swift       # Audio resampling (48kHz → 16kHz) and WAV loading
+│   ├── QwenService.swift          # Local Qwen model for speaker name inference
+│   ├── EmbeddingClusterer.swift   # Clustering utility for voice embeddings
+│   └── SpeakerClipExtractor.swift # Extracts audio clips for speaker samples
 ├── UI/
 │   ├── FloatingPanel/             # Floating pill UI
 │   │   ├── FloatingPanelController.swift  # NSWindowController
@@ -284,23 +284,20 @@ Murmur/
 │   │   │   ├── AttentionPromptView.swift  # Silence warning
 │   │   │   ├── TranscriptTrayView.swift   # Recent transcripts tray
 │   │   │   ├── TranscriptDetailView.swift # Transcript detail view
+│   │   │   ├── SpeakerNamingView.swift    # Speaker identification and naming
 │   │   │   ├── AuroraIdleView.swift       # Aurora idle animation
 │   │   │   ├── AuroraRecordingView.swift  # Aurora recording animation
 │   │   │   ├── AuroraProcessingView.swift # Aurora processing animation
 │   │   │   └── AuroraSuccessView.swift    # Aurora success animation
 │   │   └── Helpers/
 │   │       └── LawsComponents.swift       # Reusable UI primitives
-│   ├── Settings/                  # Settings sidebar+tabs system
+│   ├── Settings/                  # Settings window
 │   │   ├── SettingsWindowController.swift  # NSWindowController, 800x600
-│   │   ├── SettingsContainerView.swift     # Sidebar + content layout
+│   │   ├── SettingsContainerView.swift     # Single-page scrolling layout
 │   │   ├── SettingsSidebarView.swift       # Left sidebar navigation
 │   │   ├── Models/
-│   │   │   └── SettingsNavigationState.swift  # Tab state
-│   │   ├── Tabs/
-│   │   │   ├── DashboardView.swift        # Stats, recent transcripts
-│   │   │   └── PreferencesView.swift      # Storage, model status, appearance
+│   │   │   └── SettingsNavigationState.swift  # Tab state (Dashboard, Speakers, Preferences)
 │   │   └── Components/
-│   │       ├── RecentTranscriptsView.swift # Recent transcript list
 │   │       └── SettingsSectionCard.swift   # Reusable card component
 │   └── FailedTranscriptionsView.swift  # Retry queue management UI
 ├── TranscriptedApp.swift          # App entry point (AppDelegate pattern)
@@ -325,6 +322,7 @@ Murmur/
 | `transcription` | Parakeet/Sortformer model loading, STT/diarization |
 | `pipeline` | Task lifecycle, saving, file management, retries |
 | `speaker-db` | Speaker matching, voice embeddings, merges |
+| `services` | Service-level operations (Qwen, etc.) |
 | `ui` | Pill state transitions, UI events |
 | `stats` | Recording statistics, database operations |
 | `app` | App lifecycle, model initialization |

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -7,11 +7,11 @@ This file documents important lessons learned during development. Reference this
 ## Architecture Quick Reference
 
 ### What This App Does
-Transcripted captures mic + system audio, transcribes locally via Parakeet TDT V3 (STT) + Sortformer (speaker diarization) using the FluidAudio library, identifies speakers and extracts action items via Gemini, then sends tasks to Reminders/Todoist.
+Transcripted captures mic + system audio, transcribes locally via Parakeet TDT V3 (STT) + Sortformer (speaker diarization) using the FluidAudio library, identifies speakers via persistent voice fingerprints, and saves transcripts as Markdown.
 
 ### Core Data Flow
 ```
-Record → WAV files → Transcription → Speaker ID → Save → Action Items → Review → Tasks
+Record → WAV files → Transcription → Speaker ID → Save Markdown
 ```
 
 ### Key Components
@@ -20,19 +20,17 @@ Record → WAV files → Transcription → Speaker ID → Save → Action Items 
 | Audio capture | `Core/Audio.swift` | Mic via AVAudioEngine, coordinates system audio |
 | System audio | `Core/SystemAudioCapture.swift` | CoreAudio process taps (macOS 26+) |
 | Orchestration | `Core/TranscriptionTaskManager.swift` | Background transcription queue, progress |
-| UI State | `UI/FloatingPanel/PillStateManager.swift` | State machine: idle→recording→processing→reviewing |
-| Action Items | `Core/ActionItemExtractor.swift` | Two-pass Gemini: speaker ID, then extraction |
+| UI State | `UI/FloatingPanel/PillStateManager.swift` | State machine: idle→recording→processing |
 | Transcription | `Core/Transcription.swift` | Local Parakeet + Sortformer pipeline |
 | Speaker DB | `Services/SpeakerDatabase.swift` | Persistent voice fingerprints (SQLite, 256-dim embeddings) |
 | Transcript Output | `Core/TranscriptSaver.swift` | Markdown with YAML frontmatter |
 | StatsDatabase | `Core/StatsDatabase.swift` | SQLite persistence for recording sessions and activity |
 | StatsService | `Core/StatsService.swift` | Calculates hours, streaks, heat map data |
 | TranscriptScanner | `Core/TranscriptScanner.swift` | Scans folder for transcript metadata |
-| FailedActionItemManager | `Core/FailedActionItemManager.swift` | Retry queue for action item delivery failures |
 
 ### State Machine (PillStateManager)
 ```
-idle (40×20) → recording (180×40) → processing (180×40) → reviewing (280px tray) → idle
+idle (40×20) → recording (180×40) → processing (180×40) → idle
 ```
 
 ---
@@ -71,7 +69,7 @@ This is why the app uses `@available(macOS 26.0, *)` throughout.
 
 ### DisplayStatus (Goal-Gradient Effect)
 ```
-idle → gettingReady (0-15%) → transcribing (15-75%) → findingActionItems (75-95%) → finishing (95-100%)
+idle → gettingReady (0-15%) → transcribing (15-75%) → finishing (95-100%) → transcriptSaved
 ```
 
 ---
@@ -84,7 +82,6 @@ idle → gettingReady (0-15%) → transcribing (15-75%) → findingActionItems (
 | idle | 40×20 | Dormant waveform |
 | recording | 180×40 | Aurora + timer + stop button |
 | processing | 180×40 | Aurora + progress + status text |
-| reviewing | 280px tray | Action item list |
 
 ### Aurora Color Palette (Synthwave)
 - **Mic audio**: Hot pink coral `#EC4899` / light `#F472B6`

--- a/Murmur/Services/CLAUDE.md
+++ b/Murmur/Services/CLAUDE.md
@@ -11,6 +11,9 @@ Local ML inference engines (Parakeet STT, Sortformer diarization), persistent sp
 | `SortformerService.swift` | Local speaker diarization via FluidAudio's Sortformer (identifies who speaks when) |
 | `SpeakerDatabase.swift` | SQLite database with 256-dim voice embeddings, cosine similarity matching |
 | `AudioResampler.swift` | Resamples audio (48kHz → 16kHz mono) for model input, WAV file loading |
+| `QwenService.swift` | Local Qwen model for speaker name inference from transcript context |
+| `EmbeddingClusterer.swift` | Clustering utility for grouping similar voice embeddings |
+| `SpeakerClipExtractor.swift` | Extracts audio clips for speaker voice samples |
 
 ## Data Flow
 

--- a/Murmur/UI/CLAUDE.md
+++ b/Murmur/UI/CLAUDE.md
@@ -10,7 +10,7 @@ Settings window and failed transcription management UI. The main floating pill U
 | `Settings/SettingsWindowController.swift` | NSWindowController, 800x600 fixed settings window |
 | `Settings/SettingsContainerView.swift` | Single-page scrolling layout (stats, speakers, preferences) |
 | `Settings/SettingsSidebarView.swift` | Left sidebar navigation tabs |
-| `Settings/Models/SettingsNavigationState.swift` | Tab state enum (Dashboard, Preferences, Speakers) |
+| `Settings/Models/SettingsNavigationState.swift` | Tab state enum (Dashboard, Speakers, Preferences) |
 | `Settings/Components/SettingsSectionCard.swift` | Reusable card wrapper |
 | `FailedTranscriptionsView.swift` | Retry queue management |
 

--- a/Murmur/UI/FloatingPanel/CLAUDE.md
+++ b/Murmur/UI/FloatingPanel/CLAUDE.md
@@ -21,6 +21,7 @@ The main user-facing UI: a draggable floating pill that shows recording state, a
 | `Components/CelebrationViews.swift` | Success checkmark and pulse ring animations |
 | `Components/ErrorViews.swift` | Error banners with recovery hints |
 | `Components/AttentionPromptView.swift` | "Still recording?" silence warning |
+| `Components/SpeakerNamingView.swift` | Speaker identification and naming UI with audio clip playback |
 | `Helpers/LawsComponents.swift` | Reusable UI primitives (buttons, status text, Triangle shape) |
 
 ## State Machine

--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ A native macOS app that automatically records, transcribes, and organizes voice 
 - Persistent speaker matching - Learns voices over time via 256-dim embeddings
 - Real-time status - Visual feedback during recording and processing
 
-**AI-Powered Action Items**
-- Automatic extraction - Uses Gemini AI to identify tasks from transcripts
-- Smart parsing - Understands "next Friday", "EOW", relative dates
-- Task integration - Sends to Apple Reminders or Todoist
-- Review workflow - Approve/edit items before adding
-
 **Output & Organization**
 - Markdown transcripts - With YAML frontmatter (date, duration, word count)
 - Speaker identification - Labels by audio source (Mic/System Audio)
@@ -50,7 +44,7 @@ On first launch, Transcripted requests:
 |------------|---------|----------|
 | Microphone | Capture your voice | Yes |
 | Screen Recording | Capture system audio from meetings | For system audio |
-| Reminders | Create tasks from action items | Optional |
+| Reminders | Optional integration | Optional |
 
 ## Architecture
 
@@ -61,7 +55,6 @@ Murmur/
 │   ├── SystemAudioCapture.swift           # System audio via CoreAudio process taps
 │   ├── Transcription.swift                # Local transcription (Parakeet + Sortformer)
 │   ├── TranscriptionTaskManager.swift     # Background transcription queue
-│   ├── ActionItemExtractor.swift          # Gemini AI integration
 │   ├── DateParser.swift                   # Natural language date parsing
 │   ├── TranscriptSaver.swift              # Markdown output
 │   ├── TranscriptScanner.swift            # Transcript file discovery & parsing
@@ -74,8 +67,9 @@ Murmur/
 │   ├── SortformerService.swift            # Local speaker diarization
 │   ├── SpeakerDatabase.swift              # Persistent voice fingerprints (SQLite)
 │   ├── AudioResampler.swift               # Audio resampling + WAV loading
-│   ├── RemindersService.swift             # Apple Reminders
-│   └── TodoistService.swift               # Todoist API
+│   ├── QwenService.swift                  # Local Qwen model for speaker inference
+│   ├── EmbeddingClusterer.swift           # Voice embedding clustering
+│   └── SpeakerClipExtractor.swift         # Speaker audio clip extraction
 │
 ├── UI/
 │   ├── FloatingPanel/                     # Floating pill UI
@@ -88,18 +82,14 @@ Murmur/
 │   │       ├── CelebrationViews.swift     # Success animations
 │   │       ├── ErrorViews.swift           # Error handling UI
 │   │       ├── AttentionPromptView.swift  # Notifications
-│   │       ├── ReviewTrayView.swift       # Action item review
+│   │       ├── SpeakerNamingView.swift    # Speaker identification
 │   │       └── ...                        # Additional components
 │   │
-│   └── Settings/                          # Preferences (sidebar navigation)
+│   └── Settings/                          # Settings window
 │       ├── SettingsWindowController.swift  # Window management
-│       ├── SettingsContainerView.swift     # Main container
+│       ├── SettingsContainerView.swift     # Single-page scrolling layout
 │       ├── SettingsSidebarView.swift       # Sidebar navigation
-│       ├── Tabs/
-│       │   ├── DashboardView.swift        # Stats, recent transcripts
-│       │   └── PreferencesView.swift      # API keys, storage, appearance
 │       ├── Components/
-│       │   ├── RecentTranscriptsView.swift # Recent transcript list
 │       │   └── SettingsSectionCard.swift   # Reusable card component
 │       └── Models/
 │           └── SettingsNavigationState.swift  # Tab state
@@ -141,13 +131,10 @@ Settings are stored in UserDefaults:
 | Key | Description |
 |-----|-------------|
 | `transcriptSaveLocation` | Custom output folder |
-| `geminiAPIKey` | Gemini API key for action item extraction |
-| `taskService` | "reminders" or "todoist" |
-| `todoistAPIKey` | Todoist API key (if using Todoist) |
-| `userName` | Your name for task attribution |
-| `remindersListId` | Apple Reminders list for action items |
+| `userName` | Your name for speaker attribution |
 | `enableUISounds` | Enable/disable UI sound effects |
 | `useAuroraRecording` | Use Aurora recording mode |
+| `enableQwenSpeakerInference` | Enable Qwen-based speaker name inference |
 
 ## Privacy & Security
 


### PR DESCRIPTION
## Changes

Updated documentation to reflect current architecture and removed references to discontinued features:

### Removed Features
- Action item extraction (Gemini AI integration)
- Task management (Reminders/Todoist integration)
- Review workflow and related UI components
- Settings sidebar tab structure

### Updated Content
- Fixed AppDelegate architecture diagram in CLAUDE.md
- Updated Settings window layout (now single-page scrolling vs sidebar+tabs)
- Added new services: QwenService, EmbeddingClusterer, SpeakerClipExtractor
- Added SpeakerNamingView documentation
- Updated data flow to focus on transcription and speaker identification
- Corrected state machine (removed "reviewing" state)
- Updated UserDefaults configuration keys
- Fixed spacing and formatting in architecture diagrams
- Updated README.md feature list and permissions table

### Files Modified
- CLAUDE.md (main architecture document)
- MEMORY.md (quick reference guide)
- Murmur/Services/CLAUDE.md (service layer docs)
- Murmur/UI/CLAUDE.md (UI module docs)
- Murmur/UI/FloatingPanel/CLAUDE.md (floating panel docs)
- README.md (user-facing documentation)