### PR TITLE
[codex] Refine meeting overlay recording pill

### DIFF
--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -185,6 +185,7 @@ final class MeetingOverlayRootView: NSView {
         closeButton.layer?.cornerRadius = 8
         closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.12).cgColor
         closeButton.layer?.borderWidth = 0
+        closeButton.imageScaling = .scaleProportionallyDown
         closeButton.target = self
         closeButton.action = #selector(handleSecondaryAction)
         closeButton.isHidden = true
@@ -355,11 +356,10 @@ final class MeetingOverlayRootView: NSView {
             height: lineHeight
         )
 
-        let closeWidth = max(52, closeButton.fittingSize.width + tokens.stopHPadding * 2)
         closeButton.frame = NSRect(
-            x: bounds.width - tokens.padRight - closeWidth,
+            x: bounds.width - tokens.padRight - tokens.stopHeight,
             y: midY - tokens.stopHeight / 2,
-            width: closeWidth,
+            width: tokens.stopHeight,
             height: tokens.stopHeight
         )
 
@@ -554,7 +554,11 @@ final class MeetingOverlayRootView: NSView {
             micLabel.textColor = MeetingOverlayTokens.textSecondary
             systemLabel.font = .systemFont(ofSize: MeetingOverlayTokens.labelFontSize, weight: .regular)
             systemLabel.textColor = MeetingOverlayTokens.textSecondary
-            closeButton.attributedTitle = buttonTitle("Stop", size: 12, weight: .semibold)
+            closeButton.attributedTitle = buttonTitle("", size: 12, weight: .semibold)
+            closeButton.image = stopButtonImage()
+            closeButton.imagePosition = .imageOnly
+            closeButton.contentTintColor = MeetingOverlayTokens.textPrimary
+            closeButton.toolTip = "Stop recording"
             closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.12).cgColor
             closeButton.layer?.cornerRadius = MeetingOverlayTokens.stopHeight / 2
             closeButton.layer?.borderWidth = 0.5
@@ -604,6 +608,10 @@ final class MeetingOverlayRootView: NSView {
         systemLabel.font = .systemFont(ofSize: 8, weight: .medium)
         systemLabel.textColor = MeetingOverlayTokens.textSecondary
         closeButton.attributedTitle = buttonTitle("Stop", size: 11, weight: .semibold)
+        closeButton.image = nil
+        closeButton.imagePosition = .noImage
+        closeButton.contentTintColor = MeetingOverlayTokens.textPrimary
+        closeButton.toolTip = nil
         closeButton.layer?.cornerRadius = 8
         closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.12).cgColor
         closeButton.layer?.borderWidth = 0
