### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -6,14 +6,18 @@
 
 - dictation capture and paste-back
 - meeting capture, transcription, and transcript browsing
+- wake / sleep recovery for active recording flows
 
 Important entry points:
 
 - `TranscriptedApp.swift` — app entry point, menubar wiring, popover, overlay setup, and detected-meeting prompt wiring
-- `TranscriptedAppState.swift` — owns `ContextCaptureEngine`, `STTRouter`, and lazy `MeetingSessionController`
+- `TranscriptedAppState.swift` — owns `ContextCaptureEngine`, `STTRouter`, wake-recovery coordination, and lazy `MeetingSessionController`
+- `DraftPaths.swift` — app-support path helpers for the current Draft-named compatibility tree
+- `HotkeyPreferences.swift` — persisted hotkey settings used by capture routing
+- `TranscriptedConstants.swift` — shared timing and behavior constants used across the app target
 - `Capture/ContextCaptureEngine.swift` — right-option dictation handling, keyboard hotkeys, meeting hotkey routing
 - `UI/DictationSessionController.swift` — dictation session orchestration; removed draft-mode methods are stubs
-- `Meeting/MeetingPromptDetector.swift` — Calendar-driven meeting-link detection used to offer one-tap meeting capture prompts
+- `Meeting/MeetingPromptDetector.swift` — Calendar and runtime-app meeting detection used to offer one-tap meeting capture prompts
 - `Meeting/MeetingSessionController.swift` — app-side bridge into `TranscriptedCore`, including queued meeting transcription handoff
 - `Speech/ParakeetEngine.swift` + `Speech/STTRouter.swift` — local STT path used by dictation and by the meeting adapter
 
@@ -22,14 +26,15 @@ Important entry points:
 - `Accessibility/` — AX helpers for overlay positioning
 - `API/` — beta-only config currently; older API docs are historical
 - `Capture/` — hotkeys, context parsing, capture routing
-- `Dictation/` — dictation transcript persistence
-- `Text/` — small pure text utilities retained from the earlier drafting flow
-- `Meeting/` — app-side meeting bridge and transcript restyling
+- `Dictation/` — dictation transcript persistence and timeout helpers
+- `Meeting/` — app-side meeting bridge, prompts, storage, and transcript restyling
 - `Observability/` — events, debug log, telemetry, beta updater, crash reporting
-- `Speech/` — Parakeet STT and router
+- `Reliability/` — wake / sleep recovery coordination
+- `Speech/` — Parakeet STT, router, and recorded-audio buffering helpers
 - `Style/` — pure text heuristics retained from the older style-learning system
+- `Text/` — small pure text utilities retained from the earlier drafting flow
 - `TranscriptedCore/` — shared library boundary
-- `UI/` — menubar, overlays, settings, recent meetings, speaker naming
+- `UI/` — menubar, overlays, settings, recent meetings, speaker naming, and agent-connect
 
 The historical planning docs that used to live alongside older placeholder
 areas were moved under `docs/archive/` so the source tree reads more like the

--- a/Sources/Dictation/CLAUDE.md
+++ b/Sources/Dictation/CLAUDE.md
@@ -2,11 +2,12 @@
 
 ## What this directory does
 
-`Sources/Dictation/` owns the on-disk markdown artifacts written after a dictation completes. It does not handle audio capture or STT itself; that stays in `DictationSessionController` and `Speech/`.
+`Sources/Dictation/` owns the small persistence helpers behind completed dictation sessions. It does not handle audio capture or STT itself; that stays in `DictationSessionController` and `Speech/`.
 
 ## Files
 
 - `DictationAgentOutput.swift` — Codable models (`AgentDictationDay`, `AgentDictationEntry`) for the JSON sidecar written alongside each day's markdown
+- `DictationSessionTimeout.swift` — uptime-based timeout helper so sleep does not consume a session's remaining record window
 - `DictationStoragePaths.swift` — Draft-named storage root for dictation artifacts
 - `DictationTranscriptWriter.swift` — groups completed dictations into one markdown file per day
 
