### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -8,11 +8,13 @@
 
 - `FailedMeetingPresentation.swift` — maps `FailedTranscription` into `FailedMeetingItem` view-models with human-readable titles and retry metadata
 - `MeetingCaptureBridge.swift` — `@MainActor` wrapper around core `Audio`, converts callback-based stop into `async`
+- `MeetingFailureCopy.swift` — normalizes raw meeting failure messages into user-facing titles and recovery copy
 - `MeetingModelDownloader.swift` — loads Parakeet and diarization models together
 - `MeetingPromptDetector.swift` — polls upcoming Calendar events, watches supported meeting apps, and asks the overlay to offer one-tap recording prompts
 - `MeetingPromptHeuristics.swift` — shared scoring and snooze rules for calendar- and runtime-based prompt candidates
+- `MeetingRecordingStartGate.swift` — permission preflight for meeting recording, including missing-permission reasons and user-facing error messages
 - `MeetingSTTAdapter.swift` — adapts the app's shared `ParakeetEngine` to `TranscriptedCore.SpeechToTextEngine`
-- `MeetingSessionController.swift` — top-level meeting state machine, model warmup, capture start/stop, queued transcription handoff, failed-meeting actions, and transcript restyling
+- `MeetingSessionController.swift` — top-level meeting state machine, permission gating, model warmup, capture start/stop, queued transcription handoff, failed-meeting actions, and transcript restyling
 - `MeetingStoragePaths.swift` — current split meeting storage layout across the capture library, app state, logs, and temp folders
 - `MeetingTranscriptStyler.swift` — restyles saved transcripts and renames files after save
 
@@ -21,11 +23,11 @@
 1. `Sources/TranscriptedApp.swift` wires `MeetingSessionController` into `MeetingOverlayController`, the menubar, the `⌥M` hotkey, and the detected-meeting prompt flow.
 2. `MeetingPromptDetector` polls upcoming Calendar events, observes supported runtime apps, scores candidate prompts, and asks `MeetingOverlayController` to present a short-lived prompt when the app is idle.
 3. `Sources/TranscriptedAppState.swift` starts background model warmup through `meetingSession.prepareModels(showLoadingUI: false)`.
-4. `MeetingSessionController.startRecording(...)` uses `MeetingCaptureBridge` to start core audio capture into app-owned scratch paths.
+4. `MeetingSessionController.startRecording(...)` first runs `MeetingRecordingStartGate` so missing microphone or Screen Recording permission failures are blocked before capture starts, then uses `MeetingCaptureBridge` to start core audio capture into app-owned scratch paths.
 5. `MeetingSessionController.stopRecording(...)` awaits mic/system audio files from the bridge, then either starts transcription immediately or queues it behind the active job.
 6. `TranscriptionTaskManager` runs one diarize → transcribe → save pipeline at a time.
 7. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the recent-meetings UI state.
