### PR TITLE
refactor: nightly simplification sweep [automated]

### DIFF
--- a/Sources/Observability/AnalyticsReporter.swift
+++ b/Sources/Observability/AnalyticsReporter.swift
@@ -47,7 +47,7 @@ final class AnalyticsReporter {
     static let shared = AnalyticsReporter()
 
     static var isAvailable: Bool {
-        AnalyticsRuntimeConfiguration.apiKey() != nil && AnalyticsRuntimeConfiguration.host() != nil
+        shared.apiKey != nil && shared.captureHost != nil
     }
 
     static func track(_ event: String, properties: [String: String] = [:]) {
@@ -101,6 +101,10 @@ final class AnalyticsReporter {
 
     private init() {}
 
+    // Config is read once from env/plist/overrides file and cached for the app lifetime.
+    private let apiKey: String? = AnalyticsRuntimeConfiguration.apiKey()
+    private let captureHost: String? = AnalyticsRuntimeConfiguration.host()
+    private static let isoDateFormatter = ISO8601DateFormatter()
     private let storageKey = "observability-anonymous-analytics-id"
     private let sessionID = UUID().uuidString
     private let session: URLSession = {
@@ -121,8 +125,8 @@ final class AnalyticsReporter {
 
     private func trackEvent(_ event: String, properties: [String: String]) {
         guard AnalyticsPreferences.isEnabled() else { return }
-        guard let apiKey = AnalyticsRuntimeConfiguration.apiKey(),
-              let host = AnalyticsRuntimeConfiguration.host(),
+        guard let apiKey,
+              let captureHost,
               let policy = AnalyticsEventPolicy.policy(forEvent: event) else {
             return
         }
@@ -142,12 +146,12 @@ final class AnalyticsReporter {
             "api_key": apiKey,
             "event": policy.name,
             "distinct_id": distinctID,
-            "timestamp": ISO8601DateFormatter().string(from: Date()),
+            "timestamp": Self.isoDateFormatter.string(from: Date()),
             "properties": eventProperties,
         ]
 
         guard let data = try? JSONSerialization.data(withJSONObject: payload),
-              let url = URL(string: normalizedCaptureURL(from: host)) else {
+              let url = URL(string: normalizedCaptureURL(from: captureHost)) else {
             return
         }
 

--- a/Sources/Observability/CrashReporter.swift
+++ b/Sources/Observability/CrashReporter.swift
@@ -82,8 +82,6 @@ final class CrashReporter {
         shared.hasStarted = true
     }
 
-    func refreshPreference() {}
-
     func capture(error: Error, context: String = "") {
         var extra: [String: String] = [:]
         if !context.isEmpty {

--- a/Sources/UI/PermissionsOnboardingView.swift
+++ b/Sources/UI/PermissionsOnboardingView.swift
@@ -198,7 +198,6 @@ struct PermissionsOnboardingView: View {
     private func updateCrashReportingPreference(_ enabled: Bool) {
         crashReportingEnabled = enabled
         CrashReportingPreferences.setEnabled(enabled)
-        CrashReporter.shared.refreshPreference()
     }
 
     private func updateAnalyticsPreference(_ enabled: Bool) {

--- a/Sources/UI/TranscriptedSettingsView.swift
+++ b/Sources/UI/TranscriptedSettingsView.swift
@@ -71,7 +71,6 @@ struct TranscriptedSettingsView: View {
                         set: { newValue in
                             crashReportingEnabled = newValue
                             CrashReportingPreferences.setEnabled(newValue)
-                            CrashReporter.shared.refreshPreference()
                             sentryTestStatus = nil
                         }
                     ))


### PR DESCRIPTION
## Summary

- **Cache PostHog config on first access** (`AnalyticsReporter`): `apiKey` and `captureHost` are now stored as instance properties set at `init()` time, so `AnalyticsRuntimeConfiguration.apiKey()` / `.host()` (which internally call `NSDictionary(contentsOf:)` — a disk read — for local dev overrides) are called exactly once per app session instead of on every `track()` event and every settings view render.
- **Cache `ISO8601DateFormatter`** as `static let` on `AnalyticsReporter`: eliminates one expensive formatter allocation per analytics event.
- **Remove empty `CrashReporter.refreshPreference()` stub**: the old implementation updated a cached `userEnabled` field; the new Sentry SDK integration reads `CrashReportingPreferences.isEnabled()` directly in `beforeSend`, so the method was dead. Removed the method and its two call sites in `PermissionsOnboardingView` and `TranscriptedSettingsView`.

## Test plan

- [x] `bash build.sh` — clean build, no warnings
- [x] `bash run-tests.sh` — 133/133 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)