### PR TITLE
docs: sync Onboarding CLAUDE.md with screen recording API migration

### DIFF
--- a/Transcripted/Onboarding/CLAUDE.md
+++ b/Transcripted/Onboarding/CLAUDE.md
@@ -39,6 +39,7 @@ isMicrophoneRequestInProgress: Bool (guards concurrent permission requests)
 microphoneGranted: Bool (computed: microphoneStatus == .authorized)
 allPermissionsGranted: Bool  // requires microphone only
 allPermissionsFullyGranted: Bool  // Both mic + screen recording
+screenRecordingSkipped: Bool  // Onboarding completed but screen recording not granted (computed)
 
 // Model setup
 parakeetReady: Bool, diarizationReady: Bool, modelsReady: Bool (computed: both true)
@@ -95,7 +96,7 @@ setupApp()
 
 ## Permission Detection Details
 - **Microphone**: Direct `AVCaptureDevice.authorizationStatus(for: .audio)` — REQUIRED to proceed past step 3
-- **Screen Recording**: Side-effect check via `CGWindowListCopyWindowInfo()` - if returns windows, permission granted. Not officially documented API.
+- **Screen Recording**: Official API via `CGPreflightScreenCaptureAccess()` (macOS 15+)
 - Permission rows show 4 states: notRequested (Grant button), pending (spinner), granted (checkmark), denied (Settings button)
 - Denied state shows guidance text: "Microphone access wasn't granted. Tap 'Try Again' to see the permission prompt, or open Settings to enable it manually."
 - Continue button DISABLED until mic permission granted (canProceed = microphoneGranted)
@@ -114,7 +115,7 @@ setupApp()
 - Close button still calls completeOnboarding + onComplete as safety valve (prevents invisible app state)
 
 ## Gotchas
-- Screen recording detection is not a real API - uses CGWindowListCopyWindowInfo side-effect
+- Screen recording detection uses official `CGPreflightScreenCaptureAccess()` API in both OnboardingState and TroubleshootingSection
 - Multiple concurrent loadModels() calls blocked by isLoadingModels guard
 - Model error messages concatenated with "\n" (both errors show if both fail)
 - Progress monitoring caps at 0.99 to prevent premature "100%" display

--- a/Transcripted/Onboarding/Steps/CLAUDE.md
+++ b/Transcripted/Onboarding/Steps/CLAUDE.md
@@ -32,7 +32,8 @@
   - **Microphone** (required): mic.fill icon. Requests via `AVCaptureDevice.requestAccess(for: .audio)`
   - **Screen Recording** (recommended): rectangle.inset.filled.and.person.filled icon. Opens System Settings
 - 4 status states per row: notRequested (Grant button), pending (spinner), granted (checkmark), denied (Settings button)
-- Denied state shows guidance text: "Enable it in System Settings to continue"
+- Denied state shows guidance text: "Microphone access wasn't granted. Tap 'Try Again' to see the permission prompt, or open Settings to enable it manually."
+- Amber warning callout when screen recording not granted: explains system audio won't capture other participants without it
 - Continue button DISABLED until mic permission granted (canProceed = microphoneGranted)
 - No "Continue without mic" bypass
 
@@ -74,7 +75,7 @@
 ## Gotchas
 - `@Bindable` not `@ObservedObject` — OnboardingState uses `@Observable` macro, not ObservableObject
 - ModelSetupStep auto-starts download on `.onAppear` — no user action needed
-- Screen recording detection is NOT a real API — uses `CGWindowListCopyWindowInfo()` side-effect (undocumented)
+- Screen recording detection uses official `CGPreflightScreenCaptureAccess()` API
 - Progress capped at 0.99 to prevent premature "100%" display before CoreML compilation
 - Model errors are concatenated with "\n" (both errors show if both models fail)
 - The app does NOT initialize (no menus, no audio, no floating panel) until onboarding completes


### PR DESCRIPTION
## Summary
- Updated Onboarding/CLAUDE.md: added `screenRecordingSkipped` property, updated screen recording detection from `CGWindowListCopyWindowInfo` to `CGPreflightScreenCaptureAccess()`
- Updated Onboarding/Steps/CLAUDE.md: corrected denied-state guidance text, added amber warning callout note, updated screen recording API reference

Extracted from closed PR #147 (MCP CLAUDE.md changes already applied via #143).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>