### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,10 +47,10 @@ Rules:
 
 ## Current architecture
 
-- `Sources/TranscriptedApp.swift` wires the menubar app, popover, dictation overlay, and meeting overlay.
+- `Sources/TranscriptedApp.swift` wires the menubar app, popover, dictation overlay, meeting overlay, and detected-meeting prompt flow.
 - `Sources/TranscriptedAppState.swift` owns app-wide services: `STTRouter`, `ContextCaptureEngine`, and the lazily built `MeetingSessionController`.
 - `Sources/UI/DictationSessionController.swift` now handles dictation only. Removed draft-mode entry points surface a fixed error message.
-- `Sources/Meeting/` adapts app-owned pieces like `ParakeetEngine` into `TranscriptedCore`.
+- `Sources/Meeting/` adapts app-owned pieces like `ParakeetEngine` into `TranscriptedCore`, including meeting-link detection and app-level transcription queueing.
 - `Sources/TranscriptedCore/` contains the reusable meeting transcription library.
 - Root `Package.swift` exists so `TranscriptedCore` can be tested as a standalone package surface.
 

--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -9,11 +9,12 @@
 
 Important entry points:
 
-- `TranscriptedApp.swift` — app entry point, menubar wiring, popover, overlay setup
+- `TranscriptedApp.swift` — app entry point, menubar wiring, popover, overlay setup, and detected-meeting prompt wiring
 - `TranscriptedAppState.swift` — owns `ContextCaptureEngine`, `STTRouter`, and lazy `MeetingSessionController`
 - `Capture/ContextCaptureEngine.swift` — right-option dictation handling, keyboard hotkeys, meeting hotkey routing
 - `UI/DictationSessionController.swift` — dictation session orchestration; removed draft-mode methods are stubs
-- `Meeting/MeetingSessionController.swift` — app-side bridge into `TranscriptedCore`
+- `Meeting/MeetingPromptDetector.swift` — Calendar-driven meeting-link detection used to offer one-tap meeting capture prompts
+- `Meeting/MeetingSessionController.swift` — app-side bridge into `TranscriptedCore`, including queued meeting transcription handoff
 - `Speech/ParakeetEngine.swift` + `Speech/STTRouter.swift` — local STT path used by dictation and by the meeting adapter
 
 ## Directory map

--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -9,26 +9,30 @@
 - `FailedMeetingPresentation.swift` — maps `FailedTranscription` into `FailedMeetingItem` view-models with human-readable titles and retry metadata
 - `MeetingCaptureBridge.swift` — `@MainActor` wrapper around core `Audio`, converts callback-based stop into `async`
 - `MeetingModelDownloader.swift` — loads Parakeet and diarization models together
+- `MeetingPromptDetector.swift` — polls upcoming Calendar events, detects supported meeting URLs, and asks the overlay to offer a one-tap record prompt
 - `MeetingSTTAdapter.swift` — adapts the app's shared `ParakeetEngine` to `TranscriptedCore.SpeechToTextEngine`
-- `MeetingSessionController.swift` — top-level meeting state machine, model warmup, capture start/stop, failed-meeting actions, transcript restyling
+- `MeetingSessionController.swift` — top-level meeting state machine, model warmup, capture start/stop, queued transcription handoff, failed-meeting actions, and transcript restyling
 - `MeetingStoragePaths.swift` — current meeting storage layout under the Draft-named compatibility root
 - `MeetingTranscriptStyler.swift` — restyles saved transcripts and renames files after save
 
 ## End-to-end flow
 
