### PR TITLE
[codex] Improve first-run onboarding flow

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -211,6 +211,13 @@ class ParakeetEngine: ObservableObject {
             return
         }
 
+        switch modelDownloadState {
+        case .downloading, .loading:
+            return
+        case .notLoaded, .ready, .failed:
+            break
+        }
+
         // Request microphone permission early so it's granted before first recording
         if AVCaptureDevice.authorizationStatus(for: .audio) == .notDetermined {
             let granted = await withCheckedContinuation { continuation in

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -150,12 +150,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             }
             if !PermissionsOnboardingView.hasCompleted {
                 popover.contentViewController = NSHostingController(
-                    rootView: PermissionsOnboardingView(onComplete: { [weak self] in
-                        PermissionsOnboardingView.markCompleted()
-                        guard let self else { return }
-                        self.menuPanelController.refresh()
-                        self.popover?.contentViewController = self.menuPanelController
-                    })
+                    rootView: makeOnboardingView()
                 )
             } else {
                 menuPanelController.refresh()
@@ -182,6 +177,33 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         AgentConnectionWindowCoordinator.shared.show()
     }
 
+    private func makeOnboardingView() -> PermissionsOnboardingView {
+        PermissionsOnboardingView(
+            parakeetEngine: appState.sttRouter.parakeetEngine,
+            canStartDictation: lastExternalApplication != nil,
+            onStartDictation: { [weak self] in
+                self?.finishOnboardingAndStartDictation()
+            },
+            onComplete: { [weak self] in
+                self?.finishOnboarding()
+            }
+        )
+    }
+
+    private func finishOnboarding() {
+        PermissionsOnboardingView.markCompleted()
+        menuPanelController.refresh()
+        popover?.contentViewController = menuPanelController
+    }
+
+    private func finishOnboardingAndStartDictation() {
+        let sourceApp = resolvedSourceApp()
+        finishOnboarding()
+        closePopover()
+        sourceApp?.activate(options: [])
+        sessionController.startDictation(sourceApp: sourceApp, trigger: .onboarding)
+    }
+
     private func presentInitialOnboardingIfNeeded() {
         guard !PermissionsOnboardingView.hasCompleted, !hasPresentedInitialOnboarding else { return }
         hasPresentedInitialOnboarding = true
@@ -190,6 +212,20 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             guard let self, self.popover?.isShown != true, !PermissionsOnboardingView.hasCompleted else { return }
             self.togglePopover()
         }
+    }
+
+    private func resolvedSourceApp() -> NSRunningApplication? {
+        if let lastExternalApplication,
+           lastExternalApplication.bundleIdentifier != Bundle.main.bundleIdentifier {
+            return lastExternalApplication
+        }
+
+        if let frontmost = NSWorkspace.shared.frontmostApplication,
+           frontmost.bundleIdentifier != Bundle.main.bundleIdentifier {
+            return frontmost
+        }
+
+        return nil
     }
 
     // MARK: - NSPopoverDelegate

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -52,7 +52,13 @@ final class MenuBarPanelController: NSViewController {
     func refresh() {
         guard let content = contentView else { return }
         let warmupStatus = appState.meetingSession.warmupStatus
-        let isReady = warmupStatus == .ready
+        let dictationState = FirstRunExperience.dictationAction(
+            for: FirstRunLocalModelState(appState.sttRouter.parakeetEngine.modelDownloadState)
+        )
+        let meetingState = FirstRunExperience.meetingAction(
+            dictationReady: appState.sttRouter.isModelLoaded,
+            meetingsStatus: warmupStatus.meetingsStatus
+        )
 
         content.headerView.update(
             warmupStatus: warmupStatus,
@@ -62,7 +68,8 @@ final class MenuBarPanelController: NSViewController {
         content.shortcutsView.update(
             dictationKey: appState.contextCapture.dictationShortcutDisplay,
             meetingKey: appState.contextCapture.meetingShortcutDisplay,
-            isEnabled: isReady
+            dictationState: dictationState,
+            meetingState: meetingState
         )
 
         if #available(macOS 14.0, *) {

--- a/Sources/UI/MenuBar/MenuBarShortcutsView.swift
+++ b/Sources/UI/MenuBar/MenuBarShortcutsView.swift
@@ -19,7 +19,8 @@ final class MenuBarShortcutsView: NSView {
     )
     private var keyMonitor: Any?
     private var recordingTarget: RecordingTarget?
-    private var rowsEnabled = true
+    private var currentDictationState = MenuBarPrimaryActionState(isEnabled: true, subtitle: "Paste spoken text anywhere")
+    private var currentMeetingState = MenuBarPrimaryActionState(isEnabled: true, subtitle: "Capture mic and system audio")
 
     private enum RecordingTarget {
         case dictation
@@ -49,7 +50,7 @@ final class MenuBarShortcutsView: NSView {
 
     private func setupViews() {
         dictationRow.onPrimaryAction = { [weak self] in
-            guard let self, self.rowsEnabled, self.recordingTarget == nil else { return }
+            guard let self, self.currentDictationState.isEnabled, self.recordingTarget == nil else { return }
             self.onStartDictation?()
         }
         dictationRow.onEditShortcut = { [weak self] in
@@ -57,7 +58,7 @@ final class MenuBarShortcutsView: NSView {
         }
 
         meetingRow.onPrimaryAction = { [weak self] in
-            guard let self, self.rowsEnabled, self.recordingTarget == nil else { return }
+            guard let self, self.currentMeetingState.isEnabled, self.recordingTarget == nil else { return }
             self.onStartMeeting?()
         }
         meetingRow.onEditShortcut = { [weak self] in
@@ -97,23 +98,27 @@ final class MenuBarShortcutsView: NSView {
         )
     }
 
-    func update(dictationKey: String, meetingKey: String, isEnabled: Bool) {
-        rowsEnabled = isEnabled
-        resetButton.isEnabled = isEnabled && recordingTarget == nil
-        resetHintLabel.alphaValue = isEnabled ? 1.0 : 0.72
-        resetHintLabel.stringValue = isEnabled
-            ? "Click a shortcut badge to edit"
-            : "Shortcuts unlock when Transcripted finishes loading"
+    func update(
+        dictationKey: String,
+        meetingKey: String,
+        dictationState: MenuBarPrimaryActionState,
+        meetingState: MenuBarPrimaryActionState
+    ) {
+        currentDictationState = dictationState
+        currentMeetingState = meetingState
+        resetButton.isEnabled = recordingTarget == nil
+        resetHintLabel.alphaValue = 1.0
+        resetHintLabel.stringValue = "Click a shortcut badge to edit"
 
         dictationRow.update(
             symbolName: "mic.fill",
             title: "Dictation",
             subtitle: recordingTarget == .dictation
                 ? "Press shortcut…"
-                : (isEnabled ? "Paste spoken text anywhere" : "Local voice model is still loading"),
+                : dictationState.subtitle,
             key: recordingTarget == .dictation ? "Type keys" : dictationKey,
             isEditing: recordingTarget == .dictation,
-            isEnabled: isEnabled
+            isEnabled: dictationState.isEnabled
         )
 
         meetingRow.update(
@@ -121,17 +126,16 @@ final class MenuBarShortcutsView: NSView {
             title: "Record meeting",
             subtitle: recordingTarget == .meeting
                 ? "Press shortcut…"
-                : (isEnabled ? "Capture mic and system audio" : "Meeting tools unlock after startup warmup"),
+                : meetingState.subtitle,
             key: recordingTarget == .meeting ? "Type keys" : meetingKey,
             isEditing: recordingTarget == .meeting,
-            isEnabled: isEnabled
+            isEnabled: meetingState.isEnabled
         )
 
         needsLayout = true
     }
 
     private func startRecording(_ target: RecordingTarget) {
-        guard rowsEnabled else { return }
         stopRecording()
         recordingTarget = target
         refreshFromPreferences()
@@ -180,7 +184,8 @@ final class MenuBarShortcutsView: NSView {
         update(
             dictationKey: HotkeyPreferences.displayString(for: HotkeyPreferences.dictationBinding()),
             meetingKey: HotkeyPreferences.displayString(for: HotkeyPreferences.meetingBinding()),
-            isEnabled: rowsEnabled
+            dictationState: currentDictationState,
+            meetingState: currentMeetingState
         )
     }
 

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -15,6 +15,7 @@ class DictationSessionController: ObservableObject {
         case keyboardShortcut = "keyboard_shortcut"
         case overlayButton = "overlay_button"
         case menu = "menu"
+        case onboarding = "onboarding"
         case unknown = "unknown"
     }
 
@@ -486,6 +487,7 @@ class DictationSessionController: ObservableObject {
 
         startupTask?.cancel()
         updateLoadingOverlay(sourceApp: sourceApp)
+        retryModelWarmupIfNeeded()
 
         startupTask = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -520,6 +522,19 @@ class DictationSessionController: ObservableObject {
             self.startupTask = nil
             self.isDictating = false
             overlayController.showError("Dictation is still loading. Please try again in a moment.")
+        }
+    }
+
+    private func retryModelWarmupIfNeeded() {
+        guard let appState else { return }
+
+        switch appState.sttRouter.parakeetEngine.modelDownloadState {
+        case .notLoaded, .failed:
+            Task { @MainActor [weak appState] in
+                await appState?.sttRouter.parakeetEngine.initialize()
+            }
+        case .downloading, .loading, .ready:
+            break
         }
     }
 

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -5,7 +5,27 @@ import SwiftUI
 import AVFoundation
 import ApplicationServices
 
+extension FirstRunLocalModelState {
+    init(_ state: ParakeetModelState) {
+        switch state {
+        case .notLoaded:
+            self = .notLoaded
+        case .downloading(let progress):
+            self = .downloading(progress: progress)
+        case .loading:
+            self = .loading
+        case .ready:
+            self = .ready
+        case .failed(let message):
+            self = .failed(message)
+        }
+    }
+}
+
 struct PermissionsOnboardingView: View {
+    @ObservedObject private var parakeetEngine: ParakeetEngine
+    let canStartDictation: Bool
+    var onStartDictation: (() -> Void)?
     var onComplete: () -> Void
 
     @State private var micGranted = false
@@ -15,13 +35,25 @@ struct PermissionsOnboardingView: View {
     @State private var anonymousAnalyticsEnabled = AnalyticsPreferences.isEnabled()
     @State private var pollTimer: Timer?
 
+    init(
+        parakeetEngine: ParakeetEngine,
+        canStartDictation: Bool = false,
+        onStartDictation: (() -> Void)? = nil,
+        onComplete: @escaping () -> Void
+    ) {
+        _parakeetEngine = ObservedObject(wrappedValue: parakeetEngine)
+        self.canStartDictation = canStartDictation
+        self.onStartDictation = onStartDictation
+        self.onComplete = onComplete
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading, spacing: 10) {
                 Text("Welcome to Transcripted")
                     .font(.title3.weight(.semibold))
 
-                Text("Answer two quick privacy questions, then turn on the permissions you need to start dictating into any app right away. Meeting audio and meeting prompts can wait until you need them.")
+                Text("Start with one short dictation. Turn on Microphone and Accessibility first. Meeting audio and meeting prompts can wait until later.")
                     .font(.callout)
                     .foregroundStyle(MenuTokens.textSecondary)
 
@@ -39,6 +71,21 @@ struct PermissionsOnboardingView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 12) {
+                    ForEach(requiredPermissions) { kind in
+                        PermissionSetupCard(
+                            kind: kind,
+                            granted: isGranted(kind),
+                            action: { TranscriptedPermissionAccess.openSettings(for: kind) }
+                        )
+                    }
+
+                    LocalDictationModelCard(status: modelStatus)
+
+                    OptionalPermissionsCard(
+                        optionalPermissions: optionalPermissions,
+                        isGranted: isGranted
+                    )
+
                     ObservabilityConsentCard(
                         crashReportingEnabled: $crashReportingEnabled,
                         anonymousAnalyticsEnabled: $anonymousAnalyticsEnabled,
@@ -48,19 +95,6 @@ struct PermissionsOnboardingView: View {
                         onAnalyticsToggle: updateAnalyticsPreference
                     )
 
-                    ForEach(requiredPermissions) { kind in
-                        PermissionSetupCard(
-                            kind: kind,
-                            granted: isGranted(kind),
-                            action: { TranscriptedPermissionAccess.openSettings(for: kind) }
-                        )
-                    }
-
-                    OptionalPermissionsCard(
-                        optionalPermissions: optionalPermissions,
-                        isGranted: isGranted
-                    )
-
                     VStack(alignment: .leading, spacing: 10) {
                         Text("What happens next")
                             .font(.subheadline.weight(.semibold))
@@ -68,7 +102,9 @@ struct PermissionsOnboardingView: View {
                         QuickStartRow(
                             icon: "mic.fill",
                             title: "Dictation",
-                            detail: "Use the Dictation button or your shortcut to speak into any app."
+                            detail: canStartDictation
+                                ? "Use Start first dictation below and Transcripted will guide you into the first capture."
+                                : "Click back into any text field, then use Dictation from the Transcripted menu."
                         )
 
                         QuickStartRow(
@@ -97,15 +133,15 @@ struct PermissionsOnboardingView: View {
                 .overlay(MenuTokens.cardBorder)
 
             VStack(alignment: .leading, spacing: 10) {
-                Text(footerMessage)
+                Text(primaryAction.detail)
                     .font(.caption)
                     .foregroundStyle(MenuTokens.textSecondary)
 
-                Button(continueButtonTitle) {
-                    completeOnboarding()
+                Button(primaryAction.title) {
+                    handlePrimaryAction()
                 }
                 .buttonStyle(.borderedProminent)
-                .disabled(!hasRequiredPermissions)
+                .disabled(!primaryAction.isEnabled)
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 14)
@@ -135,18 +171,16 @@ struct PermissionsOnboardingView: View {
         TranscriptedPermissionKind.allCases.filter { !$0.isRequiredOnFirstLaunch }
     }
 
-    private var continueButtonTitle: String {
-        screenRecordingGranted ? "Continue to Transcripted" : "Continue without meeting audio"
+    private var modelStatus: FirstRunModelCardState {
+        FirstRunExperience.modelCard(for: FirstRunLocalModelState(parakeetEngine.modelDownloadState))
     }
 
-    private var footerMessage: String {
-        if hasRequiredPermissions {
-            return screenRecordingGranted
-                ? "Everything is ready. You can start dictating or record meetings from the menu."
-                : "Dictation is ready now. You can add meeting audio later from Settings."
-        }
-
-        return "Allow microphone and accessibility first. Those are the two pieces Transcripted needs to start dictating into other apps."
+    private var primaryAction: FirstRunPrimaryActionState {
+        FirstRunExperience.primaryAction(
+            hasRequiredPermissions: hasRequiredPermissions,
+            hasPasteTarget: canStartDictation && onStartDictation != nil,
+            modelState: FirstRunLocalModelState(parakeetEngine.modelDownloadState)
+        )
     }
 
     private func isGranted(_ kind: TranscriptedPermissionKind) -> Bool {
@@ -181,7 +215,12 @@ struct PermissionsOnboardingView: View {
         pollTimer = nil
     }
 
-    private func completeOnboarding() {
+    private func handlePrimaryAction() {
+        guard primaryAction.isEnabled else { return }
+        completeOnboarding(startFirstDictation: primaryAction.shouldStartDictation)
+    }
+
+    private func completeOnboarding(startFirstDictation: Bool = false) {
         guard hasRequiredPermissions else { return }
         stopPolling()
         AnalyticsReporter.track(
@@ -192,6 +231,10 @@ struct PermissionsOnboardingView: View {
                 "screen_recording_enabled": screenRecordingGranted ? "true" : "false",
             ]
         )
+        if startFirstDictation, let onStartDictation {
+            onStartDictation()
+            return
+        }
         onComplete()
     }
 
@@ -211,6 +254,73 @@ struct PermissionsOnboardingView: View {
 
     static func markCompleted() {
         UserDefaults.standard.set(true, forKey: "permissionsOnboardingCompleted")
+    }
+}
+
+private struct LocalDictationModelCard: View {
+    let status: FirstRunModelCardState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: iconName)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(iconColor)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(status.title)
+                        .font(.subheadline.weight(.semibold))
+
+                    Text(status.detail)
+                        .font(.caption)
+                        .foregroundStyle(MenuTokens.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 8)
+
+                Text(status.status)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(iconColor)
+            }
+
+            if let progress = status.progress, status.tone != .ready {
+                ProgressView(value: progress)
+                    .progressViewStyle(.linear)
+                    .tint(iconColor)
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(MenuTokens.cardBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(MenuTokens.cardBorder, lineWidth: 1)
+                )
+        )
+    }
+
+    private var iconName: String {
+        switch status.tone {
+        case .ready:
+            return "checkmark.circle.fill"
+        case .working:
+            return "arrow.down.circle.fill"
+        case .failed:
+            return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var iconColor: Color {
+        switch status.tone {
+        case .ready:
+            return MenuTokens.statusGreen
+        case .working:
+            return Color.accentColor
+        case .failed:
+            return Color.orange
+        }
     }
 }
 

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -23,6 +23,9 @@ extension FirstRunLocalModelState {
 }
 
 struct PermissionsOnboardingView: View {
+    private static let completionKey = "permissionsOnboardingCompleted"
+    private static let forceKey = "forcePermissionsOnboarding"
+
     @ObservedObject private var parakeetEngine: ParakeetEngine
     let canStartDictation: Bool
     var onStartDictation: (() -> Void)?
@@ -249,11 +252,14 @@ struct PermissionsOnboardingView: View {
     }
 
     static var hasCompleted: Bool {
-        UserDefaults.standard.bool(forKey: "permissionsOnboardingCompleted")
+        if UserDefaults.standard.bool(forKey: forceKey) {
+            return false
+        }
+        return UserDefaults.standard.bool(forKey: completionKey)
     }
 
     static func markCompleted() {
-        UserDefaults.standard.set(true, forKey: "permissionsOnboardingCompleted")
+        UserDefaults.standard.set(true, forKey: completionKey)
     }
 }
 

--- a/Sources/UI/Shared/FirstRunExperience.swift
+++ b/Sources/UI/Shared/FirstRunExperience.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+enum FirstRunLocalModelState: Equatable {
+    case notLoaded
+    case downloading(progress: Double)
+    case loading
+    case ready
+    case failed(String)
+}
+
+struct FirstRunPrimaryActionState: Equatable {
+    let title: String
+    let detail: String
+    let isEnabled: Bool
+    let shouldStartDictation: Bool
+}
+
+struct FirstRunModelCardState: Equatable {
+    enum Tone: Equatable {
+        case ready
+        case working
+        case failed
+    }
+
+    let title: String
+    let detail: String
+    let status: String
+    let progress: Double?
+    let tone: Tone
+}
+
+struct MenuBarPrimaryActionState: Equatable {
+    let isEnabled: Bool
+    let subtitle: String
+}
+
+enum FirstRunExperience {
+    static func primaryAction(
+        hasRequiredPermissions: Bool,
+        hasPasteTarget: Bool,
+        modelState: FirstRunLocalModelState
+    ) -> FirstRunPrimaryActionState {
+        guard hasRequiredPermissions else {
+            return FirstRunPrimaryActionState(
+                title: "Turn on microphone and accessibility",
+                detail: "Turn on Microphone and Accessibility first. That's enough for your first dictation.",
+                isEnabled: false,
+                shouldStartDictation: false
+            )
+        }
+
+        if hasPasteTarget {
+            let detail: String
+            switch modelState {
+            case .ready:
+                detail = "Start with a short dictation. Transcripted will paste it back into the app you were just using."
+            case .failed:
+                detail = "Start again to retry the local voice model. Transcripted will begin listening as soon as it's ready."
+            case .notLoaded, .downloading, .loading:
+                detail = "Start now. Transcripted will begin listening as soon as the local voice model finishes getting ready."
+            }
+
+            return FirstRunPrimaryActionState(
+                title: "Start first dictation",
+                detail: detail,
+                isEnabled: true,
+                shouldStartDictation: true
+            )
+        }
+
+        let detail: String
+        switch modelState {
+        case .ready:
+            detail = "Setup is done. Click back into any text field, then use Dictation from the Transcripted menu."
+        case .failed:
+            detail = "Setup is done, but the local voice model needs another try. Start Dictation from the menu to retry it."
+        case .notLoaded, .downloading, .loading:
+            detail = "Setup is done. Transcripted is still getting the local voice model ready in the background. When it's ready, click back into any text field and use Dictation from the menu."
+        }
+
+        return FirstRunPrimaryActionState(
+            title: "Continue to Transcripted",
+            detail: detail,
+            isEnabled: true,
+            shouldStartDictation: false
+        )
+    }
+
+    static func modelCard(for modelState: FirstRunLocalModelState) -> FirstRunModelCardState {
+        switch modelState {
+        case .notLoaded:
+            return FirstRunModelCardState(
+                title: "Getting local dictation ready",
+                detail: "Transcripted starts the on-device voice model the first time you use it.",
+                status: "Starting",
+                progress: 0.06,
+                tone: .working
+            )
+        case .downloading(let progress):
+            return FirstRunModelCardState(
+                title: "Downloading local dictation",
+                detail: "This one-time download stays on this Mac so dictation can run locally.",
+                status: "\(Int(progress * 100))% complete",
+                progress: max(0.12, min(0.84, 0.12 + progress * 0.72)),
+                tone: .working
+            )
+        case .loading:
+            return FirstRunModelCardState(
+                title: "Finishing local dictation setup",
+                detail: "Transcripted has the files and is loading them into memory.",
+                status: "Almost ready",
+                progress: 0.92,
+                tone: .working
+            )
+        case .ready:
+            return FirstRunModelCardState(
+                title: "Local dictation is ready",
+                detail: "Your first dictation can start immediately.",
+                status: "Ready",
+                progress: 1.0,
+                tone: .ready
+            )
+        case .failed(let message):
+            return FirstRunModelCardState(
+                title: "Couldn't load local dictation",
+                detail: message,
+                status: "Retry needed",
+                progress: nil,
+                tone: .failed
+            )
+        }
+    }
+
+    static func dictationAction(for modelState: FirstRunLocalModelState) -> MenuBarPrimaryActionState {
+        let subtitle: String
+        switch modelState {
+        case .ready:
+            subtitle = "Paste spoken text anywhere"
+        case .failed:
+            subtitle = "Try again to retry local voice setup"
+        case .notLoaded:
+            subtitle = "Starts local voice setup on first use"
+        case .downloading:
+            subtitle = "Downloads once, then starts automatically"
+        case .loading:
+            subtitle = "Finishing local voice setup"
+        }
+
+        return MenuBarPrimaryActionState(
+            isEnabled: true,
+            subtitle: subtitle
+        )
+    }
+
+    static func meetingAction(dictationReady: Bool, meetingsStatus: String) -> MenuBarPrimaryActionState {
+        let subtitle: String
+        switch meetingsStatus {
+        case "Ready":
+            subtitle = "Capture mic and system audio"
+        case "Failed":
+            subtitle = "Try again to reload meeting tools"
+        default:
+            subtitle = dictationReady
+                ? "Meeting tools are still loading in the background"
+                : "Starts local meeting setup on first use"
+        }
+
+        return MenuBarPrimaryActionState(
+            isEnabled: true,
+            subtitle: subtitle
+        )
+    }
+}

--- a/Tests/FastTests.manifest
+++ b/Tests/FastTests.manifest
@@ -19,3 +19,4 @@ SentryPayloadSanitizerTests.swift:testSentryPayloadSanitizer
 SentryEventPolicyTests.swift:testSentryEventPolicy
 TranscriptedConstantsTests.swift:testTranscriptedConstants
 ParakeetShortAudioGateTests.swift:testParakeetShortAudioGate
+FirstRunExperienceTests.swift:testFirstRunExperience

--- a/Tests/FirstRunExperienceTests.swift
+++ b/Tests/FirstRunExperienceTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+func testFirstRunExperience() {
+    runSuite("FirstRunExperience.primaryAction — starts dictation when permissions and a paste target are ready") {
+        let action = FirstRunExperience.primaryAction(
+            hasRequiredPermissions: true,
+            hasPasteTarget: true,
+            modelState: .loading
+        )
+
+        assertEqual(action.title, "Start first dictation", "first-run CTA should point to first value")
+        assertTrue(action.isEnabled, "first-run CTA should unlock once required permissions are granted")
+        assertTrue(action.shouldStartDictation, "first-run CTA should launch dictation when Transcripted knows the target app")
+        assertTrue(
+            action.detail.contains("Start now"),
+            "loading copy should explain that dictation can begin before the model fully finishes"
+        )
+    }
+
+    runSuite("FirstRunExperience.primaryAction — falls back to continue when Transcripted does not know the target app") {
+        let action = FirstRunExperience.primaryAction(
+            hasRequiredPermissions: true,
+            hasPasteTarget: false,
+            modelState: .ready
+        )
+
+        assertEqual(action.title, "Continue to Transcripted", "fallback CTA should keep onboarding moving")
+        assertFalse(action.shouldStartDictation, "continue CTA should not try to start dictation without a target app")
+        assertTrue(
+            action.detail.lowercased().contains("click back into any text field"),
+            "fallback copy should tell the user exactly what to do next"
+        )
+    }
+
+    runSuite("FirstRunExperience.dictationAction — stays enabled while dictation is still downloading") {
+        let state = FirstRunExperience.dictationAction(for: .downloading(progress: 0.35))
+
+        assertTrue(state.isEnabled, "dictation should stay reachable while the local model downloads")
+        assertEqual(
+            state.subtitle,
+            "Downloads once, then starts automatically",
+            "dictation row should explain the one-time background wait"
+        )
+    }
+
+    runSuite("FirstRunExperience.meetingAction — stays enabled while meetings load in the background") {
+        let state = FirstRunExperience.meetingAction(
+            dictationReady: true,
+            meetingsStatus: "Loading"
+        )
+
+        assertTrue(state.isEnabled, "meeting row should stay reachable while background warmup continues")
+        assertEqual(
+            state.subtitle,
+            "Meeting tools are still loading in the background",
+            "meeting row should explain why it is not fully ready yet"
+        )
+    }
+
+    runSuite("FirstRunExperience.modelCard — explains the one-time local download") {
+        let card = FirstRunExperience.modelCard(for: .downloading(progress: 0.5))
+
+        assertEqual(card.title, "Downloading local dictation", "model card should name the active first-run step")
+        assertTrue(
+            card.detail.contains("one-time download"),
+            "model card should explain why the download is happening"
+        )
+        assertEqual(card.status, "50% complete", "model card should surface live progress")
+        assertNotNil(card.progress, "model card should show a progress bar during downloads")
+    }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,6 +27,7 @@ not have to carry the full operational logic:
 ## Active helper scripts
 
 - `scripts/release/generate-sparkle-appcast.sh` — generate a Sparkle appcast from an updates folder and copy it into `docs/appcast.xml`
+- `scripts/dev/onboarding.sh` — inspect, reset, or force the first-run onboarding state while iterating on copy and layout
 
 ## Legacy scripts
 

--- a/scripts/dev/onboarding.sh
+++ b/scripts/dev/onboarding.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+
+BUNDLE_ID="${TRANSCRIPTED_BUNDLE_ID:-com.justinbetker.draft}"
+COMPLETION_KEY="permissionsOnboardingCompleted"
+FORCE_KEY="forcePermissionsOnboarding"
+
+read_bool() {
+    local key="$1"
+    if defaults read "$BUNDLE_ID" "$key" >/dev/null 2>&1; then
+        defaults read "$BUNDLE_ID" "$key"
+    else
+        echo "<unset>"
+    fi
+}
+
+case "${1:-status}" in
+    status)
+        echo "Bundle ID: $BUNDLE_ID"
+        echo "$COMPLETION_KEY=$(read_bool "$COMPLETION_KEY")"
+        echo "$FORCE_KEY=$(read_bool "$FORCE_KEY")"
+        ;;
+    reset)
+        defaults delete "$BUNDLE_ID" "$COMPLETION_KEY" >/dev/null 2>&1 || true
+        echo "Reset onboarding completion for $BUNDLE_ID"
+        ;;
+    force-on)
+        defaults write "$BUNDLE_ID" "$FORCE_KEY" -bool true
+        echo "Forced onboarding on for $BUNDLE_ID"
+        ;;
+    force-off)
+        defaults delete "$BUNDLE_ID" "$FORCE_KEY" >/dev/null 2>&1 || true
+        echo "Forced onboarding off for $BUNDLE_ID"
+        ;;
+    fresh)
+        defaults delete "$BUNDLE_ID" "$COMPLETION_KEY" >/dev/null 2>&1 || true
+        defaults delete "$BUNDLE_ID" "$FORCE_KEY" >/dev/null 2>&1 || true
+        echo "Set onboarding back to normal first-run behavior for $BUNDLE_ID"
+        ;;
+    *)
+        echo "Usage: scripts/dev/onboarding.sh [status|reset|force-on|force-off|fresh]"
+        exit 1
+        ;;
+esac

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -133,6 +133,7 @@ APP_SOURCES=(
     "Sources/TranscriptedCore/Models/TranscriptionTypes.swift"
     "Sources/TranscriptedCore/Speaker/SpeakerProfile.swift"
     "Sources/TranscriptedCore/Speaker/SpeakerNamingPolicy.swift"
+    "Sources/UI/Shared/FirstRunExperience.swift"
     "Sources/UI/Shared/AppSoundPlayer.swift"
 )
 


### PR DESCRIPTION
## What changed

- tightened the first-run onboarding copy around the actual shortest path to value: microphone + accessibility first, meetings later
- added shared first-run state helpers so onboarding and the menu describe model loading and action availability consistently
- stopped blocking dictation behind meeting warmup in the menu, so first dictation can start while meeting tools continue loading in the background
- made first-use dictation retry local model warmup if startup warmup had failed
- added a small dev helper at `scripts/dev/onboarding.sh` to inspect, reset, or force onboarding on while iterating

## Why

The first-run flow had a few confusing handoffs:

- onboarding said "dictation first" but the menu could still leave dictation effectively blocked behind broader warmup
- model download/loading state was happening without being explained in the onboarding surface itself
- iterating on onboarding was annoying because the first-run state had to be reset manually every time

## Impact

- fewer dead ends on first launch
- clearer expectation-setting around the one-time local model setup
- a faster path to the first successful dictation
- much easier onboarding QA while tuning copy and layout

## Validation

- `bash build-deps.sh --force`
- `bash run-tests.sh`
- `bash build.sh`
