### PR TITLE
Add pill onboarding callout with glow ring

### DIFF
--- a/Transcripted.xcodeproj/project.pbxproj
+++ b/Transcripted.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		FA000016 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA000006 /* CoreAudio.framework */; };
 		Q1000001 /* QwenService.swift in Sources */ = {isa = PBXBuildFile; fileRef = Q1000002 /* QwenService.swift */; };
 		A2000001 /* DiagnosticExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000002 /* DiagnosticExporter.swift */; };
+		PC000011 /* PillCalloutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = PC000001 /* PillCalloutView.swift */; };
+		PC000012 /* PillCalloutController.swift in Sources */ = {isa = PBXBuildFile; fileRef = PC000002 /* PillCalloutController.swift */; };
 		Q1000011 /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = Q1000012 /* MLXLLM */; };
 		SP000001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = SP000002 /* Sparkle */; };
 		Q1000021 /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = Q1000022 /* MLXLMCommon */; };
@@ -158,6 +160,8 @@
 		A1001021 /* TranscriptStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptStore.swift; sourceTree = "<group>"; };
 		A1001031 /* TranscriptExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptExporter.swift; sourceTree = "<group>"; };
 		A2000002 /* DiagnosticExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticExporter.swift; sourceTree = "<group>"; };
+		PC000001 /* PillCalloutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillCalloutView.swift; sourceTree = "<group>"; };
+		PC000002 /* PillCalloutController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillCalloutController.swift; sourceTree = "<group>"; };
 		A1001023 /* TranscriptTrayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTrayView.swift; sourceTree = "<group>"; };
 		A1001025 /* TranscriptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptDetailView.swift; sourceTree = "<group>"; };
 		A1001110 /* SettingsNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationState.swift; sourceTree = "<group>"; };
@@ -363,6 +367,7 @@
 			isa = PBXGroup;
 			children = (
 				A100090A /* FloatingPanelController.swift */,
+				PC000002 /* PillCalloutController.swift */,
 				A1000901 /* PillStateManager.swift */,
 				A1000909 /* FloatingPanelView.swift */,
 				A1000920 /* Components */,
@@ -386,6 +391,7 @@
 				A100090D /* AuroraProcessingView.swift */,
 				A100090E /* AuroraSuccessView.swift */,
 				A100090F /* SpeakerNamingView.swift */,
+				PC000001 /* PillCalloutView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -675,6 +681,8 @@
 				Q1000001 /* QwenService.swift in Sources */,
 				4CAF116349811906B83C0406 /* ModelSetupStep.swift in Sources */,
 				A2000001 /* DiagnosticExporter.swift in Sources */,
