### PR TITLE
security: nightly security audit findings [automated]

### DIFF
--- a/Transcripted/Core/ModelDownloadService.swift
+++ b/Transcripted/Core/ModelDownloadService.swift
@@ -249,6 +249,13 @@ enum ModelDownloadService {
         // Download each file with mirror fallback
         var downloadedCount = 0
         for file in fileList {
+            // Security: validate filename from external API before constructing a path with it.
+            // Rejects path traversal sequences (e.g. "../../.ssh") injected by a malicious server.
+            guard isSafeModelFilename(file.name) else {
+                AppLogger.services.error("Rejecting unsafe model filename from API response", ["filename": file.name])
+                throw ModelDownloadError(kind: .unknown("Unsafe filename in model file list: \(file.name)"), underlyingError: nil)
+            }
+
             let destURL = cacheDir.appendingPathComponent(file.name)
 
             // Skip if already downloaded
@@ -277,6 +284,23 @@ enum ModelDownloadService {
         let size: Int?
     }
 
+    /// Validate a filename returned by the HuggingFace API before using it in a file path.
+    /// Security: filenames are attacker-controlled data from an external API response.
+    /// A compromised or impersonated server could inject path traversal sequences (e.g. "../../../.ssh/authorized_keys")
+    /// into rfilename values. We reject any name containing ".." components or absolute paths.
+    private static func isSafeModelFilename(_ name: String) -> Bool {
+        // Reject empty names
+        guard !name.isEmpty else { return false }
+        // Reject absolute paths
+        guard !name.hasPrefix("/") else { return false }
+        // Reject names containing ".." path traversal components
+        let components = name.components(separatedBy: "/")
+        guard !components.contains("..") && !components.contains(".") else { return false }
+        // Reject names with null bytes or control characters
+        guard !name.unicodeScalars.contains(where: { $0.value < 32 }) else { return false }
+        return true
+    }
+
     /// Fetch the list of files in a HuggingFace model repository
     private static func fetchModelFileList(modelId: String) async throws -> [HFModelFile] {
         // Try each mirror for the API call
@@ -297,6 +321,12 @@ enum ModelDownloadService {
 
                 let files = siblings.compactMap { sibling -> HFModelFile? in
                     guard let name = sibling["rfilename"] as? String else { return nil }
+                    // Security: filter out any filenames that would escape the cache directory.
+                    // Malicious or compromised API responses could include path traversal sequences.
+                    guard isSafeModelFilename(name) else {
+                        AppLogger.services.warning("Skipping unsafe filename in model manifest", ["filename": name])
+                        return nil
+                    }
                     let size = sibling["size"] as? Int
                     return HFModelFile(name: name, size: size)
                 }

--- a/Transcripted/Core/TranscriptSaver.swift
+++ b/Transcripted/Core/TranscriptSaver.swift
@@ -6,17 +6,32 @@ import UserNotifications
 class TranscriptSaver {
 
     /// Default save location: ~/Documents/Transcripted/
-    /// Reads custom location from UserDefaults if set
+    /// Reads custom location from UserDefaults if set.
+    /// Security: validates the custom path against directory traversal and forbidden system
+    /// directories before use. Falls back to the default location if validation fails, so
+    /// a tampered UserDefaults value cannot redirect transcripts to an arbitrary path.
     static var defaultSaveDirectory: URL {
+        let fallback: URL = {
+            let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            return documentsPath.appendingPathComponent("Transcripted")
+        }()
+
         // Check for custom save location first
         if let customPath = UserDefaults.standard.string(forKey: "transcriptSaveLocation"),
            !customPath.isEmpty {
-            return URL(fileURLWithPath: customPath)
+            let candidateURL = URL(fileURLWithPath: customPath)
+            let validation = RecordingValidator.validateSavePath(candidateURL)
+            guard validation.isValid else {
+                AppLogger.pipeline.warning("Custom save path rejected in defaultSaveDirectory, using default", [
+                    "path": customPath,
+                    "reason": validation.errorMessage ?? "unknown"
+                ])
+                return fallback
+            }
+            return candidateURL
         }
 
-        // Fall back to default location
-        let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-        return documentsPath.appendingPathComponent("Transcripted")
+        return fallback
     }
 
     /// Serial queue for file updates — prevents concurrent reads/writes from corrupting transcripts

--- a/Transcripted/Services/SpeakerClipExtractor.swift
+++ b/Transcripted/Services/SpeakerClipExtractor.swift
@@ -204,6 +204,9 @@ enum SpeakerClipExtractor {
         }
 
         let outputFile = try AVAudioFile(forWriting: clipURL, settings: outputFormat.settings)
+        // Security: restrict temp clip file permissions to owner-only (600) immediately after
+        // creation — speaker voice clips contain biometric data and should not be world-readable.
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: clipURL.path)
         let inputFormat = audioFile.processingFormat
         let maxClipFrames = AVAudioFrameCount(8.0 * sampleRate)
         var totalFramesWritten: AVAudioFrameCount = 0

--- a/Transcripted/Services/SpeakerDatabase.swift
+++ b/Transcripted/Services/SpeakerDatabase.swift
@@ -91,8 +91,17 @@ final class SpeakerDatabase {
         }
     }
 
-    /// Query SQLite for existing column names in a table
+    /// Query SQLite for existing column names in a table.
+    /// Security: PRAGMA table_info does not support parameter binding, so the table name is
+    /// validated against a compile-time allowlist before interpolation to prevent SQL injection.
     private func getColumnNames(table: String) -> Set<String> {
+        // Allowlist of known table names — reject anything not in this set
+        let allowedTables: Set<String> = ["speakers"]
+        guard allowedTables.contains(table) else {
+            AppLogger.speakers.error("getColumnNames called with unexpected table name — rejecting", ["table": table])
+            return []
+        }
+
         var columns: Set<String> = []
         var statement: OpaquePointer?
         let sql = "PRAGMA table_info(\(table));"


### PR DESCRIPTION
## Summary

Automated nightly security audit run on 2026-03-22. Four vulnerabilities were found and fixed across four files.

## Findings by Severity

### Medium

**1. SQL injection via PRAGMA table_info string interpolation** (`SpeakerDatabase.swift`)
- `getColumnNames(table:)` used Swift string interpolation `"PRAGMA table_info(\(table));"` to build a SQL statement. SQLite's PRAGMA syntax does not accept parameter bindings for table names, so the table name cannot be bound safely. While this method is only called with the hardcoded value `"speakers"` today, the function signature accepted arbitrary strings.
- Fix: Added a compile-time allowlist `["speakers"]` that must contain the table name before interpolation proceeds. Any unexpected table name is rejected and logged.

**2. Path traversal via unvalidated HuggingFace API filenames** (`ModelDownloadService.swift`)
- Filenames from the HuggingFace `/api/models/` response (`rfilename` field) were appended directly to the local cache path using `cacheDir.appendingPathComponent(file.name)`. A compromised or impersonated server (or a future MITM attack if HuggingFace's CDN is ever vulnerable) could inject path traversal sequences like `../../.ssh/authorized_keys` into filenames.
- Fix: Added `isSafeModelFilename(_:)` which rejects empty names, absolute paths, `..` and `.` path components, and names containing control characters. Applied at both the manifest-parsing stage (filter) and the download stage (hard error).

**3. Custom save path not validated in `TranscriptSaver.defaultSaveDirectory`** (`TranscriptSaver.swift`)
- `RecordingCoordinator.handleRecordingComplete` correctly called `RecordingValidator.validateSavePath` before using the custom path, but `TranscriptSaver.defaultSaveDirectory` — the central getter used by `RetroactiveSpeakerUpdater`, `TranscriptScanner`, `AgentOutput.writeIndex`, and others — read the raw UserDefaults value without validation. A tampered or malformed UserDefaults value (e.g. from an iCloud sync conflict or preferences file manipulation) could redirect transcript writes to an arbitrary directory.
- Fix: Moved `RecordingValidator.validateSavePath` into `defaultSaveDirectory`. The getter now validates the custom path and falls back to `~/Documents/Transcripted/` if validation fails, ensuring all downstream callers are protected.

### Low

**4. Temp speaker clip files created world-readable** (`SpeakerClipExtractor.swift`)
- Temporary WAV clips written to `NSTemporaryDirectory()` for the speaker naming UI had the default file permissions (typically `0o644` on macOS). Speaker voice clips contain biometric data (voice fingerprints are derived from them).
- Fix: Set `0o600` permissions immediately after file creation, consistent with the existing approach for `speakers.sqlite`, `stats.sqlite`, and the app log file.

## Areas Confirmed Clean

- No hardcoded API keys, tokens, or credentials anywhere in source
- No `try!` calls anywhere in Swift source
- All parameterized SQL queries in `StatsDatabase` and `SpeakerDatabase` use `sqlite3_bind_*` — no string interpolation in data queries
- All network requests use HTTPS (`https://huggingface.co`, `https://hf-mirror.com`)
- Sparkle configured correctly: HTTPS feed URL, EdDSA public key in `Info.plist`, automatic checks enabled
- No `NSAllowsArbitraryLoads` or ATS exceptions in Info.plist
- `speakers.sqlite`, `stats.sqlite`, and `app.jsonl` all restricted to `0o600` at creation
- Audio temp files (`meeting_*_mic.wav`, `meeting_*_system.wav`) are cleaned up by `RecordingCoordinator.cleanupOrphanedAudioFiles` on app launch
- `RecordingValidator.validateSavePath` correctly rejects `..` components, symlinks resolving outside allowed dirs, and `/System`, `/Library`, `/usr` prefixes

## Test plan

- [ ] Build passes: `xcodebuild ... CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO build`
- [ ] Recording and transcription flow produces transcripts in the configured save directory
- [ ] Retroactive speaker renaming still updates transcript files correctly
- [ ] Model download flow works for first-time Qwen cache population
- [ ] Speaker clip extraction produces playable WAV files in the naming UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)