### PR TITLE
ops: add QA gate checker for PASS/FAIL issue comments

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,7 +34,10 @@ not have to carry the full operational logic:
 ## Operational health probes
 
 - `scripts/ops/health-probe.sh` — run health checks for observability lanes (Sentry, PostHog, GitHub, Cloudflare)
-  - Usage: `bash scripts/ops/health-probe.sh <github|sentry|posthog|cloudflare|all>`
+  - Usage: `bash scripts/ops/health-probe.sh <github|sentry|posthog|cloudflare|qa|all>`
+  - QA lane defaults to `r3dbars/transcripted#428` and can be overridden with:
+    - `QA_GATE_REPO=<owner/repo>`
+    - `QA_GATE_ISSUE_NUMBER=<issue-number>`
   - See `docs/ops-credentials.md` for credential setup and privacy guidelines
 - `scripts/ops/qa-gate-check.sh` — check a GitHub issue for a top-level QA `PASS` / `FAIL` comment
   - Usage: `bash scripts/ops/qa-gate-check.sh <owner/repo> <issue-number>`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,10 +38,14 @@ not have to carry the full operational logic:
   - QA lane defaults to `r3dbars/transcripted#428` and can be overridden with:
     - `QA_GATE_REPO=<owner/repo>`
     - `QA_GATE_ISSUE_NUMBER=<issue-number>`
+    - `QA_GATE_STATE_FILE=<path>` (persist last-seen gate state)
+    - `QA_GATE_QUIET_NO_CHANGE=1` (suppress output when gate state is unchanged)
   - See `docs/ops-credentials.md` for credential setup and privacy guidelines
 - `scripts/ops/qa-gate-check.sh` — check a GitHub issue for a top-level QA `PASS` / `FAIL` comment
   - Usage: `bash scripts/ops/qa-gate-check.sh <owner/repo> <issue-number>`
   - Optional: `--json` for structured output (status object with `repo`, `issue`, `status`)
+  - Optional: `--state-file <path>` to persist last-seen status metadata
+  - Optional: `--quiet-no-change` to emit nothing when status/comment state is unchanged
   - Exit codes:
     - `0` = `PASS`
     - `2` = `FAIL`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,6 +36,12 @@ not have to carry the full operational logic:
 - `scripts/ops/health-probe.sh` — run health checks for observability lanes (Sentry, PostHog, GitHub, Cloudflare)
   - Usage: `bash scripts/ops/health-probe.sh <github|sentry|posthog|cloudflare|all>`
   - See `docs/ops-credentials.md` for credential setup and privacy guidelines
+- `scripts/ops/qa-gate-check.sh` — check a GitHub issue for a top-level QA `PASS` / `FAIL` comment
+  - Usage: `bash scripts/ops/qa-gate-check.sh <owner/repo> <issue-number>`
+  - Exit codes:
+    - `0` = `PASS`
+    - `2` = `FAIL`
+    - `3` = pending (no top-level `PASS` / `FAIL` yet)
 - `scripts/ops/build-codex-memory-index.py` — build a safe metadata-only index from local Codex session archives for Transcripted memory briefs
   - Usage: `python3 scripts/ops/build-codex-memory-index.py --verbose`
   - Writes:
@@ -45,7 +51,12 @@ not have to carry the full operational logic:
     - `build/codex-memory-index/transcripted-paperclip-task-seeds.json`
     - `build/codex-memory-index/transcripted-codex-digest.md`
   - Optional: `--limit 200` to scan only the newest 200 session files while iterating
+  - Optional: `--since-hours 24` to only include sessions from the last N hours
+  - Optional: `--nightly-report` to generate a decision-ready nightly archive miner report
   - Optional: `--mlx-summarize --mlx-model <model-id>` to generate local intent summaries through an MLX OpenAI-compatible endpoint
