### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,13 +9,13 @@ Menu bar-only macOS app for real-time system audio transcription. Pipeline: Core
 - **UI**: Floating pill (Dynamic Island style) + Settings window + Onboarding window
 - **Core library**: `Sources/TranscriptedCore/` — Swift Package (Package.swift at repo root) that contains the audio/transcription/stats/speaker pipeline. The Transcripted app target and Draft's Sources/Meeting/ both consume it as a library.
 - **Dependencies**: Sparkle (auto-updates), FluidAudio 0.7.9 via SPM (AsrManager, DiarizerManager, OfflineDiarizerManager — phase 2.0 retired the 123MB committed binaries in favor of package resolution)
-- **Protocols**: 6 service protocols in `Sources/TranscriptedCore/Protocols/` (SpeechToTextEngine, DiarizationEngine, SpeakerStore, TranscriptStorage, AudioCaptureEngine, StatsStore) — Core is UI- and STT-agnostic; embedders supply concrete conformers
+- **Protocols**: 7 service protocols in `Sources/TranscriptedCore/Protocols/` (SpeechToTextEngine, DiarizationEngine, SpeakerStore, TranscriptStorage, AudioCaptureEngine, StatsStore, TranscriptNotifier) — Core is UI-, notification-, and STT-agnostic; embedders supply concrete conformers
 - **Embedder adapters**: `Transcripted/Services/ParakeetEngineAdapter.swift` (SpeechToTextEngine via FluidAudio), `Transcripted/Services/TranscriptedNotificationsAdapter.swift` (TranscriptNotifier via UNUserNotificationCenter). Draft supplies its own adapters in `Sources/Meeting/`.
 
 ## Folder Map
 - **Sources/TranscriptedCore/** — The extracted SPM library. Subfolders: Audio/, Pipeline/, Storage/, Speaker/, Stats/, Services/, Models/, Protocols/, Utilities/, Logging/. This is where the transcription pipeline, audio capture, stats DB, speaker DB, and transcript saver live. Consumed by both Transcripted and Draft.
 - **Tests/TranscriptedCoreTests/** — SPM test target (5 smoke tests). Run via `swift test` from repo root.
-- **Transcripted/** (app target, ~75 files) — macOS app shell that consumes TranscriptedCore:
+- **Transcripted/** (app target, ~86 Swift files) — macOS app shell that consumes TranscriptedCore:
   - **Core/** (11 files): app-target coordinators — `NotificationCoordinator`, `HotkeyManager`, `MenuBarManager`, `WindowCoordinator`, `RecordingCoordinator`, `AppDelegateDebug`, plus small UI-side helpers (`Clipboard`, `TranscriptExporter`, `TranscriptStore`, `SystemSettingsHelper`, `DiagnosticExporter`). Audio/transcription/stats/speaker code lives in `Sources/TranscriptedCore/`, NOT here.
   - **Services/** (3 files): embedder adapters — `ParakeetEngineAdapter` (wraps FluidAudio for `SpeechToTextEngine`), `TranscriptedNotificationsAdapter` (wraps `UNUserNotificationCenter` for `TranscriptNotifier`), `MeetingDetector` (Zoom/Teams/Webex auto-start). The bulk of pre-extraction ML services (ParakeetService, DiarizationService, SpeakerDatabase, EmbeddingClusterer, AudioResampler, etc.) moved to `Sources/TranscriptedCore/`.
   - **UI/FloatingPanel/**, **UI/Settings/**, **Onboarding/**, **Design/** — unchanged by extraction.
@@ -64,10 +64,10 @@ User presses Cmd+Shift+R (global hotkey)
 - **Transcripted/TranscriptedApp.swift**: @main struct + slim AppDelegate coordinator. Constructs `TranscriptionTaskManager` with embedder adapters (`ParakeetEngineAdapter`, `TranscriptedNotificationsAdapter`) and Core services (`DiarizationService`, `SpeakerDatabase.shared`).
 - **AppDelegate extensions** (in `Transcripted/Core/`): MenuBarManager, HotkeyManager, NotificationCoordinator, WindowCoordinator, RecordingCoordinator, AppDelegateDebug
 - **Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift**: Task queue (extensions: SpeakerNamingCoordinator, TranscriptionPipelineRunner). Init takes `notifier: TranscriptNotifier? = nil` — embedders pass a concrete adapter, tests/CLI pass nil.
-- **Sources/TranscriptedCore/Pipeline/DisplayStatus.swift**: DisplayStatus enum + TranscriptionTask struct
+- **Sources/TranscriptedCore/Models/DisplayStatus.swift**: DisplayStatus enum + TranscriptionTask struct
 - **Sources/TranscriptedCore/Audio/Audio.swift**: CoreAudio capture (extensions: AudioDeviceRecovery, AudioLevelMonitor, AudioFileManager)
 - **Sources/TranscriptedCore/Pipeline/Transcription.swift**: @MainActor pipeline (extensions: TranscriptionPipeline, SpeakerMatchingService)
-- **Sources/TranscriptedCore/Protocols/**: 6 service protocols (SpeechToTextEngine, DiarizationEngine, SpeakerStore, TranscriptStorage, AudioCaptureEngine, StatsStore)
+- **Sources/TranscriptedCore/Protocols/**: 7 service protocols (SpeechToTextEngine, DiarizationEngine, SpeakerStore, TranscriptStorage, AudioCaptureEngine, StatsStore, TranscriptNotifier)
 - **Transcripted/Services/ParakeetEngineAdapter.swift**: app-target conformer for `SpeechToTextEngine` wrapping FluidAudio's `AsrManager`.
 - **Transcripted/Services/TranscriptedNotificationsAdapter.swift**: app-target conformer for `TranscriptNotifier` wrapping `UNUserNotificationCenter`. Sets `categoryIdentifier = "TRANSCRIPT_SAVED"` so `NotificationCoordinator`'s "Show in Finder" action button fires.
 
@@ -98,10 +98,10 @@ Every folder with ≥2 Swift files has its own CLAUDE.md with file index, refere
 | Path | Scope |
 |------|-------|
 | `CLAUDE.md` (this file) | Architecture overview, pipeline, entry points |
-| `Sources/TranscriptedCore/CLAUDE.md` | Extracted library: audio, transcription, stats, storage, protocols |
-| `Tools/TranscriptedMCP/CLAUDE.md` | MCP server: 5 tools, index schema, build/test, Claude Desktop setup |
 | `Transcripted/Core/CLAUDE.md` | App-target coordinators only (NotificationCoordinator, HotkeyManager, etc.) |
+| `Tools/TranscriptedMCP/CLAUDE.md` | MCP server: 5 tools, index schema, build/test, Claude Desktop setup |
 | `Transcripted/Services/CLAUDE.md` | Embedder adapters (ParakeetEngineAdapter, TranscriptedNotificationsAdapter) + MeetingDetector |
+| `Transcripted/Services/Protocols/CLAUDE.md` | Historical note: app-target Protocols/ folder now only contains docs; real protocol definitions live in `Sources/TranscriptedCore/Protocols/` |
 | `Transcripted/Design/CLAUDE.md` | All token values (colors, spacing, radius, typography, animations) |
 | `Transcripted/Design/Colors/CLAUDE.md` | Complete color reference with hex/HSB values |
 | `Transcripted/Design/Components/CLAUDE.md` | PremiumButton, PremiumCard, BenefitCard, QuickTipRow, AnimatedIcon specs |

--- a/Transcripted/Core/CLAUDE.md
+++ b/Transcripted/Core/CLAUDE.md
@@ -27,12 +27,14 @@ The extraction moved these file groups to `Sources/TranscriptedCore/`:
 | Old location (`Transcripted/Core/...`) | New location |
 |---|---|
 | `Audio.swift`, `AudioDeviceRecovery.swift`, `AudioFileManager.swift`, `AudioLevelMonitor.swift`, `SystemAudioCapture.swift`, `SystemAudioProcessTap.swift`, `SystemAudioBufferWriter.swift`, `CoreAudioUtils.swift` | `Sources/TranscriptedCore/Audio/` |
-| `Transcription.swift`, `TranscriptionPipeline.swift`, `TranscriptionPipelineRunner.swift`, `TranscriptionTaskManager.swift`, `SpeakerNamingCoordinator.swift`, `TranscriptionTypes.swift`, `DisplayStatus.swift`, `SpeakerMatchingService.swift` | `Sources/TranscriptedCore/Pipeline/` |
-| `TranscriptSaver.swift`, `TranscriptFormatter.swift`, `TranscriptMetadataBuilder.swift`, `RetroactiveSpeakerUpdater.swift`, `TranscriptScanner.swift`, `TranscriptUtils.swift`, `AgentOutput.swift` | `Sources/TranscriptedCore/Storage/` |
+| `Transcription.swift`, `TranscriptionPipeline.swift`, `TranscriptionPipelineRunner.swift`, `TranscriptionTaskManager.swift` | `Sources/TranscriptedCore/Pipeline/` |
+| `DisplayStatus.swift`, `FailedTranscription.swift`, `TranscriptionTypes.swift`, `TranscriptMetadataBuilder.swift` | `Sources/TranscriptedCore/Models/` |
+| `TranscriptSaver.swift`, `TranscriptFormatter.swift`, `TranscriptScanner.swift`, `AgentOutput.swift` | `Sources/TranscriptedCore/Storage/` |
 | `StatsDatabase.swift`, `StatsDatabaseModels.swift`, `StatsDatabaseQueries.swift`, `StatsService.swift` | `Sources/TranscriptedCore/Stats/` |
-| `ModelDownloadService.swift`, `RecordingValidator.swift`, `FilePermissions.swift`, `FailedTranscription.swift`, `FailedTranscriptionManager.swift`, `AppServices.swift` | `Sources/TranscriptedCore/Services/` |
+| `ModelDownloadService.swift`, `RecordingValidator.swift`, `FailedTranscriptionManager.swift`, `AppServices.swift`, `DiarizationService.swift`, `CoreStoragePaths.swift` | `Sources/TranscriptedCore/Services/` |
+| `SpeakerNamingCoordinator.swift`, `SpeakerMatchingService.swift`, `RetroactiveSpeakerUpdater.swift` | `Sources/TranscriptedCore/Speaker/` |
 | `Logging/AppLogger.swift`, `Logging/FileLogger.swift` | `Sources/TranscriptedCore/Logging/` |
-| `DateFormattingHelper.swift`, `DateParser.swift` | `Sources/TranscriptedCore/Utilities/` |
+| `DateFormattingHelper.swift`, `DateParser.swift`, `FilePermissions.swift`, `TranscriptUtils.swift` | `Sources/TranscriptedCore/Utilities/` |
 
 If an older CLAUDE.md or comment still references `Transcripted/Core/Audio.swift`, `Transcripted/Core/Transcription.swift`, etc., treat it as stale and update the reference to `Sources/TranscriptedCore/...`.
 

--- a/Transcripted/Services/CLAUDE.md
+++ b/Transcripted/Services/CLAUDE.md
@@ -1,6 +1,6 @@
 # Services Folder (App Target)
 
-Embedder adapters that conform to TranscriptedCore protocols, plus the meeting auto-detection scanner. 3 Swift files + `Protocols/` subdirectory.
+Embedder adapters that conform to TranscriptedCore protocols, plus the meeting auto-detection scanner. 3 Swift files + a historical `Protocols/` docs stub.
 
 **IMPORTANT**: Prior to merge-plan Phase 2 Lane A extraction, this folder held 16 files including `ParakeetService`, `DiarizationService`, `SpeakerDatabase`, `SpeakerEmbeddingMatcher`, `SpeakerProfile*`, `EmbeddingClusterer`, `AudioResampler`, `SpeakerClipExtractor`. The ML-heavy code moved to `Sources/TranscriptedCore/` as a Swift Package. What remains here is only the glue between Core's protocols and concrete platform APIs (FluidAudio, UserNotifications) plus the NSWorkspace-based meeting detector.
 
@@ -14,7 +14,7 @@ Embedder adapters that conform to TranscriptedCore protocols, plus the meeting a
 
 ## Protocols/ subdirectory
 
-Historical: `Transcripted/Services/Protocols/` used to hold the 6 Core protocols. Those protocol definitions moved to `Sources/TranscriptedCore/Protocols/` as part of the extraction. If a `Protocols/` folder still exists here it contains only app-target-specific shims or is empty.
+Historical: `Transcripted/Services/Protocols/` used to hold the Core protocol definitions. Those definitions moved to `Sources/TranscriptedCore/Protocols/` as part of the extraction. The folder still exists here only because it has its own `CLAUDE.md`; there are no app-target protocol source files left in it.
 
 ## Pipeline Order (reference)
 
@@ -78,6 +78,6 @@ If older CLAUDE.md or comments reference these paths, they've moved:
 | `EmbeddingClusterer.swift` | `Sources/TranscriptedCore/Speaker/EmbeddingClusterer.swift` |
 | `AudioResampler.swift` | `Sources/TranscriptedCore/Audio/AudioResampler.swift` |
 | `SpeakerClipExtractor.swift` | `Sources/TranscriptedCore/Speaker/SpeakerClipExtractor.swift` |
-| `Protocols/SpeechToTextEngine.swift` + 5 others | `Sources/TranscriptedCore/Protocols/` |
+| `Protocols/SpeechToTextEngine.swift` + peers (including `TranscriptNotifier`) | `Sources/TranscriptedCore/Protocols/` |
 
-See `Sources/TranscriptedCore/CLAUDE.md` (or the per-subfolder CLAUDE.md files under `Sources/TranscriptedCore/`) for full details on the moved code.
+There is no umbrella `Sources/TranscriptedCore/CLAUDE.md` in the repo today; use the root `CLAUDE.md` plus the app-target folder guides when tracing the extraction boundaries.

--- a/Transcripted/Services/Protocols/CLAUDE.md
+++ b/Transcripted/Services/Protocols/CLAUDE.md
@@ -1,124 +1,29 @@
-# Service Protocols
+# Service Protocols (Historical Stub)
 
-6 protocol definitions for dependency injection. Each defines the interface for one service. Conformances exist but are **not yet adopted** in AppServices.swift (still uses concrete types).
+This directory no longer contains Swift protocol source files.
 
-## File Index
+The protocol definitions that used to live here were moved into the shared Swift package at `Sources/TranscriptedCore/Protocols/` during the TranscriptedCore extraction. Today this folder exists only because it still has this documentation file.
 
-| File | Conformer | Actor |
-|------|-----------|-------|
-| `SpeechToTextEngine.swift` | ParakeetService | @MainActor, ObservableObject |
-| `DiarizationEngine.swift` | DiarizationService | @MainActor, ObservableObject |
-| `SpeakerStore.swift` | SpeakerDatabase | (no actor — utility queue) |
-| `AudioCaptureEngine.swift` | Audio | ObservableObject (NOT @MainActor) |
-| `StatsStore.swift` | StatsDatabase | (no actor — serial queue) |
-| `TranscriptStorage.swift` | TranscriptSaver | Static methods |
+## Current source of truth
 
-## Protocol Signatures
+The active Core protocol files are:
 
-### SpeechToTextEngine
-```swift
-@MainActor protocol SpeechToTextEngine: ObservableObject {
-    var isReady: Bool { get }
-    func initialize() async
-    func transcribeSegment(samples: [Float], source: AudioSource) async throws -> String
-    func cleanup()
-}
-```
+| File | Purpose |
+|------|---------|
+| `Sources/TranscriptedCore/Protocols/SpeechToTextEngine.swift` | STT abstraction implemented by `Transcripted/Services/ParakeetEngineAdapter.swift` |
+| `Sources/TranscriptedCore/Protocols/DiarizationEngine.swift` | Offline diarization abstraction implemented by Core services |
+| `Sources/TranscriptedCore/Protocols/SpeakerStore.swift` | Speaker profile persistence / lookup abstraction |
+| `Sources/TranscriptedCore/Protocols/TranscriptStorage.swift` | Transcript persistence abstraction used by the pipeline |
+| `Sources/TranscriptedCore/Protocols/AudioCaptureEngine.swift` | Recording engine abstraction |
+| `Sources/TranscriptedCore/Protocols/StatsStore.swift` | Stats persistence abstraction |
+| `Sources/TranscriptedCore/Protocols/TranscriptNotifier.swift` | Optional notification bridge used by embedders to tag and deliver transcript-saved notifications |
 
-### DiarizationEngine
-```swift
-@MainActor protocol DiarizationEngine: ObservableObject {
-    var isReady: Bool { get }
-    func initialize() async
-    func diarizeOffline(samples: [Float], sampleRate: Int) async throws -> [SpeakerSegment]
-    func diarizeOffline(audioURL: URL) async throws -> [SpeakerSegment]
-    func cleanup()
-}
-```
+## App-target relationships
 
-### SpeakerStore
-```swift
-protocol SpeakerStore {
-    func matchSpeaker(embedding: [Float], threshold: Double) -> SpeakerMatchResult?
-    func addOrUpdateSpeaker(embedding: [Float], existingId: UUID?) -> SpeakerProfile
-    func getSpeaker(id: UUID) -> SpeakerProfile?
-    func allSpeakers() -> [SpeakerProfile]
-    func setDisplayName(id: UUID, name: String, source: String)
-    func deleteSpeaker(id: UUID)
-    func mergeProfiles(sourceId: UUID, into targetId: UUID)
-    func mergeProfilesByName()
-    func mergeDuplicates()
-    func pruneWeakProfiles()
-    func resetDisputeCount(id: UUID)
-    func findProfilesByName(_ name: String) -> [SpeakerProfile]
-}
-```
+- `Transcripted/Services/ParakeetEngineAdapter.swift` conforms to `SpeechToTextEngine`
+- `Transcripted/Services/TranscriptedNotificationsAdapter.swift` conforms to `TranscriptNotifier`
+- Most other concrete implementations now live inside `Sources/TranscriptedCore/`
 
-### AudioCaptureEngine
-```swift
-protocol AudioCaptureEngine: ObservableObject {
-    var isRecording: Bool { get }
-    var audioLevel: Float { get }
-    var recordingDuration: TimeInterval { get }
-    var systemAudioStatus: SystemAudioStatus { get }
-    var micAudioFileURL: URL? { get }
-    var systemAudioFileURL: URL? { get }
-    func start()
-    func stop()
-    var onRecordingStart: (() -> Void)? { get set }
-    var onRecordingComplete: ((URL?, URL?) -> Void)? { get set }
-    func createHealthInfo() -> RecordingHealthInfo
-}
-```
+## Gotcha
 
-### StatsStore
-```swift
-protocol StatsStore {
-    func recordTranscription(date: String, time: String, durationSeconds: Int,
-                             wordCount: Int, speakerCount: Int, processingTimeMs: Int,
-                             transcriptPath: String, title: String)
-    func totalRecordingCount() -> Int
-    func totalDurationSeconds() -> Int
-    func recordingsForDate(_ date: String) -> [RecordingMetadata]
-    func dailyActivity(from: String, to: String) -> [DailyActivity]
-}
-```
-
-### TranscriptStorage
-```swift
-protocol TranscriptStorage {
-    static func saveTranscript(_ result: TranscriptionResult,
-                               speakerMappings: [String: SpeakerMapping],
-                               speakerSources: [String: String],
-                               speakerDbIds: [String: UUID],
-                               directory: URL?,
-                               meetingTitle: String?,
-                               healthInfo: RecordingHealthInfo?) -> URL?
-    @discardableResult
-    static func updateSpeakerNames(transcriptURL: URL, updates: [SpeakerNameUpdate]) -> Bool
-    static func retroactivelyUpdateSpeaker(dbId: UUID, newName: String)
-    static var defaultSaveDirectory: URL { get }
-}
-```
-
-## DI Container Status
-
-`Core/AppServices.swift` defines the container but still uses concrete types:
-```swift
-struct AppServices {
-    let speechToText: ParakeetService     // should be: any SpeechToTextEngine
-    let diarization: DiarizationService   // should be: any DiarizationEngine
-    let speakerStore: SpeakerDatabase     // should be: any SpeakerStore
-}
-```
-Protocol conformances need to be declared on the concrete types, then AppServices switched to protocol types.
-
-## Relationships
-- Protocols used by: Core/AppServices.swift (DI container)
-- Conformers in: Services/ root (ParakeetService, DiarizationService, SpeakerDatabase) and Core/ (Audio, StatsDatabase, TranscriptSaver)
-- Key types referenced: SpeakerSegment, SpeakerProfile, SpeakerMatchResult (Services/SpeakerProfile.swift), AudioSource (FluidAudio framework), RecordingHealthInfo (Core/TranscriptMetadataBuilder.swift)
-
-## Gotchas
-- `TranscriptStorage` uses all static methods — conformer (TranscriptSaver) is a utility class, not an instance
-- `AudioCaptureEngine` is NOT @MainActor despite most protocols being @MainActor — Audio runs on audio threads
-- These protocols are aspirational — the codebase still uses concrete types directly in most places
+If you find an old comment, doc, or code review mentioning `Transcripted/Services/Protocols/*.swift`, treat it as pre-extraction history and update the reference to `Sources/TranscriptedCore/Protocols/*.swift`.


### PR DESCRIPTION
## Summary
- sync root `CLAUDE.md` with current app-target/Core protocol counts and file locations
- update extraction notes in `Transcripted/Core/CLAUDE.md` to match current `Sources/TranscriptedCore` layout
- clarify that `Transcripted/Services/Protocols/` is now a historical docs-only stub and point readers to `Sources/TranscriptedCore/Protocols/`

## Why
Recent codebase changes left a few stale references in the CLAUDE guides, especially around:
- `TranscriptNotifier` joining the shared protocol set
- `DisplayStatus` and other types moving into `Models/`, `Speaker/`, and `Utilities/`
- the app target and protocol docs no longer matching the current extracted-core layout