### PR TITLE
[codex] BET-88 QA gate: auto-create follow-up on FAIL

### DIFF
--- a/.github/workflows/qa-gate-auto-close-bet88.yml
+++ b/.github/workflows/qa-gate-auto-close-bet88.yml
@@ -8,7 +8,7 @@ permissions:
   issues: write
 
 jobs:
-  close_on_pass:
+  handle_gate_comment:
     if: >-
       ${{
         github.event.issue.number == 428 &&
@@ -54,3 +54,48 @@ jobs:
               body: "Auto-close: detected top-level PASS comment for BET-88 QA gate."
             });
 
+      - name: Open or reuse follow-up issue on FAIL
+        if: steps.detect.outputs.status == 'fail'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.payload.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const failComment = context.payload.comment?.html_url ?? "";
+            const marker = `BET-88 QA FAIL follow-up for #${issue_number}`;
+
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${owner}/${repo} is:issue is:open in:title "${marker}"`,
+              per_page: 1
+            });
+
+            let followup;
+            if ((search.data.items ?? []).length > 0) {
+              followup = search.data.items[0];
+            } else {
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title: marker,
+                body: [
+                  "Automated follow-up created from BET-88 QA gate FAIL.",
+                  "",
+                  `Source gate issue: #${issue_number}`,
+                  failComment ? `Source FAIL comment: ${failComment}` : "",
+                  "",
+                  "Next action:",
+                  "- Reproduce with docs/qa-parakeet-start-failure-smoke.md",
+                  "- Implement fix for the failing path",
+                  "- Link validation evidence back to #428"
+                ].filter(Boolean).join("\n")
+              });
+              followup = created.data;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: `Auto-follow-up: detected top-level FAIL. Tracking fix in #${followup.number}.`
+            });


### PR DESCRIPTION
## Summary
- extend BET-88 QA gate comment workflow to handle top-level FAIL
- keep existing PASS auto-close behavior unchanged
- on FAIL, open or reuse a deduplicated follow-up issue and post the link back on #428

## Why
BET-88 is QA-gated and already automated for PASS closeout. This adds durable automation for the FAIL branch so follow-up work is immediately tracked without manual triage lag.

## Test
- workflow logic inspection in `.github/workflows/qa-gate-auto-close-bet88.yml`
