### PR TITLE
[codex] Harden local artifact security

### DIFF
--- a/Sources/Dictation/DictationAgentOutput.swift
+++ b/Sources/Dictation/DictationAgentOutput.swift
@@ -135,6 +135,7 @@ enum DictationAgentOutput {
 
         let data = try encoder.encode(payload)
         try data.write(to: sidecarURL, options: .atomic)
+        FileManager.default.restrictFileToOwnerOnly(at: sidecarURL)
         return sidecarURL
     }
 

--- a/Sources/Dictation/DictationStoragePaths.swift
+++ b/Sources/Dictation/DictationStoragePaths.swift
@@ -7,14 +7,14 @@ enum DictationStoragePaths {
     /// Root: ~/Library/Application Support/Draft/dictations/
     static var root: URL {
         let url = FileManager.default.dictationSupportDir
-        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try? FileManager.default.createPrivateDirectory(at: url)
         return url
     }
 
     /// Folder for saved markdown exports.
     static var transcriptsFolder: URL {
         let url = root.appendingPathComponent("transcripts", isDirectory: true)
-        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        try? FileManager.default.createPrivateDirectory(at: url)
         return url
     }
 }

--- a/Sources/Dictation/DictationTranscriptWriter.swift
+++ b/Sources/Dictation/DictationTranscriptWriter.swift
@@ -110,6 +110,7 @@ enum DictationTranscriptWriter {
         }
 
         try body.write(to: url, atomically: true, encoding: .utf8)