-1. `Sources/TranscriptedApp.swift` wires `MeetingSessionController` into `MeetingOverlayController`, the menubar, and the `⌥M` hotkey.
-2. `Sources/TranscriptedAppState.swift` starts background model warmup through `meetingSession.prepareModels(showLoadingUI: false)`.
-3. `MeetingSessionController.startRecording(...)` uses `MeetingCaptureBridge` to start core audio capture into app-owned scratch paths.
-4. `MeetingSessionController.stopRecording(...)` awaits mic/system audio files from the bridge.
-5. `TranscriptionTaskManager.startTranscription(...)` runs the core diarize → transcribe → save pipeline.
-6. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the "recent meetings" UI state.
-7. Failed meetings can be retried, deleted, or dismissed from the menubar recent-meetings section.
+1. `Sources/TranscriptedApp.swift` wires `MeetingSessionController` into `MeetingOverlayController`, the menubar, the `⌥M` hotkey, and the detected-meeting prompt flow.
+2. `MeetingPromptDetector` polls upcoming Calendar events, scores candidate meeting links, and asks `MeetingOverlayController` to present a short-lived prompt when the app is idle.
+3. `Sources/TranscriptedAppState.swift` starts background model warmup through `meetingSession.prepareModels(showLoadingUI: false)`.
+4. `MeetingSessionController.startRecording(...)` uses `MeetingCaptureBridge` to start core audio capture into app-owned scratch paths.
+5. `MeetingSessionController.stopRecording(...)` awaits mic/system audio files from the bridge, then either starts transcription immediately or queues it behind the active job.
+6. `TranscriptionTaskManager` runs one diarize → transcribe → save pipeline at a time.
+7. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the "recent meetings" UI state.
+8. Failed meetings can be retried, deleted, or dismissed from the menubar recent-meetings section.
 
 ## Key invariants
 
 - `TranscriptedCore` owns the reusable pipeline. App code in this directory should prefer adapters and protocol seams over direct core edits.
 - `MeetingSTTAdapter.cleanup()` is intentionally a no-op. `TranscriptedAppState` owns `ParakeetEngine` lifecycle for the whole app.
 - Meeting storage must stay under the current Draft-named app-support paths, not `TranscriptedCore.default` standalone paths.
+- `MeetingPromptDetector` only offers prompts for supported meeting providers (Zoom, Google Meet, Teams, Webex, FaceTime) and only while the meeting session is idle.
+- `TranscriptionTaskManager` stays single-flight. App-level queueing belongs in `MeetingSessionController`, not in ad hoc background tasks.
 - Live PCM handlers installed through `MeetingCaptureBridge` run on capture threads. Keep them real-time safe.
 
 ## Storage

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -37,7 +37,7 @@ Draft-mode UI is not an active product path in this worktree.
 
 ### Meeting Overlay
 
-- `MeetingOverlayController.swift` — non-activating panel for meeting warmup, recording, and transcription status
+- `MeetingOverlayController.swift` — non-activating panel for detected-meeting prompts, model warmup, recording, and transcription status
 - `SpeakerNamingSheet.swift` — sheet for renaming speakers in a completed meeting
 
 ### Menubar
@@ -56,7 +56,7 @@ Draft-mode UI is not an active product path in this worktree.
 
 ### Agent Connect
 
-- `AgentConnectionGuide.swift` — shared copy and step data for the agent-connect flow
+- `AgentConnectionGuide.swift` — shared smart-prompt, MCP setup, and folder fallback copy for the agent-connect flow
 - `AgentConnectionWindowController.swift` — `AgentConnectionWindowCoordinator` and `NSWindowController` for the standalone agent-connect window
 - `AgentConnectionWindowView.swift` — SwiftUI content for the standalone agent-connect window
 
@@ -95,6 +95,7 @@ bash run-tests.sh
 Manual checks:
 
 - dictation overlay starts, stops, and auto-pastes cleanly
+- detected-meeting prompts appear only when appropriate and can start or snooze a meeting cleanly
 - meeting overlay warms up and records cleanly
-- menubar popover renders shortcuts, recents, and settings actions
+- menubar popover renders shortcuts, recents, settings actions, and the agent-connect page cleanly
 - permissions onboarding and settings window still open correctly

--- a/Tools/TranscriptedQA/CLAUDE.md
+++ b/Tools/TranscriptedQA/CLAUDE.md
@@ -1,8 +1,14 @@
 # TranscriptedQA - QA Testing CLI Tool
 
-QA testing suite for Transcripted. 23 Swift files across Commands/, Generators/, Validators/, Utilities/, Models/, and root.
+QA testing suite for Transcripted. 23 Swift files total: `Package.swift` plus 22 files under `Sources/TranscriptedQA/`.
 
 ## File Index
+
+### Package Root (1 file)
+
+| File | Purpose |
+|------|---------|
+| `Package.swift` | Swift package manifest for the standalone QA CLI |
 
 ### Root (1 file)
 


### PR DESCRIPTION
## Summary
- sync meeting docs with the new detected-meeting prompt flow and queued transcription behavior
- refresh source and UI docs so the architecture notes match the current app wiring
- fix TranscriptedQA CLAUDE.md to account for the package manifest in the Swift file count and file index

## Updated files
- `CLAUDE.md`
- `Sources/CLAUDE.md`
- `Sources/Meeting/CLAUDE.md`
- `Sources/UI/CLAUDE.md`
- `Tools/TranscriptedQA/CLAUDE.md`

## Why
Recent merges added meeting detection, app-level transcription queueing, and simplified agent-connect copy, while the QA tool docs were still missing `Package.swift` from the file index. This PR brings the CLAUDE.md files back in sync with the current codebase.
