### PR TITLE
docs: sync AGENTS.md testing gotchas with current state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ Rules:
 
 - `run-tests.sh` is a custom `swiftc` runner, not XCTest.
 - Adding a root `Tests/*Tests.swift` file is not enough by itself; it must be registered in `Tests/FastTests.manifest`.
-- Some test files in `Tests/` are historical and are not currently compiled by `run-tests.sh`. `Tests/README.md` calls these out.
+- `Tests/TranscriptedCoreTests/` is a separate Swift Package target, run via `swift test` rather than `run-tests.sh`.
 
 ## Storage
 


### PR DESCRIPTION
## Summary

Scheduled daily doc-sync audit. Verified every CLAUDE.md across `CLAUDE.md`, `AGENTS.md`, `Sources/**/CLAUDE.md`, `Tools/**/CLAUDE.md`, and `archive/backend-beta-worker/CLAUDE.md` against the current tree. The earlier same-day sync in #221 left the repo in good shape; the only drift still worth touching was one stale bullet in `AGENTS.md`.

## What changed

- `AGENTS.md` — the "Testing gotchas" section claimed some root `Tests/*Tests.swift` files were historical and excluded from `run-tests.sh`, and pointed at `Tests/README.md` to enumerate them. That is no longer true: every root `Tests/*Tests.swift` file is registered in `Tests/FastTests.manifest`, and `Tests/README.md` no longer calls out any excluded files. Replaced the stale bullet with a note that `Tests/TranscriptedCoreTests/` is a separate SPM target run via `swift test`, which matches how agents should think about the two runners.

## What was verified and left alone

- `CLAUDE.md` (root) — "Current architecture" section still accurately describes `TranscriptedApp.swift`, `TranscriptedAppState.swift`, and the meeting detected-prompt + queued-transcription flow added in #219 / #220.
- `Sources/CLAUDE.md` — directory map matches the 11 `Sources/*` subdirs.
- `Sources/UI/CLAUDE.md` — "38 Swift files" claim and file-index tables match the actual 38 files in `Sources/UI/`.
- `Sources/TranscriptedCore/CLAUDE.md` — "55 Swift files" claim and per-subsystem file counts (Audio 9, Logging 2, Models 4, Pipeline 4, Protocols 7, Services 7, Speaker 10, Stats 4, Storage 4, Utilities 4) match.
- `Sources/Meeting/CLAUDE.md` — 8 files listed match the 8 files on disk.
- `Sources/Dictation/CLAUDE.md`, `Sources/Speech/CLAUDE.md`, `Sources/Capture/CLAUDE.md`, `Sources/Observability/CLAUDE.md`, `Sources/API/CLAUDE.md`, `Sources/Style/CLAUDE.md`, `Sources/Text/CLAUDE.md`, `Sources/Accessibility/CLAUDE.md` — file lists and descriptions still match.
- `Tools/TranscriptedCLI/CLAUDE.md` — 9 files listed match.
- `Tools/TranscriptedMCP/CLAUDE.md` — "13 Swift files" claim and file index match.
- `Tools/TranscriptedQA/CLAUDE.md` — "23 Swift files" claim and per-group counts match.
- `archive/backend-beta-worker/CLAUDE.md` — files and endpoints still match.
- `docs/agent-onboarding.md` and `docs/storage-paths.md` — still accurate against the current Draft-named compatibility storage roots.

No new subdirectory `CLAUDE.md` files were created. The dirs under `Sources/TranscriptedCore/` that have ≥2 Swift files (Audio, Pipeline, Services, Speaker, Storage, Utilities, Protocols, Stats, Models, Logging) are already documented with file counts and purpose in the parent `Sources/TranscriptedCore/CLAUDE.md`; a per-subdir doc would duplicate that surface.

## Test plan

- [ ] Review the `AGENTS.md` diff — single bullet replaced
- [ ] Confirm `Tests/FastTests.manifest` actually covers every root `Tests/*Tests.swift` file (no drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)