### PR TITLE
Improve Qwen speaker name inference prompt and expand to 15 min

### DIFF
--- a/Murmur/Core/TranscriptionTaskManager.swift
+++ b/Murmur/Core/TranscriptionTaskManager.swift
@@ -476,12 +476,12 @@ class TranscriptionTaskManager: ObservableObject {
                     let unidentifiedClips = clips.filter { $0.currentName == nil }
 
                     if !unidentifiedClips.isEmpty && QwenService.isEnabled && QwenService.isModelCached {
-                        let fiveMinText = self.buildFirst5MinutesText(
+                        let inferenceText = self.buildTranscriptTextForInference(
                             utterances: result.systemUtterances,
                             speakerMappings: speakerMappings
                         )
 
-                        if !fiveMinText.isEmpty {
+                        if !inferenceText.isEmpty {
                             do {
                                 // Wait for pre-loaded model (started when recording began)
                                 if let preloadTask = await MainActor.run(body: { self.qwenPreloadTask }) {
@@ -506,7 +506,7 @@ class TranscriptionTaskManager: ObservableObject {
                                 }
 
                                 if let qwen, case .ready = await qwen.modelState {
-                                    qwenSuggestions = try await qwen.inferSpeakerNames(transcript: fiveMinText)
+                                    qwenSuggestions = try await qwen.inferSpeakerNames(transcript: inferenceText)
                                 }
                                 await MainActor.run { self.cleanupQwen() }
 
@@ -804,13 +804,13 @@ class TranscriptionTaskManager: ObservableObject {
 
     // MARK: - Qwen Transcript Builder
 
-    /// Build a text representation of the first 5 minutes of system audio transcript
-    /// for Qwen speaker name inference.
-    nonisolated private func buildFirst5MinutesText(
+    /// Build a text representation of system audio transcript for Qwen speaker name inference.
+    /// Uses the first 15 minutes — enough to capture late introductions without excessive tokens.
+    nonisolated private func buildTranscriptTextForInference(
         utterances: [TranscriptionUtterance],
         speakerMappings: [String: SpeakerMapping]
     ) -> String {
-        let maxSeconds: Double = 300  // 5 minutes
+        let maxSeconds: Double = 900  // 15 minutes
         let filtered = utterances
             .filter { $0.start < maxSeconds }
             .sorted { $0.start < $1.start }

--- a/Murmur/Services/QwenService.swift
+++ b/Murmur/Services/QwenService.swift
@@ -75,7 +75,7 @@ class QwenService: ObservableObject {
         }
     }
 
-    /// Extract speaker names from the first 5 minutes of transcript text.
+    /// Extract speaker names from transcript text (up to first 15 minutes).
     /// Returns a mapping of sortformer speaker IDs to inferred names.
     /// Example: ["0": "Jack", "1": "Sarah", "2": "Unknown"]
     nonisolated func inferSpeakerNames(transcript: String) async throws -> [String: String] {
@@ -122,16 +122,53 @@ class QwenService: ObservableObject {
 
     nonisolated private static func buildChatMessages(transcript: String) -> [Chat.Message] {
         let systemPrompt = """
-        You are a speaker name extractor. Given a meeting transcript with labels like "Speaker 1", "Speaker 2", etc., identify each speaker's real name.
+        You extract speaker names from meeting transcripts.
 
-        Look for: greetings ("Hey Jack"), introductions ("I'm Sarah from..."), third-person references ("Jack was saying..."), sign-offs.
+        RULES:
+        - Lines with [Speaker 0], [Speaker 1] etc. are UNKNOWN speakers. Find their names.
+        - Lines with a real name like [Jenny] or [Jenny?] are ALREADY IDENTIFIED. Ignore them.
+        - Return a JSON object mapping speaker numbers to names.
+        - Use "Unknown" if you cannot find a name.
 
-        Return ONLY a JSON object mapping speaker IDs to names. Use "Unknown" if a name cannot be determined. No explanation, no markdown.
-        Example: {"1": "Boris", "2": "Unknown"}
+        CRITICAL RULE — "Hey Jack" DOES NOT MEAN THE SPEAKER IS JACK:
+        When someone SAYS a name, they are talking TO that person, not introducing themselves.
+        The name belongs to the LISTENER, not the speaker.
+
+        EXAMPLE 1:
+        [00:00] [Speaker 0] Hey Jack, how are you?
+        [00:05] [Speaker 1] I'm doing great, thanks!
+
+        Speaker 0 said "Hey Jack" → Speaker 0 is talking TO Jack → Speaker 1 is Jack.
+        Answer: {"0": "Unknown", "1": "Jack"}
+
+        EXAMPLE 2:
+        [00:00] [Speaker 0] Welcome everyone. I'm Sarah from marketing.
+        [00:10] [Speaker 1] Thanks Sarah. This is Mike.
+        [00:20] [Speaker 0] Great, Mike. Let's get started.
+
+        Speaker 0 said "I'm Sarah" → Speaker 0 is Sarah.
+        Speaker 1 said "This is Mike" → Speaker 1 is Mike.
+        Answer: {"0": "Sarah", "1": "Mike"}
+
+        EXAMPLE 3:
+        [00:00] [Speaker 0] Let me hand it over to David.
+        [00:05] [Speaker 1] Thanks! So as I was saying...
+        [00:15] [Speaker 0] Good point. Alex, what do you think?
+        [00:20] [Speaker 2] I agree with what David said earlier.
+
+        Speaker 0 said "hand it over to David" → Speaker 1 is David.
+        Speaker 0 said "Alex, what do you think?" → Speaker 2 is Alex.
+        Speaker 2 said "what David said" confirms Speaker 1 is David.
+        Answer: {"0": "Unknown", "1": "David", "2": "Alex"}
+
+        OUTPUT FORMAT:
+        Return ONLY a JSON object like {"0": "Sarah", "1": "Unknown"}
+        Keys are speaker numbers only: "0", "1", "2" — not "Speaker 0".
+        No explanation. No markdown. Just the JSON object.
         """
 
         let userMessage = """
-        TRANSCRIPT (first 5 minutes):
+        TRANSCRIPT:
         ---
         \(transcript)
         """

--- a/Murmur/UI/Settings/SettingsContainerView.swift
+++ b/Murmur/UI/Settings/SettingsContainerView.swift
@@ -631,7 +631,7 @@ struct SettingsContainerView: View {
                     }
                 }
 
-                Text("Reads the first 5 minutes of transcript to extract names from greetings and introductions. Runs 100% on-device.")
+                Text("Reads the first 15 minutes of transcript to extract names from greetings and introductions. Runs 100% on-device.")
                     .font(.caption)
                     .foregroundColor(.panelTextMuted)
             }


### PR DESCRIPTION
## Summary
- Rewrote the Qwen system prompt with explicit rules, 3 worked examples with reasoning chains, and a critical rule callout for direct-address inversion (the #1 failure mode where "Hey Jack" gets misattributed to the speaker instead of the listener)
- Expanded transcript window from 5 minutes to 15 minutes to catch late introductions
- Updated settings description and renamed internal method for clarity

## Test plan
- [ ] Build the project and verify no compilation errors
- [ ] Record a meeting with 2+ speakers and verify Qwen pre-fills names correctly in the naming tray
- [ ] Verify names from greetings like "Hey Jack" are attributed to the correct speaker (the listener, not the greeter)
- [ ] Verify the Settings UI shows "first 15 minutes" in the Qwen description

🤖 Generated with [Claude Code](https://claude.com/claude-code)