### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@
 
 - dictation
 - meeting capture and local transcription
+- optional local-speaker review for people sharing the room mic during meetings
 
 The old standalone Transcripted app is preserved on:
 

--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -5,7 +5,8 @@
 `Sources/` is the app target. On `main`, the app is centered on:
 
 - dictation capture and paste-back
-- meeting capture, transcription, and transcript browsing
+- meeting capture, imported-audio transcription, and transcript browsing
+- optional local-speaker review for people sharing the room mic
 - wake / sleep recovery for active recording flows
 
 Important entry points:
@@ -14,12 +15,12 @@ Important entry points:
 - `TranscriptedAppState.swift` — owns `ContextCaptureEngine`, `STTRouter`, wake-recovery coordination, and lazy `MeetingSessionController`
 - `Support/TranscriptedStoragePaths.swift` — app-support path helpers for the Transcripted capture-library, state, cache, logs, and tmp layout
 - `Support/HotkeyPreferences.swift` — persisted hotkey settings used by capture routing
-- `Support/LocalSpeakerPreferences.swift` — persisted toggle for splitting local mic participants into multiple named speakers during meeting transcription
+- `Support/LocalSpeakerPreferences.swift` — persisted toggle that decides whether meeting transcription should split the local mic into multiple named speakers or keep it as a single "You" track
 - `Support/TranscriptedConstants.swift` — shared timing and behavior constants used across the app target
 - `Capture/ContextCaptureEngine.swift` — right-option dictation handling, keyboard hotkeys, meeting hotkey routing
-- `UI/Overlay/DictationSessionController.swift` — dictation session orchestration
+- `UI/Overlay/DictationSessionController.swift` — dictation session orchestration; removed draft-mode methods are stubs
 - `Meeting/MeetingPromptDetector.swift` — Calendar and runtime-app meeting detection used to offer one-tap meeting capture prompts
-- `Meeting/MeetingSessionController.swift` — app-side bridge into `TranscriptedCore`, including queued meeting transcription handoff
+- `Meeting/MeetingSessionController.swift` — app-side bridge into `TranscriptedCore`, including live capture, imported-audio handoff, queued meeting transcription, and local-speaker-split settings
 - `Speech/ParakeetEngine.swift` + `Speech/STTRouter.swift` — local STT path used by dictation and by the meeting adapter
 
 ## Directory map
@@ -28,11 +29,11 @@ Important entry points:
 - `Beta/` — beta-only config currently; older API docs are historical
 - `Capture/` — hotkeys, context parsing, capture routing
 - `Dictation/` — dictation transcript persistence and timeout helpers
-- `Meeting/` — app-side meeting bridge, prompts, storage, and transcript restyling
+- `Meeting/` — app-side meeting bridge, prompts, imported-audio prep, storage, and transcript restyling
 - `Observability/` — events, debug log, anonymous analytics, Sparkle updater, and crash reporting
 - `Reliability/` — wake / sleep recovery coordination
 - `Speech/` — Parakeet STT, router, and recorded-audio buffering helpers
-- `Support/` — app-wide path, storage, permission, hotkey, local-speaker, and shared constant helpers
+- `Support/` — app-wide path, storage, permission, hotkey, local-speaker preference, and shared constant helpers
 - `TranscriptedCore/` — shared library boundary
 - `UI/` — grouped app surfaces: `Overlay/`, `MenuBar/`, `Settings/`, `AgentConnect/`, and `Shared/`
 
@@ -47,7 +48,7 @@ app target entirely. If a historical doc still mentions `Sources/Text/` or
 ## Read before editing
 
 - touching dictation persistence: `Sources/Dictation/CLAUDE.md`
-- touching meeting flow: `Sources/Meeting/CLAUDE.md`
+- touching meeting flow or imported-audio transcription: `Sources/Meeting/CLAUDE.md`
 - touching core library or meeting pipeline internals: `Sources/TranscriptedCore/CLAUDE.md`
 - touching STT / recording lifecycle: `Sources/Speech/CLAUDE.md`
 - touching tests or package boundaries: `Tests/README.md`

--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -10,13 +10,13 @@
 - `MeetingCaptureBridge.swift` — `@MainActor` wrapper around core `Audio`, converts callback-based stop into `async`
 - `MeetingFailureCopy.swift` — normalizes `MeetingFailureKind` values into user-facing titles and recovery copy
 - `MeetingFailureKind.swift` — canonical failure taxonomy that classifies raw meeting errors into stable machine-readable kinds
