### PR TITLE
[codex] Rewrite repo docs around the audio artifact thesis

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -20,12 +20,23 @@ What you expected to happen.
 **Actual behavior**
 What actually happened.
 
+**Area**
+- Dictation
+- Meetings
+- Agent artifacts / external agent handoff
+- Other
+
 **Environment**
 - macOS version:
-- Draft version/commit:
+- Transcripted version/commit:
 - Audio source (mic, Zoom, Meet, etc.):
+
+**Storage details**
+- Are you using `~/Library/Application Support/Transcripted/` or a legacy `Draft/` folder?
 
 **Diagnostics**
 If you have logs, screenshots, or exported diagnostics, attach them here.
 
-If this report is about the old standalone Transcripted app, please say so and include the legacy ref you were using (`legacy/transcripted-standalone` or `pre-draft-takeover-2026-04-06`).
+If this report is about the old standalone Transcripted app, say so explicitly
+and include the legacy ref you were using (`legacy/transcripted-standalone` or
+`pre-draft-takeover-2026-04-06`).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Suggest an idea for Draft
+about: Suggest an idea for Transcripted
 title: ''
 labels: enhancement
 assignees: ''
@@ -12,10 +12,21 @@ What problem does this solve? What's frustrating about the current behavior?
 **Proposed solution**
 How should it work?
 
+**Area**
+- Dictation
+- Meetings
+- Agent artifacts / retrieval
+- Privacy / local-first behavior
+- Other
+
+**Why this matters**
+How would this improve the product for actual day-to-day use?
+
 **Alternatives considered**
 Any other approaches you've thought about.
 
 **Additional context**
 Screenshots, links, or other relevant info.
 
-If this request is specifically about the old standalone Transcripted app, say that explicitly so it can be triaged against the legacy branch/tag instead of Draft-first `main`.
+If this request is specifically about the old standalone Transcripted app, say
+that explicitly so it can be triaged against the legacy branch/tag.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,16 +2,27 @@
 
 <!-- What does this PR do and why? -->
 
+## Product Impact
+
+- Affects: `dictation` / `meetings` / `agent artifacts` / `docs only`
+- Why this matters:
+
 ## Changes
 
 -
 
-## Test plan
+## Risk Review
+
+- [ ] Privacy / local-first behavior reviewed
+- [ ] Storage path or migration impact reviewed
+- [ ] Public-facing copy stays concrete and matches current product scope
+
+## Test Plan
 
 - [ ] Builds without warnings
 - [ ] Tests pass
 - [ ] Manually tested:
 
-## Related issues
+## Related Issues
 
 <!-- Closes #123 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,12 @@
 # Contributing to Transcripted
 
-Thanks for your interest in contributing to Transcripted! This guide will help you get set up and contributing quickly.
+Transcripted is a local Mac app that turns meetings and dictation into
+structured voice artifacts people and agents can both use.
+
+In public docs and user-facing copy, prefer concrete present-tense claims about
+what the product does today. The broader "audio as a context layer" thesis is
+real, but it should be earned through proof rather than stated as if the future
+state already exists.
 
 ## Development Setup
 
@@ -13,12 +19,14 @@ Thanks for your interest in contributing to Transcripted! This guide will help y
 ### Getting Started
 
 1. Fork the repo and clone your fork:
+
    ```bash
    git clone https://github.com/YOUR_USERNAME/transcripted.git
    cd transcripted
    ```
 
 2. Build dependencies and the app:
+
    ```bash
    bash build-deps.sh
    bash build.sh
@@ -26,9 +34,9 @@ Thanks for your interest in contributing to Transcripted! This guide will help y
 
 3. Run the test suite:
 
-```bash
-bash run-tests.sh
-```
+   ```bash
+   bash run-tests.sh
+   ```
 
 If you touch meeting integration or `TranscriptedCore`, also run:
 
@@ -39,17 +47,28 @@ bash run-integration-smoke.sh
 On first launch, models may download from HuggingFace if they are not already
 cached locally.
 
+## Product Framing
+
+When you change README copy, onboarding text, or public docs, keep these rules
+in mind:
+
+- lead with the concrete product: local dictation and local meeting capture
+- treat "agent-ready artifacts" as a present-tense capability
+- treat "ambient context layer" as vision language, not current product language
+- be precise about what stays local and what may still contact external services
+- explain legacy `Draft` paths as compatibility behavior, not as a second product
+
 ## Making Changes
 
 ### Branch Naming
 
 Create a branch from `main` with a descriptive name:
 
-```
-feat/description     # New feature
-fix/description      # Bug fix
-docs/description     # Documentation only
-refactor/description # Code refactoring
+```text
+feat/description
+fix/description
+docs/description
+refactor/description
 ```
 
 ### Code Style
