### PR TITLE
[codex] Simplify Transcripted agent setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ See [docs/agent-connect.md](docs/agent-connect.md).
 - Auto Enter for selected apps after dictation
 - Launch at login
 - Local Markdown capture library
-- Optional MCP access for agents
+- One-click Claude Desktop direct tools
 
 ## Privacy
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ Transcripted also includes an optional read-only MCP server for agents that
 support MCP. It gives tools for recent context, search, recaps, meeting reads,
 dictation reads, and speaker lookup.
 
+For Claude Desktop, open Transcripted Settings, go to `Agent`, then click
+`Install for Claude Desktop`. Transcripted installs the local server, writes the
+Claude Desktop config, checks your local library, and tells you when to restart
+Claude Desktop.
+
 See [docs/agent-connect.md](docs/agent-connect.md).
 
 ## Features

--- a/Sources/Support/CLAUDE.md
+++ b/Sources/Support/CLAUDE.md
@@ -4,8 +4,9 @@
 
 `Sources/Support/` holds app-wide helpers that do not belong to a single UI or pipeline surface. These types mostly wrap persisted preferences, shared constants, permission access, storage paths, or low-level paste / launch behavior used across dictation and meetings.
 
-## Files (12 Swift files)
+## Files (13 Swift files)
 
+- `ClaudeDesktopIntegrationInstaller.swift` — installs the bundled read-only MCP helper for Claude Desktop, safely merges Claude's config JSON, and runs the helper self-test
 - `ClipboardRestoringTextPaster.swift` — paste helper that preserves clipboard contents while inserting the latest dictation into the target app
 - `CustomDictionaryPreferences.swift` — persisted custom spoken-term replacements plus text post-processing helpers
 - `DictationAutoSendPreferences.swift` — persisted auto-send rules, allowed bundle list, and keypress-sending helpers for pasted dictation
@@ -26,6 +27,7 @@
 - `CustomDictionaryPreferences` and `DictationAutoSendPreferences` back the Settings `General` and `Dictation` pages. If you change parsing rules or policy thresholds, update the relevant tests.
 - `TranscriptedPermissionAccess` is the app-level permission seam. UI flows should call into it instead of duplicating TCC branching.
 - `TranscriptedStoragePaths` should stay as the canonical path resolver for the app target. `Sources/TranscriptedCore/Services/CoreStoragePaths.swift` is the injected library-side seam.
+- `ClaudeDesktopIntegrationInstaller` owns the Claude Desktop config merge. Preserve existing MCP servers and back up invalid JSON instead of overwriting blindly.
 
 ## Verification
 

