### PR TITLE
[codex] Defer launch audio prewarm

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -606,6 +606,7 @@ class ParakeetEngine: ObservableObject {
             return false
         }
 
+        installAudioObserversIfNeeded()
         recordingInterrupted = false
         didReceiveAudioSamples = false
         sampleBuffer.removeAll(keepingCapacity: true)

--- a/Sources/TranscriptedAppState.swift
+++ b/Sources/TranscriptedAppState.swift
@@ -106,8 +106,9 @@ class TranscriptedAppState: ObservableObject {
             )
         }
 
-        // ParakeetEngine handles its own wake recovery via NSWorkspace.didWakeNotification
-        // observer installed during prewarm(). No action needed here.
+        // ParakeetEngine handles its own wake recovery once its audio lifecycle
+        // observers are armed during first recording/prewarm. No app-level
+        // action needed here.
         EventReporter.shared.capture(
             level: result.hotkeysRecovered ? .info : .warning,
             engine: "app",
@@ -135,7 +136,9 @@ class TranscriptedAppState: ObservableObject {
             guard let self else { return }
             defer { self.runtimeReadinessTask = nil }
 
-            self.sttRouter.parakeetEngine.prewarm()
+            // Loading models at launch keeps first-use latency down without
+            // touching AVAudioEngine input nodes on the main thread. Sentry app
+            // hang reports showed launch-time prewarm blocking inside CoreAudio.
             guard !Task.isCancelled else { return }
             await self.sttRouter.parakeetEngine.initialize()
             guard !Task.isCancelled else { return }


### PR DESCRIPTION
## What changed
- stop calling Parakeet `prewarm()` during launch-time runtime readiness
- keep model initialization at launch so first-use latency still stays low
- arm the Parakeet audio lifecycle observers from `startRecording()` so wake/config recovery still works once audio is actually in use

## Why
Recent Sentry app-hang reports in production pointed at launch-time audio engine work. The newest report (`APPLE-MACOS-9`) had a weak stack, but related hang issues showed `AVAudioEngine` / `inputNode` activity around startup and audio engine lifecycle handling. Launch-time `prewarm()` was touching CoreAudio on the main actor before the user started recording.

This change defers audio-engine startup until the user actually records, which should reduce startup hangs without changing the normal recording path.

## Impact
- app launch should avoid unnecessary AVAudioEngine startup work
- recording still installs the same recovery observers before using audio
- this targets the startup/prewarm hang class, but does not claim to fix every hang signature in Sentry

## Validation
- `bash run-tests.sh`
- `bash build-deps.sh --force`
- `bash build.sh`

## Sentry context
- `APPLE-MACOS-9`
- related: `APPLE-MACOS-5`, `APPLE-MACOS-8`