### PR TITLE
refactor: nightly simplification sweep [automated]

### DIFF
--- a/Sources/Dictation/DictationTranscriptWriter.swift
+++ b/Sources/Dictation/DictationTranscriptWriter.swift
@@ -161,8 +161,7 @@ enum DictationTranscriptWriter {
     }
 
     private static func hasExistingContent(at url: URL) -> Bool {
-        guard FileManager.default.fileExists(atPath: url.path),
-              let values = try? url.resourceValues(forKeys: [.fileSizeKey]),
+        guard let values = try? url.resourceValues(forKeys: [.fileSizeKey]),
               let size = values.fileSize else {
             return false
         }

--- a/Sources/Meeting/MeetingRecordingCleanup.swift
+++ b/Sources/Meeting/MeetingRecordingCleanup.swift
@@ -11,7 +11,6 @@ enum MeetingRecordingCleanup {
         let urls = Set([micURL, systemURL].compactMap { $0 })
 
         for url in urls {
-            guard fileManager.fileExists(atPath: url.path) else { continue }
             do {
                 try fileManager.removeItem(at: url)
                 discarded.append(url)

--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -402,13 +402,14 @@ enum MeetingTranscriptStyler {
         let stem = preferredURL.lastPathComponent
         var suffix = 2
 
-        while true {
+        while suffix <= 999 {
             let candidate = directory.appendingPathComponent("\(stem) \(suffix)", isDirectory: true)
             if !fm.fileExists(atPath: candidate.path) {
                 return candidate
             }
             suffix += 1
         }
+        return directory.appendingPathComponent("\(stem) \(UUID().uuidString)", isDirectory: true)
     }
 
     private static func fallbackTitle(for url: URL) -> String {
@@ -442,7 +443,7 @@ enum MeetingTranscriptStyler {
         var candidateStem = preferredStem
         var suffix = 2
 
-        while true {
+        while suffix <= 999 {
             let candidateURL = directory.appendingPathComponent(candidateStem).appendingPathExtension("md")
             let markdownTaken = candidateURL != originalURL && fm.fileExists(atPath: candidateURL.path)
 
@@ -453,6 +454,7 @@ enum MeetingTranscriptStyler {
             candidateStem = "\(preferredStem) \(suffix)"
             suffix += 1
         }
+        return directory.appendingPathComponent("\(preferredStem) \(UUID().uuidString)").appendingPathExtension("md")
     }
 }
 


### PR DESCRIPTION
## Summary

- **Remove redundant `fileExists` pre-checks** in `MeetingRecordingCleanup.discardFiles` and `DictationTranscriptWriter.hasExistingContent` — both already handle missing-file errors downstream, so the pre-check is a TOCTOU anti-pattern with no safety benefit.
- **Bound `while true` uniqueness loops** in `MeetingTranscriptStyler` (`uniqueAudioDirectoryURL` and `uniqueTranscriptURL`) to a max of 999 iterations with a UUID-based fallback, eliminating the theoretical infinite-loop risk on pathological filesystems.

## What was reviewed but skipped

- `shouldSurfaceMeetingWarmupFailure` flag refactor — functionally correct, too invasive for a sweep
- `MeetingTranscriptStyler.renameAudioDirectoryIfNeeded` fileExists — intentional conditional logic (skip if no audio directory), not a TOCTOU
- `fileEndsWithBlankLine` double FileHandle open — minor overhead on tiny files, not worth the churn
- `provider(forBundleIdentifier:)` relocation to enum — new feature, not a simplify regression
- DictationTranscriptStore early-exit sort — analyzed and confirmed correct (day files are date-named, so newer day ↔ newer entries)

## Test plan

- [x] `bash build.sh` — clean build, signed
- [x] `bash run-tests.sh` — 656/656 passed
- [x] `bash run-integration-smoke.sh` — passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)