### PR TITLE
docs: fix stale API reference in Settings Sections CLAUDE.md

### DIFF
--- a/Transcripted/UI/Settings/Sections/CLAUDE.md
+++ b/Transcripted/UI/Settings/Sections/CLAUDE.md
@@ -31,7 +31,7 @@
 - Speaker list with avatar (first letter circle, "?" fallback), display name, call count
 - Inline edit: tap name → TextField → commit on Return
   - → SpeakerDatabase.setDisplayName(id:, name:, source: "user_manual")
-  - → RetroactiveSpeakerUpdater.retroactivelyUpdateSpeaker(dbId:, newName:)
+  - → TranscriptSaver.retroactivelyUpdateSpeaker(dbId:, newName:) (defined in RetroactiveSpeakerUpdater.swift)
 - Delete: click → "Delete?" confirm → "Yes"
   - → SpeakerClipExtractor.deletePersistedClip(for:)
   - → SpeakerDatabase.deleteSpeaker(id:)


### PR DESCRIPTION
## Summary
- Fixed stale reference in `Transcripted/UI/Settings/Sections/CLAUDE.md`: changed `RetroactiveSpeakerUpdater.retroactivelyUpdateSpeaker()` to `TranscriptSaver.retroactivelyUpdateSpeaker()` since `RetroactiveSpeakerUpdater.swift` is a `TranscriptSaver` extension, not a standalone type

## Audit Results (2026-03-28)
All other CLAUDE.md files are up to date:
- Root CLAUDE.md: ~135 Swift files, all folder counts correct, Tools section accurate
- Core/CLAUDE.md: 47 files, all entries match disk
- Services/CLAUDE.md: 18 files, all entries match
- FloatingPanel/CLAUDE.md: 21 files, correct
- FloatingPanel/Components/CLAUDE.md: 16 files, correct
- Settings/CLAUDE.md: 18 files, correct
- Settings/Sections/CLAUDE.md: 7 files, correct (stale call reference fixed)
- No deleted or undocumented new app files

## Trigger
Nightly cron job — 2026-03-28