### PR TITLE
[codex] Fix AirPods dictation recovery and bundle Parakeet assets

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -491,9 +491,46 @@ class ParakeetEngine: ObservableObject {
                     message: error.localizedDescription)
                 return false
             }
-            // Re-read formats after engine restart
-            let refreshedFormat = inputNode.outputFormat(forBus: 0)
-            nativeSampleRate = refreshedFormat.sampleRate
+            // Re-read both formats after engine restart and refuse to install a
+            // tap until CoreAudio reports a stable, matching hardware graph.
+            let refreshedOutputFormat = inputNode.outputFormat(forBus: 0)
+            let refreshedHardwareFormat = inputNode.inputFormat(forBus: 0)
+            nativeSampleRate = refreshedOutputFormat.sampleRate
+
+            guard refreshedOutputFormat.sampleRate > 0, refreshedHardwareFormat.sampleRate > 0 else {
+                EventReporter.shared.capture(level: .warning, engine: "parakeet",
+                    event: "format_mismatch_retry_needed",
+                    message: "Audio hardware still settling after device change",
+                    context: [
+                        "output_rate": "\(refreshedOutputFormat.sampleRate)",
+                        "hw_rate": "\(refreshedHardwareFormat.sampleRate)"
+                    ])
+                audioEngine.stop()
+                isEnginePrewarmed = false
+                Task { @MainActor [weak self] in
+                    try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
+                    self?.prewarm()
+                }
+                return false
+            }
+
+            guard refreshedOutputFormat.sampleRate == refreshedHardwareFormat.sampleRate else {
+                print("⚠️ PARAKEET | format mismatch persisted after resync: output=\(refreshedOutputFormat.sampleRate)Hz hw=\(refreshedHardwareFormat.sampleRate)Hz")
+                EventReporter.shared.capture(level: .warning, engine: "parakeet",
+                    event: "format_mismatch_retry_needed",
+                    message: "Audio format mismatch persisted after engine resync",
+                    context: [
+                        "output_rate": "\(refreshedOutputFormat.sampleRate)",
+                        "hw_rate": "\(refreshedHardwareFormat.sampleRate)"
+                    ])
+                audioEngine.stop()
+                isEnginePrewarmed = false
+                Task { @MainActor [weak self] in
+                    try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
+                    self?.prewarm()
+                }
+                return false
+            }
         }
 
         guard nativeSampleRate > 0 else {

--- a/build.sh
+++ b/build.sh
@@ -12,13 +12,28 @@ rm -rf "$BUILD_DIR"
 mkdir -p "$APP_BUNDLE/Contents/MacOS"
 mkdir -p "$APP_BUNDLE/Contents/Resources"
 
-# Bundle Parakeet CoreML models
-PARAKEET_SRC="$HOME/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml"
-if [ -d "$PARAKEET_SRC/Encoder.mlmodelc" ]; then
-    echo "Bundling Parakeet models..."
-    mkdir -p "$APP_BUNDLE/Contents/Resources/parakeet-models"
-    cp -R "$PARAKEET_SRC" "$APP_BUNDLE/Contents/Resources/parakeet-models/"
-else
+# Bundle Parakeet model directories used by FluidAudio.
+# The runtime loader can resolve files from both the `-coreml` and legacy
+# `parakeet-tdt-0.6b-v3` layouts, so ship both when present.
+PARAKEET_MODELS_ROOT="$HOME/Library/Application Support/FluidAudio/Models"
+PARAKEET_BUNDLE_DIR="$APP_BUNDLE/Contents/Resources/parakeet-models"
+PARAKEET_MODEL_DIRS=(
+    "parakeet-tdt-0.6b-v3-coreml"
+    "parakeet-tdt-0.6b-v3"
+)
+
+bundled_parakeet_models=false
+mkdir -p "$PARAKEET_BUNDLE_DIR"
+for model_dir in "${PARAKEET_MODEL_DIRS[@]}"; do
+    model_src="$PARAKEET_MODELS_ROOT/$model_dir"
+    if [ -d "$model_src/Encoder.mlmodelc" ]; then
+        echo "Bundling Parakeet models from $model_dir..."
+        cp -R "$model_src" "$PARAKEET_BUNDLE_DIR/"
+        bundled_parakeet_models=true
+    fi
+done
+
+if [ "$bundled_parakeet_models" = false ]; then
     echo "Parakeet models not found — Parakeet engine will attempt runtime download"
 fi
 


### PR DESCRIPTION
## What changed

- Guarded `ParakeetEngine.startRecording()` so we do not install an audio tap after a device-switch resync unless the output and hardware sample rates have actually converged.
- Added a safe retry path that logs `format_mismatch_retry_needed`, backs off, and re-prewarms instead of proceeding into a crash-prone Core Audio state.
- Updated `build.sh` to bundle both `parakeet-tdt-0.6b-v3-coreml` and `parakeet-tdt-0.6b-v3` so the packaged app includes the vocab files expected by the runtime loader.

## Why this changed

AirPods switching exposed two issues in the local build:

1. Dictation could hit a sample-rate mismatch during device changes (`output_rate=48000`, `hw_rate=24000`) and continue toward tap installation before Core Audio had stabilized.
2. The packaged app only bundled the `-coreml` Parakeet directory, but the runtime loader also looked for `parakeet_vocab.json` under the legacy `parakeet-tdt-0.6b-v3` directory.

## Root cause

The device-switch recovery path handled detection but not the case where the engine restart failed to fully settle the hardware graph before the next tap installation. Separately, the app bundle was missing one of the model directory layouts that FluidAudio may resolve at runtime.

## Impact

- AirPods connect/disconnect/reconnect during dictation should recover cleanly instead of crashing or aborting during audio setup.
- Fresh bundled builds should load the local dictation model successfully instead of failing with `parakeet_vocab.json not found`.

## Validation

- `bash build.sh`
- `bash run-tests.sh`
- Verified the rebuilt bundle contains both model directories and the missing vocab file.
- Verified app logs showed `models_loaded` from `bundle` and reached `Transcripted is ready`.
- Manual QA: connected, disconnected, and reconnected AirPods successfully; device change recovery completed and dictation continued working.