### PR TITLE
[nightly-retrieval] Improve recent context previews

### DIFF
--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -358,7 +358,8 @@ enum CLIContextStore {
         }) {
             return String(firstUtterance.text.prefix(220))
         }
-        return meeting.speakers.joined(separator: ", ")
+        let speakers = meeting.speakers.joined(separator: ", ")
+        return speakers.isEmpty ? "No transcript captured." : speakers
     }
 
     private static func extractTitle(from content: String) -> String? {

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -45,6 +45,48 @@ final class ContextStoreTests: XCTestCase {
         XCTAssertEqual(items.first?.preview, "We should test the onboarding changes before touching pricing.")
     }
 
+    func testRecentMeetingWithNoTranscriptUsesExplicitPreview() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let meetingsDir = root.appendingPathComponent("meetings", isDirectory: true)
+        let dictationsDir = root.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: meetingsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dictationsDir, withIntermediateDirectories: true)
+
+        let meeting = """
+        ---
+        capture_type: meeting
+        date: 2026-04-16
+        time: 09:15:00
+        duration: "0:02"
+        total_word_count: 0
+        ---
+
+        # Quick notes
+
+        ## Transcript
+
+        _No transcript captured._
+        """
+        try meeting.write(
+            to: meetingsDir.appendingPathComponent("Quick notes.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let items = CLIContextStore.recent(
+            in: CLIContextDirectories(meetingsDir: meetingsDir, dictationsDir: dictationsDir),
+            kind: .meeting,
+            count: 5,
+            dateFrom: nil,
+            dateTo: nil
+        )
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.preview, "No transcript captured.")
+    }
+
     private func makeTempDir() -> URL {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -741,14 +741,16 @@ final class TranscriptIndex: @unchecked Sendable {
         if kind != .dictation {
             let meetings = try listMeetings(count: count, dateFrom: dateFrom, dateTo: dateTo)
             items.append(contentsOf: meetings.map {
-                RecentContextItem(
+                let firstUtterance = getFirstMeetingUtterance(filename: $0.filename)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                return RecentContextItem(
                     kind: .meeting,
                     title: $0.title ?? $0.filename,
                     filename: $0.filename,
                     entryId: nil,
                     date: $0.date,
                     datetime: $0.datetime,
-                    preview: $0.speakers.map(\.name).joined(separator: ", "),
+                    preview: firstUtterance.isEmpty ? "No transcript captured." : String(firstUtterance.prefix(220)),
                     wordCount: $0.wordCount,
                     speakers: $0.speakers.map(\.name),
                     sourceAppName: nil,
@@ -994,6 +996,20 @@ final class TranscriptIndex: @unchecked Sendable {
             return colText(stmt, 0)
         }
         return ""
+    }
+
+    private func getFirstMeetingUtterance(filename: String) -> String {
+        queue.sync {
+            var stmt: OpaquePointer?
+            let sql = "SELECT text FROM utterances WHERE filename = ? ORDER BY utterance_start LIMIT 1"
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return "" }
+            defer { sqlite3_finalize(stmt) }
+            sqlite3_bind_text(stmt, 1, (filename as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                return colText(stmt, 0)
+            }
+            return ""
+        }
     }
 
     // MARK: - SQLite Helpers

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptIndexTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptIndexTests.swift
@@ -208,4 +208,32 @@ final class TranscriptIndexTests: XCTestCase {
         XCTAssertEqual(result.items.count, 3)
         XCTAssertEqual(result.items.first?.kind, .dictation)
     }
+
+    func testRecentContextMeetingPreviewUsesFirstUtterance() throws {
+        try writeFixture(makeFixtureJSON(date: "2026-03-29T10:00:00-0500"), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try index.listRecentContext(kind: .meeting, count: 10)
+
+        XCTAssertEqual(result.items.count, 1)
+        XCTAssertEqual(result.items.first?.preview, "Good morning everyone")
+    }
+
+    func testRecentContextEmptyMeetingUsesExplicitPreview() throws {
+        try writeFixture(
+            makeFixtureJSON(
+                date: "2026-03-29T10:00:00-0500",
+                speakers: [],
+                utterances: []
+            ),
+            filename: "Call_2026-03-29_10-00-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try index.listRecentContext(kind: .meeting, count: 10)
+
+        XCTAssertEqual(result.items.count, 1)
+        XCTAssertEqual(result.items.first?.preview, "No transcript captured.")
+    }
 }


### PR DESCRIPTION
## Summary

- Make CLI recent meeting output explicit when a capture has no transcript instead of showing a blank preview.
- Make MCP `recent_context` use the first meeting utterance as the preview instead of only listing speaker names.
- Add CLI and MCP regression coverage for transcript previews and empty captures.

## Why

The nightly retrieval eval found that recent meeting results could put zero-word captures at the top with blank previews. That weakens common agent requests like "latest meeting" and "recent context" because the agent cannot tell whether the latest capture is empty or what the latest substantive meeting was about.

## Verification

- `cd Tools/TranscriptedCLI && swift build && swift test`
- `cd Tools/TranscriptedMCP && swift build && swift test`
- `cd Tools/TranscriptedCLI && ./.build/debug/transcripted-cli context-recent --kind meeting --meetings-dir "$HOME/Library/Application Support/Transcripted/captures/meetings" --dictations-dir "$HOME/Library/Application Support/Transcripted/captures/dictations" --count 5`
- `cd Tools/TranscriptedCLI && ./.build/debug/transcripted-cli list-dictations --dictations-dir "$HOME/Library/Application Support/Transcripted/captures/dictations" --count 3`
- `cd Tools/TranscriptedCLI && ./.build/debug/transcripted-cli context-search transcripted --kind meeting --meetings-dir "$HOME/Library/Application Support/Transcripted/captures/meetings" --dictations-dir "$HOME/Library/Application Support/Transcripted/captures/dictations" --count 5`