### PR TITLE
[nightly-retrieval] Fix CLI retrieval build and dictation parsing

### DIFF
--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -63,10 +63,16 @@ swift run transcripted-cli list-dictations --count 5
 swift run transcripted-cli diarize /path/to/audio.wav --json
 ```
 
+When the repo-level dependency bundle is missing, `swift build` still builds the
+local context commands so agent retrieval can work on a fresh checkout. The
+offline audio commands (`diarize` and `batch`) then exit with an explicit
+instruction to run `bash build-deps.sh` from the repo root before rebuilding.
+
 ## Gotchas
 
 - the context commands and the diarization commands serve different users, do not describe the whole package as diarization-only
 - the diarization commands depend on repo-level artifacts, so run `bash build-deps.sh` first when those are missing
+- retrieval-only commands should still build and run even when the diarization bundle is absent
 - the default context resolver prefers Transcripted capture folders, then falls back to Draft-era exports, then `~/Documents/Transcripted/`
 - `DiarizerConfigCompatibility.swift` currently keeps old bounded-speaker call sites compiling; it does not reintroduce upstream behavior by itself
 - changes here should be verified independently from the app build

--- a/Tools/TranscriptedCLI/Package.swift
+++ b/Tools/TranscriptedCLI/Package.swift
@@ -7,6 +7,17 @@ let repoRoot = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
     .deletingLastPathComponent()
     .path
+let fileManager = FileManager.default
+let depsModulesRoot = "\(repoRoot)/deps-modules"
+let depsFrameworksRoot = "\(repoRoot)/deps-frameworks"
+let depsLibsRoot = "\(repoRoot)/deps-libs"
+let fluidAudioModuleCandidates = [
+    "\(depsModulesRoot)/FluidAudio.swiftmodule",
+    "\(depsModulesRoot)/FluidAudio.swiftmodule/arm64-apple-macos.swiftmodule",
+]
+let hasDiarizationDeps = fluidAudioModuleCandidates.contains(where: { fileManager.fileExists(atPath: $0) })
+    && fileManager.fileExists(atPath: "\(depsLibsRoot)/libDraftDeps.a")
+    && fileManager.fileExists(atPath: "\(depsFrameworksRoot)/ESpeakNG.framework")
 
 let package = Package(
     name: "TranscriptedCLI",
@@ -21,19 +32,20 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             path: "Sources/TranscriptedCLI",
-            swiftSettings: [
+            swiftSettings: hasDiarizationDeps ? [
+                .define("TRANSCRIPTEDCLI_WITH_DIARIZATION"),
                 .unsafeFlags([
-                    "-F", "\(repoRoot)/deps-frameworks",
-                    "-I", "\(repoRoot)/deps-modules",
-                    "-I", "\(repoRoot)/deps-modules/FastClusterWrapper",
-                    "-I", "\(repoRoot)/deps-modules/MachTaskSelfWrapper",
-                    "-I", "\(repoRoot)/deps-modules/yyjson",
+                    "-F", depsFrameworksRoot,
+                    "-I", depsModulesRoot,
+                    "-I", "\(depsModulesRoot)/FastClusterWrapper",
+                    "-I", "\(depsModulesRoot)/MachTaskSelfWrapper",
+                    "-I", "\(depsModulesRoot)/yyjson",
                 ]),
-            ],
-            linkerSettings: [
+            ] : [],
+            linkerSettings: hasDiarizationDeps ? [
                 .unsafeFlags([
-                    "-F\(repoRoot)/deps-frameworks",
-                    "-L\(repoRoot)/deps-libs",
+                    "-F\(depsFrameworksRoot)",
+                    "-L\(depsLibsRoot)",
                     "-lDraftDeps",
                     "-lc++",
                 ]),
@@ -45,7 +57,7 @@ let package = Package(
                 .linkedFramework("CoreAudio"),
                 .linkedFramework("AVFoundation"),
                 .linkedFramework("Network"),
-            ]
+            ] : []
         ),
     ]
 )

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/BatchCommand.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/BatchCommand.swift
@@ -1,5 +1,7 @@
 import ArgumentParser
 import Foundation
+
+#if TRANSCRIPTEDCLI_WITH_DIARIZATION
 import FluidAudio
 
 struct Batch: AsyncParsableCommand {
@@ -109,3 +111,29 @@ struct Batch: AsyncParsableCommand {
         print(summaryJSON)
     }
 }
+#else
+struct Batch: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Run offline diarization on all audio files in a directory."
+    )
+
+    @Argument(help: "Directory containing audio files.")
+    var audioDir: String
+
+    @Option(name: .long, help: "Path to JSON config file for diarizer parameters.")
+    var config: String?
+
+    @Option(name: .long, help: "Path to directory containing diarization models.")
+    var modelsDir: String?
+
+    @Option(name: .long, help: "Output directory for RTTM files. Defaults to audio directory.")
+    var outputDir: String?
+
+    @Option(name: .long, help: "Audio file extension to process.")
+    var ext: String = "m4a"
+
+    func run() async throws {
+        throw ValidationError("Offline diarization dependencies are unavailable. Run `bash build-deps.sh` from the repo root, then rebuild `transcripted-cli`.")
+    }
+}
+#endif

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ConfigLoader.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ConfigLoader.swift
@@ -1,4 +1,6 @@
 import Foundation
+
+#if TRANSCRIPTEDCLI_WITH_DIARIZATION
 import FluidAudio
 
 /// JSON-decodable config that maps 1:1 to OfflineDiarizerConfig's flat init.
@@ -41,3 +43,4 @@ enum ConfigLoader {
         return config.toOfflineDiarizerConfig()
     }
 }
+#endif

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -604,9 +604,26 @@ enum CLIContextStore {
     }
 
     private static func parseDictationEntries(from body: String) -> [CLIClientDictationEntry] {
-        let sections = body.components(separatedBy: "\n## ").filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-        return sections.compactMap { rawSection in
-            let section = rawSection.hasPrefix("## ") ? rawSection : "## " + rawSection
+        let lines = body.components(separatedBy: "\n")
+        var sections: [String] = []
+        var currentSection: [String] = []
+
+        for line in lines {
+            if line.hasPrefix("## ") {
+                if !currentSection.isEmpty {
+                    sections.append(currentSection.joined(separator: "\n"))
+                }
+                currentSection = [line]
+            } else if !currentSection.isEmpty {
+                currentSection.append(line)
+            }
+        }
+
+        if !currentSection.isEmpty {
+            sections.append(currentSection.joined(separator: "\n"))
+        }
+
+        return sections.compactMap { section in
             let lines = section.components(separatedBy: "\n")
             guard let heading = lines.first, heading.hasPrefix("## ") else { return nil }
             let title = heading.replacingOccurrences(of: "## ", with: "")
@@ -623,13 +640,14 @@ enum CLIContextStore {
             var characterCount = 0
             var bodyLines: [String] = []
             var inBody = false
+            var sawMetadata = false
 
             for line in lines.dropFirst() {
                 let trimmed = line.trimmingCharacters(in: .whitespaces)
                 if trimmed.isEmpty {
-                    if !inBody {
+                    if !inBody, sawMetadata {
                         inBody = true
-                    } else {
+                    } else if inBody {
                         bodyLines.append("")
                     }
                     continue
@@ -641,29 +659,40 @@ enum CLIContextStore {
                 }
 
                 if trimmed.hasPrefix("Entry ID:") {
+                    sawMetadata = true
                     entryId = trimmed.replacingOccurrences(of: "Entry ID:", with: "")
                         .trimmingCharacters(in: .whitespacesAndNewlines)
                         .trimmingCharacters(in: CharacterSet(charactersIn: "`"))
                 } else if trimmed.hasPrefix("Captured:") {
+                    sawMetadata = true
                     createdAt = trimmed.replacingOccurrences(of: "Captured:", with: "")
                         .trimmingCharacters(in: .whitespacesAndNewlines)
                 } else if trimmed.hasPrefix("Source app:") {
+                    sawMetadata = true
                     sourceAppName = trimmed.replacingOccurrences(of: "Source app:", with: "")
                         .trimmingCharacters(in: .whitespacesAndNewlines)
                 } else if trimmed.hasPrefix("Bundle ID:") {
+                    sawMetadata = true
                     sourceAppBundleId = trimmed.replacingOccurrences(of: "Bundle ID:", with: "")
                         .trimmingCharacters(in: .whitespacesAndNewlines)
                         .trimmingCharacters(in: CharacterSet(charactersIn: "`"))
                 } else if trimmed.hasPrefix("Delivery:") {
+                    sawMetadata = true
                     delivery = trimmed.replacingOccurrences(of: "Delivery:", with: "")
                         .trimmingCharacters(in: .whitespacesAndNewlines)
                 } else if trimmed.hasPrefix("Words:") {
+                    sawMetadata = true
                     wordCount = Int(trimmed.replacingOccurrences(of: "Words:", with: "").trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
                 } else if trimmed.hasPrefix("Characters:") {
+                    sawMetadata = true
                     characterCount = Int(trimmed.replacingOccurrences(of: "Characters:", with: "").trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
                 } else if trimmed.hasPrefix("Timestamp:") {
+                    sawMetadata = true
                     createdAt = trimmed.replacingOccurrences(of: "Timestamp:", with: "")
                         .trimmingCharacters(in: .whitespacesAndNewlines)
+                } else if !sawMetadata {
+                    inBody = true
+                    bodyLines.append(line)
                 }
             }
 

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/DiarizeCommand.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/DiarizeCommand.swift
@@ -1,5 +1,7 @@
 import ArgumentParser
 import Foundation
+
+#if TRANSCRIPTEDCLI_WITH_DIARIZATION
 import FluidAudio
 
 struct Diarize: AsyncParsableCommand {
@@ -123,3 +125,29 @@ struct Diarize: AsyncParsableCommand {
         }
     }
 }
