### PR TITLE
Ignore .claude worktree mirrors in repo command contract scan

### DIFF
--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -82,6 +82,7 @@ private func shouldDescendInto(_ url: URL, root: URL) -> Bool {
     let relativePath = url.path.replacingOccurrences(of: root.path + "/", with: "")
     let excludedPrefixes = [
         ".build/",
+        ".claude/worktrees/",
         ".deps-build/",
         ".git/",
         ".swiftpm/",


### PR DESCRIPTION
## Summary
- exclude `.claude/worktrees/` from `RepoCommandContractTests` repo scan
- prevents local/mirrored worktree copies from tripping the `Transcripted.xcodeproj` live-doc assertion

## Why
`run-tests.sh` for BET-88 verification was failing on false positives from `.claude/worktrees/*` script mirrors, not from live repo docs/scripts.

## Verification
- `bash run-tests.sh` (633 passed, 0 failed)
- `bash build-deps.sh --force`
- `bash build.sh`