### PR TITLE
fix: 3-strategy transcript resolution, loading UX, overlay dismiss

### DIFF
--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -208,31 +208,79 @@ extension TranscriptSaver {
     }
 
     /// Resolve a transcript URL that may have been renamed by MeetingTranscriptStyler.
-    /// Falls back to scanning the parent directory for a .md file containing a matching speaker db_id.
+    /// Tries three strategies in order:
+    ///   1. UUID search — scan .md files for a speaker db_id in the YAML
+    ///   2. Timestamp search — extract the time from the original filename and match YAML `time:` field
+    ///   3. Most recent — fall back to the newest .md file (just saved, should be the right one)
     static func resolveTranscriptURL(_ url: URL, updates: [SpeakerNameUpdate]) -> URL {
         if FileManager.default.fileExists(atPath: url.path) { return url }
 
-        AppLogger.pipeline.info("Transcript not at expected path, scanning for renamed file", ["expected": url.lastPathComponent])
-
         let directory = url.deletingLastPathComponent()
-        guard let firstId = updates.first?.persistentSpeakerId.uuidString,
-              let files = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
-                .filter({ $0.pathExtension == "md" }) else {
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.contentModificationDateKey, .creationDateKey]
+        ).filter({ $0.pathExtension == "md" }) else {
+            AppLogger.pipeline.error("resolveTranscriptURL: cannot list directory", ["dir": directory.path])
             return url
         }
 
-        // Read only the YAML frontmatter (first 2 KB) of each file to find the match.
-        for file in files {
-            guard let handle = try? FileHandle(forReadingFrom: file) else { continue }
-            let header = handle.readData(ofLength: 2048)
-            try? handle.close()
-            guard let text = String(data: header, encoding: .utf8),
-                  text.contains(firstId) else { continue }
-            AppLogger.pipeline.info("Resolved renamed transcript", ["from": url.lastPathComponent, "to": file.lastPathComponent])
-            return file
+        AppLogger.pipeline.info("resolveTranscriptURL: file not at expected path, scanning \(files.count) .md files", ["expected": url.lastPathComponent])
+
+        // Strategy 1: Search by speaker UUID in YAML frontmatter
+        if let firstId = updates.first?.persistentSpeakerId.uuidString {
+            for file in files {
+                guard let handle = try? FileHandle(forReadingFrom: file) else { continue }
+                let header = handle.readData(ofLength: 2048)
+                try? handle.close()
+                guard let text = String(data: header, encoding: .utf8),
+                      text.contains(firstId) else { continue }
+                AppLogger.pipeline.info("resolveTranscriptURL: matched by UUID", ["to": file.lastPathComponent])
+                return file
+            }
         }
 
+        // Strategy 2: Extract timestamp from original filename and match YAML `time:` field.
+        // Original filenames look like "Call 2026-04-10 11-15-12.md" — extract "11:15:12".
+        let stem = url.deletingPathExtension().lastPathComponent
+        if let timeMatch = extractTimeFromFilename(stem) {
+            let yamlTimeString = "time: \(timeMatch)"
+            for file in files {
+                guard let handle = try? FileHandle(forReadingFrom: file) else { continue }
+                let header = handle.readData(ofLength: 512)
+                try? handle.close()
+                guard let text = String(data: header, encoding: .utf8),
+                      text.contains(yamlTimeString) else { continue }
+                AppLogger.pipeline.info("resolveTranscriptURL: matched by timestamp", ["to": file.lastPathComponent, "time": timeMatch])
+                return file
+            }
+        }
+
+        // Strategy 3: Fall back to the most recently modified .md file.
+        let sorted = files.sorted { a, b in
+            let aDate = (try? a.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+            let bDate = (try? b.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+            return aDate > bDate
+        }
+        if let newest = sorted.first {
+            AppLogger.pipeline.info("resolveTranscriptURL: fell back to newest .md file", ["to": newest.lastPathComponent])
+            return newest
+        }
+
+        AppLogger.pipeline.error("resolveTranscriptURL: no .md files found at all")
         return url
+    }
+
+    /// Extract a time string like "11:15:12" from a filename like "Call 2026-04-10 11-15-12".
+    private static func extractTimeFromFilename(_ stem: String) -> String? {
+        // Match pattern: digits-digits-digits at the end (e.g., "11-15-12")
+        guard let regex = try? NSRegularExpression(pattern: #"(\d{1,2})-(\d{2})-(\d{2})$"#),
+              let match = regex.firstMatch(in: stem, range: NSRange(location: 0, length: (stem as NSString).length)),
+              match.numberOfRanges >= 4 else { return nil }
+        let ns = stem as NSString
+        let h = ns.substring(with: match.range(at: 1))
+        let m = ns.substring(with: match.range(at: 2))
+        let s = ns.substring(with: match.range(at: 3))
+        return "\(h):\(m):\(s)"
     }
 
     /// Replace all occurrences of a speaker name throughout a transcript's YAML and body.

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -186,12 +186,29 @@ extension TranscriptionTaskManager {
                 "transcript": resolvedURL.lastPathComponent
             ])
 
-            // Only UI state updates on the main thread
+            // UI state updates on the main thread.
+            // Setting displayStatus triggers MeetingSessionController's
+            // handleDisplayStatusChange → lastTerminalTranscriptionOutcome.
+            // Then a brief delay ensures the Combine pipeline has flushed
+            // before we re-trigger the background-work check, which drives
+            // the overlay from .transcribing → .saved → auto-hide.
             await MainActor.run { [weak self] in
                 guard let self else { return }
                 self.populateSavedMetadata(from: resolvedURL)
                 self.displayStatus = .transcriptSaved
                 self.scheduleStatusReset(delay: 8)
+            }
+            // Belt-and-suspenders: if the Combine subscription missed the
+            // speakerNamingRequest nil-out (set before this Task started),
+            // re-publish the change to force the session controller to
+            // finalize its state and dismiss the overlay.
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                if self.displayStatus == .transcriptSaved || self.displayStatus == .idle {
+                    self.displayStatus = .transcriptSaved
+                    self.scheduleStatusReset(delay: 3)
+                }
             }
         }
     }

