### PR TITLE
[codex] Add agent setup and portable meeting skills

### DIFF
--- a/Resources/AgentSkills/manifest.json
+++ b/Resources/AgentSkills/manifest.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "bundle_version": "0.1.0",
+  "skills": [
+    {
+      "id": "transcripted-summarize",
+      "display_name": "Summarize",
+      "version": "0.1.0",
+      "status": "experimental",
+      "path": "transcripted-summarize/SKILL.md",
+      "description": "Create cited briefs from Transcripted meetings, dictations, or date ranges."
+    },
+    {
+      "id": "transcripted-search-memory",
+      "display_name": "Search Memory",
+      "version": "0.1.0",
+      "status": "experimental",
+      "path": "transcripted-search-memory/SKILL.md",
+      "description": "Find what was said, when it happened, and where it came from."
+    }
+  ],
+  "iteration": {
+    "versioning": "Bump the individual skill version when changing behavior. Bump bundle_version when changing the shipped starter set.",
+    "feedback_focus": [
+      "Did the skill retrieve the right captures?",
+      "Did it cite sources clearly?",
+      "Did it avoid inventing missing owners, dates, or decisions?",
+      "Was the output shape useful enough to reuse?"
+    ]
+  }
+}

--- a/Resources/AgentSkills/transcripted-search-memory/SKILL.md
+++ b/Resources/AgentSkills/transcripted-search-memory/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: transcripted-search-memory
+description: Search Transcripted meeting and dictation history for what was said, when it happened, who mentioned it, where an idea came from, or how a topic changed over time. Use for memory, recall, provenance, timeline, source-finding, and "what did I say about" questions.
+---
+
+# Transcripted Search Memory
+
+Version: 0.1.0
+
+## Purpose
+
+Find evidence across Transcripted meetings and dictations, then answer with source-backed memory. Search first, synthesize second.
+
+## Workflow
+
+1. Restate the query as a search target: topic, person, project, phrase, decision, action, or date range.
+2. Prefer Transcripted MCP tools when available. Fall back to local meeting and dictation markdown files only when MCP is unavailable.
+3. Combine available retrieval modes:
+   - exact search
+   - relevant context search
+   - recency
+   - date filters
+   - people or speaker names
+   - topic/project terms
+4. Show the best matches before or alongside the answer.
+5. Synthesize only from the evidence found.
+6. If the topic appears over time, include a short timeline.
+7. If evidence is thin or missing, say so plainly.
+
+## Default Output
+
+Use these sections when relevant:
+
+```md
+## Answer
+
+## Best Matches
+
+## Timeline
+
+## Related Threads
+
+## Confidence
+
+## Sources
+
+## Uncertainty
+```
+
+## Match Format
+
+For each strong match, include as much of this as is available:
+
+```md
+- Source:
+- Date:
+- Speaker:
+- Timestamp:
+- Snippet:
+- Why this surfaced:
+```
+
+## Rules
+
+- Do not answer from vague memory when sources are available.
+- Do not hide weak evidence. Use `low confidence` when matches are sparse, old, ambiguous, or conflicting.
+- If nothing relevant is found, say `not found` and list what was searched.
+- If the user asks for "when", prefer a timeline over a prose-only answer.
+- If the user asks "where did this come from", prioritize the earliest strong source.
+- Keep snippets short and cite the original capture instead of pasting large transcript chunks.
+
+## Quality Check
+
+Before answering, check:
+
+- The answer has at least one source unless explicitly reporting no results.
+- Important claims point to filenames, dates, speakers, or timestamps when available.
+- Conflicting or evolving decisions are described as a timeline, not flattened into one claim.
+- Search scope is clear enough that the user can ask a better follow-up.

--- a/Resources/AgentSkills/transcripted-search-memory/agents/openai.yaml
+++ b/Resources/AgentSkills/transcripted-search-memory/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Search Memory"
+  short_description: "Find Transcripted memories with sources."
+  default_prompt: "Search my Transcripted memory for this topic and cite the matching meetings or dictations."

--- a/Resources/AgentSkills/transcripted-summarize/SKILL.md
+++ b/Resources/AgentSkills/transcripted-summarize/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: transcripted-summarize
+description: Create cited summaries, recaps, briefs, daily reviews, weekly reviews, and "what did I do" answers from Transcripted meetings and dictations. Use when the user asks to summarize one capture, a date range, a person, a project, a topic, or mixed meeting and dictation history.
+---
+
+# Transcripted Summarize
+
+Version: 0.1.0
+
+## Purpose
+
+Turn Transcripted meetings and dictations into a clean brief that preserves source traceability. Treat raw transcript and dictation text as the source of truth.
+
+## Workflow
+
+1. Resolve scope first: one meeting, one dictation, a date range, a person, a project, a topic, or mixed captures.
+2. Prefer Transcripted MCP tools when available. Fall back to local meeting and dictation markdown files only when MCP is unavailable.
+3. Read the relevant source material before summarizing. For a named meeting, read the full meeting when possible.
+4. Filter obvious junk: test captures, accidental fragments, setup chatter, and empty or near-empty recordings.
+5. Normalize relative dates in the user's local timezone and state the exact dates searched.
+6. Summarize with source filenames, dates, speakers, and timestamps when available.
+7. Surface uncertainty instead of guessing.
+
+## Default Output
+
+Use these sections when relevant:
+
+```md
+## Brief
+
+## Main Threads
+
+## Decisions
+
+## Action Items
+
+## Open Questions
+
+## Risks / Blockers
+
+## Worth Remembering
+
+## Sources
+
+## Uncertainty
+```
+
+## Rules
+
+- Do not invent owners, deadlines, decisions, or action items.
+- If an owner, deadline, or status is missing, write `unknown`.
+- Separate decisions from action items.
+- Keep the brief short unless the user asks for depth.
+- Cite the source meeting or dictation for important claims.
+- When summarizing multiple captures, group repeated themes instead of repeating every similar note.
+- If no useful content is found, say so and list what was checked.
+
+## Quality Check
+
+Before answering, check:
+
+- Every decision or action item is grounded in source text.
+- Dates are absolute when the user used relative time.
+- Unclear speaker names, noisy audio, or missing transcript spans are called out.
+- The answer does not expose unrelated sensitive details from other captures.

--- a/Resources/AgentSkills/transcripted-summarize/agents/openai.yaml
+++ b/Resources/AgentSkills/transcripted-summarize/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Summarize"
+  short_description: "Create cited briefs from Transcripted meetings and dictations."
+  default_prompt: "Summarize this Transcripted meeting, dictation, or date range with sources."

