### PR TITLE
Fix notification errors and improve model initialization logging

### DIFF
--- a/Transcripted/Core/Clipboard.swift
+++ b/Transcripted/Core/Clipboard.swift
@@ -14,20 +14,28 @@ class Clipboard {
         showNotification(text: text)
     }
 
+    /// Guards on authorization status to avoid UNErrorDomain error 1.
     private static func showNotification(text: String) {
-        let content = UNMutableNotificationContent()
-        content.title = "Transcripted"
-        content.body = "Transcription copied: \(String(text.prefix(100)))"
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            guard settings.authorizationStatus == .authorized else {
+                AppLogger.pipeline.debug("Skipping clipboard notification — not authorized")
+                return
+            }
 
-        let request = UNNotificationRequest(
-            identifier: UUID().uuidString,
-            content: content,
-            trigger: nil
-        )
+            let content = UNMutableNotificationContent()
+            content.title = "Transcripted"
+            content.body = "Transcription copied: \(String(text.prefix(100)))"
 
-        UNUserNotificationCenter.current().add(request) { error in
-            if let error = error {
-                AppLogger.pipeline.warning("Notification failed", ["error": error.localizedDescription])
+            let request = UNNotificationRequest(
+                identifier: UUID().uuidString,
+                content: content,
+                trigger: nil
+            )
+
+            UNUserNotificationCenter.current().add(request) { error in
+                if let error = error {
+                    AppLogger.pipeline.warning("Notification failed", ["error": error.localizedDescription])
+                }
             }
         }
     }

--- a/Transcripted/Core/Logging/FileLogger.swift
+++ b/Transcripted/Core/Logging/FileLogger.swift
@@ -5,17 +5,20 @@ import Foundation
 /// Design decisions:
 /// - JSON Lines format: one JSON object per line, machine-parseable, grep-friendly
 /// - Rolling truncation: max 2000 entries, trims oldest 500 when full (checked every 100 writes)
-/// - Thread safety via serial DispatchQueue (.async writes) — NEVER use locks here
-///   because CoreAudio callbacks run on real-time threads where locks cause priority inversion
+/// - Thread safety: serial DispatchQueue for in-process serialization + POSIX flock() for
+///   cross-process file locking (safe because CoreAudio dispatches to utility queue, never
+///   calls the logger directly — no priority inversion risk)
+/// - Disabled during test runs to avoid polluting production logs
 /// - Short JSON keys to minimize file size: t=timestamp, l=level, s=subsystem, m=message, d=data
 final class FileLogger: @unchecked Sendable {
     private let queue = DispatchQueue(label: "com.transcripted.filelogger", qos: .utility)
-    private let logFileURL: URL
+    private var logFileURL: URL
     private var fileHandle: FileHandle?
     private var writeCount: Int = 0
     private let maxEntries = 2000
     private let trimTarget = 1500   // Keep this many after trim
     private let trimCheckInterval = 100
+    private let isDisabled: Bool
 
     private lazy var dateFormatter: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
@@ -24,11 +27,17 @@ final class FileLogger: @unchecked Sendable {
     }()
 
     init() {
+        // Disable file logging during test runs to avoid polluting production logs
+        let isTestRun = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+        self.isDisabled = isTestRun
+
         let logsDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Logs/Transcripted")
         try? FileManager.default.createDirectory(at: logsDir, withIntermediateDirectories: true)
 
         logFileURL = logsDir.appendingPathComponent("app.jsonl")
+
+        guard !isDisabled else { return }
 
         // Create file if it doesn't exist
         if !FileManager.default.fileExists(atPath: logFileURL.path) {
@@ -45,6 +54,7 @@ final class FileLogger: @unchecked Sendable {
 
     /// Write a log entry asynchronously (non-blocking)
     func write(level: String, subsystem: String, message: String, metadata: [String: String]?) {
+        guard !isDisabled else { return }
         queue.async { [weak self] in
             self?.writeSync(level: level, subsystem: subsystem, message: message, metadata: metadata)
         }
@@ -53,6 +63,7 @@ final class FileLogger: @unchecked Sendable {
     /// Synchronous flush — blocks until all pending writes complete
     /// Call from applicationWillTerminate
     func flush() {
+        guard !isDisabled else { return }
         queue.sync { [weak self] in
             self?.fileHandle?.synchronizeFile()
         }
@@ -73,8 +84,14 @@ final class FileLogger: @unchecked Sendable {
 
         json += "}\n"
 
-        if let data = json.data(using: .utf8) {
-            fileHandle?.write(data)
+        if let data = json.data(using: .utf8),
+           let handle = fileHandle {
+            // flock() provides cross-process file locking — prevents interleaved writes
+            // when multiple app instances write to the same log file simultaneously
+            let fd = handle.fileDescriptor
+            flock(fd, LOCK_EX)
+            handle.write(data)
+            flock(fd, LOCK_UN)
         }
 
         writeCount += 1
@@ -86,6 +103,14 @@ final class FileLogger: @unchecked Sendable {
     private func trimIfNeeded() {
         // Flush buffered writes before reading — otherwise Data(contentsOf:) may miss recent entries
         fileHandle?.synchronizeFile()
+
+        // Open a separate fd for an advisory lock that spans the close/reopen cycle.
+        // The main fileHandle's lock is released when it's closed during trim,
+        // so we need an independent lock fd to protect the entire operation.
+        let lockFd = open(logFileURL.path, O_RDONLY)
+        guard lockFd >= 0 else { return }
+        flock(lockFd, LOCK_EX)
+        defer { flock(lockFd, LOCK_UN); close(lockFd) }
 
         guard let data = try? Data(contentsOf: logFileURL),
               let content = String(data: data, encoding: .utf8) else { return }

--- a/Transcripted/Core/TranscriptSaver.swift
+++ b/Transcripted/Core/TranscriptSaver.swift
@@ -816,25 +816,31 @@ class TranscriptSaver {
     static let notificationCategoryId = "TRANSCRIPT_SAVED"
     static let showInFinderActionId = "SHOW_IN_FINDER"
 
-    /// Show macOS notification that transcript was saved
+    /// Show macOS notification that transcript was saved.
+    /// Guards on authorization status to avoid UNErrorDomain error 1.
     static func showSaveNotification(fileURL: URL) {
-        let center = UNUserNotificationCenter.current()
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            guard settings.authorizationStatus == .authorized else {
+                AppLogger.pipeline.debug("Skipping save notification — not authorized")
+                return
+            }
 
-        let content = UNMutableNotificationContent()
-        content.title = "Transcript Saved"
-        content.body = fileURL.lastPathComponent
-        content.categoryIdentifier = notificationCategoryId
-        content.userInfo = ["fileURL": fileURL.path]
+            let content = UNMutableNotificationContent()
+            content.title = "Transcript Saved"
+            content.body = fileURL.lastPathComponent
+            content.categoryIdentifier = notificationCategoryId
+            content.userInfo = ["fileURL": fileURL.path]
 
-        let request = UNNotificationRequest(
-            identifier: UUID().uuidString,
-            content: content,
-            trigger: nil // deliver immediately
-        )
+            let request = UNNotificationRequest(
+                identifier: UUID().uuidString,
+                content: content,
+                trigger: nil // deliver immediately
+            )
 
-        center.add(request) { error in
-            if let error = error {
-                AppLogger.pipeline.error("Failed to deliver notification", ["error": error.localizedDescription])
+            UNUserNotificationCenter.current().add(request) { error in
+                if let error = error {
+                    AppLogger.pipeline.error("Failed to deliver notification", ["error": error.localizedDescription])
+                }
             }
         }
     }

--- a/Transcripted/Core/Transcription.swift
+++ b/Transcripted/Core/Transcription.swift
@@ -43,8 +43,15 @@ class Transcription: ObservableObject {
         self.speakerDB = SpeakerDatabase.shared
     }
 
+    private var hasInitialized = false
+
     /// Initialize local models. Call once at app startup.
     func initializeModels() async {
+        guard !hasInitialized else {
+            AppLogger.transcription.debug("Models already initialized, skipping")
+            return
+        }
+        hasInitialized = true
         await parakeet.initialize()
         await diarization.initialize()
     }

--- a/Transcripted/Services/DiarizationService.swift
+++ b/Transcripted/Services/DiarizationService.swift
@@ -77,6 +77,7 @@ class DiarizationService: ObservableObject {
 
     /// Load Sortformer streaming models from the app bundle or download from HuggingFace.
     private func initializeStreaming() async throws {
+        let loadStart = Date()
         let manager = DiarizerManager(config: .default)
 
         if let bundlePath = bundledModelsPath(directory: "sortformer-models") {
@@ -84,18 +85,20 @@ class DiarizationService: ObservableObject {
             let models = try await DiarizerModels.load(from: bundlePath)
             manager.initialize(models: models)
         } else {
-            AppLogger.transcription.info("Sortformer models not bundled, downloading")
+            AppLogger.transcription.info("Sortformer models not bundled, loading from cache or downloading")
             let models = try await DiarizerModels.download()
             manager.initialize(models: models)
         }
 
         diarizerManager = manager
-        AppLogger.transcription.info("Sortformer streaming models loaded")
+        let elapsed = String(format: "%.1fs", Date().timeIntervalSince(loadStart))
+        AppLogger.transcription.info("Sortformer streaming models loaded", ["elapsed": elapsed])
     }
 
     /// Load PyAnnote offline diarization models from the app bundle or download.
     private func initializeOffline() async throws {
         offlineModelState = .loading
+        let loadStart = Date()
 
         let manager = OfflineDiarizerManager(config: .default)
 
@@ -104,13 +107,14 @@ class DiarizationService: ObservableObject {
             let models = try await OfflineDiarizerModels.load(from: bundlePath)
             manager.initialize(models: models)
         } else {
-            AppLogger.transcription.info("Offline diarizer models not bundled, downloading")
+            AppLogger.transcription.info("Offline diarizer models not bundled, loading from cache or downloading")
             try await manager.prepareModels()
         }
 
         offlineDiarizerManager = manager
         offlineModelState = .ready
-        AppLogger.transcription.info("Offline diarizer models loaded")
+        let elapsed = String(format: "%.1fs", Date().timeIntervalSince(loadStart))
+        AppLogger.transcription.info("Offline diarizer models loaded", ["elapsed": elapsed])
     }
 
     /// Check for diarization models bundled inside the app at build time.

--- a/Transcripted/Services/ParakeetService.swift
+++ b/Transcripted/Services/ParakeetService.swift
@@ -37,14 +37,15 @@ class ParakeetService: ObservableObject {
         do {
             let models: AsrModels
             let loadSource: String
+            let loadStart = Date()
 
             if let bundlePath = bundledModelsPath() {
                 AppLogger.transcription.info("Parakeet loading from bundle", ["path": bundlePath.path])
                 models = try await AsrModels.load(from: bundlePath, version: .v3)
                 loadSource = "bundle"
             } else {
-                // Fallback: download from HuggingFace (~600MB on first run)
-                AppLogger.transcription.info("Parakeet models not bundled, downloading (~600MB)")
+                // Fallback: load from cache or download from HuggingFace (~600MB on first run)
+                AppLogger.transcription.info("Parakeet models not bundled, loading from cache or downloading")
                 models = try await AsrModels.downloadAndLoad(version: .v3)
                 loadSource = "download"
             }
@@ -54,7 +55,8 @@ class ParakeetService: ObservableObject {
 
             asrManager = manager
             modelState = .ready
-            AppLogger.transcription.info("Parakeet models loaded and ready", ["source": loadSource])
+            let elapsed = String(format: "%.1fs", Date().timeIntervalSince(loadStart))
+            AppLogger.transcription.info("Parakeet models loaded and ready", ["source": loadSource, "elapsed": elapsed])
         } catch {
             modelState = .failed(error.localizedDescription)
             AppLogger.transcription.error("Parakeet model initialization failed", ["error": "\(error.localizedDescription)"])

--- a/Transcripted/TranscriptedApp.swift
+++ b/Transcripted/TranscriptedApp.swift
@@ -490,7 +490,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUserNotifi
             if granted {
                 AppLogger.app.info("Notification permission granted")
             } else if let error = error {
-                AppLogger.app.warning("Notification permission error", ["error": error.localizedDescription])
+                AppLogger.app.debug("Notification permission error", ["error": error.localizedDescription])
             } else {
                 AppLogger.app.info("Notification permission denied by user")
             }


### PR DESCRIPTION
## Changes

- **Clipboard.swift & TranscriptSaver.swift**: Guard notification calls on authorization status to prevent UNErrorDomain error 1 spam
- **FileLogger.swift**: Add cross-process POSIX flock() support for safe concurrent writes; disable logging during test runs
- **DiarizationService.swift & ParakeetService.swift**: Add elapsed time tracking to model initialization logs for better diagnostics
- **Transcription.swift**: Add initialization guard to prevent duplicate model loading
- **TranscriptedApp.swift**: Downgrade notification permission error from warning to debug level

## Benefits

- Eliminates repeated notification errors when app lacks notification permissions
- Prevents log file corruption from concurrent writes by multiple app instances
- Provides timing insights for model loading performance
- Cleaner test run logs