### PR TITLE
fix: comprehensive reliability hardening (22 findings)

### DIFF
--- a/Murmur/Core/Audio.swift
+++ b/Murmur/Core/Audio.swift
@@ -42,6 +42,7 @@ enum SystemAudioStatus: Equatable {
 @available(macOS 26.0, *)
 class Audio: ObservableObject {
     @Published var isRecording: Bool = false
+    private var isStarting: Bool = false  // Prevents double-start during async setup
     @Published var audioLevel: Float = 0.0
     @Published var recordingDuration: TimeInterval = 0.0
     @Published var audioLevelHistory: [Float] = Array(repeating: 0.0, count: 15)
@@ -230,7 +231,11 @@ class Audio: ObservableObject {
                 }
                 self.sleepTimestamp = nil
 
-                // Existing device recovery will handle reconnection via watchdog
+                // Proactively trigger mic recovery instead of waiting for the 3-5s watchdog delay
+                DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                    guard let self = self, self.isRecording else { return }
+                    self.recoverFromDeviceChange()
+                }
             }
         }
     }
@@ -264,8 +269,8 @@ class Audio: ObservableObject {
     }
 
     func start() {
-        guard !isRecording else {
-            AppLogger.audio.warning("Already recording, ignoring duplicate start request")
+        guard !isRecording, !isStarting else {
+            AppLogger.audio.warning("Already recording or starting, ignoring duplicate start request")
             return
         }
 
@@ -277,8 +282,8 @@ class Audio: ObservableObject {
             return
         }
 
-        // Set flag immediately to prevent concurrent starts
-        isRecording = true
+        // Set isStarting to prevent double-start during async setup
+        isStarting = true
         error = nil
         systemBufferCount = 0  // Reset debug counter
         resetSilenceTracking()  // Start fresh silence tracking
@@ -300,10 +305,15 @@ class Audio: ObservableObject {
         Task {
             do {
                 try await startAudioCapture()
+                await MainActor.run {
+                    self.isRecording = true
+                    self.isStarting = false
+                }
             } catch {
                 await MainActor.run {
                     self.error = "Failed to start recording: \(error.localizedDescription)"
-                    self.isRecording = false  // Reset on failure
+                    self.isRecording = false
+                    self.isStarting = false
                     self.stop()
                 }
             }
@@ -650,7 +660,10 @@ class Audio: ObservableObject {
 
                 // Audio stopped → device likely changed
                 AppLogger.audioMic.warning("Audio device disconnected or changed, switching to default")
-                self.recoverFromDeviceChange()
+                // Dispatch to background — recovery uses Thread.sleep for HAL settle time
+                DispatchQueue.global(qos: .userInitiated).async {
+                    self.recoverFromDeviceChange()
+                }
             }
         }
     }

--- a/Murmur/Core/FailedTranscriptionManager.swift
+++ b/Murmur/Core/FailedTranscriptionManager.swift
@@ -51,7 +51,10 @@ class FailedTranscriptionManager: ObservableObject {
 
             AppLogger.pipeline.info("Loaded failed transcriptions", ["count": "\(failedTranscriptions.count)"])
         } catch {
-            AppLogger.pipeline.error("Error loading failed transcriptions", ["error": "\(error)"])
+            // Backup corrupt file before it gets overwritten on next save
+            let backupURL = storageURL.deletingLastPathComponent().appendingPathComponent("failed_transcriptions_backup.json")
+            try? FileManager.default.copyItem(at: storageURL, to: backupURL)
+            AppLogger.pipeline.error("Corrupt failed transcriptions file, backed up", ["error": "\(error)"])
         }
     }
 

--- a/Murmur/Core/Logging/FileLogger.swift
+++ b/Murmur/Core/Logging/FileLogger.swift
@@ -97,6 +97,11 @@ final class FileLogger: @unchecked Sendable {
         try? newContent.write(to: logFileURL, atomically: true, encoding: .utf8)
 
         fileHandle = try? FileHandle(forWritingTo: logFileURL)
+        if fileHandle == nil {
+            // File may have been deleted during atomic write — recreate and retry
+            FileManager.default.createFile(atPath: logFileURL.path, contents: nil)
+            fileHandle = try? FileHandle(forWritingTo: logFileURL)
+        }
         fileHandle?.seekToEndOfFile()
     }
 

--- a/Murmur/Core/RecordingValidator.swift
+++ b/Murmur/Core/RecordingValidator.swift
@@ -43,14 +43,21 @@ class RecordingValidator {
         return .success
     }
 
-    /// Checks if sufficient disk space is available
+    /// Checks if sufficient disk space is available on the configured save volume
     private static func checkDiskSpace() -> ValidationResult? {
-        guard let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-            return .failure("Cannot access Documents folder")
+        // Check the actual save location, not just Documents — user may save to an external drive
+        let checkPath: URL
+        if let customPath = UserDefaults.standard.string(forKey: "transcriptSaveLocation"),
+           !customPath.isEmpty {
+            checkPath = URL(fileURLWithPath: customPath)
+        } else if let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+            checkPath = documentsPath
+        } else {
+            return .failure("Cannot access save folder")
         }
 
         do {
-            let values = try documentsPath.resourceValues(forKeys: [.volumeAvailableCapacityKey])
+            let values = try checkPath.resourceValues(forKeys: [.volumeAvailableCapacityKey])
             guard let availableCapacity = values.volumeAvailableCapacity else {
                 return .failure("Cannot determine available disk space")
             }

--- a/Murmur/Core/StatsDatabase.swift
+++ b/Murmur/Core/StatsDatabase.swift
@@ -9,6 +9,7 @@ final class StatsDatabase {
     static let shared = StatsDatabase()
 
     private var db: OpaquePointer?
+    private var isDatabaseOpen = false
     private let dbPath: URL
 
     /// Serial queue ensuring thread-safe database access
@@ -38,9 +39,28 @@ final class StatsDatabase {
     private func openDatabase() {
         if sqlite3_open(dbPath.path, &db) != SQLITE_OK {
             AppLogger.stats.error("Failed to open database", ["path": dbPath.path])
+            isDatabaseOpen = false
         } else {
+            isDatabaseOpen = true
+            // WAL mode for crash safety, busy timeout to avoid SQLITE_BUSY, NORMAL sync for performance
+            sqlite3_exec(db, "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA synchronous=NORMAL;", nil, nil, nil)
             AppLogger.stats.info("Opened database", ["path": dbPath.path])
         }
+    }
+
+    /// Execute multiple writes atomically — if the app crashes mid-block, all changes are rolled back.
+    private func transaction(_ block: () -> Void) {
+        sqlite3_exec(db, "BEGIN EXCLUSIVE", nil, nil, nil)
+        block()
+        sqlite3_exec(db, "COMMIT", nil, nil, nil)
+    }
+
+    /// Log and return the sqlite3_errmsg for the current database connection
+    private func dbErrorMessage() -> String {
+        if let db = db {
+            return String(cString: sqlite3_errmsg(db))
+        }
+        return "database not open"
     }
 
     private func createTables() {
@@ -96,45 +116,55 @@ final class StatsDatabase {
     }
 
     private func recordSessionImpl(_ metadata: RecordingMetadata) {
-        let sql = """
-        INSERT OR REPLACE INTO recordings (id, date, time, duration_seconds, word_count, speaker_count, processing_time_ms, transcript_path, title, created_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-        """
-
-        var statement: OpaquePointer?
-
-        if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd"
-            let dateString = dateFormatter.string(from: metadata.date)
-
-            let timeFormatter = DateFormatter()
-            timeFormatter.dateFormat = "HH:mm:ss"
-            let timeString = timeFormatter.string(from: metadata.date)
-
-            let isoFormatter = ISO8601DateFormatter()
-            let createdAt = isoFormatter.string(from: metadata.date)
-
-            sqlite3_bind_text(statement, 1, (metadata.id as NSString).utf8String, -1, nil)
-            sqlite3_bind_text(statement, 2, (dateString as NSString).utf8String, -1, nil)
-            sqlite3_bind_text(statement, 3, (timeString as NSString).utf8String, -1, nil)
-            sqlite3_bind_int(statement, 4, Int32(metadata.durationSeconds))
-            sqlite3_bind_int(statement, 5, Int32(metadata.wordCount))
-            sqlite3_bind_int(statement, 6, Int32(metadata.speakerCount))
-            sqlite3_bind_int(statement, 7, Int32(metadata.processingTimeMs))
-            sqlite3_bind_text(statement, 8, ((metadata.transcriptPath ?? "") as NSString).utf8String, -1, nil)
-            sqlite3_bind_text(statement, 9, ((metadata.title ?? "") as NSString).utf8String, -1, nil)
-            sqlite3_bind_text(statement, 10, (createdAt as NSString).utf8String, -1, nil)
-
-            if sqlite3_step(statement) != SQLITE_DONE {
-                AppLogger.stats.error("Failed to insert recording")
-            }
+        guard isDatabaseOpen else {
+            AppLogger.stats.error("recordSession skipped — database not open")
+            return
         }
 
-        sqlite3_finalize(statement)
+        // Wrap INSERT + daily activity update in a transaction so both succeed or neither does
+        transaction {
+            let sql = """
+            INSERT OR REPLACE INTO recordings (id, date, time, duration_seconds, word_count, speaker_count, processing_time_ms, transcript_path, title, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """
 
-        // Update daily activity
-        updateDailyActivityImpl(for: metadata.date, durationDelta: metadata.durationSeconds)
+            var statement: OpaquePointer?
+
+            if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+                let dateFormatter = DateFormatter()
+                dateFormatter.dateFormat = "yyyy-MM-dd"
+                let dateString = dateFormatter.string(from: metadata.date)
+
+                let timeFormatter = DateFormatter()
+                timeFormatter.dateFormat = "HH:mm:ss"
+                let timeString = timeFormatter.string(from: metadata.date)
+
+                let isoFormatter = ISO8601DateFormatter()
+                let createdAt = isoFormatter.string(from: metadata.date)
+
+                sqlite3_bind_text(statement, 1, (metadata.id as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(statement, 2, (dateString as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(statement, 3, (timeString as NSString).utf8String, -1, nil)
+                sqlite3_bind_int(statement, 4, Int32(metadata.durationSeconds))
+                sqlite3_bind_int(statement, 5, Int32(metadata.wordCount))
+                sqlite3_bind_int(statement, 6, Int32(metadata.speakerCount))
+                sqlite3_bind_int(statement, 7, Int32(metadata.processingTimeMs))
+                sqlite3_bind_text(statement, 8, ((metadata.transcriptPath ?? "") as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(statement, 9, ((metadata.title ?? "") as NSString).utf8String, -1, nil)
+                sqlite3_bind_text(statement, 10, (createdAt as NSString).utf8String, -1, nil)
+
+                if sqlite3_step(statement) != SQLITE_DONE {
+                    AppLogger.stats.error("Failed to insert recording", ["sqlite_error": dbErrorMessage()])
+                }
+            } else {
+                AppLogger.stats.error("Failed to prepare recordSession insert", ["sqlite_error": dbErrorMessage()])
+            }
+
+            sqlite3_finalize(statement)
+
+            // Update daily activity (inside same transaction)
+            updateDailyActivityImpl(for: metadata.date, durationDelta: metadata.durationSeconds)
+        }
     }
 
     /// Get all recordings (thread-safe, sync)
@@ -180,6 +210,8 @@ final class StatsDatabase {
                 )
                 recordings.append(recording)
             }
+        } else {
+            AppLogger.stats.error("Failed to prepare getAllRecordings", ["sqlite_error": dbErrorMessage()])
         }
 
         sqlite3_finalize(statement)
@@ -236,6 +268,8 @@ final class StatsDatabase {
                 )
                 recordings.append(recording)
             }
+        } else {
+            AppLogger.stats.error("Failed to prepare getRecordings", ["sqlite_error": dbErrorMessage()])
         }
 
         sqlite3_finalize(statement)
@@ -249,7 +283,7 @@ final class StatsDatabase {
         dateFormatter.dateFormat = "yyyy-MM-dd"
         let dateStr = dateFormatter.string(from: date)
 
-        // Try to update existing record
+        // Upsert: insert new or increment existing daily activity
         let updateSQL = """
         INSERT INTO daily_activity (date, recording_count, total_duration_seconds, action_items_count, updated_at)
         VALUES (?, 1, ?, 0, datetime('now'))
@@ -267,8 +301,10 @@ final class StatsDatabase {
             sqlite3_bind_int(statement, 3, Int32(durationDelta))
 
             if sqlite3_step(statement) != SQLITE_DONE {
-                AppLogger.stats.error("Failed to update daily activity")
+                AppLogger.stats.error("Failed to update daily activity", ["sqlite_error": dbErrorMessage()])
             }
+        } else {
+            AppLogger.stats.error("Failed to prepare updateDailyActivity", ["sqlite_error": dbErrorMessage()])
         }
 
         sqlite3_finalize(statement)
@@ -316,6 +352,8 @@ final class StatsDatabase {
                     actionItemsCount: actionItems
                 )
             }
+        } else {
+            AppLogger.stats.error("Failed to prepare getDailyActivity", ["sqlite_error": dbErrorMessage()])
         }
 
         sqlite3_finalize(statement)
@@ -340,6 +378,8 @@ final class StatsDatabase {
                 let dateStr = String(cString: sqlite3_column_text(statement, 0))
                 dates.append(dateStr)
             }
+        } else {
+            AppLogger.stats.error("Failed to prepare getAllActiveDates", ["sqlite_error": dbErrorMessage()])
         }
 
         sqlite3_finalize(statement)
@@ -364,6 +404,8 @@ final class StatsDatabase {
             if sqlite3_step(statement) == SQLITE_ROW {
                 count = Int(sqlite3_column_int(statement, 0))
             }
+        } else {
+            AppLogger.stats.error("Failed to prepare getTotalRecordingsCount", ["sqlite_error": dbErrorMessage()])
         }
 
         sqlite3_finalize(statement)
@@ -386,6 +428,8 @@ final class StatsDatabase {
             if sqlite3_step(statement) == SQLITE_ROW {
                 total = Int(sqlite3_column_int(statement, 0))
             }
+        } else {
+            AppLogger.stats.error("Failed to prepare getTotalDurationSeconds", ["sqlite_error": dbErrorMessage()])
         }
 
         sqlite3_finalize(statement)
@@ -418,6 +462,8 @@ final class StatsDatabase {
                 recordings = Int(sqlite3_column_int(statement, 0))
                 duration = Int(sqlite3_column_int(statement, 1))
             }
+        } else {
+            AppLogger.stats.error("Failed to prepare getStatsForLastDays", ["sqlite_error": dbErrorMessage()])
         }
         sqlite3_finalize(statement)
 
@@ -444,6 +490,8 @@ final class StatsDatabase {
             if sqlite3_step(statement) == SQLITE_ROW {
                 exists = sqlite3_column_int(statement, 0) > 0
             }
+        } else {
+            AppLogger.stats.error("Failed to prepare recordingExists", ["sqlite_error": dbErrorMessage()])
         }
 
         sqlite3_finalize(statement)

--- a/Murmur/Core/SystemAudioCapture.swift
+++ b/Murmur/Core/SystemAudioCapture.swift
@@ -376,7 +376,10 @@ class SystemAudioCapture: ObservableObject {
             if timeSinceLastBuffer > 3.0 {
                 // System audio stopped → output device likely changed
                 AppLogger.audioSystem.warning("Output device disconnected or changed, attempting recovery")
-                self.recoverFromOutputChange()
+                // Dispatch to self.queue — recovery uses Thread.sleep for HAL settle time
+                self.queue.async {
+                    self.recoverFromOutputChange()
+                }
             }
         }
     }

--- a/Murmur/Core/TranscriptSaver.swift
+++ b/Murmur/Core/TranscriptSaver.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppKit
+import UserNotifications
 
 /// Recording health information for transcript metadata (Phase 3)
 /// Captures quality metrics to be embedded in transcript YAML frontmatter
@@ -85,10 +86,14 @@ class TranscriptSaver {
             return nil
         }
 
-        // Generate filename with timestamp
+        // Generate filename with timestamp, avoiding collisions
         let timestamp = DateFormattingHelper.formatFilename(Date())
-        let filename = "Call_\(timestamp).md"
-        let fileURL = saveDir.appendingPathComponent(filename)
+        var fileURL = saveDir.appendingPathComponent("Call_\(timestamp).md")
+        var counter = 1
+        while FileManager.default.fileExists(atPath: fileURL.path) {
+            fileURL = saveDir.appendingPathComponent("Call_\(timestamp)_\(counter).md")
+            counter += 1
+        }
 
         // Create markdown content with metadata
         let markdown = formatMarkdown(text: text, duration: duration, date: Date())
@@ -110,6 +115,12 @@ class TranscriptSaver {
 
 
     /// Format source label for timeline display
+    /// Escape special characters for safe YAML string interpolation
+    private static func escapeYAML(_ s: String) -> String {
+        s.replacingOccurrences(of: "\\", with: "\\\\")
+         .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
     private static func formatSourceLabel(_ source: String) -> String {
         // Map "System Audio" to shorter "SysAudio"
         return source == "System Audio" ? "SysAudio" : source
@@ -176,8 +187,12 @@ class TranscriptSaver {
         }
 
         let timestamp = DateFormattingHelper.formatFilename(Date())
-        let filename = "Call_\(timestamp).md"
-        let fileURL = saveDir.appendingPathComponent(filename)
+        var fileURL = saveDir.appendingPathComponent("Call_\(timestamp).md")
+        var counter = 1
+        while FileManager.default.fileExists(atPath: fileURL.path) {
+            fileURL = saveDir.appendingPathComponent("Call_\(timestamp)_\(counter).md")
+            counter += 1
+        }
 
         let markdown = formatTranscriptMarkdown(result: result, speakerMappings: speakerMappings, speakerSources: speakerSources, speakerDbIds: speakerDbIds, date: Date(), healthInfo: healthInfo)
 
@@ -274,11 +289,11 @@ class TranscriptSaver {
                 let name = mapping.identifiedName ?? "Unknown"
                 let confidence = mapping.confidence?.rawValue ?? "unknown"
                 let source = speakerSources[mapping.speakerId] ?? "unknown"
-                yaml += "\n  - id: \"\(mapping.speakerId)\""
+                yaml += "\n  - id: \"\(Self.escapeYAML(mapping.speakerId))\""
                 if let dbId = speakerDbIds[mapping.speakerId] {
                     yaml += "\n    db_id: \"\(dbId.uuidString)\""
                 }
-                yaml += "\n    name: \"\(name)\""
+                yaml += "\n    name: \"\(Self.escapeYAML(name))\""
                 yaml += "\n    confidence: \(confidence)"
                 yaml += "\n    source: \(source)"
             }
@@ -497,49 +512,86 @@ class TranscriptSaver {
         }
     }
 
+    /// Notification category identifier for "Show in Finder" action
+    fileprivate static let notificationCategoryId = "TRANSCRIPT_SAVED"
+    fileprivate static let showInFinderActionId = "SHOW_IN_FINDER"
+
+    /// Set up notification categories (call once at app startup)
+    static func registerNotificationCategories() {
+        let showAction = UNNotificationAction(
+            identifier: showInFinderActionId,
+            title: "Show in Finder",
+            options: .foreground
+        )
+        let category = UNNotificationCategory(
+            identifier: notificationCategoryId,
+            actions: [showAction],
+            intentIdentifiers: []
+        )
+        UNUserNotificationCenter.current().setNotificationCategories([category])
+    }
+
     /// Show macOS notification that transcript was saved
     private static func showSaveNotification(fileURL: URL) {
-        let notification = NSUserNotification()
-        notification.title = "Transcript Saved"
-        notification.informativeText = fileURL.lastPathComponent
-        notification.soundName = nil // Silent notification
+        let center = UNUserNotificationCenter.current()
 
-        // Add action to open in Finder
-        notification.hasActionButton = true
-        notification.actionButtonTitle = "Show in Finder"
+        // Set delegate so we receive action callbacks
+        if notificationDelegate == nil {
+            let delegate = SaveNotificationDelegate()
+            notificationDelegate = delegate
+            center.delegate = delegate
+        }
 
-        // Deliver notification
-        NSUserNotificationCenter.default.deliver(notification)
+        // Store the file URL for the "Show in Finder" action
+        notificationDelegate?.latestFileURL = fileURL
 
-        // Set up delegate to handle "Show in Finder" action
-        let delegate = NotificationDelegate(fileURL: fileURL)
-        NSUserNotificationCenter.default.delegate = delegate
+        center.requestAuthorization(options: [.alert]) { granted, _ in
+            guard granted else { return }
 
-        // Keep delegate alive (store in static property)
-        notificationDelegates.append(delegate)
-    }
+            let content = UNMutableNotificationContent()
+            content.title = "Transcript Saved"
+            content.body = fileURL.lastPathComponent
+            content.categoryIdentifier = notificationCategoryId
 
-    // Keep notification delegates alive
-    private static var notificationDelegates: [NotificationDelegate] = []
-}
+            let request = UNNotificationRequest(
+                identifier: UUID().uuidString,
+                content: content,
+                trigger: nil // deliver immediately
+            )
 
-/// Delegate to handle notification actions (e.g., "Show in Finder")
-private class NotificationDelegate: NSObject, NSUserNotificationCenterDelegate {
-    let fileURL: URL
-
-    init(fileURL: URL) {
-        self.fileURL = fileURL
-    }
-
-    func userNotificationCenter(_ center: NSUserNotificationCenter, didActivate notification: NSUserNotification) {
-        if notification.activationType == .actionButtonClicked {
-            // Open in Finder and select the file
-            NSWorkspace.shared.activateFileViewerSelecting([fileURL])
+            center.add(request) { error in
+                if let error = error {
+                    AppLogger.pipeline.error("Failed to deliver notification", ["error": error.localizedDescription])
+                }
+            }
         }
     }
 
-    // Always show notifications even if app is in foreground
-    func userNotificationCenter(_ center: NSUserNotificationCenter, shouldPresent notification: NSUserNotification) -> Bool {
-        return true
+    private static var notificationDelegate: SaveNotificationDelegate?
+}
+
+/// Delegate to handle UNUserNotification actions (e.g., "Show in Finder")
+private class SaveNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+    var latestFileURL: URL?
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        if response.actionIdentifier == TranscriptSaver.showInFinderActionId,
+           let url = latestFileURL {
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+        }
+        completionHandler()
+    }
+
+    // Show notifications even when app is in foreground
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner])
     }
 }

--- a/Murmur/Core/Transcription.swift
+++ b/Murmur/Core/Transcription.swift
@@ -92,10 +92,11 @@ class Transcription: ObservableObject {
             let resampleStart = CFAbsoluteTimeGetCurrent()
 
             // Resample both files in parallel — they're independent I/O + compute
-            async let systemSamplesTask = Task { try AudioResampler.loadAndResample(url: systemURL, targetRate: 16000) }
-            async let micSamplesTask = Task { try AudioResampler.loadAndResample(url: micURL, targetRate: 16000) }
-            let systemSamples = try await systemSamplesTask.value
-            let micSamples = try await micSamplesTask.value
+            // Using async let (not Task {}) so cancellation propagates correctly
+            async let systemSamplesAsync = AudioResampler.loadAndResample(url: systemURL, targetRate: 16000)
+            async let micSamplesAsync = AudioResampler.loadAndResample(url: micURL, targetRate: 16000)
+            let systemSamples = try await systemSamplesAsync
+            let micSamples = try await micSamplesAsync
 
             let resampleTime = CFAbsoluteTimeGetCurrent() - resampleStart
             AppLogger.transcription.info("Resampling completed in \(String(format: "%.2f", resampleTime))s")
@@ -224,6 +225,9 @@ class Transcription: ObservableObject {
             }
 
             for (index, segment) in speakerSegments.enumerated() {
+                // Allow cancellation between segments (user hit stop or app is terminating)
+                try Task.checkCancellation()
+
                 // Extract audio slice for this segment
                 let segmentSamples = AudioResampler.extractSlice(
                     from: systemSamples,

--- a/Murmur/Core/TranscriptionTypes.swift
+++ b/Murmur/Core/TranscriptionTypes.swift
@@ -53,16 +53,10 @@ struct TranscriptionResult {
         Set(systemUtterances.map { $0.speakerId }).count
     }
 
-    /// Matched speaker profiles from the speaker database
-    var speakerProfiles: [UUID: SpeakerProfile] {
-        var profiles: [UUID: SpeakerProfile] = [:]
-        for utterance in systemUtterances {
-            if let id = utterance.persistentSpeakerId {
-                // Profile will be looked up separately — this just tracks which IDs appeared
-                profiles[id] = profiles[id] // placeholder
-            }
-        }
-        return profiles
+    /// Persistent speaker IDs that appeared in system audio utterances.
+    /// Profiles are looked up separately via SpeakerDatabase.
+    var persistentSpeakerIds: Set<UUID> {
+        Set(systemUtterances.compactMap { $0.persistentSpeakerId })
     }
 }
 

--- a/Murmur/Onboarding/OnboardingWindow.swift
+++ b/Murmur/Onboarding/OnboardingWindow.swift
@@ -98,7 +98,7 @@ class OnboardingWindowController: NSWindowController {
         guard let window = self.window else { return }
 
         window.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        NSApp.activate()
 
         // Fade in animation
         NSAnimationContext.runAnimationGroup { context in

--- a/Murmur/Services/AudioResampler.swift
+++ b/Murmur/Services/AudioResampler.swift
@@ -115,47 +115,60 @@ enum AudioResampler {
             ])
         }
 
-        // Read entire source file into buffer
-        guard let srcBuffer = AVAudioPCMBuffer(pcmFormat: srcFormat, frameCapacity: srcFrames) else {
-            throw NSError(domain: "AudioResampler", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Failed to create source audio buffer"
-            ])
-        }
-        try file.read(into: srcBuffer)
-
-        // Calculate output frame count (add margin for filter delay)
         let ratio = targetRate / srcFormat.sampleRate
-        let dstFrames = AVAudioFrameCount(Double(srcFrames) * ratio) + 16
-        guard let dstBuffer = AVAudioPCMBuffer(pcmFormat: dstFormat, frameCapacity: dstFrames) else {
-            throw NSError(domain: "AudioResampler", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Failed to create destination audio buffer"
-            ])
-        }
 
-        // Convert in one pass — the input block is called once for single-buffer conversion
-        var inputConsumed = false
-        var conversionError: NSError?
-        let status = converter.convert(to: dstBuffer, error: &conversionError) { _, outStatus in
-            if inputConsumed {
-                outStatus.pointee = .endOfStream
-                return nil
+        // Process in chunks to avoid multi-GB allocations for long recordings
+        // 30 seconds at 48kHz stereo float32 ≈ 11MB per chunk (vs 2.6GB for a 2-hour file)
+        let chunkDuration: Double = 30.0  // seconds
+        let chunkFrames = AVAudioFrameCount(srcFormat.sampleRate * chunkDuration)
+        var allSamples: [Float] = []
+        allSamples.reserveCapacity(Int(Double(srcFrames) * ratio) + 16)
+
+        while file.framePosition < file.length {
+            let framesToRead = min(chunkFrames, AVAudioFrameCount(file.length - file.framePosition))
+
+            guard let srcBuffer = AVAudioPCMBuffer(pcmFormat: srcFormat, frameCapacity: framesToRead) else {
+                throw NSError(domain: "AudioResampler", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to create source audio buffer"
+                ])
             }
-            inputConsumed = true
-            outStatus.pointee = .haveData
-            return srcBuffer
+            try file.read(into: srcBuffer, frameCount: framesToRead)
+
+            let dstFrames = AVAudioFrameCount(Double(framesToRead) * ratio) + 16
+            guard let dstBuffer = AVAudioPCMBuffer(pcmFormat: dstFormat, frameCapacity: dstFrames) else {
+                throw NSError(domain: "AudioResampler", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to create destination audio buffer"
+                ])
+            }
+
+            var inputConsumed = false
+            var conversionError: NSError?
+            let status = converter.convert(to: dstBuffer, error: &conversionError) { _, outStatus in
+                if inputConsumed {
+                    outStatus.pointee = .endOfStream
+                    return nil
+                }
+                inputConsumed = true
+                outStatus.pointee = .haveData
+                return srcBuffer
+            }
+
+            if status == .error, let conversionError {
+                throw conversionError
+            }
+
+            guard let floatData = dstBuffer.floatChannelData else {
+                throw NSError(domain: "AudioResampler", code: 2, userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to get float channel data from converted buffer"
+                ])
+            }
+
+            allSamples.append(contentsOf: UnsafeBufferPointer(start: floatData[0], count: Int(dstBuffer.frameLength)))
+            // Reset converter state between chunks for clean boundaries
+            converter.reset()
         }
 
-        if status == .error, let conversionError {
-            throw conversionError
-        }
-
-        guard let floatData = dstBuffer.floatChannelData else {
-            throw NSError(domain: "AudioResampler", code: 2, userInfo: [
-                NSLocalizedDescriptionKey: "Failed to get float channel data from converted buffer"
-            ])
-        }
-
-        return Array(UnsafeBufferPointer(start: floatData[0], count: Int(dstBuffer.frameLength)))
+        return allSamples
     }
 
     /// Extract a time slice from samples array.

--- a/Murmur/Services/SpeakerClipExtractor.swift
+++ b/Murmur/Services/SpeakerClipExtractor.swift
@@ -104,10 +104,19 @@ enum SpeakerClipExtractor {
     /// Overwrites any existing clip for this speaker (keeps the latest).
     static func persistClip(from tempClipURL: URL, speakerId: UUID) {
         let dir = clipsDirectory
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        } catch {
+            AppLogger.pipeline.error("Failed to create clips directory", ["error": error.localizedDescription])
+            return
+        }
         let dest = dir.appendingPathComponent("\(speakerId.uuidString).wav")
-        try? FileManager.default.removeItem(at: dest)
-        try? FileManager.default.copyItem(at: tempClipURL, to: dest)
+        try? FileManager.default.removeItem(at: dest) // OK if doesn't exist
+        do {
+            try FileManager.default.copyItem(at: tempClipURL, to: dest)
+        } catch {
+            AppLogger.pipeline.error("Failed to persist speaker clip", ["speakerId": speakerId.uuidString, "error": error.localizedDescription])
+        }
     }
 
     /// Look up persistent clip URL for a speaker. Returns nil if no clip exists.

--- a/Murmur/Services/SpeakerDatabase.swift
+++ b/Murmur/Services/SpeakerDatabase.swift
@@ -32,6 +32,7 @@ final class SpeakerDatabase {
     static let shared = SpeakerDatabase()
 
     private var db: OpaquePointer?
+    private var isDatabaseOpen = false
     private let dbPath: URL
     private let queue = DispatchQueue(label: "com.transcripted.speakerdb", qos: .utility)
 
@@ -55,7 +56,11 @@ final class SpeakerDatabase {
     private func openDatabase() {
         if sqlite3_open(dbPath.path, &db) != SQLITE_OK {
             AppLogger.speakers.error("Failed to open database", ["path": dbPath.path])
+            isDatabaseOpen = false
         } else {
+            isDatabaseOpen = true
+            // WAL mode for crash safety, busy timeout to avoid SQLITE_BUSY, NORMAL sync for performance
+            sqlite3_exec(db, "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA synchronous=NORMAL;", nil, nil, nil)
             AppLogger.speakers.info("Opened database", ["path": dbPath.path])
         }
     }
@@ -94,6 +99,21 @@ final class SpeakerDatabase {
                 sqlite3_free(errorMessage)
             }
         }
+    }
+
+    /// Execute multiple writes atomically — if the app crashes mid-block, all changes are rolled back.
+    private func transaction(_ block: () -> Void) {
+        sqlite3_exec(db, "BEGIN EXCLUSIVE", nil, nil, nil)
+        block()
+        sqlite3_exec(db, "COMMIT", nil, nil, nil)
+    }
+
+    /// Log and return the sqlite3_errmsg for the current database connection
+    private func dbErrorMessage() -> String {
+        if let db = db {
+            return String(cString: sqlite3_errmsg(db))
+        }
+        return "database not open"
     }
 
     // MARK: - Speaker Matching
@@ -139,7 +159,15 @@ final class SpeakerDatabase {
         }
     }
 
+    /// SQLITE_TRANSIENT tells SQLite to copy the blob data immediately, preventing dangling pointer issues
+    private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
     private func addOrUpdateSpeakerImpl(embedding: [Float], existingId: UUID?) -> SpeakerProfile {
+        guard isDatabaseOpen else {
+            AppLogger.speakers.error("addOrUpdateSpeaker skipped — database not open")
+            return SpeakerProfile(id: existingId ?? UUID(), displayName: nil, nameSource: nil, embedding: embedding, firstSeen: Date(), lastSeen: Date(), callCount: 1, confidence: 0.5, disputeCount: 0)
+        }
+
         let isoFormatter = ISO8601DateFormatter()
         let now = isoFormatter.string(from: Date())
 
@@ -159,11 +187,15 @@ final class SpeakerDatabase {
             var statement: OpaquePointer?
             if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
                 let embeddingData = normalized.withUnsafeBufferPointer { Data(buffer: $0) }
-                sqlite3_bind_blob(statement, 1, (embeddingData as NSData).bytes, Int32(embeddingData.count), nil)
+                sqlite3_bind_blob(statement, 1, (embeddingData as NSData).bytes, Int32(embeddingData.count), SQLITE_TRANSIENT)
                 sqlite3_bind_text(statement, 2, (now as NSString).utf8String, -1, nil)
                 sqlite3_bind_double(statement, 3, newConfidence)
                 sqlite3_bind_text(statement, 4, (existingId.uuidString as NSString).utf8String, -1, nil)
-                sqlite3_step(statement)
+                if sqlite3_step(statement) != SQLITE_DONE {
+                    AppLogger.speakers.error("Failed to update speaker embedding", ["sqlite_error": dbErrorMessage(), "id": existingId.uuidString])
+                }
+            } else {
+                AppLogger.speakers.error("Failed to prepare update speaker", ["sqlite_error": dbErrorMessage()])
             }
             sqlite3_finalize(statement)
 
@@ -191,10 +223,14 @@ final class SpeakerDatabase {
             var statement: OpaquePointer?
             if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
                 sqlite3_bind_text(statement, 1, (newId.uuidString as NSString).utf8String, -1, nil)
-                sqlite3_bind_blob(statement, 2, (embeddingData as NSData).bytes, Int32(embeddingData.count), nil)
+                sqlite3_bind_blob(statement, 2, (embeddingData as NSData).bytes, Int32(embeddingData.count), SQLITE_TRANSIENT)
                 sqlite3_bind_text(statement, 3, (now as NSString).utf8String, -1, nil)
                 sqlite3_bind_text(statement, 4, (now as NSString).utf8String, -1, nil)
-                sqlite3_step(statement)
+                if sqlite3_step(statement) != SQLITE_DONE {
+                    AppLogger.speakers.error("Failed to insert new speaker", ["sqlite_error": dbErrorMessage(), "id": newId.uuidString])
+                }
+            } else {
+                AppLogger.speakers.error("Failed to prepare insert speaker", ["sqlite_error": dbErrorMessage()])
             }
             sqlite3_finalize(statement)
 
@@ -219,31 +255,41 @@ final class SpeakerDatabase {
     ///   - name: Display name to set
     ///   - source: Where the name came from ("user_manual", "qwen_inferred")
     func setDisplayName(id: UUID, name: String, source: String = "qwen_inferred") {
-        queue.async { [weak self] in
-            self?.setDisplayNameImpl(id: id, name: name, source: source)
+        queue.sync {
+            setDisplayNameImpl(id: id, name: name, source: source)
         }
     }
 
     private func setDisplayNameImpl(id: UUID, name: String, source: String) {
+        guard isDatabaseOpen else { return }
         let sql = "UPDATE speakers SET display_name = ?, name_source = ? WHERE id = ?;"
         var statement: OpaquePointer?
         if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
             sqlite3_bind_text(statement, 1, (name as NSString).utf8String, -1, nil)
             sqlite3_bind_text(statement, 2, (source as NSString).utf8String, -1, nil)
             sqlite3_bind_text(statement, 3, (id.uuidString as NSString).utf8String, -1, nil)
-            sqlite3_step(statement)
+            if sqlite3_step(statement) != SQLITE_DONE {
+                AppLogger.speakers.error("Failed to set display name", ["sqlite_error": dbErrorMessage(), "id": id.uuidString])
+            }
+        } else {
+            AppLogger.speakers.error("Failed to prepare setDisplayName", ["sqlite_error": dbErrorMessage()])
         }
         sqlite3_finalize(statement)
     }
 
     /// Increment the dispute count for a speaker (inference disagreed with DB name)
     func incrementDisputeCount(id: UUID) {
-        queue.async { [weak self] in
+        queue.sync { [self] in
+            guard isDatabaseOpen else { return }
             let sql = "UPDATE speakers SET dispute_count = dispute_count + 1 WHERE id = ?;"
             var statement: OpaquePointer?
-            if sqlite3_prepare_v2(self?.db, sql, -1, &statement, nil) == SQLITE_OK {
+            if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
                 sqlite3_bind_text(statement, 1, (id.uuidString as NSString).utf8String, -1, nil)
-                sqlite3_step(statement)
+                if sqlite3_step(statement) != SQLITE_DONE {
+                    AppLogger.speakers.error("Failed to increment dispute count", ["sqlite_error": dbErrorMessage()])
+                }
+            } else {
+                AppLogger.speakers.error("Failed to prepare incrementDisputeCount", ["sqlite_error": dbErrorMessage()])
             }
             sqlite3_finalize(statement)
         }
@@ -251,12 +297,17 @@ final class SpeakerDatabase {
 
     /// Reset dispute count (after user manual rename or name confirmed)
     func resetDisputeCount(id: UUID) {
-        queue.async { [weak self] in
+        queue.sync { [self] in
+            guard isDatabaseOpen else { return }
             let sql = "UPDATE speakers SET dispute_count = 0 WHERE id = ?;"
             var statement: OpaquePointer?
-            if sqlite3_prepare_v2(self?.db, sql, -1, &statement, nil) == SQLITE_OK {
+            if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
                 sqlite3_bind_text(statement, 1, (id.uuidString as NSString).utf8String, -1, nil)
-                sqlite3_step(statement)
+                if sqlite3_step(statement) != SQLITE_DONE {
+                    AppLogger.speakers.error("Failed to reset dispute count", ["sqlite_error": dbErrorMessage()])
+                }
+            } else {
+                AppLogger.speakers.error("Failed to prepare resetDisputeCount", ["sqlite_error": dbErrorMessage()])
             }
             sqlite3_finalize(statement)
         }
@@ -310,6 +361,8 @@ final class SpeakerDatabase {
                     disputeCount: disputeCount
                 ))
             }
+        } else {
+            AppLogger.speakers.error("Failed to prepare allSpeakers query", ["sqlite_error": dbErrorMessage()])
         }
         sqlite3_finalize(statement)
         return speakers
@@ -326,12 +379,17 @@ final class SpeakerDatabase {
 
     /// Delete a speaker profile
     func deleteSpeaker(id: UUID) {
-        queue.async { [weak self] in
+        queue.sync { [self] in
+            guard isDatabaseOpen else { return }
             let sql = "DELETE FROM speakers WHERE id = ?;"
             var statement: OpaquePointer?
-            if sqlite3_prepare_v2(self?.db, sql, -1, &statement, nil) == SQLITE_OK {
+            if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
                 sqlite3_bind_text(statement, 1, (id.uuidString as NSString).utf8String, -1, nil)
-                sqlite3_step(statement)
+                if sqlite3_step(statement) != SQLITE_DONE {
+                    AppLogger.speakers.error("Failed to delete speaker", ["sqlite_error": dbErrorMessage(), "id": id.uuidString])
+                }
+            } else {
+                AppLogger.speakers.error("Failed to prepare deleteSpeaker", ["sqlite_error": dbErrorMessage()])
             }
             sqlite3_finalize(statement)
         }
@@ -397,30 +455,41 @@ final class SpeakerDatabase {
         let newCallCount = target.callCount + source.callCount
         let newConfidence = min(1.0, target.confidence + 0.15)
 
-        let sql = """
-        UPDATE speakers SET embedding = ?, last_seen = ?, call_count = ?, confidence = ?
-        WHERE id = ?;
-        """
-        var statement: OpaquePointer?
-        if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
-            let embeddingData = normalized.withUnsafeBufferPointer { Data(buffer: $0) }
-            sqlite3_bind_blob(statement, 1, (embeddingData as NSData).bytes, Int32(embeddingData.count), nil)
-            sqlite3_bind_text(statement, 2, (now as NSString).utf8String, -1, nil)
-            sqlite3_bind_int(statement, 3, Int32(newCallCount))
-            sqlite3_bind_double(statement, 4, newConfidence)
-            sqlite3_bind_text(statement, 5, (targetId.uuidString as NSString).utf8String, -1, nil)
-            sqlite3_step(statement)
-        }
-        sqlite3_finalize(statement)
+        // Wrap UPDATE + DELETE in a transaction so a crash between them can't orphan data
+        transaction {
+            let sql = """
+            UPDATE speakers SET embedding = ?, last_seen = ?, call_count = ?, confidence = ?
+            WHERE id = ?;
+            """
+            var statement: OpaquePointer?
+            if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+                let embeddingData = normalized.withUnsafeBufferPointer { Data(buffer: $0) }
+                sqlite3_bind_blob(statement, 1, (embeddingData as NSData).bytes, Int32(embeddingData.count), SQLITE_TRANSIENT)
+                sqlite3_bind_text(statement, 2, (now as NSString).utf8String, -1, nil)
+                sqlite3_bind_int(statement, 3, Int32(newCallCount))
+                sqlite3_bind_double(statement, 4, newConfidence)
+                sqlite3_bind_text(statement, 5, (targetId.uuidString as NSString).utf8String, -1, nil)
+                if sqlite3_step(statement) != SQLITE_DONE {
+                    AppLogger.speakers.error("Failed to update target in merge", ["sqlite_error": dbErrorMessage(), "targetId": targetId.uuidString])
+                }
+            } else {
+                AppLogger.speakers.error("Failed to prepare merge update", ["sqlite_error": dbErrorMessage()])
+            }
+            sqlite3_finalize(statement)
 
-        // Delete source profile
-        let deleteSql = "DELETE FROM speakers WHERE id = ?;"
-        var deleteStmt: OpaquePointer?
-        if sqlite3_prepare_v2(db, deleteSql, -1, &deleteStmt, nil) == SQLITE_OK {
-            sqlite3_bind_text(deleteStmt, 1, (sourceId.uuidString as NSString).utf8String, -1, nil)
-            sqlite3_step(deleteStmt)
+            // Delete source profile
+            let deleteSql = "DELETE FROM speakers WHERE id = ?;"
+            var deleteStmt: OpaquePointer?
+            if sqlite3_prepare_v2(db, deleteSql, -1, &deleteStmt, nil) == SQLITE_OK {
+                sqlite3_bind_text(deleteStmt, 1, (sourceId.uuidString as NSString).utf8String, -1, nil)
+                if sqlite3_step(deleteStmt) != SQLITE_DONE {
+                    AppLogger.speakers.error("Failed to delete source in merge", ["sqlite_error": dbErrorMessage(), "sourceId": sourceId.uuidString])
+                }
+            } else {
+                AppLogger.speakers.error("Failed to prepare merge delete", ["sqlite_error": dbErrorMessage()])
+            }
+            sqlite3_finalize(deleteStmt)
         }
-        sqlite3_finalize(deleteStmt)
 
         AppLogger.speakers.info("Merged profiles", [
             "source": source.displayName ?? "\(sourceId)",
@@ -447,43 +516,50 @@ final class SpeakerDatabase {
         var mergedIds: Set<UUID> = []
         var mergeCount = 0
 
-        for i in 0..<speakers.count {
-            guard !mergedIds.contains(speakers[i].id) else { continue }
+        // Wrap all deletes in a single transaction so the merge is atomic
+        transaction {
+            for i in 0..<speakers.count {
+                guard !mergedIds.contains(speakers[i].id) else { continue }
 
-            for j in (i + 1)..<speakers.count {
-                guard !mergedIds.contains(speakers[j].id) else { continue }
+                for j in (i + 1)..<speakers.count {
+                    guard !mergedIds.contains(speakers[j].id) else { continue }
 
-                let similarity = cosineSimilarity(speakers[i].embedding, speakers[j].embedding)
-                guard similarity >= threshold else { continue }
+                    let similarity = cosineSimilarity(speakers[i].embedding, speakers[j].embedding)
+                    guard similarity >= threshold else { continue }
 
-                // Determine which profile to keep (more calls = better data)
-                let keeper: SpeakerProfile
-                let absorbed: SpeakerProfile
-                if speakers[i].callCount >= speakers[j].callCount {
-                    keeper = speakers[i]
-                    absorbed = speakers[j]
-                } else {
-                    keeper = speakers[j]
-                    absorbed = speakers[i]
+                    // Determine which profile to keep (more calls = better data)
+                    let keeper: SpeakerProfile
+                    let absorbed: SpeakerProfile
+                    if speakers[i].callCount >= speakers[j].callCount {
+                        keeper = speakers[i]
+                        absorbed = speakers[j]
+                    } else {
+                        keeper = speakers[j]
+                        absorbed = speakers[i]
+                    }
+
+                    // Transfer display name if keeper doesn't have one
+                    if keeper.displayName == nil, let name = absorbed.displayName {
+                        setDisplayNameImpl(id: keeper.id, name: name, source: absorbed.nameSource ?? "qwen_inferred")
+                    }
+
+                    // Delete the absorbed profile
+                    let sql = "DELETE FROM speakers WHERE id = ?;"
+                    var statement: OpaquePointer?
+                    if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+                        sqlite3_bind_text(statement, 1, (absorbed.id.uuidString as NSString).utf8String, -1, nil)
+                        if sqlite3_step(statement) != SQLITE_DONE {
+                            AppLogger.speakers.error("Failed to delete absorbed speaker", ["sqlite_error": dbErrorMessage(), "id": absorbed.id.uuidString])
+                        }
+                    } else {
+                        AppLogger.speakers.error("Failed to prepare duplicate delete", ["sqlite_error": dbErrorMessage()])
+                    }
+                    sqlite3_finalize(statement)
+
+                    mergedIds.insert(absorbed.id)
+                    mergeCount += 1
+                    AppLogger.speakers.info("Merged duplicate speaker", ["absorbed": absorbed.displayName ?? "unnamed", "keeper": keeper.displayName ?? "unnamed", "similarity": String(format: "%.3f", similarity)])
                 }
-
-                // Transfer display name if keeper doesn't have one
-                if keeper.displayName == nil, let name = absorbed.displayName {
-                    setDisplayNameImpl(id: keeper.id, name: name, source: absorbed.nameSource ?? "qwen_inferred")
-                }
-
-                // Delete the absorbed profile
-                let sql = "DELETE FROM speakers WHERE id = ?;"
-                var statement: OpaquePointer?
-                if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
-                    sqlite3_bind_text(statement, 1, (absorbed.id.uuidString as NSString).utf8String, -1, nil)
-                    sqlite3_step(statement)
-                }
-                sqlite3_finalize(statement)
-
-                mergedIds.insert(absorbed.id)
-                mergeCount += 1
-                AppLogger.speakers.info("Merged duplicate speaker", ["absorbed": absorbed.displayName ?? "unnamed", "keeper": keeper.displayName ?? "unnamed", "similarity": String(format: "%.3f", similarity)])
             }
         }
 
@@ -552,6 +628,7 @@ final class SpeakerDatabase {
     }
 
     private func pruneWeakProfilesImpl() {
+        guard isDatabaseOpen else { return }
         // Only prune profiles created more than 1 hour ago — don't prune profiles from
         // the current recording that are about to be named in the speaker naming flow.
         let cutoff = ISO8601DateFormatter().string(from: Date().addingTimeInterval(-3600))
@@ -566,11 +643,16 @@ final class SpeakerDatabase {
         var statement: OpaquePointer?
         if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
             sqlite3_bind_text(statement, 1, (cutoff as NSString).utf8String, -1, nil)
-            sqlite3_step(statement)
-            let pruned = Int(sqlite3_changes(db))
-            if pruned > 0 {
-                AppLogger.speakers.info("Pruned weak profiles", ["count": "\(pruned)"])
+            if sqlite3_step(statement) != SQLITE_DONE {
+                AppLogger.speakers.error("Failed to prune weak profiles", ["sqlite_error": dbErrorMessage()])
+            } else {
+                let pruned = Int(sqlite3_changes(db))
+                if pruned > 0 {
+                    AppLogger.speakers.info("Pruned weak profiles", ["count": "\(pruned)"])
+                }
             }
+        } else {
+            AppLogger.speakers.error("Failed to prepare pruneWeakProfiles", ["sqlite_error": dbErrorMessage()])
         }
         sqlite3_finalize(statement)
     }

--- a/Murmur/TranscriptedApp.swift
+++ b/Murmur/TranscriptedApp.swift
@@ -285,7 +285,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         failedTranscriptionsWindow?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        NSApp.activate()
     }
 
     @objc func openSettings() {
@@ -325,7 +325,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // Create output folder if it doesn't exist
-        try? FileManager.default.createDirectory(at: outputFolder, withIntermediateDirectories: true)
+        do {
+            try FileManager.default.createDirectory(at: outputFolder, withIntermediateDirectories: true)
+        } catch {
+            AppLogger.pipeline.error("Failed to create output folder", ["error": error.localizedDescription, "path": outputFolder.path])
+        }
 
         // Start transcription in background using task manager
         taskManager?.startTranscription(
@@ -337,6 +341,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        // Stop active recording so audio files are properly finalized
+        if audio?.isRecording == true {
+            audio?.stop()
+        }
+        taskManager?.cancelAll()
         AppLogger.shared.flush()
     }
 }

--- a/Murmur/UI/FloatingPanel/Components/TranscriptDetailView.swift
+++ b/Murmur/UI/FloatingPanel/Components/TranscriptDetailView.swift
@@ -5,7 +5,8 @@ import SwiftUI
 /// Groups consecutive transcript lines from the same speaker for iMessage-style rendering.
 /// Presentation-only model — stays in this file, not in TranscriptStore.
 struct MessageGroup: Identifiable {
-    let id = UUID()
+    /// Deterministic ID derived from content so SwiftUI doesn't re-render unchanged groups
+    let id: String
     let speaker: String?    // Raw: "Mic/You" or "System/Speaker 1"
     let isUser: Bool        // true if speaker starts with "Mic"
     let lines: [TranscriptLine]
@@ -25,6 +26,7 @@ struct MessageGroup: Identifiable {
         var groups: [MessageGroup] = []
         var currentSpeaker: String?
         var currentLines: [TranscriptLine] = []
+        var groupIndex = 0
 
         for line in lines {
             if line.speaker == currentSpeaker {
@@ -32,7 +34,9 @@ struct MessageGroup: Identifiable {
             } else {
                 if !currentLines.isEmpty {
                     let isUser = currentSpeaker?.lowercased().hasPrefix("mic") ?? false
-                    groups.append(MessageGroup(speaker: currentSpeaker, isUser: isUser, lines: currentLines))
+                    let stableId = "\(groupIndex)_\(currentSpeaker ?? "nil")_\(currentLines.first?.timestamp ?? "")"
+                    groups.append(MessageGroup(id: stableId, speaker: currentSpeaker, isUser: isUser, lines: currentLines))
+                    groupIndex += 1
                 }
                 currentSpeaker = line.speaker
                 currentLines = [line]
@@ -41,7 +45,8 @@ struct MessageGroup: Identifiable {
         // Flush last group
         if !currentLines.isEmpty {
             let isUser = currentSpeaker?.lowercased().hasPrefix("mic") ?? false
-            groups.append(MessageGroup(speaker: currentSpeaker, isUser: isUser, lines: currentLines))
+            let stableId = "\(groupIndex)_\(currentSpeaker ?? "nil")_\(currentLines.first?.timestamp ?? "")"
+            groups.append(MessageGroup(id: stableId, speaker: currentSpeaker, isUser: isUser, lines: currentLines))
         }
 
         return groups

--- a/Murmur/UI/FloatingPanel/FloatingPanelController.swift
+++ b/Murmur/UI/FloatingPanel/FloatingPanelController.swift
@@ -11,6 +11,7 @@ class FloatingPanelController: NSWindowController, NSWindowDelegate {
     private var failedTranscriptionManager: FailedTranscriptionManager
     let pillStateManager = PillStateManager()
     private var cancellables = Set<AnyCancellable>()
+    private var returnToIdleWorkItem: DispatchWorkItem?
 
     // Position persistence keys
     private static let savedPositionXKey = "floatingPanelX"
@@ -205,24 +206,31 @@ class FloatingPanelController: NSWindowController, NSWindowDelegate {
     /// Schedule a quick return to idle so user can start recording again
     /// The pill shows processing/success briefly, then morphs back to idle
     private func scheduleReturnToIdle(delay: TimeInterval) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+        // Cancel any pending return-to-idle so we don't stack multiple timers
+        returnToIdleWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
             guard let self = self else { return }
             // Only return to idle if not recording, not locked, and not naming speakers
             guard !self.audio.isRecording, !self.pillStateManager.isLocked else { return }
             guard self.taskManager.speakerNamingRequest == nil else { return }
             self.pillStateManager.transition(to: .idle)
         }
+        returnToIdleWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 
-    /// Reposition window if screen changes (only if no saved position)
+    /// Reposition window if saved position is off-screen or no position saved
     func repositionIfNeeded() {
         guard let window = self.window, let screen = NSScreen.main else { return }
 
-        // Only reposition if no saved position exists
-        if UserDefaults.standard.object(forKey: Self.savedPositionXKey) != nil {
-            return
+        // Validate saved position — if it's on-screen, keep it
+        if let savedX = UserDefaults.standard.object(forKey: Self.savedPositionXKey) as? CGFloat,
+           let savedY = UserDefaults.standard.object(forKey: Self.savedPositionYKey) as? CGFloat,
+           Self.isOnScreen(x: savedX, y: savedY) {
+            return  // Saved position is still valid
         }
 
+        // No valid saved position — reposition to default center-bottom
         let dockHeight = Self.detectDockHeight(for: screen)
         let x = (screen.frame.width - maxWindowWidth) / 2
         let y = dockHeight + PillDimensions.dockPadding
@@ -235,10 +243,10 @@ class FloatingPanelController: NSWindowController, NSWindowDelegate {
 
     // MARK: - Position Persistence
 
-    /// Check if a position is visible on any connected screen
-    private static func isOnScreen(x: CGFloat, y: CGFloat) -> Bool {
-        let point = NSPoint(x: x, y: y)
-        return NSScreen.screens.contains { $0.frame.contains(point) }
+    /// Check if a position is visible on any connected screen (checks a rect, not just a point)
+    private static func isOnScreen(x: CGFloat, y: CGFloat, width: CGFloat = 280, height: CGFloat = 60) -> Bool {
+        let rect = NSRect(x: x, y: y, width: width, height: height)
+        return NSScreen.screens.contains { $0.visibleFrame.intersects(rect) }
     }
 
     // MARK: - NSWindowDelegate

--- a/Murmur/UI/Settings/SettingsContainerView.swift
+++ b/Murmur/UI/Settings/SettingsContainerView.swift
@@ -729,9 +729,8 @@ struct SettingsContainerView: View {
         panel.canCreateDirectories = true
         panel.prompt = "Choose"
         panel.message = "Select where to save your transcripts"
-        if let url = URL(string: saveLocation.isEmpty ? TranscriptSaver.defaultSaveDirectory.path : saveLocation) {
-            panel.directoryURL = url
-        }
+        let directoryPath = saveLocation.isEmpty ? TranscriptSaver.defaultSaveDirectory.path : saveLocation
+        panel.directoryURL = URL(fileURLWithPath: directoryPath)
         if panel.runModal() == .OK, let url = panel.url {
             saveLocation = url.path
         }

--- a/Murmur/UI/Settings/SettingsWindowController.swift
+++ b/Murmur/UI/Settings/SettingsWindowController.swift
@@ -75,6 +75,9 @@ final class SettingsWindowController: NSWindowController {
 
         // Set window appearance to dark
         window.appearance = NSAppearance(named: .darkAqua)
+
+        // Set delegate so NSWindowDelegate methods work
+        window.delegate = self
     }
 
     private func setupContentView() {
@@ -98,7 +101,7 @@ final class SettingsWindowController: NSWindowController {
     /// Show the settings window
     func showWindow() {
         window?.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
+        NSApp.activate()
 
         // Refresh stats when window is shown
         Task { @MainActor in


### PR DESCRIPTION
## Summary

- **SQLite safety**: WAL journal mode, busy timeout, transactions for multi-step writes, step/prepare error checking, SQLITE_TRANSIENT for blob bindings, isDatabaseOpen guards across both SpeakerDatabase and StatsDatabase
- **Audio race conditions**: `isStarting` guard prevents double-start, deferred `isRecording` flag until audio is actually capturing, device recovery dispatched to background queues, proactive mic recovery after system wake
- **App lifecycle**: proper cleanup in `applicationWillTerminate`, disk space validation on configured save volume, surfaced folder creation errors
- **Pipeline reliability**: fixed `async let` wrapping for cancellation propagation, `Task.checkCancellation()` in segment loop, chunk-based audio resampling (30s chunks) to prevent OOM on long recordings
- **Data persistence**: YAML escaping for speaker names, filename collision prevention, corrupt JSON backup before overwrite, NotificationDelegate memory leak fix
- **UI state**: cancellable return-to-idle timer via DispatchWorkItem, off-screen position detection using full rect intersection, window delegate assignment, URL(fileURLWithPath:) fix, deterministic MessageGroup IDs
- **Silent failure remediation**: SpeakerClipExtractor `try?` → `do/catch` with logging, FileLogger nil handle recovery after trim
- **Deprecated API cleanup**: removed dead `speakerProfiles` placeholder, migrated `NSUserNotification` → `UNUserNotificationCenter`, replaced `NSApp.activate(ignoringOtherApps:)`

## Test plan

- [ ] Build succeeds (`xcodebuild -scheme Murmur -configuration Debug build`)
- [ ] Record a short clip and verify transcription completes end-to-end
- [ ] Start and immediately stop recording — verify no crash (Phase 2)
- [ ] Check logs for WAL/pragma confirmation on launch (Phase 1)
- [ ] Set a speaker name with quotes/backslashes — verify YAML is valid (Phase 5)
- [ ] Disconnect external monitor — verify pill repositions (Phase 6)
- [ ] Verify save notification appears and "Show in Finder" action works (Phase 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)