@@ -15,7 +16,7 @@
 1. `Sources/UI/DictationSessionController.swift` transcribes audio with `STTRouter`.
 2. The session tries to paste the text back into the target app.
 3. The session records whether delivery was `pasted`, `copied`, or `failed`.
-4. `DictationTranscriptWriter.save(...)` appends a new section to that day's markdown file.
+4. `DictationTranscriptWriter.save(...)` appends a new section to that day's markdown file and updates the JSON sidecar.
 
 ## Storage
 
@@ -34,10 +35,12 @@ Each section captures:
 
 ## Test coverage
 
+- `Tests/DictationAgentOutputTests.swift`
+- `Tests/DictationSessionTimeoutTests.swift`
 - `Tests/DictationTranscriptWriterTests.swift`
 
 ## Agent notes
 
 - If you change the markdown layout, update the tests.
 - Dictation artifacts are append-only by day; do not assume one file per session.
-- This directory is about persistence only. Recording lifecycle changes belong in `Sources/UI/DictationSessionController.swift` and `Sources/Speech/`.
+- This directory is about persistence and timing helpers only. Recording lifecycle changes belong in `Sources/UI/DictationSessionController.swift` and `Sources/Speech/`.

--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -9,7 +9,8 @@
 - `FailedMeetingPresentation.swift` — maps `FailedTranscription` into `FailedMeetingItem` view-models with human-readable titles and retry metadata
 - `MeetingCaptureBridge.swift` — `@MainActor` wrapper around core `Audio`, converts callback-based stop into `async`
 - `MeetingModelDownloader.swift` — loads Parakeet and diarization models together
-- `MeetingPromptDetector.swift` — polls upcoming Calendar events, detects supported meeting URLs, and asks the overlay to offer a one-tap record prompt
+- `MeetingPromptDetector.swift` — polls upcoming Calendar events, watches supported meeting apps, and asks the overlay to offer one-tap recording prompts
+- `MeetingPromptHeuristics.swift` — shared scoring and snooze rules for calendar- and runtime-based prompt candidates
 - `MeetingSTTAdapter.swift` — adapts the app's shared `ParakeetEngine` to `TranscriptedCore.SpeechToTextEngine`
 - `MeetingSessionController.swift` — top-level meeting state machine, model warmup, capture start/stop, queued transcription handoff, failed-meeting actions, and transcript restyling
 - `MeetingStoragePaths.swift` — current meeting storage layout under the Draft-named compatibility root
@@ -18,12 +19,12 @@
 ## End-to-end flow
 
 1. `Sources/TranscriptedApp.swift` wires `MeetingSessionController` into `MeetingOverlayController`, the menubar, the `⌥M` hotkey, and the detected-meeting prompt flow.
-2. `MeetingPromptDetector` polls upcoming Calendar events, scores candidate meeting links, and asks `MeetingOverlayController` to present a short-lived prompt when the app is idle.
+2. `MeetingPromptDetector` polls upcoming Calendar events, observes supported runtime apps, scores candidate prompts, and asks `MeetingOverlayController` to present a short-lived prompt when the app is idle.
 3. `Sources/TranscriptedAppState.swift` starts background model warmup through `meetingSession.prepareModels(showLoadingUI: false)`.
 4. `MeetingSessionController.startRecording(...)` uses `MeetingCaptureBridge` to start core audio capture into app-owned scratch paths.
 5. `MeetingSessionController.stopRecording(...)` awaits mic/system audio files from the bridge, then either starts transcription immediately or queues it behind the active job.
 6. `TranscriptionTaskManager` runs one diarize → transcribe → save pipeline at a time.
-7. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the "recent meetings" UI state.
+7. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the recent-meetings UI state.
 8. Failed meetings can be retried, deleted, or dismissed from the menubar recent-meetings section.
 
 ## Key invariants
@@ -31,7 +32,7 @@
 - `TranscriptedCore` owns the reusable pipeline. App code in this directory should prefer adapters and protocol seams over direct core edits.
 - `MeetingSTTAdapter.cleanup()` is intentionally a no-op. `TranscriptedAppState` owns `ParakeetEngine` lifecycle for the whole app.
 - Meeting storage must stay under the current Draft-named app-support paths, not `TranscriptedCore.default` standalone paths.
