### PR TITLE
[nightly-security] Harden analytics payload secret scrubbing

### DIFF
--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -22,9 +22,11 @@ enum AnalyticsPayloadSanitizer {
     private static let userPathRegex = try! NSRegularExpression(pattern: #"/Users/[^/\s]+/"#)
     private static let absolutePathRegex = try! NSRegularExpression(pattern: #"(?<!https:)(?<!http:)/(?:Users|private|var|tmp|Volumes|Applications)[^\s"]*"#)
     private static let rawURLRegex = try! NSRegularExpression(pattern: #"https?://[^\s"]+"#, options: [.caseInsensitive])
+    private static let apiKeyRegex = try! NSRegularExpression(pattern: #"sk-[A-Za-z0-9_-]+"#)
     private static let commonSecretRegex = try! NSRegularExpression(
         pattern: #"\b(?:ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|phc_[A-Za-z0-9]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|xoxx-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9._-]{10,}\.[A-Za-z0-9._-]{10,})\b"#
     )
+    private static let bearerRegex = try! NSRegularExpression(pattern: #"Bearer [A-Za-z0-9._-]+"#)
     private static let secretAssignmentRegex = try! NSRegularExpression(
         pattern: #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature)\s*[:=]\s*([^\s,;]+)"#
     )
@@ -60,7 +62,11 @@ enum AnalyticsPayloadSanitizer {
         range = NSRange(result.startIndex..., in: result)
         result = rawURLRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-url]")
         range = NSRange(result.startIndex..., in: result)
+        result = apiKeyRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "sk-****")
+        range = NSRange(result.startIndex..., in: result)
         result = commonSecretRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
+        range = NSRange(result.startIndex..., in: result)
+        result = bearerRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "Bearer ****")
         range = NSRange(result.startIndex..., in: result)
         result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)

--- a/Tests/AnalyticsPayloadSanitizerTests.swift
+++ b/Tests/AnalyticsPayloadSanitizerTests.swift
@@ -48,4 +48,19 @@ func testAnalyticsPayloadSanitizer() {
         assertTrue(value.contains("[redacted-url]"), "URL marker should remain")
         assertTrue(value.contains("[redacted-secret]"), "secret marker should remain")
     }
+
+    runSuite("AnalyticsPayloadSanitizer redacts bearer headers and sk-style keys") {
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "failure_kind": "Request used Bearer abc123 and sk-proj-secret-value while retrying",
+            ],
+            allowedKeys: ["failure_kind"]
+        )
+
+        let value = sanitized["failure_kind"] ?? ""
+        assertFalse(value.contains("Bearer abc123"), "bearer headers should be redacted")
+        assertFalse(value.contains("sk-proj-secret-value"), "sk-style API keys should be redacted")
+        assertTrue(value.contains("Bearer ****"), "bearer marker should remain")
+        assertTrue(value.contains("sk-****"), "sk-style marker should remain")
+    }
 }


### PR DESCRIPTION
## Summary
- extend `AnalyticsPayloadSanitizer` to redact generic `sk-...` API keys and `Bearer ...` headers
- add fast-test coverage so analytics sanitization stays aligned with Transcripted's privacy boundary
- verified there was no existing open `[nightly-security]` draft PR before opening this one

## Verification
- `bash run-tests.sh`
- `bash build-deps.sh --force`
- `bash build.sh`

## Notes
This is a small, high-confidence privacy hardening change for the nightly sweep. It reduces leakage risk if a free-form analytics value ever carries a bearer token or provider API key.