### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -15,7 +15,9 @@ Important entry points:
 - `TranscriptedAppState.swift` — owns `ContextCaptureEngine`, `STTRouter`, wake-recovery coordination, and lazy `MeetingSessionController`
 - `Support/TranscriptedStoragePaths.swift` — app-support path helpers for the Transcripted capture-library, state, cache, logs, and tmp layout
 - `Support/HotkeyPreferences.swift` — persisted hotkey settings used by capture routing
+- `Support/CustomDictionaryPreferences.swift` — persisted custom spoken-term replacements applied to final dictation and meeting transcript text
 - `Support/LocalSpeakerPreferences.swift` — persisted toggle that decides whether meeting transcription should split the local mic into multiple named speakers or keep it as a single "You" track
+- `Support/TranscriptionModelPreferences.swift` — persisted local model selection shared by dictation and meetings (`Parakeet`, `Whisper Large V3 Turbo`, `Whisper Large V3`)
 - `Support/TranscriptedConstants.swift` — shared timing and behavior constants used across the app target
 - `Capture/ContextCaptureEngine.swift` — right-option dictation handling, keyboard hotkeys, meeting hotkey routing
 - `UI/Overlay/DictationSessionController.swift` — dictation session orchestration; removed draft-mode methods are stubs
@@ -33,7 +35,7 @@ Important entry points:
 - `Observability/` — events, debug log, anonymous analytics, Sparkle updater, and crash reporting
 - `Reliability/` — wake / sleep recovery coordination
 - `Speech/` — local STT engines, router, and recorded-audio buffering helpers
-- `Support/` — app-wide path, storage, permission, hotkey, local-speaker preference, clipboard paste, and shared constant helpers
+- `Support/` — app-wide path, storage, permission, hotkey, clipboard paste, custom-dictionary, auto-send, local-speaker, and transcription-model preference helpers
 - `TranscriptedCore/` — shared library boundary
 - `UI/` — grouped app surfaces: `Overlay/`, `MenuBar/`, `Settings/`, `AgentConnect/`, and `Shared/`
 

--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -12,7 +12,6 @@
 - `MeetingFailureKind.swift` — canonical failure taxonomy that classifies raw meeting errors into stable machine-readable kinds
 - `MeetingImportedAudioPreparer.swift` — copies imported recordings into app-managed scratch paths, derives titles, and prepares single-file meeting transcription jobs
 - `MeetingModelDownloader.swift` — loads the selected STT and diarization models together
-- `MeetingWarmupStatusPolicy.swift` — centralizes the title/detail copy and visibility rules for quiet vs user-visible meeting model warmup states
 - `MeetingPromptDetector.swift` — polls upcoming Calendar events, watches supported meeting apps, and asks the overlay to offer one-tap recording prompts
 - `MeetingPromptHeuristics.swift` — shared scoring and snooze rules for calendar- and runtime-based prompt candidates
 - `MeetingRecordingCleanup.swift` — removes scratch audio when a live meeting recording is explicitly discarded instead of saved
@@ -22,7 +21,7 @@
 - `MeetingSessionUIPolicy.swift` — centralizes when queued or active transcription work should keep the meeting overlay in its transcribing/saving state
 - `MeetingStoragePaths.swift` — current split meeting storage layout across the capture library, app state, logs, and temp folders
 - `MeetingTranscriptStyler.swift` — restyles saved transcripts and renames files after save
-- `MeetingWarmupStatusPolicy.swift` — centralizes the user-facing warmup progress, copy, and ready/failure state for dictation + meeting model startup across overlay, menubar, and settings surfaces
+- `MeetingWarmupStatusPolicy.swift` — centralizes the user-facing warmup progress, copy, visibility, and ready/failure state for dictation + meeting model startup across overlay, menubar, and settings surfaces
 
 ## End-to-end flow
 
@@ -100,7 +99,6 @@ Relevant direct coverage:
 - `Tests/MeetingWarmupStatusPolicyTests.swift`
 - `Tests/MeetingSessionUIPolicyTests.swift`
 - `Tests/MeetingTranscriptStylerTests.swift`
-- `Tests/MeetingWarmupStatusPolicyTests.swift`
 - `Tests/SpeakerNamingPolicyTests.swift`
 - `Tests/Integration/AppCoreIntegrationSmoke.swift`
 

--- a/Sources/Support/CLAUDE.md
+++ b/Sources/Support/CLAUDE.md
@@ -1,36 +1,47 @@
-# Support helpers
+# Support Directory
 
 ## What this directory does
 
-`Sources/Support/` contains app-wide utility types that cut across features. These are standalone helpers shared by dictation, meeting, capture, and UI code without belonging to any single feature directory.
+`Sources/Support/` holds app-wide helpers that do not belong to a single UI or pipeline surface. These types mostly wrap persisted preferences, shared constants, permission access, storage paths, or low-level paste / launch behavior used across dictation and meetings.
 
