### PR TITLE
docs: sync CLAUDE.md — document TranscriptedMCP tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ Every folder with ≥2 Swift files has its own CLAUDE.md with file index, refere
 ## Tools (external CLI utilities)
 - **Tools/TranscriptedQA/** (19 Swift files): Standalone Swift CLI (`transcripted-qa`) for validating on-disk artifacts. Subcommands: `validate-all` (default), `validate-transcripts`, `validate-database`, `validate-logs`, `validate-artifacts`, `validate-index`, `check-health`. Validators: TranscriptValidator, SpeakerDBValidator, StatsDBValidator, JSONSidecarValidator, IndexValidator, LogValidator, HealthChecker. Uses `ArgumentParser`.
 - **Tools/TranscriptedCLI/** (1 file): Legacy CLI wrapper around FluidAudio static lib.
+- **Tools/TranscriptedMCP/** (7 Swift source files): MCP server (`transcripted-mcp`) exposing Transcripted transcripts to AI agents via the Model Context Protocol. Built as a Swift Package with `swift-sdk` (MCP 0.12.0). 5 tools: `list_meetings` (list with metadata, date filter), `read_meeting` (full transcript by filename, section param: full/transcript/speakers), `search` (full-text with optional speaker + date filters, supports name variants), `who_is` (speaker profile lookup), `recap` (multi-meeting digest for a date range). Index stored at `~/Documents/Transcripted/mcp_index.sqlite` (0o600). Watches for new transcripts via `FileWatcher`. NameVariants mirrors `SpeakerProfileMerger.swift` lookups. `TRANSCRIPTED_DATA_DIR` env var overrides default data path.
 
 ## Documentation
 See CONTRIBUTING.md for full development guidelines.


### PR DESCRIPTION
## What changed

### Root `CLAUDE.md`
- Added **Tools/TranscriptedMCP** entry to the Tools section documenting the new MCP server that landed in the same merge as this PR was created.

## Why

The `Tools/TranscriptedMCP/` Swift Package (7 source files, 4 test files) was added in the previous merge (`df48860`) but the `CLAUDE.md` Tools section was not updated to describe it. This PR closes that gap.

## What TranscriptedMCP is (for context)

A standalone Swift MCP server (`transcripted-mcp`) that exposes Transcripted transcripts to AI agents via the Model Context Protocol. Key details documented:
- 5 tools: `list_meetings`, `read_meeting`, `search`, `who_is`, `recap`
- SQLite index at `~/Documents/Transcripted/mcp_index.sqlite` (0o600 permissions)
- FileWatcher for live updates
- NameVariants mirrors SpeakerProfileMerger lookups
- `TRANSCRIPTED_DATA_DIR` env override
- Built with `swift-sdk` MCP 0.12.0

## Files changed
- `CLAUDE.md` — one new bullet added to Tools section

## Notes
- No CLAUDE.md files in subdirectories required changes (TranscriptedMCP is a standalone package; parent folders are unaffected)
- Transcripted/ Swift file counts remain correct at 136