### PR TITLE
docs: CLAUDE.md navigation files for all major folders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,21 @@
 # Transcripted - AI Agent Navigation Guide
 
 ## Project Overview
-Real-time system audio transcription app for macOS. Core pipeline: CoreAudio capture → Parakeet STT → PyAnnote diarization → WeSpeaker embeddings → Qwen name inference. Output: Markdown transcripts with YAML metadata.
+Menu bar-only macOS app for real-time system audio transcription. Pipeline: CoreAudio capture -> Parakeet STT -> PyAnnote diarization -> WeSpeaker embeddings -> Qwen name inference. Output: Markdown transcripts with YAML frontmatter.
+
+## Architecture
+- **App entry**: `TranscriptedApp.swift` (@main) -> `AppDelegate` manages all systems
+- **Activation policy**: `.accessory` (menu bar only, no dock icon)
+- **UI**: Floating pill (Dynamic Island style) + Settings window + Onboarding window
+- **Dependencies**: mlx-swift-lm (Qwen LLM), Sparkle (auto-updates), FluidAudio (static lib at `fluidaudio-libs/libFluidAudioAll.a`)
 
 ## Folder Map
-- **Core/**: Audio capture, transcription pipeline, task management, SQLite databases (speakers + stats)
-- **Services/**: ML services (ParakeetService, DiarizationService, QwenService, SpeakerDatabase, EmbeddingClusterer)
-- **UI/**: SwiftUI views, status item, settings, onboarding
-- **Onboarding/**: First-run setup, model downloads from HuggingFace (~600MB)
-- **Design/**: Shared design tokens, colors, typography
+- **Core/** (23 files): Audio capture, transcription pipeline, task management, transcript saving, stats DB, failed transcription retry, logging, agent JSON output
+- **Services/** (8 files): ML services (ParakeetService, DiarizationService, QwenService, SpeakerDatabase, EmbeddingClusterer, AudioResampler, SpeakerClipExtractor, MeetingDetector)
+- **UI/FloatingPanel/** (16 files): Morphing pill UI with aurora visualizations, transcript tray, speaker naming dialog
+- **UI/Settings/** (4 files): Single-page settings dashboard with reusable components
+- **Onboarding/** (6 files): 3-step first-run flow (Welcome -> Permissions -> Model Setup)
+- **Design/** (2 files): 84 color tokens, 9 spacing values, 13 radius values, 22 animation presets, premium components
 
 ## Build & Test
 ```bash
@@ -17,25 +24,58 @@ xcodebuild -project Transcripted.xcodeproj -scheme Transcripted -configuration D
 Test command: `xcodebuild -project Transcripted.xcodeproj -scheme Transcripted test`
 
 ## Critical Rules
-1. **No I/O in CoreAudio callbacks** - Real-time audio thread cannot do file/network operations
-2. **@MainActor on all services** - UI and service code must run on main thread
-3. **Never commit to main** - Always create feature branches: `feat/description`, `fix/description`
-4. **Branch naming**: `feat/{issue-id}-{slug}` or `fix/{issue-id}-{slug}`
-5. **FluidAudio**: Pre-built static library at `fluidaudio-libs/libFluidAudioAll.a`
+1. **No I/O in CoreAudio callbacks** - Real-time audio thread cannot do file/network/lock operations
+2. **Audio.swift and SystemAudioCapture.swift are NOT @MainActor** - They manage AVAudioEngine/CoreAudio which require synchronous access from audio threads. They dispatch UI updates to main thread explicitly.
+3. **All other services are @MainActor** - ParakeetService, DiarizationService, QwenService, Transcription, TranscriptionTaskManager (exception: SpeakerDatabase uses dedicated utility queue instead)
+4. **Never commit to main** - Always create feature branches: `feat/description`, `fix/description`
+5. **Branch naming**: `feat/{issue-id}-{slug}` or `fix/{issue-id}-{slug}`
+
+## Recording -> Transcript Pipeline
+```
+User presses Cmd+Shift+R (global hotkey)
+  -> Audio.startRecording() [CoreAudio thread]
+  -> onRecordingStart callback -> TaskManager.prepareForRecording()
+  -> User stops recording
+  -> Audio.stopRecording() -> onRecordingComplete(micURL, systemURL)
+  -> TaskManager.startTranscription(micURL, systemURL, outputFolder)
+     -> Gate: reject < 2s recordings
+     -> Step 1 (0-10%): Resample both to 16kHz mono
+     -> Step 2 (10-30%): Offline diarization (PyAnnote) + EmbeddingClusterer post-process
+     -> Step 3 (30-65%): Transcribe system segments with Parakeet per speaker
+     -> Step 4 (65-90%): Transcribe mic segments per silence region
+     -> Step 5 (90-100%): Merge consecutive utterances (1.5s gap, 30s cap)
+  -> TranscriptSaver.saveTranscript() writes .md + YAML
+  -> AgentOutput.writeTranscriptJSON() writes .json sidecar
+  -> FloatingPanel shows success state
+```
 
 ## Key Entry Points
-- **TranscriptedApp.swift**: App entry point, @main struct
-- **AppDelegate.swift**: Status item, menu management, window controllers
-- **TranscriptionTaskManager.swift**: Task queue orchestration
-- **Audio.swift**: CoreAudio capture pipeline
+- **TranscriptedApp.swift**: @main struct, AppDelegate manages status bar, hotkey (Cmd+Shift+R), window controllers
+- **Core/TranscriptionTaskManager.swift**: Task queue orchestration, DisplayStatus for UI, Qwen memory management
+- **Core/Audio.swift**: CoreAudio capture, publishes isRecording/audioLevel/recordingDuration
+- **Core/Transcription.swift**: @MainActor pipeline orchestration with nonisolated transcription methods
 
 ## Threading Model
-- Audio capture runs on CoreAudio callback thread
-- All transcription, diarization, and UI code must be @MainActor
-- Use DispatchQueue for cross-thread communication
+- **Audio thread**: Audio.swift + SystemAudioCapture.swift (NOT @MainActor, sync audio access)
+- **Main thread**: All UI, Transcription, TaskManager, ParakeetService, DiarizationService, QwenService
+- **Utility queue**: SpeakerDatabase (thread-safe SQLite via `DispatchQueue(label: "com.transcripted.speakerdb", qos: .utility)`)
+- **Serial queue**: TranscriptSaver file updates, StatsDatabase writes
+- **Cross-thread**: Audio dispatches UI updates via `DispatchQueue.main.async`
+
+## Data Storage
+- **Transcripts**: `~/Documents/Transcripted/*.md` (Markdown + YAML frontmatter)
+- **Agent JSON**: `~/Documents/Transcripted/*.json` (sidecar for each transcript)
+- **Speakers DB**: `~/Documents/Transcripted/speakers.sqlite` (256-dim embeddings, profiles)
+- **Stats DB**: `~/Documents/Transcripted/stats.sqlite` (recording history, daily activity)
+- **Failed queue**: `~/Documents/Transcripted/failed_transcriptions.json`
+- **Speaker clips**: `~/Documents/Transcripted/speaker_clips/{speakerId}.wav`
+- **Qwen model**: `~/Library/Caches/models/mlx-community/Qwen3.5-4B-4bit` (~2.5GB)
+- **Logs**: `~/Library/Logs/Transcripted/app.jsonl` (JSON lines)
 
 ## Model Cache
-Models downloaded to app container on first launch. Parakeet (~600MB) + Sortformer diarization model.
+- **Parakeet**: Bundled or downloaded from HuggingFace (~600MB), 16kHz target rate
+- **Diarization**: PyAnnote offline + Sortformer streaming, bundled or via FluidAudio
+- **Qwen**: On-demand download (~2.5GB), loads/unloads to manage memory
 
 ## Documentation
 See CONTRIBUTING.md for full development guidelines.

--- a/Transcripted/Core/CLAUDE.md
+++ b/Transcripted/Core/CLAUDE.md
@@ -1,42 +1,142 @@
 # Core Folder
 
-Core owns the audio capture pipeline, transcription orchestration, file saving, and statistics tracking.
+Audio capture pipeline, transcription orchestration, file saving, stats tracking, and error recovery. 23 Swift files.
 
-## Pipeline Flow
+## File Index
 
-1. **Audio capture** → `SystemAudioCapture` captures system audio via CoreAudio process taps
-2. **Audio recording** → `Audio` class manages AVAudioEngine, publishes audio levels and state
-3. **Transcription** → `Transcription` orchestrates Parakeet → PyAnnote → WeSpeaker → Qwen pipeline
-4. **Save** → `TranscriptSaver` writes Markdown + YAML output to disk
+| File | Actor | Purpose |
+|------|-------|---------|
+| `Audio.swift` | NOT @MainActor | AVAudioEngine + SystemAudioCapture, publishes audio levels/state, device recovery |
+| `SystemAudioCapture.swift` | NOT @MainActor | CoreAudio process taps (macOS 14.2+), device switching, format negotiation |
+| `Transcription.swift` | @MainActor | Pipeline orchestration: Parakeet -> PyAnnote -> WeSpeaker -> speaker matching |
+| `TranscriptionTaskManager.swift` | @MainActor | Task queue, DisplayStatus for UI progress, Qwen memory management |
+| `TranscriptionTypes.swift` | — | TranscriptionUtterance, TranscriptionResult, PipelineError, SpeakerNamingEntry |
+| `TranscriptSaver.swift` | Static | Markdown + YAML output, retroactive speaker name updates |
+| `TranscriptStore.swift` | @MainActor | Reads saved transcripts for tray UI display |
+| `TranscriptExporter.swift` | — | Export to .md or .txt via NSSavePanel |
+| `TranscriptScanner.swift` | — | Finds transcripts in save directory, migration support |
+| `TranscriptUtils.swift` | — | Formatting utilities |
+| `StatsDatabase.swift` | NOT @MainActor | SQLite stats (serial queue `com.transcripted.statsdb`) |
+| `StatsService.swift` | @MainActor | Stats aggregation for dashboard UI |
+| `AgentOutput.swift` | Static | JSON sidecar + index for AI agent consumption |
+| `RecordingValidator.swift` | Static | Pre-recording checks (disk space, permissions, save path) |
+| `FailedTranscription.swift` | — | Model for retryable failed transcriptions |
+| `FailedTranscriptionManager.swift` | @MainActor | Retry queue, persists to JSON, auto-cleans permanent failures |
+| `DiagnosticExporter.swift` | — | Diagnostic bundle export for bug reports |
+| `Clipboard.swift` | — | Clipboard management |
+| `CoreAudioUtils.swift` | — | CoreAudio device enumeration helpers |
+| `DateFormattingHelper.swift` | — | Date formatting utilities |
+| `DateParser.swift` | — | Date parsing utilities |
+| `Logging/AppLogger.swift` | @unchecked Sendable | Dual logging: os.Logger + FileLogger (JSONL) |
+| `Logging/FileLogger.swift` | — | JSON line-delimited logs to ~/Library/Logs/Transcripted/ |
+
+## Audio.swift - Published Properties (UI Bindings)
+```
+@Published isRecording: Bool
+@Published isMonitoring: Bool
+@Published audioLevel: Float              // 0.0-1.0+ (meter)
+@Published recordingDuration: TimeInterval
+@Published audioLevelHistory: [Float]     // 15-element rolling buffer
+@Published systemAudioLevelHistory: [Float]
+@Published error: String?
+@Published systemAudioStatus: SystemAudioStatus  // healthy/reconnecting/silent/failed
+@Published silenceDuration: TimeInterval
+@Published isSilent: Bool                 // audioLevel < 0.02
+@Published micAudioFileURL: URL?
+@Published systemAudioFileURL: URL?
+```
+
+## Audio Recovery Mechanisms
+- **Device disconnect**: Watchdog timer (3-5s) -> `recoverFromDeviceChange()`, max 5 attempts, 5s cooldown
+- **Sleep/wake**: NSWorkspace notifications -> proactive recovery after 500ms stabilization
+- **System audio loss**: 10s silence -> `.silent` status, 10+ min -> `.failed`
+- **Write errors**: Stops recording after 10 consecutive write errors
+- **originalMicAudioFileURL vs micAudioFileURL**: During recovery, new WAV segment created. Pipeline MUST use `originalMicAudioFileURL` for transcription.
+
+## DisplayStatus (TranscriptionTaskManager)
+```
+case idle                           // progress: 0.0
+case gettingReady                   // progress: 0.10
+case transcribing(progress: Double) // progress: 0.15 + (p * 0.60) = 15-75%
+case finishing                      // progress: 0.97
+case transcriptSaved                // progress: 1.0
+case failed(message: String)        // progress: 0.0
+```
+
+## Transcription Pipeline Details
+```
+transcribeMultichannel(micURL, systemURL, onProgress):
+  Step 1 (0-10%):   Load & resample both to 16kHz mono (AudioResampler)
+  Step 2 (10-30%):  Offline diarization + EmbeddingClusterer.postProcess()
+                     -> DB-informed merging, ghost speaker detection
+  Step 3 (30-65%):  Transcribe system segments per speaker
+                     -> Adaptive threshold matching (1 seg=0.85, 2-3=0.78, 4+=0.70)
+                     -> Quality gate: skip segments < 0.3 quality or < 1.0s
+                     -> Ghost speakers force-merged into nearest real speaker
+  Step 4 (65-90%):  Transcribe mic segments per silence region
+                     -> Energy-based silence detection (RMS < 0.01, 25ms frames, 400ms gap)
+  Step 5 (90-100%): Merge consecutive utterances (maxGap: 1.5s, maxDuration: 30s cap)
+```
+
+## Transcript Output (YAML Frontmatter)
+```yaml
+---
+date: 2024-01-15
+time: 14:30:00
+duration: "47:32"
+processing_time: "120.5s"
+transcription_engine: parakeet_local
+diarization_engine: pyannote_offline
+sources: [mic, system_audio]
+mic_utterances: 42
+system_utterances: 156
+mic_speakers: 1
+system_speakers: 4
+total_word_count: 8291
+capture_quality: excellent|good|fair|degraded
+audio_gaps: 0
+device_switches: 0
+speakers:
+  - id: "system_0"
+    db_id: "uuid"
+    name: "Alice"
+    confidence: high|medium
+tags: [transcripted, meeting, speaker/alice]  # only if Obsidian enabled
+---
+```
+
+## StatsDatabase Schema
+```sql
+-- Table: recordings
+id TEXT PRIMARY KEY, date TEXT, time TEXT, duration_seconds INT,
+word_count INT, speaker_count INT, processing_time_ms INT,
+transcript_path TEXT, title TEXT, created_at TEXT
+
+-- Table: daily_activity
+date TEXT PRIMARY KEY, recording_count INT, total_duration_seconds INT,
+action_items_count INT, updated_at TEXT
+```
+WAL mode, busy_timeout 5000ms, NORMAL sync, 0o600 permissions.
+
+## Error Handling
+- **PipelineError**: Permanent (emptyAudioFile, recordingTooShort, invalidAudioFormat, missingSystemAudio) vs Transient (modelNotLoaded, modelInferenceFailed, saveFailed). `isRetryable` determines retry eligibility.
+- **FailedTranscriptionManager**: Auto-deletes permanent errors + retryCount >= 3 on init.
+- **Qwen timeout**: 5-minute safety timeout if model loaded but not consumed by pipeline.
+- **Memory check**: Qwen pre-load requires 2GB free (4GB headroom).
 
 ## Threading Rules
+- **Audio.swift & SystemAudioCapture.swift are NOT @MainActor** - manage real-time audio threads
+- **NO I/O in CoreAudio callbacks** - file/network/locks will cause audio glitches
+- **Transcription pipeline methods are `nonisolated`** - offloaded from main thread
+- **StatsDatabase**: Serial queue for SQLite (NOT @MainActor)
+- **TranscriptSaver**: Serial queue `com.transcripted.fileupdate` prevents concurrent writes
 
-- **NO I/O in CoreAudio callbacks** — CoreAudio callbacks run on audio threads; all file I/O must be dispatched elsewhere
-- **@MainActor for UI** — `Transcription` and all UI-related code uses `@MainActor`
-- **Audio classes are NOT @MainActor** — `Audio` and `SystemAudioCapture` manage AVAudioEngine/CoreAudio which require synchronous access from audio threads
-- **Explicit main thread dispatch** — Audio classes explicitly dispatch UI updates to main thread
+## Logger Subsystems
+AppLogger.audio, .audioMic, .audioSystem, .transcription, .pipeline, .speakers, .services, .ui, .stats, .app
 
-## Key Files
-
-- `Audio.swift` — Main audio recording class, manages microphone + system audio, publishes audio levels and recording state
-- `SystemAudioCapture.swift` — Captures system-wide audio using CoreAudio process taps (macOS 14.2+), handles device switching and format negotiation
-- `Transcription.swift` — @MainActor orchestration class, manages ParakeetService, DiarizationService, SpeakerDatabase, speaker mappings
-- `TranscriptionTaskManager.swift` — Manages display status for UI with progress phases (gettingReady → transcribing → finishing), handles task queue
-- `TranscriptSaver.swift` — Writes transcript output to disk in Markdown + YAML format
-
-## Output Format
-
-Transcripts are saved as Markdown with YAML frontmatter containing:
-- Timestamps and speaker labels
-- Identified speaker names from Qwen inference
-- Confidence scores for name matches
-- SQLite databases track speakers and statistics
-
-## Databases
-
-- **Speakers DB** — Stores speaker mappings and identified names
-- **Stats DB** — Tracks transcription metrics and usage statistics
-
-## Logging
-
-CoreAudio may emit internal framework warnings during setup/teardown (e.g., `HALC_ShellObject::SetPropertyData`). These are harmless and don't affect functionality.
+## Gotchas
+- CoreAudio warnings (HALC_ShellObject, throwing -10877) are harmless internal messages
+- SystemAudioCapture.prepare() MUST precede start() - query audioFormat after prepare
+- Generation counter in SystemAudioCapture prevents stale delayed cleanup from destroying new sessions
+- Recording duration gate: < 2s rejected automatically
+- RecordingValidator rejects symlinks, ".." traversals, system directories (/System, /Library, /usr)

--- a/Transcripted/Design/CLAUDE.md
+++ b/Transcripted/Design/CLAUDE.md
@@ -1,71 +1,122 @@
-# Transcripted Design System
+# Design System
 
-## Color Tokens
+Shared design tokens and premium components. 2 Swift files, 1161 + 561 lines.
 
-**Warm Minimalism Palette** (Laws of UX inspired):
+## Files
+- **DesignTokens.swift** (1161 lines) - 84 colors, 9 spacing values, 13 radius values, 13 typography styles, 22 animations, 16 shadows, gradients, accessibility modifiers
+- **PremiumComponents.swift** (561 lines) - PremiumButton, PremiumCard, BenefitCard, StepProgressIndicator, PermissionCard, QuickTipRow, AnimatedIcon
 
-- `surfaceBackground` - Main background: warm off-white (hue 0.167, sat 0.10, bright 0.92)
-- `surfaceEggshell` - Elevated areas and highlights (hue 0.153, sat 0.62, bright 0.89)
-- `surfaceCard` - Card backgrounds, slightly brighter (hue 0.167, sat 0.08, bright 0.96)
+## Color Tokens (all `Color.staticVar`, defined as HSB or hex)
 
-**Dark Mode** (blue-tinted, not pure black):
+**Warm Cream Surfaces (Laws of UX):**
+- `surfaceBackground` (hue 0.167, sat 0.10, bright 0.92), `surfaceEggshell` (0.153, 0.62, 0.89), `surfaceCard` (0.167, 0.08, 0.96)
 
-- `surfaceDarkBase` - Deep blue-black base (hue 0.556, sat 0.50, bright 0.05)
-- `surfaceDarkCard` - Elevated dark cards (hue 0.556, sat 0.50, bright 0.15)
-- `surfaceDarkHover` - Hover state on dark surfaces (hue 0.556, sat 0.50, bright 0.25)
+**Dark Mode Surfaces (blue-tinted, not pure black):**
+- `surfaceDarkBase` (0.556, 0.50, 0.05), `surfaceDarkCard` (0.556, 0.50, 0.15), `surfaceDarkHover` (0.556, 0.50, 0.25)
 
-**Accents**:
+**Dark Panel Theme (most UI uses these):**
+- `panelCharcoal` (#1A1A1A), `panelCharcoalElevated` (#242424), `panelCharcoalSurface` (#2E2E2E)
+- `panelTextPrimary` (#FFFFFF), `panelTextSecondary` (#B0B0B0), `panelTextMuted` (#8A8A8A, WCAG AA on #1A1A1A)
 
-- `accentBlue` - Primary interactive (hue 0.556, sat 0.50, bright 0.40)
-- `accentBlueLight` - Hover states (hue 0.556, sat 0.35, bright 0.55)
+**Accents:**
+- `accentBlue` (0.556, 0.50, 0.40), `accentBlueLight` (0.556, 0.35, 0.55)
 
-**Text on Cream**:
+**Text on Cream:**
+- `textOnCream` (0.556, 0.50, 0.10), `textOnCreamSecondary` (0.556, 0.30, 0.35), `textOnCreamMuted` (0.167, 0.10, 0.52)
 
-- `textOnCream` - Primary text (hue 0.556, sat 0.50, bright 0.10)
-- `textOnCreamSecondary` - Secondary text (hue 0.556, sat 0.30, bright 0.35)
-- `textOnCreamMuted` - Muted/hint text (hue 0.167, sat 0.10, bright 0.52)
+**Status (muted for Laws of UX):**
+- `statusSuccessMuted` (forest green), `statusWarningMuted` (warm amber), `statusErrorMuted` (soft red), `statusProcessingMuted` (blue)
 
-## Spacing
+**Brand:**
+- `terracotta` (#DA7756), `terracottaLight`/`terracottaHover`/`terracottaPressed`
+- `cream` (#FAF7F2), `warmCream` (#F5F0E8), `charcoal` (#2D2D2D), `softCharcoal` (#5A5A5A)
 
-Use `Spacing` enum values:
-- `Spacing.sm` - Small spacing (6-8pt)
-- `Spacing.lg` - Large spacing (16-20pt)
+**Semantic:**
+- `successGreen` (#4A9E6B), `recordingRed` (#D94F4F), `processingPurple` (#7B68A8), `warningAmber` (#D4A03D), `errorCoral` (#E05A5A)
 
-Apply consistently in `HStack` and `VStack` spacing parameters.
+**Aurora (recording visualizations):**
+- `recordingCoral` (#FF6B6B), `recordingCoralDeep` (#E85555)
+- `auroraCoral` (#EC4899), `auroraCoralLight` (#F472B6), `auroraTeal` (#3B82F6), `auroraTealLight` (#60A5FA)
 
-## Typography
+**Attention:**
+- `attentionGreen` (#22C55E), `attentionGreenDeep`/`Glow`, `errorRed` (#EF4444), `errorRedGlow`
 
-- `.buttonText` - Button font style
-- Tracking: 0.3 for buttons
-- System fonts with semantic weights
+**Heat Map (5 levels):**
+- `heatMapLevel0` (#2A2A2A) through `heatMapLevel4` (recordingCoral)
 
-## Premium Components
+## Spacing (`Spacing.` prefix)
+| Token | Value | Token | Value |
+|-------|-------|-------|-------|
+| `xs` | 4pt | `ml` | 20pt |
+| `sm` | 8pt | `lg` | 24pt |
+| `ms` | 12pt | `xl` | 32pt |
+| `md` | 16pt | `xxl` | 48pt |
+| | | `xxxl` | 64pt |
 
-**PremiumButton** (`PremiumComponents.swift`):
+## Radius (`Radius.` prefix)
+| Token | Value | Token | Value |
+|-------|-------|-------|-------|
+| `micro` | 1 | `xl` | 20 |
+| `tiny` | 2 | `xxl` | 24 |
+| `xs` | 4 | `full` | 999 |
+| `sm` | 8 | `lawsButton` | 6 |
+| `md` | 12 | `lawsCard` | 12 |
+| `lg` | 16 | `lawsModal` | 20 |
+| `pill` | 12 | `pillIdle` | 10 |
 
-Three variants:
-- `.primary` - Filled terracotta background
-- `.secondary` - Outlined style
-- `.ghost` - Text only
+## Typography (`Font.` prefix)
+| Token | Spec | Token | Spec |
+|-------|------|-------|------|
+| `displayLarge` | 36pt bold (Fraunces serif, system fallback) | `bodyLarge` | 16pt regular |
+| `displayMedium` | 28pt semibold (Fraunces) | `bodyMedium` | 14pt regular |
+| `displaySmall` | 22pt medium (Fraunces) | `bodySmall` | 13pt regular |
+| `headingLarge` | 20pt semibold | `buttonText` | 15pt semibold (tracking 0.3) |
+| `headingMedium` | 18pt semibold | `caption` | 12pt medium |
+| `headingSmall` | 16pt semibold | `tiny` | 11pt regular |
+| `transcript` | 14pt monospaced | | |
 
-Features:
-- Hover effects with symbol animations
-- Loading state with progress indicator
-- Disabled state handling
-- Minimum width 120pt
-- Rounded corners (Radius.md)
+## Animation Presets (`Animation.` prefix)
+**Spring:** `snappy` (0.3, 0.8), `smooth` (0.5, 0.85), `bouncy` (0.5, 0.6), `gentle` (0.7, 0.9), `elegant` (0.5, 0.92), `refined` (0.45, 0.95)
+**Laws of UX:** `lawsBase` (easeInOut 0.3), `lawsTap` (0.15, 0.8), `lawsSuccess` (0.4, 0.5), `lawsStateChange` (0.35, 0.85), `lawsCardHover` (0.3, 0.8), `lawsPanelExpand` (0.25, 0.85), `lawsPanelCollapse` (0.15, 0.9)
+**Pill:** `pillMorph` (0.3, 0.8), `trayExpand` (0.2, 0.85), `pillContentFade` (easeInOut 0.1)
 
-**When to use**:
-- Primary actions (onboarding completion, CTA buttons)
-- Secondary actions (cancel, back)
-- Inline actions (ghost buttons in text)
+**PillAnimationTiming:** morphDuration 0.175s, cooldownDuration 0.175s, contentFade 0.1s, celebrationDuration 2.0s, trayDuration 0.2s, toastDuration 8.0s, settleDelay 0.2s
 
-## Usage Guidelines
+## PremiumButton
+```swift
+PremiumButton(title:, icon:, variant:, isLoading:, isDisabled:, action:)
+```
+**Variants:** `.primary` (filled terracotta), `.secondary` (outlined), `.ghost` (text only)
+- Min width: 120pt, padding: 14pt vertical / 24pt horizontal, corner radius: Radius.md (12pt)
+- Hover: symbol .scale.up effect, shadow enhancement
+- Press: scale 0.97, .snappy animation
+- Loading: ProgressView replaces icon (0.7x scale)
 
-1. Use `surfaceBackground` for main views
-2. Use `surfaceCard` for grouped content
-3. Use `accentBlue` for interactive elements
-4. Apply `PremiumButton` for all primary actions
-5. Match dark mode surfaces with `surfaceDarkBase` and `surfaceDarkCard`
+## Other Premium Components
+- `PremiumCard(accentColor:, enableHover:, content:)` - Warm cream card with hover lift
+- `BenefitCard(icon:, iconColor:, title:, description:)` - Icon circle with glow + text, hover bounce
+- `StepProgressIndicator(currentStep:, totalSteps:)` - Capsule-based (28pt active / 10pt inactive)
+- `PermissionCard(icon:, title:, description:, status:, onGrant:, onOpenSettings:)` - 4-state status card
+- `QuickTipRow(icon:, text:, iconColor:)` - Small icon + text row
+- `AnimatedIcon(systemName:, size:, color:, showGlow:, isPulsing:)` - Icon with glow/pulse effects
 
-All colors defined in `DesignTokens.swift` lines 39-80.
+## Accessibility Modifiers (all respect `accessibilityReduceMotion`)
+`.pressEffect()`, `.hoverScale()`, `.pulse()`, `.glowPulse()`, `.successCheck()`, `.shake()`, `.slideIn()`, `.staggeredAppear()`
+
+## View Modifiers
+- `.shadowStyle(_ style: ShadowStyle)` - Apply named shadow
+- `.lawsCard(isHovered:)` - Dark card styling (panelCharcoalElevated + border)
+- `.premiumCard(isHovered:, glowColor:, cornerRadius:)` - Glass slab effect
+- `.floatingTooltip("text")` - Hover tooltip (1s delay, works with non-activating panels)
+
+## Gradients
+`LinearGradient.warmGlow`, `.centerWarmth`, `.buttonHighlight`, `.aiGradient`
+`RadialGradient.iconGlow`
+
+## Gotchas
+- Dark mode is NOT system-integrated - manually select dark colors per view (no @Environment(\.colorScheme) switching)
+- Fraunces serif font may not be bundled - display fonts fall back to system serif
+- `lawsButton`/`lawsCard`/`lawsModal` radius values are separate from the xs-xxl scale
+- PremiumButton hardcodes 14pt vertical padding (not a Spacing value)
+- PremiumCard (warmCream bg) vs `.lawsCard()` modifier (panelCharcoalElevated bg) - different aesthetics
+- Color.init(hex:) supports 3/6/8-digit RGB/ARGB formats

--- a/Transcripted/Onboarding/CLAUDE.md
+++ b/Transcripted/Onboarding/CLAUDE.md
@@ -1,35 +1,97 @@
 # Onboarding
 
-Manages the first-run experience and gates access to the main app until permissions and models are ready.
+3-step first-run flow that gates access to the main app until permissions and models are ready. 6 Swift files.
+
+## File Index
+
+| File | Purpose |
+|------|---------|
+| `OnboardingState.swift` | Central state manager (`@Observable`). Step progression, permission status, model readiness. |
+| `OnboardingContainerView.swift` | View orchestrator. Step switching with transitions, navigation buttons, skip confirmation. |
+| `OnboardingWindow.swift` | NSWindowController. Frosted glass background, fade-in animation, close = skip. |
+| `Steps/WelcomeStep.swift` | Welcome screen. Animated icon + 3 cascading BenefitCards. |
+| `Steps/PermissionsStep.swift` | Permission request. Mic (required) + Screen Recording (optional). Status-aware cards. |
+| `Steps/ModelSetupStep.swift` | Model downloads. Progress bars, tips carousel, auto-starts download on appear. |
 
 ## Step Order
+```
+1. Welcome     -> always canProceed
+2. Permissions  -> always canProceed (mic optional but recommended)
+3. Model Setup  -> canProceed only when parakeetReady AND diarizationReady
+```
 
-1. **Welcome** (`WelcomeStep.swift`) — Value proposition with animated benefit cards
-2. **Preview** (`PreviewStep.swift`) — Shows sample transcript to deliver the "aha moment"
-3. **Permissions** (`PermissionsStep.swift`) — Requests microphone access (required), screen recording (optional)
-4. **Model Setup** (`ModelSetupStep.swift`) — Downloads Parakeet STT and PyAnnote diarization models
+## OnboardingState Key Properties
+```swift
+// Step navigation
+currentStep: OnboardingStep (.welcome | .permissions | .modelSetup)
+stepProgress: Double (0.0-1.0), stepNumber: Int (1-3), totalSteps: 3
 
-## Key Files
+// Permissions
+microphoneStatus: AVAuthorizationStatus
+screenRecordingGranted: Bool (via CGWindowListCopyWindowInfo trick)
+microphoneGranted: Bool (computed: microphoneStatus == .authorized)
+allPermissionsGranted: Bool  // GATES APP: requires microphone only
+allPermissionsFullyGranted: Bool  // Both mic + screen recording
 
-- `OnboardingState.swift` — Central state manager using `@Observable` macro. Tracks `currentStep`, permission statuses, and model readiness flags (`parakeetReady`, `diarizationReady`).
-- `Steps/WelcomeStep.swift` — Welcome screen with animated cards
-- `Steps/PreviewStep.swift` — Sample transcript animation
-- `Steps/PermissionsStep.swift` — Permission request UI with status mapping
-- `Steps/ModelSetupStep.swift` — Model download progress with tips
+// Model setup
+parakeetReady: Bool, diarizationReady: Bool, modelsReady: Bool (computed: both true)
+parakeetProgress: Double, diarizationProgress: Double (0.0-1.0)
+parakeetPhase: String, diarizationPhase: String ("Downloading...", "Compiling models...", "Ready")
+isLoadingModels: Bool, modelError: String? (concatenated errors with \n)
+```
 
-## How It Gates the App
+## OnboardingState Key Methods
+- `checkPermissions()` - Polls current status (call on appear)
+- `requestMicrophonePermission() async` - `AVCaptureDevice.requestAccess(for: .audio)`
+- `openMicrophoneSettings()` / `openScreenRecordingSettings()` - Opens System Preferences deep links
+- `loadModels() async` - Guards re-entry with isLoadingModels flag, inits both models in parallel (`async let`)
+- `monitorDownloadProgress() async` - Polls model directories every 500ms, caps at 0.99 until ready
+- `completeOnboarding()` - Sets UserDefaults "hasCompletedOnboarding" = true
+- `hasCompletedOnboarding() -> Bool` / `resetOnboarding()` - Static helpers
 
-`OnboardingState.allPermissionsGranted` returns `true` only when microphone permission is authorized. The main app view checks this flag and shows the onboarding overlay if false. Screen recording is recommended but not required to proceed.
+## App Integration
+```swift
+// TranscriptedApp.swift -> AppDelegate.applicationDidFinishLaunching()
+if !OnboardingState.hasCompletedOnboarding() {
+    showOnboarding()  // -> OnboardingWindowController(onComplete: { setupApp() })
+    return  // Don't initialize main app until onboarding completes
+}
+setupApp()
+```
 
-## Permissions Required
+## Window Behavior
+- Size: 720x680, floating level, transparent background with frosted glass (NSVisualEffectView hudWindow)
+- Close button visible: closing = skip onboarding (calls onComplete)
+- Fade-in animation: alpha 0 -> 1 over 0.3s
+- Fade-out: alpha 1 -> 0 over 0.3s, then orders out
 
-- **Microphone** — Required for audio capture
-- **Screen Recording** — Optional but recommended for video meeting capture
+## Step Transitions
+- Asymmetric: `.opacity + .offset(x: +/-30) + .scale(0.98)`
+- Direction tracked for forward/backward offset
+- Respects `accessibilityReduceMotion` (opacity only)
+- Model setup auto-completes: when modelsReady, 1.5s delay then close onboarding
 
-## Threading
+## Permission Detection Details
+- **Microphone**: Direct `AVCaptureDevice.authorizationStatus(for: .audio)`
+- **Screen Recording**: Side-effect check via `CGWindowListCopyWindowInfo()` - if returns windows, permission granted. Not officially documented API.
+- Permission cards show 4 states: notRequested (Grant button), pending (spinner), granted (checkmark), denied (Settings button)
 
-All state updates happen on the main actor. Permission requests use `AVAudioSession` and `ScreenCaptureKit` APIs with async callbacks.
+## Model Download Monitoring
+- Watches FluidAudio model directories for file size growth
+- Expected sizes: Parakeet ~483MB, Diarization ~36MB
+- Progress capped at 0.99 (avoids showing 100% before CoreML compilation finishes)
+- At >95%: phase changes to "Compiling models..."
+- Tips carousel: 4 tips rotating every 4s while downloading
 
-## Next Steps
+## Skip Behavior
+- "Skip for now" link shown on Welcome + Permissions (not Model Setup)
+- Shows confirmation alert before skipping
+- Closing window via close button also triggers skip (prevents invisible app state)
 
-After onboarding completes, the app initializes the Core audio pipeline and begins listening for recording shortcuts.
+## Gotchas
+- Screen recording detection is not a real API - uses CGWindowListCopyWindowInfo side-effect
+- Multiple concurrent loadModels() calls blocked by isLoadingModels guard
+- Model error messages concatenated with "\n" (both errors show if both fail)
+- Progress monitoring caps at 0.99 to prevent premature "100%" display
+- OnboardingContainerView uses `@Bindable` (not `@ObservedObject`) because state uses `@Observable` macro
+- The app does NOT initialize (no menus, no audio, no floating panel) until onboarding completes

--- a/Transcripted/Services/CLAUDE.md
+++ b/Transcripted/Services/CLAUDE.md
@@ -1,45 +1,137 @@
 # Services Folder
 
-ML pipeline for speech-to-text, speaker diarization, and name inference.
+ML pipeline services, speaker database, audio processing utilities, and meeting detection. 8 Swift files.
+
+## File Index
+
+| File | Actor | Purpose |
+|------|-------|---------|
+| `ParakeetService.swift` | @MainActor | Local ASR via FluidAudio's Parakeet TDT V3 CoreML. Batch only. |
+| `DiarizationService.swift` | @MainActor | Dual-pipeline: Sortformer (streaming, 4 speakers max) + PyAnnote (offline, unlimited) |
+| `SpeakerDatabase.swift` | Utility queue | SQLite at ~/Documents/Transcripted/speakers.sqlite, 256-dim embeddings |
+| `QwenService.swift` | @MainActor | On-device Qwen3.5-4B-4bit via mlx-swift-lm, on-demand load/unload |
+| `EmbeddingClusterer.swift` | Static | 3-stage post-processing: pairwise merge, small cluster absorption, DB-informed split |
+| `AudioResampler.swift` | Static | AVAudioConverter-based resampling to 16kHz, WAV loading, slice extraction |
+| `SpeakerClipExtractor.swift` | Static | Extract per-speaker audio clips for naming UI playback |
+| `MeetingDetector.swift` | @MainActor | Monitors Zoom/Teams/Webex/FaceTime, auto-triggers recording |
 
 ## Pipeline Order
+```
+1. ParakeetService.transcribeSegment(samples, source) -> String
+2. DiarizationService.diarizeOffline(samples, sampleRate) -> [SpeakerSegment]
+3. EmbeddingClusterer.postProcess(segments, profiles, skipPairwiseMerge) -> [SpeakerSegment]
+4. SpeakerDatabase.matchSpeaker(embedding, threshold) -> SpeakerMatchResult?
+5. QwenService.inferSpeakerNames(transcript) -> [String: String]  // {"0": "Jack", "1": "Sarah"}
+```
 
-1. **ParakeetService** — Local ASR using FluidAudio's Parakeet TDT V3 CoreML model. Batch transcription only (no live streaming).
-2. **DiarizationService** — Dual-pipeline speaker diarization:
-   - Streaming (Sortformer): Real-time diarization for live preview (future use), up to 4 speakers.
-   - Offline (PyAnnote): Post-recording diarization with WeSpeaker embeddings + VBx clustering, unlimited speakers.
-3. **SpeakerDatabase** — Persistent SQLite storage for 256-dim speaker embeddings and matching.
-4. **QwenService** — On-device speaker name inference using Qwen3.5-4B via mlx-swift-lm, loads on-demand only.
+## Key Data Types
+```swift
+struct SpeakerSegment {
+    let speakerId: Int, startTime: Double, endTime: Double
+    let embedding: [Float]?    // 256-dim WeSpeaker
+    let qualityScore: Float    // 0-1
+}
 
-## Key Files
+struct SpeakerProfile: Identifiable {
+    let id: UUID
+    var displayName: String?, nameSource: String?  // "user_manual" | "qwen_inferred"
+    var embedding: [Float]     // 256-dim average
+    var firstSeen: Date, lastSeen: Date, callCount: Int
+    var confidence: Double     // 0.5-1.0, +0.1 per update, capped at 1.0
+    var disputeCount: Int
+}
 
-- **ParakeetService.swift** — ASR initialization, model loading from bundle or HuggingFace (~600MB), batch transcription.
-- **DiarizationService.swift** — DiarizerManager (streaming) and OfflineDiarizerManager (PyAnnote), produces SpeakerSegment with embeddings.
-- **SpeakerDatabase.swift** — SQLite database at `~/Documents/Transcripted/speakers.sqlite`, stores SpeakerProfile with 256-dim embeddings.
-- **QwenService.swift** — Loads Qwen3.5-4B-4bit model on-demand (~2.5GB), infers names from transcript text, unloads after inference.
+struct SpeakerMatchResult { let profile: SpeakerProfile, similarity: Double }
+```
 
 ## Speaker DB Schema
+```sql
+CREATE TABLE speakers (
+    id TEXT PRIMARY KEY,          -- UUID string
+    display_name TEXT,
+    name_source TEXT DEFAULT NULL, -- "user_manual", "qwen_inferred"
+    embedding BLOB NOT NULL,       -- 256-dim float32 binary
+    first_seen TEXT NOT NULL,      -- ISO8601
+    last_seen TEXT NOT NULL,
+    call_count INTEGER DEFAULT 1,
+    confidence REAL DEFAULT 0.5,
+    dispute_count INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+```
+WAL mode, busy_timeout 5000ms, 0o600 permissions. All writes via dedicated utility queue.
 
-- **Table**: `speakers`
-- **Columns**: id (UUID), displayName (String?), nameSource (String?), embedding (BLOB 256-dim), firstSeen (Date), lastSeen (Date), callCount (Int), confidence (Double), disputeCount (Int)
-- **Matching**: Cosine similarity between new embedding and stored embeddings, threshold-based assignment.
+## SpeakerDatabase Key Methods
+- `matchSpeaker(embedding:, threshold: 0.6)` -> best match above threshold via cosine similarity (vDSP-accelerated)
+- `addOrUpdateSpeaker(embedding:, existingId:)` -> NEW: confidence=0.5, callCount=1. UPDATE: EMA blend (alpha=0.15), confidence += 0.1, callCount += 1
+- `setDisplayName(id:, name:, source:)` -> updates name + source provenance
+- `allSpeakers()`, `getSpeaker(id:)`, `deleteSpeaker(id:)`, `findProfilesByName(_:)` (fuzzy, with name variants)
+- `mergeProfiles(sourceId:, into:)` -> blend by callCount weight, atomic transaction
+- `pruneWeakProfiles()` -> deletes unnamed AND callCount<=1 AND confidence<=0.5 AND age>1hr
 
-## Model Cache Locations
+## Cosine Similarity Thresholds (vary by context)
+| Context | Threshold | Purpose |
+|---------|-----------|---------|
+| `matchSpeaker()` default | 0.60 | New segment matching |
+| Pairwise merge (EmbeddingClusterer) | 0.85 | Very conservative cluster merge |
+| Small cluster absorption | 0.72 | Merge short interjections |
+| Micro-cluster absorption (<10s) | 0.15 | Force-absorb noise fragments |
+| DB-informed split per-segment | 0.62 | Re-separate mixed clusters |
+| Adaptive threshold (1 segment) | 0.85 | High certainty for single segment |
+| Adaptive threshold (2-3 segments) | 0.78 | Moderate caution |
+| Adaptive threshold (4+ segments) | 0.70 | Reliable mean embedding |
 
-- **Parakeet**: Bundled in app or downloaded to system temp (~600MB)
-- **Qwen**: `~/Library/Caches/models/mlx-community/Qwen3.5-4B-4bit` (~2.5GB)
-- **Diarization**: Bundled or downloaded via FluidAudio
+## EmbeddingClusterer 3-Stage Pipeline
+```
+postProcess(segments, existingProfiles, skipPairwiseMerge):
+  Stage 1 - Pairwise Merge (skip for PyAnnote, VBx already handles):
+    Union-find graph, merge clusters with mean similarity >= 0.85
+  Stage 2 - Small Cluster Absorption:
+    Micro-clusters (<10s): absorb at 0.15 floor (catches "Mm-hmm" fragments)
+    Small clusters (10-30s): absorb at 0.72 threshold
+  Stage 3 - DB-Informed Split:
+    Per-segment matching against known profiles (threshold 0.62)
+    Minimum 8 segments per profile to claim ownership
+    Splits mixed clusters where diarizer merged 2+ speakers
+```
 
-## Threading Rules
+## QwenService Details
+- **Model**: `mlx-community/Qwen3.5-4B-4bit` (~2.5GB)
+- **Cache**: `~/Library/Caches/models/mlx-community/Qwen3.5-4B-4bit`
+- **Inference**: temperature=0.1 (deterministic), maxTokens=200
+- **Prompt**: Teaches model that "Hey Jack" means speaker is talking TO Jack (listener), not IS Jack
+- **Output**: JSON keys are speaker numbers ("0", "1"), values are names or "Unknown"
+- **Response parsing**: Strips markdown fences, extracts JSON, returns `[:]` on parse failure
+- **Lifecycle**: Load on-demand -> inference -> unload immediately (frees ~2.5GB)
+- **Double-load guard**: Prevents 2x memory allocation during concurrent async calls
 
-- All services are `@MainActor` — never call from background threads.
-- SpeakerDatabase uses a dedicated utility queue for SQLite operations.
-- QwenService loads on-demand to avoid 2.5GB memory spike at app startup.
-- Never commit to main — these are production-critical ML components.
+## MeetingDetector
+- **Known apps**: Zoom (`us.zoom.xos`), Teams (`com.microsoft.teams2`), Webex, FaceTime, Loom
+- **Detection**: NSWorkspace app launch/quit notifications + 1s polling
+- **Auto-start trigger**: Both mic + system audio > 0.02 for >= 5 seconds
+- **Auto-stop**: 15 seconds of silence grace period
+- **Manual override**: Only auto-stops recordings it auto-triggered, not manual ones
 
-## Critical Notes
+## AudioResampler
+- `loadAndResample(url:, targetRate: 16000)` -> hardware-accelerated via AVAudioConverter
+- Streams in 30-second chunks to avoid memory spikes
+- Handles stereo-to-mono + rate conversion in one pass
+- Single `convert()` call to avoid AVAudioConverter terminal state bug
 
-- Parakeet: No I/O in CoreAudio callbacks, batch transcription only.
-- Diarization: Both pipelines produce identical 256-dim WeSpeaker embeddings.
-- Qwen: Unloads immediately after inference to free memory.
-- SpeakerDatabase: Thread-safe with queue-based SQLite access.
+## SpeakerClipExtractor
+- Extracts per-speaker clips for naming UI: prefers single long utterance >= 3s, else concatenates (cap 8s)
+- Persistent clips at `~/Documents/Transcripted/speaker_clips/{speakerId}.wav`
+- Overwrites on subsequent recordings (keeps latest voice sample)
+
+## Name Variants
+Hardcoded lookup table: mike/michael/mikey, nate/nathan/nathaniel, dave/david, alex/alexander/alexandra, dan/daniel/danny, matt/matthew, chris/christopher, nick/nicholas, rob/robert/bob, + 15 more. Also substring matching.
+
+## Gotchas
+- EMA alpha=0.15 is SLOW: takes 6-7 updates to meaningfully shift a speaker profile
+- Embeddings can be both `nil` AND empty `[]` - check both
+- SpeakerDatabase silently returns in-memory dummy profiles if DB open fails (logs CRITICAL)
+- Qwen has no chunk limits on input - very long transcripts could exceed context window
+- Quality filter cascades: EmbeddingClusterer hardcodes qualityScore >= 0.3 AND duration >= 1.0s
+- New speaker IDs from EmbeddingClusterer start above max existing ID (can create gaps)
+- Pruning is conservative: only deletes after 1 hour (won't clean up fresh noise)
+- WAL mode leaves .sqlite-wal and .sqlite-shm files alongside DB (expected)

--- a/Transcripted/UI/FloatingPanel/CLAUDE.md
+++ b/Transcripted/UI/FloatingPanel/CLAUDE.md
@@ -1,35 +1,141 @@
 # FloatingPanel
 
-Floating panel UI that morphs between states like Apple's Dynamic Island.
+Morphing pill UI (Dynamic Island style) with aurora visualizations, transcript tray, and speaker naming dialog. 16 Swift files.
 
-## Key Files
+## File Index
 
-- **PillStateManager.swift** - State machine for pill states (idle → recording → processing → idle). Handles animation timing, timeout recovery, and sound feedback.
-- **FloatingPanelView.swift** - SwiftUI view that renders the pill and tray overlays. Manages tray state (none/transcripts/speakerNaming).
-- **FloatingPanelController.swift** - NSWindowController that creates the floating panel window, handles position persistence, and wires state bindings.
+| File | Purpose |
+|------|---------|
+| **PillStateManager.swift** | State machine: idle -> recording -> processing. Timeout recovery, sound feedback. |
+| **FloatingPanelView.swift** | Root SwiftUI view. Tray mux (none/transcripts/speakerNaming), toast layer, pill content switch. |
+| **FloatingPanelController.swift** | NSWindowController. Position persistence, Combine subscriptions to Audio/TaskManager, window setup. |
+| **AuroraIdleView.swift** | Collapsed pill (40x20px). Hover-expands to 200x44px with Record + Transcripts buttons. |
+| **AuroraRecordingView.swift** | Recording state (180x40px). Live aurora fog: coral (mic, left) + teal (system, right). Timer + stop. |
+| **AuroraProcessingView.swift** | Processing state (180x40px). Progress-based aurora intensity. Warning text at 90s+. |
+| **AuroraSuccessView.swift** | Success feedback (200x44px). Animated checkmark + "Saved" + Copy/Open buttons. |
+| **TranscriptTrayView.swift** | Recent transcript list (280x300px max). Frosted glass. Detail view for single transcript. |
+| **TranscriptDetailView.swift** | Single transcript viewer. Groups lines by speaker with colored left borders. |
+| **SpeakerNamingView.swift** | Post-recording speaker naming. Play clips, confirm/reject names, merge with existing profiles. |
+| **WaveformViews.swift** | EdgePeekView, WaveformMiniView, DormantWaveformView, MinimalWaveformIcon. |
+| **PillViews.swift** | Legacy pill views (PillIdleView, PillRecordingView, PillProcessingView) - mostly unused, replaced by Aurora. |
+| **CelebrationViews.swift** | CelebrationOverlay with ring/checkmark animations. |
+| **ErrorViews.swift** | ToastNotificationView (8s auto-dismiss), PillErrorView (shake), ContextualError enum. |
+| **AttentionPromptView.swift** | Silence warning + still-recording detection prompt. |
+| **LawsComponents.swift** | AnimatedDotsView, LawsButton, FloatingTooltipModifier, Triangle connector shape. |
 
-## Pill States
+## Pill State Machine
+```
+States:
+  idle       -> 40x20px capsule (hover-expands to 200x44px)
+  recording  -> 180x40px with live aurora + timer + stop button
+  processing -> 180x40px with progress aurora + status text
 
-1. **idle** (40x20px) - Dormant waveform, capsule shape
-2. **recording** (180x40px) - Live visualizer + timer + stop button
-3. **processing** (180x40px) - Status text + progress indicator
+Timing:
+  morphDuration: 0.175s    cooldownDuration: 0.175s
+  contentFade: 0.1s        transitionTimeout: 2.0s (force-reset if stuck)
 
-## Rules
+Sounds:
+  -> recording:  "Pop"     recording -> processing: "Tink"
+  processing -> idle: "Glass"    -> failed: "Basso"
 
-- **@MainActor** - All state changes happen on main thread
-- **No I/O in CoreAudio callbacks** - Audio callbacks only update state flags
-- **Timeout recovery** - If transition stuck >2s, force-reset to idle
-- **Sound feedback** - PillSounds plays system sounds on state transitions (Pop/Tink/Glass/Basso)
-- **Position persistence** - Saves x/y coordinates to UserDefaults, centers above dock on first launch
+Lock mechanism:
+  lock()   -> prevents state changes (during review tray)
+  unlock() -> releases lock, optionally resets to idle
+  forceUnlock() -> emergency: clears all flags, forces idle
+```
 
-## Connections
+## Tray States (mutually exclusive overlays)
+```
+case none           -> pill only
+case transcripts    -> scrollable transcript list (dismisses when pill -> processing)
+case speakerNaming  -> naming dialog (STICKY - persists during pill state changes)
+```
 
-- **PillStateManager** receives `isRecording` from `Audio` class and `displayStatus` from `TranscriptionTaskManager`
-- **FloatingPanelView** embeds `TranscriptTrayView` and `SpeakerNamingView` as overlays
-- **FloatingPanelController** wires up Combine subscriptions to react to audio/task changes
+## View Hierarchy
+```
+FloatingPanelView (320pt wide)
+  |-- Spacer (pushes content to bottom)
+  |-- SpeakerNamingView OR TranscriptTrayView (conditional)
+  |-- Toast layer (ToastNotificationView, floats 60pt above pill when no tray)
+  +-- Pill content (morphs between aurora states)
+      |-- idle -> AuroraIdleView (failed badge, processing pulse dot)
+      |-- recording -> AuroraRecordingView (audio-reactive fog)
+      +-- processing -> AuroraSuccessView OR AuroraProcessingView
+```
 
-## Tray States
+## FloatingPanelController - Window Setup
+- NSPanel: borderless, nonactivatingPanel, floating level, canJoinAllSpaces
+- `isMovableByWindowBackground = true` (drag anywhere)
+- Transparent background, no shadow, always visible (`hidesOnDeactivate = false`)
+- `canBecomeKey = false` by default (doesn't steal focus). Set true during speaker naming.
+- Position saved to UserDefaults: `floatingPanelX`, `floatingPanelY`
+- Dock height detected via `visibleFrame.origin.y - screenFrame.origin.y`
 
-- **none** - Pill only, no overlay
-- **transcripts** - Expands upward to show transcript history
-- **speakerNaming** - Shows naming dialog for unidentified speakers (mutually exclusive with transcripts)
+## Combine Subscriptions (State Sync)
+```
+audio.$isRecording (.debounce 50ms):
+  true  -> transition(to: .recording)
+  false -> .processing (if status.isProcessing) or .idle
+
+taskManager.$displayStatus:
+  .gettingReady      -> show processing 1.5s, return to idle
+  .transcriptSaved   -> show success 2.5s (guard: !isRecording, !speakerNaming)
+  .failed            -> play error sound, show processing 4.0s
+
+taskManager.$speakerNamingRequest:
+  != nil -> panel.allowKeyFocus = true, makeKey()
+  == nil -> panel.resignKey()
+```
+
+## Aurora Recording Visualization
+- **Mic fog** (coral, biased LEFT): 2 orbs, audio-reactive (audioBoost: 0.6-2.1x)
+- **System fog** (teal, biased RIGHT): 2 orbs, breathing only (not audio-reactive)
+- Smoothing factor: 0.08 at 30fps (prevents jitter)
+- Pseudo-noise: 4-wave sum for organic non-repeating motion
+- `drawingGroup()` for GPU rendering, 8px blur
+- Respects `accessibilityReduceMotion`
+
+## Speaker Naming Flow
+```
+SpeakerNamingView appears -> 3-second dismiss guard (prevents accidental close)
+  Per speaker (SpeakerNamingCard):
+    - Play audio clip via ClipAudioPlayer (one at a time)
+    - IF needsNaming: text input + autocomplete from SpeakerDatabase
+    - IF needsConfirmation: show name + similarity% + Confirm/Reject
+    - IF mergeCandidate: "Link to [name]?" + checkmark/X
+  onUpdate callback: SpeakerNameUpdate { persistentSpeakerId, newName, action }
+    actions: .named, .corrected, .confirmed, .merged(targetProfileId)
+```
+
+## Error Toast System
+```
+ContextualError.from(message: String) -> classifies by keywords:
+  "microphone/mic" -> .microphoneError
+  "speech/transcri" -> .transcriptionFailed
+  "network/connection" -> .networkError
+  "disk/storage/full" -> .storageFull
+  "permission/denied" -> .permissionDenied
+  default -> .unknown
+Each has: icon, title, recoveryHint, color (amber or red)
+Auto-dismiss: 8 seconds. Hidden when tray is open.
+```
+
+## Escape Key Handling
+- Local monitor (app frontmost) + Global monitor (other app frontmost)
+- Speaker naming: 3-second guard before allowing dismiss
+- Transcript tray: dismiss immediately
+- Monitors installed/removed on trayState change
+
+## Design Tokens Used
+Colors: panelCharcoal, panelCharcoalElevated, panelCharcoalSurface, panelTextPrimary/Secondary/Muted, recordingCoral, auroraCoral/CoralLight, auroraTeal/TealLight, accentBlue, statusSuccessMuted, statusErrorMuted, statusWarningMuted, systemAudioIndicator
+Dimensions: PillDimensions (idleWidth:40, recordingWidth:180, trayWidth:280, trayMaxHeight:300)
+Animations: .pillMorph, .trayExpand, .pillContentFade
+
+## Gotchas
+- Naming tray is STICKY (persists across pill states), transcript tray is NOT (auto-closes on processing)
+- Toast notification space collapses to 0pt when tray is open
+- AuroraSuccessView auto-dismiss (2.5s) is controlled by FloatingPanelController, not the view itself
+- Speaker colors are hash-based (name % 5 palette), user always gets .accentBlue
+- `hasSettled` in AuroraIdleView: starts false after success view to allow smooth size transition
+- Silence prompt triggers at 120s of silence (not recording duration)
+- Copy button in success view shows checkmark 1.5s then reverts

--- a/Transcripted/UI/Settings/CLAUDE.md
+++ b/Transcripted/UI/Settings/CLAUDE.md
@@ -1,38 +1,88 @@
 # Settings
 
-Single-page settings view with no sidebar or tabs.
+Single-page scrolling settings dashboard. 4 Swift files.
 
-## Key Files
+## File Index
 
-- **SettingsContainerView.swift** - Main settings view with sections: Stats, Failed Transcriptions, Voice Fingerprints, Preferences
-- **SettingsWindowController.swift** - Window controller that hosts the settings panel
+| File | Purpose |
+|------|---------|
+| `SettingsContainerView.swift` (896 lines) | Main view with 8 sections + top bar + migration overlay |
+| `Components/SettingsSectionCard.swift` (497 lines) | Reusable card container + 4 helper components + 4 button styles |
+| `SettingsWindowController.swift` (144 lines) | NSWindow management, triggers migration check on show |
+| `Models/SettingsNavigationState.swift` (89 lines) | Migration state + unused SettingsTab enum (vestigial) |
 
-## Sections
+## Sections (in render order)
+1. **Top Bar** - Branding ("Transcripted" + waveform icon) + audio device name (right)
+2. **Stats** ("ALL TIME") - Total recordings + hours, Open Folder + Refresh buttons
+3. **Failed Transcriptions** (conditional) - First 3 failures with retry/delete, "Retry All" button
+4. **Voice Fingerprints** (collapsible) - Speaker list: play clip, edit name inline, delete with confirmation
+5. **Profile** - User name (TextField), save location (path picker, default ~/Documents/Transcripted/)
+6. **Meeting Detection** - Auto-record toggle, supported apps info (Zoom/Teams/Webex/FaceTime/Loom)
+7. **Speaker Intelligence** - Qwen toggle, model status/download, progress bar
+8. **AI Services** - Parakeet + Sortformer status badges, "100% local" info
 
-1. **Stats** - All-time metrics: total recordings, hours recorded, open folder button, refresh button
-2. **Failed Transcriptions** - List of failed transcripts with retry buttons (only shown if any exist)
-3. **Voice Fingerprints** - Collapsible speaker management: add/edit/delete speakers, play audio clips
-4. **Preferences** - User profile, save location, format options (Obsidian/Markdown), auto-record meetings
-5. **Meeting Detection** - Auto-record when meeting detected settings
-6. **Speaker Intelligence** - Qwen model inference toggle
-7. **AI Services** - Model management and status
+## @AppStorage Keys
+| Key | Type | Default | UI Element |
+|-----|------|---------|------------|
+| `transcriptSaveLocation` | String | "" (-> ~/Documents/Transcripted/) | Path picker |
+| `userName` | String | "" | Text field |
+| `enableQwenSpeakerInference` | Bool | true | Toggle |
+| `enableObsidianFormat` | Bool | false | (used by TranscriptSaver, no UI toggle here) |
+| `autoRecordMeetings` | Bool | false | Toggle |
+| `enableUISounds` | Bool | true | Read via UserDefaults (not @AppStorage) |
 
-## State Management
+## Reusable Components (SettingsSectionCard.swift)
 
-- Uses `@AppStorage` for user preferences (transcriptSaveLocation, userName, enableQwenSpeakerInference, etc.)
-- `StatsService` tracks metrics and writes to SQLite database
-- `SpeakerDatabase.shared` manages speaker profiles
-- `QwenService` handles speaker name inference via LLM
+**Layout Components:**
+- `SettingsSectionCard(icon:, title:, content:)` - Dark card with uppercase header
+- `SettingsToggleRow(title:, description:, isOn:)` - Toggle + label + optional description
+- `CoralToggle(isOn:)` - Custom toggle (44x24pt, coral ON / charcoal OFF, 0.2s animation)
+- `SettingsTextField(title:, placeholder:, text:, isSecure:, onVerify:)` - Input with focus border
+- `SettingsRadioGroup<T>(title:, options:, selection:, descriptions:)` - Radio buttons
+- `SettingsPathRow(title:, path:, defaultPath:, onChoose:)` - Folder picker with ~ display
 
-## Rules
+**Button Styles:**
+- `SettingsPrimaryButtonStyle` - Coral filled, white text
+- `SettingsSecondaryButtonStyle` - Gray background, hover highlight
+- `SettingsDestructiveButtonStyle` - Red text, red bg on hover
+- `SettingsIconButtonStyle` - 28x28 circle, gray bg on hover
 
-- **Single scrolling page** - No tabs or sidebars
-- **Migration overlay** - Shows progress bar when importing old transcripts
-- **Sound toggle** - Respects `enableUISounds` preference
-- **Speaker editing** - Inline editing with delete confirmation
+## Speaker Management Operations
+```
+Edit: tap name -> inline TextField -> commit on Return
+  -> SpeakerDatabase.shared.setDisplayName(id:, name:, source: "user_manual")
+  -> TranscriptSaver.retroactivelyUpdateSpeaker(dbId:, newName:)
 
-## Connections
+Delete: click delete -> "Delete?" confirm -> "Yes"
+  -> SpeakerClipExtractor.deletePersistedClip(for:)
+  -> SpeakerDatabase.shared.deleteSpeaker(id:)
 
-- Reads from `StatsService` and `SpeakerDatabase`
-- Writes to UserDefaults and SQLite databases
-- Opens System Settings for microphone/screen recording permissions
+Play: toggle clip playback via ClipAudioPlayer (requires persistent clip)
+```
+Delayed reload pattern: `DispatchQueue.main.asyncAfter(deadline: .now() + 0.1)` after DB writes.
+
+## Migration System
+- Trigger: `SettingsWindowController.showWindow()` calls `checkMigrationNeeded()`
+- Flow: `TranscriptScanner.migrateExistingTranscripts { progress, status in ... }`
+- UI: `MigrationOverlayView` with progress bar + percentage, dark overlay
+- Completion: Alert with "Successfully imported X transcripts"
+
+## Window Configuration
+- Size: 500x400 (min) to 800x900 (max), centered
+- Appearance: `.darkAqua`, titlebar transparent, title hidden
+- Background: `NSColor(Color.panelCharcoal)`
+- Not released when closed (`isReleasedWhenClosed = false`)
+
+## Design Tokens Used
+Colors: panelCharcoal/Elevated/Surface, panelText Primary/Secondary/Muted, recordingCoral, accentBlue, attentionGreen, warningAmber, errorRed
+Spacing: xs, sm, ms, md, lg, xl
+Radius: lawsCard, lawsButton
+Typography: .headingLarge, .headingMedium, .bodyMedium, .bodySmall, .caption
+
+## Gotchas
+- Sound toggle uses `UserDefaults.standard.object(forKey:)` (not @AppStorage) to distinguish "never set" vs "explicitly disabled"
+- Single `editingId: UUID?` means only one speaker can be edited at a time
+- `enableObsidianFormat` is stored in AppStorage but has no UI toggle in settings (used by TranscriptSaver)
+- SettingsNavigationState has an unused `SettingsTab` enum + `selectTab()` method (vestigial tabbed design)
+- Avatar: first letter of displayName in circle, "?" fallback if no name
+- Qwen download in settings caches the model then immediately calls `unload()` to free memory


### PR DESCRIPTION
## What

Adds 7 `CLAUDE.md` files — one at the project root and one in each major folder — to help AI agents (and humans) navigate the codebase efficiently.

## Why

Without these, an agent burns 3-4 tool calls figuring out where relevant code lives before doing any real work. With them, it reads one file and knows exactly what files matter, what the rules are, and how things connect.

## Files

| File | Purpose |
|---|---|
| `CLAUDE.md` | Project overview, build commands, critical rules, folder map |
| `Core/CLAUDE.md` | Audio pipeline, threading model (NO I/O in CoreAudio), transcript output format |
| `Services/CLAUDE.md` | ML pipeline order (Parakeet → PyAnnote → WeSpeaker → Qwen), speaker DB schema |
| `UI/FloatingPanel/CLAUDE.md` | Pill state machine, tray states, connections to Core |
| `UI/Settings/CLAUDE.md` | Settings sections, state management patterns |
| `Onboarding/CLAUDE.md` | Step order, gating logic, permissions required |
| `Design/CLAUDE.md` | Color tokens, spacing, PremiumButton usage |

## Notes

- Written by local Qwen3.5 35B agent — quality graded B+ to A overall
- Services/CLAUDE.md and root CLAUDE.md are the strongest (A grade)
- UI files are functional but thin — can be improved iteratively
- 307 lines total across all 7 files