### PR TITLE
feat: improve first-run UX with download speed, ETA, and structured errors

### DIFF
--- a/Transcripted/Onboarding/OnboardingState.swift
+++ b/Transcripted/Onboarding/OnboardingState.swift
@@ -60,7 +60,10 @@ class OnboardingState {
     var parakeetPhase: String = ""
     var diarizationPhase: String = ""
     var modelError: String?
+    var modelErrorKind: DownloadErrorKind?
     var isLoadingModels = false
+    var downloadSpeed: Double = 0  // bytes per second (smoothed)
+    var estimatedTimeRemaining: TimeInterval?  // seconds, nil when unknown
 
     var modelsReady: Bool {
         parakeetReady && diarizationReady
@@ -190,22 +193,27 @@ class OnboardingState {
         guard !isLoadingModels else { return }
         isLoadingModels = true
         modelError = nil
+        modelErrorKind = nil
         parakeetProgress = 0
         diarizationProgress = 0
+        downloadSpeed = 0
+        estimatedTimeRemaining = nil
         parakeetPhase = "Downloading..."
         diarizationPhase = "Downloading..."
 
         // Pre-flight: check network connectivity before starting long downloads
         let networkAvailable = await ModelDownloadService.checkNetworkReachability()
         if !networkAvailable {
-            modelError = DownloadErrorKind.networkOffline.title + ": " + DownloadErrorKind.networkOffline.detail
+            modelErrorKind = .networkOffline
+            modelError = DownloadErrorKind.networkOffline.detail
             isLoadingModels = false
             return
         }
 
         // Pre-flight: check disk space (~700MB needed for Parakeet + Diarization)
         if let available = ModelDownloadService.availableDiskSpace(), available < 1_000_000_000 {
-            modelError = DownloadErrorKind.diskSpace.title + ": " + DownloadErrorKind.diskSpace.detail
+            modelErrorKind = .diskSpace
+            modelError = DownloadErrorKind.diskSpace.detail
             isLoadingModels = false
             return
         }
@@ -250,7 +258,7 @@ class OnboardingState {
     private static let expectedParakeetSize: Double = 483_000_000  // ~461 MB on disk
     private static let expectedDiarizationSize: Double = 36_000_000 // ~34 MB on disk
 
-    /// Poll the FluidAudio Models directory to estimate download progress
+    /// Poll the FluidAudio Models directory to estimate download progress, speed, and ETA
     @MainActor
     private func monitorDownloadProgress() async {
         let modelsDir = FileManager.default.homeDirectoryForCurrentUser
@@ -258,12 +266,44 @@ class OnboardingState {
         let parakeetDir = modelsDir.appendingPathComponent("parakeet-tdt-0.6b-v3-coreml")
         let diarizationDir = modelsDir.appendingPathComponent("speaker-diarization-coreml")
 
+        // Speed tracking state
+        var previousTotalBytes: Double = 0
+        var previousTimestamp: Date = Date()
+        var smoothedSpeed: Double = 0
+        let smoothingFactor = 0.3  // EMA: 30% new, 70% old
+
         while !Task.isCancelled {
             let parakeetBytes = Self.directorySize(parakeetDir)
             let diarizationBytes = Self.directorySize(diarizationDir)
+            let totalBytes = parakeetBytes + diarizationBytes
 
             let pProgress = min(parakeetBytes / Self.expectedParakeetSize, 0.99)
             let sProgress = min(diarizationBytes / Self.expectedDiarizationSize, 0.99)
+
+            // Compute download speed
+            let now = Date()
+            let elapsed = now.timeIntervalSince(previousTimestamp)
+            if elapsed > 0.1 {  // Avoid division by near-zero
+                let bytesPerSecond = (totalBytes - previousTotalBytes) / elapsed
+                if bytesPerSecond > 0 {
+                    smoothedSpeed = smoothedSpeed == 0
+                        ? bytesPerSecond
+                        : smoothedSpeed * (1 - smoothingFactor) + bytesPerSecond * smoothingFactor
+                }
+                previousTotalBytes = totalBytes
+                previousTimestamp = now
+            }
+
+            downloadSpeed = smoothedSpeed
+
+            // Compute ETA from remaining bytes and smoothed speed
+            let totalExpected = Self.expectedParakeetSize + Self.expectedDiarizationSize
+            let remainingBytes = max(0, totalExpected - totalBytes)
+            if smoothedSpeed > 1000 {  // Only show ETA when speed is meaningful
+                estimatedTimeRemaining = remainingBytes / smoothedSpeed
+            } else {
+                estimatedTimeRemaining = nil
+            }
 
             if !parakeetReady {
                 parakeetProgress = pProgress

--- a/Transcripted/Onboarding/OnboardingWindow.swift
+++ b/Transcripted/Onboarding/OnboardingWindow.swift
@@ -31,6 +31,24 @@ class OnboardingWindowController: NSWindowController, NSWindowDelegate {
 
     // MARK: - NSWindowDelegate
 
+    /// Intercept close during model download — show confirmation dialog
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        if onboardingState.isLoadingModels {
+            let alert = NSAlert()
+            alert.messageText = "Download in Progress"
+            alert.informativeText = "AI models are still downloading. If you close now, you can retry later from the menu bar settings."
+            alert.addButton(withTitle: "Close Anyway")
+            alert.addButton(withTitle: "Keep Downloading")
+            alert.alertStyle = .warning
+
+            let response = alert.runModal()
+            if response == .alertSecondButtonReturn {
+                return false  // User chose to keep downloading
+            }
+        }
+        return true
+    }
+
     /// Handle close button: treat as "skip onboarding" so the app doesn't end up in a dead state.
     /// Without this, closing the window leaves no menu bar, no floating panel — just an invisible process.
     func windowWillClose(_ notification: Notification) {

--- a/Transcripted/Onboarding/Steps/ModelSetupStep.swift
+++ b/Transcripted/Onboarding/Steps/ModelSetupStep.swift
@@ -67,18 +67,59 @@ struct ModelSetupStep: View {
 
             Spacer()
 
+            // Download speed and ETA
+            if state.isLoadingModels && state.downloadSpeed > 1000 {
+                HStack(spacing: Spacing.sm) {
+                    Image(systemName: "arrow.down.circle")
+                        .font(.system(size: 12))
+                        .foregroundColor(.softCharcoal)
+
+                    Text(formatSpeed(state.downloadSpeed))
+                        .font(.caption)
+                        .foregroundColor(.softCharcoal)
+
+                    if let eta = state.estimatedTimeRemaining, eta > 0, eta < 3600 {
+                        Text("—")
+                            .font(.caption)
+                            .foregroundColor(.softCharcoal.opacity(0.5))
+                        Text("~\(formatETA(eta)) remaining")
+                            .font(.caption)
+                            .foregroundColor(.softCharcoal)
+                    }
+                }
+                .transition(.opacity)
+                .animation(.smooth, value: state.downloadSpeed)
+            }
+
             // Error state with retry
             if let error = state.modelError, !state.isLoadingModels {
                 VStack(spacing: Spacing.sm) {
-                    HStack(spacing: Spacing.xs) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.system(size: 14))
-                            .foregroundColor(.recordingRed)
+                    // Structured error card
+                    VStack(spacing: Spacing.xs) {
+                        HStack(spacing: Spacing.xs) {
+                            Image(systemName: errorIcon(for: state.modelErrorKind))
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundColor(.recordingRed)
+                            Text(state.modelErrorKind?.title ?? "Download Failed")
+                                .font(.bodyMedium)
+                                .fontWeight(.semibold)
+                                .foregroundColor(.charcoal)
+                        }
+
                         Text(error)
                             .font(.bodySmall)
                             .foregroundColor(.softCharcoal)
                             .multilineTextAlignment(.center)
                     }
+                    .padding(Spacing.md)
+                    .background(
+                        RoundedRectangle(cornerRadius: Radius.md)
+                            .fill(Color.recordingRed.opacity(0.06))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Radius.md)
+                            .strokeBorder(Color.recordingRed.opacity(0.15), lineWidth: 1)
+                    )
 
                     PremiumButton(
                         title: "Retry Download",
@@ -142,6 +183,36 @@ struct ModelSetupStep: View {
             if !state.modelsReady && !state.isLoadingModels {
                 Task { await state.loadModels() }
             }
+        }
+    }
+
+    private func formatSpeed(_ bytesPerSecond: Double) -> String {
+        if bytesPerSecond >= 1_000_000 {
+            return String(format: "%.1f MB/s", bytesPerSecond / 1_000_000)
+        } else if bytesPerSecond >= 1_000 {
+            return String(format: "%.0f KB/s", bytesPerSecond / 1_000)
+        }
+        return ""
+    }
+
+    private func formatETA(_ seconds: TimeInterval) -> String {
+        if seconds < 60 {
+            return "\(Int(seconds))s"
+        } else {
+            let minutes = Int(seconds) / 60
+            let secs = Int(seconds) % 60
+            return "\(minutes)m \(secs)s"
+        }
+    }
+
+    private func errorIcon(for kind: DownloadErrorKind?) -> String {
+        switch kind {
+        case .networkOffline: return "wifi.slash"
+        case .tlsFailure: return "lock.slash"
+        case .timeout: return "clock.badge.exclamationmark"
+        case .diskSpace: return "externaldrive.badge.xmark"
+        case .serverError: return "server.rack"
+        default: return "exclamationmark.triangle.fill"
         }
     }
 


### PR DESCRIPTION
## Summary
- Show real-time download speed (EMA-smoothed) and estimated time remaining during model downloads
- Replace raw error strings with structured error cards — type-specific icons (wifi.slash, lock.slash, etc.) and actionable guidance
- Add confirmation dialog when user tries to close onboarding window during active download
- Builds on #71 (fallback downloads) for error classification via `DownloadErrorKind`

## Test plan
- [ ] Start model download → verify speed (e.g. "12.3 MB/s") and ETA ("~30s remaining") appear below progress bars
- [ ] Disconnect wifi before download → verify structured error card with wifi.slash icon and "Connect to the internet" message
- [ ] Close onboarding window during download → verify "Download in Progress" confirmation dialog appears
- [ ] Choose "Keep Downloading" in dialog → verify window stays open and download continues
- [ ] Choose "Close Anyway" → verify window closes and app initializes

🤖 Generated with [Claude Code](https://claude.com/claude-code)