### PR TITLE
[codex] add imported audio transcription flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ your agent at the folder later.
 
 - Clean meeting notes with speaker names
 - Dictation notes for your follow-up thoughts
+- Import audio files you already have on your Mac
 - Plain Markdown files on disk
 - Files you can hand to your agent later
 - Local-first storage you can inspect yourself
@@ -22,7 +23,7 @@ your agent at the folder later.
 ## How To Get Started
 
 1. Download Transcripted from the latest GitHub release.
-2. Record a meeting or capture a dictation on your Mac.
+2. Record a meeting, capture a dictation, or import an audio file you already have.
 3. Open the saved Markdown files yourself, or point your agent at the folder.
 
 ### Install With Homebrew

--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -10,6 +10,7 @@
 - `MeetingCaptureBridge.swift` — `@MainActor` wrapper around core `Audio`, converts callback-based stop into `async`
 - `MeetingFailureCopy.swift` — normalizes `MeetingFailureKind` values into user-facing titles and recovery copy
 - `MeetingFailureKind.swift` — canonical failure taxonomy that classifies raw meeting errors into stable machine-readable kinds
+- `MeetingImportedAudioPreparer.swift` — copies user-selected audio files into app-owned scratch space before import transcription
 - `MeetingModelDownloader.swift` — loads Parakeet and diarization models together
 - `MeetingPromptDetector.swift` — polls upcoming Calendar events, watches supported meeting apps, and asks the overlay to offer one-tap recording prompts
 - `MeetingPromptHeuristics.swift` — shared scoring and snooze rules for calendar- and runtime-based prompt candidates
@@ -27,9 +28,10 @@
 3. `Sources/TranscriptedAppState.swift` starts background model warmup through `meetingSession.prepareModels(showLoadingUI: false)`.
 4. `MeetingSessionController.startRecording(...)` first runs `MeetingRecordingStartGate` so missing microphone or System Audio Recording permission failures are blocked before capture starts, then uses `MeetingCaptureBridge` to start core audio capture into app-owned scratch paths.
 5. `MeetingSessionController.stopRecording(...)` awaits mic/system audio files from the bridge, then either starts transcription immediately or queues it behind the active job.
-6. `TranscriptionTaskManager` runs one diarize → transcribe → save pipeline at a time, honoring the persisted `LocalSpeakerPreferences.isEnabled` flag via the `splitLocalSpeakers` task option.
-7. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the recent-meetings UI state.
-8. Failed meetings can be retried, deleted, or dismissed from the menubar recent-meetings section, with `MeetingFailureKind` providing stable failure categories and `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
+6. `MeetingSessionController.importAudioFile(...)` copies a user-selected audio file into app-owned scratch space, then queues a system-audio-only transcription pass through the same task manager.
+7. `TranscriptionTaskManager` runs one diarize → transcribe → save pipeline at a time, honoring the persisted `LocalSpeakerPreferences.isEnabled` flag via the `splitLocalSpeakers` task option.
+8. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the recent-meetings UI state.
+9. Failed meetings can be retried, deleted, or dismissed from the menubar recent-meetings section, with `MeetingFailureKind` providing stable failure categories and `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
 
 ## Key invariants
 

--- a/Sources/Meeting/MeetingImportedAudioPreparer.swift
+++ b/Sources/Meeting/MeetingImportedAudioPreparer.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+struct PreparedImportedMeetingAudio {
+    let copiedAudioURL: URL
+    let suggestedTitle: String
+}
+
+enum MeetingImportedAudioPreparer {
+    static func prepareImportedAudio(
+        from sourceURL: URL,
+        scratchDirectory: URL = MeetingStoragePaths.recordingsScratch
+    ) throws -> PreparedImportedMeetingAudio {
+        let fileManager = FileManager.default
+        fileManager.ensurePrivateDirectory(
+            at: scratchDirectory,
+            context: "meeting imported audio scratch"
+        )
+
+        let resolvedSourceURL = sourceURL.standardizedFileURL
+        guard fileManager.fileExists(atPath: resolvedSourceURL.path) else {
+            throw NSError(
+                domain: "MeetingImportedAudioPreparer",
+                code: 1,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "The selected audio file could not be found."
+                ]
+            )
+        }
+
+        let destinationURL = uniqueScratchURL(
+            for: resolvedSourceURL,
+            in: scratchDirectory,
+            fileManager: fileManager
+        )
+
+        do {
+            try fileManager.copyItem(at: resolvedSourceURL, to: destinationURL)
+            fileManager.restrictFileToOwnerOnly(at: destinationURL)
+        } catch {
+            throw NSError(
+                domain: "MeetingImportedAudioPreparer",
+                code: 2,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Transcripted couldn't copy that audio file into its working area."
+                ]
+            )
+        }
+
+        return PreparedImportedMeetingAudio(
+            copiedAudioURL: destinationURL,
+            suggestedTitle: suggestedTitle(from: resolvedSourceURL)
+        )
+    }
+
+    private static func uniqueScratchURL(
+        for sourceURL: URL,
+        in directory: URL,
+        fileManager: FileManager
+    ) -> URL {
+        let originalExtension = sourceURL.pathExtension
+        let safeExtension = originalExtension.isEmpty ? "m4a" : originalExtension
+        let stem = "imported-\(UUID().uuidString)"
+        var candidate = directory
+            .appendingPathComponent(stem, isDirectory: false)
+            .appendingPathExtension(safeExtension)
+        var suffix = 2
+
+        while fileManager.fileExists(atPath: candidate.path) {
+            candidate = directory
+                .appendingPathComponent("\(stem)-\(suffix)", isDirectory: false)
+                .appendingPathExtension(safeExtension)
+            suffix += 1
+        }
+
+        return candidate
+    }
+
+    private static func suggestedTitle(from sourceURL: URL) -> String {
+        let raw = sourceURL
+            .deletingPathExtension()
+            .lastPathComponent
+            .replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: "-", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return raw.isEmpty ? "Imported audio" : raw
+    }
+}

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -31,6 +31,7 @@ final class MeetingSessionController: ObservableObject {
         case hotkey = "hotkey"
         case menu = "menu"
         case detectedPrompt = "detected_prompt"
+        case fileImport = "file_import"
         case unknown = "unknown"
     }
 
