### PR TITLE
[codex] Harden audio start recovery

### DIFF
--- a/Sources/Meeting/FailedMeetingPresentation.swift
+++ b/Sources/Meeting/FailedMeetingPresentation.swift
@@ -6,6 +6,7 @@ enum FailedMeetingPresentation {
         from failed: FailedTranscription,
         isRetrying: Bool
     ) -> MeetingSessionController.FailedMeetingItem {
+        let failureKind = MeetingFailureKind.classify(message: failed.errorMessage)
         let copy = MeetingFailureCopy.make(
             forMessage: failed.errorMessage,
             shortErrorMessage: failed.shortErrorMessage,
@@ -18,6 +19,7 @@ enum FailedMeetingPresentation {
             title: copy.title,
             detail: copy.detail,
             meta: meta(for: failed, isRetrying: isRetrying),
+            failureKind: failureKind,
             isRetryable: failed.isRetryable,
             isRetrying: isRetrying,
             hasAudioFiles: failed.audioFilesExist()

--- a/Sources/Meeting/MeetingFailureCopy.swift
+++ b/Sources/Meeting/MeetingFailureCopy.swift
@@ -20,12 +20,10 @@ struct MeetingFailureCopy: Equatable {
             )
         }
 
-        if message.contains("recording too short")
-            || message.contains("at least")
-            || message.contains("invalid audio data") {
+        if MeetingFailureKind.isRecordingTooShortMessage(message) {
             return MeetingFailureCopy(
-                title: "Recording was too short",
-                detail: "Transcripted needs at least a second of audio. Keep the meeting running a little longer, then retry."
+                title: "Recording ended too soon",
+                detail: "Nothing broke - there just was not enough audio to transcribe. Record at least two seconds before stopping."
             )
         }
 

--- a/Sources/Meeting/MeetingFailureKind.swift
+++ b/Sources/Meeting/MeetingFailureKind.swift
@@ -16,6 +16,19 @@ enum MeetingFailureKind: String {
     case pipelineBusy = "pipeline_busy"
     case unexpectedError = "unexpected_error"
 
+    static func isRecordingTooShortMessage(_ message: String) -> Bool {
+        let normalized = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let mentionsAudioMinimum = (
+            normalized.contains("at least 1 second")
+                || normalized.contains("at least 2 seconds")
+                || normalized.contains("at least one second")
+                || normalized.contains("at least two seconds")
+        ) && (normalized.contains("audio") || normalized.contains("recording"))
+
+        return normalized.contains("recording too short")
+            || mentionsAudioMinimum
+    }
+
     static func classify(message: String) -> MeetingFailureKind {
         let normalized = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 
@@ -41,15 +54,13 @@ enum MeetingFailureKind: String {
             return .audioDeviceUnavailable
         }
 
-        if normalized.contains("invalid audio format") {
-            return .invalidAudioFormat
+        if isRecordingTooShortMessage(normalized) {
+            return .recordingTooShort
         }
 
-        if normalized.contains("recording too short")
-            || normalized.contains("invalid audio data")
-            || normalized.contains("at least 1 second")
-            || normalized.contains("at least 2 seconds") {
-            return .recordingTooShort
+        if normalized.contains("invalid audio format")
+            || normalized.contains("invalid audio data") {
+            return .invalidAudioFormat
         }
 
         if normalized.contains("empty audio file")

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -59,6 +59,7 @@ final class MeetingSessionController: ObservableObject {
         let title: String
         let detail: String
         let meta: String
+        let failureKind: MeetingFailureKind
         let isRetryable: Bool
         let isRetrying: Bool
         let hasAudioFiles: Bool
@@ -1110,6 +1111,7 @@ final class MeetingSessionController: ObservableObject {
                     "trigger": transcriptionTrigger.rawValue,
                 ]
             )
+            finalizeBackgroundTranscriptionStateIfNeeded()
         case .gettingReady:
             if previousStatus.diagnosticName != status.diagnosticName {
                 DiagnosticsTrail.record(

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -160,6 +160,7 @@ class ParakeetEngine: ObservableObject {
     @Published var inputFormatReady = true
 
     private let audioEngine = AVAudioEngine()
+    private var inputTapInstalled = false
     private var sampleBuffer: [Float] = []
     private var nativeSampleRate: Double = 48000
     private let pendingSamplesLock = NSLock()
@@ -207,6 +208,7 @@ class ParakeetEngine: ObservableObject {
     private var asrManagerReady = false
     private nonisolated(unsafe) var didReceiveAudioSamples = false
     private var cachedInputDeviceName = "Unknown"
+    private var lastAudioStartFailureReportAt: TimeInterval?
 
     var isModelLoaded: Bool { asrManagerReady }
     var inputDeviceName: String { cachedInputDeviceName }
@@ -623,7 +625,7 @@ class ParakeetEngine: ObservableObject {
             }
             streamingSamplesLock.withLock { streamingSampleBuffer.removeAll(keepingCapacity: true) }
             Task { await eouManager?.reset() }
-            audioEngine.inputNode.removeTap(onBus: 0)
+            removeRecordingTap()
             isRecording = false
             audioLevel = 0
         }
@@ -739,11 +741,31 @@ class ParakeetEngine: ObservableObject {
         publishRecoveryState()
     }
 
+    private func markStartFailedAndPublish() {
+        recoveryState.markStartFailed()
+        publishRecoveryState()
+    }
+
     private func markFormatReadyAndPublish() {
         if !recoveryState.inputFormatReady {
             recoveryState.markFormatReady()
             publishRecoveryState()
         }
+    }
+
+    private func removeRecordingTap(force: Bool = false) {
+        guard force || inputTapInstalled else { return }
+        audioEngine.inputNode.removeTap(onBus: 0)
+        inputTapInstalled = false
+    }
+
+    private func resetAudioGraphAfterStartFailure() {
+        removeRecordingTap()
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+        audioEngine.reset()
+        isEnginePrewarmed = false
     }
 
     private func handleSystemWake() {
@@ -762,7 +784,7 @@ class ParakeetEngine: ObservableObject {
             streamingSampleBuffer.removeAll(keepingCapacity: true)
             streamingSamplesLock.unlock()
             Task { await eouManager?.reset() }
-            audioEngine.inputNode.removeTap(onBus: 0)
+            removeRecordingTap()
             isRecording = false
             audioLevel = 0
         }
@@ -779,6 +801,64 @@ class ParakeetEngine: ObservableObject {
 
     // MARK: - Recording
 
+    private func audioStartContext(
+        attempt: Int,
+        isRecoveryAttempt: Bool,
+        engineWasRunning: Bool,
+        outputFormat: AVAudioFormat,
+        hwFormat: AVAudioFormat,
+        error: Error? = nil
+    ) -> [String: String] {
+        var context = [
+            "attempt": "\(attempt)",
+            "start_mode": isRecoveryAttempt ? "recovery" : "normal",
+            "recovering": "\(recoveryState.isRecovering)",
+            "format_ready": "\(recoveryState.inputFormatReady)",
+            "generation": "\(recoveryState.generation)",
+            "prewarmed": "\(isEnginePrewarmed)",
+            "engine_running_before_start": "\(engineWasRunning)",
+            "tap_installed": "\(inputTapInstalled)",
+            "output_rate_hz": String(format: "%.0f", outputFormat.sampleRate),
+            "output_channels": "\(outputFormat.channelCount)",
+            "input_rate_hz": String(format: "%.0f", hwFormat.sampleRate),
+            "hw_channels": "\(hwFormat.channelCount)",
+        ]
+
+        if let error {
+            let nsError = error as NSError
+            context["status_domain"] = nsError.domain
+            context["status_code"] = "\(nsError.code)"
+        }
+
+        return context
+    }
+
+    private func reportAudioStartFailureIfNeeded(message: String, context: [String: String]) {
+        let now = CFAbsoluteTimeGetCurrent()
+        guard ParakeetAudioStartRecoveryPolicy.shouldReportFailure(
+            now: now,
+            lastReportAt: lastAudioStartFailureReportAt
+        ) else {
+            EventReporter.shared.capture(
+                level: .warning,
+                engine: "parakeet",
+                event: "audio_engine_start_failed",
+                message: message,
+                context: context.merging(["report_throttled": "true"]) { current, _ in current }
+            )
+            return
+        }
+
+        lastAudioStartFailureReportAt = now
+        EventReporter.shared.capture(
+            level: .error,
+            engine: "parakeet",
+            event: "audio_engine_start_failed",
+            message: message,
+            context: context
+        )
+    }
+
     func startRecording(isRecoveryAttempt: Bool = false) -> Bool {
         guard !isRecording else { return true }
         scheduleInputDeviceNameRefresh()
@@ -790,6 +870,24 @@ class ParakeetEngine: ObservableObject {
         }
 
         installAudioObserversIfNeeded()
+        guard isRecoveryAttempt || recoveryState.canStartRecording else {
+            EventReporter.shared.capture(
+                level: .warning,
+                engine: "parakeet",
+                event: "audio_start_deferred",
+                message: "Audio start requested while input format is still recovering",
+                context: [
+                    "recovering": "\(recoveryState.isRecovering)",
+                    "format_ready": "\(recoveryState.inputFormatReady)",
+                    "generation": "\(recoveryState.generation)"
+                ]
+            )
+            if !recoveryState.isRecovering {
+                schedulePrewarmRetry()
+            }
+            return false
+        }
+
         recordingInterrupted = false
         didReceiveAudioSamples = false
         cancelAudioWatchdog()
@@ -798,131 +896,180 @@ class ParakeetEngine: ObservableObject {
         }
         sampleBuffer.removeAll(keepingCapacity: true)
 
-        let inputNode = audioEngine.inputNode
-        // The tap is installed with format: nil, which means buffers arrive at the
-        // node's OUTPUT bus format. On AirPods HFP the hw input is 24kHz but the
-        // node's output bus is 48kHz (CoreAudio's internal converter handles the
-        // upsample). The downstream resampler must use the rate the buffer
-        // actually arrives at — i.e. outputFormat — not the hw rate. Validate
-        // both so we don't proceed when the device graph is still settling.
-        let outputFormat = inputNode.outputFormat(forBus: 0)
-        let hwFormat = inputNode.inputFormat(forBus: 0)
-        guard outputFormat.sampleRate > 0, outputFormat.channelCount > 0,
-              hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
-            print("⚠️ PARAKEET | input format unavailable: output=\(outputFormat.sampleRate)Hz/\(outputFormat.channelCount)ch hw=\(hwFormat.sampleRate)Hz/\(hwFormat.channelCount)ch")
-            EventReporter.shared.capture(
-                level: .warning,
-                engine: "parakeet",
-                event: "audio_format_unavailable",
-                message: "Audio hardware format not ready while starting dictation",
-                context: [
-                    "audio_device": inputDeviceName,
-                    "output_rate": "\(outputFormat.sampleRate)",
-                    "output_channels": "\(outputFormat.channelCount)",
-                    "hw_rate": "\(hwFormat.sampleRate)",
-                    "hw_channels": "\(hwFormat.channelCount)",
-                ]
-            )
-            audioEngine.stop()
-            isEnginePrewarmed = false
-            markFormatUnreadyAndPublish()
-            schedulePrewarmRetry()
-            return false
-        }
-
-        nativeSampleRate = outputFormat.sampleRate
-
-        inputNode.installTap(onBus: 0, bufferSize: TranscriptedConstants.audioTapBufferSize, format: nil) { [weak self] buffer, _ in
-            guard let self = self,
-                  let monoSamples = self.extractMonoSamples(from: buffer) else { return }
-            let frameLength = monoSamples.count
-            guard frameLength > 0 else { return }
-
-            if !self.didReceiveAudioSamples && frameLength > 0 {
-                self.didReceiveAudioSamples = true
-                Task { @MainActor in
-                    EventReporter.shared.capture(level: .info, engine: "parakeet", event: "audio_samples_detected",
-                        message: "Audio samples started flowing",
-                        context: [
-                            "audio_device": self.inputDeviceName,
-                            "sample_rate": "\(self.nativeSampleRate)",
-                            "channels": "\(buffer.format.channelCount)",
-                            "frames": "\(frameLength)"
-                        ])
-                }
-            }
-
-            // Consumer 1: optional live streaming display (currently disabled).
-            if self.liveDisplayEnabled, let eou = self.eouManager {
-                let resampled = AudioResampler.resample(monoSamples, from: self.nativeSampleRate, to: 16000)
-                self.streamingSamplesLock.lock()
-                self.streamingSampleBuffer.append(contentsOf: resampled)
-                var chunk: [Float]? = nil
-                if self.streamingSampleBuffer.count >= self.eouChunkSamples {
-                    // Swap instead of copy — avoids memcpy under lock
-                    chunk = self.streamingSampleBuffer
-                    self.streamingSampleBuffer = []
-                }
-                self.streamingSamplesLock.unlock()
-                if let chunk = chunk, let pcm = self.makePCMBuffer(from: chunk) {
-                    Task {
-                        do { _ = try await eou.process(audioBuffer: pcm) }
-                        catch { EventReporter.shared.capture(level: .warning, engine: "parakeet",
-                            event: "eou_process_error", message: error.localizedDescription) }
-                    }
-                }
-            }
-
-            // Consumer 2: Parakeet sample buffer — lock-protected
-            self.pendingSamplesLock.lock()
-            self.pendingSamples.append(contentsOf: monoSamples)
-            // Enforce hard cap — keep only the most recent audioBufferCapacitySeconds of audio.
-            // Amortized compaction: trim once per second of overflow rather than on every tap
-            // callback, to avoid O(n) memmoves at ~47Hz.
-            let maxSamples = Int(self.nativeSampleRate) * TranscriptedConstants.audioBufferCapacitySeconds
-            if self.pendingSamples.count > maxSamples + Int(self.nativeSampleRate) {
-                self.pendingSamples.removeFirst(self.pendingSamples.count - maxSamples)
-            }
-            self.pendingSamplesLock.unlock()
-
-            // Consumer 3: Audio level metering (~20Hz throttled)
-            let now = CFAbsoluteTimeGetCurrent()
-            guard now - self.lastLevelUpdate > TranscriptedConstants.audioMeteringInterval else { return }
-            self.lastLevelUpdate = now
-
-            var sumOfSquares: Float = 0
-            for sample in monoSamples {
-                let s = sample
-                sumOfSquares += s * s
-            }
-            let rms = sqrt(sumOfSquares / Float(max(1, frameLength)))
-            let dB = rms > 0.0001 ? 20.0 * log10(rms) : -60.0
-            let normalized = max(0.0, min(1.0, (dB - TranscriptedConstants.audioLevelFloorDB) / (TranscriptedConstants.audioLevelCeilingDB - TranscriptedConstants.audioLevelFloorDB)))
-
-            Task { @MainActor [weak self] in
-                self?.audioLevel = normalized
-            }
-        }
-
-        if !isEnginePrewarmed || !audioEngine.isRunning {
-            do {
-                if !audioEngine.isRunning && isEnginePrewarmed {
-                    print("🔄 PARAKEET | engine was prewarmed but not running (likely sleep/wake), restarting")
-                    EventReporter.shared.capture(level: .warning, engine: "parakeet",
-                        event: "engine_stale_restart",
-                        message: "Audio engine was prewarmed but not running — restarting",
-                        context: ["audio_device": inputDeviceName])
-                }
-                audioEngine.prepare()
-                try audioEngine.start()
-                isEnginePrewarmed = true
-            } catch {
-                inputNode.removeTap(onBus: 0)  // Clean up tap to prevent double-install crash
-                print("❌ PARAKEET | audio engine failed: \(error.localizedDescription)")
-                EventReporter.shared.capture(level: .error, engine: "parakeet",
-                    event: "audio_engine_start_failed", message: error.localizedDescription)
+        let maxAttempts = isRecoveryAttempt ? 1 : 1 + TranscriptedConstants.audioStartRecoveryAttempts
+        for attempt in 1...maxAttempts {
+            let inputNode = audioEngine.inputNode
+            // The tap is installed with format: nil, which means buffers arrive at the
+            // node's OUTPUT bus format. On AirPods HFP the hw input is 24kHz but the
+            // node's output bus is 48kHz (CoreAudio's internal converter handles the
+            // upsample). The downstream resampler must use the rate the buffer
+            // actually arrives at — i.e. outputFormat — not the hw rate. Validate
+            // both so we don't proceed when the device graph is still settling.
+            let outputFormat = inputNode.outputFormat(forBus: 0)
+            let hwFormat = inputNode.inputFormat(forBus: 0)
+            guard outputFormat.sampleRate > 0, outputFormat.channelCount > 0,
+                  hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
+                print("⚠️ PARAKEET | input format unavailable: output=\(outputFormat.sampleRate)Hz/\(outputFormat.channelCount)ch hw=\(hwFormat.sampleRate)Hz/\(hwFormat.channelCount)ch")
+                EventReporter.shared.capture(
+                    level: .warning,
+                    engine: "parakeet",
+                    event: "audio_format_unavailable",
+                    message: "Audio hardware format not ready while starting dictation",
+                    context: audioStartContext(
+                        attempt: attempt,
+                        isRecoveryAttempt: isRecoveryAttempt,
+                        engineWasRunning: audioEngine.isRunning,
+                        outputFormat: outputFormat,
+                        hwFormat: hwFormat
+                    )
+                )
+                resetAudioGraphAfterStartFailure()
+                markFormatUnreadyAndPublish()
+                schedulePrewarmRetry()
                 return false
             }
+
+            nativeSampleRate = outputFormat.sampleRate
+            removeRecordingTap(force: true)
+
+            inputNode.installTap(onBus: 0, bufferSize: TranscriptedConstants.audioTapBufferSize, format: nil) { [weak self] buffer, _ in
+                guard let self = self,
+                      let monoSamples = self.extractMonoSamples(from: buffer) else { return }
+                let frameLength = monoSamples.count
+                guard frameLength > 0 else { return }
+
+                if !self.didReceiveAudioSamples && frameLength > 0 {
+                    self.didReceiveAudioSamples = true
+                    Task { @MainActor in
+                        EventReporter.shared.capture(level: .info, engine: "parakeet", event: "audio_samples_detected",
+                            message: "Audio samples started flowing",
+                            context: [
+                                "sample_rate": "\(self.nativeSampleRate)",
+                                "channels": "\(buffer.format.channelCount)",
+                                "frames": "\(frameLength)"
+                            ])
+                    }
+                }
+
+                // Consumer 1: optional live streaming display (currently disabled).
+                if self.liveDisplayEnabled, let eou = self.eouManager {
+                    let resampled = AudioResampler.resample(monoSamples, from: self.nativeSampleRate, to: 16000)
+                    self.streamingSamplesLock.lock()
+                    self.streamingSampleBuffer.append(contentsOf: resampled)
+                    var chunk: [Float]? = nil
+                    if self.streamingSampleBuffer.count >= self.eouChunkSamples {
+                        // Swap instead of copy — avoids memcpy under lock
+                        chunk = self.streamingSampleBuffer
+                        self.streamingSampleBuffer = []
+                    }
+                    self.streamingSamplesLock.unlock()
+                    if let chunk = chunk, let pcm = self.makePCMBuffer(from: chunk) {
+                        Task {
+                            do { _ = try await eou.process(audioBuffer: pcm) }
+                            catch { EventReporter.shared.capture(level: .warning, engine: "parakeet",
+                                event: "eou_process_error", message: error.localizedDescription) }
+                        }
+                    }
+                }
+
+                // Consumer 2: Parakeet sample buffer — lock-protected
+                self.pendingSamplesLock.lock()
+                self.pendingSamples.append(contentsOf: monoSamples)
+                // Enforce hard cap — keep only the most recent audioBufferCapacitySeconds of audio.
+                // Amortized compaction: trim once per second of overflow rather than on every tap
+                // callback, to avoid O(n) memmoves at ~47Hz.
+                let maxSamples = Int(self.nativeSampleRate) * TranscriptedConstants.audioBufferCapacitySeconds
+                if self.pendingSamples.count > maxSamples + Int(self.nativeSampleRate) {
+                    self.pendingSamples.removeFirst(self.pendingSamples.count - maxSamples)
+                }
+                self.pendingSamplesLock.unlock()
+
+                // Consumer 3: Audio level metering (~20Hz throttled)
+                let now = CFAbsoluteTimeGetCurrent()
+                guard now - self.lastLevelUpdate > TranscriptedConstants.audioMeteringInterval else { return }
+                self.lastLevelUpdate = now
+
+                var sumOfSquares: Float = 0
+                for sample in monoSamples {
+                    let s = sample
+                    sumOfSquares += s * s
+                }
+                let rms = sqrt(sumOfSquares / Float(max(1, frameLength)))
+                let dB = rms > 0.0001 ? 20.0 * log10(rms) : -60.0
+                let normalized = max(0.0, min(1.0, (dB - TranscriptedConstants.audioLevelFloorDB) / (TranscriptedConstants.audioLevelCeilingDB - TranscriptedConstants.audioLevelFloorDB)))
+
+                Task { @MainActor [weak self] in
+                    self?.audioLevel = normalized
+                }
+            }
+            inputTapInstalled = true
+
+            if !isEnginePrewarmed || !audioEngine.isRunning {
+                let engineWasRunning = audioEngine.isRunning
+                do {
+                    if !audioEngine.isRunning && isEnginePrewarmed {
+                        print("🔄 PARAKEET | engine was prewarmed but not running (likely sleep/wake), restarting")
+                        EventReporter.shared.capture(level: .warning, engine: "parakeet",
+                            event: "engine_stale_restart",
+                            message: "Audio engine was prewarmed but not running — restarting",
+                            context: ["audio_device": inputDeviceName])
+                    }
+                    audioEngine.prepare()
+                    try audioEngine.start()
+                    isEnginePrewarmed = true
+                } catch {
+                    let context = audioStartContext(
+                        attempt: attempt,
+                        isRecoveryAttempt: isRecoveryAttempt,
+                        engineWasRunning: engineWasRunning,
+                        outputFormat: outputFormat,
+                        hwFormat: hwFormat,
+                        error: error
+                    )
+                    let shouldRetry = ParakeetAudioStartRecoveryPolicy.shouldRetryStartFailure(
+                        isRecoveryAttempt: isRecoveryAttempt,
+                        failedAttempts: attempt
+                    )
+                    resetAudioGraphAfterStartFailure()
+
+                    if shouldRetry {
+                        print("🔄 PARAKEET | audio engine start failed, resetting graph and retrying once: \(error.localizedDescription)")
+                        EventReporter.shared.capture(
+                            level: .warning,
+                            engine: "parakeet",
+                            event: "audio_engine_start_retrying",
+                            message: "Audio engine failed to start; resetting graph and retrying",
+                            context: context
+                        )
+                        continue
+                    }
+
+                    print("❌ PARAKEET | audio engine failed after \(attempt) attempt(s): \(error.localizedDescription)")
+                    reportAudioStartFailureIfNeeded(message: error.localizedDescription, context: context)
+                    markStartFailedAndPublish()
+                    schedulePrewarmRetry()
+                    return false
+                }
+            }
+
+            if attempt > 1 {
+                EventReporter.shared.capture(
+                    level: .info,
+                    engine: "parakeet",
+                    event: "audio_engine_start_recovered",
+                    message: "Audio engine started after a graph reset",
+                    context: [
+                        "attempts": "\(attempt)",
+                        "start_mode": isRecoveryAttempt ? "recovery" : "normal",
+                        "output_rate_hz": String(format: "%.0f", outputFormat.sampleRate),
+                        "output_channels": "\(outputFormat.channelCount)",
+                        "input_rate_hz": String(format: "%.0f", hwFormat.sampleRate),
+                        "hw_channels": "\(hwFormat.channelCount)",
+                    ]
+                )
+            }
+            lastAudioStartFailureReportAt = nil
+            break
         }
 
         isRecording = true
@@ -1012,7 +1159,7 @@ class ParakeetEngine: ObservableObject {
                 self.pendingSamples.removeAll(keepingCapacity: true)
             }
             await self.eouManager?.reset()
-            self.audioEngine.inputNode.removeTap(onBus: 0)
+            self.removeRecordingTap()
             self.audioEngine.stop()
             self.isEnginePrewarmed = false
             self.isRecording = false
@@ -1053,7 +1200,7 @@ class ParakeetEngine: ObservableObject {
                 }
             }
         }
-        audioEngine.inputNode.removeTap(onBus: 0)
+        removeRecordingTap()
         audioEngine.stop()
         isEnginePrewarmed = false
         drainPendingSamplesIntoSampleBuffer()
@@ -1371,7 +1518,7 @@ class ParakeetEngine: ObservableObject {
                 streamingSamplesLock.unlock()
                 Task { await eouManager?.reset() }
             }
-            audioEngine.inputNode.removeTap(onBus: 0)
+            removeRecordingTap()
             isRecording = false
             audioLevel = 0
         }
@@ -1384,7 +1531,7 @@ class ParakeetEngine: ObservableObject {
 
     private func releaseIdleAudioHardware(removeTap: Bool) {
         if removeTap {
-            audioEngine.inputNode.removeTap(onBus: 0)
+            removeRecordingTap(force: true)
         }
         if audioEngine.isRunning {
             audioEngine.stop()

--- a/Sources/Speech/ParakeetRecoveryState.swift
+++ b/Sources/Speech/ParakeetRecoveryState.swift
@@ -5,6 +5,10 @@ struct ParakeetRecoveryState: Equatable {
     private(set) var inputFormatReady: Bool = true
     private(set) var generation: UInt64 = 0
 
+    var canStartRecording: Bool {
+        !isRecovering && inputFormatReady
+    }
+
     mutating func beginConfigChange() -> UInt64 {
         generation &+= 1
         isRecovering = true
@@ -13,6 +17,10 @@ struct ParakeetRecoveryState: Equatable {
     }
 
     mutating func markFormatUnready() {
+        inputFormatReady = false
+    }
+
+    mutating func markStartFailed() {
         inputFormatReady = false
     }
 
@@ -33,5 +41,26 @@ struct ParakeetRecoveryState: Equatable {
 
     func isStale(generation: UInt64) -> Bool {
         generation != self.generation
+    }
+}
+
+struct ParakeetAudioStartRecoveryPolicy: Equatable {
+    static func shouldRetryStartFailure(
+        isRecoveryAttempt: Bool,
+        failedAttempts: Int,
+        retryBudget: Int = TranscriptedConstants.audioStartRecoveryAttempts
+    ) -> Bool {
+        guard !isRecoveryAttempt else { return false }
+        guard retryBudget > 0 else { return false }
+        return failedAttempts <= retryBudget
+    }
+
+    static func shouldReportFailure(
+        now: TimeInterval,
+        lastReportAt: TimeInterval?,
+        throttle: TimeInterval = TranscriptedConstants.audioStartFailureReportThrottle
+    ) -> Bool {
+        guard let lastReportAt else { return true }
+        return now - lastReportAt >= throttle
     }
 }

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -97,6 +97,10 @@ class STTRouter: ObservableObject {
         return parakeetEngine.startRecording()
     }
 
+    func refreshInputReadiness() {
+        parakeetEngine.prewarm()
+    }
+
     func stopRecording() {
         parakeetEngine.stopRecording()
     }

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -76,6 +76,15 @@ enum TranscriptedConstants {
     /// BT format negotiation can take ~1-2s; 500ms between attempts covers most cases.
     static let recordingRestartRetryDelay: UInt64 = 500_000_000  // 500ms
 
+    /// Max immediate retries after AVAudioEngine fails to start for dictation.
+    /// Keep this small: the caller already has a readiness wait loop, and repeated
+    /// immediate attempts can spam Sentry while CoreAudio is still settling.
+    static let audioStartRecoveryAttempts: Int = 1
+
+    /// Minimum interval between Sentry reports for repeated audio-start failures.
+    /// Local logs still record each failure; off-device reports stay bounded.
+    static let audioStartFailureReportThrottle: TimeInterval = 15.0
+
     // MARK: - Model Loading
 
     /// Polling interval while waiting for voice model to load (nanoseconds)

--- a/Sources/TranscriptedCore/Models/FailedTranscription.swift
+++ b/Sources/TranscriptedCore/Models/FailedTranscription.swift
@@ -69,26 +69,39 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
     /// Attempt to reconstruct the typed PipelineError from the stored message.
     /// Returns nil for legacy entries that don't match any known pattern.
     private var pipelineError: PipelineError? {
-        if errorMessage.contains("no samples recorded") || errorMessage.contains("Empty audio file") {
+        let normalized = errorMessage.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        if normalized.contains("no samples recorded") || normalized.contains("empty audio file") {
             return .emptyAudioFile
         }
-        if errorMessage.contains("Recording too short") || errorMessage.contains("at least") {
+        if Self.isRecordingTooShortMessage(normalized) {
             return .recordingTooShort(duration: 0)
         }
-        if errorMessage.contains("Invalid audio") {
+        if normalized.contains("invalid audio") {
             return .invalidAudioFormat(detail: errorMessage)
         }
-        if errorMessage.contains("System audio is required")
-            || errorMessage.contains("System Audio Recording") {
+        if normalized.contains("system audio is required")
+            || normalized.contains("system audio recording") {
             return .missingSystemAudio
         }
-        if errorMessage.contains("model not loaded") {
+        if normalized.contains("model not loaded") {
             return .modelNotLoaded(model: "Unknown")
         }
-        if errorMessage.contains("Failed to save") {
+        if normalized.contains("failed to save") {
             return .saveFailed(detail: errorMessage)
         }
         return nil
+    }
+
+    private static func isRecordingTooShortMessage(_ message: String) -> Bool {
+        let mentionsAudioMinimum = (
+            message.contains("at least 1 second")
+                || message.contains("at least 2 seconds")
+                || message.contains("at least one second")
+                || message.contains("at least two seconds")
+        ) && (message.contains("audio") || message.contains("recording"))
+
+        return message.contains("recording too short") || mentionsAudioMinimum
     }
 
     /// Checks if the audio files still exist on disk

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -188,6 +188,10 @@ class DictationSessionController: ObservableObject {
         let startedAt = CFAbsoluteTimeGetCurrent()
         let deadline = startedAt + TranscriptedConstants.dictationRecoveryBudget
 
+        if !appState.sttRouter.isRecovering, !appState.sttRouter.inputFormatReady {
+            appState.sttRouter.refreshInputReadiness()
+        }
+
         while CFAbsoluteTimeGetCurrent() < deadline {
             guard isDictating, !Task.isCancelled else { return }
 

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -660,13 +660,18 @@ final class MeetingOverlayRootView: NSView {
             updateStatusDot(color: MeetingOverlayTokens.dotSaved)
             detailLabel.stringValue = ""
         case .error(let message):
+            let failureKind = MeetingFailureKind.classify(message: message)
             let copy = MeetingFailureCopy.make(
                 forMessage: message,
                 shortErrorMessage: message,
                 isRetryable: true
             )
             titleLabel.stringValue = copy.title
-            updateStatusDot(color: MeetingOverlayTokens.dotError)
+            updateStatusDot(
+                color: failureKind == .recordingTooShort
+                    ? MeetingOverlayTokens.dotIdle
+                    : MeetingOverlayTokens.dotError
+            )
             detailLabel.stringValue = copy.detail
         }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1426,10 +1426,17 @@ private struct SettingsFailedMeetingRow: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(.orange)
-                .frame(width: 24)
+            if item.failureKind == .recordingTooShort {
+                Image(systemName: "timer")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 24)
+            } else {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.orange)
+                    .frame(width: 24)
+            }
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(item.title)

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -8,12 +8,23 @@ func testFailedMeetingPresentation() {
             isRetryable: false
         )
 
-        assertEqual(copy.title, "Recording was too short", "short captures should stop looking like generic retries")
+        assertEqual(copy.title, "Recording ended too soon", "short captures should stop looking like generic retries")
         assertEqual(
             copy.detail,
-            "Transcripted needs at least a second of audio. Keep the meeting running a little longer, then retry.",
-            "short captures should explain how to avoid the failure next time"
+            "Nothing broke - there just was not enough audio to transcribe. Record at least two seconds before stopping.",
+            "short captures should explain the intentional terminal outcome"
         )
+    }
+
+    runSuite("FailedMeetingPresentation does not classify unrelated minimum-copy as short audio") {
+        let copy = MeetingFailureCopy.make(
+            forMessage: "Upload failed after at least one retry because the destination was unavailable.",
+            shortErrorMessage: "Upload failed after at least one retry.",
+            isRetryable: true
+        )
+
+        assertEqual(copy.title, "Transcript needs another pass", "generic retry copy should not look like short audio")
+        assertEqual(copy.detail, "Upload failed after at least one retry.", "generic retry detail should be preserved")
     }
 
     runSuite("FailedMeetingPresentation system audio failures point to settings") {

--- a/Tests/MeetingFailureKindTests.swift
+++ b/Tests/MeetingFailureKindTests.swift
@@ -9,6 +9,22 @@ func testMeetingFailureKind() {
         assertEqual(kind, .recordingTooShort, "short captures should stay out of the generic bucket")
     }
 
+    runSuite("MeetingFailureKind does not overmatch generic minimum language") {
+        let kind = MeetingFailureKind.classify(
+            message: "Upload failed after at least one retry because the destination was unavailable."
+        )
+
+        assertEqual(kind, .unexpectedError, "minimum-language without audio context should not become recording_too_short")
+    }
+
+    runSuite("MeetingFailureKind keeps generic invalid audio separate from short recordings") {
+        let kind = MeetingFailureKind.classify(
+            message: "Invalid audio data: file header could not be decoded."
+        )
+
+        assertEqual(kind, .invalidAudioFormat, "generic invalid audio should not masquerade as a too-short recording")
+    }
+
     runSuite("MeetingFailureKind classifies diarization failures") {
         let kind = MeetingFailureKind.classify(
             message: "PyAnnote inference failed: model weights missing"

--- a/Tests/ParakeetRecoveryStateTests.swift
+++ b/Tests/ParakeetRecoveryStateTests.swift
@@ -81,4 +81,58 @@ func testParakeetRecoveryState() {
         assertEqual(state.generation, before, "marking format unready should not bump generation")
         assertFalse(state.isRecovering, "marking format unready alone should not set recovery flag")
     }
+
+    runSuite("ParakeetRecoveryState.canStartRecording — requires recovery to be done and format ready") {
+        var state = ParakeetRecoveryState()
+        assertTrue(state.canStartRecording, "fresh state should allow recording starts")
+
+        let generation = state.beginConfigChange()
+        assertFalse(state.canStartRecording, "active recovery should block recording starts")
+
+        _ = state.finishRecovery(success: true, generation: generation)
+        assertTrue(state.canStartRecording, "successful recovery should allow recording starts again")
+
+        state.markStartFailed()
+        assertFalse(state.canStartRecording, "start failure should hold recording until prewarm marks format ready")
+    }
+
+    runSuite("ParakeetRecoveryState.markStartFailed — does not bump generation or enter recovery") {
+        var state = ParakeetRecoveryState()
+        let before = state.generation
+        state.markStartFailed()
+
+        assertFalse(state.inputFormatReady, "start failure should mark format unready")
+        assertFalse(state.isRecovering, "plain start failure should not pretend a device-change recovery is active")
+        assertEqual(state.generation, before, "plain start failure should not supersede device-change generations")
+    }
+
+    runSuite("ParakeetAudioStartRecoveryPolicy.shouldRetryStartFailure — retries only normal first failures") {
+        assertTrue(
+            ParakeetAudioStartRecoveryPolicy.shouldRetryStartFailure(isRecoveryAttempt: false, failedAttempts: 1, retryBudget: 1),
+            "normal first failure should get one immediate graph-reset retry"
+        )
+        assertFalse(
+            ParakeetAudioStartRecoveryPolicy.shouldRetryStartFailure(isRecoveryAttempt: false, failedAttempts: 2, retryBudget: 1),
+            "retry budget should cap repeated immediate attempts"
+        )
+        assertFalse(
+            ParakeetAudioStartRecoveryPolicy.shouldRetryStartFailure(isRecoveryAttempt: true, failedAttempts: 1, retryBudget: 1),
+            "recovery attempts should not recursively retry"
+        )
+    }
+
+    runSuite("ParakeetAudioStartRecoveryPolicy.shouldReportFailure — throttles repeated Sentry reports") {
+        assertTrue(
+            ParakeetAudioStartRecoveryPolicy.shouldReportFailure(now: 100, lastReportAt: nil, throttle: 15),
+            "first failure should report"
+        )
+        assertFalse(
+            ParakeetAudioStartRecoveryPolicy.shouldReportFailure(now: 110, lastReportAt: 100, throttle: 15),
+            "repeat failures inside the throttle window should stay local-only"
+        )
+        assertTrue(
+            ParakeetAudioStartRecoveryPolicy.shouldReportFailure(now: 116, lastReportAt: 100, throttle: 15),
+            "failures after the throttle window should report again"
+        )
+    }
 }

--- a/Tests/SentryEventPolicyTests.swift
+++ b/Tests/SentryEventPolicyTests.swift
@@ -10,6 +10,10 @@ func testSentryEventPolicy() {
             forEngine: "capture",
             event: "hotkey_register_failed"
         )
+        let audioStartFailure = SentryEventPolicy.policy(
+            forEngine: "parakeet",
+            event: "audio_engine_start_failed"
+        )
         let unknown = SentryEventPolicy.policy(
             forEngine: "dictation",
             event: "dictation_export_failed"
@@ -17,6 +21,7 @@ func testSentryEventPolicy() {
 
         assertEqual(transcriptionFailure?.summary, "Speech transcription failed.", "transcription failure should use the normalized summary")
         assertEqual(hotkeyFailure?.summary, "Transcripted could not register a keyboard shortcut.", "capture failure should stay allowlisted")
+        assertEqual(audioStartFailure?.summary, "Speech audio engine failed to start.", "audio-start failures should stay allowlisted with a privacy-safe summary")
         assertNil(unknown, "unknown events should stay local-only by default")
     }
 }

--- a/Tests/SentryPayloadSanitizerTests.swift
+++ b/Tests/SentryPayloadSanitizerTests.swift
@@ -37,6 +37,38 @@ func testSentryPayloadSanitizer() {
         assertNil(sanitized["source_app_bundle_id"], "source app bundle IDs should be dropped")
     }
 
+    runSuite("SentryPayloadSanitizer.sanitizeContext keeps audio-start recovery diagnostics coarse") {
+        let sanitized = SentryPayloadSanitizer.sanitizeContext([
+            "attempt": "2",
+            "start_mode": "normal",
+            "recovering": "false",
+            "format_ready": "true",
+            "generation": "4",
+            "input_rate_hz": "48000",
+            "output_rate_hz": "48000",
+            "hw_channels": "1",
+            "status_domain": "com.apple.coreaudio.avfaudio",
+            "status_code": "-10868",
+            "audio_device": "Private AirPods",
+            "error": "Failed to initialize active nodes",
+            "source_app": "com.example.private",
+        ])
+
+        assertEqual(sanitized["attempt"], "2", "retry attempt should remain")
+        assertEqual(sanitized["start_mode"], "normal", "start mode should remain")
+        assertEqual(sanitized["recovering"], "false", "recovery flag should remain")
+        assertEqual(sanitized["format_ready"], "true", "format readiness should remain")
+        assertEqual(sanitized["generation"], "4", "recovery generation should remain")
+        assertEqual(sanitized["input_rate_hz"], "48000", "input rate should remain")
+        assertEqual(sanitized["output_rate_hz"], "48000", "output rate should remain")
+        assertEqual(sanitized["hw_channels"], "1", "hardware channel count should remain")
+        assertEqual(sanitized["status_domain"], "com.apple.coreaudio.avfaudio", "status domain should remain")
+        assertEqual(sanitized["status_code"], "-10868", "status code should remain")
+        assertNil(sanitized["audio_device"], "raw audio device names should be dropped")
+        assertNil(sanitized["error"], "free-form errors should be dropped")
+        assertNil(sanitized["source_app"], "source app identifiers should be dropped")
+    }
+
     runSuite("SentryPayloadSanitizer.sanitizeText redacts emails hostnames and non-home paths") {
         let input = "Contact me at person@example.com from Redbarss-MacBook-Pro.local and inspect /private/var/folders/demo/file.txt"
         let sanitized = SentryPayloadSanitizer.sanitizeText(input)

--- a/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
@@ -97,6 +97,26 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertEqual(persisted, [safeEntry])
     }
 
+    func testFailedTranscriptionRetryabilityDoesNotOvermatchGenericMinimumLanguage() {
+        let failure = FailedTranscription(
+            micAudioURL: testRoot.appendingPathComponent("mic.wav"),
+            systemAudioURL: nil,
+            errorMessage: "Upload failed after at least one retry because the destination was unavailable."
+        )
+
+        XCTAssertTrue(failure.isRetryable)
+    }
+
+    func testFailedTranscriptionRetryabilityKeepsShortAudioPermanent() {
+        let failure = FailedTranscription(
+            micAudioURL: testRoot.appendingPathComponent("mic.wav"),
+            systemAudioURL: nil,
+            errorMessage: "Invalid audio data provided. Must be at least 1 second of 16kHz audio."
+        )
+
+        XCTAssertFalse(failure.isRetryable)
+    }
+
     private func makePaths(root: URL) -> CoreStoragePaths {
         CoreStoragePaths(
             transcripts: root.appendingPathComponent("captures/meetings", isDirectory: true),


### PR DESCRIPTION
## Summary

- Harden Parakeet dictation start by removing stale taps, resetting the audio graph, retrying start once, and scheduling bounded prewarm recovery on final failure.
- Add privacy-safe audio-start diagnostics with throttled Sentry reporting.
- Re-arm input readiness on fresh dictation attempts so users do not get stuck after exhausted prewarm retries.
- Make intentionally short meeting recordings show calm terminal copy instead of looking like a broken transcription pipeline.
- Tighten short-recording classification and persisted retryability so generic `at least` text does not become a permanent short-audio failure.

## Why

Production telemetry showed `parakeet.audio_engine_start_failed` in the core dictation path. The likely failure mode was a stale or unsettled CoreAudio graph around `installTap` / `AVAudioEngine.start()`. This patch makes that path recover once immediately, then fall back into the existing readiness loop with safer diagnostics.

The meeting change handles a related user-experience issue: recordings that are simply too short should feel intentional and understandable, not like a scary app failure.

## Validation

- `git diff --check`
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` - 590/590 passed
- `bash run-integration-smoke.sh`
- `swift test` - 65/65 passed

## Notes

The local dark-mode health brief HTML file was intentionally left untracked and is not part of this PR.