+#else
+struct Diarize: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        abstract: "Run offline diarization on a single audio file."
+    )
+
+    @Argument(help: "Path to audio file (WAV, M4A, etc.)")
+    var audioPath: String
+
+    @Option(name: .long, help: "Path to JSON config file for diarizer parameters.")
+    var config: String?
+
+    @Option(name: .long, help: "Path to directory containing diarization models.")
+    var modelsDir: String?
+
+    @Option(name: .shortAndLong, help: "Output RTTM file path. Prints to stdout if omitted.")
+    var output: String?
+
+    @Flag(name: .long, help: "Output JSON with full segment data instead of RTTM.")
+    var json: Bool = false
+
+    func run() async throws {
+        throw ValidationError("Offline diarization dependencies are unavailable. Run `bash build-deps.sh` from the repo root, then rebuild `transcripted-cli`.")
+    }
+}
+#endif

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/DiarizerConfigCompatibility.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/DiarizerConfigCompatibility.swift
@@ -1,3 +1,4 @@
+#if TRANSCRIPTEDCLI_WITH_DIARIZATION
 import FluidAudio
 
 extension OfflineDiarizerConfig {
@@ -12,3 +13,4 @@ extension OfflineDiarizerConfig {
         return self
     }
 }
+#endif

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/RTTMWriter.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/RTTMWriter.swift
@@ -1,4 +1,6 @@
 import Foundation
