### PR TITLE
refactor: hoist isoDateFormatter + extract logSpeakerSummaries

### DIFF
--- a/Transcripted/Core/AgentOutput.swift
+++ b/Transcripted/Core/AgentOutput.swift
@@ -118,6 +118,12 @@ enum AgentOutput {
         return e
     }()
 
+    private static let isoDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        return f
+    }()
+
     /// Write a structured JSON sidecar for a transcript.
     static func writeTranscriptJSON(
         from result: TranscriptionResult,
@@ -126,9 +132,7 @@ enum AgentOutput {
         to folder: URL,
         stem: String
     ) throws {
-        let isoFormatter = DateFormatter()
-        isoFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
-        let dateString = isoFormatter.string(from: Date())
+        let dateString = isoDateFormatter.string(from: Date())
 
         // Build speaker list
         var speakers: [AgentSpeaker] = []
@@ -243,12 +247,9 @@ enum AgentOutput {
             )
         }.sorted { $0.callCount > $1.callCount }
 
-        let isoFormatter = DateFormatter()
-        isoFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
-
         let index = AgentIndex(
             version: "1.0",
-            updatedAt: isoFormatter.string(from: Date()),
+            updatedAt: isoDateFormatter.string(from: Date()),
             transcriptCount: entries.count,
             transcripts: entries,
             knownSpeakers: knownSpeakers

--- a/Transcripted/Services/DiarizationService.swift
+++ b/Transcripted/Services/DiarizationService.swift
@@ -177,14 +177,9 @@ class DiarizationService: ObservableObject {
             )
         }
 
-        // Log summary
         let speakerIds = Set(segments.map { $0.speakerId })
         AppLogger.transcription.info("Offline diarization complete", ["segments": "\(segments.count)", "speakers": "\(speakerIds.count)"])
-        for id in speakerIds.sorted() {
-            let speakerSegments = segments.filter { $0.speakerId == id }
-            let totalDuration = speakerSegments.reduce(0.0) { $0 + $1.duration }
-            AppLogger.transcription.debug("Speaker \(id): \(speakerSegments.count) segments, \(String(format: "%.1f", totalDuration))s")
-        }
+        logSpeakerSummaries(segments)
 
         return segments
     }
@@ -223,11 +218,7 @@ class DiarizationService: ObservableObject {
 
         let speakerIds = Set(segments.map { $0.speakerId })
         AppLogger.transcription.info("Sortformer diarization complete", ["segments": "\(segments.count)", "speakers": "\(speakerIds.count)"])
-        for id in speakerIds.sorted() {
-            let speakerSegments = segments.filter { $0.speakerId == id }
-            let totalDuration = speakerSegments.reduce(0.0) { $0 + $1.duration }
-            AppLogger.transcription.debug("Speaker \(id): \(speakerSegments.count) segments, \(String(format: "%.1f", totalDuration))s")
-        }
+        logSpeakerSummaries(segments)
 
         return segments
     }
@@ -248,6 +239,16 @@ class DiarizationService: ObservableObject {
     }
 
     // MARK: - Helpers
+
+    /// Log per-speaker segment summaries (shared by offline and streaming pipelines).
+    private nonisolated func logSpeakerSummaries(_ segments: [SpeakerSegment]) {
+        let speakerIds = Set(segments.map { $0.speakerId })
+        for id in speakerIds.sorted() {
+            let speakerSegments = segments.filter { $0.speakerId == id }
+            let totalDuration = speakerSegments.reduce(0.0) { $0 + $1.duration }
+            AppLogger.transcription.debug("Speaker \(id): \(speakerSegments.count) segments, \(String(format: "%.1f", totalDuration))s")
+        }
+    }
 
     /// Convert FluidAudio's string speaker ID (e.g., "speaker_0") to integer
     private nonisolated func speakerIdFromString(_ id: String) -> Int {


### PR DESCRIPTION
## Summary
- **AgentOutput.swift**: Replace two per-call `DateFormatter` allocations with a single `static let isoDateFormatter`
- **DiarizationService.swift**: Extract duplicate per-speaker segment logging into shared `logSpeakerSummaries()` helper

Cherry-picked from closed PR #122 (whose SpeakerDatabase changes were superseded by #117's `parseSpeakerRow` extraction).

Build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)