### PR TITLE
Simplify the agent connection flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ If your agent can read a folder, it can work from Transcripted's output.
 
 ## Connect your agent
 
-Transcripted now has three clear ways to connect:
+Transcripted now has one main connection path plus two optional fallbacks:
 
-- `Start here` — copy a simple prompt and point any agent at your local folders
-- `MCP` — give supported agents direct read-only tools for search, recaps, meetings, and dictations
-- `CLI` — use `transcripted-cli` for scripts, automation, and offline audio workflows
+- `Copy one prompt` — paste a smart prompt that uses MCP when available and folders when not
+- `MCP` — optionally give supported agents direct read-only tools for search, recaps, meetings, and dictations
+- `Folders` — manually point any file-reading agent at your local Transcripted data if needed
 
 The end-user setup guide lives in `docs/agent-connect.md`.
 

--- a/Sources/UI/AgentConnectionGuide.swift
+++ b/Sources/UI/AgentConnectionGuide.swift
@@ -2,6 +2,29 @@ import Foundation
 import TranscriptedCore
 
 enum AgentConnectionGuide {
+    static var localMCPBuildDirectory: URL? {
+        let bundleURL = Bundle.main.bundleURL.standardizedFileURL
+        let buildDirectory = bundleURL.deletingLastPathComponent()
+        let repoRoot = buildDirectory.deletingLastPathComponent()
+        let toolsDirectory = repoRoot.appendingPathComponent("Tools/TranscriptedMCP", isDirectory: true)
+
+        guard FileManager.default.fileExists(atPath: toolsDirectory.path) else {
+            return nil
+        }
+
+        return toolsDirectory
+    }
+
+    static var localMCPBinary: URL? {
+        guard let buildDirectory = localMCPBuildDirectory else { return nil }
+        let binary = buildDirectory
+            .appendingPathComponent(".build", isDirectory: true)
+            .appendingPathComponent("debug", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+
+        return FileManager.default.fileExists(atPath: binary.path) ? binary : nil
+    }
+
     static var meetingsFolder: URL {
         let url = MeetingStoragePaths.transcriptsFolder
         AgentOutput.writeAgentReadme(to: url)
@@ -24,21 +47,35 @@ enum AgentConnectionGuide {
         var prompt = """
         I use Transcripted on my Mac.
 
-        If Transcripted MCP tools are available, use them first for recent context, search, meetings, dictations, and recaps.
+        Your job is to connect to my Transcripted data using the best available method, then help me search, summarize, and organize my meetings and dictations.
 
-        If Transcripted MCP tools are not available, use these local folders instead:
+        Connection priority:
+        1. If Transcripted MCP tools are already available in this environment, use them first.
+        2. If Transcripted MCP tools are not available, but this environment can build or configure a local MCP server, try to set up Transcripted MCP using the information below.
+        3. If MCP cannot be used here, fall back to direct file access using the local folders below.
+        4. If neither MCP nor folder access is possible, stop and tell me exactly what is missing, what you tried, and the smallest next step I need to take.
 
-        Meetings:
-        \(meetingsFolder.path)
+        \(mcpPromptBlock)
 
-        Dictations:
-        \(dictationsFolder.path)
+        Folder fallback:
+        - Meetings: \(meetingsFolder.path)
+        - Dictations: \(dictationsFolder.path)
 
-        If you use folders, read AGENT.md and transcripted.json in the meetings folder if they exist.
+        When using folders:
+        - Read AGENT.md and transcripted.json in the meetings folder if they exist.
+        - Prefer the most direct source available.
+        - Use exact filenames, dates, and speaker names when relevant.
+        - Do not invent access or claim data you cannot read.
 
-        Help me search, summarize, and organize my local meetings and dictations.
+        Working rules:
+        - Prefer MCP over raw file inspection when both are available.
+        - Use meetings and dictations together when the task spans both.
+        - Surface uncertainty clearly.
+        - If setup is needed, minimize back-and-forth and propose the next concrete action.
 
-        If neither MCP nor folder access is available yet, help me set up the best option and then continue.
+        First step:
+        Determine which connection mode is available: MCP, MCP setup, or folders.
+        Briefly tell me which mode you are using, then continue with my task.
         """
 
         if let filename {
@@ -48,21 +85,82 @@ enum AgentConnectionGuide {
         return prompt
     }
 
-    static let mcpConfigExample = """
-    {
-      "mcpServers": {
-        "transcripted": {
-          "command": "/path/to/transcripted-mcp"
+    static var mcpPromptBlock: String {
+        var lines = [
+            "Transcripted MCP setup:",
+            "- Server name: transcripted",
+            "- Transport: local stdio",
+        ]
+
+        if let buildDirectory = localMCPBuildDirectory {
+            lines.append("- Build directory: \(buildDirectory.path)")
+            lines.append("- Build command: cd \(buildDirectory.path) && swift build")
         }
-      }
+
+        if let binary = localMCPBinary {
+            lines.append("- Expected binary: \(binary.path)")
+            lines.append("")
+            lines.append("Example MCP config:")
+            lines.append("{")
+            lines.append("  \"mcpServers\": {")
+            lines.append("    \"transcripted\": {")
+            lines.append("      \"command\": \"\(binary.path)\"")
+            lines.append("    }")
+            lines.append("  }")
+            lines.append("}")
+        } else {
+            lines.append("- If a local transcripted-mcp binary is installed, add it to your MCP config under mcpServers.transcripted.command.")
+        }
+
+        lines.append("")
+        lines.append("If connected, Transcripted MCP provides these read-only tools:")
+        lines.append("- recent_context")
+        lines.append("- search_context")
+        lines.append("- list_meetings")
+        lines.append("- read_meeting")
+        lines.append("- list_dictations")
+        lines.append("- read_dictation")
+        lines.append("- search")
+        lines.append("- who_is")
+        lines.append("- recap")
+
+        return lines.joined(separator: "\n")
     }
-    """
 
-    static let mcpSetupText = """
-    MCP is optional. If your agent supports it, Transcripted can expose direct read-only tools for recent context, search, meetings, dictations, and recaps.
+    static var mcpConfigExample: String {
+        let command = localMCPBinary?.path ?? "/path/to/transcripted-mcp"
+        return """
+        {
+          "mcpServers": {
+            "transcripted": {
+              "command": "\(command)"
+            }
+          }
+        }
+        """
+    }
 
-    Install the read-only `transcripted-mcp` server, add it to your MCP config, then restart your client. The server reads the same local Transcripted data automatically.
-    """
+    static var mcpSetupText: String {
+        var lines = [
+            "MCP is optional. If your agent supports it, Transcripted can expose direct read-only tools for recent context, search, meetings, dictations, and recaps.",
+            "",
+            "Install the read-only `transcripted-mcp` server, add it to your MCP config, then restart your client. The server reads the same local Transcripted data automatically.",
+        ]
+
+        if let buildDirectory = localMCPBuildDirectory {
+            lines.append("")
+            lines.append("Local build directory:")
+            lines.append("`\(buildDirectory.path)`")
+        }
+
+        if let binary = localMCPBinary {
+            lines.append("")
+            lines.append("Local binary:")
+            lines.append("`\(binary.path)`")
+        }
+
+        return lines.joined(separator: "\n")
+    }
 
     static let folderPathsText = """
     Meetings:

--- a/Sources/UI/AgentConnectionGuide.swift
+++ b/Sources/UI/AgentConnectionGuide.swift
@@ -2,12 +2,6 @@ import Foundation
 import TranscriptedCore
 
 enum AgentConnectionGuide {
-    static var appSupportFolder: URL {
-        let url = FileManager.default.transcriptedAppSupportDir
-        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-        return url
-    }
-
     static var meetingsFolder: URL {
         let url = MeetingStoragePaths.transcriptsFolder
         AgentOutput.writeAgentReadme(to: url)
@@ -20,32 +14,31 @@ enum AgentConnectionGuide {
         return url
     }
 
-    static let starterExamples = [
-        "What did I miss in today's meetings?",
-        "Find every time we discussed pricing or roadmap changes.",
-        "Pull action items from my latest meeting and recent dictations.",
-    ]
-
-    static let mcpHighlights = [
-        "Recent context across meetings and dictations",
-        "Search by topic, date, or speaker",
-        "Read one meeting or one dictation directly",
-        "Look up a person with who_is",
-        "Generate a recap for a day or week",
+    static let benefitHighlights = [
+        "Search past meetings and dictations faster",
+        "Pull summaries and action items in one place",
+        "Give your agent the real spoken context from this Mac",
     ]
 
     static func starterPrompt(filename: String?) -> String {
         var prompt = """
         I use Transcripted on my Mac.
 
-        Meetings folder:
+        If Transcripted MCP tools are available, use them first for recent context, search, meetings, dictations, and recaps.
+
+        If Transcripted MCP tools are not available, use these local folders instead:
+
+        Meetings:
         \(meetingsFolder.path)
 
-        Dictations folder:
+        Dictations:
         \(dictationsFolder.path)
 
-        Read AGENT.md and transcripted.json in the meetings folder if they exist.
-        Then help me search, summarize, and organize my local meetings and dictations.
+        If you use folders, read AGENT.md and transcripted.json in the meetings folder if they exist.
+
+        Help me search, summarize, and organize my local meetings and dictations.
+
+        If neither MCP nor folder access is available yet, help me set up the best option and then continue.
         """
 
         if let filename {
@@ -66,21 +59,16 @@ enum AgentConnectionGuide {
     """
 
     static let mcpSetupText = """
-    For supported agents, install the read-only `transcripted-mcp` server and add it to your MCP config.
+    MCP is optional. If your agent supports it, Transcripted can expose direct read-only tools for recent context, search, meetings, dictations, and recaps.
 
-    Replace `/path/to/transcripted-mcp` with your installed server command, then restart your client.
-    The server reads the same local Transcripted data automatically.
+    Install the read-only `transcripted-mcp` server, add it to your MCP config, then restart your client. The server reads the same local Transcripted data automatically.
     """
 
-    static let cliExamples = """
-    transcripted-cli context-recent
-    transcripted-cli context-search "roadmap"
-    transcripted-cli read-dictation Dictations_YYYY-MM-DD
-    transcripted-cli diarize /path/to/audio.wav --json
-    """
+    static let folderPathsText = """
+    Meetings:
+    \(meetingsFolder.path)
 
-    static let cliSummary = """
-    Use the CLI when you want scripts, automation, or offline audio work.
-    The context commands read the same local Transcripted folders as the app and MCP server.
+    Dictations:
+    \(dictationsFolder.path)
     """
 }

--- a/Sources/UI/AgentConnectionWindowView.swift
+++ b/Sources/UI/AgentConnectionWindowView.swift
@@ -2,14 +2,12 @@ import AppKit
 import SwiftUI
 
 struct AgentConnectionContext {
-    let appSupportFolderURL: URL
     let meetingsFolderURL: URL
     let dictationsFolderURL: URL
     let starterPrompt: String
     let mcpSetupText: String
     let mcpConfigExample: String
-    let cliSummary: String
-    let cliExamples: String
+    let folderPathsText: String
 
     init(meetingTitle: String?, meetingDate: Date?, transcriptURL: URL?) {
         let filename = transcriptURL?.deletingPathExtension().lastPathComponent
@@ -17,21 +15,19 @@ struct AgentConnectionContext {
         _ = meetingTitle
         _ = meetingDate
 
-        self.appSupportFolderURL = AgentConnectionGuide.appSupportFolder
         self.meetingsFolderURL = AgentConnectionGuide.meetingsFolder
         self.dictationsFolderURL = AgentConnectionGuide.dictationsFolder
         self.starterPrompt = AgentConnectionGuide.starterPrompt(filename: filename)
         self.mcpSetupText = AgentConnectionGuide.mcpSetupText
         self.mcpConfigExample = AgentConnectionGuide.mcpConfigExample
-        self.cliSummary = AgentConnectionGuide.cliSummary
-        self.cliExamples = AgentConnectionGuide.cliExamples
+        self.folderPathsText = AgentConnectionGuide.folderPathsText
     }
 }
 
 private enum AgentConnectionCopyItem: Hashable {
     case prompt
     case mcp
-    case cli
+    case folders
 }
 
 @MainActor
@@ -64,23 +60,12 @@ final class AgentConnectionViewModel: ObservableObject {
         )
     }
 
-    func copyCLIExamples() {
-        copy(
-            """
-            \(context.cliSummary)
-
-            \(context.cliExamples)
-            """,
-            as: .cli
-        )
+    func copyFolderPaths() {
+        copy(context.folderPathsText, as: .folders)
     }
 
     fileprivate func copyLabel(for item: AgentConnectionCopyItem, default title: String) -> String {
         copiedItem == item ? "Copied" : title
-    }
-
-    func openAppSupportFolder() {
-        NSWorkspace.shared.open(context.appSupportFolderURL)
     }
 
     func reveal(_ url: URL?) {
@@ -127,9 +112,8 @@ struct AgentConnectionWindowView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 22) {
-                    startHereSection
+                    primarySection
                     mcpSection
-                    cliSection
                     foldersSection
                 }
                 .padding(20)
@@ -156,7 +140,7 @@ struct AgentConnectionWindowView: View {
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundStyle(AgentConnectionTheme.textPrimary)
 
-                Text("Start with the copy-paste prompt. If your agent supports MCP, you can give it a direct read-only connection too.")
+                Text("Copy one prompt, paste it into your agent, and let Transcripted use MCP when available or folders when not.")
                     .font(.system(size: 12))
                     .foregroundStyle(AgentConnectionTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -169,97 +153,46 @@ struct AgentConnectionWindowView: View {
         .background(AgentConnectionTheme.background)
     }
 
-    private var startHereSection: some View {
+    private var primarySection: some View {
         AgentConnectionSectionCard(
-            title: "Start here",
-            subtitle: "Works with Claude, Codex, ChatGPT, or any agent that can read local files."
+            title: "Copy this into your agent",
+            subtitle: "This is the main path for most people."
         ) {
-            AgentConnectionBodyText("This is the simplest setup and the best default for most people. Give your agent the folders once, then ask normal questions.")
-
-            AgentConnectionCodeBlock(text: viewModel.context.starterPrompt)
-
-            HStack(spacing: 10) {
-                Button(viewModel.copyLabel(for: .prompt, default: "Copy prompt")) {
-                    viewModel.copyStarterPrompt()
-                }
-                .buttonStyle(AgentConnectionPrimaryButtonStyle())
-
-                Button("Open Transcripted folder") {
-                    viewModel.openAppSupportFolder()
-                }
-                .buttonStyle(AgentConnectionSecondaryButtonStyle())
-            }
+            AgentConnectionBodyText("Your agent will use Transcripted MCP tools if they are already connected. If not, it will fall back to your local Transcripted folders and can help you set up the better option later.")
 
             VStack(alignment: .leading, spacing: 10) {
-                Text("Good first asks")
+                Text("What this helps with")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(AgentConnectionTheme.textPrimary)
 
-                ForEach(Array(AgentConnectionGuide.starterExamples.enumerated()), id: \.offset) { index, example in
+                ForEach(Array(AgentConnectionGuide.benefitHighlights.enumerated()), id: \.offset) { index, highlight in
                     AgentConnectionInfoRow(
-                        symbolName: "\(index + 1).circle.fill",
-                        title: example,
-                        detail: "Paste the prompt above first, then ask this directly."
+                        symbolName: index == 0 ? "sparkles" : "checkmark.circle.fill",
+                        title: highlight,
+                        detail: "Works from the same local Transcripted data already saved on this Mac."
                     )
                 }
+            }
+
+            HStack(spacing: 10) {
+                Button(viewModel.copyLabel(for: .prompt, default: "Copy agent prompt")) {
+                    viewModel.copyStarterPrompt()
+                }
+                .buttonStyle(AgentConnectionPrimaryButtonStyle())
             }
         }
     }
 
     private var mcpSection: some View {
         AgentConnectionSectionCard(
-            title: "Best on supported agents",
-            subtitle: "MCP gives your agent direct read-only tools instead of making it browse files by hand."
+            title: "Optional MCP setup",
+            subtitle: "Set this up only if your agent supports MCP and you want the better direct-tool connection."
         ) {
             AgentConnectionBodyText(viewModel.context.mcpSetupText)
 
-            VStack(alignment: .leading, spacing: 10) {
-                Text("What the Transcripted MCP server gives you")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(AgentConnectionTheme.textPrimary)
-
-                ForEach(Array(AgentConnectionGuide.mcpHighlights.enumerated()), id: \.offset) { index, highlight in
-                    AgentConnectionInfoRow(
-                        symbolName: index == 0 ? "wand.and.stars" : "checkmark.circle.fill",
-                        title: highlight,
-                        detail: "Read-only access to the local context Transcripted already saved on this Mac."
-                    )
-                }
-            }
-
-            AgentConnectionCodeBlock(text: viewModel.context.mcpConfigExample)
-
             HStack(spacing: 10) {
-                Button(viewModel.copyLabel(for: .mcp, default: "Copy MCP example")) {
+                Button(viewModel.copyLabel(for: .mcp, default: "Copy MCP setup")) {
                     viewModel.copyMCPSetup()
-                }
-                .buttonStyle(AgentConnectionPrimaryButtonStyle())
-
-                Button("Show meetings folder") {
-                    viewModel.reveal(viewModel.context.meetingsFolderURL)
-                }
-                .buttonStyle(AgentConnectionSecondaryButtonStyle())
-            }
-        }
-    }
-
-    private var cliSection: some View {
-        AgentConnectionSectionCard(
-            title: "Advanced CLI",
-            subtitle: "Use the terminal when you want scripts, automation, or offline audio work."
-        ) {
-            AgentConnectionBodyText(viewModel.context.cliSummary)
-
-            AgentConnectionCodeBlock(text: viewModel.context.cliExamples)
-
-            HStack(spacing: 10) {
-                Button(viewModel.copyLabel(for: .cli, default: "Copy CLI examples")) {
-                    viewModel.copyCLIExamples()
-                }
-                .buttonStyle(AgentConnectionPrimaryButtonStyle())
-
-                Button("Show dictations folder") {
-                    viewModel.reveal(viewModel.context.dictationsFolderURL)
                 }
                 .buttonStyle(AgentConnectionSecondaryButtonStyle())
             }
@@ -268,9 +201,11 @@ struct AgentConnectionWindowView: View {
 
     private var foldersSection: some View {
         AgentConnectionSectionCard(
-            title: "Your folders",
-            subtitle: "All three paths above work from the same local Transcripted data."
+            title: "Manual folders",
+            subtitle: "Only use these if you want to inspect or share the raw local paths yourself."
         ) {
+            AgentConnectionBodyText("The main prompt already includes these paths. They are here as a fallback for manual setup.")
+
             VStack(alignment: .leading, spacing: 12) {
                 AgentConnectionFileRow(
                     name: "Meetings",
@@ -292,6 +227,13 @@ struct AgentConnectionWindowView: View {
                     viewModel.reveal(viewModel.context.dictationsFolderURL)
                 }
             }
+
+            HStack(spacing: 10) {
+                Button(viewModel.copyLabel(for: .folders, default: "Copy folder paths")) {
+                    viewModel.copyFolderPaths()
+                }
+                .buttonStyle(AgentConnectionSecondaryButtonStyle())
+            }
         }
     }
 }
@@ -301,7 +243,6 @@ private enum AgentConnectionTheme {
     static let card = Color(MenuTokens.actionBackgroundNS)
     static let badge = Color(MenuTokens.badgeBackgroundNS)
     static let divider = Color(MenuTokens.sectionDividerNS)
-    static let promptBackground = Color.black.opacity(0.18)
     static let accent = Color(OverlayTokens.accentGreen)
     static let textPrimary = Color(MenuTokens.textPrimaryNS)
     static let textSecondary = Color(MenuTokens.textSecondaryNS)
@@ -366,28 +307,6 @@ private struct AgentConnectionBodyText: View {
             .font(.system(size: 11))
             .foregroundStyle(AgentConnectionTheme.textSecondary)
             .fixedSize(horizontal: false, vertical: true)
-    }
-}
-
-private struct AgentConnectionCodeBlock: View {
-    let text: String
-
-    var body: some View {
-        Text(text)
-            .font(.system(size: 12, design: .monospaced))
-            .foregroundStyle(AgentConnectionTheme.textPrimary)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .fixedSize(horizontal: false, vertical: true)
-            .textSelection(.enabled)
-            .padding(14)
-            .background(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(AgentConnectionTheme.promptBackground)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(AgentConnectionTheme.divider, lineWidth: 1)
-            )
     }
 }
 

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -59,9 +59,9 @@ Draft-mode UI is not an active product path in this worktree.
 
 The current agent-connect surfaces should keep one simple mental model:
 
-- start with the folder prompt
-- offer MCP as the better supported-agent path
-- keep CLI guidance clearly marked as advanced
+- lead with one smart copy-paste prompt
+- let that prompt prefer MCP when available and fall back to folders when not
+- keep manual folder paths and MCP setup secondary, not primary
 
 ### Settings and Onboarding
 

--- a/Sources/UI/MenuAgentConnectPageView.swift
+++ b/Sources/UI/MenuAgentConnectPageView.swift
@@ -2,7 +2,6 @@
 // Full-page agent connection guide embedded inside the menubar panel.
 
 import AppKit
-import TranscriptedCore
 
 @MainActor
 final class MenuAgentConnectPageView: NSView {
@@ -16,47 +15,53 @@ final class MenuAgentConnectPageView: NSView {
     )
     private let titleLabel = NSTextField(labelWithString: "Connect your agent")
     private let subtitleLabel = NSTextField(wrappingLabelWithString:
-        "Start with a simple prompt, then use MCP or the CLI if you want a deeper connection."
+        "Copy one prompt, paste it into your agent, and let Transcripted use MCP when available or folders when not."
     )
-    private let starterPromptLabel = NSTextField(labelWithString: "Start here")
+    private let starterPromptLabel = NSTextField(labelWithString: "What this helps with")
+    private let benefitOneRow = AgentConnectInfoRowView(
+        symbolName: "sparkles",
+        title: "Search past meetings faster",
+        body: "Your agent can work from the spoken context Transcripted already saved locally."
+    )
+    private let benefitTwoRow = AgentConnectInfoRowView(
+        symbolName: "checkmark.circle",
+        title: "Pull summaries and action items",
+        body: "The smart prompt can use MCP if it is ready, or fall back to local folders if it is not."
+    )
+    private let benefitThreeRow = AgentConnectInfoRowView(
+        symbolName: "checkmark.circle",
+        title: "Stay simple for beginners",
+        body: "Copy once, paste once, and only use manual setup if you actually need it."
+    )
+    private let manualSetupLabel = NSTextField(labelWithString: "Need manual setup?")
+    private let mcpRow = AgentConnectInfoRowView(
+        symbolName: "cable.connector",
+        title: "Optional MCP setup",
+        body: "Copy the MCP setup text only if your agent supports MCP and you want direct read-only tools."
+    )
     private let folderRow = AgentConnectInfoRowView(
         symbolName: "folder",
-        title: "Show your folders",
-        body: "Meetings and dictations are both saved locally on this Mac."
-    )
-    private let promptRow = AgentConnectInfoRowView(
-        symbolName: "text.quote",
-        title: "Works with any agent",
-        body: "Copy a simple folder-based prompt for Claude, Codex, ChatGPT, or any local agent."
-    )
-    private let howToLabel = NSTextField(labelWithString: "Other ways to connect")
-    private let stepOneRow = AgentConnectInfoRowView(
-        symbolName: "1.circle",
-        title: "1. Start with the prompt",
-        body: "This is the simplest setup and the right default for most people."
-    )
-    private let stepTwoRow = AgentConnectInfoRowView(
-        symbolName: "2.circle",
-        title: "2. Use MCP if supported",
-        body: "Supported agents can connect directly with read-only Transcripted tools."
-    )
-    private let stepThreeRow = AgentConnectInfoRowView(
-        symbolName: "3.circle",
-        title: "3. Use the CLI if you're advanced",
-        body: "The CLI is best for scripts, automation, and offline audio work."
+        title: "Manual folders",
+        body: "Use these only if you want to inspect or share the raw Transcripted paths yourself."
     )
 
-    private let showFolderButton = MenuOutlineButton(
-        title: "Show Transcripted folder",
+    private let copyMCPButton = MenuOutlineButton(
+        title: "Copy MCP setup",
+        symbolName: "cable.connector",
+        accessibilityLabel: "Copy MCP setup",
+        toolTip: "Copy MCP setup"
+    )
+    private let copyFoldersButton = MenuOutlineButton(
+        title: "Copy folder paths",
         symbolName: "folder",
-        accessibilityLabel: "Show Transcripted folder",
-        toolTip: "Show Transcripted folder"
+        accessibilityLabel: "Copy folder paths",
+        toolTip: "Copy folder paths"
     )
     private let copyPromptButton = MenuOutlineButton(
-        title: "Copy starter prompt",
+        title: "Copy agent prompt",
         symbolName: "doc.on.doc",
-        accessibilityLabel: "Copy starter prompt",
-        toolTip: "Copy starter prompt"
+        accessibilityLabel: "Copy agent prompt",
+        toolTip: "Copy agent prompt"
     )
 
     private var resetTask: Task<Void, Never>?
@@ -85,24 +90,28 @@ final class MenuAgentConnectPageView: NSView {
         subtitleLabel.maximumNumberOfLines = 3
         addSubview(subtitleLabel)
 
-        [starterPromptLabel, howToLabel].forEach { label in
+        [starterPromptLabel, manualSetupLabel].forEach { label in
             label.font = NSFont.systemFont(ofSize: 12, weight: .semibold)
             label.textColor = MenuTokens.textPrimaryNS
             addSubview(label)
         }
-        [promptRow, folderRow, stepOneRow, stepTwoRow, stepThreeRow].forEach { addSubview($0) }
+        [benefitOneRow, benefitTwoRow, benefitThreeRow, mcpRow, folderRow].forEach { addSubview($0) }
 
         backButton.target = self
         backButton.action = #selector(goBack)
         addSubview(backButton)
 
-        showFolderButton.target = self
-        showFolderButton.action = #selector(showAppSupportFolder)
-        addSubview(showFolderButton)
-
         copyPromptButton.target = self
         copyPromptButton.action = #selector(copyStarterPrompt)
         addSubview(copyPromptButton)
+
+        copyMCPButton.target = self
+        copyMCPButton.action = #selector(copyMCPSetup)
+        addSubview(copyMCPButton)
+
+        copyFoldersButton.target = self
+        copyFoldersButton.action = #selector(copyFolderPaths)
+        addSubview(copyFoldersButton)
     }
 
     override func layout() {
@@ -128,34 +137,45 @@ final class MenuAgentConnectPageView: NSView {
 
         let copyPromptWidth = max(132, copyPromptButton.fittingSize.width)
         let promptRowWidth = max(180, width - copyPromptWidth - inlineButtonSpacing)
-        promptRow.frame = NSRect(x: pad, y: y, width: promptRowWidth, height: AgentConnectInfoRowView.height)
+        benefitOneRow.frame = NSRect(x: pad, y: y, width: promptRowWidth, height: AgentConnectInfoRowView.height)
         copyPromptButton.frame = NSRect(
-            x: promptRow.frame.maxX + inlineButtonSpacing,
+            x: benefitOneRow.frame.maxX + inlineButtonSpacing,
             y: y + 14,
             width: copyPromptWidth,
             height: MenuTokens.secondaryButtonSize
         )
         y += AgentConnectInfoRowView.height + 14
 
-        let showFolderWidth = max(130, showFolderButton.fittingSize.width)
-        let folderRowWidth = max(180, width - showFolderWidth - inlineButtonSpacing)
-        folderRow.frame = NSRect(x: pad, y: y, width: folderRowWidth, height: AgentConnectInfoRowView.height)
-        showFolderButton.frame = NSRect(
-            x: folderRow.frame.maxX + inlineButtonSpacing,
-            y: y + 14,
-            width: showFolderWidth,
-            height: MenuTokens.secondaryButtonSize
-        )
+        benefitTwoRow.frame = NSRect(x: pad, y: y, width: width, height: AgentConnectInfoRowView.height)
+        y += AgentConnectInfoRowView.height + 8
+
+        benefitThreeRow.frame = NSRect(x: pad, y: y, width: width, height: AgentConnectInfoRowView.height)
         y += AgentConnectInfoRowView.height + 18
 
-        howToLabel.frame = NSRect(x: pad, y: y, width: width, height: 16)
+        manualSetupLabel.frame = NSRect(x: pad, y: y, width: width, height: 16)
         y += 22
 
-        [stepOneRow, stepTwoRow, stepThreeRow].forEach { row in
-            let rowHeight = row.intrinsicContentSize.height
-            row.frame = NSRect(x: pad, y: y, width: width, height: rowHeight)
-            y += rowHeight + 8
-        }
+        let copyMCPWidth = max(120, copyMCPButton.fittingSize.width)
+        let mcpRowWidth = max(180, width - copyMCPWidth - inlineButtonSpacing)
+        mcpRow.frame = NSRect(x: pad, y: y, width: mcpRowWidth, height: AgentConnectInfoRowView.height)
+        copyMCPButton.frame = NSRect(
+            x: mcpRow.frame.maxX + inlineButtonSpacing,
+            y: y + 14,
+            width: copyMCPWidth,
+            height: MenuTokens.secondaryButtonSize
+        )
+        y += AgentConnectInfoRowView.height + 10
+
+        let copyFoldersWidth = max(126, copyFoldersButton.fittingSize.width)
+        let folderRowWidth = max(180, width - copyFoldersWidth - inlineButtonSpacing)
+        folderRow.frame = NSRect(x: pad, y: y, width: folderRowWidth, height: AgentConnectInfoRowView.height)
+        copyFoldersButton.frame = NSRect(
+            x: folderRow.frame.maxX + inlineButtonSpacing,
+            y: y + 14,
+            width: copyFoldersWidth,
+            height: MenuTokens.secondaryButtonSize
+        )
+        y += AgentConnectInfoRowView.height + 8
 
         y += 4
     }
@@ -163,16 +183,15 @@ final class MenuAgentConnectPageView: NSView {
     var intrinsicHeight: CGFloat {
         MenuTokens.secondaryButtonSize + 14 + 22 + 24 + 42 + 16 + 22 +
         (AgentConnectInfoRowView.height + 14) +
+        (AgentConnectInfoRowView.height + 8) +
         (AgentConnectInfoRowView.height + 18) +
-        22 + (AgentConnectInfoRowView.height + 8) * 3 + 12
+        22 +
+        (AgentConnectInfoRowView.height + 10) +
+        (AgentConnectInfoRowView.height + 8) + 12
     }
 
     @objc private func goBack() {
         onBack?()
-    }
-
-    @objc private func showAppSupportFolder() {
-        NSWorkspace.shared.activateFileViewerSelecting([AgentConnectionGuide.appSupportFolder])
     }
 
     @objc private func copyStarterPrompt() {
@@ -182,12 +201,47 @@ final class MenuAgentConnectPageView: NSView {
 
         resetTask?.cancel()
         copyPromptButton.title = "Copied"
-        copyPromptButton.setSymbol("checkmark", accessibilityLabel: "Starter prompt copied")
+        copyPromptButton.setSymbol("checkmark", accessibilityLabel: "Agent prompt copied")
         resetTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 1_000_000_000)
             guard let self, !Task.isCancelled else { return }
-            self.copyPromptButton.title = "Copy starter prompt"
-            self.copyPromptButton.setSymbol("doc.on.doc", accessibilityLabel: "Copy starter prompt")
+            self.copyPromptButton.title = "Copy agent prompt"
+            self.copyPromptButton.setSymbol("doc.on.doc", accessibilityLabel: "Copy agent prompt")
+        }
+    }
+
+    @objc private func copyMCPSetup() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(
+            "\(AgentConnectionGuide.mcpSetupText)\n\n\(AgentConnectionGuide.mcpConfigExample)",
+            forType: .string
+        )
+
+        resetTask?.cancel()
+        copyMCPButton.title = "Copied"
+        copyMCPButton.setSymbol("checkmark", accessibilityLabel: "MCP setup copied")
+        resetTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            guard let self, !Task.isCancelled else { return }
+            self.copyMCPButton.title = "Copy MCP setup"
+            self.copyMCPButton.setSymbol("cable.connector", accessibilityLabel: "Copy MCP setup")
+        }
+    }
+
+    @objc private func copyFolderPaths() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(AgentConnectionGuide.folderPathsText, forType: .string)
+
+        resetTask?.cancel()
+        copyFoldersButton.title = "Copied"
+        copyFoldersButton.setSymbol("checkmark", accessibilityLabel: "Folder paths copied")
+        resetTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            guard let self, !Task.isCancelled else { return }
+            self.copyFoldersButton.title = "Copy folder paths"
+            self.copyFoldersButton.setSymbol("folder", accessibilityLabel: "Copy folder paths")
         }
     }
 }

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -1,23 +1,29 @@
 # Connect Your Agent
 
-Transcripted is easiest to use when the connection story is simple:
+Transcripted is easiest to use when the connection story stays focused on one main action:
 
-1. Start with a prompt.
-2. Use MCP when your agent supports it.
-3. Use the CLI when you want scripts or automation.
+1. Copy one smart prompt.
+2. Let your agent use MCP if it is already available.
+3. Fall back to folders only when you need manual setup.
 
-## Start Here: Any Agent
+## Main Path: Copy One Prompt
 
 This is the default path for most people.
 
 - Open `Connect your agent` in the app.
-- Copy the starter prompt.
+- Copy the agent prompt.
 - Paste it into your agent.
 - Ask normal questions like:
   - what did I miss today
   - summarize my latest meeting
   - find every time we discussed pricing
   - pull action items from my latest meeting and dictations
+
+The copied prompt tells the agent to:
+
+- use Transcripted MCP tools first if they are already connected
+- otherwise read the local Transcripted folders directly
+- help you set up the better option if neither path is ready yet
 
 Current local folders:
 
@@ -29,7 +35,7 @@ The meetings folder also contains:
 - `AGENT.md` — plain-English structure guide for file-based agents
 - `transcripted.json` — index of saved meeting transcripts
 
-## Better Connection: MCP
+## Optional: MCP
 
 Use MCP when your client supports it and you want direct read-only tools instead
 of asking the model to inspect files manually.
@@ -86,34 +92,3 @@ Notes:
 - If needed, override paths with `TRANSCRIPTED_DATA_DIR`,
   `TRANSCRIPTED_MEETINGS_DIR`, `TRANSCRIPTED_DICTATIONS_DIR`, and
   `TRANSCRIPTED_INDEX_DIR`.
-
-## Advanced: CLI
-
-Use the CLI when you want terminal access, scripts, automation, or offline audio
-processing.
-
-### Context Commands
-
-```bash
-cd Tools/TranscriptedCLI
-swift run transcripted-cli context-recent
-swift run transcripted-cli context-search "roadmap"
-swift run transcripted-cli list-dictations
-swift run transcripted-cli read-dictation Dictations_YYYY-MM-DD
-```
-
-### Diarization Commands
-
-```bash
-cd Tools/TranscriptedCLI
-swift run transcripted-cli diarize /path/to/audio.wav --json
-swift run transcripted-cli batch /path/to/folder --ext wav
-```
-
-Notes:
-
-- the context commands read the same local Transcripted folders as the app and
-  MCP server
-- the diarization commands are separate offline audio tools
-- the CLI depends on repo-level dependency artifacts, so run `bash build-deps.sh`
-  first if they are missing


### PR DESCRIPTION
## Summary
- simplify the agent-connect UI around one primary `Copy agent prompt` flow
- demote MCP setup and manual folder access to secondary fallback sections
- expand the copied prompt so agents prefer MCP, can attempt MCP setup when possible, and fall back cleanly to local folders

## Verification
- `bash build.sh`
- `bash run-tests.sh`