### PR TITLE
Update release metadata for 1.1.15

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.14"
-  sha256 "2afec38db36c69d68a53a5a8690b7ddd94a8293568e124145d44a689bb8c6a13"
+  version "1.1.15"
+  sha256 "29ccdc6475c42e13566e5e5734f1e18cd37205dbd0542d92b86a29dcdc66be7f"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
   version "1.1.15"
-  sha256 "29ccdc6475c42e13566e5e5734f1e18cd37205dbd0542d92b86a29dcdc66be7f"
+  sha256 "5f5977394c22ac03465b2205214d57a48d09dae50cca3a10481b8fbbaee6793b"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -15,7 +15,7 @@
             <sparkle:shortVersionString>1.1.15</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
             <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.15/Transcripted-1.1.15.dmg" length="525387839" type="application/octet-stream" sparkle:edSignature="M8MJfUbN3uNGMZYq4hNvBUcc0pARk/PhU28AQBcmiEDj4VvfNoWxk1mg9pAGtWL5C6RQMVjvHJSl3agKwhcuDg=="/>
+            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.15/Transcripted-1.1.15.dmg" length="525387622" type="application/octet-stream" sparkle:edSignature="qPXpfEd9Umelrca057dPpTz26cFTnCDhau6+/fqL5f141HWbrEZQVQFfzKCDb56Aj0QoLW9G7x9klb6FDICOBg=="/>
         </item>
         <item>
             <title>1.1.14</title>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
         <description>Release feed for Transcripted macOS updates.</description>
         <language>en</language>
         <item>
+            <title>1.1.15</title>
+            <pubDate>Tue, 21 Apr 2026 16:18:20 -0500</pubDate>
+            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.15</link>
+            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.15</sparkle:fullReleaseNotesLink>
+            <sparkle:version>1.1.15</sparkle:version>
+            <sparkle:shortVersionString>1.1.15</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.15/Transcripted-1.1.15.dmg" length="525387839" type="application/octet-stream" sparkle:edSignature="M8MJfUbN3uNGMZYq4hNvBUcc0pARk/PhU28AQBcmiEDj4VvfNoWxk1mg9pAGtWL5C6RQMVjvHJSl3agKwhcuDg=="/>
+        </item>
+        <item>
             <title>1.1.14</title>
             <pubDate>Tue, 21 Apr 2026 11:38:54 -0500</pubDate>
             <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.14</link>


### PR DESCRIPTION
## Summary
- add 1.1.15 to the Sparkle appcast
- update the Homebrew cask to the rebuilt 1.1.15 DMG
- includes the #455 rebuild artifact metadata

## Verification
- bash run-tests.sh
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-release-1-1-15 Release
- hdiutil verify build/Transcripted-1.1.15.dmg
- xcrun stapler validate build/Transcripted-1.1.15.dmg
- codesign --verify --deep --strict build/Transcripted.app
- spctl -a -t exec -vv build/Transcripted.app
- xmllint --noout docs/appcast.xml
- ruby -c Casks/transcripted.rb
- downloaded GitHub release asset sha256 matches cask