### PR TITLE
Add one-shot BET-88 QA gate closeout helper

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,6 +39,9 @@ not have to carry the full operational logic:
 - `scripts/ops/qa-gate-check.sh` — one-shot check for the BET-88 QA gate comment on `#428` using the same strict owner + first-line PASS/FAIL rules as the auto-close workflow
   - Usage: `bash scripts/ops/qa-gate-check.sh [repo] [issue_number] [owner_login]`
   - Returns JSON and exits `0` for `pass`/`fail`, `3` for `PENDING`
+- `scripts/ops/qa-gate-closeout.sh` — closeout wrapper around `qa-gate-check.sh` that prints explicit unblock owner/action when status is still pending
+  - Usage: `bash scripts/ops/qa-gate-closeout.sh [repo] [issue_number] [owner_login]`
+  - Returns `0` for pass/fail closeout-ready, `3` when still blocked/pending
 - `scripts/ops/build-codex-memory-index.py` — build a safe metadata-only index from local Codex session archives for Transcripted memory briefs
   - Usage: `python3 scripts/ops/build-codex-memory-index.py --verbose`
   - Writes:

--- a/scripts/ops/qa-gate-closeout.sh
+++ b/scripts/ops/qa-gate-closeout.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Closeout helper for BET-88 QA gate issue.
+# Uses scripts/ops/qa-gate-check.sh for a single deterministic status read.
+#
+# Usage:
+#   bash scripts/ops/qa-gate-closeout.sh [repo] [issue_number] [owner_login]
+
+REPO="${1:-r3dbars/transcripted}"
+ISSUE_NUMBER="${2:-428}"
+OWNER_LOGIN="${3:-r3dbars}"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/qa-gate-check.sh"
+
+if [[ ! -x "$CHECK_SCRIPT" ]]; then
+  echo "ERROR: missing executable check helper: $CHECK_SCRIPT" >&2
+  exit 2
+fi
+
+check_output=""
+check_exit=0
+set +e
+check_output="$(bash "$CHECK_SCRIPT" "$REPO" "$ISSUE_NUMBER" "$OWNER_LOGIN")"
+check_exit=$?
+set -e
+
+echo "$check_output"
+
+if [[ $check_exit -eq 0 ]]; then
+  status="$(jq -r '.status' <<<"$check_output")"
+  case "$status" in
+    pass)
+      echo "CLOSEOUT: PASS detected for #$ISSUE_NUMBER"
+      echo "ACTION: none (workflow should auto-close; manual closeout can proceed)"
+      ;;
+    fail)
+      echo "CLOSEOUT: FAIL detected for #$ISSUE_NUMBER"
+      echo "ACTION: open/continue follow-up fix issue and link it back to #$ISSUE_NUMBER"
+      ;;
+    *)
+      echo "ERROR: unexpected success status '$status'" >&2
+      exit 2
+      ;;
+  esac
+  exit 0
+fi
+
+if [[ $check_exit -eq 3 ]]; then
+  echo "CLOSEOUT: PENDING (no valid owner-authored PASS/FAIL gate comment yet)"
+  echo "UNBLOCK_OWNER: @$OWNER_LOGIN"
+  echo "UNBLOCK_ACTION: post top-level comment on #$ISSUE_NUMBER with first non-empty line PASS / PASS: ... / FAIL / FAIL: ..."
+  exit 3
+fi
+
+echo "ERROR: qa-gate-check failed (exit $check_exit)" >&2
+exit "$check_exit"


### PR DESCRIPTION
## Summary
- add `scripts/ops/qa-gate-closeout.sh`
- wrap `qa-gate-check.sh` with explicit closeout messaging for `PASS` / `FAIL` / `PENDING`
- document the helper in `scripts/README.md`

## Why
BET-88 is externally blocked on manual QA evidence in `#428`. This helper gives one deterministic command that reports closeout readiness and always prints unblock owner/action when still pending.

## Verification
- `bash scripts/ops/qa-gate-closeout.sh r3dbars/transcripted 428 r3dbars`
  - output includes:
    - `status: PENDING`
    - `UNBLOCK_OWNER: @r3dbars`
    - `UNBLOCK_ACTION: post top-level comment ... PASS / FAIL`
  - exit code: `3`
