### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -71,7 +71,10 @@ class ParakeetEngine: ObservableObject {
     private var asrManager: AsrManager?
     private var audioWatchdogTask: Task<Void, Never>?
     private var asrManagerReady = false
-    private var didReceiveAudioSamples = false
+    // Written true by the audio tap callback (audio thread); reset false in startRecording()
+    // before installTap(), so no write-write race. Matches the nonisolated(unsafe) pattern
+    // used for lastLevelUpdate and eouManager.
+    private nonisolated(unsafe) var didReceiveAudioSamples = false
 
     var isModelLoaded: Bool { asrManagerReady }
 


### PR DESCRIPTION
## Summary

Nightly automated code review for 2026-04-10. Reviewed all commits from the past 7 days, focusing on `Sources/Speech/ParakeetEngine.swift`, `Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift`, `Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift`, `Sources/UI/AppSoundPlayer.swift`, `Sources/UI/MenuBarPanelController.swift`, and `Sources/UI/MenuBarRecentMeetingsView.swift`.

**Findings:**

- ✅ Threading: `Audio.swift` and `SystemAudioCapture.swift` correctly not `@MainActor`
- ✅ TranscriptedCore boundary: no Draft-specific imports in Core
- ✅ Speaker naming flow (`SpeakerNamingCoordinator`, `RetroactiveSpeakerUpdater`): logic correct, DB operations safely dispatched via `SpeakerDatabase.queue.sync`
- ✅ `consolidateSpeakerBreakdown`: early-return logic and range replacement correct
- ✅ Sound cue configuration: all 3 bundled files present, fallbacks valid
- ⚠️ **Fixed:** `didReceiveAudioSamples` in `ParakeetEngine` was accessed from the AVAudioEngine tap callback (audio thread) without `nonisolated(unsafe)`, unlike the other audio-thread fields in the same class (`lastLevelUpdate`, `eouManager`). Added the annotation and a comment explaining why no actual race exists.

**Checks:**

- `bash run-tests.sh`: 180/180 passed ✓
- `bash build.sh` / `swift test` / `bash run-integration-smoke.sh`: require `build-deps.sh` (FluidAudio), not runnable in CI worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)