### PR TITLE
[nightly-review] Preserve mic speaker name rewrites

### DIFF
--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -256,9 +256,9 @@ extension TranscriptSaver {
             }
 
             let obsidianEnabled = isObsidianFormatted(content)
-            let updatesBySystemKey = Dictionary(uniqueKeysWithValues: updates.map {
+            let updatesByChannelKey = Dictionary(uniqueKeysWithValues: updates.map {
                 (
-                    "system_\($0.diarizerSpeakerId)",
+                    speakerUpdateKey(channel: $0.channel, diarizerSpeakerId: $0.diarizerSpeakerId),
                     (
                         oldName: currentSpeakerName(in: content, diarizerSpeakerId: $0.diarizerSpeakerId)
                             ?? "Speaker \($0.diarizerSpeakerId)",
@@ -274,7 +274,7 @@ extension TranscriptSaver {
             guard rewriteFullTranscriptSection(
                 in: &content,
                 result: transcriptionResult,
-                updatesBySystemKey: updatesBySystemKey,
+                updatesByChannelKey: updatesByChannelKey,
                 obsidianEnabled: obsidianEnabled
             ) else {
                 AppLogger.pipeline.error("Failed to rewrite transcript body for speaker updates", [
@@ -286,7 +286,7 @@ extension TranscriptSaver {
             guard rewriteRemoteSpeakerBreakdown(
                 in: &content,
                 result: transcriptionResult,
-                updatesBySystemKey: updatesBySystemKey
+                updatesByChannelKey: updatesByChannelKey
             ) else {
                 AppLogger.pipeline.error("Failed to rewrite speaker breakdown for speaker updates", [
                     "path": transcriptURL.lastPathComponent
@@ -556,7 +556,7 @@ extension TranscriptSaver {
     private static func rewriteFullTranscriptSection(
         in content: inout String,
         result: TranscriptionResult,
-        updatesBySystemKey: [String: (oldName: String, newName: String)],
+        updatesByChannelKey: [String: (oldName: String, newName: String)],
         obsidianEnabled: Bool
     ) -> Bool {
         if let range = fullTranscriptContentRange(in: content) {
@@ -564,7 +564,7 @@ extension TranscriptSaver {
                 in: &content,
                 range: range,
                 result: result,
-                updatesBySystemKey: updatesBySystemKey,
+                updatesByChannelKey: updatesByChannelKey,
                 obsidianEnabled: obsidianEnabled
             )
         }
@@ -574,7 +574,7 @@ extension TranscriptSaver {
                 in: &content,
                 range: range,
                 result: result,
-                updatesBySystemKey: updatesBySystemKey,
+                updatesByChannelKey: updatesByChannelKey,
                 obsidianEnabled: obsidianEnabled
             )
         }
@@ -584,7 +584,7 @@ extension TranscriptSaver {
                 in: &content,
                 range: range,
                 result: result,
-                updatesBySystemKey: updatesBySystemKey,
+                updatesByChannelKey: updatesByChannelKey,
                 obsidianEnabled: obsidianEnabled
             )
         }
@@ -595,7 +595,7 @@ extension TranscriptSaver {
     private static func rewriteRemoteSpeakerBreakdown(
         in content: inout String,
         result: TranscriptionResult,
-        updatesBySystemKey: [String: (oldName: String, newName: String)]
+        updatesByChannelKey: [String: (oldName: String, newName: String)]
     ) -> Bool {
         guard let headerRange = content.range(of: "#### Remote Speaker Breakdown\n\n") else {
             return false
@@ -615,9 +615,9 @@ extension TranscriptSaver {
         let speakerGroups = Dictionary(grouping: result.systemUtterances, by: { $0.speakerId })
         let lines = speakerGroups.keys.sorted().map { speakerId in
             let utterances = speakerGroups[speakerId] ?? []
-            let speakerKey = "system_\(speakerId)"
-            let speakerName = updatesBySystemKey[speakerKey]?.newName
-                ?? updatesBySystemKey[speakerKey]?.oldName
+            let speakerKey = speakerUpdateKey(channel: .system, diarizerSpeakerId: String(speakerId))
+            let speakerName = updatesByChannelKey[speakerKey]?.newName
+                ?? updatesByChannelKey[speakerKey]?.oldName
                 ?? currentSpeakerName(in: content, diarizerSpeakerId: String(speakerId))
                 ?? "Speaker \(speakerId)"
             let speakingTime = utterances.reduce(0.0) { $0 + ($1.end - $1.start) }
@@ -670,7 +670,7 @@ extension TranscriptSaver {
         in content: inout String,
         range: Range<String.Index>,
         result: TranscriptionResult,
-        updatesBySystemKey: [String: (oldName: String, newName: String)],
+        updatesByChannelKey: [String: (oldName: String, newName: String)],
         obsidianEnabled: Bool
     ) -> Bool {
         let lines = String(content[range]).components(separatedBy: "\n")
@@ -691,8 +691,11 @@ extension TranscriptSaver {
                 return false
             }
 
-            let speakerKey = "\(utterance.channel == 0 ? "mic" : "system")_\(utterance.speakerId)"
-            guard let update = updatesBySystemKey[speakerKey] else { continue }
+            let speakerKey = speakerUpdateKey(
+                channel: utterance.channel == 0 ? .mic : .system,
+                diarizerSpeakerId: String(utterance.speakerId)
+            )
+            guard let update = updatesByChannelKey[speakerKey] else { continue }
 
             let label = transcriptLabel(
                 for: update.newName,
@@ -711,7 +714,7 @@ extension TranscriptSaver {
         in content: inout String,
         range: Range<String.Index>,
         result: TranscriptionResult,
-        updatesBySystemKey: [String: (oldName: String, newName: String)],
+        updatesByChannelKey: [String: (oldName: String, newName: String)],
         obsidianEnabled: Bool
     ) -> Bool {
         let chunks = String(content[range])
@@ -736,8 +739,11 @@ extension TranscriptSaver {
                 return false
             }
 
-            let speakerKey = "\(utterance.channel == 0 ? "mic" : "system")_\(utterance.speakerId)"
-            if let update = updatesBySystemKey[speakerKey] {
+            let speakerKey = speakerUpdateKey(
+                channel: utterance.channel == 0 ? .mic : .system,
+                diarizerSpeakerId: String(utterance.speakerId)
+            )
+            if let update = updatesByChannelKey[speakerKey] {
                 let label = transcriptLabel(
                     for: update.newName,
                     currentLabel: components.label,
@@ -753,6 +759,13 @@ extension TranscriptSaver {
 
         content.replaceSubrange(range, with: rewrittenChunks.joined(separator: "\n\n"))
         return true
+    }
+
+    private static func speakerUpdateKey(
+        channel: UtteranceChannel,
+        diarizerSpeakerId: String
+    ) -> String {
+        "\(channel.rawValue)_\(diarizerSpeakerId)"
     }
 
     private static func parseTranscriptLine(_ line: String) -> (timestamp: String, source: String, label: String, text: String)? {

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -21,7 +21,9 @@ extension TranscriptionTaskManager {
         clips: [SpeakerNamingEntry]
     ) {
         let speakerDB = transcription.speakerDB
-        let clipsBySpeakerId = Dictionary(uniqueKeysWithValues: clips.map { ($0.diarizerSpeakerId, $0) })
+        let clipsBySpeakerId = Dictionary(uniqueKeysWithValues: clips.map {
+            (Self.speakerClipLookupKey(channel: $0.channel, diarizerSpeakerId: $0.diarizerSpeakerId), $0)
+        })
 
         DispatchQueue.global(qos: .utility).async { [weak self] in
             guard let resolvedUpdates = Self.applyNamingUpdates(
@@ -105,7 +107,7 @@ extension TranscriptionTaskManager {
         resolvedUpdates.reserveCapacity(updates.count)
 
         for update in updates {
-            let entry = clipsBySpeakerId[update.diarizerSpeakerId]
+            let entry = clipsBySpeakerId[speakerClipLookupKey(channel: update.channel, diarizerSpeakerId: update.diarizerSpeakerId)]
             guard let resolvedPersistentSpeakerId = resolvePersistentSpeakerId(
                 for: update,
                 entry: entry,
@@ -124,6 +126,7 @@ extension TranscriptionTaskManager {
             resolvedUpdates.append(SpeakerNameUpdate(
                 persistentSpeakerId: update.persistentSpeakerId,
                 diarizerSpeakerId: update.diarizerSpeakerId,
+                channel: update.channel,
                 newName: update.newName,
                 previousName: update.previousName,
                 action: update.action,
@@ -242,6 +245,13 @@ extension TranscriptionTaskManager {
         (name ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
+    }
+
+    nonisolated private static func speakerClipLookupKey(
+        channel: UtteranceChannel,
+        diarizerSpeakerId: String
+    ) -> String {
+        "\(channel.rawValue)_\(diarizerSpeakerId)"
     }
 
     @MainActor private func finishNamingFlow(

--- a/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
@@ -157,6 +157,98 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testHandleNamingCompletePreservesMicChannelUpdates() async throws {
+        let harness = try makeHarness()
+        let transcriptId = UUID()
+        let persistentSpeakerId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.3, count: 256),
+            existingId: nil
+        ).id
+        let transcriptURL = harness.paths.transcripts.appendingPathComponent("MicOnly_2026-04-10_15-01-23.md")
+        let clipURL = tempDirectory.appendingPathComponent("speaker-mic.wav")
+        let micURL = tempDirectory.appendingPathComponent("mic-source.wav")
+        let systemURL = tempDirectory.appendingPathComponent("system-source.wav")
+        let speakers = [
+            MarkdownSpeaker(
+                id: "1",
+                persistentSpeakerId: persistentSpeakerId,
+                name: "Speaker 1",
+                confidence: "unknown",
+                source: "db_pending"
+            )
+        ]
+        let utterances = [
+            MarkdownUtterance(
+                timestamp: "00:01",
+                source: "Mic",
+                label: "Speaker 1",
+                text: "I am in the room."
+            )
+        ]
+
+        try sampleTranscript(
+            transcriptId: transcriptId,
+            speakers: speakers,
+            utterances: utterances,
+            breakdownEntries: []
+        ).write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let transcriptionResult = sampleTranscriptionResult(speakers: speakers, utterances: utterances)
+        try Data().write(to: clipURL)
+        try Data().write(to: micURL)
+        try Data().write(to: systemURL)
+
+        harness.manager.speakerNamingRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: micURL,
+            onComplete: { _ in }
+        )
+
+        harness.manager.handleNamingComplete(
+            updates: [
+                SpeakerNameUpdate(
+                    persistentSpeakerId: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    channel: .mic,
+                    newName: "Michael",
+                    previousName: nil,
+                    action: .named
+                )
+            ],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            transcriptionResult: transcriptionResult,
+            micURL: micURL,
+            systemURL: systemURL,
+            clips: [
+                SpeakerNamingEntry(
+                    id: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    channel: .mic,
+                    clipURL: clipURL,
+                    sampleText: "I am in the room.",
+                    currentName: nil,
+                    matchSimilarity: nil,
+                    needsNaming: true,
+                    needsConfirmation: false,
+                    sessionEmbedding: [Float](repeating: 0.3, count: 256)
+                )
+            ]
+        )
+
+        try await waitUntil {
+            harness.manager.speakerNamingRequest == nil
+                && harness.manager.displayStatus == .transcriptSaved
+        }
+
+        let savedTranscript = try String(contentsOf: transcriptURL, encoding: .utf8)
+        XCTAssertTrue(savedTranscript.contains(#"name: "Michael""#))
+        XCTAssertTrue(savedTranscript.contains("[00:01] [Mic/Michael] I am in the room."))
+    }
+
+    @MainActor
     func testHandleNamingCompletePublishesFailureWhenRewriteFails() async throws {
         let harness = try makeHarness()
         let transcriptId = UUID()


### PR DESCRIPTION
## Finding

Speaker naming updates were being rewritten with a hard-coded `system_*` lookup key even after the diarization refactor added per-channel speaker metadata. That meant a mic-channel rename could update YAML metadata but leave `[Mic/Speaker X]` lines unchanged once local speaker naming is enabled.

## Fix

- preserve `SpeakerNameUpdate.channel` through `handleNamingComplete`
- key clip lookup and transcript rewrite state by `channel + diarizerSpeakerId`
- add an end-to-end regression test that renames a mic speaker and verifies the transcript body becomes `[Mic/<name>]`

## Verification

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `swift test`
