### PR TITLE
Show speaker names and time of day in transcript tray

### DIFF
--- a/Transcripted/Core/TranscriptStore.swift
+++ b/Transcripted/Core/TranscriptStore.swift
@@ -14,6 +14,7 @@ struct TranscriptSummary: Identifiable {
     let duration: String   // e.g. "47:32"
     let speakerCount: Int
     let speakerNames: [String]  // Parsed from YAML frontmatter
+    let timeOfDay: String?      // e.g. "14:30:21" from YAML, nil for old files
 }
 
 // MARK: - TranscriptLine
@@ -194,6 +195,7 @@ final class TranscriptStore: ObservableObject {
         var duration = ""
         var speakerCount = 0
         var speakerNames: [String] = []
+        var timeOfDay: String?
 
         // Parse YAML frontmatter for structured fields
         if raw.hasPrefix("---"),
@@ -219,6 +221,8 @@ final class TranscriptStore: ObservableObject {
                     } else {
                         AppLogger.pipeline.debug("TranscriptStore: malformed date in frontmatter", ["file": url.lastPathComponent, "value": val])
                     }
+                case "time":
+                    timeOfDay = val
                 case "duration":
                     duration = val
                 case "mic_speakers", "system_speakers":
@@ -247,6 +251,18 @@ final class TranscriptStore: ObservableObject {
                     }
                 }
             }
+
+            // Combine date + time into full datetime for accurate display and sorting
+            if let timeStr = timeOfDay {
+                let isoDF = DateFormatter()
+                isoDF.dateFormat = "yyyy-MM-dd"
+                let dateStr = isoDF.string(from: date)
+                let dtf = DateFormatter()
+                dtf.dateFormat = "yyyy-MM-dd HH:mm:ss"
+                if let fullDate = dtf.date(from: "\(dateStr) \(timeStr)") {
+                    date = fullDate
+                }
+            }
         }
 
         // Prefer a markdown heading title over the filename
@@ -267,7 +283,8 @@ final class TranscriptStore: ObservableObject {
             date: date,
             duration: duration,
             speakerCount: speakerCount,
-            speakerNames: speakerNames
+            speakerNames: speakerNames,
+            timeOfDay: timeOfDay
         )
     }
 

