### PR TITLE
[nightly-telemetry] Preserve meeting trigger attribution

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -77,6 +77,7 @@ final class MeetingSessionController: ObservableObject {
         let micURL: URL
         let systemURL: URL?
         let healthInfo: RecordingHealthInfo
+        let startTrigger: StartTrigger
     }
 
     private enum TerminalTranscriptionOutcome: Equatable {
@@ -149,6 +150,8 @@ final class MeetingSessionController: ObservableObject {
     private var retryingFailedMeetingIDs: Set<UUID> = []
     private var queuedTranscriptionJobs: [QueuedTranscriptionJob] = []
     private var lastTerminalTranscriptionOutcome: TerminalTranscriptionOutcome?
+    private var activeRecordingTrigger: StartTrigger = .unknown
+    private var activeTranscriptionTrigger: StartTrigger = .unknown
 
     // MARK: - Init
 
@@ -364,6 +367,7 @@ final class MeetingSessionController: ObservableObject {
         }
 
         capture.startRecording()
+        activeRecordingTrigger = trigger
         state = .recording
         DiagnosticsTrail.record(
             engine: "meeting",
@@ -385,12 +389,15 @@ final class MeetingSessionController: ObservableObject {
     func stopRecording(reason: StopReason = .unknown) async {
         guard case .recording = state else { return }
 
+        let recordingTrigger = activeRecordingTrigger
+
         DiagnosticsTrail.record(
             engine: "meeting",
             event: "meeting_stop_requested",
             message: "Meeting stop requested",
             context: baseDiagnosticsContext(
                 extra: [
+                    "trigger": recordingTrigger.rawValue,
                     "reason": reason.rawValue,
                     "duration_ms": "\(Int(recordingDuration * 1000))"
                 ]
@@ -400,6 +407,7 @@ final class MeetingSessionController: ObservableObject {
         let files = await capture.stopAndAwaitFiles()
         let healthInfo = capture.healthInfo()
         let durationMs = Int(recordingDuration * 1000)
+        activeRecordingTrigger = .unknown
         state = .transcribing
 
         DiagnosticsTrail.record(
@@ -409,6 +417,7 @@ final class MeetingSessionController: ObservableObject {
             message: "Meeting recording stopped",
             context: baseDiagnosticsContext(
                 extra: [
+                    "trigger": recordingTrigger.rawValue,
                     "reason": reason.rawValue,
                     "duration_ms": "\(durationMs)",
                     "mic_file_present": boolString(files.micURL != nil),
@@ -435,7 +444,8 @@ final class MeetingSessionController: ObservableObject {
         let outcome = enqueueTranscriptionJob(
             micURL: micURL,
             systemURL: files.systemURL,
-            healthInfo: healthInfo
+            healthInfo: healthInfo,
+            startTrigger: recordingTrigger
         )
 
         let queueDepth = queuedTranscriptionJobs.count
@@ -447,6 +457,7 @@ final class MeetingSessionController: ObservableObject {
                 : "Meeting queued behind an earlier transcription",
             context: baseDiagnosticsContext(
                 extra: [
+                    "trigger": recordingTrigger.rawValue,
                     "reason": reason.rawValue,
                     "duration_ms": "\(durationMs)",
                     "queue_depth": "\(queueDepth)"
@@ -460,6 +471,7 @@ final class MeetingSessionController: ObservableObject {
                 "duration_bucket": AnalyticsReporter.durationBucket(seconds: recordingDuration),
                 "reason": reason.rawValue,
                 "system_stream_present": boolString(files.systemURL != nil),
+                "trigger": recordingTrigger.rawValue,
             ]
         )
     }
@@ -470,6 +482,7 @@ final class MeetingSessionController: ObservableObject {
         let queuedJobs = queuedTranscriptionJobs
         queuedTranscriptionJobs.removeAll()
         lastTerminalTranscriptionOutcome = nil
+        activeTranscriptionTrigger = .unknown
 
         for job in queuedJobs {
             failedManager.addFailedTranscription(
@@ -495,6 +508,7 @@ final class MeetingSessionController: ObservableObject {
         guard !retryingFailedMeetingIDs.contains(id) else { return }
 
         retryingFailedMeetingIDs.insert(id)
+        activeTranscriptionTrigger = .unknown
         refreshFailedMeetings()
 
         Task { [weak self] in
@@ -757,12 +771,14 @@ final class MeetingSessionController: ObservableObject {
     private func enqueueTranscriptionJob(
         micURL: URL,
         systemURL: URL?,
-        healthInfo: RecordingHealthInfo
+        healthInfo: RecordingHealthInfo,
+        startTrigger: StartTrigger
     ) -> QueueInsertionOutcome {
         let job = QueuedTranscriptionJob(
             micURL: micURL,
             systemURL: systemURL,
-            healthInfo: healthInfo
+            healthInfo: healthInfo,
+            startTrigger: startTrigger
         )
 
         if canStartQueuedTranscriptionImmediately {
@@ -776,6 +792,7 @@ final class MeetingSessionController: ObservableObject {
 
     private func startQueuedTranscription(_ job: QueuedTranscriptionJob) {
         lastTerminalTranscriptionOutcome = nil
+        activeTranscriptionTrigger = job.startTrigger
 
         if !isCaptureSessionActive {
             state = .transcribing
@@ -818,6 +835,7 @@ final class MeetingSessionController: ObservableObject {
     private func finalizeBackgroundTranscriptionStateIfNeeded() {
         guard !hasVisibleBackgroundTranscriptionWork else { return }
         guard !isCaptureSessionActive else { return }
+        activeTranscriptionTrigger = .unknown
 
         switch lastTerminalTranscriptionOutcome {
         case .failed(let message):
@@ -835,13 +853,15 @@ final class MeetingSessionController: ObservableObject {
         switch status {
         case .transcriptSaved:
             lastTerminalTranscriptionOutcome = .transcriptSaved
+            let transcriptionTrigger = activeTranscriptionTrigger
             DiagnosticsTrail.record(
                 engine: "meeting",
                 event: "meeting_transcript_saved",
                 message: "Meeting transcript saved",
                 context: baseDiagnosticsContext(
                     extra: [
-                        "queue_depth": "\(queuedTranscriptionJobs.count)"
+                        "queue_depth": "\(queuedTranscriptionJobs.count)",
+                        "trigger": transcriptionTrigger.rawValue
                     ]
                 )
             )
@@ -849,11 +869,13 @@ final class MeetingSessionController: ObservableObject {
                 "meeting_transcript_saved",
                 properties: [
                     "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
+                    "trigger": transcriptionTrigger.rawValue,
                 ]
             )
             AppSoundPlayer.shared.play(.meetingTranscriptComplete)
         case .failed(let message):
             lastTerminalTranscriptionOutcome = .failed(message)
+            let transcriptionTrigger = activeTranscriptionTrigger
             DiagnosticsTrail.record(
                 level: .error,
                 engine: "meeting",
@@ -862,7 +884,8 @@ final class MeetingSessionController: ObservableObject {
                 context: baseDiagnosticsContext(
                     extra: [
                         "error": message,
-                        "queue_depth": "\(queuedTranscriptionJobs.count)"
+                        "queue_depth": "\(queuedTranscriptionJobs.count)",
+                        "trigger": transcriptionTrigger.rawValue
                     ]
                 )
             )
@@ -871,6 +894,7 @@ final class MeetingSessionController: ObservableObject {
                 properties: [
                     "failure_kind": analyticsFailureKind(from: message),
                     "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
+                    "trigger": transcriptionTrigger.rawValue,
                 ]
             )
         case .gettingReady:

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -84,12 +84,14 @@ struct AnalyticsEventPolicy: Equatable {
                 "duration_bucket",
                 "reason",
                 "system_stream_present",
+                "trigger",
             ]
         ),
         "meeting_transcript_saved": .init(
             name: "meeting_transcript_saved",
             allowedProperties: [
                 "queue_depth_bucket",
+                "trigger",
             ]
         ),
         "meeting_transcript_failed": .init(
@@ -97,6 +99,7 @@ struct AnalyticsEventPolicy: Equatable {
             allowedProperties: [
                 "failure_kind",
                 "queue_depth_bucket",
+                "trigger",
             ]
         ),
     ]

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -17,13 +17,26 @@ func testAnalyticsEventPolicy() {
     runSuite("AnalyticsEventPolicy meeting_recording_stopped system_stream_present key is not silently filtered") {
         let policy = AnalyticsEventPolicy.policy(forEvent: "meeting_recording_stopped")
         assertEqual(policy?.allowedProperties.contains("system_stream_present"), true, "system_stream_present should be in the allowlist")
+        assertEqual(policy?.allowedProperties.contains("trigger"), true, "meeting stop events should preserve start trigger attribution")
 
         // Verify the key passes sanitization — it must not contain a sensitive fragment
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
-            ["system_stream_present": "true"],
-            allowedKeys: ["system_stream_present"]
+            [
+                "system_stream_present": "true",
+                "trigger": "detected_prompt",
+            ],
+            allowedKeys: ["system_stream_present", "trigger"]
         )
         assertEqual(sanitized["system_stream_present"], "true", "system_stream_present must survive sanitization — if empty the metric is always missing")
+        assertEqual(sanitized["trigger"], "detected_prompt", "meeting trigger attribution must survive sanitization")
+    }
+
+    runSuite("AnalyticsEventPolicy allows meeting outcome trigger attribution") {
+        let saved = AnalyticsEventPolicy.policy(forEvent: "meeting_transcript_saved")
+        let failed = AnalyticsEventPolicy.policy(forEvent: "meeting_transcript_failed")
+
+        assertEqual(saved?.allowedProperties.contains("trigger"), true, "meeting saves should preserve trigger attribution")
+        assertEqual(failed?.allowedProperties.contains("trigger"), true, "meeting failures should preserve trigger attribution")
     }
 
     runSuite("AnalyticsEventPolicy allows coarse meeting prompt telemetry") {

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -81,5 +81,9 @@ PostHog controls described below.
 - stable trigger enums like `hotkey`, `menu`, `detected_prompt`
 - normalized failure kinds like `system_audio`, `recording_too_short`, `other`
 
+Meeting workflow analytics should keep that same stable `trigger` enum on later
+stop/save/fail events so product and reliability reviews can attribute outcomes
+without joining against any sensitive context.
+
 Anything richer than that should stay local unless there is a new explicit
 privacy review and a matching allowlist change.


### PR DESCRIPTION
## Summary
- carry the privacy-safe meeting start `trigger` through the later stop, save, and fail analytics events
- keep the same trigger on local meeting diagnostics so on-device logs and PostHog tell the same story
- extend the analytics policy test and observability doc note for the new reviewed property shape

## Why
The current telemetry showed active meeting usage over the last 7 days (`67` starts, `64` stops, `52` saves, `9` failures), but stop/save/fail events dropped the original entry path. That meant the app could tell whether meetings started from `menu`, `hotkey`, or `detected_prompt`, but it could not attribute which path actually led to saved transcripts or failures.

This keeps attribution coarse and privacy-safe while making future debugging and product decisions much easier.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`