+  - Guardrail: `--mlx-summarize` now requires `--allow-local-model-calls`
+- `scripts/ops/nightly-transcripted-archive-miner.sh` — run the nightly Transcripted archive miner profile (24h window + decision report)
+  - Usage: `bash scripts/ops/nightly-transcripted-archive-miner.sh`
 
 ## Rule of thumb
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -41,6 +41,7 @@ not have to carry the full operational logic:
   - See `docs/ops-credentials.md` for credential setup and privacy guidelines
 - `scripts/ops/qa-gate-check.sh` — check a GitHub issue for a top-level QA `PASS` / `FAIL` comment
   - Usage: `bash scripts/ops/qa-gate-check.sh <owner/repo> <issue-number>`
+  - Optional: `--json` for structured output (status object with `repo`, `issue`, `status`)
   - Exit codes:
     - `0` = `PASS`
     - `2` = `FAIL`

--- a/scripts/ops/health-probe.sh
+++ b/scripts/ops/health-probe.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../" && pwd)"
 
 usage() {
-  echo "Usage: bash scripts/ops/health-probe.sh <github|sentry|posthog|cloudflare|all>"
+  echo "Usage: bash scripts/ops/health-probe.sh <github|sentry|posthog|cloudflare|qa|all>"
   exit 0
 }
 
@@ -180,11 +180,50 @@ probe_cloudflare() {
   done
 }
 
+probe_qa() {
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "SKIP qa: gh CLI not found"
+    exit 0
+  fi
+
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "SKIP qa: not authenticated (run 'gh auth login')"
+    exit 0
+  fi
+
+  local repo issue_number script_path
+  repo="${QA_GATE_REPO:-r3dbars/transcripted}"
+  issue_number="${QA_GATE_ISSUE_NUMBER:-428}"
+  script_path="$REPO_ROOT/scripts/ops/qa-gate-check.sh"
+
+  if [[ ! -x "$script_path" ]]; then
+    echo "ERROR qa: missing executable $script_path"
+    return 1
+  fi
+
+  echo "QA gate check ($repo#$issue_number)..."
+
+  set +e
+  local output
+  output="$("$script_path" "$repo" "$issue_number" 2>&1)"
+  local rc=$?
+  set -e
+
+  echo "$output"
+
+  # Keep the lane green for PASS and pending states.
+  # Only FAIL (2) or operational errors should fail the probe.
+  if [[ $rc -eq 0 || $rc -eq 3 ]]; then
+    return 0
+  fi
+  return $rc
+}
+
 run_all() {
   local failed_lane=""
   local exit_code=0
 
-  for lane in github sentry posthog cloudflare; do
+  for lane in github sentry posthog cloudflare qa; do
     echo "=== $lane ==="
     if ! probe_$lane; then
       failed_lane="$lane"
@@ -213,6 +252,9 @@ case "${1:-}" in
     ;;
   cloudflare)
     probe_cloudflare
+    ;;
+  qa)
+    probe_qa
     ;;
   all)
     run_all