@@ -57,7 +76,7 @@ refactor/description # Code refactoring
 - Follow existing Swift conventions in the codebase
 - Use `// MARK:` comments to organize sections within files
 - Never do I/O, locks, or allocations inside CoreAudio real-time callbacks
-- Keep `@MainActor` annotations correct (see Threading below)
+- Keep `@MainActor` annotations correct
 
 ### Architecture
 
@@ -68,13 +87,29 @@ The codebase is organized around the current Transcripted app:
 | App entry + state | `Sources/` | app lifecycle, hotkeys, paths, shared state |
 | Dictation + formatting | `Sources/Draft/` | dictation cleanup, formatting, draft utilities |
 | Meeting pipeline | `Sources/Meeting/` | meeting recording, model warmup, transcript flow |
-| UI | `Sources/UI/` | overlay, menubar, onboarding |
+| UI | `Sources/UI/` | overlay, menubar, onboarding, agent connection |
 | Local inference | `Sources/Local/` | on-device MLX model integration |
-| Shared meeting core | `Sources/TranscriptedCore/` | extracted meeting/transcription library |
+| Shared meeting core | `Sources/TranscriptedCore/` | extracted meeting/transcription library and agent artifacts |
+
+Some internal folders still use `Draft` naming while the repo and product are
+being aligned publicly around Transcripted. Treat those as implementation
+details unless a change specifically affects compatibility paths.
+
+### Artifact-First Principle
+
+Transcripted prefers durable local outputs over opaque app-only state.
+
+That means changes should preserve or improve:
+
+- readable Markdown outputs
+- structured JSON sidecars and indexes
+- stable storage paths
+- the ability for external agents to consume saved artifacts directly
 
 ### Threading
 
-Transcripted has strict threading rules due to CoreAudio's real-time requirements:
+Transcripted has strict threading rules due to CoreAudio's real-time
+requirements:
 
 | Component | Thread | Notes |
 |-----------|--------|-------|
@@ -83,7 +118,8 @@ Transcripted has strict threading rules due to CoreAudio's real-time requirement
 | Local model access | actor / managed async tasks | serialized model use |
 | CoreAudio I/O callbacks | real-time thread | **No I/O, locks, allocations, or ObjC calls** |
 
-CoreAudio I/O callbacks run on real-time threads. Buffers are deep-copied before async dispatch — never processed in-place.
+CoreAudio I/O callbacks run on real-time threads. Buffers are deep-copied
+before async dispatch, never processed in-place.
 
 ### Testing
 
@@ -102,20 +138,25 @@ bash run-integration-smoke.sh
 ## Submitting a Pull Request
 
 1. Make sure your code builds without warnings
-2. Run the test suite
-3. Keep PRs focused — one feature or fix per PR
-4. Write a clear PR description explaining **what** changed and **why**
-5. Link any related issues
+2. Run the relevant test suite
+3. Keep PRs focused, one feature or fix per PR
+4. Explain both what changed and why it matters
+5. Call out privacy, storage-path, or migration implications when relevant
+6. Link any related issues
 
 ## Reporting Bugs
 
 Open a GitHub issue with:
 
 - macOS version
-- Steps to reproduce
-- Expected vs actual behavior
-- Relevant logs from `~/Library/Application Support/Draft/events.jsonl`
+- steps to reproduce
+- expected vs actual behavior
+- whether the issue affects dictation, meetings, or agent artifacts
+- relevant logs from `~/Library/Application Support/Transcripted/events.jsonl` or the legacy `Draft` path
+
+If your machine still uses the legacy `Draft` Application Support folder,
+mention that in the report.
 
 ## Questions?
 
-Open a GitHub issue for questions or discussion. We're happy to help you get oriented in the codebase.
+Open a GitHub issue for questions or discussion.

--- a/README.md
+++ b/README.md
@@ -1,70 +1,202 @@
 # Transcripted
 
-Transcripted is private voice context for your Mac.
+Transcripted is a local Mac app for dictation and meeting capture that turns
+spoken work into structured files your AI can actually use.
 
-Dictate into any app, record meetings locally, and keep searchable spoken
-context that can feed your personal AI agent.
+Use it today as a practical dictation and meeting tool. Longer term, we think
+audio is the first useful layer of local AI context, because it captures real
+work without asking you to maintain a second brain by hand.
 
-## What it does
+![Transcripted dictation mode](docs/screenshots/dictation-mode.png)
 
