### PR TITLE
docs: sync CLAUDE.md with recent UI and CLI changes

### DIFF
--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -13,7 +13,7 @@ The directory is grouped by surface so the live UI tree is easier to scan:
 
 Draft-mode UI is not an active product path in this worktree.
 
-## Files (34 Swift files)
+## Files (44 Swift files)
 
 ### Overlay/
 
@@ -34,13 +34,16 @@ dictation overlay and the meeting prompt / recording overlay.
 ### MenuBar/
 
 - `MenuBar/MenuAgentConnectPageView.swift` — agent connection page in the menubar popover
+- `MenuBar/MenuBarActionRowView.swift` — AppKit control backing both primary and utility action rows, with tone, size, and press-handler styling
 - `MenuBar/MenuBarContentView.swift` — root content view for the menubar popover
 - `MenuBar/MenuBarHeaderView.swift` — popover header with app name and status
 - `MenuBar/MenuBarModelStatusView.swift` — persistent local-model status badge with download progress, error state, and settings shortcut
 - `MenuBar/MenuBarPanelController.swift` — NSPopover controller for the menubar
+- `MenuBar/MenuBarPrimaryActionsView.swift` — groups the dictation, meeting, paste, and recent-meetings action rows at the top of the popover
 - `MenuBar/MenuBarRecentMeetingsView.swift` — recent meetings list in the popover
 - `MenuBar/MenuBarSettingsView.swift` — settings actions in the popover footer, including imported-audio transcription entry points
 - `MenuBar/MenuBarShortcutsView.swift` — keyboard shortcut hints in the popover
+- `MenuBar/MenuBarUtilityActionsView.swift` — groups the connect-agent, feedback, updates, settings, and quit action rows at the bottom of the popover
 - `MenuBar/MenuIconButton.swift` — icon-only button style for menubar items
 - `MenuBar/MenuOutlineButton.swift` — outlined button style for menubar actions
 - `MenuBar/MenuTokens.swift` — design tokens for menubar views
@@ -58,11 +61,16 @@ The current agent-connect surfaces should keep one simple mental model:
 
 ### Settings/
 
+- `Settings/HomeTranscriptionActivityPresentation.swift` — presentation model derived from `MeetingSessionController` state for the home page's live transcription activity card (tone, progress, transcript URL)
 - `Settings/HotkeyRecorderAppKitView.swift` — AppKit view for recording custom hotkey bindings
 - `Settings/PermissionsOnboardingView.swift` — first-launch permissions walkthrough
-- `Settings/TranscriptedOnboardingWindowController.swift` — dedicated first-launch window that hosts onboarding before users drop into the menubar flow
 - `Settings/SpeakerNamingSheet.swift` — sheet for reviewing speakers in a completed meeting, grouped into local room speakers vs remote participants, with a "Keep as You" escape hatch for local mic splits
 - `Settings/SpeakerPeopleSettingsSection.swift` — settings section and view model for browsing, naming, merging, previewing, and deleting saved speaker profiles, plus the toggle for identifying multiple local speakers on the mic track
+- `Settings/TranscriptedOnboardingWindowController.swift` — dedicated first-launch window that hosts onboarding before users drop into the menubar flow
+- `Settings/TranscriptedSettingsActions.swift` — struct of callbacks (start dictation, start meeting, import audio, paste, connect agent, check updates, send feedback) injected into the settings view
+- `Settings/TranscriptedSettingsComponents.swift` — shared SwiftUI building blocks (`SettingsPageIntro`, `SettingsSection`) used across settings pages
+- `Settings/TranscriptedSettingsNavigationModel.swift` — observable navigation state for the current `TranscriptedSettingsPage` selection
+- `Settings/TranscriptedSettingsPage.swift` — enum of settings pages (home, shortcuts, meetings, dictations, storage, connectAgent, privacy, about) with titles and SF Symbol names
 - `Settings/TranscriptedSettingsView.swift` — main settings view
 - `Settings/TranscriptedSettingsWindowController.swift` — NSWindowController for settings
 
