### PR TITLE
[codex] Add Home transcription activity feedback

### DIFF
--- a/Sources/UI/Settings/HomeTranscriptionActivityPresentation.swift
+++ b/Sources/UI/Settings/HomeTranscriptionActivityPresentation.swift
@@ -1,0 +1,130 @@
+import Foundation
+import TranscriptedCore
+
+struct HomeTranscriptionActivityPresentation: Equatable {
+    enum Tone: Equatable {
+        case working
+        case success
+        case caution
+    }
+
+    let symbolName: String
+    let title: String
+    let status: String
+    let detail: String
+    let tone: Tone
+    let progress: Double?
+    let transcriptURL: URL?
+
+    static func make(
+        sessionState: MeetingSessionController.State,
+        displayStatus: DisplayStatus,
+        warmupStatus: MeetingSessionController.ModelWarmupStatus,
+        lastSavedTitle: String?,
+        lastSavedTranscriptURL: URL?
+    ) -> HomeTranscriptionActivityPresentation? {
+        switch displayStatus {
+        case .gettingReady:
+            return HomeTranscriptionActivityPresentation(
+                symbolName: "tray.and.arrow.down.fill",
+                title: "Preparing audio file",
+                status: "Preparing...",
+                detail: "Transcripted is copying the audio into the meeting pipeline and getting everything ready to transcribe.",
+                tone: .working,
+                progress: displayStatus.progress,
+                transcriptURL: nil
+            )
+        case .transcribing:
+            return HomeTranscriptionActivityPresentation(
+                symbolName: "waveform.badge.magnifyingglass",
+                title: "Transcribing audio",
+                status: displayStatus.statusText,
+                detail: "Transcripted is working through the recording now. Longer files can take a bit, and speaker review will open automatically if it is needed.",
+                tone: .working,
+                progress: displayStatus.progress,
+                transcriptURL: nil
+            )
+        case .finishing:
+            return HomeTranscriptionActivityPresentation(
+                symbolName: "square.and.arrow.down.fill",
+                title: "Saving transcript",
+                status: displayStatus.statusText,
+                detail: "Transcripted is writing the transcript now. If it found multiple people on the room mic, the speaker review window may appear next.",
+                tone: .working,
+                progress: displayStatus.progress,
+                transcriptURL: nil
+            )
+        case .transcriptSaved:
+            let transcriptURL = lastSavedTranscriptURL
+            let transcriptName = resolvedTranscriptName(
+                lastSavedTitle: lastSavedTitle,
+                transcriptURL: transcriptURL
+            )
+            let detail: String
+            if let transcriptName {
+                detail = "\"\(transcriptName)\" is ready. Open it now, or keep going and let Transcripted prompt for speaker review if that step is needed."
+            } else {
+                detail = "Your transcript is ready. Open it now, or keep going and let Transcripted prompt for speaker review if that step is needed."
+            }
+
+            return HomeTranscriptionActivityPresentation(
+                symbolName: "checkmark.circle.fill",
+                title: "Transcript saved",
+                status: "Ready to review",
+                detail: detail,
+                tone: .success,
+                progress: 1.0,
+                transcriptURL: transcriptURL
+            )
+        case .failed(let message):
+            return HomeTranscriptionActivityPresentation(
+                symbolName: "exclamationmark.triangle.fill",
+                title: "Transcription didn't finish",
+                status: "Needs attention",
+                detail: message,
+                tone: .caution,
+                progress: nil,
+                transcriptURL: nil
+            )
+        case .idle:
+            break
+        }
+
+        switch sessionState {
+        case .loadingModels:
+            let detail = warmupStatus.detail.isEmpty
+                ? "Transcripted is loading the local models it needs before transcription can start."
+                : warmupStatus.detail
+            return HomeTranscriptionActivityPresentation(
+                symbolName: "gearshape.2.fill",
+                title: warmupStatus.subtitle,
+                status: "Preparing...",
+                detail: detail,
+                tone: .working,
+                progress: max(0.05, min(warmupStatus.progress, 0.92)),
+                transcriptURL: nil
+            )
+        case .error(let message):
+            return HomeTranscriptionActivityPresentation(
+                symbolName: "exclamationmark.circle.fill",
+                title: "Couldn't start that action",
+                status: "Needs attention",
+                detail: message,
+                tone: .caution,
+                progress: nil,
+                transcriptURL: nil
+            )
+        case .idle, .ready, .recording, .transcribing:
+            return nil
+        }
+    }
+
+    private static func resolvedTranscriptName(lastSavedTitle: String?, transcriptURL: URL?) -> String? {
+        if let lastSavedTitle, !lastSavedTitle.isEmpty {
+            return lastSavedTitle
+        }
+
+        guard let transcriptURL else { return nil }
+        return transcriptURL.deletingPathExtension().lastPathComponent
+    }
+}

