### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -166,7 +166,7 @@ class ParakeetEngine: ObservableObject {
     private var asrManager: AsrManager?
     private var audioWatchdogTask: Task<Void, Never>?
     private var asrManagerReady = false
-    private var didReceiveAudioSamples = false
+    private nonisolated(unsafe) var didReceiveAudioSamples = false
 
     var isModelLoaded: Bool { asrManagerReady }
 
@@ -615,6 +615,7 @@ class ParakeetEngine: ObservableObject {
             return false
         }
 
+        let tapSampleRate = nativeSampleRate
         inputNode.installTap(onBus: 0, bufferSize: TranscriptedConstants.audioTapBufferSize, format: monoFormat) { [weak self] buffer, _ in
             guard let self = self,
                   let channelData = buffer.floatChannelData?[0] else { return }
@@ -627,7 +628,7 @@ class ParakeetEngine: ObservableObject {
                         message: "Audio samples started flowing",
                         context: [
                             "audio_device": self.inputDeviceName,
-                            "sample_rate": "\(self.nativeSampleRate)",
+                            "sample_rate": "\(tapSampleRate)",
                             "frames": "\(frameLength)"
                         ])
                 }
@@ -636,7 +637,7 @@ class ParakeetEngine: ObservableObject {
             // Consumer 1: optional live streaming display (currently disabled).
             if self.liveDisplayEnabled, let eou = self.eouManager {
                 let rawSamples = Array(UnsafeBufferPointer(start: channelData, count: frameLength))
-                let resampled = AudioResampler.resample(rawSamples, from: self.nativeSampleRate, to: 16000)
+                let resampled = AudioResampler.resample(rawSamples, from: tapSampleRate, to: 16000)
                 self.streamingSamplesLock.lock()
                 self.streamingSampleBuffer.append(contentsOf: resampled)
                 var chunk: [Float]? = nil


### PR DESCRIPTION
## Summary
- fix an audio-thread isolation violation in `ParakeetEngine`
- avoid reading mutable MainActor state directly from the audio tap callback
- verify the repo build/test flow after the fix

## Findings fixed
### Threading
- Marked `didReceiveAudioSamples` as `nonisolated(unsafe)` because it is intentionally mutated from the AVAudioEngine tap callback, not the MainActor.
- Captured the tap sample rate before installing the audio tap so the callback no longer reads mutable actor-isolated state while running on the audio thread.

## Verification
- `bash build-deps.sh`
- `bash build.sh`
- `bash run-tests.sh`

## Notes
- The requested `xcodebuild -project Transcripted.xcodeproj -scheme Transcripted -configuration Debug build` command could not be used as-is because this checkout does not contain `Transcripted.xcodeproj`. Verification used the repo's checked-in build flow instead.