-## Files
+## Files (11 Swift files)
 
-- `ClipboardRestoringTextPaster.swift` — pastes text into the target app by briefly borrowing the clipboard and restoring prior contents after Cmd+V completes; reports paste/copy/fail outcomes for diagnostics
-- `HotkeyPreferences.swift` — data model, persistence, display, and validation for customizable keyboard shortcuts (dictation, meeting, draft hotkey bindings)
-- `LocalSpeakerPreferences.swift` — preference flag for local mic-channel speaker diarization; when enabled, the meeting pipeline runs offline diarization on the mic track and surfaces multiple local speakers in the post-meeting naming sheet
-- `TranscriptionModelPreferences.swift` — advanced model picker persistence; Parakeet is the default and Whisper choices are available through Settings
-- `TranscriptedConstants.swift` — centralized configuration constants for timeouts, thresholds, limits, buffer sizes, and version metadata
-- `TranscriptedPermissionAccess.swift` — unified permission checks for microphone, accessibility, system audio recording, and calendar; shared by the meeting prompt detector, settings, and onboarding flows
-- `TranscriptedStoragePaths.swift` — app-support path helpers for the Transcripted capture library, state, cache, logs, and tmp layout, including user-configurable capture library relocation
+- `ClipboardRestoringTextPaster.swift` — paste helper that preserves clipboard contents while inserting the latest dictation into the target app
+- `CustomDictionaryPreferences.swift` — persisted custom spoken-term replacements plus text post-processing helpers
+- `DictationAutoSendPreferences.swift` — persisted auto-send rules, allowed bundle list, and keypress-sending helpers for pasted dictation
+- `HotkeyPreferences.swift` — persisted global hotkey bindings, right-Option toggle, display formatting, and validation
+- `LaunchAtLoginController.swift` — app-facing wrapper for enabling or disabling launch-at-login behavior
+- `LaunchAtLoginPreferences.swift` — persisted first-run preference state around launch-at-login UX
+- `LocalSpeakerPreferences.swift` — persisted toggle for splitting the local mic channel into multiple named speakers during meeting review
+- `TranscriptedConstants.swift` — shared timing thresholds and app-wide behavior constants
+- `TranscriptedPermissionAccess.swift` — shared permission status, prompting, and Settings-deep-link helpers for microphone, accessibility, system-audio recording, and calendar access
+- `TranscriptedStoragePaths.swift` — canonical app-support path helpers for captures, state, cache, logs, and temporary files
+- `TranscriptionModelPreferences.swift` — persisted local transcription-model selection shared by dictation and meetings
 
-## Key invariants
+## Current notes
 
-- `TranscriptedPermissionAccess` is the canonical place for app-level TCC permission queries. Keep duplicate permission branching out of feature-specific code.
-- `LocalSpeakerPreferences` defaults to off. The meeting pipeline reads this flag at recording time, so changes take effect on the next meeting.
-- `TranscriptionModelPreferences` defaults to Parakeet TDT V3. Advanced Whisper choices are available when users opt into them from Settings.
-- `ClipboardRestoringTextPaster` runs on the main thread and uses brief async delays for the paste round-trip. Keep the clipboard borrow window tight.
-- `TranscriptedStoragePaths` resolves the capture library from `UserDefaults` first, falling back to the default Application Support location. App-owned state, cache, logs, and temp files always stay under the fixed Application Support root.
+- Keep preference keys and notification names centralized here so UI and controllers do not drift.
+- `TranscriptionModelPreferences` is the shared switch between `Parakeet` and the available local Whisper variants. Model-specific runtime behavior still belongs in `Sources/Speech/` and `Sources/Meeting/`.
+- `CustomDictionaryPreferences` and `DictationAutoSendPreferences` back the Settings `General` and `Dictation` pages. If you change parsing rules or policy thresholds, update the relevant tests.
+- `TranscriptedPermissionAccess` is the app-level permission seam. UI flows should call into it instead of duplicating TCC branching.
+- `TranscriptedStoragePaths` should stay as the canonical path resolver for the app target. `Sources/TranscriptedCore/Services/CoreStoragePaths.swift` is the injected library-side seam.
 
 ## Verification
+
+After changing support code:
 
 ```bash
 bash build.sh
 bash run-tests.sh
 ```
 
-Relevant direct coverage:
+Relevant direct coverage includes:
 
