### PR TITLE
Remove screenshot references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Use it today as a practical dictation and meeting tool. Longer term, we think
 audio is the first useful layer of local AI context, because it captures real
 work without asking you to maintain a second brain by hand.
 
-![Transcripted dictation mode](docs/screenshots/dictation-mode.png)
 
 ## What You Get Today
 
@@ -179,7 +178,6 @@ Operational caveats:
 - first launch may download local models from HuggingFace if they are not cached
 - beta builds can optionally contact the update/log proxy for update checks and diagnostics
 
-![Transcripted privacy architecture](docs/screenshots/privacy-architecture.png)
 
 ## What Exists Today
 


### PR DESCRIPTION
Removed screenshots from the README to streamline content.

## Why

<!-- What problem does this change solve? -->

## Product Impact

- Affects: `dictation` / `meetings` / `agent artifacts` / `docs only`
- Why this matters:

## What changed

-

## How I checked it

- [ ] `bash build.sh`
- [ ] `bash run-tests.sh`
- [ ] `bash run-integration-smoke.sh` if I touched `Sources/Meeting/` or `Sources/TranscriptedCore/`
- [ ] Manual check:

## Risk Review

- [ ] Privacy / local-first behavior reviewed
- [ ] Storage path or migration impact reviewed
- [ ] Public-facing copy stays concrete and matches current product scope

## Notes

<!-- Related issues, follow-ups, screenshots, or legacy-branch impact -->
