### PR TITLE
[nightly-security] Harden observability path scrubbing

### DIFF
--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -36,6 +36,7 @@ enum AnalyticsPayloadSanitizer {
         return try! NSRegularExpression(pattern: "(?!)")
     }
 
+    private static let appSupportPathRegex = makeRegex(#"/Users/[^/\s]+/Library/Application Support/(?:Transcripted|Draft)(?:/[^\s"]*)?"#)
     private static let userPathRegex = makeRegex(#"/Users/[^/\s]+/"#)
     private static let absolutePathRegex = makeRegex(#"(?<!https:)(?<!http:)/(?:Users|private|var|tmp|Volumes|Applications)[^\s"]*"#)
     private static let rawURLRegex = makeRegex(#"https?://[^\s"]+"#, options: [.caseInsensitive])
@@ -88,6 +89,8 @@ enum AnalyticsPayloadSanitizer {
 
         var result = trimmed
         var range = NSRange(result.startIndex..., in: result)
+        result = appSupportPathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-path]")
+        range = NSRange(result.startIndex..., in: result)
         result = userPathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "/Users/****/")
         range = NSRange(result.startIndex..., in: result)
         result = absolutePathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-path]")

--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -37,6 +37,7 @@ enum SentryPayloadSanitizer {
         return try! NSRegularExpression(pattern: "(?!)")
     }
 
+    private static let appSupportPathRegex = makeRegex(#"/Users/[^/\s]+/Library/Application Support/(?:Transcripted|Draft)(?:/[^\s"]*)?"#)
     private static let userPathRegex = makeRegex(#"/Users/[^/\s]+/"#)
     private static let absolutePathRegex = makeRegex(#"(?<!https:)(?<!http:)/(?:Users|private|var|tmp|Volumes|Applications)[^\s"]*"#)
     private static let rawURLRegex = makeRegex(#"https?://[^\s"]+"#, options: [.caseInsensitive])
@@ -108,6 +109,8 @@ enum SentryPayloadSanitizer {
 
         var result = trimmed
         var range = NSRange(result.startIndex..., in: result)
+        result = appSupportPathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-path]")
+        range = NSRange(result.startIndex..., in: result)
         result = userPathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "/Users/****/")
         range = NSRange(result.startIndex..., in: result)
         result = absolutePathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-path]")

--- a/Tests/AnalyticsPayloadSanitizerTests.swift
+++ b/Tests/AnalyticsPayloadSanitizerTests.swift
@@ -21,13 +21,14 @@ func testAnalyticsPayloadSanitizer() {
     runSuite("AnalyticsPayloadSanitizer redacts file paths and emails from values") {
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
             [
-                "failure_kind": "Saved to /Users/redbars/secret.md by person@example.com",
+                "failure_kind": "Saved to /Users/redbars/Library/Application Support/Transcripted/logs/app.jsonl by person@example.com",
             ],
             allowedKeys: ["failure_kind"]
         )
 
         let value = sanitized["failure_kind"] ?? ""
         assertFalse(value.contains("/Users/redbars/"), "user paths should be redacted")
+        assertFalse(value.contains("Application Support/Transcripted/logs/app.jsonl"), "app support paths should be fully redacted")
         assertFalse(value.contains("person@example.com"), "emails should be redacted")
         assertTrue(value.contains("[redacted-path]"), "path marker should remain")
         assertTrue(value.contains("[redacted-email]"), "email marker should remain")

--- a/Tests/SentryPayloadSanitizerTests.swift
+++ b/Tests/SentryPayloadSanitizerTests.swift
@@ -49,6 +49,15 @@ func testSentryPayloadSanitizer() {
         assertTrue(sanitized.contains("[redacted-path]"), "redacted path marker should remain")
     }
 
+    runSuite("SentryPayloadSanitizer.sanitizeText redacts Transcripted app support paths with spaces") {
+        let input = "Read /Users/redbars/Library/Application Support/Transcripted/logs/app.jsonl before retry"
+        let sanitized = SentryPayloadSanitizer.sanitizeText(input)
+
+        assertFalse(sanitized.contains("/Users/redbars/"), "username should be redacted")
+        assertFalse(sanitized.contains("Application Support/Transcripted/logs/app.jsonl"), "app support path should be fully redacted")
+        assertTrue(sanitized.contains("[redacted-path]"), "redacted path marker should remain")
+    }
+
     runSuite("SentryPayloadSanitizer.sanitizeText redacts raw URLs and common token formats") {
         let input = "Download failed at https://example.com/private?token=abc123 with ghp_123456789012345678901234567890123456 phc_abcdefghijklmnopqrstuvwxyz123456 AKIAIOSFODNN7EXAMPLE AIzaSyA-BCDEFGHIJKLMNOPQRSTUVWXYZ123456"
         let sanitized = SentryPayloadSanitizer.sanitizeText(input)


### PR DESCRIPTION
## Summary
- Add explicit Transcripted/Draft Application Support path redaction before general path scrubbing.
- Cover both Sentry and PostHog analytics sanitizers.
- Add fast tests for the spaced `Application Support` path shape.

## Security / privacy sweep
- Checked committed secret patterns; no high-confidence private secrets found. Bundled Sentry DSN/PostHog key are expected public client config per docs.
- Checked Sparkle release drift: `Info.plist`, `docs/appcast.xml`, `Casks/transcripted.rb`, and latest GitHub release are aligned on `1.1.13`.
- Reviewed Sentry/analytics allowlists and scrubbers; patched the strongest low-risk path leakage hardening gap.
- `gitleaks` and `shellcheck` are not installed in this environment, so those optional tool-backed checks could not run.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`