### PR TITLE
[codex] Improve people duplicate review settings

### DIFF
--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -69,7 +69,7 @@ The current agent-connect surfaces should keep one simple mental model:
 - `Settings/TranscriptedSettingsActions.swift` — struct of callbacks (start dictation, start meeting, import audio, paste, connect agent, check updates, send feedback) injected into the settings view
 - `Settings/TranscriptedSettingsComponents.swift` — shared SwiftUI building blocks (`SettingsPageIntro`, `SettingsSection`) used across settings pages
 - `Settings/TranscriptedSettingsNavigationModel.swift` — observable navigation state for the current `TranscriptedSettingsPage` selection
-- `Settings/TranscriptedSettingsPage.swift` — enum of settings pages (home, general, models, shortcuts, meetings, dictations, storage, connectAgent, privacy, about) with titles, summaries, and SF Symbol names
+- `Settings/TranscriptedSettingsPage.swift` — enum of settings pages (home, general, models, shortcuts, meetings, dictations, people, storage, connectAgent, privacy, about) with titles, summaries, and SF Symbol names
 - `Settings/TranscriptedSettingsView.swift` — main settings view
 - `Settings/TranscriptedSettingsWindowController.swift` — NSWindowController for settings
 
@@ -117,7 +117,7 @@ Manual checks:
 - meeting overlay warms up and records cleanly
 - imported-audio transcription can be started from the menubar and lands in the normal recent-meetings flow
 - menubar popover renders shortcuts, primary actions, settings actions, and the agent-connect page cleanly
-- speaker settings can preview clips, toggle local-speaker splitting, and rename / merge people cleanly
+- speaker settings can preview clips, surface duplicates, toggle local-speaker splitting, and rename / merge people cleanly
 - completed meeting review cleanly separates "People in the room" from remote participants, and "Keep as You" restores the single-speaker local path when needed
 - permissions onboarding and first-run onboarding window still open correctly
 - first-run CTA copy updates correctly as permissions and local-model state change

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -2,10 +2,80 @@ import SwiftUI
 import AppKit
 import TranscriptedCore
 
+enum SpeakerPeopleProfileFilter: String, CaseIterable, Identifiable {
+    case all
+    case needsReview
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all: return "All"
+        case .needsReview: return "Needs Review"
+        }
+    }
+}
+
+enum SpeakerDuplicateReason: Int {
+    case sameNameAndVoice
+    case sameName
+    case similarNameAndVoice
+    case similarName
+    case voiceMatch
+
+    var title: String {
+        switch self {
+        case .sameNameAndVoice: return "Same name and voice"
+        case .sameName: return "Same name"
+        case .similarNameAndVoice: return "Similar name and voice"
+        case .similarName: return "Similar name"
+        case .voiceMatch: return "Voice match"
+        }
+    }
+
+    var includesVoiceMatch: Bool {
+        switch self {
+        case .sameNameAndVoice, .similarNameAndVoice, .voiceMatch:
+            return true
+        case .sameName, .similarName:
+            return false
+        }
+    }
+}
+
+struct SpeakerDuplicateCandidate: Identifiable {
+    let source: SpeakerProfile
+    let target: SpeakerProfile
+    let reason: SpeakerDuplicateReason
+    let voiceSimilarity: Double?
+
+    var id: String {
+        [source.id.uuidString, target.id.uuidString].sorted().joined(separator: "-")
+    }
+
+    var detail: String {
+        let mergeLine = "Suggested merge: \(Self.displayName(for: source)) into \(Self.displayName(for: target))."
+        guard let voiceSimilarity else { return mergeLine }
+        return "\(Self.percentFormatter.string(from: NSNumber(value: voiceSimilarity)) ?? "High") voice match. \(mergeLine)"
+    }
+
+    static func displayName(for profile: SpeakerProfile) -> String {
+        profile.displayName ?? "Unnamed speaker"
+    }
+
+    private static let percentFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .percent
+        formatter.maximumFractionDigits = 0
+        return formatter
+    }()
+}
+
 @MainActor
 final class SpeakerPeopleSettingsViewModel: ObservableObject {
     @Published var profiles: [SpeakerProfile] = []
     @Published var searchText: String = ""
+    @Published var profileFilter: SpeakerPeopleProfileFilter = .all
 
     private let speakerDatabase: SpeakerDatabase
     private let preferredClipsDirectory: URL
@@ -22,17 +92,45 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         refresh()
     }
 
