### PR TITLE
[codex] Update appcast for 1.0.5

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -1,13 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0"
-    xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"
-    xmlns:atom="http://www.w3.org/2005/Atom">
+<?xml version="1.0" ?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
   <channel>
     <title>Transcripted Updates</title>
     <link>https://github.com/r3dbars/transcripted</link>
     <atom:link href="https://raw.githubusercontent.com/r3dbars/transcripted/main/docs/appcast.xml" rel="self" type="application/rss+xml"/>
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
+    <item>
+      <title>1.0.5</title>
+      <pubDate>Mon, 13 Apr 2026 13:46:48 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.5</link>
+      <sparkle:version>1.0.5</sparkle:version>
+      <sparkle:shortVersionString>1.0.5</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.5</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.5/Transcripted-1.0.5.dmg" length="502640480" type="application/octet-stream" sparkle:edSignature="kvlnlYL4tbnNLZjIjdJwA+0FCZ8CV4dW55PhYxgEWDJ9kbPrNRYNRlWq887xWhwWJ/R065gqD5WN0JtxvFeUAw=="/>
+    </item>
     <item>
       <title>1.0.4</title>
       <pubDate>Sun, 12 Apr 2026 18:58:26 GMT</pubDate>


### PR DESCRIPTION
## What changed
- add the `1.0.5` Sparkle appcast entry
- point Sparkle at the notarized GitHub release DMG for `v1.0.5`
- keep the feed item metadata aligned with the existing `arm64` / macOS 14 release pattern

## Why
Uploading the DMG to GitHub Releases is not enough for existing Transcripted installs to discover the update. `docs/appcast.xml` also has to be updated on `main`.

## Validation
- `xmllint --noout docs/appcast.xml`
- verified release asset exists at `v1.0.5`
- Sparkle EdDSA signature generated from the shipped DMG