### PR TITLE
UX simplification: floating pill, transcript viewing & interactions

### DIFF
--- a/Transcripted/Core/TranscriptionTaskManager.swift
+++ b/Transcripted/Core/TranscriptionTaskManager.swift
@@ -114,6 +114,9 @@ class TranscriptionTaskManager: ObservableObject {
     // Speaker naming flow — published when post-meeting naming is needed
     @Published var speakerNamingRequest: SpeakerNamingRequest? = nil
 
+    // Last saved transcript URL — used by success view for Open/Copy actions
+    @Published var lastSavedTranscriptURL: URL? = nil
+
     private var activeTasks: [UUID: Task<Void, Never>] = [:]
     let transcription = Transcription()
 
@@ -274,8 +277,9 @@ class TranscriptionTaskManager: ObservableObject {
                 )
 
                 await MainActor.run {
+                    self.lastSavedTranscriptURL = transcriptURL
                     self.displayStatus = .transcriptSaved
-                    self.scheduleStatusReset()
+                    self.scheduleStatusReset(delay: 4)
                 }
 
                 await MainActor.run {
@@ -444,7 +448,7 @@ class TranscriptionTaskManager: ObservableObject {
         speakerDB.mergeDuplicates()
         speakerDB.pruneWeakProfiles()
 
-        // Build sortformer-ID → persistent DB UUID mapping for YAML
+        // Build diarizer speaker-ID → persistent DB UUID mapping for YAML
         var speakerDbIds: [String: UUID] = [:]
         for utterance in result.systemUtterances {
             let sid = String(utterance.speakerId)
@@ -504,9 +508,9 @@ class TranscriptionTaskManager: ObservableObject {
                             // Free ~1.5 GB — transcription is done, these models aren't needed during speaker naming
                             await MainActor.run {
                                 self.transcription.parakeet.cleanup()
-                                self.transcription.sortformer.cleanup()
+                                self.transcription.diarization.cleanup()
                             }
-                            AppLogger.pipeline.info("Unloaded Parakeet + Sortformer before Qwen inference")
+                            AppLogger.pipeline.info("Unloaded Parakeet + diarization models before Qwen inference")
 
                             do {
                                 // Wait for pre-loaded model (started when recording began)
@@ -684,8 +688,9 @@ class TranscriptionTaskManager: ObservableObject {
                 failedTranscriptionManager.removeFailedTranscription(id: failedId)
                 self.activeCount = max(0, self.activeCount - 1)
                 self.backgroundTaskCount = max(0, self.backgroundTaskCount - 1)
+                self.lastSavedTranscriptURL = transcriptURL
                 self.displayStatus = .transcriptSaved
-                self.scheduleStatusReset()
+                self.scheduleStatusReset(delay: 4)
             }
 
             return true
@@ -762,6 +767,11 @@ class TranscriptionTaskManager: ObservableObject {
 
         // Clear the naming request
         self.speakerNamingRequest = nil
+
+        // Re-show success view after naming so user can Copy/Open the transcript
+        self.lastSavedTranscriptURL = transcriptURL
+        self.displayStatus = .transcriptSaved
+        self.scheduleStatusReset(delay: 8)
 
         AppLogger.pipeline.info("Speaker naming complete", [
             "named": "\(updates.count)",

--- a/Transcripted/UI/FloatingPanel/Components/AuroraIdleView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/AuroraIdleView.swift
@@ -41,6 +41,13 @@ struct AuroraIdleView: View {
             idleBackground
                 .clipShape(Capsule())
 
+            // Subtle mic icon in collapsed state to signal clickability
+            if !isExpanded {
+                Image(systemName: "mic.fill")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(.panelTextMuted.opacity(0.4))
+            }
+
             // Background processing badge (top-left when collapsed)
             if backgroundTaskCount > 0 && !isExpanded {
                 processingBadge
@@ -65,9 +72,14 @@ struct AuroraIdleView: View {
         .onHover { hovering in
             isHoverExpanded = hovering
         }
+        .onTapGesture {
+            if !isExpanded {
+                onRecord()
+            }
+        }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Ready to record")
-        .accessibilityHint("Hover to reveal controls")
+        .accessibilityHint("Click to start recording, or hover to reveal controls")
     }
 
     // MARK: - Idle Background
@@ -79,9 +91,15 @@ struct AuroraIdleView: View {
         }
         .overlay(
             Capsule()
-                .strokeBorder(Color.panelCharcoalSurface, lineWidth: 1)
+                .strokeBorder(
+                    failedCount > 0
+                        ? Color.recordingCoral.opacity(0.3)
+                        : Color.panelCharcoalSurface,
+                    lineWidth: failedCount > 0 ? 1.5 : 1
+                )
         )
         .shadow(color: Color.black.opacity(0.3), radius: 8, y: 2)
+        .glowPulse(when: backgroundTaskCount > 0 && !isExpanded, color: .recordingCoral)
     }
 
     // MARK: - Failed Badge
@@ -89,10 +107,10 @@ struct AuroraIdleView: View {
     private var failedBadge: some View {
         Circle()
             .fill(Color.red)
-            .frame(width: 14, height: 14)
+            .frame(width: 18, height: 18)
             .overlay(
                 Text("\(min(failedCount, 9))")
-                    .font(.system(size: 9, weight: .bold))
+                    .font(.system(size: 10, weight: .bold))
                     .foregroundColor(.white)
             )
             .offset(x: 28, y: -14)
@@ -218,7 +236,7 @@ struct ProcessingPulseDot: View {
     var body: some View {
         Circle()
             .fill(Color.recordingCoral.opacity(0.9))
-            .frame(width: 8, height: 8)
+            .frame(width: 12, height: 12)
             .scaleEffect(isPulsing ? 1.2 : 0.8)
             .opacity(isPulsing ? 1.0 : 0.5)
             .animation(

--- a/Transcripted/UI/FloatingPanel/Components/AuroraRecordingView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/AuroraRecordingView.swift
@@ -12,19 +12,14 @@ struct AuroraRecordingView: View {
     var onTranscripts: (() -> Void)? = nil
 
     @Environment(\.accessibilityReduceMotion) var reduceMotion
-    @State private var isExpanded = true  // Start expanded, auto-collapse after 5s
     @State private var isStopHovered = false
     @State private var isTranscriptsHovered = false
-    @State private var collapseTask: Task<Void, Never>?
-    @State private var initialCollapseTask: Task<Void, Never>?
 
     // Smoothed audio levels (prevents jitter)
     @State private var smoothedMicLevel: CGFloat = 0
     @State private var smoothedSystemLevel: CGFloat = 0
 
-    // Collapsed/expanded dimensions
-    private let collapsedWidth: CGFloat = 72
-    private let collapsedHeight: CGFloat = 36
+    // Fixed dimensions — always expanded during recording
     private let expandedWidth: CGFloat = 200
     private let expandedHeight: CGFloat = 44
 
@@ -37,52 +32,13 @@ struct AuroraRecordingView: View {
             auroraBackground
                 .clipShape(Capsule())
 
-            // Expanded content (timer + stop button)
-            if isExpanded {
-                expandedContent
-                    .transition(.opacity.animation(.easeOut(duration: 0.1)))
-            }
+            // Always-visible content (timer + stop button)
+            expandedContent
         }
-        .frame(
-            width: isExpanded ? expandedWidth : collapsedWidth,
-            height: isExpanded ? expandedHeight : collapsedHeight
-        )
-        .animation(.spring(response: 0.15, dampingFraction: 0.8), value: isExpanded)
-        .onHover { hovering in
-            if hovering {
-                // Cancel any pending collapse and expand immediately
-                collapseTask?.cancel()
-                collapseTask = nil
-                isExpanded = true
-            } else {
-                // Start collapse timer when mouse leaves
-                collapseTask = Task {
-                    try? await Task.sleep(nanoseconds: 1_000_000_000)
-                    if !Task.isCancelled {
-                        await MainActor.run {
-                            isExpanded = false
-                        }
-                    }
-                }
-            }
-        }
-        .onAppear {
-            // Auto-collapse after 5 seconds of initial display
-            initialCollapseTask = Task {
-                try? await Task.sleep(nanoseconds: 5_000_000_000)
-                guard !Task.isCancelled else { return }
-                await MainActor.run {
-                    isExpanded = false
-                }
-            }
-        }
-        .onDisappear {
-            initialCollapseTask?.cancel()
-            collapseTask?.cancel()
-        }
+        .frame(width: expandedWidth, height: expandedHeight)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Recording in progress, \(formatDurationAccessible(audio.recordingDuration))")
-        .accessibilityHint("Hover to reveal controls")
+        .accessibilityHint("Click stop to end recording")
     }
 
     // MARK: - Aurora Background (Gemini-style fog layers)

--- a/Transcripted/UI/FloatingPanel/Components/AuroraSuccessView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/AuroraSuccessView.swift
@@ -1,9 +1,10 @@
 import SwiftUI
+import AppKit
 
 // MARK: - Aurora Success View
-/// In-pill success feedback with animated checkmark and clear messaging
+/// In-pill success feedback with animated checkmark and action buttons
 /// Expanded size (200x44) for visual continuity with processing view
-/// Shows descriptive text so users know what happened
+/// Shows Copy and Open buttons so users can immediately act on the transcript
 
 @available(macOS 26.0, *)
 struct AuroraSuccessView: View {
@@ -13,6 +14,8 @@ struct AuroraSuccessView: View {
     }
 
     let successType: SuccessType
+    var transcriptURL: URL? = nil
+    var onCopyTranscript: (() -> Void)? = nil
 
     // Accessibility
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -20,6 +23,10 @@ struct AuroraSuccessView: View {
     @State private var checkScale: CGFloat = 0.3
     @State private var checkOpacity: CGFloat = 0
     @State private var textOpacity: CGFloat = 0
+    @State private var isHovered = false
+    @State private var isCopyHovered = false
+    @State private var isOpenHovered = false
+    @State private var showCopiedCheck = false
 
     // Expanded dimensions (matches processing view for smooth transition)
     private let width: CGFloat = 200
@@ -31,36 +38,75 @@ struct AuroraSuccessView: View {
             successBackground
                 .clipShape(Capsule())
 
-            // Content: checkmark + text
-            HStack(spacing: 12) {
+            // Content: checkmark + text + action buttons
+            HStack(spacing: 8) {
                 // Animated checkmark
                 Image(systemName: "checkmark.circle.fill")
-                    .font(.system(size: 22, weight: .medium))
+                    .font(.system(size: 18, weight: .medium))
                     .foregroundColor(.statusSuccessMuted)
                     .scaleEffect(checkScale)
                     .opacity(checkOpacity)
 
-                // Text content - fixedSize prevents truncation
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(primaryText)
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(.panelTextPrimary)
-                        .opacity(textOpacity)
-
-                    if let secondary = secondaryText {
-                        Text(secondary)
-                            .font(.system(size: 11, weight: .regular))
-                            .foregroundColor(.panelTextMuted)
-                            .opacity(textOpacity)
-                    }
-                }
-                .fixedSize(horizontal: true, vertical: false)
+                // Text content
+                Text(primaryText)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.panelTextPrimary)
+                    .opacity(textOpacity)
 
                 Spacer()
+
+                // Action buttons (visible after text fades in)
+                HStack(spacing: 4) {
+                    // Copy button
+                    if let onCopy = onCopyTranscript {
+                        Button(action: {
+                            onCopy()
+                            withAnimation(.snappy(duration: 0.15)) { showCopiedCheck = true }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                                withAnimation(.snappy(duration: 0.15)) { showCopiedCheck = false }
+                            }
+                        }) {
+                            ZStack {
+                                Circle()
+                                    .fill(isCopyHovered ? Color.panelCharcoalSurface : Color.clear)
+                                    .frame(width: 28, height: 28)
+
+                                Image(systemName: showCopiedCheck ? "checkmark" : "doc.on.doc")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundColor(showCopiedCheck ? .statusSuccessMuted : .panelTextSecondary)
+                            }
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        .onHover { hovering in isCopyHovered = hovering }
+                        .help("Copy transcript")
+                    }
+
+                    // Open button
+                    if let url = transcriptURL {
+                        Button(action: {
+                            NSWorkspace.shared.open(url)
+                        }) {
+                            ZStack {
+                                Circle()
+                                    .fill(isOpenHovered ? Color.panelCharcoalSurface : Color.clear)
+                                    .frame(width: 28, height: 28)
+
+                                Image(systemName: "arrow.up.forward.app")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundColor(.panelTextSecondary)
+                            }
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        .onHover { hovering in isOpenHovered = hovering }
+                        .help("Open transcript")
+                    }
+                }
+                .opacity(textOpacity)
             }
-            .padding(.horizontal, 16)
+            .padding(.horizontal, 12)
         }
         .frame(width: width, height: height)
+        .onHover { hovering in isHovered = hovering }
         .onAppear {
             animateSuccess()
         }
@@ -72,10 +118,6 @@ struct AuroraSuccessView: View {
 
     private var primaryText: String {
         return "Saved"
-    }
-
-    private var secondaryText: String? {
-        return nil
     }
 
     // MARK: - Success Background
@@ -139,6 +181,10 @@ struct AuroraSuccessView: View {
     private var accessibilityText: String {
         return "Transcript saved."
     }
+
+    // MARK: - Hover State (for parent to pause auto-dismiss)
+
+    var isPillHovered: Bool { isHovered }
 }
 
 // MARK: - Preview
@@ -151,6 +197,11 @@ struct AuroraSuccessView_Previews: PreviewProvider {
             Color.black
             VStack(spacing: 20) {
                 AuroraSuccessView(successType: .transcriptSaved)
+                AuroraSuccessView(
+                    successType: .transcriptSaved,
+                    transcriptURL: URL(fileURLWithPath: "/tmp/test.md"),
+                    onCopyTranscript: {}
+                )
             }
         }
         .frame(width: 300, height: 300)

--- a/Transcripted/UI/FloatingPanel/Components/SpeakerNamingView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/SpeakerNamingView.swift
@@ -98,6 +98,17 @@ struct SpeakerNamingView: View {
                 .tracking(0.8)
 
             Spacer()
+
+            if canDismiss {
+                Button(action: submitNaming) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(.panelTextMuted)
+                }
+                .buttonStyle(PlainButtonStyle())
+                .help("Dismiss")
+                .transition(.opacity)
+            }
         }
         .padding(.horizontal, Spacing.ms)
         .padding(.vertical, Spacing.xs + 2)

--- a/Transcripted/UI/FloatingPanel/Components/TranscriptDetailView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/TranscriptDetailView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 // MARK: - MessageGroup
 
-/// Groups consecutive transcript lines from the same speaker for iMessage-style rendering.
+/// Groups consecutive transcript lines from the same speaker for rendering.
 /// Presentation-only model — stays in this file, not in TranscriptStore.
 struct MessageGroup: Identifiable {
     /// Deterministic ID derived from content so SwiftUI doesn't re-render unchanged groups
@@ -14,7 +14,7 @@ struct MessageGroup: Identifiable {
     /// "You" → nil (iMessage convention: no label for self).
     /// "System/Speaker 1" → "Speaker 1".
     var displayName: String? {
-        guard !isUser, let speaker else { return nil }
+        guard let speaker else { return nil }
         let parts = speaker.split(separator: "/", maxSplits: 1)
         return parts.count == 2 ? String(parts[1]) : speaker
     }
@@ -55,8 +55,8 @@ struct MessageGroup: Identifiable {
 
 // MARK: - TranscriptDetailView
 
-/// Scrollable chat-bubble view showing a transcript as an iMessage-style conversation.
-/// "You" (mic) messages are right-aligned with a blue tint; other speakers are left-aligned.
+/// Scrollable dialogue view showing a transcript in a compact, full-width block format.
+/// Each speaker block has a colored left border, speaker name + timestamp header, and full-width text.
 @available(macOS 14.0, *)
 struct TranscriptDetailView: View {
     let lines: [TranscriptLine]
@@ -70,99 +70,81 @@ struct TranscriptDetailView: View {
             ScrollView(.vertical, showsIndicators: false) {
                 LazyVStack(spacing: 10) {
                     ForEach(groups) { group in
-                        MessageGroupView(group: group)
+                        DialogueBlockView(group: group)
                     }
-                    // Invisible anchor at the bottom
-                    Color.clear.frame(height: 1).id("bottom")
+                    // Invisible anchor at the top
+                    Color.clear.frame(height: 1).id("top")
                 }
                 .padding(.horizontal, Spacing.ms)
                 .padding(.vertical, Spacing.sm)
             }
             .frame(maxHeight: 280)
             .onAppear {
-                // Scroll to bottom so user sees most recent messages first
-                proxy.scrollTo("bottom", anchor: .bottom)
+                // Scroll to top — transcripts are read chronologically
+                proxy.scrollTo(groups.first?.id, anchor: .top)
             }
         }
     }
 }
 
-// MARK: - MessageGroupView
+// MARK: - DialogueBlockView
 
-/// Renders a group of consecutive messages from the same speaker.
-/// Right-aligned for user, left-aligned for others, with a spacer on the opposite side.
+/// A compact dialogue block: speaker name + timestamp on one line, full-width text below.
+/// Uses a 3px colored left border per speaker for visual differentiation.
 @available(macOS 14.0, *)
-private struct MessageGroupView: View {
+private struct DialogueBlockView: View {
     let group: MessageGroup
 
-    var body: some View {
-        HStack(alignment: .bottom, spacing: 0) {
-            if group.isUser { Spacer(minLength: 48) }
-
-            VStack(alignment: group.isUser ? .trailing : .leading, spacing: 2) {
-                // Speaker label (only for non-user groups)
-                if let name = group.displayName {
-                    Text(name)
-                        .font(.system(size: 9, weight: .medium))
-                        .foregroundColor(.panelTextMuted)
-                        .padding(.horizontal, 4)
-                }
-
-                // Timestamp
-                if let ts = group.timestamp {
-                    Text(ts)
-                        .font(.system(size: 8, design: .monospaced))
-                        .foregroundColor(.panelTextMuted.opacity(0.7))
-                        .padding(.horizontal, 4)
-                }
-
-                // Bubbles
-                ForEach(group.lines) { line in
-                    ChatBubbleView(text: line.text, isUser: group.isUser, speakerName: group.displayName)
-                }
-            }
-
-            if !group.isUser { Spacer(minLength: 48) }
-        }
-    }
-}
-
-// MARK: - ChatBubbleView
-
-/// A single chat bubble with rounded corners and tinted background.
-/// Non-user speakers get distinct colors based on their name for visual differentiation.
-@available(macOS 14.0, *)
-private struct ChatBubbleView: View {
-    let text: String
-    let isUser: Bool
-    var speakerName: String? = nil
-
-    /// Stable color per speaker name using hash — produces a muted, readable tint
-    private var bubbleColor: Color {
-        guard !isUser, let name = speakerName else {
-            return isUser ? Color.chatBubbleUser : Color.panelCharcoalSurface
+    /// Stable color per speaker name using hash
+    private var speakerColor: Color {
+        guard let name = group.displayName ?? group.speaker else {
+            return group.isUser ? .accentBlue : .panelTextMuted
         }
         let speakerColors: [Color] = [
-            Color(hue: 0.55, saturation: 0.35, brightness: 0.28),  // muted blue
-            Color(hue: 0.75, saturation: 0.30, brightness: 0.28),  // muted purple
-            Color(hue: 0.45, saturation: 0.35, brightness: 0.25),  // muted teal
-            Color(hue: 0.10, saturation: 0.35, brightness: 0.28),  // muted amber
-            Color(hue: 0.90, saturation: 0.30, brightness: 0.28),  // muted rose
+            Color(hue: 0.55, saturation: 0.35, brightness: 0.55),  // muted blue
+            Color(hue: 0.75, saturation: 0.30, brightness: 0.55),  // muted purple
+            Color(hue: 0.45, saturation: 0.35, brightness: 0.50),  // muted teal
+            Color(hue: 0.10, saturation: 0.35, brightness: 0.55),  // muted amber
+            Color(hue: 0.90, saturation: 0.30, brightness: 0.55),  // muted rose
         ]
+        if group.isUser { return .accentBlue }
         let index = abs(name.hashValue) % speakerColors.count
         return speakerColors[index]
     }
 
     var body: some View {
-        Text(text)
-            .font(.system(size: 11))
-            .foregroundColor(.panelTextPrimary)
-            .textSelection(.enabled)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
-                    .fill(bubbleColor)
-            )
+        HStack(spacing: 0) {
+            // Colored left border
+            RoundedRectangle(cornerRadius: 1.5)
+                .fill(speakerColor)
+                .frame(width: 3)
+
+            VStack(alignment: .leading, spacing: 3) {
+                // Header: speaker name + timestamp
+                HStack {
+                    Text(group.displayName ?? (group.isUser ? "You" : "Speaker"))
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(speakerColor)
+
+                    Spacer()
+
+                    if let ts = group.timestamp {
+                        Text(ts)
+                            .font(.system(size: 8, design: .monospaced))
+                            .foregroundColor(.panelTextMuted.opacity(0.7))
+                    }
+                }
+
+                // Full-width text content
+                ForEach(group.lines) { line in
+                    Text(line.text)
+                        .font(.system(size: 12))
+                        .foregroundColor(.panelTextPrimary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .padding(.leading, 8)
+        }
     }
 }

--- a/Transcripted/UI/FloatingPanel/Components/TranscriptTrayView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/TranscriptTrayView.swift
@@ -16,6 +16,7 @@ struct TranscriptTrayView: View {
     @ObservedObject var store: TranscriptStore
     var onOpenFolder: () -> Void
     var onDismiss: (() -> Void)? = nil
+    var onRecord: (() -> Void)? = nil
 
     @State private var isAppearing = false
     @State private var copiedId: UUID?
@@ -195,29 +196,11 @@ struct TranscriptTrayView: View {
 
             Spacer()
 
-            Button { copyAgentPrompt() } label: {
-                HStack(spacing: 4) {
-                    if agentPromptCopied {
-                        Image(systemName: "checkmark")
-                            .font(.system(size: 9, weight: .semibold))
-                            .foregroundColor(.statusSuccessMuted)
-                        Text("Copied!")
-                            .font(.system(size: 10))
-                            .foregroundColor(.statusSuccessMuted)
-                    } else {
-                        Image(systemName: "terminal")
-                            .font(.system(size: 9))
-                        Text("Connect Agent")
-                            .font(.system(size: 10))
-                    }
-                }
+            Text("\(store.transcripts.count) transcript\(store.transcripts.count == 1 ? "" : "s")")
+                .font(.system(size: 10))
                 .foregroundColor(.panelTextMuted)
                 .padding(.horizontal, Spacing.ms)
                 .padding(.vertical, Spacing.xs + 2)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(PlainButtonStyle())
-            .animation(.snappy(duration: 0.15), value: agentPromptCopied)
         }
     }
 
@@ -358,31 +341,28 @@ struct TranscriptTrayView: View {
 
             Spacer()
 
-            Button(action: {
-                let stem = transcript.title
-                copyAgentPrompt(filename: stem)
-            }) {
-                HStack(spacing: 4) {
-                    if agentPromptCopied {
-                        Image(systemName: "checkmark")
-                            .font(.system(size: 9, weight: .semibold))
-                            .foregroundColor(.statusSuccessMuted)
-                        Text("Copied!")
-                            .font(.system(size: 10))
-                            .foregroundColor(.statusSuccessMuted)
-                    } else {
-                        Image(systemName: "terminal")
-                            .font(.system(size: 9))
-                        Text("Agent")
-                            .font(.system(size: 10))
-                    }
+            // Overflow menu: Agent + Open in Finder
+            Menu {
+                Button(action: {
+                    let stem = transcript.title
+                    copyAgentPrompt(filename: stem)
+                }) {
+                    Label("Connect Agent", systemImage: "terminal")
                 }
-                .foregroundColor(.panelTextMuted)
-                .padding(.horizontal, Spacing.ms)
-                .padding(.vertical, Spacing.xs + 2)
-                .contentShape(Rectangle())
+                Button(action: {
+                    NSWorkspace.shared.selectFile(transcript.url.path, inFileViewerRootedAtPath: transcript.url.deletingLastPathComponent().path)
+                }) {
+                    Label("Open in Finder", systemImage: "folder")
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.panelTextMuted)
+                    .padding(.horizontal, Spacing.ms)
+                    .padding(.vertical, Spacing.xs + 2)
+                    .contentShape(Rectangle())
             }
-            .buttonStyle(PlainButtonStyle())
+            .menuStyle(BorderlessButtonMenuStyle())
         }
         .background(Color.panelCharcoal.opacity(0.3))
         .animation(.snappy(duration: 0.15), value: copiedId)
@@ -425,7 +405,7 @@ struct TranscriptTrayView: View {
 
     private var emptyState: some View {
         VStack(spacing: Spacing.sm) {
-            Image(systemName: "waveform.slash")
+            Image(systemName: "mic.badge.plus")
                 .font(.system(size: 24, weight: .light))
                 .foregroundColor(.panelTextMuted)
 
@@ -437,6 +417,25 @@ struct TranscriptTrayView: View {
                 .font(.system(size: 11))
                 .foregroundColor(.panelTextMuted)
                 .multilineTextAlignment(.center)
+
+            if let onRecord {
+                Button(action: onRecord) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "mic.fill")
+                            .font(.system(size: 10, weight: .medium))
+                        Text("Start Recording")
+                            .font(.system(size: 11, weight: .medium))
+                    }
+                    .foregroundColor(.accentBlue)
+                    .padding(.horizontal, Spacing.ms)
+                    .padding(.vertical, Spacing.xs + 2)
+                    .background(
+                        RoundedRectangle(cornerRadius: Radius.sm, style: .continuous)
+                            .fill(Color.accentBlue.opacity(0.12))
+                    )
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
         }
         .padding(.vertical, Spacing.xl)
         .padding(.horizontal, Spacing.md)
@@ -495,7 +494,7 @@ struct TranscriptRowView: View {
                 Text(transcript.title)
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(.panelTextPrimary)
-                    .lineLimit(2)
+                    .lineLimit(1)
                     .truncationMode(.tail)
 
                 HStack(spacing: 4) {
@@ -528,14 +527,7 @@ struct TranscriptRowView: View {
                     }
                 }
 
-                if !transcript.speakerNames.isEmpty {
-                    Text(transcript.speakerNames.joined(separator: ", "))
-                        .font(.system(size: 10))
-                        .foregroundColor(.panelTextMuted)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
-            }
+}
 
             Spacer(minLength: Spacing.xs)
 

--- a/Transcripted/UI/FloatingPanel/FloatingPanelView.swift
+++ b/Transcripted/UI/FloatingPanel/FloatingPanelView.swift
@@ -27,6 +27,13 @@ struct FloatingPanelView: View {
     @State private var showErrorToast = false
     @State private var currentError: ContextualError?
 
+    // Speaker naming dismiss guard — tracks when naming tray appeared
+    @State private var speakerNamingAppearDate: Date?
+    private var canDismissSpeakerNaming: Bool {
+        guard let appeared = speakerNamingAppearDate else { return false }
+        return Date().timeIntervalSince(appeared) >= 3.0
+    }
+
     // Attention prompt states
     @State private var showSilencePrompt = false
     @State private var silencePromptDismissed = false  // Prevents re-showing after dismiss
@@ -70,6 +77,12 @@ struct FloatingPanelView: View {
                         withAnimation(.spring(response: 0.2, dampingFraction: 0.85)) {
                             trayState = .none
                         }
+                    },
+                    onRecord: {
+                        withAnimation(.spring(response: 0.2, dampingFraction: 0.85)) {
+                            trayState = .none
+                        }
+                        audio.start()
                     }
                 )
                 .transition(.asymmetric(
@@ -95,6 +108,47 @@ struct FloatingPanelView: View {
 
             // MARK: - Pill Content (centered, morphs between states)
             pillContent
+                .contextMenu {
+                    if pillStateManager.state == .recording {
+                        Button(action: { audio.stop() }) {
+                            Label("Stop Recording", systemImage: "stop.fill")
+                        }
+                    } else if pillStateManager.state == .idle {
+                        Button(action: { audio.start() }) {
+                            Label("Start Recording", systemImage: "mic.fill")
+                        }
+                    }
+
+                    Button(action: { toggleTranscriptTray() }) {
+                        Label("View Transcripts", systemImage: "clock.arrow.circlepath")
+                    }
+
+                    Button(action: { openTranscriptsFolder() }) {
+                        Label("Open Transcripts Folder", systemImage: "folder")
+                    }
+
+                    if failedTranscriptionManager.failedTranscriptions.count > 0 {
+                        Button(action: { toggleTranscriptTray() }) {
+                            Label("Failed Transcriptions (\(failedTranscriptionManager.failedTranscriptions.count))", systemImage: "exclamationmark.triangle")
+                        }
+                    }
+
+                    Divider()
+
+                    Button(action: {
+                        NSApp.sendAction(Selector(("openSettings")), to: nil, from: nil)
+                    }) {
+                        Label("Settings...", systemImage: "gear")
+                    }
+
+                    Divider()
+
+                    Button(action: {
+                        NSApplication.shared.terminate(nil)
+                    }) {
+                        Label("Quit Transcripted", systemImage: "power")
+                    }
+                }
                 .animation(.pillMorph, value: pillStateManager.state)
                 .padding(.bottom, 10)
         }
@@ -156,8 +210,10 @@ struct FloatingPanelView: View {
                 transcriptStore.refresh()
                 installEscapeMonitor()
             case .speakerNaming:
+                speakerNamingAppearDate = Date()
                 installEscapeMonitor()
             case .none:
+                speakerNamingAppearDate = nil
                 removeEscapeMonitor()
             }
         }
@@ -215,7 +271,25 @@ struct FloatingPanelView: View {
             // Show success view for transcript saved, processing aurora otherwise
             switch taskManager.displayStatus {
             case .transcriptSaved:
-                AuroraSuccessView(successType: .transcriptSaved)
+                AuroraSuccessView(
+                    successType: .transcriptSaved,
+                    transcriptURL: taskManager.lastSavedTranscriptURL,
+                    onCopyTranscript: {
+                        guard let url = taskManager.lastSavedTranscriptURL else { return }
+                        let summary = TranscriptSummary(
+                            url: url,
+                            title: url.deletingPathExtension().lastPathComponent,
+                            date: Date(),
+                            duration: "",
+                            speakerCount: 0,
+                            speakerNames: []
+                        )
+                        if let text = transcriptStore.copyableText(for: summary), !text.isEmpty {
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(text, forType: .string)
+                        }
+                    }
+                )
             default:
                 AuroraProcessingView(status: taskManager.displayStatus)
             }
@@ -236,12 +310,15 @@ struct FloatingPanelView: View {
         guard escapeLocalMonitor == nil else { return }
 
         // Local monitor: catches Escape when our app is frontmost
-        // Naming tray is sticky — escape only dismisses the transcript tray
         escapeLocalMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             if event.keyCode == 53 {
                 if trayState == .speakerNaming {
-                    // Naming tray is sticky — escape does nothing but don't swallow the event
-                    return event
+                    // Allow escape dismiss after 3-second guard
+                    guard canDismissSpeakerNaming else { return event }
+                    if let request = taskManager.speakerNamingRequest {
+                        request.onComplete([])
+                    }
+                    return nil
                 }
                 guard trayState == .transcripts else { return event }  // Don't swallow escape app-wide
                 withAnimation(.spring(response: 0.2, dampingFraction: 0.85)) {
@@ -257,9 +334,15 @@ struct FloatingPanelView: View {
         escapeGlobalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
             if event.keyCode == 53 {
                 DispatchQueue.main.async {
-                    guard self.trayState == .transcripts else { return }
-                    withAnimation(.spring(response: 0.2, dampingFraction: 0.85)) {
-                        self.trayState = .none
+                    if self.trayState == .speakerNaming {
+                        guard self.canDismissSpeakerNaming else { return }
+                        if let request = self.taskManager.speakerNamingRequest {
+                            request.onComplete([])
+                        }
+                    } else if self.trayState == .transcripts {
+                        withAnimation(.spring(response: 0.2, dampingFraction: 0.85)) {
+                            self.trayState = .none
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- **Single-click record**: Click the collapsed idle pill to start recording instantly (hover still expands for Transcripts button)
- **Always-visible recording controls**: Removed auto-collapse — timer and stop button stay visible throughout recording
- **Compact transcript dialogue**: Replaced iMessage-style chat bubbles with full-width dialogue blocks (colored left borders, 12pt text, ~40 chars/line vs ~30)
- **Actionable success state**: Copy and Open buttons on the "Saved" pill, re-shown for 8s after speaker naming completes
- **Speaker naming escape hatch**: X dismiss button and Escape key support (after 3-second accidental-dismiss guard)
- **Simplified tray footer**: Removed "Connect Agent" from list footer (moved to detail overflow menu), added transcript count
- **Right-click context menu**: Start/Stop Recording, View Transcripts, Open Folder, Settings, Quit
- **Better badge visibility**: Larger failed badge (18px), larger processing dot (12px), red border tint on failures, coral glow pulse for background tasks

## Test plan
- [ ] Click collapsed pill → starts recording immediately
- [ ] Hover pill → expands with Record + Transcripts buttons
- [ ] Recording pill stays at 200×44 permanently (no auto-collapse)
- [ ] Right-click pill in any state → context menu appears
- [ ] After transcript saves → "Saved" shows Copy + Open buttons for 4s
- [ ] After speaker naming completes → "Saved" reappears for 8s with action buttons
- [ ] Transcript detail view shows compact dialogue format with colored left borders
- [ ] Tray list footer: "Open folder" + transcript count (no Connect Agent)
- [ ] Detail footer: Copy, Export, then ... overflow menu
- [ ] Speaker naming X button appears after 3s; Escape key dismisses after 3s
- [ ] Empty tray shows mic.badge.plus icon + "Start Recording" CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)