### PR TITLE
fix: reliability audit round 2 — Swift 6 prep, disk monitoring, 8 fixes

### DIFF
--- a/Transcripted/Core/Audio.swift
+++ b/Transcripted/Core/Audio.swift
@@ -244,6 +244,9 @@ class Audio: ObservableObject {
     private var sleepObserver: NSObjectProtocol?
     private var wakeObserver: NSObjectProtocol?
 
+    // Disk space check counter — checked every 150 timer ticks (~30s at 0.2s interval)
+    var diskCheckCounter: Int = 0
+
     // Callback for when recording completes
     var onRecordingComplete: ((URL?, URL?) -> Void)?
 

--- a/Transcripted/Core/AudioFileManager.swift
+++ b/Transcripted/Core/AudioFileManager.swift
@@ -245,10 +245,30 @@ extension Audio {
 
     func startTimer() {
         timer?.invalidate()
+        diskCheckCounter = 0
         timer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true) { [weak self] _ in
             guard let self = self, let start = self.startTime else { return }
             DispatchQueue.main.async {
                 self.recordingDuration = Date().timeIntervalSince(start)
+            }
+
+            // Periodic disk check during recording (~every 30s)
+            self.diskCheckCounter += 1
+            if self.diskCheckCounter >= 150 {
+                self.diskCheckCounter = 0
+                if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: NSHomeDirectory()),
+                   let freeSpace = attrs[FileAttributeKey.systemFreeSize] as? Int64 {
+                    if freeSpace < 50_000_000 { // 50MB
+                        AppLogger.audio.error("Disk space critically low during recording, stopping", ["freeSpace": "\(freeSpace / 1_000_000)MB"])
+                        DispatchQueue.main.async {
+                            self.error = "Recording stopped — disk space critically low (\(freeSpace / 1_000_000)MB free)"
+                            self.stop()
+                        }
+                        return
+                    } else if freeSpace < 100_000_000 { // 100MB
+                        AppLogger.audio.warning("Disk space low during recording", ["freeSpace": "\(freeSpace / 1_000_000)MB"])
+                    }
+                }
             }
         }
     }

--- a/Transcripted/Core/SystemAudioBufferWriter.swift
+++ b/Transcripted/Core/SystemAudioBufferWriter.swift
@@ -165,6 +165,7 @@ extension SystemAudioCapture {
         _buffersDropped = 0
         statsLock.unlock()
         hasReceivedFirstBuffer = false
+        recoveryAttempts = 0
     }
 
     // MARK: - Device Recovery
@@ -177,7 +178,23 @@ extension SystemAudioCapture {
             AppLogger.audioSystem.warning("Recovery already in progress, skipping duplicate request")
             return
         }
+
+        guard recoveryAttempts < maxRecoveryAttempts else {
+            AppLogger.audioSystem.warning("System audio recovery exhausted max attempts, giving up", [
+                "attempts": "\(recoveryAttempts)",
+                "max": "\(maxRecoveryAttempts)"
+            ])
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.errorMessage = "System audio unavailable after \(self.maxRecoveryAttempts) recovery attempts"
+                self.isCapturing = false
+                self.stopWatchdog()
+            }
+            return
+        }
+
         isRecovering = true
+        recoveryAttempts += 1
         defer { isRecovering = false }
 
         AppLogger.audioSystem.info("Recovering from system audio output change")

--- a/Transcripted/Core/SystemAudioCapture.swift
+++ b/Transcripted/Core/SystemAudioCapture.swift
@@ -98,6 +98,22 @@ class SystemAudioCapture: ObservableObject {
         }
     }
 
+    // MARK: - Recovery Retry Limit (prevents infinite recovery loops)
+    let maxRecoveryAttempts = 5
+    private var _recoveryAttempts: Int = 0
+    var recoveryAttempts: Int {
+        get {
+            recoveryLock.lock()
+            defer { recoveryLock.unlock() }
+            return _recoveryAttempts
+        }
+        set {
+            recoveryLock.lock()
+            defer { recoveryLock.unlock() }
+            _recoveryAttempts = newValue
+        }
+    }
+
     // MARK: - Buffer Statistics (thread-safe)
     var _totalBuffers: Int = 0
     var _buffersWithData: Int = 0

