### PR TITLE
[codex] Harden build signing preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,13 @@ bash build-deps.sh
 bash build.sh
 ```
 
+`build.sh` is the local development path. It expects the unified dependency
+artifacts from `build-deps.sh` and then signs the app for stable local
+permissions on the current machine.
+
+For signed DMG packaging and notarization workflow notes, see
+`docs/release-packaging.md`.
+
 ## Tests
 
 ```bash

--- a/build-beta.sh
+++ b/build-beta.sh
@@ -9,9 +9,9 @@
 # - NOTARY_PROFILE set to the local keychain profile name for notarytool
 # - optional: brew install create-dmg for the custom DMG layout
 
-set -e
+set -euo pipefail
 
-BETA_TOKEN="$1"
+BETA_TOKEN="${1:-}"
 USER_NAME="${2:-beta}"
 SKIP_NOTARIZATION="${SKIP_NOTARIZATION:-0}"
 
@@ -24,12 +24,46 @@ fi
 APP_NAME="Transcripted"
 BUILD_DIR="build"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
+APP_BINARY="$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 DMG_NAME="Transcripted-${USER_NAME}.dmg"
-SIGNING_IDENTITY="${SIGNING_IDENTITY:-}"
+SIGNING_IDENTITY="${SIGNING_IDENTITY:-${SIGN_IDENTITY:-}}"
 SIGNING_DISPLAY_NAME=""
 NOTARY_PROFILE="${NOTARY_PROFILE:-}"
 BETA_CONFIG_PATH="Sources/API/BetaConfig.swift"
 BETA_CONFIG_BACKUP="$(mktemp -t transcripted-beta-config)"
