### PR TITLE
security: nightly security audit findings [automated]

### DIFF
--- a/Transcripted/Core/AudioDeviceRecovery.swift
+++ b/Transcripted/Core/AudioDeviceRecovery.swift
@@ -139,6 +139,9 @@ extension Audio {
                     commonFormat: monoFormat.commonFormat,
                     interleaved: monoFormat.isInterleaved
                 )
+                // Security: restrict to owner-only (600) — recovery segment contains biometric
+                // voice data and should not be world-readable while recording is in progress.
+                try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
                 micAudioFileQueue.sync { micAudioFile = newFile }
                 AppLogger.audioMic.info("Created recovery audio file", ["file": fileURL.lastPathComponent])
 

--- a/Transcripted/Core/AudioFileManager.swift
+++ b/Transcripted/Core/AudioFileManager.swift
@@ -80,6 +80,9 @@ extension Audio {
                         commonFormat: .pcmFormatFloat32,
                         interleaved: tapFormat.isInterleaved
                     )
+                    // Security: restrict to owner-only (600) — system audio file contains biometric
+                    // voice data and should not be world-readable while recording is in progress.
+                    try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
                     strongSelf.systemAudioFileQueue.sync { strongSelf.systemAudioFile = file }
                     AppLogger.audioSystem.info("System audio file created before I/O proc", ["sampleRate": "\(Int(sampleRate))", "channels": "\(tapFormat.channelCount)"])
 
@@ -175,6 +178,9 @@ extension Audio {
                 commonFormat: monoFormat.commonFormat,
                 interleaved: monoFormat.isInterleaved
             )
+            // Security: restrict to owner-only (600) — mic audio file contains biometric voice
+            // data and should not be world-readable while recording is in progress.
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
             AppLogger.audioMic.info("Saving as mono", ["sampleRate": "\(recordingFormat.sampleRate)"])
         } catch {
             throw NSError(domain: "Audio", code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to create mic audio file: \(error.localizedDescription)"])

--- a/Transcripted/Core/ModelDownloadService.swift
+++ b/Transcripted/Core/ModelDownloadService.swift
@@ -305,7 +305,12 @@ enum ModelDownloadService {
     private static func fetchModelFileList(modelId: String) async throws -> [HFModelFile] {
         // Try each mirror for the API call
         for mirror in mirrors {
-            let apiURL = URL(string: "\(mirror)/api/models/\(modelId)")!
+            // Security: use safe URL construction — force-unwrap would crash if modelId or mirror
+            // contained URL-unsafe characters. Guard lets us skip the mirror and try the next.
+            guard let apiURL = URL(string: "\(mirror)/api/models/\(modelId)") else {
+                AppLogger.services.warning("Skipping mirror — could not construct API URL", ["mirror": mirror, "modelId": modelId])
+                continue
+            }
 
             do {
                 let (data, response) = try await URLSession.shared.data(from: apiURL)
@@ -360,7 +365,13 @@ enum ModelDownloadService {
         destination: URL
     ) async throws {
         for mirror in mirrors {
-            let fileURL = URL(string: "\(mirror)/\(modelId)/resolve/main/\(filename)")!
+            // Security: use safe URL construction — force-unwrap would crash if filename contained
+            // URL-unsafe characters (e.g., spaces) not caught by isSafeModelFilename. Skip
+            // this mirror and try the next rather than crashing.
+            guard let fileURL = URL(string: "\(mirror)/\(modelId)/resolve/main/\(filename)") else {
+                AppLogger.services.warning("Skipping mirror — could not construct file URL", ["mirror": mirror, "file": filename])
+                continue
+            }
 
             do {
                 try await withRetry(maxAttempts: 2) {


### PR DESCRIPTION
## Summary

Automated nightly security audit run on 2026-03-23. Two vulnerabilities fixed.

## Findings by Severity

### Medium — Audio recording files written without owner-only permissions

Raw meeting WAV files (`meeting_*_mic.wav`, `meeting_*_system.wav`, device-recovery segments) were created with macOS default umask permissions (644), making biometric voice recordings **world-readable** for the duration of the recording until cleanup.

**Files changed:** `AudioFileManager.swift`, `AudioDeviceRecovery.swift`
**Fix:** Apply `0o600` (owner read/write only) immediately after `AVAudioFile` creation — matching the pattern already used by `SpeakerClipExtractor` for speaker clips and by both database files.

### Low — Force-unwrapped URL construction in ModelDownloadService

`URL(string: "\(mirror)/\(modelId)/resolve/main/\(filename)")!` and `URL(string: "\(mirror)/api/models/\(modelId)")!` would crash if `filename` or `modelId` contained URL-unsafe characters (e.g., spaces) not caught by `isSafeModelFilename`, which only rejects path traversal sequences and control characters.

**File changed:** `ModelDownloadService.swift`
**Fix:** Replace force-unwrap with guarded construction that logs a warning and skips to the next mirror rather than crashing.

## Areas Audited (No Issues Found)

| Area | Result |
|------|--------|
| SQL injection (SpeakerDatabase, StatsDatabase) | ✅ All queries use parameterized binding |
| Hardcoded secrets/credentials | ✅ None found |
| Sparkle auto-updater | ✅ HTTPS feed + EdDSA public key (SUPublicEDKey) |
| Path traversal (save paths, model filenames) | ✅ RecordingValidator + isSafeModelFilename both validate |
| Race conditions (audio/main thread) | ✅ Correct threading model per architecture docs |
| Temp file cleanup (meeting_*.wav) | ✅ Cleaned up after transcription in TaskManager + Pipeline |
| Model download integrity | ✅ HTTPS-only mirrors, filename allowlist validation |
| Speaker clip permissions | ✅ Already at 0o600 in SpeakerClipExtractor |
| Database permissions | ✅ Already at 0o600 for speakers.sqlite and stats.sqlite |

## Test plan

- [x] Build succeeds: `xcodebuild ... CODE_SIGNING_REQUIRED=NO build` — **BUILD SUCCEEDED**
- [ ] Record a meeting and verify `meeting_*_mic.wav` / `meeting_*_system.wav` have permissions `-rw-------` (`ls -la ~/Documents/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)