### PR TITLE
security: nightly security audit findings [automated]

### DIFF
--- a/Sources/TranscriptedCore/Services/ModelDownloadService.swift
+++ b/Sources/TranscriptedCore/Services/ModelDownloadService.swift
@@ -377,11 +377,21 @@ public enum ModelDownloadService {
         )
     }
 
-    /// Compute the SHA-256 hex digest of a file.
-    /// Security: used to verify model file integrity after download from mirrors.
+    /// Compute the SHA-256 hex digest of a file by streaming it in chunks.
+    /// Security: avoids loading large model files (potentially several GB) entirely into memory.
+    /// A naive Data(contentsOf:) call could exhaust RAM and crash the app before the integrity
+    /// check completes, letting a compromised mirror bypass SHA-256 verification by serving an
+    /// oversized file. Streaming caps peak memory at one chunk (1MB) regardless of file size.
     static func sha256Hex(of url: URL) throws -> String {
-        let data = try Data(contentsOf: url)
-        let digest = CryptoKit.SHA256.hash(data: data)
+        let fileHandle = try FileHandle(forReadingFrom: url)
+        defer { try? fileHandle.close() }
+        var hasher = CryptoKit.SHA256()
+        let chunkSize = 1024 * 1024 // 1MB chunks — large enough for throughput, small enough for memory safety
+        while true {
+            guard let chunk = try fileHandle.read(upToCount: chunkSize), !chunk.isEmpty else { break }
+            hasher.update(data: chunk)
+        }
+        let digest = hasher.finalize()
         return digest.map { String(format: "%02x", $0) }.joined()
     }
 }


### PR DESCRIPTION
## Summary

Automated nightly security audit (2026-04-12). One medium-severity finding fixed; no critical or high findings.

## Findings

### Medium — OOM bypass of SHA-256 integrity verification (`ModelDownloadService.swift`)

**What:** `sha256Hex(of:)` used `Data(contentsOf: url)` to load a downloaded model file entirely into memory before hashing it. Model files can be several GB. A compromised third-party mirror (`hf-mirror.com`) could serve an oversized response that exhausts RAM and crashes the app before the integrity check completes — effectively bypassing the SHA-256 verification that is supposed to prevent malicious model weights.

**Fix:** Replaced the monolithic load with a streaming `FileHandle` loop reading 1MB chunks at a time. Peak memory is now O(1) (one chunk) regardless of file size.

**File:** `Sources/TranscriptedCore/Services/ModelDownloadService.swift:382`

## No-issue areas (confirmed clean)

- **SQL injection**: All queries in `SpeakerDatabase` and `StatsDatabase` use `sqlite3_prepare_v2` + `sqlite3_bind_*`. No string interpolation in query paths. `PRAGMA table_info` table-name interpolation is allowlist-guarded.
- **Path traversal**: `RecordingValidator.validateSavePath` checks `..` components before symlink resolution, then rejects forbidden system prefixes on the resolved path. `FailedTranscriptionManager` validates deserialized audio paths against home directory boundary. `ModelDownloadService.isSafeModelFilename` rejects `..`, `.`, and absolute paths from API responses.
- **Secrets/credentials**: No hardcoded API keys or tokens in source. `BetaConfig.swift` uses a build-time placeholder replaced by `build-beta.sh`. Sentry DSN in `Info.plist` is a project-scoped ingest endpoint (low-sensitivity by design).
- **Unsafe operations**: No security-critical `try!` calls. Regex `try!` in sanitizers use compile-time literal patterns and are safe. No unguarded force unwraps in file handling or network code paths.
- **Race conditions**: Audio thread / main thread access is properly serialized — `SpeakerDatabase` and `StatsDatabase` use dedicated serial queues; `SystemAudioCapture` protects shared state with `NSLock`; audio file writes dispatch to dedicated queues.
- **Dependency security (Sparkle)**: `Info.plist` configures `SUFeedURL` over HTTPS and a `SUPublicEDKey` Ed25519 key, satisfying Sparkle's required code-signing verification. `SparkleUpdaterController` delegates entirely to Sparkle's standard updater.
- **Temp file handling**: `AudioFileManager` and `TranscriptSaver` call `FileManager.default.restrictToOwnerOnly(atPath:)` immediately after creating files. Speaker clip files are cleaned up by `SpeakerClipExtractor.cleanupClips` and `cleanupPendingNaming`.
- **Storage sandbox**: `CoreStoragePaths.default` roots all output under `~/Library/Application Support/Transcripted/`. No hard-coded absolute paths outside the user domain.
- **Backend**: `backend/` directory not present on this branch.

## Test plan

- [x] `bash build-deps.sh --force` — clean
- [x] `bash build.sh` — Build complete, signed
- [x] `bash run-tests.sh` — 133 tests, 133 passed
- [x] `bash run-integration-smoke.sh` — passed
- [x] `swift test` — 46 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)