### PR TITLE
Add manual BET-88 QA gate status workflow and token fallback

### DIFF
--- a/.github/workflows/qa-gate-status-bet88.yml
+++ b/.github/workflows/qa-gate-status-bet88.yml
@@ -1,0 +1,63 @@
+name: BET-88 QA Gate Status
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Gate issue number"
+        required: false
+        default: "428"
+      owner_login:
+        description: "QA owner login"
+        required: false
+        default: "r3dbars"
+
+permissions:
+  issues: read
+  contents: read
+
+jobs:
+  check_gate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run BET-88 gate closeout helper
+        id: closeout
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number || '428' }}
+          OWNER_LOGIN: ${{ github.event.inputs.owner_login || 'r3dbars' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x scripts/ops/qa-gate-check.sh scripts/ops/qa-gate-closeout.sh
+
+          set +e
+          OUTPUT="$(bash scripts/ops/qa-gate-closeout.sh "${{ github.repository }}" "$ISSUE_NUMBER" "$OWNER_LOGIN")"
+          EXIT_CODE=$?
+          set -e
+
+          echo "$OUTPUT"
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## BET-88 QA Gate Status"
+            echo
+            echo 'Repository: `${{ github.repository }}`'
+            echo "Issue: #$ISSUE_NUMBER"
+            echo "Owner: @$OWNER_LOGIN"
+            echo "Helper exit code: $EXIT_CODE"
+            echo
+            echo '```json'
+            echo "$OUTPUT"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$EXIT_CODE" -eq 0 || "$EXIT_CODE" -eq 3 ]]; then
+            exit 0
+          fi
+
+          exit "$EXIT_CODE"

--- a/scripts/ops/qa-gate-check.sh
+++ b/scripts/ops/qa-gate-check.sh
@@ -15,19 +15,32 @@ REPO="${1:-r3dbars/transcripted}"
 ISSUE_NUMBER="${2:-428}"
 OWNER_LOGIN="${3:-r3dbars}"
 
-if ! command -v gh >/dev/null 2>&1; then
-  echo "ERROR: gh CLI is required" >&2
-  exit 2
-fi
-
 if ! command -v jq >/dev/null 2>&1; then
   echo "ERROR: jq is required" >&2
   exit 2
 fi
 
-comments_json="$(gh api --paginate \
-  "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
-  --jq '.[]' | jq -s '.')"
+fetch_comments_json() {
+  if command -v gh >/dev/null 2>&1; then
+    gh api --paginate \
+      "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+      --jq '.[]' | jq -s '.'
+    return
+  fi
+
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    curl -fsSL \
+      -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+      -H "Accept: application/vnd.github+json" \
+      "https://api.github.com/repos/${REPO}/issues/${ISSUE_NUMBER}/comments?per_page=100"
+    return
+  fi
+
+  echo "ERROR: neither gh CLI nor GITHUB_TOKEN fallback is available" >&2
+  return 2
+}
+
+comments_json="$(fetch_comments_json)"
 
 result_json="$(jq -c --arg owner "$OWNER_LOGIN" '
   def first_line:


### PR DESCRIPTION
## Summary
- add manual Actions workflow `.github/workflows/qa-gate-status-bet88.yml`
  - `workflow_dispatch` inputs: issue number + owner login
  - runs `scripts/ops/qa-gate-closeout.sh`
  - writes a Markdown job summary with JSON output and helper exit code
- update `scripts/ops/qa-gate-check.sh` with a fallback path:
  - use `gh` when available
  - otherwise use `GITHUB_TOKEN` + GitHub REST API via `curl`

## Why
This gives a no-poll, on-demand gate status path directly in GitHub Actions, so BET-88 status can be checked without local CLI setup.

## Verification
- local:
  - `bash scripts/ops/qa-gate-check.sh r3dbars/transcripted 428 r3dbars` -> `PENDING`, exit `3`
  - `bash scripts/ops/qa-gate-closeout.sh r3dbars/transcripted 428 r3dbars` -> `PENDING`, unblock owner/action printed, exit `3`
- workflow file validates YAML and invokes only repo-local scripts + GitHub token auth.