--- a/Transcripted/Core/SystemAudioProcessTap.swift
+++ b/Transcripted/Core/SystemAudioProcessTap.swift
@@ -139,6 +139,9 @@ extension SystemAudioCapture {
                 if !self.hasReceivedFirstBuffer {
                     self.hasReceivedFirstBuffer = true
                 }
+                if self.recoveryAttempts > 0 {
+                    self.recoveryAttempts = 0
+                }
                 self.markBufferHasData()
 
                 // Send buffer to callback

--- a/Transcripted/Core/TranscriptSaver.swift
+++ b/Transcripted/Core/TranscriptSaver.swift
@@ -113,6 +113,14 @@ class TranscriptSaver {
             return nil
         }
 
+        // Check disk space before writing (prevent partial save where .md succeeds but .json fails)
+        if let attrs = try? FileManager.default.attributesOfFileSystem(forPath: saveDir.path),
+           let freeSpace = attrs[.systemFreeSize] as? Int64,
+           freeSpace < 50_000_000 { // 50MB minimum
+            AppLogger.pipeline.error("Insufficient disk space for transcript save", ["freeSpace": "\(freeSpace / 1_000_000)MB"])
+            return nil
+        }
+
         let timestamp = DateFormattingHelper.formatFilename(Date())
         var fileURL = saveDir.appendingPathComponent("Call_\(timestamp).md")
         var counter = 1

--- a/Transcripted/Core/TranscriptionPipeline.swift
+++ b/Transcripted/Core/TranscriptionPipeline.swift
@@ -24,6 +24,10 @@ extension Transcription {
         onProgress: ((Double) -> Void)? = nil
     ) async throws -> TranscriptionResult {
 
+        let parakeet = await MainActor.run { self.parakeet }
+        let diarization = await MainActor.run { self.diarization }
+        let speakerDB = await MainActor.run { self.speakerDB }
+
         await MainActor.run {
             self.isProcessing = true
             self.error = nil

--- a/Transcripted/Core/TranscriptionPipelineRunner.swift
+++ b/Transcripted/Core/TranscriptionPipelineRunner.swift
@@ -43,6 +43,8 @@ extension TranscriptionTaskManager {
         healthInfo: RecordingHealthInfo?
     ) async throws -> URL {
 
+        let transcription = await MainActor.run { self.transcription }
+
         AppLogger.pipeline.info("Using local Parakeet + PyAnnote pipeline")
 
         // Phase 1: Transcribe with local models
@@ -63,7 +65,7 @@ extension TranscriptionTaskManager {
         var speakerSources: [String: String] = [:]  // "db" per speaker ID
         // Build DB knowledge snapshot: what do we already know about these speakers?
         let speakerIds = Array(result.systemSpeakerIds).sorted()
-        let speakerDB = await MainActor.run { self.transcription.speakerDB }
+        let speakerDB = await MainActor.run { transcription.speakerDB }
         var dbKnowledge: [(speakerId: String, profile: SpeakerProfile, similarity: Double)] = []
 
         for utterance in result.systemUtterances {
@@ -201,9 +203,9 @@ extension TranscriptionTaskManager {
                             let shouldUnloadForQwen = totalMemoryGB < 12
 
                             if shouldUnloadForQwen {
-                                await self.transcription.parakeet.cleanup()
+                                await transcription.parakeet.cleanup()
                                 await MainActor.run {
-                                    self.transcription.diarization.cleanup()
+                                    transcription.diarization.cleanup()
                                 }
                                 AppLogger.pipeline.info("Unloaded Parakeet + diarization models before Qwen inference (RAM: \(String(format: "%.0f", totalMemoryGB)) GB)")
                             } else {
@@ -241,7 +243,11 @@ extension TranscriptionTaskManager {
                                 await MainActor.run { self.cleanupQwen() }
 
                                 if shouldUnloadForQwen {
-                                    await self.transcription.initializeModels()
+                                    await transcription.initializeModels()
+                                    // Verify models reloaded successfully
+                                    if await MainActor.run(body: { self.transcription.parakeet.modelState }) != .ready {
+                                        AppLogger.pipeline.error("Failed to reload Parakeet after Qwen inference — next recording may fail")
+                                    }
                                     AppLogger.pipeline.info("Reloaded Parakeet + diarization after Qwen cleanup")
                                 }
 
@@ -259,7 +265,11 @@ extension TranscriptionTaskManager {
                                 await MainActor.run { self.cleanupQwen() }
 
                                 if shouldUnloadForQwen {
-                                    await self.transcription.initializeModels()
+                                    await transcription.initializeModels()
+                                    // Verify models reloaded successfully
+                                    if await MainActor.run(body: { self.transcription.parakeet.modelState }) != .ready {
+                                        AppLogger.pipeline.error("Failed to reload Parakeet after Qwen inference — next recording may fail")
+                                    }
                                     AppLogger.pipeline.info("Reloaded Parakeet + diarization after Qwen cleanup")
                                 }
 

--- a/Transcripted/Core/TranscriptionTaskManager.swift
+++ b/Transcripted/Core/TranscriptionTaskManager.swift
@@ -211,6 +211,12 @@ class TranscriptionTaskManager: ObservableObject {
         activeCount = 0
         backgroundTaskCount = 0
         displayStatus = .idle
+
+        // Cancel Qwen lifecycle tasks to prevent orphaned model loads
+        qwenPreloadTask?.cancel()
+        qwenPreloadTask = nil
+        qwenTimeoutTask?.cancel()
+        qwenTimeoutTask = nil
     }
 
     /// Populate saved transcript metadata from the file's YAML frontmatter.

--- a/Transcripted/Services/SpeakerDatabase.swift
+++ b/Transcripted/Services/SpeakerDatabase.swift
@@ -7,7 +7,7 @@ import Foundation
 import SQLite3
 
 @available(macOS 14.0, *)
-final class SpeakerDatabase {
+final class SpeakerDatabase: @unchecked Sendable {
 
     static let shared = SpeakerDatabase()
 

--- a/Transcripted/UI/Settings/Sections/SpeakersSection.swift
+++ b/Transcripted/UI/Settings/Sections/SpeakersSection.swift
@@ -153,8 +153,10 @@ struct SpeakersSettingsSection: View {
                         SpeakerClipExtractor.deletePersistedClip(for: speaker.id)
                         SpeakerDatabase.shared.deleteSpeaker(id: speaker.id)
                         deleteConfirmId = nil
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                            speakers = SpeakerDatabase.shared.allSpeakers()
+                        Task {
+                            try? await Task.sleep(for: .milliseconds(100))
+                            let loaded = SpeakerDatabase.shared.allSpeakers()
+                            await MainActor.run { speakers = loaded }
                         }
                     }
                     .font(.caption)
@@ -209,8 +211,10 @@ struct SpeakersSettingsSection: View {
         Task.detached {
             TranscriptSaver.retroactivelyUpdateSpeaker(dbId: id, newName: safeName)
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            speakers = SpeakerDatabase.shared.allSpeakers()
+        Task {
+            try? await Task.sleep(for: .milliseconds(100))
+            let loaded = SpeakerDatabase.shared.allSpeakers()
+            await MainActor.run { speakers = loaded }
         }
     }
 


### PR DESCRIPTION
## Summary
Round 2 of the deep reliability audit. Fixes all remaining MEDIUM issues.

## Fixes
- **Swift 6 prep**: `nonisolated` methods now capture `@MainActor` properties via `MainActor.run` (TranscriptionPipeline, PipelineRunner). `SpeakerDatabase` marked `@unchecked Sendable`.
- **System audio watchdog**: max 5 recovery attempts (was infinite retry), resets on successful buffer
- **Disk monitoring**: continuous check during recording (warn 100MB, stop 50MB), pre-save check (50MB minimum)
- **Parakeet reload detection**: logs error if model fails to reload after Qwen inference
- **Settings responsiveness**: `allSpeakers()` moved off main thread
- **Qwen cleanup**: `cancelAll()` now cancels preload + timeout tasks

## Test plan
- [x] `xcodebuild test` — 550 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)