### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Transcripted/Core/RecordingValidator.swift
+++ b/Transcripted/Core/RecordingValidator.swift
@@ -138,7 +138,7 @@ class RecordingValidator {
     /// Checks if audio devices are accessible
     private static func checkAudioDevices() -> ValidationResult? {
         // Check microphone device
-        guard let defaultInputDevice = AVCaptureDevice.default(for: .audio) else {
+        guard AVCaptureDevice.default(for: .audio) != nil else {
             return .failure("No microphone found. Connect a microphone or headset and try again.")
         }
 

--- a/Transcripted/UI/Settings/Sections/TroubleshootingSection.swift
+++ b/Transcripted/UI/Settings/Sections/TroubleshootingSection.swift
@@ -41,11 +41,7 @@ struct TroubleshootingSettingsSection: View {
                 notGrantedLabel: "Denied",
                 notGrantedIcon: "xmark.circle.fill",
                 notGrantedColor: .errorRed,
-                fixAction: {
-                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
-                        NSWorkspace.shared.open(url)
-                    }
-                }
+                fixAction: { SystemSettingsHelper.openMicrophoneSettings() }
             )
 
             permissionRow(
@@ -55,11 +51,7 @@ struct TroubleshootingSettingsSection: View {
                 notGrantedLabel: "Not Granted",
                 notGrantedIcon: "exclamationmark.triangle.fill",
                 notGrantedColor: .warningAmber,
-                fixAction: {
-                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
-                        NSWorkspace.shared.open(url)
-                    }
-                }
+                fixAction: { SystemSettingsHelper.openScreenRecordingSettings() }
             )
         }
     }
@@ -207,14 +199,7 @@ struct TroubleshootingSettingsSection: View {
     }
 
     private var screenRecordingGranted: Bool {
-        guard let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] else {
-            return false
-        }
-        let myPID = ProcessInfo.processInfo.processIdentifier
-        return windowList.contains { dict in
-            guard let pid = dict[kCGWindowOwnerPID as String] as? Int32 else { return false }
-            return pid != myPID
-        }
+        CGPreflightScreenCaptureAccess()
     }
 
     private var transcriptsPath: String {


### PR DESCRIPTION
## Summary

Fixes three bugs introduced by PR #140 (fix/recording-error-feedback):

- **Compiler warning** (`RecordingValidator.swift:141`): `guard let defaultInputDevice = ...` bound a variable that was never used — only the existence check matters. Changed to `guard AVCaptureDevice.default(for: .audio) != nil`.
- **Inconsistent permission check** (`TroubleshootingSection.swift`): `screenRecordingGranted` still used the old `CGWindowListCopyWindowInfo` heuristic while `OnboardingState.checkScreenRecordingPermission()` was modernized to `CGPreflightScreenCaptureAccess()` in the same PR. The two approaches can return different answers for the same permission state, causing the Troubleshooting section to show a different status than onboarding. Fixed to use `CGPreflightScreenCaptureAccess()`.
- **Dead code** (`TroubleshootingSection.swift`): `SystemSettingsHelper` was introduced in PR #140 to centralize the Settings URL-opening logic, but `TroubleshootingSection` duplicated the logic inline instead of using it. The helper was never called anywhere. Fixed by wiring up `SystemSettingsHelper.openMicrophoneSettings()` / `openScreenRecordingSettings()`.

## Test plan

- [ ] Build passes: `xcodebuild -scheme Transcripted -configuration Debug build` ✅
- [ ] Open Settings → Troubleshooting — permission row status matches System Settings reality
- [ ] "Fix" button on a denied permission opens the correct System Settings pane
- [ ] No new compiler warnings in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)