### PR TITLE
refactor: nightly simplification sweep [automated]

### DIFF
--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -24,13 +24,7 @@ final class TranscriptIndex: @unchecked Sendable {
         if sqlite3_open(indexPath.path, &db) != SQLITE_OK {
             throw MCPIndexError.databaseOpenFailed(dbError())
         }
-
-        // Set permissions to owner-only (0o600)
-        chmod(indexPath.path, 0o600)
-
-        exec("PRAGMA journal_mode=WAL")
-        exec("PRAGMA busy_timeout=5000")
-        exec("PRAGMA synchronous=NORMAL")
+        configureDatabase()
 
         // Integrity check
         var stmt: OpaquePointer?
@@ -46,16 +40,23 @@ final class TranscriptIndex: @unchecked Sendable {
                     if sqlite3_open(indexPath.path, &db) != SQLITE_OK {
                         throw MCPIndexError.databaseOpenFailed(dbError())
                     }
-                    chmod(indexPath.path, 0o600)
-                    exec("PRAGMA journal_mode=WAL")
-                    exec("PRAGMA busy_timeout=5000")
-                    exec("PRAGMA synchronous=NORMAL")
+                    configureDatabase()
                 }
             }
             sqlite3_finalize(stmt)
         }
 
         createTables()
+    }
+
+    /// Apply owner-only file permissions and WAL pragmas to an already-opened database handle.
+    /// Mirrors SpeakerDatabase.configureOpenDatabase() — called on initial open and after
+    /// corruption-recovery re-open so setup logic stays in one place.
+    private func configureDatabase() {
+        chmod(indexPath.path, 0o600)
+        exec("PRAGMA journal_mode=WAL")
+        exec("PRAGMA busy_timeout=5000")
+        exec("PRAGMA synchronous=NORMAL")
     }
 
     private func createTables() {

--- a/Transcripted/Core/RetroactiveSpeakerUpdater.swift
+++ b/Transcripted/Core/RetroactiveSpeakerUpdater.swift
@@ -335,8 +335,8 @@ extension TranscriptSaver {
         let stem = transcriptURL.deletingPathExtension().lastPathComponent
         let jsonURL = transcriptURL.deletingLastPathComponent().appendingPathComponent("\(stem).json")
         guard FileManager.default.fileExists(atPath: jsonURL.path),
-              var data = try? Data(contentsOf: jsonURL),
-              var transcript = try? JSONDecoder().decode(AgentTranscript.self, from: data) else { return }
+              let data = try? Data(contentsOf: jsonURL),
+              let transcript = try? JSONDecoder().decode(AgentTranscript.self, from: data) else { return }
 
         // Rebuild speakers with updated names
         var updatedSpeakers = transcript.speakers

--- a/Transcripted/Core/TranscriptionPipelineRunner.swift
+++ b/Transcripted/Core/TranscriptionPipelineRunner.swift
@@ -61,8 +61,6 @@ extension TranscriptionTaskManager {
         // Phase 1.5: Identify speakers — DB knowledge first, then Qwen if needed
         var speakerMappings: [String: SpeakerMapping] = [:]
         var speakerSources: [String: String] = [:]  // "db" per speaker ID
-        var speakerResult: SpeakerIdentificationResult? = nil
-
         // Build DB knowledge snapshot: what do we already know about these speakers?
         let speakerIds = Array(result.systemSpeakerIds).sorted()
         let speakerDB = await MainActor.run { self.transcription.speakerDB }
@@ -126,10 +124,6 @@ extension TranscriptionTaskManager {
                     evidence: "Voice fingerprint match (\(String(format: "%.0f", entry.similarity * 100))%, \(entry.profile.callCount) calls)"
                 ))
             }
-        }
-
-        if !autoAcceptedIds.isEmpty {
-            speakerResult = SpeakerIdentificationResult(speakers: identifiedSpeakers, userSpeakerId: nil)
         }
 
         AppLogger.speakers.info("Per-speaker classification", [

--- a/Transcripted/Core/TranscriptionTypes.swift
+++ b/Transcripted/Core/TranscriptionTypes.swift
@@ -138,12 +138,6 @@ enum QwenInferenceResult {
     case suggested(name: String)
 }
 
-/// Result of speaker identification from voice fingerprint matching
-struct SpeakerIdentificationResult: Codable {
-    let speakers: [IdentifiedSpeaker]
-    let userSpeakerId: String?
-}
-
 /// Individual speaker identified in the call
 struct IdentifiedSpeaker: Codable {
     let name: String


### PR DESCRIPTION
Automated simplification pass. See diff for details.

## Changes

**TranscriptIndex.swift** — Extracted `configureDatabase()` helper to eliminate the duplicated `chmod` + WAL pragma block that appeared verbatim in both the initial open path and the corruption-recovery re-open path. Same pattern that `SpeakerDatabase` already uses.

**TranscriptionPipelineRunner.swift** — Removed dead `speakerResult` variable (assigned on one path, never read anywhere). Also removed `SpeakerIdentificationResult` struct from `TranscriptionTypes.swift` which became unused once that variable was gone.

**RetroactiveSpeakerUpdater.swift** — Changed `var data` / `var transcript` to `let` in guard binding. Neither was ever mutated after capture; this silences two compiler warnings.

## Verification
Build passes: `xcodebuild … BUILD SUCCEEDED` (no new errors or warnings introduced).