+BETA_ENTITLEMENTS="config/entitlements/beta.plist"
+TRANSCRIPTED_CORE_MODULE="deps-modules/TranscriptedCore.swiftmodule/arm64-apple-macos.swiftmodule"
+
+validate_signed_app() {
+    echo "Validating app signature..."
+    codesign --verify --deep --strict --verbose=4 "$APP_BUNDLE"
+    codesign -dvvv --entitlements :- "$APP_BUNDLE"
+}
+
+validate_notarized_artifacts() {
+    echo "Validating Gatekeeper acceptance..."
+    spctl -a -t exec -vv "$APP_BUNDLE"
+    spctl -a -t open -vv "$BUILD_DIR/$DMG_NAME"
+}
+
+resolve_sign_identity() {
+    local requested_identity="$1"
+    local found_line
+
+    if [ -n "$requested_identity" ]; then
+        found_line="$(security find-identity -v -p codesigning 2>/dev/null | grep -F "$requested_identity" | head -1 || true)"
+        if [ -z "$found_line" ]; then
+            echo "❌ Requested signing identity not found: $requested_identity"
+            echo "Available identities:"
+            security find-identity -v -p codesigning || true
+            exit 1
+        fi
+        printf '%s\n' "$found_line"
+        return 0
+    fi
+
+    security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application" | head -1 || true
+}
 
 cleanup() {
     if [ -f "$BETA_CONFIG_BACKUP" ]; then
@@ -39,6 +73,18 @@ cleanup() {
 }
 
 trap cleanup EXIT
+
+if [ ! -f "$BETA_ENTITLEMENTS" ]; then
+    echo "❌ Missing entitlements file: $BETA_ENTITLEMENTS"
+    exit 1
+fi
+
+if [ ! -f "deps-libs/libDraftDeps.a" ] || [ ! -d "deps-modules" ] || [ ! -f "$TRANSCRIPTED_CORE_MODULE" ]; then
+    echo "❌ Dependencies missing or stale — required for beta builds"
+    echo "   Missing module: $TRANSCRIPTED_CORE_MODULE"
+    echo "   Run build-deps.sh --force first to rebuild dependencies."
+    exit 1
+fi
 
 echo "🔨 Building Transcripted Beta for $USER_NAME (token: $BETA_TOKEN)..."
 
@@ -65,41 +111,12 @@ if [ -d "Resources" ]; then
     cp -R Resources/. "$APP_BUNDLE/Contents/Resources/"
 fi
 
-# Create entitlements (hardened runtime compatible)
-cat > "$BUILD_DIR/Transcripted.entitlements" << 'EOF'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>com.apple.security.app-sandbox</key>
-    <false/>
-    <key>com.apple.security.network.client</key>
-    <true/>
-    <key>com.apple.security.device.audio-input</key>
-    <true/>
-    <key>com.apple.security.speech.recognition</key>
-    <true/>
-    <key>com.apple.security.cs.allow-jit</key>
-    <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
-</dict>
-</plist>
-EOF
-
-# Inject the user's beta token
+# Inject the user's beta token after dependency preflight succeeds.
 echo "Injecting token for $USER_NAME..."
 cp "$BETA_CONFIG_PATH" "$BETA_CONFIG_BACKUP"
 sed -i '' "s/BETA_TOKEN_PLACEHOLDER/$BETA_TOKEN/" "$BETA_CONFIG_PATH"
 
 # Unified dependencies (FluidAudio + mlx-swift-lm)
-TRANSCRIPTED_CORE_MODULE="deps-modules/TranscriptedCore.swiftmodule/arm64-apple-macos.swiftmodule"
-if [ ! -f "deps-libs/libDraftDeps.a" ] || [ ! -d "deps-modules" ] || [ ! -f "$TRANSCRIPTED_CORE_MODULE" ]; then
-    echo "❌ Dependencies missing or stale — required for beta builds"
-    echo "   Missing module: $TRANSCRIPTED_CORE_MODULE"
-    echo "   Run build-deps.sh --force first to rebuild dependencies."
-    exit 1
-fi
 echo "Dependencies found"
 
 DEPS_MODULE_FLAGS="-Ideps-modules"
@@ -120,7 +137,7 @@ SOURCE_FILES=$(find Sources -name '*.swift' -not -path 'Sources/TranscriptedCore
 swiftc \
     -O \
     -D BETA_BUILD \
-    -o "$APP_BUNDLE/Contents/MacOS/$APP_NAME" \
+    -o "$APP_BINARY" \
     -framework AVFoundation \
     -framework AppKit \
     -framework SwiftUI \
@@ -144,18 +161,15 @@ swiftc \
     -Xlinker -rpath -Xlinker @executable_path/../Frameworks \
     2>&1
 
-COMPILE_STATUS=$?
-
-if [ $COMPILE_STATUS -ne 0 ]; then
-    echo "❌ Build failed!"
+if [ ! -x "$APP_BINARY" ]; then
+    echo "❌ Build finished without a runnable app binary: $APP_BINARY"
     exit 1
 fi
 
-if [ -z "$SIGNING_IDENTITY" ]; then
-    SIGNING_IDENTITY=$(security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application" | head -1 | awk '{print $2}')
-    SIGNING_DISPLAY_NAME=$(security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)"/\1/')
-else
-    SIGNING_DISPLAY_NAME="$SIGNING_IDENTITY"
+SIGNING_MATCH="$(resolve_sign_identity "$SIGNING_IDENTITY")"
+if [ -n "$SIGNING_MATCH" ]; then
+    SIGNING_IDENTITY="$(echo "$SIGNING_MATCH" | awk '{print $2}')"
+    SIGNING_DISPLAY_NAME="$(echo "$SIGNING_MATCH" | sed 's/.*"\(.*\)"/\1/')"
 fi
 
 if [ -n "$SIGNING_IDENTITY" ]; then
@@ -164,7 +178,7 @@ if [ -n "$SIGNING_IDENTITY" ]; then
         --sign "$SIGNING_IDENTITY" \
         --options runtime \
         --timestamp \
-        --entitlements "$BUILD_DIR/Transcripted.entitlements" \
+        --entitlements "$BETA_ENTITLEMENTS" \
         "$APP_BUNDLE" 2>&1; then
         echo "❌ Signing failed! Make sure you have a valid Developer ID Application certificate."
         echo "   Open Xcode → Settings → Accounts → Manage Certificates"
@@ -174,9 +188,11 @@ else
     echo "⚠️  No Developer ID found — signing ad-hoc for local smoke testing"
     codesign --force --deep \
         --sign - \
-        --entitlements "$BUILD_DIR/Transcripted.entitlements" \
+        --entitlements "$BETA_ENTITLEMENTS" \
         "$APP_BUNDLE" 2>&1
 fi
+
+validate_signed_app
 
 # Create DMG
 echo "Creating DMG..."
@@ -201,7 +217,7 @@ if command -v create-dmg >/dev/null 2>&1; then
         $DMG_BG_FLAGS \
         "$BUILD_DIR/$DMG_NAME" \
         "$APP_BUNDLE" \
-        2>&1 || true  # create-dmg returns non-zero on "already exists" even after rm
+        2>&1 || true
 else
     echo "⚠️  create-dmg not found — using hdiutil fallback"
     STAGING_DIR="$BUILD_DIR/dmg-staging"
@@ -234,6 +250,7 @@ fi
 # Notarize (only with Developer ID — Apple Development certs can't be notarized)
 if [ "$SKIP_NOTARIZATION" = "1" ]; then
     echo "⚠️  Skipping notarization (SKIP_NOTARIZATION=1)"
+    echo "   Expect Gatekeeper to reject the Developer ID app until it is notarized."
 elif [[ "$SIGNING_DISPLAY_NAME" == Developer\ ID* ]]; then
     if [ -z "$NOTARY_PROFILE" ]; then
         echo "❌ NOTARY_PROFILE is not set."
@@ -247,9 +264,9 @@ elif [[ "$SIGNING_DISPLAY_NAME" == Developer\ ID* ]]; then
         --keychain-profile "$NOTARY_PROFILE" \
         --wait
 
-    # Staple
     echo "Stapling notarization ticket..."
     xcrun stapler staple "$BUILD_DIR/$DMG_NAME"
+    validate_notarized_artifacts
 else
     echo "⚠️  Skipping notarization (using development cert — local testing only)"
 fi

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,74 @@
 #!/bin/bash
 # Build Transcripted - local dictation + meeting transcription app
 
+set -euo pipefail
+
 APP_NAME="Transcripted"
 BUILD_DIR="build"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
+APP_BINARY="$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+LOCAL_ENTITLEMENTS="config/entitlements/local.plist"
+SIGN_IDENTITY="${SIGN_IDENTITY:-${SIGNING_IDENTITY:-}}"
+DEPS_ARCHIVE="deps-libs/libDraftDeps.a"
+DEPS_MODULE_ROOT="deps-modules"
+TRANSCRIPTED_CORE_MODULE="$DEPS_MODULE_ROOT/TranscriptedCore.swiftmodule/arm64-apple-macos.swiftmodule"
+
+ensure_build_prerequisites() {
+    if [ ! -f "$LOCAL_ENTITLEMENTS" ]; then
+        echo "Missing entitlements file: $LOCAL_ENTITLEMENTS"
+        exit 1
+    fi
+}
+
+ensure_deps_ready() {
+    if [ -f "$DEPS_ARCHIVE" ] && [ -d "$DEPS_MODULE_ROOT" ] && [ -f "$TRANSCRIPTED_CORE_MODULE" ]; then
+        return 0
+    fi
+
+    echo "Dependencies missing or stale for TranscriptedCore."
+    echo "Expected:"
+    echo "  $DEPS_ARCHIVE"
+    echo "  $DEPS_MODULE_ROOT/"
+    echo "  $TRANSCRIPTED_CORE_MODULE"
+    echo ""
+    echo "Run: bash build-deps.sh --force"
+    exit 1
+}
+
+resolve_sign_identity() {
+    local requested_identity="$1"
+    local found_line
+
+    if [ -n "$requested_identity" ]; then
+        found_line="$(security find-identity -v -p codesigning 2>/dev/null | grep -F "$requested_identity" | head -1 || true)"
+        if [ -z "$found_line" ]; then
+            echo "Requested signing identity not found: $requested_identity"
+            echo "Available identities:"
+            security find-identity -v -p codesigning || true
+            exit 1
+        fi
+        printf '%s\n' "$found_line"
+        return 0
+    fi
+
+    found_line="$(security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application" | head -1 || true)"
+    if [ -n "$found_line" ]; then
+        printf '%s\n' "$found_line"
+        return 0
+    fi
+
+    printf '%s\n' ""
+}
+
+verify_signature() {
+    codesign --verify --deep --strict --verbose=4 "$APP_BUNDLE"
+    codesign -dvvv --entitlements :- "$APP_BUNDLE"
+}
 
 echo "Building Transcripted..."
+
+ensure_build_prerequisites
+ensure_deps_ready
 
 # Clean
 rm -rf "$BUILD_DIR"
@@ -45,36 +108,12 @@ if [ -d "Resources" ]; then
     cp -R Resources/. "$APP_BUNDLE/Contents/Resources/"
 fi
 
-# Create entitlements
-cat > "$BUILD_DIR/Transcripted.entitlements" << 'EOF'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>com.apple.security.app-sandbox</key>
-    <false/>
-    <key>com.apple.security.device.audio-input</key>
-    <true/>
-    <key>com.apple.security.device.audio-capture</key>
-    <true/>
-    <key>com.apple.security.speech.recognition</key>
-    <true/>
-</dict>
-</plist>
-EOF
-
 # Unified dependencies (FluidAudio + mlx-swift-lm)
-# Run build-deps.sh first to build these artifacts
-if [ ! -f "deps-libs/libDraftDeps.a" ] || [ ! -d "deps-modules" ]; then
-    echo "Dependencies not found — required for Parakeet STT + meeting diarization"
-    echo "   Run build-deps.sh first to build dependencies."
-    exit 1
-fi
 echo "Dependencies found"
 
 # Build the -I flags for all module directories
-DEPS_MODULE_FLAGS="-Ideps-modules"
-for dir in deps-modules/*/; do
+DEPS_MODULE_FLAGS="-I$DEPS_MODULE_ROOT"
+for dir in "$DEPS_MODULE_ROOT"/*/; do
     [ -d "$dir" ] && DEPS_MODULE_FLAGS="$DEPS_MODULE_FLAGS -I$dir"
 done
 
@@ -91,7 +130,7 @@ echo "Compiling..."
 SOURCE_FILES=$(find Sources -name '*.swift' -not -path 'Sources/TranscriptedCore/*')
 swiftc \
     -O \
-    -o "$APP_BUNDLE/Contents/MacOS/$APP_NAME" \
+    -o "$APP_BINARY" \
     -framework AVFoundation \
     -framework AppKit \
     -framework SwiftUI \
@@ -114,39 +153,37 @@ swiftc \
     -Xlinker -rpath -Xlinker @executable_path/../Frameworks \
     2>&1
 
-if [ $? -ne 0 ]; then
-    echo "Build failed!"
+if [ ! -x "$APP_BINARY" ]; then
+    echo "Build finished without a runnable app binary: $APP_BINARY"
     exit 1
 fi
 
-# Sign — auto-detect the first valid Developer ID on this machine.
-# We extract the SHA-1 hash (not the name) because the same cert may exist in
-# both System.keychain and login.keychain, which makes name-based lookup
-# ambiguous and silently fails codesign — leaving the binary ad-hoc signed and
-# wiping TCC permissions on every rebuild. Hashes are unambiguous.
-SIGN_HASH=$(security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application" | head -1 | awk '{print $2}')
-SIGN_NAME=$(security find-identity -v -p codesigning 2>/dev/null | grep "Developer ID Application" | head -1 | sed 's/.*"\(.*\)"/\1/')
+SIGN_MATCH="$(resolve_sign_identity "$SIGN_IDENTITY")"
+SIGN_HASH=""
+SIGN_NAME=""
+if [ -n "$SIGN_MATCH" ]; then
+    SIGN_HASH="$(echo "$SIGN_MATCH" | awk '{print $2}')"
+    SIGN_NAME="$(echo "$SIGN_MATCH" | sed 's/.*"\(.*\)"/\1/')"
+fi
+
 if [ -n "$SIGN_HASH" ]; then
-    echo "Signing with: $SIGN_NAME ($SIGN_HASH)"
-    if ! codesign --force --deep --sign "$SIGN_HASH" \
-        --entitlements "$BUILD_DIR/Transcripted.entitlements" \
-        "$APP_BUNDLE"; then
-        echo "Codesign failed — aborting build"
-        exit 1
-    fi
+    echo "Signing with: ${SIGN_NAME:-$SIGN_HASH} ($SIGN_HASH)"
+    codesign --force --deep --sign "$SIGN_HASH" \
+        --entitlements "$LOCAL_ENTITLEMENTS" \
+        "$APP_BUNDLE"
 else
     echo "No Developer ID found — signing ad-hoc (permissions may not persist)"
     codesign --force --deep --sign - \
-        --entitlements "$BUILD_DIR/Transcripted.entitlements" \
-        "$APP_BUNDLE" 2>&1
+        --entitlements "$LOCAL_ENTITLEMENTS" \
+        "$APP_BUNDLE"
 fi
 
-# Verify the signature took — catches silent codesign failures that would
-# otherwise leave behind a linker-stamped ad-hoc binary.
-if codesign -dv "$APP_BUNDLE" 2>&1 | grep -q "Signature=adhoc"; then
-    if [ -n "$SIGN_HASH" ]; then
-        echo "WARNING: expected Developer ID signature but binary is ad-hoc — permissions will reset on each build"
-    fi
+echo "Verifying signature..."
+verify_signature
+
+if [ -n "$SIGN_HASH" ] && codesign -dv "$APP_BUNDLE" 2>&1 | grep -q "Signature=adhoc"; then
+    echo "Expected Developer ID signature but binary is ad-hoc."
+    exit 1
 fi
 
 echo "Build complete!"

--- a/config/entitlements/beta.plist
+++ b/config/entitlements/beta.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.device.audio-capture</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.speech.recognition</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/config/entitlements/local.plist
+++ b/config/entitlements/local.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <false/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.audio-capture</key>
+    <true/>
+    <key>com.apple.security.speech.recognition</key>
+    <true/>
+</dict>
+</plist>

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -1,0 +1,62 @@
+# Release Packaging
+
+`build.sh` is the local developer build.
+
+Use `build-beta.sh` for anything you intend to hand to another machine. That is
+the path that applies hardened runtime signing, builds a DMG, and optionally
+submits it for notarization.
+
+The two build flows intentionally use separate committed entitlement files:
+
+- `config/entitlements/local.plist`
+- `config/entitlements/beta.plist`
+
+`build.sh` now fails before it touches signing when the unified dependency
+artifacts are missing or stale, and it also requires the app binary to exist
+before signature validation runs.
+
+## Prerequisites
+
+1. Install a `Developer ID Application` certificate.
+2. Store a notarytool profile in the login keychain.
+3. Build the unified dependency bundle once with exact pinned versions.
+4. Make sure local Parakeet models are present if you want them bundled into
+   the app instead of downloaded at runtime.
+
+Useful checks:
+
+```bash
+security find-identity -v -p codesigning
+xcrun notarytool store-credentials <profile-name> ...
+```
+
+To force a specific certificate for either build flow:
+
+```bash
+SIGN_IDENTITY=<sha-or-name-fragment> bash build.sh
+SIGNING_IDENTITY=<sha-or-name-fragment> bash build-beta.sh <beta-token> <user-name>
+```
+
+## Release Flow
+
+```bash
+bash build-deps.sh --force
+NOTARY_PROFILE=<profile-name> bash build-beta.sh <beta-token> <user-name>
+```
+
+For a dry run that still validates the signed app and DMG assembly:
+
+```bash
+SKIP_NOTARIZATION=1 bash build-beta.sh <beta-token> <user-name>
+```
+
+## Expected Validation
+
+`build-beta.sh` should complete all of the following:
+
+- `codesign --verify --deep --strict` passes for the `.app`
+- the DMG is signed when a Developer ID identity is available
+- notarized runs staple a ticket and then pass `spctl` checks for the app and DMG
+
+If notarization is intentionally skipped, Gatekeeper rejection for the signed
+app is expected until the artifact is notarized and stapled.


### PR DESCRIPTION
## Summary
- move local and beta entitlements into committed files under `config/entitlements/`
- harden `build.sh` and `build-beta.sh` with stricter prereq checks, explicit signing identity selection, and signature verification
- document the split between local builds and distribution packaging in `README.md` and `docs/release-packaging.md`

## Why
The local build flow could leave behind a misleading `.app` bundle when dependency artifacts were missing or stale. That made signing failures look like entitlement or Gatekeeper problems when the real issue was earlier in the build pipeline.

## Impact
- local builds now fail fast before signing when `TranscriptedCore` dependency artifacts are missing
- both build scripts require a real app binary before signing
- signing configuration is reviewable in version-controlled entitlement files instead of inline heredocs
- release packaging docs now make the local-vs-distribution flow explicit

## Root Cause
`build.sh` and `build-beta.sh` mixed artifact assembly, dependency assumptions, inline entitlements, and signing in a way that could mask the first real failure. When the app binary was never produced, the scripts still left behind a partial bundle that invited the wrong diagnosis.

## Validation
- `bash -n build.sh build-beta.sh`
- `plutil -lint config/entitlements/local.plist`
- `plutil -lint config/entitlements/beta.plist`
- `bash build.sh` now fails early with a clear missing-dependency message on a clean checkout

## Follow-up
`build-deps.sh` still needs separate stabilization work before full end-to-end app builds succeed from a fresh checkout.