### PR TITLE
[nightly-simplify] Simplify right-option detector setup

### DIFF
--- a/Sources/Capture/ContextCaptureEngine.swift
+++ b/Sources/Capture/ContextCaptureEngine.swift
@@ -273,21 +273,7 @@ class ContextCaptureEngine: ObservableObject {
         // Register meeting hotkey from saved preferences (or defaults)
         registerHotkeysFromPreferences()
 
-        // Install right Option tap detector for dictation toggle
-        rightOptionDetector.maxTapDurationProvider = { [weak self] in
-            self?.sessionController?.isDictating == true ? 1.0 : 0.35
-        }
-        rightOptionDetector.onInteraction = { [weak self] event, context in
-            self?.recordRightOptionInteraction(event: event, context: context)
-        }
-        if HotkeyPreferences.rightOptionDictationEnabled() {
-            rightOptionDetector.onTap = { [weak self] in
-                Task { @MainActor [weak self] in
-                    self?.handleRightOptionTap()
-                }
-            }
-            rightOptionDetector.install()
-        }
+        configureRightOptionDetector()
 
         // Listen for preference changes (from HotkeyRecorderView)
         hotkeyChangeObserver = NotificationCenter.default.addObserver(
@@ -316,20 +302,27 @@ class ContextCaptureEngine: ObservableObject {
 
         // Re-evaluate right Option tap detector
         rightOptionDetector.remove()
+        configureRightOptionDetector()
+    }
+
+    private func configureRightOptionDetector() {
         rightOptionDetector.maxTapDurationProvider = { [weak self] in
             self?.sessionController?.isDictating == true ? 1.0 : 0.35
         }
         rightOptionDetector.onInteraction = { [weak self] event, context in
             self?.recordRightOptionInteraction(event: event, context: context)
         }
-        if HotkeyPreferences.rightOptionDictationEnabled() {
-            rightOptionDetector.onTap = { [weak self] in
-                Task { @MainActor [weak self] in
-                    self?.handleRightOptionTap()
-                }
-            }
-            rightOptionDetector.install()
+        guard HotkeyPreferences.rightOptionDictationEnabled() else {
+            rightOptionDetector.onTap = nil
+            return
         }
+
+        rightOptionDetector.onTap = { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.handleRightOptionTap()
+            }
+        }
+        rightOptionDetector.install()
     }
 
     private func registerHotkeysFromPreferences() {


### PR DESCRIPTION
## Summary
- extract the repeated right-Option detector wiring into `configureRightOptionDetector()`
- reuse that helper for both initial hotkey registration and preference-driven re-registration
- clear the tap callback when the preference is off so the disabled path stays explicit

## Why
The same setup logic lived in two places inside `ContextCaptureEngine`, which made the hotkey path harder to scan and easier to drift.

## Validation
- `bash build-deps.sh`
- `bash build.sh`
- `bash run-tests.sh`
