### PR TITLE
fix: deep reliability audit — 10 crash/race/leak fixes

### DIFF
--- a/Transcripted/Core/Audio.swift
+++ b/Transcripted/Core/Audio.swift
@@ -82,10 +82,26 @@ class Audio: ObservableObject {
     }
 
     /// Gaps detected during recording (sleep/wake, device switches)
-    var recordingGaps: [AudioGap] = []
+    /// Thread-safe: mutated from main thread (wake handler) + background thread (device recovery)
+    private var _recordingGaps: [AudioGap] = []
+    private let recordingGapsLock = NSLock()
+    var recordingGaps: [AudioGap] {
+        get { recordingGapsLock.lock(); defer { recordingGapsLock.unlock() }; return _recordingGaps }
+        set { recordingGapsLock.lock(); defer { recordingGapsLock.unlock() }; _recordingGaps = newValue }
+    }
+    func appendRecordingGap(_ gap: AudioGap) {
+        recordingGapsLock.lock(); defer { recordingGapsLock.unlock() }
+        _recordingGaps.append(gap)
+    }
 
     /// Count of device switches during this recording
-    var deviceSwitchCount: Int = 0
+    /// Thread-safe: reset on main thread, incremented on background recovery thread
+    private var _deviceSwitchCount: Int = 0
+    private let deviceSwitchCountLock = NSLock()
+    var deviceSwitchCount: Int {
+        get { deviceSwitchCountLock.lock(); defer { deviceSwitchCountLock.unlock() }; return _deviceSwitchCount }
+        set { deviceSwitchCountLock.lock(); defer { deviceSwitchCountLock.unlock() }; _deviceSwitchCount = newValue }
+    }
 
     /// Timestamp when system started sleeping (for gap calculation)
     var sleepTimestamp: Date?
@@ -170,8 +186,18 @@ class Audio: ObservableObject {
     let micAudioFileQueue = DispatchQueue(label: "MicAudioFileWrite", qos: .utility)
 
     // Audio format conversion (multi-channel to mono)
-    var monoOutputFormat: AVAudioFormat?
-    var inputChannelCount: AVAudioChannelCount = 1
+    // Thread-safe: written during init + device recovery, read during mic buffer handling
+    private var _monoOutputFormat: AVAudioFormat?
+    private var _inputChannelCount: AVAudioChannelCount = 1
+    private let formatLock = NSLock()
+    var monoOutputFormat: AVAudioFormat? {
+        get { formatLock.lock(); defer { formatLock.unlock() }; return _monoOutputFormat }
+        set { formatLock.lock(); defer { formatLock.unlock() }; _monoOutputFormat = newValue }
+    }
+    var inputChannelCount: AVAudioChannelCount {
+        get { formatLock.lock(); defer { formatLock.unlock() }; return _inputChannelCount }
+        set { formatLock.lock(); defer { formatLock.unlock() }; _inputChannelCount = newValue }
+    }
 
     // Throttle system audio visualizer updates (skip every other callback)
     // Protected by systemLevelLock — accessed from I/O callback thread
@@ -287,7 +313,7 @@ class Audio: ObservableObject {
                         duration: Date().timeIntervalSince(sleepStart),
                         reason: "Sleep/wake"
                     )
-                    self.recordingGaps.append(gap)
+                    self.appendRecordingGap(gap)
                     AppLogger.audio.info("Recorded sleep/wake gap", ["gap": gap.description])
                 }
                 self.sleepTimestamp = nil

--- a/Transcripted/Core/AudioDeviceRecovery.swift
+++ b/Transcripted/Core/AudioDeviceRecovery.swift
@@ -185,7 +185,7 @@ extension Audio {
                 duration: Date().timeIntervalSince(switchStart),
                 reason: "Device switch"
             )
-            recordingGaps.append(gap)
+            appendRecordingGap(gap)
             AppLogger.audioMic.info("Device recovery complete, recording continues", ["gap": gap.description])
         } catch {
             AppLogger.audioMic.error("Failed to restart engine", ["error": error.localizedDescription])

--- a/Transcripted/Core/NotificationCoordinator.swift
+++ b/Transcripted/Core/NotificationCoordinator.swift
@@ -121,8 +121,7 @@ extension AppDelegate {
             default:
                 break
             }
+            completionHandler()
         }
-
-        completionHandler()
     }
 }

