### PR TITLE
ops: add QA gate closeout helper script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,6 +50,12 @@ not have to carry the full operational logic:
     - `0` = `PASS`
     - `2` = `FAIL`
     - `3` = pending (no top-level `PASS` / `FAIL` yet)
+- `scripts/ops/qa-gate-closeout.sh` — close a QA-gated GitHub issue automatically when `PASS` is detected
+  - Usage: `bash scripts/ops/qa-gate-closeout.sh <owner/repo> <issue-number>`
+  - Exit codes:
+    - `0` = issue closed (`PASS`)
+    - `2` = `FAIL` detected (left open)
+    - `3` = pending (left open)
 - `scripts/ops/build-codex-memory-index.py` — build a safe metadata-only index from local Codex session archives for Transcripted memory briefs
   - Usage: `python3 scripts/ops/build-codex-memory-index.py --verbose`
   - Writes:

--- a/scripts/ops/qa-gate-closeout.sh
+++ b/scripts/ops/qa-gate-closeout.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# qa-gate-closeout.sh - Close a QA-gated issue automatically when PASS is detected.
+# Usage:
+#   bash scripts/ops/qa-gate-closeout.sh <owner/repo> <issue-number>
+# Exit codes:
+#   0 => issue closed (PASS)
+#   2 => FAIL detected (issue left open)
+#   3 => PENDING (issue left open)
+#   1 => usage/auth/tooling error
+
+usage() {
+  echo "Usage: bash scripts/ops/qa-gate-closeout.sh <owner/repo> <issue-number>"
+  echo "Example: bash scripts/ops/qa-gate-closeout.sh r3dbars/transcripted 428"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+REPO="$1"
+ISSUE_NUMBER="$2"
+
+if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: issue-number must be numeric"
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh CLI not found"
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: gh is not authenticated (run 'gh auth login')"
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE_CHECK="$SCRIPT_DIR/qa-gate-check.sh"
+
+if [[ ! -x "$GATE_CHECK" ]]; then
+  echo "ERROR: missing executable $GATE_CHECK"
+  exit 1
+fi
+
+set +e
+STATUS_JSON="$("$GATE_CHECK" --json "$REPO" "$ISSUE_NUMBER" 2>/dev/null)"
+RC=$?
+set -e
+
+STATUS="$(echo "$STATUS_JSON" | jq -r '.status // ""')"
+
+if [[ "$STATUS" == "PASS" && $RC -eq 0 ]]; then
+  gh issue close "$ISSUE_NUMBER" -R "$REPO" \
+    --comment "Auto-close: QA gate check detected top-level PASS for this issue."
+  echo "CLOSED: #$ISSUE_NUMBER (PASS)"
+  exit 0
+fi
+
+if [[ "$STATUS" == "FAIL" || $RC -eq 2 ]]; then
+  echo "FAIL: top-level FAIL detected on #$ISSUE_NUMBER (left open)"
+  exit 2
+fi
+
+echo "PENDING: no top-level PASS/FAIL on #$ISSUE_NUMBER (left open)"
+exit 3


### PR DESCRIPTION
## Summary
- add `scripts/ops/qa-gate-closeout.sh`
- close QA-gated issues automatically when a top-level PASS is detected
- keep FAIL/PENDING non-destructive with clear exit codes
- document usage in `scripts/README.md`

## Why
BET-88 is QA-gated on issue #428. We now have a detector (`qa-gate-check.sh`) and this adds a small closeout helper so a PASS can transition the issue state with one command.

## Verification
- `bash scripts/ops/qa-gate-closeout.sh r3dbars/transcripted 428`
- current behavior: `PENDING` and exit code `3` (issue left open)

## Related
- #428