### PR TITLE
[codex] Simplify macOS 26-only permission flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ state already exists.
 
 ### Prerequisites
 
-- macOS 14+
+- macOS 26+
 - Xcode command line tools
 - Apple Silicon
 

--- a/Info.plist
+++ b/Info.plist
@@ -27,7 +27,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Transcripted</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>14.0</string>
+	<string>26.0</string>
 	<key>LSUIElement</key>
 	<true/>
 	<key>SUEnableAutomaticChecks</key>

--- a/Info.plist
+++ b/Info.plist
@@ -38,8 +38,6 @@
 	<string>Ib6MHm4eeZYjhsZblNT0DEo3LzK9fYvBLkmqvw/Vo7Q=</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Transcripted needs microphone access for dictation and to capture your side of meetings.</string>
-	<key>NSSpeechRecognitionUsageDescription</key>
-	<string>Transcripted uses speech recognition to turn your voice into text.</string>
 	<key>NSScreenCaptureUsageDescription</key>
 	<string>Transcripted needs screen recording access so meeting capture can access system audio from calls, videos, and other apps.</string>
 	<key>NSAudioCaptureUsageDescription</key>

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let repoRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
 
 let package = Package(
     name: "TranscriptedCore",
-    platforms: [.macOS(.v14)],
+    platforms: [.macOS("26.0")],
     products: [
         .library(
             name: "TranscriptedCore",

--- a/Package.swift
+++ b/Package.swift
@@ -68,6 +68,7 @@ let package = Package(
                 .linkedFramework("AVFoundation"),
                 .linkedFramework("AppKit"),
                 .linkedFramework("Network"),
+                .linkedFramework("ScreenCaptureKit"),
             ]
         ),
         .testTarget(
@@ -106,6 +107,7 @@ let package = Package(
                 .linkedFramework("AVFoundation"),
                 .linkedFramework("AppKit"),
                 .linkedFramework("Network"),
+                .linkedFramework("ScreenCaptureKit"),
             ]
         ),
     ]

--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -23,7 +23,7 @@
 1. `Sources/TranscriptedApp.swift` wires `MeetingSessionController` into `MeetingOverlayController`, the menubar, the `⌥M` hotkey, and the detected-meeting prompt flow.
 2. `MeetingPromptDetector` polls upcoming Calendar events, observes supported runtime apps, scores candidate prompts, and asks `MeetingOverlayController` to present a short-lived prompt when the app is idle.
 3. `Sources/TranscriptedAppState.swift` starts background model warmup through `meetingSession.prepareModels(showLoadingUI: false)`.
-4. `MeetingSessionController.startRecording(...)` first runs `MeetingRecordingStartGate` so missing microphone or Screen Recording permission failures are blocked before capture starts, then uses `MeetingCaptureBridge` to start core audio capture into app-owned scratch paths.
+4. `MeetingSessionController.startRecording(...)` first runs `MeetingRecordingStartGate` so missing microphone or System Audio Recording permission failures are blocked before capture starts, then uses `MeetingCaptureBridge` to start core audio capture into app-owned scratch paths.
 5. `MeetingSessionController.stopRecording(...)` awaits mic/system audio files from the bridge, then either starts transcription immediately or queues it behind the active job.
 6. `TranscriptionTaskManager` runs one diarize → transcribe → save pipeline at a time.
 7. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the recent-meetings UI state.

--- a/Sources/Meeting/MeetingFailureCopy.swift
+++ b/Sources/Meeting/MeetingFailureCopy.swift
@@ -11,10 +11,12 @@ struct MeetingFailureCopy: Equatable {
     ) -> MeetingFailureCopy {
         let message = errorMessage.lowercased()
 
-        if message.contains("system audio is required") || message.contains("screen recording") {
+        if message.contains("system audio is required")
+            || message.contains("system audio recording")
+            || message.contains("screen recording") {
             return MeetingFailureCopy(
-                title: "Turn on Screen Recording",
-                detail: "Turn on Screen Recording in System Settings, then retry the meeting."
+                title: "Turn on System Audio Recording",
+                detail: "Turn on System Audio Recording in System Settings, then retry the meeting."
             )
         }
 

--- a/Sources/Meeting/MeetingRecordingStartGate.swift
+++ b/Sources/Meeting/MeetingRecordingStartGate.swift
@@ -15,14 +15,23 @@ struct MeetingRecordingStartDecision: Equatable {
 }
 
 enum MeetingRecordingStartGate {
-    static let screenRecordingSummary =
+    static var screenRecordingSummary: String {
         "Optional on first launch. Required before Transcripted can capture meeting audio from other apps."
+    }
 
-    static let screenRecordingQuickStart =
-        "Turn on Screen Recording before you record meetings so Transcripted can capture the other side of Zoom, Meet, and similar apps."
+    static var screenRecordingQuickStart: String {
+        if #available(macOS 26.0, *) {
+            return "Turn on System Audio Recording before you record meetings so Transcripted can capture the other side of Zoom, Meet, and similar apps."
+        }
+        return "Turn on Screen Recording before you record meetings so Transcripted can capture the other side of Zoom, Meet, and similar apps."
+    }
 
-    static let optionalPermissionsFootnote =
-        "You can start dictating without these. Turn on Screen Recording before you record meetings, and add Calendar later if you want meeting prompts."
+    static var optionalPermissionsFootnote: String {
+        if #available(macOS 26.0, *) {
+            return "You can start dictating without these. Turn on System Audio Recording before you record meetings, and add Calendar later if you want meeting prompts."
+        }
+        return "You can start dictating without these. Turn on Screen Recording before you record meetings, and add Calendar later if you want meeting prompts."
+    }
 
     static func evaluate(
         microphoneGranted: Bool,
@@ -53,9 +62,15 @@ enum MeetingRecordingStartGate {
                 missingPermissions: missingPermissions
             )
         case ["screen_recording"]:
+            let message: String
+            if #available(macOS 26.0, *) {
+                message = "Turn on System Audio Recording in System Settings before recording a meeting."
+            } else {
+                message = "Turn on Screen Recording in System Settings before recording a meeting."
+            }
             return MeetingRecordingStartDecision(
                 canStart: false,
-                errorMessage: "Turn on Screen Recording in System Settings before recording a meeting.",
+                errorMessage: message,
                 failureReason: "screen_recording",
                 missingPermissions: missingPermissions
             )

--- a/Sources/Meeting/MeetingRecordingStartGate.swift
+++ b/Sources/Meeting/MeetingRecordingStartGate.swift
@@ -19,10 +19,10 @@ enum MeetingRecordingStartGate {
         "Optional on first launch. Required before Transcripted can capture meeting audio from other apps."
 
     static let screenRecordingQuickStart =
-        "Turn on Screen Recording before you record meetings so Transcripted can capture the other side of Zoom, Meet, and similar apps."
+        "Turn on Screen Recording before you record meetings. After you enable it, quit and reopen Transcripted so macOS can hand over system audio."
 
     static let optionalPermissionsFootnote =
-        "You can start dictating without these. Turn on Screen Recording before you record meetings, and add Calendar later if you want meeting prompts."
+        "You can start dictating without these. Turn on Screen Recording before you record meetings, then reopen Transcripted. Add Calendar later if you want meeting prompts."
 
     static func evaluate(
         microphoneGranted: Bool,
@@ -41,7 +41,7 @@ enum MeetingRecordingStartGate {
         case ["microphone", "screen_recording"]:
             return MeetingRecordingStartDecision(
                 canStart: false,
-                errorMessage: "Turn on Microphone and Screen Recording in System Settings before recording a meeting.",
+                errorMessage: "Turn on Microphone and Screen Recording in System Settings, then quit and reopen Transcripted before recording a meeting.",
                 failureReason: "microphone_and_screen_recording",
                 missingPermissions: missingPermissions
             )
@@ -55,7 +55,7 @@ enum MeetingRecordingStartGate {
         case ["screen_recording"]:
             return MeetingRecordingStartDecision(
                 canStart: false,
-                errorMessage: "Turn on Screen Recording in System Settings before recording a meeting.",
+                errorMessage: "Turn on Screen Recording in System Settings, then quit and reopen Transcripted before recording a meeting.",
                 failureReason: "screen_recording",
                 missingPermissions: missingPermissions
             )

--- a/Sources/Meeting/MeetingRecordingStartGate.swift
+++ b/Sources/Meeting/MeetingRecordingStartGate.swift
@@ -15,31 +15,25 @@ struct MeetingRecordingStartDecision: Equatable {
 }
 
 enum MeetingRecordingStartGate {
-    static var screenRecordingSummary: String {
-        "Optional on first launch. Required before Transcripted can capture meeting audio from other apps."
+    static var systemAudioRecordingSummary: String {
+        "Needed so Transcripted can capture the other side of calls, videos, and other meeting audio."
     }
 
-    static var screenRecordingQuickStart: String {
-        if #available(macOS 26.0, *) {
-            return "Turn on System Audio Recording before you record meetings so Transcripted can capture the other side of Zoom, Meet, and similar apps."
-        }
-        return "Turn on Screen Recording before you record meetings. After you enable it, quit and reopen Transcripted so macOS can hand over system audio."
+    static var systemAudioRecordingQuickStart: String {
+        "Turn on System Audio Recording so Transcripted can capture the other side of Zoom, Meet, and similar apps."
     }
 
     static var optionalPermissionsFootnote: String {
-        if #available(macOS 26.0, *) {
-            return "You can start dictating without these. Turn on System Audio Recording before you record meetings, and add Calendar later if you want meeting prompts."
-        }
-        return "You can start dictating without these. Turn on Screen Recording before you record meetings, then reopen Transcripted. Add Calendar later if you want meeting prompts."
+        "Calendar is optional. Add it later if you want Transcripted to spot upcoming meetings and offer a record prompt."
     }
 
     static func evaluate(
         microphoneGranted: Bool,
-        screenRecordingGranted: Bool
+        systemAudioRecordingGranted: Bool
     ) -> MeetingRecordingStartDecision {
         let missingPermissions = [
             microphoneGranted ? nil : "microphone",
-            screenRecordingGranted ? nil : "screen_recording"
+            systemAudioRecordingGranted ? nil : "system_audio_recording"
         ].compactMap { $0 }
 
         guard !missingPermissions.isEmpty else {
@@ -47,17 +41,11 @@ enum MeetingRecordingStartGate {
         }
 
         switch missingPermissions {
-        case ["microphone", "screen_recording"]:
-            let message: String
-            if #available(macOS 26.0, *) {
-                message = "Turn on Microphone and System Audio Recording in System Settings before recording a meeting."
-            } else {
-                message = "Turn on Microphone and Screen Recording in System Settings, then quit and reopen Transcripted before recording a meeting."
-            }
+        case ["microphone", "system_audio_recording"]:
             return MeetingRecordingStartDecision(
                 canStart: false,
-                errorMessage: message,
-                failureReason: "microphone_and_screen_recording",
+                errorMessage: "Turn on Microphone and System Audio Recording before recording a meeting.",
+                failureReason: "microphone_and_system_audio_recording",
                 missingPermissions: missingPermissions
             )
         case ["microphone"]:
@@ -67,17 +55,11 @@ enum MeetingRecordingStartGate {
                 failureReason: "microphone",
                 missingPermissions: missingPermissions
             )
-        case ["screen_recording"]:
-            let message: String
-            if #available(macOS 26.0, *) {
-                message = "Turn on System Audio Recording in System Settings before recording a meeting."
-            } else {
-                message = "Turn on Screen Recording in System Settings, then quit and reopen Transcripted before recording a meeting."
-            }
+        case ["system_audio_recording"]:
             return MeetingRecordingStartDecision(
                 canStart: false,
-                errorMessage: message,
-                failureReason: "screen_recording",
+                errorMessage: "Turn on System Audio Recording before recording a meeting.",
+                failureReason: "system_audio_recording",
                 missingPermissions: missingPermissions
             )
         default:

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -288,7 +288,7 @@ final class MeetingSessionController: ObservableObject {
 
         let startDecision = MeetingRecordingStartGate.evaluate(
             microphoneGranted: TranscriptedPermissionAccess.isGranted(.microphone),
-            screenRecordingGranted: TranscriptedPermissionAccess.isGranted(.screenRecording)
+            systemAudioRecordingGranted: TranscriptedPermissionAccess.isGranted(.systemAudioRecording)
         )
         guard startDecision.canStart else {
             DiagnosticsTrail.record(

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -18,7 +18,7 @@ struct AnalyticsEventPolicy: Equatable {
             allowedProperties: [
                 "anonymous_usage_enabled",
                 "crash_reporting_enabled",
-                "screen_recording_enabled",
+                "system_audio_recording_enabled",
             ]
         ),
         "dictation_started": .init(

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -218,15 +218,9 @@ class ParakeetEngine: ObservableObject {
             break
         }
 
-        // Request microphone permission early so it's granted before first recording
-        if AVCaptureDevice.authorizationStatus(for: .audio) == .notDetermined {
-            let granted = await withCheckedContinuation { continuation in
-                AVCaptureDevice.requestAccess(for: .audio) { granted in
-                    continuation.resume(returning: granted)
-                }
-            }
-            print("🎤 PARAKEET | microphone permission \(granted ? "granted" : "denied")")
-        }
+        // Keep background model warmup quiet. The onboarding/settings surfaces
+        // own microphone permission requests so launch-time initialization does
+        // not surprise users with a hidden or out-of-context prompt.
 
         modelDownloadState = .loading
         print("🔄 PARAKEET | initializing models...")

--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -87,6 +87,7 @@ enum TranscriptedPermissionAccess {
         }
     }
 
+    @MainActor
     static func openSettings(for kind: TranscriptedPermissionKind) {
         switch kind {
         case .microphone:
@@ -94,6 +95,7 @@ enum TranscriptedPermissionAccess {
             case .authorized:
                 break
             case .notDetermined:
+                activateForPermissionPrompt()
                 AVCaptureDevice.requestAccess(for: .audio) { granted in
                     guard !granted else { return }
                     Task { @MainActor in
@@ -112,12 +114,12 @@ enum TranscriptedPermissionAccess {
             }
             openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
         case .screenRecording:
-            if #available(macOS 15.0, *) {
-                _ = CGRequestScreenCaptureAccess()
-            }
+            activateForPermissionPrompt()
+            _ = CGRequestScreenCaptureAccess()
             openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
         case .calendar:
             Task { @MainActor in
+                activateForPermissionPrompt()
                 let granted = await requestCalendarAccessIfNeeded()
                 guard !granted else { return }
                 openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars")
@@ -162,10 +164,14 @@ enum TranscriptedPermissionAccess {
         CGPreflightScreenCaptureAccess()
     }
 
+    @MainActor
+    private static func activateForPermissionPrompt() {
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    @MainActor
     private static func openSystemSettings(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
-        Task { @MainActor in
-            NSWorkspace.shared.open(url)
-        }
+        NSWorkspace.shared.open(url)
     }
 }

--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -2,6 +2,7 @@ import AppKit
 import AVFoundation
 import ApplicationServices
 import EventKit
+import ScreenCaptureKit
 
 enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
     case microphone
@@ -40,6 +41,9 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
         case .accessibility:
             return "Accessibility"
         case .screenRecording:
+            if #available(macOS 26.0, *) {
+                return "System Audio Recording"
+            }
             return "Screen Recording"
         case .calendar:
             return "Calendar"
@@ -112,10 +116,15 @@ enum TranscriptedPermissionAccess {
             }
             openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
         case .screenRecording:
-            if #available(macOS 15.0, *) {
-                _ = CGRequestScreenCaptureAccess()
+            if #available(macOS 26.0, *) {
+                // macOS 26: direct to the lighter "System Audio Recording Only" section
+                openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_AudioCapture")
+            } else {
+                if #available(macOS 15.0, *) {
+                    _ = CGRequestScreenCaptureAccess()
+                }
+                openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
             }
-            openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
         case .calendar:
             Task { @MainActor in
                 let granted = await requestCalendarAccessIfNeeded()
@@ -159,7 +168,16 @@ enum TranscriptedPermissionAccess {
     }
 
     static func screenRecordingGranted() -> Bool {
-        CGPreflightScreenCaptureAccess()
+        if #available(macOS 26.0, *) {
+            // On macOS 26, ScreenCaptureKit presents an inline permission dialog
+            // when SCStream.startCapture() is called — the user can approve it
+            // on the spot without visiting System Settings. CGPreflightScreenCaptureAccess()
+            // returns false before that dialog has been shown, which would incorrectly
+            // block the recording flow. Return true so the gate lets the flow proceed
+            // to SCKAudioCapture, where startCapture() will trigger the dialog.
+            return true
+        }
+        return CGPreflightScreenCaptureAccess()
     }
 
     private static func openSystemSettings(_ urlString: String) {

--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -1,12 +1,14 @@
 import AppKit
 import AVFoundation
 import ApplicationServices
+import CoreMedia
 import EventKit
+import ScreenCaptureKit
 
 enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
     case microphone
     case accessibility
-    case screenRecording
+    case systemAudioRecording
     case calendar
 
     var id: String { rawValue }
@@ -17,8 +19,8 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
             return "mic.fill"
         case .accessibility:
             return "hand.raised.fill"
-        case .screenRecording:
-            return "rectangle.on.rectangle"
+        case .systemAudioRecording:
+            return "speaker.wave.2.fill"
         case .calendar:
             return "calendar"
         }
@@ -26,9 +28,9 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
 
     var isRequiredOnFirstLaunch: Bool {
         switch self {
-        case .microphone, .accessibility:
+        case .microphone, .accessibility, .systemAudioRecording:
             return true
-        case .screenRecording, .calendar:
+        case .calendar:
             return false
         }
     }
@@ -39,11 +41,8 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
             return "Microphone"
         case .accessibility:
             return "Accessibility"
-        case .screenRecording:
-            if #available(macOS 26.0, *) {
-                return "System Audio Recording"
-            }
-            return "Screen Recording"
+        case .systemAudioRecording:
+            return "System Audio Recording"
         case .calendar:
             return "Calendar"
         }
@@ -55,8 +54,8 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
             return "Needed for dictation and your side of meetings."
         case .accessibility:
             return "Needed for global shortcuts and pasting text back into the app you were using."
-        case .screenRecording:
-            return MeetingRecordingStartGate.screenRecordingSummary
+        case .systemAudioRecording:
+            return MeetingRecordingStartGate.systemAudioRecordingSummary
         case .calendar:
             return "Optional for meeting prompts. Lets Transcripted notice upcoming meetings from Apple Calendar, Google, or Exchange calendars synced to your Mac."
         }
@@ -68,8 +67,8 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
             return "Allow microphone"
         case .accessibility:
             return "Allow accessibility"
-        case .screenRecording:
-            return "Enable meeting audio"
+        case .systemAudioRecording:
+            return "Allow system audio recording"
         case .calendar:
             return "Enable meeting prompts"
         }
@@ -77,14 +76,19 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
 }
 
 enum TranscriptedPermissionAccess {
+    private static let systemAudioRecordingGrantedKey = "systemAudioRecordingPermissionGranted"
+    private static let systemAudioRecordingKnownKey = "systemAudioRecordingPermissionKnown"
+    private static let permissionsOnboardingCompletedKey = "permissionsOnboardingCompleted"
+    @MainActor private static var activeSystemAudioRequester: SystemAudioPermissionRequester?
+
     static func isGranted(_ kind: TranscriptedPermissionKind) -> Bool {
         switch kind {
         case .microphone:
             return AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
         case .accessibility:
             return AXIsProcessTrusted()
-        case .screenRecording:
-            return screenRecordingGranted()
+        case .systemAudioRecording:
+            return systemAudioRecordingGranted()
         case .calendar:
             return calendarAccessGranted()
         }
@@ -116,15 +120,18 @@ enum TranscriptedPermissionAccess {
                 _ = AXIsProcessTrustedWithOptions(options)
             }
             openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
-        case .screenRecording:
-            if #available(macOS 26.0, *) {
-                // macOS 26: direct to the lighter "System Audio Recording Only" section
-                activateForPermissionPrompt()
+        case .systemAudioRecording:
+            if systemAudioRecordingGranted() {
                 openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_AudioCapture")
-            } else {
+                return
+            }
+
+            Task { @MainActor in
                 activateForPermissionPrompt()
-                _ = CGRequestScreenCaptureAccess()
-                openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
+                let granted = await requestSystemAudioRecordingAccess()
+                setSystemAudioRecordingGranted(granted)
+                guard !granted else { return }
+                openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_AudioCapture")
             }
         case .calendar:
             Task { @MainActor in
@@ -169,17 +176,44 @@ enum TranscriptedPermissionAccess {
         }
     }
 
-    static func screenRecordingGranted() -> Bool {
-        if #available(macOS 26.0, *) {
-            // On macOS 26, ScreenCaptureKit presents an inline permission dialog
-            // when SCStream.startCapture() is called — the user can approve it
-            // on the spot without visiting System Settings. CGPreflightScreenCaptureAccess()
-            // returns false before that dialog has been shown, which would incorrectly
-            // block the recording flow. Return true so the gate lets the flow proceed
-            // to SCKAudioCapture, where startCapture() will trigger the dialog.
+    static func systemAudioRecordingGranted() -> Bool {
+        if UserDefaults.standard.bool(forKey: systemAudioRecordingKnownKey) {
+            return UserDefaults.standard.bool(forKey: systemAudioRecordingGrantedKey)
+        }
+
+        // Older installs may have completed onboarding before Transcripted
+        // tracked system-audio permission state explicitly. Keep those users on
+        // the optimistic path so existing meeting capture can still reach the
+        // inline ScreenCaptureKit prompt or succeed immediately if permission
+        // was already granted.
+        if UserDefaults.standard.bool(forKey: permissionsOnboardingCompletedKey) {
             return true
         }
-        return CGPreflightScreenCaptureAccess()
+
+        return UserDefaults.standard.bool(forKey: systemAudioRecordingGrantedKey)
+    }
+
+    private static func setSystemAudioRecordingGranted(_ granted: Bool) {
+        UserDefaults.standard.set(true, forKey: systemAudioRecordingKnownKey)
+        UserDefaults.standard.set(granted, forKey: systemAudioRecordingGrantedKey)
+    }
+
+    @MainActor
+    private static func requestSystemAudioRecordingAccess() async -> Bool {
+        if systemAudioRecordingGranted() {
+            return true
+        }
+
+        return await withCheckedContinuation { continuation in
+            let requester = SystemAudioPermissionRequester()
+            activeSystemAudioRequester = requester
+            requester.requestAccess { granted in
+                Task { @MainActor in
+                    activeSystemAudioRequester = nil
+                    continuation.resume(returning: granted)
+                }
+            }
+        }
     }
 
     @MainActor
@@ -191,5 +225,72 @@ enum TranscriptedPermissionAccess {
     private static func openSystemSettings(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         NSWorkspace.shared.open(url)
+    }
+}
+
+@available(macOS 26.0, *)
+private final class SystemAudioPermissionRequester: NSObject, SCStreamOutput {
+    private var stream: SCStream?
+    private let sampleHandlerQueue = DispatchQueue(label: "Transcripted.SystemAudioPermission")
+    private var completion: ((Bool) -> Void)?
+
+    func requestAccess(completion: @escaping (Bool) -> Void) {
+        self.completion = completion
+
+        SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) { [weak self] content, error in
+            guard let self else { return }
+
+            if error != nil {
+                self.finish(granted: false)
+                return
+            }
+
+            guard let display = content?.displays.first else {
+                self.finish(granted: false)
+                return
+            }
+
+            let filter = SCContentFilter(display: display, excludingWindows: [])
+            let config = SCStreamConfiguration()
+            config.capturesAudio = true
+            config.excludesCurrentProcessAudio = true
+            config.sampleRate = 48000
+            config.channelCount = 2
+            config.width = 2
+            config.height = 2
+            config.minimumFrameInterval = CMTime(value: 1, timescale: 1)
+
+            let stream = SCStream(filter: filter, configuration: config, delegate: nil)
+            self.stream = stream
+
+            do {
+                try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: self.sampleHandlerQueue)
+            } catch {
+                self.finish(granted: false)
+                return
+            }
+
+            stream.startCapture { [weak self] error in
+                guard let self else { return }
+
+                if error != nil {
+                    self.finish(granted: false)
+                    return
+                }
+
+                stream.stopCapture { [weak self] _ in
+                    self?.finish(granted: true)
+                }
+            }
+        }
+    }
+
+    func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {}
+
+    private func finish(granted: Bool) {
+        stream = nil
+        let completion = completion
+        self.completion = nil
+        completion?(granted)
     }
 }

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -31,7 +31,7 @@ public enum SystemAudioStatus: Equatable {
         case .healthy: return ""
         case .reconnecting: return "Reconnecting..."
         case .silent: return "System audio silent"
-        case .failed: return "System audio unavailable \u{2014} enable Screen Recording for Transcripted in System Settings"
+        case .failed: return "System audio unavailable \u{2014} enable System Audio Recording for Transcripted in System Settings"
         }
     }
 }
@@ -337,26 +337,17 @@ public class Audio: ObservableObject {
         // prompting here makes permission dialogs appear before the user has
         // explicitly asked to record a meeting.
 
-        // Initialize system audio capture.
-        // macOS 26+: ScreenCaptureKit audio-only → lighter "System Audio Recording Only" permission
-        // macOS 14.2–25: CoreAudio process taps → full "Screen Recording" permission
-        if #available(macOS 26.0, *) {
-            let capture = SCKAudioCapture()
-            systemAudioCapture = capture
-            systemAudioCancellable = capture.errorMessagePublisher
-                .receive(on: DispatchQueue.main)
-                .sink { [weak self] errorMessage in
-                    self?.updateSystemAudioStatus(fromError: errorMessage)
-                }
-        } else if #available(macOS 14.2, *) {
-            let capture = SystemAudioCapture()
-            systemAudioCapture = capture
-            systemAudioCancellable = capture.errorMessagePublisher
-                .receive(on: DispatchQueue.main)
-                .sink { [weak self] errorMessage in
-                    self?.updateSystemAudioStatus(fromError: errorMessage)
-                }
-        }
+        // Initialize system audio capture using the macOS 26+ audio-only
+        // ScreenCaptureKit path. This keeps meeting audio on the narrower
+        // "System Audio Recording" permission tier and avoids restart-required
+        // Screen Recording flows.
+        let capture = SCKAudioCapture()
+        systemAudioCapture = capture
+        systemAudioCancellable = capture.errorMessagePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] errorMessage in
+                self?.updateSystemAudioStatus(fromError: errorMessage)
+            }
 
         // MARK: - Sleep/Wake Observers (Phase 1: Invisible Reliability)
         // Handle macOS sleep/wake to prevent AVAudioEngine crashes and log gaps

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -332,14 +332,10 @@ public class Audio: ObservableObject {
 
         AppLogger.audioMic.info("Using system default microphone")
 
-        // Request microphone permission
-        AVCaptureDevice.requestAccess(for: .audio) { granted in
-            if !granted {
-                DispatchQueue.main.async {
-                    self.error = "Microphone permission denied. Go to System Settings \u{2192} Privacy & Security \u{2192} Microphone and enable Transcripted."
-                }
-            }
-        }
+        // Do not prompt for microphone access during object construction.
+        // MeetingSessionController creates Audio during background warmup, and
+        // prompting here makes permission dialogs appear before the user has
+        // explicitly asked to record a meeting.
 
         // Initialize system audio capture (macOS 14.2+)
         if #available(macOS 14.2, *) {

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -217,7 +217,7 @@ public class Audio: ObservableObject {
     @Published var systemAudioFailed: Bool = false
 
     // System audio capture
-    var systemAudioCapture: Any? // SystemAudioCapture (macOS 14.2+)
+    var systemAudioCapture: (any SystemAudioCaptureEngine)?
 
     // Audio file recording
     var systemAudioFile: AVAudioFile?
@@ -341,14 +341,21 @@ public class Audio: ObservableObject {
             }
         }
 
-        // Initialize system audio capture (macOS 14.2+)
-        if #available(macOS 14.2, *) {
+        // Initialize system audio capture.
+        // macOS 26+: ScreenCaptureKit audio-only → lighter "System Audio Recording Only" permission
+        // macOS 14.2–25: CoreAudio process taps → full "Screen Recording" permission
+        if #available(macOS 26.0, *) {
+            let capture = SCKAudioCapture()
+            systemAudioCapture = capture
+            systemAudioCancellable = capture.errorMessagePublisher
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] errorMessage in
+                    self?.updateSystemAudioStatus(fromError: errorMessage)
+                }
+        } else if #available(macOS 14.2, *) {
             let capture = SystemAudioCapture()
             systemAudioCapture = capture
-
-            // Observe SystemAudioCapture's errorMessage to update status
-            // This allows the UI to react to device changes and failures
-            systemAudioCancellable = capture.$errorMessage
+            systemAudioCancellable = capture.errorMessagePublisher
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] errorMessage in
                     self?.updateSystemAudioStatus(fromError: errorMessage)
@@ -558,9 +565,7 @@ public class Audio: ObservableObject {
         }
 
         // Stop system audio capture
-        if #available(macOS 14.2, *), let capture = systemAudioCapture as? SystemAudioCapture {
-            capture.stop()
-        }
+        systemAudioCapture?.stop()
 
         // Use the original mic URL (set at recording start), not the potentially-overwritten
         // recovery URL. Device recovery creates a new WAV segment but the original file
