### PR TITLE
[codex] Fix dictation mic release

### DIFF
--- a/Sources/Speech/CLAUDE.md
+++ b/Sources/Speech/CLAUDE.md
@@ -6,9 +6,9 @@
 
 ## Key Files
 
-- `ParakeetEngine.swift` — app-owned Parakeet STT engine, recording control, live transcript state, model initialization, permission-aware prewarm decisions, audio-device handling, short-audio gating, wake-recovery support, and sanitized failure reporting for model init errors
+- `ParakeetEngine.swift` — app-owned Parakeet STT engine, recording control, live transcript state, model initialization, permission-aware input-readiness checks, audio-device handling, short-audio gating, wake-recovery support, and sanitized failure reporting for model init errors
 - `ParakeetModelInitDiagnostics.swift` — builds safe diagnostic context for model-initialization failures without leaking transcript or user-content data
-- `ParakeetPrewarmPolicy.swift` — central policy for deciding whether speech-engine prewarm should proceed or be skipped based on microphone authorization state
+- `ParakeetPrewarmPolicy.swift` — central policy for deciding whether speech-engine input-readiness checks should proceed or be skipped based on microphone authorization state
 - `ParakeetRecoveryState.swift` — pure-logic state machine for device-change recovery: generation counter (so stale recovery tasks can bail) and readiness flags (`isRecovering`, `inputFormatReady`) that the dictation overlay waits on instead of racing
 - `ParakeetShortAudioGate.swift` — central policy for deciding when very short recordings should be dropped, surfaced as intentional empty results, or still transcribed
 - `RecordedAudioTimeline.swift` — in-memory segmented audio buffer used when recorded audio needs to be preserved across interruptions or recovery handoffs
@@ -17,7 +17,7 @@
 ## Current Notes
 
 - This directory powers dictation.