-- `MeetingPromptDetector` only offers prompts for supported meeting providers (Zoom, Google Meet, Teams, Webex, FaceTime) and only while the meeting session is idle.
+- `MeetingPromptDetector` can prompt from either upcoming calendar events or recently active supported meeting apps (Zoom, Teams, Webex, FaceTime, plus browser-hosted providers like Google Meet).
 - `TranscriptionTaskManager` stays single-flight. App-level queueing belongs in `MeetingSessionController`, not in ad hoc background tasks.
 - Live PCM handlers installed through `MeetingCaptureBridge` run on capture threads. Keep them real-time safe.
 
@@ -58,6 +59,7 @@ See `docs/storage-paths.md` for the full map.
 
 Relevant direct coverage:
 
+- `Tests/MeetingPromptHeuristicsTests.swift`
 - `Tests/MeetingTranscriptStylerTests.swift`
 - `Tests/SpeakerNamingPolicyTests.swift`
 - `SmokeTests/CoreIntegrationSmoke.swift`

--- a/Sources/Speech/CLAUDE.md
+++ b/Sources/Speech/CLAUDE.md
@@ -6,16 +6,15 @@
 
 ## Key Files
 
-- `ParakeetEngine.swift` — app-owned Parakeet STT engine, recording control,
-  live transcript state, model initialization, and audio-device handling
+- `ParakeetEngine.swift` — app-owned Parakeet STT engine, recording control, live transcript state, model initialization, audio-device handling, and wake-recovery support
+- `RecordedAudioTimeline.swift` — in-memory segmented audio buffer used when recorded audio needs to be preserved across interruptions or recovery handoffs
 - `STTRouter.swift` — small main-actor wrapper used by the rest of the app
 
 ## Current Notes
 
-- This directory powers dictation
-- The meeting pipeline reuses the same app-owned `ParakeetEngine` through
-  `Sources/Meeting/MeetingSTTAdapter.swift`
-- Do not assume a separate local-LLM drafting path exists in this tree
+- This directory powers dictation.
+- The meeting pipeline reuses the same app-owned `ParakeetEngine` through `Sources/Meeting/MeetingSTTAdapter.swift`.
+- Do not assume a separate local-LLM drafting path exists in this tree.
 
 ## Verification
 
@@ -31,3 +30,4 @@ Manual checks:
 - dictation can start and stop cleanly
 - live transcript updates while listening
 - device changes do not leave the app stuck
+- wake / resume does not strand buffered audio or leave recovery state hanging

--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -4,18 +4,18 @@
 
 `Sources/TranscriptedCore/` is the reusable meeting transcription library embedded in this repo. It is consumed by the app through `Sources/Meeting/`, and it can also be tested as a standalone Swift package through the root `Package.swift`.
 
-## Subsystems (55 Swift files)
+## Subsystems (57 Swift files)
 
-- `Audio/` (9 files) — mic + system audio capture, device recovery, resampling, level metering, process tap, buffer writer
+- `Audio/` (11 files) — mic + system audio capture, device recovery, resampling, level metering, process tap, buffer writing, and merge helpers
 - `Logging/` (2 files) — shared app logger and JSONL file logger
-- `Models/` (4 files) — public data types: `TranscriptionResult`, `DisplayStatus`, `FailedTranscription`, metadata builders
+- `Models/` (4 files) — public data types: `TranscriptionResult`, `DisplayStatus`, `FailedTranscription`, and transcript metadata builders
 - `Pipeline/` (4 files) — transcription orchestration, pipeline runner, and task queue
 - `Protocols/` (7 files) — host-injected seams: `SpeechToTextEngine`, `DiarizationEngine`, `SpeakerStore`, `TranscriptNotifier`, `AudioCaptureEngine`, `StatsStore`, `TranscriptStorage`
