### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Transcripted/Core/TranscriptStore.swift
+++ b/Transcripted/Core/TranscriptStore.swift
@@ -213,6 +213,7 @@ final class TranscriptStore: ObservableObject {
         var speakerCount = 0
         var speakerNames: [String] = []
         var timeOfDay: String?
+        var speakerInfos: [SpeakerInfo] = []
 
         // Parse YAML frontmatter for structured fields
         if raw.hasPrefix("---"),
@@ -258,7 +259,6 @@ final class TranscriptStore: ObservableObject {
             var currentSpeakerId: String?
             var currentDbId: UUID?
             var currentName: String?
-            var speakerInfos: [SpeakerInfo] = []
 
             func flushCurrentSpeaker() {
                 if let id = currentSpeakerId {

--- a/TranscriptedTests/Core/TranscriptStoreTests.swift
+++ b/TranscriptedTests/Core/TranscriptStoreTests.swift
@@ -41,7 +41,8 @@ final class TranscriptStoreTests: XCTestCase {
             duration: "12:34",
             speakerCount: 2,
             speakerNames: ["You", "Speaker 1"],
-            timeOfDay: nil
+            timeOfDay: nil,
+            speakers: []
         )
 
         let text = store.copyableText(for: summary)


### PR DESCRIPTION
## Summary

Two compile errors introduced by `f664763` (feat: add SpeakerInfo metadata to TranscriptSummary for speaker rename UI):

**`TranscriptStore.swift` — `speakerInfos` out of scope**
- `var speakerInfos: [SpeakerInfo] = []` was declared inside the `if raw.hasPrefix("---")` block in `parseMetadata()`
- The variable is used at the `return TranscriptSummary(speakers: speakerInfos)` statement, which is outside that block
- Fix: moved declaration to function scope alongside the other metadata variables (`speakerNames`, `speakerCount`, etc.)

**`TranscriptStoreTests.swift` — missing `speakers:` parameter**
- `testCopyableTextStripsYAMLFrontmatter` created a `TranscriptSummary` without the newly-required `speakers:` field
- All other 5 test cases in the file correctly passed `speakers: []`
- Fix: added `speakers: []` to the first test case

## Test plan
- [ ] Project builds without errors (FluidAudio static lib required for full build — changes are compile-only fixes)
- [ ] `TranscriptStoreTests` all pass after adding missing `speakers: []` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)