-- `MeetingImportedAudioPreparer.swift` — copies user-selected audio files into app-owned scratch space before import transcription
+- `MeetingImportedAudioPreparer.swift` — copies imported recordings into app-managed scratch paths, derives titles, and prepares single-file meeting transcription jobs
 - `MeetingModelDownloader.swift` — loads Parakeet and diarization models together
 - `MeetingPromptDetector.swift` — polls upcoming Calendar events, watches supported meeting apps, and asks the overlay to offer one-tap recording prompts
 - `MeetingPromptHeuristics.swift` — shared scoring and snooze rules for calendar- and runtime-based prompt candidates
 - `MeetingRecordingStartGate.swift` — permission preflight for meeting recording, including missing-permission reasons and user-facing error messages
 - `MeetingSTTAdapter.swift` — adapts the app's shared `ParakeetEngine` to `TranscriptedCore.SpeechToTextEngine`
-- `MeetingSessionController.swift` — top-level meeting state machine, permission gating, model warmup, capture start/stop, local-speaker diarization toggle handoff, queued transcription handoff, failed-meeting actions, and transcript restyling
+- `MeetingSessionController.swift` — top-level meeting state machine, permission gating, model warmup, capture start/stop, imported-audio handoff, queued transcription handoff, local-speaker-split handoff, failed-meeting actions, and transcript restyling
 - `MeetingSessionUIPolicy.swift` — centralizes when queued or active transcription work should keep the meeting overlay in its transcribing/saving state
 - `MeetingStoragePaths.swift` — current split meeting storage layout across the capture library, app state, logs, and temp folders
 - `MeetingTranscriptStyler.swift` — restyles saved transcripts and renames files after save
@@ -28,22 +28,24 @@
 3. `Sources/TranscriptedAppState.swift` starts background model warmup through `meetingSession.prepareModels(showLoadingUI: false)`.
 4. `MeetingSessionController.startRecording(...)` first runs `MeetingRecordingStartGate` so missing microphone or System Audio Recording permission failures are blocked before capture starts, then uses `MeetingCaptureBridge` to start core audio capture into app-owned scratch paths.
 5. `MeetingSessionController.stopRecording(...)` awaits mic/system audio files from the bridge, then either starts transcription immediately or queues it behind the active job.
-6. `MeetingSessionController.importAudioFile(...)` copies a user-selected audio file into app-owned scratch space, then queues a system-audio-only transcription pass through the same task manager.
-7. `TranscriptionTaskManager` runs one diarize → transcribe → save pipeline at a time, honoring the persisted `LocalSpeakerPreferences.isEnabled` flag via the `splitLocalSpeakers` task option.
+6. `MeetingSessionController.importAudioFile(...)` routes standalone recordings through `MeetingImportedAudioPreparer` and into the same save / naming / restyling pipeline used by live captures.
+7. `TranscriptionTaskManager` runs one diarize → transcribe → save pipeline at a time. When `LocalSpeakerPreferences` is enabled, queued meeting work also asks the core pipeline to diarize the local mic channel instead of treating it as a single "You" speaker.
 8. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the recent-meetings UI state.
-9. Failed meetings can be retried, deleted, or dismissed from the menubar recent-meetings section, with `MeetingFailureKind` providing stable failure categories and `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
+9. If the speaker review sheet shows multiple local speakers, the user can either name them individually or collapse them back to a single "You" track via the UI's "Keep as You" path.
+10. Failed meetings can be retried, deleted, or dismissed from the menubar recent-meetings section, with `MeetingFailureKind` providing stable failure categories and `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
 
 ## Key invariants
 
 - `TranscriptedCore` owns the reusable pipeline. App code in this directory should prefer adapters and protocol seams over direct core edits.
 - `MeetingSTTAdapter.cleanup()` is intentionally a no-op. `TranscriptedAppState` owns `ParakeetEngine` lifecycle for the whole app.
 - Meeting captures should follow the current capture library, while databases, logs, and temp recordings stay under the app-owned Transcripted Application Support folders.
+- Imported meeting audio should be copied into app-controlled scratch space before transcription so later cleanup and metadata writes stay consistent with live captures.
 - `MeetingPromptDetector` can prompt from either upcoming calendar events or recently active supported meeting apps (Zoom, Teams, Webex, FaceTime, plus browser-hosted providers like Google Meet).
