### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -447,11 +447,9 @@ public class Audio: ObservableObject {
                         // Permission granted, proceed with start
                         self.startAudioCaptureAsync()
                     } else {
-                        // Permission denied
-                        DispatchQueue.main.async {
-                            self.error = "Microphone permission required. Go to System Settings \u{2192} Privacy & Security \u{2192} Microphone and enable Transcripted, then try again."
-                            self.isStarting = false
-                        }
+                        // Permission denied — already on main via the outer dispatch
+                        self.error = "Microphone permission required. Go to System Settings \u{2192} Privacy & Security \u{2192} Microphone and enable Transcripted, then try again."
+                        self.isStarting = false
                     }
                 }
             }

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -13,7 +13,7 @@ The directory is grouped by surface so the live UI tree is easier to scan:
 
 Draft-mode UI is not an active product path in this worktree.
 
-## Files (33 Swift files)
+## Files (34 Swift files)
 
 ### Overlay/
 
@@ -36,6 +36,7 @@ dictation overlay and the meeting prompt / recording overlay.
 - `MenuBar/MenuAgentConnectPageView.swift` — agent connection page in the menubar popover
 - `MenuBar/MenuBarContentView.swift` — root content view for the menubar popover
 - `MenuBar/MenuBarHeaderView.swift` — popover header with app name and status
+- `MenuBar/MenuBarModelStatusView.swift` — persistent local-model status badge with download progress, error state, and settings shortcut
 - `MenuBar/MenuBarPanelController.swift` — NSPopover controller for the menubar
 - `MenuBar/MenuBarRecentMeetingsView.swift` — recent meetings list in the popover
 - `MenuBar/MenuBarSettingsView.swift` — settings actions in the popover footer


### PR DESCRIPTION
## Summary

- **`Sources/TranscriptedCore/Audio/Audio.swift`**: Removed a redundant nested `DispatchQueue.main.async` in the microphone-permission-denied branch of `Audio.start()`. The denial handler was already executing inside an outer `DispatchQueue.main.async` callback, making the inner dispatch a no-op extra hop that delayed error visibility by one run-loop cycle.

## What was reviewed (and found clean)

- No `@MainActor` on `Audio.swift` or `SystemAudioCapture.swift` — correct
- `SpeakerNamingCoordinator.swift` plan/apply refactor — logic is sound; `Task { @MainActor in }` is intentional for the `finishNamingFlow` UI call
- `TranscriptionPipeline.swift` `nonisolated` + `await MainActor.run` pattern — legitimate, keeps heavy compute off main
- `RetroactiveSpeakerUpdater.swift` YAML name parsing (line 544-547) — correctly strips `name:` prefix and quotes
- `MeetingCaptureBridge.swift` — `audio.micAudioFileURL` read is done after a `completionContinuation` flush, safe
- `MeetingSessionController.swift` trigger attribution — clean
- `MeetingFailureKind.swift` `pipelineBusy` classifier — matches `TranscriptionTaskManager` error message exactly
- `AccessibilityBridge.swift` force-cast `as! AXValue` — valid, CF bridge casts to CoreFoundation types always succeed (compiler-confirmed)
- No TranscriptedCore boundary violations found in imports

## Test plan

- [x] `bash build.sh` — passes
- [x] `bash run-tests.sh` — 315/315 passed
- [x] `bash run-integration-smoke.sh` — all smoke checks passed
- [x] `swift test` — 54/54 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)