### PR TITLE
[nightly-docs] Refresh storage and verification docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,10 +149,16 @@ Rules:
 
 ## Storage
 
-Current persisted data on `main` uses Draft-named compatibility roots:
+Current persisted data on `main` defaults to Transcripted-named Application
+Support roots:
 
-- app support root: `~/Library/Application Support/Draft/`
-- dictations: `~/Library/Application Support/Draft/dictations/`
-- meetings: `~/Library/Application Support/Draft/meetings/`
+- app support root: `~/Library/Application Support/Transcripted/`
+- default capture library: `~/Library/Application Support/Transcripted/captures/`
+- dictations: `~/Library/Application Support/Transcripted/captures/dictations/`
+- meetings: `~/Library/Application Support/Transcripted/captures/meetings/`
+
+The user can relocate the capture library in Settings via
+`transcriptSaveLocation`. App-owned state, cache, logs, and temp files stay
+under `~/Library/Application Support/Transcripted/`.
 
 See `docs/storage-paths.md` for the full map, including `TranscriptedCore` standalone defaults.

--- a/Sources/Observability/CLAUDE.md
+++ b/Sources/Observability/CLAUDE.md
@@ -44,3 +44,4 @@ Useful files while testing:
 
 - `~/Library/Application Support/Transcripted/logs/debug.log`
 - `~/Library/Application Support/Transcripted/logs/events.jsonl`
+- `~/Library/Application Support/Transcripted/logs/app.jsonl` for embedded `TranscriptedCore` JSONL logs and QA validation

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -13,7 +13,7 @@
 
 Draft-mode UI is not an active product path in this worktree.
 
-## Files (40 Swift files)
+## Files (32 Swift files)
 
 ### Dictation Overlay
 

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -2,17 +2,16 @@
 
 ## Test Surfaces
 
-This repo has three distinct verification layers:
+This repo has four distinct verification layers:
 
 1. `bash run-tests.sh`
    Curated fast test runner built with raw `swiftc`
-2. `swift test`
-   Swift Package tests for the standalone `TranscriptedCore` package surface
-3. `bash run-integration-smoke.sh`
+2. `bash run-integration-smoke.sh`
    App-to-core linkage smoke test
-
-`bash build.sh` is also part of normal verification because the app build is
-not driven by Xcode or package test discovery.
+3. `swift test`
+   Swift Package tests for the standalone `TranscriptedCore` package surface
+4. `bash build.sh`
+   Authoritative app build for the menubar target
 
 ## Fast Test Runner
 
@@ -46,6 +45,8 @@ Use this when changing:
 
 `bash run-integration-smoke.sh` verifies that the app-side dependency bundle
 still exposes the `TranscriptedCore` types that `Sources/Meeting/` depends on.
+It also runs the wake-recovery smoke binary and currently finishes with
+`swift test --filter MicRecordingFileMergerTests`.
 
 Run it whenever you touch:
 

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -41,17 +41,17 @@ When docs disagree, prefer:
 
 ## Validation Layers
 
-This repo has three different test/build surfaces that agents should treat as
+This repo has four different verification surfaces that agents should treat as
 distinct:
 
 - `bash build.sh`
   The authoritative app build.
 - `bash run-tests.sh`
   Curated fast tests for app-facing logic.
-- `swift test`
-  SPM tests for `TranscriptedCore`.
 - `bash run-integration-smoke.sh`
   App/Core integration smoke.
+- `swift test`
+  SPM tests for `TranscriptedCore`.
 
 Rule of thumb:
 

--- a/docs/storage-paths.md
+++ b/docs/storage-paths.md
@@ -52,10 +52,15 @@ and then injected into `TranscriptedCore` through `CoreStoragePaths`.
 
 ## Logs And Events
 
-Observability output currently lives under:
+App-side observability output currently lives under:
 
 - debug log: `~/Library/Application Support/Transcripted/logs/debug.log`
 - events: `~/Library/Application Support/Transcripted/logs/events.jsonl`
+
+The embedded `TranscriptedCore` logger also writes JSONL under the same logs
+directory:
+
+- core pipeline log: `~/Library/Application Support/Transcripted/logs/app.jsonl`
 
 ## `TranscriptedCore` Defaults
 
@@ -76,4 +81,4 @@ The standalone tools do not all resolve paths the same way:
 
 - `TranscriptedCLI` prefers `~/Library/Application Support/Transcripted/captures/{meetings,dictations}/`, then falls back to legacy Draft `.../transcripts/` folders, then `~/Documents/Transcripted/`
 - `TranscriptedMCP` follows the same Transcripted -> Draft -> `~/Documents/Transcripted/` order and keeps its SQLite index under `~/Library/Application Support/Transcripted/cache/` by default
-- `TranscriptedQA` now defaults to the current Transcripted meetings/state/log layout, falls back to legacy Draft and then `~/Documents/Transcripted/`, and accepts explicit `--path`, `--state-dir`, and `--log-path` overrides for nonstandard setups
+- `TranscriptedQA` now defaults to the current Transcripted meetings/state/log layout, uses `~/Library/Application Support/Transcripted/logs/app.jsonl` for log validation, falls back to legacy Draft and then `~/Documents/Transcripted/`, and accepts explicit `--path`, `--state-dir`, and `--log-path` overrides for nonstandard setups


### PR DESCRIPTION
## Summary
- update repo docs to reflect Transcripted-named storage roots instead of stale Draft defaults
- clarify that app logs (`debug.log`, `events.jsonl`) and embedded core logs (`app.jsonl`) coexist under the Transcripted logs directory
- refresh verification docs to match the current smoke/test flow and fix the current UI CLAUDE file count

## Verification
- docs-only sweep against live repo tree, scripts, Info.plist, and storage/logging code paths
- no source changes or runtime tests were needed