### PR TITLE
[nightly-security] Harden observability secret sanitizers

### DIFF
--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -5,13 +5,17 @@ enum AnalyticsPayloadSanitizer {
     private static let sensitiveKeyFragments = [
         "audio",
         "bundle",
+        "credential",
+        "dsn",
         "email",
         "error",
         "file",
         "name",
+        "password",
         "path",
         "speaker",
         "source_app",
+        "secret",
         "text",
         "title",
         "token",
@@ -41,7 +45,7 @@ enum AnalyticsPayloadSanitizer {
     )
     private static let bearerRegex = makeRegex(#"Bearer\s+[A-Za-z0-9._-]+"#, options: [.caseInsensitive])
     private static let secretAssignmentRegex = makeRegex(
-        #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature)\s*[:=]\s*([^\s,;]+)"#
+        #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature|password|passphrase|secret|client[_-]?secret|credential|dsn)\s*[:=]\s*([^\s,;]+)"#
     )
     private static let emailRegex = makeRegex(#"[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}"#, options: [.caseInsensitive])
 

--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -7,12 +7,16 @@ enum SentryPayloadSanitizer {
         "authorization",
         "bearer",
         "bundle",
+        "credential",
+        "dsn",
         "email",
         "error",
         "file",
+        "password",
         "path",
         "speaker",
         "source_app",
+        "secret",
         "text",
         "title",
         "token",
@@ -42,7 +46,7 @@ enum SentryPayloadSanitizer {
     )
     private static let bearerRegex = makeRegex(#"Bearer\s+[A-Za-z0-9._-]+"#, options: [.caseInsensitive])
     private static let secretAssignmentRegex = makeRegex(
-        #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature)\s*[:=]\s*([^\s,;]+)"#
+        #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature|password|passphrase|secret|client[_-]?secret|credential|dsn)\s*[:=]\s*([^\s,;]+)"#
     )
     private static let emailRegex = makeRegex(#"[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}"#, options: [.caseInsensitive])
     private static let localHostnameRegex = makeRegex(#"\b[a-zA-Z0-9._-]+\.local\b"#)

--- a/Tests/AnalyticsPayloadSanitizerTests.swift
+++ b/Tests/AnalyticsPayloadSanitizerTests.swift
@@ -36,7 +36,7 @@ func testAnalyticsPayloadSanitizer() {
     runSuite("AnalyticsPayloadSanitizer redacts raw URLs and common secret values") {
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
             [
-                "failure_kind": "Upload failed at https://example.com/path?token=abc123 with github_pat_abcdefghijklmnopqrstuvwxyz_1234567890 AKIAIOSFODNN7EXAMPLE AIzaSyA-BCDEFGHIJKLMNOPQRSTUVWXYZ123456 and api_key=secret-value",
+                "failure_kind": "Upload failed at https://example.com/path?token=abc123 with github_pat_abcdefghijklmnopqrstuvwxyz_1234567890 AKIAIOSFODNN7EXAMPLE AIzaSyA-BCDEFGHIJKLMNOPQRSTUVWXYZ123456 and api_key=secret-value password=hunter2 client_secret:supersecret credential=temp-pass",
             ],
             allowedKeys: ["failure_kind"]
         )
@@ -47,6 +47,9 @@ func testAnalyticsPayloadSanitizer() {
         assertFalse(value.contains("AKIAIOSFODNN7EXAMPLE"), "AWS access key IDs should be redacted")
         assertFalse(value.contains("AIzaSyA-BCDEFGHIJKLMNOPQRSTUVWXYZ123456"), "Google API keys should be redacted")
         assertFalse(value.contains("api_key=secret-value"), "inline secret assignments should be redacted")
+        assertFalse(value.contains("hunter2"), "password assignment values should be redacted")
+        assertFalse(value.contains("supersecret"), "client secret assignment values should be redacted")
+        assertFalse(value.contains("temp-pass"), "credential assignment values should be redacted")
         assertTrue(value.contains("[redacted-url]"), "URL marker should remain")
         assertTrue(value.contains("[redacted-secret]"), "secret marker should remain")
     }

--- a/Tests/SentryPayloadSanitizerTests.swift
+++ b/Tests/SentryPayloadSanitizerTests.swift
@@ -15,8 +15,11 @@ func testSentryPayloadSanitizer() {
 
     runSuite("SentryPayloadSanitizer.sanitizeContext drops obviously sensitive keys") {
         let sanitized = SentryPayloadSanitizer.sanitizeContext([
+            "client_secret": "plain-secret",
+            "dsn": "https://example@sentry.invalid/1",
             "duration_ms": "123",
             "meeting_state": "transcribing",
+            "password": "hunter2",
             "title": "Private customer call",
             "transcript_url": "/Users/redbars/Library/Application Support/Draft/meetings/demo.md",
             "error": "meeting title leaked",
@@ -25,6 +28,9 @@ func testSentryPayloadSanitizer() {
 
         assertEqual(sanitized["duration_ms"], "123", "coarse numeric values should remain")
         assertEqual(sanitized["meeting_state"], "transcribing", "non-sensitive state should remain")
+        assertNil(sanitized["client_secret"], "client secrets should be dropped")
+        assertNil(sanitized["dsn"], "DSNs should be dropped")
+        assertNil(sanitized["password"], "password fields should be dropped")
         assertNil(sanitized["title"], "title should be dropped")
         assertNil(sanitized["transcript_url"], "transcript path should be dropped")
         assertNil(sanitized["error"], "free-form error payloads should be dropped")
@@ -54,6 +60,19 @@ func testSentryPayloadSanitizer() {
         assertFalse(sanitized.contains("AIzaSyA-BCDEFGHIJKLMNOPQRSTUVWXYZ123456"), "Google API keys should be redacted")
         assertTrue(sanitized.contains("[redacted-url]"), "redacted URL marker should remain")
         assertTrue(sanitized.contains("[redacted-secret]"), "redacted secret marker should remain")
+    }
+
+    runSuite("SentryPayloadSanitizer.sanitizeText redacts password and secret assignments") {
+        let input = "Sync failed with password=hunter2 client_secret:supersecret credential=temp-pass dsn=https://example@sentry.invalid/1"
+        let sanitized = SentryPayloadSanitizer.sanitizeText(input)
+
+        assertFalse(sanitized.contains("hunter2"), "password assignment values should be redacted")
+        assertFalse(sanitized.contains("supersecret"), "client secret assignment values should be redacted")
+        assertFalse(sanitized.contains("temp-pass"), "credential assignment values should be redacted")
+        assertFalse(sanitized.contains("https://example@sentry.invalid/1"), "DSN URLs should be redacted")
+        assertTrue(sanitized.contains("password=[redacted-secret]"), "password marker should remain")
+        assertTrue(sanitized.contains("client_secret=[redacted-secret]"), "client secret marker should remain")
+        assertTrue(sanitized.contains("credential=[redacted-secret]"), "credential marker should remain")
     }
 
     runSuite("SentryPayloadSanitizer redacts case-insensitive bearer variants with tabs and multi-space") {

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -68,8 +68,12 @@ PostHog controls described below.
 - `dictation_completed`
 - `dictation_cancelled`
 - `dictation_no_speech`
+- `meeting_prompt_shown`
+- `meeting_prompt_dismissed`
+- `meeting_prompt_record_selected`
 - `meeting_recording_started`
 - `meeting_recording_stopped`
+- `meeting_recording_cancelled`
 - `meeting_transcript_saved`
 - `meeting_transcript_failed`
 


### PR DESCRIPTION
## Summary
- expand Sentry and analytics sanitizers to drop obvious secret-bearing keys like `password`, `client_secret`, `credential`, and `dsn`
- redact password, passphrase, client secret, credential, and DSN-style assignments in free-form off-device payloads
- update privacy observability docs so the analytics allowlist matches the current reviewed event policy

## Security / Privacy Impact
This reduces the chance that newly introduced error contexts or analytics failure strings leak credentials, DSNs, or secret assignments to Sentry or PostHog. It also keeps the privacy review checklist aligned with the current analytics event allowlist.

## Sweep Notes
- No open `[nightly-security]` draft PR existed before this branch.
- Latest GitHub release `v1.1.12` matches `Info.plist`, `docs/appcast.xml`, and `Casks/transcripted.rb`.
- Sparkle feed URL and public EdDSA key match the release docs.
- No committed private key, `.env`, provisioning, or obvious private secret file was found in the scanned repo surface.

## Validation
- `bash run-tests.sh` passed: 412 tests
- `bash build-deps.sh --force` completed
- `bash build.sh` passed, including signature verification and launch smoke check