-- `ParakeetEngine` consults `ParakeetPrewarmPolicy` before prewarming the local model, so microphone-permission-aware warmup behavior belongs here rather than in app startup glue.
+- `ParakeetEngine` consults `ParakeetPrewarmPolicy` before checking microphone input readiness. Idle readiness checks must not leave `AVAudioEngine` running, because that keeps the macOS microphone indicator active.
 - `ParakeetEngine` consults `ParakeetShortAudioGate` before spending work on extremely short clips, so short-tap behavior changes belong here rather than in UI controllers.
 - `ParakeetEngine` mirrors `ParakeetRecoveryState` flags into `@Published var isRecovering` and `@Published var inputFormatReady` (forwarded through `STTRouter`). `DictationSessionController` waits on these in its wait-for-ready loop instead of blindly retrying. AirPods Hands-Free Profile (24kHz hw / 48kHz output bus) is supported: the tap is installed with `format: nil` so buffers arrive at the output rate, and `nativeSampleRate` tracks the output rate so downstream resampling is correct.
 - `ParakeetEngine` reports model-init failures with `ParakeetModelInitDiagnostics.failureContext(...)`, which keeps diagnostics useful for packaging/download/debugging issues without shipping raw transcript or device content.

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -193,6 +193,7 @@ class ParakeetEngine: ObservableObject {
     /// on a fresh config-change burst. Bounded by `prewarmRetryBudget` to prevent
     /// infinite Task chains when the mic is permanently unavailable.
     private var prewarmRetryCount: Int = 0
+    private var prewarmRetryTask: Task<Void, Never>?
 
     // FluidAudio ASR
     private var asrManager: AsrManager?
@@ -422,12 +423,14 @@ class ParakeetEngine: ObservableObject {
         return path
     }
 
-    // MARK: - Pre-warm
+    // MARK: - Input readiness
 
     func prewarm() {
-        guard !isEnginePrewarmed, !isRecording else { return }
+        guard !isRecording else { return }
         installAudioObserversIfNeeded()
         scheduleInputDeviceNameRefresh()
+
+        releaseIdleAudioHardware(removeTap: false)
 
         let microphoneStatus = AVCaptureDevice.authorizationStatus(for: .audio)
         switch ParakeetPrewarmPolicy.decision(for: microphoneStatus) {
@@ -451,43 +454,34 @@ class ParakeetEngine: ObservableObject {
             return
         }
 
-        do {
-            let inputNode = audioEngine.inputNode
-            let outputFormat = inputNode.outputFormat(forBus: 0)
-            let hwFormat = inputNode.inputFormat(forBus: 0)
+        let inputNode = audioEngine.inputNode
+        let outputFormat = inputNode.outputFormat(forBus: 0)
+        let hwFormat = inputNode.inputFormat(forBus: 0)
 
-            // Validate both formats. AirPods on macOS run input in Hands-Free Profile
-            // (24kHz hw / 48kHz output bus); CoreAudio's internal converter handles
-            // the upsample and the tap delivers at the output bus rate. Both must be
-            // valid before declaring the engine ready — input alone or output alone
-            // can transiently report zero during device transitions.
-            guard outputFormat.sampleRate > 0, outputFormat.channelCount > 0,
-                  hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
-                EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "prewarm_invalid_format",
-                    message: "Audio format invalid during prewarm",
-                    context: [
-                        "output_rate": "\(outputFormat.sampleRate)",
-                        "output_channels": "\(outputFormat.channelCount)",
-                        "hw_rate": "\(hwFormat.sampleRate)",
-                        "hw_channels": "\(hwFormat.channelCount)"
-                    ])
-                schedulePrewarmRetry()
-                return
-            }
-
-            nativeSampleRate = outputFormat.sampleRate
-
-            audioEngine.prepare()
-            try audioEngine.start()
-            isEnginePrewarmed = true
-            prewarmRetryCount = 0
-            markFormatReadyAndPublish()
-            print("🔥 PARAKEET | engine pre-warmed (\(inputDeviceName), \(nativeSampleRate)Hz)")
-        } catch {
-            EventReporter.shared.capture(level: .error, engine: "parakeet", event: "prewarm_failed",
-                message: error.localizedDescription, context: ["audio_device": inputDeviceName])
+        // Validate both formats. AirPods on macOS run input in Hands-Free Profile
+        // (24kHz hw / 48kHz output bus); CoreAudio's internal converter handles
+        // the upsample and the tap delivers at the output bus rate. Both must be
+        // valid before declaring the engine ready — input alone or output alone
+        // can transiently report zero during device transitions.
+        guard outputFormat.sampleRate > 0, outputFormat.channelCount > 0,
+              hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
+            EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "prewarm_invalid_format",
+                message: "Audio format invalid during prewarm",
+                context: [
+                    "output_rate": "\(outputFormat.sampleRate)",
+                    "output_channels": "\(outputFormat.channelCount)",
+                    "hw_rate": "\(hwFormat.sampleRate)",
+                    "hw_channels": "\(hwFormat.channelCount)"
+                ])
             schedulePrewarmRetry()
+            return
         }
+
+        nativeSampleRate = outputFormat.sampleRate
+
+        prewarmRetryCount = 0
+        markFormatReadyAndPublish()
+        print("🔥 PARAKEET | input ready (\(inputDeviceName), \(nativeSampleRate)Hz)")
     }
 
     private func schedulePrewarmRetry() {
@@ -504,7 +498,8 @@ class ParakeetEngine: ObservableObject {
         }
         prewarmRetryCount += 1
         let capturedGeneration = recoveryState.generation
-        Task { @MainActor [weak self] in
+        prewarmRetryTask?.cancel()
+        prewarmRetryTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
             guard let self, !self.recoveryState.isStale(generation: capturedGeneration) else { return }
             self.prewarm()
@@ -599,6 +594,8 @@ class ParakeetEngine: ObservableObject {
         // already stopped the engine internally before posting this notification,
         // so the tap and prewarm state are stale.
         cancelAudioWatchdog()
+        prewarmRetryTask?.cancel()
+        prewarmRetryTask = nil
 
         if isRecording {
             pendingSamplesLock.withLock {
@@ -655,11 +652,7 @@ class ParakeetEngine: ObservableObject {
                         userInfo: [NSLocalizedDescriptionKey: "Invalid audio format after device change (\(newFormat.sampleRate)Hz, \(newFormat.channelCount)ch)"])
                 }
                 self.nativeSampleRate = newFormat.sampleRate
-                print("🔄 PARAKEET | audio device changed → \(self.inputDeviceName) (\(newFormat.sampleRate)Hz), re-warming")
-                self.audioEngine.prepare()
-                try self.audioEngine.start()
-                self.isEnginePrewarmed = true
-                print("🔥 PARAKEET | engine re-warmed after device change")
+                print("🔄 PARAKEET | audio device changed → \(self.inputDeviceName) (\(newFormat.sampleRate)Hz), input ready")
 
                 guard !Task.isCancelled else { return }
                 guard self.recoveryState.finishRecovery(success: true, generation: myGeneration) else { return }
@@ -761,21 +754,6 @@ class ParakeetEngine: ObservableObject {
             recordingInterrupted = true
             EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "recording_interrupted",
                 message: "Recording interrupted by system sleep/wake")
-        }
-
-        // Re-warm after a delay to let audio hardware reinitialize.
-        // Retry once if the first attempt fails (CoreAudio may need more time).
-        Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRewarmDelay)
-            guard let self = self else { return }
-            self.prewarm()
-
-            if !self.isEnginePrewarmed {
-                EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "wake_prewarm_retry",
-                    message: "First prewarm after wake failed, retrying in 1s")
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
-                self.prewarm()
-            }
         }
     }
 
