### PR TITLE
fix: guard AX force-casts against unexpected CF types

### DIFF
--- a/Sources/Accessibility/AccessibilityBridge.swift
+++ b/Sources/Accessibility/AccessibilityBridge.swift
@@ -21,6 +21,7 @@ struct AccessibilityBridge {
         let result = AXUIElementCopyAttributeValue(appElement, kAXFocusedUIElementAttribute as CFString, &focusedRef)
         guard result == .success, let focusedElement = focusedRef else { return nil }
 
+        guard CFGetTypeID(focusedElement) == AXUIElementGetTypeID() else { return nil }
         let axElement = focusedElement as! AXUIElement
 
         var roleRef: AnyObject?
@@ -59,7 +60,9 @@ struct AccessibilityBridge {
         AXUIElementCopyAttributeValue(axElement, kAXPositionAttribute as CFString, &posRef)
         AXUIElementCopyAttributeValue(axElement, kAXSizeAttribute as CFString, &sizeRef)
 
-        guard let posValue = posRef, let sizeValue = sizeRef else { return nil }
+        guard let posValue = posRef, let sizeValue = sizeRef,
+              CFGetTypeID(posValue) == AXValueGetTypeID(),
+              CFGetTypeID(sizeValue) == AXValueGetTypeID() else { return nil }
 
         var point = CGPoint.zero
         var size = CGSize.zero


### PR DESCRIPTION
## Summary

- `AccessibilityBridge` force-casts the results of `AXUIElementCopyAttributeValue` to `AXUIElement` / `AXValue` in three places. If the OS ever returns a CFTypeRef of a different type (version drift, rare edge cases), the app traps.
- Guard each cast with `CFGetTypeID()` against the expected type ID, so unexpected shapes now fall through the existing nil-return paths instead of crashing.

Came out of a broader Codex review pass over the app (P1 item: force-unwraps on OS-returned AX values). Scope intentionally narrow — the other flagged items are real design questions that belong in separate changes.

## Test plan

- [x] `bash build.sh` — green
- [x] `bash run-tests.sh` — 326 / 326 pass
- [ ] Manual smoke: dictate into a text field in a few apps; confirm overlay still lands on the focused field

🤖 Generated with [Claude Code](https://claude.com/claude-code)