### PR TITLE
Update release metadata for 1.1.14

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.13"
-  sha256 "a679ef073ba92e3669136470b0126d0aa0f6db386e93d8d089dc1da1a8baccbe"
+  version "1.1.14"
+  sha256 "2afec38db36c69d68a53a5a8690b7ddd94a8293568e124145d44a689bb8c6a13"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
         <description>Release feed for Transcripted macOS updates.</description>
         <language>en</language>
         <item>
+            <title>1.1.14</title>
+            <pubDate>Tue, 21 Apr 2026 11:38:54 -0500</pubDate>
+            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.14</link>
+            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.14</sparkle:fullReleaseNotesLink>
+            <sparkle:version>1.1.14</sparkle:version>
+            <sparkle:shortVersionString>1.1.14</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.14/Transcripted-1.1.14.dmg" length="504103210" type="application/octet-stream" sparkle:edSignature="JyTTM3YcuhRlJNfUBh3T+K5VZRt4QZHB8MibdJnhbym8x/AzwY0q2zSO2hHo2Gtvu3HCMW2qDPiJVtLFzK8OBQ=="/>
+        </item>
+        <item>
             <title>1.1.13</title>
             <pubDate>Mon, 20 Apr 2026 17:56:58 -0500</pubDate>
             <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.13</link>


### PR DESCRIPTION
Updates the Sparkle appcast and Homebrew cask for the published 1.1.14 DMG.