### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -145,7 +145,6 @@ class STTRouter: ObservableObject {
                 return text.isEmpty ? nil : text
             } catch {
                 print("❌ WHISPER | dictation failed: \(error.localizedDescription)")
-                parakeetEngine.finishExternalTranscription()
                 return nil
             }
         }


### PR DESCRIPTION
## Summary

- **Logic bug (STTRouter.swift:148)**: Removed redundant `parakeetEngine.finishExternalTranscription()` call from the `catch` block in `STTRouter.transcribe()`. Swift's `defer` in the `do` block already calls this when the block exits via throw — it runs _before_ control transfers to `catch`. The redundant call was harmless (double-set of a bool + double-clear of an empty buffer) but misleading, suggesting the `defer` was insufficient.

## Review coverage

Reviewed all commits from the last 7 days:
- `fa56789` — BET-88 workflow: no logic, CI-only
- `97b1323` — Parakeet start failure state reset hardening: correct, adds defensive pre-reset before `rebuildAudioEngine`
- `36e1d90` — Microphone recovery hardening: correct, properly introduces `rebuildAudioEngine` as a full engine replacement path
- `504c2fe` — Dictation shortcut modes: correct, CapsLock-as-toggle behavior is intentional

**No threading violations found.** `Audio.swift` and `SystemAudioCapture.swift` are correctly not `@MainActor`. **No TranscriptedCore boundary violations** — no Draft app imports found in `Sources/TranscriptedCore/`.

## Test plan

- [x] `bash build.sh` — passes
- [x] `bash run-tests.sh` — 656/656 passed
- [x] `bash run-integration-smoke.sh` — passes
- [x] `swift test` — 68/68 passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)