### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,13 +11,13 @@ Menu bar-only macOS app for real-time system audio transcription. Pipeline: Core
 - **Protocols**: 7 service protocols in `Services/Protocols/` (SpeechToTextEngine, DiarizationEngine, SpeakerStore, etc.)
 - **DI**: `AppServices` container in `Core/AppServices.swift`
 
-## Folder Map (~137 Swift files, agent-first: max ~300 lines per file, single responsibility)
+## Folder Map (~135 Swift files, agent-first: max ~300 lines per file, single responsibility)
 - **Core/** (47 files): Audio capture (Audio + 3 extensions), transcription pipeline (TaskManager + 3 extensions), transcript saving (4 files), stats DB (3 files), model downloads (ModelDownloadService), failed transcription retry, logging, coordinators (Hotkey, MenuBar, Notification, Window, Recording)
 - **Services/** (18 files): ML services (11 files) + Protocols/ subdirectory (7 service protocols)
 - **UI/FloatingPanel/** (21 files): Morphing pill UI, aurora state views (3 files), SavedPillView, transcript tray (3 files), speaker naming (3 files), Components/ (16 files), Helpers/ (1 file)
 - **UI/Settings/** (18 files): Settings container + Sections/ (7 section views) + Components/ (6 reusable components) + Models/ (1 file)
-- **Onboarding/** (5 files): 2-step first-run flow (Permissions -> Model Setup), dark theme
-- **Design/** (20 files): Colors/ (6 files), Components/ (4 premium components), root tokens (10 files: Spacing, Radius, Typography, Animations, Shadows, ViewModifiers, Gradients, Dimensions, Accessibility, CardModifiers)
+- **Onboarding/** (7 files): 4-step first-run flow (Welcome -> Preview -> Permissions -> Model Setup), dark theme
+- **Design/** (21 files): Colors/ (6 files), Components/ (5 premium components), root tokens (10 files: Spacing, Radius, Typography, Animations, Shadows, ViewModifiers, Gradients, Dimensions, Accessibility, CardModifiers)
 
 ## Build & Test
 ```bash
@@ -96,14 +96,14 @@ Every folder with ≥2 Swift files has its own CLAUDE.md with file index, refere
 | `Transcripted/Services/Protocols/CLAUDE.md` | 7 DI protocols with full signatures |
 | `Transcripted/Design/CLAUDE.md` | All token values (colors, spacing, radius, typography, animations) |
 | `Transcripted/Design/Colors/CLAUDE.md` | Complete color reference with hex/HSB values |
-| `Transcripted/Design/Components/CLAUDE.md` | PremiumButton, PremiumCard, QuickTipRow, AnimatedIcon specs |
+| `Transcripted/Design/Components/CLAUDE.md` | PremiumButton, PremiumCard, BenefitCard, QuickTipRow, AnimatedIcon specs |
 | `Transcripted/UI/FloatingPanel/CLAUDE.md` | Pill state machine, Combine subscriptions, tray states |
 | `Transcripted/UI/FloatingPanel/Components/CLAUDE.md` | Aurora views, speaker naming, error toast, celebrations |
 | `Transcripted/UI/Settings/CLAUDE.md` | @AppStorage keys, window config, speaker operations |
 | `Transcripted/UI/Settings/Sections/CLAUDE.md` | 7 section views with per-section detail |
 | `Transcripted/UI/Settings/Components/CLAUDE.md` | CoralToggle, button styles, input components |
-| `Transcripted/Onboarding/CLAUDE.md` | 2-step flow, OnboardingState properties, integration |
-| `Transcripted/Onboarding/Steps/CLAUDE.md` | Permissions, ModelSetup step implementations |
+| `Transcripted/Onboarding/CLAUDE.md` | 4-step flow, OnboardingState properties, integration |
+| `Transcripted/Onboarding/Steps/CLAUDE.md` | Welcome, Preview, Permissions, ModelSetup step implementations |
 
 **Single-file folders** (covered by parent CLAUDE.md):
 - `UI/MenuBar/MenuBarStatRow.swift` — Custom NSView (250x22), used in status bar dropdown

--- a/Transcripted/Core/CLAUDE.md
+++ b/Transcripted/Core/CLAUDE.md
@@ -21,9 +21,9 @@ Audio capture pipeline, transcription orchestration, file saving, stats tracking
 | `TranscriptionTypes.swift` | -- | TranscriptionUtterance, TranscriptionResult, PipelineError, SpeakerNamingEntry |
 | `DisplayStatus.swift` | -- | Enum for UI progress phases (idle/gettingReady/transcribing/finishing/saved/failed) |
 | `SpeakerMatchingService.swift` | nonisolated | In-memory speaker embedding matching, mean embedding computation |
-| `SpeakerNamingCoordinator.swift` | @MainActor | Speaker naming flow completion, applies names to DB and transcript |
+| `SpeakerNamingCoordinator.swift` | @MainActor | Speaker naming flow completion, applies names to DB and transcript, merges profiles by name |
 | `QwenLifecycleManager.swift` | @MainActor | Qwen model pre-load on recording start, timeout, memory checks |
-| `TranscriptSaver.swift` | Static | Markdown + YAML output, serial queue for file writes |
+| `TranscriptSaver.swift` | Static | Markdown + YAML output, serial queue for file writes, path validation, 0o600 permissions on temp clips |
 | `TranscriptFormatter.swift` | Static | YAML escaping, source label formatting, markdown generation |
 | `TranscriptMetadataBuilder.swift` | -- | RecordingHealthInfo struct, YAML frontmatter metadata construction |
 | `RetroactiveSpeakerUpdater.swift` | Static | Updates all transcripts when a speaker is renamed in Settings |
@@ -36,7 +36,7 @@ Audio capture pipeline, transcription orchestration, file saving, stats tracking
 | `StatsDatabaseModels.swift` | -- | RecordingMetadata, DailyActivity data models |
 | `StatsDatabaseQueries.swift` | NOT @MainActor | Complex queries and aggregations for StatsDatabase |
 | `StatsService.swift` | @MainActor | Stats aggregation for dashboard UI |
-| `ModelDownloadService.swift` | Static | HuggingFace download with mirror fallback (hf-mirror.com), retry with exponential backoff, Qwen cache pre-population, structured error classification (DownloadErrorKind) |
+| `ModelDownloadService.swift` | Static | HuggingFace download with mirror fallback (hf-mirror.com), retry with exponential backoff, Qwen cache pre-population, structured error classification (DownloadErrorKind), isSafeModelFilename() path traversal validation |
 | `RecordingValidator.swift` | Static | Pre-recording checks (disk space, permissions, save path) |
 | `FailedTranscription.swift` | -- | Model for retryable failed transcriptions |
 | `FailedTranscriptionManager.swift` | @MainActor | Retry queue, persists to JSON, auto-cleans permanent failures |

--- a/Transcripted/Design/CLAUDE.md
+++ b/Transcripted/Design/CLAUDE.md
@@ -1,6 +1,6 @@
 # Design System
 
-Shared design tokens and premium components. 20 Swift files across root, Colors/, and Components/.
+Shared design tokens and premium components. 21 Swift files across root, Colors/, and Components/.
 
 ## File Index
 
@@ -30,12 +30,13 @@ Shared design tokens and premium components. 20 Swift files across root, Colors/
 | `AuroraColors.swift` | Aurora recording indicator colors (auroraCoral, auroraTeal + light variants, systemAudioIndicator) |
 | `HeatMapColors.swift` | 5-level heat map gradient (heatMapLevel0 through heatMapLevel4) + legacy aliases |
 
-### Components/ (4 files) — see Components/CLAUDE.md
+### Components/ (5 files) — see Components/CLAUDE.md
 
 | File | Purpose |
 |------|---------|
 | `PremiumButton.swift` | 3-variant button (primary/secondary/ghost), hover effects, loading state |
 | `PremiumCard.swift` | Warm cream card container with hover lift animation |
+| `BenefitCard.swift` | Icon circle + title/description row, dark card style, used in onboarding welcome |
 | `QuickTipRow.swift` | Small icon + text row for tips |
 | `AnimatedIcon.swift` | SF Symbol icon with glow/pulse effects |
 
@@ -127,6 +128,7 @@ PremiumButton(title:, icon:, variant:, isLoading:, isDisabled:, action:)
 
 ## Other Premium Components (Components/)
 - `PremiumCard(accentColor:, enableHover:, content:)` - Warm cream card with hover lift
+- `BenefitCard(icon:, iconColor:, title:, description:)` - Dark card with icon circle + text row, used in onboarding
 - `QuickTipRow(icon:, text:, iconColor:)` - Small icon + text row
 - `AnimatedIcon(systemName:, size:, color:, showGlow:, isPulsing:)` - Icon with glow/pulse effects
 

--- a/Transcripted/Design/Components/CLAUDE.md
+++ b/Transcripted/Design/Components/CLAUDE.md
@@ -1,6 +1,6 @@
 # Design Components
 
-4 reusable premium UI components used across Settings and FloatingPanel. All SwiftUI views.
+5 reusable premium UI components used across Onboarding, Settings, and FloatingPanel. All SwiftUI views.
 
 ## File Index
 
@@ -8,6 +8,7 @@
 |------|---------|
 | `PremiumButton.swift` | 3-variant button (primary/secondary/ghost) with hover, press, loading states |
 | `PremiumCard.swift` | Warm cream card container with hover lift animation |
+| `BenefitCard.swift` | Dark card with icon circle + title/description row, used in onboarding welcome |
 | `QuickTipRow.swift` | Small icon + text row for inline tips |
 | `AnimatedIcon.swift` | SF Symbol icon with configurable glow and pulse effects |
 
@@ -41,6 +42,14 @@ PremiumCard(accentColor:, enableHover:, content:)
 - Shadow: black 0.05-0.1 opacity, radius 12-20, y offset 4-8
 - Scale on hover: 1.02 (if enableHover), animation: .smooth
 
+### BenefitCard
+```swift
+BenefitCard(icon:, iconColor:, title:, description:)
+```
+- Layout: 48x48 icon circle (iconColor 0.12 fill) + title (headingSmall) / description (bodySmall)
+- Background: panelCharcoalElevated, radius Radius.md, panelCharcoalSurface border
+- Used in: WelcomeStep.swift (3 cards)
+
 ### QuickTipRow
 ```swift
 QuickTipRow(icon:, text:, iconColor:)
@@ -56,7 +65,7 @@ AnimatedIcon(systemName:, size:, color:, showGlow:, isPulsing:)
 - Pulse: easeInOut repeating scale animation
 
 ## Relationships
-- Used by: Settings/ (various sections), FloatingPanel/
+- Used by: Onboarding/Steps/ (WelcomeStep), Settings/ (various sections), FloatingPanel/
 - Design tokens from: Spacing.swift, Radius.swift, Typography.swift, Animations.swift
 - Colors from: Colors/BrandColors.swift, Colors/PanelColors.swift
 

--- a/Transcripted/Onboarding/CLAUDE.md
+++ b/Transcripted/Onboarding/CLAUDE.md
@@ -65,7 +65,7 @@ setupApp()
 
 ## Window Behavior
 - Size: 640x560, floating level, dark opaque background (panelCharcoal, .darkAqua appearance)
-- Close button visible: closing persists `hasCompletedOnboarding` and starts the app
+- Close button visible: closing persists `hasCompletedOnboarding` and starts the app. During model download, shows confirmation dialog ("Download in Progress") before allowing close
 - Fade-in animation: alpha 0 -> 1 over 0.3s
 - Fade-out: alpha 1 -> 0 over 0.3s, then orders out
 

--- a/Transcripted/Onboarding/Steps/CLAUDE.md
+++ b/Transcripted/Onboarding/Steps/CLAUDE.md
@@ -14,7 +14,7 @@
 ## Step Details
 
 ### WelcomeStep (Step 1)
-- Hero icon: waveform.circle.fill, 56pt, flat terracotta color
+- Hero icon: waveform.circle.fill, 56pt, flat recordingCoral color
 - 3 BenefitCards (from Design/Components/):
   - "Transcribe Meetings" (waveform icon)
   - "Identify Speakers" (person.2.fill icon)
@@ -24,7 +24,7 @@
 ### PreviewStep (Step 2)
 - Sample transcript showing a realistic meeting conversation
 - 6 transcript lines with staggered reveal (0.2s per line)
-- Two speakers: Sarah (terracotta) and Mike (processingPurple)
+- Two speakers: Sarah (recordingCoral) and Mike (processingPurple)
 - Delivers "aha moment" — shows what Transcripted produces before asking for permissions
 - No user action required, always canProceed
 

--- a/Transcripted/Services/CLAUDE.md
+++ b/Transcripted/Services/CLAUDE.md
@@ -17,7 +17,7 @@ ML pipeline services, speaker database, audio processing utilities, meeting dete
 | `QwenService.swift` | @MainActor | On-device Qwen3.5-4B-4bit via mlx-swift-lm, on-demand load/unload. Pre-populates cache via ModelDownloadService with mirror fallback and progress tracking. |
 | `EmbeddingClusterer.swift` | Static | 3-stage post-processing: pairwise merge, small cluster absorption, DB-informed split |
 | `AudioResampler.swift` | Static | AVAudioConverter-based resampling to 16kHz, WAV loading, slice extraction |
-| `SpeakerClipExtractor.swift` | Static | Extract per-speaker audio clips for naming UI playback |
+| `SpeakerClipExtractor.swift` | Static | Extract per-speaker audio clips for naming UI playback, 0o600 permissions on temp clips |
 | `MeetingDetector.swift` | @MainActor | Monitors Zoom/Teams/Webex/FaceTime, auto-triggers recording |
 
 ### Protocols/ (7 files) — see Protocols/CLAUDE.md
@@ -86,6 +86,8 @@ WAL mode, busy_timeout 5000ms, 0o600 permissions. All writes via dedicated utili
 - `findProfilesByName(_:)` (fuzzy, with name variants) — SpeakerProfileMerger
 - `mergeProfiles(sourceId:, into:)` -> blend by callCount weight, atomic transaction — SpeakerProfileMerger
 - `pruneWeakProfiles()` -> deletes unnamed AND callCount<=1 AND confidence<=0.5 AND age>1hr — SpeakerProfileMerger
+- `mergeProfilesByName()` -> merges profiles that ended up with the same name (e.g., "Jenny Wen") — SpeakerDatabase
+- `getColumnNames(tableName:)` -> PRAGMA table_info with compile-time allowlist validation for SQL injection prevention — SpeakerDatabase
 
 ## Cosine Similarity Thresholds (vary by context)
 | Context | Threshold | Purpose |

--- a/Transcripted/UI/FloatingPanel/CLAUDE.md
+++ b/Transcripted/UI/FloatingPanel/CLAUDE.md
@@ -21,7 +21,7 @@ Morphing pill UI (Dynamic Island style) with aurora state views, saved notificat
 | `AuroraRecordingView.swift` | Recording state (160x36px). LED dots: coral (mic) + teal (system). Timer + stop. |
 | `AuroraProcessingView.swift` | Processing state (160x36px). Progress bar + status text. Warning at 90s+. |
 | `SavedPillView.swift` | Saved notification card (260x56px). Title, duration, speakers, Copy/Open buttons. Green accent. |
-| `TranscriptTrayView.swift` | Recent transcript list (280x300px max). Frosted glass. Date separators. |
+| `TranscriptTrayView.swift` | Recent transcript list (280x300px max). Frosted glass. Date separators. Click-outside dismissal. |
 | `TranscriptRowView.swift` | Single row in transcript tray: title, relative date, duration, copy button. |
 | `TranscriptDetailView.swift` | Single transcript viewer. Groups lines by speaker with colored left borders. |
 | `SpeakerNamingView.swift` | Post-recording speaker naming. Play clips, confirm/reject names, merge profiles. |


### PR DESCRIPTION
## Summary
- **Root CLAUDE.md**: Fix Onboarding description (was "5 files/2-step", now correctly "7 files/4-step"), fix Design count (20→21), fix navigation table descriptions
- **Design CLAUDE.md + Components CLAUDE.md**: Add missing BenefitCard (5 components not 4, total 21 files not 20)
- **Onboarding CLAUDE.md**: Add download confirmation dialog on close during model download
- **Onboarding/Steps CLAUDE.md**: Fix color references (terracotta→recordingCoral for WelcomeStep icon and PreviewStep speakers)
- **Core CLAUDE.md**: Add missing details for SpeakerNamingCoordinator (profile merging), TranscriptSaver (path validation, permissions), ModelDownloadService (path traversal validation)
- **Services CLAUDE.md**: Add SpeakerClipExtractor permission details, add mergeProfilesByName() and getColumnNames() methods
- **FloatingPanel CLAUDE.md**: Add click-outside dismissal detail to TranscriptTrayView

## Context
PR #80 (dark theme onboarding redesign) deleted PermissionCard.swift and StepProgressIndicator.swift from Design/Components but BenefitCard was kept. The CLAUDE.md files were partially updated in that PR but missed BenefitCard and had the root file incorrectly describing a 2-step flow.

## Test plan
- [ ] Verify file counts match (`find Transcripted -name "*.swift" | wc -l` = 135)
- [ ] Verify Onboarding has 7 files and 4 steps
- [ ] Verify Design/Components has 5 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)