### PR TITLE
[nightly-security] Harden observability redaction for URLs and tokens

### DIFF
--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -21,6 +21,13 @@ enum AnalyticsPayloadSanitizer {
 
     private static let userPathRegex = try! NSRegularExpression(pattern: #"/Users/[^/\s]+/"#)
     private static let absolutePathRegex = try! NSRegularExpression(pattern: #"(?<!https:)(?<!http:)/(?:Users|private|var|tmp|Volumes|Applications)[^\s"]*"#)
+    private static let rawURLRegex = try! NSRegularExpression(pattern: #"https?://[^\s"]+"#, options: [.caseInsensitive])
+    private static let commonSecretRegex = try! NSRegularExpression(
+        pattern: #"\b(?:ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|phc_[A-Za-z0-9]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|xoxx-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9._-]{10,}\.[A-Za-z0-9._-]{10,})\b"#
+    )
+    private static let secretAssignmentRegex = try! NSRegularExpression(
+        pattern: #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature)\s*[:=]\s*([^\s,;]+)"#
+    )
     private static let emailRegex = try! NSRegularExpression(pattern: #"[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}"#, options: [.caseInsensitive])
 
     static func sanitizeProperties(
@@ -50,6 +57,12 @@ enum AnalyticsPayloadSanitizer {
         result = userPathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "/Users/****/")
         range = NSRange(result.startIndex..., in: result)
         result = absolutePathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-path]")
+        range = NSRange(result.startIndex..., in: result)
+        result = rawURLRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-url]")
+        range = NSRange(result.startIndex..., in: result)
+        result = commonSecretRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
+        range = NSRange(result.startIndex..., in: result)
+        result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)
         result = emailRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-email]")
 

--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -22,8 +22,15 @@ enum SentryPayloadSanitizer {
 
     private static let userPathRegex = try! NSRegularExpression(pattern: #"/Users/[^/\s]+/"#)
     private static let absolutePathRegex = try! NSRegularExpression(pattern: #"(?<!https:)(?<!http:)/(?:Users|private|var|tmp|Volumes|Applications)[^\s"]*"#)
+    private static let rawURLRegex = try! NSRegularExpression(pattern: #"https?://[^\s"]+"#, options: [.caseInsensitive])
     private static let apiKeyRegex = try! NSRegularExpression(pattern: #"sk-[A-Za-z0-9_-]+"#)
+    private static let commonSecretRegex = try! NSRegularExpression(
+        pattern: #"\b(?:ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|phc_[A-Za-z0-9]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|xoxx-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9._-]{10,}\.[A-Za-z0-9._-]{10,})\b"#
+    )
     private static let bearerRegex = try! NSRegularExpression(pattern: #"Bearer [A-Za-z0-9._-]+"#)
+    private static let secretAssignmentRegex = try! NSRegularExpression(
+        pattern: #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature)\s*[:=]\s*([^\s,;]+)"#
+    )
     private static let emailRegex = try! NSRegularExpression(pattern: #"[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}"#, options: [.caseInsensitive])
     private static let localHostnameRegex = try! NSRegularExpression(pattern: #"\b[a-zA-Z0-9._-]+\.local\b"#)
 
@@ -88,9 +95,15 @@ enum SentryPayloadSanitizer {
         range = NSRange(result.startIndex..., in: result)
         result = absolutePathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-path]")
         range = NSRange(result.startIndex..., in: result)
+        result = rawURLRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-url]")
+        range = NSRange(result.startIndex..., in: result)
         result = apiKeyRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "sk-****")
         range = NSRange(result.startIndex..., in: result)
+        result = commonSecretRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
+        range = NSRange(result.startIndex..., in: result)
         result = bearerRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "Bearer ****")
+        range = NSRange(result.startIndex..., in: result)
+        result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)
         result = emailRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-email]")
         range = NSRange(result.startIndex..., in: result)

--- a/Tests/AnalyticsPayloadSanitizerTests.swift
+++ b/Tests/AnalyticsPayloadSanitizerTests.swift
@@ -32,4 +32,20 @@ func testAnalyticsPayloadSanitizer() {
         assertTrue(value.contains("[redacted-path]"), "path marker should remain")
         assertTrue(value.contains("[redacted-email]"), "email marker should remain")
     }
+
+    runSuite("AnalyticsPayloadSanitizer redacts raw URLs and common secret values") {
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "failure_kind": "Upload failed at https://example.com/path?token=abc123 with github_pat_abcdefghijklmnopqrstuvwxyz_1234567890 and api_key=secret-value",
+            ],
+            allowedKeys: ["failure_kind"]
+        )
+
+        let value = sanitized["failure_kind"] ?? ""
+        assertFalse(value.contains("https://example.com/path?token=abc123"), "raw URLs should be redacted")
+        assertFalse(value.contains("github_pat_abcdefghijklmnopqrstuvwxyz_1234567890"), "GitHub fine-grained tokens should be redacted")
+        assertFalse(value.contains("api_key=secret-value"), "inline secret assignments should be redacted")
+        assertTrue(value.contains("[redacted-url]"), "URL marker should remain")
+        assertTrue(value.contains("[redacted-secret]"), "secret marker should remain")
+    }
 }

--- a/Tests/SentryPayloadSanitizerTests.swift
+++ b/Tests/SentryPayloadSanitizerTests.swift
@@ -43,6 +43,17 @@ func testSentryPayloadSanitizer() {
         assertTrue(sanitized.contains("[redacted-path]"), "redacted path marker should remain")
     }
 
+    runSuite("SentryPayloadSanitizer.sanitizeText redacts raw URLs and common token formats") {
+        let input = "Download failed at https://example.com/private?token=abc123 with ghp_123456789012345678901234567890123456 and phc_abcdefghijklmnopqrstuvwxyz123456"
+        let sanitized = SentryPayloadSanitizer.sanitizeText(input)
+
+        assertFalse(sanitized.contains("https://example.com/private?token=abc123"), "raw URLs should be redacted")
+        assertFalse(sanitized.contains("ghp_123456789012345678901234567890123456"), "GitHub tokens should be redacted")
+        assertFalse(sanitized.contains("phc_abcdefghijklmnopqrstuvwxyz123456"), "PostHog keys should be redacted")
+        assertTrue(sanitized.contains("[redacted-url]"), "redacted URL marker should remain")
+        assertTrue(sanitized.contains("[redacted-secret]"), "redacted secret marker should remain")
+    }
+
     runSuite("SentryPayloadSanitizer.sanitizeAnyDictionary redacts nested free-form values") {
         let sanitized = SentryPayloadSanitizer.sanitizeAnyDictionary([
             "safe_count": 3,


### PR DESCRIPTION
## Summary
- redact raw `http(s)` URLs before Sentry or PostHog payloads leave the machine
- redact additional common secret formats such as GitHub tokens, PostHog keys, Slack tokens, JWT-like values, and inline `token=` / `api_key=` assignments
- extend fast tests to lock the broader privacy boundary in place

## Verification
- `bash run-tests.sh`
- `bash build-deps.sh --force`
- `bash build.sh`

## Notes
- no existing open `[nightly-security]` draft PR was present when this nightly sweep started