### PR TITLE
[codex] Add quiet update reminders

### DIFF
--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -15,6 +15,13 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
 
         var state: State
         var canCheckForUpdates: Bool
+
+        var availableUpdateVersion: String? {
+            if case .updateAvailable(let version) = state {
+                return version
+            }
+            return nil
+        }
     }
 
     @Published private(set) var updateStatus = UpdateStatus(
@@ -25,7 +32,7 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
     private lazy var updaterController = SPUStandardUpdaterController(
         startingUpdater: true,
         updaterDelegate: self,
-        userDriverDelegate: nil
+        userDriverDelegate: self
     )
     private var canCheckObservation: NSKeyValueObservation?
     private var hasPerformedStartupCheck = false
@@ -118,6 +125,10 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
     }
 
     private func versionString(for item: SUAppcastItem) -> String {
+        Self.displayVersionString(for: item)
+    }
+
+    nonisolated private static func displayVersionString(for item: SUAppcastItem) -> String {
         let displayVersion = item.displayVersionString.trimmingCharacters(in: .whitespacesAndNewlines)
         if !displayVersion.isEmpty {
             return displayVersion
@@ -158,5 +169,31 @@ extension SparkleUpdaterController: SPUUpdaterDelegate {
         }
 
         setUpdateStatus(fallbackState, canCheckForUpdates: updater.canCheckForUpdates)
+    }
+}
+
+extension SparkleUpdaterController: SPUStandardUserDriverDelegate {
+    nonisolated var supportsGentleScheduledUpdateReminders: Bool { true }
+
+    nonisolated func standardUserDriverShouldHandleShowingScheduledUpdate(
+        _ update: SUAppcastItem,
+        andInImmediateFocus immediateFocus: Bool
+    ) -> Bool {
+        false
+    }
+
+    nonisolated func standardUserDriverWillHandleShowingUpdate(
+        _ handleShowingUpdate: Bool,
+        forUpdate update: SUAppcastItem,
+        state: SPUUserUpdateState
+    ) {
+        let version = Self.displayVersionString(for: update)
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.setUpdateStatus(
+                .updateAvailable(version: version),
+                canCheckForUpdates: self.updaterController.updater.canCheckForUpdates
+            )
+        }
     }
 }

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -4,6 +4,7 @@
 import SwiftUI
 import AppKit
 import Carbon
+import Combine
 import TranscriptedCore
 import UniformTypeIdentifiers
 
@@ -24,6 +25,8 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     var popover: NSPopover?
     private var lastExternalApplication: NSRunningApplication?
     private var hasPresentedInitialOnboarding = false