+				PC000011 /* PillCalloutView.swift in Sources */,
+				PC000012 /* PillCalloutController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Transcripted/Onboarding/OnboardingContainerView.swift
+++ b/Transcripted/Onboarding/OnboardingContainerView.swift
@@ -51,15 +51,6 @@ struct OnboardingContainerView: View {
                     .transition(reduceMotion ? .opacity : pageTransition)
                     .id(state.currentStep)
                     .animation(reduceMotion ? .none : .smooth, value: state.currentStep)
-                    .onChange(of: state.modelsReady) { _, ready in
-                        if ready && state.currentStep == .modelSetup {
-                            // Brief delay so user sees the success checkmarks, then auto-complete
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                                state.completeOnboarding()
-                                onComplete()
-                            }
-                        }
-                    }
 
                 // Navigation buttons
                 navigationButtons
@@ -72,7 +63,6 @@ struct OnboardingContainerView: View {
             }
         }
         .frame(width: 720, height: 680)
-        .clipShape(RoundedRectangle(cornerRadius: Radius.xl))
         .shadow(color: .black.opacity(0.15), radius: 30, y: 10)
         .onAppear {
             state.checkPermissions()

--- a/Transcripted/Onboarding/OnboardingState.swift
+++ b/Transcripted/Onboarding/OnboardingState.swift
@@ -295,8 +295,19 @@ class OnboardingState {
         UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
     }
 
+    // MARK: - Pill Callout (first-time coach mark)
+
+    static func hasShownPillCallout() -> Bool {
+        UserDefaults.standard.bool(forKey: "hasShownPillCallout")
+    }
+
+    static func markPillCalloutShown() {
+        UserDefaults.standard.set(true, forKey: "hasShownPillCallout")
+    }
+
     // For testing: reset onboarding state
     static func resetOnboarding() {
         UserDefaults.standard.removeObject(forKey: "hasCompletedOnboarding")
+        UserDefaults.standard.removeObject(forKey: "hasShownPillCallout")
     }
 }

--- a/Transcripted/TranscriptedApp.swift
+++ b/Transcripted/TranscriptedApp.swift
@@ -37,6 +37,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUserNotifi
 
     // Onboarding
     var onboardingWindowController: OnboardingWindowController?
+    var pillCalloutController: PillCalloutController?
 
     // Auto-updates (Sparkle)
     #if canImport(Sparkle)
@@ -213,6 +214,25 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUserNotifi
             failedTranscriptionManager: ftm
         )
         floatingPanel?.showWindow(nil)
+
+        // Show pill callout for first-time users
+        if !OnboardingState.hasShownPillCallout() {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                guard let pillWindow = self?.floatingPanel?.window else { return }
+                // Enable glow ring on the pill
+                self?.floatingPanel?.pillStateManager.showOnboardingGlow = true
+                self?.pillCalloutController = PillCalloutController(
+                    pillFrame: pillWindow.frame,
+                    onDismiss: { [weak self] in
+                        OnboardingState.markPillCalloutShown()
+                        self?.floatingPanel?.pillStateManager.showOnboardingGlow = false
+                        self?.pillCalloutController?.window?.orderOut(nil)
+                        self?.pillCalloutController = nil
+                    }
+                )
+                self?.pillCalloutController?.showWindow(nil)
+            }
+        }
 
         // Dynamic menu bar icon: changes when recording starts/stops
         aud.$isRecording

--- a/Transcripted/UI/FloatingPanel/Components/AuroraIdleView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/AuroraIdleView.swift
@@ -11,6 +11,7 @@ struct AuroraIdleView: View {
     let failedCount: Int
     var backgroundTaskCount: Int = 0
     var forceExpanded: Bool = false
+    var showOnboardingGlow: Bool = false
 
     @Environment(\.accessibilityReduceMotion) var reduceMotion
     @State private var isHoverExpanded = false
@@ -100,6 +101,13 @@ struct AuroraIdleView: View {
         )
         .shadow(color: Color.black.opacity(0.3), radius: 8, y: 2)
         .glowPulse(when: backgroundTaskCount > 0 && !isExpanded, color: .recordingCoral)
+        .overlay(
+            Capsule()
+                .strokeBorder(Color.premiumCoral, lineWidth: showOnboardingGlow ? 2 : 0)
+                .shadow(color: showOnboardingGlow ? Color.premiumCoral.opacity(0.6) : .clear, radius: showOnboardingGlow ? 10 : 0)
+                .shadow(color: showOnboardingGlow ? Color.premiumCoral.opacity(0.3) : .clear, radius: showOnboardingGlow ? 20 : 0)
+                .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true), value: showOnboardingGlow)
+        )
     }
 
     // MARK: - Failed Badge

--- a/Transcripted/UI/FloatingPanel/Components/PillCalloutView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/PillCalloutView.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+
+/// Coach mark callout that appears above the pill to introduce it to first-time users.
+/// Features a downward-pointing arrow, glassmorphism background, and persists until dismissed.
+@available(macOS 26.0, *)
+struct PillCalloutView: View {
+    let onDismiss: () -> Void
+
+    @State private var isVisible = false
+    @State private var arrowBounce = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Callout bubble
+            ZStack(alignment: .topTrailing) {
+                HStack(spacing: 12) {
+                    // Icon
+                    ZStack {
+                        Circle()
+                            .fill(LinearGradient(
+                                colors: [Color.premiumCoral.opacity(0.2), Color.premiumCoral.opacity(0.05)],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            ))
+                            .frame(width: 36, height: 36)
+
+                        Image(systemName: "mic.fill")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundColor(.premiumCoral)
+                    }
+
+                    // Text
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("This is your recording pill")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(.softWhite)
+
+                        Text("Click the mic to start recording. It lives here above your dock.")
+                            .font(.system(size: 11.5, weight: .medium))
+                            .foregroundColor(.panelTextSecondary)
+                            .lineSpacing(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Spacer(minLength: 20)
+                }
+                .padding(14)
+                .padding(.trailing, 8) // Extra space for X button
+
+                // X close button
+                Button(action: dismiss) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(.panelTextSecondary)
+                        .frame(width: 22, height: 22)
+                        .background(
+                            Circle()
+                                .fill(Color.white.opacity(0.1))
+                        )
+                }
+                .buttonStyle(PlainButtonStyle())
+                .padding(8)
+            }
+            .background(
+                ZStack {
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(Color.glassBackground)
+                        .background(
+                            VisualEffectBlur(material: .hudWindow, blendingMode: .behindWindow)
+                                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                        )
+
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .strokeBorder(
+                            LinearGradient(
+                                colors: [Color.white.opacity(0.2), Color.white.opacity(0.05)],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            ),
+                            lineWidth: 1
+                        )
+                }
+            )
+            .shadow(color: .black.opacity(0.3), radius: 12, y: 6)
+
+            // Downward-pointing arrow (big, obvious, pulsing)
+            Triangle()
+                .rotation(.degrees(180))
+                .fill(Color.panelCharcoal.opacity(0.85))
+                .frame(width: 24, height: 14)
+                .shadow(color: .black.opacity(0.2), radius: 4, y: 2)
+                .offset(y: arrowBounce ? 4 : -1)
+                .animation(
+                    .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
+                    value: arrowBounce
+                )
+        }
+        .frame(width: 320)
+        .offset(y: isVisible ? 0 : 10)
+        .opacity(isVisible ? 1 : 0)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Welcome tooltip: This is your recording pill. Click the mic to start recording. It lives here above your dock.")
+        .onAppear {
+            withAnimation(.spring(response: 0.5, dampingFraction: 0.7)) {
+                isVisible = true
+            }
+            // Start arrow bounce after entry animation settles
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                arrowBounce = true
+            }
+        }
+    }
+
+    private func dismiss() {
+        withAnimation(.easeOut(duration: 0.2)) {
+            isVisible = false
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            onDismiss()
+        }
+    }
+}

--- a/Transcripted/UI/FloatingPanel/FloatingPanelView.swift
+++ b/Transcripted/UI/FloatingPanel/FloatingPanelView.swift
@@ -259,7 +259,8 @@ struct FloatingPanelView: View {
                 onTranscripts: { toggleTranscriptTray() },
                 failedCount: failedTranscriptionManager.failedTranscriptions.count,
                 backgroundTaskCount: taskManager.backgroundTaskCount,
-                forceExpanded: trayState != .none
+                forceExpanded: trayState != .none,
+                showOnboardingGlow: pillStateManager.showOnboardingGlow
             )
         case .recording:
             AuroraRecordingView(audio: audio, onStop: {

--- a/Transcripted/UI/FloatingPanel/PillCalloutController.swift
+++ b/Transcripted/UI/FloatingPanel/PillCalloutController.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import AppKit
+
+/// Manages a small floating panel that displays the pill onboarding callout.
+/// Positioned just above the pill's visual bounds (pill is pinned to the bottom of its window).
+@available(macOS 26.0, *)
+@MainActor
+class PillCalloutController: NSWindowController {
+    init(pillFrame: NSRect, onDismiss: @escaping () -> Void) {
+        let calloutWidth: CGFloat = 320
+        let calloutHeight: CGFloat = 120
+        let arrowHeight: CGFloat = 14
+        let gap: CGFloat = 12
+
+        // The pill is pinned to the BOTTOM of its window with 10pt padding.
+        // Its visual top is at: window.origin.y + 10 (bottom padding) + pill height
+        let pillVisualTop = pillFrame.origin.y + 10 + PillDimensions.idleHeight
+        let x = pillFrame.midX - calloutWidth / 2
+        let y = pillVisualTop + gap
+
+        let frame = NSRect(x: x, y: y, width: calloutWidth, height: calloutHeight + arrowHeight)
+
+        let panel = NSPanel(
+            contentRect: frame,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        super.init(window: panel)
+
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary]
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.isOpaque = false
+        panel.hidesOnDeactivate = false
+        panel.ignoresMouseEvents = false
+
+        let view = PillCalloutView(onDismiss: onDismiss)
+        panel.contentView = NSHostingView(rootView: view)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) not implemented")
+    }
+}

--- a/Transcripted/UI/FloatingPanel/PillStateManager.swift
+++ b/Transcripted/UI/FloatingPanel/PillStateManager.swift
@@ -58,6 +58,7 @@ enum PillState: Equatable {
 class PillStateManager: ObservableObject {
     @Published var state: PillState = .idle
     @Published var isLocked = false  // Prevents state changes during review
+    @Published var showOnboardingGlow = false  // Pulsing glow during pill callout
 
     /// Flag to prevent rapid state changes during animations
     @Published private(set) var isTransitioning = false


### PR DESCRIPTION
## Changes

- **New PillCalloutView**: Coach mark that appears above the pill to introduce first-time users
  - Glassmorphic design with mic icon and instructional text
  - Animated downward arrow with bounce effect
  - Dismiss button with persistent state tracking

- **New PillCalloutController**: Manages the floating callout panel
  - Positioned above the pill with proper spacing
  - Floating window with transparent background
  - Respects all spaces and stays visible

- **Onboarding glow effect**: Added to AuroraIdleView
  - Animated pulsing glow ring around the pill during callout display
  - Uses coral color with shadow layers for prominence

- **State management**: Extended OnboardingState
  - Track pill callout display with `hasShownPillCallout()` and `markPillCalloutShown()`
  - Include in onboarding reset for testing

- **Integration**: Updated TranscriptedApp delegate
  - Show callout automatically 1 second after main window appears
  - Manage glow state lifecycle
  - Clean up controller on dismissal

- **Removed**: Auto-complete model setup from OnboardingContainerView (moved to external logic)