### PR TITLE
[codex] Compact menu bar popover

### DIFF
--- a/Sources/UI/MenuBar/MenuBarActionRowView.swift
+++ b/Sources/UI/MenuBar/MenuBarActionRowView.swift
@@ -68,7 +68,7 @@ final class MenuBarActionRowView: NSControl {
 
         if let image = NSImage(systemSymbolName: symbolName, accessibilityDescription: title) {
             symbolView.image = image.withSymbolConfiguration(
-                NSImage.SymbolConfiguration(pointSize: size == .primary ? 15 : 13, weight: .semibold)
+                NSImage.SymbolConfiguration(pointSize: size == .primary ? 14 : 12, weight: .semibold)
             )
         }
 
@@ -79,7 +79,7 @@ final class MenuBarActionRowView: NSControl {
 
     private func setupViews() {
         wantsLayer = true
-        layer?.cornerRadius = 6
+        layer?.cornerRadius = MenuTokens.cardCornerRadius
 
         addSubview(symbolWellView)
 
@@ -103,27 +103,42 @@ final class MenuBarActionRowView: NSControl {
     private func updateAppearance() {
         let backgroundColor: NSColor
         let iconTint: NSColor
+        let titleColor: NSColor
+        let detailColor: NSColor
+        let trailingColor: NSColor
 
         if !isEnabled {
             backgroundColor = MenuTokens.flatRowDisabledNS
             iconTint = MenuTokens.textMutedNS
+            titleColor = MenuTokens.textMutedNS
+            detailColor = MenuTokens.textMutedNS
+            trailingColor = MenuTokens.textMutedNS
         } else if isPressing {
             backgroundColor = MenuTokens.flatRowPressedNS
-            iconTint = toneColors().pressed
+            iconTint = .white
+            titleColor = .white
+            detailColor = NSColor.white.withAlphaComponent(0.78)
+            trailingColor = NSColor.white.withAlphaComponent(0.82)
         } else if isHovering {
             backgroundColor = MenuTokens.flatRowHoverNS
-            iconTint = toneColors().normal
+            iconTint = .white
+            titleColor = .white
+            detailColor = NSColor.white.withAlphaComponent(0.78)
+            trailingColor = NSColor.white.withAlphaComponent(0.82)
         } else {
             backgroundColor = .clear
             iconTint = toneColors().normal
+            titleColor = MenuTokens.textPrimaryNS
+            detailColor = MenuTokens.textSecondaryNS
+            trailingColor = MenuTokens.textMutedNS
         }
 
         layer?.backgroundColor = backgroundColor.cgColor
         layer?.borderWidth = 0
         symbolView.contentTintColor = iconTint
-        titleLabel.textColor = MenuTokens.textPrimaryNS
-        detailLabel.textColor = MenuTokens.textSecondaryNS
-        trailingLabel.textColor = MenuTokens.textMutedNS
+        titleLabel.textColor = titleColor
+        detailLabel.textColor = detailColor
+        trailingLabel.textColor = trailingColor
         alphaValue = isEnabled ? 1.0 : 0.55
     }
 
@@ -142,10 +157,10 @@ final class MenuBarActionRowView: NSControl {
         super.layout()
 
         let hasDetail = !detailLabel.isHidden
-        let padX: CGFloat = 2
-        let iconWidth: CGFloat = rowSize == .primary ? 18 : 16
-        let symbolSize: CGFloat = rowSize == .primary ? 15 : 13
-        let trailingWidth: CGFloat = trailingLabel.isHidden ? 0 : (rowSize == .primary ? 92 : 70)
+        let padX: CGFloat = 6
+        let iconWidth: CGFloat = rowSize == .primary ? 17 : 16
+        let symbolSize: CGFloat = rowSize == .primary ? 14 : 12
+        let trailingWidth: CGFloat = trailingLabel.isHidden ? 0 : (rowSize == .primary ? 76 : 64)
         let trailingSpacing: CGFloat = trailingWidth > 0 ? 8 : 0
         let contentWidth = bounds.width - (padX * 2) - iconWidth - 8 - trailingWidth - trailingSpacing
         let textWidth = max(CGFloat(0), contentWidth)
@@ -166,7 +181,7 @@ final class MenuBarActionRowView: NSControl {
             titleLabel.frame = NSRect(x: textX, y: centeredY, width: textWidth, height: 16)
             detailLabel.frame = .zero
         } else {
-            let titleY: CGFloat = rowSize == .primary ? 2 : 1
+            let titleY: CGFloat = rowSize == .primary ? 1 : 1
             titleLabel.frame = NSRect(x: textX, y: titleY, width: textWidth, height: 16)
             detailLabel.frame = NSRect(x: textX, y: titleLabel.frame.maxY + 1, width: textWidth, height: 13)
         }
@@ -181,13 +196,13 @@ final class MenuBarActionRowView: NSControl {
     private func updateTypography() {
         switch rowSize {
         case .primary:
-            titleLabel.font = NSFont.systemFont(ofSize: 12.5, weight: .semibold)
-            detailLabel.font = NSFont.systemFont(ofSize: 10.5)
-            trailingLabel.font = NSFont.systemFont(ofSize: 11, weight: .medium)
-        case .utility:
             titleLabel.font = NSFont.systemFont(ofSize: 12.5, weight: .medium)
-            detailLabel.font = NSFont.systemFont(ofSize: 10.5)
+            detailLabel.font = NSFont.systemFont(ofSize: 10)
             trailingLabel.font = NSFont.systemFont(ofSize: 10.5, weight: .medium)
+        case .utility:
+            titleLabel.font = NSFont.systemFont(ofSize: 12.5, weight: .regular)
+            detailLabel.font = NSFont.systemFont(ofSize: 10)
+            trailingLabel.font = NSFont.systemFont(ofSize: 10, weight: .medium)
         }
     }
 
@@ -195,7 +210,7 @@ final class MenuBarActionRowView: NSControl {
         let hasDetail = !detailLabel.stringValue.isEmpty
         switch rowSize {
         case .primary:
-            return hasDetail ? 32 : 24
+            return hasDetail ? MenuTokens.compactActionRowHeight : 24
         case .utility:
             return hasDetail ? 28 : 24
         }

--- a/Sources/UI/MenuBar/MenuBarContentView.swift
+++ b/Sources/UI/MenuBar/MenuBarContentView.swift
@@ -65,18 +65,25 @@ final class MenuBarContentView: NSView {
         var y = pad
 
         let headerHeight = headerView.intrinsicHeight
-        headerView.frame = NSRect(x: pad, y: y, width: width, height: headerHeight)
-        y += headerHeight + 10
+        headerView.isHidden = headerHeight <= 0
+        headerDivider.isHidden = headerHeight <= 0
+        if headerHeight > 0 {
+            headerView.frame = NSRect(x: pad, y: y, width: width, height: headerHeight)
+            y += headerHeight + 8
 
-        headerDivider.frame = NSRect(x: pad, y: y, width: width, height: 1)
-        y += 9
+            headerDivider.frame = NSRect(x: pad, y: y, width: width, height: 1)
+            y += 7
+        } else {
+            headerView.frame = .zero
+            headerDivider.frame = .zero
+        }
 
         let primaryHeight = primaryActionsView.intrinsicHeight
         primaryActionsView.frame = NSRect(x: pad, y: y, width: width, height: primaryHeight)
         y += primaryHeight + MenuTokens.sectionSpacing
 
         sectionDivider.frame = NSRect(x: pad, y: y, width: width, height: 1)
-        y += 9
+        y += 7
 
         let utilityHeight = utilityActionsView.intrinsicHeight
         utilityActionsView.frame = NSRect(x: pad, y: y, width: width, height: utilityHeight)

--- a/Sources/UI/MenuBar/MenuBarHeaderView.swift
+++ b/Sources/UI/MenuBar/MenuBarHeaderView.swift
@@ -119,7 +119,7 @@ final class MenuBarHeaderView: NSView {
         let isReady = currentWarmupStatus == .ready
         let hasWarning = currentHotkeyError?.isEmpty == false
         if isReady {
-            return hasWarning ? 56 : 20
+            return hasWarning ? 56 : 0
         }
         return hasWarning ? 110 : 78
     }

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -34,6 +34,7 @@ final class MenuBarPanelController: NSViewController {
     override func loadView() {
         let content = MenuBarContentView(frame: NSRect(x: 0, y: 0, width: MenuTokens.panelWidth, height: MenuTokens.panelHeight))
         content.appState = appState
+        content.primaryActionsView.onOpenHome = { [weak self] in self?.openSettingsFromMenu(.home) }
         content.primaryActionsView.onStartDictation = { [weak self] in self?.startDictationFromMenu() }
         content.primaryActionsView.onStartMeeting = { [weak self] in self?.startMeetingFromMenu() }
         content.primaryActionsView.onPasteLastDictation = { [weak self] in self?.pasteLastDictationFromMenu() }

--- a/Sources/UI/MenuBar/MenuBarPrimaryActionsView.swift
+++ b/Sources/UI/MenuBar/MenuBarPrimaryActionsView.swift
@@ -2,11 +2,14 @@ import AppKit
 
 @MainActor
 final class MenuBarPrimaryActionsView: NSView {
+    var onOpenHome: (() -> Void)?
     var onStartDictation: (() -> Void)?
     var onStartMeeting: (() -> Void)?
     var onPasteLastDictation: (() -> Void)?
     var onOpenRecentMeetings: (() -> Void)?
 
+    private let homeRow = MenuBarActionRowView()
+    private let homeDivider = NSView()
     private let dictationRow = MenuBarActionRowView()
     private let meetingRow = MenuBarActionRowView()
     private let pasteRow = MenuBarActionRowView()
@@ -23,12 +26,16 @@ final class MenuBarPrimaryActionsView: NSView {
     override var isFlipped: Bool { true }
 
     private func setupViews() {
+        homeRow.onPress = { [weak self] in self?.onOpenHome?() }
         dictationRow.onPress = { [weak self] in self?.onStartDictation?() }
         meetingRow.onPress = { [weak self] in self?.onStartMeeting?() }
         pasteRow.onPress = { [weak self] in self?.onPasteLastDictation?() }
         recentMeetingsRow.onPress = { [weak self] in self?.onOpenRecentMeetings?() }
 
-        [dictationRow, meetingRow, pasteRow, recentMeetingsRow].forEach(addSubview(_:))
+        homeDivider.wantsLayer = true
+        homeDivider.layer?.backgroundColor = MenuTokens.sectionDividerNS.cgColor
+
+        [homeRow, homeDivider, dictationRow, meetingRow, pasteRow, recentMeetingsRow].forEach(addSubview(_:))
     }
 
     func update(
@@ -39,6 +46,14 @@ final class MenuBarPrimaryActionsView: NSView {
         pasteDetail: String,
         pasteEnabled: Bool
     ) {
+        homeRow.update(
+            symbolName: "house.fill",
+            title: "Home",
+            detail: "",
+            tone: .standard,
+            size: .utility
+        )
+
         dictationRow.update(
             symbolName: "mic.fill",
             title: "Start Dictation",
@@ -88,14 +103,24 @@ final class MenuBarPrimaryActionsView: NSView {
         let thirdHeight = pasteRow.intrinsicContentSize.height
         let fourthHeight = recentMeetingsRow.intrinsicContentSize.height
 
-        dictationRow.frame = NSRect(x: 0, y: 0, width: bounds.width, height: firstHeight)
+        var y: CGFloat = 0
+        let homeHeight = homeRow.intrinsicContentSize.height
+        homeRow.frame = NSRect(x: 0, y: y, width: bounds.width, height: homeHeight)
+        y += homeHeight + 6
+
+        homeDivider.frame = NSRect(x: 0, y: y, width: bounds.width, height: 1)
+        y += 7
+
+        dictationRow.frame = NSRect(x: 0, y: y, width: bounds.width, height: firstHeight)
         meetingRow.frame = NSRect(x: 0, y: dictationRow.frame.maxY + 2, width: bounds.width, height: secondHeight)
         pasteRow.frame = NSRect(x: 0, y: meetingRow.frame.maxY + 2, width: bounds.width, height: thirdHeight)
         recentMeetingsRow.frame = NSRect(x: 0, y: pasteRow.frame.maxY + 2, width: bounds.width, height: fourthHeight)
     }
 
     var intrinsicHeight: CGFloat {
-        dictationRow.intrinsicContentSize.height
+        homeRow.intrinsicContentSize.height
+            + 14
+            + dictationRow.intrinsicContentSize.height
             + meetingRow.intrinsicContentSize.height
             + pasteRow.intrinsicContentSize.height
             + recentMeetingsRow.intrinsicContentSize.height

--- a/Sources/UI/MenuBar/MenuBarSettingsView.swift
+++ b/Sources/UI/MenuBar/MenuBarSettingsView.swift
@@ -14,8 +14,8 @@ final class MenuBarSettingsView: NSView {
     )
     private let settingsButton = MenuIconButton(
         symbolName: "gearshape",
-        accessibilityLabel: "Open settings",
-        toolTip: "Open settings"
+        accessibilityLabel: "Settings",
+        toolTip: "Settings"
     )
     private let updatesButton = MenuIconButton(
         symbolName: "arrow.triangle.2.circlepath.circle",

--- a/Sources/UI/MenuBar/MenuBarUtilityActionsView.swift
+++ b/Sources/UI/MenuBar/MenuBarUtilityActionsView.swift
@@ -68,7 +68,7 @@ final class MenuBarUtilityActionsView: NSView {
 
         settingsRow.update(
             symbolName: "gearshape",
-            title: "Open Settings",
+            title: "Settings",
             detail: "",
             tone: .standard,
             size: .utility

--- a/Sources/UI/MenuBar/MenuTokens.swift
+++ b/Sources/UI/MenuBar/MenuTokens.swift
@@ -22,8 +22,8 @@ enum MenuTokens {
     static let actionPressedNS = NSColor.white.withAlphaComponent(0.10)
     static let actionDisabledNS = NSColor.white.withAlphaComponent(0.03)
     static let actionBorderNS = NSColor.white.withAlphaComponent(0.08)
-    static let flatRowHoverNS = NSColor.white.withAlphaComponent(0.045)
-    static let flatRowPressedNS = NSColor.white.withAlphaComponent(0.08)
+    static let flatRowHoverNS = NSColor.systemBlue.withAlphaComponent(0.95)
+    static let flatRowPressedNS = NSColor.systemBlue.withAlphaComponent(0.78)
     static let flatRowDisabledNS = NSColor.white.withAlphaComponent(0.02)
     static let badgeBackgroundNS = NSColor.white.withAlphaComponent(0.08)
     static let badgeBorderNS = NSColor.white.withAlphaComponent(0.12)
@@ -65,14 +65,15 @@ enum MenuTokens {
     static let savedBorder = Color(MenuTokens.savedBorderNS)
 
     // Layout
-    static let panelWidth: CGFloat = 372
-    static let panelHeight: CGFloat = 360
+    static let panelWidth: CGFloat = 304
+    static let panelHeight: CGFloat = 320
     static let onboardingWindowWidth: CGFloat = 620
     static let onboardingWindowHeight: CGFloat = 760
-    static let innerPadding: CGFloat = 12
-    static let sectionSpacing: CGFloat = 8
-    static let surfaceCornerRadius: CGFloat = 16
-    static let cardCornerRadius: CGFloat = 12
+    static let innerPadding: CGFloat = 10
+    static let sectionSpacing: CGFloat = 7
+    static let surfaceCornerRadius: CGFloat = 14
+    static let cardCornerRadius: CGFloat = 8
+    static let compactActionRowHeight: CGFloat = 30
     static let actionRowHeight: CGFloat = 46
     static let recentRowHeight: CGFloat = 40
     static let savedRowHeight: CGFloat = 54


### PR DESCRIPTION
## Summary

- Make the menu bar popover narrower and more compact.
- Add a top-level Home row and keep the main Transcripted actions grouped cleanly.
- Rename Open Settings to Settings and apply a blue selected-menu hover/press state.

## Why

The current menu bar panel felt larger and heavier than comparable compact menu bar apps. This keeps the same core actions while making the surface simpler and easier to scan.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`