### PR TITLE
security: nightly security audit findings [automated]

### DIFF
--- a/Sources/Observability/BetaTelemetry.swift
+++ b/Sources/Observability/BetaTelemetry.swift
@@ -33,7 +33,12 @@ final class BetaTelemetry {
     func sendEvent(type: String, sourceApp: String? = nil, payload: [String: Any] = [:]) {
         let token = BetaConfig.userToken
         guard token != "BETA_TOKEN_PLACEHOLDER" else { return }
-        let url = URL(string: "\(BetaConfig.proxyBaseURL)/events")!
+        // Security: guard against a malformed proxyBaseURL rather than force-unwrapping,
+        // which would crash the app if the URL string ever becomes invalid.
+        guard let url = URL(string: "\(BetaConfig.proxyBaseURL)/events") else {
+            fputs("⚠️ TELEMETRY | Invalid proxy events URL — dropping event\n", stderr)
+            return
+        }
 
         Task.detached(priority: .utility) {
             var request = URLRequest(url: url)
@@ -91,7 +96,12 @@ final class BetaTelemetry {
         if let log = logChunk { body["log_lines"] = redactChunk(log) }
         if let events = eventChunk { body["event_lines"] = redactChunk(events) }
 
-        var request = URLRequest(url: URL(string: "\(BetaConfig.proxyBaseURL)/logs")!)
+        // Security: guard against a malformed proxyBaseURL rather than force-unwrapping.
+        guard let logsURL = URL(string: "\(BetaConfig.proxyBaseURL)/logs") else {
+            fputs("⚠️ TELEMETRY | Invalid proxy logs URL — dropping quit-time logs\n", stderr)
+            return
+        }
+        var request = URLRequest(url: logsURL)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
@@ -126,7 +136,12 @@ final class BetaTelemetry {
         if let log = logChunk { body["log_lines"] = redactChunk(log) }
         if let events = eventChunk { body["event_lines"] = redactChunk(events) }
 
-        var request = URLRequest(url: URL(string: "\(BetaConfig.proxyBaseURL)/logs")!)
+        // Security: guard against a malformed proxyBaseURL rather than force-unwrapping.
+        guard let logsURL = URL(string: "\(BetaConfig.proxyBaseURL)/logs") else {
+            fputs("⚠️ TELEMETRY | Invalid proxy logs URL — dropping incremental logs\n", stderr)
+            return
+        }
+        var request = URLRequest(url: logsURL)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")


### PR DESCRIPTION
## Summary

Automated nightly security audit (2026-04-10). One low-severity issue fixed; remaining findings documented below for reference.

---

## Findings by severity

### Medium — Fixed ✅

**Force-unwrap URL construction in `BetaTelemetry.swift`** (`#if BETA_BUILD` only)

Three call sites constructed `URLRequest` targets from `BetaConfig.proxyBaseURL` using `URL(string:)!`. A malformed base URL (e.g. from a misconfigured build) would crash the app instead of degrading gracefully. Replaced with `guard let url = URL(...) else { return }` at all three locations (lines 36, 94, 129).

*Risk in practice: low — `proxyBaseURL` is a hardcoded compile-time constant. Fixed anyway as a defence-in-depth measure.*

---

### No-issue / reviewed clean ✅

| Area | Verdict |
|------|---------|
| SQL injection — `SpeakerDatabase`, `StatsDatabase` | All queries use `sqlite3_bind_*` parameterized bindings. No string interpolation into SQL. |
| Path traversal — transcript save path | `RecordingValidator.validateSavePath()` explicitly checks for `..` components before use. Custom UserDefaults path is validated before being accepted. |
| Path traversal — YAML frontmatter parsing (`TranscriptScanner`) | Parsed values (dates, integers, durations) are never used as file paths — no traversal vector. |
| Model download integrity | SHA-256 verification against HuggingFace API manifest. HTTPS-only mirrors. `isSafeModelFilename()` rejects `..`/`/` in filenames. |
| File permissions | `restrictToOwnerOnly()` (chmod 600) applied consistently to transcripts, audio files, databases, logs, and model files. |
| Secrets / credentials | No hardcoded secrets. Beta token is a build-time placeholder with a guard in `BetaTelemetry`. |
| Temp file cleanup | Partial downloads cleaned up on SHA mismatch and on mirror failure. |
| CoreAudio threading | Audio thread ↔ main thread boundaries use NSLock / DispatchQueue throughout. |
| `try!` on literal regex patterns | `NSRegularExpression` initialized with known-valid literal patterns — safe Swift practice, not a crash risk. |
| Backend | No `backend/` directory present on this branch. |

---

## Test plan

- [x] `bash build-deps.sh` — passed
- [x] `bash build.sh` — passed (warnings pre-existing, no new warnings)
- [x] `bash run-tests.sh` — 180/180 passed
- [x] `bash run-integration-smoke.sh` — passed
- [x] `swift test` — 18/18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)