--- a/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
+++ b/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
@@ -1,0 +1,334 @@
+import Foundation
+
+struct ClaudeDesktopIntegrationStatus: Equatable {
+    enum State: Equatable {
+        case notInstalled
+        case installed
+        case needsRepair
+    }
+
+    let state: State
+    let configURL: URL
+    let installedBinaryURL: URL
+    let bundledBinaryURL: URL?
+    let configuredCommandPath: String?
+    let installedBinaryExists: Bool
+    let bundledBinaryExists: Bool
+    let configExists: Bool
+    let configIsReadable: Bool
+    let claudeDesktopLikelyInstalled: Bool
+
+    var isInstalled: Bool {
+        state == .installed
+    }
+}
+
+struct ClaudeDesktopIntegrationInstallResult: Equatable {
+    let configURL: URL
+    let installedBinaryURL: URL
+    let backupURL: URL?
+    let selfTest: TranscriptedMCPSelfTest
+}
+
+struct TranscriptedMCPSelfTest: Codable, Equatable {
+    let ok: Bool
+    let meetingsDirectory: String
+    let dictationsDirectory: String
+    let indexDirectory: String
+    let meetingFileCount: Int
+    let dictationFileCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case ok
+        case meetingsDirectory = "meetings_directory"
+        case dictationsDirectory = "dictations_directory"
+        case indexDirectory = "index_directory"
+        case meetingFileCount = "meeting_file_count"
+        case dictationFileCount = "dictation_file_count"
+    }
+}
+
+enum ClaudeDesktopIntegrationError: LocalizedError, Equatable {
+    case bundledBinaryMissing(URL?)
+    case installedBinaryNotExecutable(URL)
+    case selfTestFailed(status: Int32, output: String)
+    case selfTestOutputUnreadable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .bundledBinaryMissing(let url):
+            if let url {
+                return "Transcripted direct tools are missing from this app build at \(url.path)."
+            }
+            return "Transcripted direct tools are missing from this app build."
+        case .installedBinaryNotExecutable(let url):
+            return "Transcripted direct tools were installed, but the file is not executable at \(url.path)."
+        case .selfTestFailed(_, let output):
+            let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty
+                ? "Transcripted direct tools did not pass the local check."
+                : trimmed
+        case .selfTestOutputUnreadable:
+            return "Transcripted direct tools ran, but the health check output could not be read."
+        }
+    }
+}
+
+enum ClaudeDesktopIntegrationInstaller {
+    static let serverName = "transcripted"
+    static let helperBinaryName = "transcripted-mcp"
+
+    static var installedMCPBinaryURL: URL {
+        FileManager.default.transcriptedAppSupportDir
+            .appendingPathComponent("mcp", isDirectory: true)
+            .appendingPathComponent(helperBinaryName, isDirectory: false)
+    }
+
+    static var claudeDesktopConfigURL: URL {
+        let applicationSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+        return applicationSupport
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("claude_desktop_config.json", isDirectory: false)
+    }
+
+    static func bundledMCPBinaryURL(
+        bundle: Bundle = .main,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        let helperURL = bundle.bundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Helpers", isDirectory: true)
+            .appendingPathComponent(helperBinaryName, isDirectory: false)
+
+        if fileManager.isExecutableFile(atPath: helperURL.path) {
+            return helperURL
+        }
+
+        if let resourceURL = bundle.resourceURL {
+            let legacyResourceURL = resourceURL.appendingPathComponent(helperBinaryName, isDirectory: false)
+            if fileManager.isExecutableFile(atPath: legacyResourceURL.path) {
+                return legacyResourceURL
+            }
+        }
+
+        return nil
+    }
+
+    static func currentStatus(
+        configURL: URL = claudeDesktopConfigURL,
+        installedBinaryURL: URL = installedMCPBinaryURL,
+        bundledBinaryURL: URL? = bundledMCPBinaryURL(),
+        fileManager: FileManager = .default
+    ) -> ClaudeDesktopIntegrationStatus {
+        let configExists = fileManager.fileExists(atPath: configURL.path)
+        let installedBinaryExists = fileManager.isExecutableFile(atPath: installedBinaryURL.path)
+        let bundledBinaryExists = bundledBinaryURL.map { fileManager.isExecutableFile(atPath: $0.path) } ?? false
+        let configRead = readClaudeDesktopConfig(at: configURL, fileManager: fileManager)
+        let configuredCommandPath = configRead.config.flatMap(transcriptedCommandPath(in:))
+        let configIsReadable = !configExists || configRead.config != nil
+        let isConfiguredForInstalledBinary = configuredCommandPath == installedBinaryURL.path
+
+        let state: ClaudeDesktopIntegrationStatus.State
+        if installedBinaryExists && isConfiguredForInstalledBinary {
+            state = .installed
+        } else if !configExists && !installedBinaryExists {
+            state = .notInstalled
+        } else {
+            state = .needsRepair
+        }
+
+        return ClaudeDesktopIntegrationStatus(
+            state: state,
+            configURL: configURL,
+            installedBinaryURL: installedBinaryURL,
+            bundledBinaryURL: bundledBinaryURL,
+            configuredCommandPath: configuredCommandPath,
+            installedBinaryExists: installedBinaryExists,
+            bundledBinaryExists: bundledBinaryExists,
+            configExists: configExists,
+            configIsReadable: configIsReadable,
+            claudeDesktopLikelyInstalled: claudeDesktopLikelyInstalled(fileManager: fileManager)
+        )
+    }
+
+    static func installForClaudeDesktop(
+        bundledBinaryURL: URL? = bundledMCPBinaryURL(),
+        installedBinaryURL: URL = installedMCPBinaryURL,
+        configURL: URL = claudeDesktopConfigURL,
+        fileManager: FileManager = .default
+    ) throws -> ClaudeDesktopIntegrationInstallResult {
+        guard let bundledBinaryURL,
+              fileManager.isExecutableFile(atPath: bundledBinaryURL.path) else {
+            throw ClaudeDesktopIntegrationError.bundledBinaryMissing(bundledBinaryURL)
+        }
+
+        try installBundledBinary(
+            from: bundledBinaryURL,
+            to: installedBinaryURL,
+            fileManager: fileManager
+        )
+
+        let backupURL = try writeClaudeDesktopConfig(
+            commandPath: installedBinaryURL.path,
+            configURL: configURL,
+            fileManager: fileManager
+        )
+
+        let selfTest = try runSelfTest(binaryURL: installedBinaryURL, fileManager: fileManager)
+        return ClaudeDesktopIntegrationInstallResult(
+            configURL: configURL,
+            installedBinaryURL: installedBinaryURL,
+            backupURL: backupURL,
+            selfTest: selfTest
+        )
+    }
+
+    static func configSnippet(commandPath: String = installedMCPBinaryURL.path) -> String {
+        """
+        {
+          "mcpServers": {
+            "\(serverName)": {
+              "command": "\(commandPath)"
+            }
+          }
+        }
+        """
+    }
+
+    static func installBundledBinary(
+        from bundledBinaryURL: URL,
+        to installedBinaryURL: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        let installDirectory = installedBinaryURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: installDirectory, withIntermediateDirectories: true)
+
+        if fileManager.fileExists(atPath: installedBinaryURL.path) {
+            try fileManager.removeItem(at: installedBinaryURL)
+        }
+
+        try fileManager.copyItem(at: bundledBinaryURL, to: installedBinaryURL)
+        try fileManager.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o755)],
+            ofItemAtPath: installedBinaryURL.path
+        )
+    }
+
+    @discardableResult
+    static func writeClaudeDesktopConfig(
+        commandPath: String,
+        configURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> URL? {
+        try fileManager.createDirectory(
+            at: configURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        let configRead = readClaudeDesktopConfig(at: configURL, fileManager: fileManager)
+        var root = configRead.config ?? [:]
+        let backupURL = configRead.needsBackup ? try backupConfig(at: configURL, fileManager: fileManager) : nil
+        var servers = root["mcpServers"] as? [String: Any] ?? [:]
+        servers[serverName] = ["command": commandPath]
+        root["mcpServers"] = servers
+
+        let data = try JSONSerialization.data(
+            withJSONObject: root,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        )
+        try data.write(to: configURL, options: [.atomic])
+        try fileManager.setAttributes(
+            [.posixPermissions: NSNumber(value: 0o600)],
+            ofItemAtPath: configURL.path
+        )
+        return backupURL
+    }
+
+    static func runSelfTest(
+        binaryURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> TranscriptedMCPSelfTest {
+        guard fileManager.isExecutableFile(atPath: binaryURL.path) else {
+            throw ClaudeDesktopIntegrationError.installedBinaryNotExecutable(binaryURL)
+        }
+
+        let process = Process()
+        process.executableURL = binaryURL
+        process.arguments = ["--self-test"]
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: stdoutData + stderrData, as: UTF8.self)
+
+        guard process.terminationStatus == 0 else {
+            throw ClaudeDesktopIntegrationError.selfTestFailed(
+                status: process.terminationStatus,
+                output: output
+            )
+        }
+
+        do {
+            return try JSONDecoder().decode(TranscriptedMCPSelfTest.self, from: stdoutData)
+        } catch {
+            throw ClaudeDesktopIntegrationError.selfTestOutputUnreadable(output)
+        }
+    }
+
+    static func claudeDesktopLikelyInstalled(fileManager: FileManager = .default) -> Bool {
+        let homeApplications = fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent("Applications", isDirectory: true)
+            .appendingPathComponent("Claude.app", isDirectory: true)
+
+        return fileManager.fileExists(atPath: "/Applications/Claude.app")
+            || fileManager.fileExists(atPath: homeApplications.path)
+    }
+
+    private static func readClaudeDesktopConfig(
+        at configURL: URL,
+        fileManager: FileManager
+    ) -> (config: [String: Any]?, needsBackup: Bool) {
+        guard fileManager.fileExists(atPath: configURL.path) else {
+            return ([:], false)
+        }
+
+        do {
+            let data = try Data(contentsOf: configURL)
+            let json = try JSONSerialization.jsonObject(with: data)
+            guard let config = json as? [String: Any] else {
+                return (nil, true)
+            }
+            return (config, false)
+        } catch {
+            return (nil, true)
+        }
+    }
+
+    private static func transcriptedCommandPath(in config: [String: Any]) -> String? {
+        guard let servers = config["mcpServers"] as? [String: Any],
+              let transcripted = servers[serverName] as? [String: Any] else {
+            return nil
+        }
+
+        return transcripted["command"] as? String
+    }
+
+    private static func backupConfig(at configURL: URL, fileManager: FileManager) throws -> URL? {
+        guard fileManager.fileExists(atPath: configURL.path) else { return nil }
+
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+        let backupURL = configURL.deletingLastPathComponent()
+            .appendingPathComponent("\(configURL.lastPathComponent).backup-\(timestamp)", isDirectory: false)
+        try fileManager.copyItem(at: configURL, to: backupURL)
+        return backupURL
+    }
+}

--- a/Sources/UI/AgentConnect/AgentConnectionWindowView.swift
+++ b/Sources/UI/AgentConnect/AgentConnectionWindowView.swift
@@ -5,6 +5,7 @@ struct AgentConnectionContext {
     let meetingsFolderURL: URL
     let dictationsFolderURL: URL
     let starterPrompt: String
+    let folderAccessPrompt: String
     let mcpSetupText: String
     let mcpConfigExample: String
     let folderPathsText: String
@@ -18,6 +19,7 @@ struct AgentConnectionContext {
         self.meetingsFolderURL = AgentConnectionGuide.meetingsFolder
         self.dictationsFolderURL = AgentConnectionGuide.dictationsFolder
         self.starterPrompt = AgentConnectionGuide.starterPrompt(filename: filename)
+        self.folderAccessPrompt = AgentConnectionGuide.folderAccessPrompt
         self.mcpSetupText = AgentConnectionGuide.mcpSetupText
         self.mcpConfigExample = AgentConnectionGuide.mcpConfigExample
         self.folderPathsText = AgentConnectionGuide.folderPathsText
@@ -27,6 +29,7 @@ struct AgentConnectionContext {
 private enum AgentConnectionCopyItem: Hashable {
     case prompt
     case mcp
+    case folderPrompt
     case folders
 }
 
@@ -47,6 +50,10 @@ final class AgentConnectionViewModel: ObservableObject {
 
     func copyStarterPrompt() {
         copy(context.starterPrompt, as: .prompt)
+    }
+
+    func copyFolderAccessPrompt() {
+        copy(context.folderAccessPrompt, as: .folderPrompt)
     }
 
     func copyMCPSetup() {
@@ -112,9 +119,9 @@ struct AgentConnectionWindowView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 22) {
-                    primarySection
-                    mcpSection
-                    foldersSection
+                    claudeDesktopSection
+                    localAgentSection
+                    webFallbackSection
                 }
                 .padding(20)
             }
@@ -136,11 +143,11 @@ struct AgentConnectionWindowView: View {
             }
 
             VStack(alignment: .leading, spacing: 4) {
-                Text("Connect your agent")
+                Text("Pick your agent")
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundStyle(AgentConnectionTheme.textPrimary)
 
-                Text("Copy once, paste anywhere, and let your agent pick the best available Transcripted connection.")
+                Text("Claude Desktop gets direct tools. Local coding agents get one prompt. Web chats are fallback only.")
                     .font(.system(size: 12))
                     .foregroundStyle(AgentConnectionTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -153,45 +160,15 @@ struct AgentConnectionWindowView: View {
         .background(AgentConnectionTheme.background)
     }
 
-    private var primarySection: some View {
+    private var claudeDesktopSection: some View {
         AgentConnectionSectionCard(
-            title: "Copy this into your agent",
-            subtitle: "This is the main path for most people."
+            title: "Claude Desktop",
+            subtitle: "Best path: install Transcripted direct tools, then restart Claude Desktop."
         ) {
-            AgentConnectionBodyText("Your agent will choose the best route automatically. Local agents can read Transcripted directly; remote chats get one clear next step if they cannot reach this Mac.")
-
-            VStack(alignment: .leading, spacing: 10) {
-                Text("Starter skills")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(AgentConnectionTheme.textPrimary)
-
-                ForEach(Array(AgentConnectionGuide.starterSkills.enumerated()), id: \.offset) { _, skill in
-                    AgentConnectionInfoRow(
-                        symbolName: skill.symbolName,
-                        title: skill.title,
-                        detail: skill.displayDetail
-                    )
-                }
-            }
+            AgentConnectionBodyText("Use Transcripted Settings > Agent > Install for Claude Desktop. The app writes the Claude config and checks your local library.")
 
             HStack(spacing: 10) {
-                Button(viewModel.copyLabel(for: .prompt, default: "Copy Agent Setup")) {
-                    viewModel.copyStarterPrompt()
-                }
-                .buttonStyle(AgentConnectionPrimaryButtonStyle())
-            }
-        }
-    }
-
-    private var mcpSection: some View {
-        AgentConnectionSectionCard(
-            title: "Optional MCP setup",
-            subtitle: "Set this up only if your agent supports MCP and you want the better direct-tool connection."
-        ) {
-            AgentConnectionBodyText(viewModel.context.mcpSetupText)
-
-            HStack(spacing: 10) {
-                Button(viewModel.copyLabel(for: .mcp, default: "Copy MCP setup")) {
+                Button(viewModel.copyLabel(for: .mcp, default: "Copy Steps")) {
                     viewModel.copyMCPSetup()
                 }
                 .buttonStyle(AgentConnectionSecondaryButtonStyle())
@@ -199,14 +176,30 @@ struct AgentConnectionWindowView: View {
         }
     }
 
-    private var foldersSection: some View {
+    private var localAgentSection: some View {
         AgentConnectionSectionCard(
-            title: "Manual folders",
-            subtitle: "Only use these if you want to inspect or share the raw local paths yourself."
+            title: "Local Coding Agents",
+            subtitle: "Claude Code, Codex, Cursor, Windsurf, Zed, OpenCode, OpenClaw, Cline, Continue, and VS Code agents."
         ) {
-            AgentConnectionBodyText("The main prompt already includes these paths. They are here as a fallback for manual setup.")
+            AgentConnectionBodyText("Paste one prompt into the agent. It will use direct tools if available, otherwise it reads your Transcripted Markdown folders.")
 
-            VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Button(viewModel.copyLabel(for: .prompt, default: "Copy Prompt")) {
+                    viewModel.copyStarterPrompt()
+                }
+                .buttonStyle(AgentConnectionPrimaryButtonStyle())
+            }
+        }
+    }
+
+    private var webFallbackSection: some View {
+        AgentConnectionSectionCard(
+            title: "Fallback Only: Web Chat Or Cowork",
+            subtitle: "Not recommended for full Transcripted memory."
+        ) {
+            AgentConnectionBodyText("Claude web, ChatGPT web, Cowork, and mobile chats usually cannot see your Mac. Use this only for granted folders or pasted meetings.")
+
+            VStack(alignment: .leading, spacing: 10) {
                 AgentConnectionFileRow(
                     name: "Meetings",
                     detail: "Saved meeting markdown files live here.",
@@ -229,7 +222,12 @@ struct AgentConnectionWindowView: View {
             }
 
             HStack(spacing: 10) {
-                Button(viewModel.copyLabel(for: .folders, default: "Copy folder paths")) {
+                Button(viewModel.copyLabel(for: .folderPrompt, default: "Copy Folder Prompt")) {
+                    viewModel.copyFolderAccessPrompt()
+                }
+                .buttonStyle(AgentConnectionSecondaryButtonStyle())
+
+                Button(viewModel.copyLabel(for: .folders, default: "Copy Paths")) {
                     viewModel.copyFolderPaths()
                 }
                 .buttonStyle(AgentConnectionSecondaryButtonStyle())

--- a/Sources/UI/MenuBar/MenuAgentConnectPageView.swift
+++ b/Sources/UI/MenuBar/MenuAgentConnectPageView.swift
@@ -15,36 +15,36 @@ final class MenuAgentConnectPageView: NSView {
     )
     private let titleLabel = NSTextField(labelWithString: "Connect your agent")
     private let subtitleLabel = NSTextField(wrappingLabelWithString:
-        "Copy once, paste anywhere, and let your agent pick the best available Transcripted connection."
+        "Claude Desktop gets direct tools. Local coding agents get one prompt. Web chats are fallback only."
     )
-    private let starterPromptLabel = NSTextField(labelWithString: "Starter skills")
+    private let starterPromptLabel = NSTextField(labelWithString: "Best options")
     private let benefitOneRow = AgentConnectInfoRowView(
-        symbolName: AgentConnectionGuide.starterSkills[0].symbolName,
-        title: AgentConnectionGuide.starterSkills[0].title,
-        body: AgentConnectionGuide.starterSkills[0].displayDetail
+        symbolName: "bubble.left.and.text.bubble.right.fill",
+        title: "Claude Desktop",
+        body: "Install Transcripted direct tools in Settings > Agent, then restart Claude Desktop."
     )
     private let benefitTwoRow = AgentConnectInfoRowView(
-        symbolName: AgentConnectionGuide.starterSkills[1].symbolName,
-        title: AgentConnectionGuide.starterSkills[1].title,
-        body: AgentConnectionGuide.starterSkills[1].displayDetail
+        symbolName: "terminal.fill",
+        title: "Local coding agents",
+        body: "Claude Code, Codex, Cursor, Windsurf, Zed, Cline, Continue, OpenCode, and OpenClaw."
     )
-    private let manualSetupLabel = NSTextField(labelWithString: "Need manual setup?")
+    private let manualSetupLabel = NSTextField(labelWithString: "Fallback only")
     private let mcpRow = AgentConnectInfoRowView(
-        symbolName: "cable.connector",
-        title: "Optional MCP setup",
-        body: "Copy the MCP setup text only if your agent supports MCP and you want direct read-only tools."
+        symbolName: "globe",
+        title: "Web or Cowork",
+        body: "Not recommended for full library access. Grant folders or paste one meeting."
     )
     private let folderRow = AgentConnectInfoRowView(
         symbolName: "folder",
-        title: "Manual folders",
-        body: "Use these only if you want to inspect or share the raw Transcripted paths yourself."
+        title: "Raw folders",
+        body: "Copy paths only when a web chat or support agent asks for them."
     )
 
     private let copyMCPButton = MenuOutlineButton(
-        title: "Copy MCP setup",
+        title: "Copy steps",
         symbolName: "cable.connector",
-        accessibilityLabel: "Copy MCP setup",
-        toolTip: "Copy MCP setup"
+        accessibilityLabel: "Copy Claude Desktop steps",
+        toolTip: "Copy Claude Desktop steps"
     )
     private let copyFoldersButton = MenuOutlineButton(
         title: "Copy folder paths",
@@ -53,10 +53,10 @@ final class MenuAgentConnectPageView: NSView {
         toolTip: "Copy folder paths"
     )
     private let copyPromptButton = MenuOutlineButton(
-        title: "Copy Agent Setup",
+        title: "Copy prompt",
         symbolName: "doc.on.doc",
-        accessibilityLabel: "Copy Agent Setup",
-        toolTip: "Copy Agent Setup"
+        accessibilityLabel: "Copy local agent prompt",
+        toolTip: "Copy local agent prompt"
     )
 
     private var resetTask: Task<Void, Never>?
@@ -130,32 +130,32 @@ final class MenuAgentConnectPageView: NSView {
         starterPromptLabel.frame = NSRect(x: pad, y: y, width: width, height: 16)
         y += 22
 
-        let copyPromptWidth = max(132, copyPromptButton.fittingSize.width)
-        let promptRowWidth = max(180, width - copyPromptWidth - inlineButtonSpacing)
-        benefitOneRow.frame = NSRect(x: pad, y: y, width: promptRowWidth, height: AgentConnectInfoRowView.height)
-        copyPromptButton.frame = NSRect(
+        let copyMCPWidth = max(116, copyMCPButton.fittingSize.width)
+        let desktopRowWidth = max(180, width - copyMCPWidth - inlineButtonSpacing)
+        benefitOneRow.frame = NSRect(x: pad, y: y, width: desktopRowWidth, height: AgentConnectInfoRowView.height)
+        copyMCPButton.frame = NSRect(
             x: benefitOneRow.frame.maxX + inlineButtonSpacing,
             y: y + 14,
-            width: copyPromptWidth,
+            width: copyMCPWidth,
             height: MenuTokens.secondaryButtonSize
         )
         y += AgentConnectInfoRowView.height + 14
 
-        benefitTwoRow.frame = NSRect(x: pad, y: y, width: width, height: AgentConnectInfoRowView.height)
+        let copyPromptWidth = max(116, copyPromptButton.fittingSize.width)
+        let promptRowWidth = max(180, width - copyPromptWidth - inlineButtonSpacing)
+        benefitTwoRow.frame = NSRect(x: pad, y: y, width: promptRowWidth, height: AgentConnectInfoRowView.height)
+        copyPromptButton.frame = NSRect(
+            x: benefitTwoRow.frame.maxX + inlineButtonSpacing,
+            y: y + 14,
+            width: copyPromptWidth,
+            height: MenuTokens.secondaryButtonSize
+        )
         y += AgentConnectInfoRowView.height + 18
 
         manualSetupLabel.frame = NSRect(x: pad, y: y, width: width, height: 16)
         y += 22
 
-        let copyMCPWidth = max(120, copyMCPButton.fittingSize.width)
-        let mcpRowWidth = max(180, width - copyMCPWidth - inlineButtonSpacing)
-        mcpRow.frame = NSRect(x: pad, y: y, width: mcpRowWidth, height: AgentConnectInfoRowView.height)
-        copyMCPButton.frame = NSRect(
-            x: mcpRow.frame.maxX + inlineButtonSpacing,
-            y: y + 14,
-            width: copyMCPWidth,
-            height: MenuTokens.secondaryButtonSize
-        )
+        mcpRow.frame = NSRect(x: pad, y: y, width: width, height: AgentConnectInfoRowView.height)
         y += AgentConnectInfoRowView.height + 10
 
         let copyFoldersWidth = max(126, copyFoldersButton.fittingSize.width)
@@ -196,8 +196,8 @@ final class MenuAgentConnectPageView: NSView {
         resetTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 1_000_000_000)
             guard let self, !Task.isCancelled else { return }
-            self.copyPromptButton.title = "Copy Agent Setup"
-            self.copyPromptButton.setSymbol("doc.on.doc", accessibilityLabel: "Copy Agent Setup")
+            self.copyPromptButton.title = "Copy prompt"
+            self.copyPromptButton.setSymbol("doc.on.doc", accessibilityLabel: "Copy local agent prompt")
         }
     }
 
@@ -215,8 +215,8 @@ final class MenuAgentConnectPageView: NSView {
         resetTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 1_000_000_000)
             guard let self, !Task.isCancelled else { return }
-            self.copyMCPButton.title = "Copy MCP setup"
-            self.copyMCPButton.setSymbol("cable.connector", accessibilityLabel: "Copy MCP setup")
+            self.copyMCPButton.title = "Copy steps"
+            self.copyMCPButton.setSymbol("cable.connector", accessibilityLabel: "Copy Claude Desktop steps")
         }
     }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1546,7 +1546,7 @@ private struct AgentConnectionSettingsPage: View {
         VStack(alignment: .leading, spacing: 24) {
             SettingsPageIntro(
                 title: "Agent",
-                summary: "Claude Desktop gets direct tools. Local agents get one prompt."
+                summary: "Pick one."
             )
 
             agentActionSection
@@ -1564,7 +1564,7 @@ private struct AgentConnectionSettingsPage: View {
 
             SettingsSection(
                 title: "Details",
-                detail: "Only needed when something is not working."
+                detail: "Advanced setup."
             ) {
                 DisclosureGroup("Show setup details", isExpanded: $showAdvancedAgentSetup) {
                     VStack(alignment: .leading, spacing: 14) {
@@ -1642,22 +1642,11 @@ private struct AgentConnectionSettingsPage: View {
 
     private var agentActionSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Choose Your App")
-                    .font(.headline)
-
-                Text("Pick one. No JSON, no Terminal, no source build.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
             HStack(spacing: 12) {
                 AgentConnectActionButton(
                     symbolName: claudeDesktopActionSymbol,
-                    eyebrow: "Claude Desktop",
                     title: claudeDesktopActionTitle,
-                    detail: "Best full-library experience. Installs Transcripted direct tools.",
+                    subtitle: "Claude Desktop",
                     statusText: claudeDesktopStatusText,
                     statusSymbolName: claudeDesktopStatusSymbol,
                     tint: claudeDesktopStatusTint,
@@ -1668,10 +1657,9 @@ private struct AgentConnectionSettingsPage: View {
 
                 AgentConnectActionButton(
                     symbolName: copiedLocalAgentPrompt ? "checkmark" : "chevron.left.forwardslash.chevron.right",
-                    eyebrow: "Local Coding Agents",
                     title: copiedLocalAgentPrompt ? "Copied" : "Copy for Agent",
-                    detail: "Claude Code, Codex, Cursor, Windsurf, Zed, Cline, Continue, OpenCode, and OpenClaw.",
-                    statusText: "For agents running on this Mac",
+                    subtitle: "Codex, Claude Code, Cursor",
+                    statusText: "Local files",
                     statusSymbolName: "folder",
                     tint: Color(nsColor: .systemBlue),
                     isEnabled: true
@@ -1729,16 +1717,16 @@ private struct AgentConnectionSettingsPage: View {
 
     private var claudeDesktopStatusText: String {
         if !claudeDesktopStatus.bundledBinaryExists {
-            return "Direct tools missing from this build"
+            return "Missing"
         }
 
         switch claudeDesktopStatus.state {
         case .installed:
-            return "Installed. Restart Claude if needed"
+            return "Installed"
         case .notInstalled:
-            return "One click, then restart Claude Desktop"
+            return "Not installed"
         case .needsRepair:
-            return "Needs repair"
+            return "Repair"
         }
     }
 
@@ -1845,9 +1833,8 @@ private struct AgentConnectionSettingsPage: View {
 
 private struct AgentConnectActionButton: View {
     let symbolName: String
-    let eyebrow: String
     let title: String
-    let detail: String
+    let subtitle: String
     let statusText: String
     let statusSymbolName: String
     let tint: Color
@@ -1869,22 +1856,18 @@ private struct AgentConnectActionButton: View {
                             .stroke(tint.opacity(0.18), lineWidth: 1)
                     )
 
-                VStack(alignment: .leading, spacing: 7) {
-                    Text(eyebrow.uppercased())
-                        .font(.caption2.weight(.semibold))
-                        .foregroundStyle(.secondary)
-
+                VStack(alignment: .leading, spacing: 8) {
                     Text(title)
                         .font(.title3.weight(.semibold))
                         .foregroundStyle(.primary)
                         .lineLimit(1)
                         .minimumScaleFactor(0.88)
 
-                    Text(detail)
+                    Text(subtitle)
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                        .lineLimit(2)
-                        .fixedSize(horizontal: false, vertical: true)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.9)
 
                     Label(statusText, systemImage: statusSymbolName)
                         .font(.caption.weight(.semibold))
@@ -1902,7 +1885,7 @@ private struct AgentConnectActionButton: View {
                     .background(tint.opacity(isEnabled ? 0.11 : 0.06), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
             }
             .padding(16)
-            .frame(maxWidth: .infinity, minHeight: 142, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: 112, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .fill(Color(nsColor: .controlBackgroundColor).opacity(isHovered && isEnabled ? 0.95 : 0.78))
@@ -2018,12 +2001,12 @@ private struct ClaudeDesktopSelfTestResultView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             Label(
-                "Ready. Found \(result.selfTest.meetingFileCount) meeting files and \(result.selfTest.dictationFileCount) dictation files.",
+                "Ready. Restart Claude.",
                 systemImage: "checkmark.circle.fill"
             )
             .foregroundStyle(.green)
 
-            Text("Restart Claude Desktop to use Transcripted direct tools.")
+            Text("\(result.selfTest.meetingFileCount) meetings, \(result.selfTest.dictationFileCount) dictation files found.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1537,131 +1537,150 @@ private struct AgentConnectionSettingsPage: View {
     @State private var claudeDesktopInstallError: String?
     @State private var isInstallingClaudeDesktop = false
     @State private var copiedClaudeDesktopConfig = false
+    @State private var copiedLocalAgentPrompt = false
+    @State private var copiedFolderPrompt = false
+    @State private var copiedFolderPaths = false
+    @State private var showAdvancedAgentSetup = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
             SettingsPageIntro(
                 title: "Agent",
-                summary: "Connect Claude Desktop or copy one prompt for other agents."
+                summary: "Two good paths. Web chats are fallback only."
             )
 
             SettingsSection(
-                title: "Claude Desktop",
-                detail: "Install Transcripted direct tools with one click."
+                title: "Choose Your App",
+                detail: "Use Claude Desktop for direct tools, or copy one prompt for a local coding agent."
             ) {
-                ClaudeDesktopStatusRow(status: claudeDesktopStatus)
-
-                HStack(spacing: 10) {
-                    Button {
-                        installClaudeDesktop()
-                    } label: {
-                        Label(
-                            isInstallingClaudeDesktop ? "Installing..." : "Install for Claude Desktop",
-                            systemImage: isInstallingClaudeDesktop ? "hourglass" : "checkmark.circle"
-                        )
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(isInstallingClaudeDesktop || !claudeDesktopStatus.bundledBinaryExists)
-
-                    Button {
-                        copyClaudeDesktopConfig()
-                    } label: {
-                        Label(copiedClaudeDesktopConfig ? "Copied" : "Copy Config", systemImage: "doc.on.doc")
-                    }
-                    .buttonStyle(.bordered)
-
-                    Button {
-                        revealClaudeDesktopConfig()
-                    } label: {
-                        Label("Show Config", systemImage: "folder")
-                    }
-                    .buttonStyle(.bordered)
-                    .disabled(!claudeDesktopStatus.configExists)
-
-                    if !claudeDesktopStatus.claudeDesktopLikelyInstalled {
+                AgentRouteCard(
+                    symbolName: "bubble.left.and.text.bubble.right.fill",
+                    title: "Claude Desktop",
+                    detail: "Best experience. Transcripted installs direct tools, then you restart Claude Desktop."
+                ) {
+                    HStack(spacing: 10) {
                         Button {
-                            openClaudeDesktopDownload()
+                            installClaudeDesktop()
                         } label: {
-                            Label("Get Claude", systemImage: "arrow.down.circle")
+                            Label(
+                                isInstallingClaudeDesktop ? "Installing..." : "Install",
+                                systemImage: isInstallingClaudeDesktop ? "hourglass" : "checkmark.circle"
+                            )
                         }
-                        .buttonStyle(.bordered)
+                        .buttonStyle(.borderedProminent)
+                        .disabled(isInstallingClaudeDesktop || !claudeDesktopStatus.bundledBinaryExists)
+
+                        if !claudeDesktopStatus.claudeDesktopLikelyInstalled {
+                            Button {
+                                openClaudeDesktopDownload()
+                            } label: {
+                                Label("Get Claude", systemImage: "arrow.down.circle")
+                            }
+                            .buttonStyle(.bordered)
+                        }
                     }
+
+                    ClaudeDesktopCompactStatus(status: claudeDesktopStatus)
                 }
 
-                if let claudeDesktopInstallResult {
-                    ClaudeDesktopSelfTestResultView(result: claudeDesktopInstallResult)
-                }
-
-                if let claudeDesktopInstallError {
-                    Label(claudeDesktopInstallError, systemImage: "exclamationmark.triangle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
-
-            SettingsSection(
-                title: "Main Prompt",
-                detail: "Best first step for Codex, Claude, Cursor, and similar agents."
-            ) {
-                ForEach(Array(AgentConnectionGuide.starterSkills.enumerated()), id: \.offset) { _, skill in
-                    SettingsQuickLinkRow(
-                        symbolName: skill.symbolName,
-                        title: skill.title,
-                        detail: skill.displayDetail
-                    ) {}
-                    .disabled(true)
-                }
-
-                HStack {
-                    Button("Copy Prompt") {
-                        viewModel.copyStarterPrompt()
+                AgentRouteCard(
+                    symbolName: "terminal.fill",
+                    title: "Local Coding Agents",
+                    detail: "Claude Code, Codex, Cursor, Windsurf, Zed, OpenCode, OpenClaw, Cline, Continue, and VS Code agents."
+                ) {
+                    Button {
+                        copyLocalAgentPrompt()
+                    } label: {
+                        Label(copiedLocalAgentPrompt ? "Copied" : "Copy Prompt", systemImage: "doc.on.doc")
                     }
                     .buttonStyle(.borderedProminent)
                 }
             }
 
-            SettingsSection(
-                title: "Direct Tools",
-                detail: "Manual setup text for agents that support local MCP."
-            ) {
-                Text(viewModel.context.mcpSetupText)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+            if let claudeDesktopInstallResult {
+                ClaudeDesktopSelfTestResultView(result: claudeDesktopInstallResult)
+            }
 
-                Button("Copy Setup") {
-                    viewModel.copyMCPSetup()
-                }
-                .buttonStyle(.bordered)
+            if let claudeDesktopInstallError {
+                Label(claudeDesktopInstallError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             SettingsSection(
-                title: "Manual Folders",
-                detail: "Fallback paths for agents or quick inspection."
+                title: "Details",
+                detail: "Only needed when something is not working."
             ) {
-                AgentFolderRow(
-                    name: "Meetings",
-                    detail: "Meeting Markdown files.",
-                    path: viewModel.context.meetingsFolderURL.path,
-                    isAvailable: viewModel.fileExists(viewModel.context.meetingsFolderURL)
-                ) {
-                    viewModel.reveal(viewModel.context.meetingsFolderURL)
-                }
+                DisclosureGroup("Show setup details", isExpanded: $showAdvancedAgentSetup) {
+                    VStack(alignment: .leading, spacing: 14) {
+                        ClaudeDesktopStatusRow(status: claudeDesktopStatus)
 
-                AgentFolderRow(
-                    name: "Dictation",
-                    detail: "Dictation Markdown files.",
-                    path: viewModel.context.dictationsFolderURL.path,
-                    isAvailable: viewModel.fileExists(viewModel.context.dictationsFolderURL)
-                ) {
-                    viewModel.reveal(viewModel.context.dictationsFolderURL)
-                }
+                        HStack(spacing: 10) {
+                            Button {
+                                copyClaudeDesktopConfig()
+                            } label: {
+                                Label(copiedClaudeDesktopConfig ? "Copied" : "Copy Claude Config", systemImage: "doc.on.doc")
+                            }
+                            .buttonStyle(.bordered)
 
-                Button("Copy Folder Paths") {
-                    viewModel.copyFolderPaths()
+                            Button {
+                                revealClaudeDesktopConfig()
+                            } label: {
+                                Label("Show Config", systemImage: "folder")
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(!claudeDesktopStatus.configExists)
+                        }
+
+                        AgentFolderRow(
+                            name: "Meetings",
+                            detail: "Meeting Markdown files.",
+                            path: viewModel.context.meetingsFolderURL.path,
+                            isAvailable: viewModel.fileExists(viewModel.context.meetingsFolderURL)
+                        ) {
+                            viewModel.reveal(viewModel.context.meetingsFolderURL)
+                        }
+
+                        AgentFolderRow(
+                            name: "Dictation",
+                            detail: "Dictation Markdown files.",
+                            path: viewModel.context.dictationsFolderURL.path,
+                            isAvailable: viewModel.fileExists(viewModel.context.dictationsFolderURL)
+                        ) {
+                            viewModel.reveal(viewModel.context.dictationsFolderURL)
+                        }
+
+                        Divider()
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            Label("Web chats are fallback only", systemImage: "globe")
+                                .font(.subheadline.weight(.semibold))
+
+                            Text("Claude web, ChatGPT web, Cowork, and mobile chats usually cannot see your Mac. Use them for a pasted meeting or granted folders, not full Transcripted memory.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+
+                            HStack(spacing: 10) {
+                                Button {
+                                    copyFolderAccessPrompt()
+                                } label: {
+                                    Label(copiedFolderPrompt ? "Copied" : "Copy Folder Prompt", systemImage: "doc.on.doc")
+                                }
+                                .buttonStyle(.bordered)
+
+                                Button {
+                                    copyFolderPaths()
+                                } label: {
+                                    Label(copiedFolderPaths ? "Copied" : "Copy Paths", systemImage: "folder")
+                                }
+                                .buttonStyle(.bordered)
+                            }
+                        }
+                    }
+                    .padding(.top, 10)
                 }
-                .buttonStyle(.bordered)
             }
         }
         .onAppear(perform: refreshClaudeDesktopStatus)
@@ -1694,19 +1713,46 @@ private struct AgentConnectionSettingsPage: View {
         }
     }
 
-    private func copyClaudeDesktopConfig() {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(
-            ClaudeDesktopIntegrationInstaller.configSnippet(),
-            forType: .string
-        )
+    private func copyLocalAgentPrompt() {
+        copyText(AgentConnectionGuide.starterPrompt(filename: nil))
+        copiedLocalAgentPrompt = true
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            copiedLocalAgentPrompt = false
+        }
+    }
 
+    private func copyFolderAccessPrompt() {
+        copyText(AgentConnectionGuide.folderAccessPrompt)
+        copiedFolderPrompt = true
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            copiedFolderPrompt = false
+        }
+    }
+
+    private func copyFolderPaths() {
+        copyText(AgentConnectionGuide.folderPathsText)
+        copiedFolderPaths = true
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            copiedFolderPaths = false
+        }
+    }
+
+    private func copyClaudeDesktopConfig() {
+        copyText(ClaudeDesktopIntegrationInstaller.configSnippet())
         copiedClaudeDesktopConfig = true
         Task { @MainActor in
             try? await Task.sleep(nanoseconds: 1_500_000_000)
             copiedClaudeDesktopConfig = false
         }
+    }
+
+    private func copyText(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
     }
 
     private func revealClaudeDesktopConfig() {
@@ -1716,6 +1762,105 @@ private struct AgentConnectionSettingsPage: View {
     private func openClaudeDesktopDownload() {
         guard let url = URL(string: "https://claude.ai/download") else { return }
         NSWorkspace.shared.open(url)
+    }
+}
+
+private struct AgentRouteCard<Content: View>: View {
+    let symbolName: String
+    let title: String
+    let detail: String
+    let content: Content
+
+    init(
+        symbolName: String,
+        title: String,
+        detail: String,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.symbolName = symbolName
+        self.title = title
+        self.detail = detail
+        self.content = content()
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: symbolName)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 34, height: 34)
+                .background(Color.accentColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title)
+                    .font(.headline)
+
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack(spacing: 10) {
+                    content
+                }
+                .padding(.top, 2)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.75))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
+    }
+}
+
+private struct ClaudeDesktopCompactStatus: View {
+    let status: ClaudeDesktopIntegrationStatus
+
+    var body: some View {
+        Label(text, systemImage: symbolName)
+            .font(.caption)
+            .foregroundStyle(tint)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var text: String {
+        switch status.state {
+        case .installed:
+            return "Installed. Restart Claude Desktop if you just installed it."
+        case .notInstalled:
+            return status.bundledBinaryExists ? "Not installed yet." : "This app build is missing direct tools."
+        case .needsRepair:
+            return "Needs update. Click Install to repair it."
+        }
+    }
+
+    private var symbolName: String {
+        switch status.state {
+        case .installed:
+            return "checkmark.circle.fill"
+        case .notInstalled:
+            return "circle"
+        case .needsRepair:
+            return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var tint: Color {
+        switch status.state {
+        case .installed:
+            return .green
+        case .notInstalled:
+            return .secondary
+        case .needsRepair:
+            return .orange
+        }
     }
 }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1546,56 +1546,10 @@ private struct AgentConnectionSettingsPage: View {
         VStack(alignment: .leading, spacing: 24) {
             SettingsPageIntro(
                 title: "Agent",
-                summary: "Two good paths. Web chats are fallback only."
+                summary: "Claude Desktop gets direct tools. Local agents get one prompt."
             )
 
-            SettingsSection(
-                title: "Choose Your App",
-                detail: "Use Claude Desktop for direct tools, or copy one prompt for a local coding agent."
-            ) {
-                AgentRouteCard(
-                    symbolName: "bubble.left.and.text.bubble.right.fill",
-                    title: "Claude Desktop",
-                    detail: "Best experience. Transcripted installs direct tools, then you restart Claude Desktop."
-                ) {
-                    HStack(spacing: 10) {
-                        Button {
-                            installClaudeDesktop()
-                        } label: {
-                            Label(
-                                isInstallingClaudeDesktop ? "Installing..." : "Install",
-                                systemImage: isInstallingClaudeDesktop ? "hourglass" : "checkmark.circle"
-                            )
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .disabled(isInstallingClaudeDesktop || !claudeDesktopStatus.bundledBinaryExists)
-
-                        if !claudeDesktopStatus.claudeDesktopLikelyInstalled {
-                            Button {
-                                openClaudeDesktopDownload()
-                            } label: {
-                                Label("Get Claude", systemImage: "arrow.down.circle")
-                            }
-                            .buttonStyle(.bordered)
-                        }
-                    }
-
-                    ClaudeDesktopCompactStatus(status: claudeDesktopStatus)
-                }
-
-                AgentRouteCard(
-                    symbolName: "terminal.fill",
-                    title: "Local Coding Agents",
-                    detail: "Claude Code, Codex, Cursor, Windsurf, Zed, OpenCode, OpenClaw, Cline, Continue, and VS Code agents."
-                ) {
-                    Button {
-                        copyLocalAgentPrompt()
-                    } label: {
-                        Label(copiedLocalAgentPrompt ? "Copied" : "Copy Prompt", systemImage: "doc.on.doc")
-                    }
-                    .buttonStyle(.borderedProminent)
-                }
-            }
+            agentActionSection
 
             if let claudeDesktopInstallResult {
                 ClaudeDesktopSelfTestResultView(result: claudeDesktopInstallResult)
@@ -1686,6 +1640,130 @@ private struct AgentConnectionSettingsPage: View {
         .onAppear(perform: refreshClaudeDesktopStatus)
     }
 
+    private var agentActionSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Choose Your App")
+                    .font(.headline)
+
+                Text("Pick one. No JSON, no Terminal, no source build.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: 12) {
+                AgentConnectActionButton(
+                    symbolName: claudeDesktopActionSymbol,
+                    eyebrow: "Claude Desktop",
+                    title: claudeDesktopActionTitle,
+                    detail: "Best full-library experience. Installs Transcripted direct tools.",
+                    statusText: claudeDesktopStatusText,
+                    statusSymbolName: claudeDesktopStatusSymbol,
+                    tint: claudeDesktopStatusTint,
+                    isEnabled: claudeDesktopActionEnabled
+                ) {
+                    installClaudeDesktop()
+                }
+
+                AgentConnectActionButton(
+                    symbolName: copiedLocalAgentPrompt ? "checkmark" : "chevron.left.forwardslash.chevron.right",
+                    eyebrow: "Local Coding Agents",
+                    title: copiedLocalAgentPrompt ? "Copied" : "Copy for Agent",
+                    detail: "Claude Code, Codex, Cursor, Windsurf, Zed, Cline, Continue, OpenCode, and OpenClaw.",
+                    statusText: "For agents running on this Mac",
+                    statusSymbolName: "folder",
+                    tint: Color(nsColor: .systemBlue),
+                    isEnabled: true
+                ) {
+                    copyLocalAgentPrompt()
+                }
+            }
+
+            if !claudeDesktopStatus.claudeDesktopLikelyInstalled {
+                Button {
+                    openClaudeDesktopDownload()
+                } label: {
+                    Label("Get Claude Desktop", systemImage: "arrow.down.circle")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
+    }
+
+    private var claudeDesktopActionTitle: String {
+        if isInstallingClaudeDesktop {
+            return "Installing..."
+        }
+
+        switch claudeDesktopStatus.state {
+        case .installed:
+            return "Install in Claude"
+        case .notInstalled:
+            return "Install in Claude"
+        case .needsRepair:
+            return "Repair Claude Setup"
+        }
+    }
+
+    private var claudeDesktopActionSymbol: String {
+        if isInstallingClaudeDesktop {
+            return "hourglass"
+        }
+
+        switch claudeDesktopStatus.state {
+        case .installed:
+            return "checkmark"
+        case .notInstalled:
+            return "sparkles"
+        case .needsRepair:
+            return "arrow.clockwise"
+        }
+    }
+
+    private var claudeDesktopActionEnabled: Bool {
+        !isInstallingClaudeDesktop
+            && claudeDesktopStatus.bundledBinaryExists
+    }
+
+    private var claudeDesktopStatusText: String {
+        if !claudeDesktopStatus.bundledBinaryExists {
+            return "Direct tools missing from this build"
+        }
+
+        switch claudeDesktopStatus.state {
+        case .installed:
+            return "Installed. Restart Claude if needed"
+        case .notInstalled:
+            return "One click, then restart Claude Desktop"
+        case .needsRepair:
+            return "Needs repair"
+        }
+    }
+
+    private var claudeDesktopStatusSymbol: String {
+        switch claudeDesktopStatus.state {
+        case .installed:
+            return "checkmark.circle.fill"
+        case .notInstalled:
+            return "arrow.right.circle"
+        case .needsRepair:
+            return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var claudeDesktopStatusTint: Color {
+        switch claudeDesktopStatus.state {
+        case .installed:
+            return .green
+        case .notInstalled:
+            return Color(nsColor: .systemOrange)
+        case .needsRepair:
+            return .orange
+        }
+    }
+
     private func refreshClaudeDesktopStatus() {
         claudeDesktopStatus = ClaudeDesktopIntegrationInstaller.currentStatus()
     }
@@ -1765,102 +1843,80 @@ private struct AgentConnectionSettingsPage: View {
     }
 }
 
-private struct AgentRouteCard<Content: View>: View {
+private struct AgentConnectActionButton: View {
     let symbolName: String
+    let eyebrow: String
     let title: String
     let detail: String
-    let content: Content
+    let statusText: String
+    let statusSymbolName: String
+    let tint: Color
+    let isEnabled: Bool
+    let action: () -> Void
 
-    init(
-        symbolName: String,
-        title: String,
-        detail: String,
-        @ViewBuilder content: () -> Content
-    ) {
-        self.symbolName = symbolName
-        self.title = title
-        self.detail = detail
-        self.content = content()
-    }
+    @State private var isHovered = false
 
     var body: some View {
-        HStack(alignment: .top, spacing: 14) {
-            Image(systemName: symbolName)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(Color.accentColor)
-                .frame(width: 34, height: 34)
-                .background(Color.accentColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        Button(action: action) {
+            HStack(alignment: .top, spacing: 14) {
+                Image(systemName: symbolName)
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(tint)
+                    .frame(width: 42, height: 42)
+                    .background(tint.opacity(0.13), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(tint.opacity(0.18), lineWidth: 1)
+                    )
 
-            VStack(alignment: .leading, spacing: 6) {
-                Text(title)
-                    .font(.headline)
+                VStack(alignment: .leading, spacing: 7) {
+                    Text(eyebrow.uppercased())
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
 
-                Text(detail)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                    Text(title)
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.88)
 
-                HStack(spacing: 10) {
-                    content
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Label(statusText, systemImage: statusSymbolName)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(tint)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.88)
+                        .padding(.top, 2)
                 }
-                .padding(.top, 2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                Image(systemName: "arrow.right")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(tint.opacity(isEnabled ? 0.95 : 0.45))
+                    .frame(width: 26, height: 26)
+                    .background(tint.opacity(isEnabled ? 0.11 : 0.06), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(16)
+            .frame(maxWidth: .infinity, minHeight: 142, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor).opacity(isHovered && isEnabled ? 0.95 : 0.78))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(tint.opacity(isHovered && isEnabled ? 0.56 : 0.28), lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .opacity(isEnabled ? 1.0 : 0.72)
         }
-        .padding(14)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.75))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        )
-    }
-}
-
-private struct ClaudeDesktopCompactStatus: View {
-    let status: ClaudeDesktopIntegrationStatus
-
-    var body: some View {
-        Label(text, systemImage: symbolName)
-            .font(.caption)
-            .foregroundStyle(tint)
-            .fixedSize(horizontal: false, vertical: true)
-    }
-
-    private var text: String {
-        switch status.state {
-        case .installed:
-            return "Installed. Restart Claude Desktop if you just installed it."
-        case .notInstalled:
-            return status.bundledBinaryExists ? "Not installed yet." : "This app build is missing direct tools."
-        case .needsRepair:
-            return "Needs update. Click Install to repair it."
-        }
-    }
-
-    private var symbolName: String {
-        switch status.state {
-        case .installed:
-            return "checkmark.circle.fill"
-        case .notInstalled:
-            return "circle"
-        case .needsRepair:
-            return "exclamationmark.triangle.fill"
-        }
-    }
-
-    private var tint: Color {
-        switch status.state {
-        case .installed:
-            return .green
-        case .notInstalled:
-            return .secondary
-        case .needsRepair:
-            return .orange
-        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .onHover { isHovered = $0 }
     }
 }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1532,13 +1532,73 @@ private struct AgentConnectionSettingsPage: View {
     @StateObject private var viewModel = AgentConnectionViewModel(
         context: AgentConnectionContext(meetingTitle: nil, meetingDate: nil, transcriptURL: nil)
     )
+    @State private var claudeDesktopStatus = ClaudeDesktopIntegrationInstaller.currentStatus()
+    @State private var claudeDesktopInstallResult: ClaudeDesktopIntegrationInstallResult?
+    @State private var claudeDesktopInstallError: String?
+    @State private var isInstallingClaudeDesktop = false
+    @State private var copiedClaudeDesktopConfig = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
             SettingsPageIntro(
                 title: "Agent",
-                summary: "Copy one prompt so your agent can read Transcripted notes."
+                summary: "Connect Claude Desktop or copy one prompt for other agents."
             )
+
+            SettingsSection(
+                title: "Claude Desktop",
+                detail: "Install Transcripted direct tools with one click."
+            ) {
+                ClaudeDesktopStatusRow(status: claudeDesktopStatus)
+
+                HStack(spacing: 10) {
+                    Button {
+                        installClaudeDesktop()
+                    } label: {
+                        Label(
+                            isInstallingClaudeDesktop ? "Installing..." : "Install for Claude Desktop",
+                            systemImage: isInstallingClaudeDesktop ? "hourglass" : "checkmark.circle"
+                        )
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isInstallingClaudeDesktop || !claudeDesktopStatus.bundledBinaryExists)
+
+                    Button {
+                        copyClaudeDesktopConfig()
+                    } label: {
+                        Label(copiedClaudeDesktopConfig ? "Copied" : "Copy Config", systemImage: "doc.on.doc")
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button {
+                        revealClaudeDesktopConfig()
+                    } label: {
+                        Label("Show Config", systemImage: "folder")
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(!claudeDesktopStatus.configExists)
+
+                    if !claudeDesktopStatus.claudeDesktopLikelyInstalled {
+                        Button {
+                            openClaudeDesktopDownload()
+                        } label: {
+                            Label("Get Claude", systemImage: "arrow.down.circle")
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+
+                if let claudeDesktopInstallResult {
+                    ClaudeDesktopSelfTestResultView(result: claudeDesktopInstallResult)
+                }
+
+                if let claudeDesktopInstallError {
+                    Label(claudeDesktopInstallError, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
 
             SettingsSection(
                 title: "Main Prompt",
@@ -1563,7 +1623,7 @@ private struct AgentConnectionSettingsPage: View {
 
             SettingsSection(
                 title: "Direct Tools",
-                detail: "Optional read-only MCP setup."
+                detail: "Manual setup text for agents that support local MCP."
             ) {
                 Text(viewModel.context.mcpSetupText)
                     .font(.caption)
@@ -1604,6 +1664,176 @@ private struct AgentConnectionSettingsPage: View {
                 .buttonStyle(.bordered)
             }
         }
+        .onAppear(perform: refreshClaudeDesktopStatus)
+    }
+
+    private func refreshClaudeDesktopStatus() {
+        claudeDesktopStatus = ClaudeDesktopIntegrationInstaller.currentStatus()
+    }
+
+    private func installClaudeDesktop() {
+        guard !isInstallingClaudeDesktop else { return }
+        isInstallingClaudeDesktop = true
+        claudeDesktopInstallResult = nil
+        claudeDesktopInstallError = nil
+
+        Task {
+            do {
+                let result = try await Task.detached(priority: .userInitiated) {
+                    try ClaudeDesktopIntegrationInstaller.installForClaudeDesktop()
+                }.value
+
+                claudeDesktopInstallResult = result
+                refreshClaudeDesktopStatus()
+            } catch {
+                claudeDesktopInstallError = error.localizedDescription
+                refreshClaudeDesktopStatus()
+            }
+
+            isInstallingClaudeDesktop = false
+        }
+    }
+
+    private func copyClaudeDesktopConfig() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(
+            ClaudeDesktopIntegrationInstaller.configSnippet(),
+            forType: .string
+        )
+
+        copiedClaudeDesktopConfig = true
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            copiedClaudeDesktopConfig = false
+        }
+    }
+
+    private func revealClaudeDesktopConfig() {
+        NSWorkspace.shared.activateFileViewerSelecting([claudeDesktopStatus.configURL])
+    }
+
+    private func openClaudeDesktopDownload() {
+        guard let url = URL(string: "https://claude.ai/download") else { return }
+        NSWorkspace.shared.open(url)
+    }
+}
+
+private struct ClaudeDesktopStatusRow: View {
+    let status: ClaudeDesktopIntegrationStatus
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: symbolName)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(tint)
+                .frame(width: 28, height: 28)
+                .background(tint.opacity(0.12), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let configuredPath = status.configuredCommandPath,
+                   configuredPath != status.installedBinaryURL.path {
+                    Text(configuredPath)
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(2)
+                        .textSelection(.enabled)
+                }
+            }
+
+            Spacer(minLength: 12)
+        }
+    }
+
+    private var symbolName: String {
+        switch status.state {
+        case .installed:
+            return "checkmark.circle.fill"
+        case .notInstalled:
+            return "circle"
+        case .needsRepair:
+            return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var tint: Color {
+        switch status.state {
+        case .installed:
+            return .green
+        case .notInstalled:
+            return .secondary
+        case .needsRepair:
+            return .orange
+        }
+    }
+
+    private var title: String {
+        switch status.state {
+        case .installed:
+            return "Installed"
+        case .notInstalled:
+            return "Not installed yet"
+        case .needsRepair:
+            return "Needs update"
+        }
+    }
+
+    private var detail: String {
+        if !status.bundledBinaryExists {
+            return "This app build does not include Transcripted direct tools yet."
+        }
+
+        if !status.configIsReadable {
+            return "Claude Desktop config is not readable JSON. Install will back it up and write a clean config."
+        }
+
+        switch status.state {
+        case .installed:
+            return "Claude Desktop is configured. Restart Claude Desktop if you just installed it."
+        case .notInstalled:
+            return status.claudeDesktopLikelyInstalled
+                ? "Click Install for Claude Desktop, then restart Claude Desktop."
+                : "Claude Desktop was not found. You can still install now, then install Claude Desktop."
+        case .needsRepair:
+            if !status.installedBinaryExists {
+                return "The server file is missing. Install will copy a fresh one and update Claude Desktop."
+            }
+            return "Claude Desktop points at another Transcripted server. Install will update it."
+        }
+    }
+}
+
+private struct ClaudeDesktopSelfTestResultView: View {
+    let result: ClaudeDesktopIntegrationInstallResult
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Label(
+                "Ready. Found \(result.selfTest.meetingFileCount) meeting files and \(result.selfTest.dictationFileCount) dictation files.",
+                systemImage: "checkmark.circle.fill"
+            )
+            .foregroundStyle(.green)
+
+            Text("Restart Claude Desktop to use Transcripted direct tools.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if let backupURL = result.backupURL {
+                Text("Previous config backed up to \(backupURL.lastPathComponent).")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .font(.caption)
+        .fixedSize(horizontal: false, vertical: true)
     }
 }
 

--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -136,15 +136,15 @@ enum AgentConnectionGuide {
 
         Automatic route priority:
         1. If Transcripted MCP tools are already available in this environment, use them first.
-        2. If Transcripted MCP tools are not available, but this environment can build or configure a local MCP server, try to set up Transcripted MCP using the information below.
-        3. If MCP cannot be used here, fall back to direct file access using the local folders below.
+        2. If Transcripted MCP tools are not available, but this is Claude Desktop on my Mac, tell me to use Transcripted Settings > Agent > Install for Claude Desktop, then restart Claude Desktop.
+        3. If MCP cannot be used in this chat, fall back to direct file access using any folders or files explicitly granted in this session first, then the default local folders below.
         4. If neither MCP nor folder access is possible, stop and tell me exactly what is missing, what you tried, and the smallest next step I need to take.
 
         Automatic environment routing:
-        - Local agents running on this Mac, such as Codex, Claude Code in the terminal, Claude Code in an app, OpenCode, or OpenClaw, can usually read the local folders and bundled skill files. Use MCP when configured; otherwise use folder fallback.
-        - Desktop clients with local stdio MCP support, such as Claude Desktop, can use Transcripted MCP after the MCP config is added and the client is restarted.
+        - Local agents running on this Mac, such as Codex, Claude Code in the terminal, Claude Code in an app, OpenCode, or OpenClaw, can usually read local folders and any folders I explicitly grant. Use MCP when configured; otherwise use folder fallback.
+        - Desktop clients with local stdio MCP support, such as Claude Desktop, can use Transcripted MCP after Transcripted's in-app installer adds the config and the client is restarted. Do not ask me to build Transcripted MCP from source for a normal DMG install.
         - Remote or web chats, such as Claude chat in a browser, mobile chat, or any sandbox that cannot read `/Users/...` paths, cannot use local folders, local skill files, or local stdio MCP. Do not ask me to choose a mode. Say that this chat cannot reach my Mac directly, then ask me for the single smallest useful action: upload or paste captures, switch to a local agent, or use a remote connector if one is available.
-        - Cowork or shared-agent environments may be local or remote. First determine whether the execution environment can read local Mac paths, then follow the matching rule above.
+        - Cowork or shared-agent environments may be local or remote. First determine whether this session has access to local Mac paths or user-granted folders. If I granted folders in Cowork, use those folders before deciding Transcripted has no data.
 
         Concierge setup style:
         - Start with "I'll check what I can use now."
@@ -157,14 +157,17 @@ enum AgentConnectionGuide {
         \(mcpPromptBlock)
 
         Folder fallback:
+        - First use any Transcripted folders, files, or workspace mounts explicitly granted in this chat.
         - Meetings: \(meetingsFolder.path)
         - Dictations: \(dictationsFolder.path)
 
         When using folders:
+        - Check user-granted folders before checking the default paths.
         - Read meeting and dictation markdown files directly.
         - Prefer the newest or most relevant meeting `.md` file when you need one meeting first.
         - Use exact filenames, dates, and speaker names when relevant.
         - Do not invent access or claim data you cannot read.
+        - Do not say Transcripted is empty just because the default paths are empty or unavailable if I granted another folder.
 
         Working rules:
         - Prefer MCP over raw file inspection when both are available.
@@ -179,11 +182,11 @@ enum AgentConnectionGuide {
         \(starterSkillPromptBlock)
 
         Skill loading rules:
-        - Before offering task options, check whether the manifest and bundled SKILL.md files above are readable.
+        - Try to read the manifest and bundled SKILL.md files above when they are available.
         - If the files are readable, say "Bundled skills active" and list Summarize and Search Memory with their versions.
         - When I ask for Summarize or Search Memory behavior, open the matching SKILL.md before answering and treat it as the canonical behavior.
         - Use the skill versions above when giving feedback or suggesting improvements.
-        - If you cannot read the skill files, say that clearly and use this fallback:
+        - If you cannot read the skill files, do not treat that as a setup failure. Use this fallback and continue:
           - Summarize: create a cited brief from meetings, dictations, or a date range.
           - Search Memory: find what was said, when it happened, and where it came from.
         - If MCP setup requires restarting the agent, say so, then continue with folder fallback for the current session when folders are readable.
@@ -191,8 +194,8 @@ enum AgentConnectionGuide {
         First step:
         1. Silently determine which environment type you are in: local Mac agent, desktop MCP client, remote/web chat, or unknown cowork/shared context.
         2. Silently determine which connection mode is available: MCP, MCP setup, folders, uploaded/pasted files, or unavailable.
-        3. Confirm whether the bundled SKILL.md files are readable.
-        4. Briefly tell me the chosen route and active skill versions in natural language. Do not make me choose.
+        3. Try bundled SKILL.md files if they are readable, but continue with fallback skills if they are not.
+        4. Briefly tell me the chosen route in natural language. Mention missing skill files only if I am debugging setup.
         5. Then continue with my task.
         """
 
@@ -267,29 +270,25 @@ enum AgentConnectionGuide {
 
     static var mcpPromptBlock: String {
         var lines = [
-            "Transcripted MCP setup:",
+            "Transcripted direct tools setup:",
             "- Server name: transcripted",
             "- Transport: local stdio",
+            "- Claude Desktop app flow: open Transcripted Settings > Agent, click Install for Claude Desktop, then restart Claude Desktop.",
+            "- Installed command path after setup: \(ClaudeDesktopIntegrationInstaller.installedMCPBinaryURL.path)",
+            "- Claude Desktop config path: \(ClaudeDesktopIntegrationInstaller.claudeDesktopConfigURL.path)",
         ]
 
         if let buildDirectory = localMCPBuildDirectory {
+            lines.append("")
+            lines.append("Developer source fallback:")
             lines.append("- Build directory: \(buildDirectory.path)")
             lines.append("- Build command: cd \(buildDirectory.path) && swift build -c release")
         }
 
         if let binary = localMCPBinary {
-            lines.append("- Expected binary: \(binary.path)")
-            lines.append("")
-            lines.append("Example MCP config:")
-            lines.append("{")
-            lines.append("  \"mcpServers\": {")
-            lines.append("    \"transcripted\": {")
-            lines.append("      \"command\": \"\(binary.path)\"")
-            lines.append("    }")
-            lines.append("  }")
-            lines.append("}")
+            lines.append("- Current app helper path: \(binary.path)")
         } else {
-            lines.append("- If a local transcripted-mcp binary is installed, add it to your MCP config under mcpServers.transcripted.command.")
+            lines.append("- If the helper is missing, ask me to install or update Transcripted, then use the in-app installer.")
         }
 
         lines.append("")
@@ -308,7 +307,7 @@ enum AgentConnectionGuide {
     }
 
     static var mcpConfigExample: String {
-        let command = localMCPBinary?.path ?? "/path/to/transcripted-mcp"
+        let command = ClaudeDesktopIntegrationInstaller.installedMCPBinaryURL.path
         return """
         {
           "mcpServers": {
@@ -325,6 +324,9 @@ enum AgentConnectionGuide {
             "MCP is optional. If your agent supports it, Transcripted can expose direct read-only tools for recent context, search, meetings, dictations, and recaps.",
             "",
             "For Claude Desktop, use Transcripted Settings > Agent > Install for Claude Desktop. Transcripted installs the read-only server, writes the config, checks your local library, then asks you to restart Claude Desktop.",
+            "",
+            "Installed command path after setup:",
+            "`\(ClaudeDesktopIntegrationInstaller.installedMCPBinaryURL.path)`",
         ]
 
         if let binary = localMCPBinary {

--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -37,13 +37,33 @@ enum AgentConnectionGuide {
     }
 
     static var localMCPBinary: URL? {
+        let fileManager = FileManager.default
+
+        if let bundledBinary = ClaudeDesktopIntegrationInstaller.bundledMCPBinaryURL(fileManager: fileManager) {
+            return bundledBinary
+        }
+
+        let installedBinary = ClaudeDesktopIntegrationInstaller.installedMCPBinaryURL
+        if fileManager.isExecutableFile(atPath: installedBinary.path) {
+            return installedBinary
+        }
+
         guard let buildDirectory = localMCPBuildDirectory else { return nil }
-        let binary = buildDirectory
+        let releaseBinary = buildDirectory
+            .appendingPathComponent(".build", isDirectory: true)
+            .appendingPathComponent("release", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+
+        if fileManager.isExecutableFile(atPath: releaseBinary.path) {
+            return releaseBinary
+        }
+
+        let debugBinary = buildDirectory
             .appendingPathComponent(".build", isDirectory: true)
             .appendingPathComponent("debug", isDirectory: true)
             .appendingPathComponent("transcripted-mcp", isDirectory: false)
 
-        return FileManager.default.fileExists(atPath: binary.path) ? binary : nil
+        return fileManager.isExecutableFile(atPath: debugBinary.path) ? debugBinary : nil
     }
 
     static var meetingsFolder: URL {
@@ -254,7 +274,7 @@ enum AgentConnectionGuide {
 
         if let buildDirectory = localMCPBuildDirectory {
             lines.append("- Build directory: \(buildDirectory.path)")
-            lines.append("- Build command: cd \(buildDirectory.path) && swift build")
+            lines.append("- Build command: cd \(buildDirectory.path) && swift build -c release")
         }
 
         if let binary = localMCPBinary {
@@ -304,19 +324,19 @@ enum AgentConnectionGuide {
         var lines = [
             "MCP is optional. If your agent supports it, Transcripted can expose direct read-only tools for recent context, search, meetings, dictations, and recaps.",
             "",
-            "Install the read-only `transcripted-mcp` server, add it to your MCP config, then restart your client. The server reads the same local Transcripted data automatically.",
+            "For Claude Desktop, use Transcripted Settings > Agent > Install for Claude Desktop. Transcripted installs the read-only server, writes the config, checks your local library, then asks you to restart Claude Desktop.",
         ]
-
-        if let buildDirectory = localMCPBuildDirectory {
-            lines.append("")
-            lines.append("Local build directory:")
-            lines.append("`\(buildDirectory.path)`")
-        }
 
         if let binary = localMCPBinary {
             lines.append("")
             lines.append("Local binary:")
             lines.append("`\(binary.path)`")
+        }
+
+        if let buildDirectory = localMCPBuildDirectory {
+            lines.append("")
+            lines.append("Source build fallback:")
+            lines.append("`cd \(buildDirectory.path) && swift build -c release`")
         }
 
         return lines.joined(separator: "\n")

--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -123,17 +123,10 @@ enum AgentConnectionGuide {
 
     static func starterPrompt(filename: String?) -> String {
         var prompt = """
-        I use Transcripted on my Mac.
+        I use Transcripted on this Mac.
 
-        Help me search and summarize my saved meetings and dictations.
+        You are a local coding agent with filesystem access. Help me search and summarize my saved meetings and dictations by reading these Markdown folders directly:
 
-        Use the best route available:
-        1. If Transcripted direct tools are connected, use them.
-        2. If this is a local coding agent, read the Transcripted folders below.
-        3. If this is Claude Desktop and direct tools are missing, tell me to open Transcripted Settings > Agent, click Install for Claude Desktop, then restart Claude Desktop.
-        4. If this is a web chat or Cowork session, treat it as fallback only: ask me to grant the folders or paste a meeting.
-
-        Transcripted folders:
         - Meetings: \(meetingsFolder.path)
         - Dictations: \(dictationsFolder.path)
 
@@ -141,9 +134,10 @@ enum AgentConnectionGuide {
         - Check any folders I granted in this chat before declaring Transcripted empty.
         - Treat the Markdown files as the source of truth.
         - Cite filenames, dates, speakers, and timestamps when useful.
-        - Use meetings and dictations together when the task spans both.
+        - Search meetings and dictations together when the task spans both.
         - If a date is relative, state the exact calendar dates you searched.
-        - If you cannot read anything, tell me the one next step I need to take.
+        - If you cannot read a folder, tell me exactly which folder failed and the one next step I should take.
+        - Do not tell me to set up Claude Desktop or MCP unless I ask about Claude Desktop specifically.
         """
 
         if let filename {

--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -125,78 +125,25 @@ enum AgentConnectionGuide {
         var prompt = """
         I use Transcripted on my Mac.
 
-        Your job is to connect to my Transcripted data using the best available method, then help me search and summarize my meetings and dictations.
+        Help me search and summarize my saved meetings and dictations.
 
-        Connection behavior:
-        - Do not ask me to choose a connection mode.
-        - Silently pick the best available route, then continue.
-        - Only stop when you cannot read any Transcripted data. If that happens, give me one smallest next step.
-        - If setup is needed, behave like a friendly setup concierge. Ask one short, natural question at a time.
-        - Prefer plain language like "I found a working path" and "This chat cannot reach your Mac directly" over protocol or debug language.
+        Use the best route available:
+        1. If Transcripted direct tools are connected, use them.
+        2. If this is a local coding agent, read the Transcripted folders below.
+        3. If this is Claude Desktop and direct tools are missing, tell me to open Transcripted Settings > Agent, click Install for Claude Desktop, then restart Claude Desktop.
+        4. If this is a web chat or Cowork session, treat it as fallback only: ask me to grant the folders or paste a meeting.
 
-        Automatic route priority:
-        1. If Transcripted MCP tools are already available in this environment, use them first.
-        2. If Transcripted MCP tools are not available, but this is Claude Desktop on my Mac, tell me to use Transcripted Settings > Agent > Install for Claude Desktop, then restart Claude Desktop.
-        3. If MCP cannot be used in this chat, fall back to direct file access using any folders or files explicitly granted in this session first, then the default local folders below.
-        4. If neither MCP nor folder access is possible, stop and tell me exactly what is missing, what you tried, and the smallest next step I need to take.
-
-        Automatic environment routing:
-        - Local agents running on this Mac, such as Codex, Claude Code in the terminal, Claude Code in an app, OpenCode, or OpenClaw, can usually read local folders and any folders I explicitly grant. Use MCP when configured; otherwise use folder fallback.
-        - Desktop clients with local stdio MCP support, such as Claude Desktop, can use Transcripted MCP after Transcripted's in-app installer adds the config and the client is restarted. Do not ask me to build Transcripted MCP from source for a normal DMG install.
-        - Remote or web chats, such as Claude chat in a browser, mobile chat, or any sandbox that cannot read `/Users/...` paths, cannot use local folders, local skill files, or local stdio MCP. Do not ask me to choose a mode. Say that this chat cannot reach my Mac directly, then ask me for the single smallest useful action: upload or paste captures, switch to a local agent, or use a remote connector if one is available.
-        - Cowork or shared-agent environments may be local or remote. First determine whether this session has access to local Mac paths or user-granted folders. If I granted folders in Cowork, use those folders before deciding Transcripted has no data.
-
-        Concierge setup style:
-        - Start with "I'll check what I can use now."
-        - If a route works, say "I found a working path" and keep going.
-        - If direct tools are missing but folders work, say "We can use this now. Direct tools can be set up later."
-        - If setup is truly needed, ask one question such as "Which app are you using: Claude Desktop, Claude Code, Codex, or something else?"
-        - After the answer, give the exact next step for that app. Do not list every possible client.
-        - Avoid acronyms unless needed. If you mention MCP, call it "Transcripted direct tools" first.
-
-        \(mcpPromptBlock)
-
-        Folder fallback:
-        - First use any Transcripted folders, files, or workspace mounts explicitly granted in this chat.
+        Transcripted folders:
         - Meetings: \(meetingsFolder.path)
         - Dictations: \(dictationsFolder.path)
 
-        When using folders:
-        - Check user-granted folders before checking the default paths.
-        - Read meeting and dictation markdown files directly.
-        - Prefer the newest or most relevant meeting `.md` file when you need one meeting first.
-        - Use exact filenames, dates, and speaker names when relevant.
-        - Do not invent access or claim data you cannot read.
-        - Do not say Transcripted is empty just because the default paths are empty or unavailable if I granted another folder.
-
-        Working rules:
-        - Prefer MCP over raw file inspection when both are available.
+        Rules:
+        - Check any folders I granted in this chat before declaring Transcripted empty.
+        - Treat the Markdown files as the source of truth.
+        - Cite filenames, dates, speakers, and timestamps when useful.
         - Use meetings and dictations together when the task spans both.
-        - Treat the raw transcript or dictation text as the source of truth.
-        - Keep summaries and answers grounded in source filenames, dates, speakers, and timestamps when available.
-        - Interpret relative dates in my local time zone. When I ask about today, yesterday, or last week, state the exact calendar dates you searched.
-        - Surface uncertainty clearly.
-        - If setup is needed, minimize back-and-forth and propose the next concrete action.
-
-        Bundled starter skill files:
-        \(starterSkillPromptBlock)
-
-        Skill loading rules:
-        - Try to read the manifest and bundled SKILL.md files above when they are available.
-        - If the files are readable, say "Bundled skills active" and list Summarize and Search Memory with their versions.
-        - When I ask for Summarize or Search Memory behavior, open the matching SKILL.md before answering and treat it as the canonical behavior.
-        - Use the skill versions above when giving feedback or suggesting improvements.
-        - If you cannot read the skill files, do not treat that as a setup failure. Use this fallback and continue:
-          - Summarize: create a cited brief from meetings, dictations, or a date range.
-          - Search Memory: find what was said, when it happened, and where it came from.
-        - If MCP setup requires restarting the agent, say so, then continue with folder fallback for the current session when folders are readable.
-
-        First step:
-        1. Silently determine which environment type you are in: local Mac agent, desktop MCP client, remote/web chat, or unknown cowork/shared context.
-        2. Silently determine which connection mode is available: MCP, MCP setup, folders, uploaded/pasted files, or unavailable.
-        3. Try bundled SKILL.md files if they are readable, but continue with fallback skills if they are not.
-        4. Briefly tell me the chosen route in natural language. Mention missing skill files only if I am debugging setup.
-        5. Then continue with my task.
+        - If a date is relative, state the exact calendar dates you searched.
+        - If you cannot read anything, tell me the one next step I need to take.
         """
 
         if let filename {
@@ -204,6 +151,22 @@ enum AgentConnectionGuide {
         }
 
         return prompt
+    }
+
+    static var folderAccessPrompt: String {
+        """
+        I use Transcripted on my Mac.
+
+        This is fallback setup for a web chat or Cowork session.
+
+        I may have granted you access to my Transcripted folders in this chat. Use those granted folders first.
+
+        Default folders:
+        - Meetings: \(meetingsFolder.path)
+        - Dictations: \(dictationsFolder.path)
+
+        Read the Markdown files directly. If you cannot access the folders, tell me exactly which folder is missing and ask me to grant it.
+        """
     }
 
     static var starterSkillPromptBlock: String {
@@ -320,28 +283,16 @@ enum AgentConnectionGuide {
     }
 
     static var mcpSetupText: String {
-        var lines = [
-            "MCP is optional. If your agent supports it, Transcripted can expose direct read-only tools for recent context, search, meetings, dictations, and recaps.",
-            "",
-            "For Claude Desktop, use Transcripted Settings > Agent > Install for Claude Desktop. Transcripted installs the read-only server, writes the config, checks your local library, then asks you to restart Claude Desktop.",
+        [
+            "Claude Desktop setup:",
+            "1. Open Transcripted Settings.",
+            "2. Go to Agent.",
+            "3. Click Install for Claude Desktop.",
+            "4. Restart Claude Desktop.",
             "",
             "Installed command path after setup:",
             "`\(ClaudeDesktopIntegrationInstaller.installedMCPBinaryURL.path)`",
-        ]
-
-        if let binary = localMCPBinary {
-            lines.append("")
-            lines.append("Local binary:")
-            lines.append("`\(binary.path)`")
-        }
-
-        if let buildDirectory = localMCPBuildDirectory {
-            lines.append("")
-            lines.append("Source build fallback:")
-            lines.append("`cd \(buildDirectory.path) && swift build -c release`")
-        }
-
-        return lines.joined(separator: "\n")
+        ].joined(separator: "\n")
     }
 
     static let folderPathsText = """

--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -125,19 +125,22 @@ enum AgentConnectionGuide {
         var prompt = """
         I use Transcripted on this Mac.
 
-        You are a local coding agent with filesystem access. Help me search and summarize my saved meetings and dictations by reading these Markdown folders directly:
+        Read my saved Transcripted Markdown files directly:
 
-        - Meetings: \(meetingsFolder.path)
-        - Dictations: \(dictationsFolder.path)
+        Meetings:
+        - \(meetingsFolder.path)
+
+        Dictations:
+        - \(dictationsFolder.path)
+
+        Use these files as the source of truth.
 
         Rules:
-        - Check any folders I granted in this chat before declaring Transcripted empty.
-        - Treat the Markdown files as the source of truth.
+        - Search meetings and dictations together when useful.
         - Cite filenames, dates, speakers, and timestamps when useful.
-        - Search meetings and dictations together when the task spans both.
-        - If a date is relative, state the exact calendar dates you searched.
-        - If you cannot read a folder, tell me exactly which folder failed and the one next step I should take.
-        - Do not tell me to set up Claude Desktop or MCP unless I ask about Claude Desktop specifically.
+        - For relative dates like today or yesterday, state the exact dates searched.
+        - If you cannot read a folder, tell me which folder failed.
+        - Do not suggest Claude Desktop or MCP unless I ask.
         """
 
         if let filename {

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -19,86 +19,90 @@ func testAgentConnectionGuide() {
         )
     }
 
-    runSuite("AgentConnectionGuide.starterPrompt — points to bundled skill files") {
+    runSuite("AgentConnectionGuide.starterPrompt — explains the two good setup paths") {
         let prompt = AgentConnectionGuide.starterPrompt(filename: "Planning Sync")
 
-        assertTrue(prompt.contains("Bundled starter skill files:"), "prompt should include bundled skill section")
-        assertTrue(prompt.contains("Manifest:"), "prompt should point to the skill manifest")
-        assertTrue(prompt.contains("transcripted-summarize/SKILL.md"), "prompt should include Summarize skill file")
-        assertTrue(prompt.contains("transcripted-search-memory/SKILL.md"), "prompt should include Search Memory skill file")
-        assertTrue(prompt.contains("Summarize v0.1.0"), "prompt should include Summarize version")
-        assertTrue(prompt.contains("Search Memory v0.1.0"), "prompt should include Search Memory version")
         assertTrue(
-            prompt.contains("Automatic environment routing:"),
-            "prompt should include environment-specific routing guidance"
+            prompt.contains("If Transcripted direct tools are connected, use them."),
+            "prompt should prefer direct tools when available"
         )
         assertTrue(
-            prompt.contains("Do not ask me to choose a connection mode."),
-            "prompt should keep routing decisions away from the user"
+            prompt.contains("If this is a local coding agent, read the Transcripted folders below."),
+            "prompt should make local coding agents use the saved folders"
         )
         assertTrue(
-            prompt.contains("behave like a friendly setup concierge"),
-            "prompt should request concierge-style setup behavior"
+            prompt.contains("Install for Claude Desktop"),
+            "prompt should route Claude Desktop users to the in-app installer"
         )
         assertTrue(
-            prompt.contains("Ask one short, natural question at a time."),
-            "prompt should avoid dumping setup choices"
+            prompt.contains("web chat or Cowork session, treat it as fallback only"),
+            "prompt should not sell web chats as a first-class full-library path"
         )
         assertTrue(
-            prompt.contains("Local agents running on this Mac, such as Codex, Claude Code in the terminal"),
-            "prompt should name local agent contexts"
+            prompt.contains("Check any folders I granted in this chat before declaring Transcripted empty."),
+            "prompt should prefer user-granted folders before declaring Transcripted empty"
         )
         assertTrue(
-            prompt.contains("Remote or web chats, such as Claude chat in a browser"),
-            "prompt should explain remote chat limitations"
-        )
-        assertTrue(
-            prompt.contains("If I granted folders in Cowork, use those folders before deciding Transcripted has no data."),
-            "prompt should prefer user-granted Cowork folders before declaring Transcripted empty"
-        )
-        assertTrue(
-            prompt.contains("Concierge setup style:"),
-            "prompt should include natural setup behavior guidance"
-        )
-        assertTrue(
-            prompt.contains("If a route works, say \"I found a working path\" and keep going."),
-            "prompt should keep working when any usable route exists"
-        )
-        assertTrue(
-            prompt.contains("Which app are you using: Claude Desktop, Claude Code, Codex, or something else?"),
-            "prompt should ask one natural setup question when blocked"
-        )
-        assertTrue(
-            prompt.contains("Treat the raw transcript or dictation text as the source of truth."),
+            prompt.contains("Treat the Markdown files as the source of truth."),
             "prompt should ground answers in raw captures"
         )
         assertTrue(
-            prompt.contains("If you cannot read the skill files, do not treat that as a setup failure."),
-            "prompt should treat unreadable skill files as optional fallback, not a setup failure"
+            prompt.contains("If a date is relative, state the exact calendar dates you searched."),
+            "prompt should force exact dates for relative-date work"
         )
         assertTrue(
-            prompt.contains("When I ask for Summarize or Search Memory behavior, open the matching SKILL.md before answering"),
-            "prompt should make SKILL.md files canonical for matching tasks"
+            prompt.contains("If you cannot read anything, tell me the one next step I need to take."),
+            "prompt should give one clear next step when blocked"
         )
         assertTrue(
-            prompt.contains("Briefly tell me the chosen route in natural language."),
-            "prompt should report the chosen route without making the user choose"
+            prompt.contains("Meetings: \(AgentConnectionGuide.meetingsFolder.path)"),
+            "prompt should include the meetings folder"
         )
         assertTrue(
-            prompt.contains("Do not ask me to build Transcripted MCP from source for a normal DMG install."),
-            "prompt should route Claude Desktop users through the DMG-installed app flow"
-        )
-        assertTrue(
-            prompt.contains("Check user-granted folders before checking the default paths."),
-            "prompt should use granted folders before default Transcripted paths"
-        )
-        assertTrue(
-            prompt.contains("continue with folder fallback for the current session when folders are readable"),
-            "prompt should keep Claude Code moving when MCP setup needs restart"
+            prompt.contains("Dictations: \(AgentConnectionGuide.dictationsFolder.path)"),
+            "prompt should include the dictations folder"
         )
         assertTrue(
             prompt.contains("If helpful, start with this meeting:\nPlanning Sync.md"),
             "meeting-specific prompt should preserve the selected filename"
+        )
+    }
+
+    runSuite("AgentConnectionGuide.folderAccessPrompt — marks web setup as fallback") {
+        let prompt = AgentConnectionGuide.folderAccessPrompt
+
+        assertTrue(
+            prompt.contains("fallback setup for a web chat or Cowork session"),
+            "folder prompt should be explicit that web chat setup is fallback only"
+        )
+        assertTrue(
+            prompt.contains("Use those granted folders first."),
+            "folder prompt should prefer folders granted in the current chat"
+        )
+        assertTrue(
+            prompt.contains("tell me exactly which folder is missing"),
+            "folder prompt should ask for a precise missing folder instead of guessing"
+        )
+    }
+
+    runSuite("AgentConnectionGuide.mcpSetupText — avoids source-build instructions for DMG users") {
+        let setupText = AgentConnectionGuide.mcpSetupText
+
+        assertTrue(
+            setupText.contains("Open Transcripted Settings."),
+            "Claude Desktop setup should start inside the app"
+        )
+        assertTrue(
+            setupText.contains("Click Install for Claude Desktop."),
+            "Claude Desktop setup should use the in-app installer"
+        )
+        assertTrue(
+            setupText.contains(ClaudeDesktopIntegrationInstaller.installedMCPBinaryURL.path),
+            "Claude Desktop setup should show the stable installed helper path"
+        )
+        assertTrue(
+            !setupText.contains("swift build"),
+            "DMG setup copy should not ask normal users to build from source"
         )
     }
 

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -19,28 +19,24 @@ func testAgentConnectionGuide() {
         )
     }
 
-    runSuite("AgentConnectionGuide.starterPrompt — explains the two good setup paths") {
+    runSuite("AgentConnectionGuide.starterPrompt — is specific to local coding agents") {
         let prompt = AgentConnectionGuide.starterPrompt(filename: "Planning Sync")
 
         assertTrue(
-            prompt.contains("If Transcripted direct tools are connected, use them."),
-            "prompt should prefer direct tools when available"
+            prompt.contains("You are a local coding agent with filesystem access."),
+            "prompt should name the expected local coding-agent context"
         )
         assertTrue(
-            prompt.contains("If this is a local coding agent, read the Transcripted folders below."),
-            "prompt should make local coding agents use the saved folders"
+            prompt.contains("reading these Markdown folders directly"),
+            "prompt should tell local agents to use folder access directly"
         )
         assertTrue(
-            prompt.contains("Install for Claude Desktop"),
-            "prompt should route Claude Desktop users to the in-app installer"
+            !prompt.contains("Install for Claude Desktop"),
+            "local agent prompt should not route users through Claude Desktop setup"
         )
         assertTrue(
-            prompt.contains("web chat or Cowork session, treat it as fallback only"),
-            "prompt should not sell web chats as a first-class full-library path"
-        )
-        assertTrue(
-            prompt.contains("Check any folders I granted in this chat before declaring Transcripted empty."),
-            "prompt should prefer user-granted folders before declaring Transcripted empty"
+            !prompt.contains("web chat") && !prompt.contains("Cowork"),
+            "local agent prompt should not include web/Cowork routing"
         )
         assertTrue(
             prompt.contains("Treat the Markdown files as the source of truth."),
@@ -51,8 +47,12 @@ func testAgentConnectionGuide() {
             "prompt should force exact dates for relative-date work"
         )
         assertTrue(
-            prompt.contains("If you cannot read anything, tell me the one next step I need to take."),
-            "prompt should give one clear next step when blocked"
+            prompt.contains("If you cannot read a folder, tell me exactly which folder failed"),
+            "prompt should name the exact folder failure when blocked"
+        )
+        assertTrue(
+            prompt.contains("Do not tell me to set up Claude Desktop or MCP unless I ask about Claude Desktop specifically."),
+            "prompt should keep local-agent flow separate from Claude Desktop setup"
         )
         assertTrue(
             prompt.contains("Meetings: \(AgentConnectionGuide.meetingsFolder.path)"),

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -53,8 +53,8 @@ func testAgentConnectionGuide() {
             "prompt should explain remote chat limitations"
         )
         assertTrue(
-            prompt.contains("Cowork or shared-agent environments may be local or remote."),
-            "prompt should force cowork-style environments to classify local vs remote execution"
+            prompt.contains("If I granted folders in Cowork, use those folders before deciding Transcripted has no data."),
+            "prompt should prefer user-granted Cowork folders before declaring Transcripted empty"
         )
         assertTrue(
             prompt.contains("Concierge setup style:"),
@@ -73,16 +73,24 @@ func testAgentConnectionGuide() {
             "prompt should ground answers in raw captures"
         )
         assertTrue(
-            prompt.contains("Before offering task options, check whether the manifest and bundled SKILL.md files above are readable."),
-            "prompt should require a skill-file check before offering tasks"
+            prompt.contains("If you cannot read the skill files, do not treat that as a setup failure."),
+            "prompt should treat unreadable skill files as optional fallback, not a setup failure"
         )
         assertTrue(
             prompt.contains("When I ask for Summarize or Search Memory behavior, open the matching SKILL.md before answering"),
             "prompt should make SKILL.md files canonical for matching tasks"
         )
         assertTrue(
-            prompt.contains("Briefly tell me the chosen route and active skill versions in natural language. Do not make me choose."),
+            prompt.contains("Briefly tell me the chosen route in natural language."),
             "prompt should report the chosen route without making the user choose"
+        )
+        assertTrue(
+            prompt.contains("Do not ask me to build Transcripted MCP from source for a normal DMG install."),
+            "prompt should route Claude Desktop users through the DMG-installed app flow"
+        )
+        assertTrue(
+            prompt.contains("Check user-granted folders before checking the default paths."),
+            "prompt should use granted folders before default Transcripted paths"
         )
         assertTrue(
             prompt.contains("continue with folder fallback for the current session when folders are readable"),

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -19,16 +19,16 @@ func testAgentConnectionGuide() {
         )
     }
 
-    runSuite("AgentConnectionGuide.starterPrompt — is specific to local coding agents") {
+    runSuite("AgentConnectionGuide.starterPrompt — keeps the local agent path simple") {
         let prompt = AgentConnectionGuide.starterPrompt(filename: "Planning Sync")
 
         assertTrue(
-            prompt.contains("You are a local coding agent with filesystem access."),
-            "prompt should name the expected local coding-agent context"
+            prompt.contains("Read my saved Transcripted Markdown files directly:"),
+            "prompt should tell local agents to read Transcripted files directly"
         )
         assertTrue(
-            prompt.contains("reading these Markdown folders directly"),
-            "prompt should tell local agents to use folder access directly"
+            prompt.contains("Use these files as the source of truth."),
+            "prompt should ground answers in saved Markdown files"
         )
         assertTrue(
             !prompt.contains("Install for Claude Desktop"),
@@ -39,27 +39,27 @@ func testAgentConnectionGuide() {
             "local agent prompt should not include web/Cowork routing"
         )
         assertTrue(
-            prompt.contains("Treat the Markdown files as the source of truth."),
-            "prompt should ground answers in raw captures"
+            prompt.contains("Search meetings and dictations together when useful."),
+            "prompt should support combined meeting and dictation searches"
         )
         assertTrue(
-            prompt.contains("If a date is relative, state the exact calendar dates you searched."),
+            prompt.contains("For relative dates like today or yesterday, state the exact dates searched."),
             "prompt should force exact dates for relative-date work"
         )
         assertTrue(
-            prompt.contains("If you cannot read a folder, tell me exactly which folder failed"),
-            "prompt should name the exact folder failure when blocked"
+            prompt.contains("If you cannot read a folder, tell me which folder failed."),
+            "prompt should name the folder failure when blocked"
         )
         assertTrue(
-            prompt.contains("Do not tell me to set up Claude Desktop or MCP unless I ask about Claude Desktop specifically."),
+            prompt.contains("Do not suggest Claude Desktop or MCP unless I ask."),
             "prompt should keep local-agent flow separate from Claude Desktop setup"
         )
         assertTrue(
-            prompt.contains("Meetings: \(AgentConnectionGuide.meetingsFolder.path)"),
+            prompt.contains("Meetings:\n- \(AgentConnectionGuide.meetingsFolder.path)"),
             "prompt should include the meetings folder"
         )
         assertTrue(
-            prompt.contains("Dictations: \(AgentConnectionGuide.dictationsFolder.path)"),
+            prompt.contains("Dictations:\n- \(AgentConnectionGuide.dictationsFolder.path)"),
             "prompt should include the dictations folder"
         )
         assertTrue(

--- a/Tests/ClaudeDesktopIntegrationInstallerTests.swift
+++ b/Tests/ClaudeDesktopIntegrationInstallerTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+func testClaudeDesktopIntegrationInstaller() {
+    runSuite("ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig — preserves existing MCP servers") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeConfigTests-\(UUID().uuidString)", isDirectory: true)
+        let configURL = tempRoot
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("claude_desktop_config.json", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try? FileManager.default.createDirectory(at: configURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let existing = """
+        {
+          "mcpServers": {
+            "notes": {
+              "command": "/usr/local/bin/notes-mcp"
+            }
+          },
+          "globalShortcut": "disabled"
+        }
+        """
+        try? existing.write(to: configURL, atomically: true, encoding: .utf8)
+
+        let backupURL = try? ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig(
+            commandPath: "/tmp/transcripted-mcp",
+            configURL: configURL
+        )
+        assertNil(backupURL, "valid existing config should not be backed up")
+
+        guard let data = try? Data(contentsOf: configURL),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let servers = root["mcpServers"] as? [String: Any],
+              let notes = servers["notes"] as? [String: Any],
+              let transcripted = servers["transcripted"] as? [String: Any] else {
+            assertTrue(false, "config should remain valid JSON with both MCP servers")
+            return
+        }
+
+        assertEqual(root["globalShortcut"] as? String, "disabled", "top-level config should be preserved")
+        assertEqual(notes["command"] as? String, "/usr/local/bin/notes-mcp", "other MCP server should be preserved")
+        assertEqual(transcripted["command"] as? String, "/tmp/transcripted-mcp", "Transcripted command should be written")
+    }
+
+    runSuite("ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig — backs up invalid config") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeInvalidConfigTests-\(UUID().uuidString)", isDirectory: true)
+        let configURL = tempRoot
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("claude_desktop_config.json", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try? FileManager.default.createDirectory(at: configURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? "{ invalid json".write(to: configURL, atomically: true, encoding: .utf8)
+
+        let backupURL = try? ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig(
+            commandPath: "/tmp/transcripted-mcp",
+            configURL: configURL
+        )
+
+        assertNotNil(backupURL, "invalid config should be backed up before writing a clean config")
+        if let backupURL {
+            assertTrue(FileManager.default.fileExists(atPath: backupURL.path), "backup file should exist")
+        }
+
+        guard let data = try? Data(contentsOf: configURL),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let servers = root["mcpServers"] as? [String: Any],
+              let transcripted = servers["transcripted"] as? [String: Any] else {
+            assertTrue(false, "replacement config should be valid JSON")
+            return
+        }
+
+        assertEqual(transcripted["command"] as? String, "/tmp/transcripted-mcp", "Transcripted command should be written after repair")
+    }
+
+    runSuite("ClaudeDesktopIntegrationInstaller.currentStatus — detects installed config") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeStatusTests-\(UUID().uuidString)", isDirectory: true)
+        let configURL = tempRoot
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("claude_desktop_config.json", isDirectory: false)
+        let binaryURL = tempRoot
+            .appendingPathComponent("mcp", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try? FileManager.default.createDirectory(at: binaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? "#!/bin/sh\nexit 0\n".write(to: binaryURL, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: binaryURL.path)
+        _ = try? ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig(commandPath: binaryURL.path, configURL: configURL)
+
+        let status = ClaudeDesktopIntegrationInstaller.currentStatus(
+            configURL: configURL,
+            installedBinaryURL: binaryURL,
+            bundledBinaryURL: binaryURL
+        )
+
+        assertEqual(status.state, .installed, "matching executable and config should be installed")
+        assertTrue(status.isInstalled, "installed convenience flag should be true")
+        assertEqual(status.configuredCommandPath, binaryURL.path, "status should expose configured command")
+    }
+}

--- a/Tests/FastTests.manifest
+++ b/Tests/FastTests.manifest
@@ -2,6 +2,7 @@
 # Format: <TestFile.swift>:<top-level entry function>
 
 AgentConnectionGuideTests.swift:testAgentConnectionGuide
+ClaudeDesktopIntegrationInstallerTests.swift:testClaudeDesktopIntegrationInstaller
 AnalyticsEventPolicyTests.swift:testAnalyticsEventPolicy
 AnalyticsPayloadSanitizerTests.swift:testAnalyticsPayloadSanitizer
 ClipboardRestoringTextPasterTests.swift:testClipboardRestoringTextPaster

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -95,14 +95,26 @@ This lets the server answer both meeting-specific queries (`who_is`, `read_meeti
 
 ```bash
 cd Tools/TranscriptedMCP
-swift build
+swift build -c release
 swift test
 ```
 
 Binary path after build:
 
 ```text
-.build/debug/transcripted-mcp
+.build/release/transcripted-mcp
+```
+
+App builds also bundle a signed copy at:
+
+```text
+Transcripted.app/Contents/Helpers/transcripted-mcp
+```
+
+The in-app Claude Desktop installer copies that helper into:
+
+```text
+~/Library/Application Support/Transcripted/mcp/transcripted-mcp
 ```
 
 ## Example MCP Config
@@ -131,4 +143,4 @@ Binary path after build:
 - the server auto-creates missing data and index directories
 - the index rebuilds from disk on startup
 - `read_meeting` and `read_dictation` read markdown directly from disk, not from the SQLite index
-- the server binary is separate from the app, updating the app does not update the MCP binary automatically
+- source builds can run the server standalone, but shipped app builds bundle the helper for the one-click Claude Desktop installer

--- a/Tools/TranscriptedMCP/README.md
+++ b/Tools/TranscriptedMCP/README.md
@@ -1,0 +1,45 @@
+# Transcripted MCP
+
+Read-only local tools for Transcripted meetings and dictations.
+
+For Claude Desktop users, the best setup is inside the app:
+
+1. Open Transcripted.
+2. Open Settings.
+3. Go to `Agent`.
+4. Click `Install for Claude Desktop`.
+5. Restart Claude Desktop.
+
+That path installs the bundled helper, updates Claude Desktop's config, and
+runs a local self-test.
+
+## Source Build
+
+Use this only when developing the MCP server directly:
+
+```bash
+swift build -c release
+swift test
+```
+
+Binary:
+
+```text
+.build/release/transcripted-mcp
+```
+
+Self-test:
+
+```bash
+.build/release/transcripted-mcp --self-test
+```
+
+The server reads:
+
+```text
+~/Library/Application Support/Transcripted/captures/meetings
+~/Library/Application Support/Transcripted/captures/dictations
+```
+
+Override paths with `TRANSCRIPTED_DATA_DIR`, `TRANSCRIPTED_MEETINGS_DIR`,
+`TRANSCRIPTED_DICTATIONS_DIR`, or `TRANSCRIPTED_INDEX_DIR`.

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
@@ -4,6 +4,16 @@ import MCP
 @main
 struct TranscriptedMCP {
     static func main() async throws {
+        if CommandLine.arguments.contains("--version") {
+            print("transcripted-mcp 1.0.0")
+            return
+        }
+
+        if CommandLine.arguments.contains("--self-test") {
+            try runSelfTest()
+            return
+        }
+
         let directories = TranscriptedDataDirectories.resolve()
 
         log("Starting transcripted-mcp v1.0.0")
@@ -57,5 +67,70 @@ struct TranscriptedMCP {
 
         watchers.forEach { $0.stop() }
         log("MCP server stopped")
+    }
+
+    private static func runSelfTest() throws {
+        let directories = TranscriptedDataDirectories.resolve()
+
+        for directory in directories.watchedDirectories + [directories.indexDir] {
+            if !FileManager.default.fileExists(atPath: directory.path) {
+                try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            }
+        }
+
+        let index = try TranscriptIndex(indexDir: directories.indexDir)
+        try index.reconcile(meetingsDir: directories.meetingsDir, dictationsDir: directories.dictationsDir)
+
+        let result = TranscriptedMCPSelfTestResult(
+            ok: true,
+            meetingsDirectory: directories.meetingsDir.path,
+            dictationsDirectory: directories.dictationsDir.path,
+            indexDirectory: directories.indexDir.path,
+            meetingFileCount: markdownFileCount(in: directories.meetingsDir),
+            dictationFileCount: markdownFileCount(in: directories.dictationsDir)
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(result)
+        print(String(decoding: data, as: UTF8.self))
+    }
+
+    private static func markdownFileCount(in directory: URL) -> Int {
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return 0
+        }
+
+        var count = 0
+        for case let url as URL in enumerator {
+            guard url.pathExtension.lowercased() == "md" else { continue }
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
+            if values?.isRegularFile == true {
+                count += 1
+            }
+        }
+        return count
+    }
+}
+
+private struct TranscriptedMCPSelfTestResult: Codable {
+    let ok: Bool
+    let meetingsDirectory: String
+    let dictationsDirectory: String
+    let indexDirectory: String
+    let meetingFileCount: Int
+    let dictationFileCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case ok
+        case meetingsDirectory = "meetings_directory"
+        case dictationsDirectory = "dictations_directory"
+        case indexDirectory = "index_directory"
+        case meetingFileCount = "meeting_file_count"
+        case dictationFileCount = "dictation_file_count"
     }
 }

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -1,54 +1,16 @@
 # Connect Your Agent
 
-Transcripted is easiest to use when the connection story stays focused on one main action:
+The setup should feel like this:
 
-1. Copy one smart prompt.
-2. Let your agent use MCP if it is already available.
-3. Fall back to folders only when you need manual setup.
+1. Pick the app you use.
+2. Click one button.
+3. Restart or paste the copied prompt.
 
-## Main Path: Copy One Prompt
+No manual JSON for normal users. No source build for DMG installs.
 
-This is the default path for most people.
+## Best Path: Claude Desktop
 
-- Open `Connect your agent` in the app.
-- Copy the agent prompt.
-- Paste it into your agent.
-- Ask normal questions like:
-  - what did I miss today
-  - summarize my latest meeting
-  - find every time we discussed pricing
-  - pull action items from my latest meeting and dictations
-
-The copied prompt tells the agent to:
-
-- use Transcripted MCP tools first if they are already connected
-- otherwise read any Transcripted folders you granted in that chat
-- fall back to the default local Transcripted folders when they are readable
-- for Claude Desktop, use the in-app installer instead of source-build setup
-
-The intended user path is:
-
-- click `Connect your agent`
-- copy the prompt
-- paste it into your agent
-- let the agent use MCP first or fall back to the saved folders
-
-Current local folders:
-
-- meetings: `~/Library/Application Support/Transcripted/captures/meetings`
-- dictations: `~/Library/Application Support/Transcripted/captures/dictations`
-
-## Optional: MCP
-
-Use MCP when your client supports it and you want direct read-only tools instead
-of asking the model to inspect files manually.
-
-If you installed Transcripted from the DMG, you should not need to clone the
-repo or build the MCP server yourself.
-
-### Claude Desktop
-
-Use the in-app setup:
+Claude Desktop is the best full-library experience.
 
 1. Open Transcripted.
 2. Open Settings.
@@ -83,15 +45,60 @@ Current `transcripted-mcp` capabilities:
 - `who_is`
 - `recap`
 
-### What it gives the user
+## Good Path: Local Coding Agents
 
-- one place to search meetings and dictations together
-- fast recaps over a date range
-- direct access to one meeting or one dictation entry
-- people lookups without hand-rolling folder searches
-- read-only access to local Transcripted data
+Use this for local agents that can read files on the user's Mac.
 
-### Source Build Fallback
+Examples:
+
+- Claude Code
+- Codex
+- Cursor
+- Windsurf
+- Zed
+- OpenCode
+- OpenClaw
+- Cline
+- Continue
+- VS Code agents
+
+The user copies the local-agent prompt from Transcripted, pastes it into the
+agent, and asks normal questions like:
+
+- what did I miss today
+- summarize my latest meeting
+- find every time we discussed pricing
+- pull action items from my latest meeting and dictations
+
+The copied prompt tells the agent to use Transcripted direct tools when they are
+connected, otherwise read the saved Markdown folders:
+
+```text
+~/Library/Application Support/Transcripted/captures/meetings
+~/Library/Application Support/Transcripted/captures/dictations
+```
+
+## Fallback Only: Web And Cowork
+
+Do not present web chat as a main setup path.
+
+This includes:
+
+- Claude web
+- ChatGPT web
+- Cowork or shared browser sessions
+- mobile chats
+
+These are usually a bad full-library experience because the chat cannot
+reliably see the user's Mac or keep folder access. Use them only for:
+
+- a pasted meeting bundle
+- folders the user explicitly granted in that chat
+- quick support/debugging
+
+The copy should say this plainly: web chats are fallback only.
+
+## Source Build Fallback
 
 This is for contributors working from a checkout. Normal DMG installs should use
 the Claude Desktop button in Transcripted Settings.

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -22,8 +22,9 @@ This is the default path for most people.
 The copied prompt tells the agent to:
 
 - use Transcripted MCP tools first if they are already connected
-- otherwise read the local Transcripted folders directly
-- help you set up the better option if neither path is ready yet
+- otherwise read any Transcripted folders you granted in that chat
+- fall back to the default local Transcripted folders when they are readable
+- for Claude Desktop, use the in-app installer instead of source-build setup
 
 The intended user path is:
 
@@ -41,6 +42,9 @@ Current local folders:
 
 Use MCP when your client supports it and you want direct read-only tools instead
 of asking the model to inspect files manually.
+
+If you installed Transcripted from the DMG, you should not need to clone the
+repo or build the MCP server yourself.
 
 ### Claude Desktop
 
@@ -88,6 +92,9 @@ Current `transcripted-mcp` capabilities:
 - read-only access to local Transcripted data
 
 ### Source Build Fallback
+
+This is for contributors working from a checkout. Normal DMG installs should use
+the Claude Desktop button in Transcripted Settings.
 
 ```bash
 cd Tools/TranscriptedMCP

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -42,6 +42,31 @@ Current local folders:
 Use MCP when your client supports it and you want direct read-only tools instead
 of asking the model to inspect files manually.
 
+### Claude Desktop
+
+Use the in-app setup:
+
+1. Open Transcripted.
+2. Open Settings.
+3. Go to `Agent`.
+4. Click `Install for Claude Desktop`.
+5. Restart Claude Desktop.
+
+Transcripted copies the bundled `transcripted-mcp` helper into:
+
+```text
+~/Library/Application Support/Transcripted/mcp/transcripted-mcp
+```
+
+Then it safely merges this entry into Claude Desktop's config:
+
+```text
+~/Library/Application Support/Claude/claude_desktop_config.json
+```
+
+Existing MCP servers are preserved. If the config is invalid JSON,
+Transcripted backs it up before writing a clean config.
+
 Current `transcripted-mcp` capabilities:
 
 - `recent_context`
@@ -62,17 +87,17 @@ Current `transcripted-mcp` capabilities:
 - people lookups without hand-rolling folder searches
 - read-only access to local Transcripted data
 
-### Repo Setup
+### Source Build Fallback
 
 ```bash
 cd Tools/TranscriptedMCP
-swift build
+swift build -c release
 ```
 
 Binary path after build:
 
 ```text
-Tools/TranscriptedMCP/.build/debug/transcripted-mcp
+Tools/TranscriptedMCP/.build/release/transcripted-mcp
 ```
 
 Example Claude Desktop config:
@@ -81,7 +106,7 @@ Example Claude Desktop config:
 {
   "mcpServers": {
     "transcripted": {
-      "command": "/absolute/path/to/Tools/TranscriptedMCP/.build/debug/transcripted-mcp"
+      "command": "/absolute/path/to/Tools/TranscriptedMCP/.build/release/transcripted-mcp"
     }
   }
 }

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -42,6 +42,11 @@ The two build flows intentionally use separate committed entitlement files:
 - `config/entitlements/local.plist`
 - `config/entitlements/beta.plist`
 
+Both app build flows also build the release `transcripted-mcp` helper and
+bundle it at `Transcripted.app/Contents/Helpers/transcripted-mcp`. The helper is
+signed with the rest of the app so the in-app Claude Desktop installer can copy
+and self-test it without asking users to install Swift or clone the repo.
+
 `build.sh` and `build-beta.sh` now fail before they touch signing when the
 unified dependency artifacts are missing or older than the current
 `Sources/TranscriptedCore/`, `Package.swift`, or `build-deps.sh` inputs. They

--- a/docs/storage-paths.md
+++ b/docs/storage-paths.md
@@ -41,6 +41,10 @@ App-owned meeting state is stored separately under:
 - stats DB: `~/Library/Application Support/Transcripted/state/stats.sqlite`
 - failed queue: `~/Library/Application Support/Transcripted/state/failed_transcriptions.json`
 
+Claude Desktop integration installs the bundled read-only MCP helper under:
+
+- MCP helper: `~/Library/Application Support/Transcripted/mcp/transcripted-mcp`
+
 Temporary audio scratch paths live under:
 
 - raw recordings: `~/Library/Application Support/Transcripted/tmp/recordings/`

--- a/scripts/entrypoints/build-beta.sh
+++ b/scripts/entrypoints/build-beta.sh
@@ -68,6 +68,9 @@ SPARKLE_FRAMEWORK="$DEPS_FRAMEWORK_ROOT/Sparkle.framework"
 TRANSCRIPTED_CORE_MODULE="deps-modules/TranscriptedCore.swiftmodule/arm64-apple-macos.swiftmodule"
 ARGMAX_CORE_MODULE="deps-modules/ArgmaxCore.swiftmodule/arm64-apple-macos.swiftmodule"
 WHISPERKIT_MODULE="deps-modules/WhisperKit.swiftmodule/arm64-apple-macos.swiftmodule"
+MCP_PACKAGE_DIR="Tools/TranscriptedMCP"
+MCP_BINARY="$MCP_PACKAGE_DIR/.build/release/transcripted-mcp"
+BUNDLED_MCP_BINARY="$APP_BUNDLE/Contents/Helpers/transcripted-mcp"
 
 dependency_input_listing() {
     {
@@ -278,6 +281,7 @@ sign_embedded_payloads() {
     local framework_path
     local metallib_path
     local nested_code_path
+    local helper_path
 
     while IFS= read -r -d '' nested_code_path; do
         if [ "$sign_hash" = "-" ]; then
@@ -307,6 +311,32 @@ sign_embedded_payloads() {
         [ -f "$metallib_path" ] || continue
         codesign --force --sign "$sign_hash" "$metallib_path"
     done
+
+    for helper_path in "$APP_BUNDLE"/Contents/Helpers/*; do
+        [ -f "$helper_path" ] || continue
+        if [ "$sign_hash" = "-" ]; then
+            codesign --force --sign "$sign_hash" "$helper_path"
+        else
+            codesign --force \
+                --sign "$sign_hash" \
+                --options runtime \
+                --timestamp \
+                "$helper_path"
+        fi
+    done
+}
+
+bundle_mcp_server() {
+    echo "Building Transcripted MCP server..."
+    swift build -c release --package-path "$MCP_PACKAGE_DIR"
+
+    if [ ! -x "$MCP_BINARY" ]; then
+        echo "❌ MCP build finished without a runnable binary: $MCP_BINARY"
+        exit 1
+    fi
+
+    cp "$MCP_BINARY" "$BUNDLED_MCP_BINARY"
+    chmod 755 "$BUNDLED_MCP_BINARY"
 }
 
 cleanup() {
@@ -356,6 +386,7 @@ rm -rf "$APP_BUNDLE"
 mkdir -p "$APP_BUNDLE/Contents/MacOS"
 mkdir -p "$APP_BUNDLE/Contents/Resources"
 mkdir -p "$APP_BUNDLE/Contents/Frameworks"
+mkdir -p "$APP_BUNDLE/Contents/Helpers"
 
 # Bundle Parakeet CoreML models
 PARAKEET_SRC="$HOME/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml"
@@ -384,6 +415,8 @@ cp Info.plist "$APP_BUNDLE/Contents/"
 if [ -d "Resources" ]; then
     cp -R Resources/. "$APP_BUNDLE/Contents/Resources/"
 fi
+
+bundle_mcp_server
 
 # Inject the user's beta token after dependency preflight succeeds.
 echo "Injecting token for $USER_NAME..."

--- a/scripts/entrypoints/build.sh
+++ b/scripts/entrypoints/build.sh
@@ -14,6 +14,9 @@ APP_BINARY="$APP_BUNDLE/Contents/MacOS/$APP_NAME"
 STAGED_APP_BINARY="$BUILD_DIR/$APP_NAME-bin"
 LOCAL_ENTITLEMENTS="config/entitlements/local.plist"
 SIGN_IDENTITY="${SIGN_IDENTITY:-${SIGNING_IDENTITY:-}}"
+MCP_PACKAGE_DIR="Tools/TranscriptedMCP"
+MCP_BINARY="$MCP_PACKAGE_DIR/.build/release/transcripted-mcp"
+BUNDLED_MCP_BINARY="$APP_BUNDLE/Contents/Helpers/transcripted-mcp"
 DEPS_ARCHIVE="deps-libs/libDraftDeps.a"
 DEPS_BUILD_STAMP="deps-libs/.build-deps-stamp"
 DEPS_MODULE_ROOT="deps-modules"
@@ -154,6 +157,7 @@ sign_embedded_code() {
     local framework_path
     local metallib_path
     local nested_code_path
+    local helper_path
 
     while IFS= read -r -d '' nested_code_path; do
         codesign --force --sign "$sign_hash" "$nested_code_path"
@@ -174,6 +178,24 @@ sign_embedded_code() {
         [ -f "$metallib_path" ] || continue
         codesign --force --sign "$sign_hash" "$metallib_path"
     done
+
+    for helper_path in "$APP_BUNDLE"/Contents/Helpers/*; do
+        [ -f "$helper_path" ] || continue
+        codesign --force --sign "$sign_hash" "$helper_path"
+    done
+}
+
+bundle_mcp_server() {
+    echo "Building Transcripted MCP server..."
+    swift build -c release --package-path "$MCP_PACKAGE_DIR"
+
+    if [ ! -x "$MCP_BINARY" ]; then
+        echo "MCP build finished without a runnable binary: $MCP_BINARY"
+        exit 1
+    fi
+
+    cp "$MCP_BINARY" "$BUNDLED_MCP_BINARY"
+    chmod 755 "$BUNDLED_MCP_BINARY"
 }
 
 echo "Building Transcripted..."
@@ -186,6 +208,7 @@ rm -rf "$BUILD_DIR"
 mkdir -p "$APP_BUNDLE/Contents/MacOS"
 mkdir -p "$APP_BUNDLE/Contents/Resources"
 mkdir -p "$APP_BUNDLE/Contents/Frameworks"
+mkdir -p "$APP_BUNDLE/Contents/Helpers"
 
 # Bundle Parakeet model directories used by FluidAudio.
 # The runtime loader can resolve files from both the `-coreml` and legacy
@@ -220,6 +243,8 @@ cp Info.plist "$APP_BUNDLE/Contents/"
 if [ -d "Resources" ]; then
     cp -R Resources/. "$APP_BUNDLE/Contents/Resources/"
 fi
+
+bundle_mcp_server
 
 # Unified dependencies (FluidAudio + mlx-swift-lm + WhisperKit)
 echo "Dependencies found"

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -114,6 +114,7 @@ APP_SOURCES=(
     "Sources/Support/TranscriptedPermissionKind.swift"
     "Sources/Support/TranscriptedPermissionAccess.swift"
     "Sources/Support/TranscriptedStoragePaths.swift"
+    "Sources/Support/ClaudeDesktopIntegrationInstaller.swift"
     "Sources/Support/LaunchAtLoginPreferences.swift"
     "Sources/Support/MenuBarVisibilityPreferences.swift"
     "Sources/Support/HotkeyPreferences.swift"


### PR DESCRIPTION
## What changed

- Simplified the local `Copy for Agent` prompt so it only tells local coding agents to read the Transcripted Markdown folders directly.
- Removed extra Claude Desktop, MCP, web chat, and granted-folder routing from that local-agent prompt.
- Updated the AgentConnectionGuide tests to lock in the shorter prompt behavior.

## Why

The Agent page now has two clear choices: `Install in Claude` and `Copy for Agent`. The copied local-agent prompt should match that choice and avoid re-explaining other setup paths.

## Validation

- `bash run-tests.sh` passed: 662 tests
- `bash build.sh` passed, including signing verification and launch smoke check