--- a/Sources/UI/Settings/TranscriptedSettingsComponents.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsComponents.swift
@@ -203,6 +203,85 @@ struct SettingsStatusCard: View {
     }
 }
 
+struct SettingsActivityCard: View {
+    let symbolName: String
+    let title: String
+    let status: String
+    let detail: String
+    let tone: HomeTranscriptionActivityPresentation.Tone
+    let progress: Double?
+    let actionTitle: String?
+    let action: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: symbolName)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(tintColor)
+                    .frame(width: 34, height: 34)
+                    .background(tintColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.headline)
+
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 12)
+
+                Text(status)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(tintColor)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(tintColor.opacity(0.12), in: Capsule())
+            }
+
+            if let progress {
+                VStack(alignment: .leading, spacing: 6) {
+                    ProgressView(value: progress)
+                        .progressViewStyle(.linear)
+                        .tint(tintColor)
+
+                    Text("\(Int(progress * 100))% complete")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if let actionTitle, let action {
+                Button(actionTitle, action: action)
+            }
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.88))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(tintColor.opacity(0.18), lineWidth: 1)
+        )
+    }
+
+    private var tintColor: Color {
+        switch tone {
+        case .working:
+            return .blue
+        case .success:
+            return .green
+        case .caution:
+            return .orange
+        }
+    }
+}
+
 struct SettingsQuickLinkRow: View {
     let symbolName: String
     let title: String

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -90,6 +90,9 @@ struct TranscriptedSettingsView: View {
         .onChange(of: navigation.selectedPage) { _, _ in
             refreshRecentCaptures()
         }
+        .onChange(of: meetingSession.lastSavedTranscriptURL) { _, _ in
+            refreshRecentCaptures()
+        }
     }
 
     @ViewBuilder
@@ -160,6 +163,24 @@ struct TranscriptedSettingsView: View {
                 )
             }
 
+            if let activity = homeTranscriptionActivity {
+                SettingsActivityCard(
+                    symbolName: activity.symbolName,
+                    title: activity.title,
+                    status: activity.status,
+                    detail: activity.detail,
+                    tone: activity.tone,
+                    progress: activity.progress,
+                    actionTitle: activity.transcriptURL == nil ? nil : "Open Transcript",
+                    action: activity.transcriptURL.map { transcriptURL in
+                        {
+                            NSWorkspace.shared.open(transcriptURL)
+                        }
+                    }
+                )
+                .transition(.move(edge: .top).combined(with: .opacity))
+            }
+
             SettingsSection(
                 title: "Setup Status",
                 detail: "These cards show whether Transcripted is ready for dictation, meetings, and local storage."
@@ -226,6 +247,7 @@ struct TranscriptedSettingsView: View {
                 }
             }
         }
+        .animation(.snappy(duration: 0.22), value: homeTranscriptionActivity)
     }
 
     private var shortcutsPage: some View {
@@ -612,6 +634,16 @@ struct TranscriptedSettingsView: View {
         case .failed:
             return .caution
         }
+    }
+
+    private var homeTranscriptionActivity: HomeTranscriptionActivityPresentation? {
+        HomeTranscriptionActivityPresentation.make(
+            sessionState: meetingSession.state,
+            displayStatus: meetingSession.displayStatus,
+            warmupStatus: meetingSession.warmupStatus,
+            lastSavedTitle: meetingSession.lastSavedTitle,
+            lastSavedTranscriptURL: meetingSession.lastSavedTranscriptURL
+        )
     }
 
     private func refreshState() {


### PR DESCRIPTION
## What changed
- added a Home-page transcription activity presentation that turns the meeting pipeline state into user-facing copy
- added a new Home activity card with phase text, a progress bar, and an `Open Transcript` action when the file is ready
- refreshed recent captures when a new transcript lands so the settings UI updates without needing to leave and come back

## Why
Importing an audio file from Settings kicked off the work correctly, but the Home page gave almost no feedback while transcription was running. That made the flow feel broken until the speaker review sheet or saved transcript appeared.

## User impact
People importing audio from the Home settings page now get immediate feedback that Transcripted is preparing, transcribing, or saving the file, plus a clearer finish state once the transcript is ready.

## Root cause
The meeting transcription pipeline already published useful state, but the Home settings screen was not rendering that state in a visible end-user progress surface.

## Validation
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
