### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Transcripted/Core/CLAUDE.md
+++ b/Transcripted/Core/CLAUDE.md
@@ -27,7 +27,7 @@ Audio capture pipeline, transcription orchestration, file saving, stats tracking
 | `TranscriptFormatter.swift` | Static | YAML escaping, source label formatting, markdown generation |
 | `TranscriptMetadataBuilder.swift` | -- | RecordingHealthInfo struct, YAML frontmatter metadata construction |
 | `RetroactiveSpeakerUpdater.swift` | Static | Updates all transcripts when a speaker is renamed in Settings |
-| `TranscriptStore.swift` | @MainActor | Reads saved transcripts for tray UI display |
+| `TranscriptStore.swift` | @MainActor | Reads saved transcripts for tray UI display, SpeakerInfo metadata for rename UI, parseSingle() for re-opening rename |
 | `TranscriptExporter.swift` | -- | Export to .md or .txt via NSSavePanel |
 | `TranscriptScanner.swift` | -- | Finds transcripts in save directory, migration support |
 | `TranscriptUtils.swift` | -- | Formatting utilities |

--- a/Transcripted/Services/CLAUDE.md
+++ b/Transcripted/Services/CLAUDE.md
@@ -12,7 +12,7 @@ ML pipeline services, speaker database, audio processing utilities, meeting dete
 | `DiarizationService.swift` | @MainActor | Dual-pipeline: Sortformer (streaming) + PyAnnote (offline). Downloads via ModelDownloadService with mirror fallback. |
 | `SpeakerDatabase.swift` | Utility queue | SQLite at ~/Documents/Transcripted/speakers.sqlite, core CRUD + schema |
 | `SpeakerEmbeddingMatcher.swift` | Utility queue | Cosine similarity matching against stored speaker profiles (vDSP-accelerated) |
-| `SpeakerProfile.swift` | -- | SpeakerProfile struct (256-dim embeddings) + SpeakerMatchResult |
+| `SpeakerProfile.swift` | -- | NameSource constants, SpeakerProfile struct (256-dim embeddings) + SpeakerMatchResult |
 | `SpeakerProfileMerger.swift` | Utility queue | Profile name updates, merging, pruning, and name variant lookup |
 | `QwenService.swift` | @MainActor | On-device Qwen3.5-4B-4bit via mlx-swift-lm, on-demand load/unload. Pre-populates cache via ModelDownloadService with mirror fallback and progress tracking. |
 | `EmbeddingClusterer.swift` | Static | 3-stage post-processing: pairwise merge, small cluster absorption, DB-informed split |
@@ -43,6 +43,11 @@ ML pipeline services, speaker database, audio processing utilities, meeting dete
 
 ## Key Data Types (SpeakerProfile.swift + TranscriptionTypes.swift)
 ```swift
+enum NameSource {
+    static let userManual = "user_manual"
+    static let qwenInferred = "qwen_inferred"
+}
+
 struct SpeakerSegment {
     let speakerId: Int, startTime: Double, endTime: Double
     let embedding: [Float]?    // 256-dim WeSpeaker
@@ -51,7 +56,7 @@ struct SpeakerSegment {
 
 struct SpeakerProfile: Identifiable {
     let id: UUID
-    var displayName: String?, nameSource: String?  // "user_manual" | "qwen_inferred"
+    var displayName: String?, nameSource: String?  // NameSource.userManual | .qwenInferred
     var embedding: [Float]     // 256-dim average
     var firstSeen: Date, lastSeen: Date, callCount: Int
     var confidence: Double     // 0.5-1.0, +0.1 per update, capped at 1.0


### PR DESCRIPTION
## Summary
- **Services/CLAUDE.md**: Added `NameSource` enum (new in `SpeakerProfile.swift`) to file description and Key Data Types section; updated `SpeakerProfile.nameSource` comment from string literals to `NameSource` constants
- **Core/CLAUDE.md**: Updated `TranscriptStore.swift` description to mention new `SpeakerInfo` struct and `parseSingle(url:)` method added for speaker rename UI

## Context
Catches up with changes from `feat: add SpeakerInfo metadata to TranscriptSummary for speaker rename UI` (f664763) and `refactor: nightly simplification sweep` (ec08d63) which introduced `NameSource` constants.

All other CLAUDE.md files verified: file counts, file indexes, and descriptions all match current codebase state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)