### PR TITLE
docs: rewrite all CLAUDE.md files for agent-optimized workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,360 +1,79 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Important References
-
-- **MEMORY.md** - Contains lessons learned and debugging references from past issues. **Check this file first when debugging audio, transcription, or performance issues.**
-
 ## Behavioral Guidelines
+- **Implement, don't suggest.** If intent is unclear, infer the most useful action and proceed.
+- **Read before answering.** Never speculate about code you haven't opened. This is critical given CoreAudio/Speech framework nuances.
+- **Parallel tool calls.** When independent, make all calls in parallel.
+- **No overengineering.** Only changes that are directly requested. Don't refactor surrounding code, add features, or clean up unless asked.
+- **Work summaries.** After completing tool-based work, summarize what was done.
+- **Check MEMORY.md first** when debugging any runtime issue.
 
-### Proactive Implementation
-By default, implement changes rather than only suggesting them. If intent is unclear, infer the most useful likely action and proceed, using tools to discover missing details instead of guessing.
+## Project Summary
+**Transcripted** — macOS app that records, transcribes, and organizes voice conversations. Uses Parakeet TDT V3 (STT) + Sortformer (diarization) via FluidAudio — 100% local, no cloud APIs. Outputs Markdown transcripts to `~/Documents/Transcripted/`.
 
-### Read Before Answering
-Never speculate about code you have not opened. If a specific file is referenced, read it before answering. Investigate and read relevant files BEFORE answering questions about the codebase. This is especially critical for this codebase given the nuanced CoreAudio and Speech framework APIs.
-
-### Work Summaries
-After completing a task that involves tool use (file edits, builds, searches), provide a quick summary of the work done.
-
-### Parallel Tool Execution
-When calling multiple tools with no dependencies between them, make all independent calls in parallel to maximize speed and efficiency.
-
-### No Overengineering
-Avoid over-engineering. Only make changes that are directly requested or clearly necessary:
-- Don't add features beyond what was asked
-- Don't refactor surrounding code unless explicitly requested
-- A bug fix doesn't need surrounding code cleaned up
-- A simple feature doesn't need extra configurability
-
-## Project Overview
-
-**Transcripted** is a native macOS application that automatically records, transcribes, and organizes voice conversations from meetings and calls. The app uses **Parakeet TDT V3** (local CoreML speech-to-text) and **Sortformer** (local CoreML speaker diarization) via the FluidAudio library — all transcription runs 100% on-device with no cloud API or internet required. Transcripts are saved as Markdown and easily copied to clipboard for pasting into AI tools like Claude or ChatGPT.
-
-## Build & Run Commands
-
+## Build Commands
 ```bash
-# Open in Xcode (primary development method)
-open Murmur.xcodeproj
-
-# Build from command line
 xcodebuild -project Murmur.xcodeproj -scheme Murmur -configuration Debug build
-
-# Build for release
 xcodebuild -project Murmur.xcodeproj -scheme Murmur -configuration Release build
-
-# Clean build
 xcodebuild -project Murmur.xcodeproj -scheme Murmur clean
 ```
+Requires: macOS 14.2+, Xcode 15+, Swift 5.9+
 
-**Requirements:**
-- macOS 14.2+ (Sonoma) - required for system audio capture APIs
-- Xcode 15+
-- Swift 5.9+
+## Agent Routing Table
+Read the component CLAUDE.md in the relevant directory FIRST:
 
-## Architecture
+| Task / Issue | Read first |
+|---|---|
+| Audio capture, mic, recording | `Murmur/Core/CLAUDE.md` |
+| System audio, process taps | `Murmur/Core/CLAUDE.md` |
+| Transcription pipeline, saving | `Murmur/Core/CLAUDE.md` |
+| Task queue, retries, progress | `Murmur/Core/CLAUDE.md` |
+| STT model (Parakeet) | `Murmur/Services/CLAUDE.md` |
+| Speaker diarization (Sortformer) | `Murmur/Services/CLAUDE.md` |
+| Speaker matching, voice DB | `Murmur/Services/CLAUDE.md` |
+| Speaker name inference (Qwen) | `Murmur/Services/CLAUDE.md` |
+| Audio resampling | `Murmur/Services/CLAUDE.md` |
+| Floating pill UI, state machine | `Murmur/UI/FloatingPanel/CLAUDE.md` |
+| Transcript tray, speaker naming | `Murmur/UI/FloatingPanel/CLAUDE.md` |
+| Settings window | `Murmur/UI/Settings/CLAUDE.md` |
+| Design tokens, colors, animations | `Murmur/Design/CLAUDE.md` |
+| Onboarding flow | `Murmur/Onboarding/CLAUDE.md` |
+| App entry point, bootstrap | `Murmur/TranscriptedApp.swift` |
+| Runtime debugging | `MEMORY.md` |
 
-### Core Audio Pipeline
+## Critical Invariants (All Changes)
+- All classes use `@available(macOS 26.0, *)` — required for `AudioHardwareCreateProcessTap`
+- **@MainActor classes:** Audio, Transcription, TranscriptionTaskManager, PillStateManager, ParakeetService, SortformerService, QwenService, StatsService, FailedTranscriptionManager
+- **NOT @MainActor:** SystemAudioCapture (DispatchQueue + NSLock), SpeakerDatabase (DispatchQueue + SQLite), StatsDatabase (DispatchQueue)
+- **CoreAudio I/O callbacks run on real-time threads** — NEVER do I/O, locks, allocations, or Objective-C calls inside them. Deep-copy buffers before async dispatch.
+- System audio is 48kHz (tap reports 96kHz — always hardcode 48000.0)
+- Mic format: use `inputFormat(forBus: 1)` (hardware), NEVER `outputFormat(forBus: 0)`
+- Model states: `.notLoaded` → `.loading` → `.ready` | `.failed`
+- App runs as LSUIElement (no dock icon), NSPanel floating UI
 
