### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -14,7 +14,8 @@ Important entry points:
 - `TranscriptedApp.swift` — app entry point, menubar wiring, popover, overlay setup, and detected-meeting prompt wiring
 - `TranscriptedAppState.swift` — owns `ContextCaptureEngine`, `STTRouter`, wake-recovery coordination, and lazy `MeetingSessionController`
 - `Support/TranscriptedStoragePaths.swift` — app-support path helpers for the Transcripted capture-library, state, cache, logs, and tmp layout
-- `Support/HotkeyPreferences.swift` — persisted hotkey settings used by capture routing
+- `Support/HotkeyPreferences.swift` — persisted dictation shortcut mode plus legacy hotkey migration helpers
+- `Support/PhysicalDictationTriggerPreferences.swift` — canonical physical key / modifier bindings used by capture routing for push-to-talk, hands-free dictation, and meeting shortcuts
 - `Support/CustomDictionaryPreferences.swift` — persisted custom spoken-term replacements applied to final dictation and meeting transcript text
 - `Support/LocalSpeakerPreferences.swift` — persisted toggle that decides whether meeting transcription should split the local mic into multiple named speakers or keep it as a single "You" track
 - `Support/TranscriptionModelPreferences.swift` — persisted local model selection shared by dictation and meetings (`Parakeet`, `Whisper Large V3 Turbo`, `Whisper Large V3`)
@@ -35,7 +36,7 @@ Important entry points:
 - `Observability/` — events, debug log, anonymous analytics, Sparkle updater, and crash reporting
 - `Reliability/` — wake / sleep recovery coordination
 - `Speech/` — local STT engines, router, and recorded-audio buffering helpers
-- `Support/` — app-wide path, storage, permission, hotkey, clipboard paste, custom-dictionary, auto-send, local-speaker, and transcription-model preference helpers
+- `Support/` — app-wide path, storage, permission metadata, physical trigger bindings, shortcut-mode preferences, clipboard paste, custom-dictionary, auto-send, local-speaker, and transcription-model preference helpers
 - `TranscriptedCore/` — shared library boundary
 - `UI/` — grouped app surfaces: `Overlay/`, `MenuBar/`, `Settings/`, `AgentConnect/`, and `Shared/`
 

--- a/Sources/Observability/CLAUDE.md
+++ b/Sources/Observability/CLAUDE.md
@@ -19,6 +19,7 @@ anonymous analytics, and Sparkle update plumbing.
 - `AnalyticsPayloadSanitizer.swift` — strips sensitive analytics properties before send
 - `SentryEventPolicy.swift` — explicit allowlist of non-fatal events permitted to reach Sentry
 - `SentryPayloadSanitizer.swift` — strips obvious sensitive values before Sentry sends
+- `SentryRuntimeConfiguration.swift` — resolves Sentry DSN, environment, release, and dist from `Info.plist` or process environment
 - `SparkleUpdaterController.swift` — live Sparkle update controller used by the menubar app
 
 ## Current Notes
@@ -28,7 +29,7 @@ anonymous analytics, and Sparkle update plumbing.
 - Do not assume older draft/style/analysis event flows are still active just because they appear in historical docs or event logs
 - `build.sh` and beta behavior can affect logs, signing, and permissions during local testing
 - `TRANSCRIPTED_DISABLE_FILE_LOGGER=1` disables `app.jsonl` writes for test and smoke runs so local production logs stay clean