-### Dictation
+## What You Get Today
 
-Click into any text field, start dictation, speak, and Transcripted pastes the
-text back into the app you were already using.
+- Dictate into any app and paste text back where you were already working
+- Record meetings locally with mic and system audio capture
+- Save human-readable Markdown and machine-readable JSON artifacts on disk
+- Point Claude, Codex, or another local agent at those artifacts with a starter prompt
 
-Useful for:
+## Why This Exists
 
-- messages
-- notes
-- docs
-- quick thoughts
+A lot of important context never makes it into docs or chat logs.
 
-### Meetings
+It shows up in:
 
-Start a meeting recording, let Transcripted capture your mic and system audio,
-and when you stop it, Transcripted saves a local transcript.
+- meetings
+- dictated messages
+- voice notes
+- half-formed spoken thinking
 
-Useful when you want to keep track of:
+Most of that context disappears as soon as the conversation ends.
 
-- what people said
-- what got decided
-- what questions came up
-- what needs to happen next
+Transcripted tries to preserve that high-signal spoken work locally, then turn
+it into files that stay inspectable, reusable, and easy to load on demand.
 
-Meeting transcripts are currently saved here:
+## How It Works
 
-`~/Library/Application Support/Draft/meetings/transcripts`
+### 1. Capture spoken work
 
-That Draft-named storage path stays in place for now so the rebrand does not
-break existing local data.
+Transcripted supports two concrete workflows today:
 
-### Agent-ready voice context
+- dictation into any app
+- local meeting recording and transcription
 
-A lot of your best context lives in your voice, not just in typed chat boxes.
+### 2. Process it locally
 
-Transcripted keeps that context local on your Mac so your personal AI agent can
-work from what actually happened in your messages, calls, and meetings.
+Transcripted transcribes audio on-device and keeps the resulting artifacts on
+your Mac.
 
-## Important transition note
+### 3. Save durable artifacts
 
-The old standalone Transcripted app is preserved on:
+Meeting recordings become:
 
-- branch: `legacy/transcripted-standalone`
-- tag: `pre-draft-takeover-2026-04-06`
+- a Markdown transcript
+- a structured JSON sidecar
+- a `transcripted.json` index of saved meetings
+- `AGENT.md` and `CLAUDE.md` helper docs for external agents
 
-This repo cutover uses the manual migration path:
+Dictation becomes:
 
-- existing Transcripted installs do not auto-upgrade into the new app
-- Transcripted should currently be treated as a new install
-- permissions and settings do not carry over automatically
+- daily Markdown logs like `Dictations_2026-04-07.md`
+- timestamped sections with source-app metadata and delivery status
 
-## Privacy
+### 4. Load the right slice later
 
-Transcripted is local-first.
+Instead of asking an agent to read everything all the time, Transcripted gives
+you durable files that can be loaded when needed:
 
