### PR TITLE
Use actions/checkout v5 in BET-88 gate status workflow

### DIFF
--- a/.github/workflows/qa-gate-status-bet88.yml
+++ b/.github/workflows/qa-gate-status-bet88.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run BET-88 gate closeout helper
         id: closeout


### PR DESCRIPTION
## Summary
- bump `actions/checkout` from `@v4` to `@v5` in `.github/workflows/qa-gate-status-bet88.yml`

## Why
Manual gate-status runs were emitting a Node 20 deprecation annotation. `@v5` is the current checkout major and removes that warning path.

## Scope
- no behavior change to gate logic
- workflow inputs, closeout helper invocation, and summary output are unchanged