-- `Services/` (7 files) — DI container (`AppServices`), model download, path indirection, recording validation, diarization, failed transcription manager
-- `Speaker/` (10 files) — speaker DB, embedding matching/clustering, clip extraction, naming policy/coordinator, profile merging, retroactive updater
+- `Services/` (7 files) — DI container (`AppServices`), model bundle / download management, path indirection, recording validation, diarization, and failed-transcription persistence
+- `Speaker/` (10 files) — speaker DB, embedding matching / clustering, clip extraction, naming policy / coordinator, profile merging, retroactive transcript updates
 - `Stats/` (4 files) — recording stats database, models, queries, and service
 - `Storage/` (4 files) — transcript save, scanner, formatter, JSON sidecar output
-- `Utilities/` (4 files) — date helpers, permissions, transcript utility functions
+- `Utilities/` (4 files) — date formatting / parsing, file permissions, and transcript update helpers
 
 ## The seams embedders should know
 
@@ -68,9 +68,17 @@ Also run when the package seam changes:
 
 - `swift test`
 
-Current direct core coverage is thin and concentrated around the public seam:
+Current direct core coverage includes:
 
 - `Tests/TranscriptedCoreTests/CoreStoragePathsTests.swift`
+- `Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift`
+- `Tests/TranscriptedCoreTests/MicRecordingFileMergerTests.swift`
+- `Tests/TranscriptedCoreTests/RetroactiveSpeakerUpdaterTests.swift`
+- `Tests/TranscriptedCoreTests/SpeakerMatchingServiceTests.swift`
+- `Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift`
+- `Tests/TranscriptedCoreTests/SpeakerProfileMergerTests.swift`
+- `Tests/TranscriptedCoreTests/StatsDatabaseTests.swift`
+- `Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift`
 - `SmokeTests/CoreIntegrationSmoke.swift`
 
-That means many core changes still depend heavily on build + smoke validation.
+Core coverage is still selective, but it is no longer limited just to the package seam. Speaker reconciliation, file merging, stats, and storage-path behavior now have direct tests.

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -2,8 +2,7 @@
 
 ## What This Does
 
-`Sources/UI/` contains the current app surfaces for Transcripted's active
-features:
+`Sources/UI/` contains the current app surfaces for Transcripted's active features:
 
 - dictation overlay
 - meeting overlay
@@ -14,7 +13,7 @@ features:
 
 Draft-mode UI is not an active product path in this worktree.
 
-## Files (38 Swift files)
+## Files (40 Swift files)
 
 ### Dictation Overlay
 
@@ -70,7 +69,9 @@ The current agent-connect surfaces should keep one simple mental model:
 
 - `HotkeyRecorderAppKitView.swift` — AppKit view for recording custom hotkey bindings
 - `PermissionsOnboardingView.swift` — first-launch permissions walkthrough
-- `TranscriptedPermissionAccess.swift` — accessibility and screen recording permission checks
+- `SpeakerClipPlayback.swift` — simple shared audio-preview helper for persisted speaker sample clips
+- `SpeakerPeopleSettingsSection.swift` — settings section and view model for browsing, naming, merging, previewing, and deleting saved speaker profiles
+- `TranscriptedPermissionAccess.swift` — accessibility, screen recording, and calendar permission checks
 - `TranscriptedSettingsView.swift` — main settings view
 - `TranscriptedSettingsWindowController.swift` — NSWindowController for settings
 
@@ -98,4 +99,5 @@ Manual checks:
 - detected-meeting prompts appear only when appropriate and can start or snooze a meeting cleanly
 - meeting overlay warms up and records cleanly
 - menubar popover renders shortcuts, recents, settings actions, and the agent-connect page cleanly
+- speaker settings can preview clips and rename / merge people cleanly
 - permissions onboarding and settings window still open correctly

--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -44,6 +44,7 @@ They also honor:
 | `DiarizeCommand.swift` | Single-file diarization command |
 | `BatchCommand.swift` | Directory diarization command |
 | `ConfigLoader.swift` | JSON-to-`OfflineDiarizerConfig` loader |
