### PR TITLE
[codex] Tame Teams meeting prompts

### DIFF
--- a/Sources/Meeting/MeetingPromptDetector.swift
+++ b/Sources/Meeting/MeetingPromptDetector.swift
@@ -2,42 +2,6 @@ import AppKit
 import EventKit
 import Foundation
 
-enum MeetingPromptProvider: String, CaseIterable, Hashable {
-    case zoom
-    case googleMeet
-    case teams
-    case webex
-    case facetime
-
-    var browserHosted: Bool {
-        switch self {
-        case .googleMeet, .teams, .webex:
-            return true
-        case .zoom, .facetime:
-            return false
-        }
-    }
-
-    var activeBundleIdentifiers: Set<String> {
-        switch self {
-        case .zoom:
-            return ["us.zoom.xos"]
-        case .googleMeet:
-            return []
-        case .teams:
-            return ["com.microsoft.teams", "com.microsoft.teams2"]
-        case .webex:
-            return ["com.cisco.webexmeetingsapp", "com.webex.meetingmanager"]
-        case .facetime:
-            return ["com.apple.FaceTime"]
-        }
-    }
-
-    var supportsNativeRuntimePrompt: Bool {
-        !activeBundleIdentifiers.isEmpty
-    }
-}
-
 @available(macOS 14.0, *)
 @MainActor
 final class MeetingPromptDetector {
@@ -46,6 +10,7 @@ final class MeetingPromptDetector {
         let title: String
         let detail: String
         let provider: MeetingPromptProvider
+        let reason: MeetingPromptReason
         let source: MeetingPromptSource
         let startDate: Date
         let endDate: Date
@@ -107,28 +72,48 @@ final class MeetingPromptDetector {
         workspaceObservers.removeAll()
     }
 
-    func snooze(candidate: Candidate, interval: TimeInterval? = nil) {
+    @discardableResult
+    func snooze(candidate: Candidate, interval: TimeInterval? = nil) -> MeetingPromptBackoffDecision {
         let now = Date()
         let baseInterval = MeetingPromptHeuristics.snoozeInterval(
             for: candidate.source,
             explicit: interval,
             defaultInterval: defaultSnoozeInterval
         )
+        let decision: MeetingPromptBackoffDecision
         let until: Date
         switch candidate.source {
         case .calendarEvent:
+            let minimumInterval = MeetingPromptHeuristics.calendarDismissMinimumInterval(
+                for: candidate.provider,
+                defaultInterval: baseInterval
+            )
             until = max(
-                now.addingTimeInterval(baseInterval),
+                now.addingTimeInterval(minimumInterval),
                 candidate.endDate.addingTimeInterval(MeetingPromptHeuristics.calendarReminderPostStartGrace)
+            )
+            decision = MeetingPromptBackoffDecision(
+                kind: candidate.provider == .teams ? .calendarTeamsExtended : .calendarDefault,
+                until: until
             )
             suppressRuntimePrompts(for: candidate.provider, until: until)
         case .runtimeApp:
-            until = nextRuntimePromptResumeDate(for: candidate.provider, now: now)
-                ?? now.addingTimeInterval(MeetingPromptHeuristics.runtimeDismissFallbackInterval)
+            if let resumeDate = nextRuntimePromptResumeDate(for: candidate.provider, now: now) {
+                until = resumeDate
+                decision = MeetingPromptBackoffDecision(kind: .runtimeUntilNextCalendar, until: until)
+            } else {
+                let fallbackInterval = MeetingPromptHeuristics.runtimeDismissFallbackInterval(for: candidate.provider)
+                until = now.addingTimeInterval(fallbackInterval)
+                decision = MeetingPromptBackoffDecision(
+                    kind: candidate.provider == .teams ? .runtimeTeamsExtended : .runtimeDefaultFallback,
+                    until: until
+                )
+            }
             suppressRuntimePrompts(for: candidate.provider, until: until)
         }
         snoozedUntil[candidate.id] = until
         pendingUntil[candidate.id] = until
+        return decision
     }
 
     func markAccepted(candidate: Candidate) {
@@ -231,6 +216,7 @@ final class MeetingPromptDetector {
     ) -> [ScoredCandidate] {
         MeetingPromptProvider.allCases.compactMap { provider in
             guard provider.supportsNativeRuntimePrompt else { return nil }
+            guard MeetingPromptHeuristics.allowsRuntimeOnlyPrompt(for: provider) else { return nil }
             guard provider.activeBundleIdentifiers.contains(where: runningBundleIDs.contains) else { return nil }
             if let suppressedUntil = runtimeSuppressedUntil[provider], suppressedUntil > now {
                 return nil
@@ -250,6 +236,7 @@ final class MeetingPromptDetector {
                     title: presentation.title,
                     detail: presentation.detail,
                     provider: provider,
+                    reason: MeetingPromptHeuristics.reason(for: .runtimeApp, hasRuntimeContext: false),
                     source: .runtimeApp,
                     startDate: now,
                     endDate: now.addingTimeInterval(MeetingPromptHeuristics.runtimeReminderSnoozeInterval),
@@ -316,6 +303,10 @@ final class MeetingPromptDetector {
                 title: "Meeting detected",
                 detail: detail,
                 provider: provider,
+                reason: MeetingPromptHeuristics.reason(
+                    for: .calendarEvent,
+                    hasRuntimeContext: runtimeReason != nil
+                ),
                 source: .calendarEvent,
                 startDate: event.startDate,
                 endDate: event.endDate,

--- a/Sources/Meeting/MeetingPromptHeuristics.swift
+++ b/Sources/Meeting/MeetingPromptHeuristics.swift
@@ -1,8 +1,63 @@
 import Foundation
 
+enum MeetingPromptProvider: String, CaseIterable, Hashable {
+    case zoom
+    case googleMeet
+    case teams
+    case webex
+    case facetime
+
+    var browserHosted: Bool {
+        switch self {
+        case .googleMeet, .teams, .webex:
+            return true
+        case .zoom, .facetime:
+            return false
+        }
+    }
+
+    var activeBundleIdentifiers: Set<String> {
+        switch self {
+        case .zoom:
+            return ["us.zoom.xos"]
+        case .googleMeet:
+            return []
+        case .teams:
+            return ["com.microsoft.teams", "com.microsoft.teams2"]
+        case .webex:
+            return ["com.cisco.webexmeetingsapp", "com.webex.meetingmanager"]
+        case .facetime:
+            return ["com.apple.FaceTime"]
+        }
+    }
+
+    var supportsNativeRuntimePrompt: Bool {
+        !activeBundleIdentifiers.isEmpty
+    }
+}
+
 enum MeetingPromptSource: Equatable {
     case calendarEvent
     case runtimeApp
+}
+
+enum MeetingPromptReason: String, Equatable {
+    case calendarNearby = "calendar_nearby"
+    case calendarPlusRuntimeMatch = "calendar_plus_runtime_match"
+    case runtimeOnly = "runtime_only"
+}
+
+enum MeetingPromptBackoffKind: String, Equatable {
+    case calendarDefault = "calendar_default"
+    case calendarTeamsExtended = "calendar_teams_extended"
+    case runtimeUntilNextCalendar = "runtime_until_next_calendar"
+    case runtimeDefaultFallback = "runtime_default_fallback"
+    case runtimeTeamsExtended = "runtime_teams_extended"
+}
+
+struct MeetingPromptBackoffDecision: Equatable {
+    let kind: MeetingPromptBackoffKind
+    let until: Date
 }
 
 enum MeetingPromptWindowPolicy {
@@ -20,10 +75,15 @@ struct RuntimeMeetingPromptPresentation: Equatable {
 
 enum MeetingPromptHeuristics {
     static let runtimeReminderSnoozeInterval: TimeInterval = 2 * 60
-    static let runtimeDismissFallbackInterval: TimeInterval = 30 * 60
+    static let defaultRuntimeDismissFallbackInterval: TimeInterval = 30 * 60
+    static let teamsDismissMinimumInterval: TimeInterval = 2 * 60 * 60
     static let runtimeActivityFreshness: TimeInterval = 5 * 60
     static let calendarReminderLeadTime: TimeInterval = 60
     static let calendarReminderPostStartGrace: TimeInterval = 5 * 60
+
+    static func allowsRuntimeOnlyPrompt(for provider: MeetingPromptProvider) -> Bool {
+        provider != .teams
+    }
 
     static func snoozeInterval(
         for source: MeetingPromptSource,
@@ -39,6 +99,35 @@ enum MeetingPromptHeuristics {
             return defaultInterval
         case .runtimeApp:
             return runtimeReminderSnoozeInterval
+        }
+    }
+
+    static func calendarDismissMinimumInterval(
+        for provider: MeetingPromptProvider,
+        defaultInterval: TimeInterval
+    ) -> TimeInterval {
+        if provider == .teams {
+            return max(defaultInterval, teamsDismissMinimumInterval)
+        }
+        return defaultInterval
+    }
+
+    static func runtimeDismissFallbackInterval(for provider: MeetingPromptProvider) -> TimeInterval {
+        if provider == .teams {
+            return teamsDismissMinimumInterval
+        }
+        return defaultRuntimeDismissFallbackInterval
+    }
+
+    static func reason(
+        for source: MeetingPromptSource,
+        hasRuntimeContext: Bool
+    ) -> MeetingPromptReason {
+        switch source {
+        case .calendarEvent:
+            return hasRuntimeContext ? .calendarPlusRuntimeMatch : .calendarNearby
+        case .runtimeApp:
+            return .runtimeOnly
         }
     }
 

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -59,6 +59,7 @@ struct AnalyticsEventPolicy: Equatable {
         "meeting_prompt_shown": .init(
             name: "meeting_prompt_shown",
             allowedProperties: [
+                "prompt_reason",
                 "provider",
                 "source",
             ]
@@ -66,6 +67,8 @@ struct AnalyticsEventPolicy: Equatable {
         "meeting_prompt_dismissed": .init(
             name: "meeting_prompt_dismissed",
             allowedProperties: [
+                "backoff_kind",
+                "prompt_reason",
                 "provider",
                 "source",
             ]
@@ -73,6 +76,7 @@ struct AnalyticsEventPolicy: Equatable {
         "meeting_prompt_record_selected": .init(
             name: "meeting_prompt_record_selected",
             allowedProperties: [
+                "prompt_reason",
                 "provider",
                 "source",
             ]

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -81,11 +81,14 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             }
             meetingOverlayController.onPromptDismiss = { [weak self] candidate in
                 guard let self else { return }
+                let backoffDecision = self.meetingPromptDetector.snooze(candidate: candidate)
                 AnalyticsReporter.track(
                     "meeting_prompt_dismissed",
-                    properties: self.analyticsProperties(for: candidate)
+                    properties: self.analyticsProperties(
+                        for: candidate,
+                        backoffKind: backoffDecision.kind
+                    )
                 )
-                self.meetingPromptDetector.snooze(candidate: candidate)
             }
             meetingPromptDetector.onPromptRequest = { [weak self] candidate in
                 guard PermissionsOnboardingView.hasCompleted else { return false }
@@ -263,11 +266,19 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     }
 
     @available(macOS 14.0, *)
-    private func analyticsProperties(for candidate: MeetingPromptDetector.Candidate) -> [String: String] {
-        [
+    private func analyticsProperties(
+        for candidate: MeetingPromptDetector.Candidate,
+        backoffKind: MeetingPromptBackoffKind? = nil
+    ) -> [String: String] {
+        var properties = [
+            "prompt_reason": candidate.reason.rawValue,
             "provider": candidate.provider.rawValue,
             "source": candidate.source.analyticsValue,
         ]
+        if let backoffKind {
+            properties["backoff_kind"] = backoffKind.rawValue
+        }
+        return properties
     }
 
     // MARK: - NSPopoverDelegate

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -45,7 +45,19 @@ func testAnalyticsEventPolicy() {
         let recorded = AnalyticsEventPolicy.policy(forEvent: "meeting_prompt_record_selected")
 
         assertEqual(shown?.allowedProperties.contains("provider"), true, "prompt shown should allow provider attribution")
+        assertEqual(shown?.allowedProperties.contains("prompt_reason"), true, "prompt shown should preserve why it appeared")
         assertEqual(dismissed?.allowedProperties.contains("source"), true, "prompt dismiss should allow source attribution")
+        assertEqual(dismissed?.allowedProperties.contains("backoff_kind"), true, "prompt dismiss should preserve which backoff rule fired")
         assertEqual(recorded?.allowedProperties.contains("provider"), true, "prompt accept should allow provider attribution")
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "prompt_reason": "calendar_plus_runtime_match",
+                "backoff_kind": "calendar_teams_extended",
+            ],
+            allowedKeys: ["prompt_reason", "backoff_kind"]
+        )
+        assertEqual(sanitized["prompt_reason"], "calendar_plus_runtime_match", "prompt reason should survive sanitization")
+        assertEqual(sanitized["backoff_kind"], "calendar_teams_extended", "dismiss backoff kind should survive sanitization")
     }
 }

--- a/Tests/MeetingPromptHeuristicsTests.swift
+++ b/Tests/MeetingPromptHeuristicsTests.swift
@@ -42,6 +42,17 @@ func testMeetingPromptHeuristics() {
         assertNil(prompt, "stale app activity should not keep prompting forever")
     }
 
+    runSuite("MeetingPromptHeuristics.allowsRuntimeOnlyPrompt — Teams must rely on stronger evidence") {
+        assertFalse(
+            MeetingPromptHeuristics.allowsRuntimeOnlyPrompt(for: .teams),
+            "Teams should not prompt just because the app is open"
+        )
+        assertTrue(
+            MeetingPromptHeuristics.allowsRuntimeOnlyPrompt(for: .zoom),
+            "Zoom should keep the existing runtime-only prompt path"
+        )
+    }
+
     runSuite("MeetingPromptHeuristics.snoozeInterval — runtime reminders use a short follow-up interval") {
         let interval = MeetingPromptHeuristics.snoozeInterval(
             for: .runtimeApp,
@@ -64,6 +75,55 @@ func testMeetingPromptHeuristics() {
         )
 
         assertEqual(interval, 30 * 60, "calendar prompts should preserve the longer snooze")
+    }
+
+    runSuite("MeetingPromptHeuristics.calendarDismissMinimumInterval — Teams get a stickier dismissal") {
+        let zoomInterval = MeetingPromptHeuristics.calendarDismissMinimumInterval(
+            for: .zoom,
+            defaultInterval: 30 * 60
+        )
+        let teamsInterval = MeetingPromptHeuristics.calendarDismissMinimumInterval(
+            for: .teams,
+            defaultInterval: 30 * 60
+        )
+
+        assertEqual(zoomInterval, 30 * 60, "Zoom should keep the default calendar dismissal interval")
+        assertEqual(
+            teamsInterval,
+            MeetingPromptHeuristics.teamsDismissMinimumInterval,
+            "Teams should stay quiet longer after a dismissal"
+        )
+    }
+
+    runSuite("MeetingPromptHeuristics.runtimeDismissFallbackInterval — Teams get the longer fallback backoff") {
+        assertEqual(
+            MeetingPromptHeuristics.runtimeDismissFallbackInterval(for: .zoom),
+            MeetingPromptHeuristics.defaultRuntimeDismissFallbackInterval,
+            "Zoom should keep the standard runtime fallback"
+        )
+        assertEqual(
+            MeetingPromptHeuristics.runtimeDismissFallbackInterval(for: .teams),
+            MeetingPromptHeuristics.teamsDismissMinimumInterval,
+            "Teams should fall back to the longer dismissal interval"
+        )
+    }
+
+    runSuite("MeetingPromptHeuristics.reason — calendar prompts distinguish runtime-backed prompts") {
+        assertEqual(
+            MeetingPromptHeuristics.reason(for: .calendarEvent, hasRuntimeContext: false),
+            .calendarNearby,
+            "calendar-only prompts should record the nearby-calendar reason"
+        )
+        assertEqual(
+            MeetingPromptHeuristics.reason(for: .calendarEvent, hasRuntimeContext: true),
+            .calendarPlusRuntimeMatch,
+            "calendar prompts with app evidence should record the combined reason"
+        )
+        assertEqual(
+            MeetingPromptHeuristics.reason(for: .runtimeApp, hasRuntimeContext: false),
+            .runtimeOnly,
+            "runtime prompts should keep the runtime-only reason"
+        )
     }
 
     runSuite("MeetingPromptWindowPolicy.shouldOfferCalendarPrompt — only prompts in the one-minute lead window") {


### PR DESCRIPTION
## What changed
- disable Teams runtime-only meeting prompts so Transcripted stops prompting just because Teams is open
- make Teams dismissals back off longer than the generic provider path
- add prompt analytics context for `prompt_reason` and dismissal `backoff_kind`
- add fast-test coverage for the new Teams-specific prompt rules and analytics allowlist

## Why
Teams prompt data showed a bad fit for the generic runtime heuristic: prompts were being shown and dismissed repeatedly with almost no record selections. Zoom prompts looked healthy, so the fix is provider-specific rather than a global reduction in prompting.

## User impact
- Teams users should see fewer noisy meeting prompts
- Zoom behavior stays on the lighter existing path
- PostHog should now make it clearer why prompts appeared and which suppression path fired after a dismissal

## Root cause
The app treated Teams like Zoom in the native runtime prompt path, even though Teams is commonly left open for chat outside active meetings. That made `Teams is open` too weak a signal to justify a prompt.

## Validation
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`