### PR TITLE
security: nightly security audit findings [automated]

### DIFF
--- a/Transcripted/Core/SystemAudioProcessTap.swift
+++ b/Transcripted/Core/SystemAudioProcessTap.swift
@@ -69,9 +69,13 @@ extension SystemAudioCapture {
         // device actually operates at. Read the device's nominal rate and correct the format.
         // Without this, the WAV file header has the wrong rate and audio plays back at the wrong speed.
         let deviceNominalRate = try aggregateDeviceID.readNominalSampleRate()
-        if deviceNominalRate > 0 && deviceNominalRate != tapStreamDescription!.mSampleRate {
-            AppLogger.audioSystem.warning("Tap format rate (\(Int(tapStreamDescription!.mSampleRate))Hz) differs from device nominal rate (\(Int(deviceNominalRate))Hz) — correcting")
-            tapStreamDescription!.mSampleRate = deviceNominalRate
+        // Security: avoid force-unwrap — a nil crash here is a denial-of-service.
+        // tapStreamDescription was assigned via `try` above, but guard defensively in case
+        // code flow ever changes and nil reaches this point.
+        if var currentDesc = tapStreamDescription, deviceNominalRate > 0, deviceNominalRate != currentDesc.mSampleRate {
+            AppLogger.audioSystem.warning("Tap format rate (\(Int(currentDesc.mSampleRate))Hz) differs from device nominal rate (\(Int(deviceNominalRate))Hz) — correcting")
+            currentDesc.mSampleRate = deviceNominalRate
+            tapStreamDescription = currentDesc
         }
         AppLogger.audioSystem.info("Aggregate device nominal sample rate", ["rate": "\(Int(deviceNominalRate))"])
     }


### PR DESCRIPTION
## Security Audit Summary

Automated nightly security review of the Transcripted codebase. All areas were audited; one vulnerability was found and fixed.

---

## Findings by Severity

### Medium — Fixed ✅

**Force-unwrap denial-of-service in `SystemAudioProcessTap.swift`**

Three consecutive force-unwraps of `tapStreamDescription!` at the sample-rate correction block (previously lines 72–74) had no guard. While the property is assigned via `try` two lines above (making nil impossible in the current control flow), a nil crash in CoreAudio setup code constitutes a denial-of-service: the app would terminate and recording would be lost. The code was also fragile — any future refactor that wraps the setup block in a try/catch or reorders the assignment would silently introduce a crash.

**Fix:** Replaced the three force-unwraps with `if var currentDesc = tapStreamDescription, ...` optional binding. The mutated copy is assigned back to `tapStreamDescription`. A security comment explains why the guard exists.

---

### No Issues Found ✅

| Category | Result |
|----------|--------|
| SQL injection (SpeakerDatabase, StatsDatabase) | All queries use `sqlite3_bind_*` parameterized statements |
| Path traversal (TranscriptSaver, ModelDownloadService) | `RecordingValidator` blocks `..`, symlinks, and system directories; `isSafeModelFilename()` validates download paths |
| Hardcoded secrets | None found |
| Sparkle auto-updater | HTTPS appcast URL + Ed25519 public key for signature verification |
| Temp file handling | Files cleaned up via `cleanupClips()`; `0o600` permissions set immediately |
| Model downloads | HTTPS-only mirrors; filename validated before path construction |
| Speaker name in file paths | Speaker clips keyed by UUID, not display name |
| Race conditions | Shared mutable state protected by `NSLock` and serial dispatch queues |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)