### PR TITLE
Redesign settings and simplify menu bar

### DIFF
--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -2,17 +2,57 @@ import Foundation
 import Sparkle
 
 @MainActor
-final class SparkleUpdaterController: NSObject {
-    private let updaterController: SPUStandardUpdaterController
-    private var hasPerformedStartupCheck = false
+final class SparkleUpdaterController: NSObject, ObservableObject, SPUUpdaterDelegate {
+    enum UpdateState: Equatable {
+        case idle
+        case checking
+        case available(version: String)
+        case upToDate
+        case error(String)
 
-    override init() {
-        self.updaterController = SPUStandardUpdaterController(
+        var buttonTitle: String {
+            switch self {
+            case .idle, .upToDate:
+                return "Check for updates"
+            case .checking:
+                return "Checking updates..."
+            case .available:
+                return "Update available"
+            case .error:
+                return "Try updates again"
+            }
+        }
+
+        var detailText: String {
+            switch self {
+            case .idle:
+                return "Sparkle is configured and ready."
+            case .checking:
+                return "Looking for a newer Transcripted build."
+            case .available(let version):
+                return "Transcripted \(version) is ready to install."
+            case .upToDate:
+                return "You already have the latest Transcripted build."
+            case .error(let message):
+                return message
+            }
+        }
+    }
+
+    @Published private(set) var updateState: UpdateState = .idle
+
+    private var hasPerformedStartupCheck = false
+    private lazy var updaterController: SPUStandardUpdaterController = {
+        SPUStandardUpdaterController(
             startingUpdater: true,
-            updaterDelegate: nil,
+            updaterDelegate: self,
             userDriverDelegate: nil
         )
+    }()
+
+    override init() {
         super.init()
+        _ = updaterController
     }
 
     func performStartupUpdateCheckIfNeeded() {
@@ -22,13 +62,12 @@ final class SparkleUpdaterController: NSObject {
         guard hasConfiguredFeedURL else { return }
         guard updaterController.updater.automaticallyChecksForUpdates else { return }
 
-        // Sparkle recommends forcing launch-time background checks, if desired,
-        // immediately after the updater has started and only when automatic
-        // checks are enabled.
+        updateState = .checking
         updaterController.updater.checkForUpdatesInBackground()
     }
 
     func checkForUpdates() {
+        updateState = .checking
         updaterController.checkForUpdates(nil)
     }
 
@@ -37,5 +76,26 @@ final class SparkleUpdaterController: NSObject {
             return false
         }
         return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        updateState = .available(version: item.displayVersionString)
+    }
+
+    func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
+        updateState = .upToDate
+    }
+
+    func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: Error) {
+        updateState = .upToDate
+    }
+
+    func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
+        updateState = .error(error.localizedDescription)
+    }
+
+    func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor updateCheck: SPUUpdateCheck, error: Error?) {
+        guard let error else { return }
+        updateState = .error(error.localizedDescription)
     }
 }

--- a/Sources/Support/TranscriptedAppActions.swift
+++ b/Sources/Support/TranscriptedAppActions.swift
@@ -1,0 +1,35 @@
+import AppKit
+import Foundation
+
+enum TranscriptedAppActions {
+    static var versionString: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "dev"
+    }
+
+    static var buildString: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "0"
+    }
+
+    static var versionDisplay: String {
+        "v\(versionString)"
+    }
+
+    static var fullVersionDisplay: String {
+        "Version \(versionString) (\(buildString))"
+    }
+
+    static func sendFeedback(logEntries: [String]) {
+        let logLines = logEntries.suffix(80).joined(separator: "\n")
+        let subject = "Transcripted Feedback"
+        let body = "What happened:\n[describe the issue here]\n\n---\nLogs:\n\(logLines)"
+        let encodedSubject = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? subject
+        let encodedBody = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+
+        guard let url = URL(string: "mailto:hi@transcripted.app?subject=\(encodedSubject)&body=\(encodedBody)") else {
+            NSSound.beep()
+            return
+        }
+
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -31,7 +31,6 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         appState: appState,
         preferredSourceAppProvider: { [weak self] in self?.lastExternalApplication },
         openSettingsWindow: { [weak self] in self?.showSettingsWindow() },
-        openAgentConnectWindow: { [weak self] in self?.showAgentConnectWindow() },
         dismissPopover: { [weak self] in self?.closePopover() }
     )
 