-- your dictation stays on your Mac
-- your meeting recordings stay on your Mac
-- your transcripts are saved locally
+- latest meeting
+- meetings for a named speaker
+- dictations from a specific day
+- transcripts related to a topic or decision
+
+## Artifacts, Not A Black Box
+
+Transcripted is opinionated about file output because inspectable artifacts are
+more useful than opaque app state.
+
+Example meeting transcript:
+
+```md
+# Meeting with Alex
+
+## Full Transcript
+
+**[00:00] [Mic/You]**
+Thanks for making time today.
+
+**[00:04] [System/Alex]**
+Happy to help. Let's get started.
+```
+
+Example meeting sidecar:
+
+```json
+{
+  "version": "1.0",
+  "recording": {
+    "duration_seconds": 750,
+    "engines": {
+      "stt": "parakeet-tdt-v3",
+      "diarization": "pyannote-offline"
+    }
+  },
+  "speakers": [
+    { "id": "mic_0", "name": "You" },
+    { "id": "system_0", "name": "Alex" }
+  ],
+  "utterances": [
+    { "start": 0.0, "end": 4.0, "speaker_id": "mic_0", "text": "Thanks for making time today." }
+  ]
+}
+```
+
+Example dictation artifact:
+
+```md
+---
+title: "Dictations for April 7, 2026"
+date: 2026-04-07
+capture_type: dictation_day
+---
+
+## 9:15 AM - First note from the morning
+
+Source app: Messages
+Timestamp: 2026-04-07 09:15:00
+
+first note from the morning
+```
+
+## Why Audio First
+
+We do not think the answer is "capture everything."
+
+We think the better path is:
+
+- start with a signal people already produce during real work
+- structure it into useful artifacts automatically
+- let agents load more context only when they need it
+
+Audio is a good first wedge because it is:
+
+- high signal
+- already part of meetings and messaging
+- less invasive than full screen capture
+- easier to structure than a full visual memory system
+
+That does not make Transcripted an "ambient context layer" yet. It means audio
+is the first practical layer of one.
+
+## Local By Default
+
+Transcripted keeps its core workflows on-device:
+
+- dictation capture and saved dictation logs stay on your Mac
+- meeting capture, transcription, and saved transcripts stay on your Mac
+- agent-facing artifacts are plain local files you can inspect directly
+
+Fresh installs use:
+
+- `~/Library/Application Support/Transcripted/dictations/`
+- `~/Library/Application Support/Transcripted/meetings/`
+
+If a legacy `Draft` Application Support folder already exists, current builds
+continue using that location for compatibility while the rename settles.
+
+Operational caveats:
+
+- first launch may download local models from HuggingFace if they are not cached
+- beta builds can optionally contact the update/log proxy for update checks and diagnostics
+
+![Transcripted privacy architecture](docs/screenshots/privacy-architecture.png)
+
+## What Exists Today
+
+Today, Transcripted is already useful as:
+
+- a local dictation tool
+- a local meeting recorder and transcription tool
+- a file-based handoff point for external agents
+
+The current product is not a full passive memory system. Capture is still
+explicitly user-invoked. The value is that what you capture becomes durable,
+structured, and reusable instead of disappearing.
+
+## Where This Goes Next
+
+The broader direction is to improve the audio context layer before expanding
+scope.
+
+That likely means:
+
+- better summarization and extraction from saved artifacts
+- more selective retrieval for agents
+- stronger cross-meeting speaker and topic navigation
+- light non-audio context later, where it clearly improves usefulness
+
+The goal is not to make context gathering feel like a job. The goal is to make
+useful context accumulate quietly, then make the right slice easy to load.
 
 ## Build
 
