### PR TITLE
Update README to remove old image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
+<img width="625" height="329" alt="Screenshot 2026-04-10 at 7 31 17 PM" src="https://github.com/user-attachments/assets/86453a3e-9eee-4525-b985-777366296cf5" />
 
-(https://github.com/user-attachments/assets/40ff75aa-9202-46f3-b536-8303217028a3) 
 
 ## Transcripted
 Transcripted is a local Mac app for dictation and meeting capture that turns


### PR DESCRIPTION
Removed outdated image link from README.

## Why

<!-- What problem does this change solve? -->

## Product Impact

- Affects: `dictation` / `meetings` / `agent artifacts` / `docs only`
- Why this matters:

## What changed

-

## How I checked it

- [ ] `bash build.sh`
- [ ] `bash run-tests.sh`
- [ ] `bash run-integration-smoke.sh` if I touched `Sources/Meeting/` or `Sources/TranscriptedCore/`
- [ ] Manual check:

## Risk Review

- [ ] Privacy / local-first behavior reviewed
- [ ] Storage path or migration impact reviewed
- [ ] Public-facing copy stays concrete and matches current product scope

## Notes

<!-- Related issues, follow-ups, screenshots, or legacy-branch impact -->
