### PR TITLE
refactor: nightly simplification sweep [automated]

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -455,9 +455,11 @@ class ParakeetEngine: ObservableObject {
             return
         }
         prewarmRetryCount += 1
+        let capturedGeneration = recoveryState.generation
         Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
-            self?.prewarm()
+            guard let self, !self.recoveryState.isStale(generation: capturedGeneration) else { return }
+            self.prewarm()
         }
     }
 
@@ -627,7 +629,7 @@ class ParakeetEngine: ObservableObject {
                 // samples. The watchdog gets one retry before giving up.
                 if shouldRestartRecording {
                     var restarted = false
-                    for attempt in 1...4 {
+                    for attempt in 1...TranscriptedConstants.recordingRestartAttempts {
                         guard !Task.isCancelled else { return }
                         guard !self.recoveryState.isStale(generation: myGeneration) else { return }
                         if self.startRecording() {
@@ -644,7 +646,7 @@ class ParakeetEngine: ObservableObject {
                             break
                         }
                         // BT format negotiation can take ~1-2s; wait between attempts.
-                        try? await Task.sleep(nanoseconds: 500_000_000)
+                        try? await Task.sleep(nanoseconds: TranscriptedConstants.recordingRestartRetryDelay)
                     }
                     if !restarted {
                         self.recordingInterrupted = true
@@ -673,12 +675,8 @@ class ParakeetEngine: ObservableObject {
     }
 
     private func publishRecoveryState() {
-        if isRecovering != recoveryState.isRecovering {
-            isRecovering = recoveryState.isRecovering
-        }
-        if inputFormatReady != recoveryState.inputFormatReady {
-            inputFormatReady = recoveryState.inputFormatReady
-        }
+        isRecovering = recoveryState.isRecovering
+        inputFormatReady = recoveryState.inputFormatReady
     }
 
     private func markFormatUnreadyAndPublish() {
@@ -688,7 +686,7 @@ class ParakeetEngine: ObservableObject {
 
     private func markFormatReadyAndPublish() {
         if !recoveryState.inputFormatReady {
-            _ = recoveryState.finishRecovery(success: true, generation: recoveryState.generation)
+            recoveryState.markFormatReady()
             publishRecoveryState()
         }
     }

--- a/Sources/Speech/ParakeetRecoveryState.swift
+++ b/Sources/Speech/ParakeetRecoveryState.swift
@@ -16,6 +16,14 @@ struct ParakeetRecoveryState: Equatable {
         inputFormatReady = false
     }
 
+    /// Marks the engine as ready without generation gating. Use only from non-Task
+    /// contexts where no stale-generation race is possible (e.g. after a successful
+    /// synchronous prewarm or after recording starts on the current generation).
+    mutating func markFormatReady() {
+        isRecovering = false
+        inputFormatReady = true
+    }
+
     mutating func finishRecovery(success: Bool, generation: UInt64) -> Bool {
         guard generation == self.generation else { return false }
         isRecovering = false

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -66,6 +66,14 @@ enum TranscriptedConstants {
     /// Prevents infinite Task chains when the mic is permanently unavailable.
     static let prewarmRetryBudget: Int = 10
 
+    /// Max attempts to restart recording after a device change. Each attempt waits
+    /// `recordingRestartRetryDelay` (500ms) to give Bluetooth format negotiation time to settle.
+    static let recordingRestartAttempts: Int = 4
+
+    /// Delay between recording-restart attempts after a device change (nanoseconds).
+    /// BT format negotiation can take ~1-2s; 500ms between attempts covers most cases.
+    static let recordingRestartRetryDelay: UInt64 = 500_000_000  // 500ms
+
     // MARK: - Model Loading
 
     /// Polling interval while waiting for voice model to load (nanoseconds)

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -461,7 +461,7 @@ class DictationSessionController: ObservableObject {
                     "delivery": pasteOutcome.delivery.rawValue,
                     "duration_bucket": AnalyticsReporter.durationBucket(seconds: CFAbsoluteTimeGetCurrent() - sessionStartTime),
                     "trigger": currentDictationTrigger.rawValue,
-                    "word_count_bucket": AnalyticsReporter.wordCountBucket(text.split(whereSeparator: \.isWhitespace).count),
+                    "word_count_bucket": AnalyticsReporter.wordCountBucket(wordCount),
                 ]
             )
         }

--- a/Tests/ParakeetRecoveryStateTests.swift
+++ b/Tests/ParakeetRecoveryStateTests.swift
@@ -62,6 +62,16 @@ func testParakeetRecoveryState() {
         assertTrue(state.isStale(generation: g1), "earlier generation is stale once superseded")
     }
 
+    runSuite("ParakeetRecoveryState.markFormatReady — clears recovery and marks format ready without bumping generation") {
+        var state = ParakeetRecoveryState()
+        let g = state.beginConfigChange()
+        state.markFormatReady()
+
+        assertFalse(state.isRecovering, "markFormatReady should clear recovery flag")
+        assertTrue(state.inputFormatReady, "markFormatReady should mark format ready")
+        assertEqual(state.generation, g, "markFormatReady should not bump generation")
+    }
+
     runSuite("ParakeetRecoveryState.markFormatUnready — flips format flag without bumping generation") {
         var state = ParakeetRecoveryState()
         let before = state.generation


### PR DESCRIPTION
## Summary

Automated nightly simplification pass over the recent AirPods/device-recovery work (PRs #311–315).

- **Stale-prewarm race fix (correctness)** — `schedulePrewarmRetry` now captures the generation counter before the sleep Task. If a new device-change fires during the sleep, the stale retry bails instead of calling `markFormatReadyAndPublish` prematurely and clearing `isRecovering` while a `configRecoveryTask` is still mid-flight. This prevents a narrow race where `DictationSessionController.waitForEngineAndStart` could see `isRecovering = false` and call `startRecording()` while the engine is still torn down.

- **`markFormatReady()` added to `ParakeetRecoveryState`** — symmetrical partner to the existing `markFormatUnready()`. Replaces the leaky workaround in `markFormatReadyAndPublish` that called the generation-gated `finishRecovery(generation: recoveryState.generation)` with the *current* generation, defeating the generation guard. New method is intentionally ungated with a doc comment explaining when that's safe.

- **Named constants for retry magic numbers** — `recordingRestartAttempts = 4` and `recordingRestartRetryDelay = 500ms` added to `TranscriptedConstants` alongside `prewarmRetryBudget`. Replaces `1...4` and `500_000_000` literals embedded in `ParakeetEngine.attemptDeviceRecovery`.

- **`publishRecoveryState()` simplified** — removed redundant equality guards around `@Published Bool` assignments. Combine suppresses downstream notifications when the value is unchanged; the guards were defensive noise.

- **Eliminate redundant `text.split` in `stopDictationAndPaste`** — reuses the `wordCount` local already computed a few lines earlier instead of re-splitting the full transcript string for the analytics call.

- **Test coverage** — added a test for `ParakeetRecoveryState.markFormatReady`. 273 tests, all pass.

## Test plan

- [x] `bash build.sh` — clean build, no warnings
- [x] `bash run-tests.sh` — 273/273 pass