### PR TITLE
Fix startup hangs from storage and audio setup

### DIFF
--- a/Sources/Observability/AppLogger.swift
+++ b/Sources/Observability/AppLogger.swift
@@ -14,6 +14,7 @@ private actor AppLogFileWriter {
         closeHandle()
 
         let fm = FileManager.default
+        try? fm.createPrivateDirectory(at: URL(fileURLWithPath: path).deletingLastPathComponent())
         if fm.fileExists(atPath: path) {
             do {
                 let attrs = try fm.attributesOfItem(atPath: path)
@@ -69,7 +70,7 @@ private actor AppLogFileWriter {
 class AppLogger: ObservableObject {
     @Published var entries: [String] = []
 
-    private let logFilePath = FileManager.default.transcriptedLogsDir
+    private let logFilePath = FileManager.default.transcriptedLogsDirURL
         .appendingPathComponent("debug.log", isDirectory: false)
         .path
     private let fileWriter = AppLogFileWriter()

--- a/Sources/Observability/EventReporter.swift
+++ b/Sources/Observability/EventReporter.swift
@@ -37,18 +37,19 @@ private actor EventFileWriter {
     }()
 
     init() {
-        let storageDir = FileManager.default.transcriptedLogsDir
+        let storageDir = FileManager.default.transcriptedLogsDirURL
         fileURL = storageDir.appendingPathComponent("events.jsonl")
+    }
 
-        // Ensure directory exists
+    func append(_ event: ObservabilityEvent) {
+        let storageDir = fileURL.deletingLastPathComponent()
         do {
             try FileManager.default.createPrivateDirectory(at: storageDir)
         } catch {
             fputs("⚠️ EVENT | failed to create directory \(storageDir.path): \(error.localizedDescription)\n", stderr)
+            return
         }
-    }
 
-    func append(_ event: ObservabilityEvent) {
         let data: Data
         do {
             data = try encoder.encode(event)

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -199,10 +199,16 @@ class ParakeetEngine: ObservableObject {
     private var audioWatchdogTask: Task<Void, Never>?
     private var asrManagerReady = false
     private nonisolated(unsafe) var didReceiveAudioSamples = false
+    private var cachedInputDeviceName = "Unknown"
 
     var isModelLoaded: Bool { asrManagerReady }
+    var inputDeviceName: String { cachedInputDeviceName }
 
-    var inputDeviceName: String {
+    init() {
+        scheduleInputDeviceNameRefresh()
+    }
+
+    nonisolated private static func loadInputDeviceName() -> String {
         do {
             return try CoreAudioInputDeviceLookup.defaultInputDeviceName()
         } catch {
@@ -210,11 +216,37 @@ class ParakeetEngine: ObservableObject {
         }
     }
 
+    private func scheduleInputDeviceNameRefresh() {
+        Task.detached(priority: .utility) { [weak self] in
+            let deviceName = Self.loadInputDeviceName()
+            await self?.updateCachedInputDeviceName(deviceName)
+        }
+    }
+
+    private func updateCachedInputDeviceName(_ deviceName: String) {
+        cachedInputDeviceName = deviceName
+    }
+
+    private func handleDefaultInputDeviceChange(deviceName: String) {
+        cachedInputDeviceName = deviceName
+        print("🎤 PARAKEET | default input changed → \(deviceName)")
+        EventReporter.shared.capture(
+            level: .info,
+            engine: "parakeet",
+            event: "default_input_device_changed",
+            message: "Default input device changed",
+            context: ["audio_device": deviceName]
+        )
+        handleAudioConfigChange()
+    }
+
     // MARK: - Model Initialization
 
     /// Load Parakeet models from the app bundle (preferred) or download from HuggingFace (fallback).
     /// Bundle path: Contents/Resources/parakeet-models/parakeet-tdt-0.6b-v3-coreml/
     func initialize() async {
+        scheduleInputDeviceNameRefresh()
+
         guard asrManager == nil else {
             EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "already_initialized",
                 message: "initialize() called but ASR manager already exists — ignoring")
@@ -395,6 +427,7 @@ class ParakeetEngine: ObservableObject {
     func prewarm() {
         guard !isEnginePrewarmed, !isRecording else { return }
         installAudioObserversIfNeeded()
+        scheduleInputDeviceNameRefresh()
 
         let microphoneStatus = AVCaptureDevice.authorizationStatus(for: .audio)
         switch ParakeetPrewarmPolicy.decision(for: microphoneStatus) {
@@ -516,17 +549,9 @@ class ParakeetEngine: ObservableObject {
         )
 
         let listener: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
-            Task { @MainActor [weak self] in
-                guard let self = self else { return }
-                print("🎤 PARAKEET | default input changed → \(self.inputDeviceName)")
-                EventReporter.shared.capture(
-                    level: .info,
-                    engine: "parakeet",
-                    event: "default_input_device_changed",
-                    message: "Default input device changed",
-                    context: ["audio_device": self.inputDeviceName]
-                )
-                self.handleAudioConfigChange()
+            Task.detached(priority: .utility) { [weak self] in
+                let deviceName = Self.loadInputDeviceName()
+                await self?.handleDefaultInputDeviceChange(deviceName: deviceName)
             }
         }
 
@@ -758,6 +783,7 @@ class ParakeetEngine: ObservableObject {
 
     func startRecording(isRecoveryAttempt: Bool = false) -> Bool {
         guard !isRecording else { return true }
+        scheduleInputDeviceNameRefresh()
         let micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
         guard micStatus == .authorized else {
             EventReporter.shared.capture(level: .error, engine: "parakeet", event: "mic_not_authorized",

--- a/Sources/Support/TranscriptedStoragePaths.swift
+++ b/Sources/Support/TranscriptedStoragePaths.swift
@@ -34,8 +34,33 @@ extension FileManager {
             ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
     }
 
+    var transcriptedAppSupportRootURL: URL {
+        userApplicationSupportDir.appendingPathComponent("Transcripted", isDirectory: true)
+    }
+
+    var transcriptedLogsDirURL: URL {
+        transcriptedAppSupportRootURL.appendingPathComponent("logs", isDirectory: true)
+    }
+
     private func logDirectoryCreationFailure(context: String, url: URL, error: Error) {
         fputs("⚠️ STORAGE | failed to create \(context) at \(url.path): \(error.localizedDescription)\n", stderr)
+    }
+
+    private func ensuredPrivateDirectory(at url: URL, context: String) -> URL {
+        ensurePrivateDirectory(at: url, context: context)
+        return url
+    }
+
+    private func setPOSIXPermissionsIfNeeded(_ permissions: NSNumber, ofItemAtPath path: String) {
+        guard fileExists(atPath: path) else { return }
+
+        if let attributes = try? attributesOfItem(atPath: path),
+           let currentPermissions = attributes[.posixPermissions] as? NSNumber,
+           currentPermissions == permissions {
+            return
+        }
+
+        try? setAttributes([.posixPermissions: permissions], ofItemAtPath: path)
     }
 
     func ensurePrivateDirectory(at url: URL, context: String) {
@@ -48,32 +73,7 @@ extension FileManager {
 
     /// App-owned Transcripted root.
     var transcriptedAppSupportDir: URL {
-        let url = userApplicationSupportDir.appendingPathComponent("Transcripted", isDirectory: true)
-        let captures = url.appendingPathComponent("captures", isDirectory: true)
-        let meetings = captures.appendingPathComponent("meetings", isDirectory: true)
-        let dictations = captures.appendingPathComponent("dictations", isDirectory: true)
-        let state = url.appendingPathComponent("state", isDirectory: true)
-        let cache = url.appendingPathComponent("cache", isDirectory: true)
-        let logs = url.appendingPathComponent("logs", isDirectory: true)
-        let tmp = url.appendingPathComponent("tmp", isDirectory: true)
-        let recordings = tmp.appendingPathComponent("recordings", isDirectory: true)
-
-        let directories: [(URL, String)] = [
-            (url, "Transcripted app support root"),
-            (captures, "Transcripted capture library parent"),
-            (meetings, "Transcripted meeting captures"),
-            (dictations, "Transcripted dictation captures"),
-            (state, "Transcripted state"),
-            (cache, "Transcripted cache"),
-            (logs, "Transcripted logs"),
-            (tmp, "Transcripted tmp"),
-            (recordings, "Transcripted temporary recordings"),
-        ]
-
-        for (directory, context) in directories {
-            ensurePrivateDirectory(at: directory, context: context)
-        }
-        return url
+        ensuredPrivateDirectory(at: transcriptedAppSupportRootURL, context: "Transcripted app support root")
     }
 
     /// Historic Draft compatibility root, retained only for migration / cleanup flows.
@@ -82,33 +82,37 @@ extension FileManager {
     }
 
     var transcriptedDefaultCaptureLibraryDir: URL {
-        transcriptedAppSupportDir.appendingPathComponent("captures", isDirectory: true)
+        let url = transcriptedAppSupportDir.appendingPathComponent("captures", isDirectory: true)
+        return ensuredPrivateDirectory(at: url, context: "Transcripted capture library parent")
     }
 
     var transcriptedCaptureLibraryDir: URL {
         let url = TranscriptedStoragePreferences.captureLibraryURL(fileManager: self)
-        ensurePrivateDirectory(at: url, context: "Transcripted capture library")
-        return url
+        return ensuredPrivateDirectory(at: url, context: "Transcripted capture library")
     }
 
     var transcriptedStateDir: URL {
-        transcriptedAppSupportDir.appendingPathComponent("state", isDirectory: true)
+        let url = transcriptedAppSupportDir.appendingPathComponent("state", isDirectory: true)
+        return ensuredPrivateDirectory(at: url, context: "Transcripted state")
     }
 
     var transcriptedCacheDir: URL {
-        transcriptedAppSupportDir.appendingPathComponent("cache", isDirectory: true)
+        let url = transcriptedAppSupportDir.appendingPathComponent("cache", isDirectory: true)
+        return ensuredPrivateDirectory(at: url, context: "Transcripted cache")
     }
 
     var transcriptedLogsDir: URL {
-        transcriptedAppSupportDir.appendingPathComponent("logs", isDirectory: true)
+        ensuredPrivateDirectory(at: transcriptedLogsDirURL, context: "Transcripted logs")
     }
 
     var transcriptedTemporaryDir: URL {
-        transcriptedAppSupportDir.appendingPathComponent("tmp", isDirectory: true)
+        let url = transcriptedAppSupportDir.appendingPathComponent("tmp", isDirectory: true)
+        return ensuredPrivateDirectory(at: url, context: "Transcripted tmp")
     }
 
     var transcriptedRecordingsDir: URL {
-        transcriptedTemporaryDir.appendingPathComponent("recordings", isDirectory: true)
+        let url = transcriptedTemporaryDir.appendingPathComponent("recordings", isDirectory: true)
+        return ensuredPrivateDirectory(at: url, context: "Transcripted temporary recordings")
     }
 
     /// <capture-library>/meetings/
@@ -123,18 +127,17 @@ extension FileManager {
 
     private func transcriptedCaptureLibrarySubdirectory(_ name: String) -> URL {
         let url = transcriptedCaptureLibraryDir.appendingPathComponent(name, isDirectory: true)
-        ensurePrivateDirectory(at: url, context: "Transcripted \(name) folder")
-        return url
+        return ensuredPrivateDirectory(at: url, context: "Transcripted \(name) folder")
     }
 
     /// Create a directory and tighten it to owner-only access (0700).
     func createPrivateDirectory(at url: URL) throws {
         try createDirectory(at: url, withIntermediateDirectories: true)
-        try? setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+        setPOSIXPermissionsIfNeeded(NSNumber(value: 0o700), ofItemAtPath: url.path)
     }
 
     /// Tighten a file to owner-only access (0600).
     func restrictFileToOwnerOnly(at url: URL) {
-        try? setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        setPOSIXPermissionsIfNeeded(NSNumber(value: 0o600), ofItemAtPath: url.path)
     }
 }

--- a/Tests/TranscriptedStoragePathsTests.swift
+++ b/Tests/TranscriptedStoragePathsTests.swift
@@ -40,6 +40,32 @@ func testTranscriptedStoragePaths() {
         )
     }
 
+    runSuite("FileManager.restrictFileToOwnerOnly — tightens existing files to owner-only") {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedStoragePathsTests-file-\(UUID().uuidString).txt", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        FileManager.default.createFile(
+            atPath: file.path,
+            contents: Data("hello".utf8),
+            attributes: [.posixPermissions: 0o644]
+        )
+
+        assertEqual(
+            permissions(of: file),
+            NSNumber(value: 0o644),
+            "test setup should start from a broader file permission"
+        )
+
+        FileManager.default.restrictFileToOwnerOnly(at: file)
+
+        assertEqual(
+            permissions(of: file),
+            NSNumber(value: 0o600),
+            "owner-only file helper should tighten permissions to 0600"
+        )
+    }
+
     runSuite("Transcripted capture library helpers — custom capture folders stay owner-only") {
         let original = UserDefaults.standard.object(forKey: TranscriptedStoragePreferences.captureLibraryLocationKey)
         defer {


### PR DESCRIPTION
## Summary
- avoid repeated startup directory chmod work by only ensuring the specific storage path being used
- defer app-side log/event log directory creation until the writer actually needs it
- stop doing synchronous main-thread CoreAudio device-name lookups by caching and refreshing the input device name off the main actor
- add a fast test for owner-only file permission tightening

## Verification
- `bash run-tests.sh`
- `bash build.sh`
- post-merge sanity: `bash run-tests.sh` on `main`