### PR TITLE
[nightly-artifact] stop test runs from polluting app.jsonl

### DIFF
--- a/Sources/Observability/CLAUDE.md
+++ b/Sources/Observability/CLAUDE.md
@@ -27,6 +27,7 @@ anonymous analytics, and Sparkle update plumbing.
 - Sparkle is the live in-app update path on `main`; the older beta DMG self-update flow is no longer part of the app target
 - Do not assume older draft/style/analysis event flows are still active just because they appear in historical docs or event logs
 - `build.sh` and beta behavior can affect logs, signing, and permissions during local testing
+- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1` disables `app.jsonl` writes for test and smoke runs so local production logs stay clean
 - Sentry DSN/config is read from `Info.plist` (`TranscriptedSentryDSN`) or process environment for local testing, and crash reports must stay scrubbed of transcript/audio/title/path data
 - PostHog config is read from `Info.plist` (`TranscriptedPostHogAPIKey`, `TranscriptedPostHogHost`) or process environment (`POSTHOG_API_KEY`, `POSTHOG_HOST`), and anonymous analytics must stay event-allowlisted and bucketed rather than sending raw payloads
 - Non-fatal error forwarding to Sentry is allowlisted. New `.error` events should not automatically assume they are safe to send off-device.

--- a/Sources/TranscriptedCore/Logging/FileLogger.swift
+++ b/Sources/TranscriptedCore/Logging/FileLogger.swift
@@ -27,8 +27,10 @@ final class FileLogger: @unchecked Sendable {
     }()
 
     init(paths: CoreStoragePaths = .default, isDisabledOverride: Bool? = nil) {
-        // Disable file logging during test runs to avoid polluting production logs
-        let isTestRun = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+        // Disable file logging during test runs to avoid polluting production logs.
+        let env = ProcessInfo.processInfo.environment
+        let isTestRun = env["XCTestConfigurationFilePath"] != nil
+            || Self.isEnabledFlag(env["TRANSCRIPTED_DISABLE_FILE_LOGGER"])
         self.isDisabled = isDisabledOverride ?? isTestRun
 
         let logsDir = paths.logs
@@ -147,5 +149,15 @@ final class FileLogger: @unchecked Sendable {
     deinit {
         fileHandle?.synchronizeFile()
         fileHandle?.closeFile()
+    }
+
+    private static func isEnabledFlag(_ value: String?) -> Bool {
+        guard let value else { return false }
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        default:
+            return false
+        }
     }
 }

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -51,6 +51,9 @@ It also runs the wake-recovery smoke binary and currently finishes with
 The smoke sources now live under `Tests/Integration/` so the repo’s verification
 surface stays under one top-level `Tests/` umbrella.
 
+Fast tests and smoke runs set `TRANSCRIPTED_DISABLE_FILE_LOGGER=1` so they do
+not append test-only entries into the real `~/Library/Application Support/Transcripted/logs/app.jsonl`.
+
 Run it whenever you touch:
 
 - `Sources/Meeting/`

--- a/Tests/TranscriptedCoreTests/FileLoggerTests.swift
+++ b/Tests/TranscriptedCoreTests/FileLoggerTests.swift
@@ -45,4 +45,35 @@ final class FileLoggerTests: XCTestCase {
 
         XCTAssertEqual(messages, ["first", "second", "third"])
     }
+
+    func testDisableFlagSkipsFileLogging() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FileLoggerDisableTests-\(UUID().uuidString)", isDirectory: true)
+        let logs = root.appendingPathComponent("logs", isDirectory: true)
+        try FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+        defer {
+            unsetenv("TRANSCRIPTED_DISABLE_FILE_LOGGER")
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let paths = CoreStoragePaths(
+            transcripts: root.appendingPathComponent("captures/meetings", isDirectory: true),
+            speakerDB: root.appendingPathComponent("state/speakers.sqlite"),
+            statsDB: root.appendingPathComponent("state/stats.sqlite"),
+            failedQueue: root.appendingPathComponent("state/failed_transcriptions.json"),
+            speakerClips: root.appendingPathComponent("tmp/recordings/speaker_clips", isDirectory: true),
+            audioCaptures: root.appendingPathComponent("tmp/recordings", isDirectory: true),
+            logs: logs
+        )
+
+        setenv("TRANSCRIPTED_DISABLE_FILE_LOGGER", "1", 1)
+
+        let logger = FileLogger(paths: paths)
+        logger.write(level: "info", subsystem: "app", message: "should-not-write", metadata: nil)
+        logger.flush()
+
+        let logURL = logs.appendingPathComponent("app.jsonl")
+        let content = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
+        XCTAssertTrue(content.isEmpty)
+    }
 }

--- a/scripts/entrypoints/run-integration-smoke.sh
+++ b/scripts/entrypoints/run-integration-smoke.sh
@@ -79,12 +79,12 @@ swiftc \
 
 echo ""
 echo "Running core smoke…"
-"$SMOKE_BIN"
+TRANSCRIPTED_DISABLE_FILE_LOGGER=1 "$SMOKE_BIN"
 
 echo ""
 echo "Running wake smoke…"
-"$WAKE_SMOKE_BIN"
+TRANSCRIPTED_DISABLE_FILE_LOGGER=1 "$WAKE_SMOKE_BIN"
 
 echo ""
 echo "Running recovery merge package tests…"
-swift test --filter MicRecordingFileMergerTests
+TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift test --filter MicRecordingFileMergerTests

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -150,4 +150,4 @@ swiftc \
 
 echo "Running tests..."
 echo ""
-./build/tests
+TRANSCRIPTED_DISABLE_FILE_LOGGER=1 ./build/tests


### PR DESCRIPTION
## Summary
- honor `TRANSCRIPTED_DISABLE_FILE_LOGGER=1` inside `FileLogger`
- run fast tests and integration smoke with file logging disabled so test-only entries stop landing in the real `~/Library/Application Support/Transcripted/logs/app.jsonl`
- add package coverage for the disable flag and document the test-run logging contract

## Why
The nightly artifact sweep still finds malformed historic JSONL lines in the local `app.jsonl`. The log includes test-only paths like `RetroactiveSpeakerUpdaterTests-*` and `DraftMeetingSmoke-*`, so test/smoke runs have been contaminating the production log surface that TranscriptedQA checks.

This change prevents new test and smoke executions from adding more noise or corruption to the real app log. It does not rewrite the already-corrupt local log file.

## Verification
- `cd Tools/TranscriptedQA && swift build`
- `cd Tools/TranscriptedQA && swift run transcripted-qa check-health --format json`
- `cd Tools/TranscriptedQA && swift run transcripted-qa validate-all --format json`
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `swift test`

## Current local artifact status
The rerun after this patch still reports one existing artifact failure on this machine:
- `~/Library/Application Support/Transcripted/logs/app.jsonl` has 13 malformed historic lines and remains above the rolling target at 3585 entries

Smallest safe follow-up after this lands:
- rotate or archive the current `app.jsonl` locally so future nightly sweeps can confirm the prevention fix on a clean log