### PR TITLE
BET-88 support artifacts: failure-policy regression + QA PASS/FAIL template

### DIFF
--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -1,6 +1,21 @@
 import Foundation
 
 func testParakeetStartRecordingFailurePolicy() {
+    runSuite("ParakeetStartRecordingFailurePolicy all known failures mark format unready") {
+        let reasons: [ParakeetStartRecordingFailureReason] = [
+            .invalidAudioFormat,
+            .audioEngineStartFailed
+        ]
+
+        for reason in reasons {
+            let initial = ParakeetStartRecordingFailurePolicy.action(for: reason, isRecoveryAttempt: false)
+            let recovery = ParakeetStartRecordingFailurePolicy.action(for: reason, isRecoveryAttempt: true)
+
+            assertTrue(initial.markFormatUnready, "\(reason) should mark format unready on initial start")
+            assertTrue(recovery.markFormatUnready, "\(reason) should mark format unready on recovery start")
+        }
+    }
+
     runSuite("ParakeetStartRecordingFailurePolicy invalid format on initial start schedules retry") {
         let action = ParakeetStartRecordingFailurePolicy.action(
             for: .invalidAudioFormat,

--- a/docs/qa-parakeet-start-failure-smoke.md
+++ b/docs/qa-parakeet-start-failure-smoke.md
@@ -9,6 +9,34 @@ failure handling and retry behavior.
 - Transcripted launches normally.
 - Dictation hotkey works in a normal path.
 - You can monitor logs/events while testing.
+- QA issue to update: `https://github.com/r3dbars/transcripted/issues/428`
+
+## Completion Protocol (required for BET-88 closeout)
+
+After running this checklist, post exactly one top-level comment in `#428`:
+
+- `PASS` if all pass criteria are met.
+- `FAIL` if any pass criterion fails.
+
+Use one of these templates:
+
+```md
+PASS
+
+- Scenarios run: 1, 2, 3
+- Device(s):
+- Notes:
+```
+
+```md
+FAIL
+
+- Failed scenario(s):
+- Repro steps:
+- Observed behavior:
+- Expected behavior:
+- `events.jsonl` excerpt (sanitized):
+```
 
 ## Suggested Log Monitoring
 
@@ -71,3 +99,8 @@ Expected:
 - No persistent “stuck” state after a failed start.
 - Dictation can recover and start again after transient device instability.
 - Logged failure events include enough context for debugging (`audio_device`, format details, `is_recovery_attempt`).
+
+## Closeout Mapping
+
+- If result is `PASS`: close `#428` and mark BET-88 complete.
+- If result is `FAIL`: open/link a follow-up fix issue and reference it from `#428`.


### PR DESCRIPTION
## Summary
- add regression coverage for BET-88 start-failure policy behavior
- add explicit QA closeout protocol/templates for PASS/FAIL in the BET-88 smoke checklist

## Changes
- `Tests/ParakeetStartRecordingFailurePolicyTests.swift`
  - adds suite: `ParakeetStartRecordingFailurePolicy all known failures mark format unready`
- `docs/qa-parakeet-start-failure-smoke.md`
  - adds required completion protocol for `#428`
  - adds copy/paste top-level `PASS` and `FAIL` templates
  - adds closeout mapping

## Validation
- `bash run-tests.sh` -> 376 passed, 0 failed

## Context
- Related blocker thread: #428
- This PR is intentionally narrow and supports BET-88 closeout evidence flow.