### PR TITLE
security: nightly security audit findings [automated]

### DIFF
--- a/Transcripted/Core/DiagnosticExporter.swift
+++ b/Transcripted/Core/DiagnosticExporter.swift
@@ -156,8 +156,12 @@ class DiagnosticExporter {
 
     /// Generate a pre-filled GitHub issue URL with system info
     static func gitHubIssueURL(title: String = "", body: String = "") -> URL {
+        // Security: avoid force-unwrapping URL(string:) — if URLComponents construction fails
+        // (e.g. due to a future URL change), crash in a diagnostics helper is undesirable.
+        // Use a safe fallback instead of a force unwrap.
+        let fallbackURL = URL(fileURLWithPath: "/")  // Unreachable fallback; construction below always succeeds
         guard var components = URLComponents(string: "https://github.com/r3dbars/transcripted/issues/new") else {
-            return URL(string: "https://github.com/r3dbars/transcripted/issues/new")!
+            return URL(string: "https://github.com/r3dbars/transcripted/issues/new") ?? fallbackURL
         }
         var queryItems: [URLQueryItem] = [
             URLQueryItem(name: "template", value: "bug_report.md"),
@@ -177,6 +181,8 @@ class DiagnosticExporter {
         """
         queryItems.append(URLQueryItem(name: "body", value: fullBody))
         components.queryItems = queryItems
-        return components.url ?? URL(string: "https://github.com/r3dbars/transcripted/issues/new")!
+        // Security: avoid force-unwrap on components.url — fall back to the base URL rather than crashing
+        // if query encoding unexpectedly fails (e.g. extremely long body overflows URL length limits).
+        return components.url ?? URL(string: "https://github.com/r3dbars/transcripted/issues/new") ?? fallbackURL
     }
 }

--- a/Transcripted/Core/TranscriptionPipelineRunner.swift
+++ b/Transcripted/Core/TranscriptionPipelineRunner.swift
@@ -284,8 +284,11 @@ extension TranscriptionTaskManager {
                         let hasQwenSuggestion = qwenName != nil && qwenName != "Unknown"
 
                         let qwenResult: QwenInferenceResult
-                        if hasQwenSuggestion {
-                            qwenResult = .suggested(name: qwenName!)
+                        // Security: guard against force-unwrap; hasQwenSuggestion only becomes true
+                        // when qwenName != nil, but use guard let for defensive nil safety —
+                        // avoids a crash if the predicate logic is ever refactored.
+                        if hasQwenSuggestion, let safeName = qwenName {
+                            qwenResult = .suggested(name: safeName)
                         } else if qwenRan {
                             qwenResult = .noNameFound
                         } else {

--- a/Transcripted/Services/MeetingDetector.swift
+++ b/Transcripted/Services/MeetingDetector.swift
@@ -211,7 +211,10 @@ class MeetingDetector: ObservableObject {
                 silenceStartTime = nil
             } else {
                 if silenceStartTime == nil { silenceStartTime = Date() }
-                let silenceDuration = Date().timeIntervalSince(silenceStartTime!)
+                // Security: guard against force-unwrap — silenceStartTime is set on the line above,
+                // but use guard let for defensive safety in case of future async/reentrant refactors.
+                guard let silenceStart = silenceStartTime else { return }
+                let silenceDuration = Date().timeIntervalSince(silenceStart)
                 if silenceDuration >= silenceGracePeriod {
                     AppLogger.app.info("MeetingDetector: silence grace period elapsed — stopping")
                     if UserDefaults.standard.bool(forKey: "autoRecordMeetings") {
@@ -235,7 +238,11 @@ class MeetingDetector: ObservableObject {
                 bidirectionalStartTime = Date()
                 AppLogger.app.debug("MeetingDetector: bidirectional audio started")
             }
-            let duration = Date().timeIntervalSince(bidirectionalStartTime!)
+            // Security: guard against force-unwrap — bidirectionalStartTime is set above,
+            // but guard let protects against a crash if state is mutated concurrently or
+            // the surrounding logic is refactored in the future.
+            guard let bidirectionalStart = bidirectionalStartTime else { return }
+            let duration = Date().timeIntervalSince(bidirectionalStart)
             if duration >= requiredBidirectionalDuration {
                 let appName = activeMeetingApp ?? "Meeting"
                 AppLogger.app.info("MeetingDetector: sustained bidirectional audio — auto-starting", [


### PR DESCRIPTION
## Nightly Security Audit — 2026-04-02

Automated security review of the Transcripted codebase. Build: ✅ **SUCCEEDED**

---

## Findings Summary

### No Critical, High, or Medium Issues Found

| Category | Status | Notes |
|---|---|---|
| File handling / path traversal | ✅ Clean | All paths sandboxed under ~/Documents/Transcripted/ and ~/Library/. Prefix checks verified in TranscriptSaver, AudioFileManager, FailedTranscriptionManager. |
| SQL injection (SpeakerDatabase) | ✅ Clean | All queries use sqlite3_bind_* parameterized bindings. No string interpolation. |
| SQL injection (StatsDatabase / Queries) | ✅ Clean | All parameterized. Date strings are bound via sqlite3_bind_text, not interpolated. |
| Input validation — audio file inputs | ✅ Clean | RecordingValidator checks file existence, extension allowlist, and size limits. |
| Input validation — speaker names | ✅ Clean | Speaker names used only as display strings or as UUID-keyed filenames (not user-controlled path components). |
| Secrets / hardcoded credentials | ✅ Clean | No API keys, tokens, or passwords found in source. |
| Unsafe pointer usage (CoreAudio) | ✅ Clean | CoreAudioUtils and SystemAudioBufferWriter use withUnsafe* with bounded lifetimes. |
| Race conditions — audio/main thread | ✅ Clean | Audio thread uses serial DispatchQueue; main-thread model uses @MainActor. No unguarded shared mutable state. |
| Sparkle auto-updater security | ✅ Clean | SUFeedURL uses HTTPS. SUPublicEDKey present in Info.plist (EdDSA signature verification enabled). |
| Temp file permissions | ✅ Clean | restrictToOwnerOnly (0o600) called immediately after creating all temp/output files. |
| Model download security | ✅ Clean | ModelDownloadService uses HTTPS-only HuggingFace URLs. No http:// URLs found anywhere. |
| Failed transcription queue path traversal | ✅ Clean | FailedTranscriptionManager validates deserialized audio paths against homeDirectory prefix. |
| Diagnostic temp directory permissions | ✅ Clean | DiagnosticExporter creates its staging tempDir with 0o700. |

---

## Low Severity — Force Unwraps in Active Code Paths (Fixed)

Three force-unwrap (!)-dereferences were replaced with safe alternatives. None are exploitable remotely, but unguarded unwraps on optional state can cause unexpected crashes if surrounding logic is refactored.

### Fix 1 — DiagnosticExporter.swift: Force unwrap on URL(string:) fallback

- **Risk:** Two `URL(string: "https://...")!` force-unwraps in the GitHub issue URL builder. Impossible to fail with a static literal today, but fragile if the URL is ever changed to a variable.
- **Fix:** Replaced both force unwraps with `??`-chained optionals using a safe non-optional fallback.

### Fix 2 — TranscriptionPipelineRunner.swift: Force unwrap on qwenName

- **Risk:** `qwenName!` is guarded by `hasQwenSuggestion` which checks `qwenName != nil`, but if the predicate logic is refactored in the future, the force unwrap becomes a live crash path in the post-transcription naming flow.
- **Fix:** Replaced with `guard let safeName = qwenName` inside the conditional.

### Fix 3 — MeetingDetector.swift: Force unwraps on silenceStartTime and bidirectionalStartTime

- **Risk:** Both optional properties are assigned on the line immediately before the force unwrap. Safe today, but the detector runs on the main actor and could be refactored to be async, making these latent crash sites.
- **Fix:** Replaced both with `guard let` early-exit patterns that document the intent and survive future refactors.

---

## Build Verification

```
xcodebuild -scheme Transcripted -configuration Debug CODE_SIGN_IDENTITY="" ...
→ BUILD SUCCEEDED (0 errors, pre-existing warnings only)
```
