### PR TITLE
[codex] Release Transcripted 1.1.16

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.15"
-  sha256 "5f5977394c22ac03465b2205214d57a48d09dae50cca3a10481b8fbbaee6793b"
+  version "1.1.16"
+  sha256 "a928175a158e13ac9fac04737d555b9d939ba58cd8dcd7b58d06bd0beaf85c44"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.15</string>
+	<string>1.1.16</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.15</string>
+	<string>1.1.16</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
         <description>Release feed for Transcripted macOS updates.</description>
         <language>en</language>
         <item>
+            <title>1.1.16</title>
+            <pubDate>Tue, 21 Apr 2026 21:14:50 -0500</pubDate>
+            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.16</link>
+            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.16</sparkle:fullReleaseNotesLink>
+            <sparkle:version>1.1.16</sparkle:version>
+            <sparkle:shortVersionString>1.1.16</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.16/Transcripted-1.1.16.dmg" length="527808505" type="application/octet-stream" sparkle:edSignature="AMpY3nl6FgbHI05aKbevDPw05Ja+D419dMKwLPSwCwxEV7dfLFaScLU80t5rN2y7q1oAY630z6w51mugt1EWBQ=="/>
+        </item>
+        <item>
             <title>1.1.15</title>
             <pubDate>Tue, 21 Apr 2026 16:18:20 -0500</pubDate>
             <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.15</link>


### PR DESCRIPTION
## Summary
- bump Transcripted bundle version to 1.1.16
- publish and wire the v1.1.16 Sparkle appcast entry
- update the Homebrew cask to the v1.1.16 DMG SHA

## Validation
- bash build-deps.sh --force
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- bash build.sh
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-release-1.1.16 Transcripted
- xmllint --noout docs/appcast.xml
- ruby -c Casks/transcripted.rb
- git diff --check