+| `DiarizerConfigCompatibility.swift` | Compatibility shim for speaker-bound tuning while newer FluidAudio APIs are in flux |
 | `RTTMWriter.swift` | RTTM output formatter |
 
 ## Build And Run
@@ -62,4 +63,5 @@ swift run transcripted-cli diarize /path/to/audio.wav --json
 - the context commands and the diarization commands serve different users, do not describe the whole package as diarization-only
 - the diarization commands depend on repo-level artifacts, so run `bash build-deps.sh` first when those are missing
 - the default context paths now point at `~/Library/Application Support/Draft/`, not only the older `~/Documents/Transcripted/` layout
+- `DiarizerConfigCompatibility.swift` currently keeps old bounded-speaker call sites compiling; it does not reintroduce upstream behavior by itself
 - changes here should be verified independently from the app build

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -23,10 +23,10 @@ Path overrides:
 - `TRANSCRIPTED_DICTATIONS_DIR` — dictations directory override
 - `TRANSCRIPTED_INDEX_DIR` — SQLite index directory override
 
-## Package Layout (13 Swift files)
+## Package Layout (14 Swift files)
 
 - `Package.swift` — Swift package manifest for the standalone MCP server
-- `Sources/TranscriptedMCP/` — 8 source files for server startup, directory resolution, indexing, and tool handlers
+- `Sources/TranscriptedMCP/` — 9 source files for server startup, directory resolution, path validation, indexing, and tool handlers
 - `Tests/TranscriptedMCPTests/` — 4 test files for index lifecycle, markdown loading, name variants, and shared fixtures
 
 ## File Index
@@ -40,6 +40,7 @@ Path overrides:
 | `TranscriptLoader.swift` | Loads markdown meeting transcripts and dictation day files directly from disk |
 | `Models.swift` | Codable input/output models and `MCPIndexError` |
 | `NameVariants.swift` | Speaker-name fuzzy matching for speaker-aware queries |
+| `PathSecurity.swift` | Guards direct file reads against traversal, symlinks, and out-of-root paths |
 | `FileWatcher.swift` | Watches the local transcript directories and incrementally reindexes changed files |
 
 ## Test Files
@@ -47,7 +48,7 @@ Path overrides:
 | File | Purpose |
 |------|---------|
 | `TranscriptIndexTests.swift` | Full index lifecycle: reconcile, query, date filters, speaker search, and mixed-context indexing |
-| `TranscriptLoaderTests.swift` | Markdown and YAML frontmatter parsing edge cases |
+| `TranscriptLoaderTests.swift` | Markdown and YAML frontmatter parsing edge cases, including path-safety checks |
 | `NameVariantsTests.swift` | Name variant matching accuracy |
 | `TestHelpers.swift` | Shared fixture builders for sample sidecars and temp directories |
 
@@ -126,6 +127,7 @@ Binary path after build:
 ## Gotchas
 
 - transport is stdio, not HTTP
+- direct file reads are path-validated and reject traversal or symlink escapes
 - the server auto-creates missing data and index directories
 - the index rebuilds from disk on startup
 - `read_meeting` and `read_dictation` read markdown directly from disk, not from the SQLite index

--- a/Tools/TranscriptedQA/CLAUDE.md
+++ b/Tools/TranscriptedQA/CLAUDE.md
@@ -21,28 +21,28 @@ QA testing suite for Transcripted. 23 Swift files total: `Package.swift` plus 22
 | File | Purpose |
 |------|---------|
 | `CheckHealth.swift` | Quick health check: DB integrity, model presence, disk space |
+| `GenerateFixtures.swift` | Generate valid test data (transcripts, sidecars, DB records) for CI or manual verification |
+| `RoundTrip.swift` | Generate test data, validate, corrupt, re-validate, and confirm validators catch real defects |
+| `StressTest.swift` | Generate large datasets and validate performance + correctness |
 | `ValidateAll.swift` | Run all validators: transcripts, DB, index, logs, artifacts |
