### PR TITLE
[nightly-review] Align Screen Recording onboarding copy

### DIFF
--- a/Sources/Meeting/MeetingRecordingStartGate.swift
+++ b/Sources/Meeting/MeetingRecordingStartGate.swift
@@ -15,6 +15,15 @@ struct MeetingRecordingStartDecision: Equatable {
 }
 
 enum MeetingRecordingStartGate {
+    static let screenRecordingSummary =
+        "Optional on first launch. Required before Transcripted can capture meeting audio from other apps."
+
+    static let screenRecordingQuickStart =
+        "Turn on Screen Recording before you record meetings so Transcripted can capture the other side of Zoom, Meet, and similar apps."
+
+    static let optionalPermissionsFootnote =
+        "You can start dictating without these. Turn on Screen Recording before you record meetings, and add Calendar later if you want meeting prompts."
+
     static func evaluate(
         microphoneGranted: Bool,
         screenRecordingGranted: Bool

--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -53,7 +53,7 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
         case .accessibility:
             return "Needed for global shortcuts and pasting text back into the app you were using."
         case .screenRecording:
-            return "Optional for meeting capture. Needed when you want call audio from other apps."
+            return MeetingRecordingStartGate.screenRecordingSummary
         case .calendar:
             return "Optional for meeting prompts. Lets Transcripted notice upcoming meetings from Apple Calendar, Google, or Exchange calendars synced to your Mac."
         }

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -104,7 +104,7 @@ struct PermissionsOnboardingView: View {
                             title: "Meetings",
                             detail: screenRecordingGranted
                                 ? "Meeting audio is ready too. Calendar prompts stay optional."
-                                : "You can enable Screen Recording later when you want call audio from Zoom, Meet, or other apps."
+                                : MeetingRecordingStartGate.screenRecordingQuickStart
                         )
                     }
                     .padding(14)
@@ -481,7 +481,7 @@ private struct OptionalPermissionsCard: View {
             Text("Optional later")
                 .font(.subheadline.weight(.semibold))
 
-            Text("You can start dictating without these. Add them later from Settings when you want richer meeting capture.")
+            Text(MeetingRecordingStartGate.optionalPermissionsFootnote)
                 .font(.caption)
                 .foregroundStyle(MenuTokens.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Tests/MeetingRecordingStartGateTests.swift
+++ b/Tests/MeetingRecordingStartGateTests.swift
@@ -44,4 +44,22 @@ func testMeetingRecordingStartGate() {
             "combined permission failures should preserve a stable missing-permission list"
         )
     }
+
+    runSuite("MeetingPermissionCopy — keeps screen recording copy aligned with the meeting gate") {
+        assertEqual(
+            MeetingRecordingStartGate.screenRecordingSummary,
+            "Optional on first launch. Required before Transcripted can capture meeting audio from other apps.",
+            "shared summary copy should explain that screen recording is optional for dictation setup but required for meetings"
+        )
+        assertEqual(
+            MeetingRecordingStartGate.screenRecordingQuickStart,
+            "Turn on Screen Recording before you record meetings so Transcripted can capture the other side of Zoom, Meet, and similar apps.",
+            "quick-start copy should stop implying that full meeting capture works without screen recording"
+        )
+        assertEqual(
+            MeetingRecordingStartGate.optionalPermissionsFootnote,
+            "You can start dictating without these. Turn on Screen Recording before you record meetings, and add Calendar later if you want meeting prompts.",
+            "onboarding footnote should match the current meeting recording requirement"
+        )
+    }
 }


### PR DESCRIPTION
## What changed
- aligned the shared Screen Recording permission copy with the current meeting start gate
- updated onboarding messaging so it no longer implies full meeting capture works before Screen Recording is enabled
- added a fast regression test that keeps the meeting gate and shared copy in sync

## Why
A recent reliability change now blocks meeting recording when Screen Recording is missing, but the permission/onboarding copy still said Screen Recording was optional for meeting capture. That mismatch points users at the wrong setup path.

## Validation
- `bash build-deps.sh --force`
- `bash run-tests.sh`
- `bash build.sh`
- `bash run-integration-smoke.sh`