### PR TITLE
security: nightly security audit findings [automated]

### DIFF
--- a/Sources/Beta/BetaConfig.swift
+++ b/Sources/Beta/BetaConfig.swift
@@ -9,7 +9,17 @@ import Foundation
 enum BetaConfig {
     /// Per-user beta token, baked in at build time.
     /// build-beta.sh replaces BETA_TOKEN_PLACEHOLDER with the actual token.
-    static let userToken = "BETA_TOKEN_PLACEHOLDER"
+    static let userToken: String = {
+        let token = "BETA_TOKEN_PLACEHOLDER"
+        // Security: fail fast if build-beta.sh forgot to substitute the token.
+        // Shipping the literal placeholder would allow unauthenticated access to beta
+        // endpoints under the BETA_TOKEN_PLACEHOLDER identity.
+        precondition(
+            !token.hasSuffix("PLACEHOLDER"),
+            "BetaConfig.userToken was not replaced by build-beta.sh — do not ship this build"
+        )
+        return token
+    }()
 
     /// Proxy base URL for beta-only proxy traffic.
     static let proxyBaseURL = "https://draft-proxy.tz427gsydr.workers.dev"

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -43,7 +43,16 @@ public enum SystemAudioStatus: Equatable {
 public class Audio: ObservableObject {
     @Published public var isRecording: Bool = false
     @Published public private(set) var isMonitoring: Bool = false  // Lightweight level metering without file recording
-    private var isStarting: Bool = false  // Prevents double-start during async setup
+    // Security: isStarting is read and written from both the main thread and
+    // background queues (e.g. the AVCaptureDevice permission callback). Protect it
+    // with a lock to prevent a narrow race where two concurrent start() calls both
+    // pass the guard and set up two recording sessions.
+    private var _isStarting: Bool = false
+    private let isStartingLock = NSLock()
+    private var isStarting: Bool {
+        get { isStartingLock.lock(); defer { isStartingLock.unlock() }; return _isStarting }
+        set { isStartingLock.lock(); defer { isStartingLock.unlock() }; _isStarting = newValue }
+    }
     @Published public var audioLevel: Float = 0.0
     @Published public var recordingDuration: TimeInterval = 0.0
     @Published public var audioLevelHistory: [Float] = Array(repeating: 0.0, count: 15)

--- a/Sources/TranscriptedCore/Services/ModelDownloadService.swift
+++ b/Sources/TranscriptedCore/Services/ModelDownloadService.swift
@@ -222,6 +222,30 @@ public enum ModelDownloadService {
         return true
     }
 
+    /// Validate a HuggingFace model ID before interpolating it into download URLs.
+    /// Security: modelId is string-interpolated directly into HTTPS URLs. An attacker-controlled
+    /// or misconfigured value containing path traversal sequences (e.g. "../../foo") or
+    /// URL-breaking characters could cause the request to hit an unexpected endpoint.
+    /// Allowlist: "namespace/model-name" — alphanumerics, hyphens, underscores, dots, and
+    /// exactly one optional slash separating namespace from model name.
+    static func isSafeModelId(_ modelId: String) -> Bool {
+        guard !modelId.isEmpty, modelId.count <= 200 else { return false }
+        // Must not contain ".." traversal components
+        let components = modelId.components(separatedBy: "/")
+        guard !components.contains(".."), !components.contains(".") else { return false }
+        // At most two path components (namespace/model) — extra slashes are suspicious
+        guard components.count <= 2 else { return false }
+        // Each component must be non-empty and consist only of safe characters
+        let safeChars = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+        for component in components {
+            guard !component.isEmpty,
+                  component.unicodeScalars.allSatisfy({ safeChars.contains($0) }) else {
+                return false
+            }
+        }
+        return true
+    }
+
 
     // MARK: - HuggingFace Model Download Infrastructure
 
@@ -238,6 +262,15 @@ public enum ModelDownloadService {
 
     /// Fetch the list of files in a HuggingFace model repository
     static func fetchModelFileList(modelId: String) async throws -> [HFModelFile] {
+        // Security: validate modelId against an allowlist before interpolating into URLs.
+        // An untrusted or misconfigured modelId containing ".." or extra slashes could cause
+        // the request to hit an unintended endpoint on the mirror server.
+        guard isSafeModelId(modelId) else {
+            throw ModelDownloadError(
+                kind: .unknown("Invalid model ID '\(modelId)' — must match namespace/model-name format"),
+                underlyingError: nil
+            )
+        }
         // Try each mirror for the API call
         for mirror in mirrors {
             // Security: use safe URL construction — force-unwrap would crash if modelId or mirror
@@ -310,6 +343,15 @@ public enum ModelDownloadService {
         destination: URL,
         expectedSHA256: String? = nil
     ) async throws {
+        // Security: validate modelId against an allowlist before interpolating into URLs.
+        // Mirrors this check in fetchModelFileList — defense-in-depth for callers that
+        // invoke downloadFileWithMirrorFallback directly.
+        guard isSafeModelId(modelId) else {
+            throw ModelDownloadError(
+                kind: .unknown("Invalid model ID '\(modelId)' — must match namespace/model-name format"),
+                underlyingError: nil
+            )
+        }
         for mirror in mirrors {
             // Security: use safe URL construction — force-unwrap would crash if filename contained
             // URL-unsafe characters (e.g., spaces) not caught by isSafeModelFilename. Skip

--- a/Sources/TranscriptedCore/Services/RecordingValidator.swift
+++ b/Sources/TranscriptedCore/Services/RecordingValidator.swift
@@ -121,7 +121,15 @@ public enum RecordingValidator {
     // MARK: - Save Path Validation
 
     /// System directories that must never be used as a transcript save location.
-    private static let forbiddenPrefixes = ["/System", "/Library", "/usr", "/bin", "/sbin", "/private"]
+    /// Security: ~/Library is included because a tampered UserDefaults value could otherwise
+    /// direct transcript writes into ~/Library/Preferences or ~/Library/Keychains, potentially
+    /// corrupting preference plists or creating confusing files in sensitive locations.
+    private static let forbiddenPrefixes: [String] = {
+        var prefixes = ["/System", "/Library", "/usr", "/bin", "/sbin", "/private"]
+        // Append the user-home Library path at runtime so it resolves correctly for all users.
+        prefixes.append(NSHomeDirectory() + "/Library")
+        return prefixes
+    }()
 
     /// Validates a custom save path is safe to use.
     /// Resolves symlinks and rejects paths containing `..` traversals or targeting system directories.

--- a/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
@@ -25,8 +25,14 @@ public final class SpeakerDatabase: @unchecked Sendable {
             withIntermediateDirectories: true
         )
         dbPath = paths.speakerDB
-        openDatabase()
-        createTables()
+        // Security: run database setup on the serial queue so that isDatabaseOpen is set
+        // within the same queue context that all public methods use. This establishes a
+        // memory barrier preventing public methods from observing a stale isDatabaseOpen=false
+        // if init and a concurrent public-method call race on the same instance.
+        queue.sync {
+            openDatabase()
+            createTables()
+        }
     }
 
     /// Public initializer that accepts a custom SQLite path.
@@ -38,8 +44,11 @@ public final class SpeakerDatabase: @unchecked Sendable {
             at: dbPath.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        openDatabase()
-        createTables()
+        // Security: same queue.sync pattern as private init() — see comment there.
+        queue.sync {
+            openDatabase()
+            createTables()
+        }
     }
 
     deinit {

--- a/Sources/TranscriptedCore/Stats/StatsDatabase.swift
+++ b/Sources/TranscriptedCore/Stats/StatsDatabase.swift
@@ -36,8 +36,14 @@ public final class StatsDatabase {
             withIntermediateDirectories: true
         )
         dbPath = paths.statsDB
-        openDatabase()
-        createTables()
+        // Security: run database setup on the serial queue so that isDatabaseOpen is set
+        // within the same queue context that all public methods use. This establishes a
+        // memory barrier preventing public methods from observing a stale isDatabaseOpen=false
+        // if init and a concurrent public-method call race on the same instance.
+        queue.sync {
+            openDatabase()
+            createTables()
+        }
     }
 
     /// Public initializer that accepts a custom SQLite path.
@@ -49,8 +55,11 @@ public final class StatsDatabase {
             at: dbPath.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        openDatabase()
-        createTables()
+        // Security: same queue.sync pattern as private init() — see comment there.
+        queue.sync {
+            openDatabase()
+            createTables()
+        }
     }
 
     deinit {

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -13,7 +13,7 @@ The directory is grouped by surface so the live UI tree is easier to scan:
 
 Draft-mode UI is not an active product path in this worktree.
 
-## Files (33 Swift files)
+## Files (34 Swift files)
 
 ### Overlay/
 
@@ -36,6 +36,7 @@ dictation overlay and the meeting prompt / recording overlay.
 - `MenuBar/MenuAgentConnectPageView.swift` — agent connection page in the menubar popover
 - `MenuBar/MenuBarContentView.swift` — root content view for the menubar popover
 - `MenuBar/MenuBarHeaderView.swift` — popover header with app name and status
+- `MenuBar/MenuBarModelStatusView.swift` — persistent local-model status badge with download progress, error state, and settings shortcut
 - `MenuBar/MenuBarPanelController.swift` — NSPopover controller for the menubar
 - `MenuBar/MenuBarRecentMeetingsView.swift` — recent meetings list in the popover
 - `MenuBar/MenuBarSettingsView.swift` — settings actions in the popover footer


### PR DESCRIPTION
## Summary

Automated nightly security review — 5 findings fixed, 0 CRITICAL or HIGH.

## Findings by Severity

### MEDIUM (3)

**`isStarting` race in `Audio.swift`**
- `isStarting` was a plain `Bool` read and written from both the main thread and background queues (e.g. the `AVCaptureDevice` permission callback). A narrow race between two concurrent `start()` calls could let both pass the `!isStarting` guard and set up two concurrent recording sessions. Fixed by adding an `NSLock`-backed computed property matching the `isMicRecovering` pattern already used in this class.

**`isDatabaseOpen` unsynchronized init in `SpeakerDatabase` and `StatsDatabase`**
- Both database classes set `isDatabaseOpen = true` inside `configureOpenDatabase()`, called from `init()` outside the serial queue. Public methods check `isDatabaseOpen` inside `queue.sync`/`queue.async` blocks. There was no memory barrier between the non-queue init path and the queue-protected reads. Fixed by wrapping `openDatabase()` + `createTables()` in `queue.sync` in both `init` variants.

**Unvalidated `modelId` interpolated into download URLs in `ModelDownloadService.swift`**
- `modelId` was string-interpolated directly into HuggingFace API and CDN URLs without any validation. A value containing `..` or extra slashes could cause the request to hit an unintended endpoint on the mirror. Fixed by adding an `isSafeModelId` allowlist validator (alphanumerics + `-_.`, max 2 slash-separated components, no `..`) applied at both URL construction sites in `fetchModelFileList` and `downloadFileWithMirrorFallback`.

### LOW (2)

**`BetaConfig` placeholder could ship unreplaced**
- `BetaConfig.userToken` defaulted to the literal string `"BETA_TOKEN_PLACEHOLDER"`. If `build-beta.sh` forgot the substitution step, the literal would be sent as a credential. Fixed by adding a `precondition(!token.hasSuffix("PLACEHOLDER"), ...)` that crashes the beta build at startup rather than silently shipping with a broken credential.

**`validateSavePath` did not block `~/Library`**
- The forbidden-prefix list blocked `/Library` (system) but not `~/Library` (user). A tampered `UserDefaults` value could direct transcript writes into `~/Library/Preferences` or `~/Library/Keychains`. Fixed by appending `NSHomeDirectory() + "/Library"` to the forbidden list at runtime.

## Not Fixed (informational only)

- **Sentry DSN / PostHog key in `Info.plist`**: Standard for client analytics SDKs in macOS apps; no code change needed. Mitigate via rate-limiting in the Sentry/PostHog project settings.
- **Sparkle appcast URL on mutable `main` branch**: EdDSA signature requirement is in place, so full RCE would require the private key. Consider moving to a versioned CDN path in a follow-up.

## Test Plan

- [x] `bash build.sh` — passes, signed successfully
- [x] `bash run-tests.sh` — 315 tests, 0 failures
- [x] `bash run-integration-smoke.sh` — all smoke checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)