### PR TITLE
feat: resilient model downloads with HuggingFace mirror fallback

### DIFF
--- a/Transcripted.xcodeproj/project.pbxproj
+++ b/Transcripted.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		MDS00001 /* ModelDownloadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = MDS00002 /* ModelDownloadService.swift */; };
 		MB000001 /* MenuBarStatRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = MB000002 /* MenuBarStatRow.swift */; };
 		4CAF116349811906B83C0406 /* ModelSetupStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF26FA6ED2054F3DCF8D0B45 /* ModelSetupStep.swift */; };
 		A1000001 /* TranscriptedApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1000002 /* TranscriptedApp.swift */; };
@@ -250,6 +251,7 @@
 		A1001021 /* TranscriptStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptStore.swift; sourceTree = "<group>"; };
 		A1001031 /* TranscriptExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptExporter.swift; sourceTree = "<group>"; };
 		A2000002 /* DiagnosticExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticExporter.swift; sourceTree = "<group>"; };
+		MDS00002 /* ModelDownloadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelDownloadService.swift; sourceTree = "<group>"; };
 		PC000001 /* PillCalloutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillCalloutView.swift; sourceTree = "<group>"; };
 		PC000002 /* PillCalloutController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillCalloutController.swift; sourceTree = "<group>"; };
 		A1001023 /* TranscriptTrayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptTrayView.swift; sourceTree = "<group>"; };
@@ -526,6 +528,7 @@
 				NF5C99141500 /* StatsDatabaseQueries.swift */,
 				NF321D21DA00 /* SpeakerMatchingService.swift */,
 				NF405F06D000 /* TranscriptionPipeline.swift */,
+				MDS00002 /* ModelDownloadService.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1047,6 +1050,7 @@
 				Q1000001 /* QwenService.swift in Sources */,
 				4CAF116349811906B83C0406 /* ModelSetupStep.swift in Sources */,
 				A2000001 /* DiagnosticExporter.swift in Sources */,
+				MDS00001 /* ModelDownloadService.swift in Sources */,
 				PC000011 /* PillCalloutView.swift in Sources */,
 				PC000012 /* PillCalloutController.swift in Sources */,
 			

