### PR TITLE
Update README to include Transcripted logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-<img width="1024" height="1024" alt="transcripted-logo" src="https://github.com/user-attachments/assets/5027f97c-f5cf-4e77-8e99-e4ebe9ca1098" />
-# Transcripted
 
+(https://github.com/user-attachments/assets/40ff75aa-9202-46f3-b536-8303217028a3) 
+
+## Transcripted
 Transcripted is a local Mac app for dictation and meeting capture that turns
 spoken words into structured files your agent can actually use.
 


### PR DESCRIPTION
Added a link to the Transcripted logo in the README.

## Why

<!-- What problem does this change solve? -->

## Product Impact

- Affects: `dictation` / `meetings` / `agent artifacts` / `docs only`
- Why this matters:

## What changed

-

## How I checked it

- [ ] `bash build.sh`
- [ ] `bash run-tests.sh`
- [ ] `bash run-integration-smoke.sh` if I touched `Sources/Meeting/` or `Sources/TranscriptedCore/`
- [ ] Manual check:

## Risk Review

- [ ] Privacy / local-first behavior reviewed
- [ ] Storage path or migration impact reviewed
- [ ] Public-facing copy stays concrete and matches current product scope

## Notes

<!-- Related issues, follow-ups, screenshots, or legacy-branch impact -->
