### PR TITLE
[nightly-artifact] Detect indexed transcripts missing markdown

### DIFF
--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/RoundTrip.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/RoundTrip.swift
@@ -65,13 +65,13 @@ struct RoundTrip: ParsableCommand {
                 }
             }),
 
-            ("Remove JSON sidecar file", {
-                try corruptionTest(cleanDir: cleanDir, tmpBase: tmpBase, name: "sidecar-missing") { dir in
-                    let jsonFile = dir.appendingPathComponent("Call_2026-03-26_10-30-00.json")
-                    try fm.removeItem(at: jsonFile)
+            ("Remove Markdown file for JSON sidecar", {
+                try corruptionTest(cleanDir: cleanDir, tmpBase: tmpBase, name: "markdown-missing") { dir in
+                    let mdFile = dir.appendingPathComponent("Call_2026-03-26_10-30-00.md")
+                    try fm.removeItem(at: mdFile)
 
-                    let results = TranscriptValidator(directory: dir).validate()
-                    return results.contains { $0.status == .fail && $0.check == "transcript/sidecar-exists" }
+                    let results = JSONSidecarValidator(directory: dir).validate()
+                    return results.contains { $0.status == .fail && $0.check == "artifact/md-match" }
                 }
             }),
 

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Validators/IndexValidator.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Validators/IndexValidator.swift
@@ -28,19 +28,30 @@ struct IndexValidator {
                 results.append(.fail("index/count-match", target: target, detail: "transcript_count=\(count) but array has \(transcripts.count) entries"))
             }
 
-            // Files exist on disk
-            var allExist = true
+            // Files exist on disk. Legacy indexes were built around JSON
+            // artifacts, but current Transcripted output is Markdown-first.
+            var allLegacyJSONExist = true
+            var allMarkdownExist = true
             for transcript in transcripts {
                 if let filename = transcript["filename"] as? String {
                     let jsonFile = directory.appendingPathComponent("\(filename).json")
                     if !FileManager.default.fileExists(atPath: jsonFile.path) {
                         results.append(.fail("index/file-on-disk", target: target, detail: "\(filename).json not found on disk"))
-                        allExist = false
+                        allLegacyJSONExist = false
+                    }
+
+                    let markdownFile = directory.appendingPathComponent("\(filename).md")
+                    if !FileManager.default.fileExists(atPath: markdownFile.path) {
+                        results.append(.fail("index/markdown-on-disk", target: target, detail: "\(filename).md not found on disk"))
+                        allMarkdownExist = false
                     }
                 }
             }
-            if allExist {
+            if allLegacyJSONExist {
                 results.append(.pass("index/files-exist", target: target))
+            }
+            if allMarkdownExist {
+                results.append(.pass("index/markdown-files-exist", target: target))
             }
         } else {
             results.append(.fail("index/structure", target: target, detail: "Missing transcript_count or transcripts array"))


### PR DESCRIPTION
## Summary
- Make the TranscriptedQA index validator check that indexed transcripts have Markdown files, not only legacy JSON artifacts.
- Update the round-trip corruption test to cover the real orphan sidecar case: JSON present, Markdown missing.

## Why
Tonight's artifact sweep found a legacy JSON artifact and `transcripted.json` entry with no corresponding Markdown file. The artifact validator caught the orphan JSON, but the index validator still passed because the JSON file existed.

## Validation
- `swift build` in `Tools/TranscriptedQA`
- `swift run transcripted-qa round-trip`
- `swift run transcripted-qa check-health`
- `swift run transcripted-qa validate-all` (expected local artifact failures remain)
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`