### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -15,6 +15,7 @@
 - `MeetingSessionController.swift` — top-level meeting state machine, model warmup, capture start/stop, queued transcription handoff, failed-meeting actions, and transcript restyling
 - `MeetingStoragePaths.swift` — current split meeting storage layout across the capture library, app state, logs, and temp folders
 - `MeetingTranscriptStyler.swift` — restyles saved transcripts and renames files after save
+- `TranscriptSaver+AppSpeakerMaintenance.swift` — app-side speaker rename/merge compatibility helper that refreshes the agent index after `TranscriptedCore` rewrites transcript speaker names
 
 ## End-to-end flow
 

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -13,7 +13,7 @@
 
 Draft-mode UI is not an active product path in this worktree.
 
-## Files (40 Swift files)
+## Files (32 Swift files)
 
 ### Dictation Overlay
 

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -121,7 +121,7 @@ Binary path after build:
 ## Relationships
 
 - reads meeting sidecars written by `Sources/TranscriptedCore/Storage/AgentOutput.swift`
-- reads dictation sidecars written by `Sources/Dictation/DictationAgentOutput.swift`
+- reads dictation markdown day files written by `Sources/Dictation/DictationTranscriptWriter.swift`
 - mirrors speaker-name matching logic from the app with `NameVariants.swift`
 - has no compile-time dependency on the main Transcripted app target
 


### PR DESCRIPTION
## Summary
- add the new Meeting speaker-maintenance helper to `Sources/Meeting/CLAUDE.md`
- correct the live Swift file count in `Sources/UI/CLAUDE.md` after overlay/menu cleanup
- update `Tools/TranscriptedMCP/CLAUDE.md` to point at the current dictation markdown writer instead of the removed `DictationAgentOutput.swift`

## Why
These docs drifted behind recent cleanup and observability-related merges, so this sync keeps the local CLAUDE.md guidance aligned with the current codebase.