### PR TITLE
security: nightly security audit findings [automated]

### DIFF
--- a/Transcripted/Core/RecordingValidator.swift
+++ b/Transcripted/Core/RecordingValidator.swift
@@ -111,14 +111,19 @@ class RecordingValidator {
     /// - Parameter url: The candidate save directory URL
     /// - Returns: `.success` if the path is safe, `.failure` with reason otherwise
     static func validateSavePath(_ url: URL) -> ValidationResult {
-        let resolved = url.resolvingSymlinksInPath()
-        let resolvedPath = resolved.path
-
-        // Reject paths with ".." components (directory traversal)
-        let components = resolved.pathComponents
-        if components.contains("..") {
+        // Security: check for ".." traversal components on the RAW path before symlink resolution.
+        // After resolvingSymlinksInPath(), ".." components are already normalised away and would
+        // never appear in pathComponents — making a post-resolution check useless dead code.
+        // Checking the raw components first ensures the check is actually exercised.
+        let rawComponents = url.pathComponents
+        if rawComponents.contains("..") {
             return .failure("Save path cannot contain '..' components")
         }
+
+        // Resolve symlinks so that a symlink pointing at e.g. /System cannot bypass
+        // the forbidden-prefix check below.
+        let resolved = url.resolvingSymlinksInPath()
+        let resolvedPath = resolved.path
 
         // Reject system directories
         for prefix in forbiddenPrefixes {


### PR DESCRIPTION
## Nightly Security Audit — 2026-03-29

Automated security review of the Transcripted codebase. One low-severity vulnerability was found and fixed.

---

## Findings Summary

### 🟡 LOW — Dead-code path traversal check in `validateSavePath()`

**File:** `Transcripted/Core/RecordingValidator.swift`

**Vulnerability:** The `validateSavePath()` function checked for `".."` path components *after* calling `resolvingSymlinksInPath()`. Since `resolvingSymlinksInPath()` normalises away all `".."` components before `pathComponents` is computed, the check could **never** fire — it was dead code. This gave a misleading sense of defence-in-depth: the comment said ".."-traversal was being rejected, but it never actually was.

**Risk:** An attacker-controlled or malicious path like `/Users/victim/../../etc/passwd` would have the `".."` stripped before the check, so the check would pass. The actual protection was provided only by the symlink-resolution + forbidden-prefix check below it, which is narrower in scope (only blocks explicit /System, /Library, etc. prefixes).

**Fix:** Moved the `".."` check to run against `url.pathComponents` (the raw, pre-resolution path). Symlink resolution now happens after that check, immediately before the forbidden-prefix test where it is needed.

---

## Areas Reviewed — No Issues Found

| Area | Status | Notes |
|------|--------|-------|
| **File handling / path traversal** | ✅ Clean | Transcript filenames are timestamp-only; model filenames validated by `isSafeModelFilename()` before path construction; speaker clip filenames use integer IDs |
| **SQL injection** | ✅ Clean | All queries in `SpeakerDatabase` and `StatsDatabase` use parameterized `sqlite3_bind_*` calls; no string interpolation in SQL |
| **Input validation — audio files** | ✅ Clean | Only system-managed URLs accepted from `AVAudioRecorder`; no direct user path input to audio pipeline |
| **Input validation — model paths** | ✅ Clean | `isSafeModelFilename()` rejects absolute paths, `".."` components, single-dot components, and control characters |
| **Input validation — speaker names** | ✅ Clean | Display names are stored/retrieved via parameterized SQL; not used in file path construction |
| **Secrets / credentials** | ✅ Clean | No hardcoded API keys, tokens, or credentials found in source |
| **Unsafe operations (force unwraps)** | ✅ Clean | No `try!` calls; force-unwraps in `RetroactiveSpeakerUpdater` are logically guarded by nil-checks inserted in the same iteration |
| **Race conditions** | ✅ Clean | `Audio.swift` uses `NSLock` for all shared state across audio thread and main thread; `SpeakerDatabase` and `StatsDatabase` serialize on a `DispatchQueue` |
| **Sparkle auto-updater** | ✅ Clean | Appcast URL is HTTPS; `SUPublicEDKey` is set (Sparkle 2 EdDSA signature verification enabled) |
| **Temp file handling** | ✅ Clean | `DiagnosticExporter` uses `defer { cleanup }`; `SpeakerClipExtractor` cleans up temp clips; no world-readable temp files found |
| **File permissions** | ✅ Clean | Transcripts, SQLite databases, and failed-transcription queue all set to `0o600` (owner-read/write only); `FileLogger` sets `0o600` on log file at open |
| **Model download security** | ✅ Clean | All mirror URLs use HTTPS; `NSAppTransportSecurity` has no `NSAllowsArbitraryLoads` exception |
| **CoreAudio unsafe pointers** | ✅ Clean | `UnsafeBufferPointer` usage in `SpeakerDatabase` for BLOB reads follows standard patterns with explicit bounds |

---

*Generated by automated nightly security audit — Sunday, March 29th 2026, 12:30 AM CT*