### PR TITLE
[nightly-agent] Fix agent fallback path resolution

### DIFF
--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -52,11 +52,18 @@ They also honor:
 | `DiarizerConfigCompatibility.swift` | Compatibility shim for speaker-bound tuning while newer FluidAudio APIs are in flux |
 | `RTTMWriter.swift` | RTTM output formatter |
 
+## Test Files
+
+| File | Purpose |
+|------|---------|
+| `Tests/TranscriptedCLITests/ContextDirectoriesTests.swift` | Coverage for current Transcripted captures vs legacy Draft fallback path resolution |
+
 ## Build And Run
 
 ```bash
 cd Tools/TranscriptedCLI
 swift build
+swift test
 swift run transcripted-cli context-recent
 swift run transcripted-cli context-search "roadmap"
 swift run transcripted-cli list-dictations --count 5
@@ -73,6 +80,7 @@ instruction to run `bash build-deps.sh` from the repo root before rebuilding.
 - the context commands and the diarization commands serve different users, do not describe the whole package as diarization-only
 - the diarization commands depend on repo-level artifacts, so run `bash build-deps.sh` first when those are missing
 - retrieval-only commands should still build and run even when the diarization bundle is absent
+- `swift test` currently covers the agent-facing context path resolver only
 - the default context resolver prefers Transcripted capture folders, then falls back to Draft-era exports, then `~/Documents/Transcripted/`
 - `DiarizerConfigCompatibility.swift` currently keeps old bounded-speaker call sites compiling; it does not reintroduce upstream behavior by itself
 - changes here should be verified independently from the app build

--- a/Tools/TranscriptedCLI/Package.swift
+++ b/Tools/TranscriptedCLI/Package.swift
@@ -61,5 +61,10 @@ let package = Package(
                 .linkedFramework("Network"),
             ] : []
         ),
+        .testTarget(
+            name: "TranscriptedCLITests",
+            dependencies: ["transcripted-cli"],
+            path: "Tests/TranscriptedCLITests"
+        ),
     ]
 )

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -5,11 +5,18 @@ struct CLIContextDirectories {
     let meetingsDir: URL
     let dictationsDir: URL
 
-    static func resolve(dataDir: String?, meetingsDir: String?, dictationsDir: String?) -> CLIContextDirectories {
+    static func resolve(
+        dataDir: String?,
+        meetingsDir: String?,
+        dictationsDir: String?,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default,
+        homeDirectory: URL? = nil
+    ) -> CLIContextDirectories {
         if let dataDir, !dataDir.isEmpty {
             let shared = URL(fileURLWithPath: dataDir)
-            if FileManager.default.fileExists(atPath: shared.appendingPathComponent("meetings", isDirectory: true).path)
-                || FileManager.default.fileExists(atPath: shared.appendingPathComponent("dictations", isDirectory: true).path) {
+            if fileManager.fileExists(atPath: shared.appendingPathComponent("meetings", isDirectory: true).path)
+                || fileManager.fileExists(atPath: shared.appendingPathComponent("dictations", isDirectory: true).path) {
                 return CLIContextDirectories(
                     meetingsDir: shared.appendingPathComponent("meetings", isDirectory: true),
                     dictationsDir: shared.appendingPathComponent("dictations", isDirectory: true)
@@ -18,11 +25,10 @@ struct CLIContextDirectories {
             return CLIContextDirectories(meetingsDir: shared, dictationsDir: shared)
         }
 
-        let env = ProcessInfo.processInfo.environment
-        if let shared = env["TRANSCRIPTED_DATA_DIR"], !shared.isEmpty {
+        if let shared = environment["TRANSCRIPTED_DATA_DIR"], !shared.isEmpty {
             let sharedURL = URL(fileURLWithPath: shared)
-            if FileManager.default.fileExists(atPath: sharedURL.appendingPathComponent("meetings", isDirectory: true).path)
-                || FileManager.default.fileExists(atPath: sharedURL.appendingPathComponent("dictations", isDirectory: true).path) {
+            if fileManager.fileExists(atPath: sharedURL.appendingPathComponent("meetings", isDirectory: true).path)
+                || fileManager.fileExists(atPath: sharedURL.appendingPathComponent("dictations", isDirectory: true).path) {
                 return CLIContextDirectories(
                     meetingsDir: sharedURL.appendingPathComponent("meetings", isDirectory: true),
                     dictationsDir: sharedURL.appendingPathComponent("dictations", isDirectory: true)
@@ -31,7 +37,7 @@ struct CLIContextDirectories {
             return CLIContextDirectories(meetingsDir: sharedURL, dictationsDir: sharedURL)
         }
 
-        let home = FileManager.default.homeDirectoryForCurrentUser
+        let home = homeDirectory ?? fileManager.homeDirectoryForCurrentUser
         let transcriptedRoot = home
             .appendingPathComponent("Library", isDirectory: true)
             .appendingPathComponent("Application Support", isDirectory: true)
@@ -55,21 +61,24 @@ struct CLIContextDirectories {
             .appendingPathComponent("Transcripted", isDirectory: true)
 
         let meetingsURL = meetingsDir.map(URL.init(fileURLWithPath:))
-            ?? env["TRANSCRIPTED_MEETINGS_DIR"].map(URL.init(fileURLWithPath:))
+            ?? environment["TRANSCRIPTED_MEETINGS_DIR"].map(URL.init(fileURLWithPath:))
         let dictationsURL = dictationsDir.map(URL.init(fileURLWithPath:))
-            ?? env["TRANSCRIPTED_DICTATIONS_DIR"].map(URL.init(fileURLWithPath:))
-        let currentTranscriptedCapturesExist = FileManager.default.fileExists(atPath: defaultMeetings.path)
-            || FileManager.default.fileExists(atPath: defaultDictations.path)
+            ?? environment["TRANSCRIPTED_DICTATIONS_DIR"].map(URL.init(fileURLWithPath:))
+        let currentTranscriptedCapturesExist = fileManager.fileExists(atPath: defaultMeetings.path)
+            || fileManager.fileExists(atPath: defaultDictations.path)
+
+        let legacyDraftCapturesExist = fileManager.fileExists(atPath: legacyDraftMeetings.path)
+            || fileManager.fileExists(atPath: legacyDraftDictations.path)
 
         let useLegacyDraft = meetingsURL == nil
             && dictationsURL == nil
             && !currentTranscriptedCapturesExist
-            && FileManager.default.fileExists(atPath: legacyDraftMeetings.path)
+            && legacyDraftCapturesExist
         let useLegacyShared = meetingsURL == nil
             && dictationsURL == nil
             && !currentTranscriptedCapturesExist
-            && !FileManager.default.fileExists(atPath: legacyDraftMeetings.path)
-            && FileManager.default.fileExists(atPath: legacyShared.path)
+            && !legacyDraftCapturesExist
+            && fileManager.fileExists(atPath: legacyShared.path)
 
         return CLIContextDirectories(
             meetingsDir: meetingsURL ?? (useLegacyDraft ? legacyDraftMeetings : (useLegacyShared ? legacyShared : defaultMeetings)),

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextDirectoriesTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextDirectoriesTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import transcripted_cli
+
+final class ContextDirectoriesTests: XCTestCase {
+    func testResolveFallsBackToLegacyDraftWhenOnlyLegacyDictationsExist() throws {
+        let tempHome = makeTempDir()
+        defer { removeTempDir(tempHome) }
+
+        let legacyDraftDictations = tempHome
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Draft", isDirectory: true)
+            .appendingPathComponent("dictations", isDirectory: true)
+            .appendingPathComponent("transcripts", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyDraftDictations, withIntermediateDirectories: true)
+
+        let directories = CLIContextDirectories.resolve(
+            dataDir: nil,
+            meetingsDir: nil,
+            dictationsDir: nil,
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(
+            directories.meetingsDir.path,
+            tempHome
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("Application Support", isDirectory: true)
+                .appendingPathComponent("Draft", isDirectory: true)
+                .appendingPathComponent("meetings", isDirectory: true)
+                .appendingPathComponent("transcripts", isDirectory: true)
+                .path
+        )
+        XCTAssertEqual(directories.dictationsDir.path, legacyDraftDictations.path)
+    }
+
+    func testResolvePrefersCurrentTranscriptedLayoutWhenOnlyCurrentDictationsExist() throws {
+        let tempHome = makeTempDir()
+        defer { removeTempDir(tempHome) }
+
+        let transcriptedDictations = tempHome
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Transcripted", isDirectory: true)
+            .appendingPathComponent("captures", isDirectory: true)
+            .appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: transcriptedDictations, withIntermediateDirectories: true)
+
+        let legacyDraftMeetings = tempHome
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Draft", isDirectory: true)
+            .appendingPathComponent("meetings", isDirectory: true)
+            .appendingPathComponent("transcripts", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyDraftMeetings, withIntermediateDirectories: true)
+
+        let directories = CLIContextDirectories.resolve(
+            dataDir: nil,
+            meetingsDir: nil,
+            dictationsDir: nil,
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(
+            directories.meetingsDir.path,
+            tempHome
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("Application Support", isDirectory: true)
+                .appendingPathComponent("Transcripted", isDirectory: true)
+                .appendingPathComponent("captures", isDirectory: true)
+                .appendingPathComponent("meetings", isDirectory: true)
+                .path
+        )
+        XCTAssertEqual(directories.dictationsDir.path, transcriptedDictations.path)
+    }
+    private func makeTempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func removeTempDir(_ dir: URL) {
+        try? FileManager.default.removeItem(at: dir)
+    }
+}

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/DataDirectories.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/DataDirectories.swift
@@ -76,14 +76,17 @@ struct TranscriptedDataDirectories {
         let currentTranscriptedCapturesExist = fileManager.fileExists(atPath: defaultMeetings.path)
             || fileManager.fileExists(atPath: defaultDictations.path)
 
+        let legacyDraftCapturesExist = fileManager.fileExists(atPath: legacyDraftMeetings.path)
+            || fileManager.fileExists(atPath: legacyDraftDictations.path)
+
         let useLegacyDraft = meetingsOverride == nil
             && dictationsOverride == nil
             && !currentTranscriptedCapturesExist
-            && fileManager.fileExists(atPath: legacyDraftMeetings.path)
+            && legacyDraftCapturesExist
         let useLegacyShared = meetingsOverride == nil
             && dictationsOverride == nil
             && !currentTranscriptedCapturesExist
-            && !fileManager.fileExists(atPath: legacyDraftMeetings.path)
+            && !legacyDraftCapturesExist
             && fileManager.fileExists(atPath: legacyShared.path)
 
         return TranscriptedDataDirectories(

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/DataDirectoriesTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/DataDirectoriesTests.swift
@@ -47,4 +47,32 @@ final class DataDirectoriesTests: XCTestCase {
         )
         XCTAssertEqual(directories.dictationsDir.path, dictationsDir.path)
     }
+
+    func testResolveFallsBackToLegacyDraftWhenOnlyLegacyDictationsExist() throws {
+        let legacyDraftDictations = tempHome
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Draft", isDirectory: true)
+            .appendingPathComponent("dictations", isDirectory: true)
+            .appendingPathComponent("transcripts", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyDraftDictations, withIntermediateDirectories: true)
+
+        let directories = TranscriptedDataDirectories.resolve(
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(
+            directories.meetingsDir.path,
+            tempHome
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("Application Support", isDirectory: true)
+                .appendingPathComponent("Draft", isDirectory: true)
+                .appendingPathComponent("meetings", isDirectory: true)
+                .appendingPathComponent("transcripts", isDirectory: true)
+                .path
+        )
+        XCTAssertEqual(directories.dictationsDir.path, legacyDraftDictations.path)
+    }
 }


### PR DESCRIPTION
## Summary
- fix CLI and MCP Draft fallback resolution so agent tools also fall back when only legacy dictation artifacts exist
- add CLI package tests for resolver behavior and extend MCP resolver coverage for the same edge case
- document the new CLI package test surface in Tools/TranscriptedCLI/CLAUDE.md

## Why
Both agent-facing tools only switched to Draft fallback when the legacy meetings folder existed. Legacy installs with only Draft dictations were missed and silently resolved to the empty current Transcripted paths instead.

## Impact
Outside agents using TranscriptedCLI or TranscriptedMCP now resolve older Draft dictation-only setups correctly.

## Validation
- `cd Tools/TranscriptedCLI && swift build && swift test`
- `cd Tools/TranscriptedMCP && swift build && swift test`
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
