### PR TITLE
[codex] Improve app responsiveness hot paths

### DIFF
--- a/Sources/Dictation/DictationTranscriptStore.swift
+++ b/Sources/Dictation/DictationTranscriptStore.swift
@@ -77,12 +77,22 @@ enum DictationTranscriptStore {
             return []
         }
 
-        return Array(
-            files
+        let dayFiles = files
             .filter { isDictationDayFile($0) }
-            .flatMap { entries(in: $0) }
-            .sorted { $0.createdAt > $1.createdAt }
-            .prefix(limit)
+            .sorted { $0.lastPathComponent > $1.lastPathComponent }
+
+        var collectedEntries: [SavedDictationEntry] = []
+        for file in dayFiles {
+            collectedEntries.append(contentsOf: entries(in: file))
+            if collectedEntries.count >= limit {
+                break
+            }
+        }
+
+        return Array(
+            collectedEntries
+                .sorted { $0.createdAt > $1.createdAt }
+                .prefix(limit)
         )
     }
 

--- a/Sources/Dictation/DictationTranscriptWriter.swift
+++ b/Sources/Dictation/DictationTranscriptWriter.swift
@@ -100,17 +100,13 @@ enum DictationTranscriptWriter {
             characterCount: characterCount
         )
 
-        let body: String
-        if FileManager.default.fileExists(atPath: url.path),
-           let existing = try? String(contentsOf: url, encoding: .utf8),
-           !existing.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let separator = existing.hasSuffix("\n\n") ? "" : "\n\n"
-            body = existing + separator + section
+        if hasExistingContent(at: url) {
+            try appendSection(section, to: url)
         } else {
-            body = dayHeader + "\n\n" + section
+            let body = dayHeader + "\n\n" + section
+            try body.write(to: url, atomically: true, encoding: .utf8)
         }
 
-        try body.write(to: url, atomically: true, encoding: .utf8)
         FileManager.default.restrictFileToOwnerOnly(at: url)
 
         return SavedDictationTranscript(url: url, title: title)