--- a/scripts/ops/health-probe.sh
+++ b/scripts/ops/health-probe.sh
@@ -191,9 +191,11 @@ probe_qa() {
     exit 0
   fi
 
-  local repo issue_number script_path
+  local repo issue_number script_path state_file quiet_no_change
   repo="${QA_GATE_REPO:-r3dbars/transcripted}"
   issue_number="${QA_GATE_ISSUE_NUMBER:-428}"
+  state_file="${QA_GATE_STATE_FILE:-}"
+  quiet_no_change="${QA_GATE_QUIET_NO_CHANGE:-0}"
   script_path="$REPO_ROOT/scripts/ops/qa-gate-check.sh"
 
   if [[ ! -x "$script_path" ]]; then
@@ -205,11 +207,22 @@ probe_qa() {
 
   set +e
   local output
-  output="$("$script_path" "$repo" "$issue_number" 2>&1)"
+  local cmd=("$script_path")
+  if [[ -n "$state_file" ]]; then
+    cmd+=(--state-file "$state_file")
+  fi
+  if [[ "$quiet_no_change" == "1" ]]; then
+    cmd+=(--quiet-no-change)
+  fi
+  cmd+=("$repo" "$issue_number")
+
+  output="$("${cmd[@]}" 2>&1)"
   local rc=$?
   set -e
 
-  echo "$output"
+  if [[ -n "$output" ]]; then
+    echo "$output"
+  fi
 
   # Keep the lane green for PASS and pending states.
   # Only FAIL (2) or operational errors should fail the probe.

--- a/scripts/ops/qa-gate-check.sh
+++ b/scripts/ops/qa-gate-check.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# qa-gate-check.sh - Check a GitHub issue for a top-level QA PASS/FAIL gate comment.
+# Usage:
+#   bash scripts/ops/qa-gate-check.sh <owner/repo> <issue-number>
+# Exit codes:
+#   0 => PASS found
+#   2 => FAIL found
+#   3 => no PASS/FAIL found yet (pending)
+#   1 => usage/auth/tooling error
+
+usage() {
+  echo "Usage: bash scripts/ops/qa-gate-check.sh <owner/repo> <issue-number>"
+  echo "Example: bash scripts/ops/qa-gate-check.sh r3dbars/transcripted 428"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+REPO="$1"
+ISSUE_NUMBER="$2"
+
+if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: issue-number must be numeric"
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI not found"
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: gh is not authenticated (run 'gh auth login')"
+  exit 1
+fi
+
+# Only top-level issue comments are checked here (not review comments).
+COMMENTS_JSON=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments")
+
+LATEST_RESULT=$(
+  echo "$COMMENTS_JSON" | jq -r '
+    map({
+      id: .id,
+      body: (.body // ""),
+      created_at: .created_at
+    })
+    | map(. + {
+        result:
+          (if (.body | test("(^|\\n)[[:space:]]*PASS([[:space:]]|$)"; "m")) then "PASS"
+           elif (.body | test("(^|\\n)[[:space:]]*FAIL([[:space:]]|$)"; "m")) then "FAIL"
+           else ""
+           end)
+      })
+    | map(select(.result != ""))
+    | sort_by(.created_at)
+    | last
+    | .result // ""
+  '
+)
+
+if [[ "$LATEST_RESULT" == "PASS" ]]; then
+  echo "PASS: issue #$ISSUE_NUMBER has a top-level PASS comment"
+  exit 0
+fi
+
+if [[ "$LATEST_RESULT" == "FAIL" ]]; then
+  echo "FAIL: issue #$ISSUE_NUMBER has a top-level FAIL comment"
+  exit 2
+fi
+
+echo "PENDING: no top-level PASS/FAIL comment on issue #$ISSUE_NUMBER"
+exit 3

--- a/scripts/ops/qa-gate-check.sh
+++ b/scripts/ops/qa-gate-check.sh
@@ -13,15 +13,38 @@ set -euo pipefail
 usage() {
   echo "Usage: bash scripts/ops/qa-gate-check.sh <owner/repo> <issue-number>"
   echo "Optional: --json (print structured status output)"
+  echo "Optional: --state-file <path> (persist last seen gate state)"
+  echo "Optional: --quiet-no-change (suppress output if state did not change)"
   echo "Example: bash scripts/ops/qa-gate-check.sh r3dbars/transcripted 428"
 }
 
 JSON_MODE=0
+STATE_FILE=""
+QUIET_NO_CHANGE=0
 
-if [[ "${1:-}" == "--json" ]]; then
-  JSON_MODE=1
-  shift
-fi
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json)
+      JSON_MODE=1
+      shift
+      ;;
+    --state-file)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: --state-file requires a path"
+        exit 1
+      fi
+      STATE_FILE="$2"
+      shift 2
+      ;;
+    --quiet-no-change)
+      QUIET_NO_CHANGE=1
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   usage
@@ -53,6 +76,8 @@ fi
 
 # Only top-level issue comments are checked here (not review comments).
 COMMENTS_JSON=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER/comments")
+COMMENTS_COUNT=$(echo "$COMMENTS_JSON" | jq -r 'length')
+LATEST_COMMENT_ID=$(echo "$COMMENTS_JSON" | jq -r 'sort_by(.created_at) | last | .id // 0')
 
 LATEST_RESULT=$(
   echo "$COMMENTS_JSON" | jq -r '
@@ -76,29 +101,59 @@ LATEST_RESULT=$(
 )
 
 if [[ "$LATEST_RESULT" == "PASS" ]]; then
-  if [[ $JSON_MODE -eq 1 ]]; then
-    jq -n --arg repo "$REPO" --argjson issue "$ISSUE_NUMBER" --arg status "PASS" \
-      '{repo: $repo, issue: $issue, status: $status}'
-  else
-    echo "PASS: issue #$ISSUE_NUMBER has a top-level PASS comment"
-  fi
-  exit 0
+  STATUS="PASS"
+  EXIT_CODE=0
+elif [[ "$LATEST_RESULT" == "FAIL" ]]; then
+  STATUS="FAIL"
+  EXIT_CODE=2
+else
+  STATUS="PENDING"
+  EXIT_CODE=3
 fi
 
-if [[ "$LATEST_RESULT" == "FAIL" ]]; then
-  if [[ $JSON_MODE -eq 1 ]]; then
-    jq -n --arg repo "$REPO" --argjson issue "$ISSUE_NUMBER" --arg status "FAIL" \
-      '{repo: $repo, issue: $issue, status: $status}'
-  else
-    echo "FAIL: issue #$ISSUE_NUMBER has a top-level FAIL comment"
+NO_CHANGE=0
+if [[ -n "$STATE_FILE" && -f "$STATE_FILE" ]]; then
+  PREV_STATUS=$(jq -r '.status // ""' "$STATE_FILE" 2>/dev/null || echo "")
+  PREV_COUNT=$(jq -r '.comments_count // ""' "$STATE_FILE" 2>/dev/null || echo "")
+  PREV_LATEST_ID=$(jq -r '.latest_comment_id // ""' "$STATE_FILE" 2>/dev/null || echo "")
+  if [[ "$PREV_STATUS" == "$STATUS" && "$PREV_COUNT" == "$COMMENTS_COUNT" && "$PREV_LATEST_ID" == "$LATEST_COMMENT_ID" ]]; then
+    NO_CHANGE=1
   fi
-  exit 2
+fi
+
+if [[ -n "$STATE_FILE" ]]; then
+  mkdir -p "$(dirname "$STATE_FILE")"
+  jq -n \
+    --arg repo "$REPO" \
+    --argjson issue "$ISSUE_NUMBER" \
+    --arg status "$STATUS" \
+    --argjson comments_count "$COMMENTS_COUNT" \
+    --argjson latest_comment_id "$LATEST_COMMENT_ID" \
+    '{repo: $repo, issue: $issue, status: $status, comments_count: $comments_count, latest_comment_id: $latest_comment_id}' \
+    > "$STATE_FILE"
+fi
+
+if [[ $QUIET_NO_CHANGE -eq 1 && $NO_CHANGE -eq 1 ]]; then
+  exit "$EXIT_CODE"
 fi
 
 if [[ $JSON_MODE -eq 1 ]]; then
-  jq -n --arg repo "$REPO" --argjson issue "$ISSUE_NUMBER" --arg status "PENDING" \
-    '{repo: $repo, issue: $issue, status: $status}'
+  jq -n \
+    --arg repo "$REPO" \
+    --argjson issue "$ISSUE_NUMBER" \
+    --arg status "$STATUS" \
+    --argjson comments_count "$COMMENTS_COUNT" \
+    --argjson latest_comment_id "$LATEST_COMMENT_ID" \
+    --argjson no_change "$NO_CHANGE" \
+    '{repo: $repo, issue: $issue, status: $status, comments_count: $comments_count, latest_comment_id: $latest_comment_id, no_change: $no_change}'
 else
-  echo "PENDING: no top-level PASS/FAIL comment on issue #$ISSUE_NUMBER"
+  if [[ "$STATUS" == "PASS" ]]; then
+    echo "PASS: issue #$ISSUE_NUMBER has a top-level PASS comment"
+  elif [[ "$STATUS" == "FAIL" ]]; then
+    echo "FAIL: issue #$ISSUE_NUMBER has a top-level FAIL comment"
+  else
+    echo "PENDING: no top-level PASS/FAIL comment on issue #$ISSUE_NUMBER"
+  fi
 fi
-exit 3
+
+exit "$EXIT_CODE"

--- a/scripts/ops/qa-gate-check.sh
+++ b/scripts/ops/qa-gate-check.sh
@@ -12,8 +12,16 @@ set -euo pipefail
 
 usage() {
   echo "Usage: bash scripts/ops/qa-gate-check.sh <owner/repo> <issue-number>"
+  echo "Optional: --json (print structured status output)"
   echo "Example: bash scripts/ops/qa-gate-check.sh r3dbars/transcripted 428"
 }
+
+JSON_MODE=0
+
+if [[ "${1:-}" == "--json" ]]; then
+  JSON_MODE=1
+  shift
+fi
 
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   usage
@@ -68,14 +76,29 @@ LATEST_RESULT=$(
 )
 
 if [[ "$LATEST_RESULT" == "PASS" ]]; then
-  echo "PASS: issue #$ISSUE_NUMBER has a top-level PASS comment"
+  if [[ $JSON_MODE -eq 1 ]]; then
+    jq -n --arg repo "$REPO" --argjson issue "$ISSUE_NUMBER" --arg status "PASS" \
+      '{repo: $repo, issue: $issue, status: $status}'
+  else
+    echo "PASS: issue #$ISSUE_NUMBER has a top-level PASS comment"
+  fi
   exit 0
 fi
 
 if [[ "$LATEST_RESULT" == "FAIL" ]]; then
-  echo "FAIL: issue #$ISSUE_NUMBER has a top-level FAIL comment"
+  if [[ $JSON_MODE -eq 1 ]]; then
+    jq -n --arg repo "$REPO" --argjson issue "$ISSUE_NUMBER" --arg status "FAIL" \
+      '{repo: $repo, issue: $issue, status: $status}'
+  else
+    echo "FAIL: issue #$ISSUE_NUMBER has a top-level FAIL comment"
+  fi
   exit 2
 fi
 
-echo "PENDING: no top-level PASS/FAIL comment on issue #$ISSUE_NUMBER"
+if [[ $JSON_MODE -eq 1 ]]; then
+  jq -n --arg repo "$REPO" --argjson issue "$ISSUE_NUMBER" --arg status "PENDING" \
+    '{repo: $repo, issue: $issue, status: $status}'
+else
+  echo "PENDING: no top-level PASS/FAIL comment on issue #$ISSUE_NUMBER"
+fi
 exit 3


### PR DESCRIPTION
## Summary
- add `scripts/ops/qa-gate-check.sh` to check whether a GitHub issue has a top-level `PASS` / `FAIL` QA gate comment
- return machine-friendly exit codes (`0` PASS, `2` FAIL, `3` pending)
- document usage in `scripts/README.md`

## Why
BET-88 has been blocked on manual QA evidence in issue #428. This helper reduces repeated manual status checks and gives us a consistent automation hook for QA-gated blockers.

## Verification
- `bash scripts/ops/qa-gate-check.sh r3dbars/transcripted 428` -> `PENDING` and exit code `3`

## Related
- #428
- #432