--- a/Transcripted/Core/StatsDatabase.swift
+++ b/Transcripted/Core/StatsDatabase.swift
@@ -22,7 +22,16 @@ final class StatsDatabase {
 
     private init() {
         // Store database in the Transcripted folder
-        let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        // Guard against force unwrap: FileManager.urls() is empty in restricted sandboxes
+        guard let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            AppLogger.stats.error("CRITICAL: Documents directory unavailable — falling back to temp directory for stats database")
+            let tempFolder = FileManager.default.temporaryDirectory.appendingPathComponent("Transcripted")
+            try? FileManager.default.createDirectory(at: tempFolder, withIntermediateDirectories: true)
+            dbPath = tempFolder.appendingPathComponent("stats.sqlite")
+            openDatabase()
+            createTables()
+            return
+        }
         let transcriptedFolder = documentsPath.appendingPathComponent("Transcripted")
 
         // Create folder if needed
@@ -42,15 +51,59 @@ final class StatsDatabase {
 
     private func openDatabase() {
         if sqlite3_open(dbPath.path, &db) != SQLITE_OK {
-            AppLogger.stats.error("Failed to open database", ["path": dbPath.path])
+            let sqliteError = db.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown"
+            AppLogger.stats.error("Failed to open stats database", ["path": dbPath.path, "sqlite_error": sqliteError])
             isDatabaseOpen = false
         } else {
-            isDatabaseOpen = true
-            FileManager.default.restrictToOwnerOnly(atPath: dbPath.path)
-            // WAL mode for crash safety, busy timeout to avoid SQLITE_BUSY, NORMAL sync for performance
-            sqlite3_exec(db, "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA synchronous=NORMAL;", nil, nil, nil)
-            AppLogger.stats.info("Opened database", ["path": dbPath.path])
+            configureOpenDatabase()
+
+            // Corruption detection: run quick_check to verify database integrity
+            if !verifyDatabaseIntegrity() {
+                AppLogger.stats.error("CRITICAL: Stats database corrupt — backing up and recreating", ["path": dbPath.path])
+                sqlite3_close(db)
+                db = nil
+                // Backup corrupt file with timestamp
+                let backupName = "stats_corrupt_\(DateFormattingHelper.formatFilename(Date())).sqlite"
+                let backupPath = dbPath.deletingLastPathComponent().appendingPathComponent(backupName)
+                try? FileManager.default.moveItem(at: dbPath, to: backupPath)
+                // Recreate fresh database
+                if sqlite3_open(dbPath.path, &db) == SQLITE_OK {
+                    configureOpenDatabase()
+                    AppLogger.stats.info("Recreated fresh database after corruption recovery")
+                } else {
+                    isDatabaseOpen = false
+                    AppLogger.stats.error("Failed to recreate database after corruption recovery")
+                }
+            } else {
+                AppLogger.stats.info("Opened database", ["path": dbPath.path])
+            }
         }
+    }
+
+    /// Apply permissions and WAL pragmas to an already-opened database handle.
+    /// Called on both initial open and corruption-recovery re-open.
+    private func configureOpenDatabase() {
+        isDatabaseOpen = true
+        FileManager.default.restrictToOwnerOnly(atPath: dbPath.path)
+        // WAL mode for crash safety, busy timeout to avoid SQLITE_BUSY, NORMAL sync for performance
+        sqlite3_exec(db, "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA synchronous=NORMAL;", nil, nil, nil)
+    }
+
+    /// Verify database integrity using PRAGMA quick_check.
+    /// Returns true if the database is healthy.
+    private func verifyDatabaseIntegrity() -> Bool {
+        guard let db = db else { return false }
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, "PRAGMA quick_check;", -1, &stmt, nil) == SQLITE_OK else {
+            return false
+        }
+        defer { sqlite3_finalize(stmt) }
+        if sqlite3_step(stmt) == SQLITE_ROW {
+            if let text = sqlite3_column_text(stmt, 0) {
+                return String(cString: text) == "ok"
+            }
+        }
+        return false
     }
 
     /// Execute multiple writes atomically — if the app crashes mid-block, all changes are rolled back.
@@ -194,9 +247,10 @@ final class StatsDatabase {
 
         if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
             while sqlite3_step(statement) == SQLITE_ROW {
-                let id = String(cString: sqlite3_column_text(statement, 0))
-                let dateStr = String(cString: sqlite3_column_text(statement, 1))
-                let timeStr = String(cString: sqlite3_column_text(statement, 2))
+                guard let idPtr = sqlite3_column_text(statement, 0) else { continue }
+                let id = String(cString: idPtr)
+                let dateStr = sqlite3_column_text(statement, 1).map(String.init(cString:)) ?? ""
+                let timeStr = sqlite3_column_text(statement, 2).map(String.init(cString:)) ?? ""
                 let duration = Int(sqlite3_column_int(statement, 3))
                 let wordCount = Int(sqlite3_column_int(statement, 4))
                 let speakerCount = Int(sqlite3_column_int(statement, 5))

--- a/Transcripted/Core/StatsDatabaseQueries.swift
+++ b/Transcripted/Core/StatsDatabaseQueries.swift
@@ -29,9 +29,10 @@ extension StatsDatabase {
             sqlite3_bind_text(statement, 2, (endStr as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
             while sqlite3_step(statement) == SQLITE_ROW {
-                let id = String(cString: sqlite3_column_text(statement, 0))
-                let dateStr = String(cString: sqlite3_column_text(statement, 1))
-                let timeStr = String(cString: sqlite3_column_text(statement, 2))
+                guard let idPtr = sqlite3_column_text(statement, 0) else { continue }
+                let id = String(cString: idPtr)
+                let dateStr = sqlite3_column_text(statement, 1).map(String.init(cString:)) ?? ""
+                let timeStr = sqlite3_column_text(statement, 2).map(String.init(cString:)) ?? ""
                 let duration = Int(sqlite3_column_int(statement, 3))
                 let wordCount = Int(sqlite3_column_int(statement, 4))
                 let speakerCount = Int(sqlite3_column_int(statement, 5))
@@ -96,7 +97,7 @@ extension StatsDatabase {
             sqlite3_bind_text(statement, 2, (endStr as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
             while sqlite3_step(statement) == SQLITE_ROW {
-                let dateStr = String(cString: sqlite3_column_text(statement, 0))
+                let dateStr = sqlite3_column_text(statement, 0).map(String.init(cString:)) ?? ""
                 let recordingCount = Int(sqlite3_column_int(statement, 1))
                 let totalDuration = Int(sqlite3_column_int(statement, 2))
                 let actionItems = Int(sqlite3_column_int(statement, 3))
@@ -131,7 +132,7 @@ extension StatsDatabase {
 
         if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
             while sqlite3_step(statement) == SQLITE_ROW {
-                let dateStr = String(cString: sqlite3_column_text(statement, 0))
+                let dateStr = sqlite3_column_text(statement, 0).map(String.init(cString:)) ?? ""
                 dates.append(dateStr)
             }
         } else {

--- a/Transcripted/Core/TranscriptionTaskManager.swift
+++ b/Transcripted/Core/TranscriptionTaskManager.swift
@@ -39,6 +39,19 @@ class TranscriptionTaskManager: ObservableObject {
     /// Start a new transcription task in the background
     func startTranscription(micURL: URL, systemURL: URL?, outputFolder: URL, healthInfo: RecordingHealthInfo? = nil) {
 
+        // Guard: reject concurrent pipelines to prevent model contention
+        if !activeTasks.isEmpty {
+            AppLogger.pipeline.warning("Rejecting transcription — another pipeline is already active", ["activeCount": "\(activeTasks.count)"])
+            failedTranscriptionManager.addFailedTranscription(
+                micAudioURL: micURL,
+                systemAudioURL: systemURL,
+                errorMessage: "Transcription already in progress"
+            )
+            displayStatus = .failed(message: "Transcription already in progress")
+            scheduleStatusReset(delay: 4)
+            return
+        }
+
         // Cancel the pre-load timeout — the pipeline will handle Qwen cleanup itself
         qwenTimeoutTask?.cancel()
         qwenTimeoutTask = nil

--- a/Transcripted/Services/SpeakerDatabase.swift
+++ b/Transcripted/Services/SpeakerDatabase.swift
@@ -18,7 +18,13 @@ final class SpeakerDatabase {
 
     private init() {
         guard let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
-            fatalError("SpeakerDatabase: no documents directory available")
+            AppLogger.speakers.error("CRITICAL: Documents directory unavailable — falling back to temp directory for speaker database")
+            let tempFolder = FileManager.default.temporaryDirectory.appendingPathComponent("Transcripted")
+            try? FileManager.default.createDirectory(at: tempFolder, withIntermediateDirectories: true)
+            dbPath = tempFolder.appendingPathComponent("speakers.sqlite")
+            openDatabase()
+            createTables()
+            return
         }
         let transcriptedFolder = documentsPath.appendingPathComponent("Transcripted")
         try? FileManager.default.createDirectory(at: transcriptedFolder, withIntermediateDirectories: true)
@@ -324,7 +330,7 @@ final class SpeakerDatabase {
     ///   0=id, 1=display_name, 2=name_source, 3=embedding,
     ///   4=first_seen, 5=last_seen, 6=call_count, 7=confidence, 8=dispute_count
     private func parseSpeakerRow(_ statement: OpaquePointer, isoFormatter: ISO8601DateFormatter) -> SpeakerProfile {
-        let idStr = String(cString: sqlite3_column_text(statement, 0))
+        let idStr = sqlite3_column_text(statement, 0).map(String.init(cString:)) ?? ""
         let displayName: String? = sqlite3_column_text(statement, 1).map { String(cString: $0) }
         let nameSource: String? = sqlite3_column_text(statement, 2).map { String(cString: $0) }
 
@@ -340,8 +346,8 @@ final class SpeakerDatabase {
             ))
         }
 
-        let firstSeenStr = String(cString: sqlite3_column_text(statement, 4))
-        let lastSeenStr = String(cString: sqlite3_column_text(statement, 5))
+        let firstSeenStr = sqlite3_column_text(statement, 4).map(String.init(cString:)) ?? ""
+        let lastSeenStr = sqlite3_column_text(statement, 5).map(String.init(cString:)) ?? ""
         let callCount = Int(sqlite3_column_int(statement, 6))
         let confidence = sqlite3_column_double(statement, 7)
         let disputeCount = Int(sqlite3_column_int(statement, 8))

--- a/Transcripted/UI/FloatingPanel/Components/AttentionPromptView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/AttentionPromptView.swift
@@ -12,6 +12,7 @@ struct AttentionPromptView: View {
 
     @State private var isVisible = false
     @State private var dismissProgress: CGFloat = 1.0
+    @State private var dismissTask: Task<Void, Never>?
 
     private let autoDismissSeconds: Double = 10.0
 
@@ -165,13 +166,17 @@ struct AttentionPromptView: View {
     }
 
     private func startDismissCountdown() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + autoDismissSeconds) {
+        // Cancel any existing timer to prevent stacking
+        dismissTask?.cancel()
+        dismissTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: UInt64(autoDismissSeconds * 1_000_000_000))
+            guard !Task.isCancelled else { return }
             withAnimation(.easeOut(duration: 0.3)) {
                 isVisible = false
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                onDismiss()
-            }
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard !Task.isCancelled else { return }
+            onDismiss()
         }
     }
 }

--- a/Transcripted/UI/FloatingPanel/Components/PillErrorView.swift
+++ b/Transcripted/UI/FloatingPanel/Components/PillErrorView.swift
@@ -12,6 +12,7 @@ struct PillErrorView: View {
 
     @State private var shakeOffset: CGFloat = 0
     @State private var contentOpacity: Double = 0
+    @State private var dismissTask: Task<Void, Never>?
 
     var body: some View {
         ZStack {
@@ -90,14 +91,17 @@ struct PillErrorView: View {
             }
         }
 
-        // Auto-dismiss after 4 seconds
-        DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+        // Auto-dismiss after 4 seconds (cancellable to prevent timer stacking)
+        dismissTask?.cancel()
+        dismissTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            guard !Task.isCancelled else { return }
             withAnimation(.easeOut(duration: 0.3)) {
                 contentOpacity = 0
             }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                isVisible = false
-            }
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard !Task.isCancelled else { return }
+            isVisible = false
         }
     }
 }

--- a/Transcripted/UI/FloatingPanel/FloatingPanelController.swift
+++ b/Transcripted/UI/FloatingPanel/FloatingPanelController.swift
@@ -84,6 +84,22 @@ class FloatingPanelController: NSWindowController, NSWindowDelegate {
 
         // Wire up pill state transitions based on app events
         setupStateBindings()
+
+        // Reposition pill when displays change (external monitor connect/disconnect)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(screenParametersDidChange(_:)),
+            name: NSApplication.didChangeScreenParametersNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func screenParametersDidChange(_ notification: Notification) {
+        repositionIfNeeded()
     }
 
     required init?(coder: NSCoder) {

--- a/Transcripted/UI/FloatingPanel/FloatingPanelView.swift
+++ b/Transcripted/UI/FloatingPanel/FloatingPanelView.swift
@@ -232,6 +232,13 @@ struct FloatingPanelView: View {
             }
         }
         .onDisappear { removeEscapeMonitor() }
+        // Backup cleanup: if the hosting NSWindow is torn down without onDisappear firing,
+        // this catches the close notification and removes leaked monitors.
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.willCloseNotification)) { notification in
+            guard let window = notification.object as? NSPanel,
+                  window.level == .floating else { return }
+            removeEscapeMonitor()
+        }
         // Trigger error toasts based on displayStatus changes
         // (Success is now shown in-pill via SavedPillView, not as overlay)
         // Note: Use Task to debounce rapid status changes and prevent


### PR DESCRIPTION
## Summary
Deep reliability audit found 1 CRITICAL, 12 HIGH, 22 MEDIUM issues. This PR fixes the top 10.

## Fixes
- **Audio data races** (3): recordingGaps COW crash, deviceSwitchCount race, monoOutputFormat/inputChannelCount race during device recovery
- **SQLite nil crashes** (4): 10 `String(cString:)` calls on nullable pointers, StatsDB integrity check + force subscript, SpeakerDB fatalError removal
- **UI reliability** (3): display-change observer, event monitor leak cleanup, timer stacking
- **Concurrency** (2): concurrent pipeline guard, notification completionHandler timing

## Test plan
- [x] `xcodebuild test` — 550 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)