### PR TITLE
Add Homebrew cask and release updater

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,0 +1,26 @@
+cask "transcripted" do
+  version "1.1.10"
+  sha256 "f7a2a1ef59602dd1569f5c019fdf205ad95bee4b35dd8520c2a89d46c98e5e07"
+
+  url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
+      verified: "github.com/r3dbars/transcripted/"
+  name "Transcripted"
+  desc "Local macOS menubar app for dictation and meeting transcription"
+  homepage "https://transcripted.app/"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :sequoia"
+
+  app "Transcripted.app"
+
+  zap trash: [
+    "~/Library/Application Support/Transcripted",
+    "~/Library/Caches/com.transcripted.Transcripted",
+    "~/Library/Preferences/com.transcripted.Transcripted.plist",
+  ]
+end

--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -5,7 +5,7 @@ cask "transcripted" do
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"
   name "Transcripted"
-  desc "Local macOS menubar app for dictation and meeting transcription"
+  desc "Menubar app for dictation and meeting transcription"
   homepage "https://transcripted.app/"
 
   livecheck do
@@ -14,13 +14,14 @@ cask "transcripted" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sequoia"
+  depends_on arch: :arm64
+  depends_on macos: ">= :tahoe"
 
   app "Transcripted.app"
 
   zap trash: [
     "~/Library/Application Support/Transcripted",
-    "~/Library/Caches/com.transcripted.Transcripted",
-    "~/Library/Preferences/com.transcripted.Transcripted.plist",
+    "~/Library/Caches/com.justinbetker.draft",
+    "~/Library/Preferences/com.justinbetker.draft.plist",
   ]
 end

--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ your agent at the folder later.
 2. Record a meeting or capture a dictation on your Mac.
 3. Open the saved Markdown files yourself, or point your agent at the folder.
 
+### Install With Homebrew
+
+If you prefer Homebrew, you can install and update Transcripted from the
+terminal:
+
+```bash
+brew tap r3dbars/transcripted https://github.com/r3dbars/transcripted
+brew install --cask transcripted
+```
+
+`brew upgrade --cask transcripted` picks up new releases. Transcripted also
+self-updates through Sparkle, so you can install either way.
+
 ## Just Markdown. Not A Black Box.
 
 Transcripted starts with readable Markdown. You do not need to learn a

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -86,6 +86,17 @@ If you expect existing installs of Transcripted to discover the new version
 inside the app, do not stop after the DMG is built. You must also complete the
 Sparkle steps in `docs/sparkle-updates.md`.
 
+After the release is published on GitHub, refresh the Homebrew cask so `brew
+upgrade` picks the new DMG up:
+
+```bash
+bash scripts/release/update-cask.sh <version>
+```
+
+The script downloads the published `Transcripted-<version>.dmg`, computes its
+sha256, and rewrites `Casks/transcripted.rb` in place. Commit that change with
+the rest of the release bookkeeping.
+
 Even after a DMG is properly signed, notarized, and stapled, users should still
 expect the normal macOS first-open confirmation for an app downloaded from the
 Internet. The healthy path is the standard one-click confirmation dialog, not a

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -27,6 +27,7 @@ not have to carry the full operational logic:
 ## Active helper scripts
 
 - `scripts/release/generate-sparkle-appcast.sh` — generate a Sparkle appcast from an updates folder and copy it into `docs/appcast.xml`
+- `scripts/release/update-cask.sh` — bump `Casks/transcripted.rb` to point at a newly published GitHub release
 - `scripts/dev/onboarding.sh` — inspect, reset, or force the first-run onboarding state while iterating on copy and layout
 
 ## Rule of thumb

