### PR TITLE
Document Homebrew release step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Rules:
 3. If you touch `Package.swift`, `Sources/TranscriptedCore/`, or the public core seam, also run `swift test`.
 4. `build.sh` must not compile `Sources/TranscriptedCore/` directly into the app target.
 
-## Releases and Sparkle
+## Releases, Sparkle, and Homebrew
 
 When the task is a user-facing release, package handoff, or update-path change,
 agents must treat Sparkle as part of the release contract, not as optional
@@ -58,13 +58,18 @@ Rules:
    - publish the signed archive where users can fetch it
    - update `docs/appcast.xml`
    - push the updated appcast to the branch that backs the live feed
-4. If Sparkle metadata was not updated, say explicitly that existing installs will not discover the new release in-app yet.
-5. If the release artifact URL, appcast URL, public key, or Sparkle tooling changes, update the docs in the same change.
-6. Keep `Info.plist` Sparkle settings aligned with the actual release feed:
+4. If the release should also be installable or upgradeable through Homebrew, the release flow must also:
+   - run `bash scripts/release/update-cask.sh <version>` after the GitHub release is published
+   - commit the updated `Casks/transcripted.rb`
+   - push that cask update so `brew install` and `brew upgrade` see the new version
+5. If Sparkle metadata was not updated, say explicitly that existing installs will not discover the new release in-app yet.
+6. If the Homebrew cask was not updated, say explicitly that `brew install` / `brew upgrade` will still point at the older release.
+7. If the release artifact URL, appcast URL, public key, Sparkle tooling, or Homebrew install path changes, update the docs in the same change.
+8. Keep `Info.plist` Sparkle settings aligned with the actual release feed:
    - `SUFeedURL`
    - `SUPublicEDKey`
    - any automatic-check / automatic-download flags
-7. Preferred release verification for Sparkle-related changes:
+9. Preferred release verification for release-path changes:
    - `bash build-deps.sh --force` when dependency tooling changes
    - `bash build.sh`
    - `bash run-tests.sh`

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -86,6 +86,10 @@ If you expect existing installs of Transcripted to discover the new version
 inside the app, do not stop after the DMG is built. You must also complete the
 Sparkle steps in `docs/sparkle-updates.md`.
 
+If you expect `brew install` or `brew upgrade` to pick up the new version, do
+not stop after the GitHub release is published. You must also refresh and push
+the Homebrew cask update.
+
 After the release is published on GitHub, refresh the Homebrew cask so `brew
 upgrade` picks the new DMG up:
 
@@ -94,8 +98,11 @@ bash scripts/release/update-cask.sh <version>
 ```
 
 The script downloads the published `Transcripted-<version>.dmg`, computes its
-sha256, and rewrites `Casks/transcripted.rb` in place. Commit that change with
-the rest of the release bookkeeping.
+sha256, and rewrites `Casks/transcripted.rb` in place. Commit and push that
+change with the rest of the release bookkeeping.
+
+If you skip this step, the GitHub release exists, but Homebrew users will still
+install or upgrade to the older version.
 
 Even after a DMG is properly signed, notarized, and stapled, users should still
 expect the normal macOS first-open confirmation for an app downloaded from the


### PR DESCRIPTION
## Summary
- make Homebrew part of the release contract in AGENTS
- make the release doc say plainly that skipping the cask update leaves brew users on the old version

## Test plan
- docs only
