### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -33,7 +33,7 @@ Important entry points:
 - `Observability/` — events, debug log, anonymous analytics, Sparkle updater, and crash reporting
 - `Reliability/` — wake / sleep recovery coordination
 - `Speech/` — Parakeet STT, router, and recorded-audio buffering helpers
-- `Support/` — app-wide path, storage, permission, hotkey, local-speaker preference, and shared constant helpers
+- `Support/` — app-wide path, storage, permission, hotkey, local-speaker preference, clipboard paste, and shared constant helpers
 - `TranscriptedCore/` — shared library boundary
 - `UI/` — grouped app surfaces: `Overlay/`, `MenuBar/`, `Settings/`, `AgentConnect/`, and `Shared/`
 
@@ -51,6 +51,7 @@ app target entirely. If a historical doc still mentions `Sources/Text/` or
 - touching meeting flow or imported-audio transcription: `Sources/Meeting/CLAUDE.md`
 - touching core library or meeting pipeline internals: `Sources/TranscriptedCore/CLAUDE.md`
 - touching STT / recording lifecycle: `Sources/Speech/CLAUDE.md`
+- touching app-wide support utilities: `Sources/Support/CLAUDE.md`
 - touching tests or package boundaries: `Tests/README.md`
 
 Prefer the local doc plus the actual Swift file list before assuming an older

--- a/Sources/Dictation/CLAUDE.md
+++ b/Sources/Dictation/CLAUDE.md
@@ -37,6 +37,7 @@ Each section captures:
 ## Test coverage
 
 - `Tests/DictationSessionTimeoutTests.swift`
+- `Tests/DictationTranscriptStoreTests.swift`
 - `Tests/DictationTranscriptWriterTests.swift`
 
 ## Agent notes

--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -87,6 +87,7 @@ Relevant direct coverage:
 - `Tests/MeetingFailureKindTests.swift`
 - `Tests/MeetingPromptHeuristicsTests.swift`
 - `Tests/MeetingRecordingStartGateTests.swift`
+- `Tests/MeetingRecordingCleanupTests.swift`
 - `Tests/MeetingWarmupStatusPolicyTests.swift`
 - `Tests/MeetingSessionUIPolicyTests.swift`
 - `Tests/MeetingTranscriptStylerTests.swift`

--- a/Sources/Support/CLAUDE.md
+++ b/Sources/Support/CLAUDE.md
@@ -1,0 +1,34 @@
+# Support helpers
+
+## What this directory does
+
+`Sources/Support/` contains app-wide utility types that cut across features. These are standalone helpers shared by dictation, meeting, capture, and UI code without belonging to any single feature directory.
+
+## Files
+
+- `ClipboardRestoringTextPaster.swift` — pastes text into the target app by briefly borrowing the clipboard and restoring prior contents after Cmd+V completes; reports paste/copy/fail outcomes for diagnostics
+- `HotkeyPreferences.swift` — data model, persistence, display, and validation for customizable keyboard shortcuts (dictation, meeting, draft hotkey bindings)
+- `LocalSpeakerPreferences.swift` — preference flag for local mic-channel speaker diarization; when enabled, the meeting pipeline runs offline diarization on the mic track and surfaces multiple local speakers in the post-meeting naming sheet
+- `TranscriptedConstants.swift` — centralized configuration constants for timeouts, thresholds, limits, buffer sizes, and version metadata
+- `TranscriptedPermissionAccess.swift` — unified permission checks for microphone, accessibility, system audio recording, and calendar; shared by the meeting prompt detector, settings, and onboarding flows
+- `TranscriptedStoragePaths.swift` — app-support path helpers for the Transcripted capture library, state, cache, logs, and tmp layout, including user-configurable capture library relocation
+
+## Key invariants
+
+- `TranscriptedPermissionAccess` is the canonical place for app-level TCC permission queries. Keep duplicate permission branching out of feature-specific code.
+- `LocalSpeakerPreferences` defaults to off. The meeting pipeline reads this flag at recording time, so changes take effect on the next meeting.
+- `ClipboardRestoringTextPaster` runs on the main thread and uses brief async delays for the paste round-trip. Keep the clipboard borrow window tight.
+- `TranscriptedStoragePaths` resolves the capture library from `UserDefaults` first, falling back to the default Application Support location. App-owned state, cache, logs, and temp files always stay under the fixed Application Support root.
+
+## Verification
+
+```bash
+bash build.sh
+bash run-tests.sh
+```
+
+Relevant direct coverage:
+
+- `Tests/TranscriptedConstantsTests.swift`
+- `Tests/TranscriptedPermissionAccessTests.swift`
+- `Tests/TranscriptedStoragePathsTests.swift`


### PR DESCRIPTION
## Summary

- **New**: Created `Sources/Support/CLAUDE.md` documenting the 6 utility files in the Support directory (clipboard paste helper, hotkey preferences, local speaker preferences, constants, permission access, storage paths)
- **Updated**: `Sources/Meeting/CLAUDE.md` — added missing `Tests/MeetingRecordingCleanupTests.swift` to test coverage list
- **Updated**: `Sources/Dictation/CLAUDE.md` — added missing `Tests/DictationTranscriptStoreTests.swift` to test coverage list
- **Updated**: `Sources/CLAUDE.md` — added clipboard paste mention to Support directory description, added Support CLAUDE.md cross-reference

## Context

Changes since last sync (PRs #381–#385): nightly security hardening, dead draft overlay state removal, simplification sweep, index validator improvements, and code review fixes. File lists and counts in all CLAUDE.md files verified against current tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)