### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,12 @@ Menu bar-only macOS app for real-time system audio transcription. Pipeline: Core
 - **Protocols**: 7 service protocols in `Services/Protocols/` (SpeechToTextEngine, DiarizationEngine, SpeakerStore, etc.)
 - **DI**: `AppServices` container in `Core/AppServices.swift`
 
-## Folder Map (~140 Swift files, agent-first: max ~300 lines per file, single responsibility)
-- **Core/** (46 files): Audio capture (Audio + 3 extensions), transcription pipeline (TaskManager + 3 extensions), transcript saving (4 files), stats DB (3 files), failed transcription retry, logging, coordinators (Hotkey, MenuBar, Notification, Window, Recording)
+## Folder Map (~143 Swift files, agent-first: max ~300 lines per file, single responsibility)
+- **Core/** (47 files): Audio capture (Audio + 3 extensions), transcription pipeline (TaskManager + 3 extensions), transcript saving (4 files), stats DB (3 files), model downloads (ModelDownloadService), failed transcription retry, logging, coordinators (Hotkey, MenuBar, Notification, Window, Recording)
 - **Services/** (18 files): ML services (11 files) + Protocols/ subdirectory (7 service protocols)
 - **UI/FloatingPanel/** (26 files): Morphing pill UI, aurora visualizations (4 files), transcript tray (3 files), speaker naming (3 files), Components/ (21 files), Helpers/ (1 file)
 - **UI/Settings/** (18 files): Settings container + Sections/ (7 section views) + Components/ (6 reusable components) + Models/ (1 file)
-- **Onboarding/** (6 files): 3-step first-run flow (Welcome -> Permissions -> Model Setup)
+- **Onboarding/** (7 files): 4-step first-run flow (Welcome -> Preview -> Permissions -> Model Setup)
 - **Design/** (23 files): Colors/ (6 files), Components/ (7 premium components), root tokens (10 files: Spacing, Radius, Typography, Animations, Shadows, ViewModifiers, Gradients, Dimensions, Accessibility, CardModifiers)
 
 ## Build & Test
@@ -82,6 +82,7 @@ User presses Cmd+Shift+R (global hotkey)
 - **Parakeet**: Bundled or downloaded from HuggingFace (~600MB), 16kHz target rate
 - **Diarization**: PyAnnote offline + Sortformer streaming, bundled or via FluidAudio
 - **Qwen**: On-demand download (~2.5GB), loads/unloads to manage memory
+- **Download resilience**: All downloads use `ModelDownloadService` with HuggingFace mirror fallback (`hf-mirror.com`), retry with exponential backoff, and structured error classification
 
 ## CLAUDE.md Navigation (15 files)
 Every folder with ≥2 Swift files has its own CLAUDE.md with file index, reference data, and gotchas.
@@ -101,8 +102,8 @@ Every folder with ≥2 Swift files has its own CLAUDE.md with file index, refere
 | `Transcripted/UI/Settings/CLAUDE.md` | @AppStorage keys, window config, speaker operations |
 | `Transcripted/UI/Settings/Sections/CLAUDE.md` | 7 section views with per-section detail |
 | `Transcripted/UI/Settings/Components/CLAUDE.md` | CoralToggle, button styles, input components |
-| `Transcripted/Onboarding/CLAUDE.md` | 3-step flow, OnboardingState properties, integration |
-| `Transcripted/Onboarding/Steps/CLAUDE.md` | Welcome, Permissions, ModelSetup step implementations |
+| `Transcripted/Onboarding/CLAUDE.md` | 4-step flow, OnboardingState properties, integration |
+| `Transcripted/Onboarding/Steps/CLAUDE.md` | Welcome, Preview, Permissions, ModelSetup step implementations |
 
 **Single-file folders** (covered by parent CLAUDE.md):
 - `UI/MenuBar/MenuBarStatRow.swift` — Custom NSView (250x22), used in status bar dropdown

--- a/Transcripted/Core/CLAUDE.md
+++ b/Transcripted/Core/CLAUDE.md
@@ -1,6 +1,6 @@
 # Core Folder
 
-Audio capture pipeline, transcription orchestration, file saving, stats tracking, error recovery, and app lifecycle. 46 Swift files (including Logging/).
+Audio capture pipeline, transcription orchestration, file saving, stats tracking, model downloads, error recovery, and app lifecycle. 47 Swift files (including Logging/).
 
 ## File Index
 
@@ -36,6 +36,7 @@ Audio capture pipeline, transcription orchestration, file saving, stats tracking
 | `StatsDatabaseModels.swift` | -- | RecordingMetadata, DailyActivity data models |
 | `StatsDatabaseQueries.swift` | NOT @MainActor | Complex queries and aggregations for StatsDatabase |
 | `StatsService.swift` | @MainActor | Stats aggregation for dashboard UI |
+| `ModelDownloadService.swift` | Static | HuggingFace download with mirror fallback (hf-mirror.com), retry with exponential backoff, Qwen cache pre-population, structured error classification (DownloadErrorKind) |
 | `RecordingValidator.swift` | Static | Pre-recording checks (disk space, permissions, save path) |
 | `FailedTranscription.swift` | -- | Model for retryable failed transcriptions |
 | `FailedTranscriptionManager.swift` | @MainActor | Retry queue, persists to JSON, auto-cleans permanent failures |

--- a/Transcripted/Onboarding/CLAUDE.md
+++ b/Transcripted/Onboarding/CLAUDE.md
@@ -1,6 +1,6 @@
 # Onboarding
 
-3-step first-run flow that gates access to the main app until permissions and models are ready. 6 Swift files.
+4-step first-run flow that gates access to the main app until permissions and models are ready. 7 Swift files.
 
 ## File Index
 
@@ -10,21 +10,23 @@
 | `OnboardingContainerView.swift` | View orchestrator. Step switching with transitions, navigation buttons, skip confirmation. |
 | `OnboardingWindow.swift` | NSWindowController. Frosted glass background, fade-in animation, close = skip. |
 | `Steps/WelcomeStep.swift` | Welcome screen. Animated icon + 3 cascading BenefitCards. See Steps/CLAUDE.md |
+| `Steps/PreviewStep.swift` | Sample transcript preview. Animated lines showing "aha moment" before permissions. See Steps/CLAUDE.md |
 | `Steps/PermissionsStep.swift` | Permission request. Mic (required) + Screen Recording (optional). See Steps/CLAUDE.md |
-| `Steps/ModelSetupStep.swift` | Model downloads. Progress bars, tips carousel. See Steps/CLAUDE.md |
+| `Steps/ModelSetupStep.swift` | Model downloads. Progress bars, download speed/ETA, structured errors. See Steps/CLAUDE.md |
 
 ## Step Order
 ```
 1. Welcome     -> always canProceed
-2. Permissions  -> always canProceed (mic optional but recommended)
-3. Model Setup  -> canProceed only when parakeetReady AND diarizationReady
+2. Preview     -> always canProceed (sample transcript "aha moment")
+3. Permissions  -> always canProceed (mic optional but recommended)
+4. Model Setup  -> canProceed only when parakeetReady AND diarizationReady
 ```
 
 ## OnboardingState Key Properties
 ```swift
 // Step navigation
-currentStep: OnboardingStep (.welcome | .permissions | .modelSetup)
-stepProgress: Double (0.0-1.0), stepNumber: Int (1-3), totalSteps: 3
+currentStep: OnboardingStep (.welcome | .preview | .permissions | .modelSetup)
+stepProgress: Double (0.0-1.0), stepNumber: Int (1-4), totalSteps: 4
 
 // Permissions
 microphoneStatus: AVAuthorizationStatus
@@ -38,6 +40,8 @@ parakeetReady: Bool, diarizationReady: Bool, modelsReady: Bool (computed: both t
 parakeetProgress: Double, diarizationProgress: Double (0.0-1.0)
 parakeetPhase: String, diarizationPhase: String ("Downloading...", "Compiling models...", "Ready")
 isLoadingModels: Bool, modelError: String? (concatenated errors with \n)
+modelErrorKind: DownloadErrorKind? (structured error classification from ModelDownloadService)
+downloadSpeed: Double (bytes/sec, smoothed), estimatedTimeRemaining: TimeInterval? (nil when unknown)
 ```
 
 ## OnboardingState Key Methods

--- a/Transcripted/Onboarding/Steps/CLAUDE.md
+++ b/Transcripted/Onboarding/Steps/CLAUDE.md
@@ -1,14 +1,15 @@
 # Onboarding Steps
 
-3 SwiftUI views implementing individual onboarding steps. Hosted by OnboardingContainerView.swift (parent). All use `@Bindable var state: OnboardingState` (Observable macro).
+4 SwiftUI views implementing individual onboarding steps. Hosted by OnboardingContainerView.swift (parent). All use `@Bindable var state: OnboardingState` (Observable macro).
 
 ## File Index
 
 | File | Step | canProceed |
 |------|------|------------|
 | `WelcomeStep.swift` | 1. Welcome | Always true |
-| `PermissionsStep.swift` | 2. Permissions | Always true (mic optional but recommended) |
-| `ModelSetupStep.swift` | 3. Model Setup | Only when parakeetReady AND diarizationReady |
+| `PreviewStep.swift` | 2. Preview | Always true |
+| `PermissionsStep.swift` | 3. Permissions | Always true (mic optional but recommended) |
+| `ModelSetupStep.swift` | 4. Model Setup | Only when parakeetReady AND diarizationReady |
 
 ## Step Details
 
@@ -22,7 +23,14 @@
 - Stagger animation: 0.3s base + 0.12s per card (delays: 0.3, 0.42, 0.54s)
 - Content entry: .smooth.delay(0.1)
 
-### PermissionsStep (Step 2)
+### PreviewStep (Step 2)
+- Sample transcript showing a realistic meeting conversation
+- 6 animated transcript lines appear sequentially (0.3s stagger)
+- Two speakers: Sarah (terracotta) and Mike (processingPurple)
+- Delivers "aha moment" — shows what Transcripted produces before asking for permissions
+- No user action required, always canProceed
+
+### PermissionsStep (Step 3)
 - 2 PermissionCards (from Design/Components/):
   - **Microphone** (required): mic.fill icon. Requests via `AVCaptureDevice.requestAccess(for: .audio)`
   - **Screen Recording** (optional): rectangle.inset.filled.and.person.filled icon. Checks via `CGWindowListCopyWindowInfo()` side-effect
@@ -31,7 +39,7 @@
 - Status icons: same icon (not requested) → hourglass (pending) → checkmark.circle.fill (granted) → xmark.circle.fill (denied)
 - Success message: green checkmark 20pt, bouncy.delay(0.1) scale, .smooth.delay(0.2) text
 
-### ModelSetupStep (Step 3)
+### ModelSetupStep (Step 4)
 - Downloads 2 models in parallel (`async let`):
   - **Parakeet**: ~483MB expected (ASR model)
   - **Diarization**: ~36MB expected (speaker separation)

--- a/Transcripted/Services/CLAUDE.md
+++ b/Transcripted/Services/CLAUDE.md
@@ -8,13 +8,13 @@ ML pipeline services, speaker database, audio processing utilities, meeting dete
 
 | File | Actor | Purpose |
 |------|-------|---------|
-| `ParakeetService.swift` | @MainActor | Local ASR via FluidAudio's Parakeet TDT V3 CoreML. Batch only. |
-| `DiarizationService.swift` | @MainActor | Dual-pipeline: Sortformer (streaming) + PyAnnote (offline) |
+| `ParakeetService.swift` | @MainActor | Local ASR via FluidAudio's Parakeet TDT V3 CoreML. Batch only. Downloads via ModelDownloadService with mirror fallback. |
+| `DiarizationService.swift` | @MainActor | Dual-pipeline: Sortformer (streaming) + PyAnnote (offline). Downloads via ModelDownloadService with mirror fallback. |
 | `SpeakerDatabase.swift` | Utility queue | SQLite at ~/Documents/Transcripted/speakers.sqlite, core CRUD + schema |
 | `SpeakerEmbeddingMatcher.swift` | Utility queue | Cosine similarity matching against stored speaker profiles (vDSP-accelerated) |
 | `SpeakerProfile.swift` | -- | SpeakerProfile struct (256-dim embeddings) + SpeakerMatchResult |
 | `SpeakerProfileMerger.swift` | Utility queue | Profile name updates, merging, pruning, and name variant lookup |
-| `QwenService.swift` | @MainActor | On-device Qwen3.5-4B-4bit via mlx-swift-lm, on-demand load/unload |
+| `QwenService.swift` | @MainActor | On-device Qwen3.5-4B-4bit via mlx-swift-lm, on-demand load/unload. Pre-populates cache via ModelDownloadService with mirror fallback and progress tracking. |
 | `EmbeddingClusterer.swift` | Static | 3-stage post-processing: pairwise merge, small cluster absorption, DB-informed split |
 | `AudioResampler.swift` | Static | AVAudioConverter-based resampling to 16kHz, WAV loading, slice extraction |
 | `SpeakerClipExtractor.swift` | Static | Extract per-speaker audio clips for naming UI playback |
@@ -116,6 +116,7 @@ postProcess(segments, existingProfiles, skipPairwiseMerge):
 ## QwenService Details (QwenService.swift)
 - **Model**: `mlx-community/Qwen3.5-4B-4bit` (~2.5GB)
 - **Cache**: `~/Library/Caches/models/mlx-community/Qwen3.5-4B-4bit`
+- **Download**: Pre-populates cache via `ModelDownloadService.prePopulateQwenCache()` with HuggingFace mirror fallback, progress tracking, and disk space validation. Falls back to mlx-swift-lm's built-in download on failure.
 - **Inference**: temperature=0.1 (deterministic), maxTokens=200
 - **Prompt**: Teaches model that "Hey Jack" means speaker is talking TO Jack (listener), not IS Jack
 - **Output**: JSON keys are speaker numbers ("0", "1"), values are names or "Unknown"
@@ -152,6 +153,16 @@ Hardcoded lookup table: mike/michael/mikey, nate/nathan/nathaniel, dave/david, a
 - **SpeakerDatabase, SpeakerEmbeddingMatcher, SpeakerProfileMerger** -- dedicated utility queue (`com.transcripted.speakerdb`), NOT @MainActor
 - **ParakeetService, DiarizationService, QwenService, MeetingDetector** -- @MainActor
 - **EmbeddingClusterer, AudioResampler, SpeakerClipExtractor** -- static methods, called from pipeline threads
+
+## Model Download Resilience (via Core/ModelDownloadService.swift)
+All three ML services (Parakeet, Diarization, Qwen) use `ModelDownloadService` for resilient downloads:
+- **Mirror fallback**: Primary `huggingface.co` -> fallback `hf-mirror.com`
+- **Retry**: Exponential backoff (2s, 5s, 10s), max 3 attempts per mirror
+- **Error classification**: `DownloadErrorKind` (networkOffline, tlsFailure, timeout, diskSpace, serverError, unknown) with user-friendly messages
+- **Network check**: NWPathMonitor reachability probe with 3s timeout
+- **Disk validation**: Requires ~2.5GB free for Qwen
+- Services call `ModelDownloadService.withRetry()` for Parakeet/Diarization, `ModelDownloadService.prePopulateQwenCache()` for Qwen
+- Errors classified via `ModelDownloadService.classifyError()` and surfaced to UI as `OnboardingState.modelErrorKind`
 
 ## Gotchas
 - EMA alpha=0.15 is SLOW: takes 6-7 updates to meaningfully shift a speaker profile


### PR DESCRIPTION
## Summary
- **Root CLAUDE.md**: Updated file counts (Core/ 46→47, Onboarding/ 6→7, total ~140→~143), updated Onboarding from 3-step to 4-step flow, added ModelDownloadService to Core description and Model Cache section, updated navigation table descriptions
- **Core/CLAUDE.md**: Updated file count 46→47, added `ModelDownloadService.swift` to file index (mirror fallback, retry, error classification, Qwen cache pre-population)
- **Onboarding/CLAUDE.md**: Updated from 3→4 steps and 6→7 files, added PreviewStep to file index and step order, updated OnboardingStep enum to include `.preview`, added new state properties (`modelErrorKind`, `downloadSpeed`, `estimatedTimeRemaining`)
- **Onboarding/Steps/CLAUDE.md**: Updated from 3→4 views, added PreviewStep file index row and detail section, renumbered Permissions→Step 3 and ModelSetup→Step 4
- **Services/CLAUDE.md**: Added ModelDownloadService references to Parakeet/Diarization/Qwen descriptions, added Qwen download detail, added new "Model Download Resilience" section

## Context
Catches up documentation after PRs #57 (Preview Transcript onboarding step), #71 (HuggingFace mirror fallback), and #72 (download speed/ETA/structured errors).

## Test plan
- [ ] Verify file counts match actual Swift file counts in each directory
- [ ] Confirm step order matches `OnboardingState.OnboardingStep` enum
- [ ] Check that ModelDownloadService behavior description matches implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)