### PR TITLE
docs: sync CLAUDE.md and agents.md with recent codebase changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,11 +25,12 @@
 - `Sources/` — app shell, hotkeys, speech, dictation UI, meeting bridge, shared app paths
 - `Sources/Dictation/` — markdown persistence for completed dictations
 - `Sources/Meeting/` — app-side bridge into `TranscriptedCore`
+- `Sources/Reliability/` — wake / sleep recovery coordination for active recording flows
 - `Sources/TranscriptedCore/` — reusable meeting transcription library
 - `Tests/` — fast custom Swift test runner plus `TranscriptedCore` package tests
-- `SmokeTests/` — integration smoke for the bundled core library seam
-- `Tools/TranscriptedCLI/` — standalone offline diarization CLI
-- `Tools/TranscriptedMCP/` — read-only MCP server for saved meeting artifacts
+- `SmokeTests/` — integration smoke for the bundled core library seam, plus a wake-recovery smoke check
+- `Tools/TranscriptedCLI/` — standalone CLI for local context queries and offline diarization
+- `Tools/TranscriptedMCP/` — read-only MCP server for saved meeting and dictation artifacts
 - `Tools/TranscriptedQA/` — artifact validation CLI
 - `archive/backend-beta-worker/` — archived beta proxy / telemetry backend
 
@@ -49,6 +50,8 @@ Current source-of-truth docs:
 - `Tests/README.md`
 - `docs/storage-paths.md`
 - `Tools/TranscriptedCLI/CLAUDE.md`
+- `Tools/TranscriptedMCP/CLAUDE.md`
+- `Tools/TranscriptedQA/CLAUDE.md`
 
 Beta/distribution-only docs:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@
 
 The old standalone Transcripted app is preserved on:
 
-- `legacy/transcripted-standalone`
-- `pre-draft-takeover-2026-04-06`
+- branch `legacy/transcripted-standalone`
+- tag `pre-draft-takeover-2026-04-06`
 
 The older drafting / ghostwriting flow does not live on `main` anymore. `DictationSessionController` still exposes compatibility stubs for removed draft-mode entry points.
 
@@ -48,9 +48,10 @@ Rules:
 ## Current architecture
 
 - `Sources/TranscriptedApp.swift` wires the menubar app, popover, dictation overlay, meeting overlay, and detected-meeting prompt flow.
-- `Sources/TranscriptedAppState.swift` owns app-wide services: `STTRouter`, `ContextCaptureEngine`, and the lazily built `MeetingSessionController`.
+- `Sources/TranscriptedAppState.swift` owns app-wide services: `STTRouter`, `ContextCaptureEngine`, the lazily built `MeetingSessionController`, and a `WakeRecoveryCoordinator` for handling sleep / wake transitions during active recording.
 - `Sources/UI/DictationSessionController.swift` now handles dictation only. Removed draft-mode entry points surface a fixed error message.
 - `Sources/Meeting/` adapts app-owned pieces like `ParakeetEngine` into `TranscriptedCore`, including meeting-link detection and app-level transcription queueing.
+- `Sources/Reliability/` holds the `WakeRecoveryCoordinator` used by the app state above.
 - `Sources/TranscriptedCore/` contains the reusable meeting transcription library.
 - Root `Package.swift` exists so `TranscriptedCore` can be tested as a standalone package surface.
 


### PR DESCRIPTION
## Summary

Small follow-up to the most recent docs sync (PR #245). I audited every `CLAUDE.md` and `AGENTS.md` against the actual code on `main` and found three small gaps that crept in or were missed last round.

## Changes

- **`AGENTS.md`**
  - Add `Sources/Reliability/` to the directory map (this directory exists on `main` but was not listed).
  - Mention that `SmokeTests/` now also covers wake recovery (`WakeRecoverySmoke.swift`), not just core integration smoke.
  - Tighten the `Tools/TranscriptedCLI/` description so it does not read as diarization-only — it also serves local context queries.
  - Tweak the `Tools/TranscriptedMCP/` description to mention dictations as well as meetings.
  - Add `Tools/TranscriptedMCP/CLAUDE.md` and `Tools/TranscriptedQA/CLAUDE.md` to the "Current source-of-truth docs" list. These are first-class docs but were missing from the index.

- **`CLAUDE.md`** (root)
  - Update the `Current architecture` section so `TranscriptedAppState` is described as also owning a `WakeRecoveryCoordinator`. The Sources/CLAUDE.md doc was updated last round but the root doc was not.
  - Add a one-line bullet for `Sources/Reliability/` in the same section.
  - Clarify that `legacy/transcripted-standalone` is a branch and `pre-draft-takeover-2026-04-06` is a tag (the previous wording listed both as branches).

## Verification

- Cross-checked file counts and file lists in every existing `Sources/*/CLAUDE.md`, `Sources/TranscriptedCore/CLAUDE.md`, and every `Tools/*/CLAUDE.md` against the actual `*.swift` files on `main`. All other docs are already in sync after PR #245, so this PR is intentionally narrow.
- Confirmed `Sources/Reliability/` only contains `WakeRecoveryCoordinator.swift` (1 Swift file), so it does not need its own `CLAUDE.md` per the existing convention.
- Confirmed `pre-draft-takeover-2026-04-06` is a tag (not a branch) via `git ls-remote --tags origin`.

## Test plan

- [ ] Visual diff review of the two doc files — no code changes.