+
+#if TRANSCRIPTEDCLI_WITH_DIARIZATION
 import FluidAudio
 
 enum RTTMWriter {
@@ -24,3 +26,4 @@ enum RTTMWriter {
         }
     }
 }
+#endif


### PR DESCRIPTION
## Summary
- let `transcripted-cli` build in retrieval-only mode when repo audio deps are missing
- return a clear `build-deps.sh` prerequisite error from `diarize` and `batch` instead of failing compilation
- fix CLI dictation parsing so recency sorting, entry counts, and source app summaries use real metadata

## Verification
- `cd Tools/TranscriptedCLI && swift build`
- `cd Tools/TranscriptedMCP && swift build`
- `cd Tools/TranscriptedMCP && swift test`
- `cd Tools/TranscriptedCLI && ./.build/debug/transcripted-cli context-recent --count 4 --json`
- `cd Tools/TranscriptedCLI && ./.build/debug/transcripted-cli list-dictations --count 3 --json`
- `cd Tools/TranscriptedCLI && ./.build/debug/transcripted-cli context-search excited --kind meeting --speaker Peter --count 3 --meetings-dir "$HOME/Documents/Transcripted" --dictations-dir "$HOME/Library/Application Support/Transcripted/captures/dictations" --json`
- `cd Tools/TranscriptedCLI && ./.build/debug/transcripted-cli diarize /tmp/does-not-matter.wav`
- `bash run-tests.sh`

## Notes
- `bash build.sh` still fails in this worktree because the repo does not currently have `deps-libs/`, `deps-modules/`, or `deps-frameworks/`; the app build continues to require `bash build-deps.sh --force` first.