@@ -648,7 +653,7 @@ public class Audio: ObservableObject {
         }
 
         // Start system audio capture for level metering only (no file writing)
-        if #available(macOS 14.2, *), let capture = systemAudioCapture as? SystemAudioCapture {
+        if let capture = systemAudioCapture {
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 do {
                     try capture.prepare()
@@ -681,9 +686,7 @@ public class Audio: ObservableObject {
             }
         }
 
-        if #available(macOS 14.2, *), let capture = systemAudioCapture as? SystemAudioCapture {
-            capture.stopSync()  // Synchronous — avoids race where delayed cleanup destroys the next recording's tap
-        }
+        systemAudioCapture?.stopSync()  // Synchronous — avoids race where delayed cleanup destroys the next recording's tap
 
         DispatchQueue.main.async {
             self.isMonitoring = false

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -138,11 +138,7 @@ extension Audio {
                 } catch {
                     AppLogger.audioSystem.warning("System audio failed", ["error": error.localizedDescription])
                     DispatchQueue.main.async {
-                        if #available(macOS 26.0, *) {
                         strongSelf.error = "System audio unavailable \u{2014} can only record your microphone. To capture Zoom/Teams audio, go to System Settings \u{2192} Privacy & Security \u{2192} System Audio Recording and enable Transcripted."
-                    } else {
-                        strongSelf.error = "System audio unavailable \u{2014} can only record your microphone. To capture Zoom/Teams audio, go to System Settings \u{2192} Privacy & Security \u{2192} Screen Recording and enable Transcripted."
-                    }
                         strongSelf.systemAudioFailed = true
                     }
                 }

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -32,7 +32,7 @@ extension Audio {
         // Start system audio capture
         // CRITICAL: Create audio file BEFORE starting I/O proc to avoid CPU overload
         // Creating files in the audio callback causes HALC_ProxyIOContext::IOWorkLoop overload
-        if #available(macOS 14.2, *), let capture = systemAudioCapture as? SystemAudioCapture {
+        if let capture = systemAudioCapture {
             AppLogger.audioSystem.info("System audio capture object exists, setting up")
             let captureDir = self.paths.audioCaptures
             try? FileManager.default.createDirectory(at: captureDir, withIntermediateDirectories: true)
@@ -138,7 +138,11 @@ extension Audio {
                 } catch {
                     AppLogger.audioSystem.warning("System audio failed", ["error": error.localizedDescription])
                     DispatchQueue.main.async {
+                        if #available(macOS 26.0, *) {
+                        strongSelf.error = "System audio unavailable \u{2014} can only record your microphone. To capture Zoom/Teams audio, go to System Settings \u{2192} Privacy & Security \u{2192} System Audio Recording and enable Transcripted."
+                    } else {
                         strongSelf.error = "System audio unavailable \u{2014} can only record your microphone. To capture Zoom/Teams audio, go to System Settings \u{2192} Privacy & Security \u{2192} Screen Recording and enable Transcripted."
+                    }
                         strongSelf.systemAudioFailed = true
                     }
                 }

--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -1,0 +1,242 @@
+import AVFoundation
+import Combine
+import CoreMedia
+import ScreenCaptureKit
+
+/// ScreenCaptureKit-based system audio capture (macOS 26+).
+///
+/// Uses `SCStream` with audio-only output — no screen pixels are captured.
+/// On macOS 26, this triggers the lighter "System Audio Recording Only" permission
+/// tier instead of full Screen Recording. The permission dialog behaves like the
+/// microphone prompt: click Allow and it works immediately — no app restart needed.
+///
+/// The public interface matches `SystemAudioCaptureEngine` so `Audio` can swap
+/// between this and the CoreAudio-based `SystemAudioCapture` transparently.
+@available(macOS 26.0, *)
+final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine {
+    @Published var errorMessage: String?
+
+    private var stream: SCStream?
+    private var streamOutput: SCKAudioStreamOutput?
+    private var _audioFormat: AVAudioFormat?
+    private var _isCapturing = false
+    private var bufferCallback: ((AVAudioPCMBuffer) -> Void)?
+
+    // Buffer statistics (thread-safe)
+    private var _totalBuffers: Int = 0
+    private var _buffersWithData: Int = 0
+    private let statsLock = NSLock()
+
+    var audioFormat: AVAudioFormat? { _audioFormat }
+
+    var bufferSuccessRate: Double {
+        statsLock.lock()
+        defer { statsLock.unlock() }
+        guard _totalBuffers > 0 else { return 1.0 }
+        return Double(_buffersWithData) / Double(_totalBuffers)
+    }
+
+    var errorMessagePublisher: AnyPublisher<String?, Never> {
+        $errorMessage.eraseToAnyPublisher()
+    }
+
+    // MARK: - Lifecycle
+
+    func prepare() throws {
+        AppLogger.audioSystem.info("SCKAudioCapture: preparing ScreenCaptureKit audio stream")
+
+        // Fetch shareable content — triggers the system permission dialog on first use.
+        // Called from a background thread (AudioFileManager dispatches to .userInitiated),
+        // so the semaphore won't deadlock.
+        let semaphore = DispatchSemaphore(value: 0)
+        var content: SCShareableContent?
+        var fetchError: Error?
+
+        SCShareableContent.getExcludingDesktopWindows(false, onScreenWindowsOnly: false) { result, error in
+            content = result
+            fetchError = error
+            semaphore.signal()
+        }
+        semaphore.wait()
+
+        if let error = fetchError {
+            AppLogger.audioSystem.error("SCKAudioCapture: failed to get shareable content", ["error": error.localizedDescription])
+            throw error
+        }
+
+        guard let display = content?.displays.first else {
+            throw "SCKAudioCapture: no display found"
+        }
+
+        // Content filter scoped to the full display — captures all app audio.
+        let filter = SCContentFilter(display: display, excludingWindows: [])
+
+        // Audio-only configuration. We never add a .screen output, so macOS 26
+        // categorizes this under "System Audio Recording Only".
+        let config = SCStreamConfiguration()
+        config.capturesAudio = true
+        config.excludesCurrentProcessAudio = true
+        config.sampleRate = 48000
+        config.channelCount = 2
+        // Minimal video settings — the stream requires a config even though we
+        // never attach a screen output. Keep overhead negligible.
+        config.width = 2
+        config.height = 2
+        config.minimumFrameInterval = CMTime(value: 1, timescale: 1)
+
+        // Pre-create the format the WAV file will use. ScreenCaptureKit delivers
+        // float32 non-interleaved audio matching the configured rate/channels.
+        _audioFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48000,
+            channels: 2,
+            interleaved: false
+        )
+
+        stream = SCStream(filter: filter, configuration: config, delegate: nil)
+
+        AppLogger.audioSystem.info("SCKAudioCapture: stream prepared", [
+            "sampleRate": "48000",
+            "channels": "2"
+        ])
+    }
+
+    func start(bufferCallback: @escaping (AVAudioPCMBuffer) -> Void) throws {
+        guard let stream = stream else {
+            AppLogger.audioSystem.info("SCKAudioCapture: auto-preparing in start()")
+            try prepare()
+            guard self.stream != nil else { throw "SCKAudioCapture: prepare failed silently" }
+            return try start(bufferCallback: bufferCallback)
+        }
+
+        self.bufferCallback = bufferCallback
+
+        // Output handler converts CMSampleBuffer → AVAudioPCMBuffer
+        let output = SCKAudioStreamOutput { [weak self] buffer in
+            guard let self = self else { return }
+            self.statsLock.lock()
+            self._totalBuffers += 1
+            self._buffersWithData += 1
+            self.statsLock.unlock()
+            bufferCallback(buffer)
+        }
+        self.streamOutput = output
+
+        let queue = DispatchQueue(label: "SCKAudioCapture.output", qos: .userInitiated)
+        try stream.addStreamOutput(output, type: .audio, sampleHandlerQueue: queue)
+
+        // Start capture — synchronous wait since we're on a background thread.
+        let semaphore = DispatchSemaphore(value: 0)
+        var startError: Error?
+        stream.startCapture { error in
+            startError = error
+            semaphore.signal()
+        }
+        semaphore.wait()
+
+        if let error = startError {
+            AppLogger.audioSystem.error("SCKAudioCapture: start failed", ["error": error.localizedDescription])
+            DispatchQueue.main.async { self.errorMessage = error.localizedDescription }
+            throw error
+        }
+
+        _isCapturing = true
+        AppLogger.audioSystem.info("SCKAudioCapture: now capturing system audio")
+    }
+
+    func stop() {
+        guard _isCapturing, let stream = stream else { return }
+        _isCapturing = false
+
+        stream.stopCapture { [weak self] error in
+            if let error = error {
+                AppLogger.audioSystem.warning("SCKAudioCapture: stop error", ["error": error.localizedDescription])
+            }
+            self?.cleanup()
+        }
+    }
+
+    func stopSync() {
+        guard _isCapturing, let stream = stream else { return }
+        _isCapturing = false
+
+        let semaphore = DispatchSemaphore(value: 0)
+        stream.stopCapture { _ in
+            semaphore.signal()
+        }
+        semaphore.wait()
+        cleanup()
+    }
+
+    private func cleanup() {
+        AppLogger.audioSystem.info("SCKAudioCapture: cleanup")
+        logStats()
+        stream = nil
+        streamOutput = nil
+        bufferCallback = nil
+        _audioFormat = nil
+    }
+
+    private func logStats() {
+        statsLock.lock()
+        let total = _totalBuffers
+        let withData = _buffersWithData
+        statsLock.unlock()
+        AppLogger.audioSystem.info("SCKAudioCapture: buffer stats", [
+            "total": "\(total)",
+            "withData": "\(withData)"
+        ])
+    }
+}
+
+// MARK: - SCStream Audio Output
+
+/// Receives audio sample buffers from SCStream and converts them to AVAudioPCMBuffer.
+@available(macOS 26.0, *)
+private final class SCKAudioStreamOutput: NSObject, SCStreamOutput {
+    private let onBuffer: (AVAudioPCMBuffer) -> Void
+
+    init(onBuffer: @escaping (AVAudioPCMBuffer) -> Void) {
+        self.onBuffer = onBuffer
+    }
+
+    func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
+        guard type == .audio else { return }
+        guard let pcmBuffer = Self.createPCMBuffer(from: sampleBuffer) else { return }
+        onBuffer(pcmBuffer)
+    }
+
+    /// Convert CMSampleBuffer (ScreenCaptureKit's delivery format) to AVAudioPCMBuffer
+    /// (the format the rest of the pipeline expects).
+    ///
+    /// Allocates a new buffer and copies the audio data — the CMSampleBuffer's backing
+    /// memory is only valid during this callback, so the copy is required.
+    static func createPCMBuffer(from sampleBuffer: CMSampleBuffer) -> AVAudioPCMBuffer? {
+        guard let formatDesc = CMSampleBufferGetFormatDescription(sampleBuffer),
+              let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(formatDesc) else {
+            return nil
+        }
+
+        guard let format = AVAudioFormat(streamDescription: asbd) else { return nil }
+
+        let numFrames = CMSampleBufferGetNumSamples(sampleBuffer)
+        guard numFrames > 0 else { return nil }
+
+        guard let pcmBuffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(numFrames)
+        ) else { return nil }
+
+        pcmBuffer.frameLength = AVAudioFrameCount(numFrames)
+
+        let status = CMSampleBufferCopyPCMDataIntoAudioBufferList(
+            sampleBuffer,
+            at: 0,
+            frameCount: Int32(numFrames),
+            into: pcmBuffer.mutableAudioBufferList
+        )
+
+        guard status == noErr else { return nil }
+        return pcmBuffer
+    }
+}

