### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Transcripted/Core/CLAUDE.md
+++ b/Transcripted/Core/CLAUDE.md
@@ -27,7 +27,7 @@ Audio capture pipeline, transcription orchestration, file saving, stats tracking
 | `TranscriptFormatter.swift` | Static | YAML escaping, source label formatting, markdown generation |
 | `TranscriptMetadataBuilder.swift` | -- | RecordingHealthInfo struct, YAML frontmatter metadata construction |
 | `RetroactiveSpeakerUpdater.swift` | Static | Updates all transcripts when a speaker is renamed in Settings |
-| `TranscriptStore.swift` | @MainActor | Reads saved transcripts for tray UI display |
+| `TranscriptStore.swift` | @MainActor | Reads saved transcripts for tray UI display. SpeakerInfo struct (yamlId, dbId, name) + parseSingle(url:) for external metadata access. |
 | `TranscriptExporter.swift` | -- | Export to .md or .txt via NSSavePanel |
 | `TranscriptScanner.swift` | -- | Finds transcripts in save directory, migration support |
 | `TranscriptUtils.swift` | -- | Formatting utilities |

--- a/Transcripted/Services/CLAUDE.md
+++ b/Transcripted/Services/CLAUDE.md
@@ -12,7 +12,7 @@ ML pipeline services, speaker database, audio processing utilities, meeting dete
 | `DiarizationService.swift` | @MainActor | Dual-pipeline: Sortformer (streaming) + PyAnnote (offline). Downloads via ModelDownloadService with mirror fallback. |
 | `SpeakerDatabase.swift` | Utility queue | SQLite at ~/Documents/Transcripted/speakers.sqlite, core CRUD + schema |
 | `SpeakerEmbeddingMatcher.swift` | Utility queue | Cosine similarity matching against stored speaker profiles (vDSP-accelerated) |
-| `SpeakerProfile.swift` | -- | SpeakerProfile struct (256-dim embeddings) + SpeakerMatchResult |
+| `SpeakerProfile.swift` | -- | SpeakerProfile struct (256-dim embeddings) + SpeakerMatchResult + NameSource constants (userManual, qwenInferred) |
 | `SpeakerProfileMerger.swift` | Utility queue | Profile name updates, merging, pruning, and name variant lookup |
 | `QwenService.swift` | @MainActor | On-device Qwen3.5-4B-4bit via mlx-swift-lm, on-demand load/unload. Pre-populates cache via ModelDownloadService with mirror fallback and progress tracking. |
 | `EmbeddingClusterer.swift` | Static | 3-stage post-processing: pairwise merge, small cluster absorption, DB-informed split |
@@ -51,7 +51,7 @@ struct SpeakerSegment {
 
 struct SpeakerProfile: Identifiable {
     let id: UUID
-    var displayName: String?, nameSource: String?  // "user_manual" | "qwen_inferred"
+    var displayName: String?, nameSource: String?  // NameSource.userManual | .qwenInferred
     var embedding: [Float]     // 256-dim average
     var firstSeen: Date, lastSeen: Date, callCount: Int
     var confidence: Double     // 0.5-1.0, +0.1 per update, capped at 1.0


### PR DESCRIPTION
## Summary
- **Core/CLAUDE.md**: Updated TranscriptStore.swift description to document new SpeakerInfo struct, speakers metadata array, and `parseSingle(url:)` method added in f664763
- **Services/CLAUDE.md**: Updated SpeakerProfile.swift description to document extracted NameSource constants (userManual, qwenInferred) added in ec08d63

All file counts verified correct (135 total, per-folder counts unchanged). No other CLAUDE.md files needed updates — remaining changes (security fixes, race condition fix, doc comment cleanup) were implementation-level details already covered by existing descriptions.

Generated by scheduled task `daily-claude-md-review`