### PR TITLE
[codex] Split dictation shortcuts by capture mode

### DIFF
--- a/Sources/Capture/ContextCaptureEngine.swift
+++ b/Sources/Capture/ContextCaptureEngine.swift
@@ -107,19 +107,43 @@ private func hotkeyHandler(
     return noErr
 }
 
-private final class PhysicalDictationTriggerDetector {
-    var bindingProvider: (() -> PhysicalDictationTriggerBinding)?
-    var onPress: (() -> Void)?
-    var onRelease: (() -> Void)?
+private enum PhysicalShortcutAction {
+    case dictationPushToTalk
+    case dictationHandsFree
+    case meeting
+}
+
+private enum PhysicalShortcutPhase {
+    case press
+    case release
+}
+
+private struct PhysicalShortcutBinding {
+    let action: PhysicalShortcutAction
+    let binding: PhysicalDictationTriggerBinding
+}
+
+private final class PhysicalShortcutDetector {
+    var bindingProvider: (() -> [PhysicalShortcutBinding])?
+    var onShortcut: ((PhysicalShortcutAction, PhysicalShortcutPhase) -> Void)?
 
     private var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
-    private var triggerDown = false
-    private var consumedKeyCode: UInt32?
+    private var activePushToTalkKeyCode: UInt32?
+    private var consumedKeyCodes: Set<UInt32> = []
+    private var pendingModifierShortcut: PendingModifierShortcut?
+
+    private struct PendingModifierShortcut {
+        let keyCode: UInt32
+        let action: PhysicalShortcutAction
+        let workItem: DispatchWorkItem
+    }
+
+    private static let modifierChordDelay: TimeInterval = 0.14
 
     private static let callback: CGEventTapCallBack = { _, type, event, userInfo in
         guard let userInfo else { return Unmanaged.passUnretained(event) }
-        let detector = Unmanaged<PhysicalDictationTriggerDetector>
+        let detector = Unmanaged<PhysicalShortcutDetector>
             .fromOpaque(userInfo)
             .takeUnretainedValue()
         return detector.handle(type: type, event: event)
@@ -142,18 +166,16 @@ private final class PhysicalDictationTriggerDetector {
             callback: Self.callback,
             userInfo: userInfo
         ) else {
-            triggerDown = false
-            consumedKeyCode = nil
+            resetState()
             return TranscriptedPermissionAccess.isGranted(.accessibility)
-                ? "Dictation trigger failed to start"
-                : "Dictation trigger needs Accessibility permission"
+                ? "Shortcut trigger failed to start"
+                : "Shortcut trigger needs Accessibility permission"
         }
 
         guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
             CFMachPortInvalidate(tap)
-            triggerDown = false
-            consumedKeyCode = nil
-            return "Dictation trigger failed to start"
+            resetState()
+            return "Shortcut trigger failed to start"
         }
 
         eventTap = tap
@@ -173,8 +195,14 @@ private final class PhysicalDictationTriggerDetector {
         }
         runLoopSource = nil
         eventTap = nil
-        triggerDown = false
-        consumedKeyCode = nil
+        resetState()
+    }
+
+    private func resetState() {
+        pendingModifierShortcut?.workItem.cancel()
+        pendingModifierShortcut = nil
+        activePushToTalkKeyCode = nil
+        consumedKeyCodes.removeAll()
     }
 
     private func handle(type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
@@ -185,7 +213,7 @@ private final class PhysicalDictationTriggerDetector {
             return Unmanaged.passUnretained(event)
         }
 
-        guard let binding = bindingProvider?() else {
+        guard let shortcutBindings = bindingProvider?(), !shortcutBindings.isEmpty else {
             return Unmanaged.passUnretained(event)
         }
 
@@ -194,54 +222,170 @@ private final class PhysicalDictationTriggerDetector {
 
         switch type {
         case .keyDown:
-            guard PhysicalDictationTriggerPreferences.matchesKeyDown(binding, keyCode: keyCode, modifiers: modifiers) else {
+            let isRepeat = event.getIntegerValueField(.keyboardEventAutorepeat) != 0
+            if isRepeat, consumedKeyCodes.contains(keyCode) {
+                return nil
+            }
+
+            guard !isRepeat,
+                  let shortcut = matchingKeyDownShortcut(shortcutBindings, keyCode: keyCode, modifiers: modifiers) else {
                 return Unmanaged.passUnretained(event)
             }
 
-            let isRepeat = event.getIntegerValueField(.keyboardEventAutorepeat) != 0
-            if !triggerDown && !isRepeat {
-                triggerDown = true
-                consumedKeyCode = keyCode
-                onPress?()
+            cancelPendingModifierShortcut()
+            consumedKeyCodes.insert(keyCode)
+
+            switch shortcut.action {
+            case .dictationPushToTalk:
+                guard activePushToTalkKeyCode == nil else { return nil }
+                activePushToTalkKeyCode = keyCode
+                onShortcut?(.dictationPushToTalk, .press)
+            case .dictationHandsFree:
+                onShortcut?(.dictationHandsFree, .press)
+            case .meeting:
+                onShortcut?(.meeting, .press)
             }
             return nil
 
         case .keyUp:
-            if consumedKeyCode == keyCode {
-                triggerDown = false
-                consumedKeyCode = nil
-                onRelease?()
+            if activePushToTalkKeyCode == keyCode {
+                activePushToTalkKeyCode = nil
+                consumedKeyCodes.remove(keyCode)
+                onShortcut?(.dictationPushToTalk, .release)
                 return nil
             }
+
+            if consumedKeyCodes.remove(keyCode) != nil {
+                return nil
+            }
+
             return Unmanaged.passUnretained(event)
 
         case .flagsChanged:
-            if binding.keyCode == UInt32(kVK_CapsLock),
-               PhysicalDictationTriggerPreferences.matchesFlagsChangedPress(binding, keyCode: keyCode, modifiers: modifiers) {
-                onPress?()
+            if pendingModifierShortcut?.keyCode == keyCode,
+               let pending = pendingModifierShortcut,
+               matchesRelease(for: pending.action, in: shortcutBindings, keyCode: keyCode, modifiers: modifiers) {
+                cancelPendingModifierShortcut()
                 return nil
             }
 
-            if PhysicalDictationTriggerPreferences.matchesFlagsChangedPress(binding, keyCode: keyCode, modifiers: modifiers) {
-                if !triggerDown {
-                    triggerDown = true
-                    onPress?()
+            if activePushToTalkKeyCode == keyCode,
+               matchesRelease(for: .dictationPushToTalk, in: shortcutBindings, keyCode: keyCode, modifiers: modifiers) {
+                activePushToTalkKeyCode = nil
+                onShortcut?(.dictationPushToTalk, .release)
+                return nil
+            }
+
+            guard let shortcut = matchingFlagsChangedPressShortcut(shortcutBindings, keyCode: keyCode, modifiers: modifiers) else {
+                return Unmanaged.passUnretained(event)
+            }
+
+            switch shortcut.action {
+            case .dictationPushToTalk:
+                guard activePushToTalkKeyCode == nil else { return nil }
+                if hasChordUsingModifier(keyCode, in: shortcutBindings, excluding: shortcut.action) {
+                    schedulePendingModifierShortcut(keyCode: keyCode, action: .dictationPushToTalk)
+                } else {
+                    activePushToTalkKeyCode = keyCode
+                    onShortcut?(.dictationPushToTalk, .press)
                 }
-                return nil
+            case .dictationHandsFree:
+                cancelPendingModifierShortcut()
+                onShortcut?(.dictationHandsFree, .press)
+            case .meeting:
+                cancelPendingModifierShortcut()
+                onShortcut?(.meeting, .press)
             }
-
-            if triggerDown,
-               PhysicalDictationTriggerPreferences.matchesFlagsChangedRelease(binding, keyCode: keyCode, modifiers: modifiers) {
-                triggerDown = false
-                onRelease?()
-                return nil
-            }
-
-            return Unmanaged.passUnretained(event)
+            return nil
 
         default:
             return Unmanaged.passUnretained(event)
         }
+    }
+
+    private func matchingKeyDownShortcut(
+        _ shortcuts: [PhysicalShortcutBinding],
+        keyCode: UInt32,
+        modifiers: UInt32
+    ) -> PhysicalShortcutBinding? {
+        shortcuts.first {
+            PhysicalDictationTriggerPreferences.matchesKeyDown($0.binding, keyCode: keyCode, modifiers: modifiers)
+        }
+    }
+
+    private func matchingFlagsChangedPressShortcut(
+        _ shortcuts: [PhysicalShortcutBinding],
+        keyCode: UInt32,
+        modifiers: UInt32
+    ) -> PhysicalShortcutBinding? {
+        if let exact = shortcuts.first(where: {
+            $0.binding.keyCode == keyCode
+                && PhysicalDictationTriggerPreferences.matchesFlagsChangedPress($0.binding, keyCode: keyCode, modifiers: modifiers)
+        }) {
+            return exact
+        }
+
+        return shortcuts.first {
+            PhysicalDictationTriggerPreferences.matchesFlagsChangedPress($0.binding, keyCode: keyCode, modifiers: modifiers)
+        }
+    }
+
+    private func matchesRelease(
+        for action: PhysicalShortcutAction,
+        in shortcuts: [PhysicalShortcutBinding],
+        keyCode: UInt32,
+        modifiers: UInt32
+    ) -> Bool {
+        guard let shortcut = shortcuts.first(where: { $0.action == action }) else { return false }
+        return PhysicalDictationTriggerPreferences.matchesFlagsChangedRelease(
+            shortcut.binding,
+            keyCode: keyCode,
+            modifiers: modifiers
+        )
+    }
+
+    private func hasChordUsingModifier(
+        _ keyCode: UInt32,
+        in shortcuts: [PhysicalShortcutBinding],
+        excluding action: PhysicalShortcutAction
+    ) -> Bool {
+        guard let modifier = PhysicalDictationTriggerPreferences.primaryModifierMask(for: keyCode) else {
+            return false
+        }
+
+        return shortcuts.contains {
+            $0.action != action
+                && !PhysicalDictationTriggerPreferences.isModifierKey($0.binding.keyCode)
+                && ($0.binding.modifiers & modifier) != 0
+        }
+    }
+
+    private func schedulePendingModifierShortcut(keyCode: UInt32, action: PhysicalShortcutAction) {
+        cancelPendingModifierShortcut()
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self,
+                  self.pendingModifierShortcut?.keyCode == keyCode,
+                  self.pendingModifierShortcut?.action == action else {
+                return
+            }
+
+            self.pendingModifierShortcut = nil
+            self.activePushToTalkKeyCode = keyCode
+            self.onShortcut?(action, .press)
+        }
+
+        pendingModifierShortcut = PendingModifierShortcut(
+            keyCode: keyCode,
+            action: action,
+            workItem: workItem
+        )
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.modifierChordDelay, execute: workItem)
+    }
+
+    private func cancelPendingModifierShortcut() {
+        pendingModifierShortcut?.workItem.cancel()
+        pendingModifierShortcut = nil
     }
 }
 
@@ -252,13 +396,15 @@ class ContextCaptureEngine: ObservableObject {
     private var meetingHotkeyRef: EventHotKeyRef?
     private var eventHandlerRef: EventHandlerRef?
     private var hotkeyChangeObserver: NSObjectProtocol?
-    private let physicalDictationTriggerDetector = PhysicalDictationTriggerDetector()
+    private let physicalShortcutDetector = PhysicalShortcutDetector()
     private var carbonHotkeyError: String?
     private var physicalTriggerError: String?
 
     /// Human-readable display strings for current shortcuts (drives MenuBarPanel pills + overlay hints)
     @Published var dictationShortcutDisplay: String = ContextCaptureEngine.currentDictationShortcutDisplay()
-    @Published var meetingShortcutDisplay: String = HotkeyPreferences.displayString(for: HotkeyPreferences.meetingBinding())
+    @Published var meetingShortcutDisplay: String = PhysicalDictationTriggerPreferences.displayString(
+        for: PhysicalDictationTriggerPreferences.meetingBinding()
+    )
 
     /// Non-nil when hotkey registration failed — shown as a dismissible banner in MenuBarPanel
     @Published var hotkeyError: String?
@@ -280,7 +426,7 @@ class ContextCaptureEngine: ObservableObject {
     }
 
     func registerHotkey() {
-        guard eventHandlerRef == nil else {
+        guard hotkeyChangeObserver == nil else {
             EventReporter.shared.capture(level: .warning, engine: "capture", event: "hotkey_already_registered",
                 message: "registerHotkey() called but hotkey already registered — ignoring")
             return
@@ -291,21 +437,8 @@ class ContextCaptureEngine: ObservableObject {
         _sharedSessionController = sessionController
         _sharedMeetingToggle = onMeetingToggle
 
-        // Register for kEventHotKeyPressed (meeting mode)
-        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
-        InstallEventHandler(
-            GetApplicationEventTarget(),
-            hotkeyHandler,
-            1,
-            &eventType,
-            nil,
-            &eventHandlerRef
-        )
-
-        // Register meeting hotkey from saved preferences (or defaults)
-        registerHotkeysFromPreferences()
-
-        configurePhysicalDictationTriggerDetector()
+        refreshShortcutDisplays()
+        configurePhysicalShortcutDetector()
 
         // Listen for preference changes (from HotkeyRecorderView)
         hotkeyChangeObserver = NotificationCenter.default.addObserver(
@@ -322,56 +455,28 @@ class ContextCaptureEngine: ObservableObject {
     /// Unregisters the current meeting hotkey and re-registers with latest preferences.
     /// Preserves the event handler — only the key+modifier binding changes.
     private func reRegisterHotkeys() {
-        if let ref = meetingHotkeyRef {
-            UnregisterEventHotKey(ref)
-            meetingHotkeyRef = nil
-        }
-        registerHotkeysFromPreferences()
-
-        // Re-evaluate physical dictation trigger detector.
-        physicalDictationTriggerDetector.remove()
-        configurePhysicalDictationTriggerDetector()
+        refreshShortcutDisplays()
+        physicalShortcutDetector.remove()
+        configurePhysicalShortcutDetector()
     }
 
-    private func registerHotkeysFromPreferences() {
-        let meetingBinding = HotkeyPreferences.meetingBinding()
-        var errors: [String] = []
-
-        // Meeting mode — hotkey ID 3 (Carbon hotkey: modifier + key)
-        let meetingHotkeyID = EventHotKeyID(signature: OSType(0x44524654), id: 3)  // 'DRFT'
-        let meetingStatus = RegisterEventHotKey(
-            meetingBinding.keyCode,
-            meetingBinding.modifiers,
-            meetingHotkeyID,
-            GetApplicationEventTarget(),
-            0,
-            &meetingHotkeyRef
-        )
-        if meetingStatus != noErr {
-            meetingHotkeyRef = nil
-            errors.append("Meeting shortcut")
-            EventReporter.shared.capture(level: .error, engine: "capture", event: "hotkey_register_failed",
-                message: "Meeting hotkey registration failed", context: ["os_status": "\(meetingStatus)"])
-        }
-
-        carbonHotkeyError = errors.isEmpty ? nil : "\(errors.joined(separator: " and ")) failed to register"
-        updateHotkeyError()
-
-        // Update display strings.
+    private func refreshShortcutDisplays() {
+        carbonHotkeyError = nil
         dictationShortcutDisplay = Self.currentDictationShortcutDisplay()
-        meetingShortcutDisplay = HotkeyPreferences.displayString(for: meetingBinding)
+        meetingShortcutDisplay = PhysicalDictationTriggerPreferences.displayString(
+            for: PhysicalDictationTriggerPreferences.meetingBinding()
+        )
+        updateHotkeyError()
     }
 
     private static func currentDictationShortcutDisplay() -> String {
-        let trigger = PhysicalDictationTriggerPreferences.displayString(
-            for: PhysicalDictationTriggerPreferences.binding()
+        let pushToTalk = PhysicalDictationTriggerPreferences.displayString(
+            for: PhysicalDictationTriggerPreferences.pushToTalkBinding()
         )
-        switch HotkeyPreferences.dictationShortcutMode() {
-        case .pushToTalk:
-            return "Hold \(trigger)"
-        case .handsFree:
-            return trigger
-        }
+        let handsFree = PhysicalDictationTriggerPreferences.displayString(
+            for: PhysicalDictationTriggerPreferences.handsFreeBinding()
+        )
+        return "\(pushToTalk) / \(handsFree)"
     }
 
     func refreshShortcutStatus() {
@@ -380,7 +485,9 @@ class ContextCaptureEngine: ObservableObject {
             dictationShortcutDisplay = nextDictationDisplay
         }
 
-        let nextMeetingDisplay = HotkeyPreferences.displayString(for: HotkeyPreferences.meetingBinding())
+        let nextMeetingDisplay = PhysicalDictationTriggerPreferences.displayString(
+            for: PhysicalDictationTriggerPreferences.meetingBinding()
+        )
         if meetingShortcutDisplay != nextMeetingDisplay {
             meetingShortcutDisplay = nextMeetingDisplay
         }
@@ -388,32 +495,40 @@ class ContextCaptureEngine: ObservableObject {
         updateHotkeyError()
     }
 
-    private func configurePhysicalDictationTriggerDetector() {
-        physicalDictationTriggerDetector.bindingProvider = {
-            PhysicalDictationTriggerPreferences.binding()
+    private func configurePhysicalShortcutDetector() {
+        physicalShortcutDetector.bindingProvider = {
+            [
+                PhysicalShortcutBinding(
+                    action: .dictationPushToTalk,
+                    binding: PhysicalDictationTriggerPreferences.pushToTalkBinding()
+                ),
+                PhysicalShortcutBinding(
+                    action: .dictationHandsFree,
+                    binding: PhysicalDictationTriggerPreferences.handsFreeBinding()
+                ),
+                PhysicalShortcutBinding(
+                    action: .meeting,
+                    binding: PhysicalDictationTriggerPreferences.meetingBinding()
+                )
+            ]
         }
-        physicalDictationTriggerDetector.onPress = { [weak self] in
+        physicalShortcutDetector.onShortcut = { [weak self] action, phase in
             Task { @MainActor [weak self] in
-                self?.handlePhysicalDictationTriggerPress()
-            }
-        }
-        physicalDictationTriggerDetector.onRelease = { [weak self] in
-            Task { @MainActor [weak self] in
-                self?.handlePhysicalDictationTriggerRelease()
+                self?.handlePhysicalShortcut(action, phase: phase)
             }
         }
 
-        physicalTriggerError = physicalDictationTriggerDetector.install()
+        physicalTriggerError = physicalShortcutDetector.install()
         if let physicalTriggerError {
             EventReporter.shared.capture(
                 level: .warning,
                 engine: "capture",
-                event: "physical_dictation_trigger_failed",
+                event: "physical_shortcut_trigger_failed",
                 message: physicalTriggerError,
                 context: [
-                    "trigger": PhysicalDictationTriggerPreferences.displayString(
-                        for: PhysicalDictationTriggerPreferences.binding()
-                    )
+                    "push_to_talk": PhysicalDictationTriggerPreferences.displayString(for: PhysicalDictationTriggerPreferences.pushToTalkBinding()),
+                    "hands_free": PhysicalDictationTriggerPreferences.displayString(for: PhysicalDictationTriggerPreferences.handsFreeBinding()),
+                    "meeting": PhysicalDictationTriggerPreferences.displayString(for: PhysicalDictationTriggerPreferences.meetingBinding())
                 ]
             )
         }
@@ -424,7 +539,9 @@ class ContextCaptureEngine: ObservableObject {
         let errors = [
             carbonHotkeyError,
             physicalTriggerError,
-            PhysicalDictationTriggerPreferences.functionKeyConflictWarning()
+            PhysicalDictationTriggerPreferences.functionKeyConflictWarning(
+                for: PhysicalDictationTriggerPreferences.handsFreeBinding()
+            )
         ].compactMap { $0 }
         let nextError = errors.isEmpty ? nil : errors.joined(separator: " and ")
         if hotkeyError != nextError {
@@ -432,16 +549,31 @@ class ContextCaptureEngine: ObservableObject {
         }
     }
 
-    private func handlePhysicalDictationTriggerPress() {
+    private func handlePhysicalShortcut(_ action: PhysicalShortcutAction, phase: PhysicalShortcutPhase) {
+        switch (action, phase) {
+        case (.dictationPushToTalk, .press):
+            handlePhysicalDictationPushToTalkPress()
+        case (.dictationPushToTalk, .release):
+            handlePhysicalDictationPushToTalkRelease()
+        case (.dictationHandsFree, .press):
+            handlePhysicalDictationHandsFreePress()
+        case (.meeting, .press):
+            handlePhysicalMeetingPress()
+        case (.dictationHandsFree, .release), (.meeting, .release):
+            break
+        }
+    }
+
+    private func handlePhysicalDictationHandsFreePress() {
         guard shouldAcceptHotkeyAction() else {
             DiagnosticsTrail.record(
                 logger: sessionController?.appState?.logger,
                 level: .info,
                 engine: "capture",
                 event: "hotkey_repeat_ignored",
-                message: "Ignored rapid repeat dictation trigger",
+                message: "Ignored rapid repeat hands-free dictation trigger",
                 context: [
-                    "hotkey_id": "physical_dictation_trigger",
+                    "hotkey_id": "dictation_hands_free",
                     "session_state": sessionController?.isDictating == true ? "dictating" : (sessionController?.isInSession == true ? "drafting" : "idle"),
                     "overlay_state": overlayStateName(sessionController?.overlayController?.state)
                 ]
@@ -450,35 +582,50 @@ class ContextCaptureEngine: ObservableObject {
         }
 
         let frontApp = NSWorkspace.shared.frontmostApplication
-        switch HotkeyPreferences.dictationShortcutMode() {
-        case .handsFree:
-            routeDictationToggle(sourceApp: frontApp, trigger: .physicalKey)
-        case .pushToTalk:
-            guard let session = sessionController else { return }
-            DiagnosticsTrail.record(
-                logger: session.appState?.logger,
-                engine: "capture",
-                event: "dictation_push_to_talk_pressed",
-                message: "Dictation push-to-talk trigger pressed",
-                context: [
-                    "trigger": "physical_key",
-                    "source_app_name": frontApp?.localizedName ?? "",
-                    "source_app_bundle_id": frontApp?.bundleIdentifier ?? "",
-                    "session_state": session.isDictating ? "dictating" : (session.isInSession ? "drafting" : "idle"),
-                    "overlay_state": overlayStateName(session.overlayController?.state)
-                ]
-            )
-
-            guard !session.isDictating else { return }
-            if session.isInSession {
-                session.cancelSession()
-            }
-            session.startDictation(sourceApp: frontApp, trigger: .physicalKey)
-        }
+        routeDictationToggle(sourceApp: frontApp, trigger: .physicalKey)
     }
 
-    private func handlePhysicalDictationTriggerRelease() {
-        guard HotkeyPreferences.dictationShortcutMode() == .pushToTalk else { return }
+    private func handlePhysicalDictationPushToTalkPress() {
+        guard shouldAcceptHotkeyAction() else {
+            DiagnosticsTrail.record(
+                logger: sessionController?.appState?.logger,
+                level: .info,
+                engine: "capture",
+                event: "hotkey_repeat_ignored",
+                message: "Ignored rapid repeat push-to-talk dictation trigger",
+                context: [
+                    "hotkey_id": "dictation_push_to_talk",
+                    "session_state": sessionController?.isDictating == true ? "dictating" : (sessionController?.isInSession == true ? "drafting" : "idle"),
+                    "overlay_state": overlayStateName(sessionController?.overlayController?.state)
+                ]
+            )
+            return
+        }
+
+        let frontApp = NSWorkspace.shared.frontmostApplication
+        guard let session = sessionController else { return }
+        DiagnosticsTrail.record(
+            logger: session.appState?.logger,
+            engine: "capture",
+            event: "dictation_push_to_talk_pressed",
+            message: "Dictation push-to-talk trigger pressed",
+            context: [
+                "trigger": "physical_key",
+                "source_app_name": frontApp?.localizedName ?? "",
+                "source_app_bundle_id": frontApp?.bundleIdentifier ?? "",
+                "session_state": session.isDictating ? "dictating" : (session.isInSession ? "drafting" : "idle"),
+                "overlay_state": overlayStateName(session.overlayController?.state)
+            ]
+        )
+
+        guard !session.isDictating else { return }
+        if session.isInSession {
+            session.cancelSession()
+        }
+        session.startDictation(sourceApp: frontApp, trigger: .physicalKey)
+    }
+
+    private func handlePhysicalDictationPushToTalkRelease() {
         guard let session = sessionController else { return }
 
         DiagnosticsTrail.record(
@@ -497,13 +644,28 @@ class ContextCaptureEngine: ObservableObject {
         session.stopDictationAndPaste(trigger: .physicalKey)
     }
 
+    private func handlePhysicalMeetingPress() {
+        guard shouldAcceptHotkeyAction() else {
+            EventReporter.shared.capture(
+                level: .info,
+                engine: "capture",
+                event: "hotkey_repeat_ignored",
+                message: "Ignored rapid repeat meeting trigger",
+                context: ["hotkey_id": "meeting_physical_trigger"]
+            )
+            return
+        }
+
+        onMeetingToggle?()
+    }
+
     deinit {
         if let ref = meetingHotkeyRef { UnregisterEventHotKey(ref) }
         if let ref = eventHandlerRef { RemoveEventHandler(ref) }
         if let observer = hotkeyChangeObserver {
             NotificationCenter.default.removeObserver(observer)
         }
-        physicalDictationTriggerDetector.remove()
+        physicalShortcutDetector.remove()
     }
 
     func unregisterHotkey() {
@@ -519,7 +681,7 @@ class ContextCaptureEngine: ObservableObject {
             NotificationCenter.default.removeObserver(observer)
             hotkeyChangeObserver = nil
         }
-        physicalDictationTriggerDetector.remove()
+        physicalShortcutDetector.remove()
         _sharedSessionController = nil
         _sharedMeetingToggle = nil
     }

--- a/Sources/Capture/ContextCaptureEngine.swift
+++ b/Sources/Capture/ContextCaptureEngine.swift
@@ -374,6 +374,20 @@ class ContextCaptureEngine: ObservableObject {
         }
     }
 
+    func refreshShortcutStatus() {
+        let nextDictationDisplay = Self.currentDictationShortcutDisplay()
+        if dictationShortcutDisplay != nextDictationDisplay {
+            dictationShortcutDisplay = nextDictationDisplay
+        }
+
+        let nextMeetingDisplay = HotkeyPreferences.displayString(for: HotkeyPreferences.meetingBinding())
+        if meetingShortcutDisplay != nextMeetingDisplay {
+            meetingShortcutDisplay = nextMeetingDisplay
+        }
+
+        updateHotkeyError()
+    }
+
     private func configurePhysicalDictationTriggerDetector() {
         physicalDictationTriggerDetector.bindingProvider = {
             PhysicalDictationTriggerPreferences.binding()
@@ -407,8 +421,15 @@ class ContextCaptureEngine: ObservableObject {
     }
 
     private func updateHotkeyError() {
-        let errors = [carbonHotkeyError, physicalTriggerError].compactMap { $0 }
-        hotkeyError = errors.isEmpty ? nil : errors.joined(separator: " and ")
+        let errors = [
+            carbonHotkeyError,
+            physicalTriggerError,
+            PhysicalDictationTriggerPreferences.functionKeyConflictWarning()
+        ].compactMap { $0 }
+        let nextError = errors.isEmpty ? nil : errors.joined(separator: " and ")
+        if hotkeyError != nextError {
+            hotkeyError = nextError
+        }
     }
 
     private func handlePhysicalDictationTriggerPress() {

--- a/Sources/Capture/ContextCaptureEngine.swift
+++ b/Sources/Capture/ContextCaptureEngine.swift
@@ -136,7 +136,7 @@ private final class PhysicalShortcutDetector {
     private struct PendingModifierShortcut {
         let keyCode: UInt32
         let action: PhysicalShortcutAction
-        let workItem: DispatchWorkItem
+        let workItem: DispatchWorkItem?
     }
 
     private static let modifierChordDelay: TimeInterval = 0.14
@@ -199,7 +199,7 @@ private final class PhysicalShortcutDetector {
     }
 
     private func resetState() {
-        pendingModifierShortcut?.workItem.cancel()
+        pendingModifierShortcut?.workItem?.cancel()
         pendingModifierShortcut = nil
         activePushToTalkKeyCode = nil
         consumedKeyCodes.removeAll()
@@ -227,8 +227,12 @@ private final class PhysicalShortcutDetector {
                 return nil
             }
 
-            guard !isRepeat,
-                  let shortcut = matchingKeyDownShortcut(shortcutBindings, keyCode: keyCode, modifiers: modifiers) else {
+            guard !isRepeat else {
+                return Unmanaged.passUnretained(event)
+            }
+
+            guard let shortcut = matchingKeyDownShortcut(shortcutBindings, keyCode: keyCode, modifiers: modifiers) else {
+                cancelPendingModifierShortcut()
                 return Unmanaged.passUnretained(event)
             }
 
@@ -266,6 +270,9 @@ private final class PhysicalShortcutDetector {
                let pending = pendingModifierShortcut,
                matchesRelease(for: pending.action, in: shortcutBindings, keyCode: keyCode, modifiers: modifiers) {
                 cancelPendingModifierShortcut()
+                if pending.action != .dictationPushToTalk {
+                    onShortcut?(pending.action, .press)
+                }
                 return nil
             }
 
@@ -290,11 +297,19 @@ private final class PhysicalShortcutDetector {
                     onShortcut?(.dictationPushToTalk, .press)
                 }
             case .dictationHandsFree:
-                cancelPendingModifierShortcut()
-                onShortcut?(.dictationHandsFree, .press)
+                if hasChordUsingModifier(keyCode, in: shortcutBindings, excluding: shortcut.action) {
+                    schedulePendingModifierShortcut(keyCode: keyCode, action: .dictationHandsFree)
+                } else {
+                    cancelPendingModifierShortcut()
+                    onShortcut?(.dictationHandsFree, .press)
+                }
             case .meeting:
-                cancelPendingModifierShortcut()
-                onShortcut?(.meeting, .press)
+                if hasChordUsingModifier(keyCode, in: shortcutBindings, excluding: shortcut.action) {
+                    schedulePendingModifierShortcut(keyCode: keyCode, action: .meeting)
+                } else {
+                    cancelPendingModifierShortcut()
+                    onShortcut?(.meeting, .press)
+                }
             }
             return nil
 
@@ -363,16 +378,23 @@ private final class PhysicalShortcutDetector {
     private func schedulePendingModifierShortcut(keyCode: UInt32, action: PhysicalShortcutAction) {
         cancelPendingModifierShortcut()
 
-        let workItem = DispatchWorkItem { [weak self] in
-            guard let self,
-                  self.pendingModifierShortcut?.keyCode == keyCode,
-                  self.pendingModifierShortcut?.action == action else {
-                return
-            }
+        let workItem: DispatchWorkItem?
+        if action == .dictationPushToTalk {
+            let delayedWorkItem = DispatchWorkItem { [weak self] in
+                guard let self,
+                      self.pendingModifierShortcut?.keyCode == keyCode,
+                      self.pendingModifierShortcut?.action == action else {
+                    return
+                }
 
-            self.pendingModifierShortcut = nil
-            self.activePushToTalkKeyCode = keyCode
-            self.onShortcut?(action, .press)
+                self.pendingModifierShortcut = nil
+                self.activePushToTalkKeyCode = keyCode
+                self.onShortcut?(action, .press)
+            }
+            workItem = delayedWorkItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.modifierChordDelay, execute: delayedWorkItem)
+        } else {
+            workItem = nil
         }
 
         pendingModifierShortcut = PendingModifierShortcut(
@@ -380,11 +402,10 @@ private final class PhysicalShortcutDetector {
             action: action,
             workItem: workItem
         )
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.modifierChordDelay, execute: workItem)
     }
 
     private func cancelPendingModifierShortcut() {
-        pendingModifierShortcut?.workItem.cancel()
+        pendingModifierShortcut?.workItem?.cancel()
         pendingModifierShortcut = nil
     }
 }
@@ -540,7 +561,7 @@ class ContextCaptureEngine: ObservableObject {
             carbonHotkeyError,
             physicalTriggerError,
             PhysicalDictationTriggerPreferences.functionKeyConflictWarning(
-                for: PhysicalDictationTriggerPreferences.handsFreeBinding()
+                for: PhysicalDictationTriggerPreferences.pushToTalkBinding()
             )
         ].compactMap { $0 }
         let nextError = errors.isEmpty ? nil : errors.joined(separator: " and ")

--- a/Sources/Support/HotkeyPreferences.swift
+++ b/Sources/Support/HotkeyPreferences.swift
@@ -100,6 +100,10 @@ enum HotkeyPreferences {
         )
     }
 
+    static func hasSavedMeetingBinding(userDefaults: UserDefaults = .standard) -> Bool {
+        userDefaults.object(forKey: meetingKeyCodeKey) != nil
+    }
+
     static func dictationShortcutMode(userDefaults: UserDefaults = .standard) -> DictationShortcutMode {
         guard
             let rawValue = userDefaults.string(forKey: dictationShortcutModeKey),

--- a/Sources/Support/PhysicalDictationTriggerPreferences.swift
+++ b/Sources/Support/PhysicalDictationTriggerPreferences.swift
@@ -60,32 +60,106 @@ enum FunctionKeySystemAction: Equatable {
 }
 
 enum PhysicalDictationTriggerPreferences {
-    static let defaultBinding = PhysicalDictationTriggerBinding(keyCode: UInt32(kVK_RightOption))
+    static let defaultPushToTalkBinding = PhysicalDictationTriggerBinding(keyCode: UInt32(kVK_Function))
+    static let defaultHandsFreeBinding = PhysicalDictationTriggerBinding(
+        keyCode: UInt32(kVK_Space),
+        modifiers: PhysicalDictationTriggerModifiers.function
+    )
+    static let defaultMeetingBinding = PhysicalDictationTriggerBinding(
+        keyCode: UInt32(kVK_ANSI_M),
+        modifiers: PhysicalDictationTriggerModifiers.function
+    )
+    static let defaultBinding = defaultPushToTalkBinding
 
     private static let keyCodeKey = "dictationTrigger-keyCode"
     private static let modifiersKey = "dictationTrigger-modifiers"
+    private static let pushToTalkKeyCodeKey = "dictationPushToTalkTrigger-keyCode"
+    private static let pushToTalkModifiersKey = "dictationPushToTalkTrigger-modifiers"
+    private static let handsFreeKeyCodeKey = "dictationHandsFreeTrigger-keyCode"
+    private static let handsFreeModifiersKey = "dictationHandsFreeTrigger-modifiers"
+    private static let meetingKeyCodeKey = "meetingTrigger-keyCode"
+    private static let meetingModifiersKey = "meetingTrigger-modifiers"
     private static let functionKeyUsageDomain = "com.apple.HIToolbox" as CFString
     private static let functionKeyUsageKey = "AppleFnUsageType" as CFString
 
     static func binding(userDefaults: UserDefaults = .standard) -> PhysicalDictationTriggerBinding {
-        guard userDefaults.object(forKey: keyCodeKey) != nil else {
-            return migratedBinding(userDefaults: userDefaults)
-        }
+        pushToTalkBinding(userDefaults: userDefaults)
+    }
 
-        return PhysicalDictationTriggerBinding(
-            keyCode: UInt32(userDefaults.integer(forKey: keyCodeKey)),
-            modifiers: UInt32(userDefaults.integer(forKey: modifiersKey)) & PhysicalDictationTriggerModifiers.all
-        )
+    static func pushToTalkBinding(userDefaults: UserDefaults = .standard) -> PhysicalDictationTriggerBinding {
+        storedBinding(
+            keyCodeKey: pushToTalkKeyCodeKey,
+            modifiersKey: pushToTalkModifiersKey,
+            userDefaults: userDefaults
+        ) ?? migratedPushToTalkBinding(userDefaults: userDefaults)
+    }
+
+    static func handsFreeBinding(userDefaults: UserDefaults = .standard) -> PhysicalDictationTriggerBinding {
+        storedBinding(
+            keyCodeKey: handsFreeKeyCodeKey,
+            modifiersKey: handsFreeModifiersKey,
+            userDefaults: userDefaults
+        ) ?? migratedHandsFreeBinding(userDefaults: userDefaults)
+    }
+
+    static func meetingBinding(userDefaults: UserDefaults = .standard) -> PhysicalDictationTriggerBinding {
+        storedBinding(
+            keyCodeKey: meetingKeyCodeKey,
+            modifiersKey: meetingModifiersKey,
+            userDefaults: userDefaults
+        ) ?? migratedMeetingBinding(userDefaults: userDefaults)
     }
 
     static func save(_ binding: PhysicalDictationTriggerBinding, userDefaults: UserDefaults = .standard) {
+        savePushToTalk(binding, userDefaults: userDefaults)
+    }
+
+    static func savePushToTalk(_ binding: PhysicalDictationTriggerBinding, userDefaults: UserDefaults = .standard) {
+        saveBinding(
+            binding,
+            keyCodeKey: pushToTalkKeyCodeKey,
+            modifiersKey: pushToTalkModifiersKey,
+            userDefaults: userDefaults
+        )
+    }
+
+    static func saveHandsFree(_ binding: PhysicalDictationTriggerBinding, userDefaults: UserDefaults = .standard) {
+        saveBinding(
+            binding,
+            keyCodeKey: handsFreeKeyCodeKey,
+            modifiersKey: handsFreeModifiersKey,
+            userDefaults: userDefaults
+        )
+    }
+
+    static func saveMeeting(_ binding: PhysicalDictationTriggerBinding, userDefaults: UserDefaults = .standard) {
+        saveBinding(
+            binding,
+            keyCodeKey: meetingKeyCodeKey,
+            modifiersKey: meetingModifiersKey,
+            userDefaults: userDefaults
+        )
+    }
+
+    private static func saveBinding(
+        _ binding: PhysicalDictationTriggerBinding,
+        keyCodeKey: String,
+        modifiersKey: String,
+        userDefaults: UserDefaults
+    ) {
         userDefaults.set(Int(binding.keyCode), forKey: keyCodeKey)
         userDefaults.set(Int(binding.modifiers), forKey: modifiersKey)
         NotificationCenter.default.post(name: .hotkeysDidChange, object: nil)
     }
 
     static func resetToDefault(userDefaults: UserDefaults = .standard) {
-        save(defaultBinding, userDefaults: userDefaults)
+        resetToDefaults(userDefaults: userDefaults)
+    }
+
+    static func resetToDefaults(userDefaults: UserDefaults = .standard) {
+        savePushToTalk(defaultPushToTalkBinding, userDefaults: userDefaults)
+        saveHandsFree(defaultHandsFreeBinding, userDefaults: userDefaults)
+        saveMeeting(defaultMeetingBinding, userDefaults: userDefaults)
     }
 
     static func functionKeySystemAction() -> FunctionKeySystemAction {
@@ -120,6 +194,7 @@ enum PhysicalDictationTriggerPreferences {
         systemAction: FunctionKeySystemAction = PhysicalDictationTriggerPreferences.functionKeySystemAction()
     ) -> String? {
         guard binding.keyCode == UInt32(kVK_Function),
+              binding.modifiers == 0,
               systemAction.conflictsWithBareFunctionKey else {
             return nil
         }
@@ -382,11 +457,73 @@ enum PhysicalDictationTriggerPreferences {
         }
     }
 
-    private static func migratedBinding(userDefaults: UserDefaults) -> PhysicalDictationTriggerBinding {
-        if HotkeyPreferences.rightOptionDictationEnabled(userDefaults: userDefaults) {
-            return defaultBinding
+    private static func storedBinding(
+        keyCodeKey: String,
+        modifiersKey: String,
+        userDefaults: UserDefaults
+    ) -> PhysicalDictationTriggerBinding? {
+        guard userDefaults.object(forKey: keyCodeKey) != nil else { return nil }
+
+        return PhysicalDictationTriggerBinding(
+            keyCode: UInt32(userDefaults.integer(forKey: keyCodeKey)),
+            modifiers: UInt32(userDefaults.integer(forKey: modifiersKey)) & PhysicalDictationTriggerModifiers.all
+        )
+    }
+
+    private static func migratedPushToTalkBinding(userDefaults: UserDefaults) -> PhysicalDictationTriggerBinding {
+        guard HotkeyPreferences.dictationShortcutMode(userDefaults: userDefaults) == .pushToTalk else {
+            return defaultPushToTalkBinding
         }
 
+        if userDefaults.object(forKey: keyCodeKey) != nil {
+            return legacyDictationBinding(userDefaults: userDefaults)
+        }
+
+        return HotkeyPreferences.rightOptionDictationEnabled(userDefaults: userDefaults)
+            ? defaultPushToTalkBinding
+            : legacyCarbonDictationBinding(userDefaults: userDefaults)
+    }
+
+    private static func migratedHandsFreeBinding(userDefaults: UserDefaults) -> PhysicalDictationTriggerBinding {
+        guard HotkeyPreferences.dictationShortcutMode(userDefaults: userDefaults) == .handsFree else {
+            return defaultHandsFreeBinding
+        }
+
+        if userDefaults.object(forKey: keyCodeKey) != nil {
+            return legacyDictationBinding(userDefaults: userDefaults)
+        }
+
+        return HotkeyPreferences.rightOptionDictationEnabled(userDefaults: userDefaults)
+            ? defaultHandsFreeBinding
+            : legacyCarbonDictationBinding(userDefaults: userDefaults)
+    }
+
+    private static func migratedMeetingBinding(userDefaults: UserDefaults) -> PhysicalDictationTriggerBinding {
+        guard HotkeyPreferences.hasSavedMeetingBinding(userDefaults: userDefaults) else {
+            return defaultMeetingBinding
+        }
+
+        let oldBinding = HotkeyPreferences.meetingBinding(userDefaults: userDefaults)
+        return PhysicalDictationTriggerBinding(
+            keyCode: oldBinding.keyCode,
+            modifiers: modifiers(fromCarbon: oldBinding.modifiers)
+        )
+    }
+
+    private static func legacyDictationBinding(userDefaults: UserDefaults) -> PhysicalDictationTriggerBinding {
+        guard userDefaults.object(forKey: keyCodeKey) != nil else {
+            return HotkeyPreferences.rightOptionDictationEnabled(userDefaults: userDefaults)
+                ? defaultPushToTalkBinding
+                : legacyCarbonDictationBinding(userDefaults: userDefaults)
+        }
+
+        return PhysicalDictationTriggerBinding(
+            keyCode: UInt32(userDefaults.integer(forKey: keyCodeKey)),
+            modifiers: UInt32(userDefaults.integer(forKey: modifiersKey)) & PhysicalDictationTriggerModifiers.all
+        )
+    }
+
+    private static func legacyCarbonDictationBinding(userDefaults: UserDefaults) -> PhysicalDictationTriggerBinding {
         let oldBinding = HotkeyPreferences.dictationBinding(userDefaults: userDefaults)
         return PhysicalDictationTriggerBinding(
             keyCode: oldBinding.keyCode,

--- a/Sources/Support/PhysicalDictationTriggerPreferences.swift
+++ b/Sources/Support/PhysicalDictationTriggerPreferences.swift
@@ -61,13 +61,10 @@ enum FunctionKeySystemAction: Equatable {
 
 enum PhysicalDictationTriggerPreferences {
     static let defaultPushToTalkBinding = PhysicalDictationTriggerBinding(keyCode: UInt32(kVK_Function))
-    static let defaultHandsFreeBinding = PhysicalDictationTriggerBinding(
-        keyCode: UInt32(kVK_Space),
-        modifiers: PhysicalDictationTriggerModifiers.function
-    )
+    static let defaultHandsFreeBinding = PhysicalDictationTriggerBinding(keyCode: UInt32(kVK_RightOption))
     static let defaultMeetingBinding = PhysicalDictationTriggerBinding(
         keyCode: UInt32(kVK_ANSI_M),
-        modifiers: PhysicalDictationTriggerModifiers.function
+        modifiers: PhysicalDictationTriggerModifiers.option
     )
     static let defaultBinding = defaultPushToTalkBinding
 

--- a/Sources/Support/PhysicalDictationTriggerPreferences.swift
+++ b/Sources/Support/PhysicalDictationTriggerPreferences.swift
@@ -24,11 +24,48 @@ enum PhysicalDictationTriggerModifiers {
     static let all: UInt32 = command | shift | option | control | function | capsLock
 }
 
+enum FunctionKeySystemAction: Equatable {
+    case notConfigured
+    case doNothing
+    case changeInputSource
+    case showEmojiAndSymbols
+    case startDictation
+    case unknown(Int)
+
+    var title: String {
+        switch self {
+        case .notConfigured:
+            return "the macOS default"
+        case .doNothing:
+            return "Do Nothing"
+        case .changeInputSource:
+            return "Change Input Source"
+        case .showEmojiAndSymbols:
+            return "Emoji & Symbols"
+        case .startDictation:
+            return "Start Dictation"
+        case .unknown:
+            return "another system action"
+        }
+    }
+
+    var conflictsWithBareFunctionKey: Bool {
+        switch self {
+        case .doNothing, .notConfigured:
+            return false
+        case .changeInputSource, .showEmojiAndSymbols, .startDictation, .unknown:
+            return true
+        }
+    }
+}
+
 enum PhysicalDictationTriggerPreferences {
     static let defaultBinding = PhysicalDictationTriggerBinding(keyCode: UInt32(kVK_RightOption))
 
     private static let keyCodeKey = "dictationTrigger-keyCode"
     private static let modifiersKey = "dictationTrigger-modifiers"
+    private static let functionKeyUsageDomain = "com.apple.HIToolbox" as CFString
+    private static let functionKeyUsageKey = "AppleFnUsageType" as CFString
 
     static func binding(userDefaults: UserDefaults = .standard) -> PhysicalDictationTriggerBinding {
         guard userDefaults.object(forKey: keyCodeKey) != nil else {
@@ -49,6 +86,45 @@ enum PhysicalDictationTriggerPreferences {
 
     static func resetToDefault(userDefaults: UserDefaults = .standard) {
         save(defaultBinding, userDefaults: userDefaults)
+    }
+
+    static func functionKeySystemAction() -> FunctionKeySystemAction {
+        let value = CFPreferencesCopyAppValue(functionKeyUsageKey, functionKeyUsageDomain)
+        if let number = value as? NSNumber {
+            return functionKeySystemAction(rawValue: number.intValue)
+        }
+        if let string = value as? String, let rawValue = Int(string) {
+            return functionKeySystemAction(rawValue: rawValue)
+        }
+        return .notConfigured
+    }
+
+    static func functionKeySystemAction(rawValue: Int?) -> FunctionKeySystemAction {
+        guard let rawValue else { return .notConfigured }
+        switch rawValue {
+        case 0:
+            return .doNothing
+        case 1:
+            return .changeInputSource
+        case 2:
+            return .showEmojiAndSymbols
+        case 3:
+            return .startDictation
+        default:
+            return .unknown(rawValue)
+        }
+    }
+
+    static func functionKeyConflictWarning(
+        for binding: PhysicalDictationTriggerBinding = PhysicalDictationTriggerPreferences.binding(),
+        systemAction: FunctionKeySystemAction = PhysicalDictationTriggerPreferences.functionKeySystemAction()
+    ) -> String? {
+        guard binding.keyCode == UInt32(kVK_Function),
+              systemAction.conflictsWithBareFunctionKey else {
+            return nil
+        }
+
+        return "Fn is also set to \(systemAction.title) in macOS. Set Keyboard > Press Fn/Globe key to Do Nothing."
     }
 
     static func displayString(for binding: PhysicalDictationTriggerBinding) -> String {

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -53,6 +53,8 @@ final class MenuBarPanelController: NSViewController {
     func refresh() {
         guard let content = contentView else { return }
 
+        appState.contextCapture.refreshShortcutStatus()
+
         let warmupStatus = appState.meetingSession.warmupStatus
         let modelState = FirstRunLocalModelState(appState.sttRouter.modelDownloadState)
         let dictationState = FirstRunExperience.dictationAction(for: modelState)

--- a/Sources/UI/MenuBar/MenuBarShortcutsView.swift
+++ b/Sources/UI/MenuBar/MenuBarShortcutsView.swift
@@ -10,7 +10,8 @@ final class MenuBarShortcutsView: NSView {
     var onStartMeeting: (() -> Void)?
     var onImportAudioFile: (() -> Void)?
 
-    private let dictationRow = PrimaryActionRowView()
+    private let pushToTalkRow = PrimaryActionRowView()
+    private let handsFreeRow = PrimaryActionRowView()
     private let meetingRow = PrimaryActionRowView()
     private let importButton = MenuOutlineButton(
         title: "Transcribe file",
@@ -34,7 +35,8 @@ final class MenuBarShortcutsView: NSView {
     private var canImportAudioFiles = true
 
     private enum RecordingTarget {
-        case dictation
+        case pushToTalk
+        case handsFree
         case meeting
     }
 
@@ -63,12 +65,20 @@ final class MenuBarShortcutsView: NSView {
     }
 
     private func setupViews() {
-        dictationRow.onPrimaryAction = { [weak self] in
+        pushToTalkRow.onPrimaryAction = { [weak self] in
             guard let self, self.currentDictationState.isEnabled, self.recordingTarget == nil else { return }
             self.onStartDictation?()
         }
-        dictationRow.onEditShortcut = { [weak self] in
-            self?.startRecording(.dictation)
+        pushToTalkRow.onEditShortcut = { [weak self] in
+            self?.startRecording(.pushToTalk)
+        }
+
+        handsFreeRow.onPrimaryAction = { [weak self] in
+            guard let self, self.currentDictationState.isEnabled, self.recordingTarget == nil else { return }
+            self.onStartDictation?()
+        }
+        handsFreeRow.onEditShortcut = { [weak self] in
+            self?.startRecording(.handsFree)
         }
 
         meetingRow.onPrimaryAction = { [weak self] in
@@ -91,16 +101,23 @@ final class MenuBarShortcutsView: NSView {
         resetButton.action = #selector(resetShortcuts)
         addSubview(resetButton)
 
-        addSubview(dictationRow)
+        addSubview(pushToTalkRow)
+        addSubview(handsFreeRow)
         addSubview(meetingRow)
     }
 
     override func layout() {
         super.layout()
-        dictationRow.frame = NSRect(x: 0, y: 0, width: bounds.width, height: MenuTokens.actionRowHeight)
-        meetingRow.frame = NSRect(
+        pushToTalkRow.frame = NSRect(x: 0, y: 0, width: bounds.width, height: MenuTokens.actionRowHeight)
+        handsFreeRow.frame = NSRect(
             x: 0,
             y: MenuTokens.actionRowHeight + 6,
+            width: bounds.width,
+            height: MenuTokens.actionRowHeight
+        )
+        meetingRow.frame = NSRect(
+            x: 0,
+            y: (MenuTokens.actionRowHeight + 6) * 2,
             width: bounds.width,
             height: MenuTokens.actionRowHeight
         )
@@ -125,7 +142,8 @@ final class MenuBarShortcutsView: NSView {
     }
 
     func update(
-        dictationKey: String,
+        pushToTalkKey: String,
+        handsFreeKey: String,
         meetingKey: String,
         dictationState: MenuBarPrimaryActionState,
         meetingState: MenuBarPrimaryActionState,
@@ -139,14 +157,25 @@ final class MenuBarShortcutsView: NSView {
         resetHintLabel.alphaValue = 1.0
         resetHintLabel.stringValue = "Edit triggers or import audio"
 
-        dictationRow.update(
+        pushToTalkRow.update(
             symbolName: "mic.fill",
-            title: "Dictation",
-            subtitle: recordingTarget == .dictation
+            title: "Push to Talk",
+            subtitle: recordingTarget == .pushToTalk
                 ? "Press key…"
                 : dictationState.subtitle,
-            key: recordingTarget == .dictation ? "Any key" : dictationKey,
-            isEditing: recordingTarget == .dictation,
+            key: recordingTarget == .pushToTalk ? "Any key" : pushToTalkKey,
+            isEditing: recordingTarget == .pushToTalk,
+            isEnabled: dictationState.isEnabled
+        )
+
+        handsFreeRow.update(
+            symbolName: "mic.badge.plus",
+            title: "Hands-Free",
+            subtitle: recordingTarget == .handsFree
+                ? "Press key…"
+                : "Tap to start or stop dictation",
+            key: recordingTarget == .handsFree ? "Any key" : handsFreeKey,
+            isEditing: recordingTarget == .handsFree,
             isEnabled: dictationState.isEnabled
         )
 
@@ -171,32 +200,19 @@ final class MenuBarShortcutsView: NSView {
 
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self else { return event }
-            if target == .meeting, event.keyCode == UInt16(kVK_Escape) {
+            if event.keyCode == UInt16(kVK_Escape) {
                 self.stopRecording()
                 self.refreshFromPreferences()
                 return nil
             }
 
-            if target == .dictation {
-                self.pendingDictationModifier = nil
-                self.pendingDictationModifierKeyCode = nil
-                let candidate = PhysicalDictationTriggerPreferences.bindingForKeyDown(
-                    keyCode: UInt32(event.keyCode),
-                    modifierFlags: event.modifierFlags
-                )
-                PhysicalDictationTriggerPreferences.save(candidate)
-                self.stopRecording()
-                self.refreshFromPreferences()
-                return nil
-            }
-
-            let candidate = HotkeyBinding(
+            self.pendingDictationModifier = nil
+            self.pendingDictationModifierKeyCode = nil
+            let candidate = PhysicalDictationTriggerPreferences.bindingForKeyDown(
                 keyCode: UInt32(event.keyCode),
-                modifiers: HotkeyPreferences.carbonModifiers(from: event.modifierFlags)
+                modifierFlags: event.modifierFlags
             )
-            guard HotkeyPreferences.isValid(candidate) else { return nil }
-
-            HotkeyPreferences.save(meeting: candidate)
+            self.save(candidate, for: target)
 
             self.stopRecording()
             self.refreshFromPreferences()
@@ -205,10 +221,6 @@ final class MenuBarShortcutsView: NSView {
 
         flagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
             guard let self else { return event }
-            guard target == .dictation else {
-                return event
-            }
-
             let keyCode = UInt32(event.keyCode)
             let modifiers = PhysicalDictationTriggerPreferences.modifiers(from: event.modifierFlags)
 
@@ -217,7 +229,7 @@ final class MenuBarShortcutsView: NSView {
                 modifierFlags: event.modifierFlags
             ) {
                 if keyCode == UInt32(kVK_CapsLock) {
-                    PhysicalDictationTriggerPreferences.save(candidate)
+                    self.save(candidate, for: target)
                     self.stopRecording()
                     self.refreshFromPreferences()
                     return nil
@@ -231,7 +243,7 @@ final class MenuBarShortcutsView: NSView {
             if let pending = self.pendingDictationModifier,
                self.pendingDictationModifierKeyCode == keyCode,
                PhysicalDictationTriggerPreferences.matchesFlagsChangedRelease(pending, keyCode: keyCode, modifiers: modifiers) {
-                PhysicalDictationTriggerPreferences.save(pending)
+                self.save(pending, for: target)
                 self.stopRecording()
                 self.refreshFromPreferences()
                 return nil
@@ -262,8 +274,9 @@ final class MenuBarShortcutsView: NSView {
 
     private func refreshFromPreferences() {
         update(
-            dictationKey: PhysicalDictationTriggerPreferences.displayString(for: PhysicalDictationTriggerPreferences.binding()),
-            meetingKey: HotkeyPreferences.displayString(for: HotkeyPreferences.meetingBinding()),
+            pushToTalkKey: PhysicalDictationTriggerPreferences.displayString(for: PhysicalDictationTriggerPreferences.pushToTalkBinding()),
+            handsFreeKey: PhysicalDictationTriggerPreferences.displayString(for: PhysicalDictationTriggerPreferences.handsFreeBinding()),
+            meetingKey: PhysicalDictationTriggerPreferences.displayString(for: PhysicalDictationTriggerPreferences.meetingBinding()),
             dictationState: currentDictationState,
             meetingState: currentMeetingState,
             canImportAudioFiles: canImportAudioFiles
@@ -271,13 +284,24 @@ final class MenuBarShortcutsView: NSView {
     }
 
     var intrinsicHeight: CGFloat {
-        MenuTokens.actionRowHeight * 2 + MenuTokens.secondaryButtonSize * 2 + 20
+        MenuTokens.actionRowHeight * 3 + MenuTokens.secondaryButtonSize * 2 + 26
     }
 
     @objc private func resetShortcuts() {
         HotkeyPreferences.resetToDefaults()
-        PhysicalDictationTriggerPreferences.resetToDefault()
+        PhysicalDictationTriggerPreferences.resetToDefaults()
         refreshFromPreferences()
+    }
+
+    private func save(_ binding: PhysicalDictationTriggerBinding, for target: RecordingTarget) {
+        switch target {
+        case .pushToTalk:
+            PhysicalDictationTriggerPreferences.savePushToTalk(binding)
+        case .handsFree:
+            PhysicalDictationTriggerPreferences.saveHandsFree(binding)
+        case .meeting:
+            PhysicalDictationTriggerPreferences.saveMeeting(binding)
+        }
     }
 
     @objc private func importAudioFile() {

--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -35,15 +35,13 @@ class FloatingOverlayController {
 
     /// Human-readable shortcut hints (reads live from UserDefaults)
     var dictationShortcutHint: String {
-        let trigger = PhysicalDictationTriggerPreferences.displayString(
-            for: PhysicalDictationTriggerPreferences.binding()
+        let pushToTalk = PhysicalDictationTriggerPreferences.displayString(
+            for: PhysicalDictationTriggerPreferences.pushToTalkBinding()
         )
-        switch HotkeyPreferences.dictationShortcutMode() {
-        case .pushToTalk:
-            return "Hold \(trigger)"
-        case .handsFree:
-            return trigger
-        }
+        let handsFree = PhysicalDictationTriggerPreferences.displayString(
+            for: PhysicalDictationTriggerPreferences.handsFreeBinding()
+        )
+        return "\(pushToTalk) / \(handsFree)"
     }
 
     // MARK: - State (plain vars with didSet — no @Published, no ObservableObject)

--- a/Sources/UI/Settings/HotkeyRecorderAppKitView.swift
+++ b/Sources/UI/Settings/HotkeyRecorderAppKitView.swift
@@ -1,12 +1,13 @@
 // HotkeyRecorderAppKitView.swift
-// Compact two-row keyboard shortcut recorder — pure AppKit
+// Compact keyboard shortcut recorder — pure AppKit
 
 import AppKit
 import Carbon
 
 @MainActor
 final class HotkeyRecorderAppKitView: NSView {
-    private var dictationRow: ShortcutRecorderRow!
+    private var pushToTalkRow: ShortcutRecorderRow!
+    private var handsFreeRow: ShortcutRecorderRow!
     private var meetingRow: ShortcutRecorderRow!
     private let resetButton = NSButton(title: "Reset to Defaults", target: nil, action: nil)
 
@@ -17,25 +18,40 @@ final class HotkeyRecorderAppKitView: NSView {
     private var pendingDictationModifierKeyCode: UInt32?
 
     enum RecordingTarget {
-        case dictation
+        case pushToTalk
+        case handsFree
         case meeting
     }
 
     override init(frame: NSRect) {
         super.init(frame: frame)
 
-        dictationRow = ShortcutRecorderRow(label: "Dictation") { [weak self] in self?.startRecording(.dictation) }
+        pushToTalkRow = ShortcutRecorderRow(label: "Push to Talk") { [weak self] in self?.startRecording(.pushToTalk) }
             resetAction: { [weak self] in
                 self?.stopRecording()
-                PhysicalDictationTriggerPreferences.resetToDefault()
+                PhysicalDictationTriggerPreferences.savePushToTalk(
+                    PhysicalDictationTriggerPreferences.defaultPushToTalkBinding
+                )
                 self?.refreshDisplay()
             }
-        addSubview(dictationRow)
+        addSubview(pushToTalkRow)
+
+        handsFreeRow = ShortcutRecorderRow(label: "Hands-Free") { [weak self] in self?.startRecording(.handsFree) }
+            resetAction: { [weak self] in
+                self?.stopRecording()
+                PhysicalDictationTriggerPreferences.saveHandsFree(
+                    PhysicalDictationTriggerPreferences.defaultHandsFreeBinding
+                )
+                self?.refreshDisplay()
+            }
+        addSubview(handsFreeRow)
 
         meetingRow = ShortcutRecorderRow(label: "Meetings") { [weak self] in self?.startRecording(.meeting) }
             resetAction: { [weak self] in
                 self?.stopRecording()
-                HotkeyPreferences.save(meeting: HotkeyPreferences.defaultMeeting)
+                PhysicalDictationTriggerPreferences.saveMeeting(
+                    PhysicalDictationTriggerPreferences.defaultMeetingBinding
+                )
                 self?.refreshDisplay()
             }
         addSubview(meetingRow)
@@ -57,8 +73,9 @@ final class HotkeyRecorderAppKitView: NSView {
     override func layout() {
         super.layout()
         let rowH: CGFloat = 28
-        dictationRow.frame = NSRect(x: 0, y: bounds.height - rowH, width: bounds.width, height: rowH)
-        meetingRow.frame = NSRect(x: 0, y: bounds.height - rowH * 2 - 4, width: bounds.width, height: rowH)
+        pushToTalkRow.frame = NSRect(x: 0, y: bounds.height - rowH, width: bounds.width, height: rowH)
+        handsFreeRow.frame = NSRect(x: 0, y: bounds.height - rowH * 2 - 4, width: bounds.width, height: rowH)
+        meetingRow.frame = NSRect(x: 0, y: bounds.height - rowH * 3 - 8, width: bounds.width, height: rowH)
         let resetSize = resetButton.fittingSize
         resetButton.frame = NSRect(x: (bounds.width - resetSize.width) / 2, y: 0, width: resetSize.width, height: resetSize.height)
     }
@@ -69,17 +86,23 @@ final class HotkeyRecorderAppKitView: NSView {
     }
 
     func refreshDisplay() {
-        let dictBinding = PhysicalDictationTriggerPreferences.binding()
-        let meetingBinding = HotkeyPreferences.meetingBinding()
-        dictationRow.update(
-            displayText: recordingTarget == .dictation ? "Press key..." : PhysicalDictationTriggerPreferences.displayString(for: dictBinding),
-            isRecording: recordingTarget == .dictation,
-            isDefault: dictBinding == PhysicalDictationTriggerPreferences.defaultBinding
+        let pushToTalkBinding = PhysicalDictationTriggerPreferences.pushToTalkBinding()
+        let handsFreeBinding = PhysicalDictationTriggerPreferences.handsFreeBinding()
+        let meetingBinding = PhysicalDictationTriggerPreferences.meetingBinding()
+        pushToTalkRow.update(
+            displayText: recordingTarget == .pushToTalk ? "Press key..." : PhysicalDictationTriggerPreferences.displayString(for: pushToTalkBinding),
+            isRecording: recordingTarget == .pushToTalk,
+            isDefault: pushToTalkBinding == PhysicalDictationTriggerPreferences.defaultPushToTalkBinding
+        )
+        handsFreeRow.update(
+            displayText: recordingTarget == .handsFree ? "Press key..." : PhysicalDictationTriggerPreferences.displayString(for: handsFreeBinding),
+            isRecording: recordingTarget == .handsFree,
+            isDefault: handsFreeBinding == PhysicalDictationTriggerPreferences.defaultHandsFreeBinding
         )
         meetingRow.update(
-            displayText: recordingTarget == .meeting ? "Press shortcut..." : HotkeyPreferences.displayString(for: meetingBinding),
+            displayText: recordingTarget == .meeting ? "Press shortcut..." : PhysicalDictationTriggerPreferences.displayString(for: meetingBinding),
             isRecording: recordingTarget == .meeting,
-            isDefault: meetingBinding == HotkeyPreferences.defaultMeeting
+            isDefault: meetingBinding == PhysicalDictationTriggerPreferences.defaultMeetingBinding
         )
     }
 
@@ -92,31 +115,19 @@ final class HotkeyRecorderAppKitView: NSView {
             guard let self = self else { return event }
             let code = event.keyCode
 
-            if target == .meeting, code == UInt16(kVK_Escape) {
+            if code == UInt16(kVK_Escape) {
                 self.stopRecording()
                 self.refreshDisplay()
                 return nil
             }
 
-            if target == .dictation {
-                self.pendingDictationModifier = nil
-                self.pendingDictationModifierKeyCode = nil
-                let candidate = PhysicalDictationTriggerPreferences.bindingForKeyDown(
-                    keyCode: UInt32(code),
-                    modifierFlags: event.modifierFlags
-                )
-                PhysicalDictationTriggerPreferences.save(candidate)
-                self.stopRecording()
-                self.refreshDisplay()
-                return nil
-            }
-
-            let carbonMods = HotkeyPreferences.carbonModifiers(from: event.modifierFlags)
-            let candidate = HotkeyBinding(keyCode: UInt32(code), modifiers: carbonMods)
-
-            guard HotkeyPreferences.isValid(candidate) else { return nil }
-
-            HotkeyPreferences.save(meeting: candidate)
+            self.pendingDictationModifier = nil
+            self.pendingDictationModifierKeyCode = nil
+            let candidate = PhysicalDictationTriggerPreferences.bindingForKeyDown(
+                keyCode: UInt32(code),
+                modifierFlags: event.modifierFlags
+            )
+            self.save(candidate, for: target)
             self.stopRecording()
             self.refreshDisplay()
             return nil
@@ -124,10 +135,6 @@ final class HotkeyRecorderAppKitView: NSView {
 
         flagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
             guard let self = self else { return event }
-            guard target == .dictation else {
-                return event
-            }
-
             let keyCode = UInt32(event.keyCode)
             let modifiers = PhysicalDictationTriggerPreferences.modifiers(from: event.modifierFlags)
 
@@ -136,7 +143,7 @@ final class HotkeyRecorderAppKitView: NSView {
                 modifierFlags: event.modifierFlags
             ) {
                 if keyCode == UInt32(kVK_CapsLock) {
-                    PhysicalDictationTriggerPreferences.save(candidate)
+                    self.save(candidate, for: target)
                     self.stopRecording()
                     self.refreshDisplay()
                     return nil
@@ -150,7 +157,7 @@ final class HotkeyRecorderAppKitView: NSView {
             if let pending = self.pendingDictationModifier,
                self.pendingDictationModifierKeyCode == keyCode,
                PhysicalDictationTriggerPreferences.matchesFlagsChangedRelease(pending, keyCode: keyCode, modifiers: modifiers) {
-                PhysicalDictationTriggerPreferences.save(pending)
+                self.save(pending, for: target)
                 self.stopRecording()
                 self.refreshDisplay()
                 return nil
@@ -174,14 +181,25 @@ final class HotkeyRecorderAppKitView: NSView {
         pendingDictationModifierKeyCode = nil
     }
 
+    private func save(_ binding: PhysicalDictationTriggerBinding, for target: RecordingTarget) {
+        switch target {
+        case .pushToTalk:
+            PhysicalDictationTriggerPreferences.savePushToTalk(binding)
+        case .handsFree:
+            PhysicalDictationTriggerPreferences.saveHandsFree(binding)
+        case .meeting:
+            PhysicalDictationTriggerPreferences.saveMeeting(binding)
+        }
+    }
+
     @objc private func resetAll() {
         stopRecording()
         HotkeyPreferences.resetToDefaults()
-        PhysicalDictationTriggerPreferences.resetToDefault()
+        PhysicalDictationTriggerPreferences.resetToDefaults()
         refreshDisplay()
     }
 
-    var intrinsicHeight: CGFloat { 76 }
+    var intrinsicHeight: CGFloat { 108 }
 }
 
 // MARK: - Single Shortcut Row
@@ -229,7 +247,7 @@ private final class ShortcutRecorderRow: NSView {
 
     override func layout() {
         super.layout()
-        let labelW: CGFloat = 60
+        let labelW: CGFloat = 82
         nameLabel.frame = NSRect(x: 0, y: (bounds.height - 16) / 2, width: labelW, height: 16)
         let btnW: CGFloat = 110
         shortcutButton.frame = NSRect(x: labelW + 8, y: (bounds.height - 24) / 2, width: btnW, height: 24)

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -27,8 +27,9 @@ struct TranscriptedSettingsView: View {
     private let actions: TranscriptedSettingsActions
     private let sidebarSections = SettingsSidebarSection.defaultSections
 
-    @State private var dictationShortcutMode = HotkeyPreferences.dictationShortcutMode()
-    @State private var dictationTriggerSystemWarning = PhysicalDictationTriggerPreferences.functionKeyConflictWarning()
+    @State private var dictationTriggerSystemWarning = PhysicalDictationTriggerPreferences.functionKeyConflictWarning(
+        for: PhysicalDictationTriggerPreferences.handsFreeBinding()
+    )
     @State private var launchAtLoginEnabled = LaunchAtLoginController.isEnabled
     @State private var launchAtLoginStatus = LaunchAtLoginController.statusDescription
     @State private var customDictionaryText = CustomDictionaryPreferences.rawText()
@@ -357,27 +358,10 @@ struct TranscriptedSettingsView: View {
 
             SettingsSection(
                 title: "Keys",
-                detail: "Set one dictation key and one meeting shortcut."
+                detail: "Set push-to-talk, hands-free, and meeting shortcuts."
             ) {
                 HotkeyRecorderContainer()
-                    .frame(height: 76)
-
-                Picker("Dictation mode", selection: Binding(
-                    get: { dictationShortcutMode },
-                    set: { newValue in
-                        dictationShortcutMode = newValue
-                        HotkeyPreferences.setDictationShortcutMode(newValue)
-                    }
-                )) {
-                    ForEach(DictationShortcutMode.allCases) { mode in
-                        Text(mode.title).tag(mode)
-                    }
-                }
-                .pickerStyle(.segmented)
-
-                Text(dictationShortcutMode.summary)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .frame(height: 108)
 
                 if let dictationTriggerSystemWarning {
                     HStack(alignment: .top, spacing: 8) {
@@ -1082,8 +1066,9 @@ struct TranscriptedSettingsView: View {
     }
 
     private func refreshShortcutState() {
-        dictationShortcutMode = HotkeyPreferences.dictationShortcutMode()
-        dictationTriggerSystemWarning = PhysicalDictationTriggerPreferences.functionKeyConflictWarning()
+        dictationTriggerSystemWarning = PhysicalDictationTriggerPreferences.functionKeyConflictWarning(
+            for: PhysicalDictationTriggerPreferences.handsFreeBinding()
+        )
     }
 
     private func refreshMenuBarVisibility() {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -28,6 +28,7 @@ struct TranscriptedSettingsView: View {
     private let sidebarSections = SettingsSidebarSection.defaultSections
 
     @State private var dictationShortcutMode = HotkeyPreferences.dictationShortcutMode()
+    @State private var dictationTriggerSystemWarning = PhysicalDictationTriggerPreferences.functionKeyConflictWarning()
     @State private var launchAtLoginEnabled = LaunchAtLoginController.isEnabled
     @State private var launchAtLoginStatus = LaunchAtLoginController.statusDescription
     @State private var customDictionaryText = CustomDictionaryPreferences.rawText()
@@ -137,9 +138,13 @@ struct TranscriptedSettingsView: View {
         .onReceive(NotificationCenter.default.publisher(for: .menuBarVisibilityPreferencesDidChange)) { _ in
             refreshMenuBarVisibility()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .hotkeysDidChange)) { _ in
+            refreshShortcutState()
+        }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             refreshPermissions()
             refreshRecentCaptures()
+            refreshShortcutState()
         }
     }
 
@@ -373,6 +378,18 @@ struct TranscriptedSettingsView: View {
                 Text(dictationShortcutMode.summary)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                if let dictationTriggerSystemWarning {
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.orange)
+
+                        Text(dictationTriggerSystemWarning)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .font(.caption)
+                }
             }
 
             SettingsSection(
@@ -1033,7 +1050,7 @@ struct TranscriptedSettingsView: View {
         refreshPermissions()
         refreshStoragePaths()
         refreshRecentCaptures()
-        dictationShortcutMode = HotkeyPreferences.dictationShortcutMode()
+        refreshShortcutState()
         refreshMenuBarVisibility()
         refreshLaunchAtLoginState()
         customDictionaryText = CustomDictionaryPreferences.rawText()
@@ -1062,6 +1079,11 @@ struct TranscriptedSettingsView: View {
     private func refreshRecentCaptures() {
         recentMeetings = RecentMeetingsScanner.loadRecent(limit: 5)
         recentDictations = DictationTranscriptStore.recentSavedDictations(limit: 5)
+    }
+
+    private func refreshShortcutState() {
+        dictationShortcutMode = HotkeyPreferences.dictationShortcutMode()
+        dictationTriggerSystemWarning = PhysicalDictationTriggerPreferences.functionKeyConflictWarning()
     }
 
     private func refreshMenuBarVisibility() {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -28,7 +28,7 @@ struct TranscriptedSettingsView: View {
     private let sidebarSections = SettingsSidebarSection.defaultSections
 
     @State private var dictationTriggerSystemWarning = PhysicalDictationTriggerPreferences.functionKeyConflictWarning(
-        for: PhysicalDictationTriggerPreferences.handsFreeBinding()
+        for: PhysicalDictationTriggerPreferences.pushToTalkBinding()
     )
     @State private var launchAtLoginEnabled = LaunchAtLoginController.isEnabled
     @State private var launchAtLoginStatus = LaunchAtLoginController.statusDescription
@@ -1067,7 +1067,7 @@ struct TranscriptedSettingsView: View {
 
     private func refreshShortcutState() {
         dictationTriggerSystemWarning = PhysicalDictationTriggerPreferences.functionKeyConflictWarning(
-            for: PhysicalDictationTriggerPreferences.handsFreeBinding()
+            for: PhysicalDictationTriggerPreferences.pushToTalkBinding()
         )
     }
 

--- a/Tests/PhysicalDictationTriggerPreferencesTests.swift
+++ b/Tests/PhysicalDictationTriggerPreferencesTests.swift
@@ -4,19 +4,39 @@ import CoreGraphics
 import Foundation
 
 func testPhysicalDictationTriggerPreferences() {
-    runSuite("PhysicalDictationTriggerPreferences defaults to right Option") {
+    runSuite("PhysicalDictationTriggerPreferences defaults to Fn, Fn Space, and Fn M") {
         let (defaults, suiteName) = makePhysicalTriggerDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         assertEqual(
-            PhysicalDictationTriggerPreferences.binding(userDefaults: defaults),
-            PhysicalDictationTriggerPreferences.defaultBinding,
-            "fresh installs should keep the existing right Option dictation trigger"
+            PhysicalDictationTriggerPreferences.pushToTalkBinding(userDefaults: defaults),
+            PhysicalDictationTriggerPreferences.defaultPushToTalkBinding,
+            "fresh installs should use Fn for push-to-talk"
         )
         assertEqual(
-            PhysicalDictationTriggerPreferences.displayString(for: PhysicalDictationTriggerPreferences.defaultBinding),
-            "Right ⌥",
-            "default trigger should display as right Option"
+            PhysicalDictationTriggerPreferences.handsFreeBinding(userDefaults: defaults),
+            PhysicalDictationTriggerPreferences.defaultHandsFreeBinding,
+            "fresh installs should use Fn Space for hands-free"
+        )
+        assertEqual(
+            PhysicalDictationTriggerPreferences.meetingBinding(userDefaults: defaults),
+            PhysicalDictationTriggerPreferences.defaultMeetingBinding,
+            "fresh installs should use Fn M for meetings"
+        )
+        assertEqual(
+            PhysicalDictationTriggerPreferences.displayString(for: PhysicalDictationTriggerPreferences.defaultPushToTalkBinding),
+            "Fn",
+            "push-to-talk default should display as Fn"
+        )
+        assertEqual(
+            PhysicalDictationTriggerPreferences.displayString(for: PhysicalDictationTriggerPreferences.defaultHandsFreeBinding),
+            "Fn Space",
+            "hands-free default should display as Fn Space"
+        )
+        assertEqual(
+            PhysicalDictationTriggerPreferences.displayString(for: PhysicalDictationTriggerPreferences.defaultMeetingBinding),
+            "Fn M",
+            "meeting default should display as Fn M"
         )
     }
 
@@ -27,7 +47,7 @@ func testPhysicalDictationTriggerPreferences() {
         let fn = PhysicalDictationTriggerBinding(keyCode: UInt32(kVK_Function))
         PhysicalDictationTriggerPreferences.save(fn, userDefaults: defaults)
 
-        assertEqual(PhysicalDictationTriggerPreferences.binding(userDefaults: defaults), fn, "Fn should persist as a bare physical key")
+        assertEqual(PhysicalDictationTriggerPreferences.pushToTalkBinding(userDefaults: defaults), fn, "Fn should persist as a bare physical key")
         assertEqual(PhysicalDictationTriggerPreferences.displayString(for: fn), "Fn", "Fn should have a readable display name")
     }
 
@@ -102,7 +122,7 @@ func testPhysicalDictationTriggerPreferences() {
         )
     }
 
-    runSuite("PhysicalDictationTriggerPreferences migrates legacy shortcut when right Option is disabled") {
+    runSuite("PhysicalDictationTriggerPreferences migrates legacy hands-free shortcut when right Option is disabled") {
         let (defaults, suiteName) = makePhysicalTriggerDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
@@ -112,13 +132,34 @@ func testPhysicalDictationTriggerPreferences() {
             userDefaults: defaults
         )
 
-        let migrated = PhysicalDictationTriggerPreferences.binding(userDefaults: defaults)
+        let migrated = PhysicalDictationTriggerPreferences.handsFreeBinding(userDefaults: defaults)
 
         assertEqual(migrated.keyCode, UInt32(kVK_Space), "disabled right Option should fall back to the old dictation shortcut key")
         assertEqual(
             migrated.modifiers,
             PhysicalDictationTriggerModifiers.option,
             "legacy Carbon Option should migrate to the physical trigger modifier mask"
+        )
+    }
+
+    runSuite("PhysicalDictationTriggerPreferences preserves legacy push-to-talk physical shortcut") {
+        let (defaults, suiteName) = makePhysicalTriggerDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let rightOption = PhysicalDictationTriggerBinding(keyCode: UInt32(kVK_RightOption))
+        defaults.set(Int(rightOption.keyCode), forKey: "dictationTrigger-keyCode")
+        defaults.set(Int(rightOption.modifiers), forKey: "dictationTrigger-modifiers")
+        HotkeyPreferences.setDictationShortcutMode(.pushToTalk, userDefaults: defaults)
+
+        assertEqual(
+            PhysicalDictationTriggerPreferences.pushToTalkBinding(userDefaults: defaults),
+            rightOption,
+            "existing push-to-talk users should keep their saved physical key"
+        )
+        assertEqual(
+            PhysicalDictationTriggerPreferences.handsFreeBinding(userDefaults: defaults),
+            PhysicalDictationTriggerPreferences.defaultHandsFreeBinding,
+            "hands-free should move to the new default when the saved key belonged to push-to-talk"
         )
     }
 

--- a/Tests/PhysicalDictationTriggerPreferencesTests.swift
+++ b/Tests/PhysicalDictationTriggerPreferencesTests.swift
@@ -4,7 +4,7 @@ import CoreGraphics
 import Foundation
 
 func testPhysicalDictationTriggerPreferences() {
-    runSuite("PhysicalDictationTriggerPreferences defaults to Fn, Fn Space, and Fn M") {
+    runSuite("PhysicalDictationTriggerPreferences defaults to Fn, Right Option, and Option M") {
         let (defaults, suiteName) = makePhysicalTriggerDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
@@ -16,12 +16,12 @@ func testPhysicalDictationTriggerPreferences() {
         assertEqual(
             PhysicalDictationTriggerPreferences.handsFreeBinding(userDefaults: defaults),
             PhysicalDictationTriggerPreferences.defaultHandsFreeBinding,
-            "fresh installs should use Fn Space for hands-free"
+            "fresh installs should use Right Option for hands-free"
         )
         assertEqual(
             PhysicalDictationTriggerPreferences.meetingBinding(userDefaults: defaults),
             PhysicalDictationTriggerPreferences.defaultMeetingBinding,
-            "fresh installs should use Fn M for meetings"
+            "fresh installs should use Option M for meetings"
         )
         assertEqual(
             PhysicalDictationTriggerPreferences.displayString(for: PhysicalDictationTriggerPreferences.defaultPushToTalkBinding),
@@ -30,13 +30,13 @@ func testPhysicalDictationTriggerPreferences() {
         )
         assertEqual(
             PhysicalDictationTriggerPreferences.displayString(for: PhysicalDictationTriggerPreferences.defaultHandsFreeBinding),
-            "Fn Space",
-            "hands-free default should display as Fn Space"
+            "Right ⌥",
+            "hands-free default should display as Right Option"
         )
         assertEqual(
             PhysicalDictationTriggerPreferences.displayString(for: PhysicalDictationTriggerPreferences.defaultMeetingBinding),
-            "Fn M",
-            "meeting default should display as Fn M"
+            "⌥M",
+            "meeting default should display as Option M"
         )
     }
 
@@ -146,14 +146,14 @@ func testPhysicalDictationTriggerPreferences() {
         let (defaults, suiteName) = makePhysicalTriggerDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        let rightOption = PhysicalDictationTriggerBinding(keyCode: UInt32(kVK_RightOption))
-        defaults.set(Int(rightOption.keyCode), forKey: "dictationTrigger-keyCode")
-        defaults.set(Int(rightOption.modifiers), forKey: "dictationTrigger-modifiers")
+        let capsLock = PhysicalDictationTriggerBinding(keyCode: UInt32(kVK_CapsLock))
+        defaults.set(Int(capsLock.keyCode), forKey: "dictationTrigger-keyCode")
+        defaults.set(Int(capsLock.modifiers), forKey: "dictationTrigger-modifiers")
         HotkeyPreferences.setDictationShortcutMode(.pushToTalk, userDefaults: defaults)
 
         assertEqual(
             PhysicalDictationTriggerPreferences.pushToTalkBinding(userDefaults: defaults),
-            rightOption,
+            capsLock,
             "existing push-to-talk users should keep their saved physical key"
         )
         assertEqual(

--- a/Tests/PhysicalDictationTriggerPreferencesTests.swift
+++ b/Tests/PhysicalDictationTriggerPreferencesTests.swift
@@ -31,6 +31,77 @@ func testPhysicalDictationTriggerPreferences() {
         assertEqual(PhysicalDictationTriggerPreferences.displayString(for: fn), "Fn", "Fn should have a readable display name")
     }
 
+    runSuite("PhysicalDictationTriggerPreferences decodes macOS Fn actions") {
+        assertEqual(
+            PhysicalDictationTriggerPreferences.functionKeySystemAction(rawValue: nil),
+            .notConfigured,
+            "missing AppleFnUsageType should be treated as not configured"
+        )
+        assertEqual(
+            PhysicalDictationTriggerPreferences.functionKeySystemAction(rawValue: 0),
+            .doNothing,
+            "AppleFnUsageType 0 should mean Do Nothing"
+        )
+        assertEqual(
+            PhysicalDictationTriggerPreferences.functionKeySystemAction(rawValue: 1),
+            .changeInputSource,
+            "AppleFnUsageType 1 should mean Change Input Source"
+        )
+        assertEqual(
+            PhysicalDictationTriggerPreferences.functionKeySystemAction(rawValue: 2),
+            .showEmojiAndSymbols,
+            "AppleFnUsageType 2 should mean Emoji & Symbols"
+        )
+        assertEqual(
+            PhysicalDictationTriggerPreferences.functionKeySystemAction(rawValue: 3),
+            .startDictation,
+            "AppleFnUsageType 3 should mean Start Dictation"
+        )
+        assertEqual(
+            PhysicalDictationTriggerPreferences.functionKeySystemAction(rawValue: 99),
+            .unknown(99),
+            "unknown values should still be preserved for diagnostics"
+        )
+    }
+
+    runSuite("PhysicalDictationTriggerPreferences warns when bare Fn conflicts with macOS") {
+        let fn = PhysicalDictationTriggerBinding(keyCode: UInt32(kVK_Function))
+        let fnSpace = PhysicalDictationTriggerBinding(
+            keyCode: UInt32(kVK_Space),
+            modifiers: PhysicalDictationTriggerModifiers.function
+        )
+        let rightOption = PhysicalDictationTriggerBinding(keyCode: UInt32(kVK_RightOption))
+
+        assertNil(
+            PhysicalDictationTriggerPreferences.functionKeyConflictWarning(
+                for: fn,
+                systemAction: .doNothing
+            ),
+            "bare Fn should be safe when macOS leaves Fn alone"
+        )
+        assertNotNil(
+            PhysicalDictationTriggerPreferences.functionKeyConflictWarning(
+                for: fn,
+                systemAction: .showEmojiAndSymbols
+            ),
+            "bare Fn should warn when macOS opens emoji with the same key"
+        )
+        assertNil(
+            PhysicalDictationTriggerPreferences.functionKeyConflictWarning(
+                for: fnSpace,
+                systemAction: .showEmojiAndSymbols
+            ),
+            "Fn chords should not warn like bare Fn"
+        )
+        assertNil(
+            PhysicalDictationTriggerPreferences.functionKeyConflictWarning(
+                for: rightOption,
+                systemAction: .showEmojiAndSymbols
+            ),
+            "non-Fn physical triggers should not warn about Fn settings"
+        )
+    }
+
     runSuite("PhysicalDictationTriggerPreferences migrates legacy shortcut when right Option is disabled") {
         let (defaults, suiteName) = makePhysicalTriggerDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }


### PR DESCRIPTION
## Summary

- Splits dictation shortcuts into separate push-to-talk and hands-free bindings, with meetings as its own binding.
- Defaults push-to-talk to `Fn`, hands-free to Right Option, and meetings to `Option+M`.
- Routes all three through the physical shortcut detector so modifier-only shortcuts and modifier chords can coexist.
- Keeps the Fn/macOS conflict warning pointed at the bare-Fn push-to-talk shortcut.

## Why

The old single dictation shortcut model made bare `Fn` awkward for hands-free mode because macOS can also treat `Fn` as Emoji/Symbols, input source switching, or system dictation. Splitting the shortcuts lets `Fn` work well for hold-to-talk while hands-free and meetings use shortcuts that do not fight that behavior.

## Validation

- `bash build.sh`
- `bash run-tests.sh` → 672 passed, 0 failed