+- Local mic diarization is opt-in and controlled by `Support/LocalSpeakerPreferences.swift`, so default meeting behavior still keeps the mic side as a single "You" speaker unless the user enables review for people in the room.
 - `MeetingRecordingStartGate` is the canonical place for meeting-recording permission policy and reason strings. Keep duplicate permission branching out of overlay code.
 - `MeetingFailureKind` is the canonical place for stable failed-meeting categories used by presentation and metadata. Keep new classification rules centralized there.
 - `MeetingFailureCopy` is the canonical place for human-facing failed-meeting titles and details. Keep retry messaging centralized there.
 - `MeetingSessionUIPolicy` is the canonical place for deciding whether background meeting work should still surface as an active transcribing/saving state. Speaker review alone should not keep that state visible.
-- The local-speaker split toggle is app-owned state. Keep the preference in `Sources/Support/LocalSpeakerPreferences.swift` and only pass the resolved boolean into core work.
 - `TranscriptionTaskManager` stays single-flight. App-level queueing belongs in `MeetingSessionController`, not in ad hoc background tasks.
 - Live PCM handlers installed through `MeetingCaptureBridge` run on capture threads. Keep them real-time safe.
 
@@ -62,6 +64,7 @@ App-owned meeting state lives under `~/Library/Application Support/Transcripted/
 Temporary meeting scratch paths live under `~/Library/Application Support/Transcripted/tmp/recordings/`:
 
 - raw audio captures
+- imported audio copies
 - `speaker_clips/`
 
 Core logging for the embedded meeting pipeline is redirected to `~/Library/Application Support/Transcripted/logs/`.
@@ -76,6 +79,7 @@ See `docs/storage-paths.md` for the full map.
 
 Relevant direct coverage:
 
+- `Tests/FailedMeetingPresentationTests.swift`
 - `Tests/MeetingFailureKindTests.swift`
 - `Tests/MeetingPromptHeuristicsTests.swift`
 - `Tests/MeetingRecordingStartGateTests.swift`

--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -4,20 +4,17 @@
 
 `Sources/TranscriptedCore/` is the reusable meeting transcription library embedded in this repo. It is consumed by the app through `Sources/Meeting/`, and it can also be tested as a standalone Swift package through the root `Package.swift`.
 
-## Subsystems (56 Swift files)
+## Subsystems (58 Swift files)
 
-- `Audio/` (13 files) — mic + system audio capture, device recovery, resampling, level metering, process tap, ScreenCaptureKit-backed system-audio capture, backend selection, buffer writing, and merge helpers
+- `Audio/` (14 files) — mic + system audio capture, imported-audio prep helpers, device recovery, resampling, level metering, process tap, ScreenCaptureKit-backed system-audio capture, backend selection, buffer writing, and merge helpers
 - `Logging/` (2 files) — shared app logger and JSONL file logger
-- `Models/` (5 files) — public data types: `TranscriptionResult`, `DisplayStatus`, `FailedTranscription`, `RecordingHealthInfo`, and shared speaker-mapping / transcript metadata models
+- `Models/` (5 files) — public data types: `TranscriptionResult`, `DisplayStatus`, `FailedTranscription`, `SpeakerMapping`, and recording-health metadata builders
 - `Pipeline/` (4 files) — transcription orchestration, pipeline runner, and task queue
 - `Protocols/` (7 files) — host-injected seams: `SpeechToTextEngine`, `DiarizationEngine`, `SpeakerStore`, `TranscriptNotifier`, `AudioCaptureEngine`, `StatsStore`, `TranscriptStorage`
 - `Services/` (7 files) — DI container (`AppServices`), model bundle / download management, path indirection, recording validation, diarization, and failed-transcription persistence
-- `Speaker/` (10 files) — speaker DB, embedding matching / clustering, clip extraction, naming policy / coordinator, profile merging, retroactive transcript updates, and local-speaker splitting helpers
+- `Speaker/` (10 files) — speaker DB, embedding matching / clustering, clip extraction, naming policy / coordinator, profile merging, retroactive transcript updates
 - `Stats/` (4 files) — recording stats database, models, queries, and service
-<<<<<<< HEAD
 - `Storage/` (3 files) — transcript save, scanner, formatter
-- `Utilities/` (2 files) — date formatting and file permission helpers
-- `Storage/` (3 files) — transcript save, local-speaker breakdown formatting, scanner, formatter
 - `Utilities/` (2 files) — date formatting and file permission helpers
 
 ## The seams embedders should know
@@ -25,7 +22,7 @@
 - `CoreStoragePaths` — redirects all persisted output away from the standalone defaults
 - `ModelBundleProvider` — lets hosts override where offline model bundles are resolved
 - `AppServices` — DI container over protocol-typed STT / diarization / speaker-store dependencies
-- `TranscriptionTaskManager` — host-facing queue and orchestration surface, including the `splitLocalSpeakers` task option
+- `TranscriptionTaskManager` — host-facing queue and orchestration surface, including imported-audio jobs and optional local-speaker mic diarization when the app asks for it
 - `TranscriptNotifier` — optional callback channel for transcript-saved / failure notifications
 
 These seams exist specifically so the app can embed the library without adopting the old standalone Transcripted app assumptions.
@@ -35,6 +32,7 @@ These seams exist specifically so the app can embed the library without adopting
 - `Audio` can switch between the legacy CoreAudio path and the newer ScreenCaptureKit system-audio path through `SystemAudioCaptureEngine`.
 - `SCKAudioCapture` is the macOS 26+ backend for audio-only ScreenCaptureKit capture, which keeps system-audio recording on the lighter permission tier and avoids full screen-pixel capture.
 - Hosts embedding `TranscriptedCore` should keep app-specific permission UX outside this directory, but they should understand that system-audio capture backend behavior now depends on OS availability.
+- Imported meeting audio is funneled through the same pipeline primitives as live captures so transcript formatting, stats, speaker naming, and retry behavior stay aligned.
 
 ## Threading model
 
@@ -56,7 +54,7 @@ The app still injects app-specific `CoreStoragePaths` for meetings so the
 capture folder follows the selected capture library rather than a hard-coded
 default path.
 
-`TranscriptSaver.saveTranscript(...)` writes a markdown transcript.
+`TranscriptSaver.saveTranscript(...)` writes a markdown transcript, including YAML speaker metadata and recording-health fields like `capture_quality`, `audio_gaps`, and `device_switches` when the host provides them.
 
 ## Editing rules
 
@@ -80,8 +78,10 @@ Also run when the package seam changes:
 Current direct core coverage includes:
 
 - `Tests/TranscriptedCoreTests/CoreStoragePathsTests.swift`
+- `Tests/TranscriptedCoreTests/DatabaseFilePermissionsTests.swift`
 - `Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift`
 - `Tests/TranscriptedCoreTests/MicRecordingFileMergerTests.swift`
+- `Tests/TranscriptedCoreTests/TranscriptMetadataBuilderTests.swift`
 - `Tests/TranscriptedCoreTests/RetroactiveSpeakerUpdaterTests.swift`
 - `Tests/TranscriptedCoreTests/SpeakerMatchingServiceTests.swift`
 - `Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift`
@@ -90,4 +90,4 @@ Current direct core coverage includes:
 - `Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift`
 - `Tests/Integration/AppCoreIntegrationSmoke.swift`
 
-Core coverage is still selective, but it is no longer limited just to the package seam. Speaker reconciliation, file merging, stats, and storage-path behavior now have direct tests.
+Core coverage is still selective, but it is no longer limited just to the package seam. Speaker reconciliation, transcript metadata, stats, storage-path behavior, and file-permission enforcement all have direct tests.

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -17,7 +17,7 @@ Draft-mode UI is not an active product path in this worktree.
 
 ### Overlay/
 
-- `Overlay/DictationSessionController.swift` — dictation session orchestration
+- `Overlay/DictationSessionController.swift` — dictation session orchestration; removed draft-mode methods are stubs
 - `Overlay/FloatingOverlayController.swift` — owns the dictation overlay panel lifecycle and Combine subscriptions
 - `Overlay/FloatingOverlayPanel.swift` — non-activating NSPanel for the dictation overlay
 - `Overlay/OverlayDraftingView.swift` — drafting/processing state view
@@ -39,7 +39,7 @@ dictation overlay and the meeting prompt / recording overlay.
 - `MenuBar/MenuBarModelStatusView.swift` — persistent local-model status badge with download progress, error state, and settings shortcut
 - `MenuBar/MenuBarPanelController.swift` — NSPopover controller for the menubar
 - `MenuBar/MenuBarRecentMeetingsView.swift` — recent meetings list in the popover
-- `MenuBar/MenuBarSettingsView.swift` — settings actions in the popover footer
+- `MenuBar/MenuBarSettingsView.swift` — settings actions in the popover footer, including imported-audio transcription entry points
 - `MenuBar/MenuBarShortcutsView.swift` — keyboard shortcut hints in the popover
 - `MenuBar/MenuIconButton.swift` — icon-only button style for menubar items
 - `MenuBar/MenuOutlineButton.swift` — outlined button style for menubar actions
@@ -61,8 +61,8 @@ The current agent-connect surfaces should keep one simple mental model:
 - `Settings/HotkeyRecorderAppKitView.swift` — AppKit view for recording custom hotkey bindings
 - `Settings/PermissionsOnboardingView.swift` — first-launch permissions walkthrough
 - `Settings/TranscriptedOnboardingWindowController.swift` — dedicated first-launch window that hosts onboarding before users drop into the menubar flow
-- `Settings/SpeakerNamingSheet.swift` — sheet for renaming speakers in a completed meeting
-- `Settings/SpeakerPeopleSettingsSection.swift` — settings section and view model for browsing, toggling multiple local-speaker identification, naming, merging, previewing, and deleting saved speaker profiles
+- `Settings/SpeakerNamingSheet.swift` — sheet for reviewing speakers in a completed meeting, grouped into local room speakers vs remote participants, with a "Keep as You" escape hatch for local mic splits
+- `Settings/SpeakerPeopleSettingsSection.swift` — settings section and view model for browsing, naming, merging, previewing, and deleting saved speaker profiles, plus the toggle for identifying multiple local speakers on the mic track
 - `Settings/TranscriptedSettingsView.swift` — main settings view
 - `Settings/TranscriptedSettingsWindowController.swift` — NSWindowController for settings
 
@@ -76,6 +76,11 @@ The current agent-connect surfaces should keep one simple mental model:
 Cross-cutting permission checks now live in `Sources/Support/TranscriptedPermissionAccess.swift`
 so the meeting prompt detector and the settings/onboarding flows share the same
 app-level permission logic outside the UI tree.
+
+Cross-cutting local-speaker behavior is split between settings and review UI:
+`SpeakerPeopleSettingsSection` owns the persisted toggle for local mic diarization,
+while `SpeakerNamingSheet` is where users confirm local-vs-remote speakers or
+collapse the local side back into a single "You" track.
 
 Keep user-visible TCC prompts user-initiated. Background warmup paths should
 not request microphone, system-audio-recording, or calendar access on their own;
@@ -100,8 +105,10 @@ Manual checks:
 - dictation overlay starts, stops, and auto-pastes cleanly
 - detected-meeting prompts appear only when appropriate and can start or snooze a meeting cleanly
 - meeting overlay warms up and records cleanly
+- imported-audio transcription can be started from the menubar and lands in the normal recent-meetings flow
 - menubar popover renders shortcuts, recents, settings actions, and the agent-connect page cleanly
-- speaker settings can preview clips and rename / merge people cleanly
+- speaker settings can preview clips, toggle local-speaker splitting, and rename / merge people cleanly
+- completed meeting review cleanly separates "People in the room" from remote participants, and "Keep as You" restores the single-speaker local path when needed
 - permissions onboarding and first-run onboarding window still open correctly
 - first-run CTA copy updates correctly as permissions and local-model state change
 - settings window still opens correctly


### PR DESCRIPTION
## Summary
- update root and `Sources/CLAUDE.md` docs for the current meeting/imported-audio runtime and local-speaker preference toggle
- refresh `Sources/Meeting/CLAUDE.md` for imported audio prep, local mic diarization handoff, and the "Keep as You" review path
- refresh `Sources/TranscriptedCore/CLAUDE.md` for the current 58-file subsystem counts, speaker/health metadata model notes, and current direct test coverage
- refresh `Sources/UI/CLAUDE.md` for imported-audio entry points plus the local-vs-remote speaker review UX

## Why
Recent merged work added imported-audio meeting transcription, local speaker review controls, and updated transcript metadata details. The affected CLAUDE.md files were slightly behind the current codebase and now match the live tree again.