-- Sentry DSN/config is read from `Info.plist` (`TranscriptedSentryDSN`) or process environment for local testing, and crash reports must stay scrubbed of transcript/audio/title/path data
+- Sentry runtime config is resolved by `SentryRuntimeConfiguration` from `Info.plist` (`TranscriptedSentryDSN`, `TranscriptedSentryEnvironment`) or process environment (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`), and crash reports must stay scrubbed of transcript/audio/title/path data
 - PostHog config is read from `Info.plist` (`TranscriptedPostHogAPIKey`, `TranscriptedPostHogHost`) or process environment (`POSTHOG_API_KEY`, `POSTHOG_HOST`), and anonymous analytics must stay event-allowlisted and bucketed rather than sending raw payloads
 - Non-fatal error forwarding to Sentry is allowlisted. New `.error` events should not automatically assume they are safe to send off-device.
 

--- a/Sources/Speech/CLAUDE.md
+++ b/Sources/Speech/CLAUDE.md
@@ -8,10 +8,12 @@
 
 - `ParakeetEngine.swift` — app-owned Parakeet STT engine, recording control, live transcript state, model initialization, permission-aware input-readiness checks, audio-device handling, short-audio gating, wake-recovery support, and sanitized failure reporting for model init errors
 - `WhisperEngine.swift` — app-owned WhisperKit STT engine used when advanced users select a Whisper model
+- `DictationInputDeviceSelectionPolicy.swift` — prefers a built-in mic over Bluetooth headset input for dictation when that avoids HFP-style playback downgrades
 - `ParakeetModelInitDiagnostics.swift` — builds safe diagnostic context for model-initialization failures without leaking transcript or user-content data
 - `ParakeetPrewarmPolicy.swift` — central policy for deciding whether speech-engine input-readiness checks should proceed or be skipped based on microphone authorization state
 - `ParakeetRecoveryState.swift` — pure-logic state machine for device-change recovery: generation counter (so stale recovery tasks can bail) and readiness flags (`isRecovering`, `inputFormatReady`) that the dictation overlay waits on instead of racing
 - `ParakeetShortAudioGate.swift` — central policy for deciding when very short recordings should be dropped, surfaced as intentional empty results, or still transcribed
+- `ParakeetStartRecordingFailurePolicy.swift` — central recovery policy for invalid-format and audio-engine-start failures during recording startup
 - `RecordedAudioTimeline.swift` — in-memory segmented audio buffer used when recorded audio needs to be preserved across interruptions or recovery handoffs
 - `STTRouter.swift` — small main-actor wrapper used by the rest of the app
 
@@ -21,6 +23,8 @@
 - `ParakeetEngine` consults `ParakeetPrewarmPolicy` before checking microphone input readiness. Idle readiness checks must not leave `AVAudioEngine` running, because that keeps the macOS microphone indicator active.
 - `ParakeetEngine` consults `ParakeetShortAudioGate` before spending work on extremely short clips, so short-tap behavior changes belong here rather than in UI controllers.
 - `ParakeetEngine` mirrors `ParakeetRecoveryState` flags into `@Published var isRecovering` and `@Published var inputFormatReady` (forwarded through `STTRouter`). `DictationSessionController` waits on these in its wait-for-ready loop instead of blindly retrying. AirPods Hands-Free Profile (24kHz hw / 48kHz output bus) is supported: the tap is installed with `format: nil` so buffers arrive at the output rate, and `nativeSampleRate` tracks the output rate so downstream resampling is correct.
+- `ParakeetEngine` consults `DictationInputDeviceSelectionPolicy` before recording so Bluetooth headset input does not unnecessarily hijack playback when a built-in mic fallback is available.
+- `ParakeetEngine` consults `ParakeetStartRecordingFailurePolicy` when startup fails so format-reset, engine rebuild, and prewarm-retry behavior stay consistent across direct starts and recovery attempts.
 - `ParakeetEngine` reports model-init failures with `ParakeetModelInitDiagnostics.failureContext(...)`, which keeps diagnostics useful for packaging/download/debugging issues without shipping raw transcript or device content.
 - The meeting pipeline reuses the same app-owned `STTRouter` through `Sources/Meeting/MeetingSTTAdapter.swift`.
 - Do not assume a separate local-LLM drafting path exists in this tree.
@@ -39,7 +43,7 @@ Manual checks:
 - dictation can start and stop cleanly
 - very short recordings follow the expected drop / empty-result / transcribe behavior
 - live transcript updates while listening
-- device changes do not leave the app stuck
+- device changes do not leave the app stuck or force a Bluetooth headset mic when a safer built-in fallback exists
 - wake / resume does not strand buffered audio or leave recovery state hanging
 
 Relevant direct coverage:

--- a/Sources/Support/CLAUDE.md
+++ b/Sources/Support/CLAUDE.md
@@ -4,28 +4,31 @@
 
 `Sources/Support/` holds app-wide helpers that do not belong to a single UI or pipeline surface. These types mostly wrap persisted preferences, shared constants, permission access, storage paths, or low-level paste / launch behavior used across dictation and meetings.
 
-## Files (13 Swift files)
+## Files (15 Swift files)
 
 - `ClaudeDesktopIntegrationInstaller.swift` — installs the bundled read-only MCP helper for Claude Desktop, safely merges Claude's config JSON, and runs the helper self-test
 - `ClipboardRestoringTextPaster.swift` — paste helper that preserves clipboard contents while inserting the latest dictation into the target app
 - `CustomDictionaryPreferences.swift` — persisted custom spoken-term replacements plus text post-processing helpers
 - `DictationAutoSendPreferences.swift` — persisted auto-send rules, allowed bundle list, and keypress-sending helpers for pasted dictation
-- `HotkeyPreferences.swift` — persisted global hotkey bindings, dictation shortcut mode, right-Option toggle, display formatting, and validation
+- `HotkeyPreferences.swift` — persisted shortcut mode, legacy Carbon hotkey migration helpers, right-Option toggle, display formatting, and validation
 - `LaunchAtLoginController.swift` — app-facing wrapper for enabling or disabling launch-at-login behavior
 - `LaunchAtLoginPreferences.swift` — persisted first-run preference state around launch-at-login UX
 - `LocalSpeakerPreferences.swift` — persisted toggle for splitting the local mic channel into multiple named speakers during meeting review
 - `MenuBarVisibilityPreferences.swift` — persisted Home toggles for optional menubar popover rows
+- `PhysicalDictationTriggerPreferences.swift` — canonical physical key / modifier trigger bindings for push-to-talk, hands-free dictation, and meeting shortcuts, including migration from older Carbon-backed settings
 - `TranscriptedConstants.swift` — shared timing thresholds and app-wide behavior constants
 - `TranscriptedPermissionAccess.swift` — shared permission status, prompting, and Settings-deep-link helpers for microphone, accessibility, system-audio recording, and calendar access
+- `TranscriptedPermissionKind.swift` — shared permission metadata, copy, icons, and action labels used by onboarding and Settings
 - `TranscriptedStoragePaths.swift` — canonical app-support path helpers for captures, state, cache, logs, and temporary files
 - `TranscriptionModelPreferences.swift` — persisted local transcription-model selection shared by dictation and meetings
 
 ## Current notes
 
 - Keep preference keys and notification names centralized here so UI and controllers do not drift.
+- `PhysicalDictationTriggerPreferences` is the canonical binding layer for push-to-talk, hands-free dictation, and meeting shortcuts. Avoid reintroducing ad hoc keycode logic in UI or capture code.
 - `TranscriptionModelPreferences` is the shared switch between `Parakeet` and the available local Whisper variants. Model-specific runtime behavior still belongs in `Sources/Speech/` and `Sources/Meeting/`.
 - `CustomDictionaryPreferences` and `DictationAutoSendPreferences` back the Settings `General` and `Dictation` pages. If you change parsing rules or policy thresholds, update the relevant tests.
-- `TranscriptedPermissionAccess` is the app-level permission seam. UI flows should call into it instead of duplicating TCC branching.
+- `TranscriptedPermissionAccess` plus `TranscriptedPermissionKind` are the app-level permission seam. UI flows should call into them instead of duplicating TCC branching or permission copy.
 - `TranscriptedStoragePaths` should stay as the canonical path resolver for the app target. `Sources/TranscriptedCore/Services/CoreStoragePaths.swift` is the injected library-side seam.
 - `ClaudeDesktopIntegrationInstaller` owns the Claude Desktop config merge. Preserve existing MCP servers and back up invalid JSON instead of overwriting blindly.
 

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -79,7 +79,9 @@ The current agent-connect surfaces should keep one simple mental model:
 - `Shared/AppSoundPlayer.swift` — UI sound preferences and playback helpers
 - `Shared/FeedbackIssueBuilder.swift` — builds sanitized feedback issue payloads and support links from current app state
 - `Shared/FirstRunExperience.swift` — shared first-run menu and onboarding state helpers for permission, local-model, dictation, and meeting CTA copy
-- `Shared/RecentCaptureScanners.swift` — `RecentMeetingsScanner` that loads recent meeting transcripts from disk for the Settings meetings page
+- `Shared/MeetingAudioArchiveResolver.swift` — resolves retained meeting-audio attachments that belong to a saved transcript
+- `Shared/MeetingAudioPlayback.swift` — shared `NSSound`-backed playback coordinator for recent-meeting audio previews in Settings
+- `Shared/RecentCaptureScanners.swift` — `RecentMeetingsScanner` that loads recent meeting transcripts plus retained audio attachments for the Settings meetings page
 - `Shared/SpeakerClipPlayback.swift` — reusable audio-preview helper for persisted speaker sample clips
 - `Shared/TranscriptedSupportActions.swift` — "Send feedback" flow that builds a GitHub-issue URL seeded with sanitized recent log lines
 
@@ -119,6 +121,7 @@ Manual checks:
 - menubar popover renders shortcuts, primary actions, settings actions, and the agent-connect page cleanly
 - speaker settings can preview clips, surface duplicates, toggle local-speaker splitting, and rename / merge people cleanly
 - completed meeting review cleanly separates "People in the room" from remote participants, and "Keep as You" restores the single-speaker local path when needed
+- recent meetings in Settings can play retained audio attachments without losing sync between transcript rows and playback state
 - permissions onboarding and first-run onboarding window still open correctly
 - first-run CTA copy updates correctly as permissions and local-model state change
 - settings window still opens correctly


### PR DESCRIPTION
## Summary
- sync `Sources/Observability/CLAUDE.md` with the new runtime Sentry configuration helper and current env/config details
- sync `Sources/Speech/CLAUDE.md` with the new dictation input selection and recording-start failure policies
- sync `Sources/Support/CLAUDE.md` and `Sources/CLAUDE.md` with the current support-layer file list and physical trigger / permission metadata helpers
- sync `Sources/UI/CLAUDE.md` with the recent meeting-audio archive and playback helpers used by Settings

## Why
Nightly CLAUDE.md audit for recent Swift changes merged in the last 3 days. This PR updates stale docs only and leaves source code untouched.

## Files updated
- `Sources/CLAUDE.md`
- `Sources/Observability/CLAUDE.md`
- `Sources/Speech/CLAUDE.md`
- `Sources/Support/CLAUDE.md`
- `Sources/UI/CLAUDE.md`
