### PR TITLE
[codex] Send feedback to GitHub issues

### DIFF
--- a/Sources/UI/MenuBar/MenuBarSettingsView.swift
+++ b/Sources/UI/MenuBar/MenuBarSettingsView.swift
@@ -95,15 +95,25 @@ final class MenuBarSettingsView: NSView {
     }
 
     @objc private func sendFeedback() {
-        guard let appState else { return }
-        let logLines = appState.logger.entries.suffix(80).joined(separator: "\n")
-        let subject = "Transcripted Feedback"
-        let body = "What happened:\n[describe the issue here]\n\n---\nLogs:\n\(logLines)"
-        let encodedSubject = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? subject
-        let encodedBody = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-        if let url = URL(string: "mailto:hi@transcripted.app?subject=\(encodedSubject)&body=\(encodedBody)") {
-            NSWorkspace.shared.open(url)
-        }
+        let logLines = appState?.logger.entries.suffix(80).joined(separator: "\n") ?? "No in-app logs attached."
+        let title = "Transcripted Feedback"
+        let body = """
+        What happened:
+        [describe the issue here]
+
+        ---
+        Logs:
+        \(logLines)
+        """
+
+        var components = URLComponents(string: "https://github.com/r3dbars/transcripted/issues/new")
+        components?.queryItems = [
+            URLQueryItem(name: "title", value: title),
+            URLQueryItem(name: "body", value: body)
+        ]
+
+        guard let url = components?.url else { return }
+        NSWorkspace.shared.open(url)
     }
 
     @objc private func quitApp() {


### PR DESCRIPTION
## What changed
The menu bar feedback action now opens a prefilled GitHub issue instead of trying to launch a `mailto:` link.

## Why this changed
The app was showing an email path that currently goes nowhere, so the feedback button looked live but did not lead users to a working support channel.

## User impact
Clicking the feedback button now takes people to a real issue form in GitHub with a starter title/body and recent in-app logs when available.

## Root cause
The UI was wired to `mailto:hi@transcripted.app`, but that address is not the active feedback path.

## Validation
- `bash run-tests.sh`
- `bash build.sh`
- Manual verification: launched the built app and confirmed the user-tested flow works