### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -8,8 +8,7 @@ Standalone MCP server (`transcripted-mcp`) for querying Transcripted meeting dat
 |------|---------|
 | `Main.swift` | `@main` entry point: initialises TranscriptIndex, starts FileWatcher, creates MCP Server with StdioTransport |
 | `ToolHandlers.swift` | Registers all 5 MCP tool handlers with the server; contains per-tool request parsing and JSON serialisation |
-| `TranscriptIndex.swift` | SQLite-backed index rebuilt from JSON sidecars; `reconcile()` full rebuild, `indexSingleFile()` incremental update, query methods for all tools |
-| `TranscriptIndex+Queries.swift` | Complex query methods on `TranscriptIndex`: `listMeetings`, `searchUtterances`, `getPersonProfile`, `indexSidecar`. |
+| `TranscriptIndex.swift` | SQLite-backed index rebuilt from JSON sidecars; `reconcile()` full rebuild, `indexSingleFile()` incremental update, query methods (`listMeetings`, `searchUtterances`, `getPersonProfile`, `indexSidecar`) |
 | `TranscriptLoader.swift` | Loads `.md` transcript files from disk for `read_meeting` |
 | `Models.swift` | All Codable input/output structs (AgentTranscript, MeetingSummary, SearchResult, SpeakerHistoryResult, etc.) and `MCPIndexError` |
 | `NameVariants.swift` | Speaker name fuzzy-matching — `Mike` finds `Michael`, handles nicknames and first-name-only lookups |

--- a/Transcripted/Onboarding/CLAUDE.md
+++ b/Transcripted/Onboarding/CLAUDE.md
@@ -39,6 +39,7 @@ isMicrophoneRequestInProgress: Bool (guards concurrent permission requests)
 microphoneGranted: Bool (computed: microphoneStatus == .authorized)
 allPermissionsGranted: Bool  // requires microphone only
 allPermissionsFullyGranted: Bool  // Both mic + screen recording
+screenRecordingSkipped: Bool  // Onboarding completed but screen recording not granted (computed)
 
 // Model setup
 parakeetReady: Bool, diarizationReady: Bool, modelsReady: Bool (computed: both true)
@@ -95,7 +96,7 @@ setupApp()
 
 ## Permission Detection Details
 - **Microphone**: Direct `AVCaptureDevice.authorizationStatus(for: .audio)` — REQUIRED to proceed past step 3
-- **Screen Recording**: Side-effect check via `CGWindowListCopyWindowInfo()` - if returns windows, permission granted. Not officially documented API.
+- **Screen Recording**: Official API via `CGPreflightScreenCaptureAccess()` (macOS 15+, class requires macOS 26.0+)
 - Permission rows show 4 states: notRequested (Grant button), pending (spinner), granted (checkmark), denied (Settings button)
 - Denied state shows guidance text: "Microphone access wasn't granted. Tap 'Try Again' to see the permission prompt, or open Settings to enable it manually."
 - Continue button DISABLED until mic permission granted (canProceed = microphoneGranted)
@@ -114,7 +115,7 @@ setupApp()
 - Close button still calls completeOnboarding + onComplete as safety valve (prevents invisible app state)
 
 ## Gotchas
-- Screen recording detection is not a real API - uses CGWindowListCopyWindowInfo side-effect
+- Screen recording detection in OnboardingState uses official `CGPreflightScreenCaptureAccess()` API (TroubleshootingSection still uses older CGWindowListCopyWindowInfo side-effect)
 - Multiple concurrent loadModels() calls blocked by isLoadingModels guard
 - Model error messages concatenated with "\n" (both errors show if both fail)
 - Progress monitoring caps at 0.99 to prevent premature "100%" display

--- a/Transcripted/Onboarding/Steps/CLAUDE.md
+++ b/Transcripted/Onboarding/Steps/CLAUDE.md
@@ -32,7 +32,8 @@
   - **Microphone** (required): mic.fill icon. Requests via `AVCaptureDevice.requestAccess(for: .audio)`
   - **Screen Recording** (recommended): rectangle.inset.filled.and.person.filled icon. Opens System Settings
 - 4 status states per row: notRequested (Grant button), pending (spinner), granted (checkmark), denied (Settings button)
-- Denied state shows guidance text: "Enable it in System Settings to continue"
+- Denied state shows guidance text: "Microphone access wasn't granted. Tap 'Try Again' to see the permission prompt, or open Settings to enable it manually."
+- Amber warning callout when screen recording not granted: explains system audio won't capture other participants without it
 - Continue button DISABLED until mic permission granted (canProceed = microphoneGranted)
 - No "Continue without mic" bypass
 
@@ -74,7 +75,7 @@
 ## Gotchas
 - `@Bindable` not `@ObservedObject` — OnboardingState uses `@Observable` macro, not ObservableObject
 - ModelSetupStep auto-starts download on `.onAppear` — no user action needed
-- Screen recording detection is NOT a real API — uses `CGWindowListCopyWindowInfo()` side-effect (undocumented)
+- Screen recording detection in OnboardingState now uses official `CGPreflightScreenCaptureAccess()` API (TroubleshootingSection still uses older CGWindowListCopyWindowInfo side-effect)
 - Progress capped at 0.99 to prevent premature "100%" display before CoreML compilation
 - Model errors are concatenated with "\n" (both errors show if both models fail)
 - The app does NOT initialize (no menus, no audio, no floating panel) until onboarding completes


### PR DESCRIPTION
## Summary
- **Tools/TranscriptedMCP/CLAUDE.md**: Removed stale `TranscriptIndex+Queries.swift` entry (file was merged into `TranscriptIndex.swift` during refactor PR #136), updated TranscriptIndex description to include query methods
- **Transcripted/Onboarding/CLAUDE.md**: Added `screenRecordingSkipped` computed property, updated screen recording detection from `CGWindowListCopyWindowInfo` side-effect to official `CGPreflightScreenCaptureAccess()` API (PR #140)
- **Transcripted/Onboarding/Steps/CLAUDE.md**: Updated PermissionsStep denied-state text, added amber warning callout for screen recording, updated screen recording detection gotcha

## Context
Changes driven by PR #140 (recording error feedback + troubleshooting settings) and PR #136 (MCP refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)