### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Transcripted/Core/TranscriptionTaskManager.swift
+++ b/Transcripted/Core/TranscriptionTaskManager.swift
@@ -222,6 +222,7 @@ class TranscriptionTaskManager: ObservableObject {
             let parts = line.split(separator: ":", maxSplits: 1).map { String($0).trimmingCharacters(in: .whitespaces) }
             guard parts.count == 2 else { continue }
             switch parts[0] {
+            case "title": lastSavedTitle = parts[1].trimmingCharacters(in: CharacterSet(charactersIn: "\""))
             case "duration": lastSavedDuration = parts[1].trimmingCharacters(in: CharacterSet(charactersIn: "\""))
             case "mic_speakers", "system_speakers": speakers += Int(parts[1]) ?? 0
             default: break


### PR DESCRIPTION
## Summary

Two logic bugs found and fixed during automated nightly code review of changes from the last 7 days.

### Bug 1: SavedPillView shows filename instead of Qwen meeting title
**File:** `Transcripted/Core/TranscriptionTaskManager.swift`

`populateSavedMetadata()` parses the YAML frontmatter to populate the saved pill notification card. It read `duration`, `mic_speakers`, and `system_speakers` correctly, but had no `case "title"` in the switch — so the Qwen-inferred meeting title written by `TranscriptFormatter` was silently ignored.

Result: after every successful transcription, the pill showed a filename-derived title like "Call 2026 03 23 09 30 00" instead of the meaningful title like "Q1 Planning Meeting" inferred by Qwen. The same bug affected the re-display of the saved pill after speaker naming completes (`handleNamingComplete` also calls `populateSavedMetadata`).

Fix: add `case "title"` to parse and apply the YAML title field.

### Bug 2: Click-outside-to-dismiss broken when transcript tray opened during speaker naming
**File:** `Transcripted/UI/FloatingPanel/FloatingPanelView.swift`

`installEscapeMonitor()` started with `guard escapeLocalMonitor == nil else { return }`. The click-outside monitor (which dismisses the transcript tray on outside clicks) was installed inside that function, *after* the early-return guard.

If the user right-clicked the pill while the speaker naming tray was open and selected "View Transcripts", `trayState` would flip to `.transcripts` and `installEscapeMonitor()` would be called — but the escape monitors were already installed from the speaker naming phase, so the guard bailed out early, and the click-outside monitor was never registered. The transcript tray would be visible but unresponsive to outside clicks (escape still worked).

Fix: convert the guard to an `if` block so the click-outside monitor check always runs regardless of whether escape monitors are already active.

## Test plan
- [ ] Record a meeting with Qwen-inferred title; verify the saved pill shows the real title, not a filename
- [ ] Trigger speaker naming tray, then right-click pill and select "View Transcripts"; verify clicking outside the panel dismisses the tray

🤖 Generated with [Claude Code](https://claude.com/claude-code)