### PR TITLE
Retain meeting recording audio

### DIFF
--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -58,6 +58,7 @@
 Meeting capture artifacts live under `<capture-library>/meetings/`:
 
 - `*.md`
+- `audio/*_audio/` retained mic/system audio copied from successful meeting captures
 
 App-owned meeting state lives under `~/Library/Application Support/Transcripted/state/`:
 
@@ -70,6 +71,12 @@ Temporary meeting scratch paths live under `~/Library/Application Support/Transc
 - raw audio captures
 - imported audio copies
 - `speaker_clips/`
+
+Successful live and imported meeting recordings are retained in the capture
+library before scratch cleanup. Failed live meeting transcriptions also copy
+their available recording audio there while keeping scratch files available for
+retry. Explicit discard still removes the scratch recording without saving a
+transcript or retained audio.
 
 Core logging for the embedded meeting pipeline is redirected to `~/Library/Application Support/Transcripted/logs/`.
 

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -169,6 +169,7 @@ final class MeetingSessionController: ObservableObject {
         _ = MeetingStoragePaths.stateFolder
         _ = MeetingStoragePaths.logsFolder
         _ = MeetingStoragePaths.recordingsScratch
+        _ = MeetingStoragePaths.audioArchiveFolder
 
         // Build app-owned CoreStoragePaths so captures and internal state stay split.
         self.storagePaths = CoreStoragePaths(
@@ -218,6 +219,7 @@ final class MeetingSessionController: ObservableObject {
             diarization: services.diarization,
             speakerStore: services.speakerStore,
             speakerClipsDirectory: storagePaths.speakerClips,
+            retainedAudioDirectory: MeetingStoragePaths.audioArchiveFolder,
             statsStore: statsDatabase
         )
 

--- a/Sources/Meeting/MeetingStoragePaths.swift
+++ b/Sources/Meeting/MeetingStoragePaths.swift
@@ -15,6 +15,13 @@ enum MeetingStoragePaths {
         root
     }
 
+    /// Retained mic/system audio for saved meetings.
+    static var audioArchiveFolder: URL {
+        let url = root.appendingPathComponent("audio", isDirectory: true)
+        FileManager.default.ensurePrivateDirectory(at: url, context: "meeting audio archive")
+        return url
+    }
+
     static var stateFolder: URL {
         FileManager.default.transcriptedStateDir
     }

--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -347,6 +347,10 @@ enum MeetingTranscriptStyler {
 
         do {
             try fm.moveItem(at: url, to: targetURL)
+            renameAudioDirectoryIfNeeded(
+                from: audioDirectoryURL(for: url),
+                to: audioDirectoryURL(for: targetURL)
+            )
             return targetURL
         } catch {
             logFailure(
@@ -359,6 +363,51 @@ enum MeetingTranscriptStyler {
                 ]
             )
             return url
+        }
+    }
+
+    private static func audioDirectoryURL(for transcriptURL: URL) -> URL {
+        transcriptURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("audio", isDirectory: true)
+            .appendingPathComponent("\(transcriptURL.deletingPathExtension().lastPathComponent)_audio", isDirectory: true)
+    }
+
+    private static func renameAudioDirectoryIfNeeded(from sourceURL: URL, to targetURL: URL) {
+        let fm = FileManager.default
+        guard sourceURL != targetURL, fm.fileExists(atPath: sourceURL.path) else { return }
+
+        let finalURL = uniqueAudioDirectoryURL(preferredURL: targetURL)
+
+        do {
+            try fm.moveItem(at: sourceURL, to: finalURL)
+        } catch {
+            logFailure(
+                event: "meeting_audio_directory_rename_failed",
+                message: "Failed to rename retained meeting audio",
+                context: [
+                    "from": sourceURL.lastPathComponent,
+                    "to": finalURL.lastPathComponent,
+                    "error": error.localizedDescription
+                ]
+            )
+        }
+    }
+
+    private static func uniqueAudioDirectoryURL(preferredURL: URL) -> URL {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: preferredURL.path) else { return preferredURL }
+
+        let directory = preferredURL.deletingLastPathComponent()
+        let stem = preferredURL.lastPathComponent
+        var suffix = 2
+
+        while true {
+            let candidate = directory.appendingPathComponent("\(stem) \(suffix)", isDirectory: true)
+            if !fm.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+            suffix += 1
         }
     }
 

--- a/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
+++ b/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
@@ -253,6 +253,7 @@ public struct SpeakerNamingRequest {
     public let transcriptURL: URL
     public let systemAudioURL: URL
     public let micAudioURL: URL?
+    public let shouldRemoveTemporaryAudioOnCleanup: Bool
     public let onComplete: ([SpeakerNameUpdate]) -> Void
 
     public init(
@@ -262,6 +263,7 @@ public struct SpeakerNamingRequest {
         transcriptId: UUID,
         systemAudioURL: URL,
         micAudioURL: URL?,
+        shouldRemoveTemporaryAudioOnCleanup: Bool = true,
         onComplete: @escaping ([SpeakerNameUpdate]) -> Void
     ) {
         self.speakers = speakers
@@ -270,6 +272,7 @@ public struct SpeakerNamingRequest {
         self.transcriptId = transcriptId
         self.systemAudioURL = systemAudioURL
         self.micAudioURL = micAudioURL
+        self.shouldRemoveTemporaryAudioOnCleanup = shouldRemoveTemporaryAudioOnCleanup
         self.onComplete = onComplete
     }
 

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -277,6 +277,12 @@ extension TranscriptionTaskManager {
 
         AppLogger.pipeline.info("Phase 2 complete: Transcript saved", ["file": savedURL.lastPathComponent])
 
+        let shouldRemoveScratchAudio = await archiveRecordingAudioIfConfigured(
+            micURL: micURL,
+            systemURL: systemURL,
+            savedURL: savedURL
+        )
+
         // Phase 3: Speaker naming — for system speakers that need action, plus any mic
         // speakers surfaced by local-speaker split. Entries from both channels flow
         // through the same SpeakerNamingSheet (grouped by channel in the UI).
@@ -370,6 +376,7 @@ extension TranscriptionTaskManager {
                     transcriptId: transcriptId,
                     systemAudioURL: systemURL,
                     micAudioURL: micURL,
+                    shouldRemoveTemporaryAudioOnCleanup: shouldRemoveScratchAudio,
                     onComplete: { [weak self] updates in
                         self?.handleNamingComplete(
                             updates: updates,
@@ -378,6 +385,7 @@ extension TranscriptionTaskManager {
                             transcriptionResult: result,
                             micURL: micURL,
                             systemURL: systemURL,
+                            shouldRemoveTemporaryAudio: shouldRemoveScratchAudio,
                             clips: capturedEntries
                         )
                     }
@@ -392,13 +400,45 @@ extension TranscriptionTaskManager {
             return savedURL
         }
 
-        // No naming needed — clean up audio files
-        if let micURL {
+        // No naming needed — clean up scratch audio once retained copies exist.
+        if shouldRemoveScratchAudio, let micURL {
             try? FileManager.default.removeItem(at: micURL)
         }
-        try? FileManager.default.removeItem(at: systemURL)
+        if shouldRemoveScratchAudio {
+            try? FileManager.default.removeItem(at: systemURL)
+        }
 
         return savedURL
+    }
+
+    nonisolated private func archiveRecordingAudioIfConfigured(
+        micURL: URL?,
+        systemURL: URL,
+        savedURL: URL
+    ) async -> Bool {
+        let retainedAudioDirectory = await MainActor.run { self.retainedAudioDirectory }
+        guard let retainedAudioDirectory else { return true }
+
+        do {
+            let retainedAudio = try RecordingAudioArchiver.archive(
+                micURL: micURL,
+                systemURL: systemURL,
+                transcriptURL: savedURL,
+                archiveRoot: retainedAudioDirectory
+            )
+            AppLogger.pipeline.info("Retained meeting audio files", [
+                "directory": retainedAudio.directory.lastPathComponent,
+                "mic": retainedAudio.micURL?.lastPathComponent ?? "none",
+                "system": retainedAudio.systemURL?.lastPathComponent ?? "none"
+            ])
+            return true
+        } catch {
+            AppLogger.pipeline.warning("Failed to retain meeting audio; leaving scratch files in place", [
+                "transcript": savedURL.lastPathComponent,
+                "error": error.localizedDescription
+            ])
+            return false
+        }
     }
 
 }

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -23,6 +23,7 @@ public class TranscriptionTaskManager: ObservableObject {
 
     public let failedTranscriptionManager: FailedTranscriptionManager
     public let statsStore: (any StatsStore)?
+    let retainedAudioDirectory: URL?
 
     /// Embedder-supplied notifier for transcript-saved and failure events. Optional — when
     /// `nil`, notification hooks become no-ops, which keeps Core usable from headless contexts
@@ -35,12 +36,14 @@ public class TranscriptionTaskManager: ObservableObject {
         diarization: any DiarizationEngine,
         speakerStore: any SpeakerStore,
         speakerClipsDirectory: URL = CoreStoragePaths.default.speakerClips,
+        retainedAudioDirectory: URL? = nil,
         statsStore: (any StatsStore)? = nil,
         notifier: TranscriptNotifier? = nil
     ) {
         self.failedTranscriptionManager = failedTranscriptionManager
         self.statsStore = statsStore
         self.notifier = notifier
+        self.retainedAudioDirectory = retainedAudioDirectory
         self.transcription = Transcription(
             speechToText: speechToText,
             diarization: diarization,
@@ -140,6 +143,11 @@ public class TranscriptionTaskManager: ObservableObject {
                 AppLogger.pipeline.error("Transcription task failed", ["taskId": "\(task.id)", "error": "\(error.localizedDescription)"])
 
                 await MainActor.run {
+                    self.archiveFailedRecordingAudioIfConfigured(
+                        micURL: micURL,
+                        systemURL: systemURL,
+                        taskId: task.id
+                    )
                     self.displayStatus = .failed(message: "Transcription failed")
                     self.failedTranscriptionManager.addFailedTranscription(
                         micAudioURL: micURL,
@@ -422,6 +430,38 @@ public class TranscriptionTaskManager: ObservableObject {
             AppLogger.pipeline.warning("Failed to remove recording file", [
                 "label": label,
                 "file": url.lastPathComponent,
+                "error": error.localizedDescription
+            ])
+        }
+    }
+
+    private func archiveFailedRecordingAudioIfConfigured(
+        micURL: URL?,
+        systemURL: URL?,
+        taskId: UUID
+    ) {
+        guard let retainedAudioDirectory else { return }
+
+        let failedStem = "Failed_\(DateFormattingHelper.formatFilename(Date()))_\(String(taskId.uuidString.prefix(8)))"
+        let placeholderTranscriptURL = retainedAudioDirectory
+            .appendingPathComponent(failedStem)
+            .appendingPathExtension("md")
+
+        do {
+            let retainedAudio = try RecordingAudioArchiver.archive(
+                micURL: micURL,
+                systemURL: systemURL,
+                transcriptURL: placeholderTranscriptURL,
+                archiveRoot: retainedAudioDirectory
+            )
+            AppLogger.pipeline.info("Retained failed meeting audio files", [
+                "directory": retainedAudio.directory.lastPathComponent,
+                "mic": retainedAudio.micURL?.lastPathComponent ?? "none",
+                "system": retainedAudio.systemURL?.lastPathComponent ?? "none"
+            ])
+        } catch {
+            AppLogger.pipeline.warning("Failed to retain failed meeting audio", [
+                "taskId": taskId.uuidString,
                 "error": error.localizedDescription
             ])
         }

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -32,6 +32,7 @@ extension TranscriptionTaskManager {
         transcriptionResult: TranscriptionResult,
         micURL: URL?,
         systemURL: URL,
+        shouldRemoveTemporaryAudio: Bool = true,
         clips: [SpeakerNamingEntry]
     ) {
         let speakerDB = transcription.speakerDB
@@ -56,8 +57,10 @@ extension TranscriptionTaskManager {
                 transcriptId: transcriptId
             ) else {
                 SpeakerClipExtractor.cleanupClips(clips)
-                Self.removeTemporaryAudioFile(micURL, label: "mic audio")
-                Self.removeTemporaryAudioFile(systemURL, label: "system audio")
+                if shouldRemoveTemporaryAudio {
+                    Self.removeTemporaryAudioFile(micURL, label: "mic audio")
+                    Self.removeTemporaryAudioFile(systemURL, label: "system audio")
+                }
 
                 Task { @MainActor in
                     self?.finishNamingFlow(
@@ -76,8 +79,10 @@ extension TranscriptionTaskManager {
                 speakerDB: speakerDB
             ) else {
                 SpeakerClipExtractor.cleanupClips(clips)
-                Self.removeTemporaryAudioFile(micURL, label: "mic audio")
-                Self.removeTemporaryAudioFile(systemURL, label: "system audio")
+                if shouldRemoveTemporaryAudio {
+                    Self.removeTemporaryAudioFile(micURL, label: "mic audio")
+                    Self.removeTemporaryAudioFile(systemURL, label: "system audio")
+                }
 
                 Task { @MainActor in
                     self?.finishNamingFlow(
@@ -117,8 +122,10 @@ extension TranscriptionTaskManager {
             }
 
             SpeakerClipExtractor.cleanupClips(clips)
-            Self.removeTemporaryAudioFile(micURL, label: "mic audio")
-            Self.removeTemporaryAudioFile(systemURL, label: "system audio")
+            if shouldRemoveTemporaryAudio {
+                Self.removeTemporaryAudioFile(micURL, label: "mic audio")
+                Self.removeTemporaryAudioFile(systemURL, label: "system audio")
+            }
 
             Task { @MainActor in
                 self?.finishNamingFlow(
@@ -135,8 +142,10 @@ extension TranscriptionTaskManager {
     /// Called from applicationWillTerminate to prevent orphaned audio files.
     public func cleanupPendingNaming() {
         if let request = speakerNamingRequest {
-            Self.removeTemporaryAudioFile(request.micAudioURL, label: "pending mic audio")
-            Self.removeTemporaryAudioFile(request.systemAudioURL, label: "pending system audio")
+            if request.shouldRemoveTemporaryAudioOnCleanup {
+                Self.removeTemporaryAudioFile(request.micAudioURL, label: "pending mic audio")
+                Self.removeTemporaryAudioFile(request.systemAudioURL, label: "pending system audio")
+            }
             SpeakerClipExtractor.cleanupClips(request.speakers)
             speakerNamingRequest = nil
             AppLogger.pipeline.info("Cleaned up pending naming on shutdown")

--- a/Sources/TranscriptedCore/Storage/RecordingAudioArchiver.swift
+++ b/Sources/TranscriptedCore/Storage/RecordingAudioArchiver.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+struct RetainedRecordingAudio: Equatable {
+    let directory: URL
+    let micURL: URL?
+    let systemURL: URL?
+}
+
+enum RecordingAudioArchiver {
+    static func archive(
+        micURL: URL?,
+        systemURL: URL?,
+        transcriptURL: URL,
+        archiveRoot: URL,
+        fileManager: FileManager = .default
+    ) throws -> RetainedRecordingAudio {
+        guard micURL != nil || systemURL != nil else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+
+        let directory = archiveRoot.appendingPathComponent(
+            "\(transcriptURL.deletingPathExtension().lastPathComponent)_audio",
+            isDirectory: true
+        )
+        try createPrivateDirectory(at: directory, fileManager: fileManager)
+
+        let archivedMicURL = try micURL.map {
+            try copyAudioFile(
+                from: $0,
+                to: directory.appendingPathComponent("microphone").appendingPathExtension(fileExtension(for: $0)),
+                fileManager: fileManager
+            )
+        }
+
+        let systemStem = micURL == nil ? "recording" : "system_audio"
+        let archivedSystemURL = try systemURL.map {
+            try copyAudioFile(
+                from: $0,
+                to: directory.appendingPathComponent(systemStem).appendingPathExtension(fileExtension(for: $0)),
+                fileManager: fileManager
+            )
+        }
+
+        return RetainedRecordingAudio(
+            directory: directory,
+            micURL: archivedMicURL,
+            systemURL: archivedSystemURL
+        )
+    }
+
+    private static func copyAudioFile(
+        from sourceURL: URL,
+        to destinationURL: URL,
+        fileManager: FileManager
+    ) throws -> URL {
+        let finalURL = uniqueURL(for: destinationURL, fileManager: fileManager)
+        try fileManager.copyItem(at: sourceURL, to: finalURL)
+        fileManager.restrictToOwnerOnly(atPath: finalURL.path)
+        return finalURL
+    }
+
+    private static func createPrivateDirectory(at url: URL, fileManager: FileManager) throws {
+        try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+        try? fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+    }
+
+    private static func fileExtension(for url: URL) -> String {
+        let ext = url.pathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ext.isEmpty ? "wav" : ext
+    }
+
+    private static func uniqueURL(for url: URL, fileManager: FileManager) -> URL {
+        guard fileManager.fileExists(atPath: url.path) else { return url }
+
+        let directory = url.deletingLastPathComponent()
+        let stem = url.deletingPathExtension().lastPathComponent
+        let ext = url.pathExtension
+        var suffix = 2
+
+        while true {
+            let candidate = directory
+                .appendingPathComponent("\(stem)-\(suffix)")
+                .appendingPathExtension(ext)
+            if !fileManager.fileExists(atPath: candidate.path) {
+                return candidate
+            }
+            suffix += 1
+        }
+    }
+}

--- a/Tests/MeetingTranscriptStylerTests.swift
+++ b/Tests/MeetingTranscriptStylerTests.swift
@@ -6,6 +6,7 @@ func testMeetingTranscriptStyler() {
         testMeetingTranscriptStylerDoesNotCreateSiblingArtifacts()
         testMeetingTranscriptStylerIsIdempotent()
         testMeetingTranscriptStylerPreservesExplicitTitle()
+        testMeetingTranscriptStylerRenamesRetainedAudioDirectory()
     }
 }
 
@@ -71,6 +72,28 @@ private func testMeetingTranscriptStylerPreservesExplicitTitle() {
     assertEqual(styled.title, "Customer Interview April", "Styler should respect an explicit imported transcript title")
     assertEqual(styled.url.lastPathComponent, "Customer Interview April.md", "Explicit titles should drive the final transcript filename")
     assertTrue(updatedMarkdown?.contains("# Customer Interview April") == true, "Explicit titles should be written back into the rendered markdown")
+}
+
+private func testMeetingTranscriptStylerRenamesRetainedAudioDirectory() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let originalStem = "Call_2026-04-07_09-14-00"
+    let transcriptURL = directory.appendingPathComponent("\(originalStem).md")
+    let audioRoot = directory.appendingPathComponent("audio", isDirectory: true)
+    let audioDirectory = audioRoot.appendingPathComponent("\(originalStem)_audio", isDirectory: true)
+    let micURL = audioDirectory.appendingPathComponent("microphone.wav")
+    try? FileManager.default.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+    FileManager.default.createFile(atPath: micURL.path, contents: Data("mic".utf8))
+    try? sampleMeetingTranscript().write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+    let styled = MeetingTranscriptStyler.restyleTranscript(at: transcriptURL)
+    let styledAudioDirectory = audioRoot.appendingPathComponent("Meeting with Alex_audio", isDirectory: true)
+
+    assertEqual(styled.url.lastPathComponent, "Meeting with Alex.md", "Styler should still rename the transcript")
+    assertTrue(FileManager.default.fileExists(atPath: styledAudioDirectory.path), "Retained audio directory should follow the transcript rename")
+    assertTrue(FileManager.default.fileExists(atPath: styledAudioDirectory.appendingPathComponent("microphone.wav").path), "Retained audio files should move with the directory")
+    assertFalse(FileManager.default.fileExists(atPath: audioDirectory.path), "Original retained audio directory should be replaced")
 }
 
 private func sampleMeetingTranscript() -> String {

--- a/Tests/TranscriptedCoreTests/RecordingAudioArchiverTests.swift
+++ b/Tests/TranscriptedCoreTests/RecordingAudioArchiverTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import TranscriptedCore
+
+final class RecordingAudioArchiverTests: XCTestCase {
+    private var tempRoot: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RecordingAudioArchiverTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        super.tearDown()
+    }
+
+    func testArchiveCopiesLiveMeetingMicAndSystemAudio() throws {
+        let scratch = tempRoot.appendingPathComponent("scratch", isDirectory: true)
+        let archiveRoot = tempRoot.appendingPathComponent("meetings", isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+
+        let micURL = scratch.appendingPathComponent("meeting_mic.wav")
+        let systemURL = scratch.appendingPathComponent("meeting_system.wav")
+        let transcriptURL = tempRoot.appendingPathComponent("Call_2026-04-20_10-30-00.md")
+        try Data("mic".utf8).write(to: micURL)
+        try Data("system".utf8).write(to: systemURL)
+
+        let retained = try RecordingAudioArchiver.archive(
+            micURL: micURL,
+            systemURL: systemURL,
+            transcriptURL: transcriptURL,
+            archiveRoot: archiveRoot
+        )
+
+        XCTAssertEqual(retained.directory.lastPathComponent, "Call_2026-04-20_10-30-00_audio")
+        XCTAssertEqual(retained.micURL?.lastPathComponent, "microphone.wav")
+        XCTAssertEqual(retained.systemURL?.lastPathComponent, "system_audio.wav")
+        XCTAssertEqual(try Data(contentsOf: retained.micURL!), Data("mic".utf8))
+        XCTAssertEqual(try Data(contentsOf: retained.systemURL!), Data("system".utf8))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))
+    }
+
+    func testArchiveUsesRecordingNameForImportedAudio() throws {
+        let scratch = tempRoot.appendingPathComponent("scratch", isDirectory: true)
+        let archiveRoot = tempRoot.appendingPathComponent("meetings", isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+
+        let audioURL = scratch.appendingPathComponent("interview.m4a")
+        let transcriptURL = tempRoot.appendingPathComponent("Imported Interview.md")
+        try Data("audio".utf8).write(to: audioURL)
+
+        let retained = try RecordingAudioArchiver.archive(
+            micURL: nil,
+            systemURL: audioURL,
+            transcriptURL: transcriptURL,
+            archiveRoot: archiveRoot
+        )
+
+        XCTAssertNil(retained.micURL)
+        XCTAssertEqual(retained.systemURL?.lastPathComponent, "recording.m4a")
+        XCTAssertEqual(try Data(contentsOf: retained.systemURL!), Data("audio".utf8))
+    }
+
+    func testArchiveKeepsMicOnlyFailedMeetingAudio() throws {
+        let scratch = tempRoot.appendingPathComponent("scratch", isDirectory: true)
+        let archiveRoot = tempRoot.appendingPathComponent("meetings", isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+
+        let micURL = scratch.appendingPathComponent("meeting_mic.wav")
+        let transcriptURL = tempRoot.appendingPathComponent("Failed_2026-04-20_10-30-00.md")
+        try Data("mic".utf8).write(to: micURL)
+
+        let retained = try RecordingAudioArchiver.archive(
+            micURL: micURL,
+            systemURL: nil,
+            transcriptURL: transcriptURL,
+            archiveRoot: archiveRoot
+        )
+
+        XCTAssertEqual(retained.micURL?.lastPathComponent, "microphone.wav")
+        XCTAssertNil(retained.systemURL)
+        XCTAssertEqual(try Data(contentsOf: retained.micURL!), Data("mic".utf8))
+    }
+}

--- a/docs/storage-paths.md
+++ b/docs/storage-paths.md
@@ -33,6 +33,7 @@ Meeting captures live under:
 The meetings capture folder contains user-facing artifacts:
 
 - markdown transcripts: `<capture-library>/meetings/*.md`
+- retained recording audio: `<capture-library>/meetings/audio/*_audio/`
 
 App-owned meeting state is stored separately under:
 
@@ -44,6 +45,12 @@ Temporary audio scratch paths live under:
 
 - raw recordings: `~/Library/Application Support/Transcripted/tmp/recordings/`
 - speaker clips: `~/Library/Application Support/Transcripted/tmp/recordings/speaker_clips/`
+
+Successful live and imported meeting recordings are copied from scratch into
+the meeting capture library before scratch cleanup. Failed live meeting
+transcriptions also copy their available recording audio there while keeping
+the scratch files available for retry. Explicitly discarded recordings still
+delete their scratch audio.
 
 These paths are defined on the app side in `Sources/Meeting/MeetingStoragePaths.swift`
 and then injected into `TranscriptedCore` through `CoreStoragePaths`.


### PR DESCRIPTION
## Summary

- Copies saved meeting audio into `<capture-library>/meetings/audio/*_audio/` before scratch cleanup
- Keeps retained audio folders aligned when the meeting transcript is renamed
- Copies available live meeting audio on transcription failure while preserving scratch files for retry
- Documents the new meeting audio storage behavior

Fixes #396.

## Validation

- `bash build-deps.sh --force`
- `swift test`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`