### PR TITLE
[nightly-security] Harden SQLite sidecar permissions

### DIFF
--- a/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
@@ -83,7 +83,7 @@ public final class SpeakerDatabase: @unchecked Sendable {
     /// Called on both initial open and corruption-recovery re-open.
     private func configureOpenDatabase() {
         isDatabaseOpen = true
-        FileManager.default.restrictToOwnerOnly(atPath: dbPath.path)
+        FileManager.default.restrictSQLiteArtifactsToOwnerOnly(atPath: dbPath.path)
         // WAL mode for crash safety, busy timeout to avoid SQLITE_BUSY, NORMAL sync for performance
         let pragmas = [
             ("journal_mode=WAL", "WAL"),
@@ -133,6 +133,7 @@ public final class SpeakerDatabase: @unchecked Sendable {
         );
         """
         executeSQL(sql)
+        FileManager.default.restrictSQLiteArtifactsToOwnerOnly(atPath: dbPath.path)
         migrateSchema()
     }
 

--- a/Sources/TranscriptedCore/Stats/StatsDatabase.swift
+++ b/Sources/TranscriptedCore/Stats/StatsDatabase.swift
@@ -94,7 +94,7 @@ public final class StatsDatabase {
     /// Called on both initial open and corruption-recovery re-open.
     private func configureOpenDatabase() {
         isDatabaseOpen = true
-        FileManager.default.restrictToOwnerOnly(atPath: dbPath.path)
+        FileManager.default.restrictSQLiteArtifactsToOwnerOnly(atPath: dbPath.path)
         // Security: check each PRAGMA return value so a silent failure (e.g. WAL mode refused
         // because another process holds the db) is logged rather than silently misconfiguring
         // the database. Matches the same pattern used in SpeakerDatabase.configureOpenDatabase().
@@ -191,6 +191,7 @@ public final class StatsDatabase {
         executeSQL(createDailyActivityTable)
         executeSQL(createDateIndex)
         executeSQL(createDateTimeIndex)
+        FileManager.default.restrictSQLiteArtifactsToOwnerOnly(atPath: dbPath.path)
     }
 
     func executeSQL(_ sql: String) {

--- a/Sources/TranscriptedCore/Utilities/FilePermissions.swift
+++ b/Sources/TranscriptedCore/Utilities/FilePermissions.swift
@@ -7,4 +7,19 @@ extension FileManager {
     func restrictToOwnerOnly(atPath path: String) {
         try? setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
     }
+
+    /// SQLite writes sensitive state into `-wal` and `-shm` sidecars alongside the
+    /// main database file. Harden all three artifacts together so write-ahead data
+    /// does not drift to broader default permissions than the primary database.
+    func restrictSQLiteArtifactsToOwnerOnly(atPath path: String) {
+        let artifacts = [
+            path,
+            path + "-wal",
+            path + "-shm",
+        ]
+
+        for artifact in artifacts where fileExists(atPath: artifact) {
+            restrictToOwnerOnly(atPath: artifact)
+        }
+    }
 }

--- a/Tests/TranscriptedCoreTests/DatabaseFilePermissionsTests.swift
+++ b/Tests/TranscriptedCoreTests/DatabaseFilePermissionsTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import TranscriptedCore
+
+@available(macOS 14.0, *)
+final class DatabaseFilePermissionsTests: XCTestCase {
+
+    func testStatsDatabaseRestrictsSQLiteArtifactsToOwnerOnly() {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DatabaseFilePermissionsStats-\(UUID().uuidString).sqlite")
+        defer { cleanupSQLiteArtifacts(at: databaseURL) }
+
+        let database = StatsDatabase(path: databaseURL.path)
+        database.recordSession(
+            RecordingMetadata(
+                id: "permission-check",
+                date: Date(),
+                durationSeconds: 90
+            )
+        )
+        database.queue.sync {}
+
+        assertSQLiteArtifactsAreOwnerOnly(at: databaseURL)
+    }
+
+    func testSpeakerDatabaseRestrictsSQLiteArtifactsToOwnerOnly() {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DatabaseFilePermissionsSpeakers-\(UUID().uuidString).sqlite")
+        defer { cleanupSQLiteArtifacts(at: databaseURL) }
+
+        let database = SpeakerDatabase(path: databaseURL.path)
+        _ = database.addOrUpdateSpeaker(embedding: Array(repeating: 0.25, count: 256))
+        database.queue.sync {}
+
+        assertSQLiteArtifactsAreOwnerOnly(at: databaseURL)
+    }
+
+    private func assertSQLiteArtifactsAreOwnerOnly(at databaseURL: URL, file: StaticString = #filePath, line: UInt = #line) {
+        for suffix in ["", "-wal", "-shm"] {
+            let artifactURL = URL(fileURLWithPath: databaseURL.path + suffix)
+            XCTAssertTrue(
+                FileManager.default.fileExists(atPath: artifactURL.path),
+                "Expected SQLite artifact to exist: \(artifactURL.lastPathComponent)",
+                file: file,
+                line: line
+            )
+
+            let attributes = try? FileManager.default.attributesOfItem(atPath: artifactURL.path)
+            let permissions = attributes?[.posixPermissions] as? NSNumber
+            XCTAssertEqual(
+                permissions,
+                NSNumber(value: 0o600),
+                "SQLite artifact should be restricted to owner-only permissions: \(artifactURL.lastPathComponent)",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    private func cleanupSQLiteArtifacts(at databaseURL: URL) {
+        for suffix in ["", "-wal", "-shm"] {
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: databaseURL.path + suffix))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- harden `speakers.sqlite` and `stats.sqlite` sidecar artifacts by applying owner-only permissions to the main DB plus `-wal` and `-shm`
- apply the SQLite artifact hardening on open and immediately after schema creation so both existing and newly created sidecars are covered
- add package tests that exercise real SpeakerDatabase and StatsDatabase writes and assert `0600` permissions on all SQLite artifacts

## Why
The repo's prior security review identified a privacy gap where sensitive SQLite write-ahead sidecars could retain broader default permissions than the primary database file. Transcripted treats local artifact privacy as a product requirement, so the database sidecars need the same owner-only hardening as transcripts, audio files, and logs.

## Validation
- `bash ./build.sh`
- `bash ./run-tests.sh`
- `bash ./run-integration-smoke.sh`
- `swift test`