### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,8 @@ Menu bar-only macOS app for real-time system audio transcription. Pipeline: Core
 - **Protocols**: 7 service protocols in `Services/Protocols/` (SpeechToTextEngine, DiarizationEngine, SpeakerStore, etc.)
 - **DI**: `AppServices` container in `Core/AppServices.swift`
 
-## Folder Map (~135 Swift files, agent-first: max ~300 lines per file, single responsibility)
-- **Core/** (47 files): Audio capture (Audio + 3 extensions), transcription pipeline (TaskManager + 3 extensions), transcript saving (4 files), stats DB (3 files), model downloads (ModelDownloadService), failed transcription retry, logging, coordinators (Hotkey, MenuBar, Notification, Window, Recording)
+## Folder Map (~136 Swift files, agent-first: max ~300 lines per file, single responsibility)
+- **Core/** (48 files): Audio capture (Audio + 3 extensions), transcription pipeline (TaskManager + 3 extensions), transcript saving (4 files), stats DB (3 files), model downloads (ModelDownloadService), failed transcription retry, file permissions, logging, coordinators (Hotkey, MenuBar, Notification, Window, Recording)
 - **Services/** (18 files): ML services (11 files) + Protocols/ subdirectory (7 service protocols)
 - **UI/FloatingPanel/** (21 files): Morphing pill UI, aurora state views (3 files), SavedPillView, transcript tray (3 files), speaker naming (3 files), Components/ (16 files), Helpers/ (1 file)
 - **UI/Settings/** (18 files): Settings container + Sections/ (7 section views) + Components/ (6 reusable components) + Models/ (1 file)
@@ -112,7 +112,7 @@ Every folder with ≥2 Swift files has its own CLAUDE.md with file index, refere
 - `UI/FailedTranscriptionsView.swift` — Standalone window for failed transcription management (600x400 min)
 
 ## Tools (external CLI utilities)
-- **Tools/TranscriptedQA/** (18 Swift files): Standalone Swift CLI (`transcripted-qa`) for validating on-disk artifacts. Subcommands: `validate-all` (default), `validate-transcripts`, `validate-database`, `validate-logs`, `validate-artifacts`, `validate-index`, `check-health`. Validators: TranscriptValidator, SpeakerDBValidator, StatsDBValidator, JSONSidecarValidator, IndexValidator, LogValidator, HealthChecker. Uses `ArgumentParser`.
+- **Tools/TranscriptedQA/** (19 Swift files): Standalone Swift CLI (`transcripted-qa`) for validating on-disk artifacts. Subcommands: `validate-all` (default), `validate-transcripts`, `validate-database`, `validate-logs`, `validate-artifacts`, `validate-index`, `check-health`. Validators: TranscriptValidator, SpeakerDBValidator, StatsDBValidator, JSONSidecarValidator, IndexValidator, LogValidator, HealthChecker. Uses `ArgumentParser`.
 - **Tools/TranscriptedCLI/** (1 file): Legacy CLI wrapper around FluidAudio static lib.
 
 ## Documentation

--- a/Transcripted/Core/CLAUDE.md
+++ b/Transcripted/Core/CLAUDE.md
@@ -1,6 +1,6 @@
 # Core Folder
 
-Audio capture pipeline, transcription orchestration, file saving, stats tracking, model downloads, error recovery, and app lifecycle. 47 Swift files (including Logging/).
+Audio capture pipeline, transcription orchestration, file saving, stats tracking, model downloads, error recovery, and app lifecycle. 48 Swift files (including Logging/).
 
 ## File Index
 
@@ -38,6 +38,7 @@ Audio capture pipeline, transcription orchestration, file saving, stats tracking
 | `StatsService.swift` | @MainActor | Stats aggregation for dashboard UI |
 | `ModelDownloadService.swift` | Static | HuggingFace download with mirror fallback (hf-mirror.com), retry with exponential backoff, Qwen cache pre-population, structured error classification (DownloadErrorKind), isSafeModelFilename() path traversal validation |
 | `RecordingValidator.swift` | Static | Pre-recording checks (disk space, permissions, save path) |
+| `FilePermissions.swift` | -- | FileManager extension: `restrictToOwnerOnly(atPath:)` applies 0o600 to all user data files |
 | `FailedTranscription.swift` | -- | Model for retryable failed transcriptions |
 | `FailedTranscriptionManager.swift` | @MainActor | Retry queue, persists to JSON, auto-cleans permanent failures |
 | `AppServices.swift` | @MainActor | Dependency injection container holding protocol-typed service instances |


### PR DESCRIPTION
## Summary
- **Core/CLAUDE.md**: Added missing `FilePermissions.swift` to file index (added in PR #114), updated file count 47→48
- **Root CLAUDE.md**: Updated Core file count 47→48, total Swift count ~135→~136, TranscriptedQA file count 18→19

## Audit findings (no action needed)
- Services CLAUDE.md: DiarizationService config params from PR #118 (Fa, Fb, thresholds) are implementation details not documented in CLAUDE.md — no staleness
- All other directories (Design, UI, Onboarding, Services/Protocols): file counts match reality
- Services: 18 files ✓ | UI/FloatingPanel: 21 ✓ | UI/Settings: 18 ✓ | Onboarding: 7 ✓ | Design: 21 ✓

## Test plan
- [ ] Verify file counts with `find Transcripted -name "*.swift" | wc -l`
- [ ] Verify Core count with `find Transcripted/Core -name "*.swift" | wc -l`

🤖 Generated with [Claude Code](https://claude.com/claude-code)