@@ -1060,6 +1038,8 @@ class ParakeetEngine: ObservableObject {
             }
         }
         audioEngine.inputNode.removeTap(onBus: 0)
+        audioEngine.stop()
+        isEnginePrewarmed = false
         pendingSamplesLock.lock()
         sampleBuffer.append(contentsOf: pendingSamples)
         pendingSamples.removeAll(keepingCapacity: true)
@@ -1291,6 +1271,8 @@ class ParakeetEngine: ObservableObject {
 
     func cancel() {
         cancelAudioWatchdog()
+        prewarmRetryTask?.cancel()
+        prewarmRetryTask = nil
         pendingSamplesLock.withLock {
             pendingSamples.removeAll(keepingCapacity: true)
         }
@@ -1305,10 +1287,21 @@ class ParakeetEngine: ObservableObject {
             isRecording = false
             audioLevel = 0
         }
+        releaseIdleAudioHardware(removeTap: false)
         sampleBuffer.removeAll()
         isTranscribing = false
         liveTranscript = ""
         committedStreamText = ""
+    }
+
+    private func releaseIdleAudioHardware(removeTap: Bool) {
+        if removeTap {
+            audioEngine.inputNode.removeTap(onBus: 0)
+        }
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+        isEnginePrewarmed = false
     }
 
     private func cancelAudioWatchdog() {
@@ -1317,6 +1310,16 @@ class ParakeetEngine: ObservableObject {
     }
 
     func cleanup() {
+        cancelAudioWatchdog()
+        prewarmRetryTask?.cancel()
+        prewarmRetryTask = nil
+        configChangeDebounceTask?.cancel()
+        configChangeDebounceTask = nil
+        configRecoveryTask?.cancel()
+        configRecoveryTask = nil
+        releaseIdleAudioHardware(removeTap: true)
+        isRecording = false
+        audioLevel = 0
         if let observer = configChangeObserver {
             NotificationCenter.default.removeObserver(observer)
             configChangeObserver = nil

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -41,12 +41,8 @@ enum TranscriptedConstants {
         sampleCount >= parakeetMinimumInferenceSamples
     }
 
-    /// Delay for audio engine re-warm after device change (nanoseconds)
+    /// Delay for audio input readiness retry after device change (nanoseconds)
     static let audioRecoveryDelay: UInt64 = 300_000_000  // 300ms
-
-    /// Delay for audio engine re-warm after system wake (nanoseconds)
-    /// Increased from 500ms to 1s — CoreAudio needs time to fully reinitialize after sleep
-    static let audioRewarmDelay: UInt64 = 1_000_000_000  // 1 second
 
     /// Watchdog timeout — if no audio samples arrive within this window after starting
     /// recording, the engine is likely a zombie (running but disconnected from hardware)


### PR DESCRIPTION
## Summary
- stop the dictation AVAudioEngine when dictation stops or is cancelled
- keep idle input-readiness checks from starting CoreAudio while the app is not recording
- cancel pending audio recovery/prewarm tasks during cleanup

## Root Cause
Dictation removed the input tap at session end, but the shared Parakeet AVAudioEngine could remain running as an idle prewarmed engine. macOS still considered that active microphone use, so the privacy indicator stayed on until app quit.

Fixes #370.

## Validation
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (383 passed)
- Manual patched-app test: started dictation via the real hotkey, confirmed the orange macOS mic indicator appeared while recording and disappeared after stop without quitting Transcripted.