--- a/Transcripted/UI/FloatingPanel/Components/TranscriptTrayView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/TranscriptTrayView.swift
@@ -344,7 +344,7 @@ struct TranscriptTrayView: View {
             // Overflow menu: Agent + Open in Finder
             Menu {
                 Button(action: {
-                    let stem = transcript.title
+                    let stem = transcript.url.deletingPathExtension().lastPathComponent
                     copyAgentPrompt(filename: stem)
                 }) {
                     Label("Connect Agent", systemImage: "terminal")
@@ -487,11 +487,34 @@ struct TranscriptRowView: View {
 
     @State private var isHovered = false
 
+    /// Smart display title: prefer speaker names over generic "Meeting"
+    private var displayTitle: String {
+        let names = transcript.speakerNames
+        if names.isEmpty {
+            if transcript.speakerCount > 0 {
+                return "Meeting \u{00B7} \(transcript.speakerCount) speaker\(transcript.speakerCount == 1 ? "" : "s")"
+            }
+            return "Meeting"
+        }
+        if names.count <= 2 {
+            return names.joined(separator: ", ")
+        }
+        // 3+ speakers: first names only + overflow
+        let firstNames = names.prefix(2).map { firstName($0) }
+        let overflow = names.count - 2
+        return "\(firstNames.joined(separator: ", ")), +\(overflow) more"
+    }
+
+    private func firstName(_ fullName: String) -> String {
+        let parts = fullName.split(separator: " ")
+        return parts.first.map(String.init) ?? fullName
+    }
+
     var body: some View {
         HStack(spacing: Spacing.sm) {
             // Left: title + metadata
             VStack(alignment: .leading, spacing: 2) {
-                Text(transcript.title)
+                Text(displayTitle)
                     .font(.system(size: 12, weight: .medium))
                     .foregroundColor(.panelTextPrimary)
                     .lineLimit(1)
@@ -503,27 +526,13 @@ struct TranscriptRowView: View {
                         .foregroundColor(.panelTextMuted)
 
                     if !transcript.duration.isEmpty {
-                        Text("·")
+                        Text("\u{00B7}")
                             .font(.system(size: 8))
                             .foregroundColor(.panelTextMuted.opacity(0.6))
 
                         Text(transcript.duration)
                             .font(.system(size: 10, design: .monospaced))
                             .foregroundColor(.panelTextMuted)
-                    }
-
-                    if transcript.speakerCount > 0 {
-                        Text("·")
-                            .font(.system(size: 8))
-                            .foregroundColor(.panelTextMuted.opacity(0.6))
-
-                        HStack(spacing: 2) {
-                            Image(systemName: "person.2")
-                                .font(.system(size: 7))
-                            Text("\(transcript.speakerCount)")
-                                .font(.system(size: 10))
-                        }
-                        .foregroundColor(.panelTextMuted)
                     }
                 }
 
@@ -592,11 +601,23 @@ struct TranscriptRowView: View {
 
     private var relativeDate: String {
         let cal = Calendar.current
-        if cal.isDateInToday(transcript.date)     { return "Today" }
-        if cal.isDateInYesterday(transcript.date) { return "Yesterday" }
+        let comps = cal.dateComponents([.hour, .minute], from: transcript.date)
+        let hasTime = !((comps.hour ?? 0) == 0 && (comps.minute ?? 0) == 0)
+
+        let tf = DateFormatter()
+        tf.dateFormat = "h:mm a"
+        let timeStr = tf.string(from: transcript.date)
+
+        if cal.isDateInToday(transcript.date) {
+            return hasTime ? "Today at \(timeStr)" : "Today"
+        }
+        if cal.isDateInYesterday(transcript.date) {
+            return hasTime ? "Yesterday at \(timeStr)" : "Yesterday"
+        }
         let df = DateFormatter()
         df.dateFormat = "MMM d"
-        return df.string(from: transcript.date)
+        let dateStr = df.string(from: transcript.date)
+        return hasTime ? "\(dateStr) at \(timeStr)" : dateStr
     }
 }
 

--- a/Transcripted/UI/FloatingPanel/FloatingPanelView.swift
+++ b/Transcripted/UI/FloatingPanel/FloatingPanelView.swift
@@ -282,7 +282,8 @@ struct FloatingPanelView: View {
                             date: Date(),
                             duration: "",
                             speakerCount: 0,
-                            speakerNames: []
+                            speakerNames: [],
+                            timeOfDay: nil
                         )
                         if let text = transcriptStore.copyableText(for: summary), !text.isEmpty {
                             NSPasteboard.general.clearContents()

--- a/TranscriptedTests/Core/TranscriptStoreTests.swift
+++ b/TranscriptedTests/Core/TranscriptStoreTests.swift
@@ -40,7 +40,8 @@ final class TranscriptStoreTests: XCTestCase {
             date: Date(),
             duration: "12:34",
             speakerCount: 2,
-            speakerNames: ["You", "Speaker 1"]
+            speakerNames: ["You", "Speaker 1"],
+            timeOfDay: nil
         )
 
         let text = store.copyableText(for: summary)
@@ -65,7 +66,7 @@ final class TranscriptStoreTests: XCTestCase {
         let url = try writeTempMarkdown("test_footer.md", content: content)
 
         let store = TranscriptStore()
-        let summary = TranscriptSummary(url: url, title: "Test", date: Date(), duration: "", speakerCount: 1, speakerNames: ["You"])
+        let summary = TranscriptSummary(url: url, title: "Test", date: Date(), duration: "", speakerCount: 1, speakerNames: ["You"], timeOfDay: nil)
 
         let text = store.copyableText(for: summary)
         XCTAssertNotNil(text)
@@ -85,7 +86,7 @@ final class TranscriptStoreTests: XCTestCase {
 
         let store = TranscriptStore()
         let date = Date()
-        let summary = TranscriptSummary(url: url, title: "Weekly Standup", date: date, duration: "05:30", speakerCount: 2, speakerNames: ["You", "Speaker 1"])
+        let summary = TranscriptSummary(url: url, title: "Weekly Standup", date: date, duration: "05:30", speakerCount: 2, speakerNames: ["You", "Speaker 1"], timeOfDay: nil)
 
         let text = store.copyableText(for: summary)
         XCTAssertNotNil(text)
@@ -109,7 +110,7 @@ final class TranscriptStoreTests: XCTestCase {
         let url = try writeTempMarkdown("test_lines.md", content: content)
 
         let store = TranscriptStore()
-        let summary = TranscriptSummary(url: url, title: "Test", date: Date(), duration: "", speakerCount: 2, speakerNames: ["You", "Speaker 1"])
+        let summary = TranscriptSummary(url: url, title: "Test", date: Date(), duration: "", speakerCount: 2, speakerNames: ["You", "Speaker 1"], timeOfDay: nil)
 
         let lines = store.displayLines(for: summary)
         XCTAssertNotNil(lines)
@@ -139,7 +140,7 @@ final class TranscriptStoreTests: XCTestCase {
         let url = try writeTempMarkdown("test_skip.md", content: content)
 
         let store = TranscriptStore()
-        let summary = TranscriptSummary(url: url, title: "Test", date: Date(), duration: "", speakerCount: 1, speakerNames: ["You"])
+        let summary = TranscriptSummary(url: url, title: "Test", date: Date(), duration: "", speakerCount: 1, speakerNames: ["You"], timeOfDay: nil)
 
         let lines = store.displayLines(for: summary)
         XCTAssertNotNil(lines)
@@ -160,7 +161,7 @@ final class TranscriptStoreTests: XCTestCase {
         let url = try writeTempMarkdown("test_unstructured.md", content: content)
 
         let store = TranscriptStore()
-        let summary = TranscriptSummary(url: url, title: "Test", date: Date(), duration: "", speakerCount: 1, speakerNames: ["You"])
+        let summary = TranscriptSummary(url: url, title: "Test", date: Date(), duration: "", speakerCount: 1, speakerNames: ["You"], timeOfDay: nil)
 
         let lines = store.displayLines(for: summary)
         XCTAssertNotNil(lines)


### PR DESCRIPTION
## Changes

- **TranscriptStore**: Added `timeOfDay` field to `TranscriptSummary` to parse and store time from YAML frontmatter. Combines date + time for accurate sorting and display.
- **TranscriptTrayView**: 
  - Display speaker names as transcript title instead of generic "Meeting" label
  - Show time of day alongside dates (e.g., "Today at 2:30 PM")
  - Remove redundant speaker count indicator from metadata row
  - Add smart name formatting (full names for ≤2 speakers, first names + overflow for 3+)
- **FloatingPanelView**: Updated mock `TranscriptSummary` to include `timeOfDay` field
- **Tests**: Updated all test cases to include new `timeOfDay: nil` parameter