@@ -184,10 +183,6 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
 
     private func showSettingsWindow() {
         settingsWindowController.present()
-    }
-
-    private func showAgentConnectWindow() {
-        AgentConnectionWindowCoordinator.shared.show()
     }
 
     private func makeOnboardingView() -> PermissionsOnboardingView {

--- a/Sources/UI/MenuBar/MenuBarContentView.swift
+++ b/Sources/UI/MenuBar/MenuBarContentView.swift
@@ -1,27 +1,12 @@
-// MenuBarContentView.swift
-// Root NSView for the menubar popover — one unified surface with four zones.
-
 import AppKit
 
 @MainActor
 final class MenuBarContentView: NSView {
-    enum Page {
-        case main
-        case agentConnect
-    }
-
-    private let scrollView = NSScrollView()
-    private let documentView = FlippedMenuDocumentView()
-
     let headerView = MenuBarHeaderView(frame: .zero)
     let shortcutsView = MenuBarShortcutsView(frame: .zero)
-    let recentMeetingsView = MenuBarRecentMeetingsView(frame: .zero)
     let settingsView = MenuBarSettingsView(frame: .zero)
-    let agentConnectView = MenuAgentConnectPageView(frame: .zero)
 
-    private let recentsDivider = NSView()
     private let footerDivider = NSView()
-    private var currentPage: Page = .main
 
     weak var appState: TranscriptedAppState?
 
@@ -42,102 +27,34 @@ final class MenuBarContentView: NSView {
         layer?.borderWidth = 1
         layer?.borderColor = MenuTokens.surfaceStrokeNS.cgColor
 
-        scrollView.drawsBackground = false
-        scrollView.borderType = .noBorder
-        scrollView.hasHorizontalScroller = false
-        scrollView.hasVerticalScroller = true
-        scrollView.autohidesScrollers = true
-        scrollView.documentView = documentView
-        addSubview(scrollView)
+        footerDivider.wantsLayer = true
+        footerDivider.layer?.backgroundColor = MenuTokens.sectionDividerNS.cgColor
+        addSubview(footerDivider)
 
-        [recentsDivider, footerDivider].forEach {
-            $0.wantsLayer = true
-            $0.layer?.backgroundColor = MenuTokens.sectionDividerNS.cgColor
-            documentView.addSubview($0)
-        }
-
-        documentView.addSubview(headerView)
-        documentView.addSubview(shortcutsView)
-        documentView.addSubview(recentMeetingsView)
-        documentView.addSubview(settingsView)
-        documentView.addSubview(agentConnectView)
-        updatePageVisibility()
+        addSubview(headerView)
+        addSubview(shortcutsView)
+        addSubview(settingsView)
     }
 
     override func layout() {
         super.layout()
 
-        scrollView.frame = bounds
-
         let pad = MenuTokens.innerPadding
         let width = bounds.width - pad * 2
-        if currentPage == .agentConnect {
-            let contentHeight = agentConnectView.intrinsicHeight
-            agentConnectView.frame = NSRect(x: pad, y: pad, width: width, height: contentHeight)
-            documentView.frame = NSRect(x: 0, y: 0, width: bounds.width, height: max(contentHeight + pad * 2, bounds.height))
-            return
-        }
-
-        let dividerHeight: CGFloat = 1
         var y = pad
+
         let headerHeight = headerView.intrinsicHeight
         headerView.frame = NSRect(x: pad, y: y, width: width, height: headerHeight)
-        y += headerHeight + MenuTokens.sectionSpacing
+        y += headerHeight + 12
 
         let shortcutsHeight = shortcutsView.intrinsicHeight
         shortcutsView.frame = NSRect(x: pad, y: y, width: width, height: shortcutsHeight)
-        y += shortcutsHeight + MenuTokens.sectionSpacing
+        y += shortcutsHeight + 12
 
-        if recentMeetingsView.hasContent {
-            recentsDivider.isHidden = false
-            recentsDivider.frame = NSRect(x: pad, y: y - (MenuTokens.sectionSpacing / 2), width: width, height: dividerHeight)
-
-            let recentsHeight = recentMeetingsView.intrinsicHeight
-            recentMeetingsView.isHidden = false
-            recentMeetingsView.frame = NSRect(x: pad, y: y, width: width, height: recentsHeight)
-            y += recentsHeight + MenuTokens.sectionSpacing
-        } else {
-            recentsDivider.isHidden = true
-            recentMeetingsView.isHidden = true
-        }
-
-        footerDivider.frame = NSRect(x: pad, y: y - (MenuTokens.sectionSpacing / 2), width: width, height: dividerHeight)
+        footerDivider.frame = NSRect(x: pad, y: y, width: width, height: 1)
+        y += 12
 
         let footerHeight = settingsView.intrinsicHeight
         settingsView.frame = NSRect(x: pad, y: y, width: width, height: footerHeight)
-        y += footerHeight + pad
-
-        documentView.frame = NSRect(x: 0, y: 0, width: bounds.width, height: max(y, bounds.height))
     }
-
-    func showMainPage() {
-        currentPage = .main
-        updatePageVisibility()
-        scrollToTop()
-        needsLayout = true
-    }
-
-    func showAgentConnectPage() {
-        currentPage = .agentConnect
-        updatePageVisibility()
-        scrollToTop()
-        needsLayout = true
-    }
-
-    private func updatePageVisibility() {
-        let isMain = currentPage == .main
-        [headerView, shortcutsView, recentMeetingsView, settingsView, recentsDivider, footerDivider].forEach {
-            $0.isHidden = !isMain
-        }
-        agentConnectView.isHidden = isMain
-    }
-
-    private func scrollToTop() {
-        scrollView.contentView.scroll(to: .zero)
-        scrollView.reflectScrolledClipView(scrollView.contentView)
-    }
-}
-
-private final class FlippedMenuDocumentView: NSView {
-    override var isFlipped: Bool { true }
 }

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -1,6 +1,3 @@
-// MenuBarPanelController.swift
-// NSViewController that hosts the menubar popover and wires actions/subscriptions.
-
 import AppKit
 import Combine
 
@@ -9,7 +6,6 @@ final class MenuBarPanelController: NSViewController {
     private let appState: TranscriptedAppState
     private let dismissPopover: () -> Void
     private let openSettingsWindow: () -> Void
-    private let openAgentConnectWindow: () -> Void
     private let preferredSourceAppProvider: () -> NSRunningApplication?
     private var contentView: MenuBarContentView?
     private var subscriptions = Set<AnyCancellable>()
@@ -18,13 +14,11 @@ final class MenuBarPanelController: NSViewController {
         appState: TranscriptedAppState,
         preferredSourceAppProvider: @escaping () -> NSRunningApplication?,
         openSettingsWindow: @escaping () -> Void,
-        openAgentConnectWindow: @escaping () -> Void,
         dismissPopover: @escaping () -> Void
     ) {
         self.appState = appState
         self.preferredSourceAppProvider = preferredSourceAppProvider
         self.openSettingsWindow = openSettingsWindow
-        self.openAgentConnectWindow = openAgentConnectWindow
         self.dismissPopover = dismissPopover
         super.init(nibName: nil, bundle: nil)
     }
@@ -33,14 +27,14 @@ final class MenuBarPanelController: NSViewController {
     required init?(coder: NSCoder) { fatalError() }
 
     override func loadView() {
-        let content = MenuBarContentView(frame: NSRect(x: 0, y: 0, width: MenuTokens.panelWidth, height: MenuTokens.panelHeight))
+        let content = MenuBarContentView(
+            frame: NSRect(x: 0, y: 0, width: MenuTokens.panelWidth, height: MenuTokens.panelHeight)
+        )
         content.appState = appState
-        content.settingsView.appState = appState
         content.shortcutsView.onStartDictation = { [weak self] in self?.startDictationFromMenu() }
         content.shortcutsView.onStartMeeting = { [weak self] in self?.startMeetingFromMenu() }
         content.settingsView.onOpenSettings = { [weak self] in self?.openSettingsFromMenu() }
         content.settingsView.onCheckForUpdates = { [weak self] in self?.checkForUpdatesFromMenu() }
-        content.settingsView.onOpenAgentConnect = { [weak self] in self?.openAgentConnectFromMenu() }
         view = content
         contentView = content
         view.appearance = NSAppearance(named: .darkAqua)
@@ -64,38 +58,13 @@ final class MenuBarPanelController: NSViewController {
             warmupStatus: warmupStatus,
             hotkeyError: appState.contextCapture.hotkeyError
         )
-
         content.shortcutsView.update(
             dictationKey: appState.contextCapture.dictationShortcutDisplay,
             meetingKey: appState.contextCapture.meetingShortcutDisplay,
             dictationState: dictationState,
             meetingState: meetingState
         )
-
-        if #available(macOS 14.0, *) {
-            content.recentMeetingsView.update(
-                meetings: RecentMeetingsScanner.loadRecent(),
-                failedMeetings: appState.meetingSession.failedMeetings,
-                onRetryFailedMeeting: { [weak self] id in
-                    self?.appState.meetingSession.retryFailedMeeting(id: id)
-                },
-                onDeleteFailedMeeting: { [weak self] id in
-                    self?.appState.meetingSession.deleteFailedMeeting(id: id)
-                },
-                onDismissFailedMeeting: { [weak self] id in
-                    self?.appState.meetingSession.dismissFailedMeeting(id: id)
-                }
-            )
-        } else {
-            content.recentMeetingsView.update(
-                meetings: RecentMeetingsScanner.loadRecent(),
-                failedMeetings: [],
-                onRetryFailedMeeting: { _ in },
-                onDeleteFailedMeeting: { _ in },
-                onDismissFailedMeeting: { _ in }
-            )
-        }
-
+        content.settingsView.update(updateState: appState.sparkleUpdater.updateState)
         content.needsLayout = true
     }
 
@@ -122,26 +91,16 @@ final class MenuBarPanelController: NSViewController {
             }
             .store(in: &subscriptions)
 
-        if #available(macOS 14.0, *) {
-            appState.meetingSession.$lastSavedTranscriptURL
-                .receive(on: RunLoop.main)
-                .sink { [weak self] _ in
-                    self?.refresh()
-                }
-                .store(in: &subscriptions)
-
-            appState.meetingSession.$failedMeetings
-                .receive(on: RunLoop.main)
-                .sink { [weak self] _ in
-                    self?.refresh()
-                }
-                .store(in: &subscriptions)
-        }
+        appState.sparkleUpdater.$updateState
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.refresh()
+            }
+            .store(in: &subscriptions)
     }
 
     func prepareForClose() {
         contentView?.shortcutsView.cancelEditing()
-        contentView?.showMainPage()
         contentView?.settingsView.dismissTransientUI()
     }
 
