### PR TITLE
[nightly-retrieval] Improve CLI recent meeting previews

### DIFF
--- a/Tools/TranscriptedCLI/Package.swift
+++ b/Tools/TranscriptedCLI/Package.swift
@@ -61,5 +61,10 @@ let package = Package(
                 .linkedFramework("Network"),
             ] : []
         ),
+        .testTarget(
+            name: "TranscriptedCLITests",
+            dependencies: ["transcripted-cli"],
+            path: "Tests/TranscriptedCLITests"
+        ),
     ]
 )

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -127,7 +127,7 @@ enum CLIContextStore {
                     entryId: nil,
                     date: meeting.date,
                     datetime: meeting.datetime,
-                    preview: meeting.speakers.joined(separator: ", "),
+                    preview: recentMeetingPreview(for: meeting),
                     wordCount: meeting.wordCount,
                     speakers: meeting.speakers,
                     sourceAppName: nil,
@@ -341,6 +341,15 @@ enum CLIContextStore {
             return filename
         }
         return extractTitle(from: content) ?? filename
+    }
+
+    private static func recentMeetingPreview(for meeting: MeetingRecord) -> String {
+        if let firstUtterance = meeting.utterances.first(where: {
+            !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }) {
+            return String(firstUtterance.text.prefix(220))
+        }
+        return meeting.speakers.joined(separator: ", ")
     }
 
     private static func extractTitle(from content: String) -> String? {

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import transcripted_cli
+
+final class ContextStoreTests: XCTestCase {
+    func testRecentMeetingUsesFirstUtteranceAsPreview() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let meetingsDir = root.appendingPathComponent("meetings", isDirectory: true)
+        let dictationsDir = root.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: meetingsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dictationsDir, withIntermediateDirectories: true)
+
+        let meeting = """
+        ---
+        capture_type: meeting
+        date: 2026-04-16
+        time: 09:15:00
+        duration: "0:18"
+        ---
+
+        # Product review
+
+        ## Full Transcript
+
+        [00:03] [Mic/You] We should test the onboarding changes before touching pricing.
+
+        [00:08] [System/Speaker 2] Agreed.
+        """
+        try meeting.write(
+            to: meetingsDir.appendingPathComponent("Product review.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let items = CLIContextStore.recent(
+            in: CLIContextDirectories(meetingsDir: meetingsDir, dictationsDir: dictationsDir),
+            kind: .meeting,
+            count: 5,
+            dateFrom: nil,
+            dateTo: nil
+        )
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.preview, "We should test the onboarding changes before touching pricing.")
+    }
+
+    private func makeTempDir() -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}


### PR DESCRIPTION
## Summary
- fix `transcripted-cli context-recent --kind meeting` so recent meeting items show the first transcript snippet instead of only the speaker list
- add a CLI package test that locks in the recent meeting preview behavior

## Why
The nightly retrieval eval found that the CLI fallback path could answer "latest meeting" with a preview as weak as `You`, which made recent meeting retrieval unreliable for agent use.

## Validation
- `cd Tools/TranscriptedCLI && swift build`
- `cd Tools/TranscriptedCLI && swift test`
- `cd Tools/TranscriptedMCP && swift build`
- `cd Tools/TranscriptedMCP && swift test`
- `cd Tools/TranscriptedCLI && swift run transcripted-cli context-recent --kind meeting --count 3`
- `cd Tools/TranscriptedCLI && swift run transcripted-cli context-search works --speaker Speaker --count 5`
- `cd Tools/TranscriptedCLI && swift run transcripted-cli list-dictations --count 3`
- `cd Tools/TranscriptedCLI && swift run transcripted-cli context-recent --kind meeting --count 3 --data-dir "$HOME/Library/Application Support/Transcripted/captures"`
