### PR TITLE
[nightly-ux] Clarify no-speech dictation feedback

### DIFF
--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -125,7 +125,7 @@ enum TranscriptedConstants {
 
     /// Duration to show error messages in overlay before auto-dismiss (nanoseconds)
     static let errorDismissDelay: UInt64 = 2_500_000_000  // 2.5 seconds
-    static let noSpeechDismissDelay: UInt64 = 800_000_000  // 0.8 seconds — fast dismiss for empty recordings
+    static let noSpeechDismissDelay: UInt64 = 1_400_000_000  // 1.4 seconds — enough time to read the empty-recording hint
 
     // MARK: - Feedback Sounds
 

--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -429,10 +429,10 @@ class FloatingOverlayController {
         }
     }
 
-    /// Fast dismiss for "no speech detected" — brief flash then clean fade (no shake).
+    /// Fast dismiss for empty dictation audio — brief flash then clean fade (no shake).
     func showNoSpeechAndDismiss() {
         errorDismissTask?.cancel()
-        errorMessage = "No speech detected"
+        errorMessage = "No speech heard. Try speaking a little longer."
         errorActionTitle = nil
         errorActionHandler = nil
         state = .drafting


### PR DESCRIPTION
## Summary
- Replace the brief no-speech overlay text with a clearer retry hint.
- Keep the empty-audio hint visible a little longer so users can read it.

## Evidence
- PostHog showed 159 `dictation_no_speech` events in the last 7 days, with 142 in the `lt_10s` duration bucket.
- The previous overlay copy was only `No speech detected` and auto-dismissed after 0.8 seconds.
- Sentry data was unavailable in this environment because `SENTRY_AUTH_TOKEN` is not set.

## Validation
- `bash run-tests.sh`
- `bash build-deps.sh --force`
- `bash build.sh`