### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -445,14 +445,16 @@ final class MeetingSessionController: ObservableObject {
             )
         )
 
-        let files = await capture.stopAndAwaitFiles()
+        // Snapshot capture health before stop resets system-audio status/stats during cleanup.
         let healthInfo = capture.healthInfo()
+        let finalSystemAudioStatus = capture.systemAudioStatus
+        let files = await capture.stopAndAwaitFiles()
         let durationMs = Int(recordingDuration * 1000)
         activeRecordingTrigger = .unknown
         state = .transcribing
 
         DiagnosticsTrail.record(
-            level: capture.systemAudioStatus.isWarning ? .warning : .info,
+            level: finalSystemAudioStatus.isWarning ? .warning : .info,
             engine: "meeting",
             event: "meeting_recording_stopped",
             message: "Meeting recording stopped",


### PR DESCRIPTION
## Summary
- preserve the final meeting capture health snapshot before stop cleanup resets system-audio status and buffer stats
- keep stop diagnostics aligned with the actual final system-audio warning state

## Findings fixed
### Logic bug
- `MeetingSessionController.stopRecording` was reading `capture.healthInfo()` and warning state after `stopAndAwaitFiles()`, but stop cleanup resets ScreenCaptureKit/system-audio stats and status. That could misclassify degraded captures as healthy in transcript metadata and suppress warning-level stop diagnostics.

## Validation
- `bash build-deps.sh --force`
- `bash build.sh`

## Notes
- The requested `xcodebuild -project Transcripted.xcodeproj ...` surface is not present in this checkout, so validation used the repo's current documented build entrypoint (`bash build.sh`).