--- a/Transcripted/Core/ModelDownloadService.swift
+++ b/Transcripted/Core/ModelDownloadService.swift
@@ -1,0 +1,369 @@
+// ModelDownloadService.swift
+// Resilient model download with HuggingFace mirror fallback, retry logic,
+// and error classification. Provides pre-population for Qwen cache and
+// retry wrapping for FluidAudio model initialization.
+
+import Foundation
+import Network
+
+// MARK: - Error Classification
+
+/// Categorizes download errors for user-friendly messaging
+enum DownloadErrorKind: Equatable {
+    case networkOffline
+    case tlsFailure
+    case timeout
+    case diskSpace
+    case serverError(statusCode: Int)
+    case unknown(String)
+
+    var title: String {
+        switch self {
+        case .networkOffline: return "No Internet Connection"
+        case .tlsFailure: return "Secure Connection Failed"
+        case .timeout: return "Download Timed Out"
+        case .diskSpace: return "Not Enough Disk Space"
+        case .serverError: return "Server Error"
+        case .unknown: return "Download Failed"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .networkOffline:
+            return "Connect to the internet and try again."
+        case .tlsFailure:
+            return "Could not establish a secure connection to the download server. Check your network or try a VPN."
+        case .timeout:
+            return "The download took too long. Try again or check your connection speed."
+        case .diskSpace:
+            return "Free up at least 1 GB of disk space and try again."
+        case .serverError(let code):
+            return "The download server returned an error (\(code)). This is usually temporary — try again in a few minutes."
+        case .unknown(let message):
+            return message
+        }
+    }
+}
+
+/// Structured download error with classification
+struct ModelDownloadError: Error, LocalizedError {
+    let kind: DownloadErrorKind
+    let underlyingError: Error?
+
+    var errorDescription: String? {
+        kind.detail
+    }
+}
+
+// MARK: - Download Service
+
+enum ModelDownloadService {
+
+    /// HuggingFace mirror URLs, tried in order
+    private static let mirrors: [String] = [
+        "https://huggingface.co",
+        "https://hf-mirror.com"
+    ]
+
+    /// Default retry configuration
+    private static let maxRetries = 3
+    private static let retryDelays: [UInt64] = [2_000_000_000, 5_000_000_000, 10_000_000_000] // 2s, 5s, 10s
+
+    // MARK: - Network Reachability
+
+    /// Quick network connectivity check using NWPathMonitor.
+    /// Returns true if any network path is available.
+    static func checkNetworkReachability() async -> Bool {
+        // Box to safely track whether continuation has been resumed.
+        // Both the handler and timeout run on the same serial queue, so no lock needed.
+        class ResumeGuard { var done = false }
+
+        return await withCheckedContinuation { continuation in
+            let monitor = NWPathMonitor()
+            let queue = DispatchQueue(label: "com.transcripted.network-check", qos: .utility)
+            let guard_ = ResumeGuard()
+
+            monitor.pathUpdateHandler = { path in
+                guard !guard_.done else { return }
+                guard_.done = true
+                monitor.cancel()
+                continuation.resume(returning: path.status == .satisfied)
+            }
+            monitor.start(queue: queue)
+
+            // Timeout after 3 seconds — if we can't determine network status, assume offline
+            queue.asyncAfter(deadline: .now() + 3) {
+                guard !guard_.done else { return }
+                guard_.done = true
+                monitor.cancel()
+                continuation.resume(returning: false)
+            }
+        }
+    }
+
+    // MARK: - Error Classification
+
+    /// Classify any Error into a user-friendly DownloadErrorKind
+    static func classifyError(_ error: Error) -> DownloadErrorKind {
+        let nsError = error as NSError
+
+        // Check for disk space first
+        if nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileWriteOutOfSpaceError {
+            return .diskSpace
+        }
+        if nsError.domain == NSPOSIXErrorDomain && nsError.code == 28 { // ENOSPC
+            return .diskSpace
+        }
+
+        // URL errors
+        if nsError.domain == NSURLErrorDomain {
+            switch nsError.code {
+            case NSURLErrorNotConnectedToInternet,
+                 NSURLErrorNetworkConnectionLost,
+                 NSURLErrorDataNotAllowed,
+                 NSURLErrorCannotFindHost,
+                 NSURLErrorCannotConnectToHost,
+                 NSURLErrorDNSLookupFailed:
+                return .networkOffline
+            case NSURLErrorSecureConnectionFailed,
+                 NSURLErrorServerCertificateHasBadDate,
+                 NSURLErrorServerCertificateUntrusted,
+                 NSURLErrorServerCertificateHasUnknownRoot,
+                 NSURLErrorServerCertificateNotYetValid,
+                 NSURLErrorClientCertificateRejected,
+                 NSURLErrorClientCertificateRequired:
+                return .tlsFailure
+            case NSURLErrorTimedOut:
+                return .timeout
+            default:
+                break
+            }
+        }
+
+        return .unknown(error.localizedDescription)
+    }
+
+    /// Check available disk space in bytes
+    static func availableDiskSpace() -> UInt64? {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        guard let values = try? home.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey]),
+              let available = values.volumeAvailableCapacityForImportantUsage else {
+            return nil
+        }
+        return UInt64(available)
+    }
+
+    // MARK: - Retry Wrapper
+
+    /// Execute an async operation with retry logic and exponential backoff.
+    /// Classifies errors on each attempt and only retries transient failures.
+    static func withRetry<T>(
+        maxAttempts: Int = maxRetries,
+        operation: @escaping () async throws -> T
+    ) async throws -> T {
+        var lastError: Error?
+
+        for attempt in 0..<maxAttempts {
+            do {
+                return try await operation()
+            } catch {
+                lastError = error
+                let kind = classifyError(error)
+
+                // Don't retry permanent failures
+                switch kind {
+                case .diskSpace:
+                    throw ModelDownloadError(kind: kind, underlyingError: error)
+                default:
+                    break
+                }
+
+                // Log retry
+                AppLogger.services.warning("Download attempt \(attempt + 1)/\(maxAttempts) failed", [
+                    "error": error.localizedDescription,
+                    "kind": kind.title
+                ])
+
+                // Wait before retrying (unless this was the last attempt)
+                if attempt < maxAttempts - 1 {
+                    let delay = retryDelays[min(attempt, retryDelays.count - 1)]
+                    try? await Task.sleep(nanoseconds: delay)
+                }
+            }
+        }
+
+        // All retries exhausted
+        let kind = classifyError(lastError!)
+        throw ModelDownloadError(kind: kind, underlyingError: lastError)
+    }
+
+    // MARK: - Qwen Pre-Population
+
+    /// Pre-populate the Qwen model cache by downloading files directly from HuggingFace
+    /// with mirror fallback. If cache already exists, skips download.
+    ///
+    /// mlx-swift-lm stores models at ~/Library/Caches/models/{org}/{model}/
+    /// If files exist there, loadModelContainer() skips its own download.
+    static func prePopulateQwenCache(
+        modelId: String = "mlx-community/Qwen3.5-4B-4bit",
+        progressHandler: ((Double) -> Void)? = nil
+    ) async throws {
+        let cacheDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Caches/models")
+            .appendingPathComponent(modelId)
+
+        // If cache directory already has files, skip
+        if FileManager.default.fileExists(atPath: cacheDir.path) {
+            let contents = (try? FileManager.default.contentsOfDirectory(atPath: cacheDir.path)) ?? []
+            if !contents.isEmpty {
+                AppLogger.services.info("Qwen cache already populated, skipping pre-download", [
+                    "path": cacheDir.path,
+                    "files": "\(contents.count)"
+                ])
+                return
+            }
+        }
+
+        // Check disk space (~2.5GB needed)
+        if let available = availableDiskSpace(), available < 3_000_000_000 {
+            throw ModelDownloadError(kind: .diskSpace, underlyingError: nil)
+        }
+
+        // Check network first
+        guard await checkNetworkReachability() else {
+            throw ModelDownloadError(kind: .networkOffline, underlyingError: nil)
+        }
+
+        // Fetch file manifest from HuggingFace API
+        let fileList = try await fetchModelFileList(modelId: modelId)
+
+        AppLogger.services.info("Qwen pre-population starting", [
+            "files": "\(fileList.count)",
+            "modelId": modelId
+        ])
+
+        // Create cache directory
+        try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+
+        // Download each file with mirror fallback
+        var downloadedCount = 0
+        for file in fileList {
+            let destURL = cacheDir.appendingPathComponent(file.name)
+
+            // Skip if already downloaded
+            if FileManager.default.fileExists(atPath: destURL.path) {
+                downloadedCount += 1
+                progressHandler?(Double(downloadedCount) / Double(fileList.count))
+                continue
+            }
+
+            try await downloadFileWithMirrorFallback(
+                modelId: modelId,
+                filename: file.name,
+                destination: destURL
+            )
+
+            downloadedCount += 1
+            progressHandler?(Double(downloadedCount) / Double(fileList.count))
+        }
+
+        AppLogger.services.info("Qwen pre-population complete", ["path": cacheDir.path])
+    }
+
+    /// Represents a file in a HuggingFace model repository
+    private struct HFModelFile {
+        let name: String
+        let size: Int?
+    }
+
+    /// Fetch the list of files in a HuggingFace model repository
+    private static func fetchModelFileList(modelId: String) async throws -> [HFModelFile] {
+        // Try each mirror for the API call
+        for mirror in mirrors {
+            let apiURL = URL(string: "\(mirror)/api/models/\(modelId)")!
+
+            do {
+                let (data, response) = try await URLSession.shared.data(from: apiURL)
+
+                if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+                    continue
+                }
+
+                guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let siblings = json["siblings"] as? [[String: Any]] else {
+                    continue
+                }
+
+                let files = siblings.compactMap { sibling -> HFModelFile? in
+                    guard let name = sibling["rfilename"] as? String else { return nil }
+                    let size = sibling["size"] as? Int
+                    return HFModelFile(name: name, size: size)
+                }
+
+                if !files.isEmpty {
+                    AppLogger.services.info("Fetched model file list", [
+                        "mirror": mirror,
+                        "files": "\(files.count)"
+                    ])
+                    return files
+                }
+            } catch {
+                AppLogger.services.warning("Failed to fetch file list from mirror", [
+                    "mirror": mirror,
+                    "error": error.localizedDescription
+                ])
+                continue
+            }
+        }
+
+        throw ModelDownloadError(
+            kind: .unknown("Could not fetch model file list from any mirror"),
+            underlyingError: nil
+        )
+    }
+
+    /// Download a single file with mirror fallback and retry
+    private static func downloadFileWithMirrorFallback(
+        modelId: String,
+        filename: String,
+        destination: URL
+    ) async throws {
+        for mirror in mirrors {
+            let fileURL = URL(string: "\(mirror)/\(modelId)/resolve/main/\(filename)")!
+
+            do {
+                try await withRetry(maxAttempts: 2) {
+                    let (tempURL, response) = try await URLSession.shared.download(from: fileURL)
+
+                    if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+                        throw ModelDownloadError(
+                            kind: .serverError(statusCode: httpResponse.statusCode),
+                            underlyingError: nil
+                        )
+                    }
+
+                    // Move to destination
+                    try FileManager.default.moveItem(at: tempURL, to: destination)
+                }
+
+                AppLogger.services.debug("Downloaded \(filename) from \(mirror)")
+                return
+            } catch {
+                AppLogger.services.warning("Mirror download failed", [
+                    "mirror": mirror,
+                    "file": filename,
+                    "error": error.localizedDescription
+                ])
+                // Clean up partial file
+                try? FileManager.default.removeItem(at: destination)
+                continue
+            }
+        }
+
+        throw ModelDownloadError(
+            kind: .unknown("Failed to download \(filename) from all mirrors"),
+            underlyingError: nil
+        )
+    }
+}

