### PR TITLE
Release 1.0.9 terminal paste fix

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.8</string>
+	<string>1.0.9</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.8</string>
+	<string>1.0.9</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -726,37 +726,8 @@ class DictationSessionController: ObservableObject {
         }
     }
 
-    /// Bundle identifiers of dedicated terminal emulators. Auto-paste is refused into
-    /// these targets because dictated text containing a trailing newline (or any
-    /// shell metacharacter) would be interpreted as a command and executed. The user
-    /// can still press Cmd+V manually if they really meant to paste into a shell.
-    private static let terminalBundleIDs: Set<String> = [
-        "com.apple.Terminal",
-        "com.googlecode.iterm2",
-        "dev.warp.Warp-Stable",
-        "co.zeit.hyper",
-        "net.kovidgoyal.kitty",
-        "io.alacritty",
-        "com.mitchellh.ghostty",
-    ]
-
-    private func isFrontmostAppATerminal() -> Bool {
-        guard let bundleID = NSWorkspace.shared.frontmostApplication?.bundleIdentifier else {
-            return false
-        }
-        return Self.terminalBundleIDs.contains(bundleID)
-    }
-
     private func pasteWithClipboardRestore(_ text: String) -> DictationPasteOutcome {
         guard let appState = appState else { return .failed("Couldn't paste dictation") }
-
-        // Refuse to auto-paste into a terminal: a trailing newline or shell
-        // metacharacter in the dictated text would execute as a command.
-        if isFrontmostAppATerminal() {
-            appState.logger.log("DICTATION | terminal frontmost, copying instead of auto-paste")
-            copyTextToClipboard(text)
-            return .copied("Dictation won't auto-paste into a terminal for safety. Press Cmd+V to paste.")
-        }
 
         // Check Accessibility permission BEFORE modifying clipboard
         guard AXIsProcessTrusted() else {

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.0.9</title>
+      <pubDate>Fri, 17 Apr 2026 18:24:06 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.9</link>
+      <sparkle:version>1.0.9</sparkle:version>
+      <sparkle:shortVersionString>1.0.9</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.9</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.9/Transcripted-1.0.9.dmg" length="502688154" type="application/octet-stream" sparkle:edSignature="w4Cw8zDn/4vfeJbuIq8OPJNs5naALADafyVZSrLsg/W68eBqVw4HRy/8c/lSvB68/sCZgwrfa9vWLPVLEpnZDA=="/>
+    </item>
+    <item>
       <title>1.0.8</title>
       <pubDate>Fri, 17 Apr 2026 17:13:16 GMT</pubDate>
       <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.8</link>


### PR DESCRIPTION
## Summary
- allow dictation to auto-paste into terminal apps again
- bump Transcripted to 1.0.9
- add the Sparkle appcast entry for the notarized 1.0.9 DMG

## Verification
- bash run-tests.sh
- bash build-deps.sh --force
- bash build.sh
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-release-1-0-9 1.0.9
- deps-tools/sparkle/bin/sign_update build/Transcripted-1.0.9.dmg