### PR TITLE
Accept --json for QA gate checker

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,7 +37,7 @@ not have to carry the full operational logic:
   - Usage: `bash scripts/ops/health-probe.sh <github|sentry|posthog|cloudflare|all>`
   - See `docs/ops-credentials.md` for credential setup and privacy guidelines
 - `scripts/ops/qa-gate-check.sh` — one-shot check for the BET-88 QA gate comment on `#428` using the same strict owner + first-line PASS/FAIL rules as the auto-close workflow
-  - Usage: `bash scripts/ops/qa-gate-check.sh [repo] [issue_number] [owner_login]`
+  - Usage: `bash scripts/ops/qa-gate-check.sh [--json] [repo] [issue_number] [owner_login]`
   - Returns JSON and exits `0` for `pass`/`fail`, `3` for `PENDING`
 - `scripts/ops/qa-gate-closeout.sh` — closeout wrapper around `qa-gate-check.sh` that prints explicit unblock owner/action when status is still pending
   - Usage: `bash scripts/ops/qa-gate-closeout.sh [repo] [issue_number] [owner_login]`

--- a/scripts/ops/qa-gate-check.sh
+++ b/scripts/ops/qa-gate-check.sh
@@ -7,9 +7,15 @@ set -euo pipefail
 # - first non-empty line must be PASS / PASS: ... / FAIL / FAIL: ...
 #
 # Usage:
-#   bash scripts/ops/qa-gate-check.sh [repo] [issue_number] [owner_login]
+#   bash scripts/ops/qa-gate-check.sh [--json] [repo] [issue_number] [owner_login]
 # Example:
 #   bash scripts/ops/qa-gate-check.sh r3dbars/transcripted 428 r3dbars
+
+if [[ "${1:-}" == "--json" ]]; then
+  # Compatibility no-op. The script always emits JSON; this accepts the flag
+  # form used in older issue comments and automation notes.
+  shift
+fi
 
 REPO="${1:-r3dbars/transcripted}"
 ISSUE_NUMBER="${2:-428}"


### PR DESCRIPTION
## Summary

- Accept `--json` as a no-op compatibility flag for `scripts/ops/qa-gate-check.sh`
- Document the optional flag in `scripts/README.md`

## Verification

- `bash scripts/ops/qa-gate-check.sh --json r3dbars/transcripted 428 r3dbars` exits `3` with pending JSON, as expected
- `bash scripts/ops/qa-gate-check.sh r3dbars/transcripted 428 r3dbars` exits `3` with pending JSON, as expected
- `bash scripts/ops/qa-gate-closeout.sh r3dbars/transcripted 428 r3dbars` exits `3` with pending closeout guidance, as expected
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (688 passed, 0 failed)