### PR TITLE
[codex] refresh repo and agent guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,10 @@
 7. `Sources/TranscriptedCore/CLAUDE.md` when touching the shared library
 8. `Tests/README.md`
 9. `docs/storage-paths.md`
-10. `Sources/Observability/CLAUDE.md` when touching crash reporting, event forwarding, beta telemetry, or app updates
-11. `docs/release-packaging.md` when touching packaging, signing, notarization, or user-facing releases
-12. `docs/sparkle-updates.md` when touching app updates or cutting a release users should receive in-app
+10. `Sources/Reliability/CLAUDE.md` when touching wake / sleep recovery or hotkey recovery
+11. `Sources/Observability/CLAUDE.md` when touching crash reporting, event forwarding, beta telemetry, or app updates
+12. `docs/release-packaging.md` when touching packaging, signing, notarization, or user-facing releases
+13. `docs/sparkle-updates.md` when touching app updates or cutting a release users should receive in-app
 
 ## Directory map
 
@@ -49,6 +50,7 @@ Current source-of-truth docs:
 - `Sources/CLAUDE.md`
 - `Sources/Dictation/CLAUDE.md`
 - `Sources/Meeting/CLAUDE.md`
+- `Sources/Reliability/CLAUDE.md`
 - `Sources/Observability/CLAUDE.md`
 - `Sources/TranscriptedCore/CLAUDE.md`
 - `Tests/README.md`
@@ -147,17 +149,10 @@ Rules:
 
 ## Storage
 
-Current persisted data on `main` defaults to Transcripted-named roots:
+Current persisted data on `main` uses Draft-named compatibility roots:
 
-- app support root: `~/Library/Application Support/Transcripted/`
-- default capture library: `~/Library/Application Support/Transcripted/captures/`
-- dictations: `<capture-library>/dictations/`
-- meetings: `<capture-library>/meetings/`
-- app-owned state: `~/Library/Application Support/Transcripted/state/`
-- logs: `~/Library/Application Support/Transcripted/logs/`
-- temporary recordings: `~/Library/Application Support/Transcripted/tmp/recordings/`
-
-The capture library can be moved in Settings. Legacy `Draft` paths remain only
-for migration/cleanup flows and some standalone-tool fallback logic.
+- app support root: `~/Library/Application Support/Draft/`
+- dictations: `~/Library/Application Support/Draft/dictations/`
+- meetings: `~/Library/Application Support/Draft/meetings/`
 
 See `docs/storage-paths.md` for the full map, including `TranscriptedCore` standalone defaults.

--- a/Sources/API/CLAUDE.md
+++ b/Sources/API/CLAUDE.md
@@ -1,17 +1,15 @@
-# API directory
+# API
 
 ## Current status
 
-`Sources/API/` currently contains only `BetaConfig.swift`.
+`Sources/API/` currently contains only beta-build configuration.
 
-The older `GeminiEngine` / `KeychainHelper` documentation that used to live here does not match the current tree on `main`.
+## Important file
 
-## Current file
+- `BetaConfig.swift` — `#if BETA_BUILD` constants for proxy token, proxy base URL, app version, and update URL
 
-- `BetaConfig.swift` — `#if BETA_BUILD` constants for the beta proxy token, proxy base URL, app version, and update URL
+## Notes
 
-## Agent notes
-
-- Core dictation and meeting flows on `main` do not depend on a live app-side API client in this directory.
-- If you need network or beta-backend context, read `archive/backend-beta-worker/README.md` and the beta-only files under `Sources/Observability/`.
-- Verify any old references to `GeminiEngine`, API keys, or chat-drafting HTTP paths against the actual source tree before changing code.
+- the core dictation and meeting flows do not depend on a live app-side API client here
+- networked beta behavior lives mostly in `Sources/Observability/`
+- older docs mentioning `GeminiEngine`, keychain helpers, or chat-drafting HTTP paths do not match the current tree

--- a/Sources/Accessibility/CLAUDE.md
+++ b/Sources/Accessibility/CLAUDE.md
@@ -1,15 +1,17 @@
 # Accessibility
 
-## What This Contains
+## What this directory owns
 
-Accessibility and AXUIElement helpers for positioning Transcripted near the focused text field and reading editable text context.
+`Sources/Accessibility/` is the small AX bridge used to understand the
+currently focused editor so Transcripted can place UI near it and recover text
+context safely.
 
-Current Swift files: **1**
+## Important file
 
-| File | Purpose |
-|---|---|
-| `AccessibilityBridge.swift` | AXUIElement queries for focused-element metadata, text values, bounds, and related accessibility helpers |
+- `AccessibilityBridge.swift` — AXUIElement queries for focused-element metadata, text values, bounds, and related accessibility helpers
 
-## Notes
-- This directory is intentionally small and focused.
-- Use it when the app needs to discover where to place UI relative to the currently focused editor.
+## Guardrails
+
+- keep this directory small and focused
+- prefer reading focused-element metadata over adding product logic here
+- changes here can affect overlay placement and paste-back behavior across the app

--- a/Sources/Reliability/CLAUDE.md
+++ b/Sources/Reliability/CLAUDE.md
@@ -1,0 +1,34 @@
+# Reliability
+
+## What this directory owns
+
+`Sources/Reliability/` contains cross-cutting runtime recovery logic that does
+not belong to the UI, capture, or speech subsystems directly.
+
+## Important file
+
+- `WakeRecoveryCoordinator.swift` — deduplicates system-wake recovery, retries hotkey re-registration, waits for runtime readiness, and avoids duplicate recovery work across near-simultaneous wake signals
+
+## Current behavior
+
+- `TranscriptedAppDelegate` listens for `NSWorkspace.didWakeNotification`
+- `TranscriptedAppState.handleSystemWake()` delegates recovery here
+- hotkeys are unregistered and re-registered with bounded retries
+- repeated wake calls reuse an in-flight or just-completed recovery task briefly to avoid stampedes
+
+## Guardrails
+
+- keep this layer UI-free and dependency-injected through closures
+- recovery should coordinate existing subsystem behavior, not duplicate it
+- changes here can affect both dictation and meeting hotkeys after sleep / wake
+
+## Verify
+
+```bash
+bash build.sh
+bash run-tests.sh
+```
+
+Manual check:
+
+- sleep and wake the Mac, then confirm hotkeys still work and the app does not enter duplicate recovery loops


### PR DESCRIPTION
## Summary
- add a local guide for  so wake and hotkey recovery has explicit documentation
- add the reliability guide to  so future agents know when to read it
- tighten the  and  docs around the current tree

## Why
The original PR #254 no longer merged cleanly after  moved, but a few doc improvements from that work are still useful and accurate on today’s tree.

## Validation
- docs-only change
- no build or test commands run