+- `Tests/ClipboardRestoringTextPasterTests.swift`
+- `Tests/CustomDictionaryPreferencesTests.swift`
+- `Tests/DictationAutoSendPreferencesTests.swift`
+- `Tests/LaunchAtLoginPreferencesTests.swift`
 - `Tests/TranscriptedConstantsTests.swift`
 - `Tests/TranscriptedPermissionAccessTests.swift`
 - `Tests/TranscriptedStoragePathsTests.swift`
+- `Tests/TranscriptionModelPreferencesTests.swift`

--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -4,7 +4,7 @@
 
 `Sources/TranscriptedCore/` is the reusable meeting transcription library embedded in this repo. It is consumed by the app through `Sources/Meeting/`, and it can also be tested as a standalone Swift package through the root `Package.swift`.
 
-## Subsystems (58 Swift files)
+## Subsystems (59 Swift files)
 
 - `Audio/` (14 files) — mic + system audio capture, imported-audio prep helpers, device recovery, resampling, level metering, process tap, ScreenCaptureKit-backed system-audio capture, backend selection, buffer writing, and merge helpers
 - `Logging/` (2 files) — shared app logger and JSONL file logger
@@ -14,7 +14,7 @@
 - `Services/` (7 files) — DI container (`AppServices`), model bundle / download management, path indirection, recording validation, diarization, and failed-transcription persistence
 - `Speaker/` (10 files) — speaker DB, embedding matching / clustering, clip extraction, naming policy / coordinator, profile merging, retroactive transcript updates
 - `Stats/` (4 files) — recording stats database, models, queries, and service
-- `Storage/` (3 files) — transcript save, scanner, formatter
+- `Storage/` (4 files) — transcript save, scanner, formatter, and retained-recording audio archiving
 - `Utilities/` (2 files) — date formatting and file permission helpers
 
 ## The seams embedders should know

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -13,7 +13,7 @@ The directory is grouped by surface so the live UI tree is easier to scan:
 
 Draft-mode UI is not an active product path in this worktree.
 
-## Files (43 Swift files)
+## Files (46 Swift files)
 
 ### Overlay/
 
@@ -69,7 +69,7 @@ The current agent-connect surfaces should keep one simple mental model:
 - `Settings/TranscriptedSettingsActions.swift` — struct of callbacks (start dictation, start meeting, import audio, paste, connect agent, check updates, send feedback) injected into the settings view
 - `Settings/TranscriptedSettingsComponents.swift` — shared SwiftUI building blocks (`SettingsPageIntro`, `SettingsSection`) used across settings pages
 - `Settings/TranscriptedSettingsNavigationModel.swift` — observable navigation state for the current `TranscriptedSettingsPage` selection
-- `Settings/TranscriptedSettingsPage.swift` — enum of settings pages (home, shortcuts, meetings, dictations, storage, connectAgent, privacy, about) with titles and SF Symbol names
+- `Settings/TranscriptedSettingsPage.swift` — enum of settings pages (home, general, models, shortcuts, meetings, dictations, storage, connectAgent, privacy, about) with titles, summaries, and SF Symbol names
 - `Settings/TranscriptedSettingsView.swift` — main settings view
 - `Settings/TranscriptedSettingsWindowController.swift` — NSWindowController for settings
 
@@ -77,6 +77,7 @@ The current agent-connect surfaces should keep one simple mental model:
 
 - `Shared/AgentConnectionGuide.swift` — shared smart-prompt, MCP setup, and folder fallback copy for the agent-connect flow
 - `Shared/AppSoundPlayer.swift` — UI sound preferences and playback helpers
+- `Shared/FeedbackIssueBuilder.swift` — builds sanitized feedback issue payloads and support links from current app state
 - `Shared/FirstRunExperience.swift` — shared first-run menu and onboarding state helpers for permission, local-model, dictation, and meeting CTA copy
 - `Shared/RecentCaptureScanners.swift` — `RecentMeetingsScanner` that loads recent meeting transcripts from disk for the Settings meetings page
 - `Shared/SpeakerClipPlayback.swift` — reusable audio-preview helper for persisted speaker sample clips


### PR DESCRIPTION
## Summary
- sync `Sources/Support/CLAUDE.md` with the current support helpers, including custom dictionary, auto-send, launch-at-login, and transcription-model preferences
- update `Sources/UI/CLAUDE.md` for the current 46-file UI tree, the `General` and `Models` settings pages, and shared feedback issue support
- fix stale `Sources/TranscriptedCore/CLAUDE.md` and `Sources/Meeting/CLAUDE.md` details, including storage/file-count drift and duplicate warmup/test entries
- refresh `Sources/CLAUDE.md` so the top-level source map calls out the current support-layer responsibilities

## Why
Recent merged changes added or reshaped support preferences, UI navigation, and retained-recording/storage behavior. These CLAUDE docs had drifted from the current source tree and feature set, so this PR brings the directory guides back in line with the live codebase.