### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -1,6 +1,19 @@
 import Foundation
 import MCP
 
+// MARK: - Helpers
+
+private extension DateFormatter {
+    /// YYYY-MM-DD formatter in the local timezone, matching how transcript dates are stored.
+    static let localYYYYMMDD: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        // Intentionally uses the system (local) timezone — transcript dates are stored in local time.
+        return f
+    }()
+}
+
 func registerToolHandlers(server: Server, index: TranscriptIndex, dataDir: URL) async {
     await server.withMethodHandler(ListTools.self) { _ in
         .init(tools: [
@@ -271,7 +284,8 @@ private func handleWhoIs(params: CallTool.Parameters, index: TranscriptIndex) th
 // MARK: - recap
 
 private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, dataDir: URL) throws -> CallTool.Result {
-    let today = ISO8601DateFormatter().string(from: Date()).prefix(10)
+    // Use local calendar so "today" matches transcript dates (which are stored in local time)
+    let today = DateFormatter.localYYYYMMDD.string(from: Date())
     let dateFrom = params.arguments?["date_from"]?.stringValue ?? String(today)
     let dateTo = params.arguments?["date_to"]?.stringValue ?? dateFrom
 

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -153,10 +153,7 @@ final class TranscriptIndex: @unchecked Sendable {
     func indexSingleFile(_ url: URL) throws {
         try queue.sync {
             let filename = url.deletingPathExtension().lastPathComponent
-            let modDate = (try? url.resourceValues(forKeys: [.contentModificationDateKey])
-                .contentModificationDate?.timeIntervalSince1970) ?? Date().timeIntervalSince1970
             try reindex(file: url, filename: filename)
-            _ = modDate // used in reindex via file read
         }
     }
 

--- a/Transcripted/Core/Audio.swift
+++ b/Transcripted/Core/Audio.swift
@@ -4,7 +4,6 @@ import QuartzCore
 import AppKit
 import CoreAudio
 import Combine
-import QuartzCore
 
 /// Status of system audio capture for UI feedback
 /// Used to show warnings when device switching or audio loss occurs

--- a/Transcripted/Services/SpeakerDatabase.swift
+++ b/Transcripted/Services/SpeakerDatabase.swift
@@ -371,6 +371,10 @@ final class SpeakerDatabase {
     }
 
     func allSpeakersImpl() -> [SpeakerProfile] {
+        guard isDatabaseOpen else {
+            AppLogger.speakers.error("allSpeakers called while database is not open")
+            return []
+        }
         var speakers: [SpeakerProfile] = []
         let sql = "SELECT id, display_name, name_source, embedding, first_seen, last_seen, call_count, confidence, dispute_count FROM speakers ORDER BY last_seen DESC;"
         var statement: OpaquePointer?


### PR DESCRIPTION
Four issues found and fixed. Both the Transcripted app and TranscriptedMCP Swift package build cleanly.

## Logic Bug

### `get_digest` defaults 'today' to UTC instead of local time
**File:** `Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift`

`ISO8601DateFormatter()` returns a UTC-based string. Transcript dates are stored in the system's local timezone (via `DateFormatter` in `AgentOutput.swift`). Any user not in UTC running `get_digest` without explicit dates in the evening would get tomorrow's UTC date, returning zero results for today's meetings.

**Fix:** Added a `localYYYYMMDD` DateFormatter extension using the system local timezone, matching how transcripts are saved.

## Dead Code

### `indexSingleFile` computes a `modDate` it never uses
**File:** `Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift`

`indexSingleFile` computed the file's modification date, then called `reindex()` which independently fetches its own `modDate`. The local variable was suppressed with `_ = modDate` and an incorrect comment. Removed.

## Missing Guard

### `allSpeakersImpl` missing `isDatabaseOpen` guard
**File:** `Transcripted/Services/SpeakerDatabase.swift`

Every other `Impl` method guards with `isDatabaseOpen` before calling into SQLite. `allSpeakersImpl` was the only exception. When `db == nil` (after a failed corruption recovery), it silently returns an empty array — indistinguishable from "no speakers saved" at the call site. Added the guard with an error log, consistent with all other `Impl` methods.

## Redundant Import

### Duplicate `import QuartzCore` in `Audio.swift`
**File:** `Transcripted/Core/Audio.swift`

`QuartzCore` was imported twice. Removed the duplicate.

---
*Build verified: `xcodebuild ... BUILD SUCCEEDED`, `swift build` for TranscriptedMCP: `Build complete!`*
