### PR TITLE
[nightly-security] Harden analytics payload sanitization

### DIFF
--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -4,6 +4,8 @@ enum AnalyticsPayloadSanitizer {
     private static let maxValueLength = 80
     private static let sensitiveKeyFragments = [
         "audio",
+        "authorization",
+        "bearer",
         "bundle",
         "credential",
         "dsn",
@@ -49,6 +51,7 @@ enum AnalyticsPayloadSanitizer {
         #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature|password|passphrase|secret|client[_-]?secret|credential|dsn)\s*[:=]\s*([^\s,;]+)"#
     )
     private static let emailRegex = makeRegex(#"[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}"#, options: [.caseInsensitive])
+    private static let localHostnameRegex = makeRegex(#"\b[a-zA-Z0-9._-]+\.local\b"#)
 
     static func sanitizeProperties(
         _ properties: [String: String],
@@ -106,6 +109,8 @@ enum AnalyticsPayloadSanitizer {
         result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)
         result = emailRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-email]")
+        range = NSRange(result.startIndex..., in: result)
+        result = localHostnameRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-host]")
 
         return result
     }

--- a/Tests/AnalyticsPayloadSanitizerTests.swift
+++ b/Tests/AnalyticsPayloadSanitizerTests.swift
@@ -21,7 +21,7 @@ func testAnalyticsPayloadSanitizer() {
     runSuite("AnalyticsPayloadSanitizer redacts file paths and emails from values") {
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
             [
-                "failure_kind": "Saved to /Users/redbars/Library/Application Support/Transcripted/logs/app.jsonl by person@example.com",
+                "failure_kind": "Saved to /Users/redbars/Library/Application Support/Transcripted/logs/app.jsonl by person@example.com on Redbarss-MacBook-Pro.local",
             ],
             allowedKeys: ["failure_kind"]
         )
@@ -30,8 +30,25 @@ func testAnalyticsPayloadSanitizer() {
         assertFalse(value.contains("/Users/redbars/"), "user paths should be redacted")
         assertFalse(value.contains("Application Support/Transcripted/logs/app.jsonl"), "app support paths should be fully redacted")
         assertFalse(value.contains("person@example.com"), "emails should be redacted")
+        assertFalse(value.contains("Redbarss-MacBook-Pro.local"), "local hostnames should be redacted")
         assertTrue(value.contains("[redacted-path]"), "path marker should remain")
         assertTrue(value.contains("[redacted-email]"), "email marker should remain")
+        assertTrue(value.contains("[redacted-host]"), "host marker should remain")
+    }
+
+    runSuite("AnalyticsPayloadSanitizer drops authorization-like keys even if allowlisted") {
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "authorization_header": "Bearer abc123",
+                "bearer_source": "settings",
+                "duration_bucket": "10_29s",
+            ],
+            allowedKeys: ["authorization_header", "bearer_source", "duration_bucket"]
+        )
+
+        assertNil(sanitized["authorization_header"], "authorization headers should never become analytics properties")
+        assertNil(sanitized["bearer_source"], "bearer-like properties should never become analytics properties")
+        assertEqual(sanitized["duration_bucket"], "10_29s", "unrelated coarse properties should remain")
     }
 
     runSuite("AnalyticsPayloadSanitizer redacts raw URLs and common secret values") {


### PR DESCRIPTION
## Summary
- Add analytics redaction for local `.local` hostnames so diagnostic strings do not expose machine names.
- Drop authorization-like analytics property keys even if a future caller accidentally allowlists them.
- Extend sanitizer tests for host redaction and authorization-key rejection.

## Validation
- `bash run-tests.sh` passed, 693/693.
- `bash build-deps.sh --force` completed to restore missing dependency artifacts.
- `bash build.sh` passed, including signature verification and launch smoke.

## Security note
This keeps the analytics privacy boundary closer to the existing Sentry scrubber and reduces accidental leakage from future allowlist changes.