--- a/Transcripted/Onboarding/OnboardingState.swift
+++ b/Transcripted/Onboarding/OnboardingState.swift
@@ -195,6 +195,21 @@ class OnboardingState {
         parakeetPhase = "Downloading..."
         diarizationPhase = "Downloading..."
 
+        // Pre-flight: check network connectivity before starting long downloads
+        let networkAvailable = await ModelDownloadService.checkNetworkReachability()
+        if !networkAvailable {
+            modelError = DownloadErrorKind.networkOffline.title + ": " + DownloadErrorKind.networkOffline.detail
+            isLoadingModels = false
+            return
+        }
+
+        // Pre-flight: check disk space (~700MB needed for Parakeet + Diarization)
+        if let available = ModelDownloadService.availableDiskSpace(), available < 1_000_000_000 {
+            modelError = DownloadErrorKind.diskSpace.title + ": " + DownloadErrorKind.diskSpace.detail
+            isLoadingModels = false
+            return
+        }
+
         // Start monitoring download progress on disk
         let progressTask = Task { @MainActor in
             await monitorDownloadProgress()
@@ -203,7 +218,7 @@ class OnboardingState {
         let parakeet = ParakeetService()
         let diarization = DiarizationService()
 
-        // Initialize both in parallel
+        // Initialize both in parallel (retry logic built into each service)
         async let p: Void = parakeet.initialize()
         async let s: Void = diarization.initialize()
         await p

--- a/Transcripted/Services/DiarizationService.swift
+++ b/Transcripted/Services/DiarizationService.swift
@@ -70,8 +70,9 @@ class DiarizationService: ObservableObject {
             modelState = .ready
             AppLogger.transcription.info("Diarization models loaded and ready")
         } catch {
-            modelState = .failed(error.localizedDescription)
-            AppLogger.transcription.error("Diarization model initialization failed", ["error": "\(error.localizedDescription)"])
+            let kind = ModelDownloadService.classifyError(error)
+            modelState = .failed(kind.detail)
+            AppLogger.transcription.error("Diarization model initialization failed", ["error": "\(error.localizedDescription)", "kind": kind.title])
         }
     }
 
@@ -86,7 +87,9 @@ class DiarizationService: ObservableObject {
             manager.initialize(models: models)
         } else {
             AppLogger.transcription.info("Sortformer models not bundled, loading from cache or downloading")
-            let models = try await DiarizerModels.download()
+            let models = try await ModelDownloadService.withRetry {
+                try await DiarizerModels.download()
+            }
             manager.initialize(models: models)
         }
 
@@ -108,7 +111,9 @@ class DiarizationService: ObservableObject {
             manager.initialize(models: models)
         } else {
             AppLogger.transcription.info("Offline diarizer models not bundled, loading from cache or downloading")
-            try await manager.prepareModels()
+            try await ModelDownloadService.withRetry {
+                try await manager.prepareModels()
+            }
         }
 
         offlineDiarizerManager = manager

--- a/Transcripted/Services/ParakeetService.swift
+++ b/Transcripted/Services/ParakeetService.swift
@@ -44,9 +44,11 @@ class ParakeetService: ObservableObject {
                 models = try await AsrModels.load(from: bundlePath, version: .v3)
                 loadSource = "bundle"
             } else {
-                // Fallback: load from cache or download from HuggingFace (~600MB on first run)
+                // Download from HuggingFace (~600MB) with retry on transient failures
                 AppLogger.transcription.info("Parakeet models not bundled, loading from cache or downloading")
-                models = try await AsrModels.downloadAndLoad(version: .v3)
+                models = try await ModelDownloadService.withRetry {
+                    try await AsrModels.downloadAndLoad(version: .v3)
+                }
                 loadSource = "download"
             }
 
@@ -58,8 +60,9 @@ class ParakeetService: ObservableObject {
             let elapsed = String(format: "%.1fs", Date().timeIntervalSince(loadStart))
             AppLogger.transcription.info("Parakeet models loaded and ready", ["source": loadSource, "elapsed": elapsed])
         } catch {
-            modelState = .failed(error.localizedDescription)
-            AppLogger.transcription.error("Parakeet model initialization failed", ["error": "\(error.localizedDescription)"])
+            let kind = ModelDownloadService.classifyError(error)
+            modelState = .failed(kind.detail)
+            AppLogger.transcription.error("Parakeet model initialization failed", ["error": "\(error.localizedDescription)", "kind": kind.title])
         }
     }
 

--- a/Transcripted/Services/QwenService.swift
+++ b/Transcripted/Services/QwenService.swift
@@ -73,6 +73,28 @@ class QwenService: ObservableObject {
         AppLogger.transcription.info("Qwen loading model", ["modelId": Self.modelId])
 
         do {
+            // Pre-populate cache from HuggingFace with mirror fallback before
+            // mlx-swift-lm tries its own download. If files already exist, this is a no-op.
+            if !Self.isModelCached {
+                modelState = .downloading(progress: 0)
+                do {
+                    try await ModelDownloadService.prePopulateQwenCache(
+                        modelId: Self.modelId,
+                        progressHandler: { [weak self] progress in
+                            Task { @MainActor in
+                                self?.modelState = .downloading(progress: progress)
+                            }
+                        }
+                    )
+                } catch {
+                    // Pre-population failed — fall through to mlx-swift-lm's built-in download
+                    // which may still succeed (e.g. if only the mirror API was unreachable)
+                    AppLogger.transcription.warning("Qwen pre-population failed, falling back to mlx-swift-lm download", [
+                        "error": error.localizedDescription
+                    ])
+                }
+            }
+
             let container = try await loadModelContainer(
                 id: Self.modelId,
                 progressHandler: { [weak self] progress in
@@ -86,8 +108,9 @@ class QwenService: ObservableObject {
             modelState = .ready
             AppLogger.transcription.info("Qwen model loaded and ready")
         } catch {
-            modelState = .failed(error.localizedDescription)
-            AppLogger.transcription.error("Qwen model load failed", ["error": error.localizedDescription])
+            let kind = ModelDownloadService.classifyError(error)
+            modelState = .failed(kind.detail)
+            AppLogger.transcription.error("Qwen model load failed", ["error": error.localizedDescription, "kind": kind.title])
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `ModelDownloadService` with HuggingFace mirror fallback (`hf-mirror.com`), retry with exponential backoff (3 attempts, 2s/5s/10s), and error classification
- Qwen pre-populates cache directory before mlx-swift-lm attempts download, so if primary CDN fails, mirror is tried automatically
- Parakeet and diarization FluidAudio downloads wrapped with retry logic
- Onboarding checks network connectivity and disk space before starting downloads, failing fast with user-friendly messages

## Test plan
- [ ] Disconnect wifi → attempt model download → verify "No internet" error appears immediately
- [ ] With Qwen cache empty, verify pre-population downloads files then `loadModelContainer` finds them
- [ ] Kill network mid-download → verify retry kicks in (check logs for "Download attempt X/3 failed")
- [ ] Verify normal download flow still works end-to-end
- [ ] Verify disk space < 1GB shows appropriate error

🤖 Generated with [Claude Code](https://claude.com/claude-code)