### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Transcripted/Core/SpeakerNamingCoordinator.swift
+++ b/Transcripted/Core/SpeakerNamingCoordinator.swift
@@ -63,8 +63,8 @@ extension TranscriptionTaskManager {
         // Clear the naming request
         self.speakerNamingRequest = nil
 
-        // Re-show success view after naming so user can Copy/Open the transcript
-        self.lastSavedTranscriptURL = transcriptURL
+        // Re-show saved pill after naming so user can Copy/Open the transcript
+        self.populateSavedMetadata(from: transcriptURL)
         self.displayStatus = .transcriptSaved
         self.scheduleStatusReset(delay: 8)
 

--- a/Transcripted/Core/TranscriptionTaskManager.swift
+++ b/Transcripted/Core/TranscriptionTaskManager.swift
@@ -16,6 +16,9 @@ class TranscriptionTaskManager: ObservableObject {
     @Published var backgroundTaskCount: Int = 0
     @Published var speakerNamingRequest: SpeakerNamingRequest? = nil
     @Published var lastSavedTranscriptURL: URL? = nil
+    @Published var lastSavedTitle: String? = nil
+    @Published var lastSavedDuration: String? = nil
+    @Published var lastSavedSpeakerCount: Int? = nil
 
     var activeTasks: [UUID: Task<Void, Never>] = [:]
     let transcription = Transcription()
@@ -80,7 +83,7 @@ class TranscriptionTaskManager: ObservableObject {
                 )
 
                 await MainActor.run {
-                    self.lastSavedTranscriptURL = transcriptURL
+                    self.populateSavedMetadata(from: transcriptURL)
                     self.displayStatus = .transcriptSaved
                     self.scheduleStatusReset(delay: 4)
                 }
@@ -161,7 +164,7 @@ class TranscriptionTaskManager: ObservableObject {
                 failedTranscriptionManager.removeFailedTranscription(id: failedId)
                 self.activeCount = max(0, self.activeCount - 1)
                 self.backgroundTaskCount = max(0, self.backgroundTaskCount - 1)
-                self.lastSavedTranscriptURL = transcriptURL
+                self.populateSavedMetadata(from: transcriptURL)
                 self.displayStatus = .transcriptSaved
                 self.scheduleStatusReset(delay: 4)
             }
@@ -207,6 +210,36 @@ class TranscriptionTaskManager: ObservableObject {
         activeCount = 0
         backgroundTaskCount = 0
         displayStatus = .idle
+    }
+
+    /// Populate saved transcript metadata from the file's YAML frontmatter.
+    /// File I/O is dispatched to a background task to avoid blocking the main thread.
+    func populateSavedMetadata(from url: URL) {
+        lastSavedTranscriptURL = url
+        let name = url.deletingPathExtension().lastPathComponent
+        lastSavedTitle = name.replacingOccurrences(of: "_", with: " ").replacingOccurrences(of: "-", with: " ")
+        Task.detached(priority: .utility) { [weak self] in
+            guard let raw = try? String(contentsOf: url, encoding: .utf8),
+                  raw.hasPrefix("---"),
+                  let endRange = raw.range(of: "\n---\n", range: raw.index(raw.startIndex, offsetBy: 3)..<raw.endIndex)
+            else { return }
+            let yaml = String(raw[raw.index(raw.startIndex, offsetBy: 4)..<endRange.lowerBound])
+            var duration: String? = nil
+            var speakers = 0
+            for line in yaml.components(separatedBy: "\n") {
+                let parts = line.split(separator: ":", maxSplits: 1).map { String($0).trimmingCharacters(in: .whitespaces) }
+                guard parts.count == 2 else { continue }
+                switch parts[0] {
+                case "duration": duration = parts[1].trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                case "mic_speakers", "system_speakers": speakers += Int(parts[1]) ?? 0
+                default: break
+                }
+            }
+            await MainActor.run { [weak self] in
+                self?.lastSavedDuration = duration
+                self?.lastSavedSpeakerCount = speakers
+            }
+        }
     }
 
     func scheduleStatusReset(delay: TimeInterval = 3) {

--- a/Transcripted/Design/Animations.swift
+++ b/Transcripted/Design/Animations.swift
@@ -44,6 +44,8 @@ struct PillDimensions {
     static let idleExpandedHeight: CGFloat = 28
     static let recordingWidth: CGFloat = 180
     static let recordingHeight: CGFloat = 40
+    static let savedWidth: CGFloat = 260
+    static let savedHeight: CGFloat = 56
     static let trayWidth: CGFloat = 280
     static let trayMaxHeight: CGFloat = 300
     static let dockPadding: CGFloat = 8

--- a/Transcripted/UI/FloatingPanel/Components/AuroraIdleView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/AuroraIdleView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
 
 // MARK: - Aurora Idle View
-/// Idle state view matching the recording state's visual pattern
-/// Same dimensions and hover-to-expand behavior as AuroraRecordingView
+/// Idle state: confident but minimal presence
+/// Collapsed: 52x26px capsule with mic icon — visible against any wallpaper
+/// Expanded: 160x36px on hover with Record + Transcripts buttons
 
 @available(macOS 26.0, *)
 struct AuroraIdleView: View {
@@ -15,51 +16,50 @@ struct AuroraIdleView: View {
 
     @Environment(\.accessibilityReduceMotion) var reduceMotion
     @State private var isHoverExpanded = false
-
-    /// True when pill should show expanded state (hover OR forced by tray)
-    private var isExpanded: Bool { isHoverExpanded || forceExpanded }
     @State private var isRecordHovered = false
     @State private var isFilesHovered = false
 
-    /// Tracks whether the view has settled after appearing
-    /// When false, view starts at success view's size (200×44) to enable smooth transition
-    /// When true, view uses normal collapsed/expanded sizing
-    @State private var hasSettled = false
+    private var isExpanded: Bool { isHoverExpanded || forceExpanded }
 
-    // Ultra-small collapsed state (smaller than recording)
-    private let collapsedWidth: CGFloat = 40
-    private let collapsedHeight: CGFloat = 20
-    private let expandedWidth: CGFloat = 200
-    private let expandedHeight: CGFloat = 44
-
-    // Initial size matches AuroraSuccessView for smooth transition
-    private let initialWidth: CGFloat = 200
-    private let initialHeight: CGFloat = 44
+    // Confident resting size — visible but unobtrusive
+    private let collapsedWidth: CGFloat = 52
+    private let collapsedHeight: CGFloat = 26
+    private let expandedWidth: CGFloat = 160
+    private let expandedHeight: CGFloat = 36
 
     var body: some View {
         ZStack {
-            // Idle background - subtle dark capsule
+            // Dark capsule background with border for definition
             idleBackground
                 .clipShape(Capsule())
 
-            // Subtle mic icon in collapsed state to signal clickability
+            // Mic icon in collapsed state
             if !isExpanded {
                 Image(systemName: "mic.fill")
-                    .font(.system(size: 10, weight: .medium))
-                    .foregroundColor(.panelTextMuted.opacity(0.4))
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.panelTextMuted)
             }
 
             // Background processing badge (top-left when collapsed)
             if backgroundTaskCount > 0 && !isExpanded {
-                processingBadge
+                ProcessingPulseDot()
+                    .offset(x: -20, y: -14)
             }
 
             // Failed badge (top-right when collapsed)
             if failedCount > 0 && !isExpanded {
-                failedBadge
+                Circle()
+                    .fill(Color.red)
+                    .frame(width: 18, height: 18)
+                    .overlay(
+                        Text("\(min(failedCount, 9))")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundColor(.white)
+                    )
+                    .offset(x: 28, y: -14)
             }
 
-            // Expanded content (buttons + waveform)
+            // Expanded content
             if isExpanded {
                 expandedContent
                     .transition(.opacity.animation(.easeOut(duration: 0.1)))
@@ -83,12 +83,11 @@ struct AuroraIdleView: View {
         .accessibilityHint("Click to start recording, or hover to reveal controls")
     }
 
-    // MARK: - Idle Background
+    // MARK: - Background
 
     private var idleBackground: some View {
         ZStack {
             Color.panelCharcoal
-            // Ultra-minimal: empty capsule when collapsed
         }
         .overlay(
             Capsule()
@@ -96,10 +95,10 @@ struct AuroraIdleView: View {
                     failedCount > 0
                         ? Color.recordingCoral.opacity(0.3)
                         : Color.panelCharcoalSurface,
-                    lineWidth: failedCount > 0 ? 1.5 : 1
+                    lineWidth: 1
                 )
         )
-        .shadow(color: Color.black.opacity(0.3), radius: 8, y: 2)
+        .shadow(color: Color.black.opacity(0.3), radius: 4, y: 1)
         .glowPulse(when: backgroundTaskCount > 0 && !isExpanded, color: .recordingCoral)
         .overlay(
             Capsule()
@@ -110,40 +109,19 @@ struct AuroraIdleView: View {
         )
     }
 
-    // MARK: - Failed Badge
-
-    private var failedBadge: some View {
-        Circle()
-            .fill(Color.red)
-            .frame(width: 18, height: 18)
-            .overlay(
-                Text("\(min(failedCount, 9))")
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundColor(.white)
-            )
-            .offset(x: 28, y: -14)
-    }
-
-    // MARK: - Processing Badge
-
-    private var processingBadge: some View {
-        ProcessingPulseDot()
-            .offset(x: -20, y: -14)
-    }
-
     // MARK: - Expanded Content
 
     private var expandedContent: some View {
         HStack(spacing: 0) {
-            // Record button (left) - PRIMARY ACTION
+            // Record button (left)
             Button(action: onRecord) {
                 ZStack {
                     Circle()
                         .fill(isRecordHovered ? Color.panelCharcoalSurface : Color.panelCharcoalElevated)
-                        .frame(width: 32, height: 32)
+                        .frame(width: 26, height: 26)
 
                     Image(systemName: "mic.fill")
-                        .font(.system(size: 14, weight: .medium))
+                        .font(.system(size: 12, weight: .medium))
                         .foregroundColor(isRecordHovered ? .recordingCoral : .panelTextPrimary)
                 }
                 .scaleEffect(isRecordHovered ? 1.1 : 1.0)
@@ -156,26 +134,26 @@ struct AuroraIdleView: View {
                 }
             }
             .accessibilityLabel("Start recording")
-            .frame(width: 44)
+            .frame(width: 36)
 
             Spacer()
 
-            // Center: processing indicator (when background tasks active)
+            // Center: processing indicator
             if backgroundTaskCount > 0 {
                 ProcessingPulseDot()
             }
 
             Spacer()
 
-            // Transcripts button (right) - SECONDARY ACTION
+            // Transcripts button (right)
             Button(action: onTranscripts) {
                 ZStack {
                     Circle()
                         .fill(isFilesHovered ? Color.panelCharcoalSurface : Color.panelCharcoalElevated)
-                        .frame(width: 32, height: 32)
+                        .frame(width: 26, height: 26)
 
                     Image(systemName: "clock.arrow.circlepath")
-                        .font(.system(size: 13, weight: .medium))
+                        .font(.system(size: 11, weight: .medium))
                         .foregroundColor(.panelTextPrimary)
                 }
                 .scaleEffect(isFilesHovered ? 1.1 : 1.0)
@@ -188,56 +166,15 @@ struct AuroraIdleView: View {
                 }
             }
             .accessibilityLabel("Browse recent transcripts")
-            .frame(width: 44)
+            .frame(width: 36)
         }
-        .padding(.horizontal, 8)
-    }
-}
-
-// MARK: - Idle Panel Waveform View
-
-/// A subtle, gently pulsing waveform for the dark panel theme
-/// Distinct from DormantWaveformView in WaveformViews.swift which uses terracotta/warm theme
-struct IdlePanelWaveformView: View {
-    let isAnimating: Bool
-
-    @State private var phase: CGFloat = 0
-
-    private let barCount = 5
-    private let barWidth: CGFloat = 3
-    private let barSpacing: CGFloat = 2
-    private let baseHeights: [CGFloat] = [6, 10, 14, 10, 6]
-
-    var body: some View {
-        HStack(spacing: barSpacing) {
-            ForEach(0..<barCount, id: \.self) { index in
-                RoundedRectangle(cornerRadius: 1)
-                    .fill(Color.panelTextMuted)
-                    .frame(width: barWidth, height: barHeight(for: index))
-            }
-        }
-        .onAppear {
-            if isAnimating {
-                withAnimation(.easeInOut(duration: 2).repeatForever(autoreverses: true)) {
-                    phase = 1
-                }
-            }
-        }
-    }
-
-    private func barHeight(for index: Int) -> CGFloat {
-        guard isAnimating else {
-            return baseHeights[index]
-        }
-        let variation = sin(Double(index) * 0.5 + Double(phase) * .pi) * 2
-        return baseHeights[index] + CGFloat(variation)
+        .padding(.horizontal, 6)
     }
 }
 
 // MARK: - Processing Pulse Dot
 
 /// Subtle pulsing dot indicating background transcription is in progress
-/// Communicates "work is happening" without blocking the user from recording
 struct ProcessingPulseDot: View {
     @State private var isPulsing = false
 
@@ -264,10 +201,7 @@ struct AuroraIdleView_Previews: PreviewProvider {
         ZStack {
             Color.black
             VStack(spacing: 40) {
-                // Collapsed state
                 AuroraIdleView(onRecord: {}, onTranscripts: {}, failedCount: 0)
-
-                // With failed badge
                 AuroraIdleView(onRecord: {}, onTranscripts: {}, failedCount: 3)
             }
         }

--- a/Transcripted/UI/FloatingPanel/Components/AuroraProcessingView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/AuroraProcessingView.swift
@@ -1,9 +1,9 @@
 import SwiftUI
 
 // MARK: - Aurora Processing View
-/// Enhanced processing view with progress-based aurora intensity
-/// Always expanded (200x44) - no collapse for processing since users want to see status
-/// Progress shown through brightness and animation speed, not color changes
+/// Clean processing view with a progress bar at the bottom of the capsule
+/// Replaces the previous aurora fog with a simple, informative design
+/// Progress bar fills with accentBlue; indeterminate shimmer when progress unknown
 
 @available(macOS 26.0, *)
 struct AuroraProcessingView: View {
@@ -11,45 +11,51 @@ struct AuroraProcessingView: View {
 
     @Environment(\.accessibilityReduceMotion) var reduceMotion
 
-    // Celebration bloom effect
-    @State private var showCelebrationBloom = true
-
-    // Warning state tracking
+    @State private var shimmerOffset: CGFloat = -1.0
     @State private var stepStartTime: Date = Date()
     @State private var stepElapsedTime: TimeInterval = 0
 
-    // Fixed expanded dimensions (no collapse for processing - users want to see status)
-    private let width: CGFloat = 200
-    private let height: CGFloat = 44
+    private let width: CGFloat = PillDimensions.recordingWidth
+    private let height: CGFloat = PillDimensions.recordingHeight
 
     var body: some View {
         ZStack {
-            // Aurora background with progress-based intensity
-            auroraBackground
-                .clipShape(Capsule())
-                .brightness(showCelebrationBloom ? 0.3 : 0)  // Celebration flash
+            // Dark capsule background
+            Capsule()
+                .fill(Color.panelCharcoal)
 
-            // Always show expanded content (no collapse for processing)
-            expandedContent
+            // Subtle blue border
+            Capsule()
+                .strokeBorder(Color.accentBlue.opacity(0.25), lineWidth: 1)
+
+            // Progress bar at bottom
+            progressBar
+                .clipShape(Capsule())
+
+            // Status text
+            VStack(spacing: 2) {
+                Text(progressText)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.panelTextPrimary)
+                    .lineLimit(1)
+
+                if let warning = warningText {
+                    Text(warning)
+                        .font(.system(size: 10))
+                        .foregroundColor(.panelTextMuted)
+                        .lineLimit(1)
+                }
+            }
         }
         .frame(width: width, height: height)
         .onAppear {
-            // Celebration bloom animation
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                withAnimation(.easeOut(duration: 0.2)) {
-                    showCelebrationBloom = false
-                }
-            }
-
-            // Reset step timer on appear
             stepStartTime = Date()
-            stepElapsedTime = 0
+            startShimmer()
         }
         .onReceive(Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()) { _ in
             stepElapsedTime = Date().timeIntervalSince(stepStartTime)
         }
         .onChange(of: status) { _, _ in
-            // Reset step timer when status changes
             stepStartTime = Date()
             stepElapsedTime = 0
         }
@@ -57,220 +63,93 @@ struct AuroraProcessingView: View {
         .accessibilityLabel("Processing: \(status.statusText)")
     }
 
-    // MARK: - Progress-Based Aurora Properties
+    // MARK: - Progress Bar
 
-    /// Aurora opacity based on progress phase (dim → normal → bright)
-    private var auroraOpacity: Double {
-        let progress = status.progress
-        if progress < 0.15 { return 0.45 }       // Getting ready: dim
-        else if progress < 0.75 { return 0.60 }  // Transcribing: normal
-        else { return 0.75 }                      // Finding items/finishing: bright
+    private var progressBar: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .bottom) {
+                Color.clear
+
+                // Track
+                Rectangle()
+                    .fill(Color.panelCharcoalSurface.opacity(0.4))
+                    .frame(height: 3)
+
+                // Fill
+                if let progress = determinateProgress {
+                    Rectangle()
+                        .fill(Color.accentBlue)
+                        .frame(width: geo.size.width * progress, height: 3)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    // Indeterminate shimmer
+                    Rectangle()
+                        .fill(
+                            LinearGradient(
+                                colors: [
+                                    Color.accentBlue.opacity(0.0),
+                                    Color.accentBlue.opacity(0.6),
+                                    Color.accentBlue.opacity(0.0)
+                                ],
+                                startPoint: UnitPoint(x: shimmerOffset, y: 0.5),
+                                endPoint: UnitPoint(x: shimmerOffset + 0.4, y: 0.5)
+                            )
+                        )
+                        .frame(height: 3)
+                }
+            }
+        }
     }
 
-    /// Aurora animation speed based on progress phase (slow → medium → fast)
-    private var auroraPulseSpeed: Double {
-        let progress = status.progress
-        if reduceMotion { return 0 }
-        if progress < 0.15 { return 0.03 }       // 4s cycle (slow breathe)
-        else if progress < 0.75 { return 0.08 }  // 2s cycle (steady pulse)
-        else { return 0.15 }                      // 1s cycle (active pulse)
+    // MARK: - Progress Logic
+
+    private var determinateProgress: CGFloat? {
+        switch status {
+        case .transcribing(let progress):
+            return CGFloat(progress).clamped(to: 0...1)
+        case .finishing:
+            return 0.95
+        default:
+            return nil
+        }
     }
 
-    /// Warning text for long-running steps
+    private var progressText: String {
+        if let progress = determinateProgress {
+            let pct = Int(progress * 100)
+            return "Processing \(pct)%"
+        }
+        return "Processing..."
+    }
+
     private var warningText: String? {
         if stepElapsedTime > 120 {
-            return "Taking longer than usual. Hang tight."
+            return "Taking longer than usual"
         } else if stepElapsedTime > 90 {
-            return "Still working on this one..."
+            return "Taking a moment..."
         }
         return nil
     }
 
-    // MARK: - Content
+    // MARK: - Shimmer
 
-    private var expandedContent: some View {
-        VStack(spacing: 2) {
-            Text(status.statusText)
-                .font(.system(size: 14, weight: .medium))
-                .foregroundColor(.panelTextPrimary)
-                .lineLimit(1)
-
-            // Warning text (if applicable)
-            if let warning = warningText {
-                Text(warning)
-                    .font(.system(size: 10, weight: .regular))
-                    .foregroundColor(.statusWarningMuted)
-                    .lineLimit(1)
-            }
+    private func startShimmer() {
+        guard !reduceMotion else {
+            shimmerOffset = 0.3
+            return
+        }
+        withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
+            shimmerOffset = 1.0
         }
     }
+}
 
-    // MARK: - Aurora Background
+// MARK: - Clamped Helper
 
-    private var auroraBackground: some View {
-        ZStack {
-            // Base dark background
-            Color.panelCharcoal
-
-            // CORAL FOG: Warm tones, biased LEFT
-            fogLayer(
-                color: Color.auroraCoral,
-                secondaryColor: Color.auroraCoralLight,
-                blurRadius: 8,
-                opacity: auroraOpacity,
-                orbCount: 2,
-                phaseOffset: 0,
-                positionBias: -0.8
-            )
-            .blendMode(.plusLighter)
-
-            // TEAL FOG: Cool tones, biased RIGHT
-            fogLayer(
-                color: Color.auroraTeal,
-                secondaryColor: Color.auroraTealLight,
-                blurRadius: 8,
-                opacity: auroraOpacity * 0.9,
-                orbCount: 2,
-                phaseOffset: .pi / 3,
-                positionBias: 0.8
-            )
-            .blendMode(.plusLighter)
-        }
-        .overlay(
-            // Subtle capsule border
-            Capsule()
-                .strokeBorder(
-                    LinearGradient(
-                        colors: [
-                            Color.auroraCoral.opacity(0.25),
-                            Color.auroraTeal.opacity(0.25)
-                        ],
-                        startPoint: .leading,
-                        endPoint: .trailing
-                    ),
-                    lineWidth: 1
-                )
-        )
-        // Subtle outer glow
-        .shadow(color: Color.auroraCoral.opacity(0.15), radius: 12, x: -3, y: 0)
-        .shadow(color: Color.auroraTeal.opacity(0.12), radius: 12, x: 3, y: 0)
+private extension CGFloat {
+    func clamped(to range: ClosedRange<CGFloat>) -> CGFloat {
+        Swift.min(Swift.max(self, range.lowerBound), range.upperBound)
     }
-
-    // MARK: - Fog Layer
-
-    private func fogLayer(
-        color: Color,
-        secondaryColor: Color,
-        blurRadius: CGFloat,
-        opacity: Double,
-        orbCount: Int,
-        phaseOffset: Double,
-        positionBias: CGFloat
-    ) -> some View {
-        TimelineView(.animation(minimumInterval: 1/30)) { timeline in
-            Canvas { context, size in
-                let time = timeline.date.timeIntervalSinceReferenceDate
-
-                drawFogOrbs(
-                    context: &context,
-                    size: size,
-                    time: time,
-                    color: color,
-                    secondaryColor: secondaryColor,
-                    orbCount: orbCount,
-                    phaseOffset: phaseOffset,
-                    opacity: opacity,
-                    positionBias: positionBias
-                )
-            }
-        }
-        .blur(radius: blurRadius)
-    }
-
-    // MARK: - Pseudo-noise Function
-
-    private func pseudoNoise(time: Double, phase: Double, seed: Double) -> Double {
-        let t = time + seed
-        let p = phase
-
-        let wave1 = sin(t * 1.0 + p)
-        let wave2 = sin(t * 1.7 + p * 2.3) * 0.5
-        let wave3 = sin(t * 0.3 + p * 0.7) * 0.3
-        let wave4 = sin(t * 2.3 + p * 1.1) * 0.2
-
-        return (wave1 + wave2 + wave3 + wave4) / 2.0
-    }
-
-    // MARK: - Draw Fog Orbs
-
-    private func drawFogOrbs(
-        context: inout GraphicsContext,
-        size: CGSize,
-        time: Double,
-        color: Color,
-        secondaryColor: Color,
-        orbCount: Int,
-        phaseOffset: Double,
-        opacity: Double,
-        positionBias: CGFloat
-    ) {
-        let width = size.width
-        let height = size.height
-        let centerY = height / 2
-
-        // Progress-based animation speed
-        let slowTime = time * auroraPulseSpeed
-
-        // Fixed intensity boost (no audio reactivity in processing)
-        let fixedBoost = 0.55
-
-        let biasOffset = positionBias * width * 0.15
-
-        for i in 0..<orbCount {
-            let orbPhase = Double(i) * (.pi * 2 / Double(orbCount)) + phaseOffset
-
-            // Organic movement using pseudo-noise
-            let xNoise = pseudoNoise(time: slowTime, phase: orbPhase, seed: 0)
-            let yNoise = pseudoNoise(time: slowTime * 0.8, phase: orbPhase * 1.3, seed: 100)
-
-            let xOffset = xNoise * (width * 0.18)
-            let yOffset = yNoise * (height * 0.15)
-
-            let orbCenterX = width / 2 + biasOffset + xOffset
-            let orbCenterY = centerY + yOffset
-
-            // Subtle breathing
-            let breatheNoise = pseudoNoise(time: slowTime * 0.4, phase: orbPhase, seed: 200)
-            let breathe = 1.0 + breatheNoise * 0.08
-            let baseSize = max(width, height) * 0.8
-            let orbSize = baseSize * fixedBoost * breathe
-
-            let orbRect = CGRect(
-                x: orbCenterX - orbSize / 2,
-                y: orbCenterY - orbSize / 2,
-                width: orbSize,
-                height: orbSize
-            )
-
-            let gradient = Gradient(stops: [
-                .init(color: color.opacity(opacity * fixedBoost), location: 0),
-                .init(color: secondaryColor.opacity(opacity * 0.5), location: 0.4),
-                .init(color: color.opacity(opacity * 0.25), location: 0.7),
-                .init(color: Color.clear, location: 1.0)
-            ])
-
-            context.fill(
-                Path(ellipseIn: orbRect),
-                with: .radialGradient(
-                    gradient,
-                    center: CGPoint(x: orbCenterX, y: orbCenterY),
-                    startRadius: 0,
-                    endRadius: orbSize / 2
-                )
-            )
-        }
-    }
-
 }
 
 // MARK: - Preview
@@ -287,7 +166,7 @@ struct AuroraProcessingView_Previews: PreviewProvider {
                 AuroraProcessingView(status: .finishing)
             }
         }
-        .frame(width: 400, height: 400)
+        .frame(width: 400, height: 300)
     }
 }
 #endif

--- a/Transcripted/UI/FloatingPanel/Components/AuroraRecordingView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/AuroraRecordingView.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 
 // MARK: - Aurora Recording View
-/// A living aurora visualization that dances with your conversation
-/// Gemini-inspired: Soft, glowing fog that gently pulses with audio
-/// Uses layered radial gradients with heavy blur for diffuse, smoky effect
+/// Audio-reactive neon border for recording state.
+/// Mic audio (coral) glows from the LEFT side, fading toward center.
+/// System audio (teal) glows from the RIGHT side, fading toward center.
+/// Uses masked Capsule strokes layered for bloom effect — strokes always stay on the border.
 
 @available(macOS 26.0, *)
 struct AuroraRecordingView: View {
@@ -13,249 +14,135 @@ struct AuroraRecordingView: View {
 
     @Environment(\.accessibilityReduceMotion) var reduceMotion
     @State private var isStopHovered = false
-    @State private var isTranscriptsHovered = false
-
-    // Smoothed audio levels (prevents jitter)
     @State private var smoothedMicLevel: CGFloat = 0
     @State private var smoothedSystemLevel: CGFloat = 0
 
-    // Fixed dimensions — always expanded during recording
-    private let expandedWidth: CGFloat = 200
-    private let expandedHeight: CGFloat = 44
+    private let width: CGFloat = PillDimensions.recordingWidth
+    private let height: CGFloat = PillDimensions.recordingHeight
 
-    // Animation smoothing factor (lower = smoother, slower response)
-    private let smoothingFactor: CGFloat = 0.08
+    private let attackFactor: CGFloat = 0.25
+    private let decayFactor: CGFloat = 0.06
 
     var body: some View {
         ZStack {
-            // Aurora background (always visible)
-            auroraBackground
-                .clipShape(Capsule())
+            // Dark capsule background
+            Capsule()
+                .fill(Color.panelCharcoal)
 
-            // Always-visible content (timer + stop button)
-            expandedContent
+            // Base dim border
+            Capsule()
+                .strokeBorder(Color.panelCharcoalSurface.opacity(0.5), lineWidth: 1)
+
+            if reduceMotion {
+                staticBorder
+            } else {
+                // Neon glow layers — padded outward so bloom doesn't clip at frame edges
+                ZStack {
+                    neonGlow(color: .recordingCoral, level: smoothedMicLevel, fromLeading: true)
+                    neonGlow(color: .auroraTeal, level: smoothedSystemLevel, fromLeading: false)
+                }
+                .padding(-30)
+            }
+
+            // Content: stop button + timer
+            recordingContent
         }
-        .frame(width: expandedWidth, height: expandedHeight)
+        .frame(width: width, height: height)
+        .shadow(color: Color.recordingCoral.opacity(0.12 + Double(smoothedMicLevel) * 0.38),
+                radius: 14 + smoothedMicLevel * 14, x: -3, y: 0)
+        .shadow(color: Color.auroraTeal.opacity(0.10 + Double(smoothedSystemLevel) * 0.32),
+                radius: 12 + smoothedSystemLevel * 12, x: 3, y: 0)
+        .onChange(of: audio.audioLevel) { _, _ in updateLevels() }
+        .onChange(of: audio.systemAudioLevelHistory) { _, _ in updateLevels() }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Recording in progress, \(formatDurationAccessible(audio.recordingDuration))")
         .accessibilityHint("Click stop to end recording")
     }
 
-    // MARK: - Aurora Background (Gemini-style fog layers)
+    // MARK: - Neon Glow Layer
 
-    private var auroraBackground: some View {
-        ZStack {
-            // Base dark background
-            Color.panelCharcoal
+    /// Three layered capsule strokes masked to fade from one side, creating the apex-glow effect.
+    @ViewBuilder
+    private func neonGlow(color: Color, level: CGFloat, fromLeading: Bool) -> some View {
+        let coverage = 0.15 + level * 0.85 // 15% base → 100% at peak
 
-            // MIC FOG: Coral/warm tones, biased LEFT
-            fogLayer(
-                color: Color.auroraCoral,
-                secondaryColor: Color.auroraCoralLight,
-                blurRadius: 8,
-                opacity: 0.75,
-                orbCount: 2,
-                phaseOffset: 0,
-                isMicLevel: true,
-                positionBias: -0.8  // Bias left
-            )
-            .blendMode(.plusLighter)
+        // Pass 1: Outer bloom (wide, blurred)
+        Capsule()
+            .stroke(color.opacity(0.2 + Double(level) * 0.35), lineWidth: 8 + level * 8)
+            .blur(radius: 10 + level * 8)
+            .mask(coverageMask(coverage: coverage, fromLeading: fromLeading))
 
-            // SYSTEM FOG: Teal/cool tones, biased RIGHT
-            fogLayer(
-                color: Color.auroraTeal,
-                secondaryColor: Color.auroraTealLight,
-                blurRadius: 8,
-                opacity: 0.7,
-                orbCount: 2,
-                phaseOffset: .pi / 3,
-                isMicLevel: false,
-                positionBias: 0.8  // Bias right
-            )
-            .blendMode(.plusLighter)
-        }
-        .overlay(
-            // Capsule border glow matches position bias (coral left, teal right)
-            Capsule()
-                .strokeBorder(
-                    LinearGradient(
-                        colors: [
-                            Color.auroraCoral.opacity(0.4),
-                            Color.auroraTeal.opacity(0.4)
-                        ],
-                        startPoint: .leading,
-                        endPoint: .trailing
-                    ),
-                    lineWidth: 1
-                )
+        // Pass 2: Mid glow
+        Capsule()
+            .stroke(color.opacity(0.4 + Double(level) * 0.35), lineWidth: 4 + level * 4)
+            .blur(radius: 4 + level * 3)
+            .mask(coverageMask(coverage: coverage, fromLeading: fromLeading))
+
+        // Pass 3: Inner core (sharp, bright)
+        Capsule()
+            .stroke(color.opacity(0.7 + Double(level) * 0.3), lineWidth: 2 + level * 1.5)
+            .mask(coverageMask(coverage: coverage, fromLeading: fromLeading))
+    }
+
+    /// Gradient mask that reveals from one side based on coverage (0→1).
+    /// Creates the "crawling from apex" effect without custom paths.
+    private func coverageMask(coverage: CGFloat, fromLeading: Bool) -> some View {
+        LinearGradient(
+            stops: [
+                .init(color: .white, location: 0),
+                .init(color: .white, location: coverage * 0.8),
+                .init(color: .clear, location: coverage),
+            ],
+            startPoint: fromLeading ? .leading : .trailing,
+            endPoint: fromLeading ? .trailing : .leading
         )
-        // Single combined glow shadow (reduced from two radius-20 shadows)
-        .shadow(color: Color.auroraCoral.opacity(0.25), radius: 12, x: -3, y: 0)
     }
 
-    // MARK: - Fog Layer
+    // MARK: - Static Border (reduce motion)
 
-    private func fogLayer(
-        color: Color,
-        secondaryColor: Color,
-        blurRadius: CGFloat,
-        opacity: Double,
-        orbCount: Int,
-        phaseOffset: Double,
-        isMicLevel: Bool,
-        positionBias: CGFloat = 0  // -1 = left, 0 = center, 1 = right
-    ) -> some View {
-        TimelineView(.animation(minimumInterval: 1/30)) { timeline in
-            let time = timeline.date.timeIntervalSinceReferenceDate
-
-            // Compute smoothed levels OUTSIDE Canvas (in View body, safe for @State reads)
-            let targetMic = CGFloat(audio.audioLevelHistory.last ?? 0)
-            let targetSystem = CGFloat(audio.systemAudioLevelHistory.last ?? 0)
-            let effectiveSmoothing = reduceMotion ? 0.02 : smoothingFactor
-            let currentMic = smoothedMicLevel + (targetMic - smoothedMicLevel) * effectiveSmoothing
-            let currentSystem = smoothedSystemLevel + (targetSystem - smoothedSystemLevel) * effectiveSmoothing
-            let audioLevel = isMicLevel ? currentMic : currentSystem
-
-            Canvas { context, size in
-                // Draw fog orbs (Canvas closure is pure rendering, no state mutation)
-                drawFogOrbs(
-                    context: &context,
-                    size: size,
-                    time: time,
-                    audioLevel: audioLevel,
-                    color: color,
-                    secondaryColor: secondaryColor,
-                    orbCount: orbCount,
-                    phaseOffset: phaseOffset,
-                    opacity: opacity,
-                    positionBias: positionBias
-                )
-            }
-            .onChange(of: time) { _, _ in
-                // Update smoothed state on the main run loop, outside Canvas render
-                smoothedMicLevel = currentMic
-                smoothedSystemLevel = currentSystem
-            }
-        }
-        .blur(radius: blurRadius)
-        .drawingGroup()  // Flatten to Metal texture for GPU performance
-    }
-
-    // MARK: - Pseudo-noise Function
-
-    /// Creates organic, non-repeating motion by layering sine waves with prime-ratio frequencies
-    private func pseudoNoise(time: Double, phase: Double, seed: Double) -> Double {
-        let t = time + seed
-        let p = phase
-
-        // Layer multiple sine waves with incommensurate frequencies
-        let wave1 = sin(t * 1.0 + p)
-        let wave2 = sin(t * 1.7 + p * 2.3) * 0.5
-        let wave3 = sin(t * 0.3 + p * 0.7) * 0.3
-        let wave4 = sin(t * 2.3 + p * 1.1) * 0.2
-
-        // Sum and normalize (max amplitude ~2.0)
-        return (wave1 + wave2 + wave3 + wave4) / 2.0
-    }
-
-    // MARK: - Draw Fog Orbs
-
-    private func drawFogOrbs(
-        context: inout GraphicsContext,
-        size: CGSize,
-        time: Double,
-        audioLevel: CGFloat,
-        color: Color,
-        secondaryColor: Color,
-        orbCount: Int,
-        phaseOffset: Double,
-        opacity: Double,
-        positionBias: CGFloat = 0  // -1 = left, 0 = center, 1 = right
-    ) {
-        let width = size.width
-        let height = size.height
-        let centerY = height / 2
-
-        // Slow animation speed (0.15x for calm, organic feel)
-        let slowTime = reduceMotion ? 0 : time * 0.15
-
-        // Audio reactivity affects SIZE and BRIGHTNESS, not speed
-        // Base level of 0.6 ensures visibility even in silence, peaks at 1.8x with audio
-        let audioBoost = 0.6 + Double(audioLevel) * 1.5  // 0.6 to 2.1x
-
-        // Position bias shifts center point left or right
-        let biasOffset = positionBias * width * 0.15
-
-        for i in 0..<orbCount {
-            let orbPhase = Double(i) * (.pi * 2 / Double(orbCount)) + phaseOffset
-
-            // Organic movement using pseudo-noise
-            let xNoise = pseudoNoise(time: slowTime, phase: orbPhase, seed: 0)
-            let yNoise = pseudoNoise(time: slowTime * 0.8, phase: orbPhase * 1.3, seed: 100)
-
-            let xOffset = xNoise * (width * 0.18)
-            let yOffset = yNoise * (height * 0.15)
-
-            let orbCenterX = width / 2 + biasOffset + xOffset
-            let orbCenterY = centerY + yOffset
-
-            // Orb size varies with audio and subtle breathing
-            let breatheNoise = pseudoNoise(time: slowTime * 0.4, phase: orbPhase, seed: 200)
-            let breathe = 1.0 + breatheNoise * 0.12
-            let baseSize = max(width, height) * 0.8  // Larger orbs to fill the capsule
-            let orbSize = baseSize * audioBoost * breathe
-
-            // Draw radial gradient orb
-            let orbRect = CGRect(
-                x: orbCenterX - orbSize / 2,
-                y: orbCenterY - orbSize / 2,
-                width: orbSize,
-                height: orbSize
+    private var staticBorder: some View {
+        Capsule()
+            .strokeBorder(
+                LinearGradient(
+                    colors: [Color.recordingCoral.opacity(0.3), Color.auroraTeal.opacity(0.3)],
+                    startPoint: .leading, endPoint: .trailing
+                ),
+                lineWidth: 2
             )
-
-            // Radial gradient: color center fading to transparent
-            let gradient = Gradient(stops: [
-                .init(color: color.opacity(opacity * audioBoost), location: 0),
-                .init(color: secondaryColor.opacity(opacity * 0.6), location: 0.4),
-                .init(color: color.opacity(opacity * 0.3), location: 0.7),
-                .init(color: Color.clear, location: 1.0)
-            ])
-
-            context.fill(
-                Path(ellipseIn: orbRect),
-                with: .radialGradient(
-                    gradient,
-                    center: CGPoint(x: orbCenterX, y: orbCenterY),
-                    startRadius: 0,
-                    endRadius: orbSize / 2
-                )
-            )
-        }
     }
 
-    // MARK: - Expanded Content
+    // MARK: - Level Smoothing
 
-    private var expandedContent: some View {
+    private func updateLevels() {
+        let targetMic = CGFloat(audio.audioLevel)
+        let targetSystem = CGFloat(audio.systemAudioLevelHistory.last ?? 0)
+
+        let micFactor = targetMic > smoothedMicLevel ? attackFactor : decayFactor
+        smoothedMicLevel += (targetMic - smoothedMicLevel) * micFactor
+
+        let sysFactor = targetSystem > smoothedSystemLevel ? attackFactor : decayFactor
+        smoothedSystemLevel += (targetSystem - smoothedSystemLevel) * sysFactor
+    }
+
+    // MARK: - Content
+
+    private var recordingContent: some View {
         ZStack {
-            // Timer (absolutely centered, independent of button layout)
             Text(formatDuration(audio.recordingDuration))
-                .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                .font(.system(size: 16, weight: .semibold, design: .monospaced))
                 .foregroundColor(.panelTextPrimary)
                 .lineLimit(1)
                 .fixedSize()
 
-            // Buttons pinned to edges
             HStack(spacing: 0) {
-                // Stop button (left)
                 Button(action: onStop) {
                     ZStack {
                         Circle()
                             .fill(isStopHovered ? Color.panelCharcoalSurface : Color.panelCharcoalElevated)
-                            .frame(width: 32, height: 32)
-
+                            .frame(width: 28, height: 28)
                         RoundedRectangle(cornerRadius: 3)
                             .fill(Color.panelTextPrimary)
-                            .frame(width: 12, height: 12)
+                            .frame(width: 10, height: 10)
                     }
                     .scaleEffect(isStopHovered ? 1.1 : 1.0)
                 }
@@ -267,40 +154,11 @@ struct AuroraRecordingView: View {
                     }
                 }
                 .accessibilityLabel("Stop recording")
-                .frame(width: 44)
-
+                .frame(width: 40)
                 Spacer()
-
-                // Transcripts button (right)
-                if let onTranscripts {
-                    Button(action: onTranscripts) {
-                        ZStack {
-                            Circle()
-                                .fill(isTranscriptsHovered ? Color.panelCharcoalSurface : Color.panelCharcoalElevated)
-                                .frame(width: 32, height: 32)
-
-                            Image(systemName: "clock.arrow.circlepath")
-                                .font(.system(size: 13, weight: .medium))
-                                .foregroundColor(.panelTextPrimary)
-                        }
-                        .scaleEffect(isTranscriptsHovered ? 1.1 : 1.0)
-                    }
-                    .buttonStyle(PlainButtonStyle())
-                    .floatingTooltip("Transcripts")
-                    .onHover { hovering in
-                        withAnimation(.spring(response: 0.15, dampingFraction: 0.8)) {
-                            isTranscriptsHovered = hovering
-                        }
-                    }
-                    .accessibilityLabel("Browse transcripts")
-                    .frame(width: 44)
-                } else {
-                    Spacer()
-                        .frame(width: 44)
-                }
             }
+            .padding(.horizontal, 8)
         }
-        .padding(.horizontal, 8)
     }
 
     // MARK: - Helpers
@@ -320,37 +178,3 @@ struct AuroraRecordingView: View {
         return "\(seconds) second\(seconds == 1 ? "" : "s")"
     }
 }
-
-// MARK: - Aurora Dimensions
-
-struct AuroraDimensions {
-    /// Collapsed width - pure aurora
-    static let collapsedWidth: CGFloat = 72
-
-    /// Collapsed height
-    static let collapsedHeight: CGFloat = 36
-
-    /// Expanded width - aurora + timer + stop
-    static let expandedWidth: CGFloat = 200
-
-    /// Expanded height
-    static let expandedHeight: CGFloat = 44
-}
-
-// MARK: - Preview
-
-#if DEBUG
-@available(macOS 26.0, *)
-struct AuroraRecordingView_Previews: PreviewProvider {
-    static var previews: some View {
-        ZStack {
-            Color.black
-            // Note: Preview needs actual Audio instance
-            // AuroraRecordingView(audio: Audio(), onStop: {})
-            Text("Preview requires Audio instance")
-                .foregroundColor(.white)
-        }
-        .frame(width: 300, height: 200)
-    }
-}
-#endif

--- a/Transcripted/UI/FloatingPanel/Components/SavedPillView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/SavedPillView.swift
@@ -1,0 +1,229 @@
+import SwiftUI
+import AppKit
+
+// MARK: - Saved Pill View
+/// Notification card shown when a transcript is saved.
+/// Displays the transcript title, duration, speaker count, and quick actions (Copy/Open).
+/// Morphs from the processing pill into a wider card (260x56px) with a green accent.
+/// Tapping the card body dismisses it; auto-dismisses after 6 seconds.
+
+@available(macOS 26.0, *)
+struct SavedPillView: View {
+    let title: String?
+    let duration: String?
+    let speakerCount: Int?
+    var transcriptURL: URL? = nil
+    var onCopyTranscript: (() -> Void)? = nil
+    var onOpenTranscript: (() -> Void)? = nil
+    var onDismiss: (() -> Void)? = nil
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @State private var checkScale: CGFloat = 0.3
+    @State private var checkOpacity: CGFloat = 0
+    @State private var contentOpacity: CGFloat = 0
+    @State private var isHovered = false
+    @State private var isCopyHovered = false
+    @State private var isOpenHovered = false
+    @State private var showCopiedCheck = false
+
+    private let width: CGFloat = PillDimensions.savedWidth
+    private let height: CGFloat = PillDimensions.savedHeight
+
+    var body: some View {
+        ZStack {
+            // Background with green accent border
+            savedBackground
+                .clipShape(RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+
+            // Content layout
+            HStack(spacing: 8) {
+                // Animated checkmark
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(.statusSuccessMuted)
+                    .scaleEffect(checkScale)
+                    .opacity(checkOpacity)
+
+                // Title + metadata
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(displayTitle)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(.panelTextPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+
+                    if let subtitle = subtitleText {
+                        Text(subtitle)
+                            .font(.system(size: 11))
+                            .foregroundColor(.panelTextSecondary)
+                            .lineLimit(1)
+                    }
+                }
+                .opacity(contentOpacity)
+
+                Spacer(minLength: 4)
+
+                // Action buttons
+                HStack(spacing: 4) {
+                    // Copy button
+                    if let onCopy = onCopyTranscript {
+                        Button(action: {
+                            onCopy()
+                            withAnimation(.snappy(duration: 0.15)) { showCopiedCheck = true }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                                withAnimation(.snappy(duration: 0.15)) { showCopiedCheck = false }
+                            }
+                        }) {
+                            ZStack {
+                                Circle()
+                                    .fill(isCopyHovered ? Color.panelCharcoalSurface : Color.clear)
+                                    .frame(width: 28, height: 28)
+
+                                Image(systemName: showCopiedCheck ? "checkmark" : "doc.on.doc")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundColor(showCopiedCheck ? .statusSuccessMuted : .panelTextSecondary)
+                            }
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        .onHover { hovering in isCopyHovered = hovering }
+                        .help("Copy transcript")
+                    }
+
+                    // Open in tray button
+                    if transcriptURL != nil {
+                        Button(action: {
+                            onOpenTranscript?()
+                        }) {
+                            ZStack {
+                                Circle()
+                                    .fill(isOpenHovered ? Color.panelCharcoalSurface : Color.clear)
+                                    .frame(width: 28, height: 28)
+
+                                Image(systemName: "arrow.up.forward.app")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundColor(.panelTextSecondary)
+                            }
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        .onHover { hovering in isOpenHovered = hovering }
+                        .help("Open transcript")
+                    }
+                }
+                .opacity(contentOpacity)
+            }
+            .padding(.horizontal, 14)
+        }
+        .frame(width: width, height: height)
+        .onTapGesture {
+            onDismiss?()
+        }
+        .onHover { hovering in isHovered = hovering }
+        .onAppear { animateEntrance() }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityText)
+    }
+
+    // MARK: - Display Content
+
+    private var displayTitle: String {
+        if let title, !title.isEmpty, title != "Meeting" {
+            return title
+        }
+        return "Transcript Saved"
+    }
+
+    private var subtitleText: String? {
+        var parts: [String] = []
+        if let duration, !duration.isEmpty {
+            parts.append(duration)
+        }
+        if let count = speakerCount, count > 0 {
+            parts.append("\(count) speaker\(count == 1 ? "" : "s")")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    // MARK: - Background
+
+    private var savedBackground: some View {
+        ZStack {
+            Color.panelCharcoal
+
+            // Subtle green radial glow from left
+            RadialGradient(
+                colors: [
+                    Color.statusSuccessMuted.opacity(0.15),
+                    Color.statusSuccessMuted.opacity(0.06),
+                    Color.clear
+                ],
+                center: .leading,
+                startRadius: 0,
+                endRadius: 140
+            )
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
+                .strokeBorder(Color.statusSuccessMuted.opacity(0.45), lineWidth: 1.5)
+        )
+        .shadow(color: Color.statusSuccessMuted.opacity(0.2), radius: 10, y: 0)
+    }
+
+    // MARK: - Animation
+
+    private func animateEntrance() {
+        if reduceMotion {
+            checkScale = 1.0
+            checkOpacity = 1.0
+            contentOpacity = 1.0
+            return
+        }
+
+        // Phase 1: Scale in checkmark
+        withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
+            checkScale = 1.0
+            checkOpacity = 1.0
+        }
+
+        // Phase 2: Slight bounce
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            withAnimation(.spring(response: 0.2, dampingFraction: 0.5)) {
+                checkScale = 1.1
+            }
+        }
+
+        // Phase 3: Settle
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            withAnimation(.spring(response: 0.15, dampingFraction: 0.8)) {
+                checkScale = 1.0
+            }
+        }
+
+        // Phase 4: Fade in content
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            withAnimation(.easeOut(duration: 0.2)) {
+                contentOpacity = 1.0
+            }
+        }
+    }
+
+    // MARK: - Accessibility
+
+    private var accessibilityText: String {
+        var label = "Transcript saved"
+        if let title, !title.isEmpty {
+            label += ": \(title)"
+        }
+        if let duration, !duration.isEmpty {
+            label += ", \(duration)"
+        }
+        if let count = speakerCount, count > 0 {
+            label += ", \(count) speaker\(count == 1 ? "" : "s")"
+        }
+        return label
+    }
+
+    // MARK: - Hover State
+
+    var isPillHovered: Bool { isHovered }
+}

--- a/Transcripted/UI/FloatingPanel/FloatingPanelController.swift
+++ b/Transcripted/UI/FloatingPanel/FloatingPanelController.swift
@@ -177,17 +177,18 @@ class FloatingPanelController: NSWindowController, NSWindowDelegate {
                 case .transcriptSaved:
                     // Don't interrupt an active recording with success from a background task
                     guard !self.audio.isRecording else { break }
-                    // Don't show success animation if speaker naming is pending —
+                    // Don't show saved card if speaker naming is pending —
                     // the naming tray IS the post-transcription UI
                     guard self.taskManager.speakerNamingRequest == nil else { break }
-                    // Show success briefly in pill, then return to idle
-                    if self.pillStateManager.state != .processing {
-                        self.pillStateManager.transition(to: .processing)
-                    }
-                    // Quick return to idle after success animation
-                    self.scheduleReturnToIdle(delay: 2.5)
+                    // Show saved notification card with transcript info
+                    self.pillStateManager.transition(to: .saved)
+                    // Return to idle after 10 seconds — enough time to read and act
+                    self.scheduleReturnToIdle(delay: 10.0)
                 case .idle:
-                    if !self.audio.isRecording {
+                    // Don't preempt the saved card — scheduleReturnToIdle(10s) handles it.
+                    // Without this guard, scheduleStatusReset(delay:4) in TaskManager would
+                    // fire displayStatus=.idle after 4s, cutting the saved card short.
+                    if !self.audio.isRecording && self.pillStateManager.state != .saved {
                         self.pillStateManager.transition(to: .idle)
                     }
                 case .failed:

--- a/Transcripted/UI/FloatingPanel/FloatingPanelView.swift
+++ b/Transcripted/UI/FloatingPanel/FloatingPanelView.swift
@@ -269,32 +269,42 @@ struct FloatingPanelView: View {
                 toggleTranscriptTray()
             })
         case .processing:
-            // Show success view for transcript saved, processing aurora otherwise
-            switch taskManager.displayStatus {
-            case .transcriptSaved:
-                AuroraSuccessView(
-                    successType: .transcriptSaved,
-                    transcriptURL: taskManager.lastSavedTranscriptURL,
-                    onCopyTranscript: {
-                        guard let url = taskManager.lastSavedTranscriptURL else { return }
-                        let summary = TranscriptSummary(
-                            url: url,
-                            title: url.deletingPathExtension().lastPathComponent,
-                            date: Date(),
-                            duration: "",
-                            speakerCount: 0,
-                            speakerNames: [],
-                            timeOfDay: nil
-                        )
-                        if let text = transcriptStore.copyableText(for: summary), !text.isEmpty {
-                            NSPasteboard.general.clearContents()
-                            NSPasteboard.general.setString(text, forType: .string)
+            AuroraProcessingView(status: taskManager.displayStatus)
+        case .saved:
+            SavedPillView(
+                title: taskManager.lastSavedTitle,
+                duration: taskManager.lastSavedDuration,
+                speakerCount: taskManager.lastSavedSpeakerCount,
+                transcriptURL: taskManager.lastSavedTranscriptURL,
+                onCopyTranscript: {
+                    guard let url = taskManager.lastSavedTranscriptURL else { return }
+                    let summary = TranscriptSummary(
+                        url: url,
+                        title: url.deletingPathExtension().lastPathComponent,
+                        date: Date(),
+                        duration: "",
+                        speakerCount: 0,
+                        speakerNames: [],
+                        timeOfDay: nil
+                    )
+                    if let text = transcriptStore.copyableText(for: summary), !text.isEmpty {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(text, forType: .string)
+                    }
+                },
+                onOpenTranscript: {
+                    // Dismiss saved card, go to idle, and open transcript tray
+                    pillStateManager.transition(to: .idle)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        withAnimation(.spring(response: 0.25, dampingFraction: 0.85)) {
+                            trayState = .transcripts
                         }
                     }
-                )
-            default:
-                AuroraProcessingView(status: taskManager.displayStatus)
-            }
+                },
+                onDismiss: {
+                    pillStateManager.transition(to: .idle)
+                }
+            )
         }
     }
 

--- a/Transcripted/UI/FloatingPanel/PillStateManager.swift
+++ b/Transcripted/UI/FloatingPanel/PillStateManager.swift
@@ -44,9 +44,10 @@ enum PillSounds {
 
 /// Represents the visual states of the floating pill UI
 enum PillState: Equatable {
-    case idle           // 40x20px - Dormant waveform, capsule shape
-    case recording      // 180x40px - Live visualizer + timer + stop
-    case processing     // 180x40px - Status text + progress
+    case idle           // 52x26px - Mic icon capsule, hover-expands
+    case recording      // 180x40px - Gradient border + timer + stop
+    case processing     // 180x40px - Progress bar + status text
+    case saved          // 260x56px - Transcript title + actions notification card
 }
 
 // MARK: - Pill State Manager
@@ -87,6 +88,8 @@ class PillStateManager: ObservableObject {
             return PillDimensions.idleWidth
         case .recording, .processing:
             return PillDimensions.recordingWidth
+        case .saved:
+            return PillDimensions.savedWidth
         }
     }
 
@@ -96,6 +99,8 @@ class PillStateManager: ObservableObject {
             return PillDimensions.idleHeight
         case .recording, .processing:
             return PillDimensions.recordingHeight
+        case .saved:
+            return PillDimensions.savedHeight
         }
     }
 
@@ -106,6 +111,8 @@ class PillStateManager: ObservableObject {
             return PillDimensions.idleHeight + 20  // Small padding
         case .recording, .processing:
             return PillDimensions.recordingHeight + 20
+        case .saved:
+            return PillDimensions.savedHeight + 20
         }
     }
 
@@ -197,8 +204,8 @@ class PillStateManager: ObservableObject {
         case (.recording, .processing):
             // Stopped recording, starting transcription - subtle tink
             PillSounds.playRecordingStop()
-        case (.processing, .idle):
-            // Transcription complete — glass chime
+        case (_, .saved):
+            // Transcript ready — glass chime
             PillSounds.playComplete()
         default:
             // No sound for other transitions (keeps it unobtrusive)


### PR DESCRIPTION
## Summary

Two bugs found and fixed during automated nightly code review (2026-03-22) of the WIP `saved-pill` feature:

- **Race condition — SavedPillView dismissed after ~4s instead of 10s** (`FloatingPanelController.swift`): The `.idle` case in the `taskManager.$displayStatus` Combine subscription unconditionally called `pillStateManager.transition(to: .idle)`. When transcription completes, `TaskManager.scheduleStatusReset(delay: 4)` resets `displayStatus` to `.idle` after 4 seconds. This fired the `.idle` handler and preempted the 10-second `SavedPillView` display. Fixed by guarding the transition: only move to idle if `pillStateManager.state != .saved`.

- **Main-thread file I/O — `populateSavedMetadata` blocks UI** (`TranscriptionTaskManager.swift`): `populateSavedMetadata(from:)` is called on `@MainActor` and read the transcript file synchronously via `String(contentsOf: url, encoding: .utf8)`. For large transcripts this blocks the UI thread. Fixed by dispatching the file read to `Task.detached(priority: .utility)` and publishing parsed metadata back on `MainActor`.

## Files changed

| File | Change |
|------|--------|
| `FloatingPanelController.swift` | Guard `.idle` handler against overwriting `.saved` pill state |
| `TranscriptionTaskManager.swift` | Offload YAML frontmatter file read off main thread |
| `SavedPillView.swift` | New WIP file (untracked) included in this branch |
| `PillStateManager.swift`, `Animations.swift` | WIP: add `PillState.saved` + dimensions |
| `AuroraIdleView/RecordingView/ProcessingView.swift` | WIP: aurora redesign |
| `FloatingPanelView.swift`, `SpeakerNamingCoordinator.swift` | WIP: wire `.saved` state |

## Test plan

- [ ] Build passes: `xcodebuild ... build CODE_SIGN_IDENTITY="" ...` returns `BUILD SUCCEEDED`
- [ ] After transcription completes, `SavedPillView` stays visible for the full 10 seconds before returning to idle
- [ ] `SavedPillView` shows correct title, duration, and speaker count (metadata arrives asynchronously from background task)
- [ ] No UI jank or main-thread stalls on large transcript files

🤖 Generated with [Claude Code](https://claude.com/claude-code)