### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Transcripted/Core/TranscriptionPipeline.swift
+++ b/Transcripted/Core/TranscriptionPipeline.swift
@@ -434,10 +434,8 @@ extension Transcription {
         }
     }
 
-    // MARK: - Utterance Merging
+    // MARK: - Embedding Quality
 
-    /// Merge consecutive utterances from the same speaker when the time gap between them
-    /// is smaller than `maxGap` seconds. This produces cleaner transcripts by joining
     /// Calculate embedding weight based on mic activity fraction during a system audio segment.
     /// Returns nil if the segment should be excluded entirely (>80% mic overlap).
     /// Uses a 4-tier gradient to avoid sharp threshold cliffs:
@@ -454,6 +452,10 @@ extension Transcription {
         }
     }
 
+    // MARK: - Utterance Merging
+
+    /// Merge consecutive utterances from the same speaker when the time gap between them
+    /// is smaller than `maxGap` seconds. This produces cleaner transcripts by joining
     /// fragments that the diarizer split mid-sentence.
     ///
     /// A `maxDuration` cap prevents runaway merges — even if the speaker and gap criteria

--- a/Transcripted/UI/FloatingPanel/Components/ClipAudioPlayer.swift
+++ b/Transcripted/UI/FloatingPanel/Components/ClipAudioPlayer.swift
@@ -13,18 +13,20 @@ class ClipAudioPlayer: NSObject, ObservableObject {
     @Published var currentClipURL: URL?
 
     private var player: AVAudioPlayer?
+    private var loadTask: Task<Void, Never>?
 
     func play(url: URL) {
-        stop()  // stop any current playback
+        stop()  // cancels any in-flight load task and stops current playback
 
         // Load audio file on a background thread to avoid blocking the main thread
         // with file I/O — especially with 7 speaker clips being played rapidly.
         let capturedURL = url
-        Task.detached { [weak self] in
+        loadTask = Task.detached { [weak self] in
             do {
                 let audioPlayer = try AVAudioPlayer(contentsOf: capturedURL)
+                guard !Task.isCancelled else { return }
                 await MainActor.run {
-                    guard let self else { return }
+                    guard let self, !Task.isCancelled else { return }
                     self.player = audioPlayer
                     self.player?.delegate = self
                     self.player?.play()
@@ -38,6 +40,8 @@ class ClipAudioPlayer: NSObject, ObservableObject {
     }
 
     func stop() {
+        loadTask?.cancel()
+        loadTask = nil
         player?.stop()
         player = nil
         isPlaying = false


### PR DESCRIPTION
## Summary

- **Race condition in ClipAudioPlayer** — `play()` launched a `Task.detached` to load audio off the main thread but never stored or cancelled it. Rapid clip switching (or calling `stop()` while a file was loading) could cause a stale task to complete after the stop and (a) start playing audio that the user had already stopped, or (b) overwrite the result of a newer load with an older one, playing the wrong clip.

- **Garbled doc comments in TranscriptionPipeline** — `embeddingWeight` was accidentally positioned between the two halves of `mergeConsecutiveUtterances`'s doc comment, making Xcode Quick Help show nonsense for both functions. Moved `embeddingWeight` to its own `// MARK: - Embedding Quality` section and restored the complete, contiguous doc comment for `mergeConsecutiveUtterances`.

## What was fixed

| File | Issue | Fix |
|------|-------|-----|
| `ClipAudioPlayer.swift` | In-flight load task not cancelled on `stop()` or new `play()` call | Store task in `loadTask`; cancel + nil it in `stop()`; guard `isCancelled` before applying player |
| `TranscriptionPipeline.swift` | `embeddingWeight` inserted mid-doc-comment of `mergeConsecutiveUtterances` | Moved method to its own MARK section; restored contiguous doc comments |

## Test plan

- [ ] With 7+ speakers, rapidly click play on different speaker clips during naming — confirm no audio plays after clicking stop
- [ ] Confirm Xcode Quick Help on `mergeConsecutiveUtterances` and `embeddingWeight` shows correct, complete documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)