### PR TITLE
refactor: nightly simplification sweep [automated]

### DIFF
--- a/Transcripted/Core/Audio.swift
+++ b/Transcripted/Core/Audio.swift
@@ -379,47 +379,11 @@ class Audio: ObservableObject {
             return
         }
 
-        // Set isStarting to prevent double-start during async setup
-        isStarting = true
-        error = nil
-        systemBufferCount = 0  // Reset debug counter (lock-protected)
-        resetSilenceTracking()  // Start fresh silence tracking
-        systemAudioStatus = .healthy  // Assume healthy until we hear otherwise
-        systemAudioSilenceStart = nil  // Reset system audio silence tracking
-
-        // Reset health tracking for new recording session
-        recordingGaps = []
-        deviceSwitchCount = 0
-        sleepTimestamp = nil
-        lastRecoveryTime = nil
-        consecutiveMicWriteErrors = 0
-        consecutiveSystemWriteErrors = 0
-        systemAudioFailed = false
-
-        AppLogger.audio.info("Starting audio capture")
-
-        onRecordingStart?()
-
-        Task {
-            do {
-                try await startAudioCapture()
-                await MainActor.run {
-                    self.isRecording = true
-                    self.isStarting = false
-                }
-            } catch {
-                await MainActor.run {
-                    self.error = "Recording failed to start: \(error.localizedDescription). Try quitting and reopening Transcripted."
-                    self.isRecording = false
-                    self.isStarting = false
-                    self.stop()
-                }
-            }
-        }
+        startAudioCaptureAsync()
     }
 
