### PR TITLE
docs: sync CLAUDE.md test coverage lists with recent codebase changes

### DIFF
--- a/Sources/Speech/CLAUDE.md
+++ b/Sources/Speech/CLAUDE.md
@@ -48,8 +48,10 @@ Manual checks:
 
 Relevant direct coverage:
 
+- `Tests/DictationInputDeviceSelectionPolicyTests.swift`
 - `Tests/ParakeetModelInitDiagnosticsTests.swift`
 - `Tests/ParakeetPrewarmPolicyTests.swift`
 - `Tests/ParakeetRecoveryStateTests.swift`
 - `Tests/ParakeetShortAudioGateTests.swift`
+- `Tests/ParakeetStartRecordingFailurePolicyTests.swift`
 - `Tests/RecordedAudioTimelineTests.swift`

--- a/Sources/Support/CLAUDE.md
+++ b/Sources/Support/CLAUDE.md
@@ -43,11 +43,14 @@ bash run-tests.sh
 
 Relevant direct coverage includes:
 
+- `Tests/ClaudeDesktopIntegrationInstallerTests.swift`
 - `Tests/ClipboardRestoringTextPasterTests.swift`
 - `Tests/CustomDictionaryPreferencesTests.swift`
 - `Tests/DictationAutoSendPreferencesTests.swift`
+- `Tests/HotkeyPreferencesTests.swift`
 - `Tests/LaunchAtLoginPreferencesTests.swift`
 - `Tests/MenuBarVisibilityPreferencesTests.swift`
+- `Tests/PhysicalDictationTriggerPreferencesTests.swift`
 - `Tests/TranscriptedConstantsTests.swift`
 - `Tests/TranscriptedPermissionAccessTests.swift`
 - `Tests/TranscriptedStoragePathsTests.swift`

--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -77,17 +77,22 @@ Also run when the package seam changes:
 
 Current direct core coverage includes:
 
+- `Tests/TranscriptedCoreTests/AudioInitializationTests.swift`
 - `Tests/TranscriptedCoreTests/CoreStoragePathsTests.swift`
 - `Tests/TranscriptedCoreTests/DatabaseFilePermissionsTests.swift`
 - `Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift`
+- `Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift`
+- `Tests/TranscriptedCoreTests/FileLoggerTests.swift`
 - `Tests/TranscriptedCoreTests/MicRecordingFileMergerTests.swift`
-- `Tests/TranscriptedCoreTests/TranscriptMetadataBuilderTests.swift`
+- `Tests/TranscriptedCoreTests/RecordingAudioArchiverTests.swift`
 - `Tests/TranscriptedCoreTests/RetroactiveSpeakerUpdaterTests.swift`
 - `Tests/TranscriptedCoreTests/SpeakerMatchingServiceTests.swift`
 - `Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift`
 - `Tests/TranscriptedCoreTests/SpeakerProfileMergerTests.swift`
 - `Tests/TranscriptedCoreTests/StatsDatabaseTests.swift`
+- `Tests/TranscriptedCoreTests/TranscriptMetadataBuilderTests.swift`
 - `Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift`
+- `Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift`
 - `Tests/Integration/AppCoreIntegrationSmoke.swift`
 
-Core coverage is still selective, but it is no longer limited just to the package seam. Speaker reconciliation, transcript metadata, stats, storage-path behavior, and file-permission enforcement all have direct tests.
+Core coverage spans the package seam, audio initialization, speaker reconciliation, transcript metadata, stats, storage-path behavior, file-permission enforcement, failed-transcription persistence, file logging, recording archiving, and task-manager metadata.


### PR DESCRIPTION
## Summary

- **Sources/TranscriptedCore/CLAUDE.md**: Added 5 missing test files to coverage list (AudioInitializationTests, FailedTranscriptionManagerTests, FileLoggerTests, RecordingAudioArchiverTests, TranscriptionTaskManagerMetadataTests) and updated the coverage summary
- **Sources/Speech/CLAUDE.md**: Added 2 missing test files (DictationInputDeviceSelectionPolicyTests, ParakeetStartRecordingFailurePolicyTests)
- **Sources/Support/CLAUDE.md**: Added 3 missing test files (ClaudeDesktopIntegrationInstallerTests, HotkeyPreferencesTests, PhysicalDictationTriggerPreferencesTests)

All file indexes, file counts, and source-level documentation verified current. No new source files were added since the last doc sync (PR #464).

🤖 Generated with [Claude Code](https://claude.com/claude-code)