### PR TITLE
[nightly-agent] Document CLI binary path

### DIFF
--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -70,6 +70,12 @@ swift run transcripted-cli list-dictations --count 5
 swift run transcripted-cli diarize /path/to/audio.wav --json
 ```
 
+Binary path after build:
+
+```text
+.build/debug/transcripted-cli
+```
+
 When the repo-level dependency bundle is missing, `swift build` still builds the
 local context commands so agent retrieval can work on a fresh checkout. The
 offline audio commands (`diarize` and `batch`) then exit with an explicit


### PR DESCRIPTION
## Summary
- Add the post-build `transcripted-cli` binary path to the CLI agent guide.

## Why
- The MCP agent guide already documents its built binary path, but the CLI guide only listed commands. This makes the CLI surface easier for outside agents to wire up after `swift build`.

## Verification
- `swift build` in `Tools/TranscriptedCLI`
- `swift test` in `Tools/TranscriptedCLI`
- Nightly surface check also confirmed `Tools/TranscriptedMCP` builds/tests and both debug binaries exist at the documented paths.