### PR TITLE
Surface Parakeet TDT V3 model identity + TLS friendly copy

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -271,7 +271,8 @@ class ParakeetEngine: ObservableObject {
             }
 
         } catch {
-            modelDownloadState = .failed(error.localizedDescription)
+            let friendlyMessage = ModelDownloadService.classifyError(error).detail
+            modelDownloadState = .failed(friendlyMessage)
             print("❌ PARAKEET | model initialization failed: \(error.localizedDescription)")
             EventReporter.shared.capture(level: .error, engine: "parakeet", event: "model_init_failed",
                 message: error.localizedDescription,

--- a/Sources/UI/MenuBar/MenuBarContentView.swift
+++ b/Sources/UI/MenuBar/MenuBarContentView.swift
@@ -16,10 +16,12 @@ final class MenuBarContentView: NSView {
     let headerView = MenuBarHeaderView(frame: .zero)
     let shortcutsView = MenuBarShortcutsView(frame: .zero)
     let recentMeetingsView = MenuBarRecentMeetingsView(frame: .zero)
+    let modelStatusView = MenuBarModelStatusView(frame: .zero)
     let settingsView = MenuBarSettingsView(frame: .zero)
     let agentConnectView = MenuAgentConnectPageView(frame: .zero)
 
     private let recentsDivider = NSView()
+    private let modelStatusDivider = NSView()
     private let footerDivider = NSView()
     private var currentPage: Page = .main
 
@@ -50,7 +52,7 @@ final class MenuBarContentView: NSView {
         scrollView.documentView = documentView
         addSubview(scrollView)
 
-        [recentsDivider, footerDivider].forEach {
+        [recentsDivider, modelStatusDivider, footerDivider].forEach {
             $0.wantsLayer = true
             $0.layer?.backgroundColor = MenuTokens.sectionDividerNS.cgColor
             documentView.addSubview($0)
@@ -59,6 +61,7 @@ final class MenuBarContentView: NSView {
         documentView.addSubview(headerView)
         documentView.addSubview(shortcutsView)
         documentView.addSubview(recentMeetingsView)
+        documentView.addSubview(modelStatusView)
         documentView.addSubview(settingsView)
         documentView.addSubview(agentConnectView)
         updatePageVisibility()
@@ -101,6 +104,12 @@ final class MenuBarContentView: NSView {
             recentMeetingsView.isHidden = true
         }
 
+        modelStatusDivider.frame = NSRect(x: pad, y: y - (MenuTokens.sectionSpacing / 2), width: width, height: dividerHeight)
+
+        let modelStatusHeight = modelStatusView.intrinsicHeight
+        modelStatusView.frame = NSRect(x: pad, y: y, width: width, height: modelStatusHeight)
+        y += modelStatusHeight + MenuTokens.sectionSpacing
+
         footerDivider.frame = NSRect(x: pad, y: y - (MenuTokens.sectionSpacing / 2), width: width, height: dividerHeight)
 
         let footerHeight = settingsView.intrinsicHeight
@@ -126,7 +135,7 @@ final class MenuBarContentView: NSView {
 
     private func updatePageVisibility() {
         let isMain = currentPage == .main
-        [headerView, shortcutsView, recentMeetingsView, settingsView, recentsDivider, footerDivider].forEach {
+        [headerView, shortcutsView, recentMeetingsView, modelStatusView, settingsView, recentsDivider, modelStatusDivider, footerDivider].forEach {
             $0.isHidden = !isMain
         }
         agentConnectView.isHidden = isMain

--- a/Sources/UI/MenuBar/MenuBarModelStatusView.swift
+++ b/Sources/UI/MenuBar/MenuBarModelStatusView.swift
@@ -1,0 +1,141 @@
+// MenuBarModelStatusView.swift
+// Persistent model status badge in the menu bar popover — shows which voice
+// model is running, with download progress and error affordance.
+
+import AppKit
+
+@MainActor
+final class MenuBarModelStatusView: NSControl {
+    private let statusDot = NSView()
+    private let label = NSTextField(labelWithString: "")
+    private let chevron = NSImageView()
+
+    var onOpenSettings: (() -> Void)?
+    private var currentState: FirstRunLocalModelState = .notLoaded
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        setupViews()
+        applyState()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    override var isFlipped: Bool { true }
+
+    private func setupViews() {
+        wantsLayer = true
+        layer?.cornerRadius = 8
+        layer?.backgroundColor = NSColor.clear.cgColor
+
+        statusDot.wantsLayer = true
+        statusDot.layer?.cornerRadius = MenuTokens.statusDotSize / 2
+        addSubview(statusDot)
+
+        label.font = NSFont.systemFont(ofSize: 11, weight: .medium)
+        label.textColor = MenuTokens.textSecondaryNS
+        label.lineBreakMode = .byTruncatingTail
+        label.cell?.usesSingleLineMode = true
+        addSubview(label)
+
+        if let image = NSImage(systemSymbolName: "chevron.right", accessibilityDescription: nil) {
+            chevron.image = image
+            chevron.contentTintColor = MenuTokens.textMutedNS
+            chevron.imageScaling = .scaleProportionallyDown
+        }
+        addSubview(chevron)
+
+        let track = NSTrackingArea(
+            rect: .zero,
+            options: [.inVisibleRect, .activeInKeyWindow, .mouseEnteredAndExited],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(track)
+    }
+
+    override func layout() {
+        super.layout()
+        let pad: CGFloat = 8
+        let dotSize = MenuTokens.statusDotSize
+        let chevronSize: CGFloat = 10
+        let midY = bounds.midY
+
+        statusDot.frame = NSRect(
+            x: pad,
+            y: midY - dotSize / 2,
+            width: dotSize,
+            height: dotSize
+        )
+        chevron.frame = NSRect(
+            x: bounds.width - pad - chevronSize,
+            y: midY - chevronSize / 2,
+            width: chevronSize,
+            height: chevronSize
+        )
+        let labelX = statusDot.frame.maxX + 8
+        label.frame = NSRect(
+            x: labelX,
+            y: midY - 8,
+            width: chevron.frame.minX - labelX - 6,
+            height: 16
+        )
+    }
+
+    func update(state: FirstRunLocalModelState) {
+        currentState = state
+        applyState()
+        needsLayout = true
+    }
+
+    private func applyState() {
+        switch currentState {
+        case .ready:
+            statusDot.layer?.backgroundColor = MenuTokens.statusGreenNS.cgColor
+            label.stringValue = "Parakeet TDT V3 · On-device"
+            toolTip = "Parakeet TDT V3 is ready. Click to open settings."
+        case .downloading(let progress):
+            statusDot.layer?.backgroundColor = NSColor.systemBlue.cgColor
+            label.stringValue = "Downloading Parakeet TDT V3 · \(Int(progress * 100))%"
+            toolTip = "Downloading from huggingface.co. Click to open settings."
+        case .loading:
+            statusDot.layer?.backgroundColor = NSColor.systemBlue.cgColor
+            label.stringValue = "Loading Parakeet TDT V3…"
+            toolTip = "Finishing local model setup. Click to open settings."
+        case .notLoaded:
+            statusDot.layer?.backgroundColor = MenuTokens.textMutedNS.cgColor
+            label.stringValue = "Parakeet TDT V3 · Not loaded"
+            toolTip = "Parakeet TDT V3 has not started yet. Click to open settings."
+        case .failed:
+            statusDot.layer?.backgroundColor = MenuTokens.statusOrangeNS.cgColor
+            label.stringValue = "Parakeet TDT V3 · Tap to retry"
+            toolTip = "Local model failed. Click to open settings for details."
+        }
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        layer?.backgroundColor = MenuTokens.actionBackgroundNS.cgColor
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        layer?.backgroundColor = NSColor.clear.cgColor
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        layer?.backgroundColor = MenuTokens.actionPressedNS.cgColor
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        layer?.backgroundColor = bounds.contains(convert(event.locationInWindow, from: nil))
+            ? MenuTokens.actionBackgroundNS.cgColor
+            : NSColor.clear.cgColor
+        if bounds.contains(convert(event.locationInWindow, from: nil)) {
+            onOpenSettings?()
+        }
+    }
+
+    var intrinsicHeight: CGFloat { 26 }
+
+    override var acceptsFirstResponder: Bool { true }
+}

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -38,6 +38,7 @@ final class MenuBarPanelController: NSViewController {
         content.settingsView.appState = appState
         content.shortcutsView.onStartDictation = { [weak self] in self?.startDictationFromMenu() }
         content.shortcutsView.onStartMeeting = { [weak self] in self?.startMeetingFromMenu() }
+        content.modelStatusView.onOpenSettings = { [weak self] in self?.openSettingsFromMenu() }
         content.settingsView.onOpenSettings = { [weak self] in self?.openSettingsFromMenu() }
         content.settingsView.onCheckForUpdates = { [weak self] in self?.checkForUpdatesFromMenu() }
         content.settingsView.onOpenAgentConnect = { [weak self] in self?.openAgentConnectFromMenu() }
@@ -52,9 +53,9 @@ final class MenuBarPanelController: NSViewController {
     func refresh() {
         guard let content = contentView else { return }
         let warmupStatus = appState.meetingSession.warmupStatus
-        let dictationState = FirstRunExperience.dictationAction(
-            for: FirstRunLocalModelState(appState.sttRouter.parakeetEngine.modelDownloadState)
-        )
+        let modelState = FirstRunLocalModelState(appState.sttRouter.parakeetEngine.modelDownloadState)
+        let dictationState = FirstRunExperience.dictationAction(for: modelState)
+        content.modelStatusView.update(state: modelState)
         let meetingState = FirstRunExperience.meetingAction(
             dictationReady: appState.sttRouter.isModelLoaded,
             meetingsStatus: warmupStatus.meetingsStatus
@@ -101,6 +102,13 @@ final class MenuBarPanelController: NSViewController {
 
     private func setupSubscriptions() {
         appState.meetingSession.$warmupStatus
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.refresh()
+            }
+            .store(in: &subscriptions)
+
+        appState.sttRouter.parakeetEngine.$modelDownloadState
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 self?.refresh()

--- a/Sources/UI/Shared/FirstRunExperience.swift
+++ b/Sources/UI/Shared/FirstRunExperience.swift
@@ -98,31 +98,31 @@ enum FirstRunExperience {
         switch modelState {
         case .notLoaded:
             return FirstRunModelCardState(
-                title: "Getting local dictation ready",
-                detail: "Transcripted starts the on-device voice model the first time you use it.",
+                title: "Getting Parakeet TDT V3 ready",
+                detail: "Transcripted uses Parakeet TDT V3, an on-device voice model, and starts it the first time you use it.",
                 status: "Starting",
                 progress: 0.06,
                 tone: .working
             )
         case .downloading(let progress):
             return FirstRunModelCardState(
-                title: "Downloading local dictation",
-                detail: "This one-time download stays on this Mac so dictation can run locally.",
+                title: "Downloading Parakeet TDT V3",
+                detail: "One-time ~600 MB download from huggingface.co. The model stays on this Mac so dictation runs locally.",
                 status: "\(Int(progress * 100))% complete",
                 progress: max(0.12, min(0.84, 0.12 + progress * 0.72)),
                 tone: .working
             )
         case .loading:
             return FirstRunModelCardState(
-                title: "Finishing local dictation setup",
-                detail: "Transcripted has the files and is loading them into memory.",
+                title: "Loading Parakeet TDT V3",
+                detail: "Transcripted has the model files and is loading them into memory.",
                 status: "Almost ready",
                 progress: 0.92,
                 tone: .working
             )
         case .ready:
             return FirstRunModelCardState(
-                title: "Local dictation is ready",
+                title: "Parakeet TDT V3 ready on device",
                 detail: "Your first dictation can start immediately.",
                 status: "Ready",
                 progress: 1.0,
@@ -130,7 +130,7 @@ enum FirstRunExperience {
             )
         case .failed(let message):
             return FirstRunModelCardState(
-                title: "Couldn't load local dictation",
+                title: "Couldn't load Parakeet TDT V3",
                 detail: message,
                 status: "Retry needed",
                 progress: nil,

--- a/Tests/FirstRunExperienceTests.swift
+++ b/Tests/FirstRunExperienceTests.swift
@@ -124,15 +124,25 @@ func testFirstRunExperience() {
         )
     }
 
-    runSuite("FirstRunExperience.modelCard — explains the one-time local download") {
+    runSuite("FirstRunExperience.modelCard — names the model and download source during first-run") {
         let card = FirstRunExperience.modelCard(for: .downloading(progress: 0.5))
 
-        assertEqual(card.title, "Downloading local dictation", "model card should name the active first-run step")
+        assertEqual(card.title, "Downloading Parakeet TDT V3", "model card should name the active first-run step and the model")
         assertTrue(
-            card.detail.contains("one-time download"),
-            "model card should explain why the download is happening"
+            card.detail.contains("huggingface.co"),
+            "model card should tell the user where the model is being downloaded from"
+        )
+        assertTrue(
+            card.detail.contains("on this Mac") || card.detail.contains("locally"),
+            "model card should reassure the user the model stays local"
         )
         assertEqual(card.status, "50% complete", "model card should surface live progress")
         assertNotNil(card.progress, "model card should show a progress bar during downloads")
+    }
+
+    runSuite("FirstRunExperience.modelCard — names Parakeet TDT V3 in ready state") {
+        let card = FirstRunExperience.modelCard(for: .ready)
+
+        assertTrue(card.title.contains("Parakeet TDT V3"), "ready card should tell the user which model is running")
     }
 }


### PR DESCRIPTION
## Summary

Addresses #295. User asked *"no model config, and no an error about secure connection while trying to setup app. Show clearly what model is being used to transcribe audio and what's being connected to during setup."*

The title says "model configuration" but the body is really about **transparency** — so this PR does transparency, not a picker. We ship one model today; a picker with one option would be cargo cult.

- **Onboarding model card names Parakeet TDT V3** and the `huggingface.co` download source, so first-run users can see exactly what the app is pulling and from where.
- **TLS errors now surface the friendly classifier message** on the onboarding card. Previously `ParakeetEngine` init errors used raw `error.localizedDescription`, which for `NSURLErrorSecureConnectionFailed` is macOS's default "An SSL error has occurred and a secure connection to the server cannot be made" — unhelpful. Routing through `ModelDownloadService.classifyError(_:).detail` maps that to *"Could not establish a secure connection to the download server. Check your network or try a VPN."* That was the exact error the reporter hit.
- **New persistent status badge** in the menu bar popover shows `● Parakeet TDT V3 · <state>` (On-device / Downloading NN% / Loading / Tap to retry) with a colored dot (green / blue / orange). Clicking it opens settings. Inspired by Handy's footer pattern — always answers "what's running" without any clicks.

## What I did NOT do (deferred)

- **No model picker**. We ship one model. A catalog would be worse than no catalog.
- **No tabbed settings refactor** — that's the follow-up PR from the plan (split the 6-section scrolling view into General / Models / Privacy / Data / About).
- **No `ModelPreferences` layer** — nothing to pick yet.

## Test plan

- [x] `bash build.sh` — clean build, signed, notarized locally
- [x] `bash run-tests.sh` — 247/247 pass (two `FirstRunExperienceTests` assertions updated to match the new Parakeet TDT V3 copy, plus a new assertion covering the ready-state model name)
- [ ] Manual: delete first-run state, relaunch, verify onboarding card reads "Downloading Parakeet TDT V3" with huggingface.co mention during download and "Parakeet TDT V3 ready on device" when complete
- [ ] Manual: menu bar popover shows "● Parakeet TDT V3" row above the settings footer; clicking it opens the settings window
- [ ] Manual: force a TLS failure (e.g., block `huggingface.co` via `/etc/hosts → 127.0.0.1`) and verify the onboarding card shows "Could not establish a secure connection… Check your network or try a VPN" rather than raw SSL error text

Closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)