### PR TITLE
[codex] Improve dictation mic recovery

### DIFF
--- a/Sources/Meeting/MeetingFailureCopy.swift
+++ b/Sources/Meeting/MeetingFailureCopy.swift
@@ -20,6 +20,15 @@ struct MeetingFailureCopy: Equatable {
             )
         }
 
+        if message.contains("microphone access")
+            || message.contains("microphone permission")
+            || message.contains("mic_not_authorized") {
+            return MeetingFailureCopy(
+                title: "Turn on Microphone",
+                detail: "Turn on Microphone access in System Settings, then retry the meeting."
+            )
+        }
+
         if MeetingFailureKind.isRecordingTooShortMessage(message) {
             return MeetingFailureCopy(
                 title: "Recording ended too soon",

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -361,7 +361,7 @@ final class MeetingSessionController: ObservableObject {
     private func resolveStartRecordingPermissionDecision(
         trigger: StartTrigger
     ) async -> MeetingRecordingStartDecision {
-        let microphoneGranted = TranscriptedPermissionAccess.isGranted(.microphone)
+        let microphoneGranted = await TranscriptedPermissionAccess.requestMicrophoneAccessIfNeeded()
         var systemAudioRecordingGranted = TranscriptedPermissionAccess.isGranted(.systemAudioRecording)
         var startDecision = MeetingRecordingStartGate.evaluate(
             microphoneGranted: microphoneGranted,

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -822,6 +822,7 @@ class ParakeetEngine: ObservableObject {
             "output_channels": "\(outputFormat.channelCount)",
             "input_rate_hz": String(format: "%.0f", hwFormat.sampleRate),
             "hw_channels": "\(hwFormat.channelCount)",
+            "input_device_class": inputDeviceClass(for: inputDeviceName),
         ]
 
         if let error {
@@ -831,6 +832,35 @@ class ParakeetEngine: ObservableObject {
         }
 
         return context
+    }
+
+    private func inputDeviceClass(for deviceName: String) -> String {
+        let normalized = deviceName.lowercased()
+
+        if normalized.contains("airpods")
+            || normalized.contains("bluetooth")
+            || normalized.contains("beats")
+            || normalized.contains("buds")
+            || normalized.contains("headset") {
+            return "bluetooth"
+        }
+
+        if normalized.contains("macbook")
+            || normalized.contains("built-in")
+            || normalized.contains("built in")
+            || normalized.contains("studio display") {
+            return "built_in"
+        }
+
+        if normalized.contains("usb")
+            || normalized.contains("scarlett")
+            || normalized.contains("rode")
+            || normalized.contains("shure")
+            || normalized.contains("yeti") {
+            return "external"
+        }
+
+        return "unknown"
     }
 
     private func reportAudioStartFailureIfNeeded(message: String, context: [String: String]) {

--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -23,7 +23,7 @@ enum TranscriptedPermissionAccess {
     static func isGranted(_ kind: TranscriptedPermissionKind) -> Bool {
         switch kind {
         case .microphone:
-            return AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+            return microphoneAuthorizationStatus() == .authorized
         case .accessibility:
             return AXIsProcessTrusted()
         case .systemAudioRecording:
@@ -33,11 +33,40 @@ enum TranscriptedPermissionAccess {
         }
     }
 
+    static func microphoneAuthorizationStatus() -> AVAuthorizationStatus {
+        AVCaptureDevice.authorizationStatus(for: .audio)
+    }
+
+    @MainActor
+    static func requestMicrophoneAccessIfNeeded(
+        statusProvider: () -> AVAuthorizationStatus = { AVCaptureDevice.authorizationStatus(for: .audio) },
+        activateForPrompt: @MainActor () -> Void = { activateForPermissionPrompt() },
+        requester: @escaping (@escaping @Sendable (Bool) -> Void) -> Void = { completion in
+            AVCaptureDevice.requestAccess(for: .audio, completionHandler: completion)
+        }
+    ) async -> Bool {
+        switch statusProvider() {
+        case .authorized:
+            return true
+        case .notDetermined:
+            activateForPrompt()
+            return await withCheckedContinuation { continuation in
+                requester { granted in
+                    continuation.resume(returning: granted)
+                }
+            }
+        case .denied, .restricted:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
     @MainActor
     static func openSettings(for kind: TranscriptedPermissionKind) {
         switch kind {
         case .microphone:
-            switch AVCaptureDevice.authorizationStatus(for: .audio) {
+            switch microphoneAuthorizationStatus() {
             case .authorized:
                 break
             case .notDetermined:

--- a/Sources/Support/TranscriptedPermissionKind.swift
+++ b/Sources/Support/TranscriptedPermissionKind.swift
@@ -65,7 +65,7 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
     var actionButtonTitle: String {
         switch self {
         case .microphone:
-            return Self.microphoneActionTitle(for: AVCaptureDevice.authorizationStatus(for: .audio))
+            return Self.microphoneActionTitle(for: TranscriptedPermissionAccess.microphoneAuthorizationStatus())
         case .accessibility:
             return Self.accessibilityActionTitle(isTrusted: AXIsProcessTrusted())
         case .systemAudioRecording:

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -118,6 +118,56 @@ class DictationSessionController: ObservableObject {
         currentDictationTrigger = trigger
         lastCompletedText = nil
 
+        switch TranscriptedPermissionAccess.microphoneAuthorizationStatus() {
+        case .authorized:
+            recordDictationStarted(appState: appState, trigger: trigger)
+            continueDictationStart(
+                appState: appState,
+                overlayController: overlayController,
+                sourceApp: sourceApp
+            )
+        case .notDetermined:
+            overlayController.showLoadingState(
+                near: sourceApp,
+                presentation: microphonePermissionPresentation()
+            )
+            startupTask?.cancel()
+            startupTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                let granted = await TranscriptedPermissionAccess.requestMicrophoneAccessIfNeeded()
+                guard !Task.isCancelled, self.isDictating else { return }
+                self.startupTask = nil
+                if granted {
+                    self.recordDictationStarted(appState: appState, trigger: trigger)
+                    self.continueDictationStart(
+                        appState: appState,
+                        overlayController: overlayController,
+                        sourceApp: sourceApp
+                    )
+                } else {
+                    self.presentMicrophonePermissionError(
+                        TranscriptedPermissionAccess.microphoneAuthorizationStatus(),
+                        sourceApp: sourceApp
+                    )
+                }
+            }
+        case .denied, .restricted:
+            presentMicrophonePermissionError(
+                TranscriptedPermissionAccess.microphoneAuthorizationStatus(),
+                sourceApp: sourceApp
+            )
+        @unknown default:
+            presentMicrophonePermissionError(
+                TranscriptedPermissionAccess.microphoneAuthorizationStatus(),
+                sourceApp: sourceApp
+            )
+        }
+    }
+
+    private func recordDictationStarted(
+        appState: TranscriptedAppState,
+        trigger: DictationTrigger
+    ) {
         DiagnosticsTrail.record(
             logger: appState.logger,
             engine: "dictation",
@@ -135,7 +185,14 @@ class DictationSessionController: ObservableObject {
                 "trigger": trigger.rawValue,
             ]
         )
+    }
 
+    private func continueDictationStart(
+        appState: TranscriptedAppState,
+        overlayController: FloatingOverlayController,
+        sourceApp: NSRunningApplication?
+    ) {
+        guard isDictating else { return }
         if appState.sttRouter.isModelLoaded {
             overlayController.state = .listening
             overlayController.showPanel(near: sourceApp)
@@ -179,9 +236,9 @@ class DictationSessionController: ObservableObject {
         guard isDictating else { return }
 
         // Permission check up front — no point waiting if the user denied mic access.
-        let microphoneStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+        let microphoneStatus = TranscriptedPermissionAccess.microphoneAuthorizationStatus()
         guard microphoneStatus == .authorized else {
-            presentMicrophonePermissionError(microphoneStatus)
+            presentMicrophonePermissionError(microphoneStatus, sourceApp: sourceApp)
             return
         }
 
@@ -255,9 +312,12 @@ class DictationSessionController: ObservableObject {
         isDictating = false
     }
 
-    private func presentMicrophonePermissionError(_ status: AVAuthorizationStatus) {
+    private func presentMicrophonePermissionError(
+        _ status: AVAuthorizationStatus,
+        sourceApp: NSRunningApplication? = nil
+    ) {
         guard let appState = appState, let overlayController = overlayController else { return }
-        let shouldOfferSettingsAction = shouldOfferMicrophoneSettingsAction(for: status)
+        let shouldOfferRecoveryAction = shouldOfferMicrophoneRecoveryAction(for: status)
         DiagnosticsTrail.record(
             logger: appState.logger,
             level: .error,
@@ -271,11 +331,35 @@ class DictationSessionController: ObservableObject {
                 ]
             )
         )
+        if !overlayController.isVisible {
+            overlayController.showPanel(near: sourceApp)
+        }
         overlayController.showError(
             microphoneUnavailableMessage(for: status, openedSettings: false),
-            actionTitle: shouldOfferSettingsAction ? "Open Microphone Settings" : nil,
-            action: shouldOfferSettingsAction ? {
-                TranscriptedPermissionAccess.openSettings(for: .microphone)
+            actionTitle: shouldOfferRecoveryAction ? TranscriptedPermissionKind.microphoneActionTitle(for: status) : nil,
+            action: shouldOfferRecoveryAction ? { [weak self] in
+                guard let self else { return }
+                switch status {
+                case .notDetermined:
+                    Task { @MainActor [weak self] in
+                        guard let self else { return }
+                        let granted = await TranscriptedPermissionAccess.requestMicrophoneAccessIfNeeded()
+                        guard granted else {
+                            self.presentMicrophonePermissionError(
+                                TranscriptedPermissionAccess.microphoneAuthorizationStatus(),
+                                sourceApp: sourceApp
+                            )
+                            return
+                        }
+                        self.startDictation(sourceApp: sourceApp, trigger: self.currentDictationTrigger)
+                    }
+                case .denied, .restricted:
+                    TranscriptedPermissionAccess.openSettings(for: .microphone)
+                case .authorized:
+                    self.startDictation(sourceApp: sourceApp, trigger: self.currentDictationTrigger)
+                @unknown default:
+                    TranscriptedPermissionAccess.openSettings(for: .microphone)
+                }
             } : nil
         )
         isDictating = false
@@ -486,10 +570,16 @@ class DictationSessionController: ObservableObject {
 
         startupTask?.cancel()
         updateLoadingOverlay(sourceApp: sourceApp)
-        retryModelWarmupIfNeeded()
 
         startupTask = Task { @MainActor [weak self] in
             guard let self else { return }
+
+            switch appState.sttRouter.modelDownloadState {
+            case .notLoaded, .failed:
+                await appState.sttRouter.initializeSelectedModel()
+            case .downloading, .loading, .ready:
+                break
+            }
 
             for _ in 0..<TranscriptedConstants.modelLoadMaxIterations {
                 guard !Task.isCancelled, self.isDictating else { return }
@@ -508,7 +598,13 @@ class DictationSessionController: ObservableObject {
                 case .failed(let message):
                     self.startupTask = nil
                     self.isDictating = false
-                    overlayController.showError("Dictation couldn't start: \(message)")
+                    overlayController.showError(
+                        "Dictation couldn't start: \(message)",
+                        actionTitle: "Retry Dictation",
+                        action: { [weak self] in
+                            self?.startDictation(sourceApp: sourceApp, trigger: self?.currentDictationTrigger ?? .unknown)
+                        }
+                    )
                     return
                 default:
                     break
@@ -520,20 +616,13 @@ class DictationSessionController: ObservableObject {
             guard !Task.isCancelled else { return }
             self.startupTask = nil
             self.isDictating = false
-            overlayController.showError("Dictation is still loading. Please try again in a moment.")
-        }
-    }
-
-    private func retryModelWarmupIfNeeded() {
-        guard let appState else { return }
-
-        switch appState.sttRouter.modelDownloadState {
-        case .notLoaded, .failed:
-            Task { @MainActor [weak appState] in
-                await appState?.sttRouter.initializeSelectedModel()
-            }
-        case .downloading, .loading, .ready:
-            break
+            overlayController.showError(
+                "Dictation is still loading. Please try again in a moment.",
+                actionTitle: "Retry Dictation",
+                action: { [weak self] in
+                    self?.startDictation(sourceApp: sourceApp, trigger: self?.currentDictationTrigger ?? .unknown)
+                }
+            )
         }
     }
 
@@ -595,6 +684,15 @@ class DictationSessionController: ObservableObject {
             detail: "Connecting to the new audio device.",
             progress: progress,
             status: status
+        )
+    }
+
+    private func microphonePermissionPresentation() -> FloatingOverlayController.LoadingPresentation {
+        .init(
+            title: "Allow microphone",
+            detail: "Transcripted needs microphone access before dictation can listen.",
+            progress: 0.16,
+            status: "Waiting for macOS permission"
         )
     }
 
@@ -671,17 +769,23 @@ class DictationSessionController: ObservableObject {
                 ]
             )
         )
-        overlayController?.showError("Recording was interrupted. Try again.")
+        overlayController?.showError(
+            "Recording was interrupted. Check your microphone or audio device, then try again.",
+            actionTitle: "Retry Dictation",
+            action: { [weak self] in
+                self?.startDictation(sourceApp: self?.sessionSourceApp, trigger: self?.currentDictationTrigger ?? .unknown)
+            }
+        )
     }
 
-    private func shouldOfferMicrophoneSettingsAction(for status: AVAuthorizationStatus) -> Bool {
+    private func shouldOfferMicrophoneRecoveryAction(for status: AVAuthorizationStatus) -> Bool {
         switch status {
-        case .denied, .restricted:
+        case .notDetermined, .denied, .restricted:
             return true
-        case .notDetermined, .authorized:
+        case .authorized:
             return false
         @unknown default:
-            return false
+            return true
         }
     }
 
@@ -691,7 +795,7 @@ class DictationSessionController: ObservableObject {
     ) -> String {
         switch status {
         case .notDetermined:
-            return "Transcripted is still waiting for microphone permission."
+            return "Transcripted needs microphone access before dictation can listen."
         case .denied, .restricted:
             if openedSettings {
                 return "Microphone access is off. Transcripted opened the Microphone pane in System Settings."

--- a/Sources/UI/Overlay/OverlayHeaderView.swift
+++ b/Sources/UI/Overlay/OverlayHeaderView.swift
@@ -237,7 +237,8 @@ final class OverlayHeaderView: NSView {
     func update(
         state: FloatingOverlayController.OverlayState,
         dictationShortcutHint: String,
-        loadingTitle: String?
+        loadingTitle: String?,
+        isError: Bool = false
     ) {
         // Mode label text + color
         switch state {
@@ -245,7 +246,7 @@ final class OverlayHeaderView: NSView {
             modeLabel.stringValue = "Listening"
             modeLabel.textColor = OverlayTokens.textPrimary
         case .drafting:
-            modeLabel.stringValue = "Transcribing"
+            modeLabel.stringValue = isError ? "Dictation issue" : "Transcribing"
             modeLabel.textColor = OverlayTokens.textPrimary
         case .success:
             modeLabel.stringValue = "Pasted"
@@ -259,7 +260,7 @@ final class OverlayHeaderView: NSView {
         }
 
         // Spinner visibility
-        let showSpinner = state == .drafting || state == .loading
+        let showSpinner = (state == .drafting && !isError) || state == .loading
         spinner.isHidden = !showSpinner
         if showSpinner { spinner.startAnimation(nil) } else { spinner.stopAnimation(nil) }
 

--- a/Sources/UI/Overlay/OverlayRootView.swift
+++ b/Sources/UI/Overlay/OverlayRootView.swift
@@ -128,16 +128,17 @@ final class OverlayRootView: NSView {
         currentState = state
         currentErrorMessage = errorMessage
 
+        let showLoading = state == .loading
+        let showError = state == .drafting && !errorMessage.isEmpty
+        let showContent = showLoading || showError
+
         // Update header
         headerView.update(
             state: state,
             dictationShortcutHint: dictationShortcutHint,
-            loadingTitle: state == .loading ? loadingPresentation.title : nil
+            loadingTitle: state == .loading ? loadingPresentation.title : nil,
+            isError: showError
         )
-
-        let showLoading = state == .loading
-        let showError = state == .drafting && !errorMessage.isEmpty
-        let showContent = showLoading || showError
 
         contentContainer.isHidden = !showContent
 

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -41,4 +41,19 @@ func testFailedMeetingPresentation() {
             "permission failures should point to the recovery step"
         )
     }
+
+    runSuite("FailedMeetingPresentation microphone failures point to settings") {
+        let copy = MeetingFailureCopy.make(
+            forMessage: "Turn on Microphone access in System Settings before recording a meeting.",
+            shortErrorMessage: "Turn on Microphone access in System Settings before recording a meeting.",
+            isRetryable: false
+        )
+
+        assertEqual(copy.title, "Turn on Microphone", "microphone failures should name the missing permission")
+        assertEqual(
+            copy.detail,
+            "Turn on Microphone access in System Settings, then retry the meeting.",
+            "microphone failures should point to the recovery step"
+        )
+    }
 }

--- a/Tests/MeetingRecordingStartGateTests.swift
+++ b/Tests/MeetingRecordingStartGateTests.swift
@@ -31,6 +31,22 @@ func testMeetingRecordingStartGate() {
         assertEqual(decision.missingPermissions, ["system_audio_recording"], "missing permission list should stay explicit")
     }
 
+    runSuite("MeetingRecordingStartGate.evaluate — blocks meeting capture when Microphone is missing") {
+        let decision = MeetingRecordingStartGate.evaluate(
+            microphoneGranted: false,
+            systemAudioRecordingGranted: true
+        )
+
+        assertFalse(decision.canStart, "meeting capture should fail fast when Microphone is missing")
+        assertEqual(
+            decision.errorMessage,
+            "Turn on Microphone access in System Settings before recording a meeting.",
+            "microphone failures should tell the user exactly what to fix"
+        )
+        assertEqual(decision.failureReason, "microphone", "microphone failures should stay classified for diagnostics")
+        assertEqual(decision.missingPermissions, ["microphone"], "missing permission list should stay explicit")
+    }
+
     runSuite("MeetingRecordingStartGate.evaluate — blocks meeting capture when both permissions are missing") {
         let decision = MeetingRecordingStartGate.evaluate(
             microphoneGranted: false,

--- a/Tests/SentryEventPolicyTests.swift
+++ b/Tests/SentryEventPolicyTests.swift
@@ -14,6 +14,10 @@ func testSentryEventPolicy() {
             forEngine: "parakeet",
             event: "audio_engine_start_failed"
         )
+        let modelInitFailure = SentryEventPolicy.policy(
+            forEngine: "parakeet",
+            event: "model_init_failed"
+        )
         let unknown = SentryEventPolicy.policy(
             forEngine: "dictation",
             event: "dictation_export_failed"
@@ -22,6 +26,7 @@ func testSentryEventPolicy() {
         assertEqual(transcriptionFailure?.summary, "Speech transcription failed.", "transcription failure should use the normalized summary")
         assertEqual(hotkeyFailure?.summary, "Transcripted could not register a keyboard shortcut.", "capture failure should stay allowlisted")
         assertEqual(audioStartFailure?.summary, "Speech audio engine failed to start.", "audio-start failures should stay allowlisted with a privacy-safe summary")
+        assertEqual(modelInitFailure?.summary, "Speech model initialization failed.", "model-init failures should stay allowlisted with a privacy-safe summary")
         assertNil(unknown, "unknown events should stay local-only by default")
     }
 }

--- a/Tests/SentryPayloadSanitizerTests.swift
+++ b/Tests/SentryPayloadSanitizerTests.swift
@@ -49,6 +49,7 @@ func testSentryPayloadSanitizer() {
             "hw_channels": "1",
             "status_domain": "com.apple.coreaudio.avfaudio",
             "status_code": "-10868",
+            "input_device_class": "bluetooth",
             "audio_device": "Private AirPods",
             "error": "Failed to initialize active nodes",
             "source_app": "com.example.private",
@@ -64,6 +65,7 @@ func testSentryPayloadSanitizer() {
         assertEqual(sanitized["hw_channels"], "1", "hardware channel count should remain")
         assertEqual(sanitized["status_domain"], "com.apple.coreaudio.avfaudio", "status domain should remain")
         assertEqual(sanitized["status_code"], "-10868", "status code should remain")
+        assertEqual(sanitized["input_device_class"], "bluetooth", "coarse input device classes should remain")
         assertNil(sanitized["audio_device"], "raw audio device names should be dropped")
         assertNil(sanitized["error"], "free-form errors should be dropped")
         assertNil(sanitized["source_app"], "source app identifiers should be dropped")

--- a/Tests/TranscriptedPermissionAccessTests.swift
+++ b/Tests/TranscriptedPermissionAccessTests.swift
@@ -164,6 +164,51 @@ func testTranscriptedPermissionAccess() async {
         )
     }
 
+    await runSuite("TranscriptedPermissionAccess.requestMicrophoneAccessIfNeeded — skips requester when microphone is already authorized") {
+        let requestBox = PermissionRequestBox()
+        let granted = await TranscriptedPermissionAccess.requestMicrophoneAccessIfNeeded(
+            statusProvider: { .authorized },
+            activateForPrompt: {},
+            requester: { completion in
+                requestBox.callCount += 1
+                completion(false)
+            }
+        )
+
+        assertTrue(granted, "authorized microphone status should return true")
+        assertEqual(requestBox.callCount, 0, "authorized microphone status should not trigger another prompt")
+    }
+
+    await runSuite("TranscriptedPermissionAccess.requestMicrophoneAccessIfNeeded — prompts when microphone is not determined") {
+        let requestBox = PermissionRequestBox()
+        let granted = await TranscriptedPermissionAccess.requestMicrophoneAccessIfNeeded(
+            statusProvider: { .notDetermined },
+            activateForPrompt: {},
+            requester: { completion in
+                requestBox.callCount += 1
+                completion(true)
+            }
+        )
+
+        assertTrue(granted, "not-determined microphone access should return the requester result")
+        assertEqual(requestBox.callCount, 1, "not-determined microphone access should ask macOS once")
+    }
+
+    await runSuite("TranscriptedPermissionAccess.requestMicrophoneAccessIfNeeded — does not prompt after denial") {
+        let requestBox = PermissionRequestBox()
+        let granted = await TranscriptedPermissionAccess.requestMicrophoneAccessIfNeeded(
+            statusProvider: { .denied },
+            activateForPrompt: {},
+            requester: { completion in
+                requestBox.callCount += 1
+                completion(true)
+            }
+        )
+
+        assertFalse(granted, "denied microphone access should stay blocked until Settings changes")
+        assertEqual(requestBox.callCount, 0, "denied microphone access should not show a repeat system prompt")
+    }
+
     runSuite("TranscriptedPermissionAccess.systemAudioRecordingStatus — separates unknown from denied state") {
         let originalKnown = UserDefaults.standard.object(forKey: knownKey)
         let originalGranted = UserDefaults.standard.object(forKey: grantedKey)


### PR DESCRIPTION
## Summary
- requests microphone access proactively before dictation or meeting recording tries to start
- turns denied/restricted mic states into actionable overlay/settings recovery instead of generic failures
- makes dictation interruption/model-load failures retryable from the overlay and stops showing the misleading Transcribing header on error
- adds coarse input device class to Sentry audio-start diagnostics without sending raw device names

## Why
Sentry showed recurring Parakeet mic/model/audio-start failures, and a user screenshot showed dictation failing with `Recording was interrupted. Try again.` under a misleading transcribing state. This PR makes the permission path explicit and improves what we can see for the remaining CoreAudio start failures.

## Validation
- `bash run-tests.sh`
- `bash build.sh`
- `bash run-integration-smoke.sh`
