### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -44,6 +44,8 @@ final class MeetingCaptureBridge: ObservableObject {
     /// time `startRecording` runs so back-to-back sessions do not leak state.
     private var completionContinuation: CheckedContinuation<(micURL: URL?, systemURL: URL?), Never>?
     private var startContinuation: CheckedContinuation<Bool, Never>?
+    private var startAttemptID: UUID?
+    private var startTimeoutTask: Task<Void, Never>?
 
     init(audio: Audio = Audio()) {
         self.audio = audio
@@ -69,18 +71,26 @@ final class MeetingCaptureBridge: ObservableObject {
         errorMessage = nil
 
         return await withCheckedContinuation { continuation in
+            startTimeoutTask?.cancel()
             startContinuation?.resume(returning: false)
+
+            let attemptID = UUID()
+            startAttemptID = attemptID
             startContinuation = continuation
 
             audio.start()
 
-            Task { @MainActor [weak self] in
+            startTimeoutTask = Task { @MainActor [weak self] in
                 try? await Task.sleep(nanoseconds: TranscriptedConstants.meetingStartTimeout)
-                guard let self, let continuation = self.startContinuation else { return }
+                guard let self,
+                      self.startAttemptID == attemptID,
+                      let continuation = self.startContinuation else { return }
                 self.errorMessage = AudioCaptureStartState.timeoutFailureMessage(
                     existingErrorMessage: self.errorMessage
                 )
                 self.startContinuation = nil
+                self.startAttemptID = nil
+                self.startTimeoutTask = nil
                 if self.audio.isRecording {
                     self.audio.stop()
                 }
@@ -145,9 +155,15 @@ final class MeetingCaptureBridge: ObservableObject {
             return
         case .ready:
             startContinuation = nil
+            startAttemptID = nil
+            startTimeoutTask?.cancel()
+            startTimeoutTask = nil
             continuation.resume(returning: true)
         case .failed(let message):
             startContinuation = nil
+            startAttemptID = nil
+            startTimeoutTask?.cancel()
+            startTimeoutTask = nil
             errorMessage = message
             if audio.isRecording {
                 audio.stop()


### PR DESCRIPTION
## What I found

### Logic / lifecycle bug
- Fixed a stale meeting-capture start timeout in `MeetingCaptureBridge`.
- Before this change, a timeout task from an earlier start attempt could fire during a later recording start if the earlier timeout window had not elapsed yet. That could incorrectly stop a fresh recording and surface a false timeout failure.

## What I changed
- Scoped the timeout to a specific start attempt with an attempt ID.
- Cancel and clear the timeout task when the start attempt resolves successfully or fails.
- Prevent older timeout tasks from touching newer start continuations.

## Validation
- `bash build-deps.sh --force`
- `bash build.sh`
- `swift test --filter TranscriptionPipelineHelpersTests`

## Notes
- The requested `xcodebuild -project Transcripted.xcodeproj -scheme Transcripted -configuration Debug build` command was not runnable in this repo snapshot because `Transcripted.xcodeproj` is not present here, so validation used the repo's supported build entrypoints instead.