-```
-Murmur/Core/Audio.swift              → Microphone capture via AVAudioEngine
-                                     → Writes to WAV file in real-time
-                                     → Monitors audio levels for silence detection
-
-Murmur/Core/SystemAudioCapture.swift → System-wide audio via CoreAudio process taps
-                                     → Creates aggregate device with tap
-                                     → Captures all system audio including meeting apps
-
-Murmur/Core/Transcription.swift      → Local transcription via Parakeet + Sortformer
-                                     → Diarizes system audio, transcribes per-segment
-                                     → Speaker matching via persistent voice database
-
-Murmur/Core/TranscriptSaver.swift    → Outputs markdown with YAML frontmatter
-                                     → Saves to ~/Documents/Transcripted/
-```
-
-### Transcription Engine (Local)
-
-The app uses **FluidAudio** for 100% local transcription — no cloud API, no internet, no cost:
-
-| Component | Model | Purpose |
-|-----------|-------|---------|
-| Speech-to-text | Parakeet TDT V3 (~600MB CoreML) | Transcribes audio to text on Neural Engine |
-| Speaker diarization | Sortformer (~CoreML) | Identifies who speaks when in system audio |
-| Voice fingerprints | WeSpeaker (256-dim embeddings) | Persistent speaker matching across sessions |
-
-**Services:** `Murmur/Services/ParakeetService.swift`, `Murmur/Services/SortformerService.swift`
-**Database:** `Murmur/Services/SpeakerDatabase.swift` (SQLite, voice embeddings)
-**Resampler:** `Murmur/Services/AudioResampler.swift` (48kHz → 16kHz for model input)
-
-**Pipeline:** Record → Sortformer diarizes system audio → Parakeet transcribes each speaker segment → Parakeet transcribes mic → Match speakers to database → Merge utterances chronologically
-
-**Note:** Models are downloaded from HuggingFace on first launch if not bundled. System audio capture requires appropriate permissions.
-
-### State Management
-
-```
-TranscriptedApp.swift (AppDelegate)
-├── Audio                      → Recording state, audio levels
-├── TranscriptionTaskManager   → Background transcription queue, progress tracking
-├── FailedTranscriptionManager → Retry queue with persistent storage
-├── FloatingPanelController    → UI coordination
-├── SettingsWindowController   → Settings window
-└── OnboardingWindowController → Onboarding flow
-```
-
-### UI Components
-
-The floating panel UI is organized in `Murmur/UI/FloatingPanel/`:
-
-```
-FloatingPanel/
-├── FloatingPanelController.swift   # NSWindowController, window management
-├── FloatingPanelView.swift         # Main SwiftUI view composition
-├── PillStateManager.swift          # State machine (idle/recording/processing)
-├── Components/
-│   ├── PillViews.swift             # Pill state views (Idle, Recording, Processing)
-│   ├── WaveformViews.swift         # Audio visualizers (EdgePeek, WaveformMini, Dormant)
-│   ├── CelebrationViews.swift      # Success animations (checkmarks, pulse rings)
-│   ├── ErrorViews.swift            # Error banners with recovery hints
-│   ├── AttentionPromptView.swift   # Notification prompts (silence warning)
-│   ├── TranscriptTrayView.swift    # Recent transcripts tray with copy-to-clipboard
-│   ├── TranscriptDetailView.swift  # Transcript detail with chat bubbles
-│   ├── SpeakerNamingView.swift     # Speaker identification and naming UI
-│   ├── AuroraIdleView.swift        # Aurora animation for idle state
-│   ├── AuroraRecordingView.swift   # Aurora animation for recording state
-│   ├── AuroraProcessingView.swift  # Aurora animation for processing state
-│   └── AuroraSuccessView.swift     # Aurora animation for success state
-└── Helpers/
-    └── LawsComponents.swift        # Reusable UI primitives (buttons, status text)
-```
-
-Settings window (`Murmur/UI/Settings/`):
-```
-Settings/
-├── SettingsWindowController.swift          # NSWindowController, 800x600 fixed window
-├── SettingsContainerView.swift             # Single-page scrolling layout (stats, speakers, preferences)
-├── SettingsSidebarView.swift               # Left sidebar navigation
-├── Models/
-│   └── SettingsNavigationState.swift       # Tab state (Dashboard, Speakers, Preferences)
-└── Components/
-    └── SettingsSectionCard.swift            # Reusable card component
-```
-
-Other UI files:
-- **FailedTranscriptionsView** (`Murmur/UI/FailedTranscriptionsView.swift`) - UI for retry queue management
-
-### Onboarding Flow
-
-Four-step onboarding managed by `Murmur/Onboarding/OnboardingState.swift`:
-1. Welcome → 2. How It Works → 3. Permissions → 4. Ready
-
-Permissions requested: Microphone (required), Screen Recording (for system audio)
-
-## Design System
-
-Defined in `Murmur/Design/DesignTokens.swift`:
-- **Panel theme**: Dark charcoal (`panelCharcoal`, `panelCharcoalElevated`)
-- **Recording accent**: Coral red (`recordingCoral` #FF6B6B)
-- **Text**: `panelTextPrimary`, `panelTextSecondary`, `panelTextMuted`
-- **Onboarding theme**: Warm cream with terracotta accents
-- **Animation presets**: `.elegant` (0.5s), `.refined`, `.snappy`
-
-## Data Flow
-
-1. **Recording starts** → `RecordingValidator.validateRecordingConditions()` checks disk space, permissions, devices
-2. **Audio capture** → `Audio.start()` + `SystemAudioCapture.start()` write WAV files
-3. **Recording stops** → `onRecordingComplete` callback triggers
-4. **Transcription queued** → `TranscriptionTaskManager.startTranscription()`
-5. **On failure** → `FailedTranscriptionManager.addFailedTranscription()` persists to `~/Documents/Transcripted/failed_transcriptions.json`
-6. **On success** → `TranscriptSaver.save()` writes markdown, audio files deleted
-
-## Configuration
-
-User settings stored in `UserDefaults`:
-
-| Key | Description |
-|-----|-------------|
-| `transcriptSaveLocation` | Custom output folder path |
-| `userName` | User's name for speaker attribution |
-| `hasCompletedOnboarding` | Onboarding completion flag |
-| `enableUISounds` | Enable/disable recording sounds |
-| `useAuroraRecording` | Enable aurora animation |
-| `enableQwenSpeakerInference` | Enable Qwen-based speaker name inference |
-| `floatingPanelX` | Saved pill X position |
-| `floatingPanelY` | Saved pill Y position |
-
-## Debug Features
-
-In DEBUG builds, the menu bar includes "Reset Onboarding (Debug)" to test the onboarding flow.
-
-To test failed transcription retry:
-```swift
-// In TranscriptionTaskManager.startTranscription(), uncomment:
-// throw NSError(domain: "TestError", code: 999, ...)
-```
-
-## Important Implementation Notes
-
-### macOS Version Annotations
-The app uses `@available(macOS 26.0, *)` annotations throughout, targeting macOS 14.2+ due to:
-- `AudioHardwareCreateProcessTap` API for system audio capture
-
-### Audio Format Handling
-- Mic audio: Uses hardware format from `inputNode.inputFormat(forBus: 1)` (NOT `outputFormat`)
-- System audio: Native 48kHz (tap claims 96kHz but actual rate is 48kHz)
-- Transcription: Resampled to 16kHz mono for Parakeet/Sortformer input
-
-### Transcript Format
-Output is markdown with YAML frontmatter:
-```yaml
----
-date: YYYY-MM-DD
-time: HH:mm:ss
-duration: "MM:SS"
-processing_time: "X.Xs"
-word_count: N
----
-```
-Timeline entries: `[MM:SS] [Mic/SysAudio/Speaker X] Text`
-
-### Local Model Loading
-- **Parakeet + Sortformer**: Models loaded from app bundle on launch, or downloaded from HuggingFace on first run
-- Model states: `.notLoaded` → `.loading` → `.ready` (or `.failed`)
-- Initialization triggered in `setupApp()` via `taskManager?.transcription.initializeModels()`
-
-## File Organization
-
-```
-Murmur/
-├── Core/
-│   ├── Logging/
-│   │   ├── AppLogger.swift        # Unified logging (os.Logger + JSON Lines file)
-│   │   └── FileLogger.swift       # Rolling JSON Lines logger at ~/Library/Logs/
-│   ├── Audio.swift                # Microphone capture via AVAudioEngine
-│   ├── SystemAudioCapture.swift   # System audio via CoreAudio process taps
-│   ├── Transcription.swift        # Local transcription via Parakeet + Sortformer
-│   ├── TranscriptionTypes.swift   # Engine-agnostic result types (TranscriptionResult, etc.)
-│   ├── TranscriptionTaskManager.swift  # Background transcription queue
-│   ├── TranscriptSaver.swift      # Markdown output with YAML frontmatter
-│   ├── TranscriptScanner.swift    # Transcript file discovery
-│   ├── TranscriptStore.swift      # ObservableObject store for transcript tray UI
-│   ├── TranscriptUtils.swift      # Transcript helper utilities
-│   ├── DateParser.swift           # Natural language date parsing
-│   ├── DateFormattingHelper.swift # Date formatting utilities
-│   ├── Clipboard.swift            # Clipboard operations
-│   ├── CoreAudioUtils.swift       # CoreAudio helper utilities
-│   ├── RecordingValidator.swift   # Pre-recording system checks
-│   ├── FailedTranscription.swift  # Failed transcription model
-│   ├── FailedTranscriptionManager.swift  # Retry queue with persistent storage
-│   ├── StatsService.swift         # Recording statistics and streak tracking
-│   └── StatsDatabase.swift        # SQLite persistence for stats
-├── Design/                        # Visual design system
-│   ├── DesignTokens.swift         # Colors, spacing, animation presets
-│   └── PremiumComponents.swift    # Reusable premium UI components
-├── Onboarding/                    # Four-step onboarding flow
-│   ├── OnboardingState.swift      # State management for onboarding
-│   ├── OnboardingContainerView.swift  # Container view for steps
-│   ├── OnboardingWindow.swift     # Onboarding window controller
-│   ├── Steps/
-│   │   ├── WelcomeStep.swift      # Step 1: Welcome
-│   │   ├── HowItWorksStep.swift   # Step 2: How It Works
-│   │   ├── PermissionsStep.swift  # Step 3: Permissions
-│   │   └── ReadyStep.swift        # Step 4: Ready
-│   └── Animations/
-│       └── ParticleExplosionView.swift  # Celebration particle effects
-├── Services/                      # Local engines + external integrations
-│   ├── ParakeetService.swift      # Local STT via FluidAudio (Parakeet TDT V3)
-│   ├── SortformerService.swift    # Local speaker diarization via FluidAudio
-│   ├── SpeakerDatabase.swift      # Persistent voice fingerprints (SQLite + 256-dim embeddings)
-│   ├── AudioResampler.swift       # Audio resampling (48kHz → 16kHz) and WAV loading
-│   ├── QwenService.swift          # Local Qwen model for speaker name inference
-│   ├── EmbeddingClusterer.swift   # Clustering utility for voice embeddings
-│   └── SpeakerClipExtractor.swift # Extracts audio clips for speaker samples
-├── UI/
-│   ├── FloatingPanel/             # Floating pill UI
-│   │   ├── FloatingPanelController.swift  # NSWindowController
-│   │   ├── FloatingPanelView.swift        # Main SwiftUI composition
-│   │   ├── PillStateManager.swift         # State machine
-│   │   ├── Components/
-│   │   │   ├── PillViews.swift            # Pill state views
-│   │   │   ├── WaveformViews.swift        # Audio visualizers
-│   │   │   ├── CelebrationViews.swift     # Success animations
-│   │   │   ├── ErrorViews.swift           # Error banners
-│   │   │   ├── AttentionPromptView.swift  # Silence warning
-│   │   │   ├── TranscriptTrayView.swift   # Recent transcripts tray
-│   │   │   ├── TranscriptDetailView.swift # Transcript detail view
-│   │   │   ├── SpeakerNamingView.swift    # Speaker identification and naming
-│   │   │   ├── AuroraIdleView.swift       # Aurora idle animation
-│   │   │   ├── AuroraRecordingView.swift  # Aurora recording animation
-│   │   │   ├── AuroraProcessingView.swift # Aurora processing animation
-│   │   │   └── AuroraSuccessView.swift    # Aurora success animation
-│   │   └── Helpers/
-│   │       └── LawsComponents.swift       # Reusable UI primitives
-│   ├── Settings/                  # Settings window
-│   │   ├── SettingsWindowController.swift  # NSWindowController, 800x600
-│   │   ├── SettingsContainerView.swift     # Single-page scrolling layout
-│   │   ├── SettingsSidebarView.swift       # Left sidebar navigation
-│   │   ├── Models/
-│   │   │   └── SettingsNavigationState.swift  # Tab state (Dashboard, Speakers, Preferences)
-│   │   └── Components/
-│   │       └── SettingsSectionCard.swift   # Reusable card component
-│   └── FailedTranscriptionsView.swift  # Retry queue management UI
-├── TranscriptedApp.swift          # App entry point (AppDelegate pattern)
-└── Transcripted.entitlements
-```
+## Data Locations
+| Data | Path |
+|---|---|
+| Transcripts | `~/Documents/Transcripted/` (customizable via UserDefaults `transcriptSaveLocation`) |
+| Stats DB | `~/Documents/Transcripted/stats.sqlite` |
+| Speaker DB | `~/Documents/Transcripted/speakers.sqlite` |
+| Failed queue | `~/Documents/Transcripted/failed_transcriptions.json` |
+| Speaker clips | `~/Documents/Transcripted/speaker_clips/` |
+| Logs | `~/Library/Logs/Transcripted/app.jsonl` |
+| Qwen cache | `~/Library/Caches/models/mlx-community/` |
 
 ## Logging
-
-**Log file:** `~/Library/Logs/Transcripted/app.jsonl`
-**Format:** JSON Lines (one JSON object per line)
-**Max entries:** 2000 (rolling, trims oldest 500 when full)
-**Read logs:** `Read ~/Library/Logs/Transcripted/app.jsonl`
-**Filter by subsystem:** `Grep` for `"s":"audio.mic"` etc.
-
-**Subsystems:**
+**File:** `~/Library/Logs/Transcripted/app.jsonl` — JSON Lines, rolling 2000 entries.
 
 | Subsystem | Covers |
-|-----------|--------|
-| `audio` | General audio start/stop, sleep/wake |
-| `audio.mic` | Mic capture, device switches, recovery |
-| `audio.system` | System audio tap, buffers, device changes |
-| `transcription` | Parakeet/Sortformer model loading, STT/diarization |
-| `pipeline` | Task lifecycle, saving, file management, retries |
-| `speaker-db` | Speaker matching, voice embeddings, merges |
-| `services` | Service-level operations (Qwen, etc.) |
+|---|---|
+| `audio`, `audio.mic`, `audio.system` | Recording, mic, system audio |
+| `transcription` | Model loading, STT, diarization |
+| `pipeline` | Task lifecycle, saving, retries |
+| `speaker-db` | Speaker matching, embeddings, merges |
+| `services` | Qwen, service-level ops |
 | `ui` | Pill state transitions, UI events |
-| `stats` | Recording statistics, database operations |
-| `app` | App lifecycle, model initialization |
+| `stats` | Recording statistics, DB ops |
+| `app` | App lifecycle, initialization |
 
-**For ANY runtime issue: Read the log file first.**
-
-## Agent Task Routing
-
-Read the component CLAUDE.md in the relevant folder FIRST:
-
-| Issue domain | Read first |
-|-------------|------------|
-| Audio/recording issues | `Murmur/Core/CLAUDE.md` |
-| Transcription/STT issues | `Murmur/Services/CLAUDE.md` |
-| Speaker ID issues | `Murmur/Services/CLAUDE.md` |
-| Pipeline/saving issues | `Murmur/Core/CLAUDE.md` |
-| UI/settings issues | `Murmur/UI/CLAUDE.md` |
-| Floating pill issues | `Murmur/UI/FloatingPanel/CLAUDE.md` |
-| Design system changes | `Murmur/Design/CLAUDE.md` |
-| Onboarding flow | `Murmur/Onboarding/CLAUDE.md` |
-
-## Component Dependencies
-
-```
-TranscriptedApp.swift (entry point)
-├── Core/Audio.swift + Core/SystemAudioCapture.swift
-├── Core/TranscriptionTaskManager.swift
-│   ├── Core/Transcription.swift
-│   │   ├── Services/ParakeetService.swift
-│   │   ├── Services/SortformerService.swift
-│   │   └── Services/SpeakerDatabase.swift
-│   └── Core/TranscriptSaver.swift
-├── UI/FloatingPanel/FloatingPanelController.swift
-└── UI/Settings/SettingsWindowController.swift
-```
+**For ANY runtime issue:** Read the log file first.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,329 +1,174 @@
-# Memory: Lessons Learned & Debugging Reference
+# MEMORY.md — Debugging Reference
 
-This file documents important lessons learned during development. Reference this when debugging similar issues.
-
----
-
-## Architecture Quick Reference
-
-### What This App Does
-Transcripted captures mic + system audio, transcribes locally via Parakeet TDT V3 (STT) + Sortformer (speaker diarization) using the FluidAudio library, identifies speakers via persistent voice fingerprints, and saves transcripts as Markdown.
-
-### Core Data Flow
-```
-Record → WAV files → Transcription → Speaker ID → Save Markdown
-```
-
-### Key Components
-| Component | File | Purpose |
-|-----------|------|---------|
-| Audio capture | `Core/Audio.swift` | Mic via AVAudioEngine, coordinates system audio |
-| System audio | `Core/SystemAudioCapture.swift` | CoreAudio process taps (macOS 26+) |
-| Orchestration | `Core/TranscriptionTaskManager.swift` | Background transcription queue, progress |
-| UI State | `UI/FloatingPanel/PillStateManager.swift` | State machine: idle→recording→processing |
-| Transcription | `Core/Transcription.swift` | Local Parakeet + Sortformer pipeline |
-| Speaker DB | `Services/SpeakerDatabase.swift` | Persistent voice fingerprints (SQLite, 256-dim embeddings) |
-| Transcript Output | `Core/TranscriptSaver.swift` | Markdown with YAML frontmatter |
-| StatsDatabase | `Core/StatsDatabase.swift` | SQLite persistence for recording sessions and activity |
-| StatsService | `Core/StatsService.swift` | Calculates hours, streaks, heat map data |
-| TranscriptScanner | `Core/TranscriptScanner.swift` | Scans folder for transcript metadata |
-
-### State Machine (PillStateManager)
-```
-idle (40×20) → recording (180×40) → processing (180×40) → idle
-```
+Read this file FIRST when debugging runtime issues. Indexed by symptom for fast lookup.
 
 ---
 
-## macOS 26 System Audio Permissions
+## Symptom Index
 
-**Important**: System audio capture via `AudioHardwareCreateProcessTap` does NOT require Screen Recording permission on macOS 26. The OS provides an audio-only permission flow, which is more privacy-preserving.
-
-This is why the app uses `@available(macOS 26.0, *)` throughout.
-
----
-
-## Transcription Pipeline
-
-### Engine: Parakeet + Sortformer (Local, via FluidAudio)
-| Component | Model | Purpose |
-|-----------|-------|---------|
-| Speech-to-text | Parakeet TDT V3 | CoreML, ~600MB, runs on Neural Engine |
-| Speaker diarization | Sortformer | CoreML, identifies speaker segments |
-| Voice fingerprints | WeSpeaker | 256-dim embeddings, persistent matching |
-
-### Pipeline (batch, after recording stops)
-1. Load & resample audio to 16kHz mono (AudioResampler)
-2. Sortformer diarizes system audio → speaker segments with timestamps + embeddings
-3. Parakeet transcribes each speaker segment individually
-4. Parakeet transcribes full mic track (split into sentences for timestamps)
-5. Match speaker embeddings against SpeakerDatabase (cosine similarity)
-6. Merge mic + system utterances chronologically
-
-### Historical Providers (Removed)
-| Provider | Status | Notes |
-|----------|--------|-------|
-| Deepgram | **Removed (Feb 2026)** | Replaced by local Parakeet + Sortformer |
-| Apple | **Legacy/Unused** | Was used pre-Deepgram migration |
-| AssemblyAI | **Legacy/Unused** | Was evaluated, not integrated |
-
-### DisplayStatus (Goal-Gradient Effect)
-```
-idle → gettingReady (0-15%) → transcribing (15-75%) → finishing (95-100%) → transcriptSaved
-```
+| Symptom | Section |
+|---|---|
+| Tiny system audio file (~50KB) | [CoreAudio I/O Overload](#coreaudio-io-overload) |
+| "skipping cycle due to overload" in console | [CoreAudio I/O Overload](#coreaudio-io-overload) |
+| System audio cuts out mid-recording | [Dual Tap Conflict](#dual-tap-conflict) |
+| "0Hz 0ch" in logs | [Audio Format Rules](#audio-format-rules) |
+| 96kHz mismatch / half-duration files | [Audio Format Rules](#audio-format-rules) |
+| Model stuck in `.loading` | [Model Loading Issues](#model-loading-issues) |
+| Wrong speaker names / poor matching | [Speaker Matching Debugging](#speaker-matching-debugging) |
+| HALC_ShellObject warnings | [Expected Console Warnings](#expected-console-warnings) |
+| "throwing -10877" at startup | [Expected Console Warnings](#expected-console-warnings) |
+| onChange tried to update multiple times | [Expected Console Warnings](#expected-console-warnings) |
+| Garbled/silent audio | [Common Audio Issues](#common-audio-issues) |
+| Pill stuck in state | Check `ui` logs for "Blocked transition" |
 
 ---
 
-## UI & Design System
+## Audio Format Rules
 
-### Floating Panel States
-| State | Dimensions | Content |
-|-------|------------|---------|
-| idle | 40×20 | Dormant waveform |
-| recording | 180×40 | Aurora + timer + stop button |
-| processing | 180×40 | Aurora + progress + status text |
-
-### Aurora Color Palette (Synthwave)
-- **Mic audio**: Hot pink coral `#EC4899` / light `#F472B6`
-- **System audio**: Electric blue `#3B82F6` / light `#60A5FA`
-- **Background**: Dark charcoal `#1A1A1A`
-- **Text primary**: White `#FFFFFF`
-
-### Animation Timing
-- Pill morph: 175ms spring (response: 0.175, damping: 0.8)
-- Content fade: 100ms
-- Toast duration: 5s
-- Success celebration: 2s
-
-### Key UI Files
-- `Design/DesignTokens.swift` - All colors, spacing, animations
-- `UI/FloatingPanel/Components/Aurora*.swift` - Recording/Processing/Success views
-- `UI/FloatingPanel/PillStateManager.swift` - State machine with sound feedback
+- **Mic format**: Use `inputFormat(forBus: 1)` (hardware format). NEVER `outputFormat(forBus: 0)` — returns 0Hz 0ch.
+- **System audio**: Actual rate is 48kHz. Tap reports 96kHz — always hardcode `48000.0` when creating files. Using 96kHz causes files to appear half expected duration.
+- **Mic saving**: Mono (manually downmixed if multi-channel hardware)
+- **System audio buffers**: Use `bufferListNoCopy` — memory only valid during callback. Deep-copy before async dispatch.
 
 ---
 
-## CoreAudio I/O Callback CPU Overload (Jan 2, 2026)
+## CoreAudio I/O Overload
 
-### Symptom
-- System audio files were tiny (~50KB instead of ~2MB for a 40-second recording)
-- Console showed: `HALC_ProxyIOContext::IOWorkLoop: skipping cycle due to overload` (hundreds of times)
-- Only 3 I/O callbacks completed, then all subsequent audio frames were dropped
-- System audio duration reported as 0.0 seconds
-- Transcripts showed `system_utterances: 0` despite visualizer showing audio levels
+**Symptom**: System audio files tiny (~50KB instead of ~2MB). Console: `HALC_ProxyIOContext::IOWorkLoop: skipping cycle due to overload`. Only 3 I/O callbacks complete, then all frames dropped. `system_utterances: 0` despite visualizer showing levels.
 
-### Root Cause
-**Creating `AVAudioFile` inside the CoreAudio I/O callback caused CPU overload.**
+**Root cause**: Creating `AVAudioFile` inside CoreAudio I/O callback. For 512-sample buffer at 48kHz, callback must return within ~10.7ms. File creation takes 10-100ms.
 
-The I/O callback (created via `AudioDeviceCreateIOProcIDWithBlock`) runs on a real-time audio thread with strict timing requirements. For a 512-sample buffer at 48kHz, the callback must return within ~10.7ms (realistically <1ms to be safe).
-
-Creating an `AVAudioFile` involves:
-1. File system metadata operations
-2. Disk space allocation
-3. WAV header writing
-4. Potential disk I/O blocking
-
-This can take 10-100ms, causing CoreAudio to skip subsequent cycles.
-
-### The Broken Pattern
+**Fix pattern**: Create audio file BEFORE starting I/O proc.
 ```swift
-// BAD: File creation inside I/O callback
-try capture.start { systemBuffer in
-    // First callback creates the file - BLOCKS AUDIO THREAD!
-    if self.systemAudioFile == nil {
-        self.systemAudioFile = try AVAudioFile(forWriting: fileURL, ...)  // 10-100ms!
-    }
-    try self.systemAudioFile?.write(from: systemBuffer)
-}
-```
-
-### The Fix
-**Create the audio file BEFORE starting the I/O proc.**
-
-1. Added `prepare()` method to `SystemAudioCapture` that creates the tap without starting I/O
-2. Exposed `audioFormat` property to get the tap's format after preparation
-3. Created audio file synchronously before calling `start()`
-4. Callback now only does lightweight operations
-
-```swift
-// GOOD: File creation before I/O callback starts
+// GOOD: File creation before callbacks
 try capture.prepare()  // Creates tap, gets format
-let format = capture.audioFormat!
-self.systemAudioFile = try AVAudioFile(forWriting: fileURL, settings: ...)  // Done BEFORE callbacks
-
-try capture.start { systemBuffer in
-    // Callback is now lightweight - no file creation!
-    let copy = self.deepCopyBuffer(systemBuffer)
-    self.fileQueue.async {
-        try self.systemAudioFile?.write(from: copy)
-    }
+systemAudioFile = try AVAudioFile(forWriting: url, settings: ...)  // Before I/O
+try capture.start { buffer in
+    let copy = deepCopyBuffer(buffer)  // Deep copy required
+    fileQueue.async { try systemAudioFile?.write(from: copy) }
 }
 ```
 
-### Key Rules for CoreAudio Callbacks
-
-1. **NEVER do disk I/O** - No file creation, no file reads, no logging to files
-2. **NEVER allocate large memory blocks** - Pre-allocate buffers before starting
-3. **NEVER block on locks** - Use lock-free queues or try-locks
-4. **NEVER call Objective-C/Swift methods that might allocate** - Be careful with string interpolation
-5. **Dispatch heavy work to background queues** - Use async dispatch for file writes
-6. **Deep copy buffers before async dispatch** - System audio uses `bufferListNoCopy`, memory is only valid during callback
-
-### How to Debug Similar Issues
-
-1. **Check console for overload messages:**
-   ```
-   HALC_ProxyIOContext::IOWorkLoop: skipping cycle due to overload
-   ```
-
-2. **Add callback counters:**
-   ```swift
-   var callbackCount = 0
-   // In callback:
-   callbackCount += 1
-   if callbackCount <= 3 { print("Callback #\(callbackCount)") }
-   ```
-
-3. **Check file sizes after recording:**
-   ```bash
-   ls -la ~/Documents/Transcripted/meeting_*_system.wav
-   ```
-   If system files are tiny (~50KB) but mic files are normal (~2MB), system audio callbacks are being dropped.
-
-4. **Compare working vs broken commits:**
-   ```bash
-   git log --oneline -- Murmur/Core/Audio.swift
-   git show <commit>:Murmur/Core/Audio.swift | grep -A 50 "system audio"
-   ```
-
-### Files Involved
-- `Murmur/Core/Audio.swift` - Main recording class, manages mic + system audio files
-- `Murmur/Core/SystemAudioCapture.swift` - CoreAudio process tap for system-wide audio
-- `Murmur/Services/AudioResampler.swift` - Resamples audio to 16kHz for Parakeet/Sortformer
+**CoreAudio callback rules**:
+1. NEVER do disk I/O — no file creation, reads, or logging
+2. NEVER allocate large memory — pre-allocate buffers
+3. NEVER block on locks — use lock-free queues or try-locks
+4. NEVER call ObjC/Swift methods that might allocate
+5. Dispatch heavy work to background queues
+6. Deep-copy buffers before async dispatch
 
 ---
 
-## General Audio Debugging Tips
+## Dual Tap Conflict
 
-### Audio Format Critical Details
-- **Hardware format**: Use `inputFormat(forBus: 1)`, NOT `outputFormat(forBus: 0)`
-- **Mic audio**: Saved as mono (manually downmixed if multi-channel)
-- **System audio**: 48kHz stereo (tap claims 96kHz but actual is 48kHz)
-  - **CRITICAL**: Always use 48kHz when creating system audio files, NOT the tap's reported rate
-  - If you use the reported 96kHz, files will appear half the expected duration (Jan 6, 2026 fix)
-- **Deep copy required**: System audio buffers use `bufferListNoCopy` - memory only valid during callback
+**Symptom**: System audio captured for ~60s then goes silent. Mic works for full duration. `system_utterances: 1` vs `mic_utterances: 18`.
 
-### Verify Audio Pipeline Health
-```swift
-// Add to callback for debugging
-print("Buffer: \(buffer.frameLength) frames, \(buffer.format.sampleRate)Hz")
-```
+**Root cause**: Two concurrent `SystemAudioCapture` instances (recording + passive monitor) conflict. When passive monitor calls `cleanup()`, it destroys the shared process tap and breaks the recording's capture.
 
-### Check Audio File Contents
-```bash
-# Get duration of WAV file
-afinfo ~/Documents/Transcripted/meeting_*_system.wav | grep duration
+**Key lesson**: CoreAudio process taps are system resources. Multiple concurrent taps for same processes cause conflicts. Ensure only one tap active at a time. Stop passive monitors BEFORE starting recording capture.
 
-# Play audio file to verify content
-afplay ~/Documents/Transcripted/meeting_*_system.wav
-```
+**Note**: The MeetingDetector component that caused this was removed (Feb 2026), but the lesson applies to any future use of multiple SystemAudioCapture instances.
 
-### Common Audio Issues
+---
 
-| Symptom | Likely Cause | Fix |
-|---------|--------------|-----|
-| Tiny file size | Callbacks being dropped | Move heavy work out of callback |
-| Wrong sample rate | Format mismatch | Use buffer's actual format, not hardcoded |
+## Expected Console Warnings
+
+These CoreAudio framework warnings are **expected and harmless** — they cannot be suppressed from user code:
+
+| Warning | When | Why |
+|---|---|---|
+| `HALC_ShellObject::SetPropertyData: call to the proxy failed` | Startup | Internal format negotiation during aggregate device creation |
+| `throwing -10877` | Startup | `kAudioUnitErr_InvalidElement` during tap initialization |
+| `AudioObjectRemovePropertyListener: no object with given ID` | Cleanup | Race condition destroying audio objects |
+
+**SwiftUI warning**: `onChange action tried to update multiple times per frame` — caused by rapid DisplayStatus changes. Fixed by wrapping state updates in `Task { @MainActor in }`.
+
+**Verifying audio works despite warnings**: Check callback count (should see callbacks #1, #2, #3 at startup), check file sizes (system audio ~384KB/sec), no "skipping cycle due to overload".
+
+---
+
+## Common Audio Issues
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Tiny system audio file | Callbacks dropped (I/O overload) | Move heavy work out of callback. See [CoreAudio I/O Overload](#coreaudio-io-overload) |
+| Wrong sample rate | Format mismatch | System = 48kHz (NOT 96kHz). Mic = use buffer's actual format |
 | Mono instead of stereo | Channel count mismatch | Check `format.channelCount` |
 | Garbled audio | Interleaved/non-interleaved mismatch | Match `isInterleaved` setting |
 | Silent audio | Wrong bus or format | Use `inputFormat(forBus: 1)` for hardware format |
+| Half-expected duration | Using tap's 96kHz instead of actual 48kHz | Hardcode `48000.0` for system audio |
 
 ---
 
-## Expected Console Warnings (Jan 4, 2026)
+## Audio Debugging Commands
 
-### CoreAudio Internal Warnings
+```bash
+# Check file duration
+afinfo ~/Documents/Transcripted/meeting_*_system.wav | grep duration
 
-During system audio setup and teardown, the macOS CoreAudio framework emits internal log messages that **cannot be suppressed from user code**. These are **expected and harmless**:
+# Play audio to verify content
+afplay ~/Documents/Transcripted/meeting_*_system.wav
 
-| Warning | When | Why |
-|---------|------|-----|
-| `HALC_ShellObject::SetPropertyData: call to the proxy failed` | Startup | Internal format negotiation during aggregate device creation |
-| `throwing -10877` | Startup | `kAudioUnitErr_InvalidElement` during tap initialization |
-| `AudioObjectRemovePropertyListener: no object with given ID` | Cleanup | Race condition when destroying audio objects |
+# Check file sizes (system should be ~384KB/sec)
+ls -la ~/Documents/Transcripted/meeting_*_system.wav
 
-### Why These Can't Be Suppressed
-
-These messages are logged directly by the CoreAudio framework (HALC = Hardware Abstraction Layer Core), not by our code. They appear even when all our error handling is correct. The messages indicate internal operations that the framework handles gracefully.
-
-### Verifying Audio Is Working Despite Warnings
-
-If you see these warnings but want to confirm audio capture is working:
-
-1. **Check callback count** - Should see "I/O Proc callback #1", #2, #3 at startup
-2. **Check file sizes** - System audio should grow continuously (~384KB/sec)
-3. **No "skipping cycle due to overload"** - This is the critical error (see CPU Overload section above)
-
-### SwiftUI Warning
-
-`onChange(of: DisplayStatus) action tried to update multiple times per frame` - Fixed by wrapping state updates in `Task { @MainActor in ... }` to debounce rapid status changes during transcription progress updates.
+# Read app logs
+# Use Read tool on: ~/Library/Logs/Transcripted/app.jsonl
+# Filter with Grep for subsystem: "s":"audio.system"
+```
 
 ---
 
-> **HISTORICAL NOTE (Feb 2026):** The `MeetingDetector` component described below was removed from the codebase as part of a settings redesign. The architectural lesson about concurrent CoreAudio taps remains valid.
+## Model Loading Issues
 
-## Dual SystemAudioCapture Conflict Bug (Jan 6, 2026)
+**Symptom**: Model stuck in `.loading`, transcription never starts.
 
-### Symptom
-- System audio captured for only ~60 seconds, then went silent for remainder of recording
-- Mic audio worked perfectly for entire duration
-- Console showed: `✅ System audio capture started` but later `⚠️ System audio: Silent for 10s`
-- Transcript showed `system_utterances: 1` vs `mic_utterances: 18`
-- System audio file had audio at start, then silence
+**Check**: Grep logs for subsystem `transcription`. Common causes:
+- HuggingFace download failed (network or disk space)
+- Bundle path wrong — models expected at `Contents/Resources/parakeet-models/` and `sortformer-models/`
+- Qwen: needs 4GB free memory — check `hasMemoryForQwen()` in TranscriptionTaskManager
 
-### Root Cause
-**Two concurrent `SystemAudioCapture` instances conflicted.**
-
-1. `MeetingDetector` creates a passive `SystemAudioCapture` for meeting detection (monitoring audio levels without recording)
-2. `Audio.swift` creates another `SystemAudioCapture` for actual recording
-3. When recording starts, both taps run simultaneously
-4. After 3 seconds, `MeetingDetector.checkForMeetingApps()` sees `isRecording == true`
-5. It calls `stopPassiveAudioMonitor()` → `SystemAudioCapture.stop()` → `cleanup()`
-6. Cleanup destroys the process tap and aggregate device
-7. **This breaks the recording's tap** - CoreAudio doesn't handle concurrent taps well
-
-### Evidence
-- System audio captured "Hello" (first word) at 60% confidence before passive monitor stopped
-- System audio duration: 66.0s (until passive monitor cleanup)
-- Mic audio duration: 131.9s (full recording)
-- Log sequence: passive starts → recording starts → passive destroyed → silence begins
-
-### The Fix
-**Stop the passive monitor BEFORE starting the recording's capture.**
-
-1. Added `stopPassiveMonitorForRecording()` method to `MeetingDetector`
-2. Added `meetingDetector` weak reference to `Audio`
-3. Call `meetingDetector?.stopPassiveMonitorForRecording()` at start of `startAudioCapture()`
-4. Wired up dependency in `TranscriptedApp.setupMeetingDetection()`
-
-### Files Modified
-- `Murmur/Core/MeetingDetector.swift` **[DELETED]** - Added `stopPassiveMonitorForRecording()` method
-- `Murmur/Core/Audio.swift` - Added `meetingDetector` reference and call before capture
-- `Murmur/TranscriptedApp.swift` **[SIMPLIFIED]** - Wire up `audio.setMeetingDetector(meetingDetector!)`
-
-### Key Lesson
-**CoreAudio process taps and aggregate devices are system resources.** Having multiple concurrent taps for the same processes can cause resource conflicts. When one tap is destroyed during cleanup, it can affect others. Always ensure only one tap is active at a time.
-
-### How to Debug Similar Issues
-1. **Check for multiple SystemAudioCapture instances** - Search for `SystemAudioCapture()` constructor calls
-2. **Check cleanup timing** - Look at "Cleaning up system audio capture" logs vs recording duration
-3. **Compare audio durations** - If system audio is shorter than mic, something killed the tap mid-recording
-4. **Look for the first captured system audio** - If present, proves tap WAS working initially
+**Qwen-specific**: Model cached at `~/Library/Caches/models/mlx-community/Qwen3.5-4B-4bit/`. `QwenService.isModelCached` checks this path. Model is loaded on-demand (NOT at startup).
 
 ---
 
-## Related Documentation
+## Speaker Matching Debugging
 
-- [Apple Audio Unit Hosting Guide](https://developer.apple.com/documentation/audiotoolbox/audio_unit_hosting_guide)
+**Symptom**: Wrong speaker names, speakers merged incorrectly, or speakers not recognized.
+
+**Check**: Grep logs for subsystem `speaker-db`.
+
+**Key parameters** (in SpeakerDatabase.swift):
+- Match threshold: adaptive 0.85 (1 segment) → 0.70 (4+ segments)
+- EMA alpha: 0.15 for embedding blending
+- Post-processing: pairwise merge 0.85, DB-informed split 0.62
+
+**Common issues**:
+- Threshold too low → different speakers merged
+- Threshold too high → same speaker gets multiple profiles
+- Stale profiles → run `pruneWeakProfiles()`
+- Name variants not recognized → check `areNameVariants()` in SpeakerDatabase
+
+---
+
+## Transcription Pipeline Reference
+
+**Pipeline** (batch, after recording stops):
+1. Resample audio to 16kHz mono (AudioResampler)
+2. Sortformer diarizes system audio → speaker segments with embeddings
+3. EmbeddingClusterer post-processes segments (merge + split)
+4. Parakeet transcribes each speaker segment individually
+5. Parakeet transcribes full mic track (split into sentences)
+6. Match speaker embeddings against SpeakerDatabase
+7. Merge mic + system utterances chronologically
+
+**DisplayStatus progression**: idle → gettingReady (0-15%) → transcribing (15-75%) → finishing (95-100%) → transcriptSaved | failed
+
+**Historical providers (removed)**: Deepgram (removed Feb 2026), Apple Speech (legacy), AssemblyAI (never integrated).
+
+---
+
+## Reference Links
 - [Core Audio Overview](https://developer.apple.com/library/archive/documentation/MusicAudio/Conceptual/CoreAudioOverview/)
-- Process taps via `AudioHardwareCreateProcessTap` - macOS 26 provides audio-only permission (no Screen Recording needed)
-- [OSStatus Lookup](https://www.osstatus.com/) - For decoding CoreAudio error codes
+- [OSStatus Lookup](https://www.osstatus.com/) — decode CoreAudio error codes
+- Process taps via `AudioHardwareCreateProcessTap` — macOS 26 provides audio-only permission (no Screen Recording needed)

--- a/Murmur/Core/CLAUDE.md
+++ b/Murmur/Core/CLAUDE.md
@@ -1,84 +1,95 @@
 # Core — CLAUDE.md
 
 ## Purpose
-Audio capture, transcription pipeline orchestration, task management, transcript saving, and recording statistics. This is the engine room of Transcripted. Everything runs 100% locally — no cloud APIs.
+Audio capture, transcription pipeline, task management, transcript saving, statistics, and logging. The engine room of Transcripted — everything runs 100% locally.
 
-## Key Files
+## Files
 
-| File | Responsibility |
-|------|---------------|
-| `Audio.swift` | Microphone capture via AVAudioEngine, writes WAV in real-time, monitors levels/silence |
-| `SystemAudioCapture.swift` | System-wide audio via CoreAudio process taps, aggregate device management |
-| `Transcription.swift` | Orchestrates Parakeet STT + Sortformer diarization + speaker matching |
-| `TranscriptionTaskManager.swift` | Background transcription queue, progress tracking, status management |
-| `TranscriptionTypes.swift` | Engine-agnostic result types (TranscriptionResult, SpeakerIdentificationResult, etc.) |
-| `TranscriptSaver.swift` | Writes markdown with YAML frontmatter to ~/Documents/Transcripted/ |
-| `TranscriptStore.swift` | ObservableObject store for transcript tray UI (recent transcripts, copy-to-clipboard) |
-| `TranscriptScanner.swift` | Discovers and indexes existing transcript files |
-| `TranscriptUtils.swift` | Transcript file management, renaming, cleanup |
-| `DateParser.swift` | Natural language date parsing ("next Friday", "EOW") |
-| `DateFormattingHelper.swift` | Date formatting utilities |
-| `FailedTranscriptionManager.swift` | Persistent retry queue for failed transcriptions (JSON file) |
-| `RecordingValidator.swift` | Pre-recording checks: disk space, permissions, devices |
-| `StatsService.swift` | Recording statistics and streak tracking |
-| `StatsDatabase.swift` | SQLite persistence for stats |
-| `Logging/AppLogger.swift` | Unified logging interface with subsystem loggers |
-| `Logging/FileLogger.swift` | JSON Lines file logger at ~/Library/Logs/Transcripted/app.jsonl |
+| File | Responsibility | Threading |
+|---|---|---|
+| `Audio.swift` | Mic capture via AVAudioEngine, WAV writing, silence detection | class (ObservableObject, manages real-time audio threads) |
+| `SystemAudioCapture.swift` | System audio via CoreAudio process taps, aggregate device | class (ObservableObject, NOT @MainActor, DispatchQueue + NSLock) |
+| `Transcription.swift` | Orchestrates Parakeet STT + Sortformer diarization + speaker matching | @MainActor, nonisolated for heavy compute |
+| `TranscriptionTaskManager.swift` | Background transcription queue, progress tracking, speaker naming flow | @MainActor |
+| `TranscriptionTypes.swift` | Engine-agnostic types: TranscriptionResult, SpeakerNamingRequest, etc. | Value types |
+| `TranscriptSaver.swift` | Markdown output with YAML frontmatter, retroactive speaker updates | Static methods |
+| `TranscriptStore.swift` | ObservableObject for transcript tray (recent 10, copy-to-clipboard) | @MainActor |
+| `TranscriptScanner.swift` | Transcript file discovery, migration to StatsDB | Static methods |
+| `TranscriptUtils.swift` | Summary updates, file renaming | Static methods |
+| `RecordingValidator.swift` | Pre-recording checks: disk space, permissions, devices | Static methods |
+| `FailedTranscriptionManager.swift` | Persistent retry queue (JSON at ~/Documents/Transcripted/failed_transcriptions.json) | @MainActor |
+| `StatsService.swift` | Recording statistics, streaks, motivational messages | @MainActor, singleton |
+| `StatsDatabase.swift` | SQLite persistence for stats (recordings, daily_activity tables) | DispatchQueue serial |
+| `DateParser.swift` | Natural language date parsing ("next Friday", "EOW") | Static methods |
+| `DateFormattingHelper.swift` | Cached date formatters | Static methods |
+| `Clipboard.swift` | NSPasteboard copy | Static methods |
+| `CoreAudioUtils.swift` | AudioObjectID extensions, property reading helpers | Extensions |
+| `Logging/AppLogger.swift` | Unified logging with subsystem loggers (os.Logger + file) | Sendable singleton |
+| `Logging/FileLogger.swift` | JSON Lines logger at ~/Library/Logs/Transcripted/app.jsonl | DispatchQueue serial |
+
+## Key Types
+
+**Audio**: `@Published isRecording`, `audioLevel` (0-1), `recordingDuration`, `audioLevelHistory` ([Float], 15 samples), `systemAudioStatus`, `recordingGaps`. Callbacks: `onRecordingStart`, `onRecordingComplete(micURL, systemURL)`.
+
+**SystemAudioCapture**: `prepare()` → `start(bufferCallback:)` → `stop()`. Exposes `audioFormat` after prepare. Recovery: `recoverFromOutputChange()` on device switch. Watchdog: 3s silence timeout.
+
+**TranscriptionTaskManager**: `@Published displayStatus: DisplayStatus` — idle → gettingReady → transcribing(progress:Double) → finishing → transcriptSaved | failed(String). `@Published speakerNamingRequest: SpeakerNamingRequest?` triggers naming tray. Key methods: `startTranscription(micURL:systemURL:outputFolder:healthInfo:)`, `retryFailedTranscription(failedId:)`.
+
+**TranscriptionResult**: `micUtterances: [TranscriptionUtterance]`, `systemUtterances`, `duration`, `processingTime`. Computed: `allUtterances`, word counts, speaker counts.
+
+**TranscriptionUtterance**: `start`, `end`, `channel`, `speakerId`, `persistentSpeakerId: UUID?`, `transcript: String`.
+
+**RecordingHealthInfo**: `captureQuality` (.excellent/.good/.fair/.degraded), `audioGaps`, `deviceSwitches`. Factory: `from(audio:systemCapture:)`.
+
+## Threading Rules
+- **Audio**: NOT explicitly @MainActor. AVAudioEngine callbacks on real-time threads. UI updates dispatched to main.
+- **SystemAudioCapture**: NOT @MainActor. Uses `DispatchQueue("SystemAudioCapture", qos: .userInitiated)` + NSLock. I/O proc callback on CoreAudio real-time thread — **NEVER** do I/O, locks, allocations, or ObjC inside it. Deep-copy buffers before async dispatch.
+- **TranscriptionTaskManager**: @MainActor. Spawns `Task {}` for background work. Heavy compute via `nonisolated` methods on Transcription.
+- **Transcription**: @MainActor for UI updates. `transcribeMultichannel()` is nonisolated (CPU-heavy). Uses `MainActor.run {}` hops for published property updates.
+- **StatsDatabase / SpeakerDatabase**: DispatchQueue serial. Sync reads, async writes.
 
 ## Data Flow
-
 ```
-Recording starts
-  → RecordingValidator checks conditions
-  → Audio.start() captures mic (AVAudioEngine)
-  → SystemAudioCapture captures system audio (CoreAudio process tap)
-  → Both write WAV files to ~/Documents/
+Recording start → RecordingValidator.validateRecordingConditions()
+  → Audio.start() + SystemAudioCapture.prepare() then start() → WAV files
 
-Recording stops
-  → Audio.stop() triggers onRecordingComplete callback
-  → TranscriptionTaskManager.startTranscription() queued
-  → Transcription.swift runs pipeline:
-      Sortformer diarizes → Parakeet transcribes per-segment → Speaker matching
-  → TranscriptSaver writes markdown
-  → Status transitions to .transcriptSaved → auto-resets to .idle
+Recording stop → Audio.stop() → onRecordingComplete(micURL, systemURL)
+  → TranscriptionTaskManager.startTranscription()
+  → Transcription.transcribeMultichannel(): resample → diarize → transcribe segments → match speakers → merge
+  → TranscriptSaver.saveTranscript() → markdown file
+  → Audio files deleted on success
 
-On failure → FailedTranscriptionManager persists for retry
+Failure → FailedTranscriptionManager.addFailedTranscription() → JSON persistence
 ```
 
-## Common Tasks
+## Transcript Output Format
+YAML frontmatter: `date`, `time`, `duration`, `processing_time`, `word_count`, `engines`, `speakers` (list with `name`, `db_id`, `utterances`, `word_count`).
+Timeline entries: `[MM:SS] [Source/Speaker Name] Text`
+Sections: Meeting Recording title → Channel & Speaker Analytics → Full Transcript
 
-| Task | Files to touch | Watch out for |
-|------|---------------|---------------|
-| Fix audio capture bug | `Audio.swift`, `SystemAudioCapture.swift` | NEVER do I/O or locks in audio callbacks (real-time threads) |
-| Fix transcription output | `Transcription.swift`, `TranscriptSaver.swift` | Check model loading state first |
-| Fix retry/queue behavior | `TranscriptionTaskManager.swift`, `FailedTranscriptionManager.swift` | Retry state persisted to JSON file |
-| Fix stats/counts | `StatsService.swift`, `StatsDatabase.swift` | SQLite database, check schema |
-| Fix transcript tray | `TranscriptStore.swift` | Reads from TranscriptScanner, provides copy-to-clipboard |
-| Add new log subsystem | `Logging/AppLogger.swift` | Add static let, follow existing pattern |
+## Modification Recipes
 
-## Failure Modes
+| Task | Files to touch |
+|---|---|
+| Fix audio capture | `Audio.swift`, `SystemAudioCapture.swift` — check MEMORY.md first |
+| Fix transcription output | `Transcription.swift`, `TranscriptSaver.swift` |
+| Add field to transcript YAML | `TranscriptSaver.formatTranscriptMarkdown()` |
+| Fix retry/queue behavior | `TranscriptionTaskManager.swift`, `FailedTranscriptionManager.swift` |
+| Fix stats/counts | `StatsService.swift`, `StatsDatabase.swift` |
+| Fix transcript tray data | `TranscriptStore.swift` (reads from TranscriptScanner) |
+| Add new log subsystem | `Logging/AppLogger.swift` — add static let, follow existing pattern |
+| Change recording validation | `RecordingValidator.swift` |
 
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| "0Hz 0ch" in logs | Using `outputFormat` instead of `inputFormat(forBus: 1)` | Always use hardware format from bus 1 |
-| Audio glitches/pops | Doing I/O or locks in audio callback | Move to DispatchQueue.async |
-| 96kHz mismatch | System tap reports 96kHz but actual is 48kHz | Use hardcoded 48000.0 for system audio |
-| Transcription empty | Models not loaded | Check `transcription` subsystem logs for model state |
-| System audio silent | Output device changed | Check device change listener in SystemAudioCapture |
-| Recording not saving | Disk space or permissions | Check RecordingValidator output |
+## Gotchas
+- System audio: always 48kHz. Tap reports 96kHz — hardcode `48000.0`
+- Mic format: `inputFormat(forBus: 1)`, NOT `outputFormat(forBus: 0)` (the latter returns 0Hz 0ch)
+- File creation MUST happen BEFORE I/O callback starts — never create AVAudioFile inside callback
+- `SystemAudioCapture.prepare()` must be called before `start()` (separates setup from I/O)
+- Audio callbacks use `bufferListNoCopy` — buffer memory only valid during callback, deep-copy before async
+- Recordings < 2s are rejected by TranscriptionTaskManager
 
-## Dependencies
-
-**Imports from Services/**: ParakeetService, SortformerService, SpeakerDatabase, AudioResampler
-**Imported by**: TranscriptedApp.swift, UI/ (FloatingPanel reads task manager state)
-
-## Logging
-
-| Subsystem | What to grep |
-|-----------|-------------|
-| `audio` | General audio start/stop, sleep/wake |
-| `audio.mic` | Mic format, device switches, recovery, writes |
-| `audio.system` | System tap setup, buffers, device changes, recovery |
-| `transcription` | Model loading, STT/diarization results |
-| `pipeline` | Task lifecycle, saving, file management, retries |
-| `stats` | Database operations, recording stats |
+## Logging Subsystems
+`audio`, `audio.mic`, `audio.system` — recording, devices, format
+`transcription` — model loading, STT/diarization results
+`pipeline` — task lifecycle, saving, retries
+`stats` — database operations

--- a/Murmur/Design/CLAUDE.md
+++ b/Murmur/Design/CLAUDE.md
@@ -3,40 +3,64 @@
 ## Purpose
 Visual design system: colors, spacing, typography, animation presets, and reusable premium UI components. Single source of truth for all visual constants.
 
-## Key Files
+## Files
 
 | File | Responsibility |
-|------|---------------|
-| `DesignTokens.swift` | All colors, spacing, typography, animation presets, pill dimensions |
-| `PremiumComponents.swift` | Reusable premium UI components (glassmorphic cards, etc.) |
+|---|---|
+| `DesignTokens.swift` | All colors, spacing, typography, animations, pill dimensions, microinteraction modifiers |
+| `PremiumComponents.swift` | PremiumButton (primary/secondary/ghost), PremiumCard, BenefitCard, StepProgressIndicator, PermissionCard |
 
-## Design Tokens
+## Color Constants
 
-**Panel theme** (dark charcoal):
-- `panelCharcoal`, `panelCharcoalElevated` — backgrounds
-- `panelTextPrimary`, `panelTextSecondary`, `panelTextMuted` — text hierarchy
+**Panel theme (dark)**:
+- `panelCharcoal` (#1A1A1A), `panelCharcoalElevated` (#242424), `panelCharcoalSurface` (#2E2E2E)
+- `panelTextPrimary` (white), `panelTextSecondary` (#B0B0B0), `panelTextMuted` (#6B6B6B)
 
-**Accent colors**:
-- `recordingCoral` (#FF6B6B) — recording state accent
-- Onboarding: warm cream with terracotta accents
+**Accents**:
+- `recordingCoral` (#FF6B6B), `recordingCoralDeep`
+- `attentionGreen` (#22C55E), `errorRed` (#EF4444)
 
-**Animation presets**:
-- `.elegant` (0.5s ease) — standard transitions
-- `.refined` — subtle state changes
-- `.snappy` — quick interactions
+**Aurora (synthwave)**:
+- `auroraCoral` (#EC4899), `auroraCoralLight` (#F472B6) — mic side
+- `auroraTeal` (#3B82F6), `auroraTealLight` (#60A5FA) — system audio side
 
-**Pill dimensions**: `PillDimensions` struct with sizes per state (idle, recording, processing)
+**Onboarding (warm light)**:
+- `cream`, `warmCream` (#FAF7F2), `terracotta` (#DA7756), `charcoal`, `softCharcoal`
 
-## Common Tasks
+**Chat**: `chatBubbleUser` (muted navy for "you" messages)
 
-| Task | Files to touch | Watch out for |
-|------|---------------|---------------|
-| Change color scheme | `DesignTokens.swift` | Update the Color extensions, check all consumers |
-| Adjust pill sizes | `DesignTokens.swift` (PillDimensions) | Affects FloatingPanel layout |
-| Change animation speed | `DesignTokens.swift` (animation presets) | Test with all pill states |
-| Add new component | `PremiumComponents.swift` | Follow existing glassmorphic patterns |
+**Heat map**: 5-level gradient from `heatMapEmpty` to `heatMapMax`
+
+## Spacing & Layout
+- `Spacing`: `.xs` (4), `.sm` (8), `.md` (12), `.lg` (16), `.xl` (24), `.xxl` (32), `.xxxl` (64)
+- `Radius`: `.xs` (4), `.sm` (6), `.md` (8), `.lg` (12), `.xl` (16), `.full` (999), `.lawsCard` (12)
+- `PillDimensions`: idleWidth (40), idleHeight (20), idleExpandedWidth (120), recordingWidth (180), recordingHeight (40), trayWidth (280), trayMaxHeight (300)
+
+## Animation Presets
+- `.elegant` — 0.5s spring (response: 0.5, damping: 0.92) — buttery smooth, no bounce
+- `.snappy` — 0.3s spring (response: 0.3, damping: 0.8)
+- `.smooth` — 0.5s spring (response: 0.5, damping: 0.85)
+- `.refined` — 0.45s spring (response: 0.45, damping: 0.95)
+- `PillAnimationTiming`: morphDuration (0.175s), cooldownDuration (0.175s), contentFadeDuration (0.1s), celebrationDuration (2.0s), trayDuration (0.2s), toastDuration (5.0s), stateTransitionDuration (0.2s)
+- `.pillMorph` — spring (response: 0.175, damping: 0.8)
+- `.trayExpand` — spring (response: 0.2, damping: 0.85)
+
+## Typography
+Font extensions: `.displayLarge` (Fraunces 36pt), `.displayMedium` (28pt), `.heading` (20pt semibold), `.bodyLarge` (16pt), `.body` (14pt), `.buttonText` (15pt medium), `.caption` (12pt), `.tiny` (11pt), `.transcriptMono` (14pt monospace)
+
+## Microinteraction Modifiers
+`PressEffectModifier` (0.96x on press), `HoverScaleModifier` (1.02x on hover), `PulseModifier` (0.95↔1.05), `GlowPulseModifier` (pulsing shadow), `ShakeModifier` (5-cycle shake), `SlideInModifier` (edge slide + fade)
+
+## Modification Recipes
+
+| Task | Files to touch |
+|---|---|
+| Change color | `DesignTokens.swift` Color extensions — grep for old constant name across UI/ and Onboarding/ |
+| Adjust pill sizes | `DesignTokens.swift` `PillDimensions` — affects FloatingPanel layout |
+| Change animation speed | `DesignTokens.swift` `PillAnimationTiming` or Animation presets — test all pill states |
+| Add reusable component | `PremiumComponents.swift` — follow PremiumButton pattern |
+| Add microinteraction | `DesignTokens.swift` — add ViewModifier, follow PressEffectModifier pattern |
 
 ## Dependencies
-
-**Imported by**: All UI/ files, Onboarding/ views
+**Imported by**: All `UI/` files, all `Onboarding/` files
 **Imports**: SwiftUI only

--- a/Murmur/Onboarding/CLAUDE.md
+++ b/Murmur/Onboarding/CLAUDE.md
@@ -1,48 +1,72 @@
 # Onboarding — CLAUDE.md
 
 ## Purpose
-Four-step first-launch onboarding flow: Welcome → How It Works → Permissions → Ready. Requests microphone and screen recording permissions.
+Four-step first-launch onboarding flow: Welcome → How It Works → Permissions → Ready. Gates app setup behind microphone permission.
 
-## Key Files
+## Files
 
 | File | Responsibility |
-|------|---------------|
-| `OnboardingState.swift` | State management, step tracking, completion persistence (UserDefaults) |
-| `OnboardingWindow.swift` | NSWindowController for the onboarding window |
-| `OnboardingContainerView.swift` | Step container with navigation and progress |
-| `Steps/WelcomeStep.swift` | Step 1: App introduction |
-| `Steps/HowItWorksStep.swift` | Step 2: Feature overview |
-| `Steps/PermissionsStep.swift` | Step 3: Request mic, screen recording |
-| `Steps/ReadyStep.swift` | Step 4: Completion with celebration animation |
-| `Animations/ParticleExplosionView.swift` | Celebration particle effects for completion |
+|---|---|
+| `OnboardingState.swift` | @Observable state manager, step tracking, permission requests, completion persistence |
+| `OnboardingWindow.swift` | NSWindowController (720×680), frosted glass (`hudWindow` material), fade animations |
+| `OnboardingContainerView.swift` | Step container with navigation, progress indicator, page transitions, keyboard shortcuts |
+| `Steps/WelcomeStep.swift` | Step 1: App intro with icon and tagline |
+| `Steps/HowItWorksStep.swift` | Step 2: Auto-advancing 4-phase animation (Recording → Transcribing → Analyzing → Insights) |
+| `Steps/PermissionsStep.swift` | Step 3: Microphone permission request with status-dependent UI |
+| `Steps/ReadyStep.swift` | Step 4: Celebration + Quick Start Guide (4 tips) |
+| `Animations/ParticleExplosionView.swift` | Celebration particle effects |
+
+## Key Types
+
+**OnboardingState** (@Observable class):
+- `currentStep: OnboardingStep` — `.welcome(0)` → `.howItWorks(1)` → `.permissions(2)` → `.ready(3)`
+- `microphoneStatus: AVAuthorizationStatus`
+- Computed: `microphoneGranted`, `allPermissionsGranted`, `canProceed` (varies by step), `stepProgress` (0.0-1.0)
+- `advance()`, `goBack()`, `goToStep(_:)` — navigation
+- `requestMicrophonePermission()` async — requests and updates status
+- `completeOnboarding()` — sets UserDefaults `hasCompletedOnboarding` to true
+- `static hasCompletedOnboarding()` / `static resetOnboarding()` — persistence
+
+**OnboardingWindowController** (NSWindowController):
+- 720×680, transparent title bar, floating level, hudWindow material
+- `onComplete: (() -> Void)?` callback → triggers `TranscriptedApp.setupApp()`
+- `showWithAnimation()` — 0.3s fade-in
+- `handleOnboardingComplete()` — fade-out, call onComplete
+
+**OnboardingContainerView** (SwiftUI View):
+- Warm cream background with terracotta gradient
+- Asymmetric page transitions (forward/backward)
+- Keyboard: Left arrow = back, Return = advance
+- "Skip for now" link with confirmation alert
+- Respects `accessibilityReduceMotion`
 
 ## Flow
-
 ```
 App launch → OnboardingState.hasCompletedOnboarding() check
   → false: show OnboardingWindow
     Step 1 (Welcome) → Step 2 (How It Works) → Step 3 (Permissions) → Step 4 (Ready)
-    → onComplete callback → setupApp() runs
-  → true: skip to setupApp()
+    Step 3 blocks advance until microphone granted
+    → completeOnboarding() → onComplete → TranscriptedApp.setupApp()
+  → true: skip directly to setupApp()
 ```
 
-## Permissions Requested
+## Permissions
 
-| Permission | Required | Purpose |
-|-----------|----------|---------|
-| Microphone | Yes | Record voice audio |
-| Screen Recording | For system audio | Capture meeting/call audio via process taps |
+| Permission | Required | API |
+|---|---|---|
+| Microphone | Yes | `AVCaptureDevice.requestAccess(for: .audio)` |
+| Screen Recording | For system audio | System preferences link (not requested in onboarding) |
 
-## Common Tasks
+## Modification Recipes
 
-| Task | Files to touch | Watch out for |
-|------|---------------|---------------|
-| Add onboarding step | New step view, `OnboardingContainerView.swift`, `OnboardingState.swift` | Update step count and navigation |
-| Fix permissions | `Steps/PermissionsStep.swift` | macOS permission APIs are async |
-| Change onboarding theme | Step views + `DesignTokens.swift` | Warm cream + terracotta color scheme |
-| Test onboarding | Menu bar → "Reset Onboarding (Debug)" | DEBUG builds only |
+| Task | Files to touch |
+|---|---|
+| Add onboarding step | New `Steps/` view + `OnboardingContainerView.swift` + `OnboardingState.swift` (update step count) |
+| Fix permissions | `Steps/PermissionsStep.swift` — macOS permission APIs are async |
+| Change theme | Step views + `DesignTokens.swift` (warm cream + terracotta scheme) |
+| Test onboarding | Menu bar → "Reset Onboarding (Debug)" — DEBUG builds only |
+| Change window size | `OnboardingWindow.swift` — constructor dimensions |
 
 ## Dependencies
-
-**Imports from Design/**: DesignTokens (onboarding color scheme)
-**Imported by**: TranscriptedApp.swift (shows onboarding or skips to setupApp)
+**From Design/**: DesignTokens (onboarding color scheme: cream, terracotta, charcoal)
+**Imported by**: `TranscriptedApp.swift` (shows onboarding or skips to setupApp)

--- a/Murmur/Services/CLAUDE.md
+++ b/Murmur/Services/CLAUDE.md
@@ -1,55 +1,87 @@
 # Services — CLAUDE.md
 
 ## Purpose
-Local ML inference engines (Parakeet STT, Sortformer diarization), persistent speaker voice database, and audio resampling. All services run 100% on-device — no cloud APIs.
+Local ML inference engines (Parakeet STT, Sortformer diarization), persistent speaker voice database, audio resampling, and optional Qwen speaker name inference. All services run 100% on-device — no cloud APIs.
 
-## Key Files
+## Files
 
-| File | Responsibility |
-|------|---------------|
-| `ParakeetService.swift` | Local speech-to-text via FluidAudio's Parakeet TDT V3 (~600MB CoreML model) |
-| `SortformerService.swift` | Local speaker diarization via FluidAudio's Sortformer (identifies who speaks when) |
-| `SpeakerDatabase.swift` | SQLite database with 256-dim voice embeddings, cosine similarity matching |
-| `AudioResampler.swift` | Resamples audio (48kHz → 16kHz mono) for model input, WAV file loading |
-| `QwenService.swift` | Local Qwen model for speaker name inference from transcript context |
-| `EmbeddingClusterer.swift` | Clustering utility for grouping similar voice embeddings |
-| `SpeakerClipExtractor.swift` | Extracts audio clips for speaker voice samples |
+| File | Responsibility | Threading |
+|---|---|---|
+| `ParakeetService.swift` | Local STT via FluidAudio Parakeet TDT V3 (~600MB CoreML) | @MainActor, nonisolated for transcription |
+| `SortformerService.swift` | Speaker diarization via FluidAudio Sortformer | @MainActor, nonisolated for diarization |
+| `SpeakerDatabase.swift` | SQLite with 256-dim voice embeddings, cosine similarity matching | Singleton (.shared), DispatchQueue serial |
+| `AudioResampler.swift` | Audio format conversion (48kHz→16kHz mono), WAV loading | Static methods |
+| `QwenService.swift` | Local Qwen3.5-4B for speaker name inference from transcript | @MainActor, nonisolated for inference |
+| `EmbeddingClusterer.swift` | Post-processing: pairwise merge + DB-informed split | Static methods |
+| `SpeakerClipExtractor.swift` | Extracts 5-8s audio clips per speaker for naming UI | Static methods |
 
-## Data Flow
+## Key Types
 
-```
-Audio files (WAV)
-  → AudioResampler converts to 16kHz mono Float32 samples
-  → SortformerService.performCompleteDiarization() → speaker segments
-  → ParakeetService.transcribe() → text per segment
-  → SpeakerDatabase matches voice embeddings → speaker names
-```
+**ParakeetService**: `@Published modelState: ParakeetModelState` (.notLoaded/.loading/.ready/.failed). `initialize()` async loads from bundle or HuggingFace. `transcribe(audioURL:)` nonisolated — loads, resamples to 16kHz, transcribes. `transcribeSegment(samples:source:)` nonisolated — pre-resampled input. Uses FluidAudio `AsrManager`.
 
-## Common Tasks
+**SortformerService**: `@Published modelState: SortformerModelState`. `initialize()` async. `diarize(samples:sampleRate:)` nonisolated → `[SpeakerSegment]`. Uses FluidAudio `DiarizerManager`.
 
-| Task | Files to touch | Watch out for |
-|------|---------------|---------------|
-| Fix STT accuracy | `ParakeetService.swift` | Model must be `.ready` state; check `transcription` logs |
-| Fix diarization | `SortformerService.swift` | Segment boundaries come from Sortformer, not Parakeet |
-| Fix speaker matching | `SpeakerDatabase.swift` | Cosine similarity threshold, embedding dimension = 256 |
-| Fix resampling | `AudioResampler.swift` | System audio is 48kHz (not 96kHz), mic varies by device |
+**SpeakerSegment**: `speakerId: Int`, `startTime: Double`, `endTime: Double`, `embedding: [Float]?` (256-dim), `qualityScore: Double`, `duration: Double` (computed).
 
-## Failure Modes
+**SpeakerDatabase**: Singleton (`SpeakerDatabase.shared`). NOT @MainActor — internal DispatchQueue.
+- `matchSpeaker(embedding:threshold:)` → `SpeakerMatchResult?` (profile + similarity score)
+- `addOrUpdateSpeaker(embedding:existingId:)` → `SpeakerProfile` (creates or EMA-blends)
+- `setDisplayName(id:name:source:)` async — source: "user_manual" or "qwen_inferred"
+- `allSpeakers()`, `getSpeaker(id:)`, `deleteSpeaker(id:)`, `mergeProfiles(sourceId:into:)`
+- `findProfilesByName(_:)` — fuzzy matching with name variants
+- `pruneWeakProfiles()` — removes unnamed, single-call, low-confidence, stale (>1hr) profiles
 
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| Model stuck in `.loading` | Download failed or bundle path wrong | Check `transcription` logs for HuggingFace errors |
-| Wrong speaker names | Similarity threshold too low/high | Adjust in SpeakerDatabase (default ~0.7) |
-| Resampled audio sounds wrong | Wrong source sample rate | System audio = 48kHz, verify in `audio.system` logs |
+**SpeakerProfile**: `id: UUID`, `displayName: String?`, `nameSource: String?`, `embedding: [Float]` (256-dim), `confidence: Double`, `callCount: Int`, `disputeCount: Int`.
 
-## Dependencies
+**QwenService**: `@Published modelState: QwenModelState`. On-demand only — NOT loaded at startup.
+- `loadModel()` async — downloads ~2.5GB Qwen3.5-4B-4bit if not cached
+- `inferSpeakerNames(transcript:)` nonisolated → `[String: String]` ("0": "Jack", "1": "Sarah")
+- `unload()` — frees memory immediately
+- `static isEnabled` → UserDefaults "enableQwenSpeakerInference"
+- `static isModelCached` → checks ~/Library/Caches/models/mlx-community/Qwen3.5-4B-4bit/
 
-**Imports**: FluidAudio (AsrManager, DiarizerManager), Foundation
-**Imported by**: Core/Transcription.swift, Core/TranscriptionTaskManager.swift
+**AudioResampler**: `resample(_:from:to:)`, `loadWAV(url:)` → (samples, sampleRate), `loadAndResample(url:targetRate:)`, `extractSlice(from:sampleRate:startTime:endTime:)`. Stereo→mono by averaging.
 
-## Logging
+**EmbeddingClusterer**: `postProcess(segments:existingProfiles:)` → applies pairwise merge then DB-informed split. Fixes fragmentation (same speaker→multiple IDs) and merging (different speakers→same ID).
 
-| Subsystem | What to grep |
-|-----------|-------------|
-| `transcription` | Parakeet/Sortformer model loading, transcription results, diarization |
-| `speaker-db` | Database open/close, speaker matching, merges |
+## Speaker Matching Algorithm
+- **Embeddings**: 256-dim WeSpeaker, L2-normalized, cosine similarity via Accelerate vDSP
+- **Adaptive threshold**: 0.85 (1 segment) → 0.80 (2) → 0.75 (3) → 0.70 (4+ segments)
+- **EMA blending**: alpha=0.15 for embedding updates on match
+- **Post-processing** (EmbeddingClusterer):
+  - Pairwise merge: union-find transitive, 0.85 cosine threshold
+  - DB-informed split: per-segment 0.62 threshold, requires 8+ segments per profile to split
+- **Name variants**: 34 hardcoded pairs ("mike"↔"michael", "nate"↔"nathan", etc.) in `areNameVariants()`
+- **Pruning**: `pruneWeakProfiles()` removes unnamed profiles with 1 call, low confidence, >1hr stale
+
+## Model Lifecycle
+- **Parakeet + Sortformer**: Loaded at app startup via `Transcription.initializeModels()`. From bundle (`Contents/Resources/*-models/`) or HuggingFace download on first run.
+- **Qwen**: Loaded on-demand when unidentified speakers exist. `loadModel()` → `inferSpeakerNames()` → `unload()`. Requires ~4GB free memory (checked via `mach_host_self()` free pages). Model cached at `~/Library/Caches/models/mlx-community/Qwen3.5-4B-4bit/`.
+- **State progression**: `.notLoaded` → `.loading` → `.ready` | `.failed(String)`
+
+## Modification Recipes
+
+| Task | Files to touch |
+|---|---|
+| Adjust speaker matching sensitivity | `SpeakerDatabase.swift` — threshold constants in `matchSpeaker()` |
+| Change STT model | `ParakeetService.swift` — update `AsrModels` loading path |
+| Change diarization model | `SortformerService.swift` — update `DiarizerModels` loading path |
+| Add speaker DB field | `SpeakerDatabase.swift` — createTables + migrateSchema + SpeakerProfile struct |
+| Fix Qwen inference | `QwenService.swift` — check model cache path, prompt in `buildChatMessages()` |
+| Fix audio resampling | `AudioResampler.swift` — system audio input is 48kHz, NOT 96kHz |
+| Add name variant | `SpeakerDatabase.swift` — `areNameVariants()` dictionary |
+| Fix embedding clustering | `EmbeddingClusterer.swift` — pairwiseMerge threshold or dbInformedSplit params |
+
+## Gotchas
+- SpeakerDatabase is singleton — always use `.shared`
+- Qwen needs 4GB free memory — `hasMemoryForQwen()` check in TranscriptionTaskManager
+- AudioResampler: system audio is 48kHz input, NOT the tap's reported 96kHz
+- Qwen prompt has critical rule: "Hey Jack" = talking TO Jack, not introducing self
+- Sortformer max 4 speakers per diarization run
+- SpeakerClipExtractor writes temp clips — call `cleanupClips()` after use
+- Speaker clips persisted at `~/Documents/Transcripted/speaker_clips/{UUID}.wav`
+
+## Logging Subsystems
+`transcription` — Parakeet/Sortformer model loading, transcription/diarization results
+`speaker-db` — database open/close, speaker matching, merges, pruning
+`services` — Qwen loading, inference results

--- a/Murmur/UI/CLAUDE.md
+++ b/Murmur/UI/CLAUDE.md
@@ -1,43 +1,40 @@
 # UI — CLAUDE.md
 
 ## Purpose
-Settings window and failed transcription management UI. The main floating pill UI lives in `FloatingPanel/` (see its own CLAUDE.md).
+Top-level UI directory. Contains Settings window and failed transcription management. The main floating pill UI lives in `FloatingPanel/` — see its own CLAUDE.md.
 
-## Key Files
+## Sub-component Routing
+
+| Area | Read |
+|---|---|
+| Floating pill, transcript tray, speaker naming | `FloatingPanel/CLAUDE.md` |
+| Settings window, stats, speaker management | `Settings/CLAUDE.md` |
+
+## Files (this directory only)
 
 | File | Responsibility |
-|------|---------------|
-| `Settings/SettingsWindowController.swift` | NSWindowController, 800x600 fixed settings window |
-| `Settings/SettingsContainerView.swift` | Single-page scrolling layout (stats, speakers, preferences) |
-| `Settings/SettingsSidebarView.swift` | Left sidebar navigation tabs |
-| `Settings/Models/SettingsNavigationState.swift` | Tab state enum (Dashboard, Speakers, Preferences) |
-| `Settings/Components/SettingsSectionCard.swift` | Reusable card wrapper |
-| `FailedTranscriptionsView.swift` | Retry queue management |
+|---|---|
+| `FailedTranscriptionsView.swift` | Retry queue management: list of failed transcriptions with retry/delete per item, retry all button |
 
-## Data Flow
+## Key Types
 
-```
-Settings:
-  SettingsWindowController → SettingsContainerView (single-page layout)
+**FailedTranscriptionsView** (SwiftUI View):
+- `@State retryingIds: Set<UUID>` — tracks which items are being retried
+- Retry: calls `taskManager.retryFailedTranscription(failedId:)`
+- Delete: confirmation alert, then `failedManager.deleteFailedTranscription(id:)`
+- Opened from menu bar (Cmd+F) in a standalone 650×500 NSWindow
 
-Failed Transcriptions:
-  FailedTranscriptionManager (Core) → FailedTranscriptionsView
-    → User triggers retry → TranscriptionTaskManager.retryFailedTranscription()
-```
+## Modification Recipes
 
-## Common Tasks
-
-| Task | Files to touch | Watch out for |
-|------|---------------|---------------|
-| Add settings section | `SettingsContainerView.swift` | Single-page scrolling layout |
-| Fix settings layout | `SettingsContainerView.swift` | 800x600 fixed window |
-| Fix failed transcription UI | `FailedTranscriptionsView.swift` | Binds to FailedTranscriptionManager |
+| Task | Files to touch |
+|---|---|
+| Fix retry UI | `FailedTranscriptionsView.swift` — binds to FailedTranscriptionManager from Core/ |
+| Fix retry logic | `Core/TranscriptionTaskManager.swift` — `retryFailedTranscription()` |
+| Add new UI area | Create subdirectory with its own CLAUDE.md, import DesignTokens |
 
 ## Dependencies
-
-**Imports from Core/**: TranscriptionTaskManager, FailedTranscriptionManager, StatsService
-**Imports from Design/**: DesignTokens (colors, spacing, animations)
+**From Core/**: TranscriptionTaskManager, FailedTranscriptionManager
+**From Design/**: DesignTokens (colors, spacing, animations)
 
 ## Logging
-
-Subsystem: `ui` — covers pill transitions, retry actions.
+Subsystem: `ui`

--- a/Murmur/UI/FloatingPanel/CLAUDE.md
+++ b/Murmur/UI/FloatingPanel/CLAUDE.md
@@ -1,66 +1,106 @@
 # FloatingPanel — CLAUDE.md
 
 ## Purpose
-The main user-facing UI: a draggable floating pill that shows recording state, audio visualizations, processing progress, and a transcript tray for browsing/copying recent transcripts. Implements a state machine with animation guards.
+The main user-facing UI: a draggable floating pill that shows recording state, audio visualizations, processing progress, transcript tray, and speaker naming flow. Implements a state machine with animation guards and stuck-state recovery.
 
-## Key Files
+## Files
 
 | File | Responsibility |
-|------|---------------|
-| `FloatingPanelController.swift` | NSWindowController for the floating NSPanel, drag handling, position persistence |
-| `PillStateManager.swift` | State machine: idle → recording → processing, with transition guards |
-| `FloatingPanelView.swift` | Main SwiftUI composition, switches view based on PillState |
-| `Components/PillViews.swift` | State-specific pill layouts (IdlePill, RecordingPill, ProcessingPill) |
-| `Components/WaveformViews.swift` | Audio level visualizers (EdgePeek, WaveformMini, DormantWaveform) |
-| `Components/TranscriptTrayView.swift` | Recent transcripts tray with copy-to-clipboard and detail navigation |
-| `Components/TranscriptDetailView.swift` | Transcript detail view with chat bubble layout |
-| `Components/AuroraIdleView.swift` | Animated aurora background for idle state |
-| `Components/AuroraRecordingView.swift` | Animated aurora background for recording state |
-| `Components/AuroraProcessingView.swift` | Animated aurora for processing state |
-| `Components/AuroraSuccessView.swift` | Animated aurora for success state |
-| `Components/CelebrationViews.swift` | Success checkmark and pulse ring animations |
-| `Components/ErrorViews.swift` | Error banners with recovery hints |
-| `Components/AttentionPromptView.swift` | "Still recording?" silence warning |
-| `Components/SpeakerNamingView.swift` | Speaker identification and naming UI with audio clip playback |
-| `Helpers/LawsComponents.swift` | Reusable UI primitives (buttons, status text, Triangle shape) |
+|---|---|
+| `FloatingPanelController.swift` | NSWindowController for floating NSPanel, drag handling, position persistence, state observer wiring |
+| `PillStateManager.swift` | State machine: idle → recording → processing, with transition guards and cooldown |
+| `FloatingPanelView.swift` | Main SwiftUI composition, routes to state-specific views, manages trays and overlays |
+| `Components/PillViews.swift` | Idle pill (collapsed 40×24 / expanded ~120×28), slide-out record/files buttons, badges |
+| `Components/WaveformViews.swift` | EdgePeekView, WaveformMiniView (8-bar dual-layer), DormantWaveformView, MinimalWaveformIcon |
+| `Components/AuroraIdleView.swift` | Idle state: collapsed capsule (40×20) or expanded with record/files buttons (200×44) |
+| `Components/AuroraRecordingView.swift` | Canvas-based aurora fog (mic=coral, system=teal), timer, stop button. Auto-collapses after 5s |
+| `Components/AuroraProcessingView.swift` | Progress-based aurora opacity/speed, status text with animated dots, warning for long runs |
+| `Components/AuroraSuccessView.swift` | Green radial glow, checkmark bounce animation sequence (3 phases) |
+| `Components/CelebrationViews.swift` | PillSuccessCelebration, CelebrationOverlay (.recordingStopped/.transcriptSaved) |
+| `Components/ErrorViews.swift` | ToastNotificationView (slide-in, 5s auto-dismiss), PillErrorView (shake), ContextualError parser |
+| `Components/AttentionPromptView.swift` | "Still recording?" silence prompt (triggers at 120s silence, 10s auto-dismiss) |
+| `Components/TranscriptTrayView.swift` | Frosted glass tray (280×300), recent 10 transcripts, copy-to-clipboard, detail navigation |
+| `Components/TranscriptDetailView.swift` | Chat bubble layout with MessageGroup grouping, right-aligned user/left-aligned others |
+| `Components/SpeakerNamingView.swift` | Sticky naming tray, speaker cards with audio playback, merge awareness, NOT dismissible by Escape |
+| `Helpers/LawsComponents.swift` | AnimatedDotsView, LawsButton, LawsStatusTextView, FloatingTooltipModifier, Triangle shape |
+
+## Key Types
+
+**PillState** (enum): `.idle` (40×20) | `.recording` (180×40) | `.processing` (180×40)
+
+**PillStateManager** (@MainActor, ObservableObject):
+- `@Published state: PillState`, `isTransitioning: Bool`, `isLocked: Bool`
+- `transition(to:)` — main method with guards: cooldown, lock check, stuck-state timeout (2s)
+- `lock()` / `unlock(transitionToIdle:)` — review mode control
+- `forceUnlock()` — emergency recovery bypassing all guards
+- Sound feedback: Pop (→recording), Tink (→processing), Glass (→idle)
+
+**FloatingPanelController** (NSWindowController):
+- Window: borderless, non-activating NSPanel, `.floating` level, `canJoinAllSpaces`
+- Position persistence: UserDefaults `floatingPanelX`/`floatingPanelY`, saved on `windowDidMove`
+- `hidesOnDeactivate = false` — stays visible when app loses focus
+- Observers: `audio.isRecording` → pill state, `taskManager.displayStatus` → processing states, `taskManager.speakerNamingRequest` → naming tray
+
+**ContextualError** (enum): Parses error messages → type, icon, color, recoveryHint. Maps permission/network/storage/processing errors to appropriate display.
 
 ## State Machine
 
 ```
-idle → recording (user taps record)
-recording → processing (user stops, transcription begins)
-processing → idle (transcript saved, auto-reset after brief success display)
-
-Guards:
-- Transition cooldown prevents rapid state changes
-- Stuck transition timeout (2s) auto-recovers
+idle → recording    (Audio.isRecording becomes true)
+recording → processing  (Audio.isRecording becomes false, transcription starts)
+processing → idle   (transcriptSaved, auto-reset after 2.5s celebration)
 ```
 
-## Common Tasks
+**Transition guards** (in order):
+1. Stuck-state timeout: 2s max transition duration, auto-force-reset
+2. Lock guard: don't transition while locked (except to .idle)
+3. Same-state check: no-op if already in target state
+4. Cooldown guard: `PillAnimationTiming.cooldownDuration` between transitions
 
-| Task | Files to touch | Watch out for |
-|------|---------------|---------------|
-| Fix pill behavior | `PillStateManager.swift` | Check transition guards, cooldown |
-| Fix window/dragging | `FloatingPanelController.swift` | NSPanel level, position saved in UserDefaults |
-| Fix recording animations | `AuroraRecordingView.swift`, `WaveformViews.swift` | Audio level data comes from Audio.swift |
-| Fix success/error states | `CelebrationViews.swift`, `ErrorViews.swift` | Triggered by PillStateManager transitions |
-| Fix silence prompt | `AttentionPromptView.swift` | Reads silenceDuration from Audio.swift |
-| Fix transcript tray | `TranscriptTrayView.swift`, `TranscriptDetailView.swift` | Binds to TranscriptStore |
-| Add new pill state | `PillStateManager.swift`, new view in `Components/` | Update FloatingPanelView switch |
+**DisplayStatus → Pill transitions** (in FloatingPanelController):
+- `gettingReady` → `.processing`, return to idle after 1.5s
+- `transcriptSaved` → `.processing`, return to idle after 2.5s
+- `failed` → `.processing`, return to idle after 4.0s
 
-## Failure Modes
+## View Composition
 
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| Pill stuck in state | Transition guard blocking | Check `ui` logs for "Blocked transition" |
-| Animations jittery | Too many concurrent animations | Check animation presets in DesignTokens |
-| Pill position lost | UserDefaults keys cleared | Check `floatingPanelX`/`floatingPanelY` |
+FloatingPanelView switches on `pillStateManager.state`:
+- `.idle` → `AuroraIdleView` (collapsed/expanded capsule with record/files buttons)
+- `.recording` → `AuroraRecordingView` (aurora fog + timer + stop) or legacy `PillRecordingView`
+- `.processing` → `AuroraSuccessView` (if transcriptSaved) else `AuroraProcessingView`
+
+**Overlays** (in VStack above pill):
+- `SpeakerNamingView` — mutually exclusive with transcript tray, sticky (no Escape dismiss)
+- `TranscriptTrayView` — only when .idle or .recording, dismissible by Escape
+- `ToastNotificationView` — error display, auto-dismisses after 5s
+
+**Escape key handling**: Dual local + global NSEvent monitors (panel is non-activating, so global catches when other apps have focus). Speaker naming is exempt from Escape dismissal.
+
+## Modification Recipes
+
+| Task | Files to touch |
+|---|---|
+| Fix pill state transitions | `PillStateManager.swift` — check guards, cooldown |
+| Fix window position/dragging | `FloatingPanelController.swift` — NSPanel config |
+| Fix recording animation | `AuroraRecordingView.swift` — audio level data from `Audio.audioLevelHistory` |
+| Fix processing/success display | `AuroraProcessingView.swift` / `AuroraSuccessView.swift` |
+| Fix error display | `ErrorViews.swift` — ContextualError parser or ToastNotificationView layout |
+| Fix silence prompt | `AttentionPromptView.swift` — threshold is 120s from `Audio.silenceDuration` |
+| Fix transcript tray | `TranscriptTrayView.swift` + `TranscriptDetailView.swift`, data from TranscriptStore |
+| Fix speaker naming | `SpeakerNamingView.swift`, data from `SpeakerNamingRequest` |
+| Add new pill visual state | `PillStateManager.swift` (add to enum) + new view in Components + update FloatingPanelView switch |
+
+## Gotchas
+- Window: `.borderless` + `.nonactivatingPanel` — clicks don't steal focus from other apps
+- Position saved on every drag via `windowDidMove` delegate
+- `hidesOnDeactivate = false` required to stay visible
+- Audio level data from `Audio.audioLevelHistory` (circular buffer, 15 samples, 0-1 Float)
+- Aurora recording auto-collapses to 72×36 after 5s, re-expands on hover
+- Speaker naming tray has `canDismiss = false` for first 3s to prevent accidental dismiss
 
 ## Dependencies
-
-**Imports from Core/**: Audio (levels), TranscriptionTaskManager (progress/state), TranscriptStore, FailedTranscriptionManager
-**Imports from Design/**: DesignTokens (colors, spacing, PillDimensions, PillAnimationTiming)
+**From Core/**: Audio (levels, isRecording), TranscriptionTaskManager (displayStatus, speakerNamingRequest), TranscriptStore, FailedTranscriptionManager
+**From Design/**: DesignTokens (PillDimensions, PillAnimationTiming, all colors, animation presets)
 
 ## Logging
-
-Subsystem: `ui` — pill transitions, blocked transitions.
+Subsystem: `ui` — pill transitions, blocked transitions, tray events

--- a/Murmur/UI/Settings/CLAUDE.md
+++ b/Murmur/UI/Settings/CLAUDE.md
@@ -1,0 +1,67 @@
+# Settings — CLAUDE.md
+
+## Purpose
+Settings window: stats dashboard, speaker voice fingerprints management, app preferences, and transcript migration.
+
+## Files
+
+| File | Responsibility |
+|---|---|
+| `SettingsWindowController.swift` | NSWindowController, 800×600 fixed window, dark aqua appearance |
+| `SettingsContainerView.swift` | Single-page scrolling layout: stats → failed transcriptions → speakers → preferences |
+| `SettingsSidebarView.swift` | Left sidebar navigation (Dashboard, Speakers, Preferences tabs) |
+| `Models/SettingsNavigationState.swift` | Tab state, migration progress tracking |
+| `Components/SettingsSectionCard.swift` | Reusable card wrapper, CoralToggle, SettingsToggleRow, SettingsTextField |
+
+## Key Types
+
+**SettingsWindowController** (NSWindowController): Creates 800×600 window with `.titled`, `.closable`, `.miniaturizable`, `.resizable`. Dark Aqua appearance. `showWindow()` refreshes stats and checks migration on focus.
+
+**SettingsContainerView** (SwiftUI View):
+- `@ObservedObject`: statsService, navigationState
+- `@AppStorage` keys: `transcriptSaveLocation`, `userName`, `useAuroraRecording`, `enableQwenSpeakerInference`
+- `@State`: speakers list, editingId, retryingIds, speakersExpanded, qwenModelCached
+
+**SettingsTab** (enum): `.dashboard` (chart.bar.fill) | `.speakers` (person.2.fill) | `.preferences` (gearshape.fill)
+
+**SettingsNavigationState** (@MainActor, ObservableObject):
+- `@Published selectedTab`, `isMigrating`, `migrationProgress`, `migrationStatus`
+- `startMigration()` — calls TranscriptScanner to migrate existing transcripts to StatsDB
+- `checkMigrationNeeded()` — checks if DB empty but transcript files exist
+
+**Components**: `SettingsSectionCard` (card wrapper), `CoralToggle` (44×24 capsule toggle with coral accent), `SettingsToggleRow`, `SettingsTextField`
+
+## Layout Sections (in scroll order)
+1. **Stats**: Total meetings, total hours, Open Folder button, Refresh
+2. **Failed Transcriptions**: (if any) Retry queue with individual + retry all
+3. **Voice Fingerprints**: Collapsible speaker list with edit name, delete, play clip
+4. **Profile**: User name text field, transcript save location
+5. **Appearance**: Aurora recording toggle, UI sounds toggle
+6. **Speaker Intelligence**: Qwen toggle, model cache status
+7. **AI Services**: External service integrations
+
+## @AppStorage Keys Used
+- `transcriptSaveLocation` (String) — custom output folder
+- `userName` (String) — user's name for speaker attribution
+- `useAuroraRecording` (Bool) — aurora animation enabled
+- `enableQwenSpeakerInference` (Bool) — Qwen speaker name inference enabled
+- `enableUISounds` (Bool) — recording sounds enabled
+
+## Modification Recipes
+
+| Task | Files to touch |
+|---|---|
+| Add new preference | `SettingsContainerView.swift` — add `@AppStorage` + UI row in appropriate section |
+| Add settings section | `SettingsContainerView.swift` — new section in ScrollView VStack |
+| Change window size | `SettingsWindowController.swift` — windowWidth/Height constants |
+| Fix speaker editing | `SettingsContainerView.swift` — `speakersSection` computed property |
+| Fix migration | `SettingsNavigationState.swift` — `startMigration()` uses TranscriptScanner |
+| Add toggle component | `Components/SettingsSectionCard.swift` — follow CoralToggle pattern |
+
+## Dependencies
+**From Core/**: StatsService, TranscriptionTaskManager, FailedTranscriptionManager, TranscriptScanner
+**From Services/**: SpeakerDatabase (.shared), QwenService (model cache check), SpeakerClipExtractor
+**From Design/**: DesignTokens, PremiumComponents
+
+## Logging
+Subsystem: `ui`


### PR DESCRIPTION
## Summary
Completely rewrote all CLAUDE.md documentation files to be agent-optimized, focusing on actionable information over narrative explanation.

### Changes

**Main CLAUDE.md** (~407 → 79 lines)
- Removed verbose architecture sections and narrative descriptions
- Added concise **Agent Routing Table** mapping issues to component CLAUDE.md files
- Condensed **Project Summary** to single paragraph
- Created **Critical Invariants** checklist (threading, CoreAudio rules, audio formats)
- Simplified **Build Commands** and **Data Locations** to quick-lookup tables
- Kept subsystem-indexed **Logging** reference

**MEMORY.md** (~377 → 174 lines)
- Added **Symptom Index** at top for fast lookup during debugging
- Reorganized content by symptom rather than chronological lessons learned
- Expanded **Audio Format Rules** section with practical do/don't examples
- Clarified **CoreAudio I/O Overload** root cause and fix pattern
- Added **Expected Console Warnings** reference table (HALC warnings, error codes)
- Condensed speaker matching, model loading, and transcription pipeline into actionable sections
- Kept debugging commands reference

**Component CLAUDE.md files** (Core, Design, Onboarding, Services, UI, FloatingPanel, Settings)
- Restructured from narrative to **Purpose + Files + Key Types + Threading Rules + Patterns** format
- Each file now leads with routing guidance ("read parent CLAUDE.md first")
- Added threading annotations (@MainActor, DispatchQueue) to file responsibility tables
- Converted architecture diagrams to compact quick-reference tables
- Emphasized invariants and rules ("NEVER...", "ALWAYS...")
- Removed duplicate explanations—refer back to parent docs

### Design Principles Applied
1. **Implement, don't suggest** — docs assume agent will read before acting
2. **Symptom-first** — MEMORY.md indexes by problem, not story
3. **Routing clarity** — top-level CLAUDE.md directs agent to right component doc
4. **Threading visible** — every file shows @MainActor, DispatchQueue, SendActor annotations
5. **Rules over narrative** — "NEVER allocate in callback" beats 10 paragraphs of history
6. **Code-ready** — swift snippets and file paths immediately actionable