### PR TITLE
Release 1.1.10

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.9</string>
+	<string>1.1.10</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.9</string>
+	<string>1.1.10</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.10</title>
+      <pubDate>Fri, 17 Apr 2026 19:44:46 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.10</link>
+      <sparkle:version>1.1.10</sparkle:version>
+      <sparkle:shortVersionString>1.1.10</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.10</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.10/Transcripted-1.1.10.dmg" length="502721532" type="application/octet-stream" sparkle:edSignature="bShxoOEQ6bKgHQGBGiXAQ3BIOmudVrgnbtGS1h9f3yYGE6Yd091mqjR+BD7mg4FJ9jjQlZstE4ZNGugrF3f4DQ=="/>
+    </item>
+    <item>
       <title>1.0.9</title>
       <pubDate>Fri, 17 Apr 2026 18:24:06 GMT</pubDate>
       <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.9</link>


### PR DESCRIPTION
## Summary
- bump Transcripted to 1.1.10
- publish the notarized 1.1.10 DMG to GitHub Releases
- update the Sparkle appcast for the 1.1.10 update