### PR TITLE
[nightly-artifact] restore meeting agent artifacts and safe log appends

### DIFF
--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -303,6 +303,8 @@ enum MeetingTranscriptStyler {
 
         do {
             try fm.moveItem(at: url, to: targetURL)
+            renameSiblingJSONIfNeeded(in: url.deletingLastPathComponent(), fromStem: url.deletingPathExtension().lastPathComponent, toStem: targetURL.deletingPathExtension().lastPathComponent)
+            updateAgentIndexIfNeeded(in: url.deletingLastPathComponent(), fromStem: url.deletingPathExtension().lastPathComponent, toStem: targetURL.deletingPathExtension().lastPathComponent)
             return targetURL
         } catch {
             return url
@@ -339,6 +341,49 @@ enum MeetingTranscriptStyler {
             candidateStem = "\(preferredStem) \(suffix)"
             suffix += 1
         }
+    }
+
+    private static func renameSiblingJSONIfNeeded(in directory: URL, fromStem: String, toStem: String) {
+        guard fromStem != toStem else { return }
+
+        let fm = FileManager.default
+        let originalURL = directory.appendingPathComponent(fromStem).appendingPathExtension("json")
+        let targetURL = directory.appendingPathComponent(toStem).appendingPathExtension("json")
+
+        guard fm.fileExists(atPath: originalURL.path),
+              !fm.fileExists(atPath: targetURL.path) else { return }
+
+        try? fm.moveItem(at: originalURL, to: targetURL)
+    }
+
+    private static func updateAgentIndexIfNeeded(in directory: URL, fromStem: String, toStem: String) {
+        guard fromStem != toStem else { return }
+
+        let indexURL = directory.appendingPathComponent("transcripted.json")
+        guard let data = try? Data(contentsOf: indexURL),
+              var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              var transcripts = json["transcripts"] as? [[String: Any]] else {
+            return
+        }
+
+        var didChange = false
+        for idx in transcripts.indices {
+            guard let filename = transcripts[idx]["filename"] as? String,
+                  filename == fromStem else {
+                continue
+            }
+            transcripts[idx]["filename"] = toStem
+            didChange = true
+        }
+
+        guard didChange else { return }
+
+        json["transcripts"] = transcripts
+        guard let updated = try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys]) else {
+            return
+        }
+
+        try? updated.write(to: indexURL, options: .atomic)
     }
 }
 

--- a/Sources/TranscriptedCore/Logging/FileLogger.swift
+++ b/Sources/TranscriptedCore/Logging/FileLogger.swift
@@ -26,10 +26,10 @@ final class FileLogger: @unchecked Sendable {
         return f
     }()
 