--- a/Sources/UI/DictationSessionController.swift
+++ b/Sources/UI/DictationSessionController.swift
@@ -501,38 +501,38 @@ class DictationSessionController: ObservableObject {
         switch modelState {
         case .notLoaded:
             return .init(
-                title: "Starting dictation",
-                detail: "Transcripted is waking up the local voice model before it starts listening.",
+                title: "Getting ready",
+                detail: "Setting up the voice model. This only takes a moment.",
                 progress: 0.08,
-                status: "Preparing local model"
+                status: ""
             )
         case .downloading(let progress):
             return .init(
-                title: "Downloading dictation model",
-                detail: "Transcripted is downloading the on-device voice model needed for local dictation.",
+                title: "Downloading voice model",
+                detail: "One-time download for local dictation.",
                 progress: max(0.12, min(0.84, 0.12 + progress * 0.72)),
-                status: "\(Int(progress * 100))% complete"
+                status: "\(Int(progress * 100))%"
             )
         case .loading:
             return .init(
-                title: "Loading dictation",
-                detail: "Transcripted has the model files and is loading them into memory. Recording starts automatically when it finishes.",
+                title: "Almost ready",
+                detail: "Starting up. Recording begins automatically.",
                 progress: 0.92,
-                status: "Almost ready"
+                status: ""
             )
         case .ready:
             return .init(
-                title: "Starting dictation",
-                detail: "The local voice model is ready. Opening the microphone now.",
+                title: "Starting",
+                detail: "",
                 progress: 1.0,
-                status: "Starting microphone"
+                status: ""
             )
         case .failed(let message):
             return .init(
-                title: "Dictation couldn't start",
+                title: "Couldn't start",
                 detail: message,
                 progress: 0,
-                status: "Model load failed"
+                status: ""
             )
         }
     }

