### PR TITLE
[nightly-artifact] Heal file logger startup and test isolation

### DIFF
--- a/Sources/TranscriptedCore/Logging/FileLogger.swift
+++ b/Sources/TranscriptedCore/Logging/FileLogger.swift
@@ -29,7 +29,7 @@ final class FileLogger: @unchecked Sendable {
     init(paths: CoreStoragePaths = .default, isDisabledOverride: Bool? = nil) {
         // Disable file logging during test runs to avoid polluting production logs.
         let env = ProcessInfo.processInfo.environment
-        let isTestRun = env["XCTestConfigurationFilePath"] != nil
+        let isTestRun = Self.isRunningUnderTests(environment: env)
             || Self.isEnabledFlag(env["TRANSCRIPTED_DISABLE_FILE_LOGGER"])
         self.isDisabled = isDisabledOverride ?? isTestRun
 
@@ -50,6 +50,9 @@ final class FileLogger: @unchecked Sendable {
         // Open file handle for appending
         fileHandle = try? FileHandle(forWritingTo: logFileURL)
         fileHandle?.seekToEndOfFile()
+
+        // Heal oversized inherited logs on startup even if this process never reaches 100 writes.
+        trimIfNeeded()
     }
 
     /// Write a log entry asynchronously (non-blocking)
@@ -159,5 +162,17 @@ final class FileLogger: @unchecked Sendable {
         default:
             return false
         }
+    }
+
+    private static func isRunningUnderTests(environment: [String: String]) -> Bool {
+        if environment["XCTestConfigurationFilePath"] != nil || environment["XCTestBundlePath"] != nil {
+            return true
+        }
+
+        if CommandLine.arguments.first?.contains(".xctest") == true {
+            return true
+        }
+
+        return NSClassFromString("XCTestCase") != nil
     }
 }

--- a/Tests/TranscriptedCoreTests/FileLoggerTests.swift
+++ b/Tests/TranscriptedCoreTests/FileLoggerTests.swift
@@ -76,4 +76,65 @@ final class FileLoggerTests: XCTestCase {
         let content = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
         XCTAssertTrue(content.isEmpty)
     }
+
+    func testDefaultLoggerSkipsWritesInTestProcess() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FileLoggerDefaultDisableTests-\(UUID().uuidString)", isDirectory: true)
+        let logs = root.appendingPathComponent("logs", isDirectory: true)
+        try FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let paths = CoreStoragePaths(
+            transcripts: root.appendingPathComponent("captures/meetings", isDirectory: true),
+            speakerDB: root.appendingPathComponent("state/speakers.sqlite"),
+            statsDB: root.appendingPathComponent("state/stats.sqlite"),
+            failedQueue: root.appendingPathComponent("state/failed_transcriptions.json"),
+            speakerClips: root.appendingPathComponent("tmp/recordings/speaker_clips", isDirectory: true),
+            audioCaptures: root.appendingPathComponent("tmp/recordings", isDirectory: true),
+            logs: logs
+        )
+
+        let logger = FileLogger(paths: paths)
+        logger.write(level: "info", subsystem: "app", message: "test-process-write", metadata: nil)
+        logger.flush()
+
+        let logURL = logs.appendingPathComponent("app.jsonl")
+        let content = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
+        XCTAssertTrue(content.isEmpty)
+    }
+
+    func testLoggerTrimsOversizedExistingLogOnInit() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FileLoggerTrimTests-\(UUID().uuidString)", isDirectory: true)
+        let logs = root.appendingPathComponent("logs", isDirectory: true)
+        try FileManager.default.createDirectory(at: logs, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let logURL = logs.appendingPathComponent("app.jsonl")
+        let lines = (0..<2105).map { index in
+            #"{"t":"2026-04-14T00:00:00.000Z","l":"info","s":"app","m":"line-\#(index)"}"#
+        }
+        try (lines.joined(separator: "\n") + "\n").write(to: logURL, atomically: true, encoding: .utf8)
+
+        let paths = CoreStoragePaths(
+            transcripts: root.appendingPathComponent("captures/meetings", isDirectory: true),
+            speakerDB: root.appendingPathComponent("state/speakers.sqlite"),
+            statsDB: root.appendingPathComponent("state/stats.sqlite"),
+            failedQueue: root.appendingPathComponent("state/failed_transcriptions.json"),
+            speakerClips: root.appendingPathComponent("tmp/recordings/speaker_clips", isDirectory: true),
+            audioCaptures: root.appendingPathComponent("tmp/recordings", isDirectory: true),
+            logs: logs
+        )
+
+        _ = FileLogger(paths: paths, isDisabledOverride: false)
+
+        let trimmedLines = try String(contentsOf: logURL, encoding: .utf8)
+            .split(separator: "\n")
+            .map(String.init)
+
+        XCTAssertEqual(trimmedLines.count, 1500)
+
+        let firstObject = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(trimmedLines[0].utf8)) as? [String: Any])
+        XCTAssertEqual(firstObject["m"] as? String, "line-605")
+    }
 }


### PR DESCRIPTION
## Summary
- disable `FileLogger` automatically when running inside XCTest and SwiftPM test processes so package tests stop polluting the real `app.jsonl`
- trim oversized inherited `app.jsonl` files during logger startup so stale bad logs self-heal even if the current process never reaches the rolling trim threshold
- add package regression tests for default test-process disable behavior and startup trimming of oversized logs

## Nightly artifact QA
- `transcripted-qa check-health` now reports `0 failed, 1 warning` on the live Transcripted paths
- `transcripted-qa validate-all` now reports `0 failed, 3 warnings` on the live Transcripted paths
- the live `~/Library/Application Support/Transcripted/logs/app.jsonl` dropped from 5,502 lines with 13 malformed JSON entries to 1,510 valid JSONL entries after app startup exercised the new trim path
- remaining warnings are expected today: one crash report (`Transcripted-2026-04-14-202532.ips`), no legacy JSON sidecars in meetings, and no legacy `transcripted.json` index file

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `swift test`
- `cd Tools/TranscriptedQA && swift build`
- `cd Tools/TranscriptedQA && swift run transcripted-qa check-health --format json`
- `cd Tools/TranscriptedQA && swift run transcripted-qa validate-all --format json`

## Notes
The live artifact sweep stayed local and private. This PR fixes the repo-side logger behavior that caused the nightly QA failure and confirms the live artifact set is structurally healthy after the fix.