### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Transcripted/Core/RetroactiveSpeakerUpdater.swift
+++ b/Transcripted/Core/RetroactiveSpeakerUpdater.swift
@@ -156,6 +156,8 @@ extension TranscriptSaver {
 
     /// Update speaker names in an already-saved transcript file.
     /// Replaces "Speaker X" labels in both YAML frontmatter and transcript body.
+    /// Thread-safe: serialized via fileUpdateQueue to prevent concurrent file corruption
+    /// with retroactivelyUpdateSpeaker (called from Settings).
     ///
     /// - Parameters:
     ///   - transcriptURL: Path to the saved markdown transcript
@@ -165,58 +167,60 @@ extension TranscriptSaver {
     static func updateSpeakerNames(transcriptURL: URL, updates: [SpeakerNameUpdate]) -> Bool {
         guard !updates.isEmpty else { return true }
 
-        guard var content = try? String(contentsOf: transcriptURL, encoding: .utf8) else {
-            AppLogger.pipeline.error("Failed to read transcript for name update", ["path": transcriptURL.path])
-            return false
-        }
+        return fileUpdateQueue.sync {
+            guard var content = try? String(contentsOf: transcriptURL, encoding: .utf8) else {
+                AppLogger.pipeline.error("Failed to read transcript for name update", ["path": transcriptURL.path])
+                return false
+            }
 
-        for update in updates {
-            let speakerId = update.sortformerSpeakerId
-            let oldLabel = "Speaker \(speakerId)"
-            let newName = update.newName
+            for update in updates {
+                let speakerId = update.sortformerSpeakerId
+                let oldLabel = "Speaker \(speakerId)"
+                let newName = update.newName
 
-            // YAML frontmatter: name: "Speaker X" → name: "NewName"
-            content = content.replacingOccurrences(
-                of: "name: \"\(oldLabel)\"",
-                with: "name: \"\(newName)\""
-            )
+                // YAML frontmatter: name: "Speaker X" → name: "NewName"
+                content = content.replacingOccurrences(
+                    of: "name: \"\(oldLabel)\"",
+                    with: "name: \"\(newName)\""
+                )
 
-            // Transcript body: [System/Speaker X] → [System/NewName]
-            content = content.replacingOccurrences(
-                of: "[System/\(oldLabel)]",
-                with: "[System/\(newName)]"
-            )
+                // Transcript body: [System/Speaker X] → [System/NewName]
+                content = content.replacingOccurrences(
+                    of: "[System/\(oldLabel)]",
+                    with: "[System/\(newName)]"
+                )
 
-            // Obsidian wiki links: [[Speaker X]] → [[NewName]]
-            content = content.replacingOccurrences(
-                of: "[[\(oldLabel)]]",
-                with: "[[\(newName)]]"
-            )
+                // Obsidian wiki links: [[Speaker X]] → [[NewName]]
+                content = content.replacingOccurrences(
+                    of: "[[\(oldLabel)]]",
+                    with: "[[\(newName)]]"
+                )
 
-            // Speaker breakdown: **Speaker X:** → **NewName:**
-            content = content.replacingOccurrences(
-                of: "**\(oldLabel):**",
-                with: "**\(newName):**"
-            )
-        }
+                // Speaker breakdown: **Speaker X:** → **NewName:**
+                content = content.replacingOccurrences(
+                    of: "**\(oldLabel):**",
+                    with: "**\(newName):**"
+                )
+            }
 
-        // Consolidate speaker breakdown when multiple diarizer IDs got the same name.
-        // PyAnnote can over-segment one person into 2 clusters; after naming, both become
-        // e.g. "Timothy", producing duplicate lines in the breakdown.
-        content = consolidateSpeakerBreakdown(content)
+            // Consolidate speaker breakdown when multiple diarizer IDs got the same name.
+            // PyAnnote can over-segment one person into 2 clusters; after naming, both become
+            // e.g. "Timothy", producing duplicate lines in the breakdown.
+            content = consolidateSpeakerBreakdown(content)
 
-        // Atomic write back
-        do {
-            try content.write(to: transcriptURL, atomically: true, encoding: .utf8)
-            AppLogger.pipeline.info("Updated speaker names in transcript", ["path": transcriptURL.lastPathComponent, "updates": "\(updates.count)"])
+            // Atomic write back
+            do {
+                try content.write(to: transcriptURL, atomically: true, encoding: .utf8)
+                AppLogger.pipeline.info("Updated speaker names in transcript", ["path": transcriptURL.lastPathComponent, "updates": "\(updates.count)"])
 
-            // Update JSON sidecar
-            updateAgentJSON(transcriptURL: transcriptURL, updates: updates)
+                // Update JSON sidecar
+                updateAgentJSON(transcriptURL: transcriptURL, updates: updates)
 
-            return true
-        } catch {
-            AppLogger.pipeline.error("Failed to write updated transcript", ["error": error.localizedDescription])
-            return false
+                return true
+            } catch {
+                AppLogger.pipeline.error("Failed to write updated transcript", ["error": error.localizedDescription])
+                return false
+            }
         }
     }
 

--- a/Transcripted/Services/CLAUDE.md
+++ b/Transcripted/Services/CLAUDE.md
@@ -95,7 +95,7 @@ WAL mode, busy_timeout 5000ms, 0o600 permissions. All writes via dedicated utili
 | `matchSpeaker()` default | 0.60 | New segment matching |
 | Pairwise merge (EmbeddingClusterer) | 0.85 | Very conservative cluster merge |
 | Small cluster absorption | 0.72 | Merge short interjections |
-| Micro-cluster absorption (<10s) | 0.15 | Force-absorb noise fragments |
+| Micro-cluster absorption (<10s) | 0.62 | Absorb noise fragments (above codec similarity range) |
 | DB-informed split per-segment | 0.62 | Re-separate mixed clusters |
 | Adaptive threshold (1 segment) | 0.85 | High certainty for single segment |
 | Adaptive threshold (2-3 segments) | 0.78 | Moderate caution |
@@ -107,7 +107,8 @@ postProcess(segments, existingProfiles, skipPairwiseMerge):
   Stage 1 - Pairwise Merge (skip for PyAnnote, VBx already handles):
     Union-find graph, merge clusters with mean similarity >= 0.85
   Stage 2 - Small Cluster Absorption:
-    Micro-clusters (<10s): absorb at 0.15 floor (catches "Mm-hmm" fragments)
+    Micro-clusters (<10s): absorb at 0.62 threshold (above codec similarity range)
+    Clusters with 3+ segments protected from absorption (real speaker)
     Small clusters (10-30s): absorb at 0.72 threshold
   Stage 3 - DB-Informed Split:
     Per-segment matching against known profiles (threshold 0.62)


### PR DESCRIPTION
## Summary

- **updateSpeakerNames missing fileUpdateQueue serialization**: All other transcript write functions (`retroactivelyUpdateSpeaker`, `retroactivelyUpdateTitle`) serialize through `fileUpdateQueue`, but `updateSpeakerNames` did not. Wrapped the read-replace-write in `fileUpdateQueue.sync` to prevent concurrent file corruption if a speaker rename in Settings races with the naming tray submission.
- **Stale CLAUDE.md threshold**: `microAbsorptionThreshold` was raised from 0.15 to 0.62 in recent commits but the Services CLAUDE.md table still showed the old value. Updated to match code. Added 3+ segment protection note to pipeline description.

## Test plan
- [x] Build passes (`xcodebuild -configuration Debug CODE_SIGNING_ALLOWED=NO`)
- [ ] Verify speaker naming flow still works (naming tray -> submit names -> transcript updated)
- [ ] Verify retroactive rename from Settings still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)