### PR TITLE
[nightly-compat] Remove dead draft overlay states

### DIFF
--- a/Sources/Capture/ContextCaptureEngine.swift
+++ b/Sources/Capture/ContextCaptureEngine.swift
@@ -61,9 +61,6 @@ private func overlayStateName(_ state: FloatingOverlayController.OverlayState?) 
     case .listening: return "listening"
     case .drafting: return "drafting"
     case .success: return "success"
-    case .streaming: return "streaming"
-    case .review: return "review"
-    case .diffFlash: return "diff_flash"
     }
 }
 

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -622,9 +622,6 @@ class DictationSessionController: ObservableObject {
         case .listening: return "listening"
         case .drafting: return "drafting"
         case .success: return "success"
-        case .streaming: return "streaming"
-        case .review: return "review"
-        case .diffFlash: return "diff_flash"
         }
     }
 

--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -28,12 +28,9 @@ class FloatingOverlayController {
     enum OverlayState {
         case idle
         case loading      // Voice model still loading — waiting for readiness
-        case listening    // Recording (both modes)
-        case drafting     // Processing (vision+draft for draft mode, polish for dictation)
+        case listening    // Recording dictation
+        case drafting     // Processing dictation
         case success      // Finished successfully — brief confirmation before dismiss
-        case streaming    // Tokens arriving (draft mode only)
-        case review       // Editable draft (draft mode only)
-        case diffFlash    // Read-only word diff of user's edits before confirming
     }
 
     /// Human-readable shortcut hints (reads live from UserDefaults)
@@ -51,8 +48,6 @@ class FloatingOverlayController {
         }
     }
     var isVisible = false
-    var reviewText: String = ""
-    var streamingText: String = ""
     var errorMessage: String = ""
     private var errorActionTitle: String?
     private var errorActionHandler: (() -> Void)?
@@ -62,7 +57,7 @@ class FloatingOverlayController {
     var loadingPresentation: LoadingPresentation = .initial {
         didSet { pushStateToViews() }
     }
-    /// Closure for Escape during non-review states (listening/drafting/streaming)
+    /// Closure for Escape during active dictation overlay states.
     var onEscapeDuringSession: (() -> Void)?
     var onStopListening: (() -> Void)?
 
@@ -250,7 +245,6 @@ class FloatingOverlayController {
 
         panel.setFrameOrigin(origin)
         panel.setContentSize(panelSize)
-        panel.allowKeyStatus = false
         panel.ignoresMouseEvents = false
 
         // Spring entrance
@@ -295,8 +289,7 @@ class FloatingOverlayController {
         let gen = hideGeneration
         panel.ignoresMouseEvents = true
 
-        // Demote panel from key BEFORE animation — prevents intercepting ⌘V paste
-        panel.allowKeyStatus = false
+        // Make sure the overlay cannot intercept the follow-up paste.
         panel.resignKey()
         panel.orderOut(nil)
 
@@ -481,7 +474,6 @@ class FloatingOverlayController {
         guard isVisible else { return }
         removeEscapeMonitor()
         panel?.ignoresMouseEvents = true
-        panel?.allowKeyStatus = false
         panel?.orderOut(nil)
         panel?.alphaValue = 1.0
         panel?.contentView?.layer?.removeAllAnimations()
@@ -494,8 +486,6 @@ class FloatingOverlayController {
         successDismissTask?.cancel()
         successDismissTask = nil
         state = .idle
-        reviewText = ""
-        streamingText = ""
         errorMessage = ""
         errorActionTitle = nil
         errorActionHandler = nil
@@ -564,8 +554,6 @@ class FloatingOverlayController {
             return errorPanelSize()
         case .idle, .listening, .drafting, .success:
             return NSSize(width: OverlayTokens.panelCompactWidth, height: OverlayTokens.panelCompactHeight)
-        default:
-            return NSSize(width: OverlayTokens.panelWidth, height: OverlayTokens.panelMinHeight)
         }
     }
 

--- a/Sources/UI/Overlay/FloatingOverlayPanel.swift
+++ b/Sources/UI/Overlay/FloatingOverlayPanel.swift
@@ -4,9 +4,6 @@
 import AppKit
 
 class FloatingOverlayPanel: NSPanel {
-    /// When true, the panel can become key window (for text editing in review mode)
-    var allowKeyStatus = false
-
     override init(
         contentRect: NSRect,
         styleMask style: NSWindow.StyleMask,
@@ -31,7 +28,6 @@ class FloatingOverlayPanel: NSPanel {
         self.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     }
 
-    // Dynamic: non-key during listening/drafting, key-capable during review
-    override var canBecomeKey: Bool { allowKeyStatus }
+    override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
 }

--- a/Sources/UI/Overlay/OverlayHeaderView.swift
+++ b/Sources/UI/Overlay/OverlayHeaderView.swift
@@ -256,13 +256,10 @@ final class OverlayHeaderView: NSView {
         case .idle:
             modeLabel.stringValue = "Dictation"
             modeLabel.textColor = OverlayTokens.textMuted
-        default:
-            modeLabel.stringValue = "Dictation"
-            modeLabel.textColor = OverlayTokens.textSecondary
         }
 
         // Spinner visibility
-        let showSpinner = state == .drafting || state == .streaming || state == .loading
+        let showSpinner = state == .drafting || state == .loading
         spinner.isHidden = !showSpinner
         if showSpinner { spinner.startAnimation(nil) } else { spinner.stopAnimation(nil) }
 

--- a/Sources/UI/Overlay/OverlayTokens.swift
+++ b/Sources/UI/Overlay/OverlayTokens.swift
@@ -12,15 +12,6 @@ enum OverlayTokens {
     static let textSecondary = NSColor(white: 0.74, alpha: 1.0)
     static let textMuted     = NSColor(white: 0.58, alpha: 1.0)
 
-    // Diff colors
-    static let diffDeleteText    = NSColor(red: 1.0, green: 0.4, blue: 0.4, alpha: 1.0)
-    static let diffDeleteBg      = NSColor(red: 1.0, green: 0.3, blue: 0.3, alpha: 0.15)
-    static let diffDeleteBorder  = NSColor(red: 1.0, green: 0.4, blue: 0.4, alpha: 0.5)
-    static let diffInsertText    = NSColor(red: 0.3, green: 0.9, blue: 0.5, alpha: 1.0)
-    static let diffInsertBg      = NSColor(red: 0.3, green: 0.9, blue: 0.5, alpha: 0.15)
-    static let diffReplaceText   = NSColor(red: 0.4, green: 0.7, blue: 1.0, alpha: 1.0)
-    static let diffReplaceBorder = NSColor(red: 0.4, green: 0.7, blue: 1.0, alpha: 0.5)
-
     // Layout
     static let panelWidth: CGFloat         = 360
     static let panelCompactWidth: CGFloat  = 276


### PR DESCRIPTION
## Summary

- Removed draft-only `streaming`, `review`, and `diffFlash` states from the dictation overlay state machine.
- Removed the now-unused review-mode key-window toggle and diff color tokens.
- Kept storage, migration, Sparkle, and documented legacy fallback behavior unchanged.

## Verification

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`