--- a/Sources/TranscriptedCore/Audio/SystemAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SystemAudioCapture.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AudioToolbox
 import AVFoundation
+import Combine
 import QuartzCore  // CACurrentMediaTime — real-time-safe monotonic clock
 
 /// Captures system-wide audio output using CoreAudio process taps (macOS 14.2+)
@@ -16,7 +17,12 @@ import QuartzCore  // CACurrentMediaTime — real-time-safe monotonic clock
 /// - `AudioObjectRemovePropertyListener: no object with given ID` - Cleanup race condition (harmless)
 /// These are internal CoreAudio logs that cannot be suppressed from user code and don't affect functionality.
 @available(macOS 14.2, *)
-class SystemAudioCapture: ObservableObject {
+class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine {
+
+    var errorMessagePublisher: AnyPublisher<String?, Never> {
+        $errorMessage.eraseToAnyPublisher()
+    }
+
     @Published var isCapturing: Bool = false
     @Published var errorMessage: String?
 

--- a/Sources/TranscriptedCore/Audio/SystemAudioCaptureEngine.swift
+++ b/Sources/TranscriptedCore/Audio/SystemAudioCaptureEngine.swift
@@ -1,0 +1,34 @@
+import AVFoundation
+import Combine
+
+/// Common interface for system audio capture backends.
+///
+/// Two implementations exist:
+/// - `SystemAudioCapture` (macOS 14.2+) — CoreAudio process taps, requires full Screen Recording permission
+/// - `SCKAudioCapture` (macOS 26+) — ScreenCaptureKit audio-only stream, requires lighter "System Audio Recording Only" permission
+///
+/// `Audio` creates the right one at init time and uses this protocol everywhere else.
+public protocol SystemAudioCaptureEngine: AnyObject {
+    /// Audio format available after `prepare()`. Used to create the WAV file before starting capture.
+    var audioFormat: AVAudioFormat? { get }
+
+    /// Fraction of received buffers that contained actual audio data (0.0–1.0).
+    var bufferSuccessRate: Double { get }
+
+    /// Publishes error messages for UI status updates (device changes, failures, etc.).
+    var errorMessagePublisher: AnyPublisher<String?, Never> { get }
+
+    /// Set up the capture pipeline (tap/stream creation, format negotiation).
+    /// Call once before `start()`. Makes `audioFormat` available.
+    func prepare() throws
+
+    /// Begin delivering audio buffers through `bufferCallback`.
+    /// Calls `prepare()` automatically if not already called.
+    func start(bufferCallback: @escaping (AVAudioPCMBuffer) -> Void) throws
+
+    /// Stop capture with a short delay to let the pipeline settle.
+    func stop()
+
+    /// Stop capture immediately (no delay). Use when re-preparing the same instance.
+    func stopSync()
+}

--- a/Sources/TranscriptedCore/Audio/SystemAudioCaptureEngine.swift
+++ b/Sources/TranscriptedCore/Audio/SystemAudioCaptureEngine.swift
@@ -3,11 +3,12 @@ import Combine
 
 /// Common interface for system audio capture backends.
 ///
-/// Two implementations exist:
-/// - `SystemAudioCapture` (macOS 14.2+) — CoreAudio process taps, requires full Screen Recording permission
-/// - `SCKAudioCapture` (macOS 26+) — ScreenCaptureKit audio-only stream, requires lighter "System Audio Recording Only" permission
+/// The current app uses `SCKAudioCapture` (macOS 26+) — a ScreenCaptureKit
+/// audio-only stream that stays on the lighter "System Audio Recording Only"
+/// permission tier.
 ///
-/// `Audio` creates the right one at init time and uses this protocol everywhere else.
+/// Legacy `SystemAudioCapture` still conforms to this protocol for older or
+/// standalone paths, but the live Transcripted app no longer routes through it.
 public protocol SystemAudioCaptureEngine: AnyObject {
     /// Audio format available after `prepare()`. Used to create the WAV file before starting capture.
     var audioFormat: AVAudioFormat? { get }

--- a/Sources/TranscriptedCore/Models/FailedTranscription.swift
+++ b/Sources/TranscriptedCore/Models/FailedTranscription.swift
@@ -60,7 +60,8 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
             "Invalid audio data",
             "Recording too short",
             "Invalid audio format",
-            "System audio is required"
+            "System audio is required",
+            "System Audio Recording"
         ]
         return !permanent.contains(where: { errorMessage.localizedCaseInsensitiveContains($0) })
     }
@@ -77,7 +78,8 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
         if errorMessage.contains("Invalid audio") {
             return .invalidAudioFormat(detail: errorMessage)
         }
-        if errorMessage.contains("System audio is required") {
+        if errorMessage.contains("System audio is required")
+            || errorMessage.contains("System Audio Recording") {
             return .missingSystemAudio
         }
         if errorMessage.contains("model not loaded") {

--- a/Sources/TranscriptedCore/Models/TranscriptMetadataBuilder.swift
+++ b/Sources/TranscriptedCore/Models/TranscriptMetadataBuilder.swift
@@ -33,17 +33,8 @@ public struct RecordingHealthInfo {
     }
 
     /// Create health info from Audio instance.
-    /// `systemCapture` is typed as `Any?` so this file does not leak the
-    /// `@available(macOS 14.2, *)` gate from `SystemAudioCapture` across
-    /// the whole transcript-metadata surface. The cast is scoped to the
-    /// single line below, under an availability check.
-    public static func from(audio: Audio, systemCapture: Any?) -> RecordingHealthInfo {
-        let successRate: Double
-        if #available(macOS 14.2, *), let sc = systemCapture as? SystemAudioCapture {
-            successRate = sc.bufferSuccessRate
-        } else {
-            successRate = 1.0
-        }
+    public static func from(audio: Audio, systemCapture: (any SystemAudioCaptureEngine)?) -> RecordingHealthInfo {
+        let successRate = systemCapture?.bufferSuccessRate ?? 1.0
         return RecordingHealthInfo(
             captureQuality: CaptureQuality.from(successRate: successRate),
             audioGaps: audio.recordingGaps.count,

--- a/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
+++ b/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
@@ -128,7 +128,7 @@ public enum PipelineError: LocalizedError {
         case .invalidAudioFormat(let detail):
             return "Invalid audio format: \(detail)"
         case .missingSystemAudio:
-            return "System audio is required. Please grant Screen Recording permission in System Settings."
+            return "System audio is required. Please grant System Audio Recording permission in System Settings."
         case .modelNotLoaded(let model):
             return "\(model) model not loaded"
         case .modelInferenceFailed(let model, let underlying):

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -76,6 +76,10 @@ Cross-cutting permission checks now live in `Sources/Support/TranscriptedPermiss
 so the meeting prompt detector and the settings/onboarding flows share the same
 app-level permission logic outside the UI tree.
 
+Keep user-visible TCC prompts user-initiated. Background warmup paths should
+not request microphone, screen-recording, or calendar access on their own;
+onboarding and Settings own those prompts so the dialogs appear in context.
+
 ## Observation Pattern
 
 Controllers own Combine subscriptions and push explicit `update(...)` calls into

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -77,7 +77,7 @@ so the meeting prompt detector and the settings/onboarding flows share the same
 app-level permission logic outside the UI tree.
 
 Keep user-visible TCC prompts user-initiated. Background warmup paths should
-not request microphone, screen-recording, or calendar access on their own;
+not request microphone, system-audio-recording, or calendar access on their own;
 onboarding and Settings own those prompts so the dialogs appear in context.
 
 ## Observation Pattern

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -217,6 +217,7 @@ class DictationSessionController: ObservableObject {
 
         let microphoneStatus = AVCaptureDevice.authorizationStatus(for: .audio)
         guard microphoneStatus == .authorized else {
+            let openedMicrophoneSettings = shouldOpenMicrophoneSettings(for: microphoneStatus)
             DiagnosticsTrail.record(
                 logger: appState.logger,
                 level: .error,
@@ -231,7 +232,15 @@ class DictationSessionController: ObservableObject {
                     ]
                 )
             )
-            overlayController.showError(microphoneUnavailableMessage(for: microphoneStatus))
+            if openedMicrophoneSettings {
+                TranscriptedPermissionAccess.openSettings(for: .microphone)
+            }
+            overlayController.showError(
+                microphoneUnavailableMessage(
+                    for: microphoneStatus,
+                    openedSettings: openedMicrophoneSettings
+                )
+            )
             isDictating = false
             return
         }
@@ -654,11 +663,28 @@ class DictationSessionController: ObservableObject {
         overlayController?.showError("Recording was interrupted. Try again.")
     }
 
-    private func microphoneUnavailableMessage(for status: AVAuthorizationStatus) -> String {
+    private func shouldOpenMicrophoneSettings(for status: AVAuthorizationStatus) -> Bool {
+        switch status {
+        case .denied, .restricted:
+            return true
+        case .notDetermined, .authorized:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    private func microphoneUnavailableMessage(
+        for status: AVAuthorizationStatus,
+        openedSettings: Bool = false
+    ) -> String {
         switch status {
         case .notDetermined:
             return "Transcripted is still waiting for microphone permission."
         case .denied, .restricted:
+            if openedSettings {
+                return "Microphone access is off. Transcripted opened the Microphone pane in System Settings."
+            }
             return "Microphone access is off. Turn it on in System Settings."
         case .authorized:
             return "Microphone unavailable. Check your audio input and try again."

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -217,7 +217,7 @@ class DictationSessionController: ObservableObject {
 
         let microphoneStatus = AVCaptureDevice.authorizationStatus(for: .audio)
         guard microphoneStatus == .authorized else {
-            let openedMicrophoneSettings = shouldOpenMicrophoneSettings(for: microphoneStatus)
+            let shouldOfferSettingsAction = shouldOfferMicrophoneSettingsAction(for: microphoneStatus)
             DiagnosticsTrail.record(
                 logger: appState.logger,
                 level: .error,
@@ -232,14 +232,15 @@ class DictationSessionController: ObservableObject {
                     ]
                 )
             )
-            if openedMicrophoneSettings {
-                TranscriptedPermissionAccess.openSettings(for: .microphone)
-            }
             overlayController.showError(
                 microphoneUnavailableMessage(
                     for: microphoneStatus,
-                    openedSettings: openedMicrophoneSettings
-                )
+                    openedSettings: false
+                ),
+                actionTitle: shouldOfferSettingsAction ? "Open Microphone Settings" : nil,
+                action: shouldOfferSettingsAction ? {
+                    TranscriptedPermissionAccess.openSettings(for: .microphone)
+                } : nil
             )
             isDictating = false
             return
@@ -663,7 +664,7 @@ class DictationSessionController: ObservableObject {
         overlayController?.showError("Recording was interrupted. Try again.")
     }
 
-    private func shouldOpenMicrophoneSettings(for status: AVAuthorizationStatus) -> Bool {
+    private func shouldOfferMicrophoneSettingsAction(for status: AVAuthorizationStatus) -> Bool {
         switch status {
         case .denied, .restricted:
             return true

--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -54,6 +54,8 @@ class FloatingOverlayController {
     var reviewText: String = ""
     var streamingText: String = ""
     var errorMessage: String = ""
+    private var errorActionTitle: String?
+    private var errorActionHandler: (() -> Void)?
     var loadingElapsedSeconds: Int = 0 {
         didSet { pushStateToViews() }
     }
@@ -178,6 +180,8 @@ class FloatingOverlayController {
             state,
             dictationShortcutHint: dictationShortcutHint,
             errorMessage: errorMessage,
+            errorActionTitle: errorActionTitle,
+            onErrorAction: errorActionHandler,
             loadingPresentation: loadingPresentation,
             loadingElapsedSeconds: loadingElapsedSeconds,
             isTranscribing: sttRouter?.isTranscribing ?? false,
@@ -366,6 +370,8 @@ class FloatingOverlayController {
     func showLoadingState(near sourceApp: NSRunningApplication? = nil, presentation: LoadingPresentation? = nil) {
         errorDismissTask?.cancel()
         errorMessage = ""
+        errorActionTitle = nil
+        errorActionHandler = nil
         if let presentation {
             loadingPresentation = presentation
         }
@@ -395,23 +401,32 @@ class FloatingOverlayController {
         }
     }
 
-    func showError(_ message: String) {
+    func showError(
+        _ message: String,
+        actionTitle: String? = nil,
+        action: (() -> Void)? = nil
+    ) {
         errorDismissTask?.cancel()
         loadingTimerTask?.cancel()
         loadingTimerTask = nil
         errorMessage = message
+        errorActionTitle = actionTitle
+        errorActionHandler = action
         state = .drafting
-        resizePanel(to: NSSize(width: OverlayTokens.panelWidth, height: OverlayTokens.panelMinHeight))
+        resizePanel(to: errorPanelSize())
         if !isVisible {
             showPanel(near: nil)
         }
         pushStateToViews()  // Force update for error message
+        guard actionTitle == nil else { return }
         errorDismissTask = Task { @MainActor [weak self] in
             do {
                 try await Task.sleep(nanoseconds: TranscriptedConstants.errorDismissDelay)
             } catch { return }
             guard let self = self, !self.errorMessage.isEmpty else { return }
             self.errorMessage = ""
+            self.errorActionTitle = nil
+            self.errorActionHandler = nil
             self.hideWithCancelAnimation()
         }
     }
@@ -420,6 +435,8 @@ class FloatingOverlayController {
     func showNoSpeechAndDismiss() {
         errorDismissTask?.cancel()
         errorMessage = "No speech detected"
+        errorActionTitle = nil
+        errorActionHandler = nil
         state = .drafting
         resizePanel(to: NSSize(width: OverlayTokens.panelWidth, height: OverlayTokens.panelMinHeight))
         if !isVisible {
@@ -441,6 +458,8 @@ class FloatingOverlayController {
         loadingTimerTask?.cancel()
         successDismissTask?.cancel()
         errorMessage = ""
+        errorActionTitle = nil
+        errorActionHandler = nil
         state = .success
         resizePanelToCompact()
         if !isVisible {
@@ -478,6 +497,8 @@ class FloatingOverlayController {
         reviewText = ""
         streamingText = ""
         errorMessage = ""
+        errorActionTitle = nil
+        errorActionHandler = nil
         loadingPresentation = .initial
     }
 
@@ -540,11 +561,18 @@ class FloatingOverlayController {
         case .loading:
             return NSSize(width: OverlayTokens.panelWidth, height: OverlayTokens.panelLoadingHeight)
         case .drafting where !errorMessage.isEmpty:
-            return NSSize(width: OverlayTokens.panelWidth, height: OverlayTokens.panelMinHeight)
+            return errorPanelSize()
         case .idle, .listening, .drafting, .success:
             return NSSize(width: OverlayTokens.panelCompactWidth, height: OverlayTokens.panelCompactHeight)
         default:
             return NSSize(width: OverlayTokens.panelWidth, height: OverlayTokens.panelMinHeight)
         }
+    }
+
+    private func errorPanelSize() -> NSSize {
+        let height = errorActionTitle == nil
+            ? OverlayTokens.panelMinHeight
+            : OverlayTokens.panelActionErrorHeight
+        return NSSize(width: OverlayTokens.panelWidth, height: height)
     }
 }

--- a/Sources/UI/Overlay/OverlayDraftingView.swift
+++ b/Sources/UI/Overlay/OverlayDraftingView.swift
@@ -4,16 +4,75 @@
 import AppKit
 
 @MainActor
+private final class OverlaySecondaryButton: NSButton {
+    override var title: String {
+        didSet {
+            updateTitleAppearance()
+            invalidateIntrinsicContentSize()
+        }
+    }
+
+    override var intrinsicContentSize: NSSize {
+        let base = super.intrinsicContentSize
+        return NSSize(width: base.width + 20, height: max(28, base.height + 8))
+    }
+
+    override var isHighlighted: Bool {
+        didSet { updateLayerAppearance() }
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        commonInit()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    private func commonInit() {
+        isBordered = false
+        bezelStyle = .regularSquare
+        setButtonType(.momentaryPushIn)
+        wantsLayer = true
+        layer?.cornerRadius = 8
+        layer?.borderWidth = 1
+        focusRingType = .none
+        updateTitleAppearance()
+        updateLayerAppearance()
+    }
+
+    private func updateTitleAppearance() {
+        attributedTitle = NSAttributedString(
+            string: title,
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
+                .foregroundColor: OverlayTokens.textPrimary
+            ]
+        )
+    }
+
+    private func updateLayerAppearance() {
+        layer?.backgroundColor = (isHighlighted
+            ? NSColor.white.withAlphaComponent(0.12)
+            : NSColor.white.withAlphaComponent(0.07)
+        ).cgColor
+        layer?.borderColor = NSColor.white.withAlphaComponent(0.12).cgColor
+    }
+}
+
+@MainActor
 final class OverlayDraftingView: NSView {
     private let spinner = NSProgressIndicator()
     private let statusLabel = NSTextField(labelWithString: "")
     private let errorIcon = NSImageView()
     private let errorLabel = NSTextField(labelWithString: "")
+    private let errorActionButton = OverlaySecondaryButton(frame: .zero)
 
     // Secondary state: dimmed transcript + "Refining..." spinner
     private let dimmedTranscript = NSTextField(wrappingLabelWithString: "")
     private let refiningSpinner = NSProgressIndicator()
     private let refiningLabel = NSTextField(labelWithString: "")
+    private var errorAction: (() -> Void)?
 
     override init(frame: NSRect) {
         super.init(frame: frame)
@@ -59,6 +118,11 @@ final class OverlayDraftingView: NSView {
         errorLabel.isHidden = true
         addSubview(errorLabel)
 
+        errorActionButton.isHidden = true
+        errorActionButton.target = self
+        errorActionButton.action = #selector(handleErrorAction)
+        addSubview(errorActionButton)
+
         // Dimmed transcript (for showing text at reduced opacity during processing)
         dimmedTranscript.font = NSFont.systemFont(ofSize: 13)
         dimmedTranscript.textColor = OverlayTokens.textPrimary
@@ -98,9 +162,34 @@ final class OverlayDraftingView: NSView {
             // Error mode: icon + label centered
             let iconSize: CGFloat = 24
             let labelSize = errorLabel.fittingSize
-            let totalHeight = iconSize + 8 + labelSize.height
-            errorIcon.frame = NSRect(x: centerX - iconSize / 2, y: centerY - totalHeight / 2 + labelSize.height + 8, width: iconSize, height: iconSize)
-            errorLabel.frame = NSRect(x: pad, y: centerY - totalHeight / 2, width: bounds.width - pad * 2, height: labelSize.height)
+            let buttonSize = errorActionButton.isHidden ? .zero : errorActionButton.fittingSize
+            let hasAction = !errorActionButton.isHidden
+            let buttonSpacing: CGFloat = hasAction ? 10 : 0
+            let totalHeight = iconSize + 8 + labelSize.height + buttonSpacing + buttonSize.height
+            let startY = centerY - totalHeight / 2
+
+            errorIcon.frame = NSRect(
+                x: centerX - iconSize / 2,
+                y: startY + buttonSize.height + buttonSpacing + labelSize.height + 8,
+                width: iconSize,
+                height: iconSize
+            )
+            errorLabel.frame = NSRect(
+                x: pad,
+                y: startY + buttonSize.height + buttonSpacing,
+                width: bounds.width - pad * 2,
+                height: labelSize.height
+            )
+            if hasAction {
+                errorActionButton.frame = NSRect(
+                    x: centerX - buttonSize.width / 2,
+                    y: startY,
+                    width: buttonSize.width,
+                    height: buttonSize.height
+                )
+            } else {
+                errorActionButton.frame = .zero
+            }
         } else if !dimmedTranscript.isHidden {
             // Dimmed transcript mode
             dimmedTranscript.preferredMaxLayoutWidth = bounds.width - pad * 2
@@ -123,12 +212,26 @@ final class OverlayDraftingView: NSView {
         }
     }
 
-    func update(error: String?, isTranscribing: Bool, transcriptText: String, statusText: String) {
+    func update(
+        error: String?,
+        errorActionTitle: String?,
+        onErrorAction: (() -> Void)?,
+        isTranscribing: Bool,
+        transcriptText: String,
+        statusText: String
+    ) {
         if let error = error, !error.isEmpty {
             // Error mode
+            errorAction = onErrorAction
             errorIcon.isHidden = false
             errorLabel.isHidden = false
             errorLabel.stringValue = error
+            if let errorActionTitle, !errorActionTitle.isEmpty {
+                errorActionButton.title = errorActionTitle
+                errorActionButton.isHidden = false
+            } else {
+                errorActionButton.isHidden = true
+            }
             spinner.isHidden = true
             spinner.stopAnimation(nil)
             statusLabel.isHidden = true
@@ -137,6 +240,7 @@ final class OverlayDraftingView: NSView {
             refiningLabel.isHidden = true
         } else if isTranscribing, !transcriptText.isEmpty {
             // Dimmed transcript + refining
+            errorAction = nil
             dimmedTranscript.isHidden = false
             dimmedTranscript.stringValue = transcriptText
             refiningSpinner.isHidden = false
@@ -147,8 +251,10 @@ final class OverlayDraftingView: NSView {
             statusLabel.isHidden = true
             errorIcon.isHidden = true
             errorLabel.isHidden = true
+            errorActionButton.isHidden = true
         } else {
             // Default: spinner + status
+            errorAction = nil
             spinner.isHidden = false
             spinner.startAnimation(nil)
             statusLabel.isHidden = false
@@ -158,7 +264,13 @@ final class OverlayDraftingView: NSView {
             dimmedTranscript.isHidden = true
             refiningSpinner.isHidden = true
             refiningLabel.isHidden = true
+            errorActionButton.isHidden = true
         }
         needsLayout = true
+    }
+
+    @objc
+    private func handleErrorAction() {
+        errorAction?()
     }
 }

--- a/Sources/UI/Overlay/OverlayRootView.swift
+++ b/Sources/UI/Overlay/OverlayRootView.swift
@@ -118,6 +118,8 @@ final class OverlayRootView: NSView {
         _ state: FloatingOverlayController.OverlayState,
         dictationShortcutHint: String,
         errorMessage: String,
+        errorActionTitle: String?,
+        onErrorAction: (() -> Void)?,
         loadingPresentation: FloatingOverlayController.LoadingPresentation,
         loadingElapsedSeconds: Int,
         isTranscribing: Bool,
@@ -155,6 +157,8 @@ final class OverlayRootView: NSView {
             let statusText = isTranscribing ? "Transcribing..." : "Processing..."
             draftingView.update(
                 error: errorMessage.isEmpty ? nil : errorMessage,
+                errorActionTitle: errorActionTitle,
+                onErrorAction: onErrorAction,
                 isTranscribing: isTranscribing,
                 transcriptText: liveTranscript,
                 statusText: statusText

--- a/Sources/UI/Overlay/OverlayTokens.swift
+++ b/Sources/UI/Overlay/OverlayTokens.swift
@@ -27,6 +27,7 @@ enum OverlayTokens {
     static let panelCompactHeight: CGFloat = 42   // header bar only, no content area
     static let panelLoadingHeight: CGFloat = 100
     static let panelMinHeight: CGFloat     = 92
+    static let panelActionErrorHeight: CGFloat = 122
     static let panelMaxHeight: CGFloat     = 340
     static let cornerRadius: CGFloat   = 12
     static let contentPadding: CGFloat = 12

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -34,7 +34,7 @@ struct PermissionsOnboardingView: View {
 
     @State private var micGranted = false
     @State private var accessibilityGranted = false
-    @State private var screenRecordingGranted = false
+    @State private var systemAudioRecordingGranted = false
     @State private var crashReportingEnabled = CrashReportingPreferences.isEnabled()
     @State private var anonymousAnalyticsEnabled = AnalyticsPreferences.isEnabled()
     @State private var pollTimer: Timer?
@@ -102,9 +102,9 @@ struct PermissionsOnboardingView: View {
                         QuickStartRow(
                             icon: "record.circle.fill",
                             title: "Meetings",
-                            detail: screenRecordingGranted
+                            detail: systemAudioRecordingGranted
                                 ? "Meeting audio is ready too. Calendar prompts stay optional."
-                                : MeetingRecordingStartGate.screenRecordingQuickStart
+                                : MeetingRecordingStartGate.systemAudioRecordingQuickStart
                         )
                     }
                     .padding(14)
@@ -152,7 +152,7 @@ struct PermissionsOnboardingView: View {
     }
 
     private var hasRequiredPermissions: Bool {
-        micGranted && accessibilityGranted
+        micGranted && accessibilityGranted && systemAudioRecordingGranted
     }
 
     private var requiredPermissions: [TranscriptedPermissionKind] {
@@ -181,8 +181,8 @@ struct PermissionsOnboardingView: View {
             return micGranted
         case .accessibility:
             return accessibilityGranted
-        case .screenRecording:
-            return screenRecordingGranted
+        case .systemAudioRecording:
+            return systemAudioRecordingGranted
         case .calendar:
             return TranscriptedPermissionAccess.isGranted(.calendar)
         }
@@ -191,7 +191,7 @@ struct PermissionsOnboardingView: View {
     private func checkAllPermissions() {
         micGranted = TranscriptedPermissionAccess.isGranted(.microphone)
         accessibilityGranted = TranscriptedPermissionAccess.isGranted(.accessibility)
-        screenRecordingGranted = TranscriptedPermissionAccess.isGranted(.screenRecording)
+        systemAudioRecordingGranted = TranscriptedPermissionAccess.isGranted(.systemAudioRecording)
     }
 
     private func startPolling() {
@@ -220,7 +220,7 @@ struct PermissionsOnboardingView: View {
             properties: [
                 "anonymous_usage_enabled": anonymousAnalyticsEnabled ? "true" : "false",
                 "crash_reporting_enabled": crashReportingEnabled ? "true" : "false",
-                "screen_recording_enabled": screenRecordingGranted ? "true" : "false",
+                "system_audio_recording_enabled": systemAudioRecordingGranted ? "true" : "false",
             ]
         )
         if startFirstDictation, let onStartDictation {

--- a/Sources/UI/Shared/FirstRunExperience.swift
+++ b/Sources/UI/Shared/FirstRunExperience.swift
@@ -42,8 +42,8 @@ enum FirstRunExperience {
     ) -> FirstRunPrimaryActionState {
         guard hasRequiredPermissions else {
             return FirstRunPrimaryActionState(
-                title: "Turn on microphone and accessibility",
-                detail: "Turn on Microphone and Accessibility first. That's enough for your first dictation.",
+                title: "Turn on the required permissions",
+                detail: "Turn on Microphone, Accessibility, and System Audio Recording first so dictation and meetings are ready right away.",
                 isEnabled: false,
                 shouldStartDictation: false
             )

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -16,17 +16,17 @@ func testFailedMeetingPresentation() {
         )
     }
 
-    runSuite("FailedMeetingPresentation screen recording failures point to settings") {
+    runSuite("FailedMeetingPresentation system audio failures point to settings") {
         let copy = MeetingFailureCopy.make(
-            forMessage: "System audio is required. Turn on Screen Recording and retry.",
-            shortErrorMessage: "System audio is required. Turn on Screen Recording and retry.",
+            forMessage: "System audio is required. Turn on System Audio Recording and retry.",
+            shortErrorMessage: "System audio is required. Turn on System Audio Recording and retry.",
             isRetryable: false
         )
 
-        assertEqual(copy.title, "Turn on Screen Recording", "permission failures should name the missing permission")
+        assertEqual(copy.title, "Turn on System Audio Recording", "permission failures should name the missing permission")
         assertEqual(
             copy.detail,
-            "Turn on Screen Recording in System Settings, then retry the meeting.",
+            "Turn on System Audio Recording in System Settings, then retry the meeting.",
             "permission failures should point to the recovery step"
         )
     }

--- a/Tests/MeetingRecordingStartGateTests.swift
+++ b/Tests/MeetingRecordingStartGateTests.swift
@@ -19,7 +19,7 @@ func testMeetingRecordingStartGate() {
         assertFalse(decision.canStart, "meeting capture should fail fast when Screen Recording is missing")
         assertEqual(
             decision.errorMessage,
-            "Turn on Screen Recording in System Settings before recording a meeting.",
+            "Turn on Screen Recording in System Settings, then quit and reopen Transcripted before recording a meeting.",
             "screen recording failures should tell the user exactly what to fix"
         )
         assertEqual(decision.failureReason, "screen_recording", "screen recording failures should stay classified for diagnostics")
@@ -35,7 +35,7 @@ func testMeetingRecordingStartGate() {
         assertFalse(decision.canStart, "meeting capture should not start when both required permissions are missing")
         assertEqual(
             decision.errorMessage,
-            "Turn on Microphone and Screen Recording in System Settings before recording a meeting.",
+            "Turn on Microphone and Screen Recording in System Settings, then quit and reopen Transcripted before recording a meeting.",
             "combined permission failures should mention both missing requirements"
         )
         assertEqual(
@@ -53,13 +53,13 @@ func testMeetingRecordingStartGate() {
         )
         assertEqual(
             MeetingRecordingStartGate.screenRecordingQuickStart,
-            "Turn on Screen Recording before you record meetings so Transcripted can capture the other side of Zoom, Meet, and similar apps.",
-            "quick-start copy should stop implying that full meeting capture works without screen recording"
+            "Turn on Screen Recording before you record meetings. After you enable it, quit and reopen Transcripted so macOS can hand over system audio.",
+            "quick-start copy should explain that screen recording changes need a relaunch before meeting capture works"
         )
         assertEqual(
             MeetingRecordingStartGate.optionalPermissionsFootnote,
-            "You can start dictating without these. Turn on Screen Recording before you record meetings, and add Calendar later if you want meeting prompts.",
-            "onboarding footnote should match the current meeting recording requirement"
+            "You can start dictating without these. Turn on Screen Recording before you record meetings, then reopen Transcripted. Add Calendar later if you want meeting prompts.",
+            "onboarding footnote should match the current meeting recording requirement and relaunch guidance"
         )
     }
 }

--- a/Tests/MeetingRecordingStartGateTests.swift
+++ b/Tests/MeetingRecordingStartGateTests.swift
@@ -1,52 +1,40 @@
 import Foundation
 
 func testMeetingRecordingStartGate() {
-    let screenRecordingError: String
-    let combinedPermissionsError: String
-    let quickStartCopy: String
-    let optionalPermissionsCopy: String
-
-    if #available(macOS 26.0, *) {
-        screenRecordingError = "Turn on System Audio Recording in System Settings before recording a meeting."
-        combinedPermissionsError = "Turn on Microphone and System Audio Recording in System Settings before recording a meeting."
-        quickStartCopy = "Turn on System Audio Recording before you record meetings so Transcripted can capture the other side of Zoom, Meet, and similar apps."
-        optionalPermissionsCopy = "You can start dictating without these. Turn on System Audio Recording before you record meetings, and add Calendar later if you want meeting prompts."
-    } else {
-        screenRecordingError = "Turn on Screen Recording in System Settings, then quit and reopen Transcripted before recording a meeting."
-        combinedPermissionsError = "Turn on Microphone and Screen Recording in System Settings, then quit and reopen Transcripted before recording a meeting."
-        quickStartCopy = "Turn on Screen Recording before you record meetings. After you enable it, quit and reopen Transcripted so macOS can hand over system audio."
-        optionalPermissionsCopy = "You can start dictating without these. Turn on Screen Recording before you record meetings, then reopen Transcripted. Add Calendar later if you want meeting prompts."
-    }
+    let systemAudioRecordingError = "Turn on System Audio Recording before recording a meeting."
+    let combinedPermissionsError = "Turn on Microphone and System Audio Recording before recording a meeting."
+    let quickStartCopy = "Turn on System Audio Recording so Transcripted can capture the other side of Zoom, Meet, and similar apps."
+    let optionalPermissionsCopy = "Calendar is optional. Add it later if you want Transcripted to spot upcoming meetings and offer a record prompt."
 
     runSuite("MeetingRecordingStartGate.evaluate — allows meeting capture when required permissions exist") {
         let decision = MeetingRecordingStartGate.evaluate(
             microphoneGranted: true,
-            screenRecordingGranted: true
+            systemAudioRecordingGranted: true
         )
 
         assertEqual(decision, .allowed, "meeting capture should start normally when both permissions are granted")
     }
 
-    runSuite("MeetingRecordingStartGate.evaluate — blocks meeting capture when Screen Recording is missing") {
+    runSuite("MeetingRecordingStartGate.evaluate — blocks meeting capture when System Audio Recording is missing") {
         let decision = MeetingRecordingStartGate.evaluate(
             microphoneGranted: true,
-            screenRecordingGranted: false
+            systemAudioRecordingGranted: false
         )
 
-        assertFalse(decision.canStart, "meeting capture should fail fast when Screen Recording is missing")
+        assertFalse(decision.canStart, "meeting capture should fail fast when System Audio Recording is missing")
         assertEqual(
             decision.errorMessage,
-            screenRecordingError,
-            "screen recording failures should tell the user exactly what to fix"
+            systemAudioRecordingError,
+            "system-audio failures should tell the user exactly what to fix"
         )
-        assertEqual(decision.failureReason, "screen_recording", "screen recording failures should stay classified for diagnostics")
-        assertEqual(decision.missingPermissions, ["screen_recording"], "missing permission list should stay explicit")
+        assertEqual(decision.failureReason, "system_audio_recording", "system-audio failures should stay classified for diagnostics")
+        assertEqual(decision.missingPermissions, ["system_audio_recording"], "missing permission list should stay explicit")
     }
 
     runSuite("MeetingRecordingStartGate.evaluate — blocks meeting capture when both permissions are missing") {
         let decision = MeetingRecordingStartGate.evaluate(
             microphoneGranted: false,
-            screenRecordingGranted: false
+            systemAudioRecordingGranted: false
         )
 
         assertFalse(decision.canStart, "meeting capture should not start when both required permissions are missing")
@@ -57,19 +45,19 @@ func testMeetingRecordingStartGate() {
         )
         assertEqual(
             decision.missingPermissions,
-            ["microphone", "screen_recording"],
+            ["microphone", "system_audio_recording"],
             "combined permission failures should preserve a stable missing-permission list"
         )
     }
 
-    runSuite("MeetingPermissionCopy — keeps screen recording copy aligned with the meeting gate") {
+    runSuite("MeetingPermissionCopy — keeps system-audio copy aligned with the meeting gate") {
         assertEqual(
-            MeetingRecordingStartGate.screenRecordingSummary,
-            "Optional on first launch. Required before Transcripted can capture meeting audio from other apps.",
-            "shared summary copy should explain that screen recording is optional for dictation setup but required for meetings"
+            MeetingRecordingStartGate.systemAudioRecordingSummary,
+            "Needed so Transcripted can capture the other side of calls, videos, and other meeting audio.",
+            "shared summary copy should explain why system audio recording matters"
         )
         assertEqual(
-            MeetingRecordingStartGate.screenRecordingQuickStart,
+            MeetingRecordingStartGate.systemAudioRecordingQuickStart,
             quickStartCopy,
             "quick-start copy should reflect the current meeting-audio permission path"
         )

--- a/config/entitlements/beta.plist
+++ b/config/entitlements/beta.plist
@@ -10,8 +10,6 @@
     <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
-    <key>com.apple.security.speech.recognition</key>
-    <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>

--- a/config/entitlements/local.plist
+++ b/config/entitlements/local.plist
@@ -8,7 +8,5 @@
     <true/>
     <key>com.apple.security.device.audio-capture</key>
     <true/>
-    <key>com.apple.security.speech.recognition</key>
-    <true/>
 </dict>
 </plist>

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -6,6 +6,10 @@ Use `build-beta.sh` for anything you intend to hand to another machine. That is
 the path that applies hardened runtime signing, builds a DMG, and optionally
 submits it for notarization.
 
+Transcripted now targets macOS 26+ for app builds and packaged releases. If a
+build is meant to ship to users, keep the bundle metadata, build targets, and
+Sparkle release metadata aligned with that floor.
+
 The distribution DMG now uses committed release art:
 
 - app icon: `Resources/Transcripted.icns`

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -2,6 +2,9 @@
 
 Transcripted now uses Sparkle for in-app update checks.
 
+The live app now targets macOS 26+ only. When cutting a new release, the
+generated appcast entry for that release should advertise the same 26+ floor.
+
 Future agents should treat this as a release requirement:
 
 - if a build is meant to reach existing users through the app's updater, the

--- a/scripts/entrypoints/build-beta.sh
+++ b/scripts/entrypoints/build-beta.sh
@@ -381,7 +381,7 @@ swiftc \
     $DEPS_FLAGS \
     $SOURCE_FILES \
     -parse-as-library \
-    -target arm64-apple-macos14.0 \
+    -target arm64-apple-macos26.0 \
     -Xlinker -rpath -Xlinker @executable_path/../Frameworks \
     2>&1
 

--- a/scripts/entrypoints/build-beta.sh
+++ b/scripts/entrypoints/build-beta.sh
@@ -365,7 +365,6 @@ swiftc \
     -framework SwiftUI \
     -framework Combine \
     -framework EventKit \
-    -framework Speech \
     -framework Security \
     -framework Carbon \
     -framework Metal \

--- a/scripts/entrypoints/build-deps.sh
+++ b/scripts/entrypoints/build-deps.sh
@@ -223,7 +223,7 @@ cat > "$DEPS_BUILD/Package.swift" << 'PACKAGE_EOF'
 import PackageDescription
 let package = Package(
     name: "DraftDeps",
-    platforms: [.macOS(.v14)],
+    platforms: [.macOS("26.0")],
     dependencies: [
         .package(url: "https://github.com/FluidInference/FluidAudio.git", exact: "FLUID_AUDIO_VERSION_PLACEHOLDER"),
         .package(url: "https://github.com/ml-explore/mlx-swift-lm", revision: "MLX_SWIFT_LM_REVISION_PLACEHOLDER"),
@@ -434,7 +434,7 @@ if [ -n "$CMLX_SRC" ]; then
                 -I "$METAL_KERNELS/steel/gemm" \
                 -I "$METAL_KERNELS/steel/attn" \
                 -I "$METAL_KERNELS/steel/conv" \
-                -target air64-apple-macos14.0 \
+                -target air64-apple-macos26.0 \
                 "$metal_file" -o "$METAL_OUT/$name.air" 2>&1
         done
 

--- a/scripts/entrypoints/build.sh
+++ b/scripts/entrypoints/build.sh
@@ -196,6 +196,7 @@ swiftc \
     -framework Vision \
     -framework MetalPerformanceShaders \
     -framework MetalPerformanceShadersGraph \
+    -framework ScreenCaptureKit \
     -framework Sentry \
     -framework Sparkle \
     -lc++ \

--- a/scripts/entrypoints/build.sh
+++ b/scripts/entrypoints/build.sh
@@ -203,7 +203,7 @@ swiftc \
     $DEPS_FLAGS \
     $SOURCE_FILES \
     -parse-as-library \
-    -target arm64-apple-macos14.0 \
+    -target arm64-apple-macos26.0 \
     -Xlinker -rpath -Xlinker @executable_path/../Frameworks \
     2>&1
 

--- a/scripts/entrypoints/build.sh
+++ b/scripts/entrypoints/build.sh
@@ -187,7 +187,6 @@ swiftc \
     -framework SwiftUI \
     -framework Combine \
     -framework EventKit \
-    -framework Speech \
     -framework Security \
     -framework Carbon \
     -framework Metal \

--- a/scripts/entrypoints/run-integration-smoke.sh
+++ b/scripts/entrypoints/run-integration-smoke.sh
@@ -63,7 +63,7 @@ swiftc \
     -Xlinker -rpath -Xlinker "$REPO_ROOT/deps-frameworks" \
     "$REPO_ROOT/Tests/Integration/AppCoreIntegrationSmoke.swift" \
     -parse-as-library \
-    -target arm64-apple-macos14.0 \
+    -target arm64-apple-macos26.0 \
     -Xlinker -rpath -Xlinker "$DEPS_FRAMEWORK_ROOT" \
     2>&1
 
@@ -74,7 +74,7 @@ swiftc \
     "$REPO_ROOT/Sources/Reliability/WakeRecoveryCoordinator.swift" \
     "$REPO_ROOT/Tests/Integration/WakeRecoveryIntegrationSmoke.swift" \
     -parse-as-library \
-    -target arm64-apple-macos14.0 \
+    -target arm64-apple-macos26.0 \
     2>&1
 
 echo ""


### PR DESCRIPTION
## What changed

This PR simplifies Transcripted's permission model around the new macOS 26 system-audio-only path.

- make Transcripted macOS 26+ only in app/package/build metadata
- remove the old Screen Recording fallback path and restart-required copy
- treat onboarding as Microphone, Accessibility, and System Audio Recording, with Calendar optional
- add an explicit ScreenCaptureKit audio-only permission request path for system audio
- clean stale permission copy across onboarding, meeting failures, and dictation/meeting flows
- remove the unused Apple Speech permission, entitlement, and framework link
- improve denied microphone recovery in dictation by offering an in-overlay "Open Microphone Settings" action instead of auto-opening Settings

## Why

We want the end-user setup flow to be simpler and more truthful:

- meetings should use the narrower System Audio Recording permission on macOS 26+
- users should not be sent through the old full Screen Recording flow
- users should not see old "quit and reopen" guidance
- denied permissions should recover cleanly without surprising settings jumps

## User impact

After onboarding, users should be set up with:

- Microphone for dictation and their side of meetings
- Accessibility for paste-back and shortcuts
- System Audio Recording for meeting audio capture
- Calendar optionally for meeting prompts

If a user denies microphone access and later tries dictation, they now see the overlay error plus an inline button to open the correct Settings pane.

## Validation

Ran:

- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `swift test`

And after the follow-up dictation permission UX change:

- `bash build.sh`
- `bash run-tests.sh`

## Notes

I intentionally did not update `docs/appcast.xml` here. That should happen with the real release cut so shipped Sparkle metadata stays accurate.