### PR TITLE
Release 1.1.12

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.11"
-  sha256 "4bfe1d1449a2704b3dd36596914523d3f5b163ba26a5b04ad82f37feba2e217e"
+  version "1.1.12"
+  sha256 "547b697195c39d7819a06ba9e80874ad6a40e5611668a463849034c1301fe5c7"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.11</string>
+	<string>1.1.12</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.11</string>
+	<string>1.1.12</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.12</title>
+      <pubDate>Sun, 19 Apr 2026 02:22:54 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.12</link>
+      <sparkle:version>1.1.12</sparkle:version>
+      <sparkle:shortVersionString>1.1.12</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.12</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.12/Transcripted-1.1.12.dmg" length="503316542" type="application/octet-stream" sparkle:edSignature="tyMGBXTf61HJp9NL+rHFGn0Kmay2FZ2g5aiJWMAOUFfgjDMeXpaQEt7l7cwMHKuqUFVCr8/TDAto5sAM3K14Cw=="/>
+    </item>
+    <item>
       <title>1.1.11</title>
       <pubDate>Sat, 18 Apr 2026 12:00:39 GMT</pubDate>
       <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.11</link>


### PR DESCRIPTION
## Summary

Ship Transcripted 1.1.12.

- Bumps app bundle version to 1.1.12.
- Publishes the notarized DMG on GitHub Releases.
- Updates Sparkle appcast for in-app updates.
- Updates the Homebrew cask to 1.1.12 with the release DMG SHA.

## Release Notes

- Add a safer meeting recording cancel flow with an explicit cancel button, confirmation before discarding audio, and no Escape-to-cancel behavior.
- Fix dictation microphone cleanup so the macOS mic indicator turns off after dictation stops or is cancelled.
- Keep background meeting model warmup failures quiet, especially while offline.
- Polish the meeting recording overlay with a compact mirrored mic/system waveform, calmer gray controls, and faster hover hints.
- Add clearer Home import transcription progress, including preparing, transcribing, saving, finished states, and an Open Transcript action.
- Tighten the menu bar popover with a more compact layout, cleaner Home row, and improved hover/selected styling.
- Add a small playful feedback sound cue while keeping the normal GitHub feedback flow.

## Validation

- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-release-1-1-12 Transcripted
- xcrun stapler validate build/Transcripted-1.1.12.dmg
- deps-tools/sparkle/bin/sign_update --verify build/Transcripted-1.1.12.dmg <signature>
- ruby -c Casks/transcripted.rb
- appcast XML parse
- bash run-tests.sh
- bash build.sh
- bash run-integration-smoke.sh
- swift test