### PR TITLE
refactor: nightly simplification sweep [automated]

### DIFF
--- a/Transcripted/Core/TranscriptionTaskManager.swift
+++ b/Transcripted/Core/TranscriptionTaskManager.swift
@@ -140,20 +140,11 @@ class TranscriptionTaskManager: ObservableObject {
             self.displayStatus = .gettingReady
         }
 
-        let transcriptedFolder: URL
-        if let customPath = UserDefaults.standard.string(forKey: "transcriptSaveLocation"),
-           !customPath.isEmpty {
-            transcriptedFolder = URL(fileURLWithPath: customPath)
-        } else {
-            let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-            transcriptedFolder = documentsURL.appendingPathComponent("Transcripted")
-        }
-
         do {
             let transcriptURL = try await transcribeWithSpeakerIdentification(
                 micURL: failed.micAudioURL,
                 systemURL: failed.systemAudioURL,
-                outputFolder: transcriptedFolder,
+                outputFolder: TranscriptSaver.defaultSaveDirectory,
                 taskId: failedId,
                 healthInfo: nil
             )
@@ -212,12 +203,16 @@ class TranscriptionTaskManager: ObservableObject {
         displayStatus = .idle
     }
 
-    /// Populate saved transcript metadata from the file's YAML frontmatter
+    /// Populate saved transcript metadata from the file's YAML frontmatter.
+    /// Reads only the first 2 KB to avoid blocking the main thread on large transcript files.
     func populateSavedMetadata(from url: URL) {
         lastSavedTranscriptURL = url
         let name = url.deletingPathExtension().lastPathComponent
         lastSavedTitle = name.replacingOccurrences(of: "_", with: " ").replacingOccurrences(of: "-", with: " ")
-        guard let raw = try? String(contentsOf: url, encoding: .utf8),
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return }
+        let headerData = handle.readData(ofLength: 2048)
+        try? handle.close()
+        guard let raw = String(data: headerData, encoding: .utf8),
               raw.hasPrefix("---"),
               let endRange = raw.range(of: "\n---\n", range: raw.index(raw.startIndex, offsetBy: 3)..<raw.endIndex)
         else { return }

--- a/Transcripted/UI/FloatingPanel/Components/SavedPillView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/SavedPillView.swift
@@ -222,8 +222,4 @@ struct SavedPillView: View {
         }
         return label
     }
-
-    // MARK: - Hover State
-
-    var isPillHovered: Bool { isHovered }
 }

--- a/Transcripted/UI/FloatingPanel/FloatingPanelView.swift
+++ b/Transcripted/UI/FloatingPanel/FloatingPanelView.swift
@@ -210,6 +210,19 @@ struct FloatingPanelView: View {
             case .transcripts:
                 transcriptStore.refresh()
                 installEscapeMonitor()
+                // Install click-outside monitor separately: installEscapeMonitor() may return early
+                // if escape monitors are already set (e.g., after speakerNaming -> transcripts
+                // transition), leaving the click-outside monitor uninstalled.
+                if clickOutsideMonitor == nil {
+                    clickOutsideMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { _ in
+                        DispatchQueue.main.async {
+                            guard self.trayState == .transcripts else { return }
+                            withAnimation(.spring(response: 0.2, dampingFraction: 0.85)) {
+                                self.trayState = .none
+                            }
+                        }
+                    }
+                }
             case .speakerNaming:
                 speakerNamingAppearDate = Date()
                 installEscapeMonitor()
@@ -361,17 +374,6 @@ struct FloatingPanelView: View {
             }
         }
 
-        // Click-outside monitor: dismiss transcript tray when clicking anywhere outside the panel
-        if clickOutsideMonitor == nil && trayState == .transcripts {
-            clickOutsideMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { _ in
-                DispatchQueue.main.async {
-                    guard self.trayState == .transcripts else { return }
-                    withAnimation(.spring(response: 0.2, dampingFraction: 0.85)) {
-                        self.trayState = .none
-                    }
-                }
-            }
-        }
     }
 
     private func removeEscapeMonitor() {
@@ -392,14 +394,7 @@ struct FloatingPanelView: View {
     // MARK: - Helper Functions
 
     private func openTranscriptsFolder() {
-        let transcriptsFolder: URL
-        if let customPath = UserDefaults.standard.string(forKey: "transcriptSaveLocation"),
-           !customPath.isEmpty {
-            transcriptsFolder = URL(fileURLWithPath: customPath)
-        } else {
-            let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-            transcriptsFolder = documentsPath.appendingPathComponent("Transcripted")
-        }
+        let transcriptsFolder = TranscriptSaver.defaultSaveDirectory
         try? FileManager.default.createDirectory(at: transcriptsFolder, withIntermediateDirectories: true)
         NSWorkspace.shared.open(transcriptsFolder)
     }


### PR DESCRIPTION
## Summary

Nightly automated simplification review found 4 issues in the recent floating pill redesign (PRs #77/#78):

- **Dead code**: Removed unused `isPillHovered` computed property from `SavedPillView` — it exposed a private `@State` but was never read externally
- **Bug fix**: Click-outside monitor was never installed when the tray transitioned from `.speakerNaming` → `.transcripts`. The `installEscapeMonitor()` guard (`guard escapeLocalMonitor == nil`) prevented reinstallation, leaving the transcript tray un-dismissable by clicking outside. Fixed by moving click-outside setup to the `onChange(of: trayState)` `.transcripts` case directly.
- **Efficiency**: `populateSavedMetadata` called `String(contentsOf:)` on the full transcript file (can be 100KB+ for long recordings) on the main thread. Only the first 2 KB (YAML frontmatter) is needed — switched to `FileHandle.readData(ofLength: 2048)`
- **Deduplication**: Two callers (`FloatingPanelView.openTranscriptsFolder` and `TranscriptionTaskManager.retryFailedTranscription`) reimplemented the transcript folder path resolution inline. Replaced with `TranscriptSaver.defaultSaveDirectory` which already exists and includes security validation for custom save paths.

## Test plan

- [ ] Build passes (verified: `xcodebuild` with no signing errors)
- [ ] Click-outside dismissal works after speaker naming tray → transcript tray transition
- [ ] Saved pill metadata appears correctly after transcription completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)