### PR TITLE
[nightly-telemetry] Track no-speech dictation exits

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -43,6 +43,13 @@ struct AnalyticsEventPolicy: Equatable {
                 "trigger",
             ]
         ),
+        "dictation_no_speech": .init(
+            name: "dictation_no_speech",
+            allowedProperties: [
+                "duration_bucket",
+                "trigger",
+            ]
+        ),
         "meeting_recording_started": .init(
             name: "meeting_recording_started",
             allowedProperties: [

--- a/Sources/UI/DictationSessionController.swift
+++ b/Sources/UI/DictationSessionController.swift
@@ -305,6 +305,15 @@ class DictationSessionController: ObservableObject {
                 appState.logger.log("DICTATION | no transcription, cancelling")
                 EventReporter.shared.capture(level: .warning, engine: "overlay", event: "no_voice_input",
                     message: "Dictation transcription empty")
+                AnalyticsReporter.track(
+                    "dictation_no_speech",
+                    properties: [
+                        "duration_bucket": AnalyticsReporter.durationBucket(
+                            seconds: CFAbsoluteTimeGetCurrent() - sessionStartTime
+                        ),
+                        "trigger": currentDictationTrigger.rawValue,
+                    ]
+                )
                 AppSoundPlayer.shared.play(.noSpeech)
                 overlayController.showNoSpeechAndDismiss()
                 isDictating = false

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -3,10 +3,13 @@ import Foundation
 func testAnalyticsEventPolicy() {
     runSuite("AnalyticsEventPolicy only permits reviewed analytics events") {
         let dictationCompleted = AnalyticsEventPolicy.policy(forEvent: "dictation_completed")
+        let dictationNoSpeech = AnalyticsEventPolicy.policy(forEvent: "dictation_no_speech")
         let meetingFailed = AnalyticsEventPolicy.policy(forEvent: "meeting_transcript_failed")
         let unknown = AnalyticsEventPolicy.policy(forEvent: "raw_transcript_uploaded")
 
         assertEqual(dictationCompleted?.allowedProperties.contains("word_count_bucket"), true, "dictation completion should allow bucketed word counts")
+        assertEqual(dictationNoSpeech?.allowedProperties.contains("duration_bucket"), true, "dictation no-speech should keep a coarse duration bucket")
+        assertEqual(dictationNoSpeech?.allowedProperties.contains("trigger"), true, "dictation no-speech should preserve trigger attribution")
         assertEqual(meetingFailed?.allowedProperties.contains("failure_kind"), true, "meeting failures should allow normalized failure kinds")
         assertNil(unknown, "unreviewed analytics events should not be allowed")
     }

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -62,6 +62,7 @@ PostHog controls described below.
 - `dictation_started`
 - `dictation_completed`
 - `dictation_cancelled`
+- `dictation_no_speech`
 - `meeting_recording_started`
 - `meeting_recording_stopped`
 - `meeting_transcript_saved`


### PR DESCRIPTION
## Summary
- add a privacy-safe `dictation_no_speech` analytics event on the existing no-voice-input dictation path
- allowlist the event with only coarse `trigger` and `duration_bucket` properties
- document the new event and add a regression test for the analytics policy

## Why
Recent product signal shows dictation is the active workflow, but PostHog only captured `83` dictation starts vs `61` completions and `0` cancellations over the last 7 days. The missing gap is the no-speech exit path: it already emits a local observability event (`overlay.no_voice_input`) but never reaches PostHog, so roughly a quarter of recent dictation sessions are invisible in product analytics.

This change closes that blind spot without broadening Sentry payloads or sending sensitive content.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`