### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,12 @@ Menu bar-only macOS app for real-time system audio transcription. Pipeline: Core
 - **Protocols**: 7 service protocols in `Services/Protocols/` (SpeechToTextEngine, DiarizationEngine, SpeakerStore, etc.)
 - **DI**: `AppServices` container in `Core/AppServices.swift`
 
-## Folder Map (~136 Swift files, agent-first: max ~300 lines per file, single responsibility)
+## Folder Map (~137 Swift files, agent-first: max ~300 lines per file, single responsibility)
 - **Core/** (48 files): Audio capture (Audio + 3 extensions), transcription pipeline (TaskManager + 3 extensions), transcript saving (4 files), stats DB (3 files), model downloads (ModelDownloadService), failed transcription retry, file permissions, logging, coordinators (Hotkey, MenuBar, Notification, Window, Recording)
 - **Services/** (18 files): ML services (11 files) + Protocols/ subdirectory (7 service protocols)
 - **UI/FloatingPanel/** (21 files): Morphing pill UI, aurora state views (3 files), SavedPillView, transcript tray (3 files), speaker naming (3 files), Components/ (16 files), Helpers/ (1 file)
 - **UI/Settings/** (18 files): Settings container + Sections/ (7 section views) + Components/ (6 reusable components) + Models/ (1 file)
-- **Onboarding/** (7 files): 4-step first-run flow (Welcome -> Preview -> Permissions -> Model Setup), dark theme
+- **Onboarding/** (8 files): 5-step first-run flow (Preview -> Permissions -> Model Setup -> HowItWorks -> TestRecording), dark theme
 - **Design/** (21 files): Colors/ (6 files), Components/ (5 premium components), root tokens (10 files: Spacing, Radius, Typography, Animations, Shadows, ViewModifiers, Gradients, Dimensions, Accessibility, CardModifiers)
 
 ## Build & Test
@@ -84,7 +84,7 @@ User presses Cmd+Shift+R (global hotkey)
 - **Qwen**: On-demand download (~2.5GB), loads/unloads to manage memory
 - **Download resilience**: All downloads use `ModelDownloadService` with HuggingFace mirror fallback (`hf-mirror.com`), retry with exponential backoff, and structured error classification
 
-## CLAUDE.md Navigation (15 files)
+## CLAUDE.md Navigation (16 files)
 Every folder with ≥2 Swift files has its own CLAUDE.md with file index, reference data, and gotchas.
 
 | Path | Scope |
@@ -102,8 +102,9 @@ Every folder with ≥2 Swift files has its own CLAUDE.md with file index, refere
 | `Transcripted/UI/Settings/CLAUDE.md` | @AppStorage keys, window config, speaker operations |
 | `Transcripted/UI/Settings/Sections/CLAUDE.md` | 7 section views with per-section detail |
 | `Transcripted/UI/Settings/Components/CLAUDE.md` | CoralToggle, button styles, input components |
-| `Transcripted/Onboarding/CLAUDE.md` | 4-step flow, OnboardingState properties, integration |
-| `Transcripted/Onboarding/Steps/CLAUDE.md` | Welcome, Preview, Permissions, ModelSetup step implementations |
+| `Transcripted/Onboarding/CLAUDE.md` | 5-step flow, OnboardingState properties, integration |
+| `Transcripted/Onboarding/Steps/CLAUDE.md` | Preview, Permissions, ModelSetup, HowItWorks, TestRecording step implementations |
+| `Tools/TranscriptedMCP/CLAUDE.md` | MCP server tools, SQLite index schema, name variants, file watcher |
 
 **Single-file folders** (covered by parent CLAUDE.md):
 - `UI/MenuBar/MenuBarStatRow.swift` — Custom NSView (250x22), used in status bar dropdown
@@ -113,8 +114,8 @@ Every folder with ≥2 Swift files has its own CLAUDE.md with file index, refere
 
 ## Tools (external CLI utilities)
 - **Tools/TranscriptedQA/** (19 Swift files): Standalone Swift CLI (`transcripted-qa`) for validating on-disk artifacts. Subcommands: `validate-all` (default), `validate-transcripts`, `validate-database`, `validate-logs`, `validate-artifacts`, `validate-index`, `check-health`. Validators: TranscriptValidator, SpeakerDBValidator, StatsDBValidator, JSONSidecarValidator, IndexValidator, LogValidator, HealthChecker. Uses `ArgumentParser`.
-- **Tools/TranscriptedCLI/** (1 file): Legacy CLI wrapper around FluidAudio static lib.
-- **Tools/TranscriptedMCP/** (7 Swift source files): MCP server (`transcripted-mcp`) exposing Transcripted transcripts to AI agents via the Model Context Protocol. Built as a Swift Package with `swift-sdk` (MCP 0.12.0). 5 tools: `list_meetings` (list with metadata, date filter), `read_meeting` (full transcript by filename, section param: full/transcript/speakers), `search` (full-text with optional speaker + date filters, supports name variants), `who_is` (speaker profile lookup), `recap` (multi-meeting digest for a date range). Index stored at `~/Documents/Transcripted/mcp_index.sqlite` (0o600). Watches for new transcripts via `FileWatcher`. NameVariants mirrors `SpeakerProfileMerger.swift` lookups. `TRANSCRIPTED_DATA_DIR` env var overrides default data path.
+- **Tools/TranscriptedCLI/** (5 Swift files): Standalone Swift CLI (`transcripted-cli`) for offline diarization via FluidAudio. Entry: `TranscriptedCLI.swift` (ArgumentParser root). Subcommands: `diarize` (single file, `DiarizeCommand.swift`), `batch` (directory, `BatchCommand.swift`). Shared: `ConfigLoader.swift` (JSON config -> OfflineDiarizerConfig), `RTTMWriter.swift` (RTTM + JSON output).
+- **Tools/TranscriptedMCP/** (8 Swift files): MCP server (`transcripted-mcp`) for Claude Desktop integration. Exposes 5 tools: `list_meetings`, `read_meeting`, `search`, `who_is`, `recap`. Uses SQLite index (`mcp_index.sqlite`) via `TranscriptIndex.swift`; file watching via `FileWatcher.swift`; name variant expansion via `NameVariants.swift` (mirrors SpeakerProfileMerger). Data dir: `~/Documents/Transcripted/` (override via `TRANSCRIPTED_DATA_DIR` env). See `Tools/TranscriptedMCP/CLAUDE.md`.
 
 ## Documentation
 See CONTRIBUTING.md for full development guidelines.

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -1,0 +1,82 @@
+# TranscriptedMCP
+
+MCP (Model Context Protocol) server that gives Claude Desktop direct read-only access to Transcripted meeting data. 8 Swift files.
+
+## File Index
+
+| File | Purpose |
+|------|---------|
+| `Main.swift` | Entry point. Parses `TRANSCRIPTED_DATA_DIR` env, initialises `TranscriptIndex`, launches `FileWatcher`, starts MCP server over stdio. |
+| `ToolHandlers.swift` | Registers all 5 tools with the MCP server and implements their handler logic. |
+| `Models.swift` | Shared model types decoded from JSON sidecars: `AgentTranscript`, `AgentUtterance`, `AgentSpeaker`, `MeetingRow`, `SearchResults`. |
+| `TranscriptIndex.swift` | SQLite index (`mcp_index.sqlite`) over `~/Documents/Transcripted/`. Thread-safe via serial DispatchQueue. FTS5 full-text search, speaker analytics. |
+| `TranscriptLoader.swift` | Loads and decodes `.json` sidecar files from the data directory. `enumerateSidecars()` enumerates `Call_*.json`. |
+| `FileWatcher.swift` | FSEvents-based directory watcher + 30s reconciliation timer. Calls `onChange` when new/modified sidecars are detected. |
+| `NameVariants.swift` | Name variant expansion (mirrors `SpeakerProfileMerger.swift`). `NameVariants.expand("mike")` → `["michael", "mike", "mikey"]`. |
+| `TranscriptIndex+Queries.swift` | Complex query methods on `TranscriptIndex`: `listMeetings`, `searchUtterances`, `getPersonProfile`, `indexSidecar`. |
+
+## Tools Exposed (5)
+
+| Tool | Required params | Description |
+|------|----------------|-------------|
+| `list_meetings` | — | Lists meetings with speakers, duration, word count. Filters: `count` (default 10), `date`, `date_from`, `date_to`. |
+| `read_meeting` | `filename` | Full transcript markdown for a meeting. `section`: `full` (default), `transcript`, `speakers`. |
+| `search` | `query` | FTS5 full-text search across all utterances. Filters: `speaker`, `date_from`, `date_to`. Name variants applied to speaker filter. |
+| `who_is` | `speaker` | Speaker profile: meeting count, total words, speaking minutes, frequent co-speakers, representative quotes. |
+| `recap` | — | Digest of meetings in a date range. Defaults to today. Returns title, speakers, duration, first ~15 transcript lines per meeting. |
+
+## Data Directory
+- Default: `~/Documents/Transcripted/`
+- Override: `TRANSCRIPTED_DATA_DIR` environment variable
+- Reads: `Call_*.json` JSON sidecars written by `AgentOutput.writeTranscriptJSON()`
+- Index: `mcp_index.sqlite` (auto-built and kept up to date via `FileWatcher`)
+- Index permissions: `0o600` (owner-only)
+
+## SQLite Index Schema (TranscriptIndex.swift)
+- **meetings** table: `filename`, `date`, `datetime`, `duration_seconds`, `word_count`, `speakers_json`
+- **utterances** table: `filename`, `speaker`, `start_time`, `end_time`, `text`, `channel`
+- **utterances_fts** virtual FTS5 table: mirrors `utterances.text` for full-text search
+
+## Name Variants (NameVariants.swift)
+Bidirectional mapping sourced from `SpeakerProfileMerger.swift`. Example expansions:
+- `mike` / `michael` / `mikey` → each finds all three
+- `nate` / `nathan` / `nathaniel` → each finds all three
+- `dave` / `david` → each finds both
+Applied automatically in `search` (speaker filter) and `who_is`.
+
+## File Watcher (FileWatcher.swift)
+- FSEvents `O_EVTONLY` watch on the data directory + 30s fallback polling timer
+- On change: calls `TranscriptIndex.indexSidecar()` for new/modified files
+- Reconciliation: scans all sidecars on timer tick to catch missed events
+
+## Build
+```bash
+cd Tools/TranscriptedMCP
+swift build -c release
+.build/release/transcripted-mcp
+```
+
+## Claude Desktop Config
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+```json
+{
+  "mcpServers": {
+    "transcripted": {
+      "command": "/path/to/transcripted-mcp"
+    }
+  }
+}
+```
+
+## Relationships
+- Reads JSON sidecars written by `Core/AgentOutput.swift` (main app)
+- Name variant logic mirrors `Services/SpeakerProfileMerger.swift`
+- No compile-time dependency on the main Transcripted target — standalone Swift package
+
+## Gotchas
+- Server communicates over stdio (MCP transport) — no HTTP port
+- Index is rebuilt from scratch if `PRAGMA quick_check` fails (corrupt DB auto-recovery)
+- `who_is` and `search speaker` filters expand names via NameVariants before querying
+- `read_meeting` reads `.md` files (not JSON sidecars) to return formatted transcript markdown
+- `recap` preview is first 15 non-empty transcript lines (not a summary — just raw dialogue)
+- All tools are `readOnlyHint: true` — no writes to the data directory

--- a/Transcripted/Onboarding/CLAUDE.md
+++ b/Transcripted/Onboarding/CLAUDE.md
@@ -1,32 +1,34 @@
 # Onboarding
 
-4-step first-run flow that gates access to the main app until permissions and models are ready. 7 Swift files. Dark theme matching the product.
+5-step first-run flow that gates access to the main app until permissions and models are ready. 8 Swift files. Dark theme matching the product.
 
 ## File Index
 
 | File | Purpose |
 |------|---------|
-| `OnboardingState.swift` | Central state manager (`@Observable`). Step progression, permission status, model readiness. |
+| `OnboardingState.swift` | Central state manager (`@Observable`). Step progression, permission status, model readiness, test recording. |
 | `OnboardingContainerView.swift` | View orchestrator. Opacity transitions, circle progress dots, standard nav buttons, auto-advance. |
 | `OnboardingWindow.swift` | NSWindowController. 640x560 window, dark opaque background, fade-in animation, close = skip. |
-| `Steps/WelcomeStep.swift` | Welcome screen. Icon + 3 BenefitCards with simple fade-in. See Steps/CLAUDE.md |
 | `Steps/PreviewStep.swift` | Sample transcript preview. Staggered line reveal showing "aha moment". See Steps/CLAUDE.md |
 | `Steps/PermissionsStep.swift` | Permission request. Mic (REQUIRED to proceed) + Screen Recording (optional). See Steps/CLAUDE.md |
 | `Steps/ModelSetupStep.swift` | Model downloads. Progress bars, download speed/ETA, structured errors. See Steps/CLAUDE.md |
+| `Steps/HowItWorksStep.swift` | Explains menu bar pill location, hotkey, and transcript save path. See Steps/CLAUDE.md |
+| `Steps/TestRecordingStep.swift` | 8-screen guided demo: meets pill UI, live test recording, transcription preview. canProceed when testRecordingPhase == .complete. See Steps/CLAUDE.md |
 
 ## Step Order
 ```
-1. Welcome     -> always canProceed
-2. Preview     -> always canProceed (sample transcript "aha moment")
-3. Permissions  -> canProceed only when microphoneGranted (mic REQUIRED)
-4. Model Setup  -> canProceed only when parakeetReady AND diarizationReady
+1. Preview       -> always canProceed (sample transcript "aha moment")
+2. Permissions   -> canProceed only when microphoneGranted (mic REQUIRED)
+3. Model Setup   -> canProceed only when parakeetReady AND diarizationReady
+4. How It Works  -> always canProceed (menu bar location, hotkey, save path)
+5. Test Recording -> canProceed only when testRecordingPhase == .complete
 ```
 
 ## OnboardingState Key Properties
 ```swift
 // Step navigation
-currentStep: OnboardingStep (.welcome | .preview | .permissions | .modelSetup)
-stepProgress: Double (0.0-1.0), stepNumber: Int (1-4), totalSteps: 4
+currentStep: OnboardingStep (.preview | .permissions | .modelSetup | .howItWorks | .testRecording)
+stepProgress: Double (0.0-1.0), stepNumber: Int (1-5), totalSteps: 5
 
 // Permissions
 microphoneStatus: AVAuthorizationStatus
@@ -43,6 +45,11 @@ parakeetPhase: String, diarizationPhase: String ("Downloading...", "Compiling mo
 isLoadingModels: Bool, modelError: String? (concatenated errors with \n)
 modelErrorKind: DownloadErrorKind? (structured error classification from ModelDownloadService)
 downloadSpeed: Double (bytes/sec, smoothed), estimatedTimeRemaining: TimeInterval? (nil when unknown)
+
+// Test recording (step 5)
+testRecordingPhase: TestRecordingPhase (.ready | .recording | .transcribing | .complete | .failed)
+testRecordingError: String? (e.g. "Recording too short", "No speech detected")
+testRecordingDuration: Int (seconds recorded)
 ```
 
 ## Microphone Permission Fix (OnboardingState.swift + PermissionsStep.swift)

--- a/Transcripted/Onboarding/Steps/CLAUDE.md
+++ b/Transcripted/Onboarding/Steps/CLAUDE.md
@@ -1,34 +1,27 @@
 # Onboarding Steps
 
-4 SwiftUI views implementing individual onboarding steps. Hosted by OnboardingContainerView.swift (parent). WelcomeStep and PreviewStep are stateless; PermissionsStep and ModelSetupStep use `@Bindable var state: OnboardingState`.
+5 SwiftUI views implementing individual onboarding steps. Hosted by OnboardingContainerView.swift (parent). PreviewStep and HowItWorksStep are stateless; PermissionsStep, ModelSetupStep, and TestRecordingStep use `@Bindable var state: OnboardingState`.
 
 ## File Index
 
 | File | Step | canProceed |
 |------|------|------------|
-| `WelcomeStep.swift` | 1. Welcome | Always true |
-| `PreviewStep.swift` | 2. Preview | Always true |
-| `PermissionsStep.swift` | 3. Permissions | Only when microphoneGranted (mic REQUIRED) |
-| `ModelSetupStep.swift` | 4. Model Setup | Only when parakeetReady AND diarizationReady |
+| `PreviewStep.swift` | 1. Preview | Always true |
+| `PermissionsStep.swift` | 2. Permissions | Only when microphoneGranted (mic REQUIRED) |
+| `ModelSetupStep.swift` | 3. Model Setup | Only when parakeetReady AND diarizationReady |
+| `HowItWorksStep.swift` | 4. How It Works | Always true |
+| `TestRecordingStep.swift` | 5. Test Recording | Only when testRecordingPhase == .complete |
 
 ## Step Details
 
-### WelcomeStep (Step 1)
-- Hero icon: waveform.circle.fill, 56pt, flat recordingCoral color
-- 3 BenefitCards (from Design/Components/):
-  - "Transcribe Meetings" (waveform icon)
-  - "Identify Speakers" (person.2.fill icon)
-  - "Completely Private" (lock.shield.fill icon)
-- Simple opacity fade-in (0.3s easeInOut), no stagger
-
-### PreviewStep (Step 2)
+### PreviewStep (Step 1)
 - Sample transcript showing a realistic meeting conversation
 - 6 transcript lines with staggered reveal (0.2s per line)
 - Two speakers: Sarah (recordingCoral) and Mike (processingPurple)
 - Delivers "aha moment" — shows what Transcripted produces before asking for permissions
 - No user action required, always canProceed
 
-### PermissionsStep (Step 3)
+### PermissionsStep (Step 2)
 - 2 simple PermissionRow components (Draft-style HStack layout):
   - **Microphone** (required): mic.fill icon. Requests via `AVCaptureDevice.requestAccess(for: .audio)`
   - **Screen Recording** (recommended): rectangle.inset.filled.and.person.filled icon. Opens System Settings
@@ -37,7 +30,7 @@
 - Continue button DISABLED until mic permission granted (canProceed = microphoneGranted)
 - No "Continue without mic" bypass
 
-### ModelSetupStep (Step 4)
+### ModelSetupStep (Step 3)
 - Downloads 2 models in parallel (`async let`):
   - **Parakeet**: ~483MB expected (ASR model)
   - **Diarization**: ~36MB expected (speaker separation)
@@ -48,6 +41,19 @@
 - Error handling: structured error card with retry button
 - Success message when both models ready
 
+### HowItWorksStep (Step 4)
+- Explains where the app lives (menu bar pill above dock), the global hotkey, and transcript save path
+- 3 InfoCards: "Lives in your menu bar", HotkeyCard (interactive), "Transcripts saved to: ~/Documents/Transcripted/"
+- Simple opacity fade-in animation; no user action required, always canProceed
+- `@available(macOS 26.0, *)`
+
+### TestRecordingStep (Step 5)
+- 8-screen guided product demo (`DemoScreen` enum: meetPill, hoverExpand, duringRecording, letsRecord, liveRecording, processing, result, ready)
+- Live mic level monitoring (smoothedMicLevel), countdown timer, silence detection
+- Drives a real test recording via OnboardingState (`startTestRecording()`, `stopTestRecording()`)
+- Auto-polls transcription result; canProceed only when `testRecordingPhase == .complete`
+- `@available(macOS 26.0, *)`
+
 ## Shared Dependencies
 - `@Bindable var state: OnboardingState` — NOT `@ObservedObject` (because `@Observable` macro)
 - Design components: BenefitCard (from Design/Components/)
@@ -56,14 +62,16 @@
 
 ## Relationships
 - Parent: `OnboardingContainerView.swift` (handles step switching, navigation buttons, auto-advance)
-- State: `OnboardingState.swift` (step progression, permission status, model readiness)
+- State: `OnboardingState.swift` (step progression, permission status, model readiness, test recording)
 - Window: `OnboardingWindow.swift` (NSWindowController, 640x560)
 
 ## Gotchas
 - `@Bindable` not `@ObservedObject` — OnboardingState uses `@Observable` macro, not ObservableObject
+- `WelcomeStep.swift` was removed — step 1 is now PreviewStep
 - ModelSetupStep auto-starts download on `.onAppear` — no user action needed
 - Screen recording detection is NOT a real API — uses `CGWindowListCopyWindowInfo()` side-effect (undocumented)
 - Progress capped at 0.99 to prevent premature "100%" display before CoreML compilation
 - Model errors are concatenated with "\n" (both errors show if both models fail)
 - The app does NOT initialize (no menus, no audio, no floating panel) until onboarding completes
 - Microphone permission is REQUIRED — users cannot proceed without granting it
+- TestRecordingStep requires min 8 seconds of recording before stop is valid


### PR DESCRIPTION
## Summary

Automated nightly CLAUDE.md sync — 4 files updated to match the current codebase state.

## Changes

### `CLAUDE.md` (root)
- **Folder Map**: Updated Onboarding from 7 → 8 files and from 4-step to 5-step flow; updated total Swift file count from ~136 → ~137
- **Tools section**: Expanded TranscriptedCLI description from "1 file" to accurate 5-file breakdown (TranscriptedCLI.swift, BatchCommand.swift, ConfigLoader.swift, DiarizeCommand.swift, RTTMWriter.swift); **added TranscriptedMCP** (8-file MCP server for Claude Desktop) which was entirely undocumented
- **Navigation table**: Updated count from 15 → 16 CLAUDE.md files; added `Tools/TranscriptedMCP/CLAUDE.md` entry; updated Onboarding step descriptions

### `Transcripted/Onboarding/CLAUDE.md`
- File index updated: removed `WelcomeStep.swift` (deleted), added `HowItWorksStep.swift` and `TestRecordingStep.swift`
- Step order updated: 4-step (Welcome→Preview→Permissions→ModelSetup) → 5-step (Preview→Permissions→ModelSetup→HowItWorks→TestRecording)
- `OnboardingStep` enum updated: removed `.welcome`, added `.howItWorks` and `.testRecording`
- `totalSteps` updated: 4 → 5
- Added test recording state properties: `testRecordingPhase`, `testRecordingError`, `testRecordingDuration`

### `Transcripted/Onboarding/Steps/CLAUDE.md`
- File index updated: removed WelcomeStep row, added HowItWorksStep and TestRecordingStep rows
- Step numbering corrected across all sections
- Added descriptions for HowItWorksStep (menu bar pill, hotkey, save path info cards) and TestRecordingStep (8-screen guided demo, live mic level, DemoScreen enum)
- Added gotcha: WelcomeStep was removed; TestRecordingStep requires min 8s recording

### `Tools/TranscriptedMCP/CLAUDE.md` *(new file)*
- Created full documentation for the TranscriptedMCP server (was completely undocumented)
- Covers: 8-file index, 5 tools with params/descriptions, SQLite index schema, name variant logic, FileWatcher behavior, build instructions, Claude Desktop config

## Why
Onboarding underwent a significant restructuring (WelcomeStep removed, 2 new steps added, 5-step flow). TranscriptedCLI was expanded beyond a single file. TranscriptedMCP is a new tool added to Tools/ with no prior CLAUDE.md coverage.