+    var duplicateCandidates: [SpeakerDuplicateCandidate] {
+        Self.duplicateCandidates(from: profiles)
+    }
+
     var filteredProfiles: [SpeakerProfile] {
+        let duplicateIds = duplicateProfileIDs
+        let reviewProfiles: (SpeakerProfile) -> Bool = { profile in
+            duplicateIds.contains(profile.id)
+                || profile.displayName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false
+                || profile.disputeCount > 0
+        }
+
+        let baseProfiles: [SpeakerProfile]
+        switch profileFilter {
+        case .all:
+            baseProfiles = profiles
+        case .needsReview:
+            baseProfiles = profiles.filter(reviewProfiles)
+        }
+
         let trimmed = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return profiles }
+        guard !trimmed.isEmpty else { return baseProfiles }
 
         let query = trimmed.lowercased()
-        return profiles.filter { profile in
+        return baseProfiles.filter { profile in
             if let name = profile.displayName?.lowercased(), name.contains(query) {
                 return true
             }
             return profile.id.uuidString.lowercased().contains(query)
         }
+    }
+
+    var duplicateProfileIDs: Set<UUID> {
+        var ids = Set<UUID>()
+        for candidate in duplicateCandidates {
+            ids.insert(candidate.source.id)
+            ids.insert(candidate.target.id)
+        }
+        return ids
     }
 
     func refresh() {
@@ -133,8 +231,26 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         }
     }
 
