### PR TITLE
[nightly-notes] Add release copy sanity check

### DIFF
--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -76,6 +76,12 @@ bash build-deps.sh --force
 NOTARY_PROFILE=<profile-name> bash build-beta.sh <beta-token> <user-name>
 ```
 
+Before you publish a user-facing release note, sanity-check the release state:
+
+- compare `Info.plist` `CFBundleShortVersionString` against the latest GitHub release tag
+- review the merged PRs since that latest published release so the note reflects shipped changes, not just local branch state
+- if `docs/appcast.xml` still points at the older release, say plainly that existing installs will not discover the new build in-app yet
+
 If you expect existing installs of Transcripted to discover the new version
 inside the app, do not stop after the DMG is built. You must also complete the
 Sparkle steps in `docs/sparkle-updates.md`.


### PR DESCRIPTION
## Why
Release copy is easy to drift from actual ship state when , the latest GitHub release, and  are temporarily out of sync.

## What changed
- add a short release-flow reminder to compare the app version, latest published release, and appcast state before writing user-facing notes
- explicitly call out when existing installs still will not discover the new build in-app

## How I checked it
- verified the current mismatch case locally:  is  while the latest GitHub release and appcast are still 

## Risk
Docs only.