### PR TITLE
[nightly-security] Harden Sentry bearer token redaction

### DIFF
--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -40,7 +40,7 @@ enum SentryPayloadSanitizer {
     private static let commonSecretRegex = makeRegex(
         #"\b(?:ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|phc_[A-Za-z0-9]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|xoxx-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9._-]{10,}\.[A-Za-z0-9._-]{10,})\b"#
     )
-    private static let bearerRegex = makeRegex(#"Bearer [A-Za-z0-9._-]+"#)
+    private static let bearerRegex = makeRegex(#"Bearer\s+[A-Za-z0-9._-]+"#, options: [.caseInsensitive])
     private static let secretAssignmentRegex = makeRegex(
         #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature)\s*[:=]\s*([^\s,;]+)"#
     )

--- a/Tests/SentryPayloadSanitizerTests.swift
+++ b/Tests/SentryPayloadSanitizerTests.swift
@@ -54,6 +54,16 @@ func testSentryPayloadSanitizer() {
         assertTrue(sanitized.contains("[redacted-secret]"), "redacted secret marker should remain")
     }
 
+    runSuite("SentryPayloadSanitizer redacts case-insensitive bearer variants with tabs and multi-space") {
+        for raw in ["bearer\ttokenabc", "BEARER   abc.def_ghi", "Bearer\t token-123", "beArEr  mixed_case_token"] {
+            let sanitized = SentryPayloadSanitizer.sanitizeText(raw)
+            assertFalse(sanitized.lowercased().contains("tokenabc"), "case-insensitive bearer should still redact token part in '\(raw)'")
+            assertFalse(sanitized.contains("abc.def_ghi"), "bearer with whitespace variants should redact token in '\(raw)'")
+            assertFalse(sanitized.contains("mixed_case_token"), "mixed-case bearer should redact in '\(raw)'")
+            assertTrue(sanitized.contains("Bearer ****"), "sanitized bearer marker should remain in '\(raw)'")
+        }
+    }
+
     runSuite("SentryPayloadSanitizer.sanitizeAnyDictionary redacts nested free-form values") {
         let sanitized = SentryPayloadSanitizer.sanitizeAnyDictionary([
             "safe_count": 3,


### PR DESCRIPTION
## What changed
- Hardened `SentryPayloadSanitizer` so bearer headers are redacted even when casing or whitespace varies.
- Added a regression test covering tab-separated, multi-space, and mixed-case bearer tokens.

## Why
- The Sentry scrubber was stricter than the analytics scrubber. A malformed or oddly formatted `Authorization: Bearer ...` value could survive redaction and leave the device in a Sentry payload.

## Impact
- Keeps auth header variants inside Transcripted's privacy boundary before off-device error forwarding.
- No product behavior change outside crash/event sanitization.

## Validation
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
