### PR TITLE
[codex] Bump version to 1.0.5

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.4</string>
+	<string>1.0.5</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.4</string>
+	<string>1.0.5</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>


### PR DESCRIPTION
## What changed
- bump `Info.plist` from `1.0.4` to `1.0.5`

## Why
This is the version metadata commit for the `1.0.5` release so the release tag points at the correct app version.

## Validation
- notarized `Transcripted-1.0.5.dmg` already built locally from this commit
- `bash build.sh`
- `bash run-tests.sh`