### PR TITLE
[codex] Fix meeting warmup readiness reporting

### DIFF
--- a/Sources/Meeting/MeetingModelDownloader.swift
+++ b/Sources/Meeting/MeetingModelDownloader.swift
@@ -21,7 +21,7 @@ final class MeetingModelDownloader {
     }
 
     /// Ensure both STT and diarization models are loaded before the first meeting
-    /// recording starts. Safe to call multiple times — each underlying engine is
+    /// recording starts. Safe to call multiple times - each underlying engine is
     /// idempotent after first successful load.
     ///
     /// Network reachability is checked first so we can short-circuit with a clear
@@ -32,27 +32,41 @@ final class MeetingModelDownloader {
             return
         }
 
+        let startedAt = Date()
+
         // Kick both initializers in parallel. Each is idempotent and each owns
         // its own progress reporting via @Published properties on the engines.
-        async let sttReady: Void = stt.initialize()
-        async let diarReady: Void = diarization.initialize()
-        _ = await (sttReady, diarReady)
+        do {
+            async let sttReady: Void = stt.initialize()
+            async let diarReady: Void = diarization.initialize()
+            _ = await (sttReady, diarReady)
 
-        // After both returns, confirm they actually reached a usable state.
-        guard stt.isReady else {
-            throw NSError(domain: "MeetingModelDownloader", code: 2, userInfo: [
-                NSLocalizedDescriptionKey: "Parakeet STT failed to load."
-            ])
-        }
-        guard diarization.modelState == .ready else {
-            let detail: String
-            switch diarization.modelState {
-            case .failed(let msg): detail = msg
-            default: detail = "unknown state"
+            // After both returns, confirm they actually reached a usable state.
+            guard stt.isReady else {
+                throw NSError(domain: "MeetingModelDownloader", code: 2, userInfo: [
+                    NSLocalizedDescriptionKey: "Parakeet STT failed to load."
+                ])
             }
-            throw NSError(domain: "MeetingModelDownloader", code: 3, userInfo: [
-                NSLocalizedDescriptionKey: "Diarization models failed to load: \(detail)"
+            guard diarization.modelState == .ready else {
+                let detail: String
+                switch diarization.modelState {
+                case .failed(let msg): detail = msg
+                default: detail = "unknown state"
+                }
+                throw NSError(domain: "MeetingModelDownloader", code: 3, userInfo: [
+                    NSLocalizedDescriptionKey: "Diarization models failed to load: \(detail)"
+                ])
+            }
+
+            AppLogger.pipeline.info("Meeting model warmup complete", [
+                "elapsed_ms": "\(Int(Date().timeIntervalSince(startedAt) * 1000))"
             ])
+        } catch {
+            AppLogger.pipeline.error("Meeting model warmup failed", [
+                "elapsed_ms": "\(Int(Date().timeIntervalSince(startedAt) * 1000))",
+                "error": error.localizedDescription
+            ])
+            throw error
         }
     }
 }

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -537,20 +537,14 @@ final class MeetingSessionController: ObservableObject {
     private func refreshWarmupStatus() {
         let dictationState = parakeetEngine.modelDownloadState
         let meetingState = diarization.modelState
-        let shouldSurfaceMeetingWarmup: Bool
-
-        switch state {
-        case .loadingModels:
-            shouldSurfaceMeetingWarmup = true
-        case .error:
-            if case .failed = meetingState {
-                shouldSurfaceMeetingWarmup = true
-            } else {
-                shouldSurfaceMeetingWarmup = false
-            }
-        default:
-            shouldSurfaceMeetingWarmup = false
+        let isMeetingWarmupInFlight = modelPreparationTask != nil || state == .loadingModels
+        let hasMeetingWarmupFailure: Bool
+        if case .failed = meetingState {
+            hasMeetingWarmupFailure = true
+        } else {
+            hasMeetingWarmupFailure = false
         }
+        let shouldSurfaceMeetingWarmup = isMeetingWarmupInFlight || hasMeetingWarmupFailure
 
         if case .ready = dictationState, case .ready = meetingState {
             warmupStatus = .ready


### PR DESCRIPTION
## Summary
This fixes a startup/warmup UX issue surfaced during the performance audit.

Current logs showed the app advertising full readiness before meeting transcription was actually ready:
- Parakeet `models_loaded` at `2026-04-11T01:53:03.237Z`
- `meeting_state_changed` to `ready` at `2026-04-11T01:53:07.741Z`
- gap: `4.504s`

## What changed
- Keep meeting warmup visible while the background `modelPreparationTask` is still in flight instead of collapsing to `.ready` as soon as dictation finishes loading.
- Log total meeting model warmup duration and failures in one place so later audits can measure startup cost directly.

## Why
This is mostly a readiness/reporting issue rather than a dictation throughput issue.

The same audit showed:
- dictation STT remained fast (`16` recent transcription events averaged `0.149s` elapsed, average RTF `0.029`)
- storage-path helper access and current markdown corpus scans were measurable but small locally

That makes meeting warmup the highest-leverage measured startup cost from this run.

## Impact
- The UI no longer says "ready" while meeting diarization is still loading.
- Startup telemetry is better grounded for the next performance pass.

## Validation
- `bash run-tests.sh` ✅
- `bash build-deps.sh --force` ✅
- `bash build.sh` ❌ blocked by unrelated existing compile errors in `Sources/UI/SpeakerPeopleSettingsSection.swift` against the current `TranscriptSaver` API
- `bash run-integration-smoke.sh` ❌ blocked by unrelated existing API drift in `Tests/TranscriptedCoreTests/RetroactiveSpeakerUpdaterTests.swift`

## Follow-up
The next measured performance target is still `DiarizationService.initialize()`: defer or parallelize part of diarizer warmup once the unrelated build drift is cleaned up so the change can be re-measured safely.