-| `ValidateArtifacts.swift` | Check transcript sidecars (.json), YAML frontmatter, speaker clips |
+| `ValidateArtifacts.swift` | Check transcript sidecars (`.json`), YAML frontmatter, speaker clips |
 | `ValidateDatabase.swift` | SpeakerDB and StatsDB integrity, schema validation, corruption check |
 | `ValidateIndex.swift` | Transcript index consistency, missing sidecars, orphan files |
 | `ValidateLogs.swift` | Log file analysis and `app.jsonl` format validation |
 | `ValidateTranscripts.swift` | Transcript content validation, speaker attribution, timestamp checks |
-| `GenerateFixtures.swift` | Generate valid test data (transcripts, sidecars, DB records) that passes all validators; outputs to configurable directory (default: `/tmp/transcripted-test-data`) |
-| `RoundTrip.swift` | Generate test data, validate, corrupt, re-validate, verifies validators catch real defects |
-| `StressTest.swift` | Generate large datasets (configurable transcript/speaker/utterance counts) and validate performance + correctness |
 
 ### Generators/ (1 file)
 
 | File | Purpose |
 |------|---------|
-| `TestDataGenerator.swift` | Shared fixture builder used by GenerateFixtures, RoundTrip, and StressTest commands |
+| `TestDataGenerator.swift` | Shared fixture builder used by `GenerateFixtures`, `RoundTrip`, and `StressTest` |
 
 ### Validators/ (7 files)
 
 | File | Purpose |
 |------|---------|
 | `HealthChecker.swift` | System health: disk space, model files, DB existence |
-| `IndexValidator.swift` | Index consistency, transcript/sidecar pairing |
+| `IndexValidator.swift` | Index consistency, transcript / sidecar pairing |
 | `JSONSidecarValidator.swift` | YAML frontmatter and agent JSON structure |
 | `LogValidator.swift` | Log file parsing and error pattern detection |
 | `SpeakerDBValidator.swift` | SpeakerDB schema, record count, embedding integrity |
@@ -94,9 +94,9 @@ transcripted-qa stress-test --transcripts 100 --speakers-per-transcript 4 --utte
 ## Key Features
 
 - **Health checks**: Quick system status before deep validation
-- **Database integrity**: SpeakerDB and StatsDB corruption detection with backup/recreate pattern
+- **Database integrity**: SpeakerDB and StatsDB corruption detection with backup / recreate pattern
 - **Transcript validation**: Content, speaker attribution, timestamp consistency
-- **Index validation**: Transcript/sidecar pairing, orphan file detection
+- **Index validation**: Transcript / sidecar pairing, orphan file detection
 - **Log analysis**: Error pattern detection, warning frequency tracking
 - **Artifact validation**: YAML frontmatter, JSON sidecars, speaker clips
 - **Fixture generation**: `generate-fixtures` creates valid test data for use in CI or manual testing


### PR DESCRIPTION
## Summary
- sync the affected `CLAUDE.md` files with the current Swift file layout and recent runtime changes
- fix stale file counts, file index tables, and subsystem summaries across app, core, and tooling docs
- document newly added behavior around dictation timeout handling, meeting prompt heuristics, wake-recovery audio buffering, speaker settings management, and MCP path validation

## Updated docs
- `Sources/CLAUDE.md`
- `Sources/Dictation/CLAUDE.md`
- `Sources/Meeting/CLAUDE.md`
- `Sources/Speech/CLAUDE.md`
- `Sources/TranscriptedCore/CLAUDE.md`
- `Sources/UI/CLAUDE.md`
- `Tools/TranscriptedCLI/CLAUDE.md`
- `Tools/TranscriptedMCP/CLAUDE.md`
- `Tools/TranscriptedQA/CLAUDE.md`

## Why
Recent changes added or expanded several documented surfaces, including:
- `DictationSessionTimeout.swift`
- `MeetingPromptHeuristics.swift`
- `RecordedAudioTimeline.swift`
- `SpeakerClipPlayback.swift`
- `SpeakerPeopleSettingsSection.swift`
- `DiarizerConfigCompatibility.swift`
- `PathSecurity.swift`
- expanded `TranscriptedCore` subsystem coverage and tests

This keeps the repo's navigation docs accurate for future agents and contributors.
