### PR TITLE
[codex] Add meeting detected prompt

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -28,5 +28,7 @@
     <string>Transcripted needs screen recording access so meeting capture can access system audio from calls, videos, and other apps.</string>
     <key>NSAudioCaptureUsageDescription</key>
     <string>Transcripted records system audio alongside your microphone so meetings can be transcribed locally on your Mac.</string>
+    <key>NSCalendarsFullAccessUsageDescription</key>
+    <string>Transcripted can optionally use your calendar to spot upcoming meetings and offer a local record prompt right when they start.</string>
 </dict>
 </plist>

--- a/Sources/Meeting/MeetingPromptDetector.swift
+++ b/Sources/Meeting/MeetingPromptDetector.swift
@@ -1,0 +1,326 @@
+import AppKit
+import EventKit
+import Foundation
+
+@available(macOS 14.0, *)
+@MainActor
+final class MeetingPromptDetector {
+    struct Candidate: Equatable {
+        let id: String
+        let title: String
+        let detail: String
+        let startDate: Date
+        let endDate: Date
+        let meetingURL: URL
+    }
+
+    private enum Provider: Equatable {
+        case zoom
+        case googleMeet
+        case teams
+        case webex
+        case facetime
+
+        var browserHosted: Bool {
+            switch self {
+            case .googleMeet, .teams, .webex:
+                return true
+            case .zoom, .facetime:
+                return false
+            }
+        }
+
+        var activeBundleIdentifiers: Set<String> {
+            switch self {
+            case .zoom:
+                return ["us.zoom.xos"]
+            case .googleMeet:
+                return []
+            case .teams:
+                return ["com.microsoft.teams", "com.microsoft.teams2"]
+            case .webex:
+                return ["com.cisco.webexmeetingsapp", "com.webex.meetingmanager"]
+            case .facetime:
+                return ["com.apple.FaceTime"]
+            }
+        }
+    }
+
+    private struct ScoredCandidate {
+        let candidate: Candidate
+        let score: Int
+    }
+
+    var onPromptRequest: ((Candidate) -> Bool)?
+
+    private let eventStore = EKEventStore()
+    private var pollingTask: Task<Void, Never>?
+    private var snoozedUntil: [String: Date] = [:]
+    private var pendingUntil: [String: Date] = [:]
+
+    private let defaultSnoozeInterval: TimeInterval = 30 * 60
+    private let pendingCooldown: TimeInterval = 90
+    private let pollIntervalNanoseconds: UInt64 = 20_000_000_000
+
+    private static let browserBundleIdentifiers: Set<String> = [
+        "com.apple.Safari",
+        "com.google.Chrome",
+        "com.google.Chrome.canary",
+        "com.microsoft.edgemac",
+        "com.brave.Browser",
+        "company.thebrowser.Browser",
+        "org.mozilla.firefox"
+    ]
+
+    func start() {
+        guard pollingTask == nil else { return }
+
+        pollingTask = Task { [weak self] in
+            guard let self else { return }
+
+            await evaluate()
+
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: pollIntervalNanoseconds)
+                guard !Task.isCancelled else { return }
+                await evaluate()
+            }
+        }
+    }
+
+    func stop() {
+        pollingTask?.cancel()
+        pollingTask = nil
+    }
+
+    func snooze(candidate: Candidate, interval: TimeInterval? = nil) {
+        let until = max(
+            Date().addingTimeInterval(interval ?? defaultSnoozeInterval),
+            candidate.endDate.addingTimeInterval(5 * 60)
+        )
+        snoozedUntil[candidate.id] = until
+        pendingUntil[candidate.id] = until
+    }
+
+    func markAccepted(candidate: Candidate) {
+        let until = max(Date().addingTimeInterval(defaultSnoozeInterval), candidate.endDate.addingTimeInterval(5 * 60))
+        snoozedUntil[candidate.id] = until
+        pendingUntil[candidate.id] = until
+    }
+
+    private func evaluate() async {
+        pruneExpiredEntries()
+
+        guard TranscriptedPermissionAccess.calendarAccessGranted() else { return }
+
+        let now = Date()
+        let runningBundleIDs = Set(NSWorkspace.shared.runningApplications.compactMap(\.bundleIdentifier))
+        let frontmostBundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+
+        guard let match = upcomingCandidates(
+            now: now,
+            runningBundleIDs: runningBundleIDs,
+            frontmostBundleID: frontmostBundleID
+        ).first else {
+            return
+        }
+
+        guard snoozedUntil[match.candidate.id] == nil, pendingUntil[match.candidate.id] == nil else { return }
+
+        if onPromptRequest?(match.candidate) == true {
+            pendingUntil[match.candidate.id] = now.addingTimeInterval(pendingCooldown)
+        }
+    }
+
+    private func upcomingCandidates(
+        now: Date,
+        runningBundleIDs: Set<String>,
+        frontmostBundleID: String?
+    ) -> [ScoredCandidate] {
+        let searchStart = now.addingTimeInterval(-5 * 60)
+        let searchEnd = now.addingTimeInterval(15 * 60)
+        let predicate = eventStore.predicateForEvents(withStart: searchStart, end: searchEnd, calendars: nil)
+
+        return eventStore.events(matching: predicate)
+            .compactMap { event in
+                scoredCandidate(
+                    from: event,
+                    now: now,
+                    runningBundleIDs: runningBundleIDs,
+                    frontmostBundleID: frontmostBundleID
+                )
+            }
+            .sorted {
+                if $0.score != $1.score {
+                    return $0.score > $1.score
+                }
+                return $0.candidate.startDate < $1.candidate.startDate
+            }
+    }
+
+    private func scoredCandidate(
+        from event: EKEvent,
+        now: Date,
+        runningBundleIDs: Set<String>,
+        frontmostBundleID: String?
+    ) -> ScoredCandidate? {
+        guard !event.isAllDay else { return nil }
+        guard let meetingURL = extractMeetingURL(from: event), let provider = provider(for: meetingURL) else { return nil }
+
+        let startsIn = event.startDate.timeIntervalSince(now)
+        let genericWindow = (-90.0 ... 5 * 60).contains(startsIn)
+        let runtimeReason = activeRuntimeReason(
+            for: provider,
+            runningBundleIDs: runningBundleIDs,
+            frontmostBundleID: frontmostBundleID
+        )
+        let extendedRuntimeWindow = runtimeReason != nil && (-5 * 60 ... 10 * 60).contains(startsIn)
+
+        guard genericWindow || extendedRuntimeWindow else { return nil }
+
+        let title = trimmedTitle(from: event)
+        let detail = buildDetail(title: title, startsIn: startsIn, runtimeReason: runtimeReason)
+        let score = scoreForCandidate(startsIn: startsIn, runtimeReason: runtimeReason)
+
+        return ScoredCandidate(
+            candidate: Candidate(
+                id: event.calendarItemIdentifier,
+                title: title,
+                detail: detail,
+                startDate: event.startDate,
+                endDate: event.endDate,
+                meetingURL: meetingURL
+            ),
+            score: score
+        )
+    }
+
+    private func trimmedTitle(from event: EKEvent) -> String {
+        let trimmed = (event.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Upcoming meeting" : trimmed
+    }
+
+    private func buildDetail(title: String, startsIn: TimeInterval, runtimeReason: String?) -> String {
+        if let runtimeReason {
+            return "\(title) - \(runtimeReason)"
+        }
+
+        if startsIn > 90 {
+            let minutes = Int(ceil(startsIn / 60))
+            return "\(title) - starts in \(minutes) min"
+        }
+
+        if startsIn > 15 {
+            return "\(title) - starts soon"
+        }
+
+        if startsIn >= -120 {
+            return "\(title) - starting now"
+        }
+
+        return "\(title) - already in progress"
+    }
+
+    private func scoreForCandidate(startsIn: TimeInterval, runtimeReason: String?) -> Int {
+        var score = runtimeReason == nil ? 1 : 3
+
+        if (-60 ... 120).contains(startsIn) {
+            score += 2
+        } else if (-5 * 60 ... 5 * 60).contains(startsIn) {
+            score += 1
+        }
+
+        return score
+    }
+
+    private func activeRuntimeReason(
+        for provider: Provider,
+        runningBundleIDs: Set<String>,
+        frontmostBundleID: String?
+    ) -> String? {
+        if !provider.activeBundleIdentifiers.isEmpty,
+           provider.activeBundleIdentifiers.contains(where: runningBundleIDs.contains) {
+            return "\(displayName(for: provider)) is open"
+        }
+
+        if provider.browserHosted,
+           let frontmostBundleID,
+           Self.browserBundleIdentifiers.contains(frontmostBundleID) {
+            return "meeting tab is active"
+        }
+
+        return nil
+    }
+
+    private func displayName(for provider: Provider) -> String {
+        switch provider {
+        case .zoom:
+            return "Zoom"
+        case .googleMeet:
+            return "Google Meet"
+        case .teams:
+            return "Teams"
+        case .webex:
+            return "Webex"
+        case .facetime:
+            return "FaceTime"
+        }
+    }
+
+    private func extractMeetingURL(from event: EKEvent) -> URL? {
+        if let url = event.url, provider(for: url) != nil {
+            return url
+        }
+
+        for source in [event.location, event.notes] {
+            guard let source else { continue }
+            guard let url = extractFirstMeetingURL(in: source) else { continue }
+            return url
+        }
+
+        return nil
+    }
+
+    private func extractFirstMeetingURL(in text: String) -> URL? {
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            return nil
+        }
+
+        let matches = detector.matches(in: text, options: [], range: range)
+        for match in matches {
+            guard let url = match.url, provider(for: url) != nil else { continue }
+            return url
+        }
+
+        return nil
+    }
+
+    private func provider(for url: URL) -> Provider? {
+        guard let host = url.host?.lowercased() else { return nil }
+
+        if host.contains("zoom.us") {
+            return .zoom
+        }
+        if host == "meet.google.com" {
+            return .googleMeet
+        }
+        if host.contains("teams.microsoft.com") {
+            return .teams
+        }
+        if host.contains("webex.com") {
+            return .webex
+        }
+        if host.contains("facetime.apple.com") {
+            return .facetime
+        }
+
+        return nil
+    }
+
+    private func pruneExpiredEntries() {
+        let now = Date()
+        snoozedUntil = snoozedUntil.filter { $0.value > now }
+        pendingUntil = pendingUntil.filter { $0.value > now }
+    }
+}

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -28,6 +28,7 @@ final class MeetingSessionController: ObservableObject {
     enum StartTrigger: String {
         case hotkey = "hotkey"
         case menu = "menu"
+        case detectedPrompt = "detected_prompt"
         case unknown = "unknown"
     }
 

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -39,6 +39,8 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     /// the dictation overlay so regressions to one can't break the other.
     @available(macOS 14.0, *)
     lazy var meetingOverlayController = MeetingOverlayController()
+    @available(macOS 14.0, *)
+    lazy var meetingPromptDetector = MeetingPromptDetector()
     private var workspaceObservers: [NSObjectProtocol] = []
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -60,6 +62,22 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         if #available(macOS 14.0, *) {
             let meetingSession = appState.meetingSession
             meetingOverlayController.setup(meetingSession: meetingSession)
+            meetingOverlayController.onPromptRecord = { [weak self] candidate in
+                guard let self else { return }
+                self.meetingPromptDetector.markAccepted(candidate: candidate)
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    await self.appState.meetingSession.startRecording(trigger: .detectedPrompt)
+                }
+            }
+            meetingOverlayController.onPromptDismiss = { [weak self] candidate in
+                self?.meetingPromptDetector.snooze(candidate: candidate)
+            }
+            meetingPromptDetector.onPromptRequest = { [weak self] candidate in
+                guard PermissionsOnboardingView.hasCompleted else { return false }
+                self?.meetingOverlayController.presentDetectedMeetingPrompt(candidate) ?? false
+            }
+            meetingPromptDetector.start()
             appState.contextCapture.onMeetingToggle = { [weak self] in
                 self?.meetingOverlayController.toggleFromHotkey()
             }