+        FileManager.default.restrictFileToOwnerOnly(at: url)
 
         let sidecarURL = try? DictationAgentOutput.appendEntry(
             title: title,

--- a/Sources/DraftPaths.swift
+++ b/Sources/DraftPaths.swift
@@ -27,4 +27,15 @@ extension FileManager {
     var dictationSupportDir: URL {
         transcriptedAppSupportDir.appendingPathComponent("dictations", isDirectory: true)
     }
+
+    /// Create a directory and tighten it to owner-only access (0700).
+    func createPrivateDirectory(at url: URL) throws {
+        try createDirectory(at: url, withIntermediateDirectories: true)
+        try? setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+    }
+
+    /// Tighten a file to owner-only access (0600).
+    func restrictFileToOwnerOnly(at url: URL) {
+        try? setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
 }

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -508,12 +508,7 @@ final class MeetingSessionController: ObservableObject {
                     engine: "meeting",
                     event: "meeting_transcript_artifact_ready",
                     message: "Meeting transcript artifact is ready",
-                    context: self.baseDiagnosticsContext(
-                        extra: [
-                            "title": styled.title,
-                            "transcript_url": styled.url.path
-                        ]
-                    )
+                    context: self.baseDiagnosticsContext()
                 )
             }
             .store(in: &cancellables)
@@ -760,8 +755,6 @@ final class MeetingSessionController: ObservableObject {
                 message: "Meeting transcript saved",
                 context: baseDiagnosticsContext(
                     extra: [
-                        "title": lastSavedTitle ?? "",
-                        "transcript_url": lastSavedTranscriptURL?.path ?? "",
                         "queue_depth": "\(queuedTranscriptionJobs.count)"
                     ]
                 )

--- a/Sources/Observability/AppLogger.swift
+++ b/Sources/Observability/AppLogger.swift
@@ -37,6 +37,8 @@ private actor AppLogFileWriter {
             fm.createFile(atPath: path, contents: nil)
         }
 
+        fm.restrictFileToOwnerOnly(at: URL(fileURLWithPath: path))
+
         openHandleIfNeeded()
     }
 

--- a/Sources/Observability/EventReporter.swift
+++ b/Sources/Observability/EventReporter.swift
@@ -46,7 +46,7 @@ private actor EventFileWriter {
 
         // Ensure directory exists
         do {
-            try FileManager.default.createDirectory(at: storageDir, withIntermediateDirectories: true)
+            try FileManager.default.createPrivateDirectory(at: storageDir)
         } catch {
             fputs("⚠️ EVENT | failed to create directory \(storageDir.path): \(error.localizedDescription)\n", stderr)
         }
@@ -80,6 +80,7 @@ private actor EventFileWriter {
         } else {
             do {
                 try lineData.write(to: fileURL)
+                FileManager.default.restrictFileToOwnerOnly(at: fileURL)
                 print("📊 EVENT | created events.jsonl at \(fileURL.path)")
             } catch {
                 fputs("⚠️ EVENT | failed to create events.jsonl: \(error.localizedDescription)\n", stderr)
@@ -90,6 +91,8 @@ private actor EventFileWriter {
                 fputs("⚠️ EVENT | failed to open FileHandle after creation: \(error.localizedDescription)\n", stderr)
             }
         }
+
+        FileManager.default.restrictFileToOwnerOnly(at: fileURL)
     }
 
     deinit {

--- a/Sources/UI/DictationSessionController.swift
+++ b/Sources/UI/DictationSessionController.swift
@@ -167,9 +167,7 @@ class DictationSessionController: ObservableObject {
             message: "Dictation started",
             context: dictationContext(
                 extra: [
-                    "trigger": trigger.rawValue,
-                    "source_app_name": sourceApp?.localizedName ?? "",
-                    "source_app_bundle_id": sourceApp?.bundleIdentifier ?? ""
+                    "trigger": trigger.rawValue
                 ]
             )
         )
@@ -725,9 +723,7 @@ class DictationSessionController: ObservableObject {
                 message: "Saved dictation markdown export",
                 context: dictationContext(
                     extra: [
-                        "delivery": delivery.rawValue,
-                        "title": saved.title,
-                        "filename": saved.url.lastPathComponent
+                        "delivery": delivery.rawValue
                     ]
                 )
             )
@@ -746,8 +742,6 @@ class DictationSessionController: ObservableObject {
 
     private func dictationContext(extra: [String: String] = [:]) -> [String: String] {
         var context: [String: String] = [
-            "source_app_name": sessionSourceApp?.localizedName ?? "",
-            "source_app_bundle_id": sessionSourceApp?.bundleIdentifier ?? "",
             "audio_device": appState?.sttRouter.inputDeviceName ?? ""
         ]
 

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/PathSecurity.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/PathSecurity.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+enum PathResolutionStatus {
+    case valid(URL)
+    case missing
+    case invalid
+}
+
+enum PathSecurity {
+    static func resolveReadableFile(
+        named requestedName: String,
+        appendingExtension pathExtension: String? = nil,
+        in baseDirectory: URL
+    ) -> PathResolutionStatus {
+        let candidateName: String
+        if let pathExtension, !requestedName.hasSuffix(".\(pathExtension)") {
+            candidateName = requestedName + ".\(pathExtension)"
+        } else {
+            candidateName = requestedName
+        }
+
+        let candidateURL = baseDirectory
+            .appendingPathComponent(candidateName)
+            .standardizedFileURL
+        let standardizedBase = baseDirectory.standardizedFileURL
+
+        guard candidateURL.path.hasPrefix(standardizedBase.path + "/") else {
+            return .invalid
+        }
+        guard FileManager.default.fileExists(atPath: candidateURL.path) else {
+            return .missing
+        }
+
+        return validateExistingFile(candidateURL, under: baseDirectory)
+    }
+
+    static func validateExistingFile(_ url: URL, under baseDirectory: URL) -> PathResolutionStatus {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return .missing
+        }
+
+        guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
+              values.isRegularFile == true,
+              values.isSymbolicLink != true else {
+            return .invalid
+        }
+
+        let resolvedBase = baseDirectory.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedURL = url.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedBasePath = resolvedBase.path
+        let resolvedPath = resolvedURL.path
+
+        guard resolvedPath == resolvedBasePath || resolvedPath.hasPrefix(resolvedBasePath + "/") else {
+            return .invalid
+        }
+
+        return .valid(resolvedURL)
+    }
+}

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -273,7 +273,11 @@ private func handleListMeetings(params: CallTool.Parameters, index: TranscriptIn
 
     // Populate titles from markdown YAML frontmatter
     for i in results.indices {
-        let mdURL = meetingsDir.appendingPathComponent(results[i].filename + ".md")
+        guard case .valid(let mdURL) = PathSecurity.resolveReadableFile(
+            named: results[i].filename,
+            appendingExtension: "md",
+            in: meetingsDir
+        ) else { continue }
         if let content = try? String(contentsOf: mdURL, encoding: .utf8) {
             results[i].title = extractTitle(from: content) ?? results[i].filename
         }
@@ -337,12 +341,13 @@ private func handleReadMeeting(params: CallTool.Parameters, meetingsDir: URL) th
 
     let section = params.arguments?["section"]?.stringValue ?? "full"
 
-    // Try .md file first, then without extension
-    let mdURL = meetingsDir.appendingPathComponent(filename.hasSuffix(".md") ? filename : filename + ".md")
-        .standardizedFileURL
-
-    // Reject path traversal (e.g., filename = "../../etc/passwd")
-    guard mdURL.path.hasPrefix(meetingsDir.standardizedFileURL.path + "/") else {
+    let mdURL: URL
+    switch PathSecurity.resolveReadableFile(named: filename, appendingExtension: "md", in: meetingsDir) {
+    case .valid(let url):
+        mdURL = url
+    case .missing:
+        return .init(content: [.text(text: "Meeting not found: \(filename). Use list_meetings to see available meetings.")], isError: true)
+    case .invalid:
         return .init(content: [.text(text: "Invalid filename: \(filename)")], isError: true)
     }
 
@@ -382,11 +387,13 @@ private func handleReadDictation(params: CallTool.Parameters, dictationsDir: URL
     }
 
     let entryId = params.arguments?["entry_id"]?.stringValue
-    let sidecarURL = dictationsDir
-        .appendingPathComponent(filename.hasSuffix(".json") ? filename : filename + ".json")
-        .standardizedFileURL
-
-    guard sidecarURL.path.hasPrefix(dictationsDir.standardizedFileURL.path + "/") else {
+    let sidecarURL: URL
+    switch PathSecurity.resolveReadableFile(named: filename, appendingExtension: "json", in: dictationsDir) {
+    case .valid(let url):
+        sidecarURL = url
+    case .missing:
+        return .init(content: [.text(text: "Dictation not found: \(filename). Use list_dictations to see available days.")], isError: true)
+    case .invalid:
         return .init(content: [.text(text: "Invalid filename: \(filename)")], isError: true)
     }
 
@@ -412,11 +419,14 @@ private func handleReadDictation(params: CallTool.Parameters, dictationsDir: URL
         return .init(content: [.text(text: result)])
     }
 
-    let markdownURL = dictationsDir
-        .appendingPathComponent(day.markdownFilename)
-        .standardizedFileURL
-
-    guard markdownURL.path.hasPrefix(dictationsDir.standardizedFileURL.path + "/") else {
+    let markdownURL: URL
+    switch PathSecurity.resolveReadableFile(named: day.markdownFilename, in: dictationsDir) {
+    case .valid(let url):
+        markdownURL = url
+    case .missing:
+        let json = try JSONEncoder.pretty.encode(day)
+        return .init(content: [.text(text: String(data: json, encoding: .utf8) ?? "{}")])
+    case .invalid:
         return .init(content: [.text(text: "Invalid markdown filename for \(filename)")], isError: true)
     }
 
@@ -533,9 +543,11 @@ private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, me
 
     for meeting in meetings {
         // Read first ~200 words of transcript as preview
-        let mdURL = meetingsDir.appendingPathComponent(meeting.filename + ".md")
-        // Skip files that would escape dataDir (path traversal)
-        guard mdURL.standardizedFileURL.path.hasPrefix(meetingsDir.standardizedFileURL.path) else { continue }
+        guard case .valid(let mdURL) = PathSecurity.resolveReadableFile(
+            named: meeting.filename,
+            appendingExtension: "md",
+            in: meetingsDir
+        ) else { continue }
         var preview = ""
         var title = meeting.filename
         if let content = try? String(contentsOf: mdURL, encoding: .utf8) {
@@ -594,8 +606,12 @@ private func parseContextKind(_ raw: String?) -> ContextKind {
 }
 
 private func meetingTitle(for filename: String, meetingsDir: URL) -> String {
-    let mdURL = meetingsDir.appendingPathComponent(filename + ".md")
-    guard let content = try? String(contentsOf: mdURL, encoding: .utf8) else {
+    guard case .valid(let mdURL) = PathSecurity.resolveReadableFile(
+        named: filename,
+        appendingExtension: "md",
+        in: meetingsDir
+    ),
+    let content = try? String(contentsOf: mdURL, encoding: .utf8) else {
         return filename
     }
     return extractTitle(from: content) ?? filename

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
@@ -68,10 +68,11 @@ enum TranscriptLoader {
         }
 
         return files.compactMap { url in
-            guard let kind = sidecarKind(for: url) else { return nil }
-            let modDate = (try? url.resourceValues(forKeys: [.contentModificationDateKey])
+            guard case .valid(let safeURL) = PathSecurity.validateExistingFile(url, under: directory),
+                  let kind = sidecarKind(for: safeURL) else { return nil }
+            let modDate = (try? safeURL.resourceValues(forKeys: [.contentModificationDateKey])
                 .contentModificationDate?.timeIntervalSince1970) ?? 0
-            return ContextSidecarFile(url: url, modDate: modDate, kind: kind)
+            return ContextSidecarFile(url: safeURL, modDate: modDate, kind: kind)
         }
     }
 

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptLoaderTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptLoaderTests.swift
@@ -56,6 +56,36 @@ final class TranscriptLoaderTests: XCTestCase {
         XCTAssertEqual(day?.entries.first?.title, "Morning note")
     }
 
+    func testEnumerateSidecarsSkipsSymlinkedFiles() throws {
+        let outsideDir = makeTempDir()
+        defer { removeTempDir(outsideDir) }
+
+        let outsideFile = outsideDir.appendingPathComponent("Call_2026-03-29_10-00-00.json")
+        try makeFixtureJSON().write(to: outsideFile)
+
+        let symlinkURL = tempDir.appendingPathComponent("Call_2026-03-29_10-00-00.json")
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: outsideFile)
+
+        let sidecars = TranscriptLoader.enumerateSidecars(in: tempDir)
+        XCTAssertTrue(sidecars.isEmpty)
+    }
+
+    func testResolveReadableFileRejectsSymlinkEscape() throws {
+        let outsideDir = makeTempDir()
+        defer { removeTempDir(outsideDir) }
+
+        let outsideFile = outsideDir.appendingPathComponent("Dictations_2026-04-07.md")
+        try "# Secret".write(to: outsideFile, atomically: true, encoding: .utf8)
+
+        let symlinkURL = tempDir.appendingPathComponent("Dictations_2026-04-07.md")
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: outsideFile)
+
+        let result = PathSecurity.resolveReadableFile(named: "Dictations_2026-04-07.md", in: tempDir)
+        guard case .invalid = result else {
+            return XCTFail("Expected symlink escape to be rejected")
+        }
+    }
+
     func testSpeakerLookup() {
         let fixture = makeFixtureJSON()
         let transcript = try! JSONDecoder().decode(AgentTranscript.self, from: fixture)


### PR DESCRIPTION
## Summary
- harden dictation and observability artifacts to owner-only local file permissions
- reduce sensitive metadata included in exported diagnostics contexts
- block `transcripted-mcp` symlink/path escapes and add regression tests

## Validation
- `bash run-tests.sh`
- `swift test` in `Tools/TranscriptedMCP`

## Notes
- `bash build.sh` and `bash run-integration-smoke.sh` in the clean PR worktree are currently blocked by missing generated dependencies (`build-deps.sh`), not by this patch.
- `bash run-integration-smoke.sh` had already passed earlier in the original implementation worktree before the PR split.
- A full app build in the original workspace also hit a pre-existing compile issue in `Sources/UI/SpeakerNamingSheet.swift`, outside this PR’s scope.