### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Transcripted/Core/TranscriptionPipeline.swift
+++ b/Transcripted/Core/TranscriptionPipeline.swift
@@ -428,10 +428,8 @@ extension Transcription {
         }
     }
 
-    // MARK: - Utterance Merging
+    // MARK: - Embedding Quality
 
-    /// Merge consecutive utterances from the same speaker when the time gap between them
-    /// is smaller than `maxGap` seconds. This produces cleaner transcripts by joining
     /// Calculate embedding weight based on mic activity fraction during a system audio segment.
     /// Returns nil if the segment should be excluded entirely (>80% mic overlap).
     /// Uses a 4-tier gradient to avoid sharp threshold cliffs:
@@ -448,6 +446,10 @@ extension Transcription {
         }
     }
 
+    // MARK: - Utterance Merging
+
+    /// Merge consecutive utterances from the same speaker when the time gap between them
+    /// is smaller than `maxGap` seconds. This produces cleaner transcripts by joining
     /// fragments that the diarizer split mid-sentence.
     ///
     /// A `maxDuration` cap prevents runaway merges — even if the speaker and gap criteria

--- a/Transcripted/Services/Protocols/TranscriptStorage.swift
+++ b/Transcripted/Services/Protocols/TranscriptStorage.swift
@@ -11,18 +11,23 @@ protocol TranscriptStorage {
         speakerMappings: [String: SpeakerMapping],
         speakerSources: [String: String],
         speakerDbIds: [String: UUID],
-        directory: URL,
+        directory: URL?,
+        meetingTitle: String?,
         healthInfo: RecordingHealthInfo?
     ) -> URL?
 
     /// Update speaker names in an existing transcript file
-    static func updateSpeakerNames(transcriptURL: URL, updates: [SpeakerNameUpdate])
+    /// - Returns: true if the file was updated successfully
+    @discardableResult
+    static func updateSpeakerNames(transcriptURL: URL, updates: [SpeakerNameUpdate]) -> Bool
 
     /// Retroactively update a speaker name across existing transcripts
     static func retroactivelyUpdateSpeaker(dbId: UUID, newName: String)
 
     /// Retroactively update the meeting title in transcript YAML
-    static func retroactivelyUpdateTitle(transcriptURL: URL, title: String)
+    /// - Returns: true if the file was updated successfully
+    @discardableResult
+    static func retroactivelyUpdateTitle(transcriptURL: URL, title: String) -> Bool
 
     /// Default save directory
     static var defaultSaveDirectory: URL { get }


### PR DESCRIPTION
## Summary

- **Scrambled doc comments in `TranscriptionPipeline.swift`**: A prior refactor accidentally split `mergeConsecutiveUtterances`'s docstring across two functions — the first half ended up on `embeddingWeight` and the second half stayed on `mergeConsecutiveUtterances`. Xcode Quick Help and `///` navigation were showing the wrong documentation for both functions. Also moved `embeddingWeight` into a new `// MARK: - Embedding Quality` section (it was incorrectly nested under `// MARK: - Utterance Merging`).

- **`TranscriptStorage` protocol mismatches**: The protocol signatures didn't match `TranscriptSaver`'s actual implementations, preventing future conformance declaration:
  - `saveTranscript()` had `directory: URL` (non-optional) vs implementation's `directory: URL? = nil`; also missing `meetingTitle: String?`
  - `updateSpeakerNames()` and `retroactivelyUpdateTitle()` declared `Void` return but implementations return `@discardableResult Bool`

## Test plan
- [x] Build passes: `xcodebuild -project Transcripted.xcodeproj -scheme Transcripted -configuration Debug CODE_SIGNING_ALLOWED=NO build`
- [x] No logic changes — doc comments and protocol signatures only

🤖 Generated with [Claude Code](https://claude.com/claude-code)