--- a/Sources/UI/OverlayRootView.swift
+++ b/Sources/UI/OverlayRootView.swift
@@ -171,11 +171,9 @@ final class OverlayRootView: NSView {
 
 @MainActor
 final class OverlayLoadingView: NSView {
-    private let titleLabel = NSTextField(labelWithString: "Loading dictation")
+    private let titleLabel = NSTextField(labelWithString: "Getting ready")
     private let detailLabel = NSTextField(wrappingLabelWithString: "")
     private let progressBar = NSProgressIndicator()
-    private let statusLabel = NSTextField(labelWithString: "")
-    private let elapsedLabel = NSTextField(labelWithString: "First launch can take a minute or two.")
 
     override var isFlipped: Bool { true }
 
@@ -206,17 +204,6 @@ final class OverlayLoadingView: NSView {
         progressBar.maxValue = 1
         progressBar.doubleValue = 0
         addSubview(progressBar)
-
-        statusLabel.font = NSFont.systemFont(ofSize: 10, weight: .medium)
-        statusLabel.textColor = OverlayTokens.textSecondary
-        addSubview(statusLabel)
-
-        elapsedLabel.font = NSFont.systemFont(ofSize: 11)
-        elapsedLabel.textColor = OverlayTokens.textMuted
-        elapsedLabel.isBezeled = false
-        elapsedLabel.isEditable = false
-        elapsedLabel.drawsBackground = false
-        addSubview(elapsedLabel)
     }
 
     override func layout() {
@@ -224,11 +211,9 @@ final class OverlayLoadingView: NSView {
         let pad: CGFloat = 14
         let contentWidth = max(0, bounds.width - pad * 2)
 
-        titleLabel.frame = NSRect(x: pad, y: 10, width: contentWidth, height: 16)
-        detailLabel.frame = NSRect(x: pad, y: 30, width: contentWidth, height: 28)
-        progressBar.frame = NSRect(x: pad, y: 64, width: contentWidth, height: 8)
-        statusLabel.frame = NSRect(x: pad, y: 76, width: contentWidth, height: 12)
-        elapsedLabel.frame = NSRect(x: pad, y: 88, width: contentWidth, height: 12)
+        titleLabel.frame = NSRect(x: pad, y: 12, width: contentWidth, height: 16)
+        detailLabel.frame = NSRect(x: pad, y: 32, width: contentWidth, height: 16)
+        progressBar.frame = NSRect(x: pad, y: 54, width: contentWidth, height: 6)
     }
 
     func update(
@@ -238,12 +223,6 @@ final class OverlayLoadingView: NSView {
         titleLabel.stringValue = presentation.title
         detailLabel.stringValue = presentation.detail
         progressBar.doubleValue = presentation.progress
-        statusLabel.stringValue = presentation.status
-        if elapsedSeconds > 0 {
-            elapsedLabel.stringValue = "First launch can take a minute or two. \(elapsedSeconds)s elapsed."
-        } else {
-            elapsedLabel.stringValue = "First launch can take a minute or two."
-        }
         needsLayout = true
     }
 }

--- a/Sources/UI/OverlayTokens.swift
+++ b/Sources/UI/OverlayTokens.swift
@@ -25,7 +25,7 @@ enum OverlayTokens {
     static let panelWidth: CGFloat         = 360
     static let panelCompactWidth: CGFloat  = 296
     static let panelCompactHeight: CGFloat = 42   // header bar only, no content area
-    static let panelLoadingHeight: CGFloat = 136
+    static let panelLoadingHeight: CGFloat = 100
     static let panelMinHeight: CGFloat     = 92
     static let panelMaxHeight: CGFloat     = 340
     static let cornerRadius: CGFloat   = 12


### PR DESCRIPTION
## Summary
- **3-strategy resolveTranscriptURL** — UUID search → timestamp match → newest file fallback. Fixes naming write-back when upstream format drops `db_id` from YAML.
- **Overlay dismiss fix** — delayed re-trigger of `displayStatus` after naming ensures "Saving transcript" overlay transitions to "Saved" and auto-hides.
- **Simplified loading screen** — removed status label, elapsed timer, and technical jargon. Just title + detail + progress bar in a smaller panel.

## Test plan
- [ ] Record a meeting, name speakers → verify names appear in transcript
- [ ] After naming, verify "Saving transcript" overlay dismisses within ~2 seconds
- [ ] Start dictation before model loads → verify simplified loading screen
- [ ] Verify Recent Meetings title updates after naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)