--- a/Sources/UI/AgentConnect/AgentConnectionWindowView.swift
+++ b/Sources/UI/AgentConnect/AgentConnectionWindowView.swift
@@ -161,15 +161,15 @@ struct AgentConnectionWindowView: View {
             AgentConnectionBodyText("Your agent will use Transcripted MCP tools if they are already connected. If not, it will fall back to your local Transcripted folders and can help you set up the better option later.")
 
             VStack(alignment: .leading, spacing: 10) {
-                Text("What this helps with")
+                Text("Starter skills")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(AgentConnectionTheme.textPrimary)
 
-                ForEach(Array(AgentConnectionGuide.benefitHighlights.enumerated()), id: \.offset) { index, highlight in
+                ForEach(Array(AgentConnectionGuide.starterSkills.enumerated()), id: \.offset) { _, skill in
                     AgentConnectionInfoRow(
-                        symbolName: index == 0 ? "sparkles" : "checkmark.circle.fill",
-                        title: highlight,
-                        detail: "Works from the same local Transcripted data already saved on this Mac."
+                        symbolName: skill.symbolName,
+                        title: skill.title,
+                        detail: skill.detail
                     )
                 }
             }

--- a/Sources/UI/AgentConnect/AgentConnectionWindowView.swift
+++ b/Sources/UI/AgentConnect/AgentConnectionWindowView.swift
@@ -140,7 +140,7 @@ struct AgentConnectionWindowView: View {
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundStyle(AgentConnectionTheme.textPrimary)
 
-                Text("Copy one prompt, paste it into your agent, and let Transcripted use MCP when available or folders when not.")
+                Text("Copy once, paste anywhere, and let your agent pick the best available Transcripted connection.")
                     .font(.system(size: 12))
                     .foregroundStyle(AgentConnectionTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -158,7 +158,7 @@ struct AgentConnectionWindowView: View {
             title: "Copy this into your agent",
             subtitle: "This is the main path for most people."
         ) {
-            AgentConnectionBodyText("Your agent will use Transcripted MCP tools if they are already connected. If not, it will fall back to your local Transcripted folders and can help you set up the better option later.")
+            AgentConnectionBodyText("Your agent will choose the best route automatically. Local agents can read Transcripted directly; remote chats get one clear next step if they cannot reach this Mac.")
 
             VStack(alignment: .leading, spacing: 10) {
                 Text("Starter skills")

--- a/Sources/UI/AgentConnect/AgentConnectionWindowView.swift
+++ b/Sources/UI/AgentConnect/AgentConnectionWindowView.swift
@@ -175,7 +175,7 @@ struct AgentConnectionWindowView: View {
             }
 
             HStack(spacing: 10) {
-                Button(viewModel.copyLabel(for: .prompt, default: "Copy agent prompt")) {
+                Button(viewModel.copyLabel(for: .prompt, default: "Copy Agent Setup")) {
                     viewModel.copyStarterPrompt()
                 }
                 .buttonStyle(AgentConnectionPrimaryButtonStyle())

--- a/Sources/UI/AgentConnect/AgentConnectionWindowView.swift
+++ b/Sources/UI/AgentConnect/AgentConnectionWindowView.swift
@@ -169,7 +169,7 @@ struct AgentConnectionWindowView: View {
                     AgentConnectionInfoRow(
                         symbolName: skill.symbolName,
                         title: skill.title,
-                        detail: skill.detail
+                        detail: skill.displayDetail
                     )
                 }
             }

--- a/Sources/UI/MenuBar/MenuAgentConnectPageView.swift
+++ b/Sources/UI/MenuBar/MenuAgentConnectPageView.swift
@@ -17,21 +17,16 @@ final class MenuAgentConnectPageView: NSView {
     private let subtitleLabel = NSTextField(wrappingLabelWithString:
         "Copy one prompt, paste it into your agent, and let Transcripted use MCP when available or folders when not."
     )
-    private let starterPromptLabel = NSTextField(labelWithString: "What this helps with")
+    private let starterPromptLabel = NSTextField(labelWithString: "Starter skills")
     private let benefitOneRow = AgentConnectInfoRowView(
-        symbolName: "sparkles",
-        title: "Search past meetings faster",
-        body: "Your agent can work from the spoken context Transcripted already saved locally."
+        symbolName: "doc.text",
+        title: "Summarize",
+        body: "Create a cited brief from meetings, dictations, or a date range."
     )
     private let benefitTwoRow = AgentConnectInfoRowView(
-        symbolName: "checkmark.circle",
-        title: "Pull summaries and action items",
-        body: "The smart prompt can use MCP if it is ready, or fall back to local folders if it is not."
-    )
-    private let benefitThreeRow = AgentConnectInfoRowView(
-        symbolName: "checkmark.circle",
-        title: "Stay simple for beginners",
-        body: "Copy once, paste once, and only use manual setup if you actually need it."
+        symbolName: "magnifyingglass",
+        title: "Search Memory",
+        body: "Find what was said, when it happened, and where it came from."
     )
     private let manualSetupLabel = NSTextField(labelWithString: "Need manual setup?")
     private let mcpRow = AgentConnectInfoRowView(
@@ -95,7 +90,7 @@ final class MenuAgentConnectPageView: NSView {
             label.textColor = MenuTokens.textPrimaryNS
             addSubview(label)
         }
-        [benefitOneRow, benefitTwoRow, benefitThreeRow, mcpRow, folderRow].forEach { addSubview($0) }
+        [benefitOneRow, benefitTwoRow, mcpRow, folderRow].forEach { addSubview($0) }
 
         backButton.target = self
         backButton.action = #selector(goBack)
@@ -147,9 +142,6 @@ final class MenuAgentConnectPageView: NSView {
         y += AgentConnectInfoRowView.height + 14
 
         benefitTwoRow.frame = NSRect(x: pad, y: y, width: width, height: AgentConnectInfoRowView.height)
-        y += AgentConnectInfoRowView.height + 8
-
-        benefitThreeRow.frame = NSRect(x: pad, y: y, width: width, height: AgentConnectInfoRowView.height)
         y += AgentConnectInfoRowView.height + 18
 
         manualSetupLabel.frame = NSRect(x: pad, y: y, width: width, height: 16)
@@ -183,7 +175,6 @@ final class MenuAgentConnectPageView: NSView {
     var intrinsicHeight: CGFloat {
         MenuTokens.secondaryButtonSize + 14 + 22 + 24 + 42 + 16 + 22 +
         (AgentConnectInfoRowView.height + 14) +
-        (AgentConnectInfoRowView.height + 8) +
         (AgentConnectInfoRowView.height + 18) +
         22 +
         (AgentConnectInfoRowView.height + 10) +

--- a/Sources/UI/MenuBar/MenuAgentConnectPageView.swift
+++ b/Sources/UI/MenuBar/MenuAgentConnectPageView.swift
@@ -15,7 +15,7 @@ final class MenuAgentConnectPageView: NSView {
     )
     private let titleLabel = NSTextField(labelWithString: "Connect your agent")
     private let subtitleLabel = NSTextField(wrappingLabelWithString:
-        "Copy one prompt, paste it into your agent, and let Transcripted use MCP when available or folders when not."
+        "Copy once, paste anywhere, and let your agent pick the best available Transcripted connection."
     )
     private let starterPromptLabel = NSTextField(labelWithString: "Starter skills")
     private let benefitOneRow = AgentConnectInfoRowView(

--- a/Sources/UI/MenuBar/MenuAgentConnectPageView.swift
+++ b/Sources/UI/MenuBar/MenuAgentConnectPageView.swift
@@ -19,14 +19,14 @@ final class MenuAgentConnectPageView: NSView {
     )
     private let starterPromptLabel = NSTextField(labelWithString: "Starter skills")
     private let benefitOneRow = AgentConnectInfoRowView(
-        symbolName: "doc.text",
-        title: "Summarize",
-        body: "Create a cited brief from meetings, dictations, or a date range."
+        symbolName: AgentConnectionGuide.starterSkills[0].symbolName,
+        title: AgentConnectionGuide.starterSkills[0].title,
+        body: AgentConnectionGuide.starterSkills[0].displayDetail
     )
     private let benefitTwoRow = AgentConnectInfoRowView(
-        symbolName: "magnifyingglass",
-        title: "Search Memory",
-        body: "Find what was said, when it happened, and where it came from."
+        symbolName: AgentConnectionGuide.starterSkills[1].symbolName,
+        title: AgentConnectionGuide.starterSkills[1].title,
+        body: AgentConnectionGuide.starterSkills[1].displayDetail
     )
     private let manualSetupLabel = NSTextField(labelWithString: "Need manual setup?")
     private let mcpRow = AgentConnectInfoRowView(

--- a/Sources/UI/MenuBar/MenuAgentConnectPageView.swift
+++ b/Sources/UI/MenuBar/MenuAgentConnectPageView.swift
@@ -53,10 +53,10 @@ final class MenuAgentConnectPageView: NSView {
         toolTip: "Copy folder paths"
     )
     private let copyPromptButton = MenuOutlineButton(
-        title: "Copy agent prompt",
+        title: "Copy Agent Setup",
         symbolName: "doc.on.doc",
-        accessibilityLabel: "Copy agent prompt",
-        toolTip: "Copy agent prompt"
+        accessibilityLabel: "Copy Agent Setup",
+        toolTip: "Copy Agent Setup"
     )
 
     private var resetTask: Task<Void, Never>?
@@ -196,8 +196,8 @@ final class MenuAgentConnectPageView: NSView {
         resetTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 1_000_000_000)
             guard let self, !Task.isCancelled else { return }
-            self.copyPromptButton.title = "Copy agent prompt"
-            self.copyPromptButton.setSymbol("doc.on.doc", accessibilityLabel: "Copy agent prompt")
+            self.copyPromptButton.title = "Copy Agent Setup"
+            self.copyPromptButton.setSymbol("doc.on.doc", accessibilityLabel: "Copy Agent Setup")
         }
     }
 

--- a/Sources/UI/MenuBar/MenuBarRecentMeetingsView.swift
+++ b/Sources/UI/MenuBar/MenuBarRecentMeetingsView.swift
@@ -6,7 +6,7 @@ import Foundation
 
 @MainActor
 final class MenuBarRecentMeetingsView: NSView {
-    private let headerLabel = NSTextField(labelWithString: "Meetings")
+    private let headerLabel = NSTextField(labelWithString: "Recent meetings")
     private let emptyLabel = NSTextField(labelWithString: "No meetings yet.")
     private let listContainer = FlippedRecentMeetingsContainer()
 
@@ -109,8 +109,13 @@ private final class FlippedRecentMeetingsContainer: NSView {
 }
 
 @MainActor
-private func copyTranscriptBody(from url: URL) -> Bool {
-    guard let text = MeetingTranscriptStyler.transcriptBody(at: url) else { return false }
+private func copyAgentBundle(for item: RecentMeetingItem) -> Bool {
+    guard let text = AgentConnectionGuide.portableMeetingBundle(
+        title: item.title,
+        date: item.date,
+        transcriptURL: item.transcriptURL
+    ) else { return false }
+
     let pasteboard = NSPasteboard.general
     pasteboard.clearContents()
     pasteboard.setString(text, forType: .string)
@@ -122,10 +127,11 @@ private final class RecentMeetingRowView: NSView {
     private let item: RecentMeetingItem
     private let titleLabel = NSTextField(labelWithString: "")
     private let dateLabel = NSTextField(labelWithString: "")
-    private let copyButton = MenuIconButton(
-        symbolName: "doc.on.doc",
-        accessibilityLabel: "Copy transcript",
-        toolTip: "Copy transcript"
+    private let copyForAgentButton = MenuOutlineButton(
+        title: "Copy for Agent",
+        symbolName: "sparkles",
+        accessibilityLabel: "Copy meeting for agent",
+        toolTip: "Copy meeting for agent"
     )
     private let divider = NSView()
     private let showsDivider: Bool
@@ -171,9 +177,9 @@ private final class RecentMeetingRowView: NSView {
         dateLabel.textColor = MenuTokens.textSecondaryNS
         addSubview(dateLabel)
 
-        addSubview(copyButton)
-        copyButton.target = self
-        copyButton.action = #selector(copyTranscript)
+        addSubview(copyForAgentButton)
+        copyForAgentButton.target = self
+        copyForAgentButton.action = #selector(copyForAgent)
 
         divider.wantsLayer = true
         divider.layer?.backgroundColor = MenuTokens.sectionDividerNS.cgColor
@@ -206,7 +212,7 @@ private final class RecentMeetingRowView: NSView {
 
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-        guard !copyButton.frame.contains(point) else {
+        guard !copyForAgentButton.frame.contains(point) else {
             super.mouseDown(with: event)
             return
         }
@@ -215,15 +221,15 @@ private final class RecentMeetingRowView: NSView {
 
     override func layout() {
         super.layout()
-        let buttonSize = MenuTokens.secondaryButtonSize
-        copyButton.frame = NSRect(
-            x: bounds.width - buttonSize,
-            y: (bounds.height - buttonSize) / 2,
-            width: buttonSize,
-            height: buttonSize
+        let buttonSize = copyForAgentButton.fittingSize
+        copyForAgentButton.frame = NSRect(
+            x: bounds.width - buttonSize.width,
+            y: (bounds.height - MenuTokens.secondaryButtonSize) / 2,
+            width: buttonSize.width,
+            height: MenuTokens.secondaryButtonSize
         )
 
-        let textWidth = max(0, copyButton.frame.minX - 12)
+        let textWidth = max(0, copyForAgentButton.frame.minX - 12)
         titleLabel.frame = NSRect(x: 0, y: 6, width: textWidth, height: 14)
         dateLabel.frame = NSRect(x: 0, y: 21, width: textWidth, height: 12)
         divider.frame = NSRect(x: 0, y: bounds.height - 1, width: bounds.width, height: 1)
@@ -233,15 +239,17 @@ private final class RecentMeetingRowView: NSView {
         NSSize(width: NSView.noIntrinsicMetric, height: MenuTokens.recentRowHeight)
     }
 
-    @objc private func copyTranscript() {
-        guard copyTranscriptBody(from: item.transcriptURL) else { return }
+    @objc private func copyForAgent() {
+        guard copyAgentBundle(for: item) else { return }
 
         resetTask?.cancel()
-        copyButton.setSymbol("checkmark", accessibilityLabel: "Transcript copied", tintOverride: MenuTokens.statusGreenNS)
+        copyForAgentButton.title = "Copied"
+        copyForAgentButton.setSymbol("checkmark", accessibilityLabel: "Meeting copied for agent")
         resetTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 1_000_000_000)
             guard let self, !Task.isCancelled else { return }
-            self.copyButton.setSymbol("doc.on.doc", accessibilityLabel: "Copy transcript")
+            self.copyForAgentButton.title = "Copy for Agent"
+            self.copyForAgentButton.setSymbol("sparkles", accessibilityLabel: "Copy meeting for agent")
         }
     }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -796,7 +796,7 @@ private struct AgentConnectionSettingsPage: View {
                 }
 
                 HStack {
-                    Button("Copy Agent Prompt") {
+                    Button("Copy Agent Setup") {
                         viewModel.copyStarterPrompt()
                     }
                     .buttonStyle(.borderedProminent)

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -779,18 +779,18 @@ private struct AgentConnectionSettingsPage: View {
         VStack(alignment: .leading, spacing: 24) {
             SettingsPageIntro(
                 title: "Connect Your Agent",
-                summary: "Copy one smart prompt first, then use MCP or raw folders only if you need the more manual setup."
+                summary: "Copy one smart prompt with the Summarize and Search Memory starter skills."
             )
 
             SettingsSection(
                 title: "Main Path",
-                detail: "Most people only need the main prompt. It tells the agent to prefer MCP when available and fall back to folders when not."
+                detail: "Most people only need the main prompt. It tells the agent to prefer MCP when available, fall back to folders when not, and use the two starter skills."
             ) {
-                ForEach(Array(AgentConnectionGuide.benefitHighlights.enumerated()), id: \.offset) { index, highlight in
+                ForEach(Array(AgentConnectionGuide.starterSkills.enumerated()), id: \.offset) { _, skill in
                     SettingsQuickLinkRow(
-                        symbolName: index == 0 ? "sparkles" : "checkmark.circle.fill",
-                        title: highlight,
-                        detail: "Works from the same local Transcripted data already saved on this Mac."
+                        symbolName: skill.symbolName,
+                        title: skill.title,
+                        detail: skill.detail
                     ) {}
                     .disabled(true)
                 }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -790,7 +790,7 @@ private struct AgentConnectionSettingsPage: View {
                     SettingsQuickLinkRow(
                         symbolName: skill.symbolName,
                         title: skill.title,
-                        detail: skill.detail
+                        detail: skill.displayDetail
                     ) {}
                     .disabled(true)
                 }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -22,6 +22,7 @@ struct TranscriptedSettingsView: View {
     @State private var recentMeetings = RecentMeetingsScanner.loadRecent(limit: 5)
     @State private var recentDictations = DictationTranscriptStore.recentSavedDictations(limit: 5)
     @State private var showSupportFolders = false
+    @State private var copiedAgentMeetingID: String?
 
     init(
         appState: TranscriptedAppState,
@@ -324,13 +325,17 @@ struct TranscriptedSettingsView: View {
                         .foregroundStyle(.secondary)
                 } else {
                     ForEach(recentMeetings) { item in
-                        SettingsQuickLinkRow(
-                            symbolName: "doc.text",
-                            title: item.title,
-                            detail: formattedRecentDate(item.date)
-                        ) {
-                            NSWorkspace.shared.open(item.transcriptURL)
-                        }
+                        SettingsRecentMeetingRow(
+                            item: item,
+                            detail: formattedRecentDate(item.date),
+                            isCopied: copiedAgentMeetingID == item.id,
+                            openAction: {
+                                NSWorkspace.shared.open(item.transcriptURL)
+                            },
+                            copyForAgentAction: {
+                                copyMeetingForAgent(item)
+                            }
+                        )
                     }
                 }
             }
@@ -760,6 +765,29 @@ struct TranscriptedSettingsView: View {
         Self.recentCaptureDateFormatter.string(from: date)
     }
 
+    private func copyMeetingForAgent(_ item: RecentMeetingItem) {
+        guard let bundle = AgentConnectionGuide.portableMeetingBundle(
+            title: item.title,
+            date: item.date,
+            transcriptURL: item.transcriptURL
+        ) else {
+            NSSound.beep()
+            return
+        }
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(bundle, forType: .string)
+        copiedAgentMeetingID = item.id
+
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_200_000_000)
+            if copiedAgentMeetingID == item.id {
+                copiedAgentMeetingID = nil
+            }
+        }
+    }
+
     private static let recentCaptureDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = .current
@@ -768,6 +796,54 @@ struct TranscriptedSettingsView: View {
         formatter.timeStyle = .short
         return formatter
     }()
+}
+
+private struct SettingsRecentMeetingRow: View {
+    let item: RecentMeetingItem
+    let detail: String
+    let isCopied: Bool
+    let openAction: () -> Void
+    let copyForAgentAction: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Button(action: openAction) {
+                HStack(alignment: .top, spacing: 12) {
+                    Image(systemName: "doc.text")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 24)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(item.title)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(Color.primary)
+
+                        Text(detail)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Spacer(minLength: 12)
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+
+            Button {
+                copyForAgentAction()
+            } label: {
+                Label(isCopied ? "Copied" : "Copy for Agent", systemImage: isCopied ? "checkmark" : "sparkles")
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+    }
 }
 
 private struct AgentConnectionSettingsPage: View {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -779,12 +779,12 @@ private struct AgentConnectionSettingsPage: View {
         VStack(alignment: .leading, spacing: 24) {
             SettingsPageIntro(
                 title: "Connect Your Agent",
-                summary: "Copy one smart prompt with the Summarize and Search Memory starter skills."
+                summary: "Copy one smart prompt with the Summarize and Search Memory starter skills. The agent picks the best route automatically."
             )
 
             SettingsSection(
                 title: "Main Path",
-                detail: "Most people only need the main prompt. It tells the agent to prefer MCP when available, fall back to folders when not, and use the two starter skills."
+                detail: "Most people only need the main prompt. Local agents read Transcripted directly; remote chats get one clear next step if they cannot reach this Mac."
             ) {
                 ForEach(Array(AgentConnectionGuide.starterSkills.enumerated()), id: \.offset) { _, skill in
                     SettingsQuickLinkRow(

--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -101,16 +101,21 @@ enum AgentConnectionGuide {
 
         Your job is to connect to my Transcripted data using the best available method, then help me search and summarize my meetings and dictations.
 
-        Connection priority:
+        Connection behavior:
+        - Do not ask me to choose a connection mode.
+        - Silently pick the best available route, then continue.
+        - Only stop when you cannot read any Transcripted data. If that happens, give me one smallest next step.
+
+        Automatic route priority:
         1. If Transcripted MCP tools are already available in this environment, use them first.
         2. If Transcripted MCP tools are not available, but this environment can build or configure a local MCP server, try to set up Transcripted MCP using the information below.
         3. If MCP cannot be used here, fall back to direct file access using the local folders below.
         4. If neither MCP nor folder access is possible, stop and tell me exactly what is missing, what you tried, and the smallest next step I need to take.
 
-        Agent environment guidance:
+        Automatic environment routing:
         - Local agents running on this Mac, such as Codex, Claude Code in the terminal, Claude Code in an app, OpenCode, or OpenClaw, can usually read the local folders and bundled skill files. Use MCP when configured; otherwise use folder fallback.
         - Desktop clients with local stdio MCP support, such as Claude Desktop, can use Transcripted MCP after the MCP config is added and the client is restarted.
-        - Remote or web chats, such as Claude chat in a browser, mobile chat, or any sandbox that cannot read `/Users/...` paths, cannot use local folders, local skill files, or local stdio MCP. Ask me to upload or paste captures, or use a remote MCP connector if one exists.
+        - Remote or web chats, such as Claude chat in a browser, mobile chat, or any sandbox that cannot read `/Users/...` paths, cannot use local folders, local skill files, or local stdio MCP. Do not ask me to choose a mode. Say that this chat cannot reach my Mac directly, then ask me for the single smallest useful action: upload or paste captures, switch to a local agent, or use a remote connector if one is available.
         - Cowork or shared-agent environments may be local or remote. First determine whether the execution environment can read local Mac paths, then follow the matching rule above.
 
         \(mcpPromptBlock)
@@ -148,10 +153,10 @@ enum AgentConnectionGuide {
         - If MCP setup requires restarting the agent, say so, then continue with folder fallback for the current session when folders are readable.
 
         First step:
-        1. Determine which environment type you are in: local Mac agent, desktop MCP client, remote/web chat, or unknown cowork/shared context.
-        2. Determine which connection mode is available: MCP, MCP setup, folders, uploaded/pasted files, or unavailable.
+        1. Silently determine which environment type you are in: local Mac agent, desktop MCP client, remote/web chat, or unknown cowork/shared context.
+        2. Silently determine which connection mode is available: MCP, MCP setup, folders, uploaded/pasted files, or unavailable.
         3. Confirm whether the bundled SKILL.md files are readable.
-        4. Briefly tell me which environment, connection mode, and skill versions are active.
+        4. Briefly tell me the chosen route and active skill versions. Do not make me choose.
         5. Then continue with my task.
         """
 

--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -107,6 +107,12 @@ enum AgentConnectionGuide {
         3. If MCP cannot be used here, fall back to direct file access using the local folders below.
         4. If neither MCP nor folder access is possible, stop and tell me exactly what is missing, what you tried, and the smallest next step I need to take.
 
+        Agent environment guidance:
+        - Local agents running on this Mac, such as Codex, Claude Code in the terminal, Claude Code in an app, OpenCode, or OpenClaw, can usually read the local folders and bundled skill files. Use MCP when configured; otherwise use folder fallback.
+        - Desktop clients with local stdio MCP support, such as Claude Desktop, can use Transcripted MCP after the MCP config is added and the client is restarted.
+        - Remote or web chats, such as Claude chat in a browser, mobile chat, or any sandbox that cannot read `/Users/...` paths, cannot use local folders, local skill files, or local stdio MCP. Ask me to upload or paste captures, or use a remote MCP connector if one exists.
+        - Cowork or shared-agent environments may be local or remote. First determine whether the execution environment can read local Mac paths, then follow the matching rule above.
+
         \(mcpPromptBlock)
 
         Folder fallback:
@@ -132,15 +138,21 @@ enum AgentConnectionGuide {
         \(starterSkillPromptBlock)
 
         Skill loading rules:
-        - When your environment can read local files, open the relevant SKILL.md file above and treat it as the canonical behavior.
+        - Before offering task options, check whether the manifest and bundled SKILL.md files above are readable.
+        - If the files are readable, say "Bundled skills active" and list Summarize and Search Memory with their versions.
+        - When I ask for Summarize or Search Memory behavior, open the matching SKILL.md before answering and treat it as the canonical behavior.
         - Use the skill versions above when giving feedback or suggesting improvements.
         - If you cannot read the skill files, say that clearly and use this fallback:
           - Summarize: create a cited brief from meetings, dictations, or a date range.
           - Search Memory: find what was said, when it happened, and where it came from.
+        - If MCP setup requires restarting the agent, say so, then continue with folder fallback for the current session when folders are readable.
 
         First step:
-        Determine which connection mode is available: MCP, MCP setup, or folders.
-        Briefly tell me which mode you are using, then continue with my task.
+        1. Determine which environment type you are in: local Mac agent, desktop MCP client, remote/web chat, or unknown cowork/shared context.
+        2. Determine which connection mode is available: MCP, MCP setup, folders, uploaded/pasted files, or unavailable.
+        3. Confirm whether the bundled SKILL.md files are readable.
+        4. Briefly tell me which environment, connection mode, and skill versions are active.
+        5. Then continue with my task.
         """
 
         if let filename {

--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -224,7 +224,12 @@ enum AgentConnectionGuide {
         - Summarize v\(starterSkills[0].version)
         - Search Memory v\(starterSkills[1].version)
 
-        If I ask for a summary, use the Summarize skill. If I ask what was said, where something came from, or when something happened, use the Search Memory skill. Cite the source file and meeting date for important claims.
+        Portable response rules:
+        - If no task was included, ask one short question instead of analyzing the meeting: "I can read this Transcripted meeting bundle. I can summarize it, find decisions/action items, or search within it. What would you like?"
+        - Do not critique tone, metaphors, writing style, usefulness, or what to ignore unless I explicitly ask for critique or opinion.
+        - If I ask for a summary or recap, use the Summarize skill and include these sections when useful: Brief, Main Threads, Decisions, Action Items, Open Questions, Risks / Blockers, Worth Remembering, Sources, Uncertainty.
+        - If I ask what was said, where something came from, or when something happened, use the Search Memory skill within this pasted meeting only.
+        - Cite the source file and meeting date for important claims.
 
         Source:
         - Title: \(title)

--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -1,5 +1,10 @@
 import Foundation
-import TranscriptedCore
+
+struct AgentConnectionStarterSkill {
+    let symbolName: String
+    let title: String
+    let detail: String
+}
 
 enum AgentConnectionGuide {
     static var localMCPBuildDirectory: URL? {
@@ -33,17 +38,24 @@ enum AgentConnectionGuide {
         DictationStoragePaths.transcriptsFolder
     }
 
-    static let benefitHighlights = [
-        "Search past meetings and dictations faster",
-        "Pull summaries and action items in one place",
-        "Give your agent the real spoken context from this Mac",
+    static let starterSkills = [
+        AgentConnectionStarterSkill(
+            symbolName: "doc.text",
+            title: "Summarize",
+            detail: "Create a cited brief from meetings, dictations, or a date range."
+        ),
+        AgentConnectionStarterSkill(
+            symbolName: "magnifyingglass",
+            title: "Search Memory",
+            detail: "Find what was said, when it happened, and where it came from."
+        ),
     ]
 
     static func starterPrompt(filename: String?) -> String {
         var prompt = """
         I use Transcripted on my Mac.
 
-        Your job is to connect to my Transcripted data using the best available method, then help me search, summarize, and organize my meetings and dictations.
+        Your job is to connect to my Transcripted data using the best available method, then help me search and summarize my meetings and dictations.
 
         Connection priority:
         1. If Transcripted MCP tools are already available in this environment, use them first.
@@ -66,8 +78,51 @@ enum AgentConnectionGuide {
         Working rules:
         - Prefer MCP over raw file inspection when both are available.
         - Use meetings and dictations together when the task spans both.
+        - Treat the raw transcript or dictation text as the source of truth.
+        - Keep summaries and answers grounded in source filenames, dates, speakers, and timestamps when available.
+        - Interpret relative dates in my local time zone. When I ask about today, yesterday, or last week, state the exact calendar dates you searched.
         - Surface uncertainty clearly.
         - If setup is needed, minimize back-and-forth and propose the next concrete action.
+
+        Starter skills:
+
+        1. Summarize
+        Use this when I ask for a summary, recap, brief, daily review, weekly review, or "what did I do" style answer.
+
+        What to do:
+        - Resolve the scope first: one meeting, one dictation, a date range, a person, a project, or a topic.
+        - Read the relevant source material before summarizing. For a specific meeting, read the full meeting when possible.
+        - Filter out obvious junk such as test captures, accidental fragments, setup chatter, and empty or near-empty recordings.
+        - Produce a clean brief with these sections when relevant:
+          - Brief
+          - Main Threads
+          - Decisions
+          - Action Items
+          - Open Questions
+          - Risks / Blockers
+          - Worth Remembering
+          - Sources
+          - Uncertainty
+
+        Summarize rules:
+        - Do not invent owners, deadlines, decisions, or action items.
+        - If an owner, deadline, or status is missing, write "unknown".
+        - Separate decisions from action items.
+        - Cite the source meeting or dictation for important claims.
+
+        2. Search Memory
+        Use this when I ask what I said, when something happened, where an idea came from, who mentioned something, or what the history of a topic is.
+
+        What to do:
+        - Search first, then synthesize.
+        - Combine exact search, relevant context search, recency, date filters, people, and topics when the available connection mode supports them.
+        - Show the best matches with source name, date, speaker, timestamp, snippet, and why each match surfaced when available.
+        - Then give the answer, timeline, related threads, confidence level, sources, and uncertainty when relevant.
+
+        Search Memory rules:
+        - Do not answer from vague memory when sources are available.
+        - If the evidence is thin, say so and suggest the narrower search that would help.
+        - If nothing relevant is found, say "not found" and list what you searched.
 
         First step:
         Determine which connection mode is available: MCP, MCP setup, or folders.

--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -17,6 +17,12 @@ struct AgentConnectionStarterSkill {
 }
 
 enum AgentConnectionGuide {
+    private static let portableDateFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
     static var localMCPBuildDirectory: URL? {
         let bundleURL = Bundle.main.bundleURL.standardizedFileURL
         let buildDirectory = bundleURL.deletingLastPathComponent()
@@ -185,6 +191,53 @@ enum AgentConnectionGuide {
         }
 
         return lines.joined(separator: "\n")
+    }
+
+    static func portableMeetingBundle(
+        title: String,
+        date: Date,
+        transcriptURL: URL
+    ) -> String? {
+        guard let transcriptBody = MeetingTranscriptStyler.transcriptBody(at: transcriptURL),
+              !transcriptBody.isEmpty else {
+            return nil
+        }
+
+        let skillBlocks = starterSkills.map { skill in
+            let skillText = (try? String(contentsOf: skillFileURL(for: skill), encoding: .utf8))?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                ?? "\(skill.title): \(skill.detail)"
+
+            return """
+            <skill id="\(skill.id)" name="\(skill.title)" version="\(skill.version)">
+            \(skillText)
+            </skill>
+            """
+        }.joined(separator: "\n\n")
+
+        return """
+        I use Transcripted on my Mac.
+
+        This is a portable Transcripted meeting bundle for any chat or agent. Use only the meeting content and embedded skills below. Do not claim access to my Mac, Transcripted MCP, or local folders unless this chat separately provides that access.
+
+        Embedded skills:
+        - Summarize v\(starterSkills[0].version)
+        - Search Memory v\(starterSkills[1].version)
+
+        If I ask for a summary, use the Summarize skill. If I ask what was said, where something came from, or when something happened, use the Search Memory skill. Cite the source file and meeting date for important claims.
+
+        Source:
+        - Title: \(title)
+        - Recorded at: \(portableDateFormatter.string(from: date))
+        - Source file: \(transcriptURL.lastPathComponent)
+        - Scope: this pasted meeting only
+
+        \(skillBlocks)
+
+        <meeting_transcript>
+        \(transcriptBody)
+        </meeting_transcript>
+        """
     }
 
     static var mcpPromptBlock: String {

--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -1,9 +1,19 @@
 import Foundation
 
 struct AgentConnectionStarterSkill {
+    let id: String
     let symbolName: String
     let title: String
+    let version: String
     let detail: String
+
+    var relativeSkillPath: String {
+        "\(id)/SKILL.md"
+    }
+
+    var displayDetail: String {
+        "v\(version) - \(detail)"
+    }
 }
 
 enum AgentConnectionGuide {
@@ -40,16 +50,50 @@ enum AgentConnectionGuide {
 
     static let starterSkills = [
         AgentConnectionStarterSkill(
+            id: "transcripted-summarize",
             symbolName: "doc.text",
             title: "Summarize",
+            version: "0.1.0",
             detail: "Create a cited brief from meetings, dictations, or a date range."
         ),
         AgentConnectionStarterSkill(
+            id: "transcripted-search-memory",
             symbolName: "magnifyingglass",
             title: "Search Memory",
+            version: "0.1.0",
             detail: "Find what was said, when it happened, and where it came from."
         ),
     ]
+
+    static var agentSkillsFolder: URL {
+        let fileManager = FileManager.default
+
+        if let resourceURL = Bundle.main.resourceURL {
+            let bundledURL = resourceURL.appendingPathComponent("AgentSkills", isDirectory: true)
+            if fileManager.fileExists(atPath: bundledURL.path) {
+                return bundledURL
+            }
+        }
+
+        let repoURL = URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+            .appendingPathComponent("AgentSkills", isDirectory: true)
+
+        if fileManager.fileExists(atPath: repoURL.path) {
+            return repoURL
+        }
+
+        return (Bundle.main.resourceURL ?? repoURL.deletingLastPathComponent())
+            .appendingPathComponent("AgentSkills", isDirectory: true)
+    }
+
+    static var agentSkillsManifest: URL {
+        agentSkillsFolder.appendingPathComponent("manifest.json", isDirectory: false)
+    }
+
+    static func skillFileURL(for skill: AgentConnectionStarterSkill) -> URL {
+        agentSkillsFolder.appendingPathComponent(skill.relativeSkillPath, isDirectory: false)
+    }
 
     static func starterPrompt(filename: String?) -> String {
         var prompt = """
@@ -84,45 +128,15 @@ enum AgentConnectionGuide {
         - Surface uncertainty clearly.
         - If setup is needed, minimize back-and-forth and propose the next concrete action.
 
-        Starter skills:
+        Bundled starter skill files:
+        \(starterSkillPromptBlock)
 
-        1. Summarize
-        Use this when I ask for a summary, recap, brief, daily review, weekly review, or "what did I do" style answer.
-
-        What to do:
-        - Resolve the scope first: one meeting, one dictation, a date range, a person, a project, or a topic.
-        - Read the relevant source material before summarizing. For a specific meeting, read the full meeting when possible.
-        - Filter out obvious junk such as test captures, accidental fragments, setup chatter, and empty or near-empty recordings.
-        - Produce a clean brief with these sections when relevant:
-          - Brief
-          - Main Threads
-          - Decisions
-          - Action Items
-          - Open Questions
-          - Risks / Blockers
-          - Worth Remembering
-          - Sources
-          - Uncertainty
-
-        Summarize rules:
-        - Do not invent owners, deadlines, decisions, or action items.
-        - If an owner, deadline, or status is missing, write "unknown".
-        - Separate decisions from action items.
-        - Cite the source meeting or dictation for important claims.
-
-        2. Search Memory
-        Use this when I ask what I said, when something happened, where an idea came from, who mentioned something, or what the history of a topic is.
-
-        What to do:
-        - Search first, then synthesize.
-        - Combine exact search, relevant context search, recency, date filters, people, and topics when the available connection mode supports them.
-        - Show the best matches with source name, date, speaker, timestamp, snippet, and why each match surfaced when available.
-        - Then give the answer, timeline, related threads, confidence level, sources, and uncertainty when relevant.
-
-        Search Memory rules:
-        - Do not answer from vague memory when sources are available.
-        - If the evidence is thin, say so and suggest the narrower search that would help.
-        - If nothing relevant is found, say "not found" and list what you searched.
+        Skill loading rules:
+        - When your environment can read local files, open the relevant SKILL.md file above and treat it as the canonical behavior.
+        - Use the skill versions above when giving feedback or suggesting improvements.
+        - If you cannot read the skill files, say that clearly and use this fallback:
+          - Summarize: create a cited brief from meetings, dictations, or a date range.
+          - Search Memory: find what was said, when it happened, and where it came from.
 
         First step:
         Determine which connection mode is available: MCP, MCP setup, or folders.
@@ -134,6 +148,16 @@ enum AgentConnectionGuide {
         }
 
         return prompt
+    }
+
+    static var starterSkillPromptBlock: String {
+        var lines = ["- Manifest: \(agentSkillsManifest.path)"]
+
+        for skill in starterSkills {
+            lines.append("- \(skill.title) v\(skill.version): \(skillFileURL(for: skill).path)")
+        }
+
+        return lines.joined(separator: "\n")
     }
 
     static var mcpPromptBlock: String {

--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -105,6 +105,8 @@ enum AgentConnectionGuide {
         - Do not ask me to choose a connection mode.
         - Silently pick the best available route, then continue.
         - Only stop when you cannot read any Transcripted data. If that happens, give me one smallest next step.
+        - If setup is needed, behave like a friendly setup concierge. Ask one short, natural question at a time.
+        - Prefer plain language like "I found a working path" and "This chat cannot reach your Mac directly" over protocol or debug language.
 
         Automatic route priority:
         1. If Transcripted MCP tools are already available in this environment, use them first.
@@ -117,6 +119,14 @@ enum AgentConnectionGuide {
         - Desktop clients with local stdio MCP support, such as Claude Desktop, can use Transcripted MCP after the MCP config is added and the client is restarted.
         - Remote or web chats, such as Claude chat in a browser, mobile chat, or any sandbox that cannot read `/Users/...` paths, cannot use local folders, local skill files, or local stdio MCP. Do not ask me to choose a mode. Say that this chat cannot reach my Mac directly, then ask me for the single smallest useful action: upload or paste captures, switch to a local agent, or use a remote connector if one is available.
         - Cowork or shared-agent environments may be local or remote. First determine whether the execution environment can read local Mac paths, then follow the matching rule above.
+
+        Concierge setup style:
+        - Start with "I'll check what I can use now."
+        - If a route works, say "I found a working path" and keep going.
+        - If direct tools are missing but folders work, say "We can use this now. Direct tools can be set up later."
+        - If setup is truly needed, ask one question such as "Which app are you using: Claude Desktop, Claude Code, Codex, or something else?"
+        - After the answer, give the exact next step for that app. Do not list every possible client.
+        - Avoid acronyms unless needed. If you mention MCP, call it "Transcripted direct tools" first.
 
         \(mcpPromptBlock)
 
@@ -156,7 +166,7 @@ enum AgentConnectionGuide {
         1. Silently determine which environment type you are in: local Mac agent, desktop MCP client, remote/web chat, or unknown cowork/shared context.
         2. Silently determine which connection mode is available: MCP, MCP setup, folders, uploaded/pasted files, or unavailable.
         3. Confirm whether the bundled SKILL.md files are readable.
-        4. Briefly tell me the chosen route and active skill versions. Do not make me choose.
+        4. Briefly tell me the chosen route and active skill versions in natural language. Do not make me choose.
         5. Then continue with my task.
         """
 

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+func testAgentConnectionGuide() {
+    runSuite("AgentConnectionGuide.starterSkills — exposes the two starter skills") {
+        let skills = AgentConnectionGuide.starterSkills
+
+        assertEqual(skills.count, 2, "connect-agent should ship two starter skills")
+        assertEqual(skills[0].title, "Summarize", "first starter skill should be Summarize")
+        assertEqual(skills[1].title, "Search Memory", "second starter skill should be Search Memory")
+        assertTrue(
+            skills[0].detail.lowercased().contains("cited brief"),
+            "Summarize copy should promise cited briefs"
+        )
+        assertTrue(
+            skills[1].detail.lowercased().contains("where it came from"),
+            "Search Memory copy should promise source traceability"
+        )
+    }
+
+    runSuite("AgentConnectionGuide.starterPrompt — embeds skill playbooks") {
+        let prompt = AgentConnectionGuide.starterPrompt(filename: "Planning Sync")
+
+        assertTrue(prompt.contains("Starter skills:"), "prompt should include starter skill section")
+        assertTrue(prompt.contains("1. Summarize"), "prompt should include Summarize skill")
+        assertTrue(prompt.contains("2. Search Memory"), "prompt should include Search Memory skill")
+        assertTrue(
+            prompt.contains("Treat the raw transcript or dictation text as the source of truth."),
+            "prompt should ground answers in raw captures"
+        )
+        assertTrue(
+            prompt.contains("Do not invent owners, deadlines, decisions, or action items."),
+            "Summarize should guard against invented action items"
+        )
+        assertTrue(
+            prompt.contains("If nothing relevant is found, say \"not found\" and list what you searched."),
+            "Search Memory should define the empty-result behavior"
+        )
+        assertTrue(
+            prompt.contains("If helpful, start with this meeting:\nPlanning Sync.md"),
+            "meeting-specific prompt should preserve the selected filename"
+        )
+    }
+}

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -135,4 +135,50 @@ func testAgentConnectionGuide() {
             )
         }
     }
+
+    runSuite("AgentConnectionGuide.portableMeetingBundle — embeds meeting and skills for any chat") {
+        let meetingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedAgentBundleTests-\(UUID().uuidString).md")
+        defer { try? FileManager.default.removeItem(at: meetingURL) }
+
+        let meetingMarkdown = """
+        ---
+        title: "Launch Sync"
+        date: "2026-04-18"
+        time: "09:30:00"
+        duration: "0:03"
+        total_word_count: 12
+        ---
+
+        # Launch Sync
+
+        ## Transcript
+
+        **00:00**  [Speaker 1]
+        We decided to ship the agent setup and copy for agent flow.
+        """
+
+        try? meetingMarkdown.write(to: meetingURL, atomically: true, encoding: .utf8)
+
+        let bundle = AgentConnectionGuide.portableMeetingBundle(
+            title: "Launch Sync",
+            date: Date(timeIntervalSince1970: 1_765_994_400),
+            transcriptURL: meetingURL
+        )
+
+        assertNotNil(bundle, "portable meeting bundle should be produced for readable meeting markdown")
+        let text = bundle ?? ""
+        assertTrue(text.contains("portable Transcripted meeting bundle"), "bundle should explain that it works in any chat")
+        assertTrue(text.contains("transcripted-summarize"), "bundle should embed the Summarize skill")
+        assertTrue(text.contains("transcripted-search-memory"), "bundle should embed the Search Memory skill")
+        assertTrue(text.contains("Source file: \(meetingURL.lastPathComponent)"), "bundle should include source filename")
+        assertTrue(
+            text.contains("We decided to ship the agent setup and copy for agent flow."),
+            "bundle should include the meeting transcript body"
+        )
+        assertTrue(
+            text.contains("Do not claim access to my Mac"),
+            "bundle should prevent remote chats from pretending they have local access"
+        )
+    }
 }

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -7,37 +7,80 @@ func testAgentConnectionGuide() {
         assertEqual(skills.count, 2, "connect-agent should ship two starter skills")
         assertEqual(skills[0].title, "Summarize", "first starter skill should be Summarize")
         assertEqual(skills[1].title, "Search Memory", "second starter skill should be Search Memory")
+        assertEqual(skills[0].version, "0.1.0", "Summarize should expose its shipped version")
+        assertEqual(skills[1].version, "0.1.0", "Search Memory should expose its shipped version")
         assertTrue(
-            skills[0].detail.lowercased().contains("cited brief"),
+            skills[0].displayDetail.lowercased().contains("cited brief"),
             "Summarize copy should promise cited briefs"
         )
         assertTrue(
-            skills[1].detail.lowercased().contains("where it came from"),
+            skills[1].displayDetail.lowercased().contains("where it came from"),
             "Search Memory copy should promise source traceability"
         )
     }
 
-    runSuite("AgentConnectionGuide.starterPrompt — embeds skill playbooks") {
+    runSuite("AgentConnectionGuide.starterPrompt — points to bundled skill files") {
         let prompt = AgentConnectionGuide.starterPrompt(filename: "Planning Sync")
 
-        assertTrue(prompt.contains("Starter skills:"), "prompt should include starter skill section")
-        assertTrue(prompt.contains("1. Summarize"), "prompt should include Summarize skill")
-        assertTrue(prompt.contains("2. Search Memory"), "prompt should include Search Memory skill")
+        assertTrue(prompt.contains("Bundled starter skill files:"), "prompt should include bundled skill section")
+        assertTrue(prompt.contains("Manifest:"), "prompt should point to the skill manifest")
+        assertTrue(prompt.contains("transcripted-summarize/SKILL.md"), "prompt should include Summarize skill file")
+        assertTrue(prompt.contains("transcripted-search-memory/SKILL.md"), "prompt should include Search Memory skill file")
+        assertTrue(prompt.contains("Summarize v0.1.0"), "prompt should include Summarize version")
+        assertTrue(prompt.contains("Search Memory v0.1.0"), "prompt should include Search Memory version")
         assertTrue(
             prompt.contains("Treat the raw transcript or dictation text as the source of truth."),
             "prompt should ground answers in raw captures"
         )
         assertTrue(
-            prompt.contains("Do not invent owners, deadlines, decisions, or action items."),
-            "Summarize should guard against invented action items"
-        )
-        assertTrue(
-            prompt.contains("If nothing relevant is found, say \"not found\" and list what you searched."),
-            "Search Memory should define the empty-result behavior"
+            prompt.contains("When your environment can read local files, open the relevant SKILL.md file above"),
+            "prompt should make SKILL.md files canonical"
         )
         assertTrue(
             prompt.contains("If helpful, start with this meeting:\nPlanning Sync.md"),
             "meeting-specific prompt should preserve the selected filename"
         )
+    }
+
+    runSuite("AgentConnectionGuide bundled skills — files and manifest are versioned") {
+        let skillsFolder = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent("Resources", isDirectory: true)
+            .appendingPathComponent("AgentSkills", isDirectory: true)
+        let manifestURL = skillsFolder.appendingPathComponent("manifest.json", isDirectory: false)
+
+        assertTrue(
+            FileManager.default.fileExists(atPath: manifestURL.path),
+            "agent skill manifest should exist in app resources"
+        )
+
+        if let manifestData = try? Data(contentsOf: manifestURL),
+           let manifest = try? JSONSerialization.jsonObject(with: manifestData) as? [String: Any] {
+            assertEqual(
+                manifest["bundle_version"] as? String,
+                "0.1.0",
+                "skill manifest should expose the starter bundle version"
+            )
+        } else {
+            assertTrue(false, "skill manifest should be readable JSON")
+        }
+
+        for skill in AgentConnectionGuide.starterSkills {
+            let skillURL = skillsFolder.appendingPathComponent(skill.relativeSkillPath, isDirectory: false)
+
+            assertTrue(
+                FileManager.default.fileExists(atPath: skillURL.path),
+                "expected bundled skill file: \(skill.relativeSkillPath)"
+            )
+
+            let skillText = (try? String(contentsOf: skillURL, encoding: .utf8)) ?? ""
+            assertTrue(
+                skillText.contains("Version: \(skill.version)"),
+                "skill file should carry the same version as UI metadata: \(skill.id)"
+            )
+            assertTrue(
+                skillText.contains("name: \(skill.id)"),
+                "skill file should use the same skill id as UI metadata: \(skill.id)"
+            )
+        }
     }
 }

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -29,8 +29,12 @@ func testAgentConnectionGuide() {
         assertTrue(prompt.contains("Summarize v0.1.0"), "prompt should include Summarize version")
         assertTrue(prompt.contains("Search Memory v0.1.0"), "prompt should include Search Memory version")
         assertTrue(
-            prompt.contains("Agent environment guidance:"),
+            prompt.contains("Automatic environment routing:"),
             "prompt should include environment-specific routing guidance"
+        )
+        assertTrue(
+            prompt.contains("Do not ask me to choose a connection mode."),
+            "prompt should keep routing decisions away from the user"
         )
         assertTrue(
             prompt.contains("Local agents running on this Mac, such as Codex, Claude Code in the terminal"),
@@ -57,8 +61,8 @@ func testAgentConnectionGuide() {
             "prompt should make SKILL.md files canonical for matching tasks"
         )
         assertTrue(
-            prompt.contains("Briefly tell me which environment, connection mode, and skill versions are active."),
-            "prompt should report active environment, connection, and skill versions"
+            prompt.contains("Briefly tell me the chosen route and active skill versions. Do not make me choose."),
+            "prompt should report the chosen route without making the user choose"
         )
         assertTrue(
             prompt.contains("continue with folder fallback for the current session when folders are readable"),

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -180,5 +180,21 @@ func testAgentConnectionGuide() {
             text.contains("Do not claim access to my Mac"),
             "bundle should prevent remote chats from pretending they have local access"
         )
+        assertTrue(
+            text.contains("If no task was included, ask one short question"),
+            "bundle should prevent pasted chats from summarizing before the user asks"
+        )
+        assertTrue(
+            text.contains("Do not critique tone, metaphors, writing style"),
+            "bundle should keep any-chat responses from turning into unsolicited critique"
+        )
+        assertTrue(
+            text.contains("Brief, Main Threads, Decisions, Action Items"),
+            "bundle should steer summaries into the embedded Summarize skill shape"
+        )
+        assertTrue(
+            text.contains("use the Search Memory skill within this pasted meeting only"),
+            "bundle should scope search-memory answers to the portable meeting"
+        )
     }
 }

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -29,12 +29,40 @@ func testAgentConnectionGuide() {
         assertTrue(prompt.contains("Summarize v0.1.0"), "prompt should include Summarize version")
         assertTrue(prompt.contains("Search Memory v0.1.0"), "prompt should include Search Memory version")
         assertTrue(
+            prompt.contains("Agent environment guidance:"),
+            "prompt should include environment-specific routing guidance"
+        )
+        assertTrue(
+            prompt.contains("Local agents running on this Mac, such as Codex, Claude Code in the terminal"),
+            "prompt should name local agent contexts"
+        )
+        assertTrue(
+            prompt.contains("Remote or web chats, such as Claude chat in a browser"),
+            "prompt should explain remote chat limitations"
+        )
+        assertTrue(
+            prompt.contains("Cowork or shared-agent environments may be local or remote."),
+            "prompt should force cowork-style environments to classify local vs remote execution"
+        )
+        assertTrue(
             prompt.contains("Treat the raw transcript or dictation text as the source of truth."),
             "prompt should ground answers in raw captures"
         )
         assertTrue(
-            prompt.contains("When your environment can read local files, open the relevant SKILL.md file above"),
-            "prompt should make SKILL.md files canonical"
+            prompt.contains("Before offering task options, check whether the manifest and bundled SKILL.md files above are readable."),
+            "prompt should require a skill-file check before offering tasks"
+        )
+        assertTrue(
+            prompt.contains("When I ask for Summarize or Search Memory behavior, open the matching SKILL.md before answering"),
+            "prompt should make SKILL.md files canonical for matching tasks"
+        )
+        assertTrue(
+            prompt.contains("Briefly tell me which environment, connection mode, and skill versions are active."),
+            "prompt should report active environment, connection, and skill versions"
+        )
+        assertTrue(
+            prompt.contains("continue with folder fallback for the current session when folders are readable"),
+            "prompt should keep Claude Code moving when MCP setup needs restart"
         )
         assertTrue(
             prompt.contains("If helpful, start with this meeting:\nPlanning Sync.md"),

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -37,6 +37,14 @@ func testAgentConnectionGuide() {
             "prompt should keep routing decisions away from the user"
         )
         assertTrue(
+            prompt.contains("behave like a friendly setup concierge"),
+            "prompt should request concierge-style setup behavior"
+        )
+        assertTrue(
+            prompt.contains("Ask one short, natural question at a time."),
+            "prompt should avoid dumping setup choices"
+        )
+        assertTrue(
             prompt.contains("Local agents running on this Mac, such as Codex, Claude Code in the terminal"),
             "prompt should name local agent contexts"
         )
@@ -47,6 +55,18 @@ func testAgentConnectionGuide() {
         assertTrue(
             prompt.contains("Cowork or shared-agent environments may be local or remote."),
             "prompt should force cowork-style environments to classify local vs remote execution"
+        )
+        assertTrue(
+            prompt.contains("Concierge setup style:"),
+            "prompt should include natural setup behavior guidance"
+        )
+        assertTrue(
+            prompt.contains("If a route works, say \"I found a working path\" and keep going."),
+            "prompt should keep working when any usable route exists"
+        )
+        assertTrue(
+            prompt.contains("Which app are you using: Claude Desktop, Claude Code, Codex, or something else?"),
+            "prompt should ask one natural setup question when blocked"
         )
         assertTrue(
             prompt.contains("Treat the raw transcript or dictation text as the source of truth."),
@@ -61,7 +81,7 @@ func testAgentConnectionGuide() {
             "prompt should make SKILL.md files canonical for matching tasks"
         )
         assertTrue(
-            prompt.contains("Briefly tell me the chosen route and active skill versions. Do not make me choose."),
+            prompt.contains("Briefly tell me the chosen route and active skill versions in natural language. Do not make me choose."),
             "prompt should report the chosen route without making the user choose"
         )
         assertTrue(

--- a/Tests/FastTests.manifest
+++ b/Tests/FastTests.manifest
@@ -1,6 +1,7 @@
 # Fast test manifest
 # Format: <TestFile.swift>:<top-level entry function>
 
+AgentConnectionGuideTests.swift:testAgentConnectionGuide
 AnalyticsEventPolicyTests.swift:testAnalyticsEventPolicy
 AnalyticsPayloadSanitizerTests.swift:testAnalyticsPayloadSanitizer
 FailedMeetingPresentationTests.swift:testFailedMeetingPresentation

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -117,6 +117,7 @@ APP_SOURCES=(
     "Sources/Dictation/DictationStoragePaths.swift"
     "Sources/Dictation/DictationTranscriptWriter.swift"
     "Sources/Dictation/DictationTranscriptStore.swift"
+    "Sources/Meeting/MeetingStoragePaths.swift"
     "Sources/Support/TranscriptedConstants.swift"
     "Sources/Speech/ParakeetModelInitDiagnostics.swift"
     "Sources/Speech/ParakeetPrewarmPolicy.swift"
@@ -144,6 +145,7 @@ APP_SOURCES=(
     "Sources/TranscriptedCore/Models/TranscriptionTypes.swift"
     "Sources/TranscriptedCore/Speaker/SpeakerProfile.swift"
     "Sources/TranscriptedCore/Speaker/SpeakerNamingPolicy.swift"
+    "Sources/UI/Shared/AgentConnectionGuide.swift"
     "Sources/UI/Shared/FirstRunExperience.swift"
     "Sources/UI/Shared/AppSoundPlayer.swift"
 )


### PR DESCRIPTION
## Summary

Adds the first Transcripted agent setup flow:

- bundles two starter skill files: Summarize and Search Memory
- updates Connect Your Agent copy to guide local agents, desktop direct tools, and remote/web chats without making users choose modes
- adds Copy Agent Setup for the agent connection surfaces
- adds Copy for Agent on recent meetings so a single meeting can be pasted into any chat
- embeds portable instructions that prevent remote chats from claiming local access and steer summaries/searches into the embedded skill behavior

## Why

Users may bring Transcripted captures into many different agent environments: Codex, Claude Code, Claude Desktop, browser chats, OpenCode/OpenClaw, and shared/cowork contexts. The product needs a simple one-stop setup copy path that routes automatically where possible and falls back gracefully when a chat cannot reach the Mac.

## Impact

This gives users two practical ways to work with agents immediately:

- copy the setup prompt for local/direct-tool capable agents
- copy a current meeting bundle for any chat, including sandboxed web chats

The portable meeting bundle now tells pasted chats to wait for a task if none was given, avoid unsolicited critique, cite the meeting source, and use the embedded Summarize/Search Memory skill shapes.

## Validation

- `bash build.sh`
- `bash run-tests.sh` — 447 passed, 0 failed