### PR TITLE
[nightly-notes] Add release-impact prompt to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@
 - [ ] Privacy / local-first behavior reviewed
 - [ ] Storage path or migration impact reviewed
 - [ ] Public-facing copy stays concrete and matches current product scope
+- [ ] Release/update impact reviewed (`CFBundleShortVersionString`, `docs/appcast.xml`, or user-facing caveats if applicable)
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add a release/update-impact checkbox to the PR template
- prompt authors to call out version, appcast, and user-facing caveat implications when relevant

## Why
Nightly release-notes drafting depends on PRs clearly signaling whether a change affects update discovery or should surface in user-facing notes. This keeps that signal close to the merge path without changing runtime behavior.

## Validation
- reviewed the updated template locally