-8. Failed meetings can be retried, deleted, or dismissed from the menubar recent-meetings section.
+8. Failed meetings can be retried, deleted, or dismissed from the menubar recent-meetings section, with `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
 
 ## Key invariants
 
@@ -33,6 +35,8 @@
 - `MeetingSTTAdapter.cleanup()` is intentionally a no-op. `TranscriptedAppState` owns `ParakeetEngine` lifecycle for the whole app.
 - Meeting captures should follow the current capture library, while databases, logs, and temp recordings stay under the app-owned Transcripted Application Support folders.
 - `MeetingPromptDetector` can prompt from either upcoming calendar events or recently active supported meeting apps (Zoom, Teams, Webex, FaceTime, plus browser-hosted providers like Google Meet).
+- `MeetingRecordingStartGate` is the canonical place for meeting-recording permission policy and reason strings. Keep duplicate permission branching out of overlay code.
+- `MeetingFailureCopy` is the canonical place for human-facing failed-meeting titles and details. Keep retry messaging centralized there.
 - `TranscriptionTaskManager` stays single-flight. App-level queueing belongs in `MeetingSessionController`, not in ad hoc background tasks.
 - Live PCM handlers installed through `MeetingCaptureBridge` run on capture threads. Keep them real-time safe.
 

--- a/Sources/Speech/CLAUDE.md
+++ b/Sources/Speech/CLAUDE.md
@@ -6,13 +6,17 @@
 
 ## Key Files
 
-- `ParakeetEngine.swift` — app-owned Parakeet STT engine, recording control, live transcript state, model initialization, audio-device handling, and wake-recovery support
+- `ParakeetEngine.swift` — app-owned Parakeet STT engine, recording control, live transcript state, model initialization, permission-aware prewarm decisions, audio-device handling, short-audio gating, and wake-recovery support
+- `ParakeetPrewarmPolicy.swift` — central policy for deciding whether speech-engine prewarm should proceed or be skipped based on microphone authorization state
+- `ParakeetShortAudioGate.swift` — central policy for deciding when very short recordings should be dropped, surfaced as intentional empty results, or still transcribed
 - `RecordedAudioTimeline.swift` — in-memory segmented audio buffer used when recorded audio needs to be preserved across interruptions or recovery handoffs
 - `STTRouter.swift` — small main-actor wrapper used by the rest of the app
 
 ## Current Notes
 
 - This directory powers dictation.
+- `ParakeetEngine` consults `ParakeetPrewarmPolicy` before prewarming the local model, so microphone-permission-aware warmup behavior belongs here rather than in app startup glue.
+- `ParakeetEngine` consults `ParakeetShortAudioGate` before spending work on extremely short clips, so short-tap behavior changes belong here rather than in UI controllers.
 - The meeting pipeline reuses the same app-owned `ParakeetEngine` through `Sources/Meeting/MeetingSTTAdapter.swift`.
 - Do not assume a separate local-LLM drafting path exists in this tree.
 
@@ -28,6 +32,13 @@ bash run-tests.sh
 Manual checks:
 
 - dictation can start and stop cleanly
+- very short recordings follow the expected drop / empty-result / transcribe behavior
 - live transcript updates while listening
 - device changes do not leave the app stuck
 - wake / resume does not strand buffered audio or leave recovery state hanging
+
+Relevant direct coverage:
+
+- `Tests/ParakeetPrewarmPolicyTests.swift`
+- `Tests/ParakeetShortAudioGateTests.swift`
+- `Tests/RecordedAudioTimelineTests.swift`

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -13,7 +13,7 @@ The directory is grouped by surface so the live UI tree is easier to scan:
 
 Draft-mode UI is not an active product path in this worktree.
 
-## Files (32 Swift files)
+## Files (33 Swift files)
 
 ### Overlay/
 
@@ -69,6 +69,7 @@ The current agent-connect surfaces should keep one simple mental model:
 
 - `Shared/AgentConnectionGuide.swift` — shared smart-prompt, MCP setup, and folder fallback copy for the agent-connect flow
 - `Shared/AppSoundPlayer.swift` — UI sound preferences and playback helpers
+- `Shared/FirstRunExperience.swift` — shared first-run menu and onboarding state helpers for permission, local-model, dictation, and meeting CTA copy
 - `Shared/SpeakerClipPlayback.swift` — reusable audio-preview helper for persisted speaker sample clips
 
 Cross-cutting permission checks now live in `Sources/Support/TranscriptedPermissionAccess.swift`
@@ -96,4 +97,6 @@ Manual checks:
 - meeting overlay warms up and records cleanly
 - menubar popover renders shortcuts, recents, settings actions, and the agent-connect page cleanly
 - speaker settings can preview clips and rename / merge people cleanly
-- permissions onboarding and settings window still open correctly
+- permissions onboarding and first-run onboarding window still open correctly
+- first-run CTA copy updates correctly as permissions and local-model state change
+- settings window still opens correctly


### PR DESCRIPTION
## Summary
- add MeetingFailureCopy and MeetingRecordingStartGate to Sources/Meeting/CLAUDE.md
- document ParakeetPrewarmPolicy and related test coverage in Sources/Speech/CLAUDE.md
- add FirstRunExperience, correct the UI Swift file count, and refresh first-run verification notes in Sources/UI/CLAUDE.md

## Why
Nightly CLAUDE.md sync for recent Transcripted changes.