### PR TITLE
[codex] Harden release dependency safety

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -296,19 +296,33 @@ final class MeetingSessionController: ObservableObject {
             microphoneGranted: microphoneGranted,
             systemAudioRecordingGranted: systemAudioRecordingGranted
         )
+        let shouldRevalidateCachedSystemAudioPermission = microphoneGranted && systemAudioRecordingGranted
+        let shouldRequestMissingSystemAudioPermission =
+            microphoneGranted &&
+            !startDecision.canStart &&
+            startDecision.failureReason == "system_audio_recording"
 
-        if !startDecision.canStart,
-           startDecision.failureReason == "system_audio_recording",
-           microphoneGranted
-        {
+        if shouldRevalidateCachedSystemAudioPermission || shouldRequestMissingSystemAudioPermission {
+            let permissionCheckMode = shouldRevalidateCachedSystemAudioPermission ? "revalidation" : "request"
             DiagnosticsTrail.record(
                 engine: "meeting",
-                event: "meeting_start_requesting_system_audio_permission",
-                message: "Meeting start is requesting system audio permission",
-                context: baseDiagnosticsContext(extra: ["trigger": trigger.rawValue])
+                event: shouldRevalidateCachedSystemAudioPermission
+                    ? "meeting_start_revalidating_system_audio_permission"
+                    : "meeting_start_requesting_system_audio_permission",
+                message: shouldRevalidateCachedSystemAudioPermission
+                    ? "Meeting start is revalidating cached system audio permission"
+                    : "Meeting start is requesting system audio permission",
+                context: baseDiagnosticsContext(
+                    extra: [
+                        "trigger": trigger.rawValue,
+                        "permission_check": permissionCheckMode
+                    ]
+                )
             )
 
-            systemAudioRecordingGranted = await TranscriptedPermissionAccess.requestSystemAudioRecordingAccessIfNeeded()
+            systemAudioRecordingGranted = await TranscriptedPermissionAccess.requestSystemAudioRecordingAccessIfNeeded(
+                forceRefresh: shouldRevalidateCachedSystemAudioPermission
+            )
             startDecision = MeetingRecordingStartGate.evaluate(
                 microphoneGranted: microphoneGranted,
                 systemAudioRecordingGranted: systemAudioRecordingGranted
@@ -323,7 +337,12 @@ final class MeetingSessionController: ObservableObject {
                 message: systemAudioRecordingGranted
                     ? "System audio permission is ready for meeting capture"
                     : "System audio permission is still missing for meeting capture",
-                context: baseDiagnosticsContext(extra: ["trigger": trigger.rawValue])
+                context: baseDiagnosticsContext(
+                    extra: [
+                        "trigger": trigger.rawValue,
+                        "permission_check": permissionCheckMode
+                    ]
+                )
             )
         }
 

--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -249,8 +249,8 @@ enum TranscriptedPermissionAccess {
     }
 
     @MainActor
-    static func requestSystemAudioRecordingAccessIfNeeded() async -> Bool {
-        if systemAudioRecordingStatus() == .granted {
+    static func requestSystemAudioRecordingAccessIfNeeded(forceRefresh: Bool = false) async -> Bool {
+        if !forceRefresh, systemAudioRecordingStatus() == .granted {
             return true
         }
 
@@ -262,9 +262,10 @@ enum TranscriptedPermissionAccess {
 
     @MainActor
     static func requestSystemAudioRecordingAccessIfNeeded(
+        forceRefresh: Bool = false,
         requester: @escaping @MainActor () async -> Bool
     ) async -> Bool {
-        if systemAudioRecordingStatus() == .granted {
+        if !forceRefresh, systemAudioRecordingStatus() == .granted {
             return true
         }
 

--- a/Tests/TranscriptedPermissionAccessTests.swift
+++ b/Tests/TranscriptedPermissionAccessTests.swift
@@ -99,6 +99,38 @@ func testTranscriptedPermissionAccess() async {
         assertEqual(requestBox.callCount, 0, "known granted permission should not trigger another request")
     }
 
+    await runSuite("TranscriptedPermissionAccess.requestSystemAudioRecordingAccessIfNeeded(forceRefresh:) — rechecks cached grants before meeting start") {
+        let originalKnown = UserDefaults.standard.object(forKey: knownKey)
+        let originalGranted = UserDefaults.standard.object(forKey: grantedKey)
+        let originalOnboarding = UserDefaults.standard.object(forKey: onboardingKey)
+        defer {
+            restore(originalKnown, forKey: knownKey)
+            restore(originalGranted, forKey: grantedKey)
+            restore(originalOnboarding, forKey: onboardingKey)
+        }
+
+        UserDefaults.standard.set(true, forKey: knownKey)
+        UserDefaults.standard.set(true, forKey: grantedKey)
+        UserDefaults.standard.set(true, forKey: onboardingKey)
+
+        let requestBox = PermissionRequestBox()
+        let granted = await TranscriptedPermissionAccess.requestSystemAudioRecordingAccessIfNeeded(forceRefresh: true) {
+            requestBox.callCount += 1
+            return false
+        }
+
+        assertFalse(granted, "a forced recheck should surface revoked system audio permission")
+        assertEqual(requestBox.callCount, 1, "meeting start should bypass the cached grant and perform a real recheck")
+        assertTrue(
+            UserDefaults.standard.bool(forKey: knownKey),
+            "forced rechecks should keep the permission state marked as known"
+        )
+        assertFalse(
+            UserDefaults.standard.bool(forKey: grantedKey),
+            "a failed forced recheck should clear the cached granted state"
+        )
+    }
+
     runSuite("TranscriptedPermissionKind action titles — name the real recovery path for blocked permissions") {
         assertEqual(
             TranscriptedPermissionKind.microphoneActionTitle(for: .notDetermined),

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -22,6 +22,9 @@ depend on `create-dmg` being present just to avoid a blank DMG.
 `build-beta.sh` also treats the per-user beta token as sensitive build input:
 it escapes the token before injecting it into `Sources/Beta/BetaConfig.swift`
 and only prints a masked preview in build logs.
+The packaged release archive is still versioned from `Info.plist`, so published
+artifacts keep the stable `Transcripted-<version>.dmg` name expected by Sparkle
+and Homebrew even when the embedded beta token is per-user.
 
 Transcripted's Sparkle update plumbing is documented in `docs/sparkle-updates.md`.
 `build-deps.sh` now downloads the pinned Sparkle framework and release tools,
@@ -33,9 +36,10 @@ The two build flows intentionally use separate committed entitlement files:
 - `config/entitlements/local.plist`
 - `config/entitlements/beta.plist`
 
-`build.sh` now fails before it touches signing when the unified dependency
-artifacts are missing or stale, and it also requires the app binary to exist
-before signature validation runs.
+`build.sh` and `build-beta.sh` now fail before they touch signing when the
+unified dependency artifacts are missing or older than the current
+`Sources/TranscriptedCore/`, `Package.swift`, or `build-deps.sh` inputs. They
+also require the app binary to exist before signature validation runs.
 
 ## Prerequisites
 

--- a/scripts/entrypoints/build-beta.sh
+++ b/scripts/entrypoints/build-beta.sh
@@ -11,6 +11,12 @@
 
 set -euo pipefail
 
+plist_value() {
+    local plist_path="$1"
+    local key="$2"
+    /usr/libexec/PlistBuddy -c "Print :$key" "$plist_path" 2>/dev/null || true
+}
+
 ENTRYPOINT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$ENTRYPOINT_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
@@ -19,10 +25,16 @@ BETA_TOKEN="${1:-}"
 USER_NAME="${2:-beta}"
 SKIP_NOTARIZATION="${SKIP_NOTARIZATION:-0}"
 REQUIRE_BUNDLED_PARAKEET_MODELS="${REQUIRE_BUNDLED_PARAKEET_MODELS:-1}"
+APP_VERSION="$(plist_value Info.plist CFBundleShortVersionString)"
 
 if [ -z "$BETA_TOKEN" ]; then
     echo "Usage: ./build-beta.sh <beta-token> <user-name>"
     echo "Example: ./build-beta.sh transcripted-beta-nate Nate"
+    exit 1
+fi
+
+if [ -z "$APP_VERSION" ]; then
+    echo "❌ Could not read CFBundleShortVersionString from Info.plist"
     exit 1
 fi
 
@@ -31,7 +43,7 @@ BUILD_DIR="build"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 APP_BINARY="$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 STAGED_APP_BINARY="$BUILD_DIR/$APP_NAME-beta-bin"
-DMG_NAME="Transcripted-${USER_NAME}.dmg"
+DMG_NAME="Transcripted-${APP_VERSION}.dmg"
 DMG_VOLUME_NAME="Install Transcripted"
 DMG_WINDOW_WIDTH=720
 DMG_WINDOW_HEIGHT=460
@@ -42,11 +54,33 @@ NOTARY_PROFILE="${NOTARY_PROFILE:-}"
 BETA_CONFIG_PATH="Sources/Beta/BetaConfig.swift"
 BETA_CONFIG_BACKUP="$(mktemp -t transcripted-beta-config)"
 BETA_ENTITLEMENTS="config/entitlements/beta.plist"
+DEPS_BUILD_STAMP="deps-libs/.build-deps-stamp"
 DEPS_FRAMEWORK_ROOT="deps-frameworks"
 ESPEAK_FRAMEWORK="$DEPS_FRAMEWORK_ROOT/ESpeakNG.framework"
 SENTRY_FRAMEWORK="$DEPS_FRAMEWORK_ROOT/Sentry.framework"
 SPARKLE_FRAMEWORK="$DEPS_FRAMEWORK_ROOT/Sparkle.framework"
 TRANSCRIPTED_CORE_MODULE="deps-modules/TranscriptedCore.swiftmodule/arm64-apple-macos.swiftmodule"
+
+dependency_input_listing() {
+    {
+        printf '%s\n' "Package.swift"
+        printf '%s\n' "scripts/entrypoints/build-deps.sh"
+        find "Sources/TranscriptedCore" -type f ! -name "CLAUDE.md"
+    } | while IFS= read -r path; do
+        [ -e "$path" ] || continue
+        printf '%s\t%s\n' "$(stat -f '%m' "$path")" "$path"
+    done
+}
+
+newest_dependency_input() {
+    dependency_input_listing | sort -nr | head -1
+}
+
+deps_build_stamp_info() {
+    if [ -f "$DEPS_BUILD_STAMP" ]; then
+        printf '%s\t%s\n' "$(stat -f '%m' "$DEPS_BUILD_STAMP")" "$DEPS_BUILD_STAMP"
+    fi
+}
 
 mask_secret() {
     local value="$1"
@@ -278,12 +312,26 @@ if [ ! -f "$BETA_ENTITLEMENTS" ]; then
     exit 1
 fi
 
-if [ ! -f "deps-libs/libDraftDeps.a" ] || [ ! -d "deps-modules" ] || [ ! -f "$TRANSCRIPTED_CORE_MODULE" ] || [ ! -d "$ESPEAK_FRAMEWORK" ] || [ ! -d "$SENTRY_FRAMEWORK" ] || [ ! -d "$SPARKLE_FRAMEWORK" ]; then
+if [ ! -f "deps-libs/libDraftDeps.a" ] || [ ! -f "$DEPS_BUILD_STAMP" ] || [ ! -d "deps-modules" ] || [ ! -f "$TRANSCRIPTED_CORE_MODULE" ] || [ ! -d "$ESPEAK_FRAMEWORK" ] || [ ! -d "$SENTRY_FRAMEWORK" ] || [ ! -d "$SPARKLE_FRAMEWORK" ]; then
     echo "❌ Dependencies missing or stale — required for beta builds"
+    echo "   Missing stamp: $DEPS_BUILD_STAMP"
     echo "   Missing module: $TRANSCRIPTED_CORE_MODULE"
     echo "   Missing framework: $ESPEAK_FRAMEWORK"
     echo "   Missing framework: $SENTRY_FRAMEWORK"
     echo "   Missing framework: $SPARKLE_FRAMEWORK"
+    echo "   Run build-deps.sh --force first to rebuild dependencies."
+    exit 1
+fi
+
+newest_input="$(newest_dependency_input)"
+build_stamp="$(deps_build_stamp_info)"
+IFS=$'\t' read -r newest_input_mtime newest_input_path <<< "$newest_input"
+IFS=$'\t' read -r build_stamp_mtime build_stamp_path <<< "$build_stamp"
+
+if [ -n "${newest_input_mtime:-}" ] && [ -n "${build_stamp_mtime:-}" ] && [ "$newest_input_mtime" -gt "$build_stamp_mtime" ]; then
+    echo "❌ Dependencies are stale for TranscriptedCore."
+    echo "   Newest input: $newest_input_path"
+    echo "   Built deps stamp: $build_stamp_path"
     echo "   Run build-deps.sh --force first to rebuild dependencies."
     exit 1
 fi

--- a/scripts/entrypoints/build-deps.sh
+++ b/scripts/entrypoints/build-deps.sh
@@ -17,6 +17,7 @@ if [ -z "$TMP_ROOT" ]; then
 fi
 DEPS_BUILD="$(mktemp -d "$TMP_ROOT/transcripted-deps-build.XXXXXX")"
 DEPS_LIBS="$DRAFT_DIR/deps-libs"
+DEPS_BUILD_STAMP="$DEPS_LIBS/.build-deps-stamp"
 DEPS_MODULES="$DRAFT_DIR/deps-modules"
 DEPS_FRAMEWORKS="$DRAFT_DIR/deps-frameworks"
 DEPS_TOOLS="$DRAFT_DIR/deps-tools"
@@ -25,6 +26,23 @@ MLX_SWIFT_LM_REVISION="${MLX_SWIFT_LM_REVISION:-25b00d4}"
 SWIFT_TRANSFORMERS_VERSION="${SWIFT_TRANSFORMERS_VERSION:-1.2.1}"
 SPARKLE_VERSION="${SPARKLE_VERSION:-2.9.1}"
 SENTRY_COCOA_VERSION="${SENTRY_COCOA_VERSION:-9.10.0}"
+SPARKLE_SHA256="${SPARKLE_SHA256:-9fec2b888e6e2940b1bfbd5d3d010b9f67076b52170923549095cbb74132403b}"
+SENTRY_COCOA_SHA256="${SENTRY_COCOA_SHA256:-1dd70512f3b5af6c74f1b8f11279531900173fb638d7d541320a7cbc00ed06bc}"
+
+verify_download_sha256() {
+    local downloaded_file="$1"
+    local expected_sha256="$2"
+    local label="$3"
+    local actual_sha256
+
+    actual_sha256="$(shasum -a 256 "$downloaded_file" | awk '{print $1}')"
+    if [ "$actual_sha256" != "$expected_sha256" ]; then
+        echo "[build-deps] ERROR: SHA-256 mismatch for $label"
+        echo "[build-deps]   expected: $expected_sha256"
+        echo "[build-deps]   actual:   $actual_sha256"
+        exit 1
+    fi
+}
 
 download_sparkle_distribution() {
     local sparkle_root="$DEPS_BUILD/sparkle"
@@ -36,6 +54,7 @@ download_sparkle_distribution() {
     echo "Downloading Sparkle $SPARKLE_VERSION..."
     mkdir -p "$sparkle_root"
     curl --fail --location --silent --show-error "$sparkle_url" -o "$sparkle_zip"
+    verify_download_sha256 "$sparkle_zip" "$SPARKLE_SHA256" "Sparkle $SPARKLE_VERSION"
     unzip -q "$sparkle_zip" -d "$unpacked_root"
 
     if [ ! -d "$framework_src" ]; then
@@ -66,6 +85,7 @@ download_sentry_distribution() {
     echo "Downloading Sentry Cocoa $SENTRY_COCOA_VERSION..."
     mkdir -p "$sentry_root"
     curl --fail --location --silent --show-error "$sentry_url" -o "$sentry_zip"
+    verify_download_sha256 "$sentry_zip" "$SENTRY_COCOA_SHA256" "Sentry Cocoa $SENTRY_COCOA_VERSION"
     unzip -q "$sentry_zip" -d "$unpacked_root"
 
     if [ ! -d "$framework_src" ]; then
@@ -193,10 +213,11 @@ echo "[build-deps] Using TranscriptedCore from: $TRANSCRIPTED_ROOT"
 # Skip if already built (use --force to rebuild).
 # libExternalDeps.a was added later for SPM-based `swift test`, so require it too;
 # otherwise legacy worktrees would keep skipping while missing the archive.
-if [ -f "$DEPS_LIBS/libDraftDeps.a" ] && [ -f "$DEPS_LIBS/libExternalDeps.a" ] && [ -d "$DEPS_MODULES" ] && [ -d "$DEPS_FRAMEWORKS/ESpeakNG.framework" ] && [ -d "$DEPS_FRAMEWORKS/Sentry.framework" ] && [ -d "$DEPS_FRAMEWORKS/Sparkle.framework" ] && [ -x "$DEPS_TOOLS/sparkle/bin/generate_appcast" ] && [ "${1:-}" != "--force" ]; then
+if [ -f "$DEPS_LIBS/libDraftDeps.a" ] && [ -f "$DEPS_LIBS/libExternalDeps.a" ] && [ -f "$DEPS_BUILD_STAMP" ] && [ -d "$DEPS_MODULES" ] && [ -d "$DEPS_FRAMEWORKS/ESpeakNG.framework" ] && [ -d "$DEPS_FRAMEWORKS/Sentry.framework" ] && [ -d "$DEPS_FRAMEWORKS/Sparkle.framework" ] && [ -x "$DEPS_TOOLS/sparkle/bin/generate_appcast" ] && [ "${1:-}" != "--force" ]; then
     echo "Dependencies already built. Use --force to rebuild."
     echo "  libs:    $DEPS_LIBS/libDraftDeps.a"
     echo "           $DEPS_LIBS/libExternalDeps.a"
+    echo "  stamp:   $DEPS_BUILD_STAMP"
     echo "  modules: $DEPS_MODULES/"
     echo "  frameworks: $DEPS_FRAMEWORKS/ESpeakNG.framework"
     echo "              $DEPS_FRAMEWORKS/Sentry.framework"
@@ -452,6 +473,8 @@ if [ -n "$CMLX_SRC" ]; then
 else
     echo "  WARNING: Cmlx source not found — cannot compile Metal shaders"
 fi
+
+touch "$DEPS_BUILD_STAMP"
 
 echo ""
 echo "=== Results ==="

--- a/scripts/entrypoints/build.sh
+++ b/scripts/entrypoints/build.sh
@@ -15,12 +15,34 @@ STAGED_APP_BINARY="$BUILD_DIR/$APP_NAME-bin"
 LOCAL_ENTITLEMENTS="config/entitlements/local.plist"
 SIGN_IDENTITY="${SIGN_IDENTITY:-${SIGNING_IDENTITY:-}}"
 DEPS_ARCHIVE="deps-libs/libDraftDeps.a"
+DEPS_BUILD_STAMP="deps-libs/.build-deps-stamp"
 DEPS_MODULE_ROOT="deps-modules"
 DEPS_FRAMEWORK_ROOT="deps-frameworks"
 ESPEAK_FRAMEWORK="$DEPS_FRAMEWORK_ROOT/ESpeakNG.framework"
 SENTRY_FRAMEWORK="$DEPS_FRAMEWORK_ROOT/Sentry.framework"
 SPARKLE_FRAMEWORK="$DEPS_FRAMEWORK_ROOT/Sparkle.framework"
 TRANSCRIPTED_CORE_MODULE="$DEPS_MODULE_ROOT/TranscriptedCore.swiftmodule/arm64-apple-macos.swiftmodule"
+
+dependency_input_listing() {
+    {
+        printf '%s\n' "Package.swift"
+        printf '%s\n' "scripts/entrypoints/build-deps.sh"
+        find "Sources/TranscriptedCore" -type f ! -name "CLAUDE.md"
+    } | while IFS= read -r path; do
+        [ -e "$path" ] || continue
+        printf '%s\t%s\n' "$(stat -f '%m' "$path")" "$path"
+    done
+}
+
+newest_dependency_input() {
+    dependency_input_listing | sort -nr | head -1
+}
+
+deps_build_stamp_info() {
+    if [ -f "$DEPS_BUILD_STAMP" ]; then
+        printf '%s\t%s\n' "$(stat -f '%m' "$DEPS_BUILD_STAMP")" "$DEPS_BUILD_STAMP"
+    fi
+}
 
 ensure_build_prerequisites() {
     if [ ! -f "$LOCAL_ENTITLEMENTS" ]; then
@@ -30,13 +52,38 @@ ensure_build_prerequisites() {
 }
 
 ensure_deps_ready() {
-    if [ -f "$DEPS_ARCHIVE" ] && [ -d "$DEPS_MODULE_ROOT" ] && [ -f "$TRANSCRIPTED_CORE_MODULE" ] && [ -d "$ESPEAK_FRAMEWORK" ] && [ -d "$SENTRY_FRAMEWORK" ] && [ -d "$SPARKLE_FRAMEWORK" ]; then
+    local newest_input
+    local build_stamp
+    local newest_input_mtime
+    local newest_input_path
+    local build_stamp_mtime
+    local build_stamp_path
+
+    if [ -f "$DEPS_ARCHIVE" ] && [ -f "$DEPS_BUILD_STAMP" ] && [ -d "$DEPS_MODULE_ROOT" ] && [ -f "$TRANSCRIPTED_CORE_MODULE" ] && [ -d "$ESPEAK_FRAMEWORK" ] && [ -d "$SENTRY_FRAMEWORK" ] && [ -d "$SPARKLE_FRAMEWORK" ]; then
+        newest_input="$(newest_dependency_input)"
+        build_stamp="$(deps_build_stamp_info)"
+
+        IFS=$'\t' read -r newest_input_mtime newest_input_path <<< "$newest_input"
+        IFS=$'\t' read -r build_stamp_mtime build_stamp_path <<< "$build_stamp"
+
+        if [ -n "$newest_input_mtime" ] && [ -n "$build_stamp_mtime" ] && [ "$newest_input_mtime" -gt "$build_stamp_mtime" ]; then
+            echo "Dependencies are stale for TranscriptedCore."
+            echo "Newest input:"
+            echo "  $newest_input_path"
+            echo "Built deps stamp:"
+            echo "  $build_stamp_path"
+            echo ""
+            echo "Run: bash build-deps.sh --force"
+            exit 1
+        fi
+
         return 0
     fi
 
     echo "Dependencies missing or stale for TranscriptedCore."
     echo "Expected:"
     echo "  $DEPS_ARCHIVE"
+    echo "  $DEPS_BUILD_STAMP"
     echo "  $DEPS_MODULE_ROOT/"
     echo "  $TRANSCRIPTED_CORE_MODULE"
     echo "  $ESPEAK_FRAMEWORK"


### PR DESCRIPTION
## Summary
- fail `build.sh` and `build-beta.sh` when cached TranscriptedCore deps are older than the current core inputs, using a dedicated deps build stamp
- restore version-based beta DMG naming from `Info.plist` so release artifacts match the Sparkle/Homebrew contract
- revalidate cached system-audio permission before meeting start so revoked access falls back into the guided permission flow
- verify downloaded Sparkle and Sentry release zips with pinned SHA-256 values before unpacking, and update docs/tests for the new behavior

## Why
The release path could previously ship stale core code, produce beta DMGs with names the updater could not find, trust revoked system-audio permission state, and sign framework downloads without validating integrity first.

## Impact
These changes make release packaging safer, keep updater-facing artifact naming consistent, and improve permission recovery for meeting capture.

## Validation
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `swift test`
- `SKIP_NOTARIZATION=1 bash build-beta.sh transcripted-beta-review CodexReview`
