### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -8,7 +8,8 @@
 
 - `FailedMeetingPresentation.swift` — maps `FailedTranscription` into `FailedMeetingItem` view-models with human-readable titles and retry metadata
 - `MeetingCaptureBridge.swift` — `@MainActor` wrapper around core `Audio`, converts callback-based stop into `async`
-- `MeetingFailureCopy.swift` — normalizes raw meeting failure messages into user-facing titles and recovery copy
+- `MeetingFailureCopy.swift` — normalizes `MeetingFailureKind` values into user-facing titles and recovery copy
+- `MeetingFailureKind.swift` — canonical failure taxonomy that classifies raw meeting errors into stable machine-readable kinds
 - `MeetingModelDownloader.swift` — loads Parakeet and diarization models together
 - `MeetingPromptDetector.swift` — polls upcoming Calendar events, watches supported meeting apps, and asks the overlay to offer one-tap recording prompts
 - `MeetingPromptHeuristics.swift` — shared scoring and snooze rules for calendar- and runtime-based prompt candidates
@@ -28,7 +29,7 @@
 5. `MeetingSessionController.stopRecording(...)` awaits mic/system audio files from the bridge, then either starts transcription immediately or queues it behind the active job.
 6. `TranscriptionTaskManager` runs one diarize → transcribe → save pipeline at a time.
 7. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the recent-meetings UI state.
-8. Failed meetings can be retried, deleted, or dismissed from the menubar recent-meetings section, with `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
+8. Failed meetings can be retried, deleted, or dismissed from the menubar recent-meetings section, with `MeetingFailureKind` providing stable failure categories and `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
 
 ## Key invariants
 
@@ -37,6 +38,7 @@
 - Meeting captures should follow the current capture library, while databases, logs, and temp recordings stay under the app-owned Transcripted Application Support folders.
 - `MeetingPromptDetector` can prompt from either upcoming calendar events or recently active supported meeting apps (Zoom, Teams, Webex, FaceTime, plus browser-hosted providers like Google Meet).
 - `MeetingRecordingStartGate` is the canonical place for meeting-recording permission policy and reason strings. Keep duplicate permission branching out of overlay code.
+- `MeetingFailureKind` is the canonical place for stable failed-meeting categories used by presentation and metadata. Keep new classification rules centralized there.
 - `MeetingFailureCopy` is the canonical place for human-facing failed-meeting titles and details. Keep retry messaging centralized there.
 - `MeetingSessionUIPolicy` is the canonical place for deciding whether background meeting work should still surface as an active transcribing/saving state. Speaker review alone should not keep that state visible.
 - `TranscriptionTaskManager` stays single-flight. App-level queueing belongs in `MeetingSessionController`, not in ad hoc background tasks.
@@ -71,6 +73,7 @@ See `docs/storage-paths.md` for the full map.
 
 Relevant direct coverage:
 
+- `Tests/MeetingFailureKindTests.swift`
 - `Tests/MeetingPromptHeuristicsTests.swift`
 - `Tests/MeetingRecordingStartGateTests.swift`
 - `Tests/MeetingSessionUIPolicyTests.swift`

--- a/Sources/Meeting/MeetingFailureKind.swift
+++ b/Sources/Meeting/MeetingFailureKind.swift
@@ -63,7 +63,7 @@ enum MeetingFailureKind: String {
             return .saveFailed
         }
 
