### PR TITLE
Harden security findings from Codex audit

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -242,7 +242,21 @@ class ParakeetEngine: ObservableObject {
                 models = try await AsrModels.load(from: bundlePath, version: .v3)
                 loadSourceName = loadSource.rawValue
             } else {
-                // Fallback: download from HuggingFace (~600MB on first run)
+                // Fallback: download from HuggingFace (~600MB on first run).
+                //
+                // SECURITY: AsrModels.download() pulls model artifacts from HuggingFace
+                // through FluidAudio. Transcripted does not currently re-verify the
+                // downloaded artifacts against pinned SHA-256 digests. Trust here rests
+                // on the system TLS chain plus HuggingFace's CDN integrity. A targeted
+                // TLS interception or CDN compromise could swap the model files, with
+                // a worst-case impact of bad transcriptions or — much less likely —
+                // exploitation of a Core ML deserialization bug.
+                //
+                // To close this gap we'd ship a static `[filename: sha256]` table for
+                // each supported Parakeet variant and verify it after download, before
+                // calling AsrModels.load(...). The hashes need to be computed from a
+                // trusted release of the model bundle; without that source of truth a
+                // verification stub would be worse than no check at all.
                 failureStage = .downloadModels
                 loadSource = .download
                 print("🌐 PARAKEET | models not bundled, downloading (~600MB)...")

--- a/Sources/Support/TranscriptedStoragePaths.swift
+++ b/Sources/Support/TranscriptedStoragePaths.swift
@@ -39,8 +39,8 @@ extension FileManager {
         let url = userApplicationSupportDir.appendingPathComponent("Transcripted", isDirectory: true)
         try? createPrivateDirectory(at: url)
         try? createPrivateDirectory(at: url.appendingPathComponent("captures", isDirectory: true))
-        try? createDirectory(at: url.appendingPathComponent("captures/meetings", isDirectory: true), withIntermediateDirectories: true)
-        try? createDirectory(at: url.appendingPathComponent("captures/dictations", isDirectory: true), withIntermediateDirectories: true)
+        try? createPrivateDirectory(at: url.appendingPathComponent("captures/meetings", isDirectory: true))
+        try? createPrivateDirectory(at: url.appendingPathComponent("captures/dictations", isDirectory: true))
         try? createPrivateDirectory(at: url.appendingPathComponent("state", isDirectory: true))
         try? createPrivateDirectory(at: url.appendingPathComponent("cache", isDirectory: true))
         try? createPrivateDirectory(at: url.appendingPathComponent("logs", isDirectory: true))
@@ -60,7 +60,7 @@ extension FileManager {
 
     var transcriptedCaptureLibraryDir: URL {
         let url = TranscriptedStoragePreferences.captureLibraryURL(fileManager: self)
-        try? createDirectory(at: url, withIntermediateDirectories: true)
+        try? createPrivateDirectory(at: url)
         return url
     }
 
@@ -87,14 +87,14 @@ extension FileManager {
     /// <capture-library>/meetings/
     var meetingSupportDir: URL {
         let url = transcriptedCaptureLibraryDir.appendingPathComponent("meetings", isDirectory: true)
-        try? createDirectory(at: url, withIntermediateDirectories: true)
+        try? createPrivateDirectory(at: url)
         return url
     }
 
     /// <capture-library>/dictations/
     var dictationSupportDir: URL {
         let url = transcriptedCaptureLibraryDir.appendingPathComponent("dictations", isDirectory: true)
-        try? createDirectory(at: url, withIntermediateDirectories: true)
+        try? createPrivateDirectory(at: url)
         return url
     }
 

--- a/Sources/TranscriptedCore/Logging/AppLogger.swift
+++ b/Sources/TranscriptedCore/Logging/AppLogger.swift
@@ -44,7 +44,10 @@ public final class AppLogger: @unchecked Sendable {
         case "error": .fault
         default: .info
         }
-        os_log("%{public}@", log: osLog, type: logType, "[\(subsystem)] \(message)\(metadataString(metadata))")
+        // Default to %{private}@ so caller-supplied metadata (paths, titles, errors)
+        // is redacted in production system logs. Console.app on a development device
+        // can still surface this with `sudo log config --mode "private_data:on"`.
+        os_log("%{private}@", log: osLog, type: logType, "[\(subsystem)] \(message)\(metadataString(metadata))")
     }
 
     /// Synchronous flush — call from applicationWillTerminate

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -694,8 +694,37 @@ class DictationSessionController: ObservableObject {
         }
     }
 
+    /// Bundle identifiers of dedicated terminal emulators. Auto-paste is refused into
+    /// these targets because dictated text containing a trailing newline (or any
+    /// shell metacharacter) would be interpreted as a command and executed. The user
+    /// can still press Cmd+V manually if they really meant to paste into a shell.
+    private static let terminalBundleIDs: Set<String> = [
+        "com.apple.Terminal",
+        "com.googlecode.iterm2",
+        "dev.warp.Warp-Stable",
+        "co.zeit.hyper",
+        "net.kovidgoyal.kitty",
+        "io.alacritty",
+        "com.mitchellh.ghostty",
+    ]
+
+    private func isFrontmostAppATerminal() -> Bool {
+        guard let bundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier else {
+            return false
+        }
+        return Self.terminalBundleIDs.contains(bundleID)
+    }
+
     private func pasteWithClipboardRestore(_ text: String) -> DictationPasteOutcome {
         guard let appState = appState else { return .failed("Couldn't paste dictation") }
+
+        // Refuse to auto-paste into a terminal: a trailing newline or shell
+        // metacharacter in the dictated text would execute as a command.
+        if isFrontmostAppATerminal() {
+            appState.logger.log("DICTATION | terminal frontmost, copying instead of auto-paste")
+            copyTextToClipboard(text)
+            return .copied("Dictation won't auto-paste into a terminal for safety. Press Cmd+V to paste.")
+        }
 
         // Check Accessibility permission BEFORE modifying clipboard
         guard AXIsProcessTrusted() else {
@@ -745,21 +774,26 @@ class DictationSessionController: ObservableObject {
         let changeCountAfterSet = pasteboard.changeCount
         clipboardRestoreTask?.cancel()
         clipboardRestoreTask = Task { @MainActor in
+            // Defer guarantees the dictated text is wiped from the global pasteboard
+            // even if this task is cancelled or the actor is torn down mid-loop —
+            // otherwise a clipboard manager could scrape it indefinitely.
+            defer {
+                pasteboard.clearContents()
+                let items = savedItems.map { typeData -> NSPasteboardItem in
+                    let item = NSPasteboardItem()
+                    for (type, data) in typeData {
+                        item.setData(data, forType: type)
+                    }
+                    return item
+                }
+                if !items.isEmpty {
+                    pasteboard.writeObjects(items)
+                }
+            }
             let startTime = CFAbsoluteTimeGetCurrent()
             while CFAbsoluteTimeGetCurrent() - startTime < TranscriptedConstants.clipboardRestoreTimeout {
                 try? await Task.sleep(nanoseconds: TranscriptedConstants.clipboardPollInterval)
                 if pasteboard.changeCount != changeCountAfterSet { break }
-            }
-            pasteboard.clearContents()
-            let items = savedItems.map { typeData -> NSPasteboardItem in
-                let item = NSPasteboardItem()
-                for (type, data) in typeData {
-                    item.setData(data, forType: type)
-                }
-                return item
-            }
-            if !items.isEmpty {
-                pasteboard.writeObjects(items)
             }
         }
         return .pasted


### PR DESCRIPTION
## Summary

Independent security review of `Sources/` via OpenAI Codex surfaced 5 findings: 1 HIGH, 3 MEDIUM, 1 LOW. This PR addresses all 5.

### 🔴 HIGH — Dictation can become command execution in terminals
`DictationSessionController` auto-pasted dictated text via `Cmd+V` into the frontmost app without checking whether it was a terminal. A trailing newline or shell metacharacter in the transcription would execute as a command. Now refuses auto-paste into Terminal, iTerm, Warp, Hyper, kitty, alacritty, and Ghostty — text is copied to the clipboard with a user-visible message instead.

### 🟡 MEDIUM — Pasteboard leak on task cancellation
The clipboard-restore task would skip its restore if cancelled mid-loop (e.g. another paste session starts, app tear-down). Dictated text could remain on `NSPasteboard.general` indefinitely, scrapeable by clipboard managers. Restore is now in a `defer` block that runs on every exit path.

### 🟡 MEDIUM — Logger emitted caller metadata as `%{public}@`
`AppLogger` declared the entire interpolated message as `%{public}@`, so all caller-supplied metadata (file paths, speaker names, error text) hit Console + persisted system logs unredacted. Across ~55 call sites this leaked filesystem paths, transcript locations, and username-bearing absolute paths. Flipped the format spec to `%{private}@`. No call sites need to change; production redaction is now the default.

### 🟡 MEDIUM — User-chosen capture-library dirs not chmod 0700
User-selected capture-library directories and their `meetings/`/`dictations/` subfolders were created with default permissions. If the user pointed Transcripted at `~/Desktop` or a shared mount, other local users could enumerate transcript filenames. Routed all five call sites through the existing `createPrivateDirectory(at:)` helper. Two app-owned subdirs that previously skipped the helper are also fixed.

### 🟢 LOW — Parakeet model downloads have no source-level integrity check
`AsrModels.download()` pulls model artifacts from HuggingFace through FluidAudio without source-level SHA-256 verification in Transcripted itself. A real fix needs pinned digests from a trusted release of the Parakeet bundle, which isn't computable in this PR. Added a `// SECURITY:` comment block at `ParakeetEngine.swift:244` documenting the gap, the threat model, and the recommended fix shape, so the next pass on this surface has the context to act.

## Test plan

- [x] `bash build.sh` — passes (signed app bundle built)
- [x] `bash run-tests.sh` — 245/245 passed
- [x] `bash run-integration-smoke.sh` — passed
- [x] `swift test` — 51/51 passed (TranscriptedCore library boundary intact)
- [ ] Manual: dictate into Terminal — confirm text is copied with the warning message instead of auto-pasting
- [ ] Manual: dictate into a normal text field — confirm auto-paste still works
- [ ] Manual: choose a custom capture-library directory in Settings — confirm `stat -f %A` shows `700` on the dir and its `meetings/dictations` subfolders

🤖 Generated with [Claude Code](https://claude.com/claude-code)