### PR TITLE
fix: increase audio buffer from 120s to 30min

### DIFF
--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -12,8 +12,9 @@ enum TranscriptedConstants {
 
     // MARK: - Audio & Speech
 
-    /// Audio buffer pre-allocation capacity in seconds
-    static let audioBufferCapacitySeconds = 120
+    /// Audio buffer capacity in seconds — sized well above the session timeout
+    /// so batch dictation never silently drops older audio.
+    static let audioBufferCapacitySeconds = 1800
 
     /// Audio tap buffer size (AVAudioEngine installTap)
     static let audioTapBufferSize: UInt32 = 1024


### PR DESCRIPTION
## Summary
- The 120-second audio buffer cap silently discarded the beginning of longer dictations
- Raised `audioBufferCapacitySeconds` from 120 to 1800 (30 min) so no realistic dictation session is ever truncated
- Memory impact is trivial (~345MB at 48kHz for a full 30-min recording)

## Test plan
- [ ] Dictate continuously for 2+ minutes and verify all words are transcribed
- [ ] Verify short dictations still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)