@@ -172,11 +131,6 @@ final class MenuBarPanelController: NSViewController {
     private func checkForUpdatesFromMenu() {
         dismissPopover()
         appState.sparkleUpdater.checkForUpdates()
-    }
-
-    private func openAgentConnectFromMenu() {
-        dismissPopover()
-        openAgentConnectWindow()
     }
 
     private func resolvedSourceApp() -> NSRunningApplication? {

--- a/Sources/UI/MenuBar/MenuBarSettingsView.swift
+++ b/Sources/UI/MenuBar/MenuBarSettingsView.swift
@@ -1,42 +1,28 @@
-// MenuBarSettingsView.swift
-// Compact utility footer for the menubar popover.
-
 import AppKit
 
 @MainActor
 final class MenuBarSettingsView: NSView {
-    private let connectAgentButton = MenuOutlineButton(
-        title: "Connect your agent",
-        symbolName: "sparkles",
-        accessibilityLabel: "Connect your agent",
-        toolTip: "Connect your agent",
-        style: .accent
-    )
-    private let settingsButton = MenuIconButton(
+    private let settingsButton = MenuOutlineButton(
+        title: "Settings",
         symbolName: "gearshape",
         accessibilityLabel: "Open settings",
         toolTip: "Open settings"
     )
-    private let updatesButton = MenuIconButton(
+    private let updatesButton = MenuOutlineButton(
+        title: "Check updates",
         symbolName: "arrow.triangle.2.circlepath.circle",
         accessibilityLabel: "Check for updates",
         toolTip: "Check for updates"
     )
-    private let feedbackButton = MenuIconButton(
-        symbolName: "bubble.left",
-        accessibilityLabel: "Send feedback",
-        toolTip: "Send feedback"
-    )
-    private let quitButton = MenuIconButton(
+    private let quitButton = MenuOutlineButton(
+        title: "Quit",
         symbolName: "power",
         accessibilityLabel: "Quit Transcripted",
         toolTip: "Quit Transcripted"
     )
 
-    weak var appState: TranscriptedAppState?
     var onOpenSettings: (() -> Void)?
     var onCheckForUpdates: (() -> Void)?
-    var onOpenAgentConnect: (() -> Void)?
 
     override init(frame: NSRect) {
         super.init(frame: frame)
@@ -49,18 +35,12 @@ final class MenuBarSettingsView: NSView {
     override var isFlipped: Bool { true }
 
     private func setupViews() {
-        connectAgentButton.target = self
-        connectAgentButton.action = #selector(openAgentConnect)
-        addSubview(connectAgentButton)
-
-        [settingsButton, updatesButton, feedbackButton, quitButton].forEach { addSubview($0) }
+        [settingsButton, updatesButton, quitButton].forEach { addSubview($0) }
 
         settingsButton.target = self
         settingsButton.action = #selector(openSettings)
         updatesButton.target = self
         updatesButton.action = #selector(checkForUpdates)
-        feedbackButton.target = self
-        feedbackButton.action = #selector(sendFeedback)
         quitButton.target = self
         quitButton.action = #selector(quitApp)
     }
@@ -68,42 +48,25 @@ final class MenuBarSettingsView: NSView {
     override func layout() {
         super.layout()
 
-        let buttonSize = MenuTokens.secondaryButtonSize
-        let buttonY: CGFloat = 7
-        quitButton.frame = NSRect(x: bounds.width - buttonSize, y: buttonY, width: buttonSize, height: buttonSize)
-        feedbackButton.frame = NSRect(
-            x: quitButton.frame.minX - 8 - buttonSize,
-            y: buttonY,
-            width: buttonSize,
-            height: buttonSize
-        )
+        let buttonHeight = MenuTokens.secondaryButtonSize
+        let spacing: CGFloat = 8
+        let quitWidth = quitButton.fittingSize.width
+        let updatesWidth = min(max(112, updatesButton.fittingSize.width), max(112, bounds.width * 0.38))
+        let settingsWidth = bounds.width - quitWidth - updatesWidth - spacing * 2
+
+        settingsButton.frame = NSRect(x: 0, y: 0, width: max(96, settingsWidth), height: buttonHeight)
         updatesButton.frame = NSRect(
-            x: feedbackButton.frame.minX - 8 - buttonSize,
-            y: buttonY,
-            width: buttonSize,
-            height: buttonSize
+            x: settingsButton.frame.maxX + spacing,
+            y: 0,
+            width: updatesWidth,
+            height: buttonHeight
         )
-        settingsButton.frame = NSRect(
-            x: updatesButton.frame.minX - 8 - buttonSize,
-            y: buttonY,
-            width: buttonSize,
-            height: buttonSize
+        quitButton.frame = NSRect(
+            x: updatesButton.frame.maxX + spacing,
+            y: 0,
+            width: quitWidth,
+            height: buttonHeight
         )
-
-        let connectWidth = min(max(150, connectAgentButton.fittingSize.width), max(0, settingsButton.frame.minX - 12))
-        connectAgentButton.frame = NSRect(x: 0, y: buttonY, width: connectWidth, height: buttonSize)
-    }
-
-    @objc private func sendFeedback() {
-        guard let appState else { return }
-        let logLines = appState.logger.entries.suffix(80).joined(separator: "\n")
-        let subject = "Transcripted Feedback"
-        let body = "What happened:\n[describe the issue here]\n\n---\nLogs:\n\(logLines)"
-        let encodedSubject = subject.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? subject
-        let encodedBody = body.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-        if let url = URL(string: "mailto:hi@transcripted.app?subject=\(encodedSubject)&body=\(encodedBody)") {
-            NSWorkspace.shared.open(url)
-        }
     }
 
     @objc private func quitApp() {
@@ -118,11 +81,24 @@ final class MenuBarSettingsView: NSView {
         onCheckForUpdates?()
     }
 
-    @objc private func openAgentConnect() {
-        onOpenAgentConnect?()
+    func update(updateState: SparkleUpdaterController.UpdateState) {
+        updatesButton.title = updateState.buttonTitle
+        if case .available = updateState {
+            updatesButton.setSymbol(
+                "arrow.down.circle.fill",
+                accessibilityLabel: "Install available update"
+            )
+        } else {
+            updatesButton.setSymbol(
+                "arrow.triangle.2.circlepath.circle",
+                accessibilityLabel: "Check for updates"
+            )
+        }
+        updatesButton.isEnabled = updateState != .checking
+        needsLayout = true
     }
 
     func dismissTransientUI() {}
 
-    var intrinsicHeight: CGFloat { MenuTokens.secondaryButtonSize + 8 }
+    var intrinsicHeight: CGFloat { MenuTokens.secondaryButtonSize }
 }

--- a/Sources/UI/MenuBar/MenuBarShortcutsView.swift
+++ b/Sources/UI/MenuBar/MenuBarShortcutsView.swift
@@ -1,31 +1,13 @@
-// MenuBarShortcutsView.swift
-// Primary action rows for dictation and meeting capture.
-
 import AppKit
-import Carbon
 
 @MainActor
 final class MenuBarShortcutsView: NSView {
     var onStartDictation: (() -> Void)?
     var onStartMeeting: (() -> Void)?
 
-    private let dictationRow = PrimaryActionRowView()
-    private let meetingRow = PrimaryActionRowView()
-    private let resetHintLabel = NSTextField(labelWithString: "Click a shortcut badge to edit")
-    private let resetButton = MenuIconButton(
-        symbolName: "arrow.counterclockwise",
-        accessibilityLabel: "Reset shortcuts",
-        toolTip: "Reset shortcuts"
-    )
-    private var keyMonitor: Any?
-    private var recordingTarget: RecordingTarget?
-    private var currentDictationState = MenuBarPrimaryActionState(isEnabled: true, subtitle: "Paste spoken text anywhere")
-    private var currentMeetingState = MenuBarPrimaryActionState(isEnabled: true, subtitle: "Capture mic and system audio")
-
-    private enum RecordingTarget {
-        case dictation
-        case meeting
-    }
+    private let dictationButton = MenuPrimaryActionButton()
+    private let meetingButton = MenuPrimaryActionButton()
+    private let hintLabel = NSTextField(labelWithString: "Shortcut editing moved to Settings.")
 
     override init(frame: NSRect) {
         super.init(frame: frame)
@@ -37,63 +19,36 @@ final class MenuBarShortcutsView: NSView {
 
     override var isFlipped: Bool { true }
 
-    deinit {
-        if let keyMonitor {
-            NSEvent.removeMonitor(keyMonitor)
-        }
-    }
-
-    override func removeFromSuperview() {
-        stopRecording()
-        super.removeFromSuperview()
-    }
-
     private func setupViews() {
-        dictationRow.onPrimaryAction = { [weak self] in
-            guard let self, self.currentDictationState.isEnabled, self.recordingTarget == nil else { return }
-            self.onStartDictation?()
+        dictationButton.onTrigger = { [weak self] in
+            self?.onStartDictation?()
         }
-        dictationRow.onEditShortcut = { [weak self] in
-            self?.startRecording(.dictation)
+        addSubview(dictationButton)
+
+        meetingButton.onTrigger = { [weak self] in
+            self?.onStartMeeting?()
         }
+        addSubview(meetingButton)
 
-        meetingRow.onPrimaryAction = { [weak self] in
-            guard let self, self.currentMeetingState.isEnabled, self.recordingTarget == nil else { return }
-            self.onStartMeeting?()
-        }
-        meetingRow.onEditShortcut = { [weak self] in
-            self?.startRecording(.meeting)
-        }
-
-        resetHintLabel.font = NSFont.systemFont(ofSize: 10)
-        resetHintLabel.textColor = MenuTokens.textMutedNS
-        addSubview(resetHintLabel)
-
-        resetButton.target = self
-        resetButton.action = #selector(resetShortcuts)
-        addSubview(resetButton)
-
-        addSubview(dictationRow)
-        addSubview(meetingRow)
+        hintLabel.font = NSFont.systemFont(ofSize: 10)
+        hintLabel.textColor = MenuTokens.textMutedNS
+        addSubview(hintLabel)
     }
 
     override func layout() {
         super.layout()
-        dictationRow.frame = NSRect(x: 0, y: 0, width: bounds.width, height: MenuTokens.actionRowHeight)
-        meetingRow.frame = NSRect(
+
+        dictationButton.frame = NSRect(x: 0, y: 0, width: bounds.width, height: MenuTokens.actionRowHeight)
+        meetingButton.frame = NSRect(
             x: 0,
-            y: MenuTokens.actionRowHeight + 6,
+            y: dictationButton.frame.maxY + 8,
             width: bounds.width,
             height: MenuTokens.actionRowHeight
         )
-
-        let buttonSize = MenuTokens.secondaryButtonSize
-        let footerY = meetingRow.frame.maxY + 6
-        resetButton.frame = NSRect(x: bounds.width - buttonSize, y: footerY, width: buttonSize, height: buttonSize)
-        resetHintLabel.frame = NSRect(
+        hintLabel.frame = NSRect(
             x: 0,
-            y: footerY + ((buttonSize - 14) / 2),
-            width: max(0, resetButton.frame.minX - 10),
+            y: meetingButton.frame.maxY + 10,
+            width: bounds.width,
             height: 14
         )
     }
@@ -104,115 +59,49 @@ final class MenuBarShortcutsView: NSView {
         dictationState: MenuBarPrimaryActionState,
         meetingState: MenuBarPrimaryActionState
     ) {
-        currentDictationState = dictationState
-        currentMeetingState = meetingState
-        resetButton.isEnabled = recordingTarget == nil
-        resetHintLabel.alphaValue = 1.0
-        resetHintLabel.stringValue = "Click a shortcut badge to edit"
-
-        dictationRow.update(
+        dictationButton.update(
             symbolName: "mic.fill",
-            title: "Dictation",
-            subtitle: recordingTarget == .dictation
-                ? "Press shortcut…"
-                : dictationState.subtitle,
-            key: recordingTarget == .dictation ? "Type keys" : dictationKey,
-            isEditing: recordingTarget == .dictation,
+            title: "Start dictation",
+            subtitle: dictationState.subtitle,
+            key: dictationKey,
             isEnabled: dictationState.isEnabled
         )
 
-        meetingRow.update(
+        meetingButton.update(
             symbolName: "record.circle.fill",
             title: "Record meeting",
-            subtitle: recordingTarget == .meeting
-                ? "Press shortcut…"
-                : meetingState.subtitle,
-            key: recordingTarget == .meeting ? "Type keys" : meetingKey,
-            isEditing: recordingTarget == .meeting,
+            subtitle: meetingState.subtitle,
+            key: meetingKey,
             isEnabled: meetingState.isEnabled
         )
 
         needsLayout = true
     }
 
-    private func startRecording(_ target: RecordingTarget) {
-        stopRecording()
-        recordingTarget = target
-        refreshFromPreferences()
-
-        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            guard let self else { return event }
-            if event.keyCode == UInt16(kVK_Escape) {
-                self.stopRecording()
-                self.refreshFromPreferences()
-                return nil
-            }
-
-            let candidate = HotkeyBinding(
-                keyCode: UInt32(event.keyCode),
-                modifiers: HotkeyPreferences.carbonModifiers(from: event.modifierFlags)
-            )
-            guard HotkeyPreferences.isValid(candidate) else { return nil }
-
-            switch target {
-            case .dictation:
-                HotkeyPreferences.save(dictation: candidate)
-            case .meeting:
-                HotkeyPreferences.save(meeting: candidate)
-            }
-
-            self.stopRecording()
-            self.refreshFromPreferences()
-            return nil
-        }
-    }
-
-    private func stopRecording() {
-        if let keyMonitor {
-            NSEvent.removeMonitor(keyMonitor)
-            self.keyMonitor = nil
-        }
-        recordingTarget = nil
-    }
-
-    func cancelEditing() {
-        stopRecording()
-        refreshFromPreferences()
-    }
-
-    private func refreshFromPreferences() {
-        update(
-            dictationKey: HotkeyPreferences.displayString(for: HotkeyPreferences.dictationBinding()),
-            meetingKey: HotkeyPreferences.displayString(for: HotkeyPreferences.meetingBinding()),
-            dictationState: currentDictationState,
-            meetingState: currentMeetingState
-        )
-    }
+    func cancelEditing() {}
 
     var intrinsicHeight: CGFloat {
-        MenuTokens.actionRowHeight * 2 + MenuTokens.secondaryButtonSize + 12
-    }
-
-    @objc private func resetShortcuts() {
-        HotkeyPreferences.resetToDefaults()
-        refreshFromPreferences()
+        MenuTokens.actionRowHeight * 2 + 32
     }
 }
 
-private final class PrimaryActionRowView: NSView {
-    var onPrimaryAction: (() -> Void)?
-    var onEditShortcut: (() -> Void)?
+@MainActor
+private final class MenuPrimaryActionButton: NSButton {
+    var onTrigger: (() -> Void)?
 
     private let symbolWellView = NSView()
     private let symbolView = NSImageView()
     private let titleLabel = NSTextField(labelWithString: "")
     private let subtitleLabel = NSTextField(labelWithString: "")
-    private let badgeButton = NSButton(title: "", target: nil, action: nil)
-    private var rowEnabled = true
+    private let keyBadge = NSTextField(labelWithString: "")
     private var trackingAreaRef: NSTrackingArea?
+    private var rowEnabled = true
+    private var isHovering = false {
+        didSet { updateAppearance() }
+    }
 
-    override init(frame: NSRect) {
-        super.init(frame: frame)
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
         setupViews()
     }
 
@@ -223,7 +112,10 @@ private final class PrimaryActionRowView: NSView {
 
     private func setupViews() {
         wantsLayer = true
-        layer?.cornerRadius = 12
+        isBordered = false
+        title = ""
+        focusRingType = .none
+        layer?.cornerRadius = 14
         layer?.borderWidth = 1
 
         symbolWellView.wantsLayer = true
@@ -236,7 +128,7 @@ private final class PrimaryActionRowView: NSView {
         symbolView.contentTintColor = MenuTokens.textPrimaryNS
         symbolWellView.addSubview(symbolView)
 
-        titleLabel.font = NSFont.systemFont(ofSize: 12, weight: .semibold)
+        titleLabel.font = NSFont.systemFont(ofSize: 12.5, weight: .semibold)
         titleLabel.textColor = MenuTokens.textPrimaryNS
         addSubview(titleLabel)
 
@@ -244,15 +136,16 @@ private final class PrimaryActionRowView: NSView {
         subtitleLabel.textColor = MenuTokens.textSecondaryNS
         addSubview(subtitleLabel)
 
-        badgeButton.isBordered = false
-        badgeButton.bezelStyle = .inline
-        badgeButton.font = NSFont.monospacedSystemFont(ofSize: 9, weight: .semibold)
-        badgeButton.contentTintColor = MenuTokens.textPrimaryNS
-        badgeButton.wantsLayer = true
-        badgeButton.layer?.cornerRadius = 8
-        badgeButton.target = self
-        badgeButton.action = #selector(editShortcut)
-        addSubview(badgeButton)
+        keyBadge.font = NSFont.monospacedSystemFont(ofSize: 9, weight: .semibold)
+        keyBadge.textColor = MenuTokens.textPrimaryNS
+        keyBadge.alignment = .center
+        keyBadge.wantsLayer = true
+        keyBadge.layer?.cornerRadius = 8
+        keyBadge.layer?.backgroundColor = MenuTokens.badgeBackgroundNS.cgColor
+        keyBadge.layer?.borderWidth = 1
+        keyBadge.layer?.borderColor = MenuTokens.badgeBorderNS.cgColor
+        keyBadge.lineBreakMode = .byTruncatingTail
+        addSubview(keyBadge)
     }
 
     override func updateTrackingAreas() {
@@ -270,39 +163,9 @@ private final class PrimaryActionRowView: NSView {
         trackingAreaRef = area
     }
 
-    func update(symbolName: String, title: String, subtitle: String, key: String, isEditing: Bool, isEnabled: Bool) {
-        rowEnabled = isEnabled
-        symbolView.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: title)?
-            .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 12, weight: .semibold))
-        titleLabel.stringValue = title
-        subtitleLabel.stringValue = subtitle
-        badgeButton.title = key
-
-        layer?.backgroundColor = (isEnabled ? MenuTokens.actionBackgroundNS : MenuTokens.actionDisabledNS).cgColor
-        layer?.borderColor = MenuTokens.actionBorderNS.cgColor
-
-        titleLabel.alphaValue = isEnabled ? 1.0 : 0.55
-        subtitleLabel.alphaValue = isEnabled ? 1.0 : 0.55
-        badgeButton.alphaValue = isEnabled ? 1.0 : 0.55
-        badgeButton.isEnabled = isEnabled
-        badgeButton.layer?.backgroundColor = (isEditing ? NSColor.systemOrange.withAlphaComponent(0.18) : MenuTokens.badgeBackgroundNS).cgColor
-        badgeButton.layer?.borderWidth = 1
-        badgeButton.layer?.borderColor = (isEditing ? NSColor.systemOrange.withAlphaComponent(0.32) : MenuTokens.badgeBorderNS).cgColor
-
-        needsLayout = true
-    }
-
-    override func mouseEntered(with event: NSEvent) {
-        guard rowEnabled else { return }
-        layer?.backgroundColor = MenuTokens.actionPressedNS.cgColor
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        layer?.backgroundColor = (rowEnabled ? MenuTokens.actionBackgroundNS : MenuTokens.actionDisabledNS).cgColor
-    }
-
     override func layout() {
         super.layout()
+
         let pad: CGFloat = 14
         symbolWellView.frame = NSRect(
             x: pad,
@@ -312,8 +175,8 @@ private final class PrimaryActionRowView: NSView {
         )
         symbolView.frame = symbolWellView.bounds
 
-        let badgeWidth = max(70, badgeButton.fittingSize.width + 18)
-        badgeButton.frame = NSRect(
+        let badgeWidth = max(84, keyBadge.fittingSize.width + 18)
+        keyBadge.frame = NSRect(
             x: bounds.width - pad - badgeWidth,
             y: (bounds.height - MenuTokens.badgeHeight) / 2,
             width: badgeWidth,
@@ -321,22 +184,51 @@ private final class PrimaryActionRowView: NSView {
         )
 
         let textX = symbolWellView.frame.maxX + 10
-        let textWidth = badgeButton.frame.minX - textX - 10
-        titleLabel.frame = NSRect(x: textX, y: 8, width: textWidth, height: 15)
-        subtitleLabel.frame = NSRect(x: textX, y: 24, width: textWidth, height: 13)
+        let textWidth = keyBadge.frame.minX - textX - 12
+        titleLabel.frame = NSRect(x: textX, y: 10, width: textWidth, height: 15)
+        subtitleLabel.frame = NSRect(x: textX, y: 26, width: textWidth, height: 13)
+    }
+
+    func update(symbolName: String, title: String, subtitle: String, key: String, isEnabled: Bool) {
+        rowEnabled = isEnabled
+        titleLabel.stringValue = title
+        subtitleLabel.stringValue = subtitle
+        keyBadge.stringValue = key
+        symbolView.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: title)?
+            .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 12, weight: .semibold))
+
+        updateAppearance()
+        titleLabel.alphaValue = isEnabled ? 1.0 : 0.55
+        subtitleLabel.alphaValue = isEnabled ? 1.0 : 0.55
+        keyBadge.alphaValue = isEnabled ? 1.0 : 0.55
+        needsLayout = true
+    }
+
+    private func updateAppearance() {
+        let backgroundColor: NSColor
+        if !rowEnabled {
+            backgroundColor = MenuTokens.actionDisabledNS
+        } else if isHovering {
+            backgroundColor = MenuTokens.actionPressedNS
+        } else {
+            backgroundColor = MenuTokens.actionBackgroundNS
+        }
+
+        layer?.backgroundColor = backgroundColor.cgColor
+        layer?.borderColor = MenuTokens.actionBorderNS.cgColor
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        guard rowEnabled else { return }
+        isHovering = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isHovering = false
     }
 
     override func mouseDown(with event: NSEvent) {
-        let point = convert(event.locationInWindow, from: nil)
-        guard rowEnabled, !badgeButton.frame.contains(point) else {
-            super.mouseDown(with: event)
-            return
-        }
-        onPrimaryAction?()
-    }
-
-    @objc private func editShortcut() {
         guard rowEnabled else { return }
-        onEditShortcut?()
+        onTrigger?()
     }
 }

--- a/Sources/UI/MenuBar/MenuTokens.swift
+++ b/Sources/UI/MenuBar/MenuTokens.swift
@@ -62,15 +62,15 @@ enum MenuTokens {
     static let savedBorder = Color(MenuTokens.savedBorderNS)
 
     // Layout
-    static let panelWidth: CGFloat = 360
-    static let panelHeight: CGFloat = 408
+    static let panelWidth: CGFloat = 348
+    static let panelHeight: CGFloat = 246
     static let onboardingWindowWidth: CGFloat = 620
     static let onboardingWindowHeight: CGFloat = 760
     static let innerPadding: CGFloat = 14
     static let sectionSpacing: CGFloat = 8
     static let surfaceCornerRadius: CGFloat = 16
     static let cardCornerRadius: CGFloat = 12
-    static let actionRowHeight: CGFloat = 46
+    static let actionRowHeight: CGFloat = 52
     static let recentRowHeight: CGFloat = 40
     static let savedRowHeight: CGFloat = 54
     static let failedRowHeight: CGFloat = 62

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1,9 +1,59 @@
-import SwiftUI
 import AppKit
+import SwiftUI
 import TranscriptedCore
 
 struct TranscriptedSettingsView: View {
+    enum SettingsPane: String, CaseIterable, Identifiable {
+        case general
+        case models
+        case advanced
+        case people
+        case about
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .general: return "General"
+            case .models: return "Models"
+            case .advanced: return "Advanced"
+            case .people: return "People"
+            case .about: return "About"
+            }
+        }
+
+        var symbolName: String {
+            switch self {
+            case .general: return "slider.horizontal.3"
+            case .models: return "waveform.badge.mic"
+            case .advanced: return "gearshape.2"
+            case .people: return "person.2"
+            case .about: return "info.circle"
+            }
+        }
+
+        var detail: String {
+            switch self {
+            case .general:
+                return "The core controls you’ll reach for most often."
+            case .models:
+                return "How Transcripted’s local dictation and meeting tools are doing."
+            case .advanced:
+                return "Permissions, diagnostics, storage, and agent setup."
+            case .people:
+                return "Speaker matching and cleanup for meeting history."
+            case .about:
+                return "Version info, updates, and support actions."
+            }
+        }
+    }
+
     @ObservedObject var speakerPeopleModel: SpeakerPeopleSettingsViewModel
+    @ObservedObject private var parakeetEngine: ParakeetEngine
+    @ObservedObject private var meetingSession: MeetingSessionController
+    @ObservedObject private var sparkleUpdater: SparkleUpdaterController
+
+    @State private var selectedPane: SettingsPane = .general
     @State private var rightOptionEnabled = HotkeyPreferences.rightOptionDictationEnabled()
     @State private var uiSoundsEnabled = UISoundPreferences.isEnabled()
     @State private var crashReportingEnabled = CrashReportingPreferences.isEnabled()
@@ -12,152 +62,67 @@ struct TranscriptedSettingsView: View {
     @State private var permissionStates = PermissionSnapshot.current()
     @State private var captureLibraryURL = FileManager.default.transcriptedCaptureLibraryDir
 
-    init(speakerPeopleModel: SpeakerPeopleSettingsViewModel) {
+    private let onCheckForUpdates: () -> Void
+    private let onOpenAgentConnect: () -> Void
+    private let onSendFeedback: () -> Void
+
+    init(
+        speakerPeopleModel: SpeakerPeopleSettingsViewModel,
+        parakeetEngine: ParakeetEngine,
+        meetingSession: MeetingSessionController,
+        sparkleUpdater: SparkleUpdaterController,
+        onCheckForUpdates: @escaping () -> Void,
+        onOpenAgentConnect: @escaping () -> Void,
+        onSendFeedback: @escaping () -> Void
+    ) {
         self.speakerPeopleModel = speakerPeopleModel
+        _parakeetEngine = ObservedObject(wrappedValue: parakeetEngine)
+        _meetingSession = ObservedObject(wrappedValue: meetingSession)
+        _sparkleUpdater = ObservedObject(wrappedValue: sparkleUpdater)
+        self.onCheckForUpdates = onCheckForUpdates
+        self.onOpenAgentConnect = onOpenAgentConnect
+        self.onSendFeedback = onSendFeedback
     }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Transcripted Settings")
-                        .font(.title2.weight(.semibold))
+        ZStack {
+            Color(MenuTokens.surfaceBackgroundNS)
+                .ignoresSafeArea()
 
-                    Text("Transcripted is a local-first voice utility for dictation and meeting capture. These controls help you manage shortcuts, permissions, and where to find your data.")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
+            VStack(spacing: 0) {
+                HStack(spacing: 0) {
+                    settingsSidebar
+                        .frame(width: 220)
 
-                SettingsSection(title: "Shortcuts", detail: "Choose the keyboard shortcuts Transcripted listens for anywhere on your Mac.") {
-                    HotkeyRecorderContainer()
-                        .frame(height: 76)
+                    Rectangle()
+                        .fill(Color(MenuTokens.sectionDividerNS))
+                        .frame(width: 1)
 
-                    Toggle("Tap the right Option key to start dictation", isOn: Binding(
-                        get: { rightOptionEnabled },
-                        set: { newValue in
-                            rightOptionEnabled = newValue
-                            HotkeyPreferences.setRightOptionDictation(enabled: newValue)
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 24) {
+                            detailHeader
+                            paneContent
                         }
-                    ))
-
-                    Text(rightOptionEnabled
-                        ? "A quick tap of the right Option key will also start dictation."
-                        : "Dictation will only use the configured keyboard shortcut."
-                    )
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                }
-
-                SettingsSection(title: "Feedback", detail: "Use subtle macOS system sounds to confirm dictation state changes.") {
-                    Toggle("Play dictation feedback sounds", isOn: Binding(
-                        get: { uiSoundsEnabled },
-                        set: { newValue in
-                            uiSoundsEnabled = newValue
-                            UISoundPreferences.setEnabled(newValue)
-                        }
-                    ))
-
-                    Text(uiSoundsEnabled
-                        ? "Transcripted will play quiet cues when dictation starts, stops, completes, or ends with no speech."
-                        : "Dictation sounds are off."
-                    )
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                }
-
-                SettingsSection(title: "Diagnostics", detail: "Both controls are optional. Crash reports and anonymous usage statistics stay separate, scoped, and scrubbed before anything leaves this Mac.") {
-                    Toggle("Send crash and error reports", isOn: Binding(
-                        get: { crashReportingEnabled },
-                        set: { newValue in
-                            crashReportingEnabled = newValue
-                            CrashReportingPreferences.setEnabled(newValue)
-                            sentryTestStatus = nil
-                        }
-                    ))
-                    .disabled(!CrashReporter.isAvailable)
-
-                    Toggle("Send anonymous usage statistics", isOn: Binding(
-                        get: { anonymousAnalyticsEnabled },
-                        set: { newValue in
-                            anonymousAnalyticsEnabled = newValue
-                            AnalyticsPreferences.setEnabled(newValue)
-                        }
-                    ))
-                    .disabled(!AnalyticsReporter.isAvailable)
-
-                    HStack {
-                        Button("Send Test Sentry Event") {
-                            sendTestSentryEvent()
-                        }
-                        .disabled(!CrashReporter.isAvailable || !crashReportingEnabled)
-
-                        if let sentryTestStatus {
-                            Text(sentryTestStatus)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
+                        .padding(.horizontal, 28)
+                        .padding(.vertical, 24)
                     }
-
-                    Text("Transcripted never sends transcript text, audio, meeting titles, speaker names, source app names, emails, file paths, or raw URLs through either path.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    Text(crashReportingFootnote)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    Text(analyticsFootnote)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                 }
 
-                SettingsSection(title: "Permissions", detail: "Transcripted only asks for permissions that support local capture, paste-back, and optional meeting prompts.") {
-                    ForEach(TranscriptedPermissionKind.allCases) { kind in
-                        PermissionStatusRow(kind: kind, granted: permissionStates[kind] ?? false) {
-                            TranscriptedPermissionAccess.openSettings(for: kind)
-                            refreshPermissions()
-                        }
-                    }
+                Rectangle()
+                    .fill(Color(MenuTokens.sectionDividerNS))
+                    .frame(height: 1)
 
-                    HStack {
-                        Spacer()
-                        Button("Refresh Status") {
-                            refreshPermissions()
-                        }
-                    }
-                }
-
-                SpeakerPeopleSettingsSection(model: speakerPeopleModel)
-
-                SettingsSection(title: "Storage", detail: "Captures can live anywhere you want, while app state stays separated under Application Support.") {
-                    StorageRow(title: "Capture library", url: captureLibraryURL)
-                    StorageRow(title: "Meeting captures", url: MeetingStoragePaths.transcriptsFolder)
-                    StorageRow(title: "Dictation captures", url: DictationStoragePaths.transcriptsFolder)
-                    StorageRow(title: "App state", url: appStateFolder)
-                    StorageRow(title: "App cache", url: cacheFolder)
-                    StorageRow(title: "App logs", url: logsFolder)
-                    StorageRow(title: "Temporary recordings", url: recordingsFolder)
-
-                    HStack {
-                        Button("Choose Capture Library") {
-                            chooseCaptureLibrary()
-                        }
-
-                        Button("Reset to Default") {
-                            TranscriptedStoragePreferences.setCaptureLibraryURL(nil)
-                            refreshStoragePaths()
-                        }
-                    }
-
-                    Text("Choose a folder like an Obsidian vault if you want agents to read the raw Markdown captures directly. Transcripted will keep its databases, cache, logs, and tmp files under Application Support.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+                SettingsFooterView(
+                    modelState: modelBadgeState,
+                    updateState: sparkleUpdater.updateState,
+                    onOpenModels: { selectedPane = .models },
+                    onCheckForUpdates: onCheckForUpdates
+                )
             }
-            .padding(24)
         }
-        .frame(minWidth: 680, minHeight: 580)
-        .background(Color(nsColor: .windowBackgroundColor))
+        .frame(minWidth: 860, minHeight: 640)
+        .preferredColorScheme(.dark)
         .onAppear {
             refreshPermissions()
             refreshStoragePaths()
@@ -165,6 +130,505 @@ struct TranscriptedSettingsView: View {
             uiSoundsEnabled = UISoundPreferences.isEnabled()
             crashReportingEnabled = CrashReportingPreferences.isEnabled()
             anonymousAnalyticsEnabled = AnalyticsPreferences.isEnabled()
+        }
+    }
+
+    private var settingsSidebar: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 10) {
+                    Image(systemName: "waveform.badge.mic")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(Color(MenuTokens.statusGreenNS))
+
+                    Text("Transcripted")
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(Color(MenuTokens.textPrimaryNS))
+                }
+
+                Text("A smaller launcher with one place to manage the rest.")
+                    .font(.caption)
+                    .foregroundStyle(Color(MenuTokens.textSecondaryNS))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            VStack(spacing: 6) {
+                ForEach(SettingsPane.allCases) { pane in
+                    Button {
+                        selectedPane = pane
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: pane.symbolName)
+                                .font(.system(size: 13, weight: .semibold))
+                                .frame(width: 18)
+
+                            Text(pane.title)
+                                .font(.system(size: 13, weight: .semibold))
+
+                            Spacer()
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(SettingsSidebarButtonStyle(isSelected: selectedPane == pane))
+                }
+            }
+
+            Spacer()
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(TranscriptedAppActions.versionDisplay)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color(MenuTokens.textPrimaryNS))
+
+                Text("Local-first dictation and meeting capture for your Mac.")
+                    .font(.caption2)
+                    .foregroundStyle(Color(MenuTokens.textMutedNS))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(20)
+    }
+
+    private var detailHeader: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(selectedPane.title)
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(Color(MenuTokens.textPrimaryNS))
+
+            Text(selectedPane.detail)
+                .font(.callout)
+                .foregroundStyle(Color(MenuTokens.textSecondaryNS))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    @ViewBuilder
+    private var paneContent: some View {
+        switch selectedPane {
+        case .general:
+            generalPane
+        case .models:
+            modelsPane
+        case .advanced:
+            advancedPane
+        case .people:
+            SpeakerPeopleSettingsSection(model: speakerPeopleModel)
+        case .about:
+            aboutPane
+        }
+    }
+
+    private var generalPane: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            SettingsSection(
+                title: "Capture",
+                detail: "Keep the everyday controls in one place instead of scattering them across the menu bar."
+            ) {
+                VStack(spacing: 0) {
+                    SettingsRow(
+                        title: "Keyboard shortcuts",
+                        detail: "Change the shortcuts for dictation and meeting capture."
+                    ) {
+                        HotkeyRecorderContainer()
+                            .frame(width: 220, height: 76)
+                    }
+
+                    SettingsDivider()
+
+                    SettingsRow(
+                        title: "Right Option quick start",
+                        detail: "Tap the right Option key once to start dictation from anywhere."
+                    ) {
+                        Toggle("", isOn: Binding(
+                            get: { rightOptionEnabled },
+                            set: { newValue in
+                                rightOptionEnabled = newValue
+                                HotkeyPreferences.setRightOptionDictation(enabled: newValue)
+                            }
+                        ))
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                    }
+
+                    SettingsDivider()
+
+                    SettingsRow(
+                        title: "Dictation sounds",
+                        detail: "Play small macOS cues when dictation starts, stops, or finishes."
+                    ) {
+                        Toggle("", isOn: Binding(
+                            get: { uiSoundsEnabled },
+                            set: { newValue in
+                                uiSoundsEnabled = newValue
+                                UISoundPreferences.setEnabled(newValue)
+                            }
+                        ))
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                    }
+                }
+            }
+
+            SettingsSection(
+                title: "What changed",
+                detail: "The menu bar stays focused on starting work. These controls now live here instead of inside the popover."
+            ) {
+                VStack(spacing: 0) {
+                    SettingsStaticRow(
+                        title: "Menu bar",
+                        detail: "Start dictation, start a meeting, open settings, check updates, and quit."
+                    )
+
+                    SettingsDivider()
+
+                    SettingsStaticRow(
+                        title: "Settings",
+                        detail: "Shortcuts, model health, storage, permissions, and support live in one consistent shell."
+                    )
+                }
+            }
+        }
+    }
+
+    private var modelsPane: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            SettingsSection(
+                title: "Local dictation",
+                detail: "Transcripted uses a local Parakeet model for dictation. This badge lives in the footer so you always know what engine is active."
+            ) {
+                VStack(spacing: 0) {
+                    SettingsRow(
+                        title: "Current model",
+                        detail: "Bundled local speech-to-text engine for dictation."
+                    ) {
+                        SettingsStatusPill(
+                            title: "Parakeet V3",
+                            detail: dictationModelState.status,
+                            tone: modelBadgeState.tone
+                        )
+                    }
+
+                    SettingsDivider()
+
+                    SettingsRow(
+                        title: dictationModelState.title,
+                        detail: dictationModelState.detail
+                    ) {
+                        Text(dictationModelState.status)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(Color(MenuTokens.textSecondaryNS))
+                    }
+
+                    if let progress = dictationModelState.progress, dictationModelState.tone != .ready {
+                        SettingsDivider()
+
+                        SettingsProgressRow(progress: progress)
+                    }
+
+                    if dictationModelState.tone != .ready {
+                        SettingsDivider()
+
+                        SettingsActionRow(
+                            title: "Retry model setup",
+                            detail: "Ask Transcripted to try loading the local dictation model again.",
+                            buttonTitle: "Retry"
+                        ) {
+                            Task {
+                                await parakeetEngine.initialize()
+                            }
+                        }
+                    }
+                }
+            }
+
+            SettingsSection(
+                title: "Meeting tools",
+                detail: "Meeting capture warms up alongside dictation so the first recording is less awkward."
+            ) {
+                VStack(spacing: 0) {
+                    SettingsRow(
+                        title: meetingSession.warmupStatus.title,
+                        detail: meetingSession.warmupStatus.detail.isEmpty
+                            ? "Meeting capture is ready to go."
+                            : meetingSession.warmupStatus.detail
+                    ) {
+                        SettingsStatusPill(
+                            title: meetingSession.warmupStatus.meetingsStatus,
+                            detail: meetingSession.warmupStatus.subtitle,
+                            tone: meetingBadgeTone
+                        )
+                    }
+
+                    if meetingBadgeTone != .ready {
+                        SettingsDivider()
+
+                        SettingsProgressRow(progress: meetingSession.warmupStatus.progress)
+                    }
+
+                    if meetingBadgeTone != .ready {
+                        SettingsDivider()
+
+                        SettingsActionRow(
+                            title: "Retry meeting warmup",
+                            detail: "Reload the meeting transcription tools in the background.",
+                            buttonTitle: "Retry"
+                        ) {
+                            Task {
+                                await meetingSession.prepareModels(showLoadingUI: false)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var advancedPane: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            SettingsSection(
+                title: "Diagnostics",
+                detail: "Crash reports and anonymous analytics stay separate, allowlisted, and scrubbed before anything leaves this Mac."
+            ) {
+                VStack(spacing: 0) {
+                    SettingsRow(
+                        title: "Crash and error reports",
+                        detail: crashReportingFootnote
+                    ) {
+                        Toggle("", isOn: Binding(
+                            get: { crashReportingEnabled },
+                            set: { newValue in
+                                crashReportingEnabled = newValue
+                                CrashReportingPreferences.setEnabled(newValue)
+                                sentryTestStatus = nil
+                            }
+                        ))
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .disabled(!CrashReporter.isAvailable)
+                    }
+
+                    SettingsDivider()
+
+                    SettingsRow(
+                        title: "Anonymous usage stats",
+                        detail: analyticsFootnote
+                    ) {
+                        Toggle("", isOn: Binding(
+                            get: { anonymousAnalyticsEnabled },
+                            set: { newValue in
+                                anonymousAnalyticsEnabled = newValue
+                                AnalyticsPreferences.setEnabled(newValue)
+                            }
+                        ))
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .disabled(!AnalyticsReporter.isAvailable)
+                    }
+
+                    SettingsDivider()
+
+                    SettingsActionRow(
+                        title: "Send test Sentry event",
+                        detail: sentryTestStatus ?? "Verify that Sentry is wired correctly without waiting for a real issue.",
+                        buttonTitle: "Send"
+                    ) {
+                        sendTestSentryEvent()
+                    }
+                    .disabled(!CrashReporter.isAvailable || !crashReportingEnabled)
+                }
+            }
+
+            SettingsSection(
+                title: "Permissions",
+                detail: "Transcripted only asks for the permissions it needs for local capture, paste-back, and optional meeting prompts."
+            ) {
+                VStack(spacing: 0) {
+                    ForEach(Array(TranscriptedPermissionKind.allCases.enumerated()), id: \.element) { index, kind in
+                        PermissionStatusRow(
+                            kind: kind,
+                            granted: permissionStates[kind] ?? false
+                        ) {
+                            TranscriptedPermissionAccess.openSettings(for: kind)
+                            refreshPermissions()
+                        }
+
+                        if index < TranscriptedPermissionKind.allCases.count - 1 {
+                            SettingsDivider()
+                        }
+                    }
+
+                    SettingsDivider()
+
+                    SettingsActionRow(
+                        title: "Refresh permission status",
+                        detail: "Pull the latest authorization state back into the app.",
+                        buttonTitle: "Refresh"
+                    ) {
+                        refreshPermissions()
+                    }
+                }
+            }
+
+            SettingsSection(
+                title: "Storage",
+                detail: "Captures can live anywhere you want, while app state, cache, logs, and temp files stay under Application Support."
+            ) {
+                VStack(spacing: 0) {
+                    StorageRow(title: "Capture library", url: captureLibraryURL)
+                    SettingsDivider()
+                    StorageRow(title: "Meeting captures", url: MeetingStoragePaths.transcriptsFolder)
+                    SettingsDivider()
+                    StorageRow(title: "Dictation captures", url: DictationStoragePaths.transcriptsFolder)
+                    SettingsDivider()
+                    StorageRow(title: "App state", url: appStateFolder)
+                    SettingsDivider()
+                    StorageRow(title: "App cache", url: cacheFolder)
+                    SettingsDivider()
+                    StorageRow(title: "App logs", url: logsFolder)
+                    SettingsDivider()
+                    StorageRow(title: "Temporary recordings", url: recordingsFolder)
+                    SettingsDivider()
+                    SettingsActionRow(
+                        title: "Choose capture library",
+                        detail: "Point Transcripted at an Obsidian vault or any other folder you want agents to read.",
+                        buttonTitle: "Choose"
+                    ) {
+                        chooseCaptureLibrary()
+                    }
+                    SettingsDivider()
+                    SettingsActionRow(
+                        title: "Reset capture library",
+                        detail: "Move captures back to Transcripted’s default folder.",
+                        buttonTitle: "Reset"
+                    ) {
+                        TranscriptedStoragePreferences.setCaptureLibraryURL(nil)
+                        refreshStoragePaths()
+                    }
+                }
+            }
+
+            SettingsSection(
+                title: "Agent workflow",
+                detail: "The old menu bar “copy for agent” action now lives in one clearer place."
+            ) {
+                VStack(spacing: 0) {
+                    SettingsActionRow(
+                        title: "Connect your agent",
+                        detail: "Open the MCP and folder setup window for your agent.",
+                        buttonTitle: "Open"
+                    ) {
+                        onOpenAgentConnect()
+                    }
+
+                    SettingsDivider()
+
+                    SettingsActionRow(
+                        title: "Send feedback",
+                        detail: "Open a prefilled email with recent logs attached.",
+                        buttonTitle: "Email"
+                    ) {
+                        onSendFeedback()
+                    }
+                }
+            }
+        }
+    }
+
+    private var aboutPane: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            SettingsSection(
+                title: "About Transcripted",
+                detail: "Local-first voice capture that saves clean Markdown files you can inspect yourself."
+            ) {
+                VStack(spacing: 0) {
+                    SettingsStaticRow(
+                        title: "App version",
+                        detail: TranscriptedAppActions.fullVersionDisplay
+                    )
+
+                    SettingsDivider()
+
+                    SettingsStaticRow(
+                        title: "Current model",
+                        detail: "Parakeet V3 for dictation, plus meeting warmup for transcription."
+                    )
+
+                    SettingsDivider()
+
+                    SettingsStaticRow(
+                        title: "Privacy",
+                        detail: "Transcripted never sends transcript text, audio, meeting titles, speaker names, emails, tokens, or file paths through crash reporting or anonymous analytics."
+                    )
+                }
+            }
+
+            SettingsSection(
+                title: "Updates and support",
+                detail: "Keep Transcripted current and get the setup text for your agent without digging through the menu bar."
+            ) {
+                VStack(spacing: 0) {
+                    SettingsActionRow(
+                        title: sparkleUpdater.updateState.buttonTitle,
+                        detail: sparkleUpdater.updateState.detailText,
+                        buttonTitle: updateActionButtonTitle
+                    ) {
+                        onCheckForUpdates()
+                    }
+                    .disabled(sparkleUpdater.updateState == .checking)
+
+                    SettingsDivider()
+
+                    SettingsActionRow(
+                        title: "Connect your agent",
+                        detail: "Open the setup window for Codex, Claude, Cursor, or any other agent.",
+                        buttonTitle: "Open"
+                    ) {
+                        onOpenAgentConnect()
+                    }
+
+                    SettingsDivider()
+
+                    SettingsActionRow(
+                        title: "Send feedback",
+                        detail: "Email Transcripted with recent logs already attached.",
+                        buttonTitle: "Email"
+                    ) {
+                        onSendFeedback()
+                    }
+                }
+            }
+        }
+    }
+
+    private var dictationModelState: FirstRunModelCardState {
+        FirstRunExperience.modelCard(for: FirstRunLocalModelState(parakeetEngine.modelDownloadState))
+    }
+
+    private var modelBadgeState: SettingsBadgeState {
+        switch dictationModelState.tone {
+        case .ready:
+            return SettingsBadgeState(title: "Parakeet V3", detail: "Ready", tone: .ready)
+        case .working:
+            return SettingsBadgeState(title: "Parakeet V3", detail: dictationModelState.status, tone: .working)
+        case .failed:
+            return SettingsBadgeState(title: "Parakeet V3", detail: "Needs attention", tone: .warning)
+        }
+    }
+
+    private var meetingBadgeTone: SettingsStatusTone {
+        meetingSession.warmupStatus == .ready ? .ready : .working
+    }
+
+    private var updateActionButtonTitle: String {
+        switch sparkleUpdater.updateState {
+        case .available:
+            return "Install"
+        case .checking:
+            return "Checking"
+        default:
+            return "Open"
         }
     }
 
@@ -187,19 +651,21 @@ struct TranscriptedSettingsView: View {
     private var crashReportingFootnote: String {
         if CrashReporter.isAvailable {
             return crashReportingEnabled
-                ? "Enabled. Transcripted will send scrubbed crash and error data to Sentry so reliability issues are easier to diagnose. Use the test button to verify your dashboard wiring."
-                : "Off. Transcripted will keep crash and error details on this Mac only."
+                ? "Enabled. Transcripted will send scrubbed crash and error data to Sentry so reliability issues are easier to diagnose."
+                : "Off. Crash and error details stay on this Mac only."
         }
-        return "This build does not have a Sentry DSN configured yet, so crash and error reporting stay local."
+
+        return "This build does not have a Sentry DSN configured yet, so crash and error reporting stays local."
     }
 
     private var analyticsFootnote: String {
         if AnalyticsReporter.isAvailable {
             return anonymousAnalyticsEnabled
-                ? "Enabled by default. Transcripted will send only allowlisted anonymous product events such as launches, dictation completions, and meeting workflow milestones using coarse buckets instead of raw content. You can turn this off at any time."
-                : "Off. Transcripted will not send anonymous usage statistics unless you turn this back on."
+                ? "Enabled. Transcripted only sends coarse, allowlisted product events with no raw transcript content."
+                : "Off. Transcripted will not send anonymous usage statistics."
         }
-        return "This build does not have a PostHog project key configured yet, so anonymous usage statistics stay disabled."
+
+        return "This build does not have a PostHog key configured yet, so anonymous analytics stay disabled."
     }
 
     private func sendTestSentryEvent() {
@@ -259,6 +725,29 @@ private struct PermissionSnapshot {
     }
 }
 
+private enum SettingsStatusTone {
+    case ready
+    case working
+    case warning
+
+    var color: Color {
+        switch self {
+        case .ready:
+            return Color(MenuTokens.statusGreenNS)
+        case .working:
+            return Color(NSColor.systemOrange)
+        case .warning:
+            return Color(NSColor.systemPink)
+        }
+    }
+}
+
+private struct SettingsBadgeState {
+    let title: String
+    let detail: String
+    let tone: SettingsStatusTone
+}
+
 struct SettingsSection<Content: View>: View {
     let title: String
     let detail: String
@@ -269,23 +758,201 @@ struct SettingsSection<Content: View>: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .font(.headline)
+                    .foregroundStyle(Color(MenuTokens.textPrimaryNS))
+
                 Text(detail)
                     .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(Color(MenuTokens.textSecondaryNS))
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(spacing: 0) {
                 content
             }
-            .padding(16)
             .background(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(Color(nsColor: .controlBackgroundColor))
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color(MenuTokens.actionBackgroundNS))
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .stroke(Color.primary.opacity(0.06), lineWidth: 1)
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(Color(MenuTokens.sectionDividerNS), lineWidth: 1)
             )
+        }
+    }
+}
+
+private struct SettingsRow<Trailing: View>: View {
+    let title: String
+    let detail: String
+    @ViewBuilder var trailing: Trailing
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 18) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color(MenuTokens.textPrimaryNS))
+
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(Color(MenuTokens.textSecondaryNS))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 16)
+
+            trailing
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
+    }
+}
+
+private struct SettingsStaticRow: View {
+    let title: String
+    let detail: String
+
+    var body: some View {
+        SettingsRow(title: title, detail: detail) {
+            EmptyView()
+        }
+    }
+}
+
+private struct SettingsActionRow: View {
+    let title: String
+    let detail: String
+    let buttonTitle: String
+    let action: () -> Void
+
+    @Environment(\.isEnabled) private var isEnabled
+
+    var body: some View {
+        SettingsRow(title: title, detail: detail) {
+            Button(buttonTitle, action: action)
+                .buttonStyle(SettingsInlineButtonStyle())
+        }
+        .opacity(isEnabled ? 1.0 : 0.6)
+    }
+}
+
+private struct SettingsProgressRow: View {
+    let progress: Double
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ProgressView(value: max(0, min(progress, 1)))
+                .progressViewStyle(.linear)
+                .tint(Color(MenuTokens.statusGreenNS))
+
+            Text("\(Int(max(0, min(progress, 1)) * 100))% complete")
+                .font(.caption)
+                .foregroundStyle(Color(MenuTokens.textSecondaryNS))
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
+    }
+}
+
+private struct SettingsDivider: View {
+    var body: some View {
+        Rectangle()
+            .fill(Color(MenuTokens.sectionDividerNS))
+            .frame(height: 1)
+            .padding(.horizontal, 18)
+    }
+}
+
+private struct SettingsStatusPill: View {
+    let title: String
+    let detail: String
+    let tone: SettingsStatusTone
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(tone.color)
+                .frame(width: 8, height: 8)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color(MenuTokens.textPrimaryNS))
+
+                Text(detail)
+                    .font(.caption2)
+                    .foregroundStyle(Color(MenuTokens.textSecondaryNS))
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(
+            Capsule(style: .continuous)
+                .fill(Color(MenuTokens.badgeBackgroundNS))
+        )
+        .overlay(
+            Capsule(style: .continuous)
+                .stroke(Color(MenuTokens.badgeBorderNS), lineWidth: 1)
+        )
+    }
+}
+
+private struct SettingsFooterView: View {
+    let modelState: SettingsBadgeState
+    let updateState: SparkleUpdaterController.UpdateState
+    let onOpenModels: () -> Void
+    let onCheckForUpdates: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Button(action: onOpenModels) {
+                HStack(spacing: 10) {
+                    Circle()
+                        .fill(modelState.tone.color)
+                        .frame(width: 8, height: 8)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(modelState.title)
+                            .font(.caption.weight(.semibold))
+
+                        Text(modelState.detail)
+                            .font(.caption2)
+                            .foregroundStyle(Color(MenuTokens.textSecondaryNS))
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+            }
+            .buttonStyle(SettingsFooterButtonStyle(alignment: .leading))
+
+            Spacer()
+
+            Button(action: onCheckForUpdates) {
+                HStack(spacing: 8) {
+                    Text(updateState.buttonTitle)
+                        .font(.caption.weight(.semibold))
+
+                    Text("• \(updateFooterVersionText)")
+                        .font(.caption)
+                        .foregroundStyle(Color(MenuTokens.textSecondaryNS))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+            }
+            .buttonStyle(SettingsFooterButtonStyle(alignment: .trailing))
+            .disabled(updateState == .checking)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(Color(MenuTokens.surfaceBackgroundNS))
+    }
+
+    private var updateFooterVersionText: String {
+        switch updateState {
+        case .available(let version):
+            return version
+        default:
+            return TranscriptedAppActions.versionDisplay
         }
     }
 }
@@ -296,25 +963,12 @@ private struct PermissionStatusRow: View {
     let action: () -> Void
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: granted ? "checkmark.circle.fill" : "exclamationmark.circle.fill")
-                .foregroundStyle(granted ? Color.green : Color.orange)
-                .font(.system(size: 16, weight: .semibold))
-                .padding(.top, 2)
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(kind.title)
-                    .font(.subheadline.weight(.semibold))
-                Text(kind.summary)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Spacer()
-
-            Button(granted ? "Review" : "Fix") {
-                action()
-            }
+        SettingsRow(
+            title: kind.title,
+            detail: kind.summary
+        ) {
+            Button(granted ? "Review" : "Fix", action: action)
+                .buttonStyle(SettingsInlineButtonStyle())
         }
     }
 }
@@ -324,24 +978,17 @@ private struct StorageRow: View {
     let url: URL
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title)
-                    .font(.subheadline.weight(.semibold))
-                Text((url.path as NSString).abbreviatingWithTildeInPath)
-                    .font(.system(.caption, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                    .textSelection(.enabled)
-            }
-
-            Spacer()
-
+        SettingsRow(
+            title: title,
+            detail: (url.path as NSString).abbreviatingWithTildeInPath
+        ) {
             Button("Show in Finder") {
                 if !FileManager.default.fileExists(atPath: url.path) {
                     try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
                 }
                 NSWorkspace.shared.activateFileViewerSelecting([url])
             }
+            .buttonStyle(SettingsInlineButtonStyle())
         }
     }
 }
@@ -353,5 +1000,69 @@ private struct HotkeyRecorderContainer: NSViewRepresentable {
 
     func updateNSView(_ nsView: HotkeyRecorderAppKitView, context: Context) {
         nsView.refreshDisplay()
+    }
+}
+
+private struct SettingsSidebarButtonStyle: ButtonStyle {
+    let isSelected: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundStyle(isSelected ? Color.black : Color(MenuTokens.textPrimaryNS))
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(isSelected ? Color(MenuTokens.statusGreenNS) : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(
+                        isSelected ? Color.clear : Color(MenuTokens.sectionDividerNS),
+                        lineWidth: 1
+                    )
+            )
+            .opacity(configuration.isPressed ? 0.85 : 1.0)
+    }
+}
+
+private struct SettingsInlineButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(Color(MenuTokens.textPrimaryNS))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(Color(MenuTokens.badgeBackgroundNS))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(Color(MenuTokens.badgeBorderNS), lineWidth: 1)
+            )
+            .opacity(configuration.isPressed ? 0.8 : 1.0)
+    }
+}
+
+private struct SettingsFooterButtonStyle: ButtonStyle {
+    enum Alignment {
+        case leading
+        case trailing
+    }
+
+    let alignment: Alignment
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(maxWidth: alignment == .leading ? .none : .infinity, alignment: alignment == .leading ? .leading : .trailing)
+            .foregroundStyle(Color(MenuTokens.textPrimaryNS))
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(Color(MenuTokens.badgeBackgroundNS))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(Color(MenuTokens.badgeBorderNS), lineWidth: 1)
+            )
+            .opacity(configuration.isPressed ? 0.85 : 1.0)
     }
 }

--- a/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import AppKit
+import SwiftUI
 import TranscriptedCore
 
 @MainActor
@@ -16,11 +16,19 @@ final class TranscriptedSettingsWindowController: NSWindowController, NSWindowDe
         )
         self.speakerPeopleModel = speakerPeopleModel
         self.hostingController = NSHostingController(
-            rootView: TranscriptedSettingsView(speakerPeopleModel: speakerPeopleModel)
+            rootView: TranscriptedSettingsView(
+                speakerPeopleModel: speakerPeopleModel,
+                parakeetEngine: appState.sttRouter.parakeetEngine,
+                meetingSession: appState.meetingSession,
+                sparkleUpdater: appState.sparkleUpdater,
+                onCheckForUpdates: { appState.sparkleUpdater.checkForUpdates() },
+                onOpenAgentConnect: { AgentConnectionWindowCoordinator.shared.show() },
+                onSendFeedback: { TranscriptedAppActions.sendFeedback(logEntries: appState.logger.entries) }
+            )
         )
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 780, height: 760),
+            contentRect: NSRect(x: 0, y: 0, width: 980, height: 720),
             styleMask: [.titled, .closable, .miniaturizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -28,6 +36,9 @@ final class TranscriptedSettingsWindowController: NSWindowController, NSWindowDe
         window.title = "Transcripted Settings"
         window.contentViewController = hostingController
         window.isReleasedWhenClosed = false
+        window.appearance = NSAppearance(named: .darkAqua)
+        window.backgroundColor = MenuTokens.surfaceBackgroundNS
+        window.minSize = NSSize(width: 860, height: 640)
         window.center()
 
         super.init(window: window)


### PR DESCRIPTION
## Summary
- replace the long settings page with a sidebar-based settings shell inspired by Handy's cleaner structure
- simplify the menu bar popover into a compact launcher with primary actions and a smaller footer
- add shared app action/update plumbing so the footer can show model state and live update status

## Validation
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`