### PR TITLE
[nightly-ux] Clarify permission recovery actions

### DIFF
--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -61,16 +61,50 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
         }
     }
 
-    var onboardingActionTitle: String {
+    var actionButtonTitle: String {
         switch self {
         case .microphone:
-            return "Allow microphone"
+            return Self.microphoneActionTitle(for: AVCaptureDevice.authorizationStatus(for: .audio))
         case .accessibility:
-            return "Allow accessibility"
+            return Self.accessibilityActionTitle(isTrusted: AXIsProcessTrusted())
         case .systemAudioRecording:
-            return "Allow system audio recording"
+            return Self.systemAudioRecordingActionTitle(isGranted: TranscriptedPermissionAccess.systemAudioRecordingGranted())
         case .calendar:
-            return "Enable meeting prompts"
+            return Self.calendarActionTitle(for: EKEventStore.authorizationStatus(for: .event))
+        }
+    }
+
+    static func microphoneActionTitle(for status: AVAuthorizationStatus) -> String {
+        switch status {
+        case .notDetermined:
+            return "Allow microphone"
+        case .denied, .restricted:
+            return "Open Microphone Settings"
+        case .authorized:
+            return "Review"
+        @unknown default:
+            return "Open Microphone Settings"
+        }
+    }
+
+    static func accessibilityActionTitle(isTrusted: Bool) -> String {
+        isTrusted ? "Review" : "Open Accessibility Settings"
+    }
+
+    static func systemAudioRecordingActionTitle(isGranted: Bool) -> String {
+        isGranted ? "Review" : "Open Audio Recording Settings"
+    }
+
+    static func calendarActionTitle(for status: EKAuthorizationStatus) -> String {
+        switch status {
+        case .fullAccess, .authorized:
+            return "Review"
+        case .notDetermined:
+            return "Allow Calendar Access"
+        case .writeOnly, .denied, .restricted:
+            return "Open Calendar Settings"
+        @unknown default:
+            return "Open Calendar Settings"
         }
     }
 }

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -499,7 +499,7 @@ private struct PermissionSetupCard: View {
             }
 
             if !granted {
-                Button(kind.onboardingActionTitle, action: action)
+                Button(kind.actionButtonTitle, action: action)
                     .buttonStyle(.borderedProminent)
             }
         }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -312,7 +312,7 @@ private struct PermissionStatusRow: View {
 
             Spacer()
 
-            Button(granted ? "Review" : "Fix") {
+            Button(granted ? "Review" : kind.actionButtonTitle) {
                 action()
             }
         }

--- a/Tests/TranscriptedPermissionAccessTests.swift
+++ b/Tests/TranscriptedPermissionAccessTests.swift
@@ -98,4 +98,32 @@ func testTranscriptedPermissionAccess() async {
         assertTrue(granted, "known granted permission should stay ready")
         assertEqual(requestBox.callCount, 0, "known granted permission should not trigger another request")
     }
+
+    runSuite("TranscriptedPermissionKind action titles — name the real recovery path for blocked permissions") {
+        assertEqual(
+            TranscriptedPermissionKind.microphoneActionTitle(for: .notDetermined),
+            "Allow microphone",
+            "microphone action should stay prompt-like before the first decision"
+        )
+        assertEqual(
+            TranscriptedPermissionKind.microphoneActionTitle(for: .denied),
+            "Open Microphone Settings",
+            "microphone action should point to System Settings after denial"
+        )
+        assertEqual(
+            TranscriptedPermissionKind.accessibilityActionTitle(isTrusted: false),
+            "Open Accessibility Settings",
+            "accessibility action should name the settings destination instead of a vague fix label"
+        )
+        assertEqual(
+            TranscriptedPermissionKind.systemAudioRecordingActionTitle(isGranted: false),
+            "Open Audio Recording Settings",
+            "system audio action should explain the destination when the permission is still missing"
+        )
+        assertEqual(
+            TranscriptedPermissionKind.calendarActionTitle(for: .notDetermined),
+            "Allow Calendar Access",
+            "calendar action should stay prompt-like before the first decision"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- replace vague onboarding and Settings permission buttons with labels that match the real next step
- keep first-time prompts as `Allow ...`, but switch denied states to `Open ... Settings`
- add focused fast-test coverage for the new permission action-title mapping

## Why
The nightly UX sweep pointed to setup friction rather than a deep runtime bug:
- Sentry showed a clustered `parakeet.mic_not_authorized` issue (`APPLE-MACOS-E`) with 6 production events from one session on `transcripted@1.0.6`
- PostHog showed 24 launch devices vs 12 onboarding completions over the last 7 days

The existing UI could still show `Allow microphone` or a generic `Fix` button after permission had already been denied, even though the actual recovery path was opening the matching System Settings pane. This keeps the flow the same but makes the recovery step explicit.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`