@@ -85,6 +217,20 @@ If you touch meeting integration or `TranscriptedCore`, also run:
 bash run-integration-smoke.sh
 ```
 
-## In short
+## Transition Notes
 
-Transcripted is a Mac app for dictation, meetings, and private voice context.
+The old standalone Transcripted app is preserved on:
+
+- branch: `legacy/transcripted-standalone`
+- tag: `pre-draft-takeover-2026-04-06`
+
+This repo currently uses the manual migration path:
+
+- existing standalone Transcripted installs do not auto-upgrade into this app
+- fresh installs use Transcripted-named Application Support paths
+- existing Draft-named Application Support folders are still reused for compatibility
+
+## Contributing And Security
+
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and architecture notes
+- See [SECURITY.md](SECURITY.md) for privacy architecture and vulnerability reporting

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,28 +2,41 @@
 
 ## Privacy Architecture
 
-Transcripted keeps its core workflows on-device:
+Transcripted is local by default.
 
-- dictation runs locally on your Mac
-- meeting capture and transcription stay local
-- transcripts and feedback data are written to local files you control
+Its core product workflows are:
 
-Current builds still use Draft-named application-support paths for compatibility
-while the Transcripted brand rollout settles.
+- local dictation capture
+- local meeting capture and transcription
+- local artifact generation for humans and agents
+
+Those artifacts are written as files you can inspect directly rather than being
+hidden behind a cloud-only backend.
+
+Fresh installs default to Transcripted-named storage. If a legacy `Draft`
+Application Support folder already exists, current builds continue using it for
+compatibility.
 
 Data stored locally today:
 
 | Data | Location | Format |
 |------|----------|--------|
-| Meeting transcripts | `~/Library/Application Support/Draft/meetings/transcripts/` | Markdown |
-| App events | `~/Library/Application Support/Draft/events.jsonl` | JSON Lines |
-| Feedback log | `~/Library/Application Support/Draft/feedback.jsonl` | JSON Lines |
-| Style profile | `~/Library/Application Support/Draft/style.md` | Markdown |
-| Prompt overrides | `~/Library/Application Support/Draft/prompts.json` | JSON |
+| Meeting transcripts | `~/Library/Application Support/Transcripted/...` or legacy `Draft/...` | Markdown |
+| Meeting sidecars + index | `~/Library/Application Support/Transcripted/...` or legacy `Draft/...` | JSON |
+| Speaker database | `~/Library/Application Support/Transcripted/...` or legacy `Draft/...` | SQLite |
+| Speaker clips | `~/Library/Application Support/Transcripted/...` or legacy `Draft/...` | WAV |
+| Dictation logs | `~/Library/Application Support/Transcripted/...` or legacy `Draft/...` | Markdown |
+| App events | `~/Library/Application Support/Transcripted/...` or legacy `Draft/...` | JSON Lines |
+| Feedback log | `~/Library/Application Support/Transcripted/...` or legacy `Draft/...` | JSON Lines |
+| Style profile | `~/Library/Application Support/Transcripted/...` or legacy `Draft/...` | Markdown |
+| Prompt overrides | `~/Library/Application Support/Transcripted/...` or legacy `Draft/...` | JSON |
 | Model cache | `~/Library/Caches/models/mlx-community/` | MLX / CoreML |
 
-Beta builds can optionally contact the update/log proxy for update checks and
-diagnostics shipping. Core dictation and transcription do not require cloud APIs.
+Operational caveats:
+
+- first launch may download local models from HuggingFace if they are not already cached
+- beta builds can optionally contact the update/log proxy for update checks and diagnostics shipping
+- core dictation and transcription do not require cloud APIs
 
 ## Supported Versions
 
@@ -32,28 +45,31 @@ diagnostics shipping. Core dictation and transcription do not require cloud APIs
 | Latest release | Yes |
 | Older releases | Best effort |
 
-## Reporting a Vulnerability
+## Reporting A Vulnerability
 
-If you discover a security vulnerability, please report it responsibly:
+If you discover a security vulnerability, report it responsibly:
 
-1. **Do not** open a public GitHub issue for security vulnerabilities
-2. Email your report to the maintainers (open a private GitHub Security Advisory at https://github.com/r3dbars/transcripted/security/advisories/new)
+1. Do not open a public GitHub issue for security vulnerabilities
+2. Open a private GitHub Security Advisory at <https://github.com/r3dbars/transcripted/security/advisories/new>
 3. Include:
-   - Description of the vulnerability
-   - Steps to reproduce
-   - Potential impact
-   - Suggested fix (if any)
+   - description of the vulnerability
+   - steps to reproduce
+   - potential impact
+   - suggested fix, if any
 
-We will acknowledge your report within 48 hours and aim to provide a fix within 7 days for critical issues.
+We will acknowledge your report within 48 hours and aim to provide a fix within
+7 days for critical issues.
 
 ## Scope
 
-Given that Transcripted is local-first software, the primary security concerns are:
+Given that Transcripted is local-first software, the main security concerns are:
 
-- **Audio capture permissions** — ensuring the app only captures audio when the user intends
-- **Accessibility and paste-back safety** — ensuring automation targets the app the user intended
-- **Local data protection** — transcript and feedback file permissions
-- **Model integrity** — ensuring downloaded ML models haven't been tampered with
-- **Memory safety** — preventing audio buffer overflows or use-after-free in CoreAudio callbacks
+- audio capture permissions and ensuring capture only happens when the user intends
+- accessibility and paste-back safety when Transcripted writes into another app
+- local data protection for transcripts, sidecars, and feedback files
+- model integrity for downloaded local ML artifacts
+- memory safety in CoreAudio and audio-processing code
+- any optional network paths used for beta updates or diagnostics
 
-Out of scope: generic hosted-service attacks. Transcripted does not depend on cloud APIs for its core product workflows.
+Out of scope: generic hosted-service attacks. Transcripted does not depend on
+cloud APIs for its core product workflows.


### PR DESCRIPTION
## What changed

This rewrites the repo-facing docs so Transcripted is framed more concretely as a local Mac app for dictation and meeting capture that turns spoken work into structured files agents can use.

It updates:

- `README.md`
- `CONTRIBUTING.md`
- `SECURITY.md`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/ISSUE_TEMPLATE/bug_report.md`
- `.github/ISSUE_TEMPLATE/feature_request.md`

## Why this changed

The previous framing was directionally right, but it was borrowing credibility from a bigger future product too early.

This rewrite shifts the repo to:

- lead with the concrete product that exists today
- show the artifact-first/local-first story more explicitly
- keep the broader audio-context thesis, but move it into earned vision language instead of headline claims
- remove public-facing `Draft` confusion from templates and supporting docs

## User / developer impact

- GitHub visitors should understand the product faster and with less category confusion
- The README now makes more defensible present-tense claims about what Transcripted actually does today
- Supporting docs and templates now reinforce the same thesis instead of mixing Transcripted and Draft framing

## Validation

- Pressure-tested the framing with multiple critique passes before rewriting
- Reviewed the final doc diff for consistency and overclaiming
- `git diff --check`

## Notes

This is a docs-only PR. No code paths or runtime behavior changed.