-    init(paths: CoreStoragePaths = .default) {
+    init(paths: CoreStoragePaths = .default, isDisabledOverride: Bool? = nil) {
         // Disable file logging during test runs to avoid polluting production logs
         let isTestRun = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
-        self.isDisabled = isTestRun
+        self.isDisabled = isDisabledOverride ?? isTestRun
 
         let logsDir = paths.logs
         try? FileManager.default.createDirectory(at: logsDir, withIntermediateDirectories: true)
@@ -88,6 +88,7 @@ final class FileLogger: @unchecked Sendable {
             // when multiple app instances write to the same log file simultaneously
             let fd = handle.fileDescriptor
             flock(fd, LOCK_EX)
+            handle.seekToEndOfFile()
             handle.write(data)
             flock(fd, LOCK_UN)
         }

--- a/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
@@ -156,11 +156,40 @@ public class TranscriptSaver {
             healthInfo: healthInfo
         )
 
+        let artifactSpeakerStore = speakerStore ?? SpeakerDatabase.shared
+
         // Serialize file writes to prevent concurrent corruption with retroactive speaker updates
         let savedURL: URL? = fileUpdateQueue.sync {
             do {
                 try markdown.write(to: fileURL, atomically: true, encoding: .utf8)
                 FileManager.default.restrictToOwnerOnly(atPath: fileURL.path)
+
+                let stem = fileURL.deletingPathExtension().lastPathComponent
+                do {
+                    try AgentOutput.writeTranscriptJSON(
+                        from: result,
+                        transcriptId: transcriptId,
+                        speakerMappings: speakerMappings,
+                        speakerDbIds: speakerDbIds,
+                        to: saveDir,
+                        stem: stem
+                    )
+                } catch {
+                    AppLogger.pipeline.error("Failed to write agent JSON sidecar", [
+                        "error": error.localizedDescription,
+                        "file": "\(stem).json"
+                    ])
+                }
+
+                do {
+                    try AgentOutput.writeIndex(to: saveDir, speakerStore: artifactSpeakerStore)
+                } catch {
+                    AppLogger.pipeline.error("Failed to write agent index", [
+                        "error": error.localizedDescription,
+                        "file": "transcripted.json"
+                    ])
+                }
+
                 AppLogger.pipeline.info("Transcript saved", ["path": fileURL.path])
 
                 return fileURL

--- a/Tests/MeetingTranscriptStylerTests.swift
+++ b/Tests/MeetingTranscriptStylerTests.swift
@@ -3,6 +3,7 @@ import Foundation
 func testMeetingTranscriptStyler() {
     runSuite("MeetingTranscriptStylerTests") {
         testMeetingTranscriptStylerRenamesArtifacts()
+        testMeetingTranscriptStylerRenamesSiblingArtifacts()
         testMeetingTranscriptStylerIsIdempotent()
     }
 }
@@ -23,6 +24,33 @@ private func testMeetingTranscriptStylerRenamesArtifacts() {
     assertTrue(FileManager.default.fileExists(atPath: styled.url.path), "Renamed markdown should exist")
     assertFalse(FileManager.default.fileExists(atPath: transcriptURL.path), "Original markdown should be replaced")
     assertTrue(updatedMarkdown?.contains("# Meeting with Alex") == true, "Markdown body should be rewritten with the canonical title")
+}
+
+private func testMeetingTranscriptStylerRenamesSiblingArtifacts() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let originalStem = "Call_2026-04-07_09-14-00"
+    let transcriptURL = directory.appendingPathComponent("\(originalStem).md")
+    let sidecarURL = directory.appendingPathComponent("\(originalStem).json")
+    let indexURL = directory.appendingPathComponent("transcripted.json")
+
+    try? sampleMeetingTranscript().write(to: transcriptURL, atomically: true, encoding: .utf8)
+    try? """
+    {"version":"1.0","transcript_id":"abc","recording":{"date":"2026-04-07T09:14:00-0500","duration_seconds":750,"dropped_segments":0,"engines":{"stt":"parakeet-tdt-v3","diarization":"pyannote-offline"}},"speakers":[],"utterances":[]}
+    """.write(to: sidecarURL, atomically: true, encoding: .utf8)
+    try? """
+    {"version":"1.0","updated_at":"2026-04-07T09:14:00-0500","transcript_count":1,"transcripts":[{"filename":"\(originalStem)","date":"2026-04-07","duration_seconds":750,"speaker_count":1,"word_count":42,"speakers":["Alex"]}],"known_speakers":[]}
+    """.write(to: indexURL, atomically: true, encoding: .utf8)
+
+    let styled = MeetingTranscriptStyler.restyleTranscript(at: transcriptURL)
+    let renamedSidecar = directory.appendingPathComponent("Meeting with Alex.json")
+    let indexText = try? String(contentsOf: indexURL, encoding: .utf8)
+
+    assertTrue(FileManager.default.fileExists(atPath: renamedSidecar.path), "Styler should move the sibling JSON sidecar with the markdown file")
+    assertFalse(FileManager.default.fileExists(atPath: sidecarURL.path), "Original JSON sidecar should be replaced")
+    assertTrue(indexText?.contains("\"filename\" : \"Meeting with Alex\"") == true, "Styler should update transcripted.json to the renamed stem")
+    assertTrue(styled.url.lastPathComponent == "Meeting with Alex.md", "Markdown rename should still use the canonical title")
 }
 
 private func testMeetingTranscriptStylerIsIdempotent() {

--- a/Tests/TranscriptedCoreTests/AgentOutputTests.swift
+++ b/Tests/TranscriptedCoreTests/AgentOutputTests.swift
@@ -24,4 +24,130 @@ final class AgentOutputTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: claudeURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: indexURL.path))
     }
+
+    func testTranscriptSaverWritesMarkdownSidecarAndIndex() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptSaverArtifactTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let persistentSpeakerId = UUID()
+        let result = TranscriptionResult(
+            micUtterances: [
+                TranscriptionUtterance(
+                    start: 0,
+                    end: 1.2,
+                    channel: 0,
+                    speakerId: 0,
+                    persistentSpeakerId: nil,
+                    matchSimilarity: nil,
+                    transcript: "Thanks for joining."
+                )
+            ],
+            systemUtterances: [
+                TranscriptionUtterance(
+                    start: 1.5,
+                    end: 4.2,
+                    channel: 1,
+                    speakerId: 1,
+                    persistentSpeakerId: persistentSpeakerId,
+                    matchSimilarity: 0.92,
+                    transcript: "Happy to help."
+                )
+            ],
+            duration: 5,
+            processingTime: 0.25
+        )
+
+        let speakerStore = TestSpeakerStore(
+            speakers: [
+                SpeakerProfile(
+                    id: persistentSpeakerId,
+                    displayName: "Alex",
+                    nameSource: NameSource.userManual,
+                    embedding: [Float](repeating: 0.5, count: 256),
+                    firstSeen: Date(timeIntervalSince1970: 0),
+                    lastSeen: Date(timeIntervalSince1970: 0),
+                    callCount: 3,
+                    confidence: 0.9,
+                    disputeCount: 0
+                )
+            ]
+        )
+
+        let savedURL = TranscriptSaver.saveTranscript(
+            result,
+            transcriptId: UUID(),
+            speakerMappings: [
+                "system_1": SpeakerMapping(
+                    speakerId: "1",
+                    identifiedName: "Alex",
+                    confidence: .high,
+                    isConfirmedIdentity: true
+                )
+            ],
+            speakerSources: ["1": "user_manual"],
+            speakerDbIds: ["1": persistentSpeakerId],
+            directory: root,
+            healthInfo: .perfect,
+            speakerStore: speakerStore,
+            statsStore: TestStatsStore()
+        )
+
+        XCTAssertNotNil(savedURL)
+
+        let files = try FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: nil)
+        let markdownFiles = files.filter { $0.pathExtension == "md" }
+        let jsonFiles = files.filter { $0.pathExtension == "json" && $0.lastPathComponent != "transcripted.json" }
+        let indexURL = root.appendingPathComponent("transcripted.json")
+
+        XCTAssertEqual(markdownFiles.count, 1)
+        XCTAssertEqual(jsonFiles.count, 1)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: indexURL.path))
+        XCTAssertEqual(markdownFiles[0].deletingPathExtension().lastPathComponent, jsonFiles[0].deletingPathExtension().lastPathComponent)
+
+        let sidecarData = try Data(contentsOf: jsonFiles[0])
+        let sidecar = try JSONSerialization.jsonObject(with: sidecarData) as? [String: Any]
+        let speakers = sidecar?["speakers"] as? [[String: Any]]
+        XCTAssertEqual(speakers?.count, 2)
+        XCTAssertEqual(speakers?.last?["persistent_speaker_id"] as? String, persistentSpeakerId.uuidString)
+
+        let indexData = try Data(contentsOf: indexURL)
+        let index = try JSONSerialization.jsonObject(with: indexData) as? [String: Any]
+        let transcripts = index?["transcripts"] as? [[String: Any]]
+        XCTAssertEqual(transcripts?.count, 1)
+        XCTAssertEqual(transcripts?.first?["filename"] as? String, markdownFiles[0].deletingPathExtension().lastPathComponent)
+    }
+}
+
+@available(macOS 14.0, *)
+private final class TestSpeakerStore: SpeakerStore {
+    private let speakers: [SpeakerProfile]
+
+    init(speakers: [SpeakerProfile]) {
+        self.speakers = speakers
+    }
+
+    func matchSpeaker(embedding: [Float], threshold: Double) -> SpeakerMatchResult? { nil }
+    func addOrUpdateSpeaker(embedding: [Float], existingId: UUID?) -> SpeakerProfile { speakers[0] }
+    func getSpeaker(id: UUID) -> SpeakerProfile? { speakers.first { $0.id == id } }
+    func allSpeakers() -> [SpeakerProfile] { speakers }
+    func setDisplayName(id: UUID, name: String, source: String) {}
+    func restoreProfile(_ profile: SpeakerProfile) {}
+    func deleteSpeaker(id: UUID) {}
+    func mergeProfiles(sourceId: UUID, into targetId: UUID) {}
+    func mergeProfilesByName() {}
+    func mergeDuplicates() {}
+    func pruneWeakProfiles() {}
+    func incrementDisputeCount(id: UUID) {}
+    func resetDisputeCount(id: UUID) {}
+    func findProfilesByName(_ name: String) -> [SpeakerProfile] { [] }
+}
+
+@available(macOS 14.0, *)
+private final class TestStatsStore: StatsStore {
+    func recordSession(_ metadata: RecordingMetadata) {}
+    func getTotalRecordingsCount() -> Int { 0 }
+    func getRecordings(from startDate: Date, to endDate: Date) -> [RecordingMetadata] { [] }
+    func recordingExists(transcriptPath: String) -> Bool { false }
 }

