### PR TITLE
refactor: nightly simplification sweep [automated]

### DIFF
--- a/Transcripted/Core/AppDelegateDebug.swift
+++ b/Transcripted/Core/AppDelegateDebug.swift
@@ -21,13 +21,13 @@ extension AppDelegate {
         let mkbhdEmbedding = (0..<256).map { _ in Float.random(in: -1...1) }
         let travisEmbedding = (0..<256).map { _ in Float.random(in: -1...1) }
         let mkbhdProfile = speakerDB.addOrUpdateSpeaker(embedding: mkbhdEmbedding)
-        speakerDB.setDisplayName(id: mkbhdProfile.id, name: "MKBHD", source: "user_manual")
+        speakerDB.setDisplayName(id: mkbhdProfile.id, name: "MKBHD", source: NameSource.userManual)
         // Bump call count by adding a few more times
         for _ in 0..<6 {
             _ = speakerDB.addOrUpdateSpeaker(embedding: mkbhdEmbedding, existingId: mkbhdProfile.id)
         }
         let travisProfile = speakerDB.addOrUpdateSpeaker(embedding: travisEmbedding)
-        speakerDB.setDisplayName(id: travisProfile.id, name: "Travis", source: "user_manual")
+        speakerDB.setDisplayName(id: travisProfile.id, name: "Travis", source: NameSource.userManual)
         for _ in 0..<2 {
             _ = speakerDB.addOrUpdateSpeaker(embedding: travisEmbedding, existingId: travisProfile.id)
         }

--- a/Transcripted/Core/SpeakerNamingCoordinator.swift
+++ b/Transcripted/Core/SpeakerNamingCoordinator.swift
@@ -36,14 +36,14 @@ extension TranscriptionTaskManager {
                     speakerDB.setDisplayName(
                         id: update.persistentSpeakerId,
                         name: update.newName,
-                        source: "user_manual"
+                        source: NameSource.userManual
                     )
 
                 case .confirmed:
                     speakerDB.setDisplayName(
                         id: update.persistentSpeakerId,
                         name: update.newName,
-                        source: "user_manual"
+                        source: NameSource.userManual
                     )
                     speakerDB.resetDisputeCount(id: update.persistentSpeakerId)
                 }

--- a/Transcripted/Services/SpeakerProfile.swift
+++ b/Transcripted/Services/SpeakerProfile.swift
@@ -1,10 +1,16 @@
 import Foundation
 
+/// Source values for SpeakerProfile.nameSource
+enum NameSource {
+    static let userManual = "user_manual"
+    static let qwenInferred = "qwen_inferred"
+}
+
 /// A persistent speaker profile with voice fingerprint
 struct SpeakerProfile: Identifiable {
     let id: UUID
     var displayName: String?        // "Nate", "Travis", or nil if unnamed
-    var nameSource: String?         // "user_manual", "qwen_inferred", nil
+    var nameSource: String?         // NameSource.userManual, NameSource.qwenInferred, or nil
     var embedding: [Float]          // 256-dim average voice vector
     var firstSeen: Date
     var lastSeen: Date

--- a/Transcripted/Services/SpeakerProfileMerger.swift
+++ b/Transcripted/Services/SpeakerProfileMerger.swift
@@ -10,8 +10,8 @@ extension SpeakerDatabase {
     /// - Parameters:
     ///   - id: Speaker profile UUID
     ///   - name: Display name to set
-    ///   - source: Where the name came from ("user_manual", "qwen_inferred")
-    func setDisplayName(id: UUID, name: String, source: String = "qwen_inferred") {
+    ///   - source: Where the name came from (NameSource.userManual or NameSource.qwenInferred)
+    func setDisplayName(id: UUID, name: String, source: String = NameSource.qwenInferred) {
         queue.sync {
             setDisplayNameImpl(id: id, name: name, source: source)
         }
@@ -133,7 +133,7 @@ extension SpeakerDatabase {
 
         // Transfer name from source if target has none
         if target.displayName == nil, let name = source.displayName {
-            setDisplayNameImpl(id: targetId, name: name, source: source.nameSource ?? "user_manual")
+            setDisplayNameImpl(id: targetId, name: name, source: source.nameSource ?? NameSource.userManual)
         }
 
         // Update target: blended embedding, summed call count, bumped confidence

--- a/Transcripted/UI/FloatingPanel/Components/ClipAudioPlayer.swift
+++ b/Transcripted/UI/FloatingPanel/Components/ClipAudioPlayer.swift
@@ -20,10 +20,9 @@ class ClipAudioPlayer: NSObject, ObservableObject {
 
         // Load audio file on a background thread to avoid blocking the main thread
         // with file I/O — especially with 7 speaker clips being played rapidly.
-        let capturedURL = url
         loadTask = Task.detached { [weak self] in
             do {
-                let audioPlayer = try AVAudioPlayer(contentsOf: capturedURL)
+                let audioPlayer = try AVAudioPlayer(contentsOf: url)
                 guard !Task.isCancelled else { return }
                 await MainActor.run {
                     guard let self, !Task.isCancelled else { return }
@@ -31,7 +30,7 @@ class ClipAudioPlayer: NSObject, ObservableObject {
                     self.player?.delegate = self
                     self.player?.play()
                     self.isPlaying = true
-                    self.currentClipURL = capturedURL
+                    self.currentClipURL = url
                 }
             } catch {
                 AppLogger.ui.warning("Failed to play speaker clip", ["error": error.localizedDescription])

--- a/Transcripted/UI/Settings/Sections/SpeakersSection.swift
+++ b/Transcripted/UI/Settings/Sections/SpeakersSection.swift
@@ -198,7 +198,7 @@ struct SpeakersSettingsSection: View {
             editingId = nil
             return
         }
-        SpeakerDatabase.shared.setDisplayName(id: id, name: trimmed, source: "user_manual")
+        SpeakerDatabase.shared.setDisplayName(id: id, name: trimmed, source: NameSource.userManual)
         editingId = nil
         // Retroactively update all transcripts referencing this speaker
         Task.detached {


### PR DESCRIPTION
## Summary

- **NameSource constants**: Extracted `"user_manual"` and `"qwen_inferred"` string literals into a `NameSource` enum in `SpeakerProfile.swift`. Updated 6 callsites across `SpeakerNamingCoordinator`, `AppDelegateDebug`, `SpeakersSection`, and `SpeakerProfileMerger`.
- **ClipAudioPlayer**: Removed the redundant `capturedURL` local copy in `play(url:)` — `URL` is a value type captured by copy automatically.

## What was reviewed

Three parallel agents reviewed the diff from the last 3 commits. The quality and efficiency agents surfaced these two cleanups.

## Test plan

- [ ] Build succeeds (pre-existing FluidAudio static lib issue is unrelated)
- [ ] Speaker naming flow correctly persists names with `"user_manual"` source
- [ ] Clip playback behaves identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)