### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -38,6 +38,7 @@ extension Audio {
             try? FileManager.default.createDirectory(at: captureDir, withIntermediateDirectories: true)
             let timestamp = DateFormattingHelper.formatFilenamePrecise(Date())
             let fileURL = captureDir.appendingPathComponent("meeting_\(timestamp)_system.wav")
+            let sessionGeneration = recordingSessionGeneration
             AppLogger.audioSystem.info("System audio file URL", ["file": fileURL.lastPathComponent])
 
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
@@ -46,12 +47,34 @@ extension Audio {
                     return
                 }
 
+                func cleanupAbandonedSetup() {
+                    strongSelf.systemAudioFileQueue.sync {
+                        strongSelf.systemAudioFile = nil
+                    }
+                    capture.stopSync()
+                    try? FileManager.default.removeItem(at: fileURL)
+                }
+
+                func sessionIsCurrent() -> Bool {
+                    sessionGeneration == strongSelf.recordingSessionGeneration
+                }
+
                 AppLogger.audioSystem.info("Starting system audio capture on background thread")
 
                 do {
+                    guard sessionIsCurrent() else {
+                        cleanupAbandonedSetup()
+                        return
+                    }
+
                     // Step 1: Prepare the tap (creates aggregate device, gets format)
                     // This does NOT start the I/O proc yet
                     try capture.prepare()
+
+                    guard sessionIsCurrent() else {
+                        cleanupAbandonedSetup()
+                        return
+                    }
 
                     // Step 2: Get the format from the tap (now corrected to match device nominal rate)
                     guard let tapFormat = capture.audioFormat else {
@@ -81,10 +104,16 @@ extension Audio {
                     strongSelf.systemAudioFileQueue.sync { strongSelf.systemAudioFile = file }
                     AppLogger.audioSystem.info("System audio file created before I/O proc", ["sampleRate": "\(Int(sampleRate))", "channels": "\(tapFormat.channelCount)"])
 
+                    guard sessionIsCurrent() else {
+                        cleanupAbandonedSetup()
+                        return
+                    }
+
                     // Step 4: Now start the I/O proc with a lightweight callback
                     // The file already exists, so callback only needs to copy+write
                     try capture.start { [weak self] systemBuffer in
                         guard let self = self else { return }
+                        guard sessionGeneration == self.recordingSessionGeneration else { return }
 
                         self.systemBufferCount += 1
                         let currentBufferCount = self.systemBufferCount
@@ -129,12 +158,23 @@ extension Audio {
                             }
                         }
                     }
+
+                    guard sessionIsCurrent() else {
+                        cleanupAbandonedSetup()
+                        return
+                    }
+
                     DispatchQueue.main.async {
+                        guard sessionGeneration == strongSelf.recordingSessionGeneration else { return }
                         strongSelf.systemAudioFileURL = fileURL
                     }
                     AppLogger.audioSystem.info("System audio capture started")
 
                 } catch {
+                    guard sessionIsCurrent() else {
+                        cleanupAbandonedSetup()
+                        return
+                    }
                     AppLogger.audioSystem.warning("System audio failed", ["error": error.localizedDescription])
                     strongSelf.systemAudioFileQueue.sync {
                         strongSelf.systemAudioFile = nil

--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -110,6 +110,7 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine {
         }
 
         self.bufferCallback = bufferCallback
+        errorMessage = nil
 
         // Output handler converts CMSampleBuffer → AVAudioPCMBuffer
         let output = SCKAudioStreamOutput { [weak self] buffer in
@@ -123,31 +124,40 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine {
         self.streamOutput = output
 
         let queue = DispatchQueue(label: "SCKAudioCapture.output", qos: .userInitiated)
-        try stream.addStreamOutput(output, type: .audio, sampleHandlerQueue: queue)
+        do {
+            try stream.addStreamOutput(output, type: .audio, sampleHandlerQueue: queue)
 
-        // Start capture — synchronous wait since we're on a background thread.
-        let semaphore = DispatchSemaphore(value: 0)
-        var startError: Error?
-        stream.startCapture { error in
-            startError = error
-            semaphore.signal()
-        }
-        semaphore.wait()
+            // Start capture — synchronous wait since we're on a background thread.
+            let semaphore = DispatchSemaphore(value: 0)
+            var startError: Error?
+            stream.startCapture { error in
+                startError = error
+                semaphore.signal()
+            }
+            semaphore.wait()
 
-        if let error = startError {
+            if let error = startError {
+                throw error
+            }
+
+            _isCapturing = true
+            AppLogger.audioSystem.info("SCKAudioCapture: now capturing system audio")
+        } catch {
             AppLogger.audioSystem.error("SCKAudioCapture: start failed", ["error": error.localizedDescription])
+            cleanup()
             DispatchQueue.main.async { self.errorMessage = error.localizedDescription }
             throw error
         }
-
-        _isCapturing = true
-        AppLogger.audioSystem.info("SCKAudioCapture: now capturing system audio")
     }
 
     func stop() {
-        guard _isCapturing, let stream = stream else { return }
-        _isCapturing = false
+        guard let stream = stream else { return }
+        guard _isCapturing else {
+            cleanup()
+            return
+        }
 
+        _isCapturing = false
         stream.stopCapture { [weak self] error in
             if let error = error {
                 AppLogger.audioSystem.warning("SCKAudioCapture: stop error", ["error": error.localizedDescription])
@@ -157,9 +167,13 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine {
     }
 
     func stopSync() {
-        guard _isCapturing, let stream = stream else { return }
-        _isCapturing = false
+        guard let stream = stream else { return }
+        guard _isCapturing else {
+            cleanup()
+            return
+        }
 
+        _isCapturing = false
         let semaphore = DispatchSemaphore(value: 0)
         stream.stopCapture { _ in
             semaphore.signal()
@@ -171,10 +185,12 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine {
     private func cleanup() {
         AppLogger.audioSystem.info("SCKAudioCapture: cleanup")
         logStats()
+        _isCapturing = false
         stream = nil
         streamOutput = nil
         bufferCallback = nil
         _audioFormat = nil
+        resetStats()
     }
 
     private func logStats() {
@@ -186,6 +202,13 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine {
             "total": "\(total)",
             "withData": "\(withData)"
         ])
+    }
+
+    private func resetStats() {
+        statsLock.lock()
+        _totalBuffers = 0
+        _buffersWithData = 0
+        statsLock.unlock()
     }
 }
 

--- a/Sources/TranscriptedCore/Audio/SystemAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SystemAudioCapture.swift
@@ -212,6 +212,7 @@ class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine {
         } catch {
             let errMsg = "Failed to start system audio capture: \(error.localizedDescription)"
             AppLogger.audioSystem.error("Start failed", ["error": errMsg])
+            cleanup()
             errorMessage = errMsg
             throw error
         }
@@ -222,7 +223,11 @@ class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine {
     /// If a new session starts before the delay fires (e.g. monitoring -> recording),
     /// the generation counter will cause the stale cleanup to be skipped.
     func stop() {
-        guard isCapturing else { return }
+        guard isCapturing || isPrepared else { return }
+        guard isCapturing else {
+            cleanup()
+            return
+        }
 
         // Update UI immediately - don't block the main thread
         DispatchQueue.main.async { [weak self] in
@@ -260,7 +265,11 @@ class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine {
     /// (e.g. monitoring -> recording transition) to avoid the race where
     /// delayed cleanup destroys the newly created tap.
     func stopSync() {
-        guard isCapturing else { return }
+        guard isCapturing || isPrepared else { return }
+        guard isCapturing else {
+            cleanup()
+            return
+        }
 
         DispatchQueue.main.async { [weak self] in
             self?.isCapturing = false

--- a/Sources/TranscriptedCore/Models/TranscriptMetadataBuilder.swift
+++ b/Sources/TranscriptedCore/Models/TranscriptMetadataBuilder.swift
@@ -34,9 +34,32 @@ public struct RecordingHealthInfo {
 
     /// Create health info from Audio instance.
     public static func from(audio: Audio, systemCapture: (any SystemAudioCaptureEngine)?) -> RecordingHealthInfo {
-        let successRate = systemCapture?.bufferSuccessRate ?? 1.0
+        let successRate: Double = {
+            if audio.systemAudioFailed || audio.systemAudioStatus == .failed {
+                return 0.0
+            }
+            return systemCapture?.bufferSuccessRate ?? 1.0
+        }()
+
+        let baseQuality = CaptureQuality.from(successRate: successRate)
+        let adjustedQuality: CaptureQuality
+        if audio.deviceSwitchCount >= 3 {
+            adjustedQuality = .degraded
+        } else if audio.deviceSwitchCount >= 1 || !audio.recordingGaps.isEmpty {
+            switch baseQuality {
+            case .excellent:
+                adjustedQuality = .good
+            case .good:
+                adjustedQuality = .fair
+            case .fair, .degraded:
+                adjustedQuality = baseQuality
+            }
+        } else {
+            adjustedQuality = baseQuality
+        }
+
         return RecordingHealthInfo(
-            captureQuality: CaptureQuality.from(successRate: successRate),
+            captureQuality: adjustedQuality,
             audioGaps: audio.recordingGaps.count,
             deviceSwitches: audio.deviceSwitchCount,
             gapDescriptions: audio.recordingGaps.map { $0.description }

--- a/Tests/TranscriptedCoreTests/TranscriptMetadataBuilderTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptMetadataBuilderTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import TranscriptedCore
+
+@available(macOS 14.0, *)
+final class TranscriptMetadataBuilderTests: XCTestCase {
+    private var tempRoot: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        super.tearDown()
+    }
+
+    func testHealthInfoMarksFailedSystemAudioAsDegraded() {
+        let audio = Audio(paths: makePaths())
+        audio.systemAudioFailed = true
+        audio.systemAudioStatus = .failed
+
+        let health = RecordingHealthInfo.from(audio: audio, systemCapture: nil)
+
+        XCTAssertEqual(health.captureQuality, .degraded)
+    }
+
+    func testHealthInfoDowngradesForGapsAndDeviceSwitches() {
+        let audio = Audio(paths: makePaths())
+        audio.deviceSwitchCount = 1
+        audio.appendRecordingGap(.init(start: Date(), duration: 1.5, reason: "sleep_wake"))
+
+        let health = RecordingHealthInfo.from(audio: audio, systemCapture: nil)
+
+        XCTAssertEqual(health.captureQuality, .good)
+        XCTAssertEqual(health.audioGaps, 1)
+        XCTAssertEqual(health.deviceSwitches, 1)
+        XCTAssertEqual(health.gapDescriptions, ["sleep_wake: 1.5s"])
+    }
+
+    private func makePaths() -> CoreStoragePaths {
+        CoreStoragePaths(
+            transcripts: tempRoot.appendingPathComponent("transcripts", isDirectory: true),
+            speakerDB: tempRoot.appendingPathComponent("state/speakers.sqlite"),
+            statsDB: tempRoot.appendingPathComponent("state/stats.sqlite"),
+            failedQueue: tempRoot.appendingPathComponent("state/failed.json"),
+            speakerClips: tempRoot.appendingPathComponent("clips", isDirectory: true),
+            audioCaptures: tempRoot.appendingPathComponent("audio", isDirectory: true),
+            logs: tempRoot.appendingPathComponent("logs", isDirectory: true)
+        )
+    }
+}


### PR DESCRIPTION
## What I found and fixed

### Audio capture lifecycle
- cleaned up abandoned system-audio files when capture startup races against a stop or session swap, so failed/stale starts do not leave bogus scratch artifacts behind
- made both system-audio capture engines fully reset their prepared state and counters when `stop()` is called before capture is marked active, which avoids stale session state leaking into the next run

### Transcript health metadata
- fixed recording-health classification so failed system-audio capture is no longer reported as healthy/excellent
- folded recording gaps and device switches back into the capture-quality rating, so transcript metadata better reflects degraded real-world recordings

### Tests
- added focused tests covering failed system-audio health classification and quality downgrades for gaps/device switches

## Verification
- `xcodebuild -project Transcripted.xcodeproj -scheme Transcripted -configuration Debug build 2>&1` could not be used as requested because this checkout does not contain `Transcripted.xcodeproj`
- verified with the repo's supported build lane instead: `bash build.sh`