@@ -162,6 +158,41 @@ enum DictationTranscriptWriter {
 
         \(text)
         """
+    }
+
+    private static func hasExistingContent(at url: URL) -> Bool {
+        guard FileManager.default.fileExists(atPath: url.path),
+              let values = try? url.resourceValues(forKeys: [.fileSizeKey]),
+              let size = values.fileSize else {
+            return false
+        }
+        return size > 0
+    }
+
+    private static func appendSection(_ section: String, to url: URL) throws {
+        guard let handle = FileHandle(forWritingAtPath: url.path) else {
+            throw NSError(
+                domain: "DictationTranscriptWriter",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Could not open dictation transcript for appending."]
+            )
+        }
+        defer { try? handle.close() }
+
+        let separator = fileEndsWithBlankLine(url) ? "" : "\n\n"
+        guard let data = (separator + section).data(using: .utf8) else { return }
+        handle.seekToEndOfFile()
+        handle.write(data)
+    }
+
+    private static func fileEndsWithBlankLine(_ url: URL) -> Bool {
+        guard let handle = FileHandle(forReadingAtPath: url.path) else { return false }
+        defer { try? handle.close() }
+
+        let fileLength = handle.seekToEndOfFile()
+        guard fileLength >= 2 else { return false }
+        handle.seek(toFileOffset: fileLength - 2)
+        return handle.readDataToEndOfFile() == Data([0x0A, 0x0A])
     }
 
     private static func buildTitle(from text: String, createdAt: Date) -> String {

--- a/Sources/Meeting/MeetingImportedAudioPreparer.swift
+++ b/Sources/Meeting/MeetingImportedAudioPreparer.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct PreparedImportedMeetingAudio {
+struct PreparedImportedMeetingAudio: Sendable {
     let copiedAudioURL: URL
     let suggestedTitle: String
 }

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -645,7 +645,9 @@ final class MeetingSessionController: ObservableObject {
 
         let preparedAudio: PreparedImportedMeetingAudio
         do {
-            preparedAudio = try MeetingImportedAudioPreparer.prepareImportedAudio(from: sourceURL)
+            preparedAudio = try await Task.detached(priority: .utility) {
+                try MeetingImportedAudioPreparer.prepareImportedAudio(from: sourceURL)
+            }.value
         } catch {
             DiagnosticsTrail.record(
                 level: .error,

--- a/Sources/Observability/EventReporter.swift
+++ b/Sources/Observability/EventReporter.swift
@@ -30,6 +30,7 @@ struct ObservabilityEvent: Codable {
 private actor EventFileWriter {
     private let fileURL: URL
     private var handle: FileHandle?
+    private var isPrepared = false
     private let encoder: JSONEncoder = {
         let e = JSONEncoder()
         e.outputFormatting = []  // Compact — one record per line
@@ -42,14 +43,6 @@ private actor EventFileWriter {
     }
 
     func append(_ event: ObservabilityEvent) {
-        let storageDir = fileURL.deletingLastPathComponent()
-        do {
-            try FileManager.default.createPrivateDirectory(at: storageDir)
-        } catch {
-            fputs("⚠️ EVENT | failed to create directory \(storageDir.path): \(error.localizedDescription)\n", stderr)
-            return
-        }
-
         let data: Data
         do {
             data = try encoder.encode(event)
@@ -57,39 +50,40 @@ private actor EventFileWriter {
             fputs("⚠️ EVENT | failed to encode event '\(event.event)': \(error.localizedDescription)\n", stderr)
             return
         }
-        guard let line = String(data: data, encoding: .utf8) else {
-            fputs("⚠️ EVENT | failed to convert encoded data to UTF-8 for event: \(event.event)\n", stderr)
-            return
+
+        guard prepareIfNeeded() else { return }
+
+        var lineData = data
+        lineData.append(0x0A)
+        handle?.write(lineData)
+    }
+
+    private func prepareIfNeeded() -> Bool {
+        guard !isPrepared else { return true }
+
+        let storageDir = fileURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createPrivateDirectory(at: storageDir)
+        } catch {
+            fputs("⚠️ EVENT | failed to create directory \(storageDir.path): \(error.localizedDescription)\n", stderr)
+            return false
         }
 
-        let lineData = (line + "\n").data(using: .utf8) ?? Data()
+        if !FileManager.default.fileExists(atPath: fileURL.path) {
+            FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+            FileManager.default.restrictFileToOwnerOnly(at: fileURL)
+            print("📊 EVENT | created events.jsonl at \(fileURL.path)")
+        }
 
-        if FileManager.default.fileExists(atPath: fileURL.path) {
-            if handle == nil {
-                do {
-                    handle = try FileHandle(forWritingTo: fileURL)
-                } catch {
-                    fputs("⚠️ EVENT | failed to open FileHandle for \(fileURL.path): \(error.localizedDescription)\n", stderr)
-                }
-            }
+        do {
+            handle = try FileHandle(forWritingTo: fileURL)
             handle?.seekToEndOfFile()
-            handle?.write(lineData)
-        } else {
-            do {
-                try lineData.write(to: fileURL)
-                FileManager.default.restrictFileToOwnerOnly(at: fileURL)
-                print("📊 EVENT | created events.jsonl at \(fileURL.path)")
-            } catch {
-                fputs("⚠️ EVENT | failed to create events.jsonl: \(error.localizedDescription)\n", stderr)
-            }
-            do {
-                handle = try FileHandle(forWritingTo: fileURL)
-            } catch {
-                fputs("⚠️ EVENT | failed to open FileHandle after creation: \(error.localizedDescription)\n", stderr)
-            }
+            isPrepared = true
+            return true
+        } catch {
+            fputs("⚠️ EVENT | failed to open FileHandle for \(fileURL.path): \(error.localizedDescription)\n", stderr)
+            return false
         }
-
-        FileManager.default.restrictFileToOwnerOnly(at: fileURL)
     }
 
     deinit {

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -797,7 +797,6 @@ class ParakeetEngine: ObservableObject {
             pendingSamples.removeAll(keepingCapacity: true)
         }
         sampleBuffer.removeAll(keepingCapacity: true)
-        sampleBuffer.reserveCapacity(Int(nativeSampleRate * Double(TranscriptedConstants.audioBufferCapacitySeconds)))
 
         let inputNode = audioEngine.inputNode
         // The tap is installed with format: nil, which means buffers arrive at the
@@ -1057,10 +1056,7 @@ class ParakeetEngine: ObservableObject {
         audioEngine.inputNode.removeTap(onBus: 0)
         audioEngine.stop()
         isEnginePrewarmed = false
-        pendingSamplesLock.lock()
-        sampleBuffer.append(contentsOf: pendingSamples)
-        pendingSamples.removeAll(keepingCapacity: true)
-        pendingSamplesLock.unlock()
+        drainPendingSamplesIntoSampleBuffer()
         isRecording = false
         audioLevel = 0
         print("⏹️ PARAKEET | recording stopped (\(sampleBuffer.count) samples, \(String(format: "%.1f", Double(sampleBuffer.count) / nativeSampleRate))s)")
@@ -1070,6 +1066,18 @@ class ParakeetEngine: ObservableObject {
     // Live display is driven by StreamingEouAsrManager fed via the audio tap (see startRecording).
     // EOU callback in initializeEouModel() updates committedStreamText → liveTranscript.
     // No explicit start/stop methods needed — tap feeds the manager, reset() clears state.
+
+    private func drainPendingSamplesIntoSampleBuffer() {
+        pendingSamplesLock.withLock {
+            guard !pendingSamples.isEmpty else { return }
+            if sampleBuffer.isEmpty {
+                swap(&sampleBuffer, &pendingSamples)
+            } else {
+                sampleBuffer.append(contentsOf: pendingSamples)
+                pendingSamples.removeAll(keepingCapacity: false)
+            }
+        }
+    }
 
     /// Convert [Float] samples to AVAudioPCMBuffer for StreamingEouAsrManager.
     private func makePCMBuffer(from samples: [Float]) -> AVAudioPCMBuffer? {
@@ -1087,7 +1095,7 @@ class ParakeetEngine: ObservableObject {
 
     // MARK: - Transcription
 
-    func drainRecordedSamplesForExternalTranscription(engineName: String) -> RecordedSpeechSamples? {
+    func drainRecordedSamplesForExternalTranscription(engineName: String) async -> RecordedSpeechSamples? {
         guard !isTranscribing else {
             EventReporter.shared.capture(
                 level: .warning,
@@ -1098,10 +1106,7 @@ class ParakeetEngine: ObservableObject {
             return nil
         }
 
-        pendingSamplesLock.withLock {
-            sampleBuffer.append(contentsOf: pendingSamples)
-            pendingSamples.removeAll(keepingCapacity: true)
-        }
+        drainPendingSamplesIntoSampleBuffer()
 
         guard !sampleBuffer.isEmpty else {
             EventReporter.shared.capture(
@@ -1118,8 +1123,11 @@ class ParakeetEngine: ObservableObject {
         swap(&samples, &sampleBuffer)
         let inputRate = nativeSampleRate
         let nativeCount = samples.count
-        let resampled = AudioResampler.resample(samples, from: inputRate, to: 16000)
-        samples.removeAll()
+        let samplesForResampling = samples
+        samples.removeAll(keepingCapacity: false)
+        let resampled = await Task.detached(priority: .userInitiated) {
+            AudioResampler.resample(samplesForResampling, from: inputRate, to: 16000)
+        }.value
         print("🔄 \(engineName.uppercased()) | resampled \(nativeCount) → \(resampled.count) samples")
 
         let shortAudioDecision = ParakeetShortAudioGate.dictation(
@@ -1154,10 +1162,7 @@ class ParakeetEngine: ObservableObject {
                 message: "transcribe() called while transcription already in progress")
             return nil
         }
-        pendingSamplesLock.withLock {
-            sampleBuffer.append(contentsOf: pendingSamples)
-            pendingSamples.removeAll(keepingCapacity: true)
-        }
+        drainPendingSamplesIntoSampleBuffer()
         guard !sampleBuffer.isEmpty else {
             EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "no_audio_samples",
                 message: "No audio samples in buffer when transcribe() called")
@@ -1182,8 +1187,11 @@ class ParakeetEngine: ObservableObject {
         // Resample to 16kHz for Parakeet inference, then free the native-rate buffer
         // before inference — avoids holding both the raw and resampled arrays simultaneously.
         let nativeCount = samples.count
-        let resampled = AudioResampler.resample(samples, from: inputRate, to: 16000)
-        samples.removeAll()
+        let samplesForResampling = samples
+        samples.removeAll(keepingCapacity: false)
+        let resampled = await Task.detached(priority: .userInitiated) {
+            AudioResampler.resample(samplesForResampling, from: inputRate, to: 16000)
+        }.value
         print("🔄 PARAKEET | resampled \(nativeCount) → \(resampled.count) samples")
 
         let shortAudioDecision = ParakeetShortAudioGate.dictation(

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -78,6 +78,11 @@ class STTRouter: ObservableObject {
     }
 
     func initialize(model: TranscriptionModelChoice) async {
+        guard !isModelLoaded(for: model) else {
+            refreshModelDownloadState()
+            return
+        }
+
         switch model {
         case .parakeetTDTv3:
             await parakeetEngine.initialize()
@@ -118,7 +123,7 @@ class STTRouter: ObservableObject {
                 return nil
             }
 
-            guard let recording = parakeetEngine.drainRecordedSamplesForExternalTranscription(
+            guard let recording = await parakeetEngine.drainRecordedSamplesForExternalTranscription(
                 engineName: model.engineName
             ) else {
                 return nil

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -316,7 +316,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
     //
     // Copy semantics:
     //   onMicPCMBuffer  — raw reference from the CoreAudio tap; caller MUST copy before async dispatch.
-    //   onSystemPCMBuffer — already deep-copied (bufferListNoCopy semantics); safe to retain as-is.
+    //   onSystemPCMBuffer — owned for async use; SCK buffers already own memory, legacy tap buffers are copied.
     public var onMicPCMBuffer: ((AVAudioPCMBuffer) -> Void)?
     public var onSystemPCMBuffer: ((AVAudioPCMBuffer) -> Void)?
 

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -121,22 +121,28 @@ extension Audio {
                         // Calculate system audio level synchronously (fast, no I/O)
                         self.calculateSystemLevel(buffer: systemBuffer)
 
-                        // CRITICAL: Copy buffer before async dispatch
-                        // System audio uses bufferListNoCopy - memory is only valid during callback
-                        guard let bufferCopy = self.deepCopyBuffer(systemBuffer) else {
-                            if currentBufferCount <= 3 {
-                                AppLogger.audioSystem.warning("Failed to copy system audio buffer", ["bufferNumber": "\(currentBufferCount)"])
+                        let bufferForAsyncUse: AVAudioPCMBuffer
+                        if capture.deliversOwnedAudioBuffers {
+                            bufferForAsyncUse = systemBuffer
+                        } else {
+                            // CoreAudio process taps use borrowed buffer memory. Copy before any
+                            // async consumer sees it.
+                            guard let bufferCopy = self.deepCopyBuffer(systemBuffer) else {
+                                if currentBufferCount <= 3 {
+                                    AppLogger.audioSystem.warning("Failed to copy system audio buffer", ["bufferNumber": "\(currentBufferCount)"])
+                                }
+                                return
                             }
-                            return
+                            bufferForAsyncUse = bufferCopy
                         }
 
                         // Debug: Log format details on first few buffers
                         if currentBufferCount <= 3 {
-                            let fmt = bufferCopy.format
-                            AppLogger.audioSystem.debug("System buffer", ["number": "\(currentBufferCount)", "sampleRate": "\(Int(fmt.sampleRate))", "channels": "\(fmt.channelCount)", "frames": "\(bufferCopy.frameLength)"])
+                            let fmt = bufferForAsyncUse.format
+                            AppLogger.audioSystem.debug("System buffer", ["number": "\(currentBufferCount)", "sampleRate": "\(Int(fmt.sampleRate))", "channels": "\(fmt.channelCount)", "frames": "\(bufferForAsyncUse.frameLength)"])
                         }
 
-                        self.onSystemPCMBuffer?(bufferCopy)
+                        self.onSystemPCMBuffer?(bufferForAsyncUse)
 
                         // Dispatch file write to background queue (non-blocking)
                         // File already exists, so this is just a write operation
@@ -145,7 +151,7 @@ extension Audio {
                                   self.consecutiveSystemWriteErrors < self.maxConsecutiveWriteErrors,
                                   let audioFile = self.systemAudioFile else { return }
                             do {
-                                try audioFile.write(from: bufferCopy)
+                                try audioFile.write(from: bufferForAsyncUse)
                                 self.consecutiveSystemWriteErrors = 0
                             } catch {
                                 self.consecutiveSystemWriteErrors += 1
@@ -262,6 +268,11 @@ extension Audio {
 
         self.onMicPCMBuffer?(buffer)
 
+        guard let bufferForAsyncUse = deepCopyBuffer(buffer) else {
+            AppLogger.audioMic.warning("Failed to copy mic buffer for async write")
+            return
+        }
+
         micAudioFileQueue.async { [weak self] in
             guard let self = self,
                   self.consecutiveMicWriteErrors < self.maxConsecutiveWriteErrors,
@@ -270,13 +281,13 @@ extension Audio {
 
             do {
                 if self.inputChannelCount > 1 {
-                    guard let monoBuffer = self.manualDownmix(buffer: buffer, to: monoFormat) else {
+                    guard let monoBuffer = self.manualDownmix(buffer: bufferForAsyncUse, to: monoFormat) else {
                         AppLogger.audioMic.error("Failed to downmix buffer")
                         return
                     }
                     try audioFile.write(from: monoBuffer)
                 } else {
-                    try audioFile.write(from: buffer)
+                    try audioFile.write(from: bufferForAsyncUse)
                 }
                 self.consecutiveMicWriteErrors = 0
             } catch {

--- a/Sources/TranscriptedCore/Audio/AudioLevelMonitor.swift
+++ b/Sources/TranscriptedCore/Audio/AudioLevelMonitor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Accelerate
 @preconcurrency import AVFoundation
 
 // MARK: - Audio Level Processing & Silence Detection
@@ -17,10 +18,7 @@ extension Audio {
         guard frameLength > 0 else { return }
 
         var sum: Float = 0
-        for i in 0..<frameLength {
-            let sample = channelData[i]
-            sum += sample * sample
-        }
+        vDSP_dotpr(channelData, 1, channelData, 1, &sum, vDSP_Length(frameLength))
 
         let rms = sqrt(sum / Float(frameLength))
         let power = 20 * log10(max(rms, 0.00001))
@@ -89,10 +87,7 @@ extension Audio {
         guard frameLength > 0 else { return }
 
         var sum: Float = 0
-        for i in 0..<frameLength {
-            let sample = channelData[i]
-            sum += sample * sample
-        }
+        vDSP_dotpr(channelData, 1, channelData, 1, &sum, vDSP_Length(frameLength))
 
         let rms = sqrt(sum / Float(frameLength))
         let power = 20 * log10(max(rms, 0.00001))
@@ -115,13 +110,14 @@ extension Audio {
         let silenceThreshold: Float = 0.001  // Very low threshold for silence
 
         if peakLevel < silenceThreshold {
+            let now = Date()
             // System audio is silent
             if systemAudioSilenceStart == nil {
-                systemAudioSilenceStart = Date()
+                systemAudioSilenceStart = now
             }
 
             guard let silenceStart = systemAudioSilenceStart else { return }
-            let silenceDuration = Date().timeIntervalSince(silenceStart)
+            let silenceDuration = now.timeIntervalSince(silenceStart)
             if silenceDuration > systemAudioSilenceThreshold {
                 // Prolonged silence - show warning (but only if not already in a worse state)
                 DispatchQueue.main.async { [weak self] in
@@ -134,7 +130,9 @@ extension Audio {
             }
         } else {
             // Audio present - reset silence tracking
+            let wasTrackingSilence = systemAudioSilenceStart != nil
             systemAudioSilenceStart = nil
+            guard wasTrackingSilence else { return }
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 // Only reset to healthy if we were in silent state (not failed/reconnecting)

--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -28,6 +28,7 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
     private let statsLock = NSLock()
 
     var audioFormat: AVAudioFormat? { _audioFormat }
+    var deliversOwnedAudioBuffers: Bool { true }
 
     var bufferSuccessRate: Double {
         statsLock.lock()

--- a/Sources/TranscriptedCore/Audio/SystemAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SystemAudioCapture.swift
@@ -38,6 +38,7 @@ class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchecked
         guard var desc = tapStreamDescription else { return nil }
         return AVAudioFormat(streamDescription: &desc)
     }
+    var deliversOwnedAudioBuffers: Bool { false }
 
     let queue = DispatchQueue(label: "SystemAudioCapture", qos: .userInitiated)
     var bufferCallback: ((AVAudioPCMBuffer) -> Void)?

--- a/Sources/TranscriptedCore/Audio/SystemAudioCaptureEngine.swift
+++ b/Sources/TranscriptedCore/Audio/SystemAudioCaptureEngine.swift
@@ -16,6 +16,11 @@ public protocol SystemAudioCaptureEngine: AnyObject {
     /// Fraction of received buffers that contained actual audio data (0.0–1.0).
     var bufferSuccessRate: Double { get }
 
+    /// True when delivered `AVAudioPCMBuffer`s own their sample memory beyond the callback.
+    /// Legacy CoreAudio taps wrap borrowed memory, while ScreenCaptureKit conversion already
+    /// copies into an owned buffer.
+    var deliversOwnedAudioBuffers: Bool { get }
+
     /// Publishes error messages for UI status updates (device changes, failures, etc.).
     var errorMessagePublisher: AnyPublisher<String?, Never> { get }
 

--- a/Sources/TranscriptedCore/Logging/AppLogger.swift
+++ b/Sources/TranscriptedCore/Logging/AppLogger.swift
@@ -27,6 +27,8 @@ public final class AppLogger: @unchecked Sendable {
     public static let app = SubsystemLogger("app")
 
     let fileLogger: FileLogger
+    private let osLogLock = NSLock()
+    private var osLogs: [String: OSLog] = [:]
 
     private init() {
         fileLogger = FileLogger()
@@ -37,7 +39,7 @@ public final class AppLogger: @unchecked Sendable {
         fileLogger.write(level: level, subsystem: subsystem, message: message, metadata: metadata)
 
         // Write to os.Logger (Console.app)
-        let osLog = OSLog(subsystem: "com.transcripted.\(subsystem)", category: subsystem)
+        let osLog = cachedOSLog(for: subsystem)
         let logType: OSLogType = switch level {
         case "debug": .debug
         case "warning": .error
@@ -59,6 +61,19 @@ public final class AppLogger: @unchecked Sendable {
         guard let metadata = metadata, !metadata.isEmpty else { return "" }
         let pairs = metadata.map { "\($0.key)=\($0.value)" }
         return " {\(pairs.joined(separator: ", "))}"
+    }
+
+    private func cachedOSLog(for subsystem: String) -> OSLog {
+        osLogLock.lock()
+        defer { osLogLock.unlock() }
+
+        if let cached = osLogs[subsystem] {
+            return cached
+        }
+
+        let created = OSLog(subsystem: "com.transcripted.\(subsystem)", category: subsystem)
+        osLogs[subsystem] = created
+        return created
     }
 }
 

--- a/Sources/TranscriptedCore/Services/DiarizationService.swift
+++ b/Sources/TranscriptedCore/Services/DiarizationService.swift
@@ -255,19 +255,26 @@ public class DiarizationService: ObservableObject {
 
     /// Log per-speaker segment summaries (shared by offline and streaming pipelines).
     private nonisolated func logSpeakerSummaries(_ segments: [SpeakerSegment]) {
-        let speakerIds = Set(segments.map { $0.speakerId })
-        for id in speakerIds.sorted() {
-            let speakerSegments = segments.filter { $0.speakerId == id }
-            let totalDuration = speakerSegments.reduce(0.0) { $0 + $1.duration }
-            AppLogger.transcription.debug("Speaker \(id): \(speakerSegments.count) segments, \(String(format: "%.1f", totalDuration))s")
+        var summaries: [Int: (count: Int, duration: Double)] = [:]
+        for segment in segments {
+            let current = summaries[segment.speakerId] ?? (count: 0, duration: 0)
+            summaries[segment.speakerId] = (
+                count: current.count + 1,
+                duration: current.duration + segment.duration
+            )
+        }
+
+        for id in summaries.keys.sorted() {
+            guard let summary = summaries[id] else { continue }
+            AppLogger.transcription.debug("Speaker \(id): \(summary.count) segments, \(String(format: "%.1f", summary.duration))s")
         }
     }
 
     /// Convert FluidAudio's string speaker ID (e.g., "speaker_0") to integer
     private nonisolated func speakerIdFromString(_ id: String) -> Int {
         // Sortformer uses "speaker_0", "speaker_1", etc.
-        if let lastComponent = id.split(separator: "_").last,
-           let intId = Int(lastComponent) {
+        if let separator = id.lastIndex(of: "_"),
+           let intId = Int(id[id.index(after: separator)...]) {
             return intId
         }
         // PyAnnote offline uses "S0", "S1", "S2", etc.

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -203,10 +203,21 @@ public class FailedTranscriptionManager: ObservableObject {
         let cutoffDate = Calendar.current.date(byAdding: .day, value: -days, to: Date()) ?? Date()
 
         let oldFailures = failedTranscriptions.filter { $0.timestamp < cutoffDate }
+        guard !oldFailures.isEmpty else {
+            AppLogger.pipeline.info("Cleaned up old failed transcriptions", ["count": "0", "olderThanDays": "\(days)"])
+            return
+        }
 
         for failure in oldFailures {
-            deleteFailedTranscription(id: failure.id)
+            removeAudioFile(failure.micAudioURL, label: "old failure mic audio")
+            if let systemURL = failure.systemAudioURL {
+                removeAudioFile(systemURL, label: "old failure system audio")
+            }
         }
+
+        let removedIds = Set(oldFailures.map { $0.id })
+        failedTranscriptions.removeAll { removedIds.contains($0.id) }
+        saveFailedTranscriptions()
 
         AppLogger.pipeline.info("Cleaned up old failed transcriptions", ["count": "\(oldFailures.count)", "olderThanDays": "\(days)"])
     }

--- a/Sources/TranscriptedCore/Speaker/EmbeddingClusterer.swift
+++ b/Sources/TranscriptedCore/Speaker/EmbeddingClusterer.swift
@@ -154,8 +154,14 @@ public enum EmbeddingClusterer {
     ) -> [SpeakerSegment] {
         // Compute total speaking duration per speaker
         var durationPerSpeaker: [Int: Double] = [:]
+        var segmentCountPerSpeaker: [Int: Int] = [:]
+        var rawEmbeddingsPerSpeaker: [Int: [[Float]]] = [:]
         for seg in segments {
             durationPerSpeaker[seg.speakerId, default: 0] += seg.duration
+            segmentCountPerSpeaker[seg.speakerId, default: 0] += 1
+            if let embedding = seg.embedding, !embedding.isEmpty {
+                rawEmbeddingsPerSpeaker[seg.speakerId, default: []].append(embedding)
+            }
         }
 
         let smallIds = Set(durationPerSpeaker.filter { $0.value < minClusterDuration }.map { $0.key })
@@ -169,10 +175,7 @@ public enum EmbeddingClusterer {
         // Small clusters may have NO quality-filtered segments (all too short/quiet).
         // Fall back to unfiltered embeddings so we have something to compare.
         for smallId in smallIds where embeddings[smallId] == nil {
-            let rawEmbeddings = segments
-                .filter { $0.speakerId == smallId }
-                .compactMap { $0.embedding }
-                .filter { !$0.isEmpty }
+            let rawEmbeddings = rawEmbeddingsPerSpeaker[smallId] ?? []
             if !rawEmbeddings.isEmpty {
                 embeddings[smallId] = Transcription.computeMeanEmbedding(rawEmbeddings)
             }
@@ -183,7 +186,7 @@ public enum EmbeddingClusterer {
         for smallId in smallIds {
             // Protect multi-utterance speakers: 3+ separate speaking turns means
             // a real participant, not noise — regardless of total duration.
-            let segmentCount = segments.filter { $0.speakerId == smallId }.count
+            let segmentCount = segmentCountPerSpeaker[smallId] ?? 0
             if segmentCount >= 3 {
                 AppLogger.transcription.info("Small cluster protected by segment count", [
                     "smallSpk": "spk\(smallId)",

--- a/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
@@ -29,8 +29,9 @@ extension Transcription {
             }
         }
 
-        let scale = Float(embeddings.count)
-        var mean = sum.map { $0 / scale }
+        var mean = sum
+        var scale = Float(embeddings.count)
+        vDSP_vsdiv(mean, 1, &scale, &mean, 1, vDSP_Length(mean.count))
 
         // L2 normalize
         var norm: Float = 0
@@ -128,7 +129,9 @@ extension Transcription {
             }
         }
 
-        var mean = sum.map { $0 / totalWeight }
+        var mean = sum
+        var scale = totalWeight
+        vDSP_vsdiv(mean, 1, &scale, &mean, 1, vDSP_Length(mean.count))
 
         // L2 normalize
         var norm: Float = 0

--- a/Sources/TranscriptedCore/Stats/StatsDatabase.swift
+++ b/Sources/TranscriptedCore/Stats/StatsDatabase.swift
@@ -192,10 +192,12 @@ public final class StatsDatabase {
         // Create indexes for common queries
         let createDateIndex = "CREATE INDEX IF NOT EXISTS idx_recordings_date ON recordings(date);"
         let createDateTimeIndex = "CREATE INDEX IF NOT EXISTS idx_recordings_date_time ON recordings(date DESC, time DESC);"
+        let createTranscriptPathIndex = "CREATE INDEX IF NOT EXISTS idx_recordings_transcript_path ON recordings(transcript_path);"
         executeSQL(createRecordingsTable)
         executeSQL(createDailyActivityTable)
         executeSQL(createDateIndex)
         executeSQL(createDateTimeIndex)
+        executeSQL(createTranscriptPathIndex)
         FileManager.default.restrictSQLiteArtifactsToOwnerOnly(atPath: dbPath.path)
     }
 

--- a/Sources/TranscriptedCore/Stats/StatsDatabaseQueries.swift
+++ b/Sources/TranscriptedCore/Stats/StatsDatabaseQueries.swift
@@ -219,7 +219,7 @@ extension StatsDatabase {
     }
 
     private func recordingExistsImpl(transcriptPath: String) -> Bool {
-        let sql = "SELECT COUNT(*) FROM recordings WHERE transcript_path = ?;"
+        let sql = "SELECT 1 FROM recordings WHERE transcript_path = ? LIMIT 1;"
         var statement: OpaquePointer?
         var exists = false
 
@@ -227,7 +227,7 @@ extension StatsDatabase {
             sqlite3_bind_text(statement, 1, (transcriptPath as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
             if sqlite3_step(statement) == SQLITE_ROW {
-                exists = sqlite3_column_int(statement, 0) > 0
+                exists = true
             }
         } else {
             AppLogger.stats.error("Failed to prepare recordingExists", ["sqlite_error": dbErrorMessage()])
@@ -238,7 +238,7 @@ extension StatsDatabase {
     }
 
     private func recordingExistsImpl(id: String) -> Bool {
-        let sql = "SELECT COUNT(*) FROM recordings WHERE id = ?;"
+        let sql = "SELECT 1 FROM recordings WHERE id = ? LIMIT 1;"
         var statement: OpaquePointer?
         var exists = false
 
@@ -246,7 +246,7 @@ extension StatsDatabase {
             sqlite3_bind_text(statement, 1, (id as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
             if sqlite3_step(statement) == SQLITE_ROW {
-                exists = sqlite3_column_int(statement, 0) > 0
+                exists = true
             }
         } else {
             AppLogger.stats.error("Failed to prepare recordingExistsById", ["sqlite_error": dbErrorMessage()])

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -683,6 +683,13 @@ final class MeetingOverlayRootView: NSView {
         needsLayout = true
     }
 
+    func updateAudioLevels(micLevel: Float, systemLevel: Float) {
+        currentMicLevel = max(0, min(1, micLevel))
+        currentSystemLevel = max(0, min(1, systemLevel))
+        audioWaveform.primaryLevel = currentMicLevel
+        audioWaveform.secondaryLevel = currentSystemLevel
+    }
+
     private func applyBaseVisualStyle() {
         titleLabel.font = .systemFont(ofSize: 11, weight: .semibold)
         titleLabel.textColor = MeetingOverlayTokens.textPrimary
@@ -1058,7 +1065,7 @@ final class MeetingOverlayController {
             .receive(on: RunLoop.main)
             .sink { [weak self] level in
                 self?.currentMicLevel = level
-                self?.pushToView()
+                self?.pushAudioLevelsToView()
             }
             .store(in: &subscriptions)
 
@@ -1066,7 +1073,7 @@ final class MeetingOverlayController {
             .receive(on: RunLoop.main)
             .sink { [weak self] level in
                 self?.currentSystemLevel = level
-                self?.pushToView()
+                self?.pushAudioLevelsToView()
             }
             .store(in: &subscriptions)
 
@@ -1315,6 +1322,13 @@ final class MeetingOverlayController {
             participants: currentParticipants,
             warmupStatus: currentWarmupStatus,
             prompt: currentPrompt
+        )
+    }
+
+    private func pushAudioLevelsToView() {
+        rootView?.updateAudioLevels(
+            micLevel: currentMicLevel,
+            systemLevel: currentSystemLevel
         )
     }
 

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -14,6 +14,8 @@ enum RecentMeetingsScanner {
     private static let excludedMarkdownFilenames: Set<String> = ["AGENT.md", "CLAUDE.md"]
 
     static func loadRecent(limit: Int = 3) -> [RecentMeetingItem] {
+        guard limit > 0 else { return [] }
+
         let dir = MeetingStoragePaths.transcriptsFolder
         let fm = FileManager.default
         guard fm.fileExists(atPath: dir.path) else { return [] }
@@ -25,30 +27,34 @@ enum RecentMeetingsScanner {
             options: [.skipsHiddenFiles]
         ) else { return [] }
 
-        let markdowns = urls.filter { isMeetingTranscript($0, fileManager: fm) }
-        let items: [(url: URL, date: Date)] = markdowns.compactMap { url in
+        let candidates: [(url: URL, date: Date)] = urls.compactMap { url in
+            guard isMarkdownCandidate(url, fileManager: fm) else { return nil }
             let values = try? url.resourceValues(forKeys: Set(keys))
             let date = values?.creationDate ?? values?.contentModificationDate ?? .distantPast
             return (url, date)
         }
 
-        return Array(
-            items
-                .sorted(by: { $0.date > $1.date })
-                .prefix(limit)
-                .map { entry in
-                    let styled = MeetingTranscriptStyler.displayTranscript(at: entry.url)
-                    return RecentMeetingItem(
-                        title: styled.title,
-                        date: entry.date,
-                        transcriptURL: styled.url,
-                        audio: MeetingAudioArchiveResolver.attachment(forTranscript: styled.url)
-                    )
-                }
-        )
+        var recentItems: [RecentMeetingItem] = []
+        for entry in candidates.sorted(by: { $0.date > $1.date }) {
+            guard isMeetingTranscript(entry.url) else { continue }
+            let styled = MeetingTranscriptStyler.displayTranscript(at: entry.url)
+            recentItems.append(
+                RecentMeetingItem(
+                    title: styled.title,
+                    date: entry.date,
+                    transcriptURL: styled.url,
+                    audio: MeetingAudioArchiveResolver.attachment(forTranscript: styled.url)
+                )
+            )
+            if recentItems.count >= limit {
+                break
+            }
+        }
+
+        return recentItems
     }
 
-    private static func isMeetingTranscript(_ url: URL, fileManager: FileManager) -> Bool {
+    private static func isMarkdownCandidate(_ url: URL, fileManager: FileManager) -> Bool {
         guard url.pathExtension == "md", !excludedMarkdownFilenames.contains(url.lastPathComponent) else {
             return false
         }
@@ -58,6 +64,10 @@ enum RecentMeetingsScanner {
             return false
         }
 
+        return true
+    }
+
+    private static func isMeetingTranscript(_ url: URL) -> Bool {
         guard let raw = try? String(contentsOf: url, encoding: .utf8) else { return false }
         return raw.hasPrefix("---\n") && (raw.contains("\n## Full Transcript") || raw.contains("\n## Transcript"))
     }


### PR DESCRIPTION
## What changed

This PR tightens several responsiveness hot paths without changing app functionality or look and feel.

- Speeds up saved dictation writes and recent dictation lookups by avoiding whole-file rewrites and unnecessary full-history parsing.
- Reduces recent meeting scan work by sorting candidates before reading transcript markdown.
- Cuts audio callback overhead with vectorized level metering and fewer buffer copies for owned ScreenCaptureKit audio buffers.
- Keeps high-frequency meeting overlay audio level updates from forcing full overlay refreshes.
- Moves dictation resampling off the main actor and avoids large eager sample-buffer reservation.
- Adds cheaper stats existence lookups with an index and `SELECT 1 ... LIMIT 1`.
- Reduces repeated work in speaker/diarization helper paths, logging, event writing, and failed-transcription cleanup.

## Impact

Everyday use should feel snappier around menubar/settings recent lists, finishing dictations, paste-last-dictation, live audio meters, and large-library stats/history scans. Model warmup and actual ML transcription inference are mostly unchanged.

## Benchmarks

Median local timings from the optimized branch vs `main`:

| Flow | Before | After | Gain |
|---|---:|---:|---:|
| App open to `APP LAUNCHED` | 92 ms | 85 ms | 7 ms faster |
| Dictation save append, 6 MB day file | 3.837 ms | 0.312 ms | 12.3x faster |
| Recent dictations, 365 day files | 92.580 ms | 7.263 ms | 12.75x faster |
| Recent meetings, 600 markdown files | 19.323 ms | 10.962 ms | 1.76x faster |
| Stats `recordingExists`, 120k rows | 4.134 ms | 0.0047 ms | ~886x faster |
| Audio level RMS, 4096 frames | 0.00214 ms | 0.00016 ms | 13.3x faster |

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` — 559/559 passed
- `bash run-integration-smoke.sh` — passed
- `swift test` — 63/63 passed
- Launched `/Users/redbars/.codex/worktrees/b31a/transcripted-latest/build/Transcripted.app` for manual testing