### PR TITLE
security: nightly security audit findings [automated]

### DIFF
--- a/Sources/TranscriptedCore/Audio/MicRecordingFileMerger.swift
+++ b/Sources/TranscriptedCore/Audio/MicRecordingFileMerger.swift
@@ -83,7 +83,12 @@ enum MicRecordingFileMerger {
             buffer.frameLength = AVAudioFrameCount(count)
             if let channelData = buffer.floatChannelData?[0] {
                 samples.withUnsafeBufferPointer { pointer in
-                    channelData.update(from: pointer.baseAddress! + offset, count: count)
+                    // Security: guard against nil baseAddress — baseAddress is non-nil for
+                    // non-empty arrays, which is guaranteed by the loop condition (offset <
+                    // samples.count), but force-unwrapping here would crash the audio thread
+                    // if the invariant were ever violated.
+                    guard let base = pointer.baseAddress else { return }
+                    channelData.update(from: base + offset, count: count)
                 }
             }
 

--- a/Sources/TranscriptedCore/Stats/StatsDatabase.swift
+++ b/Sources/TranscriptedCore/Stats/StatsDatabase.swift
@@ -95,8 +95,22 @@ public final class StatsDatabase {
     private func configureOpenDatabase() {
         isDatabaseOpen = true
         FileManager.default.restrictToOwnerOnly(atPath: dbPath.path)
-        // WAL mode for crash safety, busy timeout to avoid SQLITE_BUSY, NORMAL sync for performance
-        sqlite3_exec(db, "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA synchronous=NORMAL;", nil, nil, nil)
+        // Security: check each PRAGMA return value so a silent failure (e.g. WAL mode refused
+        // because another process holds the db) is logged rather than silently misconfiguring
+        // the database. Matches the same pattern used in SpeakerDatabase.configureOpenDatabase().
+        let pragmas = [
+            ("journal_mode=WAL", "journal_mode"),
+            ("busy_timeout=5000", "busy_timeout"),
+            ("synchronous=NORMAL", "synchronous")
+        ]
+        for (pragma, name) in pragmas {
+            var errorMessage: UnsafeMutablePointer<CChar>?
+            if sqlite3_exec(db, "PRAGMA \(pragma);", nil, nil, &errorMessage) != SQLITE_OK {
+                let detail = errorMessage.map { String(cString: $0) } ?? "unknown"
+                AppLogger.stats.error("PRAGMA failed", ["pragma": name, "detail": detail])
+                sqlite3_free(errorMessage)
+            }
+        }
     }
 
     /// Verify database integrity using PRAGMA quick_check.


### PR DESCRIPTION
## Summary

Automated nightly security audit (2026-04-11). Two fixes applied; remaining findings are either pre-existing tree issues or accepted/mitigated risks.

---

## Fixes

### Medium — Force-unwrap on audio thread (`MicRecordingFileMerger.swift:86`)

**Vulnerability:** `pointer.baseAddress! + offset` force-unwrapped inside `writeSamples`. Swift's `UnsafeBufferPointer.baseAddress` is nil for empty buffers. While the loop condition guarantees non-empty state at that point, a force-unwrap crash on the audio callback thread would silently abort the mic recording with no error surfaced to the user.

**Fix:** Replaced `!` with `guard let base = pointer.baseAddress else { return }`.

---

### Low/Medium — PRAGMA errors silently discarded (`StatsDatabase.swift:99`)

**Vulnerability:** `sqlite3_exec` was called with a single multi-statement PRAGMA string and its return value was not checked. If WAL mode or busy-timeout setup failed (e.g. another process holding the file), the database would silently continue with unsafe settings (no WAL crash-safety, no busy timeout → SQLITE_BUSY).

**Fix:** Separated into individual PRAGMA calls with return-value checks and error logging, matching the identical pattern already used in `SpeakerDatabase.configureOpenDatabase`.

---

## Other findings (no fix needed)

| Finding | Disposition |
|---------|-------------|
| `try!` regex in `BetaTelemetry.swift:170–176` | Patterns are compile-time literals; `try!` is intentional — a crash is safer than shipping unredacted PII. Low risk. `#if BETA_BUILD` only. |
| SQL string interpolation in `SpeakerDatabase` PRAGMA | Source array is hardcoded in the same function; not attacker-controlled. Accepted. |
| `isSafeModelFilename` dot check | Correctly checks for lone `.` path *components*, not extension dots — no false positives. |
| `BetaConfig` token placeholder | By design; `BetaTelemetry.activeToken()` explicitly guards against placeholder value. |
| Audio file permission race window | `restrictToOwnerOnly` is called synchronously before first write; nanosecond window on a single-user Mac is accepted. |
| Third-party mirror fallback in `ModelDownloadService` | SHA-256 integrity check on every downloaded file mitigates MITM risk from `hf-mirror.com`. |
| `backend/` directory | Not present in tree. |

---

## Test results

- `run-tests.sh`: **239 tests, 0 failed** ✓  
- `build.sh` / `swift test` / `run-integration-smoke.sh`: pre-existing failures in `SpeakerPeopleSettingsSection.swift` and `RetroactiveSpeakerUpdaterTests.swift` unrelated to these changes (confirmed via `git stash` before/after comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)