### PR TITLE
BET-88: harden Parakeet startRecording failure-state reset

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -780,6 +780,13 @@ class ParakeetEngine: ObservableObject {
     }
 
     private func resetAudioGraphAfterStartFailure(reason: String, rebuildEngine: Bool) {
+        // Keep runtime/UI state coherent when startRecording fails before we ever
+        // transition to a stable recording session.
+        cancelAudioWatchdog()
+        isRecording = false
+        audioLevel = 0
+        didReceiveAudioSamples = false
+
         if rebuildEngine {
             rebuildAudioEngine(reason: reason)
             return


### PR DESCRIPTION
## Summary
- harden `resetAudioGraphAfterStartFailure` to explicitly reconcile runtime/UI recording state on start failures
- clear watchdog, `isRecording`, metering, and sample-flow flag before retry/fail return

## Why
`AVAudioEngine.start()` failures should leave the engine and UI in a deterministic non-recording state before recovery policy retries or returns failure.

## Verification
- `bash build.sh`
- `bash run-tests.sh` (656 passed, 0 failed)
