### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Sources/Meeting/MeetingImportedAudioPreparer.swift
+++ b/Sources/Meeting/MeetingImportedAudioPreparer.swift
@@ -27,6 +27,29 @@ enum MeetingImportedAudioPreparer {
             )
         }
 
+        let sourceAttributes: [FileAttributeKey: Any]
+        do {
+            sourceAttributes = try fileManager.attributesOfItem(atPath: resolvedSourceURL.path)
+        } catch {
+            throw NSError(
+                domain: "MeetingImportedAudioPreparer",
+                code: 1,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Transcripted couldn't inspect that audio file."
+                ]
+            )
+        }
+
+        guard sourceAttributes[.type] as? FileAttributeType == .typeRegular else {
+            throw NSError(
+                domain: "MeetingImportedAudioPreparer",
+                code: 1,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Select an audio file, not a folder or package."
+                ]
+            )
+        }
+
         let destinationURL = uniqueScratchURL(
             for: resolvedSourceURL,
             in: scratchDirectory,
@@ -37,6 +60,7 @@ enum MeetingImportedAudioPreparer {
             try fileManager.copyItem(at: resolvedSourceURL, to: destinationURL)
             fileManager.restrictFileToOwnerOnly(at: destinationURL)
         } catch {
+            try? fileManager.removeItem(at: destinationURL)
             throw NSError(
                 domain: "MeetingImportedAudioPreparer",
                 code: 2,

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -141,7 +141,7 @@ extension TranscriptionTaskManager {
                 similarity: entry.similarity
             )
             speakerMappings[key] = mapping
-            speakerSources[entry.speakerId] = autoAcceptedIds.contains(entry.speakerId) ? "db" : "db_pending"
+            speakerSources[key] = autoAcceptedIds.contains(entry.speakerId) ? "db" : "db_pending"
 
             if autoAcceptedIds.contains(entry.speakerId),
                let name = entry.profile.displayName {

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -348,19 +348,13 @@ public class TranscriptionTaskManager: ObservableObject {
     }
 
     /// Populate saved transcript metadata from the file's YAML frontmatter.
-    /// Reads only the first 2 KB to avoid blocking the main thread on large transcript files.
+    /// Reads the YAML frontmatter in bounded chunks so larger metadata blocks
+    /// (many speakers, gap events, etc.) still parse without reading the whole file.
     func populateSavedMetadata(from url: URL) {
         lastSavedTranscriptURL = url
         let name = url.deletingPathExtension().lastPathComponent
         lastSavedTitle = name.replacingOccurrences(of: "_", with: " ").replacingOccurrences(of: "-", with: " ")
-        guard let handle = try? FileHandle(forReadingFrom: url) else { return }
-        let headerData = handle.readData(ofLength: 2048)
-        try? handle.close()
-        guard let raw = String(data: headerData, encoding: .utf8),
-              raw.hasPrefix("---"),
-              let endRange = raw.range(of: "\n---\n", range: raw.index(raw.startIndex, offsetBy: 3)..<raw.endIndex)
-        else { return }
-        let yaml = String(raw[raw.index(raw.startIndex, offsetBy: 4)..<endRange.lowerBound])
+        guard let yaml = readYAMLFrontmatter(from: url) else { return }
         var speakers = 0
         for line in yaml.components(separatedBy: "\n") {
             let parts = line.split(separator: ":", maxSplits: 1).map { String($0).trimmingCharacters(in: .whitespaces) }
@@ -373,6 +367,29 @@ public class TranscriptionTaskManager: ObservableObject {
             }
         }
         lastSavedSpeakerCount = speakers
+    }
+
+    private func readYAMLFrontmatter(from url: URL, chunkSize: Int = 2048, maxBytes: Int = 64 * 1024) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+
+        var data = Data()
+        let closingMarker = Data("\n---\n".utf8)
+
+        while data.count < maxBytes {
+            let remaining = maxBytes - data.count
+            let chunk = handle.readData(ofLength: min(chunkSize, remaining))
+            guard !chunk.isEmpty else { break }
+            data.append(chunk)
+
+            if data.starts(with: Data("---".utf8)),
+               let endRange = data.range(of: closingMarker, in: 3..<data.count),
+               let raw = String(data: data[..<endRange.lowerBound], encoding: .utf8) {
+                return String(raw.dropFirst(4))
+            }
+        }
+
+        return nil
     }
 
     func scheduleStatusReset(delay: TimeInterval = 3) {

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+import Combine
+import FluidAudio
+@testable import TranscriptedCore
+
+@available(macOS 14.0, *)
+@MainActor
+final class TranscriptionTaskManagerMetadataTests: XCTestCase {
+    private var tempDirectory: URL!
+
+    override func setUpWithError() throws {
+        tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+    }
+
+    func testPopulateSavedMetadataReadsLargeFrontmatterBeyondInitialChunk() throws {
+        let manager = makeManager()
+        let transcriptURL = tempDirectory.appendingPathComponent("Call_2026-04-22.md")
+
+        let filler = (0..<180)
+            .map { "padding_\($0): \"\(String(repeating: "x", count: 20))\"" }
+            .joined(separator: "\n")
+        let content = """
+        ---
+        date: 2026-04-22
+        \(filler)
+        title: "Quarterly Planning Review"
+        duration: "42:17"
+        mic_speakers: 2
+        system_speakers: 3
+        ---
+
+        # Meeting Recording
+        """
+        try content.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+        manager.populateSavedMetadata(from: transcriptURL)
+
+        XCTAssertEqual(manager.lastSavedTitle, "Quarterly Planning Review")
+        XCTAssertEqual(manager.lastSavedDuration, "42:17")
+        XCTAssertEqual(manager.lastSavedSpeakerCount, 5)
+    }
+
+    private func makeManager() -> TranscriptionTaskManager {
+        let paths = CoreStoragePaths(
+            transcripts: tempDirectory.appendingPathComponent("transcripts"),
+            speakerDB: tempDirectory.appendingPathComponent("speakers.sqlite"),
+            statsDB: tempDirectory.appendingPathComponent("stats.sqlite"),
+            failedQueue: tempDirectory.appendingPathComponent("failed_transcriptions.json"),
+            speakerClips: tempDirectory.appendingPathComponent("speaker_clips"),
+            audioCaptures: tempDirectory.appendingPathComponent("audio"),
+            logs: tempDirectory.appendingPathComponent("logs")
+        )
+
+        try? FileManager.default.createDirectory(at: paths.transcripts, withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(at: paths.logs, withIntermediateDirectories: true)
+
+        return TranscriptionTaskManager(
+            failedTranscriptionManager: FailedTranscriptionManager(paths: paths),
+            speechToText: MetadataStubSpeechToTextEngine(),
+            diarization: MetadataStubDiarizationEngine(),
+            speakerStore: SpeakerDatabase(path: paths.speakerDB.path)
+        )
+    }
+}
+
+@available(macOS 14.0, *)
+@MainActor
+private final class MetadataStubSpeechToTextEngine: SpeechToTextEngine {
+    nonisolated let objectWillChange = ObservableObjectPublisher()
+    var isReady: Bool = true
+
+    func initialize() async {}
+    func transcribeSegment(samples: [Float], source: AudioSource) async throws -> String { "" }
+    func cleanup() {}
+}
+
+@available(macOS 14.0, *)
+@MainActor
+private final class MetadataStubDiarizationEngine: DiarizationEngine {
+    nonisolated let objectWillChange = ObservableObjectPublisher()
+    var isReady: Bool = true
+
+    func initialize() async {}
+    func diarizeOffline(samples: [Float], sampleRate: Int) async throws -> [SpeakerSegment] { [] }
+    func diarizeOffline(audioURL: URL) async throws -> [SpeakerSegment] { [] }
+    func cleanup() {}
+}


### PR DESCRIPTION
## Summary
Nightly automated code review fixes for recent transcription/imported-audio changes.

## Fixed
### Transcript metadata parsing
- fixed `TranscriptionTaskManager.populateSavedMetadata` so it reads YAML frontmatter in bounded chunks instead of only the first 2 KB
- this restores saved title, duration, and speaker-count parsing for newer transcripts whose frontmatter grew past 2 KB because of speaker metadata and gap-event details
- added a regression test covering oversized frontmatter parsing

### Imported audio boundary handling
- reject directories/packages during imported-audio preparation instead of treating them like source files
- clean up partially copied scratch files if the secure permission-hardening step fails

### Speaker metadata consistency
- fixed system-speaker `speakerSources` entries to use the same channel-qualified keys as the rest of the transcript metadata pipeline

## Validation
- `xcodebuild -project Transcripted.xcodeproj -scheme Transcripted -configuration Debug build 2>&1` could not run because this checkout does not contain `Transcripted.xcodeproj`
- `bash build-deps.sh --force`
- `swift test --filter TranscriptionTaskManagerMetadataTests`
- `bash build.sh`