-    /// Helper method to start audio capture asynchronously
-    /// Used when permission is already granted or after permission request completes
+    /// Resets recording state and launches the capture task.
+    /// Called directly when permission is already granted, or from the permission callback.
     private func startAudioCaptureAsync() {
         // Set isStarting to prevent double-start during async setup
         isStarting = true

--- a/Transcripted/Core/AudioFileManager.swift
+++ b/Transcripted/Core/AudioFileManager.swift
@@ -247,10 +247,9 @@ extension Audio {
         timer?.invalidate()
         diskCheckCounter = 0
         timer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true) { [weak self] _ in
+            // Timer is scheduled on the main run loop (startTimer is called from MainActor.run)
             guard let self = self, let start = self.startTime else { return }
-            DispatchQueue.main.async {
-                self.recordingDuration = Date().timeIntervalSince(start)
-            }
+            self.recordingDuration = Date().timeIntervalSince(start)
 
             // Periodic disk check during recording (~every 30s)
             self.diskCheckCounter += 1
@@ -260,10 +259,8 @@ extension Audio {
                    let freeSpace = attrs[FileAttributeKey.systemFreeSize] as? Int64 {
                     if freeSpace < 50_000_000 { // 50MB
                         AppLogger.audio.error("Disk space critically low during recording, stopping", ["freeSpace": "\(freeSpace / 1_000_000)MB"])
-                        DispatchQueue.main.async {
-                            self.error = "Recording stopped — disk space critically low (\(freeSpace / 1_000_000)MB free)"
-                            self.stop()
-                        }
+                        self.error = "Recording stopped — disk space critically low (\(freeSpace / 1_000_000)MB free)"
+                        self.stop()
                         return
                     } else if freeSpace < 100_000_000 { // 100MB
                         AppLogger.audio.warning("Disk space low during recording", ["freeSpace": "\(freeSpace / 1_000_000)MB"])

--- a/Transcripted/Core/RetroactiveSpeakerUpdater.swift
+++ b/Transcripted/Core/RetroactiveSpeakerUpdater.swift
@@ -136,6 +136,13 @@ extension TranscriptSaver {
         }
     }
 
+    private static let speakerBreakdownRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"- \*\*(.+?):\*\* (\d+) utterances?, ~(\d+) words?, (\d+):(\d+)"#
+    )
+    private static let footerSpeakerCountRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\| (\d+) speakers\*"#
+    )
+
     /// Merge duplicate speaker lines in the "Remote Speaker Breakdown" section.
     /// When two diarizer IDs get the same name, their stats should be combined
     /// into a single line (summing utterances, words, and speaking time).
@@ -157,8 +164,7 @@ extension TranscriptSaver {
             var speakingSeconds: Double = 0
         }
 
-        let pattern = #"- \*\*(.+?):\*\* (\d+) utterances?, ~(\d+) words?, (\d+):(\d+)"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return content }
+        guard let regex = speakerBreakdownRegex else { return content }
 
         var statsByName: [String: SpeakerStats] = [:]
         var nameOrder: [String] = []
@@ -216,8 +222,7 @@ extension TranscriptSaver {
         // The footer uses total = mic_speakers + system_speakers.
         // We can't know mic_speakers from here, so fix the total by the same delta.
         let delta = oldSystemSpeakers - newSystemSpeakers
-        let footerPattern = #"\| (\d+) speakers\*"#
-        if let footerRegex = try? NSRegularExpression(pattern: footerPattern),
+        if let footerRegex = footerSpeakerCountRegex,
            let footerMatch = footerRegex.firstMatch(in: result, range: NSRange(location: 0, length: (result as NSString).length)),
            let oldTotal = Int((result as NSString).substring(with: footerMatch.range(at: 1))) {
             let newTotal = oldTotal - delta

--- a/Transcripted/Core/StatsDatabase.swift
+++ b/Transcripted/Core/StatsDatabase.swift
@@ -25,6 +25,9 @@ final class StatsDatabase {
         return fmt
     }()
 
+    /// Cached ISO 8601 formatter for the created_at column.
+    private static let isoFormatter = ISO8601DateFormatter()
+
     /// SQLITE_TRANSIENT tells SQLite to copy text immediately, preventing dangling pointer issues
     /// from temporary (NSString).utf8String pointers
     let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
@@ -203,18 +206,9 @@ final class StatsDatabase {
             var statement: OpaquePointer?
 
             if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
-                let dateFormatter = DateFormatter()
-                dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-                dateFormatter.dateFormat = "yyyy-MM-dd"
-                let dateString = dateFormatter.string(from: metadata.date)
-
-                let timeFormatter = DateFormatter()
-                timeFormatter.locale = Locale(identifier: "en_US_POSIX")
-                timeFormatter.dateFormat = "HH:mm:ss"
-                let timeString = timeFormatter.string(from: metadata.date)
-
-                let isoFormatter = ISO8601DateFormatter()
-                let createdAt = isoFormatter.string(from: metadata.date)
+                let dateString = DateFormattingHelper.formatISODate(metadata.date)
+                let timeString = DateFormattingHelper.formatTimeOnly(metadata.date)
+                let createdAt = Self.isoFormatter.string(from: metadata.date)
 
                 sqlite3_bind_text(statement, 1, (metadata.id as NSString).utf8String, -1, SQLITE_TRANSIENT)
                 sqlite3_bind_text(statement, 2, (dateString as NSString).utf8String, -1, SQLITE_TRANSIENT)
@@ -300,9 +294,7 @@ final class StatsDatabase {
     // MARK: - Daily Activity Update
 
     func updateDailyActivityImpl(for date: Date, durationDelta: Int) {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        let dateStr = dateFormatter.string(from: date)
+        let dateStr = DateFormattingHelper.formatISODate(date)
 
         // Upsert: insert new or increment existing daily activity
         let updateSQL = """

--- a/Transcripted/Core/StatsDatabaseQueries.swift
+++ b/Transcripted/Core/StatsDatabaseQueries.swift
@@ -16,10 +16,8 @@ extension StatsDatabase {
     private func getRecordingsImpl(from startDate: Date, to endDate: Date) -> [RecordingMetadata] {
         var recordings: [RecordingMetadata] = []
 
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        let startStr = dateFormatter.string(from: startDate)
-        let endStr = dateFormatter.string(from: endDate)
+        let startStr = DateFormattingHelper.formatISODate(startDate)
+        let endStr = DateFormattingHelper.formatISODate(endDate)
 
         let sql = "SELECT id, date, time, duration_seconds, word_count, speaker_count, processing_time_ms, transcript_path, title FROM recordings WHERE date >= ? AND date <= ? ORDER BY date DESC, time DESC;"
         var statement: OpaquePointer?
@@ -60,10 +58,8 @@ extension StatsDatabase {
             return activities
         }
 
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        let startStr = dateFormatter.string(from: startOfMonth)
-        let endStr = dateFormatter.string(from: endOfMonth)
+        let startStr = DateFormattingHelper.formatISODate(startOfMonth)
+        let endStr = DateFormattingHelper.formatISODate(endOfMonth)
 
         let sql = "SELECT date, recording_count, total_duration_seconds, action_items_count FROM daily_activity WHERE date >= ? AND date <= ?;"
         var statement: OpaquePointer?
@@ -177,10 +173,8 @@ extension StatsDatabase {
     }
 
     private func getStatsForLastDaysImpl(_ days: Int) -> (recordings: Int, durationSeconds: Int) {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
         let startDate = Calendar.current.date(byAdding: .day, value: -days, to: Date()) ?? Date()
-        let startStr = dateFormatter.string(from: startDate)
+        let startStr = DateFormattingHelper.formatISODate(startDate)
 
         var recordings = 0
         var duration = 0


### PR DESCRIPTION
## Summary

Nightly automated simplification sweep — 5 files, net -48 lines:

- **`Audio.swift`**: eliminated duplicate 20-line recording-launch block; `start()` now delegates to `startAudioCaptureAsync()` instead of inlining identical Task setup a second time
- **`AudioFileManager.swift`**: removed redundant DispatchQueue.main.async inside the timer callback (already on main thread) — was doing unnecessary 5 Hz main-queue hops for the duration of every recording
- **`RetroactiveSpeakerUpdater.swift`**: promoted two NSRegularExpression patterns to static let instead of compiling fresh on every speaker-naming flow
- **`StatsDatabase.swift`**: replaced 4 inline DateFormatter/ISO8601DateFormatter allocations with DateFormattingHelper helpers + new static isoFormatter
- **`StatsDatabaseQueries.swift`**: replaced per-query DateFormatter allocations in 3 methods with DateFormattingHelper.formatISODate

Build: BUILD SUCCEEDED — no new errors or warnings.

## Test plan
- [ ] Build passes
- [ ] Record a short clip; transcript saves correctly
- [ ] Stats section loads without issue
- [ ] Speaker renaming updates existing transcripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)