### PR TITLE
Update appcast for 1.0.8 release

### DIFF
--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -1,54 +1,65 @@
-<?xml version="1.0" standalone="yes"?>
+<?xml version="1.0" ?>
 <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
-    <channel>
-        <title>Transcripted Updates</title>
-        <link>https://github.com/r3dbars/transcripted</link>
-        <atom:link href="https://raw.githubusercontent.com/r3dbars/transcripted/main/docs/appcast.xml" rel="self" type="application/rss+xml"/>
-        <description>Release feed for Transcripted macOS updates.</description>
-        <language>en</language>
-        <item>
-            <title>1.0.7</title>
-            <pubDate>Tue, 14 Apr 2026 05:51:44 -0500</pubDate>
-            <link>https://github.com/r3dbars/transcripted</link>
-            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.7</sparkle:fullReleaseNotesLink>
-            <sparkle:version>1.0.7</sparkle:version>
-            <sparkle:shortVersionString>1.0.7</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.7/Transcripted-1.0.7.dmg" length="502675765" type="application/octet-stream" sparkle:edSignature="Q98ME9znEwbm2Gy9CyYVe6Bhqel8n6seNBa0xpj2iiYi2WgSruw8FCANBGWkVBsU9gXANw8bBGS+ZfjsykVRBg=="/>
-        </item>
-        <item>
-            <title>1.0.6</title>
-            <pubDate>Mon, 13 Apr 2026 19:50:36 GMT</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.6</link>
-            <sparkle:version>1.0.6</sparkle:version>
-            <sparkle:shortVersionString>1.0.6</sparkle:shortVersionString>
-            <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.6</sparkle:releaseNotesLink>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.6/Transcripted-1.0.6.dmg" length="502646081" type="application/octet-stream" sparkle:edSignature="QWSKxul7wWJBM2GTL8F4xKhp7q/9IfJVvtZJsC63pE5BoL85oRmKSTQRtWzx0DZPmKScQmw8VXMom7E9gQJPCQ=="/>
-        </item>
-        <item>
-            <title>1.0.5</title>
-            <pubDate>Mon, 13 Apr 2026 13:46:48 GMT</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.5</link>
-            <sparkle:version>1.0.5</sparkle:version>
-            <sparkle:shortVersionString>1.0.5</sparkle:shortVersionString>
-            <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.5</sparkle:releaseNotesLink>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.5/Transcripted-1.0.5.dmg" length="502640480" type="application/octet-stream" sparkle:edSignature="kvlnlYL4tbnNLZjIjdJwA+0FCZ8CV4dW55PhYxgEWDJ9kbPrNRYNRlWq887xWhwWJ/R065gqD5WN0JtxvFeUAw=="/>
-        </item>
-        <item>
-            <title>1.0.4</title>
-            <pubDate>Sun, 12 Apr 2026 18:58:26 GMT</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.4</link>
-            <sparkle:version>1.0.4</sparkle:version>
-            <sparkle:shortVersionString>1.0.4</sparkle:shortVersionString>
-            <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.4</sparkle:releaseNotesLink>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.4/Transcripted-1.0.4.dmg" length="509228201" type="application/octet-stream" sparkle:edSignature="xz6/eZzqaQwyYX79B2ztJ79IZEPSXKrTIf9DXhEP43Aep8RSus6AJgr2WLJj5+Qq34nNWql4ynn8kDyiAjXpBg=="/>
-        </item>
-    </channel>
+  <channel>
+    <title>Transcripted Updates</title>
+    <link>https://github.com/r3dbars/transcripted</link>
+    <atom:link href="https://raw.githubusercontent.com/r3dbars/transcripted/main/docs/appcast.xml" rel="self" type="application/rss+xml"/>
+    <description>Release feed for Transcripted macOS updates.</description>
+    <language>en</language>
+    <item>
+      <title>1.0.8</title>
+      <pubDate>Fri, 17 Apr 2026 17:13:16 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.8</link>
+      <sparkle:version>1.0.8</sparkle:version>
+      <sparkle:shortVersionString>1.0.8</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.8</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.8/Transcripted-1.0.8.dmg" length="502664309" type="application/octet-stream" sparkle:edSignature="l3EA/xoFcRhpjEBPx4BYBQCWWfRd8C95qLd0/bIR0LBj2vQsUNZert5TdjTs9g5Snxm/rTIYymfX/BquXOC2Cg=="/>
+    </item>
+    <item>
+      <title>1.0.7</title>
+      <pubDate>Tue, 14 Apr 2026 05:51:44 -0500</pubDate>
+      <link>https://github.com/r3dbars/transcripted</link>
+      <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.7</sparkle:fullReleaseNotesLink>
+      <sparkle:version>1.0.7</sparkle:version>
+      <sparkle:shortVersionString>1.0.7</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.7/Transcripted-1.0.7.dmg" length="502675765" type="application/octet-stream" sparkle:edSignature="Q98ME9znEwbm2Gy9CyYVe6Bhqel8n6seNBa0xpj2iiYi2WgSruw8FCANBGWkVBsU9gXANw8bBGS+ZfjsykVRBg=="/>
+    </item>
+    <item>
+      <title>1.0.6</title>
+      <pubDate>Mon, 13 Apr 2026 19:50:36 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.6</link>
+      <sparkle:version>1.0.6</sparkle:version>
+      <sparkle:shortVersionString>1.0.6</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.6</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.6/Transcripted-1.0.6.dmg" length="502646081" type="application/octet-stream" sparkle:edSignature="QWSKxul7wWJBM2GTL8F4xKhp7q/9IfJVvtZJsC63pE5BoL85oRmKSTQRtWzx0DZPmKScQmw8VXMom7E9gQJPCQ=="/>
+    </item>
+    <item>
+      <title>1.0.5</title>
+      <pubDate>Mon, 13 Apr 2026 13:46:48 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.5</link>
+      <sparkle:version>1.0.5</sparkle:version>
+      <sparkle:shortVersionString>1.0.5</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.5</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.5/Transcripted-1.0.5.dmg" length="502640480" type="application/octet-stream" sparkle:edSignature="kvlnlYL4tbnNLZjIjdJwA+0FCZ8CV4dW55PhYxgEWDJ9kbPrNRYNRlWq887xWhwWJ/R065gqD5WN0JtxvFeUAw=="/>
+    </item>
+    <item>
+      <title>1.0.4</title>
+      <pubDate>Sun, 12 Apr 2026 18:58:26 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.4</link>
+      <sparkle:version>1.0.4</sparkle:version>
+      <sparkle:shortVersionString>1.0.4</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.4</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.4/Transcripted-1.0.4.dmg" length="509228201" type="application/octet-stream" sparkle:edSignature="xz6/eZzqaQwyYX79B2ztJ79IZEPSXKrTIf9DXhEP43Aep8RSus6AJgr2WLJj5+Qq34nNWql4ynn8kDyiAjXpBg=="/>
+    </item>
+  </channel>
 </rss>


### PR DESCRIPTION
## Summary
- add the Sparkle appcast entry for the notarized 1.0.8 DMG
- point Sparkle at the public GitHub release asset and signature

## Verification
- xcrun notarytool submit build/Transcripted-1.0.8.dmg --keychain-profile Transcripted --wait
- xcrun stapler staple build/Transcripted-1.0.8.dmg
- deps-tools/sparkle/bin/sign_update build/Transcripted-1.0.8.dmg
- xmllint --noout docs/appcast.xml