### PR TITLE
[nightly-artifact] Allow Whisper engines in QA validation

### DIFF
--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Validators/TranscriptValidator.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Validators/TranscriptValidator.swift
@@ -2,6 +2,11 @@ import Foundation
 
 struct TranscriptValidator {
     let directory: URL
+    private let validTranscriptionEngines: Set<String> = [
+        "parakeet_local",
+        "whisper_large_v3_turbo_local",
+        "whisper_large_v3_local",
+    ]
 
     func validate() -> [ValidationResult] {
         var results: [ValidationResult] = []
@@ -44,10 +49,11 @@ struct TranscriptValidator {
             }
 
             // Engine values
-            if yaml.value(for: "transcription_engine") == "parakeet_local" {
+            if let transcriptionEngine = yaml.value(for: "transcription_engine"),
+               validTranscriptionEngines.contains(transcriptionEngine) {
                 results.append(.pass("transcript/yaml-engine-stt", target: name))
             } else {
-                results.append(.fail("transcript/yaml-engine-stt", target: name, detail: "Expected parakeet_local, got \(yaml.value(for: "transcription_engine") ?? "nil")"))
+                results.append(.fail("transcript/yaml-engine-stt", target: name, detail: "Expected supported local STT engine, got \(yaml.value(for: "transcription_engine") ?? "nil")"))
             }
 
             if yaml.value(for: "diarization_engine") == "pyannote_offline" {


### PR DESCRIPTION
## Summary
- accept all supported local STT transcript engine IDs in TranscriptedQA
- stops Whisper-generated meeting Markdown from being reported as invalid artifact shape

## Nightly artifact sweep
- health check: 6 passed, 0 failed, 0 warnings
- validate-all after patch: 742 passed, 2 failed, 5 warnings
- remaining failures are local artifact/index drift for Call_2026-04-18_14-43-40, not repo validator behavior

## Verification
- cd Tools/TranscriptedQA && swift build
- cd Tools/TranscriptedQA && swift run transcripted-qa check-health
- cd Tools/TranscriptedQA && swift run transcripted-qa validate-all
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh