### PR TITLE
fix: nightly build/test failure — test runner hung before establishing connection

### DIFF
--- a/Transcripted/TranscriptedApp.swift
+++ b/Transcripted/TranscriptedApp.swift
@@ -60,6 +60,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate, UNUserNotifi
     // MARK: - App Lifecycle
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // XCTest injects a test bundle into the host app. If full app initialization
+        // runs (Audio, CoreAudio, ScreenCaptureKit, FloatingPanel, etc.) it can block
+        // the main thread long enough for the test runner to time out before connecting.
+        // Early-returning here lets XCTest establish its connection; tests use
+        // @testable import so they access types directly without needing app state.
+        guard ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil else {
+            return
+        }
+
         _ = AppLogger.shared
 
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"


### PR DESCRIPTION
## What failed

**Test failure** — all tests were failing nightly with:

```
Transcripted encountered an error (The test runner hung before establishing connection.)
** TEST FAILED **
```

The build itself succeeded. Only the test run timed out (~344 seconds, the xcodebuild default).

## Error message

```
Testing failed:
    Transcripted (28723) encountered an error (The test runner hung before establishing connection.)
```

## Root cause

When xcodebuild runs tests it launches `Transcripted.app` as the host process and injects the XCTest bundle into it. Before the test runner can establish its IPC connection, `applicationDidFinishLaunching` was running the full app startup:

- `Audio()` — initialises AVAudioEngine and `SystemAudioCapture` (CoreAudio / ScreenCaptureKit)
- `FloatingPanelController` — creates and displays the pill window
- `MeetingDetector.start()` — begins observing running apps
- Model pre-cache task — kicks off ML model loading

Some combination of these (most likely the CoreAudio / ScreenCaptureKit tap setup in `SystemAudioCapture`) was occupying enough of the startup window that the test runner timed out before the XCTest IPC connection was established.

## Fix

Detect the test environment via the `XCTestConfigurationFilePath` environment variable, which xcodebuild sets on every test run, and return early from `applicationDidFinishLaunching` before any app-level initialization:

```swift
guard ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil else {
    return
}
```

Tests use `@testable import Transcripted` and access types directly — they don't need the app to be bootstrapped. After this change all tests pass immediately (no timeout).

## Verification

- Build: ✅ `** BUILD SUCCEEDED **`
- Tests: ✅ `** TEST SUCCEEDED **` — all test cases passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)