@@ -625,6 +633,12 @@ final class MeetingOverlayRootView: NSView {
         statusDot.layer?.shadowColor = color.cgColor
         statusDot.layer?.shadowOpacity = haloOpacity
         statusDot.layer?.shadowRadius = haloRadius
+    }
+
+    private func stopButtonImage() -> NSImage? {
+        let config = NSImage.SymbolConfiguration(pointSize: 9, weight: .semibold)
+        return NSImage(systemSymbolName: "stop.fill", accessibilityDescription: "Stop recording")?
+            .withSymbolConfiguration(config)
     }
 
     private func formatDuration(_ seconds: TimeInterval) -> String {
@@ -674,7 +688,6 @@ enum MeetingOverlayTokens {
     static let timerFontSize: CGFloat = 13
     static let labelFontSize: CGFloat = 11
     static let stopHeight: CGFloat  = 28
-    static let stopHPadding: CGFloat = 14
     static let barCount: Int        = 26
     static let barWidth: CGFloat    = 2
     static let barGap: CGFloat      = 1.5

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -614,8 +614,8 @@ enum MeetingOverlayTokens {
     static let panelStroke   = NSColor.white.withAlphaComponent(0.08)
     static let textPrimary   = NSColor(calibratedWhite: 0.98, alpha: 1.0)
     static let textSecondary = NSColor.white.withAlphaComponent(0.55)
-    static let waveformMicTint = NSColor(calibratedRed: 0.20, green: 0.90, blue: 0.63, alpha: 1.0)
-    static let waveformSystemTint = NSColor(calibratedRed: 0.72, green: 0.76, blue: 0.82, alpha: 0.95)
+    static let waveformMicTint = NSColor(calibratedRed: 0.72, green: 0.82, blue: 0.79, alpha: 1.0)
+    static let waveformSystemTint = NSColor(calibratedRed: 0.74, green: 0.78, blue: 0.85, alpha: 1.0)
     static let dotIdle       = OverlayTokens.textMuted
     static let dotPrep       = OverlayTokens.textSecondary
     static let dotPrompt     = OverlayTokens.accentGreen

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -124,8 +124,8 @@ final class MeetingOverlayRootView: NSView {
         systemLabel.textColor = MeetingOverlayTokens.textSecondary
         addSubview(systemLabel)
 
-        audioWaveform.primaryTintColor = MeetingOverlayTokens.waveformTint
-        audioWaveform.secondaryTintColor = MeetingOverlayTokens.waveformTint.withAlphaComponent(MeetingOverlayTokens.waveformSystemAlpha)
+        audioWaveform.primaryTintColor = MeetingOverlayTokens.waveformMicTint
+        audioWaveform.secondaryTintColor = MeetingOverlayTokens.waveformSystemTint
         addSubview(audioWaveform)
 
         warmupTitleLabel.font = NSFont.systemFont(ofSize: 15, weight: .semibold)
@@ -323,22 +323,6 @@ final class MeetingOverlayRootView: NSView {
             height: timerSize.height
         )
 
-        let labelX = timerLabel.frame.maxX + tokens.headerGap + 4
-        let labelWidth: CGFloat = 80
-        let lineHeight: CGFloat = 13
-        micLabel.frame = NSRect(
-            x: labelX,
-            y: midY + 1,
-            width: labelWidth,
-            height: lineHeight
-        )
-        systemLabel.frame = NSRect(
-            x: labelX,
-            y: midY - lineHeight - 1,
-            width: labelWidth,
-            height: lineHeight
-        )
-
         closeButton.frame = NSRect(
             x: bounds.width - tokens.padRight - tokens.stopHeight,
             y: midY - tokens.stopHeight / 2,
@@ -346,7 +330,7 @@ final class MeetingOverlayRootView: NSView {
             height: tokens.stopHeight
         )
 
-        let barsLeft = systemLabel.frame.maxX + tokens.headerGap + 12
+        let barsLeft = timerLabel.frame.maxX + tokens.headerGap + 10
         let barsRight = closeButton.frame.minX - tokens.headerGap
         let barsWidth = max(0, barsRight - barsLeft)
         let barsHeight: CGFloat = 22
@@ -360,6 +344,8 @@ final class MeetingOverlayRootView: NSView {
 
         titleLabel.frame = .zero
         detailLabel.frame = .zero
+        micLabel.frame = .zero
+        systemLabel.frame = .zero
         chevronButton.frame = .zero
     }
 
@@ -478,12 +464,10 @@ final class MeetingOverlayRootView: NSView {
         titleLabel.isHidden = isPreparing || state == .recording
         timerLabel.isHidden = isPreparing || (state != .recording && !isPrompting)
         detailLabel.isHidden = !(isPrompting || isErrorState)
-        micLabel.isHidden = isPreparing || isPrompting
-        systemLabel.isHidden = isPreparing || isPrompting
+        micLabel.isHidden = true
+        systemLabel.isHidden = true
         audioWaveform.isHidden = isPreparing || isPrompting
         let showLevels = state == .recording
-        micLabel.isHidden = !showLevels
-        systemLabel.isHidden = !showLevels
         audioWaveform.isHidden = !showLevels
         recordButton.isHidden = !isPrompting
         closeButton.isHidden = isPreparing || (state != .recording && !isPrompting)
@@ -523,10 +507,6 @@ final class MeetingOverlayRootView: NSView {
             updateStatusDot(color: MeetingOverlayTokens.dotRecording, haloOpacity: 0.24, haloRadius: 3)
             timerLabel.font = .monospacedDigitSystemFont(ofSize: MeetingOverlayTokens.timerFontSize, weight: .medium)
             timerLabel.textColor = MeetingOverlayTokens.textPrimary
-            micLabel.font = .systemFont(ofSize: MeetingOverlayTokens.labelFontSize, weight: .regular)
-            micLabel.textColor = MeetingOverlayTokens.textSecondary
-            systemLabel.font = .systemFont(ofSize: MeetingOverlayTokens.labelFontSize, weight: .regular)
-            systemLabel.textColor = MeetingOverlayTokens.textSecondary
             closeButton.attributedTitle = buttonTitle("", size: 12, weight: .semibold)
             closeButton.image = stopButtonImage()
             closeButton.imagePosition = .imageOnly
@@ -575,10 +555,6 @@ final class MeetingOverlayRootView: NSView {
         timerLabel.textColor = MeetingOverlayTokens.textSecondary
         detailLabel.font = .systemFont(ofSize: 11, weight: .medium)
         detailLabel.textColor = MeetingOverlayTokens.textSecondary
-        micLabel.font = .systemFont(ofSize: 8, weight: .medium)
-        micLabel.textColor = MeetingOverlayTokens.textSecondary
-        systemLabel.font = .systemFont(ofSize: 8, weight: .medium)
-        systemLabel.textColor = MeetingOverlayTokens.textSecondary
         closeButton.attributedTitle = buttonTitle("Stop", size: 11, weight: .semibold)
         closeButton.image = nil
         closeButton.imagePosition = .noImage
@@ -638,8 +614,8 @@ enum MeetingOverlayTokens {
     static let panelStroke   = NSColor.white.withAlphaComponent(0.08)
     static let textPrimary   = NSColor(calibratedWhite: 0.98, alpha: 1.0)
     static let textSecondary = NSColor.white.withAlphaComponent(0.55)
-    static let waveformTint  = NSColor(calibratedWhite: 0.98, alpha: 1.0)
-    static let waveformSystemAlpha: CGFloat = 0.72
+    static let waveformMicTint = NSColor(calibratedRed: 0.20, green: 0.90, blue: 0.63, alpha: 1.0)
+    static let waveformSystemTint = NSColor(calibratedRed: 0.72, green: 0.76, blue: 0.82, alpha: 0.95)
     static let dotIdle       = OverlayTokens.textMuted
     static let dotPrep       = OverlayTokens.textSecondary
     static let dotPrompt     = OverlayTokens.accentGreen
@@ -648,6 +624,7 @@ enum MeetingOverlayTokens {
     static let dotError      = NSColor.systemRed
 
     static let panelWidth: CGFloat  = 360
+    static let recordingPanelWidth: CGFloat = 300
     static let panelHeight: CGFloat = 44
     static let promptHeight: CGFloat = 88
     static let warmupHeight: CGFloat = 96
@@ -658,7 +635,6 @@ enum MeetingOverlayTokens {
     static let padRight: CGFloat    = 5
     static let headerGap: CGFloat   = 10
     static let timerFontSize: CGFloat = 13
-    static let labelFontSize: CGFloat = 11
     static let stopHeight: CGFloat  = 28
 }
 
@@ -950,7 +926,12 @@ final class MeetingOverlayController {
     }
 
     private func currentPanelWidth() -> CGFloat {
-        MeetingOverlayTokens.panelWidth
+        switch state {
+        case .recording:
+            return MeetingOverlayTokens.recordingPanelWidth
+        default:
+            return MeetingOverlayTokens.panelWidth
+        }
     }
 
     private func hidePanel() {

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -65,8 +65,7 @@ final class MeetingOverlayRootView: NSView {
     private let detailLabel = NSTextField(labelWithString: "")
     private let micLabel = NSTextField(labelWithString: "Mic")
     private let systemLabel = NSTextField(labelWithString: "System audio")
-    private let micWaveform = WaveformHostView(frame: .zero)
-    private let systemWaveform = WaveformHostView(frame: .zero)
+    private let audioWaveform = DualWaveformHostView(frame: .zero)
     private let recordButton = NSButton()
     private let closeButton = NSButton()
     private let chevronButton = NSButton()
@@ -125,13 +124,9 @@ final class MeetingOverlayRootView: NSView {
         systemLabel.textColor = MeetingOverlayTokens.textSecondary
         addSubview(systemLabel)
 
-        micWaveform.visualizationStyle = .scrolling
-        micWaveform.tintColor = MeetingOverlayTokens.waveformTint
-        addSubview(micWaveform)
-
-        systemWaveform.visualizationStyle = .scrolling
-        systemWaveform.tintColor = MeetingOverlayTokens.waveformTint.withAlphaComponent(MeetingOverlayTokens.waveformSystemAlpha)
-        addSubview(systemWaveform)
+        audioWaveform.primaryTintColor = MeetingOverlayTokens.waveformTint
+        audioWaveform.secondaryTintColor = MeetingOverlayTokens.waveformTint.withAlphaComponent(MeetingOverlayTokens.waveformSystemAlpha)
+        addSubview(audioWaveform)
 
         warmupTitleLabel.font = NSFont.systemFont(ofSize: 15, weight: .semibold)
         warmupTitleLabel.textColor = MeetingOverlayTokens.textPrimary
@@ -301,17 +296,11 @@ final class MeetingOverlayRootView: NSView {
             height: systemLabel.fittingSize.height
         )
 
-        micWaveform.frame = NSRect(
-            x: levelBarX,
-            y: micY,
-            width: levelBarWidth,
-            height: levelBarHeight
-        )
-        systemWaveform.frame = NSRect(
+        audioWaveform.frame = NSRect(
             x: levelBarX,
             y: systemY,
             width: levelBarWidth,
-            height: levelBarHeight
+            height: levelBarHeight * 2 + levelBarGap
         )
     }
 
@@ -362,19 +351,11 @@ final class MeetingOverlayRootView: NSView {
         let barsWidth = max(0, barsRight - barsLeft)
         let barsHeight: CGFloat = 22
         let barsY = midY - barsHeight / 2
-        let halfHeight = barsHeight / 2
-
-        micWaveform.frame = NSRect(
-            x: barsLeft,
-            y: midY,
-            width: barsWidth,
-            height: halfHeight
-        )
-        systemWaveform.frame = NSRect(
+        audioWaveform.frame = NSRect(
             x: barsLeft,
             y: barsY,
             width: barsWidth,
-            height: halfHeight
+            height: barsHeight
         )
 
         titleLabel.frame = .zero
@@ -499,13 +480,11 @@ final class MeetingOverlayRootView: NSView {
         detailLabel.isHidden = !(isPrompting || isErrorState)
         micLabel.isHidden = isPreparing || isPrompting
         systemLabel.isHidden = isPreparing || isPrompting
-        micWaveform.isHidden = isPreparing || isPrompting
-        systemWaveform.isHidden = isPreparing || isPrompting
+        audioWaveform.isHidden = isPreparing || isPrompting
         let showLevels = state == .recording
         micLabel.isHidden = !showLevels
         systemLabel.isHidden = !showLevels
-        micWaveform.isHidden = !showLevels
-        systemWaveform.isHidden = !showLevels
+        audioWaveform.isHidden = !showLevels
         recordButton.isHidden = !isPrompting
         closeButton.isHidden = isPreparing || (state != .recording && !isPrompting)
         chevronButton.isHidden = true
@@ -581,11 +560,10 @@ final class MeetingOverlayRootView: NSView {
         }
         currentMicLevel = max(0, min(1, micLevel))
         currentSystemLevel = max(0, min(1, systemLevel))
-        micWaveform.level = currentMicLevel
-        systemWaveform.level = currentSystemLevel
+        audioWaveform.primaryLevel = currentMicLevel
+        audioWaveform.secondaryLevel = currentSystemLevel
         let shouldAnimate = state == .recording
-        micWaveform.isActive = shouldAnimate
-        systemWaveform.isActive = shouldAnimate
+        audioWaveform.isActive = shouldAnimate
 
         needsLayout = true
     }

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -330,15 +330,14 @@ final class MeetingOverlayRootView: NSView {
             height: tokens.stopHeight
         )
 
-        let barsLeft = timerLabel.frame.maxX + tokens.headerGap + 10
+        let barsLeft = timerLabel.frame.maxX + tokens.headerGap
         let barsRight = closeButton.frame.minX - tokens.headerGap
         let availableBarsWidth = max(0, barsRight - barsLeft)
         let barsWidth = min(tokens.recordingWaveformWidth, availableBarsWidth)
-        let barsX = barsLeft + max(0, (availableBarsWidth - barsWidth) / 2)
         let barsHeight: CGFloat = 22
         let barsY = midY - barsHeight / 2
         audioWaveform.frame = NSRect(
-            x: barsX,
+            x: barsLeft,
             y: barsY,
             width: barsWidth,
             height: barsHeight
@@ -626,16 +625,16 @@ enum MeetingOverlayTokens {
     static let dotError      = NSColor.systemRed
 
     static let panelWidth: CGFloat  = 360
-    static let recordingPanelWidth: CGFloat = 300
+    static let recordingPanelWidth: CGFloat = 256
     static let panelHeight: CGFloat = 44
     static let promptHeight: CGFloat = 88
     static let warmupHeight: CGFloat = 96
     static let errorHeight: CGFloat = 72
     static let cornerRadius: CGFloat = 22
     static let dotSize: CGFloat     = 8
-    static let padLeft: CGFloat     = 14
-    static let padRight: CGFloat    = 5
-    static let headerGap: CGFloat   = 10
+    static let padLeft: CGFloat     = 12
+    static let padRight: CGFloat    = 8
+    static let headerGap: CGFloat   = 8
     static let timerFontSize: CGFloat = 13
     static let stopHeight: CGFloat  = 28
     static let recordingWaveformWidth: CGFloat = 124

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -93,12 +93,13 @@ final class MeetingOverlayRootView: NSView {
         layer?.cornerRadius = MeetingOverlayTokens.cornerRadius
         layer?.masksToBounds = true
         layer?.backgroundColor = MeetingOverlayTokens.panelBg.cgColor
-        layer?.borderWidth = 1
+        layer?.borderWidth = 0.5
         layer?.borderColor = MeetingOverlayTokens.panelStroke.cgColor
 
         // Record status dot (red during recording, orange while prep/transcribe, grey idle).
         statusDot.wantsLayer = true
         statusDot.layer?.cornerRadius = MeetingOverlayTokens.dotSize / 2
+        statusDot.layer?.shadowOffset = .zero
         statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotIdle.cgColor
         addSubview(statusDot)
 
@@ -124,10 +125,18 @@ final class MeetingOverlayRootView: NSView {
         systemLabel.textColor = MeetingOverlayTokens.textSecondary
         addSubview(systemLabel)
 
+        micWaveform.visualizationStyle = .mirrored(anchor: .fromBottom, phaseOffset: 0)
+        micWaveform.mirroredBarCount = MeetingOverlayTokens.barCount
+        micWaveform.mirroredBarWidth = MeetingOverlayTokens.barWidth
+        micWaveform.mirroredBarSpacing = MeetingOverlayTokens.barGap
         micWaveform.tintColor = MeetingOverlayTokens.waveformTint
         addSubview(micWaveform)
 
-        systemWaveform.tintColor = MeetingOverlayTokens.waveformTint
+        systemWaveform.visualizationStyle = .mirrored(anchor: .fromTop, phaseOffset: 1.8)
+        systemWaveform.mirroredBarCount = MeetingOverlayTokens.barCount
+        systemWaveform.mirroredBarWidth = MeetingOverlayTokens.barWidth
+        systemWaveform.mirroredBarSpacing = MeetingOverlayTokens.barGap
+        systemWaveform.tintColor = MeetingOverlayTokens.waveformTint.withAlphaComponent(MeetingOverlayTokens.waveformSystemAlpha)
         addSubview(systemWaveform)
 
         warmupTitleLabel.font = NSFont.systemFont(ofSize: 15, weight: .semibold)
@@ -175,6 +184,7 @@ final class MeetingOverlayRootView: NSView {
         closeButton.wantsLayer = true
         closeButton.layer?.cornerRadius = 8
         closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.12).cgColor
+        closeButton.layer?.borderWidth = 0
         closeButton.target = self
         closeButton.action = #selector(handleSecondaryAction)
         closeButton.isHidden = true
@@ -205,7 +215,15 @@ final class MeetingOverlayRootView: NSView {
             layoutError()
             return
         }
+        if currentState == .recording {
+            layoutRecording()
+            return
+        }
 
+        layoutStandardStatus()
+    }
+
+    private func layoutStandardStatus() {
         let pad: CGFloat = 12
         let dotSize = MeetingOverlayTokens.dotSize
         let headerHeight = MeetingOverlayTokens.panelHeight
@@ -300,6 +318,74 @@ final class MeetingOverlayRootView: NSView {
             width: levelBarWidth,
             height: levelBarHeight
         )
+    }
+
+    private func layoutRecording() {
+        let tokens = MeetingOverlayTokens.self
+        let midY = bounds.height / 2
+
+        statusDot.frame = NSRect(
+            x: tokens.padLeft,
+            y: midY - tokens.dotSize / 2,
+            width: tokens.dotSize,
+            height: tokens.dotSize
+        )
+
+        let timerSize = timerLabel.fittingSize
+        timerLabel.frame = NSRect(
+            x: statusDot.frame.maxX + tokens.headerGap,
+            y: midY - timerSize.height / 2,
+            width: timerSize.width,
+            height: timerSize.height
+        )
+
+        let labelX = timerLabel.frame.maxX + tokens.headerGap + 4
+        let labelWidth: CGFloat = 80
+        let lineHeight: CGFloat = 13
+        micLabel.frame = NSRect(
+            x: labelX,
+            y: midY + 1,
+            width: labelWidth,
+            height: lineHeight
+        )
+        systemLabel.frame = NSRect(
+            x: labelX,
+            y: midY - lineHeight - 1,
+            width: labelWidth,
+            height: lineHeight
+        )
+
+        let closeWidth = max(52, closeButton.fittingSize.width + tokens.stopHPadding * 2)
+        closeButton.frame = NSRect(
+            x: bounds.width - tokens.padRight - closeWidth,
+            y: midY - tokens.stopHeight / 2,
+            width: closeWidth,
+            height: tokens.stopHeight
+        )
+
+        let barsLeft = systemLabel.frame.maxX + tokens.headerGap + 12
+        let barsRight = closeButton.frame.minX - tokens.headerGap
+        let barsWidth = max(0, barsRight - barsLeft)
+        let barsHeight: CGFloat = 22
+        let barsY = midY - barsHeight / 2
+        let halfHeight = barsHeight / 2
+
+        micWaveform.frame = NSRect(
+            x: barsLeft,
+            y: midY,
+            width: barsWidth,
+            height: halfHeight
+        )
+        systemWaveform.frame = NSRect(
+            x: barsLeft,
+            y: barsY,
+            width: barsWidth,
+            height: halfHeight
+        )
+
+        titleLabel.frame = .zero
+        detailLabel.frame = .zero
+        chevronButton.frame = .zero
     }
 
     private func layoutPrompt() {
@@ -441,46 +527,45 @@ final class MeetingOverlayRootView: NSView {
             return
         }
 
+        applyBaseVisualStyle()
+
         switch state {
         case .idle:
             titleLabel.stringValue = "Meeting"
-            statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotIdle.cgColor
+            updateStatusDot(color: MeetingOverlayTokens.dotIdle)
             detailLabel.stringValue = ""
         case .preparing:
             titleLabel.stringValue = "Loading models…"
-            statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotPrep.cgColor
+            updateStatusDot(color: MeetingOverlayTokens.dotPrep)
             detailLabel.stringValue = ""
         case .prompt:
             titleLabel.stringValue = prompt?.title ?? "Meeting detected"
             detailLabel.stringValue = prompt?.detail ?? "Record this meeting?"
             timerLabel.stringValue = prompt?.countdownText ?? ""
-            statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotPrompt.cgColor
-            closeButton.attributedTitle = NSAttributedString(
-                string: "Not now",
-                attributes: [
-                    .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
-                    .foregroundColor: MeetingOverlayTokens.textPrimary
-                ]
-            )
+            updateStatusDot(color: MeetingOverlayTokens.dotPrompt)
+            closeButton.attributedTitle = buttonTitle("Not now", size: 11, weight: .semibold)
             closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.10).cgColor
         case .recording:
             titleLabel.stringValue = "Recording meeting"
-            statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotRecording.cgColor
-            closeButton.attributedTitle = NSAttributedString(
-                string: "Stop",
-                attributes: [
-                    .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
-                    .foregroundColor: MeetingOverlayTokens.textPrimary
-                ]
-            )
+            updateStatusDot(color: MeetingOverlayTokens.dotRecording, haloOpacity: 0.24, haloRadius: 3)
+            timerLabel.font = .monospacedDigitSystemFont(ofSize: MeetingOverlayTokens.timerFontSize, weight: .medium)
+            timerLabel.textColor = MeetingOverlayTokens.textPrimary
+            micLabel.font = .systemFont(ofSize: MeetingOverlayTokens.labelFontSize, weight: .regular)
+            micLabel.textColor = MeetingOverlayTokens.textSecondary
+            systemLabel.font = .systemFont(ofSize: MeetingOverlayTokens.labelFontSize, weight: .regular)
+            systemLabel.textColor = MeetingOverlayTokens.textSecondary
+            closeButton.attributedTitle = buttonTitle("Stop", size: 12, weight: .semibold)
             closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.12).cgColor
+            closeButton.layer?.cornerRadius = MeetingOverlayTokens.stopHeight / 2
+            closeButton.layer?.borderWidth = 0.5
+            closeButton.layer?.borderColor = NSColor.white.withAlphaComponent(0.14).cgColor
         case .transcribing:
             titleLabel.stringValue = "Saving transcript"
-            statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotPrep.cgColor
+            updateStatusDot(color: MeetingOverlayTokens.dotPrep)
             detailLabel.stringValue = ""
         case .saved:
             titleLabel.stringValue = "Saved transcript"
-            statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotSaved.cgColor
+            updateStatusDot(color: MeetingOverlayTokens.dotSaved)
             detailLabel.stringValue = ""
         case .error(let message):
             let copy = MeetingFailureCopy.make(
@@ -489,7 +574,7 @@ final class MeetingOverlayRootView: NSView {
                 isRetryable: true
             )
             titleLabel.stringValue = copy.title
-            statusDot.layer?.backgroundColor = MeetingOverlayTokens.dotError.cgColor
+            updateStatusDot(color: MeetingOverlayTokens.dotError)
             detailLabel.stringValue = copy.detail
         }
 
@@ -505,6 +590,41 @@ final class MeetingOverlayRootView: NSView {
         systemWaveform.isActive = shouldAnimate
 
         needsLayout = true
+    }
+
+    private func applyBaseVisualStyle() {
+        titleLabel.font = .systemFont(ofSize: 11, weight: .semibold)
+        titleLabel.textColor = MeetingOverlayTokens.textPrimary
+        timerLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        timerLabel.textColor = MeetingOverlayTokens.textSecondary
+        detailLabel.font = .systemFont(ofSize: 11, weight: .medium)
+        detailLabel.textColor = MeetingOverlayTokens.textSecondary
+        micLabel.font = .systemFont(ofSize: 8, weight: .medium)
+        micLabel.textColor = MeetingOverlayTokens.textSecondary
+        systemLabel.font = .systemFont(ofSize: 8, weight: .medium)
+        systemLabel.textColor = MeetingOverlayTokens.textSecondary
+        closeButton.attributedTitle = buttonTitle("Stop", size: 11, weight: .semibold)
+        closeButton.layer?.cornerRadius = 8
+        closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.12).cgColor
+        closeButton.layer?.borderWidth = 0
+        closeButton.layer?.borderColor = nil
+    }
+
+    private func buttonTitle(_ title: String, size: CGFloat, weight: NSFont.Weight) -> NSAttributedString {
+        NSAttributedString(
+            string: title,
+            attributes: [
+                .font: NSFont.systemFont(ofSize: size, weight: weight),
+                .foregroundColor: MeetingOverlayTokens.textPrimary
+            ]
+        )
+    }
+
+    private func updateStatusDot(color: NSColor, haloOpacity: Float = 0, haloRadius: CGFloat = 0) {
+        statusDot.layer?.backgroundColor = color.cgColor
+        statusDot.layer?.shadowColor = color.cgColor
+        statusDot.layer?.shadowOpacity = haloOpacity
+        statusDot.layer?.shadowRadius = haloRadius
     }
 
     private func formatDuration(_ seconds: TimeInterval) -> String {
@@ -528,26 +648,36 @@ final class MeetingOverlayRootView: NSView {
 
 @available(macOS 14.0, *)
 enum MeetingOverlayTokens {
-    static let panelBg       = NSColor.black.withAlphaComponent(0.9)
+    static let panelBg       = NSColor(calibratedRed: 0.07, green: 0.07, blue: 0.08, alpha: 0.92)
     static let panelStroke   = NSColor.white.withAlphaComponent(0.08)
-    static let textPrimary   = OverlayTokens.textPrimary
-    static let textSecondary = OverlayTokens.textSecondary
-    static let waveformTint  = OverlayTokens.textPrimary
+    static let textPrimary   = NSColor(calibratedWhite: 0.98, alpha: 1.0)
+    static let textSecondary = NSColor.white.withAlphaComponent(0.55)
+    static let waveformTint  = NSColor(calibratedWhite: 0.98, alpha: 1.0)
+    static let waveformSystemAlpha: CGFloat = 0.72
     static let dotIdle       = OverlayTokens.textMuted
     static let dotPrep       = OverlayTokens.textSecondary
     static let dotPrompt     = OverlayTokens.accentGreen
-    static let dotRecording  = NSColor(red: 0.95, green: 0.22, blue: 0.22, alpha: 1.0)
+    static let dotRecording  = NSColor(calibratedRed: 1.00, green: 0.27, blue: 0.23, alpha: 1.0)
     static let dotSaved      = NSColor.systemGreen
     static let dotError      = NSColor.systemRed
 
     static let panelWidth: CGFloat  = 360
-    static let recordingPanelWidth: CGFloat = 260
-    static let panelHeight: CGFloat = 48
+    static let panelHeight: CGFloat = 44
     static let promptHeight: CGFloat = 88
     static let warmupHeight: CGFloat = 96
     static let errorHeight: CGFloat = 72
-    static let cornerRadius: CGFloat = OverlayTokens.cornerRadius
+    static let cornerRadius: CGFloat = 22
     static let dotSize: CGFloat     = 8
+    static let padLeft: CGFloat     = 14
+    static let padRight: CGFloat    = 5
+    static let headerGap: CGFloat   = 10
+    static let timerFontSize: CGFloat = 13
+    static let labelFontSize: CGFloat = 11
+    static let stopHeight: CGFloat  = 28
+    static let stopHPadding: CGFloat = 14
+    static let barCount: Int        = 26
+    static let barWidth: CGFloat    = 2
+    static let barGap: CGFloat      = 1.5
 }
 
 // MARK: - Controller
@@ -838,12 +968,7 @@ final class MeetingOverlayController {
     }
 
     private func currentPanelWidth() -> CGFloat {
-        switch state {
-        case .recording:
-            return MeetingOverlayTokens.recordingPanelWidth
-        default:
-            return MeetingOverlayTokens.panelWidth
-        }
+        MeetingOverlayTokens.panelWidth
     }
 
     private func hidePanel() {

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -125,17 +125,11 @@ final class MeetingOverlayRootView: NSView {
         systemLabel.textColor = MeetingOverlayTokens.textSecondary
         addSubview(systemLabel)
 
-        micWaveform.visualizationStyle = .mirrored(anchor: .fromBottom, phaseOffset: 0)
-        micWaveform.mirroredBarCount = MeetingOverlayTokens.barCount
-        micWaveform.mirroredBarWidth = MeetingOverlayTokens.barWidth
-        micWaveform.mirroredBarSpacing = MeetingOverlayTokens.barGap
+        micWaveform.visualizationStyle = .scrolling
         micWaveform.tintColor = MeetingOverlayTokens.waveformTint
         addSubview(micWaveform)
 
-        systemWaveform.visualizationStyle = .mirrored(anchor: .fromTop, phaseOffset: 1.8)
-        systemWaveform.mirroredBarCount = MeetingOverlayTokens.barCount
-        systemWaveform.mirroredBarWidth = MeetingOverlayTokens.barWidth
-        systemWaveform.mirroredBarSpacing = MeetingOverlayTokens.barGap
+        systemWaveform.visualizationStyle = .scrolling
         systemWaveform.tintColor = MeetingOverlayTokens.waveformTint.withAlphaComponent(MeetingOverlayTokens.waveformSystemAlpha)
         addSubview(systemWaveform)
 
@@ -688,9 +682,6 @@ enum MeetingOverlayTokens {
     static let timerFontSize: CGFloat = 13
     static let labelFontSize: CGFloat = 11
     static let stopHeight: CGFloat  = 28
-    static let barCount: Int        = 26
-    static let barWidth: CGFloat    = 2
-    static let barGap: CGFloat      = 1.5
 }
 
 // MARK: - Controller

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -332,11 +332,13 @@ final class MeetingOverlayRootView: NSView {
 
         let barsLeft = timerLabel.frame.maxX + tokens.headerGap + 10
         let barsRight = closeButton.frame.minX - tokens.headerGap
-        let barsWidth = max(0, barsRight - barsLeft)
+        let availableBarsWidth = max(0, barsRight - barsLeft)
+        let barsWidth = min(tokens.recordingWaveformWidth, availableBarsWidth)
+        let barsX = barsLeft + max(0, (availableBarsWidth - barsWidth) / 2)
         let barsHeight: CGFloat = 22
         let barsY = midY - barsHeight / 2
         audioWaveform.frame = NSRect(
-            x: barsLeft,
+            x: barsX,
             y: barsY,
             width: barsWidth,
             height: barsHeight
@@ -614,8 +616,8 @@ enum MeetingOverlayTokens {
     static let panelStroke   = NSColor.white.withAlphaComponent(0.08)
     static let textPrimary   = NSColor(calibratedWhite: 0.98, alpha: 1.0)
     static let textSecondary = NSColor.white.withAlphaComponent(0.55)
-    static let waveformMicTint = NSColor(calibratedRed: 0.72, green: 0.82, blue: 0.79, alpha: 1.0)
-    static let waveformSystemTint = NSColor(calibratedRed: 0.74, green: 0.78, blue: 0.85, alpha: 1.0)
+    static let waveformMicTint = NSColor(calibratedRed: 0.84, green: 0.69, blue: 0.48, alpha: 1.0)
+    static let waveformSystemTint = NSColor(calibratedRed: 0.57, green: 0.66, blue: 0.85, alpha: 1.0)
     static let dotIdle       = OverlayTokens.textMuted
     static let dotPrep       = OverlayTokens.textSecondary
     static let dotPrompt     = OverlayTokens.accentGreen
@@ -636,6 +638,7 @@ enum MeetingOverlayTokens {
     static let headerGap: CGFloat   = 10
     static let timerFontSize: CGFloat = 13
     static let stopHeight: CGFloat  = 28
+    static let recordingWaveformWidth: CGFloat = 124
 }
 
 // MARK: - Controller

--- a/Sources/UI/Overlay/WaveformLayer.swift
+++ b/Sources/UI/Overlay/WaveformLayer.swift
@@ -5,6 +5,16 @@
 import AppKit
 import QuartzCore
 
+enum WaveformMirroredAnchor {
+    case fromBottom
+    case fromTop
+}
+
+enum WaveformVisualizationStyle {
+    case scrolling
+    case mirrored(anchor: WaveformMirroredAnchor, phaseOffset: CGFloat)
+}
+
 // MARK: - Ring Buffer (extracted from ScrollingWaveformView, unchanged)
 
 /// Fixed-capacity circular buffer of audio level samples.
@@ -49,6 +59,10 @@ final class WaveformDrawingLayer: CALayer {
     var lastSampleTime: CFAbsoluteTime = 0
     var currentLevel: Float = 0
     var tintColor: NSColor = .white
+    var visualizationStyle: WaveformVisualizationStyle = .scrolling
+    var mirroredBarCount: Int = 26
+    var mirroredBarWidth: CGFloat = 2
+    var mirroredBarSpacing: CGFloat = 1.5
 
     // Bar geometry — matches original SwiftUI waveform
     let barWidth: CGFloat = 2
@@ -62,6 +76,15 @@ final class WaveformDrawingLayer: CALayer {
     override func draw(in ctx: CGContext) {
         let now = CFAbsoluteTimeGetCurrent()
 
+        switch visualizationStyle {
+        case .scrolling:
+            drawScrolling(in: ctx, now: now)
+        case .mirrored(let anchor, let phaseOffset):
+            drawMirrored(in: ctx, now: now, anchor: anchor, phaseOffset: phaseOffset)
+        }
+    }
+
+    private func drawScrolling(in ctx: CGContext, now: CFAbsoluteTime) {
         // 1. Sample audio level into ring buffer at 20Hz
         let elapsed = now - lastSampleTime
         if elapsed >= sampleInterval {
@@ -114,6 +137,73 @@ final class WaveformDrawingLayer: CALayer {
             ctx.fillPath()
         }
     }
+
+    private func drawMirrored(
+        in ctx: CGContext,
+        now: CFAbsoluteTime,
+        anchor: WaveformMirroredAnchor,
+        phaseOffset: CGFloat
+    ) {
+        let size = bounds.size
+        guard size.width > 0, size.height > 0 else { return }
+
+        let count = max(1, mirroredBarCount)
+        let stride = mirroredBarWidth + mirroredBarSpacing
+        let totalWidth = CGFloat(count) * mirroredBarWidth + CGFloat(max(0, count - 1)) * mirroredBarSpacing
+        let startX = max(0, (size.width - totalWidth) / 2)
+        let maxHeight = max(1, size.height - 1)
+        let level = max(0, min(1, CGFloat(currentLevel)))
+        let boostedLevel = max(0.08, sqrt(level))
+        let baseAlpha = tintColor.usingColorSpace(.deviceRGB)?.alphaComponent ?? 1
+        let time = CGFloat(now)
+
+        for index in 0..<count {
+            let env = envelopeMultiplier(for: index, of: count)
+            let phase = phaseOffset + CGFloat(index) * 0.48
+            let motionA = normalizedSine(time * 4.8 + phase)
+            let motionB = normalizedSine(time * 7.1 + phase * 1.7 + 0.9)
+            let motion = max(0.12, motionA * 0.7 + motionB * 0.3)
+            let rawLevel = min(1, boostedLevel * (0.45 + motion * 0.9))
+            let barHeight = max(minBarHeight, rawLevel * maxHeight * env)
+            let x = startX + CGFloat(index) * stride
+            let y: CGFloat = switch anchor {
+            case .fromBottom:
+                0
+            case .fromTop:
+                size.height - barHeight
+            }
+
+            let rect = CGRect(
+                x: x,
+                y: y,
+                width: mirroredBarWidth,
+                height: barHeight
+            )
+
+            let opacity = baseAlpha * (0.5 + rawLevel * 0.5)
+            ctx.setFillColor(tintColor.withAlphaComponent(opacity).cgColor)
+
+            let path = CGPath(
+                roundedRect: rect,
+                cornerWidth: mirroredBarWidth / 2,
+                cornerHeight: mirroredBarWidth / 2,
+                transform: nil
+            )
+            ctx.addPath(path)
+            ctx.fillPath()
+        }
+    }
+
+    private func envelopeMultiplier(for index: Int, of total: Int) -> CGFloat {
+        guard total > 1 else { return 1 }
+        let norm = (CGFloat(index) - CGFloat(total - 1) / 2) / (CGFloat(total - 1) / 2)
+        let envelope = pow(cos(norm * .pi / 2), 1.2) * 0.85 + 0.15
+        return max(0.15, envelope)
+    }
+
+    private func normalizedSine(_ value: CGFloat) -> CGFloat {
+        (sin(value) + 1) / 2
+    }
 }
 
 // MARK: - Host View
@@ -133,6 +223,36 @@ final class WaveformHostView: NSView {
 
     var tintColor: NSColor = .white {
         didSet { drawingLayer.tintColor = tintColor }
+    }
+
+    var visualizationStyle: WaveformVisualizationStyle = .scrolling {
+        didSet {
+            drawingLayer.visualizationStyle = visualizationStyle
+            drawingLayer.buffer.clear()
+            drawingLayer.lastSampleTime = 0
+            drawingLayer.setNeedsDisplay()
+        }
+    }
+
+    var mirroredBarCount: Int = 26 {
+        didSet {
+            drawingLayer.mirroredBarCount = mirroredBarCount
+            drawingLayer.setNeedsDisplay()
+        }
+    }
+
+    var mirroredBarWidth: CGFloat = 2 {
+        didSet {
+            drawingLayer.mirroredBarWidth = mirroredBarWidth
+            drawingLayer.setNeedsDisplay()
+        }
+    }
+
+    var mirroredBarSpacing: CGFloat = 1.5 {
+        didSet {
+            drawingLayer.mirroredBarSpacing = mirroredBarSpacing
+            drawingLayer.setNeedsDisplay()
+        }
     }
 
     /// Start/stop the render timer. Stop when not recording to avoid unnecessary GPU work.
@@ -155,6 +275,10 @@ final class WaveformHostView: NSView {
         wantsLayer = true
         drawingLayer.contentsScale = NSScreen.main?.backingScaleFactor ?? 2.0
         drawingLayer.tintColor = tintColor
+        drawingLayer.visualizationStyle = visualizationStyle
+        drawingLayer.mirroredBarCount = mirroredBarCount
+        drawingLayer.mirroredBarWidth = mirroredBarWidth
+        drawingLayer.mirroredBarSpacing = mirroredBarSpacing
         drawingLayer.frame = bounds
         layer?.addSublayer(drawingLayer)
     }

--- a/Sources/UI/Overlay/WaveformLayer.swift
+++ b/Sources/UI/Overlay/WaveformLayer.swift
@@ -337,3 +337,208 @@ final class WaveformHostView: NSView {
         drawingLayer.setNeedsDisplay()
     }
 }
+
+/// Shared-clock split waveform used by the meeting overlay so mic and system
+/// audio feel like one visualizer instead of two independent rows.
+final class DualWaveformDrawingLayer: CALayer {
+    var primaryBuffer = WaveformRingBuffer(capacity: 150)
+    var secondaryBuffer = WaveformRingBuffer(capacity: 150)
+    var lastSampleTime: CFAbsoluteTime = 0
+    var primaryLevel: Float = 0
+    var secondaryLevel: Float = 0
+    var primaryTintColor: NSColor = .white
+    var secondaryTintColor: NSColor = .white
+
+    let barWidth: CGFloat = 2
+    let barSpacing: CGFloat = 1
+    var barStride: CGFloat { barWidth + barSpacing }
+    let minBarHeight: CGFloat = 2
+    let maxBarHeight: CGFloat = 14
+    let barCornerRadius: CGFloat = 1
+    let sampleInterval: TimeInterval = 0.05
+
+    override func draw(in ctx: CGContext) {
+        let now = CFAbsoluteTimeGetCurrent()
+        recordSamplesIfNeeded(now: now)
+
+        let size = bounds.size
+        guard size.width > 0, size.height > 0 else { return }
+        guard primaryBuffer.currentCount > 0 || secondaryBuffer.currentCount > 0 else { return }
+
+        let smoothOffset = scrollingOffset(now: now)
+        let centerY = size.height / 2
+        let effectiveHalfBarHeight = max(minBarHeight, min(maxBarHeight, max(1, centerY - 1)))
+        let maxVisibleBars = Int(ceil((size.width + barStride) / barStride)) + 1
+        let barsToDraw = min(maxVisibleBars, max(primaryBuffer.currentCount, secondaryBuffer.currentCount))
+
+        for i in 0..<barsToDraw {
+            let x = size.width - CGFloat(i + 1) * barStride - smoothOffset + barSpacing
+            guard x + barWidth > 0 else { break }
+            guard x < size.width else { continue }
+
+            let primarySample = sampleForDisplay(from: primaryBuffer, stepIndex: i)
+            let secondarySample = sampleForDisplay(from: secondaryBuffer, stepIndex: i)
+
+            drawBar(
+                in: ctx,
+                sampleValue: primarySample,
+                x: x,
+                y: centerY - barHeight(for: primarySample, maxHeight: effectiveHalfBarHeight),
+                maxHeight: effectiveHalfBarHeight,
+                tintColor: primaryTintColor
+            )
+            drawBar(
+                in: ctx,
+                sampleValue: secondarySample,
+                x: x,
+                y: centerY,
+                maxHeight: effectiveHalfBarHeight,
+                tintColor: secondaryTintColor
+            )
+        }
+    }
+
+    func reset() {
+        primaryBuffer.clear()
+        secondaryBuffer.clear()
+        lastSampleTime = 0
+        setNeedsDisplay()
+    }
+
+    private func recordSamplesIfNeeded(now: CFAbsoluteTime) {
+        let elapsed = now - lastSampleTime
+        if elapsed >= sampleInterval {
+            let sampleCount = min(Int(elapsed / sampleInterval), 3)
+            for _ in 0..<sampleCount {
+                primaryBuffer.append(primaryLevel)
+                secondaryBuffer.append(secondaryLevel)
+            }
+            lastSampleTime = now
+        }
+    }
+
+    private func scrollingOffset(now: CFAbsoluteTime) -> CGFloat {
+        let currentElapsed = now - lastSampleTime
+        let fractionalProgress = min(currentElapsed / sampleInterval, 1.0)
+        return CGFloat(fractionalProgress) * barStride
+    }
+
+    private func sampleForDisplay(from buffer: WaveformRingBuffer, stepIndex: Int) -> Float {
+        guard stepIndex < buffer.currentCount else { return 0 }
+        let index = buffer.currentCount - 1 - stepIndex
+        return buffer.sample(at: index)
+    }
+
+    private func barHeight(for sampleValue: Float, maxHeight: CGFloat) -> CGFloat {
+        let boosted = CGFloat(sqrt(sampleValue))
+        return max(minBarHeight, boosted * maxHeight)
+    }
+
+    private func drawBar(
+        in ctx: CGContext,
+        sampleValue: Float,
+        x: CGFloat,
+        y: CGFloat,
+        maxHeight: CGFloat,
+        tintColor: NSColor
+    ) {
+        let height = barHeight(for: sampleValue, maxHeight: maxHeight)
+        let rect = CGRect(x: x, y: y, width: barWidth, height: height)
+        let opacity = 0.42 + CGFloat(sampleValue) * 0.48
+        ctx.setFillColor(tintColor.withAlphaComponent(opacity).cgColor)
+
+        let path = CGPath(
+            roundedRect: rect,
+            cornerWidth: barCornerRadius,
+            cornerHeight: barCornerRadius,
+            transform: nil
+        )
+        ctx.addPath(path)
+        ctx.fillPath()
+    }
+}
+
+@MainActor
+final class DualWaveformHostView: NSView {
+    private let drawingLayer = DualWaveformDrawingLayer()
+    private var renderTimer: Timer?
+
+    var primaryLevel: Float = 0 {
+        didSet { drawingLayer.primaryLevel = primaryLevel }
+    }
+
+    var secondaryLevel: Float = 0 {
+        didSet { drawingLayer.secondaryLevel = secondaryLevel }
+    }
+
+    var primaryTintColor: NSColor = .white {
+        didSet { drawingLayer.primaryTintColor = primaryTintColor }
+    }
+
+    var secondaryTintColor: NSColor = .white {
+        didSet { drawingLayer.secondaryTintColor = secondaryTintColor }
+    }
+
+    var isActive: Bool = false {
+        didSet {
+            guard isActive != oldValue else { return }
+            if isActive {
+                startTimer()
+            } else {
+                stopTimer()
+                drawingLayer.reset()
+            }
+        }
+    }
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        wantsLayer = true
+        drawingLayer.contentsScale = NSScreen.main?.backingScaleFactor ?? 2.0
+        drawingLayer.primaryTintColor = primaryTintColor
+        drawingLayer.secondaryTintColor = secondaryTintColor
+        drawingLayer.frame = bounds
+        layer?.addSublayer(drawingLayer)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func layout() {
+        super.layout()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        drawingLayer.frame = bounds
+        drawingLayer.contentsScale = window?.backingScaleFactor ?? (NSScreen.main?.backingScaleFactor ?? 2.0)
+        CATransaction.commit()
+    }
+
+    override func removeFromSuperview() {
+        stopTimer()
+        super.removeFromSuperview()
+    }
+
+    deinit {
+        renderTimer?.invalidate()
+    }
+
+    private func startTimer() {
+        guard renderTimer == nil else { return }
+        renderTimer = Timer.scheduledTimer(
+            timeInterval: 1.0 / 30.0,
+            target: self,
+            selector: #selector(handleRenderTick),
+            userInfo: nil,
+            repeats: true
+        )
+    }
+
+    private func stopTimer() {
+        renderTimer?.invalidate()
+        renderTimer = nil
+    }
+
+    @objc private func handleRenderTick() {
+        drawingLayer.setNeedsDisplay()
+    }
+}

--- a/Sources/UI/Overlay/WaveformLayer.swift
+++ b/Sources/UI/Overlay/WaveformLayer.swift
@@ -93,6 +93,7 @@ final class WaveformDrawingLayer: CALayer {
 
         let size = bounds.size
         let centerY = size.height / 2.0
+        let effectiveMaxBarHeight = max(minBarHeight, min(maxBarHeight, max(1, size.height - 1)))
 
         // 3. Draw bars right-to-left (newest at right edge)
         let maxVisibleBars = Int(ceil((size.width + barStride) / barStride)) + 1
@@ -108,7 +109,7 @@ final class WaveformDrawingLayer: CALayer {
 
             // Height: sqrt curve boosts low/mid levels
             let boosted = CGFloat(sqrt(sampleValue))
-            let barHeight = max(minBarHeight, boosted * maxBarHeight)
+            let barHeight = max(minBarHeight, boosted * effectiveMaxBarHeight)
 
             let rect = CGRect(
                 x: x,

--- a/Sources/UI/Overlay/WaveformLayer.swift
+++ b/Sources/UI/Overlay/WaveformLayer.swift
@@ -378,12 +378,15 @@ final class DualWaveformDrawingLayer: CALayer {
 
             let primarySample = sampleForDisplay(from: primaryBuffer, stepIndex: i)
             let secondarySample = sampleForDisplay(from: secondaryBuffer, stepIndex: i)
+            let secondaryHeight = barHeight(for: secondarySample, maxHeight: effectiveHalfBarHeight)
 
+            // Core Animation draws this layer in a bottom-left coordinate space,
+            // so the top stream needs to start at the center line and grow upward.
             drawBar(
                 in: ctx,
                 sampleValue: primarySample,
                 x: x,
-                y: centerY - barHeight(for: primarySample, maxHeight: effectiveHalfBarHeight),
+                y: centerY,
                 maxHeight: effectiveHalfBarHeight,
                 tintColor: primaryTintColor
             )
@@ -391,7 +394,7 @@ final class DualWaveformDrawingLayer: CALayer {
                 in: ctx,
                 sampleValue: secondarySample,
                 x: x,
-                y: centerY,
+                y: centerY - secondaryHeight,
                 maxHeight: effectiveHalfBarHeight,
                 tintColor: secondaryTintColor
             )

--- a/Sources/UI/Overlay/WaveformLayer.swift
+++ b/Sources/UI/Overlay/WaveformLayer.swift
@@ -75,6 +75,7 @@ final class WaveformDrawingLayer: CALayer {
 
     override func draw(in ctx: CGContext) {
         let now = CFAbsoluteTimeGetCurrent()
+        recordSamplesIfNeeded(now: now)
 
         switch visualizationStyle {
         case .scrolling:
@@ -85,22 +86,10 @@ final class WaveformDrawingLayer: CALayer {
     }
 
     private func drawScrolling(in ctx: CGContext, now: CFAbsoluteTime) {
-        // 1. Sample audio level into ring buffer at 20Hz
-        let elapsed = now - lastSampleTime
-        if elapsed >= sampleInterval {
-            let sampleCount = min(Int(elapsed / sampleInterval), 3)
-            for _ in 0..<sampleCount {
-                buffer.append(currentLevel)
-            }
-            lastSampleTime = now
-        }
-
         guard buffer.currentCount > 0 else { return }
 
         // 2. Smooth fractional scroll offset for sub-pixel motion
-        let currentElapsed = now - lastSampleTime
-        let fractionalProgress = min(currentElapsed / sampleInterval, 1.0)
-        let smoothOffset = CGFloat(fractionalProgress) * barStride
+        let smoothOffset = scrollingOffset(now: now, stride: barStride)
 
         let size = bounds.size
         let centerY = size.height / 2.0
@@ -146,26 +135,26 @@ final class WaveformDrawingLayer: CALayer {
     ) {
         let size = bounds.size
         guard size.width > 0, size.height > 0 else { return }
+        guard buffer.currentCount > 0 else { return }
 
-        let count = max(1, mirroredBarCount)
+        let _ = phaseOffset
         let stride = mirroredBarWidth + mirroredBarSpacing
-        let totalWidth = CGFloat(count) * mirroredBarWidth + CGFloat(max(0, count - 1)) * mirroredBarSpacing
-        let startX = max(0, (size.width - totalWidth) / 2)
+        let maxVisibleBars = min(max(1, mirroredBarCount), Int(ceil((size.width + stride) / stride)) + 1)
+        let barsToDraw = min(maxVisibleBars, buffer.currentCount)
+        let smoothOffset = scrollingOffset(now: now, stride: stride)
         let maxHeight = max(1, size.height - 1)
-        let level = max(0, min(1, CGFloat(currentLevel)))
-        let boostedLevel = max(0.08, sqrt(level))
         let baseAlpha = tintColor.usingColorSpace(.deviceRGB)?.alphaComponent ?? 1
-        let time = CGFloat(now)
 
-        for index in 0..<count {
-            let env = envelopeMultiplier(for: index, of: count)
-            let phase = phaseOffset + CGFloat(index) * 0.48
-            let motionA = normalizedSine(time * 4.8 + phase)
-            let motionB = normalizedSine(time * 7.1 + phase * 1.7 + 0.9)
-            let motion = max(0.12, motionA * 0.7 + motionB * 0.3)
-            let rawLevel = min(1, boostedLevel * (0.45 + motion * 0.9))
-            let barHeight = max(minBarHeight, rawLevel * maxHeight * env)
-            let x = startX + CGFloat(index) * stride
+        for i in 0..<barsToDraw {
+            let barIndex = buffer.currentCount - 1 - i
+            let sampleValue = smoothedSample(at: barIndex)
+            let boosted = CGFloat(sqrt(sampleValue))
+            let visualIndex = barsToDraw - 1 - i
+            let env = envelopeMultiplier(for: visualIndex, of: barsToDraw)
+            let barHeight = max(minBarHeight, boosted * maxHeight * env)
+            let x = size.width - CGFloat(i + 1) * stride - smoothOffset + mirroredBarSpacing
+            guard x + mirroredBarWidth > 0 else { break }
+            guard x < size.width else { continue }
             let y: CGFloat = switch anchor {
             case .fromBottom:
                 0
@@ -180,7 +169,7 @@ final class WaveformDrawingLayer: CALayer {
                 height: barHeight
             )
 
-            let opacity = baseAlpha * (0.5 + rawLevel * 0.5)
+            let opacity = baseAlpha * (0.42 + CGFloat(sampleValue) * 0.48)
             ctx.setFillColor(tintColor.withAlphaComponent(opacity).cgColor)
 
             let path = CGPath(
@@ -194,6 +183,30 @@ final class WaveformDrawingLayer: CALayer {
         }
     }
 
+    private func recordSamplesIfNeeded(now: CFAbsoluteTime) {
+        let elapsed = now - lastSampleTime
+        if elapsed >= sampleInterval {
+            let sampleCount = min(Int(elapsed / sampleInterval), 3)
+            for _ in 0..<sampleCount {
+                buffer.append(currentLevel)
+            }
+            lastSampleTime = now
+        }
+    }
+
+    private func scrollingOffset(now: CFAbsoluteTime, stride: CGFloat) -> CGFloat {
+        let currentElapsed = now - lastSampleTime
+        let fractionalProgress = min(currentElapsed / sampleInterval, 1.0)
+        return CGFloat(fractionalProgress) * stride
+    }
+
+    private func smoothedSample(at index: Int) -> Float {
+        let current = buffer.sample(at: index)
+        let previous = buffer.sample(at: max(0, index - 1))
+        let next = buffer.sample(at: min(buffer.currentCount - 1, index + 1))
+        return min(1, max(0, current * 0.6 + previous * 0.2 + next * 0.2))
+    }
+
     private func envelopeMultiplier(for index: Int, of total: Int) -> CGFloat {
         guard total > 1 else { return 1 }
         let norm = (CGFloat(index) - CGFloat(total - 1) / 2) / (CGFloat(total - 1) / 2)
@@ -201,9 +214,6 @@ final class WaveformDrawingLayer: CALayer {
         return max(0.15, envelope)
     }
 
-    private func normalizedSine(_ value: CGFloat) -> CGFloat {
-        (sin(value) + 1) / 2
-    }
 }
 
 // MARK: - Host View


### PR DESCRIPTION
## What changed

This PR refines the meeting recording overlay to feel tighter and more intentional.

- replaced the meeting waveform colors with the selected warm/cool split
- kept the waveform at the dictation-style width so it feels consistent with the rest of the app
- tightened the recording pill layout so the timer, waveform, and stop button sit closer together
- reduced the recording pill width and outer padding to remove dead space
- kept the mirrored split behavior with mic on top and system audio on bottom

## Why

The meeting overlay was reading too spacious during recording. Even after shortening the waveform itself, centering it inside the available gap left noticeable empty space on both sides. This update makes the recording state feel more compact and better balanced.

## User impact

The recording overlay should now feel denser and easier on the eyes:

- less wasted horizontal space
- clearer visual grouping between timer, waveform, and stop action
- a more polished top/bottom audio split with subtle color separation

## Validation

- `bash build.sh`
- `bash run-tests.sh`
