### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,5 +111,9 @@ Every folder with ≥2 Swift files has its own CLAUDE.md with file index, refere
 - `UI/Settings/Models/SettingsNavigationState.swift` — Migration state + vestigial SettingsTab
 - `UI/FailedTranscriptionsView.swift` — Standalone window for failed transcription management (600x400 min)
 
+## Tools (external CLI utilities)
+- **Tools/TranscriptedQA/** (18 Swift files): Standalone Swift CLI (`transcripted-qa`) for validating on-disk artifacts. Subcommands: `validate-all` (default), `validate-transcripts`, `validate-database`, `validate-logs`, `validate-artifacts`, `validate-index`, `check-health`. Validators: TranscriptValidator, SpeakerDBValidator, StatsDBValidator, JSONSidecarValidator, IndexValidator, LogValidator, HealthChecker. Uses `ArgumentParser`.
+- **Tools/TranscriptedCLI/** (1 file): Legacy CLI wrapper around FluidAudio static lib.
+
 ## Documentation
 See CONTRIBUTING.md for full development guidelines.

--- a/Transcripted/Core/CLAUDE.md
+++ b/Transcripted/Core/CLAUDE.md
@@ -23,7 +23,7 @@ Audio capture pipeline, transcription orchestration, file saving, stats tracking
 | `SpeakerMatchingService.swift` | nonisolated | In-memory speaker embedding matching, mean embedding computation |
 | `SpeakerNamingCoordinator.swift` | @MainActor | Speaker naming flow completion, applies names to DB and transcript, merges profiles by name |
 | `QwenLifecycleManager.swift` | @MainActor | Qwen model pre-load on recording start, timeout, memory checks |
-| `TranscriptSaver.swift` | Static | Markdown + YAML output, serial queue for file writes, path validation, 0o600 permissions on temp clips |
+| `TranscriptSaver.swift` | Static | Markdown + YAML output, serial queue for file writes, path validation, 0o600 permissions on saved transcript .md files |
 | `TranscriptFormatter.swift` | Static | YAML escaping, source label formatting, markdown generation |
 | `TranscriptMetadataBuilder.swift` | -- | RecordingHealthInfo struct, YAML frontmatter metadata construction |
 | `RetroactiveSpeakerUpdater.swift` | Static | Updates all transcripts when a speaker is renamed in Settings |

--- a/Transcripted/Services/CLAUDE.md
+++ b/Transcripted/Services/CLAUDE.md
@@ -17,7 +17,7 @@ ML pipeline services, speaker database, audio processing utilities, meeting dete
 | `QwenService.swift` | @MainActor | On-device Qwen3.5-4B-4bit via mlx-swift-lm, on-demand load/unload. Pre-populates cache via ModelDownloadService with mirror fallback and progress tracking. |
 | `EmbeddingClusterer.swift` | Static | 3-stage post-processing: pairwise merge, small cluster absorption, DB-informed split |
 | `AudioResampler.swift` | Static | AVAudioConverter-based resampling to 16kHz, WAV loading, slice extraction |
-| `SpeakerClipExtractor.swift` | Static | Extract per-speaker audio clips for naming UI playback, 0o600 permissions on temp clips |
+| `SpeakerClipExtractor.swift` | Static | Extract per-speaker audio clips for naming UI playback, 0o600 permissions on temp clips and persistent clips |
 | `MeetingDetector.swift` | @MainActor | Monitors Zoom/Teams/Webex/FaceTime, auto-triggers recording |
 
 ### Protocols/ (7 files) — see Protocols/CLAUDE.md


### PR DESCRIPTION
## Summary

Nightly CLAUDE.md sync pass for 2026-03-28.

## What Changed

### Recent activity reviewed
- PRs #101–#111 merged in the last 3 days, including:
  - `feat: Transcripted QA — AI-driven testing system` (new `Tools/TranscriptedQA/` CLI with 18 Swift files)
  - `security: apply 0o600 permissions to persistent speaker clips`
  - `security: restrict transcript file permissions to owner-only (600)`

### Files updated

**`CLAUDE.md`** (root)
- Added new **Tools** section documenting `Tools/TranscriptedQA/` (18-file Swift CLI for on-disk artifact validation) and `Tools/TranscriptedCLI/` — these existed in the repo but were undocumented in CLAUDE.md.

**`Transcripted/Core/CLAUDE.md`**
- `TranscriptSaver.swift` description: updated from "0o600 permissions on temp clips" → "0o600 permissions on saved transcript .md files" to accurately reflect what security commit `7e6d60e` actually does (applies owner-only permissions to the final `.md` transcript output, not just temp clips).

**`Transcripted/Services/CLAUDE.md`**
- `SpeakerClipExtractor.swift` description: updated to include "and persistent clips" to reflect commit `4174894` which added 0o600 permissions to persistent `speaker_clips/{speakerId}.wav` files (in addition to the existing temp clip protection).

## No code changes — CLAUDE.md files only