### PR TITLE
refactor: nightly simplification sweep [automated]

### DIFF
--- a/Sources/Support/LocalSpeakerPreferences.swift
+++ b/Sources/Support/LocalSpeakerPreferences.swift
@@ -18,10 +18,7 @@ enum LocalSpeakerPreferences {
     /// Whether mic-channel diarization runs during meeting transcription.
     /// Default: false. Read by the pipeline runner on each meeting.
     static func isEnabled() -> Bool {
-        // Default false if never set; explicit bool otherwise.
-        let ud = UserDefaults.standard
-        if ud.object(forKey: enabledKey) == nil { return false }
-        return ud.bool(forKey: enabledKey)
+        UserDefaults.standard.bool(forKey: enabledKey)
     }
 
     static func setEnabled(_ enabled: Bool) {

--- a/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
+++ b/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
@@ -226,6 +226,11 @@ public struct TranscriptionMetadata {
 public enum UtteranceChannel: String, Sendable, Hashable {
     case mic
     case system
+
+    /// Canonical key for speaker maps keyed by channel + diarizer ID (e.g. "system_0", "mic_2").
+    func speakerKey(diarizerSpeakerId: String) -> String {
+        "\(rawValue)_\(diarizerSpeakerId)"
+    }
 }
 
 /// A named person the user can link a detected speaker to.

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -225,6 +225,12 @@ extension Transcription {
             var speakerNewProfiles: [Int: UUID] = [:]
             var speakerIdRemap: [Int: Int] = [:]
 
+            // Pre-compute unweighted means for non-ghost speakers so the ghost merge inner
+            // loop doesn't recompute the same means once per ghost (O(G×N) → O(N)).
+            let nonGhostMeans: [Int: [Float]] = embeddingsPerSpeaker
+                .filter { !ghostSpeakerIdSet.contains($0.key) }
+                .reduce(into: [:]) { $0[$1.key] = Self.computeMeanEmbedding($1.value) }
+
             for (speakerId, embeddings) in embeddingsPerSpeaker {
                 let weights = embeddingWeights[speakerId] ?? Array(repeating: Float(1.0), count: embeddings.count)
                 let meanEmbedding = Self.computeWeightedMeanEmbedding(embeddings, weights: weights)
@@ -238,8 +244,7 @@ extension Transcription {
                 if isGhost {
                     var bestNonGhostId: Int?
                     var bestSimilarity: Double = -1
-                    for (otherId, otherEmbeddings) in embeddingsPerSpeaker where !ghostSpeakerIdSet.contains(otherId) {
-                        let otherMean = Self.computeMeanEmbedding(otherEmbeddings)
+                    for (otherId, otherMean) in nonGhostMeans {
                         let sim = Self.cosineSimilarityStatic(meanEmbedding, otherMean)
                         if sim > bestSimilarity {
                             bestSimilarity = sim
@@ -597,6 +602,12 @@ extension Transcription {
         var speakerIdRemap: [Int: Int] = [:]
         var newlyCreatedProfileIds: Set<UUID> = []
 
+        // Pre-compute unweighted means for non-ghost speakers so the ghost merge inner
+        // loop doesn't recompute the same means once per ghost (O(G×N) → O(N)).
+        let nonGhostMeans: [Int: [Float]] = embeddingsPerSpeaker
+            .filter { !ghostSpeakerIdSet.contains($0.key) }
+            .reduce(into: [:]) { $0[$1.key] = Self.computeMeanEmbedding($1.value) }
+
         for (speakerId, embeddings) in embeddingsPerSpeaker {
             let meanEmbedding = Self.computeMeanEmbedding(embeddings)
             let isGhost = ghostSpeakerIdSet.contains(speakerId)
@@ -604,8 +615,7 @@ extension Transcription {
             if isGhost {
                 var bestNonGhostId: Int?
                 var bestSimilarity: Double = -1
-                for (otherId, otherEmbeddings) in embeddingsPerSpeaker where !ghostSpeakerIdSet.contains(otherId) {
-                    let otherMean = Self.computeMeanEmbedding(otherEmbeddings)
+                for (otherId, otherMean) in nonGhostMeans {
                     let sim = Self.cosineSimilarityStatic(meanEmbedding, otherMean)
                     if sim > bestSimilarity { bestSimilarity = sim; bestNonGhostId = otherId }
                 }

--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -258,7 +258,7 @@ extension TranscriptSaver {
             let obsidianEnabled = isObsidianFormatted(content)
             let updatesByChannelKey = Dictionary(uniqueKeysWithValues: updates.map {
                 (
-                    speakerUpdateKey(channel: $0.channel, diarizerSpeakerId: $0.diarizerSpeakerId),
+                    $0.channel.speakerKey(diarizerSpeakerId: $0.diarizerSpeakerId),
                     (
                         oldName: currentSpeakerName(
                             in: content,
@@ -331,6 +331,14 @@ extension TranscriptSaver {
         }
     }
 
+    private static let micLabelRegex = try? NSRegularExpression(pattern: #"\[Mic/[^\]]*\]"#)
+    private static let localSpeakerBreakdownRegex = try? NSRegularExpression(
+        pattern: #"(?s)\n#### Local Speaker Breakdown\n.*?\n\n"#
+    )
+    private static let speakersDetectedLineRegex = try? NSRegularExpression(
+        pattern: #"\n- \*\*Speakers Detected:\*\* \d+\n"#
+    )
+
     /// Collapse mic speakers back to "You" after the user clicked "Keep as You" in the
     /// naming sheet. Rewrites the saved transcript to:
     ///   - Replace every `[Mic/Speaker N]` (or named) label with `[Mic/You]` in the body
@@ -356,18 +364,11 @@ extension TranscriptSaver {
             }
 
             // 1) Rewrite body mic labels. Replace `[Mic/<anything>]` with `[Mic/You]`.
-            //    Non-greedy match on bracketed content to avoid escaping other `]`.
-            do {
-                let pattern = #"\[Mic/[^\]]*\]"#
-                if let regex = try? NSRegularExpression(pattern: pattern, options: []) {
-                    let range = NSRange(content.startIndex..., in: content)
-                    content = regex.stringByReplacingMatches(
-                        in: content,
-                        options: [],
-                        range: range,
-                        withTemplate: "[Mic/You]"
-                    )
-                }
+            if let regex = micLabelRegex {
+                let range = NSRange(content.startIndex..., in: content)
+                content = regex.stringByReplacingMatches(
+                    in: content, options: [], range: range, withTemplate: "[Mic/You]"
+                )
             }
 
             // 2) Mic section header: "Microphone (People in the Room)" -> "Microphone (You)"
@@ -376,46 +377,26 @@ extension TranscriptSaver {
                 with: "### Microphone (You)"
             )
 
-            // 3) Remove the "Local Speaker Breakdown" subsection entirely. It spans from
-            //    the header line through the next blank line before the next `---` or `####`
-            //    / `###` heading. Conservative regex — only remove when the section is present.
-            do {
-                let pattern = #"(?s)\n#### Local Speaker Breakdown\n.*?\n\n"#
-                if let regex = try? NSRegularExpression(pattern: pattern, options: []) {
-                    let range = NSRange(content.startIndex..., in: content)
-                    content = regex.stringByReplacingMatches(
-                        in: content,
-                        options: [],
-                        range: range,
-                        withTemplate: "\n"
-                    )
-                }
+            // 3) Remove the "Local Speaker Breakdown" subsection entirely.
+            if let regex = localSpeakerBreakdownRegex {
+                let range = NSRange(content.startIndex..., in: content)
+                content = regex.stringByReplacingMatches(
+                    in: content, options: [], range: range, withTemplate: "\n"
+                )
             }
 
             // 4) Strip mic speakers from the YAML frontmatter `speakers:` block.
-            //    Each mic entry is a 5-line group ending with `    source: ...`, tagged
-            //    by `channel: mic`. We remove all such groups.
             content = stripYAMLSpeakerEntries(in: content, channel: "mic")
 
-            // 5) "Speakers Detected: N" line inside the mic stats block — drop it
-            //    since we're collapsing back to the single-speaker view.
-            do {
-                let pattern = #"\n- \*\*Speakers Detected:\*\* \d+\n"#
-                if let regex = try? NSRegularExpression(pattern: pattern, options: []) {
-                    // Only replace the FIRST match (the mic block's one — remote block
-                    // is always written so removing both would break the remote stats).
-                    // We find the mic block anchor and scope to that.
-                    if let micHeaderRange = content.range(of: "### Microphone (You)") {
-                        let micSectionEnd = content.range(of: "\n\n### ", range: micHeaderRange.upperBound..<content.endIndex)?.lowerBound ?? content.endIndex
-                        let micSectionRange = NSRange(micHeaderRange.upperBound..<micSectionEnd, in: content)
-                        content = regex.stringByReplacingMatches(
-                            in: content,
-                            options: [],
-                            range: micSectionRange,
-                            withTemplate: "\n"
-                        )
-                    }
-                }
+            // 5) "Speakers Detected: N" line inside the mic stats block — drop it.
+            //    Only remove inside the mic section so the remote stats line is untouched.
+            if let regex = speakersDetectedLineRegex,
+               let micHeaderRange = content.range(of: "### Microphone (You)") {
+                let micSectionEnd = content.range(of: "\n\n### ", range: micHeaderRange.upperBound..<content.endIndex)?.lowerBound ?? content.endIndex
+                let micSectionRange = NSRange(micHeaderRange.upperBound..<micSectionEnd, in: content)
+                content = regex.stringByReplacingMatches(
+                    in: content, options: [], range: micSectionRange, withTemplate: "\n"
+                )
             }
 
             do {
@@ -839,7 +820,7 @@ extension TranscriptSaver {
         let speakerGroups = Dictionary(grouping: utterances, by: { $0.speakerId })
         let lines = speakerGroups.keys.sorted().map { speakerId in
             let utterances = speakerGroups[speakerId] ?? []
-            let speakerKey = speakerUpdateKey(channel: channel, diarizerSpeakerId: String(speakerId))
+            let speakerKey = channel.speakerKey(diarizerSpeakerId: String(speakerId))
             let speakerName = updatesByChannelKey[speakerKey]?.newName
                 ?? updatesByChannelKey[speakerKey]?.oldName
                 ?? currentSpeakerName(in: content, diarizerSpeakerId: String(speakerId), channel: channel)
@@ -915,10 +896,8 @@ extension TranscriptSaver {
                 return false
             }
 
-            let speakerKey = speakerUpdateKey(
-                channel: utterance.channel == 0 ? .mic : .system,
-                diarizerSpeakerId: String(utterance.speakerId)
-            )
+            let channel: UtteranceChannel = utterance.channel == 0 ? .mic : .system
+            let speakerKey = channel.speakerKey(diarizerSpeakerId: String(utterance.speakerId))
             guard let update = updatesByChannelKey[speakerKey] else { continue }
 
             let label = transcriptLabel(
@@ -963,10 +942,8 @@ extension TranscriptSaver {
                 return false
             }
 
-            let speakerKey = speakerUpdateKey(
-                channel: utterance.channel == 0 ? .mic : .system,
-                diarizerSpeakerId: String(utterance.speakerId)
-            )
+            let utteranceChannel: UtteranceChannel = utterance.channel == 0 ? .mic : .system
+            let speakerKey = utteranceChannel.speakerKey(diarizerSpeakerId: String(utterance.speakerId))
             if let update = updatesByChannelKey[speakerKey] {
                 let label = transcriptLabel(
                     for: update.newName,
@@ -985,12 +962,6 @@ extension TranscriptSaver {
         return true
     }
 
-    private static func speakerUpdateKey(
-        channel: UtteranceChannel,
-        diarizerSpeakerId: String
-    ) -> String {
-        "\(channel.rawValue)_\(diarizerSpeakerId)"
-    }
 
     private static func parseTranscriptLine(_ line: String) -> (timestamp: String, source: String, label: String, text: String)? {
         guard line.hasPrefix("["),

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -36,19 +36,17 @@ extension TranscriptionTaskManager {
     ) {
         let speakerDB = transcription.speakerDB
         let clipsBySpeakerId = Dictionary(uniqueKeysWithValues: clips.map {
-            (Self.speakerClipLookupKey(channel: $0.channel, diarizerSpeakerId: $0.diarizerSpeakerId), $0)
+            ($0.channel.speakerKey(diarizerSpeakerId: $0.diarizerSpeakerId), $0)
         })
 
         // Partition updates: "Keep as You" collapsedToMe updates follow a different
         // path (delete newly-created profiles, rewrite mic labels to "You") than
         // regular name/merge/confirm updates. We process both during naming completion.
-        let collapsedUpdates = updates.filter {
-            if case .collapsedToMe = $0.action { return true }
-            return false
-        }
-        let regularUpdates = updates.filter {
-            if case .collapsedToMe = $0.action { return false }
-            return true
+        var collapsedUpdates: [SpeakerNameUpdate] = []
+        var regularUpdates: [SpeakerNameUpdate] = []
+        for update in updates {
+            if case .collapsedToMe = update.action { collapsedUpdates.append(update) }
+            else { regularUpdates.append(update) }
         }
         let newlyCreatedMicProfileIds = transcriptionResult.newlyCreatedMicProfileIds
 
@@ -155,7 +153,7 @@ extension TranscriptionTaskManager {
         var mutations: [PlannedSpeakerMutation] = []
 
         for update in updates {
-            let entry = clipsBySpeakerId[speakerClipLookupKey(channel: update.channel, diarizerSpeakerId: update.diarizerSpeakerId)]
+            let entry = clipsBySpeakerId[update.channel.speakerKey(diarizerSpeakerId: update.diarizerSpeakerId)]
             guard let plan = planPersistentSpeakerResolution(
                 for: update,
                 entry: entry,
@@ -319,13 +317,6 @@ extension TranscriptionTaskManager {
         (name ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-    }
-
-    nonisolated private static func speakerClipLookupKey(
-        channel: UtteranceChannel,
-        diarizerSpeakerId: String
-    ) -> String {
-        "\(channel.rawValue)_\(diarizerSpeakerId)"
     }
 
     @MainActor private func finishNamingFlow(


### PR DESCRIPTION
## Summary

- **`LocalSpeakerPreferences.isEnabled()`** — remove redundant nil check; `UserDefaults.bool(forKey:)` already returns `false` for absent keys
- **`SpeakerNamingCoordinator`** — replace double-filter for collapsed/regular updates with a single-pass partition loop
- **`TranscriptionPipeline` (system + mic paths)** — pre-compute unweighted means for non-ghost speakers before the outer loop; the ghost-merge inner loop now uses the precomputed map instead of recomputing O(G×N) times
- **`RetroactiveSpeakerUpdater.collapseMicSpeakersToYou`** — hoist three inline `NSRegularExpression` compilations to `private static let` constants; remove bare `do {}` scoping wrappers
- **`UtteranceChannel`** — add `speakerKey(diarizerSpeakerId:)` method to replace the duplicate `speakerUpdateKey` / `speakerClipLookupKey` helpers (identical bodies in two separate files)

## Test plan

- [x] `bash build.sh` — passes
- [x] `bash run-tests.sh` — 326/326 passed
- [x] `bash run-integration-smoke.sh` — passes
- [x] `swift test` — 58/58 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)