### PR TITLE
security: nightly security audit findings [automated]

### DIFF
--- a/Transcripted/Services/SpeakerClipExtractor.swift
+++ b/Transcripted/Services/SpeakerClipExtractor.swift
@@ -114,6 +114,10 @@ enum SpeakerClipExtractor {
         try? FileManager.default.removeItem(at: dest) // OK if doesn't exist
         do {
             try FileManager.default.copyItem(at: tempClipURL, to: dest)
+            // Security: restrict to owner-only (600) — persistent speaker clips contain biometric
+            // voice data and must not be world-readable on multi-user systems. copyItem inherits
+            // default umask permissions (0o644), so we restrict explicitly after copy.
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: dest.path)
         } catch {
             AppLogger.pipeline.error("Failed to persist speaker clip", ["speakerId": speakerId.uuidString, "error": error.localizedDescription])
         }


### PR DESCRIPTION
## Summary

Nightly automated security audit of the Transcripted codebase. One medium-severity vulnerability found and fixed.

## Findings by Severity

### Medium

**Persistent speaker clips stored with world-readable permissions** (`SpeakerClipExtractor.persistClip`)

- **File**: `Transcripted/Services/SpeakerClipExtractor.swift`
- **Issue**: `FileManager.copyItem()` inherits the destination's default umask permissions (0o644), leaving persistent speaker voice clips at `~/Documents/Transcripted/speaker_clips/{uuid}.wav` readable by all users on a multi-user macOS system.
- **Risk**: Speaker clips are short biometric voice recordings. On a shared Mac, another local user account could read them.
- **Fix**: Added `FileManager.setAttributes([.posixPermissions: 0o600], ...)` immediately after `copyItem()` in `persistClip()`, consistent with the established 0o600 pattern for all other biometric data in the codebase (mic/system audio files, speakers.sqlite, stats.sqlite, app.jsonl, and the temporary clips written by `writeClip()`).
- **Note**: The temporary clips created by `writeClip()` already had 0o600 applied; only the persistent copy was missing the restriction.

### No Issues Found

| Area | Status |
|------|--------|
| File handling / path traversal | ✅ `RecordingValidator.validateSavePath` resolves symlinks, rejects `..` components and forbidden system prefixes; custom paths validated in both `TranscriptSaver` and `RecordingCoordinator` |
| SQL injection | ✅ All queries use `sqlite3_prepare_v2` + `sqlite3_bind_*`; `getColumnNames` uses a compile-time allowlist for the table name |
| Input validation | ✅ `isSafeModelFilename()` validates HuggingFace API filenames before path construction; speaker names are stored as opaque display strings, not interpolated into SQL |
| Hardcoded secrets | ✅ No API keys, tokens, or credentials found in source |
| Unsafe operations | ✅ No `try!` calls; force-unwraps in `MeetingDetector` and `RetroactiveSpeakerUpdater` are logically safe (value set to non-nil on the line preceding each unwrap, @MainActor prevents concurrent modification); `SystemAudioProcessTap` already has a comment documenting the safe optional binding |
| Race conditions | ✅ Audio thread / main thread separation is correct; `SpeakerDatabase` uses a dedicated utility queue; `TranscriptSaver` uses a serial `fileUpdateQueue` |
| Sparkle updater | ✅ `SUFeedURL` uses HTTPS; `SUPublicEDKey` (Ed25519) is set for signature verification — this is the correct Sparkle 2 security model |
| Temp file cleanup | ✅ `RecordingCoordinator.cleanupOrphanedAudioFiles` removes orphaned meeting WAV files on launch; `SpeakerClipExtractor.cleanupClips` removes temp clips after naming flow; `DiagnosticExporter` uses `defer` to clean its temp directory |
| Model download security | ✅ All downloads use HTTPS mirrors; `isSafeModelFilename()` rejects path traversal, absolute paths, null bytes, and control characters from API-supplied filenames |

## Build Note

The pre-existing `FluidAudio: compiled with an older version of the compiler` error is present on `main` before this change (ABI mismatch between the bundled static module and the current Xcode toolchain). It is unrelated to this security fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)