### PR TITLE
fix: reliability hardening — crash prevention, silent failures, test coverage

### DIFF
--- a/Transcripted/Core/Audio.swift
+++ b/Transcripted/Core/Audio.swift
@@ -3,6 +3,7 @@ import Foundation
 import AppKit
 import CoreAudio
 import Combine
+import QuartzCore
 
 /// Status of system audio capture for UI feedback
 /// Used to show warnings when device switching or audio loss occurs
@@ -103,9 +104,11 @@ class Audio: ObservableObject {
     var timer: Timer?
 
     // Device change watchdog - thread-safe access via lock
-    private var _lastBufferTime: Date = Date()
+    // Uses CACurrentMediaTime() (monotonic clock) to avoid false triggers after sleep/wake.
+    // Matches SystemAudioCapture.swift which also uses CACurrentMediaTime().
+    private var _lastBufferTime: CFTimeInterval = CACurrentMediaTime()
     private let lastBufferTimeLock = NSLock()
-    var lastBufferTime: Date {
+    var lastBufferTime: CFTimeInterval {
         get {
             lastBufferTimeLock.lock()
             defer { lastBufferTimeLock.unlock() }
@@ -140,9 +143,22 @@ class Audio: ObservableObject {
     let recoveryCooldown: TimeInterval = 5.0  // Min seconds between recovery attempts
 
     // Write error tracking — stop writing after repeated failures
-    var consecutiveMicWriteErrors: Int = 0
-    var consecutiveSystemWriteErrors: Int = 0
+    // Thread-safe: accessed from audio file queues (background) and reset from start() (main thread)
+    private var _consecutiveMicWriteErrors: Int = 0
+    private var _consecutiveSystemWriteErrors: Int = 0
+    private let writeErrorLock = NSLock()
+    var consecutiveMicWriteErrors: Int {
+        get { writeErrorLock.lock(); defer { writeErrorLock.unlock() }; return _consecutiveMicWriteErrors }
+        set { writeErrorLock.lock(); defer { writeErrorLock.unlock() }; _consecutiveMicWriteErrors = newValue }
+    }
+    var consecutiveSystemWriteErrors: Int {
+        get { writeErrorLock.lock(); defer { writeErrorLock.unlock() }; return _consecutiveSystemWriteErrors }
+        set { writeErrorLock.lock(); defer { writeErrorLock.unlock() }; _consecutiveSystemWriteErrors = newValue }
+    }
     let maxConsecutiveWriteErrors = 10
+
+    // Persistent flag: system audio capture failed, recording mic only
+    @Published var systemAudioFailed: Bool = false
 
     // System audio capture
     var systemAudioCapture: Any? // SystemAudioCapture (macOS 14.2+)
@@ -349,6 +365,7 @@ class Audio: ObservableObject {
         lastRecoveryTime = nil
         consecutiveMicWriteErrors = 0
         consecutiveSystemWriteErrors = 0
+        systemAudioFailed = false
 
         AppLogger.audio.info("Starting audio capture")
 
@@ -390,6 +407,7 @@ class Audio: ObservableObject {
         lastRecoveryTime = nil
         consecutiveMicWriteErrors = 0
         consecutiveSystemWriteErrors = 0
+        systemAudioFailed = false
 
         AppLogger.audio.info("Starting audio capture")
 

--- a/Transcripted/Core/AudioDeviceRecovery.swift
+++ b/Transcripted/Core/AudioDeviceRecovery.swift
@@ -13,12 +13,12 @@ extension Audio {
     // MARK: - Watchdog Timer
 
     func startWatchdog() {
-        lastBufferTime = Date()
+        lastBufferTime = CACurrentMediaTime()
         watchdogTimer?.invalidate()
         watchdogTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
             guard let self = self, self.isRecording else { return }
 
-            let timeSinceLastBuffer = Date().timeIntervalSince(self.lastBufferTime)
+            let timeSinceLastBuffer = CACurrentMediaTime() - self.lastBufferTime
 
             if timeSinceLastBuffer > 3.0 {
                 // Enforce cooldown — don't attempt recovery more often than every 5s
@@ -32,9 +32,11 @@ extension Audio {
                     AppLogger.audioMic.error("Max recovery attempts reached, stopping recording", [
                         "attempts": "\(self.deviceSwitchCount)"
                     ])
+                    let savedError = "Audio device unavailable — recording stopped after \(self.deviceSwitchCount) attempts"
                     DispatchQueue.main.async {
-                        self.error = "Audio device unavailable — recording stopped"
                         self.stop()
+                        // Re-apply error after stop() clears it
+                        self.error = savedError
                     }
                     return
                 }
@@ -160,7 +162,7 @@ extension Audio {
             guard let self = self else { return }
 
             // Update watchdog timestamp
-            self.lastBufferTime = Date()
+            self.lastBufferTime = CACurrentMediaTime()
 
             // Calculate audio level for visualizer
             self.calculateLevel(buffer: buffer)
@@ -201,7 +203,7 @@ extension Audio {
         // Restart engine
         do {
             try engine.start()
-            lastBufferTime = Date() // Reset watchdog
+            lastBufferTime = CACurrentMediaTime() // Reset watchdog
 
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }

--- a/Transcripted/Core/AudioFileManager.swift
+++ b/Transcripted/Core/AudioFileManager.swift
@@ -138,6 +138,7 @@ extension Audio {
                     AppLogger.audioSystem.warning("System audio failed", ["error": error.localizedDescription])
                     DispatchQueue.main.async {
                         strongSelf.error = "System audio unavailable - recording mic only"
+                        strongSelf.systemAudioFailed = true
                     }
                 }
             }
@@ -194,7 +195,7 @@ extension Audio {
             guard let strongSelf = self else { return }
 
             // Update watchdog timestamp
-            strongSelf.lastBufferTime = Date()
+            strongSelf.lastBufferTime = CACurrentMediaTime()
 
             // Calculate audio level for visualizer (use original buffer)
             strongSelf.calculateLevel(buffer: buffer)

--- a/Transcripted/Core/DiagnosticExporter.swift
+++ b/Transcripted/Core/DiagnosticExporter.swift
@@ -151,7 +151,9 @@ class DiagnosticExporter {
 
     /// Generate a pre-filled GitHub issue URL with system info
     static func gitHubIssueURL(title: String = "", body: String = "") -> URL {
-        var components = URLComponents(string: "https://github.com/r3dbars/transcripted/issues/new")!
+        guard var components = URLComponents(string: "https://github.com/r3dbars/transcripted/issues/new") else {
+            return URL(string: "https://github.com/r3dbars/transcripted/issues/new")!
+        }
         var queryItems: [URLQueryItem] = [
             URLQueryItem(name: "template", value: "bug_report.md"),
         ]
@@ -170,6 +172,6 @@ class DiagnosticExporter {
         """
         queryItems.append(URLQueryItem(name: "body", value: fullBody))
         components.queryItems = queryItems
-        return components.url!
+        return components.url ?? URL(string: "https://github.com/r3dbars/transcripted/issues/new")!
     }
 }

--- a/Transcripted/Core/RecordingCoordinator.swift
+++ b/Transcripted/Core/RecordingCoordinator.swift
@@ -56,7 +56,16 @@ extension AppDelegate {
         }
 
         // Start transcription in background using task manager
-        taskManager?.startTranscription(
+        guard let taskManager = taskManager else {
+            AppLogger.app.error("Task manager unavailable — queueing as failed transcription")
+            failedTranscriptionManager?.addFailedTranscription(
+                micAudioURL: micURL,
+                systemAudioURL: systemURL,
+                errorMessage: "Task manager unavailable at recording completion"
+            )
+            return
+        }
+        taskManager.startTranscription(
             micURL: micURL,
             systemURL: systemURL,
             outputFolder: outputFolder,

--- a/Transcripted/Core/TranscriptSaver.swift
+++ b/Transcripted/Core/TranscriptSaver.swift
@@ -123,43 +123,51 @@ class TranscriptSaver {
 
         let markdown = formatTranscriptMarkdown(result: result, speakerMappings: speakerMappings, speakerSources: speakerSources, speakerDbIds: speakerDbIds, date: Date(), meetingTitle: meetingTitle, healthInfo: healthInfo)
 
-        do {
-            try markdown.write(to: fileURL, atomically: true, encoding: .utf8)
-            AppLogger.pipeline.info("Transcript saved", ["path": fileURL.path])
-            showSaveNotification(fileURL: fileURL)
+        // Serialize file writes to prevent concurrent corruption with retroactive speaker updates
+        let savedURL: URL? = fileUpdateQueue.sync {
+            do {
+                try markdown.write(to: fileURL, atomically: true, encoding: .utf8)
+                AppLogger.pipeline.info("Transcript saved", ["path": fileURL.path])
 
-            // Record to stats database
+                // Agent output: write JSON sidecar + index + CLAUDE.md
+                let stem = fileURL.deletingPathExtension().lastPathComponent
+                do {
+                    try AgentOutput.writeTranscriptJSON(
+                        from: result,
+                        speakerMappings: speakerMappings,
+                        speakerDbIds: speakerDbIds,
+                        to: saveDir,
+                        stem: stem
+                    )
+                    try AgentOutput.writeIndex(to: saveDir, speakerDB: SpeakerDatabase.shared)
+                    AgentOutput.writeAgentReadme(to: saveDir)
+                } catch {
+                    AppLogger.pipeline.error("Agent output failed", ["error": error.localizedDescription])
+                    // Non-fatal — Markdown already saved successfully
+                }
+
+                return fileURL
+            } catch {
+                AppLogger.pipeline.error("Failed to save transcript", ["error": error.localizedDescription])
+                return nil
+            }
+        }
+
+        if let savedURL {
+            showSaveNotification(fileURL: savedURL)
+
+            // Record to stats database (outside queue — dispatches to MainActor)
             Task { @MainActor in
                 let metadata = StatsService.createMetadata(
                     from: result,
-                    transcriptPath: fileURL.path,
+                    transcriptPath: savedURL.path,
                     title: meetingTitle
                 )
                 await StatsService.shared.recordSession(metadata)
             }
-
-            // Agent output: write JSON sidecar + index + CLAUDE.md
-            let stem = fileURL.deletingPathExtension().lastPathComponent
-            do {
-                try AgentOutput.writeTranscriptJSON(
-                    from: result,
-                    speakerMappings: speakerMappings,
-                    speakerDbIds: speakerDbIds,
-                    to: saveDir,
-                    stem: stem
-                )
-                try AgentOutput.writeIndex(to: saveDir, speakerDB: SpeakerDatabase.shared)
-                AgentOutput.writeAgentReadme(to: saveDir)
-            } catch {
-                AppLogger.pipeline.error("Agent output failed", ["error": error.localizedDescription])
-                // Non-fatal — Markdown already saved successfully
-            }
-
-            return fileURL
-        } catch {
-            AppLogger.pipeline.error("Failed to save transcript", ["error": error.localizedDescription])
-            return nil
         }
+
+        return savedURL
     }
 
     // MARK: - Notifications

--- a/Transcripted/Core/TranscriptionPipeline.swift
+++ b/Transcripted/Core/TranscriptionPipeline.swift
@@ -59,6 +59,16 @@ extension Transcription {
             AppLogger.transcription.debug("System: \(systemSamples.count) samples (\(String(format: "%.1f", Double(systemSamples.count) / 16000))s)")
             AppLogger.transcription.debug("Mic: \(micSamples.count) samples (\(String(format: "%.1f", Double(micSamples.count) / 16000))s)")
 
+            // Validate system audio has meaningful content (at least 1 second at 16kHz).
+            // Without this, a failed system audio capture produces an empty transcript.
+            guard systemSamples.count >= 16000 else {
+                AppLogger.transcription.error("System audio too short or empty", [
+                    "samples": "\(systemSamples.count)",
+                    "expectedMinimum": "16000"
+                ])
+                throw PipelineError.missingSystemAudio
+            }
+
             // Pre-compute mic energy per 100ms frame for embedding quality gating.
             // When the local user is speaking, system audio embeddings are contaminated
             // with their voice echo, producing unreliable remote speaker voiceprints.
@@ -154,13 +164,11 @@ extension Transcription {
                     // embeddings are contaminated with their voice (Zoom echo residual).
                     let micFraction = micActiveFraction(startTime: segment.startTime, endTime: segment.endTime)
 
-                    if micFraction > 0.8 {
+                    guard let weight = Self.embeddingWeight(forMicFraction: micFraction) else {
                         // >80% overlap with local mic: skip entirely
                         micContaminatedCount += 1
                         continue
                     }
-
-                    let weight: Float = micFraction > 0.3 ? 0.3 : 1.0
                     embeddingsPerSpeaker[segment.speakerId, default: []].append(embedding)
                     embeddingWeights[segment.speakerId, default: []].append(weight)
                 }
@@ -264,8 +272,8 @@ extension Transcription {
             // Fixes cross-cluster fragmentation: if Sortformer split one person
             // into spk1 and spk3, and DB matching identified both as the same
             // profile, unify them under the speaker ID with the most segments.
-            let profileToSpeakers = Dictionary(grouping: speakerMatchResults.keys) { speakerMatchResults[$0]!.persistentId }
-            for (_, matchedSpeakerIds) in profileToSpeakers where matchedSpeakerIds.count >= 2 {
+            let profileToSpeakers = Dictionary(grouping: speakerMatchResults.keys) { speakerMatchResults[$0]?.persistentId }
+            for (profileId, matchedSpeakerIds) in profileToSpeakers where profileId != nil && matchedSpeakerIds.count >= 2 {
                 let sorted = matchedSpeakerIds.sorted { a, b in
                     embeddingsPerSpeaker[a]?.count ?? 0 > embeddingsPerSpeaker[b]?.count ?? 0
                 }
@@ -424,6 +432,22 @@ extension Transcription {
 
     /// Merge consecutive utterances from the same speaker when the time gap between them
     /// is smaller than `maxGap` seconds. This produces cleaner transcripts by joining
+    /// Calculate embedding weight based on mic activity fraction during a system audio segment.
+    /// Returns nil if the segment should be excluded entirely (>80% mic overlap).
+    /// Uses a 4-tier gradient to avoid sharp threshold cliffs:
+    ///   - >80%: excluded (mic voice dominates system audio)
+    ///   - 50-80%: weight 0.2 (heavily contaminated)
+    ///   - 30-50%: weight 0.5 (moderately contaminated)
+    ///   - <30%: weight 1.0 (clean)
+    nonisolated static func embeddingWeight(forMicFraction micFraction: Double) -> Float? {
+        if micFraction > 0.8 { return nil }
+        switch micFraction {
+        case 0.5...: return 0.2
+        case 0.3...: return 0.5
+        default: return 1.0
+        }
+    }
+
     /// fragments that the diarizer split mid-sentence.
     ///
     /// A `maxDuration` cap prevents runaway merges — even if the speaker and gap criteria

--- a/Transcripted/Core/TranscriptionPipelineRunner.swift
+++ b/Transcripted/Core/TranscriptionPipelineRunner.swift
@@ -352,7 +352,8 @@ extension TranscriptionTaskManager {
         guard !sorted.isEmpty else { return "" }
 
         let maxChars = 8000
-        let totalDuration = sorted.last!.start
+        guard let lastUtterance = sorted.last else { return "" }
+        let totalDuration = lastUtterance.start
 
         // Strategy: first 5 min + last 5 min + ~20 samples from middle
         let firstWindow = sorted.filter { $0.start < 300 }

--- a/Transcripted/Services/EmbeddingClusterer.swift
+++ b/Transcripted/Services/EmbeddingClusterer.swift
@@ -130,9 +130,9 @@ enum EmbeddingClusterer {
     /// relaxed similarity threshold to merge these back.
     ///
     /// Two-tier thresholds:
-    /// - Micro-clusters (< `microClusterDuration`): Moderate threshold (0.50).
-    ///   Absorbs noise fragments with similar voice characteristics, but preserves
-    ///   distinct speakers (codec-compressed voices typically have 0.3-0.5 similarity).
+    /// - Micro-clusters (< `microClusterDuration`): Threshold 0.62 — safely above the
+    ///   codec-compressed voice similarity range (0.3-0.5), absorbs noise fragments
+    ///   while preserving genuinely distinct speakers.
     /// - Small clusters (< `minClusterDuration`): Standard relaxed threshold
     ///   (0.72). Safety: genuinely different speakers rarely exceed 0.6 cosine
     ///   similarity, so this won't incorrectly merge distinct people.
@@ -145,7 +145,7 @@ enum EmbeddingClusterer {
         minClusterDuration: Double = 30.0,
         absorptionThreshold: Float = 0.72,
         microClusterDuration: Double = 10.0,
-        microAbsorptionThreshold: Float = 0.50
+        microAbsorptionThreshold: Float = 0.62
     ) -> [SpeakerSegment] {
         // Compute total speaking duration per speaker
         var durationPerSpeaker: [Int: Double] = [:]

--- a/Transcripted/Services/SpeakerDatabase.swift
+++ b/Transcripted/Services/SpeakerDatabase.swift
@@ -56,8 +56,49 @@ final class SpeakerDatabase {
                     sqlite3_free(errorMessage)
                 }
             }
-            AppLogger.speakers.info("Opened database", ["path": dbPath.path])
+
+            // Corruption detection: run quick_check to verify database integrity
+            if !verifyDatabaseIntegrity() {
+                AppLogger.speakers.error("CRITICAL: Speaker database corrupt — backing up and recreating", ["path": dbPath.path])
+                sqlite3_close(db)
+                db = nil
+                // Backup corrupt file with timestamp
+                let backupName = "speakers_corrupt_\(DateFormattingHelper.formatFilename(Date())).sqlite"
+                let backupPath = dbPath.deletingLastPathComponent().appendingPathComponent(backupName)
+                try? FileManager.default.moveItem(at: dbPath, to: backupPath)
+                // Recreate fresh database
+                if sqlite3_open(dbPath.path, &db) == SQLITE_OK {
+                    isDatabaseOpen = true
+                    try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: dbPath.path)
+                    for (pragma, _) in pragmas {
+                        sqlite3_exec(db, "PRAGMA \(pragma);", nil, nil, nil)
+                    }
+                    AppLogger.speakers.info("Recreated fresh database after corruption recovery")
+                } else {
+                    isDatabaseOpen = false
+                    AppLogger.speakers.error("Failed to recreate database after corruption recovery")
+                }
+            } else {
+                AppLogger.speakers.info("Opened database", ["path": dbPath.path])
+            }
         }
+    }
+
+    /// Verify database integrity using PRAGMA quick_check.
+    /// Returns true if the database is healthy.
+    private func verifyDatabaseIntegrity() -> Bool {
+        guard let db = db else { return false }
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, "PRAGMA quick_check;", -1, &stmt, nil) == SQLITE_OK else {
+            return false
+        }
+        defer { sqlite3_finalize(stmt) }
+        if sqlite3_step(stmt) == SQLITE_ROW {
+            if let text = sqlite3_column_text(stmt, 0) {
+                return String(cString: text) == "ok"
+            }
+        }
+        return false
     }
 
     private func createTables() {

--- a/Transcripted/UI/FloatingPanel/FloatingPanelController.swift
+++ b/Transcripted/UI/FloatingPanel/FloatingPanelController.swift
@@ -27,10 +27,10 @@ class FloatingPanelController: NSWindowController, NSWindowDelegate {
         self.audio = audio
         self.failedTranscriptionManager = failedTranscriptionManager
 
-        let screen = NSScreen.main ?? NSScreen.screens.first!
+        let screen = NSScreen.main ?? NSScreen.screens.first
 
         // Calculate position: use saved position if valid, otherwise center above dock
-        let dockHeight = Self.detectDockHeight(for: screen)
+        let dockHeight = screen.map { Self.detectDockHeight(for: $0) } ?? 0
         let x: CGFloat
         let y: CGFloat
 
@@ -40,7 +40,8 @@ class FloatingPanelController: NSWindowController, NSWindowDelegate {
             x = savedX
             y = savedY
         } else {
-            x = (screen.frame.width - maxWindowWidth) / 2
+            let screenWidth = screen?.frame.width ?? 1440
+            x = (screenWidth - maxWindowWidth) / 2
             y = dockHeight + PillDimensions.dockPadding
         }
 

--- a/TranscriptedTests/Core/SpeakerMatchingServiceTests.swift
+++ b/TranscriptedTests/Core/SpeakerMatchingServiceTests.swift
@@ -1,0 +1,357 @@
+import XCTest
+@testable import Transcripted
+
+@available(macOS 26.0, *)
+final class SpeakerMatchingServiceTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func l2Norm(_ v: [Float]) -> Float {
+        sqrt(v.map { $0 * $0 }.reduce(0, +))
+    }
+
+    /// Returns an L2-normalized version of the input vector.
+    private func normalized(_ v: [Float]) -> [Float] {
+        let norm = l2Norm(v)
+        guard norm > 0 else { return v }
+        return v.map { $0 / norm }
+    }
+
+    // MARK: - computeWeightedMeanEmbedding
+
+    func testWeightedMeanEmptyReturnsEmpty() {
+        let result = Transcription.computeWeightedMeanEmbedding([], weights: [])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testWeightedMeanSingleEmbedding() {
+        let emb: [Float] = [3.0, 4.0, 0.0]
+        let result = Transcription.computeWeightedMeanEmbedding([emb], weights: [1.0])
+        // Single embedding with weight -> weighted sum / totalWeight = emb itself, then L2 normalized
+        let expected = normalized(emb)
+        XCTAssertEqual(result.count, expected.count)
+        for i in 0..<result.count {
+            XCTAssertEqual(result[i], expected[i], accuracy: 0.001)
+        }
+    }
+
+    func testWeightedMeanIdenticalEqualWeights() {
+        let emb: [Float] = [0.6, 0.8, 0.0]
+        let result = Transcription.computeWeightedMeanEmbedding([emb, emb, emb], weights: [1.0, 1.0, 1.0])
+        // Identical embeddings with equal weights -> same direction, normalized
+        let expected = normalized(emb)
+        XCTAssertEqual(result.count, expected.count)
+        for i in 0..<result.count {
+            XCTAssertEqual(result[i], expected[i], accuracy: 0.001)
+        }
+    }
+
+    func testWeightedMeanDifferentEqualWeights() {
+        let a: [Float] = [1.0, 0.0, 0.0, 0.0]
+        let b: [Float] = [0.0, 1.0, 0.0, 0.0]
+        let result = Transcription.computeWeightedMeanEmbedding([a, b], weights: [1.0, 1.0])
+        // Equal weights -> midpoint [0.5, 0.5, 0, 0], then normalized
+        let expected = normalized([0.5, 0.5, 0.0, 0.0])
+        XCTAssertEqual(result.count, expected.count)
+        for i in 0..<result.count {
+            XCTAssertEqual(result[i], expected[i], accuracy: 0.001)
+        }
+    }
+
+    func testWeightedMeanAsymmetricWeights() {
+        let a: [Float] = [1.0, 0.0, 0.0]
+        let b: [Float] = [0.0, 1.0, 0.0]
+        // Weight a heavily: 9.0 vs 1.0
+        let result = Transcription.computeWeightedMeanEmbedding([a, b], weights: [9.0, 1.0])
+        // Weighted sum = [9, 1, 0] / 10 = [0.9, 0.1, 0], normalized
+        let weightedMean: [Float] = [0.9, 0.1, 0.0]
+        let expected = normalized(weightedMean)
+        XCTAssertEqual(result.count, expected.count)
+        for i in 0..<result.count {
+            XCTAssertEqual(result[i], expected[i], accuracy: 0.001)
+        }
+        // The result should be biased toward a (the [1,0,0] direction)
+        XCTAssertGreaterThan(result[0], result[1])
+    }
+
+    func testWeightedMeanAllZeroWeightsFallback() {
+        let a: [Float] = [1.0, 0.0, 0.0]
+        let b: [Float] = [0.0, 1.0, 0.0]
+        // All zero weights -> totalWeight = 0 -> falls back to computeMeanEmbedding
+        let result = Transcription.computeWeightedMeanEmbedding([a, b], weights: [0.0, 0.0])
+        let unweighted = Transcription.computeMeanEmbedding([a, b])
+        XCTAssertEqual(result.count, unweighted.count)
+        for i in 0..<result.count {
+            XCTAssertEqual(result[i], unweighted[i], accuracy: 0.001)
+        }
+    }
+
+    func testWeightedMeanCountMismatchFallback() {
+        let a: [Float] = [1.0, 0.0, 0.0]
+        let b: [Float] = [0.0, 1.0, 0.0]
+        // weights.count (3) != embeddings.count (2) -> falls back to computeMeanEmbedding
+        let result = Transcription.computeWeightedMeanEmbedding([a, b], weights: [1.0, 1.0, 1.0])
+        let unweighted = Transcription.computeMeanEmbedding([a, b])
+        XCTAssertEqual(result.count, unweighted.count)
+        for i in 0..<result.count {
+            XCTAssertEqual(result[i], unweighted[i], accuracy: 0.001)
+        }
+    }
+
+    func testWeightedMeanResultIsNormalized() {
+        let embeddings: [[Float]] = [
+            [3.0, 4.0, 0.0],
+            [0.0, 5.0, 12.0],
+            [1.0, 1.0, 1.0]
+        ]
+        let weights: [Float] = [2.0, 0.5, 1.5]
+        let result = Transcription.computeWeightedMeanEmbedding(embeddings, weights: weights)
+        XCTAssertFalse(result.isEmpty)
+        let norm = l2Norm(result)
+        XCTAssertEqual(norm, 1.0, accuracy: 0.001)
+    }
+
+    func testWeightedMeanThreeEmbeddingsMixedWeights() {
+        let a: [Float] = [1.0, 0.0, 0.0]
+        let b: [Float] = [0.0, 1.0, 0.0]
+        let c: [Float] = [0.0, 0.0, 1.0]
+        let weights: [Float] = [1.0, 0.3, 1.0]
+        let result = Transcription.computeWeightedMeanEmbedding([a, b, c], weights: weights)
+        // Weighted sum = [1.0, 0.3, 1.0] / 2.3 -> normalized
+        let totalWeight: Float = 2.3
+        let weightedMean: [Float] = [1.0 / totalWeight, 0.3 / totalWeight, 1.0 / totalWeight]
+        let expected = normalized(weightedMean)
+        XCTAssertEqual(result.count, 3)
+        for i in 0..<result.count {
+            XCTAssertEqual(result[i], expected[i], accuracy: 0.001)
+        }
+        // Dimensions 0 and 2 should be equal (same weight * same magnitude input)
+        XCTAssertEqual(result[0], result[2], accuracy: 0.001)
+        // Dimension 1 should be smaller
+        XCTAssertLessThan(result[1], result[0])
+    }
+
+    func testWeightedMeanSingleZeroWeightAmongValid() {
+        let a: [Float] = [1.0, 0.0, 0.0]
+        let b: [Float] = [0.0, 1.0, 0.0]
+        let c: [Float] = [0.0, 0.0, 1.0]
+        // b has zero weight -> effectively ignored in weighted sum
+        let result = Transcription.computeWeightedMeanEmbedding([a, b, c], weights: [1.0, 0.0, 1.0])
+        // Weighted sum = [1, 0, 1] / 2 = [0.5, 0, 0.5] -> normalized
+        let expected = normalized([0.5, 0.0, 0.5])
+        XCTAssertEqual(result.count, 3)
+        for i in 0..<result.count {
+            XCTAssertEqual(result[i], expected[i], accuracy: 0.001)
+        }
+        // b's dimension should be zero since its weight was zero
+        XCTAssertEqual(result[1], 0.0, accuracy: 0.001)
+    }
+
+    // MARK: - computeMeanEmbedding
+
+    func testMeanEmptyReturnsEmpty() {
+        let result = Transcription.computeMeanEmbedding([])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testMeanSingleReturnsAsIs() {
+        // Single embedding returns first directly (not re-normalized)
+        let emb: [Float] = [3.0, 4.0, 0.0]
+        let result = Transcription.computeMeanEmbedding([emb])
+        // Code returns `first` directly, so should be identical
+        XCTAssertEqual(result, emb)
+    }
+
+    func testMeanIdenticalReturnsSame() {
+        let emb: [Float] = [0.6, 0.8, 0.0]
+        let result = Transcription.computeMeanEmbedding([emb, emb, emb])
+        // Mean of identical = same direction, then L2 normalized
+        let expected = normalized(emb)
+        XCTAssertEqual(result.count, expected.count)
+        for i in 0..<result.count {
+            XCTAssertEqual(result[i], expected[i], accuracy: 0.001)
+        }
+    }
+
+    func testMeanOrthogonalReturnsNormalizedMidpoint() {
+        let a: [Float] = [1.0, 0.0, 0.0, 0.0]
+        let b: [Float] = [0.0, 1.0, 0.0, 0.0]
+        let result = Transcription.computeMeanEmbedding([a, b])
+        // Mean = [0.5, 0.5, 0, 0], then normalized -> [1/sqrt(2), 1/sqrt(2), 0, 0]
+        let invSqrt2 = Float(1.0 / sqrt(2.0))
+        XCTAssertEqual(result.count, 4)
+        XCTAssertEqual(result[0], invSqrt2, accuracy: 0.001)
+        XCTAssertEqual(result[1], invSqrt2, accuracy: 0.001)
+        XCTAssertEqual(result[2], 0.0, accuracy: 0.001)
+        XCTAssertEqual(result[3], 0.0, accuracy: 0.001)
+    }
+
+    func testMeanResultIsL2Normalized() {
+        let embeddings: [[Float]] = [
+            [3.0, 4.0],
+            [1.0, 0.0]
+        ]
+        let result = Transcription.computeMeanEmbedding(embeddings)
+        let norm = l2Norm(result)
+        XCTAssertEqual(norm, 1.0, accuracy: 0.001)
+    }
+
+    func testMeanManyEmbeddings() {
+        // 10 embeddings, each a unit basis vector in a 10-dim space
+        var embeddings: [[Float]] = []
+        for i in 0..<10 {
+            var emb = [Float](repeating: 0.0, count: 10)
+            emb[i] = 1.0
+            embeddings.append(emb)
+        }
+        let result = Transcription.computeMeanEmbedding(embeddings)
+        // Mean = [0.1, 0.1, ..., 0.1], then L2 normalized
+        // All components should be equal
+        XCTAssertEqual(result.count, 10)
+        let expectedComponent = normalized([Float](repeating: 0.1, count: 10))[0]
+        for i in 0..<10 {
+            XCTAssertEqual(result[i], expectedComponent, accuracy: 0.001)
+        }
+        // L2 norm should be 1.0
+        let norm = l2Norm(result)
+        XCTAssertEqual(norm, 1.0, accuracy: 0.001)
+    }
+
+    // MARK: - matchAgainstProfiles
+
+    func testMatchEmptyProfilesReturnsNil() {
+        let embedding: [Float] = [1.0, 0.0, 0.0, 0.0]
+        let result = Transcription.matchAgainstProfiles(embedding, profiles: [], threshold: 0.5)
+        XCTAssertNil(result)
+    }
+
+    func testMatchEmptyEmbeddingReturnsNil() {
+        let profile = SpeakerProfile.mock(embedding: [1.0, 0.0, 0.0, 0.0])
+        let result = Transcription.matchAgainstProfiles([], profiles: [profile], threshold: 0.5)
+        XCTAssertNil(result)
+    }
+
+    func testMatchSingleProfileAboveThreshold() {
+        let profileId = UUID()
+        let profile = SpeakerProfile.mock(id: profileId, embedding: [1.0, 0.0, 0.0, 0.0])
+        let embedding: [Float] = [0.95, 0.05, 0.0, 0.0]
+        let result = Transcription.matchAgainstProfiles(embedding, profiles: [profile], threshold: 0.5)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.profileId, profileId)
+        XCTAssertGreaterThanOrEqual(result!.similarity, 0.5)
+        // Similarity should be close to 1.0 since vectors are nearly aligned
+        XCTAssertGreaterThan(result!.similarity, 0.9)
+    }
+
+    func testMatchSingleProfileBelowThreshold() {
+        let profile = SpeakerProfile.mock(embedding: [1.0, 0.0, 0.0, 0.0])
+        // Orthogonal embedding -> cosine similarity = 0.0
+        let embedding: [Float] = [0.0, 1.0, 0.0, 0.0]
+        let result = Transcription.matchAgainstProfiles(embedding, profiles: [profile], threshold: 0.5)
+        XCTAssertNil(result)
+    }
+
+    func testMatchMultipleProfilesReturnsBest() {
+        let idA = UUID()
+        let idB = UUID()
+        let idC = UUID()
+        let profileA = SpeakerProfile.mock(id: idA, embedding: [1.0, 0.0, 0.0, 0.0])
+        let profileB = SpeakerProfile.mock(id: idB, embedding: [0.9, 0.44, 0.0, 0.0]) // somewhat aligned
+        let profileC = SpeakerProfile.mock(id: idC, embedding: [0.0, 1.0, 0.0, 0.0]) // orthogonal
+
+        // Embedding most similar to profileA
+        let embedding: [Float] = [0.98, 0.02, 0.0, 0.0]
+        let result = Transcription.matchAgainstProfiles(
+            embedding, profiles: [profileA, profileB, profileC], threshold: 0.5
+        )
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.profileId, idA)
+
+        // Verify it's actually the highest similarity
+        let simA = Transcription.cosineSimilarityStatic(embedding, profileA.embedding)
+        let simB = Transcription.cosineSimilarityStatic(embedding, profileB.embedding)
+        let simC = Transcription.cosineSimilarityStatic(embedding, profileC.embedding)
+        XCTAssertEqual(result!.similarity, simA, accuracy: 0.001)
+        XCTAssertGreaterThan(simA, simB)
+        XCTAssertGreaterThan(simA, simC)
+    }
+
+    func testMatchAllBelowThreshold() {
+        let profileA = SpeakerProfile.mock(embedding: [1.0, 0.0, 0.0, 0.0])
+        let profileB = SpeakerProfile.mock(embedding: [0.0, 1.0, 0.0, 0.0])
+        // Embedding in a completely different direction
+        let embedding: [Float] = [0.0, 0.0, 0.0, 1.0]
+        let result = Transcription.matchAgainstProfiles(
+            embedding, profiles: [profileA, profileB], threshold: 0.5
+        )
+        XCTAssertNil(result)
+    }
+
+    func testMatchThresholdBoundaryIncluded() {
+        let profileId = UUID()
+        // Use normalized vectors for predictable cosine similarity
+        let profileEmb = normalized([1.0, 1.0, 0.0, 0.0])
+        let profile = SpeakerProfile.mock(id: profileId, embedding: profileEmb)
+
+        // The embedding is the same -> cosine similarity = 1.0
+        // Set threshold to exactly 1.0 -> should still match (>= check)
+        let embedding = profileEmb
+        let result = Transcription.matchAgainstProfiles(
+            embedding, profiles: [profile], threshold: 1.0
+        )
+        XCTAssertNotNil(result, "Similarity exactly at threshold should match (>= check)")
+        XCTAssertEqual(result?.profileId, profileId)
+        XCTAssertEqual(result!.similarity, 1.0, accuracy: 0.001)
+    }
+
+    func testMatchDimensionMismatchSkipped() {
+        let goodId = UUID()
+        let badId = UUID()
+        // Profile with wrong dimension (3 instead of 4)
+        let badProfile = SpeakerProfile.mock(id: badId, embedding: [1.0, 0.0, 0.0])
+        // Profile with correct dimension
+        let goodProfile = SpeakerProfile.mock(id: goodId, embedding: [1.0, 0.0, 0.0, 0.0])
+
+        let embedding: [Float] = [1.0, 0.0, 0.0, 0.0]
+        let result = Transcription.matchAgainstProfiles(
+            embedding, profiles: [badProfile, goodProfile], threshold: 0.5
+        )
+        XCTAssertNotNil(result)
+        // Should match the good profile, not the dimension-mismatched one
+        XCTAssertEqual(result?.profileId, goodId)
+    }
+
+    // MARK: - cosineSimilarityStatic
+
+    func testCosineIdentical() {
+        let v: [Float] = [1.0, 2.0, 3.0, 4.0]
+        let result = Transcription.cosineSimilarityStatic(v, v)
+        XCTAssertEqual(result, 1.0, accuracy: 0.001)
+    }
+
+    func testCosineOpposite() {
+        let a: [Float] = [1.0, 2.0, 3.0]
+        let b: [Float] = [-1.0, -2.0, -3.0]
+        let result = Transcription.cosineSimilarityStatic(a, b)
+        XCTAssertEqual(result, -1.0, accuracy: 0.001)
+    }
+
+    func testCosineOrthogonal() {
+        let a: [Float] = [1.0, 0.0, 0.0]
+        let b: [Float] = [0.0, 1.0, 0.0]
+        let result = Transcription.cosineSimilarityStatic(a, b)
+        XCTAssertEqual(result, 0.0, accuracy: 0.001)
+    }
+
+    func testCosineEmpty() {
+        let result = Transcription.cosineSimilarityStatic([], [])
+        XCTAssertEqual(result, 0.0)
+    }
+
+    func testCosineDifferentLengths() {
+        let a: [Float] = [1.0, 0.0]
+        let b: [Float] = [1.0, 0.0, 0.0]
+        let result = Transcription.cosineSimilarityStatic(a, b)
+        XCTAssertEqual(result, 0.0)
+    }
+}

--- a/TranscriptedTests/Core/TranscriptionPipelineTests.swift
+++ b/TranscriptedTests/Core/TranscriptionPipelineTests.swift
@@ -1,0 +1,336 @@
+import XCTest
+@testable import Transcripted
+
+@available(macOS 26.0, *)
+final class TranscriptionPipelineTests: XCTestCase {
+
+    // MARK: - mergeConsecutiveUtterances: Empty & Single
+
+    func testMergeEmptyArray() {
+        let result = Transcription.mergeConsecutiveUtterances([], maxGap: 1.5)
+        XCTAssertTrue(result.isEmpty, "Merging an empty array should return an empty array")
+    }
+
+    func testMergeSingleUtterance() {
+        let single = TranscriptionUtterance.mock(start: 0, end: 5, transcript: "Hello")
+        let result = Transcription.mergeConsecutiveUtterances([single], maxGap: 1.5)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].start, 0)
+        XCTAssertEqual(result[0].end, 5)
+        XCTAssertEqual(result[0].transcript, "Hello")
+    }
+
+    // MARK: - mergeConsecutiveUtterances: Same Speaker Merging
+
+    func testMergeSameSpeakerSmallGap() {
+        let u1 = TranscriptionUtterance.mock(start: 0, end: 3, speakerId: 1, transcript: "Hello")
+        let u2 = TranscriptionUtterance.mock(start: 3.5, end: 6, speakerId: 1, transcript: "world")
+        let result = Transcription.mergeConsecutiveUtterances([u1, u2], maxGap: 1.5)
+
+        XCTAssertEqual(result.count, 1, "Same speaker with small gap should merge into one utterance")
+        XCTAssertEqual(result[0].start, 0)
+        XCTAssertEqual(result[0].end, 6)
+        XCTAssertEqual(result[0].transcript, "Hello world")
+        XCTAssertEqual(result[0].speakerId, 1)
+    }
+
+    func testMergeDifferentSpeakersNotMerged() {
+        let u1 = TranscriptionUtterance.mock(start: 0, end: 3, speakerId: 1, transcript: "Hello")
+        let u2 = TranscriptionUtterance.mock(start: 3.5, end: 6, speakerId: 2, transcript: "Hi there")
+        let result = Transcription.mergeConsecutiveUtterances([u1, u2], maxGap: 1.5)
+
+        XCTAssertEqual(result.count, 2, "Different speakers should not be merged")
+        XCTAssertEqual(result[0].transcript, "Hello")
+        XCTAssertEqual(result[1].transcript, "Hi there")
+    }
+
+    func testMergeSameSpeakerLargeGap() {
+        let u1 = TranscriptionUtterance.mock(start: 0, end: 3, speakerId: 1, transcript: "First")
+        let u2 = TranscriptionUtterance.mock(start: 5.0, end: 8, speakerId: 1, transcript: "Second")
+        let result = Transcription.mergeConsecutiveUtterances([u1, u2], maxGap: 1.5)
+
+        XCTAssertEqual(result.count, 2, "Same speaker with gap >= maxGap should not merge")
+        XCTAssertEqual(result[0].transcript, "First")
+        XCTAssertEqual(result[1].transcript, "Second")
+    }
+
+    func testMergeSameSpeakerDifferentChannel() {
+        let u1 = TranscriptionUtterance.mock(start: 0, end: 3, channel: 0, speakerId: 1, transcript: "Mic")
+        let u2 = TranscriptionUtterance.mock(start: 3.5, end: 6, channel: 1, speakerId: 1, transcript: "System")
+        let result = Transcription.mergeConsecutiveUtterances([u1, u2], maxGap: 1.5)
+
+        XCTAssertEqual(result.count, 2, "Same speaker on different channels should not merge")
+        XCTAssertEqual(result[0].channel, 0)
+        XCTAssertEqual(result[1].channel, 1)
+    }
+
+    func testMergeThreeConsecutiveSameSpeaker() {
+        let u1 = TranscriptionUtterance.mock(start: 0, end: 3, speakerId: 1, transcript: "One")
+        let u2 = TranscriptionUtterance.mock(start: 3.5, end: 6, speakerId: 1, transcript: "two")
+        let u3 = TranscriptionUtterance.mock(start: 6.2, end: 9, speakerId: 1, transcript: "three")
+        let result = Transcription.mergeConsecutiveUtterances([u1, u2, u3], maxGap: 1.5)
+
+        XCTAssertEqual(result.count, 1, "Three consecutive utterances from same speaker should merge into one")
+        XCTAssertEqual(result[0].start, 0)
+        XCTAssertEqual(result[0].end, 9)
+        XCTAssertEqual(result[0].transcript, "One two three")
+    }
+
+    // MARK: - mergeConsecutiveUtterances: Duration Cap
+
+    func testMergeDurationCapStopsMerge() {
+        // Two utterances whose combined span would exceed maxDuration
+        let u1 = TranscriptionUtterance.mock(start: 0, end: 20, speakerId: 1, transcript: "Long speech")
+        let u2 = TranscriptionUtterance.mock(start: 20.5, end: 31.0, speakerId: 1, transcript: "More speech")
+        // Combined duration: 31.0 - 0 = 31s, exceeds 30s cap
+        let result = Transcription.mergeConsecutiveUtterances([u1, u2], maxGap: 1.5, maxDuration: 30.0)
+
+        XCTAssertEqual(result.count, 2, "Combined duration exceeding maxDuration should prevent merge")
+    }
+
+    func testMergeDurationCapBoundaryAllowed() {
+        // Combined duration exactly at maxDuration (uses <=)
+        let u1 = TranscriptionUtterance.mock(start: 0, end: 20, speakerId: 1, transcript: "First part")
+        let u2 = TranscriptionUtterance.mock(start: 20.5, end: 30.0, speakerId: 1, transcript: "Second part")
+        // Combined duration: 30.0 - 0 = 30s, exactly at cap
+        let result = Transcription.mergeConsecutiveUtterances([u1, u2], maxGap: 1.5, maxDuration: 30.0)
+
+        XCTAssertEqual(result.count, 1, "Combined duration exactly at maxDuration should still merge (uses <=)")
+        XCTAssertEqual(result[0].transcript, "First part Second part")
+    }
+
+    // MARK: - mergeConsecutiveUtterances: Gap Boundary
+
+    func testMergeGapBoundaryNotMerged() {
+        // Gap exactly at maxGap -- uses strict < so should NOT merge
+        let u1 = TranscriptionUtterance.mock(start: 0, end: 3, speakerId: 1, transcript: "First")
+        let u2 = TranscriptionUtterance.mock(start: 4.5, end: 7, speakerId: 1, transcript: "Second")
+        // Gap: 4.5 - 3.0 = 1.5, which is NOT < 1.5
+        let result = Transcription.mergeConsecutiveUtterances([u1, u2], maxGap: 1.5)
+
+        XCTAssertEqual(result.count, 2, "Gap exactly equal to maxGap should NOT merge (uses strict <)")
+    }
+
+    // MARK: - mergeConsecutiveUtterances: Persistent ID & Similarity Coalescing
+
+    func testMergePersistentIdPrefersCurrentOverNext() {
+        let currentId = UUID()
+        let nextId = UUID()
+        let u1 = TranscriptionUtterance.mock(
+            start: 0, end: 3, speakerId: 1,
+            persistentSpeakerId: currentId, transcript: "First"
+        )
+        let u2 = TranscriptionUtterance.mock(
+            start: 3.5, end: 6, speakerId: 1,
+            persistentSpeakerId: nextId, transcript: "Second"
+        )
+        let result = Transcription.mergeConsecutiveUtterances([u1, u2], maxGap: 1.5)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].persistentSpeakerId, currentId,
+                       "Merged utterance should prefer current's persistentSpeakerId over next's")
+    }
+
+    func testMergeMatchSimilarityPrefersCurrentOverNext() {
+        let u1 = TranscriptionUtterance.mock(
+            start: 0, end: 3, speakerId: 1,
+            matchSimilarity: 0.85, transcript: "First"
+        )
+        let u2 = TranscriptionUtterance.mock(
+            start: 3.5, end: 6, speakerId: 1,
+            matchSimilarity: 0.92, transcript: "Second"
+        )
+        let result = Transcription.mergeConsecutiveUtterances([u1, u2], maxGap: 1.5)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].matchSimilarity, 0.85,
+                       "Merged utterance should prefer current's matchSimilarity over next's")
+    }
+
+    // MARK: - mergeConsecutiveUtterances: Mixed Speaker Patterns
+
+    func testMergeMixedSpeakersAABB() {
+        let u1 = TranscriptionUtterance.mock(start: 0, end: 3, speakerId: 1, transcript: "A1")
+        let u2 = TranscriptionUtterance.mock(start: 3.5, end: 6, speakerId: 1, transcript: "A2")
+        let u3 = TranscriptionUtterance.mock(start: 7, end: 10, speakerId: 2, transcript: "B1")
+        let u4 = TranscriptionUtterance.mock(start: 10.5, end: 13, speakerId: 2, transcript: "B2")
+        let result = Transcription.mergeConsecutiveUtterances([u1, u2, u3, u4], maxGap: 1.5)
+
+        XCTAssertEqual(result.count, 2, "AABB pattern should merge each pair separately")
+        XCTAssertEqual(result[0].speakerId, 1)
+        XCTAssertEqual(result[0].transcript, "A1 A2")
+        XCTAssertEqual(result[1].speakerId, 2)
+        XCTAssertEqual(result[1].transcript, "B1 B2")
+    }
+
+    func testMergeAlternatingABA() {
+        let u1 = TranscriptionUtterance.mock(start: 0, end: 3, speakerId: 1, transcript: "A1")
+        let u2 = TranscriptionUtterance.mock(start: 3.5, end: 6, speakerId: 2, transcript: "B1")
+        let u3 = TranscriptionUtterance.mock(start: 6.5, end: 9, speakerId: 1, transcript: "A2")
+        let result = Transcription.mergeConsecutiveUtterances([u1, u2, u3], maxGap: 1.5)
+
+        XCTAssertEqual(result.count, 3, "Alternating speakers A-B-A should produce no merges")
+        XCTAssertEqual(result[0].speakerId, 1)
+        XCTAssertEqual(result[1].speakerId, 2)
+        XCTAssertEqual(result[2].speakerId, 1)
+    }
+
+    // MARK: - mergeConsecutiveUtterances: Long Chain with Duration Cap
+
+    func testMergeLongChainWithDurationCap() {
+        // 20 utterances, each 2s, with 0.5s gaps. maxDuration = 30s should cap merging.
+        var utterances: [TranscriptionUtterance] = []
+        for i in 0..<20 {
+            let start = Double(i) * 2.5  // 2s speech + 0.5s gap
+            let end = start + 2.0
+            utterances.append(TranscriptionUtterance.mock(
+                start: start, end: end, speakerId: 1,
+                transcript: "Segment \(i)"
+            ))
+        }
+
+        let result = Transcription.mergeConsecutiveUtterances(utterances, maxGap: 1.5, maxDuration: 30.0)
+
+        // Each merged utterance can span at most 30s. With 2.5s per utterance cycle,
+        // that's about 12 utterances per merged group (12 * 2.5 = 30s span).
+        // 20 utterances should produce at least 2 merged groups.
+        XCTAssertGreaterThan(result.count, 1, "Duration cap should prevent all 20 utterances from merging into one")
+        XCTAssertLessThan(result.count, 20, "Adjacent utterances with small gaps should merge")
+
+        // Verify no merged utterance exceeds the duration cap
+        for utterance in result {
+            let duration = utterance.end - utterance.start
+            XCTAssertLessThanOrEqual(duration, 30.0 + 0.001,
+                                     "No merged utterance should exceed maxDuration of 30s")
+        }
+    }
+
+    // MARK: - mergeConsecutiveUtterances: Whitespace Trimming
+
+    func testMergeTrimsWhitespace() {
+        let u1 = TranscriptionUtterance.mock(start: 0, end: 3, speakerId: 1, transcript: "  Hello  ")
+        let u2 = TranscriptionUtterance.mock(start: 3.5, end: 6, speakerId: 1, transcript: "  world  ")
+        let result = Transcription.mergeConsecutiveUtterances([u1, u2], maxGap: 1.5)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].transcript, "Hello world",
+                       "Merged transcript should trim leading/trailing whitespace from each part")
+        // Ensure no double spaces or leading/trailing whitespace in result
+        XCTAssertFalse(result[0].transcript.hasPrefix(" "), "Result should not have leading whitespace")
+        XCTAssertFalse(result[0].transcript.hasSuffix(" "), "Result should not have trailing whitespace")
+        XCTAssertFalse(result[0].transcript.contains("  "), "Result should not have double spaces")
+    }
+
+    // MARK: - embeddingWeight
+
+    func testEmbeddingWeightClean() {
+        // 0.0 mic fraction = completely clean system audio
+        let weight = Transcription.embeddingWeight(forMicFraction: 0.0)
+        XCTAssertEqual(weight, 1.0, "0% mic overlap should return weight 1.0 (clean)")
+    }
+
+    func testEmbeddingWeightLow() {
+        // 0.2 mic fraction = still in the <0.3 range
+        let weight = Transcription.embeddingWeight(forMicFraction: 0.2)
+        XCTAssertEqual(weight, 1.0, "20% mic overlap should return weight 1.0 (clean)")
+    }
+
+    func testEmbeddingWeightModerate() {
+        // 0.35 mic fraction = in the 0.3-0.5 range
+        let weight = Transcription.embeddingWeight(forMicFraction: 0.35)
+        XCTAssertEqual(weight, 0.5, "35% mic overlap should return weight 0.5 (moderate contamination)")
+    }
+
+    func testEmbeddingWeightHigh() {
+        // 0.6 mic fraction = in the 0.5-0.8 range
+        let weight = Transcription.embeddingWeight(forMicFraction: 0.6)
+        XCTAssertEqual(weight, 0.2, "60% mic overlap should return weight 0.2 (heavy contamination)")
+    }
+
+    func testEmbeddingWeightExcluded() {
+        // 0.85 mic fraction = above 0.8 threshold
+        let weight = Transcription.embeddingWeight(forMicFraction: 0.85)
+        XCTAssertNil(weight, "85% mic overlap should return nil (excluded)")
+    }
+
+    // MARK: - embeddingWeight: Boundary values
+
+    func testEmbeddingWeightAtExactly0Point3() {
+        // 0.3 is in the 0.3... range (Swift range pattern)
+        let weight = Transcription.embeddingWeight(forMicFraction: 0.3)
+        XCTAssertEqual(weight, 0.5, "Exactly 0.3 should return 0.5 (matches 0.3... range)")
+    }
+
+    func testEmbeddingWeightAtExactly0Point5() {
+        // 0.5 is in the 0.5... range
+        let weight = Transcription.embeddingWeight(forMicFraction: 0.5)
+        XCTAssertEqual(weight, 0.2, "Exactly 0.5 should return 0.2 (matches 0.5... range)")
+    }
+
+    func testEmbeddingWeightAtExactly0Point8() {
+        // 0.8 is NOT > 0.8, so it should match the 0.5... range
+        let weight = Transcription.embeddingWeight(forMicFraction: 0.8)
+        XCTAssertEqual(weight, 0.2, "Exactly 0.8 should return 0.2 (not excluded; 0.8 is not > 0.8)")
+    }
+
+    // MARK: - detectSpeechSegments: Edge Cases
+
+    func testDetectVeryShortBurstFiltered() {
+        // A very short speech burst (< 0.5s) surrounded by silence should be filtered out.
+        // The method has minSegmentDuration = 0.5s.
+        var samples: [Float] = []
+        samples += TestAudioGenerator.silence(duration: 1.0)
+        samples += TestAudioGenerator.tone(duration: 0.3, amplitude: 0.5)  // 300ms burst -- too short
+        samples += TestAudioGenerator.silence(duration: 1.0)
+
+        let segments = Transcription.detectSpeechSegments(samples: samples, sampleRate: 16000)
+
+        // The short burst should be filtered. Fallback returns a single full-track segment
+        // when no valid segments are detected.
+        XCTAssertEqual(segments.count, 1, "Very short burst should be filtered; fallback returns one segment")
+        // The fallback segment covers the entire track
+        XCTAssertEqual(segments[0].start, 0.0, accuracy: 0.01)
+        let expectedEnd = Double(samples.count) / 16000.0
+        XCTAssertEqual(segments[0].end, expectedEnd, accuracy: 0.01)
+    }
+
+    func testDetectConstantNoiseReturnsSingleSegment() {
+        // All samples above threshold -- should return a single continuous segment
+        let samples = TestAudioGenerator.tone(duration: 5.0, amplitude: 0.5)
+        let segments = Transcription.detectSpeechSegments(samples: samples, sampleRate: 16000)
+
+        XCTAssertEqual(segments.count, 1, "Constant noise above threshold should yield one segment")
+        XCTAssertEqual(segments[0].start, 0.0, accuracy: 0.05)
+        XCTAssertEqual(segments[0].end, 5.0, accuracy: 0.1)
+    }
+
+    func testDetectSegmentBoundariesChronological() {
+        // Create multiple speech segments with clear silence gaps
+        var samples: [Float] = []
+        samples += TestAudioGenerator.tone(duration: 1.5, amplitude: 0.5)
+        samples += TestAudioGenerator.silence(duration: 0.8)  // > 0.4s minSilenceDuration
+        samples += TestAudioGenerator.tone(duration: 1.5, amplitude: 0.5)
+        samples += TestAudioGenerator.silence(duration: 0.8)
+        samples += TestAudioGenerator.tone(duration: 1.5, amplitude: 0.5)
+
+        let segments = Transcription.detectSpeechSegments(samples: samples, sampleRate: 16000)
+
+        XCTAssertGreaterThanOrEqual(segments.count, 2,
+                                    "Multiple speech regions separated by silence should produce multiple segments")
+
+        // Verify chronological ordering
+        for i in 1..<segments.count {
+            XCTAssertGreaterThan(segments[i].start, segments[i - 1].start,
+                                 "Segment \(i) start should be after segment \(i - 1) start")
+            XCTAssertGreaterThanOrEqual(segments[i].start, segments[i - 1].end,
+                                        "Segment \(i) should not overlap with segment \(i - 1)")
+        }
+
+        // Verify all segments have positive duration
+        for (index, segment) in segments.enumerated() {
+            XCTAssertGreaterThan(segment.end, segment.start,
+                                 "Segment \(index) should have positive duration")
+        }
+    }
+}

--- a/TranscriptedTests/Helpers/TestFixtures.swift
+++ b/TranscriptedTests/Helpers/TestFixtures.swift
@@ -1,7 +1,65 @@
 import Foundation
+import Accelerate
 @testable import Transcripted
 
 // MARK: - Test Fixtures
+
+@available(macOS 14.0, *)
+extension SpeakerProfile {
+    static func mock(
+        id: UUID = UUID(),
+        displayName: String? = nil,
+        nameSource: String? = nil,
+        embedding: [Float] = [1, 0, 0, 0],
+        callCount: Int = 1,
+        confidence: Double = 0.5
+    ) -> SpeakerProfile {
+        SpeakerProfile(
+            id: id,
+            displayName: displayName,
+            nameSource: nameSource,
+            embedding: embedding,
+            firstSeen: Date(),
+            lastSeen: Date(),
+            callCount: callCount,
+            confidence: confidence,
+            disputeCount: 0
+        )
+    }
+}
+
+// MARK: - Audio Sample Generators
+
+enum TestAudioGenerator {
+    /// Generate silence (all zeros)
+    static func silence(duration: Double, sampleRate: Double = 16000) -> [Float] {
+        [Float](repeating: 0.0, count: Int(duration * sampleRate))
+    }
+
+    /// Generate a sine wave tone
+    static func tone(duration: Double, amplitude: Float = 0.5, frequency: Float = 440, sampleRate: Double = 16000) -> [Float] {
+        let count = Int(duration * sampleRate)
+        return (0..<count).map { i in
+            amplitude * sin(2.0 * .pi * frequency * Float(i) / Float(sampleRate))
+        }
+    }
+
+    /// Generate speech-like pattern: alternating tone and silence
+    static func speechLikePattern(
+        speechDuration: Double = 2.0,
+        silenceDuration: Double = 0.6,
+        repetitions: Int = 3,
+        amplitude: Float = 0.5,
+        sampleRate: Double = 16000
+    ) -> [Float] {
+        var samples: [Float] = []
+        for _ in 0..<repetitions {
+            samples += tone(duration: speechDuration, amplitude: amplitude, sampleRate: sampleRate)
+            samples += silence(duration: silenceDuration, sampleRate: sampleRate)
+        }
+        return samples
+    }
+}
 
 extension TranscriptionUtterance {
     static func mock(

--- a/TranscriptedTests/Services/EmbeddingClustererTests.swift
+++ b/TranscriptedTests/Services/EmbeddingClustererTests.swift
@@ -132,26 +132,29 @@ final class EmbeddingClustererTests: XCTestCase {
     // MARK: - Small Cluster Absorption
 
     func testAbsorbSmallClusterAboveThreshold() {
-        // Large cluster: speaker 0 with 40s total (above 30s threshold)
-        // Small cluster: speaker 1 with 6s total (below 30s threshold)
-        // Embeddings are similar enough (cos ≈ 0.75) to exceed the 0.72 standard threshold
+        // Large cluster: speaker 0 with 40s, large cluster: speaker 2 with 40s (distinct)
+        // Small cluster: speaker 1 with 6s (similar to speaker 0, cos ≈ 0.75)
+        // Third speaker prevents single-speaker safety abort
         let embA: [Float] = [1.0, 0.0, 0.0, 0.0]
         let embB: [Float] = [0.75, 0.66, 0.0, 0.0] // cos(A,B) ≈ 0.75
+        let embC: [Float] = [0.0, 0.0, 1.0, 0.0]   // distinct speaker
 
-        // 20 segments × 2s each = 40s for speaker 0
-        let largeSeg = (0..<20).map { i in
+        let largeSeg0 = (0..<20).map { i in
             SpeakerSegment(speakerId: 0, startTime: Double(i) * 2.0, endTime: Double(i) * 2.0 + 2.0,
                            embedding: embA, qualityScore: 0.8)
         }
-        // 2 segments × 3s each = 6s for speaker 1
+        let largeSeg2 = (0..<20).map { i in
+            SpeakerSegment(speakerId: 2, startTime: 100.0 + Double(i) * 2.0, endTime: 100.0 + Double(i) * 2.0 + 2.0,
+                           embedding: embC, qualityScore: 0.8)
+        }
         let smallSeg = [
             SpeakerSegment(speakerId: 1, startTime: 50.0, endTime: 53.0, embedding: embB, qualityScore: 0.8),
             SpeakerSegment(speakerId: 1, startTime: 55.0, endTime: 58.0, embedding: embB, qualityScore: 0.8)
         ]
 
-        let result = EmbeddingClusterer.absorbSmallClusters(segments: largeSeg + smallSeg)
+        let result = EmbeddingClusterer.absorbSmallClusters(segments: largeSeg0 + smallSeg + largeSeg2)
         let uniqueIds = Set(result.map { $0.speakerId })
-        XCTAssertEqual(uniqueIds.count, 1, "Small cluster with sim 0.75 should be absorbed (threshold 0.72)")
+        XCTAssertEqual(uniqueIds.count, 2, "Small cluster with sim 0.75 should be absorbed (threshold 0.72)")
     }
 
     func testAbsorbSmallClusterBelowThresholdNotAbsorbed() {
@@ -177,12 +180,39 @@ final class EmbeddingClustererTests: XCTestCase {
         XCTAssertEqual(uniqueIds.count, 2, "Small (non-micro) cluster with 0 similarity should NOT be absorbed")
     }
 
-    func testAbsorbMicroClusterModeratelySimilar() {
+    func testAbsorbMicroClusterAboveThresholdAbsorbed() {
         // Large cluster: speaker 0 with 40s
+        // Large cluster: speaker 2 with 40s (distinct, prevents single-speaker safety)
         // Micro cluster: speaker 1 with 6s (below 10s micro threshold)
-        // Moderate similarity (0.60) — passes micro threshold (0.50)
+        // High similarity to speaker 0 (0.70) — passes micro threshold (0.62)
         let embA: [Float] = [1.0, 0.0, 0.0, 0.0]
-        let embB: [Float] = [0.60, 0.80, 0.0, 0.0] // cos(A,B) ≈ 0.60
+        let embB: [Float] = [0.70, 0.71, 0.0, 0.0] // cos(A,B) ≈ 0.70
+        let embC: [Float] = [0.0, 0.0, 1.0, 0.0]   // distinct speaker
+
+        let largeSeg0 = (0..<20).map { i in
+            SpeakerSegment(speakerId: 0, startTime: Double(i) * 2.0, endTime: Double(i) * 2.0 + 2.0,
+                           embedding: embA, qualityScore: 0.8)
+        }
+        let largeSeg2 = (0..<20).map { i in
+            SpeakerSegment(speakerId: 2, startTime: 100.0 + Double(i) * 2.0, endTime: 100.0 + Double(i) * 2.0 + 2.0,
+                           embedding: embC, qualityScore: 0.8)
+        }
+        let microSeg = [
+            SpeakerSegment(speakerId: 1, startTime: 50.0, endTime: 53.0, embedding: embB, qualityScore: 0.8),
+            SpeakerSegment(speakerId: 1, startTime: 55.0, endTime: 58.3, embedding: embB, qualityScore: 0.8)
+        ]
+
+        let result = EmbeddingClusterer.absorbSmallClusters(segments: largeSeg0 + microSeg + largeSeg2)
+        let uniqueIds = Set(result.map { $0.speakerId })
+        XCTAssertEqual(uniqueIds.count, 2, "Micro cluster (6.3s) with sim 0.70 should be absorbed (micro threshold 0.62)")
+    }
+
+    func testAbsorbMicroClusterBelowThresholdPreserved() {
+        // Large cluster: speaker 0 with 40s
+        // Micro cluster: speaker 1 with 6s — similarity 0.55 (below 0.62 threshold)
+        // Should NOT be absorbed
+        let embA: [Float] = [1.0, 0.0, 0.0, 0.0]
+        let embB: [Float] = [0.55, 0.84, 0.0, 0.0] // cos(A,B) ≈ 0.55
 
         let largeSeg = (0..<20).map { i in
             SpeakerSegment(speakerId: 0, startTime: Double(i) * 2.0, endTime: Double(i) * 2.0 + 2.0,
@@ -195,13 +225,13 @@ final class EmbeddingClustererTests: XCTestCase {
 
         let result = EmbeddingClusterer.absorbSmallClusters(segments: largeSeg + microSeg)
         let uniqueIds = Set(result.map { $0.speakerId })
-        XCTAssertEqual(uniqueIds.count, 1, "Micro cluster (6.3s) with sim 0.60 should be absorbed (micro threshold 0.50)")
+        XCTAssertEqual(uniqueIds.count, 2, "Micro cluster with sim 0.55 should NOT be absorbed (threshold 0.62)")
     }
 
     func testAbsorbMicroClusterDistinctVoicePreserved() {
         // Large cluster: speaker 0 with 40s
         // Micro cluster: speaker 1 with 6s — different voice (sim 0.35)
-        // Should NOT be absorbed at the new 0.50 threshold
+        // Should NOT be absorbed at the 0.62 threshold
         let embA: [Float] = [1.0, 0.0, 0.0, 0.0]
         let embB: [Float] = [0.35, 0.94, 0.0, 0.0] // cos(A,B) ≈ 0.35
 
@@ -216,7 +246,7 @@ final class EmbeddingClustererTests: XCTestCase {
 
         let result = EmbeddingClusterer.absorbSmallClusters(segments: largeSeg + microSeg)
         let uniqueIds = Set(result.map { $0.speakerId })
-        XCTAssertEqual(uniqueIds.count, 2, "Micro cluster with distinct voice (sim 0.35) should NOT be absorbed (threshold 0.50)")
+        XCTAssertEqual(uniqueIds.count, 2, "Micro cluster with distinct voice (sim 0.35) should NOT be absorbed (threshold 0.62)")
     }
 
     func testAbsorbProtectsMultiSegmentClusters() {


### PR DESCRIPTION
## Summary
- Fix 5 force unwraps that could crash mid-pipeline, serialize transcript file writes, validate system audio before pipeline, and make recording completion recoverable
- Fix silent failures: thread-safe write error counters, system audio failure warning, device recovery error persistence, unified monotonic clock sources, and SQLite corruption detection with automatic recovery
- Tune diarization: raise micro-cluster threshold 0.50 → 0.62 (above codec similarity range), smooth mic energy gating from binary cliff to 4-tier gradient
- Add 56 new tests across 2 new test files + 3 expanded files (235 total, 0 failures)

## Test plan
- [x] `xcodebuild build` succeeds with zero new warnings
- [x] `xcodebuild test` passes all 235 tests (0 failures)
- [x] No regressions in existing test suites
- [x] New TranscriptionPipelineTests covers mergeConsecutiveUtterances, embeddingWeight, detectSpeechSegments
- [x] New SpeakerMatchingServiceTests covers computeWeightedMeanEmbedding, computeMeanEmbedding, matchAgainstProfiles, cosineSimilarityStatic
- [x] EmbeddingClusterer tests updated for new 0.62 micro-cluster threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)