### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,14 +11,14 @@ Menu bar-only macOS app for real-time system audio transcription. Pipeline: Core
 - **Protocols**: 7 service protocols in `Services/Protocols/` (SpeechToTextEngine, DiarizationEngine, SpeakerStore, etc.)
 - **DI**: `AppServices` container in `Core/AppServices.swift`
 
-## Folder Map (~138 Swift files, agent-first: max ~300 lines per file, single responsibility)
-- **Core/** (48 files): Audio capture (Audio + 3 extensions), transcription pipeline (TaskManager + 3 extensions), transcript saving (4 files), stats DB (3 files), model downloads (ModelDownloadService), failed transcription retry, file permissions, logging, coordinators (Hotkey, MenuBar, Notification, Window, Recording)
+## Folder Map (~140 Swift files, agent-first: max ~300 lines per file, single responsibility)
+- **Core/** (49 files): Audio capture (Audio + 3 extensions), transcription pipeline (TaskManager + 3 extensions), transcript saving (4 files), stats DB (3 files), model downloads (ModelDownloadService), failed transcription retry, file permissions, logging, system settings helper, coordinators (Hotkey, MenuBar, Notification, Window, Recording)
 - **Services/** (18 files): ML services (11 files) + Protocols/ subdirectory (7 service protocols)
 - **UI/FloatingPanel/** (21 files): Morphing pill UI, aurora state views (3 files), SavedPillView, transcript tray (3 files), speaker naming (3 files), Components/ (16 files), Helpers/ (1 file)
-- **UI/Settings/** (18 files): Settings container + Sections/ (7 section views) + Components/ (6 reusable components) + Models/ (1 file)
+- **UI/Settings/** (19 files): Settings container + Sections/ (8 section views) + Components/ (6 reusable components) + Models/ (1 file)
 - **Onboarding/** (9 files): 6-step first-run flow (Welcome -> Preview -> Permissions -> Model Setup -> How It Works -> Test Recording), dark theme
 - **Design/** (21 files): Colors/ (6 files), Components/ (5 premium components), root tokens (10 files: Spacing, Radius, Typography, Animations, Shadows, ViewModifiers, Gradients, Dimensions, Accessibility, CardModifiers)
-- **Tools/TranscriptedQA/** (12 files): QA testing CLI tool, health checks, transcript validation, database integrity checks, index validation, log analysis
+- **Tools/TranscriptedQA/** (23 files): QA testing CLI tool, health checks, transcript/database/index/log validation, fixture generation, round-trip testing, stress testing
 
 ## Build & Test
 ```bash
@@ -102,9 +102,9 @@ Every folder with ≥2 Swift files has its own CLAUDE.md with file index, refere
 | `Transcripted/UI/FloatingPanel/CLAUDE.md` | Pill state machine, Combine subscriptions, tray states |
 | `Transcripted/UI/FloatingPanel/Components/CLAUDE.md` | Aurora views, speaker naming, error toast, pill overlays |
 | `Transcripted/UI/Settings/CLAUDE.md` | @AppStorage keys, window config, speaker operations |
-| `Transcripted/UI/Settings/Sections/CLAUDE.md` | 7 section views with per-section detail |
+| `Transcripted/UI/Settings/Sections/CLAUDE.md` | 8 section views with per-section detail |
 | `Transcripted/UI/Settings/Components/CLAUDE.md` | CoralToggle, button styles, input components |
-| `Transcripted/Onboarding/CLAUDE.md` | 5-step flow, OnboardingState properties, integration |
+| `Transcripted/Onboarding/CLAUDE.md` | 6-step flow, OnboardingState properties, integration |
 | `Transcripted/Onboarding/Steps/CLAUDE.md` | Preview, Permissions, ModelSetup, HowItWorks, TestRecording step implementations |
 | `Tools/TranscriptedQA/CLAUDE.md` | QA CLI tool, health checks, transcript validation, database/index/log validation |
 | `Tools/TranscriptedMCP/CLAUDE.md` | MCP server tools, SQLite index schema, name variants, file watcher |
@@ -116,10 +116,9 @@ Every folder with ≥2 Swift files has its own CLAUDE.md with file index, refere
 - `UI/FailedTranscriptionsView.swift` — Standalone window for failed transcription management (600x400 min)
 
 ## Tools (external CLI utilities)
-- **Tools/TranscriptedMCP/** (7 source + 4 test Swift files): MCP server (`transcripted-mcp`) for querying transcripts from Claude Desktop or any MCP-compatible client. Exposes 5 read-only tools: `list_meetings` (metadata + participants), `read_meeting` (full transcript content), `search` (full-text with optional speaker/date filters), `who_is` (person profile — meeting history, speaking stats, co-speakers, quotes), `recap` (structured day/week digest with previews). Uses a local SQLite index rebuilt from JSON sidecars. File watcher auto-indexes new transcripts. Data dir: `~/Documents/Transcripted` or `$TRANSCRIPTED_DATA_DIR`. Dependencies: `swift-sdk` MCP library (v0.12.0), `libsqlite3`.
-- **Tools/TranscriptedQA/** (19 Swift files): Standalone Swift CLI (`transcripted-qa`) for validating on-disk artifacts. Subcommands: `validate-all` (default), `validate-transcripts`, `validate-database`, `validate-logs`, `validate-artifacts`, `validate-index`, `check-health`. Validators: TranscriptValidator, SpeakerDBValidator, StatsDBValidator, JSONSidecarValidator, IndexValidator, LogValidator, HealthChecker. Uses `ArgumentParser`.
+- **Tools/TranscriptedMCP/** (7 source + 4 test Swift files): MCP server (`transcripted-mcp`) for querying transcripts from Claude Desktop or any MCP-compatible client. Exposes 5 read-only tools: `list_meetings` (metadata + participants), `read_meeting` (full transcript content), `search` (full-text with optional speaker/date filters), `who_is` (person profile — meeting history, speaking stats, co-speakers, quotes), `recap` (structured day/week digest with previews). Uses a local SQLite index rebuilt from JSON sidecars. File watcher auto-indexes new transcripts. Data dir: `~/Documents/Transcripted` or `$TRANSCRIPTED_DATA_DIR`. Dependencies: `swift-sdk` MCP library (v0.12.0), `libsqlite3`. See `Tools/TranscriptedMCP/CLAUDE.md`.
+- **Tools/TranscriptedQA/** (23 Swift files): Standalone Swift CLI (`transcripted-qa`) for validating on-disk artifacts. Subcommands: `validate-all` (default), `validate-transcripts`, `validate-database`, `validate-logs`, `validate-artifacts`, `validate-index`, `check-health`, `generate-fixtures`, `round-trip`, `stress-test`. Validators: TranscriptValidator, SpeakerDBValidator, StatsDBValidator, JSONSidecarValidator, IndexValidator, LogValidator, HealthChecker. Generators: TestDataGenerator. Uses `ArgumentParser`. See `Tools/TranscriptedQA/CLAUDE.md`.
 - **Tools/TranscriptedCLI/** (5 Swift files): Standalone Swift CLI (`transcripted-cli`) for offline diarization via FluidAudio. Entry: `TranscriptedCLI.swift` (ArgumentParser root). Subcommands: `diarize` (single file, `DiarizeCommand.swift`), `batch` (directory, `BatchCommand.swift`). Shared: `ConfigLoader.swift` (JSON config -> OfflineDiarizerConfig), `RTTMWriter.swift` (RTTM + JSON output).
-- **Tools/TranscriptedMCP/** (8 Swift files): MCP server (`transcripted-mcp`) for Claude Desktop integration. Exposes 5 tools: `list_meetings`, `read_meeting`, `search`, `who_is`, `recap`. Uses SQLite index (`mcp_index.sqlite`) via `TranscriptIndex.swift`; file watching via `FileWatcher.swift`; name variant expansion via `NameVariants.swift` (mirrors SpeakerProfileMerger). Data dir: `~/Documents/Transcripted/` (override via `TRANSCRIPTED_DATA_DIR` env). See `Tools/TranscriptedMCP/CLAUDE.md`.
 
 ## Documentation
 See CONTRIBUTING.md for full development guidelines.

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -8,8 +8,7 @@ Standalone MCP server (`transcripted-mcp`) for querying Transcripted meeting dat
 |------|---------|
 | `Main.swift` | `@main` entry point: initialises TranscriptIndex, starts FileWatcher, creates MCP Server with StdioTransport |
 | `ToolHandlers.swift` | Registers all 5 MCP tool handlers with the server; contains per-tool request parsing and JSON serialisation |
-| `TranscriptIndex.swift` | SQLite-backed index rebuilt from JSON sidecars; `reconcile()` full rebuild, `indexSingleFile()` incremental update, query methods for all tools |
-| `TranscriptIndex+Queries.swift` | Complex query methods on `TranscriptIndex`: `listMeetings`, `searchUtterances`, `getPersonProfile`, `indexSidecar`. |
+| `TranscriptIndex.swift` | SQLite-backed index rebuilt from JSON sidecars; `reconcile()` full rebuild, `indexSingleFile()` incremental update, all query methods (`listMeetings`, `searchUtterances`, `getPersonProfile`, `indexSidecar`) |
 | `TranscriptLoader.swift` | Loads `.md` transcript files from disk for `read_meeting` |
 | `Models.swift` | All Codable input/output structs (AgentTranscript, MeetingSummary, SearchResult, SpeakerHistoryResult, etc.) and `MCPIndexError` |
 | `NameVariants.swift` | Speaker name fuzzy-matching — `Mike` finds `Michael`, handles nicknames and first-name-only lookups |

--- a/Tools/TranscriptedQA/CLAUDE.md
+++ b/Tools/TranscriptedQA/CLAUDE.md
@@ -1,10 +1,16 @@
 # TranscriptedQA - QA Testing CLI Tool
 
-QA testing suite for Transcripted. 12 Swift files across Commands/, Validators/, Utilities/, and Models/.
+QA testing suite for Transcripted. 23 Swift files across Commands/, Generators/, Validators/, Utilities/, Models/, and root.
 
 ## File Index
 
-### Commands/ (7 files)
+### Root (1 file)
+
+| File | Purpose |
+|------|---------|
+| `TranscriptedQA.swift` | CLI entry point (`@main`), registers all subcommands via ArgumentParser |
+
+### Commands/ (10 files)
 
 | File | Purpose |
 |------|---------|
@@ -15,6 +21,15 @@ QA testing suite for Transcripted. 12 Swift files across Commands/, Validators/,
 | `ValidateIndex.swift` | Transcript index consistency, missing sidecars, orphan files |
 | `ValidateLogs.swift` | Log file analysis, error patterns, warning frequency |
 | `ValidateTranscripts.swift` | Transcript content validation, speaker attribution, timestamp checks |
+| `GenerateFixtures.swift` | Generate valid test data (transcripts, sidecars, DB records) that passes all validators; outputs to configurable directory (default: `/tmp/transcripted-test-data`) |
+| `RoundTrip.swift` | Generate test data, validate, corrupt, re-validate — verifies validators catch real defects |
+| `StressTest.swift` | Generate large datasets (configurable transcript/speaker/utterance counts) and validate performance + correctness |
+
+### Generators/ (1 file)
+
+| File | Purpose |
+|------|---------|
+| `TestDataGenerator.swift` | Shared fixture builder used by GenerateFixtures, RoundTrip, and StressTest commands |
 
 ### Validators/ (7 files)
 
@@ -55,6 +70,11 @@ transcripted-qa validate-database
 transcripted-qa validate-transcripts
 transcripted-qa validate-index
 transcripted-qa validate-logs
+
+# Test data generation
+transcripted-qa generate-fixtures --output /tmp/my-test-data
+transcripted-qa round-trip
+transcripted-qa stress-test --transcripts 100 --speakers-per-transcript 4 --utterances-per-transcript 200
 ```
 
 ## Validation Results
@@ -73,6 +93,9 @@ transcripted-qa validate-logs
 - **Index validation**: Transcript/sidecar pairing, orphan file detection
 - **Log analysis**: Error pattern detection, warning frequency tracking
 - **Artifact validation**: YAML frontmatter, JSON sidecars, speaker clips
+- **Fixture generation**: `generate-fixtures` creates valid test data for use in CI or manual testing
+- **Round-trip testing**: `round-trip` validates that validators correctly catch injected corruption
+- **Stress testing**: `stress-test` generates large datasets to surface performance and correctness issues
 
 ## Gotchas
 

--- a/Transcripted/Core/CLAUDE.md
+++ b/Transcripted/Core/CLAUDE.md
@@ -1,6 +1,6 @@
 # Core Folder
 
-Audio capture pipeline, transcription orchestration, file saving, stats tracking, model downloads, error recovery, and app lifecycle. 48 Swift files (including Logging/).
+Audio capture pipeline, transcription orchestration, file saving, stats tracking, model downloads, error recovery, and app lifecycle. 49 Swift files (including Logging/).
 
 ## File Index
 
@@ -49,6 +49,7 @@ Audio capture pipeline, transcription orchestration, file saving, stats tracking
 | `WindowCoordinator.swift` | @MainActor | Window lifecycle (settings, onboarding, panel visibility) |
 | `AppDelegateDebug.swift` | @MainActor | DEBUG-only helpers (reset onboarding, test naming tray) |
 | `DiagnosticExporter.swift` | -- | Diagnostic bundle export for bug reports |
+| `SystemSettingsHelper.swift` | -- | Opens System Settings panes for permission fixes (microphone, screen recording) via `x-apple.systempreferences:` URL scheme |
 | `Clipboard.swift` | -- | Clipboard management |
 | `DateFormattingHelper.swift` | -- | Date formatting utilities |
 | `DateParser.swift` | -- | Date parsing utilities |

--- a/Transcripted/UI/Settings/CLAUDE.md
+++ b/Transcripted/UI/Settings/CLAUDE.md
@@ -1,6 +1,6 @@
 # Settings
 
-Single-page scrolling settings dashboard. 18 Swift files across root, Components/, Sections/, and Models/.
+Single-page scrolling settings dashboard. 19 Swift files across root, Components/, Sections/, and Models/.
 
 ## File Index
 
@@ -13,7 +13,7 @@ Single-page scrolling settings dashboard. 18 Swift files across root, Components
 | `SettingsWindowController.swift` | NSWindow management, triggers migration check on show |
 | `MigrationOverlayView.swift` | Progress overlay for transcript migration (dark scrim + progress bar) |
 
-### Sections/ (7 files) — see Sections/CLAUDE.md
+### Sections/ (8 files) — see Sections/CLAUDE.md
 
 | File | Purpose |
 |------|---------|
@@ -24,6 +24,7 @@ Single-page scrolling settings dashboard. 18 Swift files across root, Components
 | `MeetingDetectionSection.swift` | Auto-record toggle, supported apps info |
 | `SpeakerIntelligenceSection.swift` | Qwen toggle, model status/download, progress bar |
 | `AIServicesSection.swift` | Parakeet + Sortformer status badges, "100% local" info |
+| `TroubleshootingSection.swift` | Permission status (mic + screen recording), data locations (Open in Finder), reset (re-run onboarding, reset all settings) |
 
 ### Components/ (6 files) — see Components/CLAUDE.md
 

--- a/Transcripted/UI/Settings/Sections/CLAUDE.md
+++ b/Transcripted/UI/Settings/Sections/CLAUDE.md
@@ -1,6 +1,6 @@
 # Settings Sections
 
-7 section views composing the settings dashboard. Each is a self-contained SwiftUI view rendered inside a SettingsSectionCard. All @MainActor.
+8 section views composing the settings dashboard. Each is a self-contained SwiftUI view rendered inside a SettingsSectionCard. All @MainActor.
 
 ## File Index
 
@@ -13,6 +13,7 @@
 | `MeetingDetectionSection.swift` | "MEETING DETECTION" | Auto-record toggle, supported apps info |
 | `SpeakerIntelligenceSection.swift` | "SPEAKER INTELLIGENCE" | Qwen toggle, model status/download, progress bar |
 | `AIServicesSection.swift` | "AI SERVICES" | Parakeet + Sortformer status badges, "100% local" info |
+| `TroubleshootingSection.swift` | "TROUBLESHOOTING" | Permission status rows (mic + screen recording with Fix buttons), data location rows (Transcripts, Logs, Model Cache with Open in Finder), reset actions (Re-run Onboarding, Reset All Settings with confirmation) |
 
 ## Section Details
 
@@ -64,6 +65,13 @@
 - Info text: "100% local transcription. No cloud API, no internet, no cost."
 - Requirements: "English only · macOS 14.2+ · 16 GB RAM recommended"
 
+### TroubleshootingSection
+- **Permission Status group**: Rows for Microphone (`AVCaptureDevice.authorizationStatus`) and Screen Recording (`CGWindowListCopyWindowInfo` side-effect check). Granted shows green checkmark; denied shows error/warning icon + "Fix" button that opens System Settings deep link via `x-apple.systempreferences:` URL
+- **Data Locations group**: Rows for Transcripts, Logs (`~/Library/Logs/Transcripted`), and Model Cache (`~/Library/Caches/models/mlx-community`). Each has "Open in Finder" button; creates directory if missing
+- **Reset group**: "Re-run Onboarding" (calls `OnboardingState.resetOnboarding()`, shows onboarding window) + "Reset All Settings" (clears all UserDefaults for bundle, restarts onboarding, does NOT delete transcripts) with destructive confirmation alert
+- `@available(macOS 26.0, *)` — macOS 26+ only
+- Paths shortened to `~`-relative via `shortenedPath()` helper
+
 ## @AppStorage Keys Used by Sections
 | Key | Section | Type | Default |
 |-----|---------|------|---------|
@@ -77,6 +85,7 @@
 - Reusable components from: Components/ (SettingsSectionCard, SettingsToggleRow, SettingsTextField, SettingsPathRow)
 - Speaker operations use: SpeakerDatabase, SpeakerClipExtractor, RetroactiveSpeakerUpdater (Core/)
 - Stats from: StatsService → StatsDatabase (Core/)
+- TroubleshootingSection uses: OnboardingState.resetOnboarding() + OnboardingWindowController (Onboarding/), TranscriptSaver.defaultSaveDirectory (Core/)
 
 ## Gotchas
 - FailedTranscriptionsSection only appears when FailedTranscriptionManager has items


### PR DESCRIPTION
## Summary

Nightly CLAUDE.md sync for changes since the last review. 6 files updated.

## Changes

### `CLAUDE.md` (root)
- Folder map: Core/ 48→49 files, UI/Settings/ 18→19 files, TranscriptedQA 12→23 files, total ~138→~140 Swift files
- Onboarding navigation entry: corrected "5-step" to "6-step"
- Navigation table: Settings/Sections entry corrected to "8 section views"
- Tools section: deduplicated duplicate TranscriptedMCP entry, updated TranscriptedQA file count (19→23) and added new subcommands

### `Transcripted/Core/CLAUDE.md`
- File count: 48→49
- Added `SystemSettingsHelper.swift` entry (new file: opens System Settings panes for permission fixes via `x-apple.systempreferences:` URL scheme)

### `Transcripted/UI/Settings/CLAUDE.md`
- File count: 18→19
- Added `TroubleshootingSection.swift` row in Sections/ table

### `Transcripted/UI/Settings/Sections/CLAUDE.md`
- Section view count: 7→8
- Added `TroubleshootingSection.swift` entry with details (permission status, data locations, reset actions)
- Added TroubleshootingSection detail block (permission rows, data location rows, reset group, `@available(macOS 26.0, *)` annotation)
- Updated Relationships to include OnboardingState and TranscriptSaver dependencies

### `Tools/TranscriptedQA/CLAUDE.md`
- File count: 12→23
- Added missing Commands: `GenerateFixtures.swift`, `RoundTrip.swift`, `StressTest.swift`
- Added `Generators/` section with `TestDataGenerator.swift`
- Added root-level `TranscriptedQA.swift` entry (CLI `@main` entry point)
- Updated Usage section with new subcommand examples
- Updated Key Features section for fixture generation, round-trip testing, stress testing

### `Tools/TranscriptedMCP/CLAUDE.md`
- Removed stale `TranscriptIndex+Queries.swift` entry — this file no longer exists (its query methods were merged into `TranscriptIndex.swift`)
- Updated `TranscriptIndex.swift` description to reflect it now contains all query methods

## Why
These files were added/changed recently and the CLAUDE.md docs were not updated to match. No Swift code was modified.