+    func duplicateCount(for profile: SpeakerProfile) -> Int {
+        duplicateCandidates.filter { candidate in
+            candidate.source.id == profile.id || candidate.target.id == profile.id
+        }.count
+    }
+
     func mergeTargets(for profile: SpeakerProfile) -> [SpeakerProfile] {
-        profiles.filter { $0.id != profile.id }.sorted { lhs, rhs in
+        let duplicatePeerIds = Set(duplicateCandidates.compactMap { candidate -> UUID? in
+            if candidate.source.id == profile.id { return candidate.target.id }
+            if candidate.target.id == profile.id { return candidate.source.id }
+            return nil
+        })
+
+        return profiles.filter { $0.id != profile.id }.sorted { lhs, rhs in
+            let lhsIsDuplicate = duplicatePeerIds.contains(lhs.id)
+            let rhsIsDuplicate = duplicatePeerIds.contains(rhs.id)
+            if lhsIsDuplicate != rhsIsDuplicate {
+                return lhsIsDuplicate && !rhsIsDuplicate
+            }
+
             let lhsName = lhs.displayName ?? "Unnamed speaker"
             let rhsName = rhs.displayName ?? "Unnamed speaker"
             if lhsName == rhsName {
@@ -152,6 +268,142 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
             if lhs.callCount != rhs.callCount { return lhs.callCount > rhs.callCount }
             return lhs.lastSeen > rhs.lastSeen
         }
+    }
+
+    nonisolated private static func duplicateCandidates(from profiles: [SpeakerProfile]) -> [SpeakerDuplicateCandidate] {
+        guard profiles.count > 1 else { return [] }
+
+        var candidates: [SpeakerDuplicateCandidate] = []
+        var seenPairs = Set<String>()
+
+        for lhsIndex in profiles.indices {
+            for rhsIndex in profiles.indices where rhsIndex > lhsIndex {
+                let lhs = profiles[lhsIndex]
+                let rhs = profiles[rhsIndex]
+                let voiceSimilarity = cosineSimilarity(lhs.embedding, rhs.embedding)
+                guard let reason = duplicateReason(lhs, rhs, voiceSimilarity: voiceSimilarity) else {
+                    continue
+                }
+
+                let pairId = [lhs.id.uuidString, rhs.id.uuidString].sorted().joined(separator: "-")
+                guard !seenPairs.contains(pairId) else { continue }
+                seenPairs.insert(pairId)
+
+                let target = suggestedMergeTarget(lhs, rhs)
+                let source = target.id == lhs.id ? rhs : lhs
+                candidates.append(SpeakerDuplicateCandidate(
+                    source: source,
+                    target: target,
+                    reason: reason,
+                    voiceSimilarity: reason.includesVoiceMatch ? voiceSimilarity : nil
+                ))
+            }
+        }
+
+        return candidates.sorted { lhs, rhs in
+            if lhs.reason.rawValue != rhs.reason.rawValue {
+                return lhs.reason.rawValue < rhs.reason.rawValue
+            }
+            let lhsSimilarity = lhs.voiceSimilarity ?? 0
+            let rhsSimilarity = rhs.voiceSimilarity ?? 0
+            if lhsSimilarity != rhsSimilarity {
+                return lhsSimilarity > rhsSimilarity
+            }
+            let lhsCalls = lhs.source.callCount + lhs.target.callCount
+            let rhsCalls = rhs.source.callCount + rhs.target.callCount
+            return lhsCalls > rhsCalls
+        }
+    }
+
+    nonisolated private static func duplicateReason(
+        _ lhs: SpeakerProfile,
+        _ rhs: SpeakerProfile,
+        voiceSimilarity: Double?
+    ) -> SpeakerDuplicateReason? {
+        let lhsName = normalizedName(lhs.displayName)
+        let rhsName = normalizedName(rhs.displayName)
+        let sameName = lhsName != nil && lhsName == rhsName
+        let similarName = !sameName && namesLookRelated(lhsName, rhsName)
+
+        let nameConflict = lhsName != nil && rhsName != nil && !sameName && !similarName
+        let voiceThreshold = nameConflict ? 0.96 : 0.90
+        let voiceMatch = lhs.disputeCount == 0
+            && rhs.disputeCount == 0
+            && (voiceSimilarity ?? 0) >= voiceThreshold
+
+        switch (sameName, similarName, voiceMatch) {
+        case (true, _, true):
+            return .sameNameAndVoice
+        case (true, _, false):
+            return .sameName
+        case (false, true, true):
+            return .similarNameAndVoice
+        case (false, true, false):
+            return .similarName
+        case (false, false, true):
+            return .voiceMatch
+        default:
+            return nil
+        }
+    }
+
+    nonisolated private static func suggestedMergeTarget(_ lhs: SpeakerProfile, _ rhs: SpeakerProfile) -> SpeakerProfile {
+        if lhs.callCount != rhs.callCount {
+            return lhs.callCount > rhs.callCount ? lhs : rhs
+        }
+
+        let lhsNamed = normalizedName(lhs.displayName) != nil
+        let rhsNamed = normalizedName(rhs.displayName) != nil
+        if lhsNamed != rhsNamed {
+            return lhsNamed ? lhs : rhs
+        }
+
+        return lhs.lastSeen >= rhs.lastSeen ? lhs : rhs
+    }
+
+    nonisolated private static func normalizedName(_ name: String?) -> String? {
+        guard let trimmed = name?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed.lowercased()
+    }
+
+    nonisolated private static func namesLookRelated(_ lhs: String?, _ rhs: String?) -> Bool {
+        guard let lhs, let rhs, lhs != rhs else { return false }
+        if lhs.count >= 3 && rhs.count >= 3 && (lhs.contains(rhs) || rhs.contains(lhs)) {
+            return true
+        }
+
+        let lhsTokens = nameTokens(lhs)
+        let rhsTokens = nameTokens(rhs)
+        guard !lhsTokens.isEmpty, !rhsTokens.isEmpty else { return false }
+        return lhsTokens.isSubset(of: rhsTokens) || rhsTokens.isSubset(of: lhsTokens)
+    }
+
+    nonisolated private static func nameTokens(_ name: String) -> Set<String> {
+        Set(name
+            .split { !$0.isLetter && !$0.isNumber }
+            .map(String.init)
+            .filter { $0.count >= 3 })
+    }
+
+    nonisolated private static func cosineSimilarity(_ lhs: [Float], _ rhs: [Float]) -> Double? {
+        guard lhs.count == rhs.count, !lhs.isEmpty else { return nil }
+
+        var dotProduct: Float = 0
+        var lhsNorm: Float = 0
+        var rhsNorm: Float = 0
+
+        for (left, right) in zip(lhs, rhs) {
+            dotProduct += left * right
+            lhsNorm += left * left
+            rhsNorm += right * right
+        }
+
+        let denominator = sqrt(lhsNorm) * sqrt(rhsNorm)
+        guard denominator > 0 else { return nil }
+        return Double(dotProduct / denominator)
     }
 
     nonisolated private static func clipURL(
@@ -223,13 +475,50 @@ struct SpeakerPeopleSettingsSection: View {
                 .foregroundStyle(.secondary)
         }
 
+        if !model.profiles.isEmpty {
+            SettingsSection(
+                title: "Possible Duplicates",
+                detail: "Same names and strong voice matches show up here."
+            ) {
+                let candidates = model.duplicateCandidates
+                if candidates.isEmpty {
+                    HStack(spacing: 10) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+
+                        Text("No likely duplicates right now.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    LazyVStack(alignment: .leading, spacing: 12) {
+                        ForEach(Array(candidates.enumerated()), id: \.element.id) { index, candidate in
+                            SpeakerDuplicateCandidateRow(candidate: candidate, model: model)
+
+                            if index < candidates.count - 1 {
+                                Divider()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         SettingsSection(
             title: "People",
-            detail: "Rename, merge, or delete saved speaker profiles."
+            detail: "Rename, play samples, merge, or delete saved speaker profiles."
         ) {
             HStack(spacing: 12) {
                 TextField("Search people or IDs", text: $model.searchText)
                     .textFieldStyle(.roundedBorder)
+
+                Picker("Filter", selection: $model.profileFilter) {
+                    ForEach(SpeakerPeopleProfileFilter.allCases) { filter in
+                        Text(filter.title).tag(filter)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 190)
 
                 Button("Refresh") {
                     model.refresh()
@@ -237,17 +526,114 @@ struct SpeakerPeopleSettingsSection: View {
             }
 
             if model.filteredProfiles.isEmpty {
-                Text("No speaker profiles yet.")
+                Text(emptyPeopleMessage)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             } else {
-                LazyVStack(alignment: .leading, spacing: 10) {
-                    ForEach(model.filteredProfiles, id: \.id) { profile in
+                let profiles = model.filteredProfiles
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(profiles.enumerated()), id: \.element.id) { index, profile in
                         SpeakerPersonRow(profile: profile, model: model)
+
+                        if index < profiles.count - 1 {
+                            Divider()
+                        }
                     }
                 }
             }
         }
+    }
+
+    private var emptyPeopleMessage: String {
+        if model.profiles.isEmpty {
+            return "No speaker profiles yet."
+        }
+        if model.profileFilter == .needsReview {
+            return "No people need review."
+        }
+        return "No people match that search."
+    }
+}
+
+private struct SpeakerDuplicateCandidateRow: View {
+    let candidate: SpeakerDuplicateCandidate
+    @ObservedObject var model: SpeakerPeopleSettingsViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.system(size: 14, weight: .semibold))
+                    .frame(width: 20)
+                    .padding(.top, 2)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(candidate.reason.title)
+                        .font(.subheadline.weight(.semibold))
+
+                    Text(candidate.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 12)
+
+                Button {
+                    model.merge(source: candidate.source, into: candidate.target)
+                } label: {
+                    Label("Merge", systemImage: "arrow.triangle.merge")
+                }
+                .help("Merge \(SpeakerDuplicateCandidate.displayName(for: candidate.source)) into \(SpeakerDuplicateCandidate.displayName(for: candidate.target))")
+            }
+
+            HStack(alignment: .top, spacing: 12) {
+                DuplicatePersonSummary(profile: candidate.source, role: "Merge from", model: model)
+
+                Image(systemName: "arrow.right")
+                    .foregroundStyle(.secondary)
+                    .frame(width: 20, height: 28)
+
+                DuplicatePersonSummary(profile: candidate.target, role: "Keep", model: model)
+            }
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+private struct DuplicatePersonSummary: View {
+    let profile: SpeakerProfile
+    let role: String
+    @ObservedObject var model: SpeakerPeopleSettingsViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(role)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+
+            Text(SpeakerDuplicateCandidate.displayName(for: profile))
+                .font(.caption.weight(.semibold))
+                .lineLimit(1)
+
+            Text(profile.callCount == 1 ? "1 call" : "\(profile.callCount) calls")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            Button {
+                model.playSample(for: profile.id)
+            } label: {
+                Label(hasClip ? "Sample" : "No Sample", systemImage: hasClip ? "play.circle.fill" : "play.slash")
+            }
+            .font(.caption)
+            .disabled(!hasClip)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var hasClip: Bool {
+        model.clipURL(for: profile.id) != nil
     }
 }
 
@@ -263,8 +649,21 @@ private struct SpeakerPersonRow: View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top, spacing: 12) {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(displayName)
-                        .font(.subheadline.weight(.semibold))
+                    HStack(spacing: 8) {
+                        Text(displayName)
+                            .font(.subheadline.weight(.semibold))
+
+                        ForEach(statusBadges, id: \.self) { badge in
+                            Text(badge)
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(badge == "Duplicate" ? Color.orange : Color.secondary)
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 3)
+                                .background(
+                                    Capsule().fill((badge == "Duplicate" ? Color.orange : Color.secondary).opacity(0.12))
+                                )
+                        }
+                    }
 
                     Text(metadataLine)
                         .font(.caption)
@@ -275,30 +674,38 @@ private struct SpeakerPersonRow: View {
                 Spacer()
 
                 HStack(spacing: 8) {
-                    Button(hasClip ? "Play Sample" : "No Sample") {
+                    Button {
                         model.playSample(for: profile.id)
+                    } label: {
+                        Label(hasClip ? "Sample" : "No Sample", systemImage: hasClip ? "play.circle.fill" : "play.slash")
                     }
                     .disabled(!hasClip)
 
                     if !isEditing {
-                        Button(profile.displayName == nil ? "Name" : "Rename") {
+                        Button {
                             renameDraft = profile.displayName ?? ""
                             isEditing = true
+                        } label: {
+                            Label(profile.displayName == nil ? "Name" : "Rename", systemImage: "pencil")
                         }
                     }
 
                     if !model.mergeTargets(for: profile).isEmpty {
-                        Menu("Merge Into") {
+                        Menu {
                             ForEach(model.mergeTargets(for: profile), id: \.id) { target in
                                 Button(mergeLabel(for: target)) {
                                     model.merge(source: profile, into: target)
                                 }
                             }
+                        } label: {
+                            Label("Merge", systemImage: "arrow.triangle.merge")
                         }
                     }
 
-                    Button("Delete", role: .destructive) {
+                    Button(role: .destructive) {
                         showDeleteConfirmation = true
+                    } label: {
+                        Label("Delete", systemImage: "trash")
                     }
                 }
             }
@@ -321,15 +728,7 @@ private struct SpeakerPersonRow: View {
                 }
             }
         }
-        .padding(12)
-        .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color(nsColor: .windowBackgroundColor))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color.primary.opacity(0.06), lineWidth: 1)
-        )
+        .padding(.vertical, 12)
         .alert("Delete person?", isPresented: $showDeleteConfirmation) {
             Button("Delete", role: .destructive) {
                 model.delete(profile: profile)
@@ -362,6 +761,20 @@ private struct SpeakerPersonRow: View {
             parts.append(profile.id.uuidString.prefix(8).description)
         }
         return parts.joined(separator: " • ")
+    }
+
+    private var statusBadges: [String] {
+        var badges: [String] = []
+        if model.duplicateCount(for: profile) > 0 {
+            badges.append("Duplicate")
+        }
+        if profile.disputeCount > 0 {
+            badges.append("Review")
+        }
+        if profile.displayName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false {
+            badges.append("Unnamed")
+        }
+        return badges
     }
 
     private var hasClip: Bool {

--- a/Sources/UI/Settings/TranscriptedSettingsPage.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsPage.swift
@@ -7,6 +7,7 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
     case shortcuts
     case meetings
     case dictations
+    case people
     case storage
     case connectAgent
     case privacy
@@ -22,6 +23,7 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
         case .shortcuts: return "Shortcuts"
         case .meetings: return "Meetings"
         case .dictations: return "Dictation"
+        case .people: return "People"
         case .storage: return "Storage"
         case .connectAgent: return "Agent"
         case .privacy: return "Privacy"
@@ -40,9 +42,11 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
         case .shortcuts:
             return "Keys and send-after-paste rules."
         case .meetings:
-            return "Recording, imports, and speakers."
+            return "Recording, imports, and recent calls."
         case .dictations:
             return "Paste-back and sound cues."
+        case .people:
+            return "Speaker profiles and duplicates."
         case .storage:
             return "Where your files live."
         case .connectAgent:
@@ -62,6 +66,7 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
         case .shortcuts: return "keyboard"
         case .meetings: return "person.2.wave.2.fill"
         case .dictations: return "quote.bubble.fill"
+        case .people: return "person.2.fill"
         case .storage: return "externaldrive.fill"
         case .connectAgent: return "sparkles"
         case .privacy: return "lock.shield.fill"

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -11,7 +11,7 @@ private struct SettingsSidebarSection: Identifiable {
 
     static let defaultSections = [
         SettingsSidebarSection(id: "home", title: nil, pages: [.home]),
-        SettingsSidebarSection(id: "recording", title: "Recording", pages: [.meetings, .dictations, .shortcuts]),
+        SettingsSidebarSection(id: "recording", title: "Recording", pages: [.meetings, .dictations, .people, .shortcuts]),
         SettingsSidebarSection(id: "setup", title: "Setup", pages: [.general, .models, .storage, .connectAgent]),
         SettingsSidebarSection(id: "trust", title: "Trust", pages: [.privacy, .about])
     ]
@@ -162,6 +162,8 @@ struct TranscriptedSettingsView: View {
             meetingsPage
         case .dictations:
             dictationsPage
+        case .people:
+            peoplePage
         case .storage:
             storagePage
         case .connectAgent:
@@ -292,9 +294,17 @@ struct TranscriptedSettingsView: View {
                 SettingsQuickLinkRow(
                     symbolName: "person.2.wave.2.fill",
                     title: "Meetings",
-                    detail: "Import audio and manage speakers."
+                    detail: "Record calls and import audio."
                 ) {
                     navigation.selectedPage = .meetings
+                }
+
+                SettingsQuickLinkRow(
+                    symbolName: "person.2.fill",
+                    title: "People",
+                    detail: "Review saved speakers and duplicates."
+                ) {
+                    navigation.selectedPage = .people
                 }
 
                 SettingsQuickLinkRow(
@@ -586,7 +596,7 @@ struct TranscriptedSettingsView: View {
         VStack(alignment: .leading, spacing: 24) {
             SettingsPageIntro(
                 title: "Meetings",
-                summary: "Record meetings, import audio, and manage speakers."
+                summary: "Record meetings, import audio, and open recent transcripts."
             )
 
             SettingsSection(
@@ -661,6 +671,15 @@ struct TranscriptedSettingsView: View {
                     }
                 }
             }
+        }
+    }
+
+    private var peoplePage: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            SettingsPageIntro(
+                title: "People",
+                summary: "Review saved speakers, samples, and possible duplicates."
+            )
 
             SpeakerPeopleSettingsSection(model: speakerPeopleModel)
         }


### PR DESCRIPTION
## What changed

- Moves People into its own Settings sidebar page instead of burying speaker profiles under Meetings.
- Keeps Meetings focused on recording, imports, failed jobs, and recent transcripts.
- Adds a Possible Duplicates review section for speaker profiles.
- Flags likely duplicates from same names, related names, and strong voice-profile matches.
- Adds sample playback, suggested merge actions, and Needs Review filtering for people profiles.

## Why

A user asked how to identify duplicates in Settings > Meetings > People. That feedback suggested the People surface was both hidden and too passive: users had to already know the merge menu existed. This makes People a first-class settings area and surfaces duplicate cleanup proactively.

## Validation

- `bash build.sh`
- `bash run-tests.sh` - 602 passed, 0 failed