### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -15,6 +15,7 @@
 - `MeetingRecordingStartGate.swift` — permission preflight for meeting recording, including missing-permission reasons and user-facing error messages
 - `MeetingSTTAdapter.swift` — adapts the app's shared `ParakeetEngine` to `TranscriptedCore.SpeechToTextEngine`
 - `MeetingSessionController.swift` — top-level meeting state machine, permission gating, model warmup, capture start/stop, queued transcription handoff, failed-meeting actions, and transcript restyling
+- `MeetingSessionUIPolicy.swift` — centralizes when queued or active transcription work should keep the meeting overlay in its transcribing/saving state
 - `MeetingStoragePaths.swift` — current split meeting storage layout across the capture library, app state, logs, and temp folders
 - `MeetingTranscriptStyler.swift` — restyles saved transcripts and renames files after save
 
@@ -37,6 +38,7 @@
 - `MeetingPromptDetector` can prompt from either upcoming calendar events or recently active supported meeting apps (Zoom, Teams, Webex, FaceTime, plus browser-hosted providers like Google Meet).
 - `MeetingRecordingStartGate` is the canonical place for meeting-recording permission policy and reason strings. Keep duplicate permission branching out of overlay code.
 - `MeetingFailureCopy` is the canonical place for human-facing failed-meeting titles and details. Keep retry messaging centralized there.
+- `MeetingSessionUIPolicy` is the canonical place for deciding whether background meeting work should still surface as an active transcribing/saving state. Speaker review alone should not keep that state visible.
 - `TranscriptionTaskManager` stays single-flight. App-level queueing belongs in `MeetingSessionController`, not in ad hoc background tasks.
 - Live PCM handlers installed through `MeetingCaptureBridge` run on capture threads. Keep them real-time safe.
 
@@ -70,6 +72,8 @@ See `docs/storage-paths.md` for the full map.
 Relevant direct coverage:
 
 - `Tests/MeetingPromptHeuristicsTests.swift`
+- `Tests/MeetingRecordingStartGateTests.swift`
+- `Tests/MeetingSessionUIPolicyTests.swift`
 - `Tests/MeetingTranscriptStylerTests.swift`
 - `Tests/SpeakerNamingPolicyTests.swift`
 - `Tests/Integration/AppCoreIntegrationSmoke.swift`

--- a/Sources/Speech/CLAUDE.md
+++ b/Sources/Speech/CLAUDE.md
@@ -6,7 +6,8 @@
 
 ## Key Files
 
-- `ParakeetEngine.swift` — app-owned Parakeet STT engine, recording control, live transcript state, model initialization, permission-aware prewarm decisions, audio-device handling, short-audio gating, and wake-recovery support
+- `ParakeetEngine.swift` — app-owned Parakeet STT engine, recording control, live transcript state, model initialization, permission-aware prewarm decisions, audio-device handling, short-audio gating, wake-recovery support, and sanitized failure reporting for model init errors
+- `ParakeetModelInitDiagnostics.swift` — builds safe diagnostic context for model-initialization failures without leaking transcript or user-content data
 - `ParakeetPrewarmPolicy.swift` — central policy for deciding whether speech-engine prewarm should proceed or be skipped based on microphone authorization state
 - `ParakeetShortAudioGate.swift` — central policy for deciding when very short recordings should be dropped, surfaced as intentional empty results, or still transcribed
 - `RecordedAudioTimeline.swift` — in-memory segmented audio buffer used when recorded audio needs to be preserved across interruptions or recovery handoffs
@@ -17,6 +18,7 @@
 - This directory powers dictation.
 - `ParakeetEngine` consults `ParakeetPrewarmPolicy` before prewarming the local model, so microphone-permission-aware warmup behavior belongs here rather than in app startup glue.
 - `ParakeetEngine` consults `ParakeetShortAudioGate` before spending work on extremely short clips, so short-tap behavior changes belong here rather than in UI controllers.
+- `ParakeetEngine` reports model-init failures with `ParakeetModelInitDiagnostics.failureContext(...)`, which keeps diagnostics useful for packaging/download/debugging issues without shipping raw transcript or device content.
 - The meeting pipeline reuses the same app-owned `ParakeetEngine` through `Sources/Meeting/MeetingSTTAdapter.swift`.
 - Do not assume a separate local-LLM drafting path exists in this tree.
 
@@ -39,6 +41,7 @@ Manual checks:
 
 Relevant direct coverage:
 
+- `Tests/ParakeetModelInitDiagnosticsTests.swift`
 - `Tests/ParakeetPrewarmPolicyTests.swift`
 - `Tests/ParakeetShortAudioGateTests.swift`
 - `Tests/RecordedAudioTimelineTests.swift`


### PR DESCRIPTION
## Summary
- update `Sources/Meeting/CLAUDE.md` for the new `MeetingSessionUIPolicy.swift` file and its overlay transcribing-state responsibility
- update meeting test coverage notes to include `MeetingRecordingStartGateTests` and `MeetingSessionUIPolicyTests`
- update `Sources/Speech/CLAUDE.md` for the new `ParakeetModelInitDiagnostics.swift` helper and sanitized model-init failure reporting
- add `ParakeetModelInitDiagnosticsTests` to the speech coverage notes

## Why
Recent merges added meeting UI policy logic and Parakeet init diagnostics after the last nightly docs sync, so the local CLAUDE docs had drifted from the current codebase.