-        if normalized.contains("another pipeline is already active") {
+        if normalized.contains("transcription already in progress") {
             return .pipelineBusy
         }
 

--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -4,9 +4,9 @@
 
 `Sources/TranscriptedCore/` is the reusable meeting transcription library embedded in this repo. It is consumed by the app through `Sources/Meeting/`, and it can also be tested as a standalone Swift package through the root `Package.swift`.
 
-## Subsystems (55 Swift files)
+## Subsystems (57 Swift files)
 
-- `Audio/` (11 files) — mic + system audio capture, device recovery, resampling, level metering, process tap, buffer writing, and merge helpers
+- `Audio/` (13 files) — mic + system audio capture, device recovery, resampling, level metering, process tap, ScreenCaptureKit-backed system-audio capture, backend selection, buffer writing, and merge helpers
 - `Logging/` (2 files) — shared app logger and JSONL file logger
 - `Models/` (4 files) — public data types: `TranscriptionResult`, `DisplayStatus`, `FailedTranscription`, and transcript metadata builders
 - `Pipeline/` (4 files) — transcription orchestration, pipeline runner, and task queue
@@ -26,6 +26,12 @@
 - `TranscriptNotifier` — optional callback channel for transcript-saved / failure notifications
 
 These seams exist specifically so the app can embed the library without adopting the old standalone Transcripted app assumptions.
+
+## Audio backend notes
+
+- `Audio` can switch between the legacy CoreAudio path and the newer ScreenCaptureKit system-audio path through `SystemAudioCaptureEngine`.
+- `SCKAudioCapture` is the macOS 26+ backend for audio-only ScreenCaptureKit capture, which keeps system-audio recording on the lighter permission tier and avoids full screen-pixel capture.
+- Hosts embedding `TranscriptedCore` should keep app-specific permission UX outside this directory, but they should understand that system-audio capture backend behavior now depends on OS availability.
 
 ## Threading model
 

--- a/Tests/MeetingFailureKindTests.swift
+++ b/Tests/MeetingFailureKindTests.swift
@@ -25,6 +25,14 @@ func testMeetingFailureKind() {
         assertEqual(kind, .saveFailed, "save failures should keep their own analytics bucket")
     }
 
+    runSuite("MeetingFailureKind classifies pipeline-busy errors") {
+        let kind = MeetingFailureKind.classify(
+            message: "Transcription already in progress"
+        )
+
+        assertEqual(kind, .pipelineBusy, "pipeline-busy rejections from TranscriptionTaskManager should not fall to unexpected_error")
+    }
+
     runSuite("MeetingFailureKind falls back to an explicit unexpected bucket") {
         let kind = MeetingFailureKind.classify(
             message: "Something odd happened while processing the meeting"


### PR DESCRIPTION
## Summary

- **`MeetingFailureKind.pipelineBusy` was dead code**: The `273fb78` commit introduced `MeetingFailureKind.classify()` with a pattern check for `"another pipeline is already active"` — that is the `AppLogger` warning message, not the user-facing error stored in `FailedTranscription.errorMessage`. `TranscriptionTaskManager` stores `"Transcription already in progress"` as the error message, so every pipeline-busy rejection was silently falling through to `unexpectedError` in analytics.

## What was fixed

- [Sources/Meeting/MeetingFailureKind.swift](Sources/Meeting/MeetingFailureKind.swift): Changed the `.pipelineBusy` pattern from `"another pipeline is already active"` to `"transcription already in progress"` to match the actual stored error message.
- [Tests/MeetingFailureKindTests.swift](Tests/MeetingFailureKindTests.swift): Added a test that pins the expected `.pipelineBusy` classification for the `TranscriptionTaskManager` rejection message.

## What was reviewed but not changed

- **Audio threading**: `Audio` and `SystemAudioCapture` are correctly NOT `@MainActor`. No violations found.
- **TranscriptedCore boundary**: `NSSound` and `NSWorkspace` imports are pre-existing; not introduced this cycle.
- **`nonisolated(unsafe)` races in `ParakeetEngine`**: Pre-existing and benign on arm64 (aligned pointer reads are naturally atomic; ARC prevents use-after-free).
- **`DictationSessionController` Task blocks**: Correctly inherit `@MainActor` from the enclosing class context — no threading bug.
- **`MeetingRecordingStartGate` logic**: Guard condition is correct.
- **`ParakeetRecoveryState` / AirPods fix** (`8bcfa43`): Well-implemented; 7 new tests cover the state machine.
- **Deferred audio engine init** (`fa116c8`): Clean; `ensureEngineInitialized()` nil-guards correctly.
- **`MeetingFailureKind` other patterns**: Verified against actual error strings from `TranscriptionTaskManager`.

## Test plan

- [x] `bash run-tests.sh` — 271/271 pass (1 new test)
- [x] `bash build.sh` — clean build
- [x] `bash run-integration-smoke.sh` — passes
- [x] `swift test` — 51/51 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)