### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ Every folder with ≥2 Swift files has its own CLAUDE.md with file index, refere
 | `Transcripted/Design/Colors/CLAUDE.md` | Complete color reference with hex/HSB values |
 | `Transcripted/Design/Components/CLAUDE.md` | PremiumButton, PremiumCard, BenefitCard, QuickTipRow, AnimatedIcon specs |
 | `Transcripted/UI/FloatingPanel/CLAUDE.md` | Pill state machine, Combine subscriptions, tray states |
-| `Transcripted/UI/FloatingPanel/Components/CLAUDE.md` | Aurora views, speaker naming, error toast, celebrations |
+| `Transcripted/UI/FloatingPanel/Components/CLAUDE.md` | Aurora views, speaker naming, error toast, pill overlays |
 | `Transcripted/UI/Settings/CLAUDE.md` | @AppStorage keys, window config, speaker operations |
 | `Transcripted/UI/Settings/Sections/CLAUDE.md` | 7 section views with per-section detail |
 | `Transcripted/UI/Settings/Components/CLAUDE.md` | CoralToggle, button styles, input components |

--- a/Transcripted/Core/CLAUDE.md
+++ b/Transcripted/Core/CLAUDE.md
@@ -7,8 +7,8 @@ Audio capture pipeline, transcription orchestration, file saving, stats tracking
 | File | Actor | Purpose |
 |------|-------|---------|
 | `Audio.swift` | NOT @MainActor | AVAudioEngine setup, recording start/stop, publishes audio levels/state |
-| `AudioDeviceRecovery.swift` | NOT @MainActor | Mic watchdog timer, device disconnect recovery, sleep/wake resilience |
-| `AudioFileManager.swift` | NOT @MainActor | Audio file creation, WAV writing, buffer copying, format conversion |
+| `AudioDeviceRecovery.swift` | NOT @MainActor | Mic watchdog timer, device disconnect recovery, sleep/wake resilience, 0o600 permissions on recovery segments |
+| `AudioFileManager.swift` | NOT @MainActor | Audio file creation, WAV writing, buffer copying, format conversion, 0o600 permissions on mic/system files |
 | `AudioLevelMonitor.swift` | NOT @MainActor | Audio level metering, silence detection, rolling buffer management |
 | `SystemAudioCapture.swift` | NOT @MainActor | CoreAudio process taps (macOS 14.2+), device switching, format negotiation |
 | `SystemAudioProcessTap.swift` | NOT @MainActor | CoreAudio process tap creation, aggregate device setup |
@@ -76,6 +76,12 @@ Audio capture pipeline, transcription orchestration, file saving, stats tracking
 - **System audio loss**: 10s silence -> `.silent` status, 10+ min -> `.failed`
 - **Write errors**: Stops recording after 10 consecutive write errors
 - **originalMicAudioFileURL vs micAudioFileURL**: During recovery, new WAV segment created. Pipeline MUST use `originalMicAudioFileURL` for transcription.
+- **Security**: Recovery segments written with 0o600 permissions (owner-only) to protect biometric voice data
+
+## Audio File Security (AudioFileManager.swift + AudioDeviceRecovery.swift)
+- **Issue**: Raw meeting WAV files created with default umask permissions (644), making biometric voice recordings world-readable
+- **Fix**: Applied 0o600 permissions immediately after file creation in `AudioFileManager.swift` (mic and system files) and `AudioDeviceRecovery.swift` (recovery segments)
+- **Pattern**: Matches existing pattern used by `SpeakerClipExtractor` for speaker clips
 
 ## DisplayStatus (DisplayStatus.swift)
 ```

--- a/Transcripted/Onboarding/CLAUDE.md
+++ b/Transcripted/Onboarding/CLAUDE.md
@@ -44,6 +44,12 @@ modelErrorKind: DownloadErrorKind? (structured error classification from ModelDo
 downloadSpeed: Double (bytes/sec, smoothed), estimatedTimeRemaining: TimeInterval? (nil when unknown)
 ```
 
+## Microphone Permission Fix (OnboardingState.swift + PermissionsStep.swift)
+- **Issue**: macOS microphone permission dialog appeared behind the onboarding window because the app uses `.accessory` activation policy (no dock icon)
+- **Fix**: Added `NSApp.activate()` before `AVCaptureDevice.requestAccess` to ensure the system dialog appears in front
+- **UI change**: Added "Try Again" button in `.denied` state so users can re-trigger the permission prompt instead of being stuck
+- **Error message**: Changed from "Microphone access was denied" to "Microphone access wasn't granted. Tap 'Try Again' to see the permission prompt, or open Settings to enable it manually."
+
 ## OnboardingState Key Methods
 - `checkPermissions()` - Polls current status (call on appear)
 - `requestMicrophonePermission() async` - `AVCaptureDevice.requestAccess(for: .audio)`


### PR DESCRIPTION
## Summary
- **Core/CLAUDE.md**: Removed duplicate `AudioDeviceRecovery.swift` and `AudioFileManager.swift` entries from file index table; merged 0o600 permissions detail into canonical entries; added "Audio File Security" section documenting the recent fix
- **Onboarding/CLAUDE.md**: Added "Microphone Permission Fix" section documenting the `NSApp.activate()` fix and "Try Again" button UI change
- **Root CLAUDE.md**: Updated FloatingPanel/Components navigation table scope from "celebrations" to "pill overlays" (CelebrationViews.swift was removed)

## Audit summary
All 15 CLAUDE.md files reviewed. File counts verified: 135 total Swift files across all directories match documented counts exactly. No other stale references found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)