### PR TITLE
refactor: nightly simplification sweep [automated]

### DIFF
--- a/Sources/Meeting/MeetingPromptDetector.swift
+++ b/Sources/Meeting/MeetingPromptDetector.swift
@@ -36,6 +36,10 @@ final class MeetingPromptDetector {
     private let pendingCooldown: TimeInterval = 90
     private let pollIntervalNanoseconds: UInt64 = 20_000_000_000
 
+    private static let meetingURLDetector = try? NSDataDetector(
+        types: NSTextCheckingResult.CheckingType.link.rawValue
+    )
+
     private static let browserBundleIdentifiers: Set<String> = [
         "com.apple.Safari",
         "com.google.Chrome",
@@ -84,28 +88,34 @@ final class MeetingPromptDetector {
         let until: Date
         switch candidate.source {
         case .calendarEvent:
-            let minimumInterval = MeetingPromptHeuristics.calendarDismissMinimumInterval(
+            let minimumInterval = MeetingPromptHeuristics.dismissMinimumInterval(
                 for: candidate.provider,
-                defaultInterval: baseInterval
+                default: baseInterval
             )
             until = max(
                 now.addingTimeInterval(minimumInterval),
                 candidate.endDate.addingTimeInterval(MeetingPromptHeuristics.calendarReminderPostStartGrace)
             )
             decision = MeetingPromptBackoffDecision(
-                kind: candidate.provider == .teams ? .calendarTeamsExtended : .calendarDefault,
+                kind: MeetingPromptHeuristics.backoffKind(for: candidate.provider, source: .calendarEvent),
                 until: until
             )
             suppressRuntimePrompts(for: candidate.provider, until: until)
         case .runtimeApp:
             if let resumeDate = nextRuntimePromptResumeDate(for: candidate.provider, now: now) {
                 until = resumeDate
-                decision = MeetingPromptBackoffDecision(kind: .runtimeUntilNextCalendar, until: until)
+                decision = MeetingPromptBackoffDecision(
+                    kind: MeetingPromptHeuristics.backoffKind(for: candidate.provider, source: .runtimeApp, hasResumeDate: true),
+                    until: until
+                )
             } else {
-                let fallbackInterval = MeetingPromptHeuristics.runtimeDismissFallbackInterval(for: candidate.provider)
+                let fallbackInterval = MeetingPromptHeuristics.dismissMinimumInterval(
+                    for: candidate.provider,
+                    default: MeetingPromptHeuristics.defaultRuntimeDismissFallbackInterval
+                )
                 until = now.addingTimeInterval(fallbackInterval)
                 decision = MeetingPromptBackoffDecision(
-                    kind: candidate.provider == .teams ? .runtimeTeamsExtended : .runtimeDefaultFallback,
+                    kind: MeetingPromptHeuristics.backoffKind(for: candidate.provider, source: .runtimeApp),
                     until: until
                 )
             }
@@ -215,8 +225,7 @@ final class MeetingPromptDetector {
         frontmostBundleID: String?
     ) -> [ScoredCandidate] {
         MeetingPromptProvider.allCases.compactMap { provider in
-            guard provider.supportsNativeRuntimePrompt else { return nil }
-            guard MeetingPromptHeuristics.allowsRuntimeOnlyPrompt(for: provider) else { return nil }
+            guard provider.supportsRuntimeOnlyPrompt else { return nil }
             guard provider.activeBundleIdentifiers.contains(where: runningBundleIDs.contains) else { return nil }
             if let suppressedUntil = runtimeSuppressedUntil[provider], suppressedUntil > now {
                 return nil
@@ -272,7 +281,6 @@ final class MeetingPromptDetector {
                     frontmostBundleID: frontmostBundleID
                 )
             }
-            .sorted(by: sortCandidates)
     }
 
     private func scoredCandidate(
@@ -403,17 +411,13 @@ final class MeetingPromptDetector {
     }
 
     private func extractFirstMeetingURL(in text: String) -> URL? {
+        guard let detector = Self.meetingURLDetector else { return nil }
         let range = NSRange(text.startIndex..<text.endIndex, in: text)
-        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
-            return nil
-        }
-
         let matches = detector.matches(in: text, options: [], range: range)
         for match in matches {
             guard let url = match.url, provider(for: url) != nil else { continue }
             return url
         }
-
         return nil
     }
 

--- a/Sources/Meeting/MeetingPromptHeuristics.swift
+++ b/Sources/Meeting/MeetingPromptHeuristics.swift
@@ -34,6 +34,10 @@ enum MeetingPromptProvider: String, CaseIterable, Hashable {
     var supportsNativeRuntimePrompt: Bool {
         !activeBundleIdentifiers.isEmpty
     }
+
+    var supportsRuntimeOnlyPrompt: Bool {
+        supportsNativeRuntimePrompt && self != .teams
+    }
 }
 
 enum MeetingPromptSource: Equatable {
@@ -81,10 +85,6 @@ enum MeetingPromptHeuristics {
     static let calendarReminderLeadTime: TimeInterval = 60
     static let calendarReminderPostStartGrace: TimeInterval = 5 * 60
 
-    static func allowsRuntimeOnlyPrompt(for provider: MeetingPromptProvider) -> Bool {
-        provider != .teams
-    }
-
     static func snoozeInterval(
         for source: MeetingPromptSource,
         explicit explicitInterval: TimeInterval?,
@@ -102,21 +102,22 @@ enum MeetingPromptHeuristics {
         }
     }
 
-    static func calendarDismissMinimumInterval(
-        for provider: MeetingPromptProvider,
-        defaultInterval: TimeInterval
-    ) -> TimeInterval {
-        if provider == .teams {
-            return max(defaultInterval, teamsDismissMinimumInterval)
-        }
-        return defaultInterval
+    static func dismissMinimumInterval(for provider: MeetingPromptProvider, default defaultInterval: TimeInterval) -> TimeInterval {
+        provider == .teams ? max(defaultInterval, teamsDismissMinimumInterval) : defaultInterval
     }
 
-    static func runtimeDismissFallbackInterval(for provider: MeetingPromptProvider) -> TimeInterval {
-        if provider == .teams {
-            return teamsDismissMinimumInterval
+    static func backoffKind(
+        for provider: MeetingPromptProvider,
+        source: MeetingPromptSource,
+        hasResumeDate: Bool = false
+    ) -> MeetingPromptBackoffKind {
+        switch source {
+        case .calendarEvent:
+            return provider == .teams ? .calendarTeamsExtended : .calendarDefault
+        case .runtimeApp:
+            if hasResumeDate { return .runtimeUntilNextCalendar }
+            return provider == .teams ? .runtimeTeamsExtended : .runtimeDefaultFallback
         }
-        return defaultRuntimeDismissFallbackInterval
     }
 
     static func reason(

--- a/Tests/MeetingPromptHeuristicsTests.swift
+++ b/Tests/MeetingPromptHeuristicsTests.swift
@@ -42,13 +42,13 @@ func testMeetingPromptHeuristics() {
         assertNil(prompt, "stale app activity should not keep prompting forever")
     }
 
-    runSuite("MeetingPromptHeuristics.allowsRuntimeOnlyPrompt — Teams must rely on stronger evidence") {
+    runSuite("MeetingPromptProvider.supportsRuntimeOnlyPrompt — Teams must rely on stronger evidence") {
         assertFalse(
-            MeetingPromptHeuristics.allowsRuntimeOnlyPrompt(for: .teams),
+            MeetingPromptProvider.teams.supportsRuntimeOnlyPrompt,
             "Teams should not prompt just because the app is open"
         )
         assertTrue(
-            MeetingPromptHeuristics.allowsRuntimeOnlyPrompt(for: .zoom),
+            MeetingPromptProvider.zoom.supportsRuntimeOnlyPrompt,
             "Zoom should keep the existing runtime-only prompt path"
         )
     }
@@ -77,32 +77,31 @@ func testMeetingPromptHeuristics() {
         assertEqual(interval, 30 * 60, "calendar prompts should preserve the longer snooze")
     }
 
-    runSuite("MeetingPromptHeuristics.calendarDismissMinimumInterval — Teams get a stickier dismissal") {
-        let zoomInterval = MeetingPromptHeuristics.calendarDismissMinimumInterval(
-            for: .zoom,
-            defaultInterval: 30 * 60
-        )
-        let teamsInterval = MeetingPromptHeuristics.calendarDismissMinimumInterval(
-            for: .teams,
-            defaultInterval: 30 * 60
-        )
-
-        assertEqual(zoomInterval, 30 * 60, "Zoom should keep the default calendar dismissal interval")
+    runSuite("MeetingPromptHeuristics.dismissMinimumInterval — Teams get a stickier dismissal") {
+        let defaultInterval: TimeInterval = 30 * 60
         assertEqual(
-            teamsInterval,
+            MeetingPromptHeuristics.dismissMinimumInterval(for: .zoom, default: defaultInterval),
+            defaultInterval,
+            "Zoom should keep the default dismissal interval"
+        )
+        assertEqual(
+            MeetingPromptHeuristics.dismissMinimumInterval(for: .teams, default: defaultInterval),
             MeetingPromptHeuristics.teamsDismissMinimumInterval,
             "Teams should stay quiet longer after a dismissal"
         )
-    }
-
-    runSuite("MeetingPromptHeuristics.runtimeDismissFallbackInterval — Teams get the longer fallback backoff") {
         assertEqual(
-            MeetingPromptHeuristics.runtimeDismissFallbackInterval(for: .zoom),
+            MeetingPromptHeuristics.dismissMinimumInterval(
+                for: .zoom,
+                default: MeetingPromptHeuristics.defaultRuntimeDismissFallbackInterval
+            ),
             MeetingPromptHeuristics.defaultRuntimeDismissFallbackInterval,
             "Zoom should keep the standard runtime fallback"
         )
         assertEqual(
-            MeetingPromptHeuristics.runtimeDismissFallbackInterval(for: .teams),
+            MeetingPromptHeuristics.dismissMinimumInterval(
+                for: .teams,
+                default: MeetingPromptHeuristics.defaultRuntimeDismissFallbackInterval
+            ),
             MeetingPromptHeuristics.teamsDismissMinimumInterval,
             "Teams should fall back to the longer dismissal interval"
         )


### PR DESCRIPTION
## Summary

Automated nightly simplification pass over the meeting prompt detection code added in the last three PRs (#357–#359).

- **Cache `NSDataDetector` as a static** in `MeetingPromptDetector` — was recreated on every `extractFirstMeetingURL` call, which fires once per calendar event per poll tick (every 20 s) and during every snooze/accept action.
- **Remove redundant sort** in `upcomingCalendarCandidates` — the outer `evaluate()` sort is the only one needed; the inner sort was pure overhead.
- **Merge `calendarDismissMinimumInterval` + `runtimeDismissFallbackInterval` → `dismissMinimumInterval(for:default:)`** — both expressed the same "Teams gets the extended interval, everyone else uses the default" rule written twice; unified into one function.
- **Add `MeetingPromptHeuristics.backoffKind(for:source:hasResumeDate:)`** and move the `provider == .teams` ternaries out of `snooze()` — provider-specific backoff policy belongs in the heuristics layer, not the detector.
- **Add `MeetingPromptProvider.supportsRuntimeOnlyPrompt`** — incorporates `supportsNativeRuntimePrompt` + the Teams exclusion into a single computed property on the enum, replacing the separate `allowsRuntimeOnlyPrompt(for:)` helper in `MeetingPromptHeuristics`. Two guards in `runtimeReminderCandidates` collapse to one.

## Test plan

- [x] `bash build.sh` — clean build, signed
- [x] `bash run-tests.sh` — 364/364 pass
- [x] `bash run-integration-smoke.sh` — core + wake smoke + swift test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)