### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -173,14 +173,6 @@ private func handleListMeetings(params: CallTool.Parameters, index: TranscriptIn
     return .init(content: [.text(text: String(data: json, encoding: .utf8) ?? "[]")])
 }
 
-/// Returns the YAML frontmatter block (opening `---` through closing `---\n`) as a Substring, or nil.
-private func frontmatterBlock(in content: String) -> Substring? {
-    guard content.hasPrefix("---"),
-          let endRange = content.range(of: "\n---\n", range: content.index(content.startIndex, offsetBy: 3)..<content.endIndex)
-    else { return nil }
-    return content[content.startIndex...endRange.upperBound]
-}
-
 /// Extract title from markdown YAML frontmatter
 private func extractTitle(from content: String) -> String? {
     // Minimum valid frontmatter is "---\n...\n---\n" (8+ chars)
@@ -222,11 +214,6 @@ private func handleReadMeeting(params: CallTool.Parameters, dataDir: URL) throws
     // Reject path traversal (e.g., filename = "../../etc/passwd")
     guard mdURL.path.hasPrefix(dataDir.standardizedFileURL.path + "/") else {
         return .init(content: [.text(text: "Invalid filename: \(filename)")], isError: true)
-    }
-
-    // Prevent path traversal — resolved path must stay within dataDir
-    guard mdURL.standardizedFileURL.path.hasPrefix(dataDir.standardizedFileURL.path) else {
-        return .init(content: [.text(text: "Invalid filename")], isError: true)
     }
 
     guard let content = try? String(contentsOf: mdURL, encoding: .utf8) else {

--- a/Transcripted/Core/RecordingValidator.swift
+++ b/Transcripted/Core/RecordingValidator.swift
@@ -138,7 +138,7 @@ class RecordingValidator {
     /// Checks if audio devices are accessible
     private static func checkAudioDevices() -> ValidationResult? {
         // Check microphone device
-        guard let defaultInputDevice = AVCaptureDevice.default(for: .audio) else {
+        guard AVCaptureDevice.default(for: .audio) != nil else {
             return .failure("No microphone found. Connect a microphone or headset and try again.")
         }
 

--- a/Transcripted/UI/Settings/Sections/TroubleshootingSection.swift
+++ b/Transcripted/UI/Settings/Sections/TroubleshootingSection.swift
@@ -41,11 +41,7 @@ struct TroubleshootingSettingsSection: View {
                 notGrantedLabel: "Denied",
                 notGrantedIcon: "xmark.circle.fill",
                 notGrantedColor: .errorRed,
-                fixAction: {
-                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
-                        NSWorkspace.shared.open(url)
-                    }
-                }
+                fixAction: { SystemSettingsHelper.openMicrophoneSettings() }
             )
 
             permissionRow(
@@ -55,11 +51,7 @@ struct TroubleshootingSettingsSection: View {
                 notGrantedLabel: "Not Granted",
                 notGrantedIcon: "exclamationmark.triangle.fill",
                 notGrantedColor: .warningAmber,
-                fixAction: {
-                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
-                        NSWorkspace.shared.open(url)
-                    }
-                }
+                fixAction: { SystemSettingsHelper.openScreenRecordingSettings() }
             )
         }
     }
@@ -207,14 +199,7 @@ struct TroubleshootingSettingsSection: View {
     }
 
     private var screenRecordingGranted: Bool {
-        guard let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] else {
-            return false
-        }
-        let myPID = ProcessInfo.processInfo.processIdentifier
-        return windowList.contains { dict in
-            guard let pid = dict[kCGWindowOwnerPID as String] as? Int32 else { return false }
-            return pid != myPID
-        }
+        CGPreflightScreenCaptureAccess()
     }
 
     private var transcriptsPath: String {


### PR DESCRIPTION
## Summary

- **TroubleshootingSection — screen recording check**: Replaced `CGWindowListCopyWindowInfo` heuristic with `CGPreflightScreenCaptureAccess()`, consistent with how `OnboardingState.swift` checks the same permission. The old approach was unreliable (false negative when no other apps have windows on screen).
- **TroubleshootingSection — SystemSettingsHelper**: Replaced inline `URL(string:)` construction in `fixAction` closures with the `SystemSettingsHelper` helpers introduced in the same PR. Keeps the single URL string in one place.
- **RecordingValidator — unused binding**: `guard let defaultInputDevice = ...` bound a value that was never referenced. Changed to `guard ... != nil`.
- **ToolHandlers — dead code**: Removed `frontmatterBlock(in:)` which was defined but never called (all callers use `extractTitle` or `extractDialogueLines` instead).
- **ToolHandlers — redundant guard**: Removed the second path-traversal guard in `handleReadMeeting`. After `mdURL.path.hasPrefix(dataDir.path + "/")` passes, `mdURL.standardizedFileURL.path.hasPrefix(dataDir.path)` is trivially true and can never catch an additional case.

## Test plan
- [x] `xcodebuild … build` succeeds (no new errors or warnings introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)