### PR TITLE
[codex] Simplify first-run and menu UX

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ import Foundation
 //
 // Binary dependency layout:
 //   deps-libs/libDraftDeps.a          — prebuilt mega-library (FluidAudio 0.7.9 + MLX + deps + TranscriptedCore)
-//   deps-libs/libExternalDeps.a       — external-only archive for SPM tests (no TranscriptedCore objects)
+//   deps-libs/libExternalDeps.a       — SwiftPM compatibility archive (currently mirrors libDraftDeps.a)
 //   deps-modules/*.swiftmodule        — Swift interface files for FluidAudio et al.
 //   deps-modules/FastClusterWrapper   — C header for fast-cluster C++ wrapper
 //   deps-modules/MachTaskSelfWrapper  — C header for mach_task_self helper
@@ -37,6 +37,7 @@ let package = Package(
             name: "TranscriptedCore",
             dependencies: [],
             path: "Sources/TranscriptedCore",
+            exclude: ["CLAUDE.md"],
             swiftSettings: [
                 .unsafeFlags([
                     "-I", "\(repoRoot)/deps-modules",

--- a/README.md
+++ b/README.md
@@ -213,6 +213,13 @@ bash build-deps.sh
 bash build.sh
 ```
 
+`build.sh` is the local development path. It expects the unified dependency
+artifacts from `build-deps.sh` and then signs the app for stable local
+permissions on the current machine.
+
+For signed DMG packaging and notarization workflow notes, see
+`docs/release-packaging.md`.
+
 ## Tests
 
 ```bash

--- a/Sources/Capture/CapturedContext.swift
+++ b/Sources/Capture/CapturedContext.swift
@@ -9,9 +9,15 @@ struct CapturedContext {
     var formality: String?      // "casual", "professional", "formal"
     var conversation: String?   // Full conversation thread text
 
+    private var trimmedConversation: String? {
+        guard let conversation else { return nil }
+        let trimmed = conversation.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
     /// Whether we successfully extracted a conversation from the screenshot
     var hasConversation: Bool {
-        conversation != nil && !conversation!.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        trimmedConversation != nil
     }
 
     /// What the user sees in the input TextEditor — transparent labeled sections
@@ -28,7 +34,7 @@ struct CapturedContext {
             lines.append("FORMALITY: \(formality)")
         }
 
-        if let conversation = conversation, !conversation.isEmpty {
+        if let conversation = trimmedConversation {
             lines.append("")
             lines.append("CONVERSATION:")
             lines.append(conversation)
@@ -52,7 +58,7 @@ struct CapturedContext {
             prompt += "FORMALITY: \(formality)\n"
         }
 
-        if let conversation = conversation {
+        if let conversation = trimmedConversation {
             prompt += "\nCONVERSATION:\n\(conversation)\n"
         }
 

--- a/Sources/Dictation/DictationAgentOutput.swift
+++ b/Sources/Dictation/DictationAgentOutput.swift
@@ -135,6 +135,7 @@ enum DictationAgentOutput {
 
         let data = try encoder.encode(payload)
         try data.write(to: sidecarURL, options: .atomic)
+        FileManager.default.restrictFileToOwnerOnly(at: sidecarURL)
         return sidecarURL
     }
 

--- a/Sources/Dictation/DictationStoragePaths.swift
+++ b/Sources/Dictation/DictationStoragePaths.swift
@@ -7,14 +7,14 @@ enum DictationStoragePaths {
     /// Root: ~/Library/Application Support/Draft/dictations/
     static var root: URL {
         let url = FileManager.default.dictationSupportDir
-        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try? FileManager.default.createPrivateDirectory(at: url)
         return url
     }
 
     /// Folder for saved markdown exports.
     static var transcriptsFolder: URL {
         let url = root.appendingPathComponent("transcripts", isDirectory: true)
-        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try? FileManager.default.createPrivateDirectory(at: url)
         return url
     }
 }

--- a/Sources/Dictation/DictationTranscriptWriter.swift
+++ b/Sources/Dictation/DictationTranscriptWriter.swift
@@ -110,6 +110,7 @@ enum DictationTranscriptWriter {
         }
 
         try body.write(to: url, atomically: true, encoding: .utf8)
+        FileManager.default.restrictFileToOwnerOnly(at: url)
 
         let sidecarURL = try? DictationAgentOutput.appendEntry(
             title: title,

--- a/Sources/DraftPaths.swift
+++ b/Sources/DraftPaths.swift
@@ -27,4 +27,15 @@ extension FileManager {
     var dictationSupportDir: URL {
         transcriptedAppSupportDir.appendingPathComponent("dictations", isDirectory: true)
     }
+
+    /// Create a directory and tighten it to owner-only access (0700).
+    func createPrivateDirectory(at url: URL) throws {
+        try createDirectory(at: url, withIntermediateDirectories: true)
+        try? setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+    }
+
+    /// Tighten a file to owner-only access (0600).
+    func restrictFileToOwnerOnly(at url: URL) {
+        try? setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
 }

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -507,12 +507,7 @@ final class MeetingSessionController: ObservableObject {
                     engine: "meeting",
                     event: "meeting_transcript_artifact_ready",
                     message: "Meeting transcript artifact is ready",
-                    context: self.baseDiagnosticsContext(
-                        extra: [
-                            "title": styled.title,
-                            "transcript_url": styled.url.path
-                        ]
-                    )
+                    context: self.baseDiagnosticsContext()
                 )
             }
             .store(in: &cancellables)
@@ -759,8 +754,6 @@ final class MeetingSessionController: ObservableObject {
                 message: "Meeting transcript saved",
                 context: baseDiagnosticsContext(
                     extra: [
-                        "title": lastSavedTitle ?? "",
-                        "transcript_url": lastSavedTranscriptURL?.path ?? "",
                         "queue_depth": "\(queuedTranscriptionJobs.count)"
                     ]
                 )

--- a/Sources/Observability/AppLogger.swift
+++ b/Sources/Observability/AppLogger.swift
@@ -37,6 +37,8 @@ private actor AppLogFileWriter {
             fm.createFile(atPath: path, contents: nil)
         }
 
+        fm.restrictFileToOwnerOnly(at: URL(fileURLWithPath: path))
+
         openHandleIfNeeded()
     }
 

--- a/Sources/Observability/BetaTelemetry.swift
+++ b/Sources/Observability/BetaTelemetry.swift
@@ -11,6 +11,7 @@ import Foundation
 final class BetaTelemetry {
     static let shared = BetaTelemetry()
     private init() {}
+    private static let tokenPlaceholder = "BETA_TOKEN_PLACEHOLDER"
 
     // Byte offsets — only ship content written since last successful upload
     private var debugLogOffset: UInt64 = 0
@@ -31,26 +32,21 @@ final class BetaTelemetry {
     // MARK: - Discrete events (fire-and-forget, unchanged)
 
     func sendEvent(type: String, sourceApp: String? = nil, payload: [String: Any] = [:]) {
-        let token = BetaConfig.userToken
-        guard token != "BETA_TOKEN_PLACEHOLDER" else { return }
-        let url = URL(string: "\(BetaConfig.proxyBaseURL)/events")!
+        guard let token = Self.activeToken() else { return }
 
         Task.detached(priority: .utility) {
-            var request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-
             var body: [String: Any] = [
                 "event_type": type,
             ]
             if let app = sourceApp { body["source_app"] = app }
             if !payload.isEmpty { body["payload"] = payload }
 
-            do {
-                request.httpBody = try JSONSerialization.data(withJSONObject: body)
-            } catch {
-                fputs("⚠️ TELEMETRY | failed to serialize event body: \(error.localizedDescription)\n", stderr)
+            guard let request = Self.makeJSONRequest(
+                path: "events",
+                token: token,
+                body: body,
+                failureLabel: "event body"
+            ) else {
                 return
             }
             _ = try? await URLSession.shared.data(for: request)
@@ -78,29 +74,17 @@ final class BetaTelemetry {
     // MARK: - Quit shipping (synchronous, 3s timeout — called from applicationWillTerminate)
 
     func shipLogs() {
-        let token = BetaConfig.userToken
-        guard token != "BETA_TOKEN_PLACEHOLDER" else { return }
-
-        // Ship any remaining debug log content
-        let logChunk = readChunk(from: debugLogURL, offset: &debugLogOffset)
-        let eventChunk = readChunk(from: eventsURL, offset: &eventsOffset)
-
-        guard logChunk != nil || eventChunk != nil else { return }
-
-        var body: [String: Any] = [:]
-        if let log = logChunk { body["log_lines"] = redactChunk(log) }
-        if let events = eventChunk { body["event_lines"] = redactChunk(events) }
-
-        var request = URLRequest(url: URL(string: "\(BetaConfig.proxyBaseURL)/logs")!)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        do {
-            request.httpBody = try JSONSerialization.data(withJSONObject: body)
-        } catch {
-            fputs("⚠️ TELEMETRY | failed to serialize quit-time log body: \(error.localizedDescription)\n", stderr)
-            return
-        }
+        guard let token = Self.activeToken(),
+              let body = shippingBody(
+                logChunk: readChunk(from: debugLogURL, offset: &debugLogOffset),
+                eventChunk: readChunk(from: eventsURL, offset: &eventsOffset)
+              ),
+              let request = Self.makeJSONRequest(
+                path: "logs",
+                token: token,
+                body: body,
+                failureLabel: "quit-time log body"
+              ) else { return }
 
         // Synchronous wait — applicationWillTerminate can't use async
         let semaphore = DispatchSemaphore(value: 0)
@@ -111,8 +95,7 @@ final class BetaTelemetry {
     // MARK: - Incremental shipping
 
     private func shipIncremental() async {
-        let token = BetaConfig.userToken
-        guard token != "BETA_TOKEN_PLACEHOLDER" else { return }
+        guard let token = Self.activeToken() else { return }
 
         // Read new chunks from both files
         var tempDebugOffset = debugLogOffset
@@ -120,22 +103,13 @@ final class BetaTelemetry {
         let logChunk = readChunk(from: debugLogURL, offset: &tempDebugOffset)
         let eventChunk = readChunk(from: eventsURL, offset: &tempEventsOffset)
 
-        guard logChunk != nil || eventChunk != nil else { return }
-
-        var body: [String: Any] = [:]
-        if let log = logChunk { body["log_lines"] = redactChunk(log) }
-        if let events = eventChunk { body["event_lines"] = redactChunk(events) }
-
-        var request = URLRequest(url: URL(string: "\(BetaConfig.proxyBaseURL)/logs")!)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        do {
-            request.httpBody = try JSONSerialization.data(withJSONObject: body)
-        } catch {
-            fputs("⚠️ TELEMETRY | failed to serialize incremental log body: \(error.localizedDescription)\n", stderr)
-            return
-        }
+        guard let body = shippingBody(logChunk: logChunk, eventChunk: eventChunk),
+              let request = Self.makeJSONRequest(
+                path: "logs",
+                token: token,
+                body: body,
+                failureLabel: "incremental log body"
+              ) else { return }
 
         do {
             let (_, response) = try await URLSession.shared.data(for: request)
@@ -149,25 +123,57 @@ final class BetaTelemetry {
         }
     }
 
+    private static func activeToken() -> String? {
+        let token = BetaConfig.userToken
+        return token == tokenPlaceholder ? nil : token
+    }
+
+    private static func makeJSONRequest(
+        path: String,
+        token: String,
+        body: [String: Any],
+        failureLabel: String
+    ) -> URLRequest? {
+        guard let url = URL(string: "\(BetaConfig.proxyBaseURL)/\(path)") else {
+            fputs("⚠️ TELEMETRY | invalid \(path) URL\n", stderr)
+            return nil
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            return request
+        } catch {
+            fputs("⚠️ TELEMETRY | failed to serialize \(failureLabel): \(error.localizedDescription)\n", stderr)
+            return nil
+        }
+    }
+
+    private func shippingBody(logChunk: String?, eventChunk: String?) -> [String: Any]? {
+        var body: [String: Any] = [:]
+        if let logChunk {
+            body["log_lines"] = redactChunk(logChunk)
+        }
+        if let eventChunk {
+            body["event_lines"] = redactChunk(eventChunk)
+        }
+        return body.isEmpty ? nil : body
+    }
+
     // MARK: - Log Redaction
 
     // Pre-compiled regexes — avoids recompilation per log line
     private static let userPathRegex = try! NSRegularExpression(pattern: #"/Users/[^/]+/"#)
     private static let apiKeyRegex = try! NSRegularExpression(pattern: #"sk-ant-[A-Za-z0-9_-]+"#)
     private static let bearerRegex = try! NSRegularExpression(pattern: #"Bearer [A-Za-z0-9._-]+"#)
-
-    /// Strip sensitive data from log lines before shipping to proxy.
-    private func redactLogLine(_ line: String) -> String {
-        var result = line
-        let fullRange = NSRange(result.startIndex..., in: result)
-        // Redact file paths containing usernames: /Users/<name>/ → /Users/****/
-        result = Self.userPathRegex.stringByReplacingMatches(in: result, range: fullRange, withTemplate: "/Users/****/")
-        let range2 = NSRange(result.startIndex..., in: result)
-        result = Self.apiKeyRegex.stringByReplacingMatches(in: result, range: range2, withTemplate: "sk-ant-****")
-        let range3 = NSRange(result.startIndex..., in: result)
-        result = Self.bearerRegex.stringByReplacingMatches(in: result, range: range3, withTemplate: "Bearer ****")
-        return result
-    }
+    private static let sourceAppNameJSONRegex = try! NSRegularExpression(pattern: #""source_app_name"\s*:\s*"[^"]*""#)
+    private static let sourceAppBundleJSONRegex = try! NSRegularExpression(pattern: #""source_app_bundle_id"\s*:\s*"[^"]*""#)
+    private static let transcriptURLJSONRegex = try! NSRegularExpression(pattern: #""transcript_url"\s*:\s*"[^"]*""#)
+    private static let titleJSONRegex = try! NSRegularExpression(pattern: #""title"\s*:\s*"[^"]*""#)
 
     /// Redact all sensitive data in a multi-line log chunk.
     /// Applies regexes directly on the full chunk (avoids per-line split/rejoin).
@@ -179,6 +185,14 @@ final class BetaTelemetry {
         result = Self.apiKeyRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "sk-ant-****")
         range = NSRange(result.startIndex..., in: result)
         result = Self.bearerRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "Bearer ****")
+        range = NSRange(result.startIndex..., in: result)
+        result = Self.sourceAppNameJSONRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "\"source_app_name\":\"[redacted]\"")
+        range = NSRange(result.startIndex..., in: result)
+        result = Self.sourceAppBundleJSONRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "\"source_app_bundle_id\":\"[redacted]\"")
+        range = NSRange(result.startIndex..., in: result)
+        result = Self.transcriptURLJSONRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "\"transcript_url\":\"[redacted]\"")
+        range = NSRange(result.startIndex..., in: result)
+        result = Self.titleJSONRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "\"title\":\"[redacted]\"")
         return result
     }
 

--- a/Sources/Observability/EventReporter.swift
+++ b/Sources/Observability/EventReporter.swift
@@ -46,7 +46,7 @@ private actor EventFileWriter {
 
         // Ensure directory exists
         do {
-            try FileManager.default.createDirectory(at: storageDir, withIntermediateDirectories: true)
+            try FileManager.default.createPrivateDirectory(at: storageDir)
         } catch {
             fputs("⚠️ EVENT | failed to create directory \(storageDir.path): \(error.localizedDescription)\n", stderr)
         }
@@ -80,6 +80,7 @@ private actor EventFileWriter {
         } else {
             do {
                 try lineData.write(to: fileURL)
+                FileManager.default.restrictFileToOwnerOnly(at: fileURL)
                 print("📊 EVENT | created events.jsonl at \(fileURL.path)")
             } catch {
                 fputs("⚠️ EVENT | failed to create events.jsonl: \(error.localizedDescription)\n", stderr)
@@ -90,6 +91,8 @@ private actor EventFileWriter {
                 fputs("⚠️ EVENT | failed to open FileHandle after creation: \(error.localizedDescription)\n", stderr)
             }
         }
+
+        FileManager.default.restrictFileToOwnerOnly(at: fileURL)
     }
 
     deinit {

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -76,28 +76,13 @@ class ParakeetEngine: ObservableObject {
     var isModelLoaded: Bool { asrManagerReady }
 
     var inputDeviceName: String {
-        var deviceID = AudioDeviceID(0)
-        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultInputDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        let status = AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
-        )
-        guard status == noErr else { return "Unknown" }
-
-        var name: CFString = "" as CFString
-        var nameSize = UInt32(MemoryLayout<CFString>.size)
-        var nameAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyDeviceNameCFString,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        let nameStatus = AudioObjectGetPropertyData(deviceID, &nameAddress, 0, nil, &nameSize, &name)
-        guard nameStatus == noErr, (name as String).count > 0 else { return "Unknown" }
-        return name as String
+        do {
+            let deviceID = try AudioObjectID.readDefaultInputDevice()
+            let name = try deviceID.readString(kAudioDevicePropertyDeviceNameCFString)
+            return name.isEmpty ? "Unknown" : name
+        } catch {
+            return "Unknown"
+        }
     }
 
     // MARK: - Model Initialization

--- a/Sources/TranscriptedCore/Audio/CoreAudioUtils.swift
+++ b/Sources/TranscriptedCore/Audio/CoreAudioUtils.swift
@@ -24,6 +24,11 @@ extension AudioObjectID {
         try AudioDeviceID.system.readDefaultSystemOutputDevice()
     }
 
+    /// Reads the value for `kAudioHardwarePropertyDefaultInputDevice`.
+    static func readDefaultInputDevice() throws -> AudioDeviceID {
+        try AudioObjectID.system.readDefaultInputDevice()
+    }
+
     static func readProcessList() throws -> [AudioObjectID] {
         try AudioObjectID.system.readProcessList()
     }
@@ -80,6 +85,13 @@ extension AudioObjectID {
         try requireSystemObject()
 
         return try read(kAudioHardwarePropertyDefaultSystemOutputDevice, defaultValue: AudioDeviceID.unknown)
+    }
+
+    /// Reads the value for `kAudioHardwarePropertyDefaultInputDevice`, should only be called on the system object.
+    func readDefaultInputDevice() throws -> AudioDeviceID {
+        try requireSystemObject()
+
+        return try read(kAudioHardwarePropertyDefaultInputDevice, defaultValue: AudioDeviceID.unknown)
     }
 
     /// Reads the value for `kAudioDevicePropertyDeviceUID` for the device represented by this audio object ID.

--- a/Sources/TranscriptedCore/Services/DiarizationService.swift
+++ b/Sources/TranscriptedCore/Services/DiarizationService.swift
@@ -130,14 +130,13 @@ public class DiarizationService: ObservableObject {
             embeddingExcludeOverlap: true,
             minSegmentDuration: 1.1821,
             minGapDuration: 0.2874,
-            exclusiveSegments: true,
             speechOnsetThreshold: 0.4472,
             speechOffsetThreshold: 0.4472,
             segmentationMinDurationOn: 0.0,
             segmentationMinDurationOff: 0.2738,
             maxVBxIterations: 24,
             convergenceTolerance: 0.0001
-        ).withSpeakers(min: 3, max: 11)
+        )
         let manager = OfflineDiarizerManager(config: offlineConfig)
 
         if let bundlePath = bundleProvider("offline-diarizer-models") {

--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -108,7 +108,7 @@ extension TranscriptSaver {
             // Consolidate speaker breakdown when multiple diarizer IDs got the same name.
             // PyAnnote can over-segment one person into 2 clusters; after naming, both become
             // e.g. "Timothy", producing duplicate lines in the breakdown.
-            content = consolidateSpeakerBreakdown(content)
+            content = SpeakerBreakdownConsolidator.consolidate(content)
 
             // Atomic write back
             do {
@@ -176,104 +176,6 @@ extension TranscriptSaver {
         }
     }
 
-    /// Merge duplicate speaker lines in the "Remote Speaker Breakdown" section.
-    /// When two diarizer IDs get the same name, their stats should be combined
-    /// into a single line (summing utterances, words, and speaking time).
-    private static func consolidateSpeakerBreakdown(_ content: String) -> String {
-        // Find the breakdown section
-        guard let breakdownStart = content.range(of: "#### Remote Speaker Breakdown\n\n"),
-              let breakdownEnd = content.range(of: "\n---\n", range: breakdownStart.upperBound..<content.endIndex) else {
-            return content
-        }
-
-        let breakdownRange = breakdownStart.upperBound..<breakdownEnd.lowerBound
-        let breakdownText = String(content[breakdownRange])
-        let lines = breakdownText.components(separatedBy: "\n").filter { !$0.isEmpty }
-
-        // Parse each line: "- **Name:** N utterances, ~M words, MM:SS"
-        struct SpeakerStats {
-            var utterances: Int = 0
-            var words: Int = 0
-            var speakingSeconds: Double = 0
-        }
-
-        let pattern = #"- \*\*(.+?):\*\* (\d+) utterances?, ~(\d+) words?, (\d+):(\d+)"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return content }
-
-        var statsByName: [String: SpeakerStats] = [:]
-        var nameOrder: [String] = []
-
-        for line in lines {
-            let nsLine = line as NSString
-            guard let match = regex.firstMatch(in: line, range: NSRange(location: 0, length: nsLine.length)) else { continue }
-
-            let name = nsLine.substring(with: match.range(at: 1))
-            let utterances = Int(nsLine.substring(with: match.range(at: 2))) ?? 0
-            let words = Int(nsLine.substring(with: match.range(at: 3))) ?? 0
-            let minutes = Double(nsLine.substring(with: match.range(at: 4))) ?? 0
-            let seconds = Double(nsLine.substring(with: match.range(at: 5))) ?? 0
-
-            if statsByName[name] == nil {
-                nameOrder.append(name)
-                statsByName[name] = SpeakerStats()
-            }
-            statsByName[name]!.utterances += utterances
-            statsByName[name]!.words += words
-            statsByName[name]!.speakingSeconds += minutes * 60 + seconds
-        }
-
-        // If no duplicates were found, return unchanged
-        if statsByName.count == lines.count { return content }
-
-        // Rebuild the breakdown
-        var newBreakdown = ""
-        for name in nameOrder {
-            guard let stats = statsByName[name] else { continue }
-            let mins = Int(stats.speakingSeconds) / 60
-            let secs = Int(stats.speakingSeconds) % 60
-            let timeStr = String(format: "%02d:%02d", mins, secs)
-            newBreakdown += "- **\(name):** \(stats.utterances) utterances, ~\(stats.words) words, \(timeStr)\n"
-        }
-
-        var result = content
-        result.replaceSubrange(breakdownRange, with: newBreakdown)
-
-        // Update YAML frontmatter: system_speakers should reflect consolidated count
-        let oldSystemSpeakers = lines.count
-        let newSystemSpeakers = statsByName.count
-        result = result.replacingOccurrences(
-            of: "system_speakers: \(oldSystemSpeakers)",
-            with: "system_speakers: \(newSystemSpeakers)"
-        )
-
-        // Update analytics section: "Speakers Detected" for remote participants
-        result = result.replacingOccurrences(
-            of: "- **Speakers Detected:** \(oldSystemSpeakers)\n\n#### Remote Speaker Breakdown",
-            with: "- **Speakers Detected:** \(newSystemSpeakers)\n\n#### Remote Speaker Breakdown"
-        )
-
-        // Update footer speaker count.
-        // The footer uses total = mic_speakers + system_speakers.
-        // We can't know mic_speakers from here, so fix the total by the same delta.
-        let delta = oldSystemSpeakers - newSystemSpeakers
-        let footerPattern = #"\| (\d+) speakers\*"#
-        if let footerRegex = try? NSRegularExpression(pattern: footerPattern),
-           let footerMatch = footerRegex.firstMatch(in: result, range: NSRange(location: 0, length: (result as NSString).length)),
-           let oldTotal = Int((result as NSString).substring(with: footerMatch.range(at: 1))) {
-            let newTotal = oldTotal - delta
-            let oldFooterFragment = "| \(oldTotal) speakers*"
-            let newFooterFragment = "| \(newTotal) speakers*"
-            result = result.replacingOccurrences(of: oldFooterFragment, with: newFooterFragment)
-        }
-
-        AppLogger.pipeline.info("Consolidated duplicate speaker names in breakdown", [
-            "before": "\(lines.count)",
-            "after": "\(statsByName.count)"
-        ])
-
-        return result
-    }
-
     /// Update the JSON sidecar when speaker names change.
     private static func updateAgentJSON(
         transcriptURL: URL,
@@ -321,6 +223,142 @@ extension TranscriptSaver {
         try? AgentOutput.writeIndex(
             to: folder,
             speakerStore: speakerStore ?? SpeakerDatabase.shared
+        )
+    }
+}
+
+enum SpeakerBreakdownConsolidator {
+    private static let breakdownHeader = "#### Remote Speaker Breakdown\n\n"
+    private static let breakdownFooter = "\n---\n"
+    private static let speakerCountPrefix = "- **Speakers Detected:** "
+    private static let lineRegex = try? NSRegularExpression(
+        pattern: #"- \*\*(.+?):\*\* (\d+) utterances?, ~(\d+) words?, (\d+):(\d+)"#
+    )
+    private static let footerRegex = try? NSRegularExpression(pattern: #"\| (\d+) speakers\*"#)
+
+    struct SpeakerStats {
+        var utterances = 0
+        var words = 0
+        var speakingSeconds = 0.0
+
+        mutating func accumulate(_ entry: SpeakerBreakdownEntry) {
+            utterances += entry.utterances
+            words += entry.words
+            speakingSeconds += entry.speakingSeconds
+        }
+    }
+
+    struct SpeakerBreakdownEntry {
+        let name: String
+        let utterances: Int
+        let words: Int
+        let speakingSeconds: Double
+    }
+
+    static func consolidate(_ content: String) -> String {
+        guard let breakdownStart = content.range(of: breakdownHeader),
+              let breakdownEnd = content.range(of: breakdownFooter, range: breakdownStart.upperBound..<content.endIndex) else {
+            return content
+        }
+
+        let breakdownRange = breakdownStart.upperBound..<breakdownEnd.lowerBound
+        let entries = parseEntries(from: String(content[breakdownRange]))
+        guard !entries.isEmpty else { return content }
+
+        var statsByName: [String: SpeakerStats] = [:]
+        var nameOrder: [String] = []
+
+        for entry in entries {
+            if statsByName[entry.name] == nil {
+                nameOrder.append(entry.name)
+            }
+
+            var stats = statsByName[entry.name] ?? SpeakerStats()
+            stats.accumulate(entry)
+            statsByName[entry.name] = stats
+        }
+
+        guard statsByName.count < entries.count else { return content }
+
+        let oldSystemSpeakers = entries.count
+        let newSystemSpeakers = statsByName.count
+
+        var result = content
+        result.replaceSubrange(
+            breakdownRange,
+            with: renderedBreakdown(nameOrder: nameOrder, statsByName: statsByName)
+        )
+        result = result.replacingOccurrences(
+            of: "system_speakers: \(oldSystemSpeakers)",
+            with: "system_speakers: \(newSystemSpeakers)"
+        )
+        result = result.replacingOccurrences(
+            of: "\(speakerCountPrefix)\(oldSystemSpeakers)\n\n\(breakdownHeader.trimmingCharacters(in: .newlines))",
+            with: "\(speakerCountPrefix)\(newSystemSpeakers)\n\n\(breakdownHeader.trimmingCharacters(in: .newlines))"
+        )
+        result = adjustFooterSpeakerCount(in: result, delta: oldSystemSpeakers - newSystemSpeakers)
+
+        AppLogger.pipeline.info("Consolidated duplicate speaker names in breakdown", [
+            "before": "\(oldSystemSpeakers)",
+            "after": "\(newSystemSpeakers)"
+        ])
+
+        return result
+    }
+
+    private static func parseEntries(from breakdownText: String) -> [SpeakerBreakdownEntry] {
+        guard let lineRegex else { return [] }
+
+        return breakdownText
+            .components(separatedBy: "\n")
+            .compactMap { line in
+                let nsLine = line as NSString
+                let range = NSRange(location: 0, length: nsLine.length)
+                guard let match = lineRegex.firstMatch(in: line, range: range) else { return nil }
+
+                let name = nsLine.substring(with: match.range(at: 1))
+                let utterances = Int(nsLine.substring(with: match.range(at: 2))) ?? 0
+                let words = Int(nsLine.substring(with: match.range(at: 3))) ?? 0
+                let minutes = Double(nsLine.substring(with: match.range(at: 4))) ?? 0
+                let seconds = Double(nsLine.substring(with: match.range(at: 5))) ?? 0
+
+                return SpeakerBreakdownEntry(
+                    name: name,
+                    utterances: utterances,
+                    words: words,
+                    speakingSeconds: minutes * 60 + seconds
+                )
+            }
+    }
+
+    private static func renderedBreakdown(
+        nameOrder: [String],
+        statsByName: [String: SpeakerStats]
+    ) -> String {
+        nameOrder.compactMap { name in
+            guard let stats = statsByName[name] else { return nil }
+            let mins = Int(stats.speakingSeconds) / 60
+            let secs = Int(stats.speakingSeconds) % 60
+            let timeStr = String(format: "%02d:%02d", mins, secs)
+            return "- **\(name):** \(stats.utterances) utterances, ~\(stats.words) words, \(timeStr)\n"
+        }.joined()
+    }
+
+    private static func adjustFooterSpeakerCount(in content: String, delta: Int) -> String {
+        guard delta > 0,
+              let footerRegex,
+              let footerMatch = footerRegex.firstMatch(
+                in: content,
+                range: NSRange(location: 0, length: (content as NSString).length)
+              ),
+              let oldTotal = Int((content as NSString).substring(with: footerMatch.range(at: 1))) else {
+            return content
+        }
+
+        let newTotal = oldTotal - delta
+        return content.replacingOccurrences(
+            of: "| \(oldTotal) speakers*",
+            with: "| \(newTotal) speakers*"
         )
     }
 }

--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -208,31 +208,79 @@ extension TranscriptSaver {
     }
 
     /// Resolve a transcript URL that may have been renamed by MeetingTranscriptStyler.
-    /// Falls back to scanning the parent directory for a .md file containing a matching speaker db_id.
+    /// Tries three strategies in order:
+    ///   1. UUID search — scan .md files for a speaker db_id in the YAML
+    ///   2. Timestamp search — extract the time from the original filename and match YAML `time:` field
+    ///   3. Most recent — fall back to the newest .md file (just saved, should be the right one)
     static func resolveTranscriptURL(_ url: URL, updates: [SpeakerNameUpdate]) -> URL {
         if FileManager.default.fileExists(atPath: url.path) { return url }
 
-        AppLogger.pipeline.info("Transcript not at expected path, scanning for renamed file", ["expected": url.lastPathComponent])
-
         let directory = url.deletingLastPathComponent()
-        guard let firstId = updates.first?.persistentSpeakerId.uuidString,
-              let files = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
-                .filter({ $0.pathExtension == "md" }) else {
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.contentModificationDateKey, .creationDateKey]
+        ).filter({ $0.pathExtension == "md" }) else {
+            AppLogger.pipeline.error("resolveTranscriptURL: cannot list directory", ["dir": directory.path])
             return url
         }
 
-        // Read only the YAML frontmatter (first 2 KB) of each file to find the match.
-        for file in files {
-            guard let handle = try? FileHandle(forReadingFrom: file) else { continue }
-            let header = handle.readData(ofLength: 2048)
-            try? handle.close()
-            guard let text = String(data: header, encoding: .utf8),
-                  text.contains(firstId) else { continue }
-            AppLogger.pipeline.info("Resolved renamed transcript", ["from": url.lastPathComponent, "to": file.lastPathComponent])
-            return file
+        AppLogger.pipeline.info("resolveTranscriptURL: file not at expected path, scanning \(files.count) .md files", ["expected": url.lastPathComponent])
+
+        // Strategy 1: Search by speaker UUID in YAML frontmatter
+        if let firstId = updates.first?.persistentSpeakerId.uuidString {
+            for file in files {
+                guard let handle = try? FileHandle(forReadingFrom: file) else { continue }
+                let header = handle.readData(ofLength: 2048)
+                try? handle.close()
+                guard let text = String(data: header, encoding: .utf8),
+                      text.contains(firstId) else { continue }
+                AppLogger.pipeline.info("resolveTranscriptURL: matched by UUID", ["to": file.lastPathComponent])
+                return file
+            }
         }
 
+        // Strategy 2: Extract timestamp from original filename and match YAML `time:` field.
+        // Original filenames look like "Call 2026-04-10 11-15-12.md" — extract "11:15:12".
+        let stem = url.deletingPathExtension().lastPathComponent
+        if let timeMatch = extractTimeFromFilename(stem) {
+            let yamlTimeString = "time: \(timeMatch)"
+            for file in files {
+                guard let handle = try? FileHandle(forReadingFrom: file) else { continue }
+                let header = handle.readData(ofLength: 512)
+                try? handle.close()
+                guard let text = String(data: header, encoding: .utf8),
+                      text.contains(yamlTimeString) else { continue }
+                AppLogger.pipeline.info("resolveTranscriptURL: matched by timestamp", ["to": file.lastPathComponent, "time": timeMatch])
+                return file
+            }
+        }
+
+        // Strategy 3: Fall back to the most recently modified .md file.
+        let sorted = files.sorted { a, b in
+            let aDate = (try? a.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+            let bDate = (try? b.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+            return aDate > bDate
+        }
+        if let newest = sorted.first {
+            AppLogger.pipeline.info("resolveTranscriptURL: fell back to newest .md file", ["to": newest.lastPathComponent])
+            return newest
+        }
+
+        AppLogger.pipeline.error("resolveTranscriptURL: no .md files found at all")
         return url
+    }
+
+    /// Extract a time string like "11:15:12" from a filename like "Call 2026-04-10 11-15-12".
+    private static func extractTimeFromFilename(_ stem: String) -> String? {
+        // Match pattern: digits-digits-digits at the end (e.g., "11-15-12")
+        guard let regex = try? NSRegularExpression(pattern: #"(\d{1,2})-(\d{2})-(\d{2})$"#),
+              let match = regex.firstMatch(in: stem, range: NSRange(location: 0, length: (stem as NSString).length)),
+              match.numberOfRanges >= 4 else { return nil }
+        let ns = stem as NSString
+        let h = ns.substring(with: match.range(at: 1))
+        let m = ns.substring(with: match.range(at: 2))
+        let s = ns.substring(with: match.range(at: 3))
+        return "\(h):\(m):\(s)"
     }
 
     /// Replace all occurrences of a speaker name throughout a transcript's YAML and body.

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -186,12 +186,29 @@ extension TranscriptionTaskManager {
                 "transcript": resolvedURL.lastPathComponent
             ])
 
-            // Only UI state updates on the main thread
+            // UI state updates on the main thread.
+            // Setting displayStatus triggers MeetingSessionController's
+            // handleDisplayStatusChange → lastTerminalTranscriptionOutcome.
+            // Then a brief delay ensures the Combine pipeline has flushed
+            // before we re-trigger the background-work check, which drives
+            // the overlay from .transcribing → .saved → auto-hide.
             await MainActor.run { [weak self] in
                 guard let self else { return }
                 self.populateSavedMetadata(from: resolvedURL)
                 self.displayStatus = .transcriptSaved
                 self.scheduleStatusReset(delay: 8)
+            }
+            // Belt-and-suspenders: if the Combine subscription missed the
+            // speakerNamingRequest nil-out (set before this Task started),
+            // re-publish the change to force the session controller to
+            // finalize its state and dismiss the overlay.
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                if self.displayStatus == .transcriptSaved || self.displayStatus == .idle {
+                    self.displayStatus = .transcriptSaved
+                    self.scheduleStatusReset(delay: 3)
+                }
             }
         }
     }

--- a/Sources/UI/DictationSessionController.swift
+++ b/Sources/UI/DictationSessionController.swift
@@ -168,9 +168,7 @@ class DictationSessionController: ObservableObject {
             message: "Dictation started",
             context: dictationContext(
                 extra: [
-                    "trigger": trigger.rawValue,
-                    "source_app_name": sourceApp?.localizedName ?? "",
-                    "source_app_bundle_id": sourceApp?.bundleIdentifier ?? ""
+                    "trigger": trigger.rawValue
                 ]
             )
         )
@@ -620,9 +618,7 @@ class DictationSessionController: ObservableObject {
                 message: "Saved dictation markdown export",
                 context: dictationContext(
                     extra: [
-                        "delivery": delivery.rawValue,
-                        "title": saved.title,
-                        "filename": saved.url.lastPathComponent
+                        "delivery": delivery.rawValue
                     ]
                 )
             )
@@ -641,8 +637,6 @@ class DictationSessionController: ObservableObject {
 
     private func dictationContext(extra: [String: String] = [:]) -> [String: String] {
         var context: [String: String] = [
-            "source_app_name": sessionSourceApp?.localizedName ?? "",
-            "source_app_bundle_id": sessionSourceApp?.bundleIdentifier ?? "",
             "audio_device": appState?.sttRouter.inputDeviceName ?? ""
         ]
 

--- a/Sources/UI/DictationSessionController.swift
+++ b/Sources/UI/DictationSessionController.swift
@@ -501,38 +501,38 @@ class DictationSessionController: ObservableObject {
         switch modelState {
         case .notLoaded:
             return .init(
-                title: "Starting dictation",
-                detail: "Transcripted is waking up the local voice model before it starts listening.",
+                title: "Getting ready",
+                detail: "Setting up the voice model. This only takes a moment.",
                 progress: 0.08,
-                status: "Preparing local model"
+                status: ""
             )
         case .downloading(let progress):
             return .init(
-                title: "Downloading dictation model",
-                detail: "Transcripted is downloading the on-device voice model needed for local dictation.",
+                title: "Downloading voice model",
+                detail: "One-time download for local dictation.",
                 progress: max(0.12, min(0.84, 0.12 + progress * 0.72)),
-                status: "\(Int(progress * 100))% complete"
+                status: "\(Int(progress * 100))%"
             )
         case .loading:
             return .init(
-                title: "Loading dictation",
-                detail: "Transcripted has the model files and is loading them into memory. Recording starts automatically when it finishes.",
+                title: "Almost ready",
+                detail: "Starting up. Recording begins automatically.",
                 progress: 0.92,
-                status: "Almost ready"
+                status: ""
             )
         case .ready:
             return .init(
-                title: "Starting dictation",
-                detail: "The local voice model is ready. Opening the microphone now.",
+                title: "Starting",
+                detail: "",
                 progress: 1.0,
-                status: "Starting microphone"
+                status: ""
             )
         case .failed(let message):
             return .init(
-                title: "Dictation couldn't start",
+                title: "Couldn't start",
                 detail: message,
                 progress: 0,
-                status: "Model load failed"
+                status: ""
             )
         }
     }

--- a/Sources/UI/MenuBarContentView.swift
+++ b/Sources/UI/MenuBarContentView.swift
@@ -88,11 +88,18 @@ final class MenuBarContentView: NSView {
         shortcutsView.frame = NSRect(x: pad, y: y, width: width, height: shortcutsHeight)
         y += shortcutsHeight + MenuTokens.sectionSpacing
 
-        recentsDivider.frame = NSRect(x: pad, y: y - (MenuTokens.sectionSpacing / 2), width: width, height: dividerHeight)
+        if recentMeetingsView.hasContent {
+            recentsDivider.isHidden = false
+            recentsDivider.frame = NSRect(x: pad, y: y - (MenuTokens.sectionSpacing / 2), width: width, height: dividerHeight)
 
-        let recentsHeight = recentMeetingsView.intrinsicHeight
-        recentMeetingsView.frame = NSRect(x: pad, y: y, width: width, height: recentsHeight)
-        y += recentsHeight + MenuTokens.sectionSpacing
+            let recentsHeight = recentMeetingsView.intrinsicHeight
+            recentMeetingsView.isHidden = false
+            recentMeetingsView.frame = NSRect(x: pad, y: y, width: width, height: recentsHeight)
+            y += recentsHeight + MenuTokens.sectionSpacing
+        } else {
+            recentsDivider.isHidden = true
+            recentMeetingsView.isHidden = true
+        }
 
         footerDivider.frame = NSRect(x: pad, y: y - (MenuTokens.sectionSpacing / 2), width: width, height: dividerHeight)
 

--- a/Sources/UI/MenuBarRecentMeetingsView.swift
+++ b/Sources/UI/MenuBarRecentMeetingsView.swift
@@ -46,7 +46,7 @@ enum RecentMeetingsScanner {
 
 @MainActor
 final class MenuBarRecentMeetingsView: NSView {
-    private let headerLabel = NSTextField(labelWithString: "Recent meetings")
+    private let headerLabel = NSTextField(labelWithString: "Meetings")
     private let emptyLabel = NSTextField(labelWithString: "No meetings yet.")
     private let listContainer = FlippedRecentMeetingsContainer()
 
@@ -77,15 +77,17 @@ final class MenuBarRecentMeetingsView: NSView {
     override func layout() {
         super.layout()
 
-        headerLabel.frame = NSRect(x: 0, y: 0, width: bounds.width, height: 16)
-        let listY: CGFloat = 24
-
-        if rowViews.isEmpty {
-            emptyLabel.isHidden = false
+        guard hasContent else {
+            headerLabel.isHidden = true
+            emptyLabel.isHidden = true
             listContainer.isHidden = true
-            emptyLabel.frame = NSRect(x: 0, y: listY, width: bounds.width, height: 14)
             return
         }
+
+        headerLabel.isHidden = false
+
+        headerLabel.frame = NSRect(x: 0, y: 0, width: bounds.width, height: 16)
+        let listY: CGFloat = 24
 
         emptyLabel.isHidden = true
         listContainer.isHidden = false
@@ -131,9 +133,13 @@ final class MenuBarRecentMeetingsView: NSView {
         invalidateIntrinsicContentSize()
     }
 
+    var hasContent: Bool {
+        !rowViews.isEmpty
+    }
+
     var intrinsicHeight: CGFloat {
         let contentHeight = rowViews.reduce(CGFloat(0)) { $0 + $1.intrinsicContentSize.height }
-        if rowViews.isEmpty { return 40 }
+        if rowViews.isEmpty { return 0 }
         return 24 + contentHeight
     }
 }
@@ -160,11 +166,6 @@ private final class RecentMeetingRowView: NSView {
         symbolName: "doc.on.doc",
         accessibilityLabel: "Copy transcript",
         toolTip: "Copy transcript"
-    )
-    private let showButton = MenuIconButton(
-        symbolName: "folder",
-        accessibilityLabel: "Show in Finder",
-        toolTip: "Show in Finder"
     )
     private let divider = NSView()
     private let showsDivider: Bool
@@ -210,12 +211,9 @@ private final class RecentMeetingRowView: NSView {
         dateLabel.textColor = MenuTokens.textSecondaryNS
         addSubview(dateLabel)
 
-        [copyButton, showButton].forEach { addSubview($0) }
+        addSubview(copyButton)
         copyButton.target = self
         copyButton.action = #selector(copyTranscript)
-
-        showButton.target = self
-        showButton.action = #selector(showInFinder)
 
         divider.wantsLayer = true
         divider.layer?.backgroundColor = MenuTokens.sectionDividerNS.cgColor
@@ -248,8 +246,7 @@ private final class RecentMeetingRowView: NSView {
 
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-        guard !copyButton.frame.contains(point),
-              !showButton.frame.contains(point) else {
+        guard !copyButton.frame.contains(point) else {
             super.mouseDown(with: event)
             return
         }
@@ -266,14 +263,7 @@ private final class RecentMeetingRowView: NSView {
             height: buttonSize
         )
 
-        showButton.frame = NSRect(
-            x: copyButton.frame.minX - 8 - buttonSize,
-            y: (bounds.height - buttonSize) / 2,
-            width: buttonSize,
-            height: buttonSize
-        )
-
-        let textWidth = max(0, showButton.frame.minX - 12)
+        let textWidth = max(0, copyButton.frame.minX - 12)
         titleLabel.frame = NSRect(x: 0, y: 6, width: textWidth, height: 14)
         dateLabel.frame = NSRect(x: 0, y: 21, width: textWidth, height: 12)
         divider.frame = NSRect(x: 0, y: bounds.height - 1, width: bounds.width, height: 1)
@@ -295,9 +285,6 @@ private final class RecentMeetingRowView: NSView {
         }
     }
 
-    @objc private func showInFinder() {
-        NSWorkspace.shared.activateFileViewerSelecting([item.transcriptURL])
-    }
 }
 
 @MainActor

--- a/Sources/UI/OverlayRootView.swift
+++ b/Sources/UI/OverlayRootView.swift
@@ -171,11 +171,9 @@ final class OverlayRootView: NSView {
 
 @MainActor
 final class OverlayLoadingView: NSView {
-    private let titleLabel = NSTextField(labelWithString: "Loading dictation")
+    private let titleLabel = NSTextField(labelWithString: "Getting ready")
     private let detailLabel = NSTextField(wrappingLabelWithString: "")
     private let progressBar = NSProgressIndicator()
-    private let statusLabel = NSTextField(labelWithString: "")
-    private let elapsedLabel = NSTextField(labelWithString: "First launch can take a minute or two.")
 
     override var isFlipped: Bool { true }
 
@@ -206,17 +204,6 @@ final class OverlayLoadingView: NSView {
         progressBar.maxValue = 1
         progressBar.doubleValue = 0
         addSubview(progressBar)
-
-        statusLabel.font = NSFont.systemFont(ofSize: 10, weight: .medium)
-        statusLabel.textColor = OverlayTokens.textSecondary
-        addSubview(statusLabel)
-
-        elapsedLabel.font = NSFont.systemFont(ofSize: 11)
-        elapsedLabel.textColor = OverlayTokens.textMuted
-        elapsedLabel.isBezeled = false
-        elapsedLabel.isEditable = false
-        elapsedLabel.drawsBackground = false
-        addSubview(elapsedLabel)
     }
 
     override func layout() {
@@ -224,11 +211,9 @@ final class OverlayLoadingView: NSView {
         let pad: CGFloat = 14
         let contentWidth = max(0, bounds.width - pad * 2)
 
-        titleLabel.frame = NSRect(x: pad, y: 10, width: contentWidth, height: 16)
-        detailLabel.frame = NSRect(x: pad, y: 30, width: contentWidth, height: 28)
-        progressBar.frame = NSRect(x: pad, y: 64, width: contentWidth, height: 8)
-        statusLabel.frame = NSRect(x: pad, y: 76, width: contentWidth, height: 12)
-        elapsedLabel.frame = NSRect(x: pad, y: 88, width: contentWidth, height: 12)
+        titleLabel.frame = NSRect(x: pad, y: 12, width: contentWidth, height: 16)
+        detailLabel.frame = NSRect(x: pad, y: 32, width: contentWidth, height: 16)
+        progressBar.frame = NSRect(x: pad, y: 54, width: contentWidth, height: 6)
     }
 
     func update(
@@ -238,12 +223,6 @@ final class OverlayLoadingView: NSView {
         titleLabel.stringValue = presentation.title
         detailLabel.stringValue = presentation.detail
         progressBar.doubleValue = presentation.progress
-        statusLabel.stringValue = presentation.status
-        if elapsedSeconds > 0 {
-            elapsedLabel.stringValue = "First launch can take a minute or two. \(elapsedSeconds)s elapsed."
-        } else {
-            elapsedLabel.stringValue = "First launch can take a minute or two."
-        }
         needsLayout = true
     }
 }

--- a/Sources/UI/OverlayTokens.swift
+++ b/Sources/UI/OverlayTokens.swift
@@ -25,7 +25,7 @@ enum OverlayTokens {
     static let panelWidth: CGFloat         = 360
     static let panelCompactWidth: CGFloat  = 296
     static let panelCompactHeight: CGFloat = 42   // header bar only, no content area
-    static let panelLoadingHeight: CGFloat = 136
+    static let panelLoadingHeight: CGFloat = 100
     static let panelMinHeight: CGFloat     = 92
     static let panelMaxHeight: CGFloat     = 340
     static let cornerRadius: CGFloat   = 12

--- a/Sources/UI/PermissionsOnboardingView.swift
+++ b/Sources/UI/PermissionsOnboardingView.swift
@@ -37,13 +37,18 @@ struct PermissionsOnboardingView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 12) {
-                    ForEach(TranscriptedPermissionKind.allCases) { kind in
+                    ForEach(requiredPermissions) { kind in
                         PermissionSetupCard(
                             kind: kind,
                             granted: isGranted(kind),
                             action: { TranscriptedPermissionAccess.openSettings(for: kind) }
                         )
                     }
+
+                    OptionalPermissionsCard(
+                        optionalPermissions: optionalPermissions,
+                        isGranted: isGranted
+                    )
 
                     VStack(alignment: .leading, spacing: 10) {
                         Text("What happens next")
@@ -107,6 +112,14 @@ struct PermissionsOnboardingView: View {
 
     private var hasRequiredPermissions: Bool {
         micGranted && accessibilityGranted
+    }
+
+    private var requiredPermissions: [TranscriptedPermissionKind] {
+        TranscriptedPermissionKind.allCases.filter(\.isRequiredOnFirstLaunch)
+    }
+
+    private var optionalPermissions: [TranscriptedPermissionKind] {
+        TranscriptedPermissionKind.allCases.filter { !$0.isRequiredOnFirstLaunch }
     }
 
     private var continueButtonTitle: String {
@@ -233,6 +246,57 @@ private struct PermissionSetupCard: View {
             if !granted {
                 Button(kind.onboardingActionTitle, action: action)
                     .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(MenuTokens.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(MenuTokens.cardBorder, lineWidth: 1)
+                )
+        )
+    }
+}
+
+private struct OptionalPermissionsCard: View {
+    let optionalPermissions: [TranscriptedPermissionKind]
+    let isGranted: (TranscriptedPermissionKind) -> Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Optional later")
+                .font(.subheadline.weight(.semibold))
+
+            Text("You can start dictating without these. Add them later from Settings when you want richer meeting capture.")
+                .font(.caption)
+                .foregroundStyle(MenuTokens.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            ForEach(optionalPermissions) { kind in
+                HStack(alignment: .top, spacing: 10) {
+                    Image(systemName: kind.icon)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(MenuTokens.textMuted)
+                        .frame(width: 16, height: 16)
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: 6) {
+                            Text(kind.title)
+                                .font(.caption.weight(.semibold))
+
+                            Text(isGranted(kind) ? "Ready" : "Later")
+                                .font(.system(size: 10, weight: .semibold))
+                                .foregroundStyle(isGranted(kind) ? MenuTokens.statusGreen : MenuTokens.textMuted)
+                        }
+
+                        Text(kind.summary)
+                            .font(.caption)
+                            .foregroundStyle(MenuTokens.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
             }
         }
         .padding(14)

--- a/Tests/CapturedContextTests.swift
+++ b/Tests/CapturedContextTests.swift
@@ -18,7 +18,7 @@ func testCapturedContext() {
         assertEqual(ctx.talkingTo, "Sarah Graham", "talkingTo")
         assertEqual(ctx.formality, "casual", "formality")
         assertTrue(ctx.hasConversation, "should have conversation")
-        assertTrue(ctx.conversation!.contains("Hey, are you coming"), "conversation content")
+        assertEqual(ctx.conversation?.contains("Hey, are you coming"), true, "conversation content")
     }
 
     runSuite("CapturedContext.parse — case insensitivity") {
@@ -54,8 +54,17 @@ func testCapturedContext() {
             """
         let ctx = CapturedContext.parse(from: input)
         assertEqual(ctx.platform, "imessage")
-        let lines = ctx.conversation!.components(separatedBy: "\n").filter { !$0.isEmpty }
+        let lines = ctx.conversation?.components(separatedBy: "\n").filter { !$0.isEmpty } ?? []
         assertEqual(lines.count, 3, "should have 3 conversation lines")
+    }
+
+    runSuite("CapturedContext.hasConversation — whitespace-only conversation") {
+        var ctx = CapturedContext()
+        ctx.conversation = "  \n  "
+
+        assertFalse(ctx.hasConversation, "whitespace-only conversation should be treated as empty")
+        assertFalse(ctx.displayText.contains("CONVERSATION:"), "display text should omit empty conversation sections")
+        assertFalse(ctx.draftingPrompt(userInstructions: "").contains("CONVERSATION:"), "prompt should omit empty conversation sections")
     }
 
     runSuite("CapturedContext.parse — conversation stops at next header") {

--- a/Tests/TestHelpers.swift
+++ b/Tests/TestHelpers.swift
@@ -40,7 +40,7 @@ func assertNil<T>(_ value: T?, _ message: String = "", file: String = #file, lin
     } else {
         failedTests += 1
         let loc = "\(URL(fileURLWithPath: file).lastPathComponent):\(line)"
-        print("  FAIL [\(loc)] \(message.isEmpty ? "expected nil" : message), got \(value!)")
+        print("  FAIL [\(loc)] \(message.isEmpty ? "expected nil" : message), got \(String(describing: value))")
     }
 }
 

--- a/Tests/TranscriptedCoreTests/RetroactiveSpeakerUpdaterTests.swift
+++ b/Tests/TranscriptedCoreTests/RetroactiveSpeakerUpdaterTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import TranscriptedCore
+
+final class RetroactiveSpeakerUpdaterTests: XCTestCase {
+
+    func testConsolidateSpeakerBreakdownMergesDuplicateNamesAndCounts() {
+        let content = """
+        ---
+        system_speakers: 3
+        ---
+
+        ## Speaker Analytics
+
+        - **Speakers Detected:** 3
+
+        #### Remote Speaker Breakdown
+
+        - **Alex:** 2 utterances, ~10 words, 00:30
+        - **Alex:** 1 utterances, ~5 words, 00:15
+        - **Jordan:** 4 utterances, ~40 words, 01:00
+
+        ---
+
+        *2 channels | 4 speakers*
+        """
+
+        let updated = SpeakerBreakdownConsolidator.consolidate(content)
+
+        XCTAssertTrue(updated.contains("system_speakers: 2"))
+        XCTAssertTrue(updated.contains("- **Speakers Detected:** 2"))
+        XCTAssertTrue(updated.contains("- **Alex:** 3 utterances, ~15 words, 00:45"))
+        XCTAssertFalse(updated.contains("- **Alex:** 2 utterances, ~10 words, 00:30"))
+        XCTAssertTrue(updated.contains("*2 channels | 3 speakers*"))
+    }
+
+    func testConsolidateSpeakerBreakdownLeavesUniqueNamesUntouched() {
+        let content = """
+        ---
+        system_speakers: 2
+        ---
+
+        ## Speaker Analytics
+
+        - **Speakers Detected:** 2
+
+        #### Remote Speaker Breakdown
+
+        - **Alex:** 2 utterances, ~10 words, 00:30
+        - **Jordan:** 4 utterances, ~40 words, 01:00
+
+        ---
+
+        *2 channels | 3 speakers*
+        """
+
+        XCTAssertEqual(SpeakerBreakdownConsolidator.consolidate(content), content)
+    }
+}

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/PathSecurity.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/PathSecurity.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+enum PathResolutionStatus {
+    case valid(URL)
+    case missing
+    case invalid
+}
+
+enum PathSecurity {
+    static func resolveReadableFile(
+        named requestedName: String,
+        appendingExtension pathExtension: String? = nil,
+        in baseDirectory: URL
+    ) -> PathResolutionStatus {
+        let candidateName: String
+        if let pathExtension, !requestedName.hasSuffix(".\(pathExtension)") {
+            candidateName = requestedName + ".\(pathExtension)"
+        } else {
+            candidateName = requestedName
+        }
+
+        let candidateURL = baseDirectory
+            .appendingPathComponent(candidateName)
+            .standardizedFileURL
+        let standardizedBase = baseDirectory.standardizedFileURL
+
+        guard candidateURL.path.hasPrefix(standardizedBase.path + "/") else {
+            return .invalid
+        }
+        guard FileManager.default.fileExists(atPath: candidateURL.path) else {
+            return .missing
+        }
+
+        return validateExistingFile(candidateURL, under: baseDirectory)
+    }
+
+    static func validateExistingFile(_ url: URL, under baseDirectory: URL) -> PathResolutionStatus {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return .missing
+        }
+
+        guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
+              values.isRegularFile == true,
+              values.isSymbolicLink != true else {
+            return .invalid
+        }
+
+        let resolvedBase = baseDirectory.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedURL = url.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedBasePath = resolvedBase.path
+        let resolvedPath = resolvedURL.path
+
+        guard resolvedPath == resolvedBasePath || resolvedPath.hasPrefix(resolvedBasePath + "/") else {
+            return .invalid
+        }
+
+        return .valid(resolvedURL)
+    }
+}

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -273,7 +273,11 @@ private func handleListMeetings(params: CallTool.Parameters, index: TranscriptIn
 
     // Populate titles from markdown YAML frontmatter
     for i in results.indices {
-        let mdURL = meetingsDir.appendingPathComponent(results[i].filename + ".md")
+        guard case .valid(let mdURL) = PathSecurity.resolveReadableFile(
+            named: results[i].filename,
+            appendingExtension: "md",
+            in: meetingsDir
+        ) else { continue }
         if let content = try? String(contentsOf: mdURL, encoding: .utf8) {
             results[i].title = extractTitle(from: content) ?? results[i].filename
         }
@@ -337,12 +341,13 @@ private func handleReadMeeting(params: CallTool.Parameters, meetingsDir: URL) th
 
     let section = params.arguments?["section"]?.stringValue ?? "full"
 
-    // Try .md file first, then without extension
-    let mdURL = meetingsDir.appendingPathComponent(filename.hasSuffix(".md") ? filename : filename + ".md")
-        .standardizedFileURL
-
-    // Reject path traversal (e.g., filename = "../../etc/passwd")
-    guard mdURL.path.hasPrefix(meetingsDir.standardizedFileURL.path + "/") else {
+    let mdURL: URL
+    switch PathSecurity.resolveReadableFile(named: filename, appendingExtension: "md", in: meetingsDir) {
+    case .valid(let url):
+        mdURL = url
+    case .missing:
+        return .init(content: [.text(text: "Meeting not found: \(filename). Use list_meetings to see available meetings.")], isError: true)
+    case .invalid:
         return .init(content: [.text(text: "Invalid filename: \(filename)")], isError: true)
     }
 
@@ -382,11 +387,13 @@ private func handleReadDictation(params: CallTool.Parameters, dictationsDir: URL
     }
 
     let entryId = params.arguments?["entry_id"]?.stringValue
-    let sidecarURL = dictationsDir
-        .appendingPathComponent(filename.hasSuffix(".json") ? filename : filename + ".json")
-        .standardizedFileURL
-
-    guard sidecarURL.path.hasPrefix(dictationsDir.standardizedFileURL.path + "/") else {
+    let sidecarURL: URL
+    switch PathSecurity.resolveReadableFile(named: filename, appendingExtension: "json", in: dictationsDir) {
+    case .valid(let url):
+        sidecarURL = url
+    case .missing:
+        return .init(content: [.text(text: "Dictation not found: \(filename). Use list_dictations to see available days.")], isError: true)
+    case .invalid:
         return .init(content: [.text(text: "Invalid filename: \(filename)")], isError: true)
     }
 
@@ -412,11 +419,14 @@ private func handleReadDictation(params: CallTool.Parameters, dictationsDir: URL
         return .init(content: [.text(text: result)])
     }
 
-    let markdownURL = dictationsDir
-        .appendingPathComponent(day.markdownFilename)
-        .standardizedFileURL
-
-    guard markdownURL.path.hasPrefix(dictationsDir.standardizedFileURL.path + "/") else {
+    let markdownURL: URL
+    switch PathSecurity.resolveReadableFile(named: day.markdownFilename, in: dictationsDir) {
+    case .valid(let url):
+        markdownURL = url
+    case .missing:
+        let json = try JSONEncoder.pretty.encode(day)
+        return .init(content: [.text(text: String(data: json, encoding: .utf8) ?? "{}")])
+    case .invalid:
         return .init(content: [.text(text: "Invalid markdown filename for \(filename)")], isError: true)
     }
 
@@ -533,9 +543,11 @@ private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, me
 
     for meeting in meetings {
         // Read first ~200 words of transcript as preview
-        let mdURL = meetingsDir.appendingPathComponent(meeting.filename + ".md")
-        // Skip files that would escape dataDir (path traversal)
-        guard mdURL.standardizedFileURL.path.hasPrefix(meetingsDir.standardizedFileURL.path) else { continue }
+        guard case .valid(let mdURL) = PathSecurity.resolveReadableFile(
+            named: meeting.filename,
+            appendingExtension: "md",
+            in: meetingsDir
+        ) else { continue }
         var preview = ""
         var title = meeting.filename
         if let content = try? String(contentsOf: mdURL, encoding: .utf8) {
@@ -594,8 +606,12 @@ private func parseContextKind(_ raw: String?) -> ContextKind {
 }
 
 private func meetingTitle(for filename: String, meetingsDir: URL) -> String {
-    let mdURL = meetingsDir.appendingPathComponent(filename + ".md")
-    guard let content = try? String(contentsOf: mdURL, encoding: .utf8) else {
+    guard case .valid(let mdURL) = PathSecurity.resolveReadableFile(
+        named: filename,
+        appendingExtension: "md",
+        in: meetingsDir
+    ),
+    let content = try? String(contentsOf: mdURL, encoding: .utf8) else {
         return filename
     }
     return extractTitle(from: content) ?? filename

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
@@ -68,10 +68,11 @@ enum TranscriptLoader {
         }
 
         return files.compactMap { url in
-            guard let kind = sidecarKind(for: url) else { return nil }
-            let modDate = (try? url.resourceValues(forKeys: [.contentModificationDateKey])
+            guard case .valid(let safeURL) = PathSecurity.validateExistingFile(url, under: directory),
+                  let kind = sidecarKind(for: safeURL) else { return nil }
+            let modDate = (try? safeURL.resourceValues(forKeys: [.contentModificationDateKey])
                 .contentModificationDate?.timeIntervalSince1970) ?? 0
-            return ContextSidecarFile(url: url, modDate: modDate, kind: kind)
+            return ContextSidecarFile(url: safeURL, modDate: modDate, kind: kind)
         }
     }
 

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptLoaderTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptLoaderTests.swift
@@ -56,6 +56,36 @@ final class TranscriptLoaderTests: XCTestCase {
         XCTAssertEqual(day?.entries.first?.title, "Morning note")
     }
 
+    func testEnumerateSidecarsSkipsSymlinkedFiles() throws {
+        let outsideDir = makeTempDir()
+        defer { removeTempDir(outsideDir) }
+
+        let outsideFile = outsideDir.appendingPathComponent("Call_2026-03-29_10-00-00.json")
+        try makeFixtureJSON().write(to: outsideFile)
+
+        let symlinkURL = tempDir.appendingPathComponent("Call_2026-03-29_10-00-00.json")
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: outsideFile)
+
+        let sidecars = TranscriptLoader.enumerateSidecars(in: tempDir)
+        XCTAssertTrue(sidecars.isEmpty)
+    }
+
+    func testResolveReadableFileRejectsSymlinkEscape() throws {
+        let outsideDir = makeTempDir()
+        defer { removeTempDir(outsideDir) }
+
+        let outsideFile = outsideDir.appendingPathComponent("Dictations_2026-04-07.md")
+        try "# Secret".write(to: outsideFile, atomically: true, encoding: .utf8)
+
+        let symlinkURL = tempDir.appendingPathComponent("Dictations_2026-04-07.md")
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: outsideFile)
+
+        let result = PathSecurity.resolveReadableFile(named: "Dictations_2026-04-07.md", in: tempDir)
+        guard case .invalid = result else {
+            return XCTFail("Expected symlink escape to be rejected")
+        }
+    }
+
     func testSpeakerLookup() {
         let fixture = makeFixtureJSON()
         let transcript = try! JSONDecoder().decode(AgentTranscript.self, from: fixture)

--- a/build-beta.sh
+++ b/build-beta.sh
@@ -9,9 +9,9 @@
 # - NOTARY_PROFILE set to the local keychain profile name for notarytool
 # - optional: brew install create-dmg for the custom DMG layout
 
-set -e
+set -euo pipefail
 
-BETA_TOKEN="$1"
+BETA_TOKEN="${1:-}"
 USER_NAME="${2:-beta}"
 SKIP_NOTARIZATION="${SKIP_NOTARIZATION:-0}"
 
@@ -24,12 +24,46 @@ fi
 APP_NAME="Transcripted"
 BUILD_DIR="build"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
+APP_BINARY="$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 DMG_NAME="Transcripted-${USER_NAME}.dmg"
-SIGNING_IDENTITY="${SIGNING_IDENTITY:-}"
+SIGNING_IDENTITY="${SIGNING_IDENTITY:-${SIGN_IDENTITY:-}}"
 SIGNING_DISPLAY_NAME=""
 NOTARY_PROFILE="${NOTARY_PROFILE:-}"
 BETA_CONFIG_PATH="Sources/API/BetaConfig.swift"
 BETA_CONFIG_BACKUP="$(mktemp -t transcripted-beta-config)"
+BETA_ENTITLEMENTS="config/entitlements/beta.plist"
+TRANSCRIPTED_CORE_MODULE="deps-modules/TranscriptedCore.swiftmodule/arm64-apple-macos.swiftmodule"
+
+validate_signed_app() {
+    echo "Validating app signature..."
+    codesign --verify --deep --strict --verbose=4 "$APP_BUNDLE"
+    codesign -dvvv --entitlements :- "$APP_BUNDLE"
+}
+
+validate_notarized_artifacts() {
+    echo "Validating Gatekeeper acceptance..."
+    spctl -a -t exec -vv "$APP_BUNDLE"
+    spctl -a -t open -vv "$BUILD_DIR/$DMG_NAME"
+}
+
+resolve_sign_identity() {
+    local requested_identity="$1"
+    local found_line
+
+    if [ -n "$requested_identity" ]; then
+        found_line="$(security find-identity -v -p codesigning 2>/dev/null | grep -F "$requested_identity" | head -1 || true)"
+        if [ -z "$found_line" ]; then
+            echo "❌ Requested signing identity not found: $requested_identity"
+            echo "Available identities:"
+            security find-identity -v -p codesigning || true
+            exit 1
+        fi
+        printf '%s\n' "$found_line"
+        return 0
+    fi
+
+    security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application" | head -1 || true
+}
 
 cleanup() {
     if [ -f "$BETA_CONFIG_BACKUP" ]; then
@@ -39,6 +73,18 @@ cleanup() {
 }
 
 trap cleanup EXIT
+
+if [ ! -f "$BETA_ENTITLEMENTS" ]; then
+    echo "❌ Missing entitlements file: $BETA_ENTITLEMENTS"
+    exit 1
+fi
+
+if [ ! -f "deps-libs/libDraftDeps.a" ] || [ ! -d "deps-modules" ] || [ ! -f "$TRANSCRIPTED_CORE_MODULE" ]; then
+    echo "❌ Dependencies missing or stale — required for beta builds"
+    echo "   Missing module: $TRANSCRIPTED_CORE_MODULE"
+    echo "   Run build-deps.sh --force first to rebuild dependencies."
+    exit 1
+fi
 
 echo "🔨 Building Transcripted Beta for $USER_NAME (token: $BETA_TOKEN)..."
 
@@ -65,41 +111,12 @@ if [ -d "Resources" ]; then
     cp -R Resources/. "$APP_BUNDLE/Contents/Resources/"
 fi
 
-# Create entitlements (hardened runtime compatible)
-cat > "$BUILD_DIR/Transcripted.entitlements" << 'EOF'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>com.apple.security.app-sandbox</key>
-    <false/>
-    <key>com.apple.security.network.client</key>
-    <true/>
-    <key>com.apple.security.device.audio-input</key>
-    <true/>
-    <key>com.apple.security.speech.recognition</key>
-    <true/>
-    <key>com.apple.security.cs.allow-jit</key>
-    <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
-</dict>
-</plist>
-EOF
-
-# Inject the user's beta token
+# Inject the user's beta token after dependency preflight succeeds.
 echo "Injecting token for $USER_NAME..."
 cp "$BETA_CONFIG_PATH" "$BETA_CONFIG_BACKUP"
 sed -i '' "s/BETA_TOKEN_PLACEHOLDER/$BETA_TOKEN/" "$BETA_CONFIG_PATH"
 
 # Unified dependencies (FluidAudio + mlx-swift-lm)
-TRANSCRIPTED_CORE_MODULE="deps-modules/TranscriptedCore.swiftmodule/arm64-apple-macos.swiftmodule"
-if [ ! -f "deps-libs/libDraftDeps.a" ] || [ ! -d "deps-modules" ] || [ ! -f "$TRANSCRIPTED_CORE_MODULE" ]; then
-    echo "❌ Dependencies missing or stale — required for beta builds"
-    echo "   Missing module: $TRANSCRIPTED_CORE_MODULE"
-    echo "   Run build-deps.sh --force first to rebuild dependencies."
-    exit 1
-fi
 echo "Dependencies found"
 
 DEPS_MODULE_FLAGS="-Ideps-modules"
@@ -120,7 +137,7 @@ SOURCE_FILES=$(find Sources -name '*.swift' -not -path 'Sources/TranscriptedCore
 swiftc \
     -O \
     -D BETA_BUILD \
-    -o "$APP_BUNDLE/Contents/MacOS/$APP_NAME" \
+    -o "$APP_BINARY" \
     -framework AVFoundation \
     -framework AppKit \
     -framework SwiftUI \
@@ -144,18 +161,15 @@ swiftc \
     -Xlinker -rpath -Xlinker @executable_path/../Frameworks \
     2>&1
 
-COMPILE_STATUS=$?
-
-if [ $COMPILE_STATUS -ne 0 ]; then
-    echo "❌ Build failed!"
+if [ ! -x "$APP_BINARY" ]; then
+    echo "❌ Build finished without a runnable app binary: $APP_BINARY"
     exit 1
 fi
 
-if [ -z "$SIGNING_IDENTITY" ]; then
-    SIGNING_IDENTITY=$(security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application" | head -1 | awk '{print $2}')
-    SIGNING_DISPLAY_NAME=$(security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)"/\1/')
-else
-    SIGNING_DISPLAY_NAME="$SIGNING_IDENTITY"
+SIGNING_MATCH="$(resolve_sign_identity "$SIGNING_IDENTITY")"
+if [ -n "$SIGNING_MATCH" ]; then
+    SIGNING_IDENTITY="$(echo "$SIGNING_MATCH" | awk '{print $2}')"
+    SIGNING_DISPLAY_NAME="$(echo "$SIGNING_MATCH" | sed 's/.*"\(.*\)"/\1/')"
 fi
 
 if [ -n "$SIGNING_IDENTITY" ]; then
@@ -164,7 +178,7 @@ if [ -n "$SIGNING_IDENTITY" ]; then
         --sign "$SIGNING_IDENTITY" \
         --options runtime \
         --timestamp \
-        --entitlements "$BUILD_DIR/Transcripted.entitlements" \
+        --entitlements "$BETA_ENTITLEMENTS" \
         "$APP_BUNDLE" 2>&1; then
         echo "❌ Signing failed! Make sure you have a valid Developer ID Application certificate."
         echo "   Open Xcode → Settings → Accounts → Manage Certificates"
@@ -174,9 +188,11 @@ else
     echo "⚠️  No Developer ID found — signing ad-hoc for local smoke testing"
     codesign --force --deep \
         --sign - \
-        --entitlements "$BUILD_DIR/Transcripted.entitlements" \
+        --entitlements "$BETA_ENTITLEMENTS" \
         "$APP_BUNDLE" 2>&1
 fi
+
+validate_signed_app
 
 # Create DMG
 echo "Creating DMG..."
@@ -201,7 +217,7 @@ if command -v create-dmg >/dev/null 2>&1; then
         $DMG_BG_FLAGS \
         "$BUILD_DIR/$DMG_NAME" \
         "$APP_BUNDLE" \
-        2>&1 || true  # create-dmg returns non-zero on "already exists" even after rm
+        2>&1 || true
 else
     echo "⚠️  create-dmg not found — using hdiutil fallback"
     STAGING_DIR="$BUILD_DIR/dmg-staging"
@@ -234,6 +250,7 @@ fi
 # Notarize (only with Developer ID — Apple Development certs can't be notarized)
 if [ "$SKIP_NOTARIZATION" = "1" ]; then
     echo "⚠️  Skipping notarization (SKIP_NOTARIZATION=1)"
+    echo "   Expect Gatekeeper to reject the Developer ID app until it is notarized."
 elif [[ "$SIGNING_DISPLAY_NAME" == Developer\ ID* ]]; then
     if [ -z "$NOTARY_PROFILE" ]; then
         echo "❌ NOTARY_PROFILE is not set."
@@ -247,9 +264,9 @@ elif [[ "$SIGNING_DISPLAY_NAME" == Developer\ ID* ]]; then
         --keychain-profile "$NOTARY_PROFILE" \
         --wait
 
-    # Staple
     echo "Stapling notarization ticket..."
     xcrun stapler staple "$BUILD_DIR/$DMG_NAME"
+    validate_notarized_artifacts
 else
     echo "⚠️  Skipping notarization (using development cert — local testing only)"
 fi

--- a/build-deps.sh
+++ b/build-deps.sh
@@ -9,9 +9,46 @@
 set -e
 
 DRAFT_DIR="$(cd "$(dirname "$0")" && pwd)"
-DEPS_BUILD="$DRAFT_DIR/.deps-build"
 DEPS_LIBS="$DRAFT_DIR/deps-libs"
 DEPS_MODULES="$DRAFT_DIR/deps-modules"
+DEPS_BUILD="$(mktemp -d "$DRAFT_DIR/.deps-build.XXXXXX")"
+DEPS_LIBS_TMP="$(mktemp -d "$DRAFT_DIR/.deps-libs.XXXXXX")"
+DEPS_MODULES_TMP="$(mktemp -d "$DRAFT_DIR/.deps-modules.XXXXXX")"
+TEMP_DIRS=("$DEPS_BUILD" "$DEPS_LIBS_TMP" "$DEPS_MODULES_TMP")
+STALE_DIRS=()
+
+cleanup_temp_dirs() {
+    for dir in "${TEMP_DIRS[@]}"; do
+        if [ -e "$dir" ]; then
+            rm -rf "$dir"
+        fi
+    done
+}
+
+stash_existing_dir() {
+    local path="$1"
+    if [ -e "$path" ]; then
+        local stale_path="${path}.stale.$(date +%s).$$"
+        mv "$path" "$stale_path"
+        STALE_DIRS+=("$stale_path")
+    fi
+}
+
+promote_output_dir() {
+    local source_path="$1"
+    local target_path="$2"
+    stash_existing_dir "$target_path"
+    mv "$source_path" "$target_path"
+}
+
+cleanup_stale_dirs() {
+    for dir in "${STALE_DIRS[@]}"; do
+        rm -rf "$dir" 2>/dev/null || \
+            echo "[build-deps] NOTE: left stale directory behind for later cleanup: $dir"
+    done
+}
+
+trap cleanup_temp_dirs EXIT
 
 # ---------------------------------------------------------------------------
 # Discover the TranscriptedCore source tree to inline into the unified deps build.
@@ -99,8 +136,6 @@ fi
 
 echo "Building FluidAudio + mlx-swift-lm (unified)..."
 
-# Clean previous build
-rm -rf "$DEPS_BUILD" "$DEPS_LIBS" "$DEPS_MODULES"
 mkdir -p "$DEPS_BUILD/Sources"
 
 # Symlink TranscriptedCore's source tree into $DEPS_BUILD so SPM's target
@@ -170,9 +205,6 @@ BUILD_RELEASE="$DEPS_BUILD/.build/arm64-apple-macosx/release"
 MODULES_SRC="$DEPS_BUILD/.build/release/Modules"
 CHECKOUTS="$DEPS_BUILD/.build/checkouts"
 
-# Create output directories
-mkdir -p "$DEPS_LIBS" "$DEPS_MODULES"
-
 # --- Static library: combine all .o files into one .a ---
 echo "Creating static library..."
 cd "$BUILD_RELEASE"
@@ -184,8 +216,8 @@ echo "$ALL_BUILD_DIRS" | while read -r dir; do echo "  $dir"; done
 
 # Archive all .o files into libDraftDeps.a (includes TranscriptedCore — used by build.sh which
 # excludes Sources/TranscriptedCore from its swiftc invocation to avoid name-collision issues).
-find $ALL_BUILD_DIRS -name "*.o" -print0 | xargs -0 ar rcs "$DEPS_LIBS/libDraftDeps.a"
-OBJ_COUNT=$(ar t "$DEPS_LIBS/libDraftDeps.a" | wc -l | tr -d ' ')
+find $ALL_BUILD_DIRS -name "*.o" -print0 | xargs -0 ar rcs "$DEPS_LIBS_TMP/libDraftDeps.a"
+OBJ_COUNT=$(ar t "$DEPS_LIBS_TMP/libDraftDeps.a" | wc -l | tr -d ' ')
 echo "  $OBJ_COUNT object files archived"
 
 # Also create libExternalDeps.a — same as libDraftDeps.a but without TranscriptedCore objects.
@@ -193,8 +225,8 @@ echo "  $OBJ_COUNT object files archived"
 # source via SPM. Using libDraftDeps.a there causes duplicate-symbol linker errors because
 # Core appears in both the SPM-compiled objects and the static archive.
 EXTERNAL_DIRS=$(find . -maxdepth 1 -name "*.build" -type d | grep -v "Shim.build" | grep -v "TranscriptedCore.build" | sort)
-find $EXTERNAL_DIRS -name "*.o" -print0 | xargs -0 ar rcs "$DEPS_LIBS/libExternalDeps.a"
-EXT_COUNT=$(ar t "$DEPS_LIBS/libExternalDeps.a" | wc -l | tr -d ' ')
+find $EXTERNAL_DIRS -name "*.o" -print0 | xargs -0 ar rcs "$DEPS_LIBS_TMP/libExternalDeps.a"
+EXT_COUNT=$(ar t "$DEPS_LIBS_TMP/libExternalDeps.a" | wc -l | tr -d ' ')
 echo "  $EXT_COUNT object files archived (external-only, no TranscriptedCore)"
 
 # --- Swift modules ---
@@ -203,14 +235,14 @@ for mod in "$MODULES_SRC"/*.swiftmodule; do
     name=$(basename "$mod" .swiftmodule)
     # Skip Shim — that's our build helper
     [ "$name" = "Shim" ] && continue
-    mkdir -p "$DEPS_MODULES/${name}.swiftmodule"
-    cp "$mod" "$DEPS_MODULES/${name}.swiftmodule/arm64-apple-macos.swiftmodule"
+    mkdir -p "$DEPS_MODULES_TMP/${name}.swiftmodule"
+    cp "$mod" "$DEPS_MODULES_TMP/${name}.swiftmodule/arm64-apple-macos.swiftmodule"
     if [ -f "$MODULES_SRC/${name}.swiftdoc" ]; then
-        cp "$MODULES_SRC/${name}.swiftdoc" "$DEPS_MODULES/${name}.swiftmodule/arm64-apple-macos.swiftdoc"
+        cp "$MODULES_SRC/${name}.swiftdoc" "$DEPS_MODULES_TMP/${name}.swiftmodule/arm64-apple-macos.swiftdoc"
     fi
     # Copy .swiftinterface if present (for resilient modules)
     if [ -f "$MODULES_SRC/${name}.swiftinterface" ]; then
-        cp "$MODULES_SRC/${name}.swiftinterface" "$DEPS_MODULES/${name}.swiftmodule/arm64-apple-macos.swiftinterface"
+        cp "$MODULES_SRC/${name}.swiftinterface" "$DEPS_MODULES_TMP/${name}.swiftmodule/arm64-apple-macos.swiftinterface"
     fi
 done
 
@@ -220,30 +252,30 @@ echo "Copying C module maps..."
 # _NumericsShims (from swift-numerics)
 NUMERICS_SHIMS=$(find "$CHECKOUTS" -path "*/_NumericsShims/include" -type d 2>/dev/null | head -1)
 if [ -n "$NUMERICS_SHIMS" ]; then
-    mkdir -p "$DEPS_MODULES/_NumericsShims"
-    cp "$NUMERICS_SHIMS/"* "$DEPS_MODULES/_NumericsShims/"
+    mkdir -p "$DEPS_MODULES_TMP/_NumericsShims"
+    cp "$NUMERICS_SHIMS/"* "$DEPS_MODULES_TMP/_NumericsShims/"
 fi
 
 # FastClusterWrapper (from FluidAudio)
 if [ -d "$CHECKOUTS/FluidAudio/Sources/FastClusterWrapper/include" ]; then
-    mkdir -p "$DEPS_MODULES/FastClusterWrapper"
-    cp "$CHECKOUTS/FluidAudio/Sources/FastClusterWrapper/include/module.modulemap" "$DEPS_MODULES/FastClusterWrapper/"
-    cp "$CHECKOUTS/FluidAudio/Sources/FastClusterWrapper/include/"*.h "$DEPS_MODULES/FastClusterWrapper/" 2>/dev/null || true
+    mkdir -p "$DEPS_MODULES_TMP/FastClusterWrapper"
+    cp "$CHECKOUTS/FluidAudio/Sources/FastClusterWrapper/include/module.modulemap" "$DEPS_MODULES_TMP/FastClusterWrapper/"
+    cp "$CHECKOUTS/FluidAudio/Sources/FastClusterWrapper/include/"*.h "$DEPS_MODULES_TMP/FastClusterWrapper/" 2>/dev/null || true
 fi
 
 # MachTaskSelfWrapper (from FluidAudio)
 if [ -d "$CHECKOUTS/FluidAudio/Sources/MachTaskSelfWrapper/include" ]; then
-    mkdir -p "$DEPS_MODULES/MachTaskSelfWrapper"
-    cp "$CHECKOUTS/FluidAudio/Sources/MachTaskSelfWrapper/include/module.modulemap" "$DEPS_MODULES/MachTaskSelfWrapper/"
-    cp "$CHECKOUTS/FluidAudio/Sources/MachTaskSelfWrapper/include/"*.h "$DEPS_MODULES/MachTaskSelfWrapper/" 2>/dev/null || true
+    mkdir -p "$DEPS_MODULES_TMP/MachTaskSelfWrapper"
+    cp "$CHECKOUTS/FluidAudio/Sources/MachTaskSelfWrapper/include/module.modulemap" "$DEPS_MODULES_TMP/MachTaskSelfWrapper/"
+    cp "$CHECKOUTS/FluidAudio/Sources/MachTaskSelfWrapper/include/"*.h "$DEPS_MODULES_TMP/MachTaskSelfWrapper/" 2>/dev/null || true
 fi
 
 # yyjson
 YYJSON_H=$(find "$CHECKOUTS" -name "yyjson.h" -path "*/src/yyjson.h" 2>/dev/null | head -1)
 if [ -n "$YYJSON_H" ]; then
-    mkdir -p "$DEPS_MODULES/yyjson"
-    cp "$YYJSON_H" "$DEPS_MODULES/yyjson/"
-    cat > "$DEPS_MODULES/yyjson/module.modulemap" << 'MODULEMAP_EOF'
+    mkdir -p "$DEPS_MODULES_TMP/yyjson"
+    cp "$YYJSON_H" "$DEPS_MODULES_TMP/yyjson/"
+    cat > "$DEPS_MODULES_TMP/yyjson/module.modulemap" << 'MODULEMAP_EOF'
 module yyjson {
     umbrella header "yyjson.h"
     export *
@@ -256,15 +288,15 @@ fi
 CMLX_INCLUDE=$(find "$CHECKOUTS" -path "*/Cmlx/include" -type d 2>/dev/null | head -1)
 if [ -n "$CMLX_INCLUDE" ]; then
     echo "  Copying Cmlx headers..."
-    mkdir -p "$DEPS_MODULES/Cmlx"
-    cp -R "$CMLX_INCLUDE/"* "$DEPS_MODULES/Cmlx/"
+    mkdir -p "$DEPS_MODULES_TMP/Cmlx"
+    cp -R "$CMLX_INCLUDE/"* "$DEPS_MODULES_TMP/Cmlx/"
 fi
 
 # Also check for Cmlx module map in the build output
 CMLX_MODULEMAP=$(find "$BUILD_RELEASE" -path "*Cmlx*module.modulemap" 2>/dev/null | head -1)
-if [ -n "$CMLX_MODULEMAP" ] && [ ! -f "$DEPS_MODULES/Cmlx/module.modulemap" ]; then
-    mkdir -p "$DEPS_MODULES/Cmlx"
-    cp "$CMLX_MODULEMAP" "$DEPS_MODULES/Cmlx/"
+if [ -n "$CMLX_MODULEMAP" ] && [ ! -f "$DEPS_MODULES_TMP/Cmlx/module.modulemap" ]; then
+    mkdir -p "$DEPS_MODULES_TMP/Cmlx"
+    cp "$CMLX_MODULEMAP" "$DEPS_MODULES_TMP/Cmlx/"
 fi
 
 # --- Metal libraries: compile MLX Metal shaders ---
@@ -297,8 +329,8 @@ if [ -n "$CMLX_SRC" ]; then
         AIR_COUNT=$(ls "$METAL_OUT"/*.air 2>/dev/null | wc -l | tr -d ' ')
         if [ "$AIR_COUNT" -gt 0 ]; then
             echo "  Linking $AIR_COUNT .air files into mlx.metallib..."
-            xcrun metallib -o "$DEPS_LIBS/mlx.metallib" "$METAL_OUT"/*.air
-            ls -lh "$DEPS_LIBS/mlx.metallib"
+            xcrun metallib -o "$DEPS_LIBS_TMP/mlx.metallib" "$METAL_OUT"/*.air
+            ls -lh "$DEPS_LIBS_TMP/mlx.metallib"
         else
             echo "  WARNING: No .air files produced — Metal shaders not compiled"
         fi
@@ -308,6 +340,10 @@ if [ -n "$CMLX_SRC" ]; then
 else
     echo "  WARNING: Cmlx source not found — cannot compile Metal shaders"
 fi
+
+promote_output_dir "$DEPS_LIBS_TMP" "$DEPS_LIBS"
+promote_output_dir "$DEPS_MODULES_TMP" "$DEPS_MODULES"
+cleanup_stale_dirs
 
 echo ""
 echo "=== Results ==="

--- a/build-deps.sh
+++ b/build-deps.sh
@@ -9,10 +9,112 @@
 set -e
 
 DRAFT_DIR="$(cd "$(dirname "$0")" && pwd)"
-DEPS_BUILD="$DRAFT_DIR/.deps-build"
 DEPS_LIBS="$DRAFT_DIR/deps-libs"
 DEPS_MODULES="$DRAFT_DIR/deps-modules"
+DEPS_BUILD="$(mktemp -d "$DRAFT_DIR/.deps-build.XXXXXX")"
+DEPS_LIBS_TMP="$(mktemp -d "$DRAFT_DIR/.deps-libs.XXXXXX")"
+DEPS_MODULES_TMP="$(mktemp -d "$DRAFT_DIR/.deps-modules.XXXXXX")"
+TEMP_DIRS=("$DEPS_BUILD" "$DEPS_LIBS_TMP" "$DEPS_MODULES_TMP")
+PREVIOUS_OUTPUTS=()
+STALE_DIRS=()
+BUILD_SUCCEEDED=false
+FLUID_AUDIO_VERSION="${FLUID_AUDIO_VERSION:-0.7.9}"
+MLX_SWIFT_LM_REVISION="${MLX_SWIFT_LM_REVISION:-25b00d4}"
+SWIFT_TRANSFORMERS_VERSION="${SWIFT_TRANSFORMERS_VERSION:-1.2.1}"
 
+backup_existing_output() {
+    local path="$1"
+    if [ -e "$path" ]; then
+        local backup_path="${path}.backup.$(date +%s).$$"
+        mv "$path" "$backup_path"
+        PREVIOUS_OUTPUTS+=("$path::$backup_path")
+    fi
+}
+
+restore_previous_outputs() {
+    for entry in "${PREVIOUS_OUTPUTS[@]}"; do
+        local path="${entry%%::*}"
+        local backup_path="${entry#*::}"
+        if [ -e "$backup_path" ]; then
+            rm -rf "$path"
+            mv "$backup_path" "$path"
+        fi
+    done
+}
+
+cleanup_previous_outputs() {
+    for entry in "${PREVIOUS_OUTPUTS[@]}"; do
+        local backup_path="${entry#*::}"
+        rm -rf "$backup_path"
+    done
+}
+
+cleanup_temp_dirs() {
+    if [ "$BUILD_SUCCEEDED" != true ]; then
+        restore_previous_outputs
+    fi
+
+    for dir in "${TEMP_DIRS[@]}"; do
+        if [ -e "$dir" ]; then
+            rm -rf "$dir"
+        fi
+    done
+}
+
+stash_existing_dir() {
+    local path="$1"
+    if [ -e "$path" ]; then
+        local stale_path="${path}.stale.$(date +%s).$$"
+        mv "$path" "$stale_path"
+        STALE_DIRS+=("$stale_path")
+    fi
+}
+
+promote_output_dir() {
+    local source_path="$1"
+    local target_path="$2"
+    stash_existing_dir "$target_path"
+    mv "$source_path" "$target_path"
+}
+
+cleanup_stale_dirs() {
+    for dir in "${STALE_DIRS[@]}"; do
+        rm -rf "$dir" 2>/dev/null || \
+            echo "[build-deps] NOTE: left stale directory behind for later cleanup: $dir"
+    done
+}
+
+resolve_package_graph() {
+    local resolve_cmd=("swift" "package" "resolve")
+
+    echo "Resolving dependencies..."
+    echo "  FluidAudio:         $FLUID_AUDIO_VERSION"
+    echo "  mlx-swift-lm rev:   $MLX_SWIFT_LM_REVISION"
+    echo "  swift-transformers: $SWIFT_TRANSFORMERS_VERSION"
+
+    if "${resolve_cmd[@]}"; then
+        return 0
+    fi
+
+    echo "[build-deps] WARNING: initial resolve failed; retrying from a clean SwiftPM state"
+    rm -rf .build Package.resolved
+    "${resolve_cmd[@]}"
+}
+
+build_release_graph() {
+    echo "Building (this takes several minutes on first run)..."
+
+    if swift build -c release; then
+        return 0
+    fi
+
+    echo "[build-deps] WARNING: release build failed; clearing package state and retrying once"
+    rm -rf .build Package.resolved
+    resolve_package_graph
+    swift build -c release
+}
+
+trap cleanup_temp_dirs EXIT
 # ---------------------------------------------------------------------------
 # Discover the TranscriptedCore source tree to inline into the unified deps build.
 # ---------------------------------------------------------------------------
@@ -99,8 +201,8 @@ fi
 
 echo "Building FluidAudio + mlx-swift-lm (unified)..."
 
-# Clean previous build
-rm -rf "$DEPS_BUILD" "$DEPS_LIBS" "$DEPS_MODULES"
+backup_existing_output "$DEPS_LIBS"
+backup_existing_output "$DEPS_MODULES"
 mkdir -p "$DEPS_BUILD/Sources"
 
 # Symlink TranscriptedCore's source tree into $DEPS_BUILD so SPM's target
@@ -117,8 +219,9 @@ let package = Package(
     name: "DraftDeps",
     platforms: [.macOS(.v14)],
     dependencies: [
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.7.9"),
-        .package(url: "https://github.com/ml-explore/mlx-swift-lm", revision: "25b00d4"),
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", exact: "FLUID_AUDIO_VERSION_PLACEHOLDER"),
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm", revision: "MLX_SWIFT_LM_REVISION_PLACEHOLDER"),
+        .package(url: "https://github.com/huggingface/swift-transformers", exact: "SWIFT_TRANSFORMERS_VERSION_PLACEHOLDER"),
     ],
     targets: [
         // TranscriptedCore is built directly from its source tree rather than
@@ -135,7 +238,8 @@ let package = Package(
                 .product(name: "MLXLLM", package: "mlx-swift-lm"),
                 .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
             ],
-            path: "TranscriptedCore"
+            path: "TranscriptedCore",
+            exclude: ["CLAUDE.md"]
         ),
         .target(
             name: "Shim",
@@ -151,6 +255,13 @@ let package = Package(
 )
 PACKAGE_EOF
 
+FLUID_AUDIO_VERSION="$FLUID_AUDIO_VERSION" \
+MLX_SWIFT_LM_REVISION="$MLX_SWIFT_LM_REVISION" \
+SWIFT_TRANSFORMERS_VERSION="$SWIFT_TRANSFORMERS_VERSION" \
+perl -0pi \
+    -e 's/FLUID_AUDIO_VERSION_PLACEHOLDER/$ENV{FLUID_AUDIO_VERSION}/g; s/MLX_SWIFT_LM_REVISION_PLACEHOLDER/$ENV{MLX_SWIFT_LM_REVISION}/g; s/SWIFT_TRANSFORMERS_VERSION_PLACEHOLDER/$ENV{SWIFT_TRANSFORMERS_VERSION}/g' \
+    "$DEPS_BUILD/Package.swift"
+
 cat > "$DEPS_BUILD/Sources/Shim.swift" << 'SWIFT_EOF'
 import FluidAudio
 import MLXLLM
@@ -160,18 +271,24 @@ SWIFT_EOF
 
 # Build in release mode
 cd "$DEPS_BUILD"
-echo "Resolving dependencies..."
-swift package resolve
-echo "Building (this takes several minutes on first run)..."
-swift build -c release
+export FLUID_AUDIO_VERSION
+export MLX_SWIFT_LM_REVISION
+export SWIFT_TRANSFORMERS_VERSION
+resolve_package_graph
+
+MLX_SWIFT_CHECKOUT="$DEPS_BUILD/.build/checkouts/mlx-swift"
+if [ -d "$MLX_SWIFT_CHECKOUT/.git" ]; then
+    echo "Ensuring mlx-swift submodules are present..."
+    git -C "$MLX_SWIFT_CHECKOUT" submodule sync --recursive
+    git -C "$MLX_SWIFT_CHECKOUT" submodule update --init --recursive --jobs 1
+fi
+
+build_release_graph
 
 # Paths
 BUILD_RELEASE="$DEPS_BUILD/.build/arm64-apple-macosx/release"
 MODULES_SRC="$DEPS_BUILD/.build/release/Modules"
 CHECKOUTS="$DEPS_BUILD/.build/checkouts"
-
-# Create output directories
-mkdir -p "$DEPS_LIBS" "$DEPS_MODULES"
 
 # --- Static library: combine all .o files into one .a ---
 echo "Creating static library..."
@@ -184,18 +301,19 @@ echo "$ALL_BUILD_DIRS" | while read -r dir; do echo "  $dir"; done
 
 # Archive all .o files into libDraftDeps.a (includes TranscriptedCore — used by build.sh which
 # excludes Sources/TranscriptedCore from its swiftc invocation to avoid name-collision issues).
-find $ALL_BUILD_DIRS -name "*.o" -print0 | xargs -0 ar rcs "$DEPS_LIBS/libDraftDeps.a"
-OBJ_COUNT=$(ar t "$DEPS_LIBS/libDraftDeps.a" | wc -l | tr -d ' ')
+find $ALL_BUILD_DIRS -name "*.o" -print0 | xargs -0 ar rcs "$DEPS_LIBS_TMP/libDraftDeps.a"
+OBJ_COUNT=$(ar t "$DEPS_LIBS_TMP/libDraftDeps.a" | wc -l | tr -d ' ')
 echo "  $OBJ_COUNT object files archived"
 
-# Also create libExternalDeps.a — same as libDraftDeps.a but without TranscriptedCore objects.
-# Package.swift links against this for `swift test`, which compiles TranscriptedCore from
-# source via SPM. Using libDraftDeps.a there causes duplicate-symbol linker errors because
-# Core appears in both the SPM-compiled objects and the static archive.
-EXTERNAL_DIRS=$(find . -maxdepth 1 -name "*.build" -type d | grep -v "Shim.build" | grep -v "TranscriptedCore.build" | sort)
-find $EXTERNAL_DIRS -name "*.o" -print0 | xargs -0 ar rcs "$DEPS_LIBS/libExternalDeps.a"
-EXT_COUNT=$(ar t "$DEPS_LIBS/libExternalDeps.a" | wc -l | tr -d ' ')
-echo "  $EXT_COUNT object files archived (external-only, no TranscriptedCore)"
+# Also create libExternalDeps.a for the SwiftPM package seam.
+# In theory this could omit TranscriptedCore objects because `swift test` compiles
+# Core from source. In practice some dependency objects still reference Core-owned
+# symbols, and the "external-only" archive can fail to link. Reuse the unified
+# archive under a stable filename so package tests and embedders see a consistent
+# dependency bundle.
+cp "$DEPS_LIBS_TMP/libDraftDeps.a" "$DEPS_LIBS_TMP/libExternalDeps.a"
+EXT_COUNT=$(ar t "$DEPS_LIBS_TMP/libExternalDeps.a" | wc -l | tr -d ' ')
+echo "  $EXT_COUNT object files archived for SwiftPM compatibility"
 
 # --- Swift modules ---
 echo "Copying Swift modules..."
@@ -203,14 +321,14 @@ for mod in "$MODULES_SRC"/*.swiftmodule; do
     name=$(basename "$mod" .swiftmodule)
     # Skip Shim — that's our build helper
     [ "$name" = "Shim" ] && continue
-    mkdir -p "$DEPS_MODULES/${name}.swiftmodule"
-    cp "$mod" "$DEPS_MODULES/${name}.swiftmodule/arm64-apple-macos.swiftmodule"
+    mkdir -p "$DEPS_MODULES_TMP/${name}.swiftmodule"
+    cp "$mod" "$DEPS_MODULES_TMP/${name}.swiftmodule/arm64-apple-macos.swiftmodule"
     if [ -f "$MODULES_SRC/${name}.swiftdoc" ]; then
-        cp "$MODULES_SRC/${name}.swiftdoc" "$DEPS_MODULES/${name}.swiftmodule/arm64-apple-macos.swiftdoc"
+        cp "$MODULES_SRC/${name}.swiftdoc" "$DEPS_MODULES_TMP/${name}.swiftmodule/arm64-apple-macos.swiftdoc"
     fi
     # Copy .swiftinterface if present (for resilient modules)
     if [ -f "$MODULES_SRC/${name}.swiftinterface" ]; then
-        cp "$MODULES_SRC/${name}.swiftinterface" "$DEPS_MODULES/${name}.swiftmodule/arm64-apple-macos.swiftinterface"
+        cp "$MODULES_SRC/${name}.swiftinterface" "$DEPS_MODULES_TMP/${name}.swiftmodule/arm64-apple-macos.swiftinterface"
     fi
 done
 
@@ -220,30 +338,30 @@ echo "Copying C module maps..."
 # _NumericsShims (from swift-numerics)
 NUMERICS_SHIMS=$(find "$CHECKOUTS" -path "*/_NumericsShims/include" -type d 2>/dev/null | head -1)
 if [ -n "$NUMERICS_SHIMS" ]; then
-    mkdir -p "$DEPS_MODULES/_NumericsShims"
-    cp "$NUMERICS_SHIMS/"* "$DEPS_MODULES/_NumericsShims/"
+    mkdir -p "$DEPS_MODULES_TMP/_NumericsShims"
+    cp "$NUMERICS_SHIMS/"* "$DEPS_MODULES_TMP/_NumericsShims/"
 fi
 
 # FastClusterWrapper (from FluidAudio)
 if [ -d "$CHECKOUTS/FluidAudio/Sources/FastClusterWrapper/include" ]; then
-    mkdir -p "$DEPS_MODULES/FastClusterWrapper"
-    cp "$CHECKOUTS/FluidAudio/Sources/FastClusterWrapper/include/module.modulemap" "$DEPS_MODULES/FastClusterWrapper/"
-    cp "$CHECKOUTS/FluidAudio/Sources/FastClusterWrapper/include/"*.h "$DEPS_MODULES/FastClusterWrapper/" 2>/dev/null || true
+    mkdir -p "$DEPS_MODULES_TMP/FastClusterWrapper"
+    cp "$CHECKOUTS/FluidAudio/Sources/FastClusterWrapper/include/module.modulemap" "$DEPS_MODULES_TMP/FastClusterWrapper/"
+    cp "$CHECKOUTS/FluidAudio/Sources/FastClusterWrapper/include/"*.h "$DEPS_MODULES_TMP/FastClusterWrapper/" 2>/dev/null || true
 fi
 
 # MachTaskSelfWrapper (from FluidAudio)
 if [ -d "$CHECKOUTS/FluidAudio/Sources/MachTaskSelfWrapper/include" ]; then
-    mkdir -p "$DEPS_MODULES/MachTaskSelfWrapper"
-    cp "$CHECKOUTS/FluidAudio/Sources/MachTaskSelfWrapper/include/module.modulemap" "$DEPS_MODULES/MachTaskSelfWrapper/"
-    cp "$CHECKOUTS/FluidAudio/Sources/MachTaskSelfWrapper/include/"*.h "$DEPS_MODULES/MachTaskSelfWrapper/" 2>/dev/null || true
+    mkdir -p "$DEPS_MODULES_TMP/MachTaskSelfWrapper"
+    cp "$CHECKOUTS/FluidAudio/Sources/MachTaskSelfWrapper/include/module.modulemap" "$DEPS_MODULES_TMP/MachTaskSelfWrapper/"
+    cp "$CHECKOUTS/FluidAudio/Sources/MachTaskSelfWrapper/include/"*.h "$DEPS_MODULES_TMP/MachTaskSelfWrapper/" 2>/dev/null || true
 fi
 
 # yyjson
 YYJSON_H=$(find "$CHECKOUTS" -name "yyjson.h" -path "*/src/yyjson.h" 2>/dev/null | head -1)
 if [ -n "$YYJSON_H" ]; then
-    mkdir -p "$DEPS_MODULES/yyjson"
-    cp "$YYJSON_H" "$DEPS_MODULES/yyjson/"
-    cat > "$DEPS_MODULES/yyjson/module.modulemap" << 'MODULEMAP_EOF'
+    mkdir -p "$DEPS_MODULES_TMP/yyjson"
+    cp "$YYJSON_H" "$DEPS_MODULES_TMP/yyjson/"
+    cat > "$DEPS_MODULES_TMP/yyjson/module.modulemap" << 'MODULEMAP_EOF'
 module yyjson {
     umbrella header "yyjson.h"
     export *
@@ -256,15 +374,15 @@ fi
 CMLX_INCLUDE=$(find "$CHECKOUTS" -path "*/Cmlx/include" -type d 2>/dev/null | head -1)
 if [ -n "$CMLX_INCLUDE" ]; then
     echo "  Copying Cmlx headers..."
-    mkdir -p "$DEPS_MODULES/Cmlx"
-    cp -R "$CMLX_INCLUDE/"* "$DEPS_MODULES/Cmlx/"
+    mkdir -p "$DEPS_MODULES_TMP/Cmlx"
+    cp -R "$CMLX_INCLUDE/"* "$DEPS_MODULES_TMP/Cmlx/"
 fi
 
 # Also check for Cmlx module map in the build output
 CMLX_MODULEMAP=$(find "$BUILD_RELEASE" -path "*Cmlx*module.modulemap" 2>/dev/null | head -1)
-if [ -n "$CMLX_MODULEMAP" ] && [ ! -f "$DEPS_MODULES/Cmlx/module.modulemap" ]; then
-    mkdir -p "$DEPS_MODULES/Cmlx"
-    cp "$CMLX_MODULEMAP" "$DEPS_MODULES/Cmlx/"
+if [ -n "$CMLX_MODULEMAP" ] && [ ! -f "$DEPS_MODULES_TMP/Cmlx/module.modulemap" ]; then
+    mkdir -p "$DEPS_MODULES_TMP/Cmlx"
+    cp "$CMLX_MODULEMAP" "$DEPS_MODULES_TMP/Cmlx/"
 fi
 
 # --- Metal libraries: compile MLX Metal shaders ---
@@ -297,8 +415,8 @@ if [ -n "$CMLX_SRC" ]; then
         AIR_COUNT=$(ls "$METAL_OUT"/*.air 2>/dev/null | wc -l | tr -d ' ')
         if [ "$AIR_COUNT" -gt 0 ]; then
             echo "  Linking $AIR_COUNT .air files into mlx.metallib..."
-            xcrun metallib -o "$DEPS_LIBS/mlx.metallib" "$METAL_OUT"/*.air
-            ls -lh "$DEPS_LIBS/mlx.metallib"
+            xcrun metallib -o "$DEPS_LIBS_TMP/mlx.metallib" "$METAL_OUT"/*.air
+            ls -lh "$DEPS_LIBS_TMP/mlx.metallib"
         else
             echo "  WARNING: No .air files produced — Metal shaders not compiled"
         fi
@@ -308,6 +426,12 @@ if [ -n "$CMLX_SRC" ]; then
 else
     echo "  WARNING: Cmlx source not found — cannot compile Metal shaders"
 fi
+
+promote_output_dir "$DEPS_LIBS_TMP" "$DEPS_LIBS"
+promote_output_dir "$DEPS_MODULES_TMP" "$DEPS_MODULES"
+cleanup_stale_dirs
+cleanup_previous_outputs
+BUILD_SUCCEEDED=true
 
 echo ""
 echo "=== Results ==="

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,74 @@
 #!/bin/bash
 # Build Transcripted - local dictation + meeting transcription app
 
+set -euo pipefail
+
 APP_NAME="Transcripted"
 BUILD_DIR="build"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
+APP_BINARY="$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+LOCAL_ENTITLEMENTS="config/entitlements/local.plist"
+SIGN_IDENTITY="${SIGN_IDENTITY:-${SIGNING_IDENTITY:-}}"
+DEPS_ARCHIVE="deps-libs/libDraftDeps.a"
+DEPS_MODULE_ROOT="deps-modules"
+TRANSCRIPTED_CORE_MODULE="$DEPS_MODULE_ROOT/TranscriptedCore.swiftmodule/arm64-apple-macos.swiftmodule"
+
+ensure_build_prerequisites() {
+    if [ ! -f "$LOCAL_ENTITLEMENTS" ]; then
+        echo "Missing entitlements file: $LOCAL_ENTITLEMENTS"
+        exit 1
+    fi
+}
+
+ensure_deps_ready() {
+    if [ -f "$DEPS_ARCHIVE" ] && [ -d "$DEPS_MODULE_ROOT" ] && [ -f "$TRANSCRIPTED_CORE_MODULE" ]; then
+        return 0
+    fi
+
+    echo "Dependencies missing or stale for TranscriptedCore."
+    echo "Expected:"
+    echo "  $DEPS_ARCHIVE"
+    echo "  $DEPS_MODULE_ROOT/"
+    echo "  $TRANSCRIPTED_CORE_MODULE"
+    echo ""
+    echo "Run: bash build-deps.sh --force"
+    exit 1
+}
+
+resolve_sign_identity() {
+    local requested_identity="$1"
+    local found_line
+
+    if [ -n "$requested_identity" ]; then
+        found_line="$(security find-identity -v -p codesigning 2>/dev/null | grep -F "$requested_identity" | head -1 || true)"
+        if [ -z "$found_line" ]; then
+            echo "Requested signing identity not found: $requested_identity"
+            echo "Available identities:"
+            security find-identity -v -p codesigning || true
+            exit 1
+        fi
+        printf '%s\n' "$found_line"
+        return 0
+    fi
+
+    found_line="$(security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application" | head -1 || true)"
+    if [ -n "$found_line" ]; then
+        printf '%s\n' "$found_line"
+        return 0
+    fi
+
+    printf '%s\n' ""
+}
+
+verify_signature() {
+    codesign --verify --deep --strict --verbose=4 "$APP_BUNDLE"
+    codesign -dvvv --entitlements :- "$APP_BUNDLE"
+}
 
 echo "Building Transcripted..."
+
+ensure_build_prerequisites
+ensure_deps_ready
 
 # Clean
 rm -rf "$BUILD_DIR"
@@ -45,36 +108,12 @@ if [ -d "Resources" ]; then
     cp -R Resources/. "$APP_BUNDLE/Contents/Resources/"
 fi
 
-# Create entitlements
-cat > "$BUILD_DIR/Transcripted.entitlements" << 'EOF'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>com.apple.security.app-sandbox</key>
-    <false/>
-    <key>com.apple.security.device.audio-input</key>
-    <true/>
-    <key>com.apple.security.device.audio-capture</key>
-    <true/>
-    <key>com.apple.security.speech.recognition</key>
-    <true/>
-</dict>
-</plist>
-EOF
-
 # Unified dependencies (FluidAudio + mlx-swift-lm)
-# Run build-deps.sh first to build these artifacts
-if [ ! -f "deps-libs/libDraftDeps.a" ] || [ ! -d "deps-modules" ]; then
-    echo "Dependencies not found — required for Parakeet STT + meeting diarization"
-    echo "   Run build-deps.sh first to build dependencies."
-    exit 1
-fi
 echo "Dependencies found"
 
 # Build the -I flags for all module directories
-DEPS_MODULE_FLAGS="-Ideps-modules"
-for dir in deps-modules/*/; do
+DEPS_MODULE_FLAGS="-I$DEPS_MODULE_ROOT"
+for dir in "$DEPS_MODULE_ROOT"/*/; do
     [ -d "$dir" ] && DEPS_MODULE_FLAGS="$DEPS_MODULE_FLAGS -I$dir"
 done
 
@@ -91,7 +130,7 @@ echo "Compiling..."
 SOURCE_FILES=$(find Sources -name '*.swift' -not -path 'Sources/TranscriptedCore/*')
 swiftc \
     -O \
-    -o "$APP_BUNDLE/Contents/MacOS/$APP_NAME" \
+    -o "$APP_BINARY" \
     -framework AVFoundation \
     -framework AppKit \
     -framework SwiftUI \
@@ -114,39 +153,37 @@ swiftc \
     -Xlinker -rpath -Xlinker @executable_path/../Frameworks \
     2>&1
 
-if [ $? -ne 0 ]; then
-    echo "Build failed!"
+if [ ! -x "$APP_BINARY" ]; then
+    echo "Build finished without a runnable app binary: $APP_BINARY"
     exit 1
 fi
 
-# Sign — auto-detect the first valid Developer ID on this machine.
-# We extract the SHA-1 hash (not the name) because the same cert may exist in
-# both System.keychain and login.keychain, which makes name-based lookup
-# ambiguous and silently fails codesign — leaving the binary ad-hoc signed and
-# wiping TCC permissions on every rebuild. Hashes are unambiguous.
-SIGN_HASH=$(security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application" | head -1 | awk '{print $2}')
-SIGN_NAME=$(security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)"/\1/')
+SIGN_MATCH="$(resolve_sign_identity "$SIGN_IDENTITY")"
+SIGN_HASH=""
+SIGN_NAME=""
+if [ -n "$SIGN_MATCH" ]; then
+    SIGN_HASH="$(echo "$SIGN_MATCH" | awk '{print $2}')"
+    SIGN_NAME="$(echo "$SIGN_MATCH" | sed 's/.*"\(.*\)"/\1/')"
+fi
+
 if [ -n "$SIGN_HASH" ]; then
-    echo "Signing with: $SIGN_NAME ($SIGN_HASH)"
-    if ! codesign --force --deep --sign "$SIGN_HASH" \
-        --entitlements "$BUILD_DIR/Transcripted.entitlements" \
-        "$APP_BUNDLE"; then
-        echo "Codesign failed — aborting build"
-        exit 1
-    fi
+    echo "Signing with: ${SIGN_NAME:-$SIGN_HASH} ($SIGN_HASH)"
+    codesign --force --deep --sign "$SIGN_HASH" \
+        --entitlements "$LOCAL_ENTITLEMENTS" \
+        "$APP_BUNDLE"
 else
     echo "No Developer ID found — signing ad-hoc (permissions may not persist)"
     codesign --force --deep --sign - \
-        --entitlements "$BUILD_DIR/Transcripted.entitlements" \
-        "$APP_BUNDLE" 2>&1
+        --entitlements "$LOCAL_ENTITLEMENTS" \
+        "$APP_BUNDLE"
 fi
 
-# Verify the signature took — catches silent codesign failures that would
-# otherwise leave behind a linker-stamped ad-hoc binary.
-if codesign -dv "$APP_BUNDLE" 2>&1 | grep -q "Signature=adhoc"; then
-    if [ -n "$SIGN_HASH" ]; then
-        echo "WARNING: expected Developer ID signature but binary is ad-hoc — permissions will reset on each build"
-    fi
+echo "Verifying signature..."
+verify_signature
+
+if [ -n "$SIGN_HASH" ] && codesign -dv "$APP_BUNDLE" 2>&1 | grep -q "Signature=adhoc"; then
+    echo "Expected Developer ID signature but binary is ad-hoc."
+    exit 1
 fi
 
 echo "Build complete!"

--- a/config/entitlements/beta.plist
+++ b/config/entitlements/beta.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.device.audio-capture</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.speech.recognition</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/config/entitlements/local.plist
+++ b/config/entitlements/local.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.audio-capture</key>
+    <true/>
+    <key>com.apple.security.speech.recognition</key>
+    <true/>
+</dict>
+</plist>

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -1,0 +1,62 @@
+# Release Packaging
+
+`build.sh` is the local developer build.
+
+Use `build-beta.sh` for anything you intend to hand to another machine. That is
+the path that applies hardened runtime signing, builds a DMG, and optionally
+submits it for notarization.
+
+The two build flows intentionally use separate committed entitlement files:
+
+- `config/entitlements/local.plist`
+- `config/entitlements/beta.plist`
+
+`build.sh` now fails before it touches signing when the unified dependency
+artifacts are missing or stale, and it also requires the app binary to exist
+before signature validation runs.
+
+## Prerequisites
+
+1. Install a `Developer ID Application` certificate.
+2. Store a notarytool profile in the login keychain.
+3. Build the unified dependency bundle once with exact pinned versions.
+4. Make sure local Parakeet models are present if you want them bundled into
+   the app instead of downloaded at runtime.
+
+Useful checks:
+
+```bash
+security find-identity -v -p codesigning
+xcrun notarytool store-credentials <profile-name> ...
+```
+
+To force a specific certificate for either build flow:
+
+```bash
+SIGN_IDENTITY=<sha-or-name-fragment> bash build.sh
+SIGNING_IDENTITY=<sha-or-name-fragment> bash build-beta.sh <beta-token> <user-name>
+```
+
+## Release Flow
+
+```bash
+bash build-deps.sh --force
+NOTARY_PROFILE=<profile-name> bash build-beta.sh <beta-token> <user-name>
+```
+
+For a dry run that still validates the signed app and DMG assembly:
+
+```bash
+SKIP_NOTARIZATION=1 bash build-beta.sh <beta-token> <user-name>
+```
+
+## Expected Validation
+
+`build-beta.sh` should complete all of the following:
+
+- `codesign --verify --deep --strict` passes for the `.app`
+- the DMG is signed when a Developer ID identity is available
+- notarized runs staple a ticket and then pass `spctl` checks for the app and DMG
+
+If notarization is intentionally skipped, Gatekeeper rejection for the signed
+app is expected until the artifact is notarized and stapled.


### PR DESCRIPTION
## What changed
- focused first-run onboarding on the two permissions required to start dictation
- moved meeting-related permissions into a lighter "Optional later" section
- hid the empty meetings block from the menubar until there is actual meeting history
- simplified recent meeting rows by removing the redundant Finder action while keeping open-on-click and copy

## Why
The app was already trending toward a simpler capture-first experience, but these surfaces still asked users to process optional setup and empty-state chrome too early. This pass makes the first-use path more direct and trims secondary actions from the menubar home.

## User impact
- new users can understand the minimum setup for dictation more quickly
- the menubar home feels more focused when no meetings have been recorded yet
- recent meetings stay accessible, but the row actions are lighter

## Validation
- `bash run-tests.sh` ✅
- `bash build.sh` blocked because this checkout currently lacks generated dependency artifacts, and the existing local `build-deps.sh` changes fail during dependency bootstrap before the app build can complete
