### PR TITLE
Release 1.1.11

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.10"
-  sha256 "f7a2a1ef59602dd1569f5c019fdf205ad95bee4b35dd8520c2a89d46c98e5e07"
+  version "1.1.11"
+  sha256 "4bfe1d1449a2704b3dd36596914523d3f5b163ba26a5b04ad82f37feba2e217e"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.10</string>
+	<string>1.1.11</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.10</string>
+	<string>1.1.11</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.11</title>
+      <pubDate>Sat, 18 Apr 2026 12:00:39 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.11</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.11</sparkle:releaseNotesLink>
+      <sparkle:version>1.1.11</sparkle:version>
+      <sparkle:shortVersionString>1.1.11</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.11/Transcripted-1.1.11.dmg" length="503193049" type="application/octet-stream" sparkle:edSignature="r3XHWckeyeCU3lkgfIda5c9jDDph9K19xXbQ8ySleY6Y3umG4wS4WqX/e8M7Z4zM5cmFLrIYcqx8oJSrhYuLCw=="/>
+    </item>
+    <item>
       <title>1.1.10</title>
       <pubDate>Fri, 17 Apr 2026 19:44:46 GMT</pubDate>
       <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.10</link>


### PR DESCRIPTION
## Summary
- bump Transcripted to 1.1.11
- publish the notarized 1.1.11 DMG
- update Sparkle appcast and Homebrew cask for the release

## Verification
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-release-1-1-11 "Transcripted Release"