--- a/scripts/release/update-cask.sh
+++ b/scripts/release/update-cask.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Update Casks/transcripted.rb to point at a published GitHub release.
+#
+# Given a version, this fetches the matching release DMG, computes its
+# sha256, and rewrites the cask's `version` and `sha256` fields in place.
+# Run it after publishing a new release so the Homebrew tap tracks the
+# latest artifact.
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: bash scripts/release/update-cask.sh <version>"
+    echo "Example: bash scripts/release/update-cask.sh 1.1.11"
+    exit 1
+fi
+
+VERSION="$1"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CASK_PATH="$REPO_ROOT/Casks/transcripted.rb"
+DMG_URL="https://github.com/r3dbars/transcripted/releases/download/v${VERSION}/Transcripted-${VERSION}.dmg"
+
+if [ ! -f "$CASK_PATH" ]; then
+    echo "Cask file not found: $CASK_PATH"
+    exit 1
+fi
+
+TMP_DMG="$(mktemp -t transcripted-cask-XXXXXX.dmg)"
+trap 'rm -f "$TMP_DMG"' EXIT
+
+echo "Fetching $DMG_URL"
+if ! curl --fail --location --silent --show-error --output "$TMP_DMG" "$DMG_URL"; then
+    echo "Failed to download release asset for v${VERSION}."
+    echo "Confirm the release was published at:"
+    echo "  https://github.com/r3dbars/transcripted/releases/tag/v${VERSION}"
+    exit 1
+fi
+
+SHA256="$(shasum -a 256 "$TMP_DMG" | awk '{print $1}')"
+echo "sha256: $SHA256"
+
+# Rewrite the first `version` and `sha256` lines in the cask block.
+python3 - "$CASK_PATH" "$VERSION" "$SHA256" <<'PY'
+import re
+import sys
+
+path, version, sha256 = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, "r", encoding="utf-8") as fh:
+    text = fh.read()
+
+text, n_version = re.subn(
+    r'(?m)^(\s*version\s+)"[^"]*"',
+    rf'\g<1>"{version}"',
+    text,
+    count=1,
+)
+text, n_sha = re.subn(
+    r'(?m)^(\s*sha256\s+)"[^"]*"',
+    rf'\g<1>"{sha256}"',
+    text,
+    count=1,
+)
+
+if n_version != 1 or n_sha != 1:
+    sys.stderr.write(
+        f"Could not locate version/sha256 lines in {path} "
+        f"(version matches={n_version}, sha256 matches={n_sha}).\n"
+    )
+    sys.exit(1)
+
+with open(path, "w", encoding="utf-8") as fh:
+    fh.write(text)
+PY
+
+echo "Updated $CASK_PATH to version $VERSION."


### PR DESCRIPTION
## Summary

Adds a Homebrew tap inside this repo so users can install Transcripted with `brew` instead of downloading the DMG manually.

- `Casks/transcripted.rb` — the cask, pinned to the current published release `v1.1.10` with the real SHA256 from the release DMG.
- `scripts/release/update-cask.sh` — run after publishing a new GitHub release; downloads the matching `Transcripted-<version>.dmg`, recomputes its sha256, and rewrites `version` + `sha256` in the cask in place.
- README gets an **Install With Homebrew** section:

  ```bash
  brew tap r3dbars/transcripted https://github.com/r3dbars/transcripted
  brew install --cask transcripted
  ```

- `docs/release-packaging.md` and `scripts/README.md` updated so the release flow documents the cask bump step.

Closes #332.

## Notes for reviewer

- The cask depends on `macos: ">= :sequoia"`. The app itself requires macOS 26 via `LSMinimumSystemVersion`, but Homebrew's symbol table may not yet recognise `:tahoe`, so this uses the newest widely-supported symbol and lets the app's own floor gate at launch. Easy to tighten later once Homebrew adds the newer symbol.
- Using the repo as its own tap (via the explicit URL form of `brew tap`) avoids needing a separate `homebrew-transcripted` repo. If you'd rather publish to a dedicated tap or to `homebrew-cask` later, this cask file drops straight into either.
- `update-cask.sh` uses only tools already available in the release environment (`curl`, `shasum`, `python3`). It will refuse to run if the release DMG isn't downloadable, so it can't silently advance the cask to a missing artifact.

## Test plan

- [ ] Locally: `brew tap r3dbars/transcripted https://github.com/r3dbars/transcripted && brew install --cask transcripted` succeeds on macOS 26
- [ ] `brew style Casks/transcripted.rb` and `brew audit --cask transcripted` pass (or expected warnings documented)
- [ ] After a future release, `bash scripts/release/update-cask.sh <new-version>` updates `version` and `sha256` correctly and nothing else