### PR TITLE
docs: fix UI CLAUDE.md file count and deduplicate agent-connect entries

### DIFF
--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -14,7 +14,7 @@ features:
 
 Draft-mode UI is not an active product path in this worktree.
 
-## Files (37 Swift files)
+## Files (38 Swift files)
 
 ### Dictation Overlay
 
@@ -53,9 +53,12 @@ Draft-mode UI is not an active product path in this worktree.
 - `MenuIconButton.swift` — icon-only button style for menubar items
 - `MenuOutlineButton.swift` — outlined button style for menubar actions
 - `MenuTokens.swift` — design tokens for menubar views
-- `AgentConnectionWindowController.swift`
-- `AgentConnectionGuide.swift`
-- `AgentConnectionWindowView.swift` — main standalone agent-connect window
+
+### Agent Connect
+
+- `AgentConnectionGuide.swift` — shared copy and step data for the agent-connect flow
+- `AgentConnectionWindowController.swift` — `AgentConnectionWindowCoordinator` and `NSWindowController` for the standalone agent-connect window
+- `AgentConnectionWindowView.swift` — SwiftUI content for the standalone agent-connect window
 
 The current agent-connect surfaces should keep one simple mental model:
 
@@ -73,8 +76,6 @@ The current agent-connect surfaces should keep one simple mental model:
 
 ### Shared
 
-- `AgentConnectionWindowController.swift` — standalone window for connecting to an agent
-- `AgentConnectionWindowView.swift` — SwiftUI content for the agent connection window
 - `AppSoundPlayer.swift` — UI sound preferences and playback helpers
 
 ## Observation Pattern


### PR DESCRIPTION
## Summary

Automated daily CLAUDE.md/AGENTS.md audit run (2026-04-09).

Audited all CLAUDE.md and AGENTS.md files against the current codebase. Most docs are already accurate, but `Sources/UI/CLAUDE.md` had a few small inconsistencies left over from recent UI work:

- **Incorrect file count.** The header said "37 Swift files" but `Sources/UI/` currently has **38** `.swift` files.
- **Duplicate agent-connect entries.** `AgentConnectionWindowController.swift` and `AgentConnectionWindowView.swift` were listed under **both** the "Menubar" and "Shared" sections. The Menubar entries were bare (no descriptions), while the Shared entries had descriptions.
- **Mis-categorized Menubar section.** The standalone agent-connect window components were grouped under "Menubar" even though they are a standalone `NSWindowController`/SwiftUI window, not part of the popover surface.

## Changes

Only `Sources/UI/CLAUDE.md` was modified:

1. File count header: `37` → `38`.
2. Removed duplicate `AgentConnectionWindowController.swift` and `AgentConnectionWindowView.swift` entries from both the Menubar and Shared sections.
3. Added a new **Agent Connect** subsection that groups the three standalone-window components (`AgentConnectionGuide.swift`, `AgentConnectionWindowController.swift`, `AgentConnectionWindowView.swift`) with concrete descriptions of what each file does.
4. `MenuAgentConnectPageView.swift` stays in the Menubar section because it is the popover page, not the standalone window.

## Audit findings for the rest of the repo

Everything else checked out against the current code:

- Root `CLAUDE.md` and `AGENTS.md` — repo-truth matches current state
- `Sources/CLAUDE.md` directory map matches actual `Sources/` subdirectories
- `Sources/TranscriptedCore/CLAUDE.md` — all 55 files and per-subsystem counts (Audio 9, Logging 2, Models 4, Pipeline 4, Protocols 7, Services 7, Speaker 10, Stats 4, Storage 4, Utilities 4) match
- `Sources/Meeting/CLAUDE.md` — all 7 current files listed, no stale `MeetingLiveTranscriber.swift` reference
- `Sources/Dictation/`, `Sources/Speech/`, `Sources/Observability/`, `Sources/Capture/`, `Sources/API/`, `Sources/Style/`, `Sources/Text/`, `Sources/Accessibility/` — file lists and counts match
- `Tools/TranscriptedCLI/CLAUDE.md`, `Tools/TranscriptedMCP/CLAUDE.md`, `Tools/TranscriptedQA/CLAUDE.md` — file indexes and counts match (verified against the most recent sync in PR #210)

## Test plan

- [x] `Sources/UI/CLAUDE.md` file list diff-checked against `ls Sources/UI/*.swift`
- [x] No Swift source, build scripts, or test files changed
- [ ] Reviewer eyeballs the new "Agent Connect" subsection for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)