### PR TITLE
[nightly-review] Harden meeting prompt host matching

### DIFF
--- a/Sources/Meeting/MeetingPromptDetector.swift
+++ b/Sources/Meeting/MeetingPromptDetector.swift
@@ -422,25 +422,8 @@ final class MeetingPromptDetector {
     }
 
     private func provider(for url: URL) -> MeetingPromptProvider? {
-        guard let host = url.host?.lowercased() else { return nil }
-
-        if host.contains("zoom.us") {
-            return .zoom
-        }
-        if host == "meet.google.com" {
-            return .googleMeet
-        }
-        if host.contains("teams.microsoft.com") {
-            return .teams
-        }
-        if host.contains("webex.com") {
-            return .webex
-        }
-        if host.contains("facetime.apple.com") {
-            return .facetime
-        }
-
-        return nil
+        guard let host = url.host else { return nil }
+        return MeetingPromptProvider.provider(forMeetingHost: host)
     }
 
     private func provider(forBundleIdentifier bundleIdentifier: String) -> MeetingPromptProvider? {

--- a/Sources/Meeting/MeetingPromptHeuristics.swift
+++ b/Sources/Meeting/MeetingPromptHeuristics.swift
@@ -38,6 +38,34 @@ enum MeetingPromptProvider: String, CaseIterable, Hashable {
     var supportsRuntimeOnlyPrompt: Bool {
         supportsNativeRuntimePrompt && self != .teams
     }
+
+    static func provider(forMeetingHost host: String) -> MeetingPromptProvider? {
+        let normalizedHost = host
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+            .lowercased()
+
+        if hostMatches(normalizedHost, domain: "zoom.us") {
+            return .zoom
+        }
+        if normalizedHost == "meet.google.com" {
+            return .googleMeet
+        }
+        if hostMatches(normalizedHost, domain: "teams.microsoft.com") {
+            return .teams
+        }
+        if hostMatches(normalizedHost, domain: "webex.com") {
+            return .webex
+        }
+        if hostMatches(normalizedHost, domain: "facetime.apple.com") {
+            return .facetime
+        }
+
+        return nil
+    }
+
+    private static func hostMatches(_ host: String, domain: String) -> Bool {
+        host == domain || host.hasSuffix(".\(domain)")
+    }
 }
 
 enum MeetingPromptSource: Equatable {

--- a/Tests/MeetingPromptHeuristicsTests.swift
+++ b/Tests/MeetingPromptHeuristicsTests.swift
@@ -53,6 +53,48 @@ func testMeetingPromptHeuristics() {
         )
     }
 
+    runSuite("MeetingPromptProvider.provider(forMeetingHost:) accepts exact provider hosts and subdomains") {
+        assertEqual(
+            MeetingPromptProvider.provider(forMeetingHost: "zoom.us"),
+            .zoom,
+            "Zoom's root host should be recognized"
+        )
+        assertEqual(
+            MeetingPromptProvider.provider(forMeetingHost: "us02web.zoom.us"),
+            .zoom,
+            "Zoom subdomains should be recognized"
+        )
+        assertEqual(
+            MeetingPromptProvider.provider(forMeetingHost: "meet.google.com"),
+            .googleMeet,
+            "Google Meet's canonical host should be recognized"
+        )
+        assertEqual(
+            MeetingPromptProvider.provider(forMeetingHost: "company.webex.com."),
+            .webex,
+            "Provider subdomains with a trailing dot should be recognized"
+        )
+    }
+
+    runSuite("MeetingPromptProvider.provider(forMeetingHost:) rejects lookalike domains") {
+        assertNil(
+            MeetingPromptProvider.provider(forMeetingHost: "zoom.us.evil.example"),
+            "Zoom lookalike hosts should not trigger a meeting prompt"
+        )
+        assertNil(
+            MeetingPromptProvider.provider(forMeetingHost: "evilzoom.us"),
+            "Hosts that only contain a provider suffix should not match"
+        )
+        assertNil(
+            MeetingPromptProvider.provider(forMeetingHost: "teams.microsoft.com.example.net"),
+            "Teams lookalike hosts should not trigger a meeting prompt"
+        )
+        assertNil(
+            MeetingPromptProvider.provider(forMeetingHost: "webex.com.attacker.test"),
+            "Webex lookalike hosts should not trigger a meeting prompt"
+        )
+    }
+
     runSuite("MeetingPromptHeuristics.snoozeInterval — runtime reminders use a short follow-up interval") {
         let interval = MeetingPromptHeuristics.snoozeInterval(
             for: .runtimeApp,


### PR DESCRIPTION
## Summary
- Move calendar meeting-provider host matching into the prompt heuristics layer.
- Require exact provider hosts or real subdomains instead of substring matches.
- Add fast coverage for accepted provider hosts and rejected lookalike domains.

## Finding fixed
Calendar meeting URL detection used substring checks like host.contains("zoom.us"), so a lookalike host such as zoom.us.evil.example could be treated as a real meeting URL and trigger a recording prompt.

## Validation
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh

## Notes
- run-tests.sh initially failed while run concurrently with build.sh because both used the shared build directory. It passed when rerun sequentially.