### PR TITLE
[codex] Fix core sendability warnings

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -40,7 +40,10 @@ public enum SystemAudioStatus: Equatable {
 /// Note: This class does NOT use @MainActor because it manages AVAudioEngine
 /// which requires synchronous access from audio tap callbacks on audio threads.
 /// UI updates are dispatched to main thread explicitly.
-public class Audio: ObservableObject {
+/// The mutable audio-capture state is guarded by dedicated queues, locks, and
+/// explicit main-thread dispatch where needed, so Dispatch callbacks can safely
+/// hold weak references to this object.
+public class Audio: ObservableObject, @unchecked Sendable {
     @Published public var isRecording: Bool = false
     @Published public private(set) var isMonitoring: Bool = false  // Lightweight level metering without file recording
     private var isStarting: Bool = false  // Prevents double-start during async setup
@@ -217,7 +220,7 @@ public class Audio: ObservableObject {
     @Published var systemAudioFailed: Bool = false
 
     // System audio capture
-    var systemAudioCapture: (any SystemAudioCaptureEngine)?
+    var systemAudioCapture: (any SystemAudioCaptureEngine & Sendable)?
 
     // Audio file recording
     var systemAudioFile: AVAudioFile?

--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -13,7 +13,7 @@ import ScreenCaptureKit
 /// The public interface matches `SystemAudioCaptureEngine` so `Audio` can swap
 /// between this and the CoreAudio-based `SystemAudioCapture` transparently.
 @available(macOS 26.0, *)
-final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine {
+final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchecked Sendable {
     @Published var errorMessage: String?
 
     private var stream: SCStream?

--- a/Sources/TranscriptedCore/Audio/SystemAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SystemAudioCapture.swift
@@ -17,7 +17,7 @@ import QuartzCore  // CACurrentMediaTime — real-time-safe monotonic clock
 /// - `AudioObjectRemovePropertyListener: no object with given ID` - Cleanup race condition (harmless)
 /// These are internal CoreAudio logs that cannot be suppressed from user code and don't affect functionality.
 @available(macOS 14.2, *)
-class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine {
+class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchecked Sendable {
 
     var errorMessagePublisher: AnyPublisher<String?, Never> {
         $errorMessage.eraseToAnyPublisher()

--- a/Sources/TranscriptedCore/Services/ModelDownloadService.swift
+++ b/Sources/TranscriptedCore/Services/ModelDownloadService.swift
@@ -82,7 +82,7 @@ public enum ModelDownloadService {
     public static func checkNetworkReachability() async -> Bool {
         // Box to safely track whether continuation has been resumed.
         // Both the handler and timeout run on the same serial queue, so no lock needed.
-        class ResumeGuard { var done = false }
+        final class ResumeGuard: @unchecked Sendable { var done = false }
 
         return await withCheckedContinuation { continuation in
             let monitor = NWPathMonitor()


### PR DESCRIPTION
## Summary

- Mark the core `Audio` capture owner as unchecked `Sendable` with a short note about its queue and lock discipline.
- Store the system-audio capture backend as a Sendable existential and mark the current capture implementations as unchecked `Sendable`.
- Mark the reachability continuation guard as unchecked `Sendable` so Swift 6 accepts the serial-queue resume guard pattern.

## Why

Swift 6 warns when non-Sendable reference types are captured by `@Sendable` Dispatch callbacks. These objects already cross audio/background queues intentionally, with synchronization handled by dedicated queues, locks, and main-thread dispatch.

## Validation

- `swift test` — 63/63 passed, no previous sendability warnings observed
- `bash build-deps.sh --force` — passed, dependency core compile no longer emitted the previous sendability warnings
- `bash build.sh` — passed, signed, launch smoke checked
- `bash run-tests.sh` — 519/519 passed
- `bash run-integration-smoke.sh` — passed