+    private let statusItemUpdateBadge = NSView(frame: .zero)
+    private var statusItemUpdateSubscription: AnyCancellable?
     private let settingsTextPaster = ClipboardRestoringTextPaster()
     private lazy var settingsActions = TranscriptedSettingsActions(
         startDictation: { [weak self] in self?.startDictationFromSettings() },
@@ -128,13 +131,9 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         // Set up menubar status item
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         if let button = statusItem?.button {
-            let image = NSImage(systemSymbolName: "mic.and.signal.meter", accessibilityDescription: "Transcripted")
-            image?.isTemplate = true
-            button.image = image
-            button.toolTip = "Transcripted"
-            button.action = #selector(togglePopover)
-            button.target = self
+            configureStatusItemButton(button)
         }
+        bindStatusItemUpdateBadge()
         installSettingsMenuHandler()
 
         // Set up popover (pure AppKit — no NSHostingController, no AttributeGraph)
@@ -201,6 +200,59 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     @objc private func openSettingsFromAppMenu(_ sender: Any?) {
         closePopover()
         showSettingsWindow()
+    }
+
+    private func configureStatusItemButton(_ button: NSStatusBarButton) {
+        let image = NSImage(systemSymbolName: "mic.and.signal.meter", accessibilityDescription: "Transcripted")
+        image?.isTemplate = true
+        button.image = image
+        button.imagePosition = .imageOnly
+        button.toolTip = "Transcripted"
+        button.action = #selector(togglePopover)
+        button.target = self
+
+        installStatusItemUpdateBadge(on: button)
+    }
+
+    private func installStatusItemUpdateBadge(on button: NSStatusBarButton) {
+        guard statusItemUpdateBadge.superview !== button else { return }
+
+        statusItemUpdateBadge.translatesAutoresizingMaskIntoConstraints = false
+        statusItemUpdateBadge.wantsLayer = true
+        statusItemUpdateBadge.layer?.backgroundColor = NSColor.systemOrange.cgColor
+        statusItemUpdateBadge.layer?.borderColor = NSColor.black.withAlphaComponent(0.45).cgColor
+        statusItemUpdateBadge.layer?.borderWidth = 1
+        statusItemUpdateBadge.layer?.cornerRadius = 4
+        statusItemUpdateBadge.layer?.masksToBounds = true
+        statusItemUpdateBadge.isHidden = true
+
+        button.addSubview(statusItemUpdateBadge)
+        NSLayoutConstraint.activate([
+            statusItemUpdateBadge.widthAnchor.constraint(equalToConstant: 8),
+            statusItemUpdateBadge.heightAnchor.constraint(equalToConstant: 8),
+            statusItemUpdateBadge.trailingAnchor.constraint(equalTo: button.trailingAnchor, constant: -2),
+            statusItemUpdateBadge.topAnchor.constraint(equalTo: button.topAnchor, constant: 3),
+        ])
+    }
+
+    private func bindStatusItemUpdateBadge() {
+        statusItemUpdateSubscription = appState.sparkleUpdater.$updateStatus
+            .receive(on: RunLoop.main)
+            .sink { [weak self] status in
+                self?.updateStatusItemBadge(for: status)
+            }
+        updateStatusItemBadge(for: appState.sparkleUpdater.updateStatus)
+    }
+
+    private func updateStatusItemBadge(for status: SparkleUpdaterController.UpdateStatus) {
+        let updateVersion = status.availableUpdateVersion
+        statusItemUpdateBadge.isHidden = updateVersion == nil
+
+        if let updateVersion {
+            statusItem?.button?.toolTip = "Transcripted - update \(updateVersion) available"
+        } else {
+            statusItem?.button?.toolTip = "Transcripted"
+        }
     }
 
     private func installSettingsMenuHandler() {

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -86,6 +86,7 @@ final class MenuBarPanelController: NSViewController {
 
         content.utilityActionsView.update(
             updateTitle: updatePresentation.title,
+            updateDetail: updatePresentation.detail,
             updateVersion: updatePresentation.version,
             updateTone: updatePresentation.tone,
             updateEnabled: appState.sparkleUpdater.updateStatus.canCheckForUpdates
@@ -199,30 +200,34 @@ final class MenuBarPanelController: NSViewController {
 
     private func menuUpdatePresentation(
         for status: SparkleUpdaterController.UpdateStatus
-    ) -> (title: String, version: String?, tone: MenuBarActionRowView.Tone) {
+    ) -> (title: String, detail: String, version: String?, tone: MenuBarActionRowView.Tone) {
         switch status.state {
         case .unknown, .readyToCheck:
             return (
                 "Check for Updates",
+                "",
                 nil,
                 .standard
             )
         case .checking:
             return (
-                "Checking…",
+                "Checking for Updates…",
+                "",
                 nil,
                 .standard
             )
         case .noUpdateAvailable:
             return (
                 "Check for Updates",
+                "",
                 nil,
                 .standard
             )
         case .updateAvailable(let version):
             return (
                 "Update Available",
-                version,
+                "Version \(version) ready",
+                "Install",
                 .accent
             )
         }

--- a/Sources/UI/MenuBar/MenuBarUtilityActionsView.swift
+++ b/Sources/UI/MenuBar/MenuBarUtilityActionsView.swift
@@ -36,6 +36,7 @@ final class MenuBarUtilityActionsView: NSView {
 
     func update(
         updateTitle: String,
+        updateDetail: String,
         updateVersion: String?,
         updateTone: MenuBarActionRowView.Tone,
         updateEnabled: Bool
@@ -59,7 +60,7 @@ final class MenuBarUtilityActionsView: NSView {
         updatesRow.update(
             symbolName: "arrow.triangle.2.circlepath.circle",
             title: updateTitle,
-            detail: "",
+            detail: updateDetail,
             trailingText: updateVersion,
             tone: updateTone,
             size: .utility,

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -85,15 +85,8 @@ struct TranscriptedSettingsView: View {
             .safeAreaInset(edge: .bottom) {
                 VStack(spacing: 0) {
                     Divider()
-                    HStack {
-                        Text(TranscriptedSupportActions.appVersionDescription)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        Spacer()
-                    }
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 10)
-                    .background(.thinMaterial)
+                    settingsSidebarFooter
+                        .background(.thinMaterial)
                 }
             }
         } detail: {
@@ -155,6 +148,48 @@ struct TranscriptedSettingsView: View {
             Label(page.title, systemImage: page.systemImage)
                 .tag(page)
         }
+    }
+
+    private var settingsSidebarFooter: some View {
+        Button {
+            actions.checkForUpdates()
+        } label: {
+            HStack(spacing: 8) {
+                if sparkleUpdater.updateStatus.availableUpdateVersion != nil {
+                    Circle()
+                        .fill(Color.orange)
+                        .frame(width: 7, height: 7)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(settingsFooterTitle)
+                        .font(.caption.weight(settingsFooterIsUpdateAvailable ? .semibold : .regular))
+                        .foregroundStyle(settingsFooterIsUpdateAvailable ? Color.primary : Color.secondary)
+                        .lineLimit(1)
+
+                    if let detail = settingsFooterDetail {
+                        Text(detail)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer(minLength: 6)
+
+                Image(systemName: settingsFooterIsUpdateAvailable ? "arrow.down.circle.fill" : "arrow.triangle.2.circlepath")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(settingsFooterIsUpdateAvailable ? Color.accentColor : Color.secondary)
+                    .opacity(sparkleUpdater.updateStatus.canCheckForUpdates ? 1 : 0.45)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, settingsFooterIsUpdateAvailable ? 8 : 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!sparkleUpdater.updateStatus.canCheckForUpdates)
+        .help(settingsFooterHelp)
     }
 
     @ViewBuilder
@@ -930,6 +965,39 @@ struct TranscriptedSettingsView: View {
                 }
             }
         }
+    }
+
+    private var settingsFooterIsUpdateAvailable: Bool {
+        sparkleUpdater.updateStatus.availableUpdateVersion != nil
+    }
+
+    private var settingsFooterTitle: String {
+        if let version = sparkleUpdater.updateStatus.availableUpdateVersion {
+            return "Update \(version) available"
+        }
+
+        switch sparkleUpdater.updateStatus.state {
+        case .checking:
+            return "Checking for updates"
+        case .noUpdateAvailable, .unknown, .readyToCheck:
+            return TranscriptedSupportActions.appVersionDescription
+        case .updateAvailable:
+            return TranscriptedSupportActions.appVersionDescription
+        }
+    }
+
+    private var settingsFooterDetail: String? {
+        if sparkleUpdater.updateStatus.availableUpdateVersion != nil {
+            return TranscriptedSupportActions.appVersionDescription
+        }
+        return nil
+    }
+
+    private var settingsFooterHelp: String {
+        if let version = sparkleUpdater.updateStatus.availableUpdateVersion {
+            return "Install update \(version)."
+        }
+        return "Check for updates."
     }
 
     private var appStateFolder: URL {

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -18,7 +18,12 @@ Future agents should treat this as a release requirement:
 - `Info.plist` points Sparkle at `https://raw.githubusercontent.com/r3dbars/transcripted/main/docs/appcast.xml`
 - `SUEnableAutomaticChecks` is enabled by default
 - the app triggers a background update check on launch when automatic checks are enabled
-- the menu bar footer includes a manual `Check for updates` action
+- scheduled update reminders are handled quietly inside Transcripted instead of
+  showing automatic Sparkle pop-ups
+- the menu bar footer includes a manual `Check for updates` action and changes
+  to an update-ready action when Sparkle finds a newer release
+- the settings sidebar footer also becomes an update-ready action when Sparkle
+  finds a newer release
 
 ## Local tooling
 


### PR DESCRIPTION
## What changed

- Add quiet Sparkle update state in the menu bar without automatic pop-up reminders.
- Show an orange status-item badge when an update is available.
- Change the menu action to `Update Available` with version detail and an `Install` affordance.
- Make the Settings/Home sidebar footer clickable so it shows `Update <version> available` when Sparkle finds a newer version.
- Document the quiet reminder behavior in `docs/sparkle-updates.md`.

## Why

Users should not need to manually hunt for updates, but the app should avoid interruptive pop-ups. This gives gentle, visible reminders in the two places users already check: the menu bar and Home/settings footer.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (`688 tests, 688 passed`)
- Local visual smoke test using a throwaway app copy that pretended current version `1.1.15` had update `1.1.16` available.