### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Transcripted/Core/TranscriptionTaskManager.swift
+++ b/Transcripted/Core/TranscriptionTaskManager.swift
@@ -110,6 +110,14 @@ class TranscriptionTaskManager: ObservableObject {
 
     /// Retry a failed transcription by its ID
     func retryFailedTranscription(failedId: UUID) async -> Bool {
+        // Guard: reject if a pipeline is already active — same constraint as startTranscription.
+        // Without this guard a retry launched from Settings can run concurrently with a fresh
+        // transcription, causing model contention (both Parakeet and PyAnnote are single-instance).
+        guard activeTasks.isEmpty else {
+            AppLogger.pipeline.warning("Rejecting retry — another pipeline is already active", ["activeCount": "\(activeTasks.count)"])
+            return false
+        }
+
         guard let failed = failedTranscriptionManager.failedTranscriptions.first(where: { $0.id == failedId }) else {
             AppLogger.pipeline.error("Failed transcription not found", ["failedId": "\(failedId)"])
             return false
@@ -129,6 +137,11 @@ class TranscriptionTaskManager: ObservableObject {
         }
 
         AppLogger.pipeline.info("Retrying failed transcription", ["failedId": "\(failedId)"])
+
+        // Register a sentinel in activeTasks before the first suspension point so that
+        // startTranscription's `activeTasks.isEmpty` guard blocks until the retry finishes.
+        // The sentinel Task does no work — its presence in the dict is what matters.
+        activeTasks[failedId] = Task {}
 
         await MainActor.run {
             failedTranscriptionManager.incrementRetryCount(id: failedId)
@@ -150,6 +163,7 @@ class TranscriptionTaskManager: ObservableObject {
 
             await MainActor.run {
                 failedTranscriptionManager.removeFailedTranscription(id: failedId)
+                self.activeTasks.removeValue(forKey: failedId)
                 self.activeCount = max(0, self.activeCount - 1)
                 self.backgroundTaskCount = max(0, self.backgroundTaskCount - 1)
                 self.populateSavedMetadata(from: transcriptURL)
@@ -162,6 +176,7 @@ class TranscriptionTaskManager: ObservableObject {
         } catch {
             AppLogger.pipeline.error("Retry failed", ["error": "\(error.localizedDescription)"])
             await MainActor.run {
+                self.activeTasks.removeValue(forKey: failedId)
                 self.activeCount = max(0, self.activeCount - 1)
                 self.backgroundTaskCount = max(0, self.backgroundTaskCount - 1)
                 self.displayStatus = .failed(message: "Retry failed")


### PR DESCRIPTION
## What was found

**Category: Logic bug — concurrent ML pipeline guard bypass**

`retryFailedTranscription()` in `TranscriptionTaskManager` never checked `activeTasks.isEmpty` and never registered itself in `activeTasks`. This meant a retry launched from the Settings "Failed Transcriptions" panel could run concurrently with a fresh transcription triggered by a new recording — bypassing the existing guard in `startTranscription()` that exists precisely to prevent model contention.

Both Parakeet (ASR) and PyAnnote (diarization) are single-instance services. Running two pipelines simultaneously causes inference errors and hangs.

## What was fixed

**`Transcripted/Core/TranscriptionTaskManager.swift`**

- Added `guard activeTasks.isEmpty` at the start of `retryFailedTranscription`, matching the constraint already enforced by `startTranscription`
- Registered a sentinel `Task {}` in `activeTasks` before the first suspension point — its presence in the dict is what blocks `startTranscription`'s guard during the retry window
- Removed the sentinel in both the success and failure completion paths

## What was reviewed but not changed

- All recently changed files from the Qwen removal (PR #154): no leftover references found, cleanup was thorough
- Threading model: Audio.swift and SystemAudioCapture.swift correctly NOT `@MainActor`; all other services correctly `@MainActor`
- `RetroactiveSpeakerUpdater.consolidateSpeakerBreakdown`: early-exit check is technically fragile but safe with current transcript format
- `SpeakerNamingView` update accumulation: correctly uses `[UUID: SpeakerNameUpdate]` dict — only last update per speaker propagates to `handleNamingComplete`
- Files over 300 lines (Audio.swift 618, TranscriptionPipeline.swift 597, etc.) are pre-existing and carry no new issues

## Build

`xcodebuild -scheme Transcripted -configuration Debug` — ✅ BUILD SUCCEEDED (warnings are all pre-existing Swift 6 prep warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)