### PR TITLE
prep: foundation for local speaker diarization (#312)

### DIFF
--- a/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
+++ b/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
@@ -37,7 +37,9 @@ public struct TranscriptionUtterance: Sendable {
 public struct TranscriptionResult: Sendable {
     public let micUtterances: [TranscriptionUtterance]
     public let systemUtterances: [TranscriptionUtterance]
-    public let systemSpeakerContexts: [String: SystemSpeakerContext]
+    public let systemSpeakerContexts: [String: ChannelSpeakerContext]
+    public let micSpeakerContexts: [String: ChannelSpeakerContext]
+    public let newlyCreatedMicProfileIds: Set<UUID>
     public let duration: TimeInterval
     public let processingTime: TimeInterval
     public let droppedSegments: Int
@@ -45,7 +47,9 @@ public struct TranscriptionResult: Sendable {
     public init(
         micUtterances: [TranscriptionUtterance],
         systemUtterances: [TranscriptionUtterance],
-        systemSpeakerContexts: [String: SystemSpeakerContext] = [:],
+        systemSpeakerContexts: [String: ChannelSpeakerContext] = [:],
+        micSpeakerContexts: [String: ChannelSpeakerContext] = [:],
+        newlyCreatedMicProfileIds: Set<UUID> = [],
         duration: TimeInterval,
         processingTime: TimeInterval,
         droppedSegments: Int = 0
@@ -53,6 +57,8 @@ public struct TranscriptionResult: Sendable {
         self.micUtterances = micUtterances
         self.systemUtterances = systemUtterances
         self.systemSpeakerContexts = systemSpeakerContexts
+        self.micSpeakerContexts = micSpeakerContexts
+        self.newlyCreatedMicProfileIds = newlyCreatedMicProfileIds
         self.duration = duration
         self.processingTime = processingTime
         self.droppedSegments = droppedSegments
@@ -80,6 +86,11 @@ public struct TranscriptionResult: Sendable {
         Set(systemUtterances.map { String($0.speakerId) })
     }
 
+    /// Unique speaker IDs in mic audio (only meaningful when mic diarization ran)
+    public var micSpeakerIds: Set<String> {
+        Set(micUtterances.map { String($0.speakerId) })
+    }
+
     /// Speaker count per channel
     public var micSpeakerCount: Int {
         Set(micUtterances.map { $0.speakerId }).count
@@ -89,10 +100,15 @@ public struct TranscriptionResult: Sendable {
         Set(systemUtterances.map { $0.speakerId }).count
     }
 
-    /// Persistent speaker IDs that appeared in system audio utterances.
+    /// Persistent speaker IDs that appeared in utterances, across both channels.
     /// Profiles are looked up separately via SpeakerDatabase.
     public var persistentSpeakerIds: Set<UUID> {
-        Set(systemUtterances.compactMap { $0.persistentSpeakerId })
+        Set((systemUtterances + micUtterances).compactMap { $0.persistentSpeakerId })
+    }
+
+    /// Persistent speaker IDs seen only on the mic channel this run.
+    public var micPersistentSpeakerIds: Set<UUID> {
+        Set(micUtterances.compactMap { $0.persistentSpeakerId })
     }
 }
 
@@ -204,6 +220,14 @@ public struct TranscriptionMetadata {
 
 // MARK: - Speaker Naming Flow Types
 
+/// Which audio channel a diarized speaker came from.
+/// Remote participants come in on `.system` (Zoom/Teams/etc. output captured via process tap).
+/// People physically in the room come in on `.mic` when local diarization is enabled.
+public enum UtteranceChannel: String, Sendable, Hashable {
+    case mic
+    case system
+}
+
 /// A named person the user can link a detected speaker to.
 public struct SpeakerIdentityOption: Identifiable, Hashable {
     public let id: UUID
@@ -251,7 +275,8 @@ public struct SpeakerNamingRequest {
 public struct SpeakerNamingEntry: Identifiable, Sendable {
     public let id: UUID                     // persistent speaker ID from SpeakerDatabase
     public let suggestedProfileId: UUID?    // existing person this row suggests, if any
-    public let sortformerSpeakerId: String  // "0", "1" — for transcript string matching
+    public let diarizerSpeakerId: String    // "0", "1" — from PyAnnote/Sortformer, for transcript string matching
+    public let channel: UtteranceChannel    // .mic (local) vs .system (remote)
     public let clipURL: URL                 // temporary WAV clip for playback
     public let sampleText: String           // representative quote from transcript
     public let currentName: String?         // nil if unknown speaker
@@ -265,7 +290,8 @@ public struct SpeakerNamingEntry: Identifiable, Sendable {
     public init(
         id: UUID,
         suggestedProfileId: UUID? = nil,
-        sortformerSpeakerId: String,
+        diarizerSpeakerId: String,
+        channel: UtteranceChannel = .system,
         clipURL: URL,
         sampleText: String,
         currentName: String?,
@@ -278,7 +304,8 @@ public struct SpeakerNamingEntry: Identifiable, Sendable {
     ) {
         self.id = id
         self.suggestedProfileId = suggestedProfileId
-        self.sortformerSpeakerId = sortformerSpeakerId
+        self.diarizerSpeakerId = diarizerSpeakerId
+        self.channel = channel
         self.clipURL = clipURL
         self.sampleText = sampleText
         self.currentName = currentName
@@ -291,9 +318,9 @@ public struct SpeakerNamingEntry: Identifiable, Sendable {
     }
 }
 
-/// Per-speaker context captured during one transcription run.
+/// Per-speaker context captured during one transcription run for one channel.
 /// Keeps enough information around to safely recover from a false-positive match.
-public struct SystemSpeakerContext: Sendable {
+public struct ChannelSpeakerContext: Sendable {
     public let persistentSpeakerId: UUID
     public let sessionEmbedding: [Float]?
     public let matchedProfileSnapshot: SpeakerProfile?
@@ -315,7 +342,8 @@ public struct SystemSpeakerContext: Sendable {
 /// Result of user naming/confirming a speaker
 public struct SpeakerNameUpdate: Sendable {
     public let persistentSpeakerId: UUID
-    public let sortformerSpeakerId: String
+    public let diarizerSpeakerId: String
+    public let channel: UtteranceChannel
     public let newName: String
     public let previousName: String?
     public let action: NamingAction
@@ -323,14 +351,16 @@ public struct SpeakerNameUpdate: Sendable {
 
     public init(
         persistentSpeakerId: UUID,
-        sortformerSpeakerId: String,
+        diarizerSpeakerId: String,
+        channel: UtteranceChannel = .system,
         newName: String,
         previousName: String? = nil,
         action: NamingAction,
         resolvedPersistentSpeakerId: UUID? = nil
     ) {
         self.persistentSpeakerId = persistentSpeakerId
-        self.sortformerSpeakerId = sortformerSpeakerId
+        self.diarizerSpeakerId = diarizerSpeakerId
+        self.channel = channel
         self.newName = newName
         self.previousName = previousName
         self.action = action
@@ -342,5 +372,6 @@ public struct SpeakerNameUpdate: Sendable {
         case confirmed  // user confirmed suggested name
         case corrected  // user rejected suggestion and typed correct name
         case merged(targetProfileId: UUID)  // user linked this speaker to an existing profile
+        case collapsedToMe  // user clicked "Keep as You" — collapse this mic speaker into the single owner
     }
 }

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -309,7 +309,7 @@ extension Transcription {
                 ])
             }
 
-            var systemSpeakerContexts: [String: SystemSpeakerContext] = [:]
+            var systemSpeakerContexts: [String: ChannelSpeakerContext] = [:]
             let effectiveSpeakerIds = Set(
                 speakerSegments.map { speakerIdRemap[$0.speakerId] ?? $0.speakerId }
             )
@@ -333,7 +333,7 @@ extension Transcription {
                         existingProfiles.first(where: { $0.id == match.persistentId })
                     }
 
-                systemSpeakerContexts[String(effectiveSpeakerId)] = SystemSpeakerContext(
+                systemSpeakerContexts[String(effectiveSpeakerId)] = ChannelSpeakerContext(
                     persistentSpeakerId: persistentId,
                     sessionEmbedding: sessionEmbedding,
                     matchedProfileSnapshot: matchedProfileSnapshot,

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -191,8 +191,9 @@ extension TranscriptionTaskManager {
                     needsActionIds.contains(String($0.speakerId))
                 }
                 let clips = try SpeakerClipExtractor.extractClips(
-                    systemAudioURL: systemURL,
+                    sourceAudioURL: systemURL,
                     utterances: actionUtterances,
+                    channel: .system,
                     speakerDB: speakerDB
                 )
 
@@ -200,15 +201,15 @@ extension TranscriptionTaskManager {
                     let entries = clips.map { clip in
                         return SpeakerNamingEntry(
                             id: clip.persistentSpeakerId,
-                            sortformerSpeakerId: clip.sortformerSpeakerId,
+                            diarizerSpeakerId: clip.diarizerSpeakerId,
                             clipURL: clip.clipURL,
                             sampleText: clip.sampleText,
                             currentName: clip.currentName,
                             matchSimilarity: clip.matchSimilarity,
                             needsNaming: clip.currentName == nil,
                             needsConfirmation: clip.currentName != nil,
-                            sessionEmbedding: result.systemSpeakerContexts[clip.sortformerSpeakerId]?.sessionEmbedding,
-                            matchedProfileSnapshot: result.systemSpeakerContexts[clip.sortformerSpeakerId]?.matchedProfileSnapshot
+                            sessionEmbedding: result.systemSpeakerContexts[clip.diarizerSpeakerId]?.sessionEmbedding,
+                            matchedProfileSnapshot: result.systemSpeakerContexts[clip.diarizerSpeakerId]?.matchedProfileSnapshot
                         )
                     }
 

--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -212,7 +212,7 @@ extension TranscriptSaver {
 
             // Replace generic labels (e.g. "Speaker 0") throughout the body.
             for update in updates {
-                let genericLabel = "Speaker \(update.sortformerSpeakerId)"
+                let genericLabel = "Speaker \(update.diarizerSpeakerId)"
                 applyNameReplacement(in: &content, oldName: genericLabel, newName: update.newName, updateSpeakerTag: false)
             }
 
@@ -258,10 +258,10 @@ extension TranscriptSaver {
             let obsidianEnabled = isObsidianFormatted(content)
             let updatesBySystemKey = Dictionary(uniqueKeysWithValues: updates.map {
                 (
-                    "system_\($0.sortformerSpeakerId)",
+                    "system_\($0.diarizerSpeakerId)",
                     (
-                        oldName: currentSpeakerName(in: content, sortformerSpeakerId: $0.sortformerSpeakerId)
-                            ?? "Speaker \($0.sortformerSpeakerId)",
+                        oldName: currentSpeakerName(in: content, diarizerSpeakerId: $0.diarizerSpeakerId)
+                            ?? "Speaker \($0.diarizerSpeakerId)",
                         newName: $0.newName
                     )
                 )
@@ -429,7 +429,7 @@ extension TranscriptSaver {
         var lines = String(content[frontmatterRange])
             .components(separatedBy: "\n")
 
-        let targetIdLine = #"id: "\#(update.sortformerSpeakerId)""#
+        let targetIdLine = #"id: "\#(update.diarizerSpeakerId)""#
         let resolvedPersistentId = (update.resolvedPersistentSpeakerId ?? update.persistentSpeakerId).uuidString
         var lineIndex = 0
 
@@ -520,11 +520,11 @@ extension TranscriptSaver {
         return content.index(content.startIndex, offsetBy: 4)..<endRange.lowerBound
     }
 
-    private static func currentSpeakerName(in content: String, sortformerSpeakerId: String) -> String? {
+    private static func currentSpeakerName(in content: String, diarizerSpeakerId: String) -> String? {
         guard let frontmatterRange = frontmatterContentRange(in: content) else { return nil }
 
         let lines = String(content[frontmatterRange]).components(separatedBy: "\n")
-        let targetIdLine = #"id: "\#(sortformerSpeakerId)""#
+        let targetIdLine = #"id: "\#(diarizerSpeakerId)""#
         var lineIndex = 0
 
         while lineIndex < lines.count {
@@ -618,7 +618,7 @@ extension TranscriptSaver {
             let speakerKey = "system_\(speakerId)"
             let speakerName = updatesBySystemKey[speakerKey]?.newName
                 ?? updatesBySystemKey[speakerKey]?.oldName
-                ?? currentSpeakerName(in: content, sortformerSpeakerId: String(speakerId))
+                ?? currentSpeakerName(in: content, diarizerSpeakerId: String(speakerId))
                 ?? "Speaker \(speakerId)"
             let speakingTime = utterances.reduce(0.0) { $0 + ($1.end - $1.start) }
             let wordCount = utterances.reduce(0) { $0 + $1.transcript.split(separator: " ").count }

--- a/Sources/TranscriptedCore/Speaker/SpeakerClipExtractor.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerClipExtractor.swift
@@ -1,5 +1,5 @@
 // SpeakerClipExtractor.swift
-// Extracts short audio clips per speaker from the system WAV file.
+// Extracts short audio clips per speaker from a source WAV file (mic or system).
 // Used by the post-meeting naming flow so users can hear each speaker's voice.
 
 import Foundation
@@ -9,7 +9,8 @@ import AVFoundation
 struct ClipResult {
     let clipURL: URL              // temporary WAV file
     let persistentSpeakerId: UUID // from SpeakerDatabase
-    let sortformerSpeakerId: String // "0", "1" for transcript matching
+    let diarizerSpeakerId: String // "0", "1" for transcript matching
+    let channel: UtteranceChannel // which audio source this clip came from
     let sampleText: String        // representative transcript quote
     let matchSimilarity: Double?  // cosine similarity from DB match
     let currentName: String?      // display name if known
@@ -19,24 +20,26 @@ struct ClipResult {
 @available(macOS 14.0, *)
 public enum SpeakerClipExtractor {
 
-    /// Extract a 5-8 second audio clip per speaker from the system audio WAV.
+    /// Extract a 5-8 second audio clip per speaker from a source WAV file.
     ///
     /// For each speaker, picks the longest single utterance (capped at 8s).
     /// If the longest utterance is under 3s, concatenates short utterances up to 8s.
     /// Uses frame-level seeking to avoid loading the entire file into memory.
     ///
     /// - Parameters:
-    ///   - systemAudioURL: Path to the system audio WAV file (48kHz native)
-    ///   - utterances: System audio utterances from transcription result
+    ///   - sourceAudioURL: Path to the source WAV file (mic or system audio)
+    ///   - utterances: Utterances from this channel
+    ///   - channel: Which channel these utterances came from
     ///   - speakerDB: Speaker database for looking up profiles
     /// - Returns: Array of ClipResults, one per speaker that needs naming/confirmation
     static func extractClips(
-        systemAudioURL: URL,
+        sourceAudioURL: URL,
         utterances: [TranscriptionUtterance],
+        channel: UtteranceChannel,
         speakerDB: any SpeakerStore
     ) throws -> [ClipResult] {
 
-        let audioFile = try AVAudioFile(forReading: systemAudioURL)
+        let audioFile = try AVAudioFile(forReading: sourceAudioURL)
         let format = audioFile.processingFormat
         let sampleRate = format.sampleRate
 
@@ -54,7 +57,7 @@ public enum SpeakerClipExtractor {
             guard let firstWithId = speakerUtterances.first(where: { $0.persistentSpeakerId != nil }),
                   let persistentId = firstWithId.persistentSpeakerId else {
                 // Speaker has no persistent ID — skip (shouldn't happen but be safe)
-                AppLogger.pipeline.warning("Speaker has no persistent ID, skipping clip extraction", ["speakerId": "\(speakerId)"])
+                AppLogger.pipeline.warning("Speaker has no persistent ID, skipping clip extraction", ["speakerId": "\(speakerId)", "channel": channel.rawValue])
                 continue
             }
 
@@ -70,7 +73,8 @@ public enum SpeakerClipExtractor {
                 from: audioFile,
                 segments: clipSegments,
                 sampleRate: sampleRate,
-                speakerId: speakerId
+                speakerId: speakerId,
+                channel: channel
             )
 
             // Pick a representative text sample (longest utterance text)
@@ -81,7 +85,8 @@ public enum SpeakerClipExtractor {
             results.append(ClipResult(
                 clipURL: clipURL,
                 persistentSpeakerId: persistentId,
-                sortformerSpeakerId: String(speakerId),
+                diarizerSpeakerId: String(speakerId),
+                channel: channel,
                 sampleText: sampleText,
                 matchSimilarity: similarity,
                 currentName: profile?.displayName,
@@ -89,7 +94,7 @@ public enum SpeakerClipExtractor {
             ))
         }
 
-        AppLogger.pipeline.info("Extracted speaker clips", ["count": "\(results.count)"])
+        AppLogger.pipeline.info("Extracted speaker clips", ["count": "\(results.count)", "channel": channel.rawValue])
         return results
     }
 
@@ -199,11 +204,12 @@ public enum SpeakerClipExtractor {
         from audioFile: AVAudioFile,
         segments: [TranscriptionUtterance],
         sampleRate: Double,
-        speakerId: Int
+        speakerId: Int,
+        channel: UtteranceChannel
     ) throws -> URL {
 
         let tempDir = NSTemporaryDirectory()
-        let clipFilename = "speaker_\(speakerId)_\(UUID().uuidString.prefix(8)).wav"
+        let clipFilename = "speaker_\(channel.rawValue)_\(speakerId)_\(UUID().uuidString.prefix(8)).wav"
         let clipURL = URL(fileURLWithPath: tempDir).appendingPathComponent(clipFilename)
 
         // Output format: mono 48kHz (native quality for playback)

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -21,7 +21,7 @@ extension TranscriptionTaskManager {
         clips: [SpeakerNamingEntry]
     ) {
         let speakerDB = transcription.speakerDB
-        let clipsBySpeakerId = Dictionary(uniqueKeysWithValues: clips.map { ($0.sortformerSpeakerId, $0) })
+        let clipsBySpeakerId = Dictionary(uniqueKeysWithValues: clips.map { ($0.diarizerSpeakerId, $0) })
 
         DispatchQueue.global(qos: .utility).async { [weak self] in
             guard let resolvedUpdates = Self.applyNamingUpdates(
@@ -105,7 +105,7 @@ extension TranscriptionTaskManager {
         resolvedUpdates.reserveCapacity(updates.count)
 
         for update in updates {
-            let entry = clipsBySpeakerId[update.sortformerSpeakerId]
+            let entry = clipsBySpeakerId[update.diarizerSpeakerId]
             guard let resolvedPersistentSpeakerId = resolvePersistentSpeakerId(
                 for: update,
                 entry: entry,
@@ -123,7 +123,7 @@ extension TranscriptionTaskManager {
 
             resolvedUpdates.append(SpeakerNameUpdate(
                 persistentSpeakerId: update.persistentSpeakerId,
-                sortformerSpeakerId: update.sortformerSpeakerId,
+                diarizerSpeakerId: update.diarizerSpeakerId,
                 newName: update.newName,
                 previousName: update.previousName,
                 action: update.action,
@@ -212,6 +212,13 @@ extension TranscriptionTaskManager {
                 "name": update.newName
             ])
             return nil
+
+        case .collapsedToMe:
+            // The user clicked "Keep as You" for this mic speaker. Wiring lands in the
+            // follow-up PR that enables mic diarization end-to-end; for now, skip silently
+            // so the DB isn't mutated and the transcript rewrite path doesn't see this
+            // update. Default (off) behavior never produces this action.
+            return update.persistentSpeakerId
         }
     }
 

--- a/Sources/UI/Settings/SpeakerNamingSheet.swift
+++ b/Sources/UI/Settings/SpeakerNamingSheet.swift
@@ -305,7 +305,7 @@ final class SpeakerRowView: NSView {
         if let current = entry.currentName, !current.isEmpty {
             labelField.stringValue = "Suggested match: \(current)"
         } else {
-            labelField.stringValue = "Speaker \(entry.sortformerSpeakerId)"
+            labelField.stringValue = "Speaker \(entry.diarizerSpeakerId)"
         }
         labelField.font = NSFont.systemFont(ofSize: 13, weight: .semibold)
         labelField.textColor = NSColor.labelColor
@@ -419,14 +419,14 @@ final class SpeakerRowView: NSView {
             if let suggestedProfileId = entry.suggestedProfileId {
                 return SpeakerNameUpdate(
                     persistentSpeakerId: entry.id,
-                    sortformerSpeakerId: entry.sortformerSpeakerId,
+                    diarizerSpeakerId: entry.diarizerSpeakerId,
                     newName: current,
                     action: .merged(targetProfileId: suggestedProfileId)
                 )
             }
             return SpeakerNameUpdate(
                 persistentSpeakerId: entry.id,
-                sortformerSpeakerId: entry.sortformerSpeakerId,
+                diarizerSpeakerId: entry.diarizerSpeakerId,
                 newName: current,
                 previousName: current,
                 action: .confirmed
@@ -438,7 +438,7 @@ final class SpeakerRowView: NSView {
         if let option = knownPeopleByLabel[typed] {
             return SpeakerNameUpdate(
                 persistentSpeakerId: entry.id,
-                sortformerSpeakerId: entry.sortformerSpeakerId,
+                diarizerSpeakerId: entry.diarizerSpeakerId,
                 newName: option.displayName,
                 action: .merged(targetProfileId: option.id)
             )
@@ -457,7 +457,7 @@ final class SpeakerRowView: NSView {
 
         return SpeakerNameUpdate(
             persistentSpeakerId: entry.id,
-            sortformerSpeakerId: entry.sortformerSpeakerId,
+            diarizerSpeakerId: entry.diarizerSpeakerId,
             newName: typed,
             previousName: entry.currentName,
             action: action

--- a/Tests/TranscriptedCoreTests/RetroactiveSpeakerUpdaterTests.swift
+++ b/Tests/TranscriptedCoreTests/RetroactiveSpeakerUpdaterTests.swift
@@ -83,7 +83,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(
                     persistentSpeakerId: speakerId,
-                    sortformerSpeakerId: "0",
+                    diarizerSpeakerId: "0",
                     newName: "Alex",
                     action: .named
                 )
@@ -112,7 +112,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
         let source: String
         let label: String
         let text: String
-        let sortformerSpeakerId: Int?
+        let diarizerSpeakerId: Int?
         let speakingSeconds: Double
 
         init(
@@ -120,14 +120,14 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
             source: String,
             label: String,
             text: String,
-            sortformerSpeakerId: Int? = nil,
+            diarizerSpeakerId: Int? = nil,
             speakingSeconds: Double = 3.0
         ) {
             self.timestamp = timestamp
             self.source = source
             self.label = label
             self.text = text
-            self.sortformerSpeakerId = sortformerSpeakerId
+            self.diarizerSpeakerId = diarizerSpeakerId
             self.speakingSeconds = speakingSeconds
         }
     }
@@ -361,7 +361,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(
                     persistentSpeakerId: originalPersistentId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     newName: "Sarah Graham",
                     previousName: "Matt Vlasach",
                     action: .corrected,
@@ -419,7 +419,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(
                     persistentSpeakerId: persistentSpeakerId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     newName: "Sarah Graham",
                     previousName: "Speaker 1",
                     action: .named
@@ -473,7 +473,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(
                     persistentSpeakerId: persistentSpeakerId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     newName: "Sarah Graham",
                     previousName: "Speaker 1",
                     action: .named
@@ -529,7 +529,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(
                     persistentSpeakerId: persistentSpeakerId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     newName: "Sarah Graham",
                     previousName: "Speaker 1",
                     action: .named
@@ -585,7 +585,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(
                     persistentSpeakerId: persistentSpeakerId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     newName: "Sarah Graham",
                     previousName: "Speaker 1",
                     action: .named
@@ -629,7 +629,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
                 source: "System",
                 label: "Matt Vlasach",
                 text: "Sarah is actually joining today.",
-                sortformerSpeakerId: 1,
+                diarizerSpeakerId: 1,
                 speakingSeconds: 3.0
             ),
             MarkdownUtterance(
@@ -637,7 +637,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
                 source: "System",
                 label: "Matt Vlasach",
                 text: "Matt Vlasach is still the label on this other speaker.",
-                sortformerSpeakerId: 2,
+                diarizerSpeakerId: 2,
                 speakingSeconds: 4.0
             )
         ]
@@ -658,7 +658,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(
                     persistentSpeakerId: firstPersistentId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     newName: "Sarah Graham",
                     previousName: "Matt Vlasach",
                     action: .corrected,
@@ -699,7 +699,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
                 source: "System",
                 label: "[[Matt Vlasach]]",
                 text: #"Literal tokens: [[Matt Vlasach]] [System/Matt Vlasach] **Matt Vlasach:** name: "Matt Vlasach""#,
-                sortformerSpeakerId: 1,
+                diarizerSpeakerId: 1,
                 speakingSeconds: 3.0
             )
         ]
@@ -719,7 +719,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(
                     persistentSpeakerId: originalPersistentId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     newName: "Sarah Graham",
                     previousName: "Matt Vlasach",
                     action: .corrected,
@@ -834,7 +834,7 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
 
         let mappedUtterances = utterances.map { utterance -> TranscriptionUtterance in
             let channel = utterance.source.caseInsensitiveCompare("Mic") == .orderedSame ? 0 : 1
-            let speakerId = utterance.sortformerSpeakerId
+            let speakerId = utterance.diarizerSpeakerId
                 ?? resolvedSpeakerId(
                     for: utterance,
                     channel: channel,

--- a/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
@@ -19,7 +19,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
         let source: String
         let label: String
         let text: String
-        let sortformerSpeakerId: Int?
+        let diarizerSpeakerId: Int?
         let speakingSeconds: Double
 
         init(
@@ -27,14 +27,14 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             source: String,
             label: String,
             text: String,
-            sortformerSpeakerId: Int? = nil,
+            diarizerSpeakerId: Int? = nil,
             speakingSeconds: Double = 3.0
         ) {
             self.timestamp = timestamp
             self.source = source
             self.label = label
             self.text = text
-            self.sortformerSpeakerId = sortformerSpeakerId
+            self.diarizerSpeakerId = diarizerSpeakerId
             self.speakingSeconds = speakingSeconds
         }
     }
@@ -117,7 +117,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(
                     persistentSpeakerId: persistentSpeakerId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     newName: "Sarah Graham",
                     previousName: nil,
                     action: .named
@@ -131,7 +131,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             clips: [
                 SpeakerNamingEntry(
                     id: persistentSpeakerId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     clipURL: clipURL,
                     sampleText: "Thanks for joining.",
                     currentName: nil,
@@ -205,7 +205,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(
                     persistentSpeakerId: persistentSpeakerId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     newName: "Sarah Graham",
                     previousName: nil,
                     action: .named
@@ -219,7 +219,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             clips: [
                 SpeakerNamingEntry(
                     id: persistentSpeakerId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     clipURL: clipURL,
                     sampleText: "Thanks for joining.",
                     currentName: nil,
@@ -301,7 +301,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(
                     persistentSpeakerId: persistentSpeakerId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     newName: "Sarah Graham",
                     previousName: nil,
                     action: .named
@@ -315,7 +315,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             clips: [
                 SpeakerNamingEntry(
                     id: persistentSpeakerId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     clipURL: clipURL,
                     sampleText: "Thanks for joining.",
                     currentName: nil,
@@ -415,7 +415,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(
                     persistentSpeakerId: matchedProfile.id,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     newName: "Sarah Graham",
                     previousName: "Matt Vlasach",
                     action: .corrected
@@ -429,7 +429,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             clips: [
                 SpeakerNamingEntry(
                     id: matchedProfile.id,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     clipURL: clipURL,
                     sampleText: "Thanks for joining.",
                     currentName: "Matt Vlasach",
@@ -519,7 +519,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(
                     persistentSpeakerId: persistentSpeakerId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     newName: "Sarah Graham",
                     previousName: "Speaker 1",
                     action: .named
@@ -533,7 +533,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             clips: [
                 SpeakerNamingEntry(
                     id: persistentSpeakerId,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     clipURL: clipURL,
                     sampleText: "Thanks for joining.",
                     currentName: nil,
@@ -621,7 +621,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(
                     persistentSpeakerId: matchedProfile.id,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     newName: "Sarah Graham",
                     previousName: "Matt Vlasach",
                     action: .corrected
@@ -635,7 +635,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             clips: [
                 SpeakerNamingEntry(
                     id: matchedProfile.id,
-                    sortformerSpeakerId: "1",
+                    diarizerSpeakerId: "1",
                     clipURL: clipURL,
                     sampleText: "Thanks for joining.",
                     currentName: "Matt Vlasach",
@@ -790,7 +790,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
 
         let mappedUtterances = utterances.map { utterance -> TranscriptionUtterance in
             let channel = utterance.source.caseInsensitiveCompare("Mic") == .orderedSame ? 0 : 1
-            let speakerId = utterance.sortformerSpeakerId
+            let speakerId = utterance.diarizerSpeakerId
                 ?? resolvedSpeakerId(
                     for: utterance,
                     channel: channel,


### PR DESCRIPTION
## Summary

Foundation / scaffolding PR for the "identify multiple local speakers" feature requested in #312. Pure refactor — no behavior change. Sets up the follow-up PR that actually diarizes the mic channel and surfaces local speakers in the naming sheet.

### What this PR does

- Renames `SystemSpeakerContext` → `ChannelSpeakerContext` so the same per-speaker context type carries both mic and system speakers
- Renames `sortformerSpeakerId` → `diarizerSpeakerId` on `SpeakerNamingEntry`, `SpeakerNameUpdate`, and `ClipResult` (the offline pipeline is PyAnnote, not Sortformer — the old name was misleading)
- Adds `UtteranceChannel` enum and a `channel` field on `SpeakerNamingEntry` / `SpeakerNameUpdate` (defaults to `.system` for backward compatibility)
- Adds `.collapsedToMe` to `SpeakerNameUpdate.NamingAction` — the follow-up's "Keep as You" button will emit this; the coordinator currently treats it as a no-op passthrough
- Makes `SpeakerClipExtractor.extractClips` source-agnostic (`sourceAudioURL:` + `channel:` instead of hardcoded `systemAudioURL:`)
- Adds `TranscriptionResult.micSpeakerContexts` + `newlyCreatedMicProfileIds` + `micSpeakerIds` / `micPersistentSpeakerIds` helpers (empty defaults preserve existing behavior)

Default values on every new parameter / init keep the existing pipeline, runner, formatter, sheet, and retroactive-updater call paths identical. No mic diarization runs.

### Why split it this way

The original plan was a single big feature PR. After an adversarial review (codex session `019d8ef5-79d8-7740-a870-7f858c006f17`) the blast radius turned out bigger than first scoped — the naming pipeline is system-only end-to-end (runner, formatter, saver, retroactive updater, clip extractor). Shipping the rename + type surface first makes the follow-up PR a clean diff focused on behavior, not mechanical churn.

### What's next (follow-up PR)

- Diarize the mic track in `transcribeMultichannel` when a new `splitLocalSpeakersEnabled` settings flag is on (default **off** for v1, flip after dogfood)
- Thread mic speakers through `TranscriptionPipelineRunner` — classification, clip extraction from the mic WAV, mic entries merged into the naming request
- Extend `SpeakerNamingSheet` with a "People in the room" section above "Remote participants" + one-click **"Keep as You"** batch button
- Implement `.collapsedToMe` cleanup in `SpeakerNamingCoordinator`: delete `newlyCreatedMicProfileIds` from `SpeakerDatabase`, rewrite mic utterances back to "You" in the saved transcript
- Extend `TranscriptFormatter` with a "Local Speaker Breakdown" section mirroring the existing remote one
- Add the settings toggle in `SpeakerPeopleSettingsSection` ("People in the room: split speakers on your mic")
- New unit + integration tests for the mic naming path

The full phased plan with codex's adversarial findings baked in is in `~/.claude/plans/hashed-launching-tide.md` on the author's machine.

### Explicitly NOT in either PR

- Reverse mic-contamination gate. Codex flagged the originally planned symmetric weighting as a recall killer — normal cross-talk in a room gets silently dropped. PyAnnote's own post-processing plus the user-driven "Keep as You" escape handle the bleed case instead.
- Cross-channel matching calibration (same person on both mic and system may get two DB profiles; noted as a known limitation).
- Retroactive-rename symmetry for mic speakers (today's `RetroactiveSpeakerUpdater` rewrites system-only; follow-up PR handles initial save, not later rename).

## Test plan

- [x] `bash build.sh` — clean build, app launches
- [x] `bash run-tests.sh` — 289/289 pass
- [x] `swift test` — 51/51 pass (package boundary regression check)
- [ ] Manual check by reviewer: existing meeting flow (single local + multiple remote) still saves transcript with "Microphone (You)" and correct remote speaker labels — no regression from the renames