--- a/Tests/TranscriptedCoreTests/FileLoggerTests.swift
+++ b/Tests/TranscriptedCoreTests/FileLoggerTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import TranscriptedCore
+
+@available(macOS 14.0, *)
+final class FileLoggerTests: XCTestCase {
+
+    func testMultipleLoggersAppendWithoutOverwritingEarlierEntries() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FileLoggerTests-\(UUID().uuidString)", isDirectory: true)
+        let logs = root.appendingPathComponent("logs", isDirectory: true)
+        try FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let paths = CoreStoragePaths(
+            transcripts: root.appendingPathComponent("captures/meetings", isDirectory: true),
+            speakerDB: root.appendingPathComponent("state/speakers.sqlite"),
+            statsDB: root.appendingPathComponent("state/stats.sqlite"),
+            failedQueue: root.appendingPathComponent("state/failed_transcriptions.json"),
+            speakerClips: root.appendingPathComponent("tmp/recordings/speaker_clips", isDirectory: true),
+            audioCaptures: root.appendingPathComponent("tmp/recordings", isDirectory: true),
+            logs: logs
+        )
+
+        let first = FileLogger(paths: paths, isDisabledOverride: false)
+        let second = FileLogger(paths: paths, isDisabledOverride: false)
+
+        first.write(level: "info", subsystem: "app", message: "first", metadata: nil)
+        first.flush()
+        second.write(level: "info", subsystem: "app", message: "second", metadata: nil)
+        second.flush()
+        first.write(level: "info", subsystem: "app", message: "third", metadata: nil)
+        first.flush()
+
+        let logURL = logs.appendingPathComponent("app.jsonl")
+        let lines = try String(contentsOf: logURL, encoding: .utf8)
+            .split(separator: "\n")
+            .map(String.init)
+
+        XCTAssertEqual(lines.count, 3)
+
+        let messages = try lines.map { line -> String in
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            return try XCTUnwrap(object["m"] as? String)
+        }
+
+        XCTAssertEqual(messages, ["first", "second", "third"])
+    }
+}


### PR DESCRIPTION
## Summary
- restore JSON sidecar and `transcripted.json` writes during meeting transcript save
- keep renamed meeting artifacts in sync by moving the sibling `.json` and updating the index entry
- seek to EOF on every locked `app.jsonl` write so concurrent logger handles do not overwrite earlier lines
- add coverage for transcript save artifacts, sibling rename handling, and multi-logger append safety

## Verification
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `swift test`
- `cd Tools/TranscriptedQA && swift build`
- `cd Tools/TranscriptedQA && swift run transcripted-qa check-health`
- `cd Tools/TranscriptedQA && swift run transcripted-qa validate-all`

## Remaining local artifact failures
The rerun against the current machine's saved data still reports pre-existing local damage:
- `~/Library/Application Support/Transcripted/captures/meetings/Quick notes.md` has no `.json` sidecar
- `~/Library/Application Support/Transcripted/captures/meetings/Quick notes 2.md` has no `.json` sidecar
- `~/Library/Application Support/Transcripted/captures/meetings/transcripted.json` is missing
- `~/Library/Application Support/Transcripted/logs/app.jsonl` already contains malformed historic lines

This PR fixes the live generation/append paths so new artifacts should stop regressing, but it does not retro-repair the already-corrupt files on disk.