### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Transcripted/Services/Protocols/CLAUDE.md
+++ b/Transcripted/Services/Protocols/CLAUDE.md
@@ -99,10 +99,18 @@ protocol StatsStore {
 ### TranscriptStorage
 ```swift
 protocol TranscriptStorage {
-    static func saveTranscript(...) -> URL?
-    static func updateSpeakerNames(transcriptURL: URL, updates: [SpeakerNameUpdate])
+    static func saveTranscript(_ result: TranscriptionResult,
+                               speakerMappings: [String: SpeakerMapping],
+                               speakerSources: [String: String],
+                               speakerDbIds: [String: UUID],
+                               directory: URL?,
+                               meetingTitle: String?,
+                               healthInfo: RecordingHealthInfo?) -> URL?
+    @discardableResult
+    static func updateSpeakerNames(transcriptURL: URL, updates: [SpeakerNameUpdate]) -> Bool
     static func retroactivelyUpdateSpeaker(dbId: UUID, newName: String)
-    static func retroactivelyUpdateTitle(transcriptURL: URL, title: String)
+    @discardableResult
+    static func retroactivelyUpdateTitle(transcriptURL: URL, title: String) -> Bool
     static var defaultSaveDirectory: URL { get }
 }
 ```


### PR DESCRIPTION
## Summary
- Updated `Transcripted/Services/Protocols/CLAUDE.md` to reflect TranscriptStorage protocol signature changes from PRs #94 and #95:
  - `saveTranscript`: expanded signature showing `directory: URL?` (now optional) and new `meetingTitle: String?` parameter
  - `updateSpeakerNames`: now returns `Bool` with `@discardableResult`
  - `retroactivelyUpdateTitle`: now returns `Bool` with `@discardableResult`

All other CLAUDE.md files (14 of 15) were verified accurate — file counts, indices, and descriptions match the current codebase state (135 Swift files total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)