@@ -74,9 +75,19 @@ final class MeetingSessionController: ObservableObject {
     }
 
     private struct QueuedTranscriptionJob {
-        let micURL: URL
-        let systemURL: URL?
-        let healthInfo: RecordingHealthInfo
+        enum Kind {
+            case recorded(
+                micURL: URL,
+                systemURL: URL?,
+                healthInfo: RecordingHealthInfo
+            )
+            case imported(
+                audioURL: URL,
+                suggestedTitle: String
+            )
+        }
+
+        let kind: Kind
         let startTrigger: StartTrigger
     }
 
@@ -491,6 +502,81 @@ final class MeetingSessionController: ObservableObject {
         )
     }
 
+    @discardableResult
+    func importAudioFile(from sourceURL: URL) async -> Bool {
+        guard !isCaptureSessionActive else {
+            state = .error("Stop the current meeting before importing an audio file.")
+            return false
+        }
+
+        DiagnosticsTrail.record(
+            engine: "meeting",
+            event: "meeting_file_import_requested",
+            message: "Imported meeting transcription requested",
+            context: baseDiagnosticsContext(extra: ["trigger": StartTrigger.fileImport.rawValue])
+        )
+
+        if case .idle = state {
+            await prepareModels()
+        } else if case .loadingModels = state {
+            await prepareModels()
+        } else if case .error = state {
+            await prepareModels()
+        }
+
+        switch state {
+        case .ready, .transcribing:
+            break
+        default:
+            return false
+        }
+
+        let preparedAudio: PreparedImportedMeetingAudio
+        do {
+            preparedAudio = try MeetingImportedAudioPreparer.prepareImportedAudio(from: sourceURL)
+        } catch {
+            DiagnosticsTrail.record(
+                level: .error,
+                engine: "meeting",
+                event: "meeting_file_import_failed",
+                message: "Imported meeting audio could not be prepared",
+                context: baseDiagnosticsContext(extra: ["error": error.localizedDescription])
+            )
+            state = .error(error.localizedDescription)
+            return false
+        }
+
+        let outcome = enqueueImportedAudioJob(
+            audioURL: preparedAudio.copiedAudioURL,
+            suggestedTitle: preparedAudio.suggestedTitle,
+            startTrigger: .fileImport
+        )
+
+        DiagnosticsTrail.record(
+            engine: "meeting",
+            event: outcome == .startedImmediately
+                ? "meeting_file_import_started"
+                : "meeting_file_import_queued",
+            message: outcome == .startedImmediately
+                ? "Imported meeting transcription started"
+                : "Imported meeting transcription queued",
+            context: baseDiagnosticsContext(
+                extra: [
+                    "file": preparedAudio.copiedAudioURL.lastPathComponent,
+                    "queue_depth": "\(queuedTranscriptionJobs.count)",
+                    "title": preparedAudio.suggestedTitle
+                ]
+            )
+        )
+        AnalyticsReporter.track(
+            "meeting_file_imported",
+            properties: [
+                "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
+            ]
+        )
+        return true
+    }
+
     /// Cancel any in-progress pipeline. Does not cancel an active recording —
     /// use stopRecording() for that.
     func cancelActiveTranscription(reason: TranscriptionCancelReason = .unknown) {
@@ -500,11 +586,16 @@ final class MeetingSessionController: ObservableObject {
         activeTranscriptionTrigger = .unknown
 
         for job in queuedJobs {
-            failedManager.addFailedTranscription(
-                micAudioURL: job.micURL,
-                systemAudioURL: job.systemURL,
-                errorMessage: "Transcription cancelled"
-            )
+            switch job.kind {
+            case .recorded(let micURL, let systemURL, _):
+                failedManager.addFailedTranscription(
+                    micAudioURL: micURL,
+                    systemAudioURL: systemURL,
+                    errorMessage: "Transcription cancelled"
+                )
+            case .imported(let audioURL, _):
+                try? FileManager.default.removeItem(at: audioURL)
+            }
         }
 
         taskManager.cancelAll()
@@ -790,12 +881,34 @@ final class MeetingSessionController: ObservableObject {
         startTrigger: StartTrigger
     ) -> QueueInsertionOutcome {
         let job = QueuedTranscriptionJob(
-            micURL: micURL,
-            systemURL: systemURL,
-            healthInfo: healthInfo,
+            kind: .recorded(
+                micURL: micURL,
+                systemURL: systemURL,
+                healthInfo: healthInfo
+            ),
             startTrigger: startTrigger
         )
 
+        return enqueue(job)
+    }
+
+    private func enqueueImportedAudioJob(
+        audioURL: URL,
+        suggestedTitle: String,
+        startTrigger: StartTrigger
+    ) -> QueueInsertionOutcome {
+        let job = QueuedTranscriptionJob(
+            kind: .imported(
+                audioURL: audioURL,
+                suggestedTitle: suggestedTitle
+            ),
+            startTrigger: startTrigger
+        )
+
+        return enqueue(job)
+    }
+
+    private func enqueue(_ job: QueuedTranscriptionJob) -> QueueInsertionOutcome {
         if canStartQueuedTranscriptionImmediately {
             startQueuedTranscription(job)
             return .startedImmediately
@@ -813,13 +926,22 @@ final class MeetingSessionController: ObservableObject {
             state = .transcribing
         }
 
-        taskManager.startTranscription(
-            micURL: job.micURL,
-            systemURL: job.systemURL,
-            outputFolder: storagePaths.transcripts,
-            healthInfo: job.healthInfo,
-            splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()
-        )
+        switch job.kind {
+        case .recorded(let micURL, let systemURL, let healthInfo):
+            taskManager.startTranscription(
+                micURL: micURL,
+                systemURL: systemURL,
+                outputFolder: storagePaths.transcripts,
+                healthInfo: healthInfo,
+                splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()
+            )
+        case .imported(let audioURL, let suggestedTitle):
+            taskManager.startImportedTranscription(
+                audioURL: audioURL,
+                outputFolder: storagePaths.transcripts,
+                meetingTitle: suggestedTitle
+            )
+        }
     }
 
     private func handleBackgroundTranscriptionWorkChanged() {

--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -137,6 +137,7 @@ enum MeetingTranscriptStyler {
 
         return ParsedDocument(
             frontmatterLines: frontmatterLines,
+            explicitTitle: values["title"]?.trimmingCharacters(in: .whitespacesAndNewlines),
             recordedAt: recordedAt,
             duration: duration,
             durationSeconds: parseDurationSeconds(duration),
@@ -229,6 +230,11 @@ enum MeetingTranscriptStyler {
     }
 
     private static func buildTitle(for document: ParsedDocument) -> String {
+        if let explicitTitle = document.explicitTitle,
+           !explicitTitle.isEmpty {
+            return explicitTitle
+        }
+
         let namedRemoteParticipants = Array(
             LinkedSet(document.transcriptEntries.compactMap { entry -> String? in
                 guard entry.label.hasPrefix("System/") else { return nil }
@@ -403,6 +409,7 @@ enum MeetingTranscriptStyler {
 
 private struct ParsedDocument {
     let frontmatterLines: [String]
+    let explicitTitle: String?
     let recordedAt: Date
     let duration: String
     let durationSeconds: Int

--- a/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
+++ b/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
@@ -247,7 +247,7 @@ public struct SpeakerNamingRequest {
     public let knownPeople: [SpeakerIdentityOption]
     public let transcriptURL: URL
     public let systemAudioURL: URL
-    public let micAudioURL: URL
+    public let micAudioURL: URL?
     public let onComplete: ([SpeakerNameUpdate]) -> Void
 
     public init(
@@ -256,7 +256,7 @@ public struct SpeakerNamingRequest {
         transcriptURL: URL,
         transcriptId: UUID,
         systemAudioURL: URL,
-        micAudioURL: URL,
+        micAudioURL: URL?,
         onComplete: @escaping ([SpeakerNameUpdate]) -> Void
     ) {
         self.speakers = speakers

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -7,24 +7,25 @@ import FluidAudio
 
 extension Transcription {
 
-    /// Transcribe mic + system audio using local Parakeet STT + offline diarization.
+    /// Transcribe system audio using local Parakeet STT + offline diarization,
+    /// with optional mic audio for mixed live meeting captures.
     ///
     /// Pipeline:
-    /// 1. Load & resample both audio files to 16kHz mono
+    /// 1. Load & resample the captured audio files to 16kHz mono
     /// 2. Run PyAnnote offline diarization on system audio -> speaker segments with embeddings
     /// 3. Transcribe each system-audio speaker segment with Parakeet
-    /// 4. Transcribe mic audio with Parakeet.
+    /// 4. When present, transcribe mic audio with Parakeet.
     ///    - If `splitLocalSpeakers` is false (default), splits by silence and tags
     ///      every utterance as the single "You" speaker.
     ///    - If true, runs PyAnnote diarization on the mic channel too and threads
     ///      per-speaker embeddings through the same classification/matching path
     ///      used for system audio. Surfaces multiple local speakers in the naming sheet.
-    /// 5. Match speaker embeddings against persistent SpeakerDatabase (both channels)
-    /// 6. Merge mic + system utterances chronologically
+    /// 5. Match speaker embeddings against persistent SpeakerDatabase
+    /// 6. Merge available utterances chronologically
     ///
     /// Note: nonisolated to keep heavy compute off the main thread
     nonisolated func transcribeMultichannel(
-        micURL: URL,
+        micURL: URL?,
         systemURL: URL,
         splitLocalSpeakers: Bool = false,
         onProgress: ((Double) -> Void)? = nil
@@ -43,9 +44,9 @@ extension Transcription {
         let processingStartTime = Date()
 
         do {
-            // Get recording duration from original mic file
-            let micFile = try AVAudioFile(forReading: micURL)
-            let duration = Double(micFile.length) / micFile.processingFormat.sampleRate
+            let durationFileURL = micURL ?? systemURL
+            let durationFile = try AVAudioFile(forReading: durationFileURL)
+            let duration = Double(durationFile.length) / durationFile.processingFormat.sampleRate
 
             onProgress?(0.0)
 
@@ -60,14 +61,23 @@ extension Transcription {
             // Load sequentially to avoid both resampling buffers in memory simultaneously.
             // async let forces concurrent resampling (~460MB peak for long recordings);
             // sequential means only one resampling buffer exists at a time.
-            let systemSamples = try await AudioResampler.loadAndResample(url: systemURL, targetRate: 16000)
-            let micSamples = try await AudioResampler.loadAndResample(url: micURL, targetRate: 16000)
+            let systemSamples = try AudioResampler.loadAndResample(url: systemURL, targetRate: 16000)
+            let micSamples: [Float]
+            if let micURL {
+                micSamples = try AudioResampler.loadAndResample(url: micURL, targetRate: 16000)
+            } else {
+                micSamples = []
+            }
 
             let resampleTime = CFAbsoluteTimeGetCurrent() - resampleStart
             AppLogger.transcription.info("Resampling completed in \(String(format: "%.2f", resampleTime))s")
 
             AppLogger.transcription.debug("System: \(systemSamples.count) samples (\(String(format: "%.1f", Double(systemSamples.count) / 16000))s)")
-            AppLogger.transcription.debug("Mic: \(micSamples.count) samples (\(String(format: "%.1f", Double(micSamples.count) / 16000))s)")
+            if let _ = micURL {
+                AppLogger.transcription.debug("Mic: \(micSamples.count) samples (\(String(format: "%.1f", Double(micSamples.count) / 16000))s)")
+            } else {
+                AppLogger.transcription.debug("Mic: skipped for system-audio-only transcription")
+            }
 
             // Validate system audio has meaningful content (at least 1 second at 16kHz).
             // Without this, a failed system audio capture produces an empty transcript.
@@ -398,75 +408,79 @@ extension Transcription {
 
             AppLogger.transcription.info("System audio transcribed", ["utterances": "\(systemUtterances.count)", "speakers": "\(Set(systemUtterances.map { $0.speakerId }).count)"])
 
-            // Step 4: Transcribe mic audio.
-            // Two modes:
-            //   A) splitLocalSpeakers == false (default): silence-split, tag as single "You"
-            //   B) splitLocalSpeakers == true: diarize mic, run same classification path
-            //      used for system audio, emit per-speaker utterances
-            await MainActor.run {
-                self.processingStatus = "Transcribing mic audio..."
-            }
-
             var micUtterances: [TranscriptionUtterance] = []
             var micSpeakerContexts: [String: ChannelSpeakerContext] = [:]
             var newlyCreatedMicProfileIds: Set<UUID> = []
 
-            if splitLocalSpeakers {
-                // B) Mic diarization path
-                let micResult = try await Self.processMicChannelWithDiarization(
-                    samples: micSamples,
-                    diarization: diarization,
-                    parakeet: parakeet,
-                    speakerDB: speakerDB,
-                    existingProfiles: existingProfiles,
-                    droppedSegments: &droppedSegments,
-                    onProgress: onProgress
-                )
-                micUtterances = micResult.utterances
-                micSpeakerContexts = micResult.speakerContexts
-                newlyCreatedMicProfileIds = micResult.newlyCreatedProfileIds
-                AppLogger.transcription.info("Mic audio diarized + transcribed", [
-                    "utterances": "\(micUtterances.count)",
-                    "speakers": "\(Set(micUtterances.map { $0.speakerId }).count)",
-                    "newProfiles": "\(newlyCreatedMicProfileIds.count)"
-                ])
-            } else {
-                // A) Default: silence-split, single speaker
-                let micSegments = Self.detectSpeechSegments(samples: micSamples, sampleRate: 16000)
-                AppLogger.transcription.info("Mic audio segmented by silence", ["segments": "\(micSegments.count)"])
-
-                for (index, segment) in micSegments.enumerated() {
-                    try Task.checkCancellation()
-
-                    let segmentSamples = AudioResampler.extractSlice(
-                        from: micSamples,
-                        sampleRate: 16000,
-                        startTime: segment.start,
-                        endTime: segment.end
-                    )
-
-                    // Skip segments shorter than 1s — Parakeet requires at least 16,000 samples
-                    guard segmentSamples.count >= 16000 else { droppedSegments += 1; continue }
-
-                    let text = try await parakeet.transcribeSegment(samples: segmentSamples, source: .microphone)
-                    guard !text.isEmpty else { continue }
-
-                    micUtterances.append(TranscriptionUtterance(
-                        start: segment.start,
-                        end: segment.end,
-                        channel: 0,
-                        speakerId: 0,
-                        persistentSpeakerId: nil,
-                        matchSimilarity: nil,
-                        transcript: text
-                    ))
-
-                    // Update progress (65% to 90% during mic transcription)
-                    let micProgress = 0.65 + (Double(index + 1) / Double(max(1, micSegments.count))) * 0.25
-                    onProgress?(micProgress)
+            if micURL != nil {
+                // Step 4: Transcribe mic audio.
+                // Two modes:
+                //   A) splitLocalSpeakers == false (default): silence-split, tag as single "You"
+                //   B) splitLocalSpeakers == true: diarize mic, run same classification path
+                //      used for system audio, emit per-speaker utterances
+                await MainActor.run {
+                    self.processingStatus = "Transcribing mic audio..."
                 }
 
-                AppLogger.transcription.info("Mic audio transcribed", ["utterances": "\(micUtterances.count)"])
+                if splitLocalSpeakers {
+                    // B) Mic diarization path
+                    let micResult = try await Self.processMicChannelWithDiarization(
+                        samples: micSamples,
+                        diarization: diarization,
+                        parakeet: parakeet,
+                        speakerDB: speakerDB,
+                        existingProfiles: existingProfiles,
+                        droppedSegments: &droppedSegments,
+                        onProgress: onProgress
+                    )
+                    micUtterances = micResult.utterances
+                    micSpeakerContexts = micResult.speakerContexts
+                    newlyCreatedMicProfileIds = micResult.newlyCreatedProfileIds
+                    AppLogger.transcription.info("Mic audio diarized + transcribed", [
+                        "utterances": "\(micUtterances.count)",
+                        "speakers": "\(Set(micUtterances.map { $0.speakerId }).count)",
+                        "newProfiles": "\(newlyCreatedMicProfileIds.count)"
+                    ])
+                } else {
+                    // A) Default: silence-split, single speaker
+                    let micSegments = Self.detectSpeechSegments(samples: micSamples, sampleRate: 16000)
+                    AppLogger.transcription.info("Mic audio segmented by silence", ["segments": "\(micSegments.count)"])
+
+                    for (index, segment) in micSegments.enumerated() {
+                        try Task.checkCancellation()
+
+                        let segmentSamples = AudioResampler.extractSlice(
+                            from: micSamples,
+                            sampleRate: 16000,
+                            startTime: segment.start,
+                            endTime: segment.end
+                        )
+
+                        // Skip segments shorter than 1s — Parakeet requires at least 16,000 samples
+                        guard segmentSamples.count >= 16000 else { droppedSegments += 1; continue }
+
+                        let text = try await parakeet.transcribeSegment(samples: segmentSamples, source: .microphone)
+                        guard !text.isEmpty else { continue }
+
+                        micUtterances.append(TranscriptionUtterance(
+                            start: segment.start,
+                            end: segment.end,
+                            channel: 0,
+                            speakerId: 0,
+                            persistentSpeakerId: nil,
+                            matchSimilarity: nil,
+                            transcript: text
+                        ))
+
+                        // Update progress (65% to 90% during mic transcription)
+                        let micProgress = 0.65 + (Double(index + 1) / Double(max(1, micSegments.count))) * 0.25
+                        onProgress?(micProgress)
+                    }
+
+                    AppLogger.transcription.info("Mic audio transcribed", ["utterances": "\(micUtterances.count)"])
+                }
+            } else {
+                AppLogger.transcription.info("Mic audio skipped", ["reason": "system_audio_only"])
             }
 
             onProgress?(0.95)

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -5,7 +5,7 @@ import AVFoundation
 
 extension TranscriptionTaskManager {
 
-    /// Transcribe with multichannel mode (requires both mic and system audio)
+    /// Transcribe a captured meeting using system audio plus optional mic audio.
     /// - Returns: URL of saved transcript with speaker attribution
     /// Note: nonisolated to keep heavy async work off the main thread
     nonisolated func transcribeWithSpeakerIdentification(
@@ -14,7 +14,8 @@ extension TranscriptionTaskManager {
         outputFolder: URL,
         taskId: UUID,
         healthInfo: RecordingHealthInfo?,
-        splitLocalSpeakers: Bool = false
+        splitLocalSpeakers: Bool = false,
+        meetingTitle: String? = nil
     ) async throws -> URL {
 
         // Require system audio for multichannel transcription
@@ -28,7 +29,26 @@ extension TranscriptionTaskManager {
             outputFolder: outputFolder,
             taskId: taskId,
             healthInfo: healthInfo,
-            splitLocalSpeakers: splitLocalSpeakers
+            splitLocalSpeakers: splitLocalSpeakers,
+            meetingTitle: meetingTitle
+        )
+    }
+
+    /// Transcribe an imported audio file through the system-audio speaker path.
+    nonisolated func transcribeImportedAudio(
+        audioURL: URL,
+        outputFolder: URL,
+        taskId: UUID,
+        meetingTitle: String? = nil
+    ) async throws -> URL {
+        try await transcribeMultichannelPipeline(
+            micURL: nil,
+            systemURL: audioURL,
+            outputFolder: outputFolder,
+            taskId: taskId,
+            healthInfo: nil,
+            splitLocalSpeakers: false,
+            meetingTitle: meetingTitle
         )
     }
 
@@ -37,12 +57,13 @@ extension TranscriptionTaskManager {
     /// speakers thread through the same classification + naming flow as remote speakers.
     /// Note: nonisolated to keep heavy async work off the main thread
     nonisolated func transcribeMultichannelPipeline(
-        micURL: URL,
+        micURL: URL?,
         systemURL: URL,
         outputFolder: URL,
         taskId: UUID,
         healthInfo: RecordingHealthInfo?,
-        splitLocalSpeakers: Bool = false
+        splitLocalSpeakers: Bool = false,
+        meetingTitle: String? = nil
     ) async throws -> URL {
 
         let transcription = await MainActor.run { self.transcription }
@@ -245,6 +266,7 @@ extension TranscriptionTaskManager {
             speakerSources: speakerSources,
             speakerDbIds: speakerDbIds,
             directory: outputFolder,
+            meetingTitle: meetingTitle,
             healthInfo: healthInfo,
             notifier: notifier,
             speakerStore: speakerDB,
@@ -295,7 +317,7 @@ extension TranscriptionTaskManager {
         // user can name them or collapse the group via "Keep as You". We intentionally
         // don't filter to "needs action" on the mic side: if local split ran and produced
         // multiple speakers, the user should always see the section so they can decide.
-        if splitLocalSpeakers && !result.micPersistentSpeakerIds.isEmpty {
+        if splitLocalSpeakers && !result.micPersistentSpeakerIds.isEmpty, let micURL {
             do {
                 let micUtterancesWithProfiles = result.micUtterances.filter {
                     $0.persistentSpeakerId != nil
@@ -371,7 +393,9 @@ extension TranscriptionTaskManager {
         }
 
         // No naming needed — clean up audio files
-        try? FileManager.default.removeItem(at: micURL)
+        if let micURL {
+            try? FileManager.default.removeItem(at: micURL)
+        }
         try? FileManager.default.removeItem(at: systemURL)
 
         return savedURL

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -155,6 +155,82 @@ public class TranscriptionTaskManager: ObservableObject {
         activeTasks[task.id] = asyncTask
     }
 
+    /// Start a new transcription task for an imported audio file.
+    /// Imported files reuse the system-audio speaker path and are not added to the
+    /// failed-transcription queue because the user can simply re-import the source file.
+    public func startImportedTranscription(
+        audioURL: URL,
+        outputFolder: URL,
+        meetingTitle: String? = nil
+    ) {
+        if !activeTasks.isEmpty {
+            AppLogger.pipeline.warning("Rejecting imported transcription — another pipeline is already active", ["activeCount": "\(activeTasks.count)"])
+            displayStatus = .failed(message: "Transcription already in progress")
+            scheduleStatusReset(delay: 4)
+            return
+        }
+
+        let minDuration: TimeInterval = 2.0
+        if let audioDuration = audioDuration(url: audioURL), audioDuration < minDuration {
+            AppLogger.pipeline.info("Imported recording too short, skipping transcription", ["duration": String(format: "%.1fs", audioDuration)])
+            removeRecordingFile(audioURL, label: "short imported recording")
+            displayStatus = .failed(message: "Recording too short")
+            scheduleStatusReset(delay: 3)
+            return
+        }
+
+        let taskId = UUID()
+        activeCount += 1
+        backgroundTaskCount += 1
+        displayStatus = .gettingReady
+
+        AppLogger.pipeline.info("Starting imported transcription task", [
+            "taskId": taskId.uuidString,
+            "activeCount": "\(activeCount)"
+        ])
+
+        let asyncTask = Task {
+            do {
+                await MainActor.run {
+                    self.displayStatus = .transcribing(progress: 0.0)
+                }
+
+                let transcriptURL = try await self.transcribeImportedAudio(
+                    audioURL: audioURL,
+                    outputFolder: outputFolder,
+                    taskId: taskId,
+                    meetingTitle: meetingTitle
+                )
+
+                await MainActor.run {
+                    if self.speakerNamingRequest == nil {
+                        self.populateSavedMetadata(from: transcriptURL)
+                        self.displayStatus = .transcriptSaved
+                        self.scheduleStatusReset(delay: 4)
+                    } else {
+                        self.displayStatus = .finishing
+                    }
+                    self.handleTaskCompletion(taskId: taskId)
+                }
+            } catch {
+                AppLogger.pipeline.error("Imported transcription task failed", [
+                    "taskId": taskId.uuidString,
+                    "error": error.localizedDescription
+                ])
+
+                await MainActor.run {
+                    self.removeRecordingFile(audioURL, label: "failed imported recording")
+                    self.displayStatus = .failed(message: "Transcription failed")
+                    self.sendFailureNotification(errorMessage: error.localizedDescription)
+                    self.handleTaskCompletion(taskId: taskId)
+                    self.scheduleStatusReset(delay: 4)
+                }
+            }
+        }
+
+        activeTasks[taskId] = asyncTask
+    }
+
     /// Retry a failed transcription by its ID
     public func retryFailedTranscription(failedId: UUID, outputFolder: URL) async -> Bool {
         // Guard: reject if a pipeline is already active — same constraint as startTranscription.

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -30,7 +30,7 @@ extension TranscriptionTaskManager {
         transcriptURL: URL,
         transcriptId: UUID,
         transcriptionResult: TranscriptionResult,
-        micURL: URL,
+        micURL: URL?,
         systemURL: URL,
         clips: [SpeakerNamingEntry]
     ) {

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -3,6 +3,7 @@
 
 import AppKit
 import Combine
+import UniformTypeIdentifiers
 
 @MainActor
 final class MenuBarPanelController: NSViewController {
@@ -38,6 +39,7 @@ final class MenuBarPanelController: NSViewController {
         content.settingsView.appState = appState
         content.shortcutsView.onStartDictation = { [weak self] in self?.startDictationFromMenu() }
         content.shortcutsView.onStartMeeting = { [weak self] in self?.startMeetingFromMenu() }
+        content.shortcutsView.onImportAudioFile = { [weak self] in self?.importAudioFileFromMenu() }
         content.modelStatusView.onOpenSettings = { [weak self] in self?.openSettingsFromMenu() }
         content.settingsView.onOpenSettings = { [weak self] in self?.openSettingsFromMenu() }
         content.settingsView.onCheckForUpdates = { [weak self] in self?.checkForUpdatesFromMenu() }
@@ -70,7 +72,8 @@ final class MenuBarPanelController: NSViewController {
             dictationKey: appState.contextCapture.dictationShortcutDisplay,
             meetingKey: appState.contextCapture.meetingShortcutDisplay,
             dictationState: dictationState,
-            meetingState: meetingState
+            meetingState: meetingState,
+            canImportAudioFiles: !appState.meetingSession.isRecording
         )
 
         if #available(macOS 14.0, *) {
@@ -138,6 +141,13 @@ final class MenuBarPanelController: NSViewController {
                 }
                 .store(in: &subscriptions)
 
+            appState.meetingSession.$isRecording
+                .receive(on: RunLoop.main)
+                .sink { [weak self] _ in
+                    self?.refresh()
+                }
+                .store(in: &subscriptions)
+
             appState.meetingSession.$failedMeetings
                 .receive(on: RunLoop.main)
                 .sink { [weak self] _ in
@@ -185,6 +195,24 @@ final class MenuBarPanelController: NSViewController {
     private func openAgentConnectFromMenu() {
         dismissPopover()
         openAgentConnectWindow()
+    }
+
+    private func importAudioFileFromMenu() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.allowsMultipleSelection = false
+        panel.allowedContentTypes = [.audio]
+        panel.prompt = "Transcribe"
+        panel.message = "Choose an audio file Transcripted should transcribe."
+
+        dismissPopover()
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        Task {
+            _ = await appState.meetingSession.importAudioFile(from: url)
+        }
     }
 
     private func resolvedSourceApp() -> NSRunningApplication? {

--- a/Sources/UI/MenuBar/MenuBarShortcutsView.swift
+++ b/Sources/UI/MenuBar/MenuBarShortcutsView.swift
@@ -8,10 +8,17 @@ import Carbon
 final class MenuBarShortcutsView: NSView {
     var onStartDictation: (() -> Void)?
     var onStartMeeting: (() -> Void)?
+    var onImportAudioFile: (() -> Void)?
 
     private let dictationRow = PrimaryActionRowView()
     private let meetingRow = PrimaryActionRowView()
-    private let resetHintLabel = NSTextField(labelWithString: "Click a shortcut badge to edit")
+    private let importButton = MenuOutlineButton(
+        title: "Transcribe file",
+        symbolName: "waveform",
+        accessibilityLabel: "Transcribe file",
+        toolTip: "Choose an audio file to transcribe"
+    )
+    private let resetHintLabel = NSTextField(labelWithString: "Edit shortcuts or import audio")
     private let resetButton = MenuIconButton(
         symbolName: "arrow.counterclockwise",
         accessibilityLabel: "Reset shortcuts",
@@ -21,6 +28,7 @@ final class MenuBarShortcutsView: NSView {
     private var recordingTarget: RecordingTarget?
     private var currentDictationState = MenuBarPrimaryActionState(isEnabled: true, subtitle: "Paste spoken text anywhere")
     private var currentMeetingState = MenuBarPrimaryActionState(isEnabled: true, subtitle: "Capture mic and system audio")
+    private var canImportAudioFiles = true
 
     private enum RecordingTarget {
         case dictation
@@ -69,6 +77,10 @@ final class MenuBarShortcutsView: NSView {
         resetHintLabel.textColor = MenuTokens.textMutedNS
         addSubview(resetHintLabel)
 
+        importButton.target = self
+        importButton.action = #selector(importAudioFile)
+        addSubview(importButton)
+
         resetButton.target = self
         resetButton.action = #selector(resetShortcuts)
         addSubview(resetButton)
@@ -87,8 +99,16 @@ final class MenuBarShortcutsView: NSView {
             height: MenuTokens.actionRowHeight
         )
 
+        let importY = meetingRow.frame.maxY + 8
+        importButton.frame = NSRect(
+            x: 0,
+            y: importY,
+            width: bounds.width,
+            height: MenuTokens.secondaryButtonSize
+        )
+
         let buttonSize = MenuTokens.secondaryButtonSize
-        let footerY = meetingRow.frame.maxY + 6
+        let footerY = importButton.frame.maxY + 8
         resetButton.frame = NSRect(x: bounds.width - buttonSize, y: footerY, width: buttonSize, height: buttonSize)
         resetHintLabel.frame = NSRect(
             x: 0,
@@ -102,13 +122,16 @@ final class MenuBarShortcutsView: NSView {
         dictationKey: String,
         meetingKey: String,
         dictationState: MenuBarPrimaryActionState,
-        meetingState: MenuBarPrimaryActionState
+        meetingState: MenuBarPrimaryActionState,
+        canImportAudioFiles: Bool
     ) {
         currentDictationState = dictationState
         currentMeetingState = meetingState
+        self.canImportAudioFiles = canImportAudioFiles
+        importButton.isEnabled = canImportAudioFiles && recordingTarget == nil
         resetButton.isEnabled = recordingTarget == nil
         resetHintLabel.alphaValue = 1.0
-        resetHintLabel.stringValue = "Click a shortcut badge to edit"
+        resetHintLabel.stringValue = "Edit shortcuts or import audio"
 
         dictationRow.update(
             symbolName: "mic.fill",
@@ -185,17 +208,23 @@ final class MenuBarShortcutsView: NSView {
             dictationKey: HotkeyPreferences.displayString(for: HotkeyPreferences.dictationBinding()),
             meetingKey: HotkeyPreferences.displayString(for: HotkeyPreferences.meetingBinding()),
             dictationState: currentDictationState,
-            meetingState: currentMeetingState
+            meetingState: currentMeetingState,
+            canImportAudioFiles: canImportAudioFiles
         )
     }
 
     var intrinsicHeight: CGFloat {
-        MenuTokens.actionRowHeight * 2 + MenuTokens.secondaryButtonSize + 12
+        MenuTokens.actionRowHeight * 2 + MenuTokens.secondaryButtonSize * 2 + 20
     }
 
     @objc private func resetShortcuts() {
         HotkeyPreferences.resetToDefaults()
         refreshFromPreferences()
+    }
+
+    @objc private func importAudioFile() {
+        guard importButton.isEnabled, recordingTarget == nil else { return }
+        onImportAudioFile?()
     }
 }
 

--- a/Tests/MeetingTranscriptStylerTests.swift
+++ b/Tests/MeetingTranscriptStylerTests.swift
@@ -5,6 +5,7 @@ func testMeetingTranscriptStyler() {
         testMeetingTranscriptStylerRenamesArtifacts()
         testMeetingTranscriptStylerDoesNotCreateSiblingArtifacts()
         testMeetingTranscriptStylerIsIdempotent()
+        testMeetingTranscriptStylerPreservesExplicitTitle()
     }
 }
 
@@ -57,6 +58,21 @@ private func testMeetingTranscriptStylerIsIdempotent() {
     assertFalse(FileManager.default.fileExists(atPath: directory.appendingPathComponent("Meeting with Alex 2.md").path), "Styler should not append duplicate suffixes on repeated passes")
 }
 
+private func testMeetingTranscriptStylerPreservesExplicitTitle() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Call_2026-04-07_09-14-00.md")
+    try? sampleImportedTranscript().write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+    let styled = MeetingTranscriptStyler.restyleTranscript(at: transcriptURL)
+    let updatedMarkdown = try? String(contentsOf: styled.url, encoding: .utf8)
+
+    assertEqual(styled.title, "Customer Interview April", "Styler should respect an explicit imported transcript title")
+    assertEqual(styled.url.lastPathComponent, "Customer Interview April.md", "Explicit titles should drive the final transcript filename")
+    assertTrue(updatedMarkdown?.contains("# Customer Interview April") == true, "Explicit titles should be written back into the rendered markdown")
+}
+
 private func sampleMeetingTranscript() -> String {
     """
     ---
@@ -75,6 +91,28 @@ private func sampleMeetingTranscript() -> String {
 
     **[00:04] [System/Alex]**
     Happy to help. Let's get started.
+    """
+}
+
+private func sampleImportedTranscript() -> String {
+    """
+    ---
+    title: "Customer Interview April"
+    date: "2026-04-07"
+    time: "09:14:00"
+    duration: "12:30"
+    total_word_count: "42"
+    mic_utterances: "0"
+    system_utterances: "2"
+    ---
+
+    ## Full Transcript
+
+    **[00:00] [System/Speaker 0]**
+    Thanks for sitting down with us today.
+
+    **[00:04] [System/Speaker 1]**
+    Happy to help.
     """
 }
 


### PR DESCRIPTION
## What changed
- added a new `Transcribe file` action in the menubar so users can pick an existing audio file
- added app-side import prep that copies the selected file into Transcripted scratch space before processing so the original file is left alone
- extended the meeting transcription path to support system-audio-only imported files while reusing the current diarization, save, and speaker-naming pipeline
- preserved explicit imported titles so transcripts use the source filename instead of a generic fallback
- updated docs and added a regression test for imported-title styling

## Why
Transcripted could only transcribe live captures before this change. The transcribe-files request needs a user-triggered import path for audio that is already on disk.

## User impact
Users can now import a local audio file from the menu and get a normal Transcripted markdown transcript without having to record the audio live through the app.

## Validation
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `swift test`

## Notes
- this opens as a draft PR by default
- this covers the first pass of file import by routing imported audio through the meeting/system-audio path