@@ -71,7 +79,9 @@ The current agent-connect surfaces should keep one simple mental model:
 - `Shared/AgentConnectionGuide.swift` — shared smart-prompt, MCP setup, and folder fallback copy for the agent-connect flow
 - `Shared/AppSoundPlayer.swift` — UI sound preferences and playback helpers
 - `Shared/FirstRunExperience.swift` — shared first-run menu and onboarding state helpers for permission, local-model, dictation, and meeting CTA copy
+- `Shared/RecentCaptureScanners.swift` — `RecentMeetingsScanner` that loads recent meeting transcripts from disk for the menubar recent-meetings list
 - `Shared/SpeakerClipPlayback.swift` — reusable audio-preview helper for persisted speaker sample clips
+- `Shared/TranscriptedSupportActions.swift` — "Send feedback" flow that builds a GitHub-issue URL seeded with sanitized recent log lines
 
 Cross-cutting permission checks now live in `Sources/Support/TranscriptedPermissionAccess.swift`
 so the meeting prompt detector and the settings/onboarding flows share the same

--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -56,6 +56,7 @@ They also honor:
 | File | Purpose |
 |------|---------|
 | `Tests/TranscriptedCLITests/ContextDirectoriesTests.swift` | Coverage for current Transcripted captures vs legacy Draft fallback path resolution |
+| `Tests/TranscriptedCLITests/ContextStoreTests.swift` | Coverage for `ContextStore` recent/search loading and dictation day-file filtering |
 
 ## Build And Run
 


### PR DESCRIPTION
## Summary

Daily CLAUDE.md / AGENTS.md review — brings two stale docs back in sync with the state of `main` after the burst of settings / menubar / home-activity PRs that merged after the last docs sync ([PR #360](https://github.com/r3dbars/transcripted/pull/360)).

## Files updated

### `Sources/UI/CLAUDE.md`

Bumps the header from **34 → 44 Swift files** and indexes the 10 files added since the last sync:

**`MenuBar/`** (quick-menu popover refactor)
- `MenuBarActionRowView.swift`
- `MenuBarPrimaryActionsView.swift`
- `MenuBarUtilityActionsView.swift`

**`Settings/`** (settings redesign + home transcription activity card)
- `HomeTranscriptionActivityPresentation.swift`
- `TranscriptedSettingsActions.swift`
- `TranscriptedSettingsComponents.swift`
- `TranscriptedSettingsNavigationModel.swift`
- `TranscriptedSettingsPage.swift`

**`Shared/`**
- `RecentCaptureScanners.swift` (recent-meetings loader)
- `TranscriptedSupportActions.swift` (feedback-issue flow)

### `Tools/TranscriptedCLI/CLAUDE.md`

Adds the missing test-file entry for `ContextStoreTests.swift` so the test index matches disk.

## Audits that came back clean

Every other CLAUDE.md / AGENTS.md in the tree matches current disk state:

- Root `CLAUDE.md` and `AGENTS.md`
- `Sources/CLAUDE.md`
- `Sources/Accessibility/CLAUDE.md`
- `Sources/Beta/CLAUDE.md`
- `Sources/Capture/CLAUDE.md`
- `Sources/Dictation/CLAUDE.md`
- `Sources/Meeting/CLAUDE.md` (14 files)
- `Sources/Observability/CLAUDE.md` (13 files)
- `Sources/Reliability/CLAUDE.md`
- `Sources/Speech/CLAUDE.md` (7 files)
- `Sources/TranscriptedCore/CLAUDE.md` (58 files across 10 subdirs)
- `Tools/TranscriptedMCP/CLAUDE.md`
- `Tools/TranscriptedQA/CLAUDE.md`

## Test plan

- [x] All new files present on disk (`ls Sources/UI/{MenuBar,Settings,Shared}`)
- [x] All listed files exist and descriptions match the one-line intent of each file
- [x] File counts verified (`find Sources/UI -name '*.swift' | wc -l` → 44)
- [x] TranscriptedCLI test file list matches `Tools/TranscriptedCLI/Tests/TranscriptedCLITests/` contents
- [ ] No Swift code changed — no `build.sh` / `run-tests.sh` run needed

Docs-only PR. Do not auto-merge — scheduled docs review leaves the review to a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)