@@ -113,6 +131,9 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     func applicationWillTerminate(_ notification: Notification) {
         for observer in workspaceObservers {
             NSWorkspace.shared.notificationCenter.removeObserver(observer)
+        }
+        if #available(macOS 14.0, *) {
+            meetingPromptDetector.stop()
         }
         #if BETA_BUILD
         BetaTelemetry.shared.shipLogs()

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -75,7 +75,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             }
             meetingPromptDetector.onPromptRequest = { [weak self] candidate in
                 guard PermissionsOnboardingView.hasCompleted else { return false }
-                self?.meetingOverlayController.presentDetectedMeetingPrompt(candidate) ?? false
+                return self?.meetingOverlayController.presentDetectedMeetingPrompt(candidate) ?? false
             }
             meetingPromptDetector.start()
             appState.contextCapture.onMeetingToggle = { [weak self] in

--- a/Sources/UI/MeetingOverlayController.swift
+++ b/Sources/UI/MeetingOverlayController.swift
@@ -62,10 +62,12 @@ final class MeetingOverlayRootView: NSView {
     private let statusDot = NSView()
     private let titleLabel = NSTextField(labelWithString: "Meeting")
     private let timerLabel = NSTextField(labelWithString: "00:00")
+    private let detailLabel = NSTextField(labelWithString: "")
     private let micLabel = NSTextField(labelWithString: "Mic")
     private let systemLabel = NSTextField(labelWithString: "System audio")
     private let micWaveform = WaveformHostView(frame: .zero)
     private let systemWaveform = WaveformHostView(frame: .zero)
+    private let recordButton = NSButton()
     private let closeButton = NSButton()
     private let chevronButton = NSButton()
     private let warmupTitleLabel = NSTextField(labelWithString: "Getting Transcripted ready")
@@ -75,7 +77,8 @@ final class MeetingOverlayRootView: NSView {
     private var currentWarmupStatus: MeetingSessionController.ModelWarmupStatus = .ready
 
     /// Invoked when the user clicks the close/stop button.
-    var onClose: (() -> Void)?
+    var onSecondaryAction: (() -> Void)?
+    var onPrimaryAction: (() -> Void)?
 
     override init(frame: NSRect) {
         super.init(frame: frame)
@@ -106,6 +109,12 @@ final class MeetingOverlayRootView: NSView {
         timerLabel.font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular)
         timerLabel.textColor = MeetingOverlayTokens.textSecondary
         addSubview(timerLabel)
+
+        detailLabel.font = NSFont.systemFont(ofSize: 11, weight: .medium)
+        detailLabel.textColor = MeetingOverlayTokens.textSecondary
+        detailLabel.lineBreakMode = .byTruncatingTail
+        detailLabel.isHidden = true
+        addSubview(detailLabel)
 
         micLabel.font = NSFont.systemFont(ofSize: 8, weight: .medium)
         micLabel.textColor = MeetingOverlayTokens.textSecondary
@@ -139,6 +148,22 @@ final class MeetingOverlayRootView: NSView {
         warmupProgress.isHidden = true
         addSubview(warmupProgress)
 
+        recordButton.attributedTitle = NSAttributedString(
+            string: "Record",
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
+                .foregroundColor: NSColor.black
+            ]
+        )
+        recordButton.isBordered = false
+        recordButton.wantsLayer = true
+        recordButton.layer?.cornerRadius = 8
+        recordButton.layer?.backgroundColor = OverlayTokens.accentGreen.cgColor
+        recordButton.target = self
+        recordButton.action = #selector(handlePrimaryAction)
+        recordButton.isHidden = true
+        addSubview(recordButton)
+
         closeButton.attributedTitle = NSAttributedString(
             string: "Stop",
             attributes: [
@@ -151,7 +176,7 @@ final class MeetingOverlayRootView: NSView {
         closeButton.layer?.cornerRadius = 8
         closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.12).cgColor
         closeButton.target = self
-        closeButton.action = #selector(handleClose)
+        closeButton.action = #selector(handleSecondaryAction)
         closeButton.isHidden = true
         addSubview(closeButton)
 
@@ -170,6 +195,10 @@ final class MeetingOverlayRootView: NSView {
         super.layout()
         if currentState == .preparing {
             layoutWarmup()
+            return
+        }
+        if currentState == .prompt {
+            layoutPrompt()
             return
         }
 
@@ -266,6 +295,56 @@ final class MeetingOverlayRootView: NSView {
         )
     }
 
+    private func layoutPrompt() {
+        let pad: CGFloat = 12
+        let dotSize = MeetingOverlayTokens.dotSize
+        let topY = bounds.height - 22
+
+        statusDot.frame = NSRect(x: pad, y: topY - dotSize / 2, width: dotSize, height: dotSize)
+
+        let timerSize = timerLabel.fittingSize
+        timerLabel.frame = NSRect(
+            x: bounds.width - pad - timerSize.width,
+            y: topY - timerSize.height / 2,
+            width: timerSize.width,
+            height: timerSize.height
+        )
+
+        let titleX = statusDot.frame.maxX + 8
+        let titleWidth = max(0, timerLabel.frame.minX - titleX - 8)
+        let titleSize = titleLabel.fittingSize
+        titleLabel.frame = NSRect(
+            x: titleX,
+            y: topY - titleSize.height / 2,
+            width: min(titleWidth, titleSize.width),
+            height: titleSize.height
+        )
+
+        detailLabel.frame = NSRect(
+            x: pad,
+            y: 34,
+            width: bounds.width - pad * 2,
+            height: 16
+        )
+
+        let secondaryWidth = max(62, closeButton.fittingSize.width + 18)
+        let primaryWidth = max(74, recordButton.fittingSize.width + 18)
+        let buttonHeight: CGFloat = 24
+
+        closeButton.frame = NSRect(
+            x: bounds.width - pad - secondaryWidth - primaryWidth - 8,
+            y: 10,
+            width: secondaryWidth,
+            height: buttonHeight
+        )
+        recordButton.frame = NSRect(
+            x: bounds.width - pad - primaryWidth,
+            y: 10,
+            width: primaryWidth,
+            height: buttonHeight
+        )
+    }
+
     private func layoutWarmup() {
         let pad: CGFloat = 16
         let contentWidth = bounds.width - pad * 2
@@ -286,7 +365,8 @@ final class MeetingOverlayRootView: NSView {
         micLevel: Float,
         systemLevel: Float,
         participants: [String],
-        warmupStatus: MeetingSessionController.ModelWarmupStatus?
+        warmupStatus: MeetingSessionController.ModelWarmupStatus?,
+        prompt: MeetingOverlayController.PromptDisplay?
     ) {
         currentState = state
         if let warmupStatus {
@@ -294,19 +374,22 @@ final class MeetingOverlayRootView: NSView {
         }
 
         let isPreparing = state == .preparing
+        let isPrompting = state == .prompt
         statusDot.isHidden = isPreparing
         titleLabel.isHidden = isPreparing
-        timerLabel.isHidden = isPreparing || state != .recording
-        micLabel.isHidden = isPreparing
-        systemLabel.isHidden = isPreparing
-        micWaveform.isHidden = isPreparing
-        systemWaveform.isHidden = isPreparing
+        timerLabel.isHidden = isPreparing || (state != .recording && !isPrompting)
+        detailLabel.isHidden = !isPrompting
+        micLabel.isHidden = isPreparing || isPrompting
+        systemLabel.isHidden = isPreparing || isPrompting
+        micWaveform.isHidden = isPreparing || isPrompting
+        systemWaveform.isHidden = isPreparing || isPrompting
         let showLevels = state == .recording
         micLabel.isHidden = !showLevels
         systemLabel.isHidden = !showLevels
         micWaveform.isHidden = !showLevels
         systemWaveform.isHidden = !showLevels
-        closeButton.isHidden = isPreparing || state != .recording
+        recordButton.isHidden = !isPrompting
+        closeButton.isHidden = isPreparing || (state != .recording && !isPrompting)
         chevronButton.isHidden = true
         warmupTitleLabel.isHidden = !isPreparing
         warmupSubtitleLabel.isHidden = !isPreparing
@@ -324,24 +407,52 @@ final class MeetingOverlayRootView: NSView {
         case .idle:
             titleLabel.stringValue = "Meeting"
             statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotIdle.cgColor
+            detailLabel.stringValue = ""
         case .preparing:
             titleLabel.stringValue = "Loading models…"
             statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotPrep.cgColor
+            detailLabel.stringValue = ""
+        case .prompt:
+            titleLabel.stringValue = prompt?.title ?? "Meeting detected"
+            detailLabel.stringValue = prompt?.detail ?? "Record this meeting?"
+            timerLabel.stringValue = prompt?.countdownText ?? ""
+            statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotPrompt.cgColor
+            closeButton.attributedTitle = NSAttributedString(
+                string: "Not now",
+                attributes: [
+                    .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
+                    .foregroundColor: MeetingOverlayTokens.textPrimary
+                ]
+            )
+            closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.10).cgColor
         case .recording:
             titleLabel.stringValue = "Recording meeting"
             statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotRecording.cgColor
+            closeButton.attributedTitle = NSAttributedString(
+                string: "Stop",
+                attributes: [
+                    .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
+                    .foregroundColor: MeetingOverlayTokens.textPrimary
+                ]
+            )
+            closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.12).cgColor
         case .transcribing:
             titleLabel.stringValue = "Saving transcript"
             statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotPrep.cgColor
+            detailLabel.stringValue = ""
         case .saved:
             titleLabel.stringValue = "Saved transcript"
             statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotSaved.cgColor
+            detailLabel.stringValue = ""
         case .error(let message):
             titleLabel.stringValue = displayErrorTitle(for: message)
             statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotError.cgColor
+            detailLabel.stringValue = ""
         }
 
-        timerLabel.stringValue = formatDuration(duration)
+        if state == .recording {
+            timerLabel.stringValue = formatDuration(duration)
+        }
         currentMicLevel = max(0, min(1, micLevel))
         currentSystemLevel = max(0, min(1, systemLevel))
         micWaveform.level = currentMicLevel
@@ -378,8 +489,12 @@ final class MeetingOverlayRootView: NSView {
         return "Transcript needs retry"
     }
 
-    @objc private func handleClose() {
-        onClose?()
+    @objc private func handleSecondaryAction() {
+        onSecondaryAction?()
+    }
+
+    @objc private func handlePrimaryAction() {
+        onPrimaryAction?()
     }
 }
 
@@ -395,12 +510,14 @@ enum MeetingOverlayTokens {
     static let waveformTint  = OverlayTokens.textPrimary
     static let dotIdle       = OverlayTokens.textMuted
     static let dotPrep       = OverlayTokens.textSecondary
+    static let dotPrompt     = OverlayTokens.accentGreen
     static let dotRecording  = NSColor(red: 0.95, green: 0.22, blue: 0.22, alpha: 1.0)
     static let dotSaved      = NSColor.systemGreen
     static let dotError      = NSColor.systemRed
 
     static let panelWidth: CGFloat  = 360
     static let panelHeight: CGFloat = 48
+    static let promptHeight: CGFloat = 88
     static let warmupHeight: CGFloat = 96
     static let cornerRadius: CGFloat = OverlayTokens.cornerRadius
     static let dotSize: CGFloat     = 8
@@ -420,11 +537,18 @@ final class MeetingOverlayController {
 
     enum OverlayState: Equatable {
         case idle
+        case prompt
         case preparing
         case recording
         case transcribing
         case saved
         case error(String)
+    }
+
+    struct PromptDisplay: Equatable {
+        let title: String
+        let detail: String
+        let countdownText: String
     }
 
     // MARK: - State
@@ -435,6 +559,10 @@ final class MeetingOverlayController {
     private var currentSystemLevel: Float = 0
     private var currentParticipants: [String] = []
     private var currentWarmupStatus: MeetingSessionController.ModelWarmupStatus = .ready
+    private var currentPrompt: PromptDisplay?
+    private var promptCandidate: MeetingPromptDetector.Candidate?
+    private var promptCountdownTask: Task<Void, Never>?
+    private var promptSecondsRemaining = 0
 
     // MARK: - Panel & views
 
@@ -448,6 +576,8 @@ final class MeetingOverlayController {
     /// The session controller the overlay reflects and forwards hotkey events to.
     /// Set once by `TranscriptedAppDelegate` during app launch.
     weak var meetingSession: MeetingSessionController?
+    var onPromptRecord: ((MeetingPromptDetector.Candidate) -> Void)?
+    var onPromptDismiss: ((MeetingPromptDetector.Candidate) -> Void)?
 
     // MARK: - Setup
 
@@ -472,7 +602,8 @@ final class MeetingOverlayController {
 
         let rootView = MeetingOverlayRootView(frame: panel.contentView?.bounds ?? frame)
         rootView.autoresizingMask = [.width, .height]
-        rootView.onClose = { [weak self] in self?.handleCloseTapped() }
+        rootView.onSecondaryAction = { [weak self] in self?.handleSecondaryActionTapped() }
+        rootView.onPrimaryAction = { [weak self] in self?.handlePrimaryActionTapped() }
         panel.contentView?.addSubview(rootView)
 
         self.panel = panel
@@ -502,6 +633,36 @@ final class MeetingOverlayController {
                 break
             }
         }
+    }
+
+    @discardableResult
+    func presentDetectedMeetingPrompt(_ candidate: MeetingPromptDetector.Candidate, timeout seconds: Int = 10) -> Bool {
+        guard let session = meetingSession else { return false }
+
+        switch session.state {
+        case .recording, .transcribing, .loadingModels:
+            return false
+        case .idle, .ready, .error:
+            break
+        }
+
+        guard state == .idle || state == .saved else { return false }
+
+        autoHideTask?.cancel()
+        promptCountdownTask?.cancel()
+
+        promptCandidate = candidate
+        promptSecondsRemaining = max(1, seconds)
+        currentPrompt = PromptDisplay(
+            title: "Meeting detected",
+            detail: candidate.detail,
+            countdownText: "\(promptSecondsRemaining)s"
+        )
+        state = .prompt
+        showPanel()
+        pushToView()
+        schedulePromptCountdown()
+        return true
     }
 
     // MARK: - Subscriptions
@@ -551,12 +712,23 @@ final class MeetingOverlayController {
     private func applySessionState(_ sessionState: MeetingSessionController.State) {
         switch sessionState {
         case .idle:
+            if state == .prompt {
+                pushToView()
+                break
+            }
             state = .idle
             hidePanel()
         case .loadingModels:
             state = .preparing
+            currentPrompt = nil
+            promptCandidate = nil
+            promptCountdownTask?.cancel()
             showPanel()
         case .ready:
+            if state == .prompt {
+                pushToView()
+                break
+            }
             // Ready but not recording — hide unless we're already showing a
             // terminal state (saved/error); the auto-hide task handles those.
             if case .transcribing = state {
@@ -571,13 +743,22 @@ final class MeetingOverlayController {
             hidePanel()
         case .recording:
             state = .recording
+            currentPrompt = nil
+            promptCandidate = nil
+            promptCountdownTask?.cancel()
             autoHideTask?.cancel()
             showPanel()
         case .transcribing:
             state = .transcribing
+            currentPrompt = nil
+            promptCandidate = nil
+            promptCountdownTask?.cancel()
             showPanel()
         case .error(let message):
             state = .error(message)
+            currentPrompt = nil
+            promptCandidate = nil
+            promptCountdownTask?.cancel()
             showPanel()
             scheduleAutoHide(after: 5)
         }
@@ -619,7 +800,14 @@ final class MeetingOverlayController {
     /// Target height for the panel based on the current `isExpanded` flag.
     /// Kept as a helper so show/animate paths agree on the value.
     private func currentPanelHeight() -> CGFloat {
-        state == .preparing ? MeetingOverlayTokens.warmupHeight : MeetingOverlayTokens.panelHeight
+        switch state {
+        case .preparing:
+            return MeetingOverlayTokens.warmupHeight
+        case .prompt:
+            return MeetingOverlayTokens.promptHeight
+        default:
+            return MeetingOverlayTokens.panelHeight
+        }
     }
 
     private func hidePanel() {
@@ -652,6 +840,58 @@ final class MeetingOverlayController {
         }
     }
 
+    private func handleSecondaryActionTapped() {
+        switch state {
+        case .prompt:
+            dismissPrompt(notifyDetector: true)
+        case .recording:
+            handleCloseTapped()
+        default:
+            hidePanel()
+        }
+    }
+
+    private func handlePrimaryActionTapped() {
+        guard case .prompt = state, let candidate = promptCandidate else { return }
+        promptCountdownTask?.cancel()
+        onPromptRecord?(candidate)
+    }
+
+    private func dismissPrompt(notifyDetector: Bool) {
+        promptCountdownTask?.cancel()
+
+        if notifyDetector, let candidate = promptCandidate {
+            onPromptDismiss?(candidate)
+        }
+
+        promptCandidate = nil
+        currentPrompt = nil
+        state = .idle
+        hidePanel()
+    }
+
+    private func schedulePromptCountdown() {
+        promptCountdownTask?.cancel()
+        promptCountdownTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            while self.promptSecondsRemaining > 0 {
+                self.currentPrompt = PromptDisplay(
+                    title: "Meeting detected",
+                    detail: self.promptCandidate?.detail ?? "Record this meeting?",
+                    countdownText: "\(self.promptSecondsRemaining)s"
+                )
+                self.pushToView()
+
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard !Task.isCancelled else { return }
+                self.promptSecondsRemaining -= 1
+            }
+
+            self.dismissPrompt(notifyDetector: true)
+        }
+    }
+
     // MARK: - View push
 
     private func pushToView() {
@@ -662,7 +902,8 @@ final class MeetingOverlayController {
             micLevel: currentMicLevel,
             systemLevel: currentSystemLevel,
             participants: currentParticipants,
-            warmupStatus: currentWarmupStatus
+            warmupStatus: currentWarmupStatus,
+            prompt: currentPrompt
         )
     }
 

--- a/Sources/UI/PermissionsOnboardingView.swift
+++ b/Sources/UI/PermissionsOnboardingView.swift
@@ -131,6 +131,8 @@ struct PermissionsOnboardingView: View {
             return accessibilityGranted
         case .screenRecording:
             return screenRecordingGranted
+        case .calendar:
+            return TranscriptedPermissionAccess.isGranted(.calendar)
         }
     }
 

--- a/Sources/UI/PermissionsOnboardingView.swift
+++ b/Sources/UI/PermissionsOnboardingView.swift
@@ -19,7 +19,7 @@ struct PermissionsOnboardingView: View {
                 Text("Welcome to Transcripted")
                     .font(.title3.weight(.semibold))
 
-                Text("Turn on two quick permissions and you can start dictating into any app right away. Meeting audio can wait until you need it.")
+                Text("Turn on two quick permissions and you can start dictating into any app right away. Meeting audio and meeting prompts can wait until you need them.")
                     .font(.callout)
                     .foregroundStyle(MenuTokens.textSecondary)
 
@@ -59,7 +59,7 @@ struct PermissionsOnboardingView: View {
                             icon: "record.circle.fill",
                             title: "Meetings",
                             detail: screenRecordingGranted
-                                ? "Meeting audio is ready too."
+                                ? "Meeting audio is ready too. Calendar prompts stay optional."
                                 : "You can enable Screen Recording later when you want call audio from Zoom, Meet, or other apps."
                         )
                     }

--- a/Sources/UI/TranscriptedPermissionAccess.swift
+++ b/Sources/UI/TranscriptedPermissionAccess.swift
@@ -1,11 +1,13 @@
 import AppKit
 import AVFoundation
 import ApplicationServices
+import EventKit
 
 enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
     case microphone
     case accessibility
     case screenRecording
+    case calendar
 
     var id: String { rawValue }
 
@@ -17,6 +19,8 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
             return "hand.raised.fill"
         case .screenRecording:
             return "rectangle.on.rectangle"
+        case .calendar:
+            return "calendar"
         }
     }
 
@@ -24,7 +28,7 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
         switch self {
         case .microphone, .accessibility:
             return true
-        case .screenRecording:
+        case .screenRecording, .calendar:
             return false
         }
     }
@@ -37,6 +41,8 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
             return "Accessibility"
         case .screenRecording:
             return "Screen Recording"
+        case .calendar:
+            return "Calendar"
         }
     }
 
@@ -48,6 +54,8 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
             return "Needed for global shortcuts and pasting text back into the app you were using."
         case .screenRecording:
             return "Optional for meeting capture. Needed when you want call audio from other apps."
+        case .calendar:
+            return "Optional for meeting prompts. Lets Transcripted notice upcoming meetings from Apple Calendar, Google, or Exchange calendars synced to your Mac."
         }
     }
 
@@ -59,6 +67,8 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
             return "Allow accessibility"
         case .screenRecording:
             return "Enable meeting audio"
+        case .calendar:
+            return "Enable meeting prompts"
         }
     }
 }
@@ -72,6 +82,8 @@ enum TranscriptedPermissionAccess {
             return AXIsProcessTrusted()
         case .screenRecording:
             return screenRecordingGranted()
+        case .calendar:
+            return calendarAccessGranted()
         }
     }
 
@@ -104,6 +116,45 @@ enum TranscriptedPermissionAccess {
                 _ = CGRequestScreenCaptureAccess()
             }
             openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
+        case .calendar:
+            Task { @MainActor in
+                let granted = await requestCalendarAccessIfNeeded()
+                guard !granted else { return }
+                openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars")
+            }
+        }
+    }
+
+    static func requestCalendarAccessIfNeeded() async -> Bool {
+        let status = EKEventStore.authorizationStatus(for: .event)
+        switch status {
+        case .fullAccess:
+            return true
+        case .authorized:
+            return true
+        case .notDetermined:
+            let store = EKEventStore()
+            do {
+                return try await store.requestFullAccessToEvents()
+            } catch {
+                return false
+            }
+        case .writeOnly, .denied, .restricted:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    static func calendarAccessGranted() -> Bool {
+        let status = EKEventStore.authorizationStatus(for: .event)
+        switch status {
+        case .fullAccess, .authorized:
+            return true
+        case .writeOnly, .denied, .restricted, .notDetermined:
+            return false
+        @unknown default:
+            return false
         }
     }
 

--- a/Sources/UI/TranscriptedSettingsView.swift
+++ b/Sources/UI/TranscriptedSettingsView.swift
@@ -55,7 +55,7 @@ struct TranscriptedSettingsView: View {
                     .foregroundStyle(.secondary)
                 }
 
-                SettingsSection(title: "Permissions", detail: "Transcripted only asks for permissions that support local capture and paste-back.") {
+                SettingsSection(title: "Permissions", detail: "Transcripted only asks for permissions that support local capture, paste-back, and optional meeting prompts.") {
                     ForEach(TranscriptedPermissionKind.allCases) { kind in
                         PermissionStatusRow(kind: kind, granted: permissionStates[kind] ?? false) {
                             TranscriptedPermissionAccess.openSettings(for: kind)

--- a/build-beta.sh
+++ b/build-beta.sh
@@ -125,6 +125,7 @@ swiftc \
     -framework AppKit \
     -framework SwiftUI \
     -framework Combine \
+    -framework EventKit \
     -framework Speech \
     -framework Security \
     -framework Carbon \

--- a/build.sh
+++ b/build.sh
@@ -81,6 +81,7 @@ swiftc \
     -framework AppKit \
     -framework SwiftUI \
     -framework Combine \
+    -framework EventKit \
     -framework Speech \
     -framework Security \
     -framework Carbon \


### PR DESCRIPTION
## What changed

This adds a first pass of the meeting-detected prompt flow to Transcripted.

- added an optional calendar-backed meeting detector that scans upcoming Apple Calendar events for Zoom, Google Meet, Teams, Webex, and FaceTime links
- added a timed `Meeting detected` prompt state to the existing meeting overlay with `Record`, `Not now`, and auto-dismiss behavior
- wired the prompt into the meeting recording flow so accepting the prompt starts the existing meeting capture path
- added optional Calendar permission copy and usage description updates in onboarding/settings
- updated build scripts to link EventKit for the new detector

## Why

The goal is to let Transcripted offer a low-friction "record this meeting?" prompt without jumping straight to more invasive detection strategies like Accessibility or browser automation.

This version intentionally uses the least-invasive signal first:

- calendar events provide the primary trigger
- lightweight runtime signals only improve confidence and subtitle messaging
- recording permissions are still only used when the user actually records

## User impact

Users who opt into Calendar access can now get a top-center overlay prompt shortly before a meeting starts. The prompt matches the existing meeting overlay style and hands off directly into the normal meeting recording experience.

## Validation

- targeted Swift parse checks for the changed files
- isolated typechecks for the new EventKit-based detector paths
- local `./build.sh`
- launched the built app and manually confirmed the meeting-detected overlay appeared and could be exercised

## Notes

There are local untracked dependency symlinks in my worktree used only to make the local build runnable; they are not included in this PR.