### PR TITLE
[codex] Redesign Transcripted onboarding

### DIFF
--- a/Sources/Dictation/DictationTranscriptStore.swift
+++ b/Sources/Dictation/DictationTranscriptStore.swift
@@ -6,6 +6,7 @@ import Foundation
 
 extension Notification.Name {
     static let dictationTranscriptDidSave = Notification.Name("Transcripted.DictationTranscriptDidSave")
+    static let dictationNoSpeechDetected = Notification.Name("Transcripted.DictationNoSpeechDetected")
 }
 
 struct SavedDictationEntry: Identifiable {

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1083,10 +1083,13 @@ final class MeetingSessionController: ObservableObject {
             )
             AnalyticsReporter.track(
                 "meeting_transcript_saved",
-                properties: [
+                properties: savedTranscriptAnalyticsProperties().merging(
+                    [
                     "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
                     "trigger": transcriptionTrigger.rawValue,
-                ]
+                    ],
+                    uniquingKeysWith: { _, new in new }
+                )
             )
             AppSoundPlayer.shared.play(.meetingTranscriptComplete)
         case .failed(let message):
@@ -1183,6 +1186,66 @@ final class MeetingSessionController: ObservableObject {
 
     private func analyticsFailureKind(from message: String) -> String {
         MeetingFailureKind.classify(message: message).rawValue
+    }
+
+    private func savedTranscriptAnalyticsProperties() -> [String: String] {
+        guard let url = taskManager.lastSavedTranscriptURL ?? lastSavedTranscriptURL,
+              let raw = try? String(contentsOf: url, encoding: .utf8),
+              let values = transcriptFrontmatterValues(from: raw) else {
+            return [:]
+        }
+
+        var properties: [String: String] = [:]
+
+        if let duration = values["duration"],
+           let durationSeconds = transcriptDurationSeconds(from: duration) {
+            properties["duration_bucket"] = AnalyticsReporter.durationBucket(seconds: Double(durationSeconds))
+        }
+
+        if let wordCount = Int(values["total_word_count"] ?? "") {
+            properties["word_count_bucket"] = AnalyticsReporter.wordCountBucket(wordCount)
+        }
+
+        let participantCount = (Int(values["mic_speakers"] ?? "") ?? 0)
+            + (Int(values["system_speakers"] ?? "") ?? 0)
+        if participantCount > 0 {
+            properties["participant_count_bucket"] = AnalyticsReporter.countBucket(participantCount)
+        }
+
+        return properties
+    }
+
+    private func transcriptFrontmatterValues(from raw: String) -> [String: String]? {
+        guard raw.hasPrefix("---\n"),
+              let endRange = raw.range(
+                of: "\n---\n",
+                range: raw.index(raw.startIndex, offsetBy: 4)..<raw.endIndex
+              ) else {
+            return nil
+        }
+
+        let frontmatter = String(raw[raw.index(raw.startIndex, offsetBy: 4)..<endRange.lowerBound])
+        var values: [String: String] = [:]
+        for line in frontmatter.components(separatedBy: "\n") {
+            let parts = line.split(separator: ":", maxSplits: 1).map(String.init)
+            guard parts.count == 2 else { continue }
+            values[parts[0].trimmingCharacters(in: .whitespaces)] = parts[1]
+                .trimmingCharacters(in: .whitespaces)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+        }
+        return values
+    }
+
+    private func transcriptDurationSeconds(from value: String) -> Int? {
+        let parts = value.split(separator: ":").compactMap { Int($0) }
+        switch parts.count {
+        case 2:
+            return parts[0] * 60 + parts[1]
+        case 3:
+            return parts[0] * 3600 + parts[1] * 60 + parts[2]
+        default:
+            return nil
+        }
     }
 
     private func baseDiagnosticsContext(extra: [String: String] = [:]) -> [String: String] {

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -31,6 +31,7 @@ final class MeetingSessionController: ObservableObject {
     enum StartTrigger: String {
         case hotkey = "hotkey"
         case menu = "menu"
+        case onboarding = "onboarding"
         case detectedPrompt = "detected_prompt"
         case fileImport = "file_import"
         case unknown = "unknown"
@@ -44,6 +45,7 @@ final class MeetingSessionController: ObservableObject {
 
     enum RecordingCancelReason: String {
         case discardButton = "discard_button"
+        case onboardingDryRun = "onboarding_dry_run"
         case unknown = "unknown"
     }
 

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -13,12 +13,122 @@ struct AnalyticsEventPolicy: Equatable {
             name: "app_launched",
             allowedProperties: []
         ),
+        "onboarding_shown": .init(
+            name: "onboarding_shown",
+            allowedProperties: [
+                "analytics_available",
+                "crash_reporting_available",
+                "entrypoint",
+                "has_target",
+                "meeting_recording_ready",
+                "mic_status",
+                "model_state",
+                "pasteback_status",
+            ]
+        ),
+        "onboarding_step_viewed": .init(
+            name: "onboarding_step_viewed",
+            allowedProperties: [
+                "model_state",
+                "step_id",
+                "step_index",
+            ]
+        ),
+        "onboarding_permission_cta_clicked": .init(
+            name: "onboarding_permission_cta_clicked",
+            allowedProperties: [
+                "permission_kind",
+                "prior_status",
+                "required",
+                "step_id",
+            ]
+        ),
+        "onboarding_permission_status_changed": .init(
+            name: "onboarding_permission_status_changed",
+            allowedProperties: [
+                "from_status",
+                "permission_kind",
+                "step_id",
+                "to_status",
+            ]
+        ),
+        "onboarding_model_state_changed": .init(
+            name: "onboarding_model_state_changed",
+            allowedProperties: [
+                "from_status",
+                "step_id",
+                "to_status",
+            ]
+        ),
+        "onboarding_primary_cta_clicked": .init(
+            name: "onboarding_primary_cta_clicked",
+            allowedProperties: [
+                "cta",
+                "model_state",
+                "step_id",
+            ]
+        ),
+        "onboarding_first_dictation_started": .init(
+            name: "onboarding_first_dictation_started",
+            allowedProperties: [
+                "model_state",
+                "step_id",
+            ]
+        ),
+        "onboarding_first_dictation_saved": .init(
+            name: "onboarding_first_dictation_saved",
+            allowedProperties: [
+                "delivery",
+                "step_id",
+                "word_count_bucket",
+            ]
+        ),
+        "onboarding_first_dictation_stop_clicked": .init(
+            name: "onboarding_first_dictation_stop_clicked",
+            allowedProperties: [
+                "step_id",
+            ]
+        ),
+        "onboarding_first_dictation_empty": .init(
+            name: "onboarding_first_dictation_empty",
+            allowedProperties: [
+                "step_id",
+            ]
+        ),
+        "onboarding_meeting_dry_run_clicked": .init(
+            name: "onboarding_meeting_dry_run_clicked",
+            allowedProperties: [
+                "meeting_recording_ready",
+                "step_id",
+            ]
+        ),
+        "onboarding_agent_cta_clicked": .init(
+            name: "onboarding_agent_cta_clicked",
+            allowedProperties: [
+                "agent_cta",
+                "step_id",
+            ]
+        ),
+        "onboarding_reporting_toggle_changed": .init(
+            name: "onboarding_reporting_toggle_changed",
+            allowedProperties: [
+                "available",
+                "enabled",
+                "reporting_kind",
+                "step_id",
+            ]
+        ),
         "onboarding_completed": .init(
             name: "onboarding_completed",
             allowedProperties: [
                 "anonymous_usage_enabled",
+                "calendar_status",
+                "completion_path",
                 "crash_reporting_enabled",
-                "system_audio_recording_enabled",
+                "first_dictation_saved",
+                "meeting_recording_ready",
+                "model_state",
+                "step_id",
             ]
         ),
         "dictation_started": .init(
@@ -30,6 +140,7 @@ struct AnalyticsEventPolicy: Equatable {
         "dictation_completed": .init(
             name: "dictation_completed",
             allowedProperties: [
+                "auto_send",
                 "delivery",
                 "duration_bucket",
                 "trigger",

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -29,6 +29,7 @@ struct AnalyticsEventPolicy: Equatable {
         "onboarding_step_viewed": .init(
             name: "onboarding_step_viewed",
             allowedProperties: [
+                "flow_elapsed_bucket",
                 "model_state",
                 "step_id",
                 "step_index",
@@ -64,7 +65,10 @@ struct AnalyticsEventPolicy: Equatable {
             name: "onboarding_primary_cta_clicked",
             allowedProperties: [
                 "cta",
+                "cta_type",
+                "flow_elapsed_bucket",
                 "model_state",
+                "step_elapsed_bucket",
                 "step_id",
             ]
         ),
@@ -126,9 +130,87 @@ struct AnalyticsEventPolicy: Equatable {
                 "completion_path",
                 "crash_reporting_enabled",
                 "first_dictation_saved",
+                "flow_elapsed_bucket",
+                "meeting_dry_run_completed",
                 "meeting_recording_ready",
                 "model_state",
                 "step_id",
+            ]
+        ),
+        "onboarding_dismissed": .init(
+            name: "onboarding_dismissed",
+            allowedProperties: [
+                "first_dictation_saved",
+                "flow_elapsed_bucket",
+                "meeting_dry_run_completed",
+                "model_state",
+                "step_id",
+                "step_index",
+            ]
+        ),
+        "menu_bar_opened": .init(
+            name: "menu_bar_opened",
+            allowedProperties: [
+                "dictation_ready",
+                "entrypoint",
+                "meeting_recording_ready",
+                "model_state",
+                "paste_available",
+                "recent_meetings_available",
+                "update_state",
+            ]
+        ),
+        "menu_bar_action_clicked": .init(
+            name: "menu_bar_action_clicked",
+            allowedProperties: [
+                "action_id",
+                "dictation_ready",
+                "meeting_recording_ready",
+                "paste_available",
+            ]
+        ),
+        "settings_opened": .init(
+            name: "settings_opened",
+            allowedProperties: [
+                "page_id",
+                "source",
+            ]
+        ),
+        "settings_page_viewed": .init(
+            name: "settings_page_viewed",
+            allowedProperties: [
+                "page_id",
+                "source",
+            ]
+        ),
+        "settings_action_clicked": .init(
+            name: "settings_action_clicked",
+            allowedProperties: [
+                "action_id",
+                "page_id",
+            ]
+        ),
+        "settings_toggle_changed": .init(
+            name: "settings_toggle_changed",
+            allowedProperties: [
+                "enabled",
+                "page_id",
+                "setting_id",
+            ]
+        ),
+        "settings_permission_cta_clicked": .init(
+            name: "settings_permission_cta_clicked",
+            allowedProperties: [
+                "page_id",
+                "permission_kind",
+                "prior_status",
+            ]
+        ),
+        "settings_capture_library_changed": .init(
+            name: "settings_capture_library_changed",
+            allowedProperties: [
+                "location_type",
+                "page_id",
             ]
         ),
         "dictation_started": .init(
@@ -214,8 +296,11 @@ struct AnalyticsEventPolicy: Equatable {
         "meeting_transcript_saved": .init(
             name: "meeting_transcript_saved",
             allowedProperties: [
+                "duration_bucket",
+                "participant_count_bucket",
                 "queue_depth_bucket",
                 "trigger",
+                "word_count_bucket",
             ]
         ),
         "meeting_transcript_failed": .init(

--- a/Sources/Observability/AnalyticsReporter.swift
+++ b/Sources/Observability/AnalyticsReporter.swift
@@ -122,6 +122,21 @@ final class AnalyticsReporter {
         }
     }
 
+    static func countBucket(_ count: Int) -> String {
+        switch count {
+        case ..<1:
+            return "0"
+        case 1:
+            return "1"
+        case 2...3:
+            return "2_3"
+        case 4...9:
+            return "4_9"
+        default:
+            return "10_plus"
+        }
+    }
+
     static func queueDepthBucket(_ depth: Int) -> String {
         switch depth {
         case ..<1:

--- a/Sources/Observability/SentryEventPolicy.swift
+++ b/Sources/Observability/SentryEventPolicy.swift
@@ -65,6 +65,16 @@ struct SentryEventPolicy: Equatable {
             event: "microphone_start_timeout",
             summary: "Dictation microphone start timed out."
         ),
+        "onboarding.first_dictation_start_failed": .init(
+            engine: "onboarding",
+            event: "first_dictation_start_failed",
+            summary: "Onboarding could not start first dictation."
+        ),
+        "onboarding.first_dictation_stop_failed": .init(
+            engine: "onboarding",
+            event: "first_dictation_stop_failed",
+            summary: "Onboarding could not stop first dictation."
+        ),
         "capture.hotkey_register_failed": .init(
             engine: "capture",
             event: "hotkey_register_failed",

--- a/Sources/Support/MenuBarVisibilityPreferences.swift
+++ b/Sources/Support/MenuBarVisibilityPreferences.swift
@@ -8,6 +8,19 @@ enum MenuBarOptionalItem: String, CaseIterable, Hashable, Identifiable {
 
     var id: String { rawValue }
 
+    var analyticsValue: String {
+        switch self {
+        case .startDictation:
+            return "start_dictation"
+        case .startMeeting:
+            return "start_meeting"
+        case .pasteLastDictation:
+            return "paste_last_dictation"
+        case .recentMeetings:
+            return "recent_meetings"
+        }
+    }
+
     var title: String {
         switch self {
         case .startDictation:

--- a/Sources/Support/TranscriptedPermissionKind.swift
+++ b/Sources/Support/TranscriptedPermissionKind.swift
@@ -45,6 +45,19 @@ enum TranscriptedPermissionKind: String, CaseIterable, Identifiable {
         }
     }
 
+    var analyticsValue: String {
+        switch self {
+        case .microphone:
+            return "microphone"
+        case .accessibility:
+            return "pasteback"
+        case .systemAudioRecording:
+            return "system_recording"
+        case .calendar:
+            return "calendar"
+        }
+    }
+
     var summary: String {
         switch self {
         case .microphone:

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -231,7 +231,21 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             sttRouter: appState.sttRouter,
             canStartDictation: hasPasteTarget,
             onStartDictation: { [weak self] in
-                self?.finishOnboardingAndStartDictation()
+                self?.startOnboardingDictationTest()
+            },
+            onStopDictation: { [weak self] in
+                self?.stopOnboardingDictationTest()
+            },
+            onStartMeetingDryRun: { [weak self] in
+                guard let self else { return false }
+                return await self.startOnboardingMeetingDryRun()
+            },
+            onStopMeetingDryRun: { [weak self] in
+                guard let self else { return false }
+                return await self.stopOnboardingMeetingDryRun()
+            },
+            onOpenAgentSettings: { [weak self] in
+                self?.showSettingsWindow(page: .connectAgent)
             },
             onComplete: { [weak self] in
                 self?.finishOnboarding()
@@ -268,6 +282,26 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         closePopover()
         sourceApp?.activate(options: [])
         sessionController.startDictation(sourceApp: sourceApp, trigger: .onboarding)
+    }
+
+    private func startOnboardingDictationTest() {
+        let sourceApp = resolvedSourceApp()
+        sourceApp?.activate(options: [])
+        sessionController.startDictation(sourceApp: sourceApp, trigger: .onboarding)
+    }
+
+    private func stopOnboardingDictationTest() {
+        sessionController.stopDictationAndPaste(trigger: .onboarding)
+    }
+
+    private func startOnboardingMeetingDryRun() async -> Bool {
+        await appState.meetingSession.startRecording(trigger: .onboarding)
+    }
+
+    private func stopOnboardingMeetingDryRun() async -> Bool {
+        guard case .recording = appState.meetingSession.state else { return false }
+        await appState.meetingSession.cancelRecording(reason: .onboardingDryRun)
+        return true
     }
 
     private func showMainPopover(relativeTo button: NSStatusBarButton, popover: NSPopover) {

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -30,7 +30,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         startMeeting: { [weak self] in self?.startMeetingFromSettings() },
         importAudioFile: { [weak self] in self?.importAudioFileFromSettings() },
         pasteLastDictation: { [weak self] in self?.pasteLastDictationFromSettings() },
-        openConnectAgent: { [weak self] in self?.showSettingsWindow(page: .connectAgent) },
+        openConnectAgent: { [weak self] in self?.showSettingsWindow(page: .connectAgent, source: "settings_action") },
         checkForUpdates: { [weak self] in self?.appState.sparkleUpdater.checkForUpdates() },
         sendFeedback: { [weak self] in
             guard let self else { return }
@@ -47,7 +47,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     private lazy var menuPanelController = MenuBarPanelController(
         appState: appState,
         preferredSourceAppProvider: { [weak self] in self?.lastExternalApplication },
-        openSettingsWindow: { [weak self] page in self?.showSettingsWindow(page: page) },
+        openSettingsWindow: { [weak self] page in self?.showSettingsWindow(page: page, source: "menu_bar") },
         dismissPopover: { [weak self] in self?.closePopover() }
     )
 
@@ -200,7 +200,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
 
     @objc private func openSettingsFromAppMenu(_ sender: Any?) {
         closePopover()
-        showSettingsWindow()
+        showSettingsWindow(source: "app_menu")
     }
 
     private func installSettingsMenuHandler() {
@@ -221,8 +221,11 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         }
     }
 
-    private func showSettingsWindow(page: TranscriptedSettingsPage = .home) {
-        settingsWindowController.present(page: page)
+    private func showSettingsWindow(
+        page: TranscriptedSettingsPage = .home,
+        source: String = "unknown"
+    ) {
+        settingsWindowController.present(page: page, source: source)
     }
 
     private func makeOnboardingView() -> PermissionsOnboardingView {
@@ -245,7 +248,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                 return await self.stopOnboardingMeetingDryRun()
             },
             onOpenAgentSettings: { [weak self] in
-                self?.showSettingsWindow(page: .connectAgent)
+                self?.showSettingsWindow(page: .connectAgent, source: "onboarding")
             },
             onComplete: { [weak self] in
                 self?.finishOnboarding()
@@ -271,7 +274,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         guard let button = statusItem?.button, let popover = popover else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
             guard let self else { return }
-            self.showMainPopover(relativeTo: button, popover: popover)
+            self.showMainPopover(relativeTo: button, popover: popover, entrypoint: "onboarding_completed")
         }
     }
 
@@ -285,9 +288,8 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     }
 
     private func startOnboardingDictationTest() {
-        let sourceApp = resolvedSourceApp()
-        sourceApp?.activate(options: [])
-        sessionController.startDictation(sourceApp: sourceApp, trigger: .onboarding)
+        NSApp.activate(ignoringOtherApps: true)
+        sessionController.startDictation(sourceApp: nil, trigger: .onboarding)
     }
 
     private func stopOnboardingDictationTest() {
@@ -304,13 +306,61 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         return true
     }
 
-    private func showMainPopover(relativeTo button: NSStatusBarButton, popover: NSPopover) {
+    private func showMainPopover(
+        relativeTo button: NSStatusBarButton,
+        popover: NSPopover,
+        entrypoint: String = "status_item"
+    ) {
         _ = resolvedSourceApp()
         menuPanelController.refresh()
+        trackMenuBarOpened(entrypoint: entrypoint)
         popover.contentViewController = menuPanelController
         popover.contentSize = menuPanelController.preferredContentSize
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func trackMenuBarOpened(entrypoint: String) {
+        let modelState: String
+        switch appState.sttRouter.modelDownloadState {
+        case .notLoaded:
+            modelState = "not_loaded"
+        case .downloading:
+            modelState = "downloading"
+        case .loading:
+            modelState = "loading"
+        case .ready:
+            modelState = "ready"
+        case .failed:
+            modelState = "failed"
+        }
+
+        let updateState: String
+        switch appState.sparkleUpdater.updateStatus.state {
+        case .unknown:
+            updateState = "unknown"
+        case .readyToCheck:
+            updateState = "ready"
+        case .checking:
+            updateState = "checking"
+        case .noUpdateAvailable:
+            updateState = "up_to_date"
+        case .updateAvailable:
+            updateState = "available"
+        }
+
+        AnalyticsReporter.track(
+            "menu_bar_opened",
+            properties: [
+                "dictation_ready": appState.sttRouter.isModelLoaded ? "true" : "false",
+                "entrypoint": entrypoint,
+                "meeting_recording_ready": TranscriptedPermissionAccess.isGranted(.systemAudioRecording) ? "true" : "false",
+                "model_state": modelState,
+                "paste_available": DictationTranscriptStore.latestSavedDictation() == nil ? "false" : "true",
+                "recent_meetings_available": RecentMeetingsScanner.loadRecent(limit: 1).isEmpty ? "false" : "true",
+                "update_state": updateState,
+            ]
+        )
     }
 
     private func resolvedSourceApp() -> NSRunningApplication? {

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -233,8 +233,8 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         return PermissionsOnboardingView(
             sttRouter: appState.sttRouter,
             canStartDictation: hasPasteTarget,
-            onStartDictation: { [weak self] in
-                self?.startOnboardingDictationTest()
+            onStartDictation: { [weak self] anchorRect in
+                self?.startOnboardingDictationTest(anchorRect: anchorRect)
             },
             onStopDictation: { [weak self] in
                 self?.stopOnboardingDictationTest()
@@ -287,9 +287,9 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         sessionController.startDictation(sourceApp: sourceApp, trigger: .onboarding)
     }
 
-    private func startOnboardingDictationTest() {
+    private func startOnboardingDictationTest(anchorRect: NSRect?) {
         NSApp.activate(ignoringOtherApps: true)
-        sessionController.startDictation(sourceApp: nil, trigger: .onboarding)
+        sessionController.startDictation(sourceApp: nil, trigger: .onboarding, anchorRect: anchorRect)
     }
 
     private func stopOnboardingDictationTest() {

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -154,6 +154,7 @@ final class MenuBarPanelController: NSViewController {
 
     private func startDictationFromMenu() {
         guard let session = appState.contextCapture.sessionController else { return }
+        trackMenuAction("start_dictation")
         let sourceApp = resolvedSourceApp()
         dismissPopover()
         sourceApp?.activate(options: [])
@@ -161,6 +162,7 @@ final class MenuBarPanelController: NSViewController {
     }
 
     private func startMeetingFromMenu() {
+        trackMenuAction("start_meeting")
         let sourceApp = resolvedSourceApp()
         dismissPopover()
         sourceApp?.activate(options: [])
@@ -170,6 +172,7 @@ final class MenuBarPanelController: NSViewController {
     }
 
     private func pasteLastDictationFromMenu() {
+        trackMenuAction("paste_last_dictation")
         guard let latestText = DictationTranscriptStore.latestSavedText() else {
             NSSound.beep()
             return
@@ -182,13 +185,27 @@ final class MenuBarPanelController: NSViewController {
     }
 
     private func openSettingsFromMenu(_ page: TranscriptedSettingsPage) {
+        trackMenuAction(page == .home ? "home" : "open_\(page.analyticsValue)")
         dismissPopover()
         openSettingsWindow(page)
     }
 
     private func checkForUpdatesFromMenu() {
+        trackMenuAction("check_updates")
         dismissPopover()
         appState.sparkleUpdater.checkForUpdates()
+    }
+
+    private func trackMenuAction(_ actionID: String) {
+        AnalyticsReporter.track(
+            "menu_bar_action_clicked",
+            properties: [
+                "action_id": actionID,
+                "dictation_ready": appState.sttRouter.isModelLoaded ? "true" : "false",
+                "meeting_recording_ready": TranscriptedPermissionAccess.isGranted(.systemAudioRecording) ? "true" : "false",
+                "paste_available": DictationTranscriptStore.latestSavedDictation() == nil ? "false" : "true",
+            ]
+        )
     }
 
     private func resolvedSourceApp() -> NSRunningApplication? {

--- a/Sources/UI/MenuBar/MenuBarUtilityActionsView.swift
+++ b/Sources/UI/MenuBar/MenuBarUtilityActionsView.swift
@@ -26,10 +26,16 @@ final class MenuBarUtilityActionsView: NSView {
 
     private func setupViews() {
         connectAgentRow.onPress = { [weak self] in self?.onOpenConnectAgent?() }
-        feedbackRow.onPress = { [weak self] in self?.sendFeedback() }
+        feedbackRow.onPress = { [weak self] in
+            self?.trackMenuAction("submit_feedback")
+            self?.sendFeedback()
+        }
         updatesRow.onPress = { [weak self] in self?.onCheckForUpdates?() }
         settingsRow.onPress = { [weak self] in self?.onOpenSettings?() }
-        quitRow.onPress = { NSApplication.shared.terminate(nil) }
+        quitRow.onPress = { [weak self] in
+            self?.trackMenuAction("quit")
+            NSApplication.shared.terminate(nil)
+        }
 
         [connectAgentRow, feedbackRow, updatesRow, settingsRow, quitRow].forEach(addSubview(_:))
     }
@@ -100,6 +106,18 @@ final class MenuBarUtilityActionsView: NSView {
 
     private func sendFeedback() {
         TranscriptedSupportActions.sendFeedback(logger: appState?.logger)
+    }
+
+    private func trackMenuAction(_ actionID: String) {
+        AnalyticsReporter.track(
+            "menu_bar_action_clicked",
+            properties: [
+                "action_id": actionID,
+                "dictation_ready": appState?.sttRouter.isModelLoaded == true ? "true" : "false",
+                "meeting_recording_ready": TranscriptedPermissionAccess.isGranted(.systemAudioRecording) ? "true" : "false",
+                "paste_available": DictationTranscriptStore.latestSavedDictation() == nil ? "false" : "true",
+            ]
+        )
     }
 
     func dismissTransientUI() {}

--- a/Sources/UI/MenuBar/MenuTokens.swift
+++ b/Sources/UI/MenuBar/MenuTokens.swift
@@ -64,8 +64,8 @@ enum MenuTokens {
     // Layout
     static let panelWidth: CGFloat = 304
     static let panelHeight: CGFloat = 320
-    static let onboardingWindowWidth: CGFloat = 620
-    static let onboardingWindowHeight: CGFloat = 760
+    static let onboardingWindowWidth: CGFloat = 720
+    static let onboardingWindowHeight: CGFloat = 740
     static let innerPadding: CGFloat = 10
     static let sectionSpacing: CGFloat = 7
     static let surfaceCornerRadius: CGFloat = 14

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -59,6 +59,7 @@ class DictationSessionController: ObservableObject {
     }
 
     private var sessionSourceApp: NSRunningApplication?
+    private var sessionAnchorRect: NSRect?
     private var startupTask: Task<Void, Never>?
     private var streamingTask: Task<Void, Never>?
     private var recordingStartRetryTask: Task<Void, Never>?
@@ -110,11 +111,16 @@ class DictationSessionController: ObservableObject {
     // MARK: - Dictation Mode (Option+Space)
 
     /// Start dictation — show overlay and begin voice recording (no screenshot/vision)
-    func startDictation(sourceApp: NSRunningApplication?, trigger: DictationTrigger = .unknown) {
+    func startDictation(
+        sourceApp: NSRunningApplication?,
+        trigger: DictationTrigger = .unknown,
+        anchorRect: NSRect? = nil
+    ) {
         guard let (appState, overlayController) = readyState() else { return }
         guard !isDictating, !isInSession else { return }
         isDictating = true
         sessionSourceApp = sourceApp
+        sessionAnchorRect = anchorRect
         sessionStartTime = CFAbsoluteTimeGetCurrent()
         currentDictationTrigger = trigger
         lastCompletedText = nil
@@ -130,7 +136,8 @@ class DictationSessionController: ObservableObject {
         case .notDetermined:
             overlayController.showLoadingState(
                 near: sourceApp,
-                presentation: microphonePermissionPresentation()
+                presentation: microphonePermissionPresentation(),
+                anchorRect: anchorRect
             )
             startupTask?.cancel()
             startupTask = Task { @MainActor [weak self] in
@@ -196,7 +203,7 @@ class DictationSessionController: ObservableObject {
         guard isDictating else { return }
         if appState.sttRouter.isModelLoaded {
             overlayController.state = .listening
-            overlayController.showPanel(near: sourceApp)
+            overlayController.showPanel(near: sourceApp, anchorRect: sessionAnchorRect)
             beginDictationRecording(sourceApp: sourceApp)
             return
         }
@@ -267,7 +274,8 @@ class DictationSessionController: ObservableObject {
                     isRecovering: isRecovering,
                     inputFormatReady: inputFormatReady,
                     startAttempts: startAttempts
-                )
+                ),
+                anchorRect: sessionAnchorRect
             )
 
             if !isRecovering, inputFormatReady {
@@ -370,7 +378,7 @@ class DictationSessionController: ObservableObject {
             )
         )
         if !overlayController.isVisible {
-            overlayController.showPanel(near: sourceApp)
+            overlayController.showPanel(near: sourceApp, anchorRect: sessionAnchorRect)
         }
         overlayController.showError(
             microphoneUnavailableMessage(for: status, openedSettings: false),
@@ -389,12 +397,20 @@ class DictationSessionController: ObservableObject {
                             )
                             return
                         }
-                        self.startDictation(sourceApp: sourceApp, trigger: self.currentDictationTrigger)
+                        self.startDictation(
+                            sourceApp: sourceApp,
+                            trigger: self.currentDictationTrigger,
+                            anchorRect: self.sessionAnchorRect
+                        )
                     }
                 case .denied, .restricted:
                     TranscriptedPermissionAccess.openSettings(for: .microphone)
                 case .authorized:
-                    self.startDictation(sourceApp: sourceApp, trigger: self.currentDictationTrigger)
+                    self.startDictation(
+                        sourceApp: sourceApp,
+                        trigger: self.currentDictationTrigger,
+                        anchorRect: self.sessionAnchorRect
+                    )
                 @unknown default:
                     TranscriptedPermissionAccess.openSettings(for: .microphone)
                 }
@@ -644,7 +660,11 @@ class DictationSessionController: ObservableObject {
                         "Dictation couldn't start: \(message)",
                         actionTitle: "Retry Dictation",
                         action: { [weak self] in
-                            self?.startDictation(sourceApp: sourceApp, trigger: self?.currentDictationTrigger ?? .unknown)
+                            self?.startDictation(
+                                sourceApp: sourceApp,
+                                trigger: self?.currentDictationTrigger ?? .unknown,
+                                anchorRect: self?.sessionAnchorRect
+                            )
                         }
                     )
                     return
@@ -662,7 +682,11 @@ class DictationSessionController: ObservableObject {
                 "Dictation is still loading. Please try again in a moment.",
                 actionTitle: "Retry Dictation",
                 action: { [weak self] in
-                    self?.startDictation(sourceApp: sourceApp, trigger: self?.currentDictationTrigger ?? .unknown)
+                    self?.startDictation(
+                        sourceApp: sourceApp,
+                        trigger: self?.currentDictationTrigger ?? .unknown,
+                        anchorRect: self?.sessionAnchorRect
+                    )
                 }
             )
         }
@@ -674,7 +698,11 @@ class DictationSessionController: ObservableObject {
     ) {
         guard let appState = appState else { return }
         let presentation = loadingPresentation(for: modelState ?? appState.sttRouter.modelDownloadState)
-        overlayController?.showLoadingState(near: sourceApp, presentation: presentation)
+        overlayController?.showLoadingState(
+            near: sourceApp,
+            presentation: presentation,
+            anchorRect: sessionAnchorRect
+        )
     }
 
     private func loadingPresentation(for modelState: ParakeetModelState) -> FloatingOverlayController.LoadingPresentation {
@@ -839,7 +867,11 @@ class DictationSessionController: ObservableObject {
             "Recording was interrupted. Check your microphone or audio device, then try again.",
             actionTitle: "Retry Dictation",
             action: { [weak self] in
-                self?.startDictation(sourceApp: self?.sessionSourceApp, trigger: self?.currentDictationTrigger ?? .unknown)
+                self?.startDictation(
+                    sourceApp: self?.sessionSourceApp,
+                    trigger: self?.currentDictationTrigger ?? .unknown,
+                    anchorRect: self?.sessionAnchorRect
+                )
             }
         )
     }

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -502,6 +502,7 @@ class DictationSessionController: ObservableObject {
                         "trigger": currentDictationTrigger.rawValue,
                     ]
                 )
+                NotificationCenter.default.post(name: .dictationNoSpeechDetected, object: nil)
                 AppSoundPlayer.shared.play(.noSpeech)
                 overlayController.showNoSpeechAndDismiss()
                 isDictating = false
@@ -592,6 +593,9 @@ class DictationSessionController: ObservableObject {
                 ]
             )
         )
+        if currentDictationTrigger == .onboarding {
+            NotificationCenter.default.post(name: .dictationNoSpeechDetected, object: nil)
+        }
         AnalyticsReporter.track(
             "dictation_cancelled",
             properties: [

--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -191,7 +191,7 @@ class FloatingOverlayController {
 
     // MARK: - Panel Show/Hide
 
-    func showPanel(near sourceApp: NSRunningApplication?) {
+    func showPanel(near sourceApp: NSRunningApplication?, anchorRect: NSRect? = nil) {
         guard let panel = panel else { return }
 
         // Invalidate any pending async _performHide() from a previous session's animation
@@ -205,11 +205,19 @@ class FloatingOverlayController {
         errorMessage = ""
 
         let rawTargetRect = sourceApp.flatMap { AccessibilityBridge.focusedTextFieldRect(for: $0) }
+        let anchorTargetRect: NSRect?
+        if let anchorRect, anchorRect.width > 0, anchorRect.height > 0 {
+            anchorTargetRect = anchorRect
+        } else {
+            anchorTargetRect = nil
+        }
         let panelSize = preferredPanelSize(for: state)
 
         // Validate the accessibility rect — terminal emulators report oversized text areas
         let mousePos = NSEvent.mouseLocation
-        let currentScreen = NSScreen.screens.first { NSMouseInRect(mousePos, $0.frame, false) }
+        let referencePoint = anchorTargetRect.map { NSPoint(x: $0.midX, y: $0.midY) } ?? mousePos
+        let currentScreen = NSScreen.screens.first { NSMouseInRect(referencePoint, $0.frame, false) }
+            ?? NSScreen.screens.first { NSMouseInRect(mousePos, $0.frame, false) }
             ?? NSScreen.main
         let screenSize = currentScreen?.frame.size ?? NSSize(width: 1920, height: 1080)
         let targetRect: CGRect?
@@ -222,7 +230,12 @@ class FloatingOverlayController {
         }
 
         var origin: NSPoint
-        if let rect = targetRect, let screen = NSScreen.main {
+        if let rect = anchorTargetRect {
+            origin = NSPoint(
+                x: rect.midX - panelSize.width / 2,
+                y: rect.midY - panelSize.height / 2
+            )
+        } else if let rect = targetRect, let screen = NSScreen.main {
             let screenHeight = screen.frame.height
             let flippedY = screenHeight - rect.origin.y
             origin = NSPoint(
@@ -241,11 +254,18 @@ class FloatingOverlayController {
             origin.x = max(visibleFrame.minX + 10,
                            min(origin.x, visibleFrame.maxX - panelSize.width - 10))
             if origin.y + panelSize.height > visibleFrame.maxY {
-                origin.y = (targetRect != nil)
-                    ? origin.y - panelSize.height - 24
-                    : mousePos.y - panelSize.height - 10
+                if anchorTargetRect != nil {
+                    origin.y = visibleFrame.maxY - panelSize.height - 10
+                } else {
+                    origin.y = targetRect != nil
+                        ? origin.y - panelSize.height - 24
+                        : mousePos.y - panelSize.height - 10
+                }
             }
-            origin.y = max(visibleFrame.minY + 10, origin.y)
+            origin.y = max(
+                visibleFrame.minY + 10,
+                min(origin.y, visibleFrame.maxY - panelSize.height - 10)
+            )
         }
 
         panel.setFrameOrigin(origin)
@@ -365,7 +385,11 @@ class FloatingOverlayController {
     private var loadingTimerTask: Task<Void, Never>?
     private var successDismissTask: Task<Void, Never>?
 
-    func showLoadingState(near sourceApp: NSRunningApplication? = nil, presentation: LoadingPresentation? = nil) {
+    func showLoadingState(
+        near sourceApp: NSRunningApplication? = nil,
+        presentation: LoadingPresentation? = nil,
+        anchorRect: NSRect? = nil
+    ) {
         errorDismissTask?.cancel()
         errorMessage = ""
         errorActionTitle = nil
@@ -379,7 +403,7 @@ class FloatingOverlayController {
         }
         state = .loading
         if !isVisible {
-            showPanel(near: sourceApp)
+            showPanel(near: sourceApp, anchorRect: anchorRect)
         }
         let loadingSize = NSSize(width: OverlayTokens.panelWidth, height: OverlayTokens.panelLoadingHeight)
         if enteringLoading {

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -1,5 +1,5 @@
 // PermissionsOnboardingView.swift
-// First-run checklist for the permissions needed to start using Transcripted.
+// First-run onboarding for getting users to their first useful Transcripted capture.
 
 import SwiftUI
 import AVFoundation
@@ -30,158 +30,246 @@ struct PermissionsOnboardingView: View {
     @ObservedObject private var sttRouter: STTRouter
     let canStartDictation: Bool
     var onStartDictation: (() -> Void)?
+    var onStopDictation: (() -> Void)?
+    var onStartMeetingDryRun: (() async -> Bool)?
+    var onStopMeetingDryRun: (() async -> Bool)?
+    var onOpenAgentSettings: (() -> Void)?
     var onComplete: () -> Void
 
+    @State private var currentStep: FirstRunOnboardingStep = .hero
     @State private var micGranted = false
     @State private var accessibilityGranted = false
-    @State private var systemAudioRecordingGranted = false
+    @State private var systemRecordingGranted = false
+    @State private var calendarGranted = false
+    @State private var firstSavedDictation: SavedDictationEntry?
+    @State private var firstDictationIssue: String?
+    @State private var isFirstDictationRunning = false
     @State private var crashReportingEnabled = CrashReportingPreferences.isEnabled()
     @State private var anonymousAnalyticsEnabled = AnalyticsPreferences.isEnabled()
+    @State private var copiedFirstDictation = false
+    @State private var copiedAgentPrompt = false
+    @State private var isInstallingClaude = false
+    @State private var claudeInstallMessage: String?
+    @State private var isMeetingDryRunStarting = false
+    @State private var isMeetingDryRunRunning = false
+    @State private var meetingDryRunCompleted = false
+    @State private var meetingDryRunIssue: String?
     @State private var pollTimer: Timer?
+    @State private var previousPermissionStatuses: [TranscriptedPermissionKind: Bool] = [:]
+    @State private var trackedSteps: Set<FirstRunOnboardingStep> = []
+    @State private var trackedShown = false
+    @State private var lastTrackedModelState: String?
 
     init(
         sttRouter: STTRouter,
         canStartDictation: Bool = false,
         onStartDictation: (() -> Void)? = nil,
+        onStopDictation: (() -> Void)? = nil,
+        onStartMeetingDryRun: (() async -> Bool)? = nil,
+        onStopMeetingDryRun: (() async -> Bool)? = nil,
+        onOpenAgentSettings: (() -> Void)? = nil,
         onComplete: @escaping () -> Void
     ) {
         _sttRouter = ObservedObject(wrappedValue: sttRouter)
         self.canStartDictation = canStartDictation
         self.onStartDictation = onStartDictation
+        self.onStopDictation = onStopDictation
+        self.onStartMeetingDryRun = onStartMeetingDryRun
+        self.onStopMeetingDryRun = onStopMeetingDryRun
+        self.onOpenAgentSettings = onOpenAgentSettings
         self.onComplete = onComplete
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            OnboardingHeroCard()
-                .padding(.horizontal, 20)
-                .padding(.top, 20)
-                .padding(.bottom, 14)
+            OnboardingHeader(
+                steps: FirstRunExperience.onboardingSteps(),
+                currentStep: currentStep
+            )
+            .padding(.horizontal, 22)
+            .padding(.top, 22)
+            .padding(.bottom, 14)
 
             Divider()
                 .overlay(MenuTokens.cardBorder)
 
             ScrollView {
-                VStack(alignment: .leading, spacing: 12) {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text("Required now")
-                            .font(.headline.weight(.semibold))
-                            .foregroundStyle(MenuTokens.textPrimary)
-
-                        Text("Turn on these first so Transcripted can start dictation and paste text back into the app you were using. System Audio Recording and Calendar can wait until later.")
-                            .font(.footnote)
-                            .foregroundStyle(MenuTokens.textSecondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                    .padding(.bottom, 2)
-
-                    ForEach(requiredPermissions) { kind in
-                        PermissionSetupCard(
-                            kind: kind,
-                            granted: isGranted(kind),
-                            action: { TranscriptedPermissionAccess.openSettings(for: kind) }
-                        )
-                    }
-
-                    LocalDictationModelCard(status: modelStatus)
-
-                    OptionalPermissionsCard(
-                        optionalPermissions: optionalPermissions,
-                        isGranted: isGranted,
-                        footnote: MeetingRecordingStartGate.optionalPermissionsFootnote
-                    )
-
-                    ObservabilityConsentCard(
-                        crashReportingEnabled: $crashReportingEnabled,
-                        anonymousAnalyticsEnabled: $anonymousAnalyticsEnabled,
-                        crashReportingAvailable: CrashReporter.isAvailable,
-                        analyticsAvailable: AnalyticsReporter.isAvailable,
-                        onCrashToggle: updateCrashReportingPreference,
-                        onAnalyticsToggle: updateAnalyticsPreference
-                    )
-
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text("What happens next")
-                            .font(.headline.weight(.semibold))
-                            .foregroundStyle(MenuTokens.textPrimary)
-
-                        QuickStartRow(
-                            icon: "mic.fill",
-                            title: "Dictation",
-                            detail: canStartDictation
-                                ? "Use Start first dictation below and Transcripted will guide you into the first capture."
-                                : "Click back into any text field, then use Dictation from the Transcripted menu."
-                        )
-
-                        QuickStartRow(
-                            icon: "record.circle.fill",
-                            title: "Meetings",
-                            detail: systemAudioRecordingGranted
-                                ? "Meeting audio is ready too. Calendar prompts stay optional."
-                                : MeetingRecordingStartGate.systemAudioRecordingQuickStart
-                        )
-                    }
-                    .padding(14)
-                    .background(
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
-                            .fill(MenuTokens.cardBackground)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                                    .stroke(MenuTokens.cardBorder, lineWidth: 1)
-                            )
-                    )
-                }
-                .padding(.horizontal, 20)
-                .padding(.vertical, 14)
+                currentScreen
+                    .padding(.horizontal, 22)
+                    .padding(.vertical, 18)
             }
 
             Divider()
                 .overlay(MenuTokens.cardBorder)
 
-            VStack(alignment: .leading, spacing: 10) {
-                Text(primaryAction.detail)
-                    .font(.footnote)
-                    .foregroundStyle(MenuTokens.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                Button {
-                    handlePrimaryAction()
-                } label: {
-                    Text(primaryAction.title)
-                        .font(.headline.weight(.semibold))
-                        .frame(minWidth: 220)
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                .disabled(!primaryAction.isEnabled)
-            }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 14)
+            OnboardingFooter(
+                action: currentAction,
+                canGoBack: FirstRunExperience.previousStep(before: currentStep) != nil,
+                onBack: goBack,
+                onSecondary: handleSecondaryAction,
+                onPrimary: handlePrimaryAction
+            )
+            .padding(.horizontal, 22)
+            .padding(.vertical, 16)
         }
-        .frame(width: MenuTokens.onboardingWindowWidth, height: MenuTokens.onboardingWindowHeight)
+        .frame(
+            minWidth: MenuTokens.onboardingWindowWidth,
+            idealWidth: 680,
+            maxWidth: .infinity,
+            minHeight: 700,
+            idealHeight: MenuTokens.onboardingWindowHeight,
+            maxHeight: .infinity
+        )
         .background(MenuTokens.cardBackground)
         .preferredColorScheme(.dark)
         .onAppear {
-            checkAllPermissions()
+            checkAllPermissions(trackChanges: false)
             crashReportingEnabled = CrashReportingPreferences.isEnabled()
             anonymousAnalyticsEnabled = AnalyticsPreferences.isEnabled()
             startPolling()
+            trackShownIfNeeded()
+            trackStepIfNeeded(currentStep)
+            trackModelStateIfChanged()
         }
         .onDisappear {
+            stopMeetingDryRunIfNeeded()
             stopPolling()
+        }
+        .onChange(of: currentStep) { _, step in
+            trackStepIfNeeded(step)
+        }
+        .onChange(of: modelStateAnalyticsValue) { _, _ in
+            trackModelStateIfChanged()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .dictationTranscriptDidSave)) { _ in
+            handleDictationSaved()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .dictationNoSpeechDetected)) { _ in
+            handleNoSpeech()
         }
     }
 
-    private var hasRequiredPermissions: Bool {
-        micGranted && accessibilityGranted
+    @ViewBuilder
+    private var currentScreen: some View {
+        switch currentStep {
+        case .hero:
+            HeroStepView()
+        case .value:
+            ValueStepView()
+        case .dictationSetup:
+            DictationSetupStepView(
+                micGranted: micGranted,
+                accessibilityGranted: accessibilityGranted,
+                modelStatus: modelStatus,
+                onPermissionAction: requestPermission
+            )
+        case .testDictation:
+            TestDictationStepView(
+                isRunning: isFirstDictationRunning,
+                issue: firstDictationIssue,
+                onStart: startFirstDictation,
+                onStop: stopFirstDictation
+            )
+        case .dictationResult:
+            FirstDictationResultStepView(
+                entry: firstSavedDictation,
+                copied: copiedFirstDictation,
+                onCopy: copyFirstDictation,
+                onOpenFolder: openFirstDictationFolder,
+                onRetry: startFirstDictation
+            )
+        case .meetingsIntro:
+            MeetingsIntroStepView()
+        case .meetingSetup:
+            MeetingSetupStepView(
+                micGranted: micGranted,
+                systemRecordingGranted: systemRecordingGranted,
+                calendarGranted: calendarGranted,
+                isDryRunStarting: isMeetingDryRunStarting,
+                isDryRunRunning: isMeetingDryRunRunning,
+                dryRunCompleted: meetingDryRunCompleted,
+                dryRunIssue: meetingDryRunIssue,
+                onPermissionAction: requestPermission,
+                onDryRun: startMeetingDryRun,
+                onStopDryRun: stopMeetingDryRun
+            )
+        case .agentPayoff:
+            AgentPayoffStepView(
+                copiedAgentPrompt: copiedAgentPrompt,
+                isInstallingClaude: isInstallingClaude,
+                installMessage: claudeInstallMessage,
+                crashReportingEnabled: $crashReportingEnabled,
+                anonymousAnalyticsEnabled: $anonymousAnalyticsEnabled,
+                crashReportingAvailable: CrashReporter.isAvailable,
+                analyticsAvailable: AnalyticsReporter.isAvailable,
+                onInstallClaude: installClaude,
+                onCopyAgentPrompt: copyAgentPrompt,
+                onOpenAgentSettings: openAgentSettings,
+                onCrashToggle: updateCrashReportingPreference,
+                onAnalyticsToggle: updateAnalyticsPreference
+            )
+        }
     }
 
-    private var requiredPermissions: [TranscriptedPermissionKind] {
-        FirstRunExperience.onboardingRequiredPermissions()
+    private var hasRequiredDictationSetup: Bool {
+        FirstRunExperience.hasRequiredDictationSetup(
+            microphoneGranted: micGranted,
+            accessibilityGranted: accessibilityGranted
+        )
     }
 
-    private var optionalPermissions: [TranscriptedPermissionKind] {
-        FirstRunExperience.onboardingOptionalPermissions()
+    private var currentAction: FirstRunOnboardingActionState {
+        if currentStep == .testDictation, isFirstDictationRunning {
+            return FirstRunOnboardingActionState(
+                primaryTitle: "Stop and Save",
+                secondaryTitle: nil,
+                detail: "Stop when you finish the sentence. Transcripted will transcribe and save the result.",
+                isPrimaryEnabled: true
+            )
+        }
+
+        if currentStep == .testDictation, firstDictationIssue != nil {
+            return FirstRunOnboardingActionState(
+                primaryTitle: "Try Again",
+                secondaryTitle: "Continue anyway",
+                detail: "Try again for the best setup check, or keep going and start dictation later from the menu.",
+                isPrimaryEnabled: true
+            )
+        }
+
+        if currentStep == .meetingSetup, isMeetingDryRunStarting {
+            return FirstRunOnboardingActionState(
+                primaryTitle: "Starting...",
+                secondaryTitle: nil,
+                detail: "Starting a short recording test.",
+                isPrimaryEnabled: false
+            )
+        }
+
+        if currentStep == .meetingSetup, isMeetingDryRunRunning {
+            return FirstRunOnboardingActionState(
+                primaryTitle: "Stop Dry Run",
+                secondaryTitle: nil,
+                detail: "Stop the dry run when you see recording is active. Test audio will be discarded.",
+                isPrimaryEnabled: true
+            )
+        }
+
+        if currentStep == .meetingSetup, meetingDryRunCompleted {
+            return FirstRunOnboardingActionState(
+                primaryTitle: "Continue",
+                secondaryTitle: "Skip for now",
+                detail: "Meeting recording is ready. The test audio was discarded.",
+                isPrimaryEnabled: true
+            )
+        }
+
+        return FirstRunExperience.onboardingAction(
+            for: currentStep,
+            microphoneGranted: micGranted,
+            accessibilityGranted: accessibilityGranted,
+            hasFirstDictation: firstSavedDictation != nil
+        )
     }
 
     private var modelStatus: FirstRunModelCardState {
@@ -191,31 +279,404 @@ struct PermissionsOnboardingView: View {
         )
     }
 
-    private var primaryAction: FirstRunPrimaryActionState {
-        FirstRunExperience.primaryAction(
-            hasRequiredPermissions: hasRequiredPermissions,
-            hasPasteTarget: canStartDictation && onStartDictation != nil,
-            modelState: FirstRunLocalModelState(sttRouter.modelDownloadState)
-        )
-    }
-
-    private func isGranted(_ kind: TranscriptedPermissionKind) -> Bool {
-        switch kind {
-        case .microphone:
-            return micGranted
-        case .accessibility:
-            return accessibilityGranted
-        case .systemAudioRecording:
-            return systemAudioRecordingGranted
-        case .calendar:
-            return TranscriptedPermissionAccess.isGranted(.calendar)
+    private var modelStateAnalyticsValue: String {
+        switch sttRouter.modelDownloadState {
+        case .notLoaded:
+            return "not_loaded"
+        case .downloading(let progress):
+            return "downloading_\(Int(progress * 100))"
+        case .loading:
+            return "loading"
+        case .ready:
+            return "ready"
+        case .failed:
+            return "failed"
         }
     }
 
-    private func checkAllPermissions() {
-        micGranted = TranscriptedPermissionAccess.isGranted(.microphone)
-        accessibilityGranted = TranscriptedPermissionAccess.isGranted(.accessibility)
-        systemAudioRecordingGranted = TranscriptedPermissionAccess.isGranted(.systemAudioRecording)
+    private func handlePrimaryAction() {
+        trackPrimaryCTA(currentAction.primaryTitle)
+
+        switch currentStep {
+        case .hero, .value:
+            moveToNextStep()
+        case .dictationSetup:
+            guard hasRequiredDictationSetup else { return }
+            moveToNextStep()
+        case .testDictation:
+            if isFirstDictationRunning {
+                stopFirstDictation()
+            } else {
+                startFirstDictation()
+            }
+        case .dictationResult:
+            if firstSavedDictation == nil {
+                startFirstDictation()
+            } else {
+                move(to: .meetingsIntro)
+            }
+        case .meetingsIntro:
+            move(to: .meetingSetup)
+        case .meetingSetup:
+            if isMeetingDryRunRunning {
+                stopMeetingDryRun()
+                return
+            }
+            guard !isMeetingDryRunStarting else { return }
+            move(to: .agentPayoff)
+        case .agentPayoff:
+            completeOnboarding()
+        }
+    }
+
+    private func handleSecondaryAction() {
+        guard let title = currentAction.secondaryTitle else { return }
+        trackPrimaryCTA(title)
+
+        switch currentStep {
+        case .testDictation:
+            move(to: .meetingsIntro)
+        case .meetingsIntro, .meetingSetup:
+            move(to: .agentPayoff)
+        default:
+            break
+        }
+    }
+
+    private func goBack() {
+        guard let previous = FirstRunExperience.previousStep(before: currentStep) else { return }
+        move(to: previous)
+    }
+
+    private func moveToNextStep() {
+        guard let next = FirstRunExperience.nextStep(after: currentStep) else { return }
+        move(to: next)
+    }
+
+    private func move(to step: FirstRunOnboardingStep) {
+        currentStep = step
+    }
+
+    private func requestPermission(_ kind: TranscriptedPermissionKind) {
+        AnalyticsReporter.track(
+            "onboarding_permission_cta_clicked",
+            properties: [
+                "permission_kind": kind.analyticsValue,
+                "prior_status": permissionStatusValue(kind),
+                "required": kind.isRequiredOnFirstLaunch ? "true" : "false",
+                "step_id": currentStep.analyticsValue,
+            ]
+        )
+        TranscriptedPermissionAccess.openSettings(for: kind)
+    }
+
+    private func startFirstDictation() {
+        guard hasRequiredDictationSetup else {
+            move(to: .dictationSetup)
+            return
+        }
+
+        firstDictationIssue = nil
+        isFirstDictationRunning = true
+        AnalyticsReporter.track(
+            "onboarding_first_dictation_started",
+            properties: [
+                "model_state": modelStateAnalyticsValue,
+                "step_id": currentStep.analyticsValue,
+            ]
+        )
+
+        guard let onStartDictation else {
+            isFirstDictationRunning = false
+            firstDictationIssue = "Dictation could not start from onboarding. Open Transcripted and try Start Dictation."
+            EventReporter.shared.capture(
+                level: .error,
+                engine: "onboarding",
+                event: "first_dictation_start_failed",
+                message: "Onboarding first dictation callback was not wired",
+                context: ["step_id": currentStep.analyticsValue]
+            )
+            return
+        }
+
+        onStartDictation()
+    }
+
+    private func stopFirstDictation() {
+        AnalyticsReporter.track(
+            "onboarding_first_dictation_stop_clicked",
+            properties: [
+                "step_id": currentStep.analyticsValue,
+            ]
+        )
+
+        guard let onStopDictation else {
+            firstDictationIssue = "Dictation is running, but onboarding could not stop it. Use the floating control to stop."
+            EventReporter.shared.capture(
+                level: .error,
+                engine: "onboarding",
+                event: "first_dictation_stop_failed",
+                message: "Onboarding first dictation stop callback was not wired",
+                context: ["step_id": currentStep.analyticsValue]
+            )
+            return
+        }
+
+        onStopDictation()
+    }
+
+    private func startMeetingDryRun() {
+        guard !isMeetingDryRunStarting, !isMeetingDryRunRunning else { return }
+        meetingDryRunIssue = nil
+        meetingDryRunCompleted = false
+        isMeetingDryRunStarting = true
+
+        AnalyticsReporter.track(
+            "onboarding_meeting_dry_run_clicked",
+            properties: [
+                "meeting_recording_ready": systemRecordingGranted ? "true" : "false",
+                "step_id": currentStep.analyticsValue,
+            ]
+        )
+
+        guard let onStartMeetingDryRun else {
+            isMeetingDryRunStarting = false
+            meetingDryRunIssue = "Meeting recording could not start from onboarding. You can still start meetings later from the menu."
+            return
+        }
+
+        Task { @MainActor in
+            let started = await onStartMeetingDryRun()
+            isMeetingDryRunStarting = false
+            isMeetingDryRunRunning = started
+            if !started {
+                meetingDryRunIssue = "Meeting recording could not start. Check Microphone and System Audio Recording, then try again."
+            }
+        }
+    }
+
+    private func stopMeetingDryRun() {
+        guard isMeetingDryRunStarting || isMeetingDryRunRunning else { return }
+        meetingDryRunIssue = nil
+
+        guard let onStopMeetingDryRun else {
+            isMeetingDryRunStarting = false
+            isMeetingDryRunRunning = false
+            meetingDryRunIssue = "Meeting recording is running, but onboarding could not stop it. Use the meeting overlay stop button."
+            return
+        }
+
+        Task { @MainActor in
+            let stopped = await onStopMeetingDryRun()
+            isMeetingDryRunStarting = false
+            isMeetingDryRunRunning = false
+            meetingDryRunCompleted = stopped
+            if !stopped {
+                meetingDryRunIssue = "Meeting recording had already stopped. You can continue or run the dry run again."
+            }
+        }
+    }
+
+    private func stopMeetingDryRunIfNeeded() {
+        guard isMeetingDryRunStarting || isMeetingDryRunRunning else { return }
+        guard let onStopMeetingDryRun else { return }
+        Task { @MainActor in
+            _ = await onStopMeetingDryRun()
+        }
+    }
+
+    private func copyFirstDictation() {
+        guard let text = firstSavedDictation?.text else { return }
+        copyText(text)
+        copiedFirstDictation = true
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            copiedFirstDictation = false
+        }
+    }
+
+    private func openFirstDictationFolder() {
+        guard let url = firstSavedDictation?.url else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    private func installClaude() {
+        guard !isInstallingClaude else { return }
+        isInstallingClaude = true
+        claudeInstallMessage = nil
+        AnalyticsReporter.track(
+            "onboarding_agent_cta_clicked",
+            properties: [
+                "agent_cta": "install_claude",
+                "step_id": currentStep.analyticsValue,
+            ]
+        )
+
+        Task {
+            do {
+                _ = try await Task.detached(priority: .userInitiated) {
+                    try ClaudeDesktopIntegrationInstaller.installForClaudeDesktop()
+                }.value
+                claudeInstallMessage = "Ready. Restart Claude Desktop."
+            } catch {
+                claudeInstallMessage = error.localizedDescription
+            }
+            isInstallingClaude = false
+        }
+    }
+
+    private func copyAgentPrompt() {
+        copyText(AgentConnectionGuide.starterPrompt(filename: nil))
+        copiedAgentPrompt = true
+        AnalyticsReporter.track(
+            "onboarding_agent_cta_clicked",
+            properties: [
+                "agent_cta": "copy_for_agent",
+                "step_id": currentStep.analyticsValue,
+            ]
+        )
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            copiedAgentPrompt = false
+        }
+    }
+
+    private func openAgentSettings() {
+        AnalyticsReporter.track(
+            "onboarding_agent_cta_clicked",
+            properties: [
+                "agent_cta": "open_agent_settings",
+                "step_id": currentStep.analyticsValue,
+            ]
+        )
+        onOpenAgentSettings?()
+    }
+
+    private func updateCrashReportingPreference(_ enabled: Bool) {
+        crashReportingEnabled = enabled
+        CrashReportingPreferences.setEnabled(enabled)
+        AnalyticsReporter.track(
+            "onboarding_reporting_toggle_changed",
+            properties: [
+                "available": CrashReporter.isAvailable ? "true" : "false",
+                "enabled": enabled ? "true" : "false",
+                "reporting_kind": "crash",
+                "step_id": currentStep.analyticsValue,
+            ]
+        )
+    }
+
+    private func updateAnalyticsPreference(_ enabled: Bool) {
+        if anonymousAnalyticsEnabled {
+            AnalyticsReporter.track(
+                "onboarding_reporting_toggle_changed",
+                properties: [
+                    "available": AnalyticsReporter.isAvailable ? "true" : "false",
+                    "enabled": enabled ? "true" : "false",
+                    "reporting_kind": "analytics",
+                    "step_id": currentStep.analyticsValue,
+                ]
+            )
+        }
+        anonymousAnalyticsEnabled = enabled
+        AnalyticsPreferences.setEnabled(enabled)
+        if enabled {
+            AnalyticsReporter.track(
+                "onboarding_reporting_toggle_changed",
+                properties: [
+                    "available": AnalyticsReporter.isAvailable ? "true" : "false",
+                    "enabled": "true",
+                    "reporting_kind": "analytics",
+                    "step_id": currentStep.analyticsValue,
+                ]
+            )
+        }
+    }
+
+    private func completeOnboarding() {
+        stopPolling()
+        AnalyticsReporter.track(
+            "onboarding_completed",
+            properties: [
+                "anonymous_usage_enabled": anonymousAnalyticsEnabled ? "true" : "false",
+                "calendar_status": calendarGranted ? "ready" : "pending",
+                "completion_path": "guided",
+                "crash_reporting_enabled": crashReportingEnabled ? "true" : "false",
+                "first_dictation_saved": firstSavedDictation == nil ? "false" : "true",
+                "meeting_recording_ready": systemRecordingGranted ? "true" : "false",
+                "model_state": modelStateAnalyticsValue,
+                "step_id": currentStep.analyticsValue,
+            ]
+        )
+        onComplete()
+    }
+
+    private func handleDictationSaved() {
+        guard isFirstDictationRunning || currentStep == .testDictation else { return }
+        firstSavedDictation = DictationTranscriptStore.latestSavedDictation()
+        isFirstDictationRunning = false
+        firstDictationIssue = nil
+        NSApp.activate(ignoringOtherApps: true)
+
+        if let firstSavedDictation {
+            AnalyticsReporter.track(
+                "onboarding_first_dictation_saved",
+                properties: [
+                    "delivery": firstSavedDictation.delivery.rawValue,
+                    "step_id": currentStep.analyticsValue,
+                    "word_count_bucket": AnalyticsReporter.wordCountBucket(
+                        firstSavedDictation.text.split(whereSeparator: \.isWhitespace).count
+                    ),
+                ]
+            )
+        }
+        move(to: .dictationResult)
+    }
+
+    private func handleNoSpeech() {
+        guard currentStep == .testDictation || isFirstDictationRunning else { return }
+        isFirstDictationRunning = false
+        firstDictationIssue = "No speech detected. Try one clear sentence, like: remind me to review the pricing call."
+        NSApp.activate(ignoringOtherApps: true)
+        AnalyticsReporter.track(
+            "onboarding_first_dictation_empty",
+            properties: [
+                "step_id": currentStep.analyticsValue,
+            ]
+        )
+    }
+
+    private func checkAllPermissions(trackChanges: Bool = true) {
+        let statuses: [TranscriptedPermissionKind: Bool] = [
+            .microphone: TranscriptedPermissionAccess.isGranted(.microphone),
+            .accessibility: TranscriptedPermissionAccess.isGranted(.accessibility),
+            .systemAudioRecording: TranscriptedPermissionAccess.isGranted(.systemAudioRecording),
+            .calendar: TranscriptedPermissionAccess.isGranted(.calendar),
+        ]
+
+        micGranted = statuses[.microphone] ?? false
+        accessibilityGranted = statuses[.accessibility] ?? false
+        systemRecordingGranted = statuses[.systemAudioRecording] ?? false
+        calendarGranted = statuses[.calendar] ?? false
+
+        if trackChanges, !previousPermissionStatuses.isEmpty {
+            for kind in TranscriptedPermissionKind.allCases {
+                let old = previousPermissionStatuses[kind] ?? false
+                let new = statuses[kind] ?? false
+                guard old != new else { continue }
+                AnalyticsReporter.track(
+                    "onboarding_permission_status_changed",
+                    properties: [
+                        "from_status": old ? "ready" : "pending",
+                        "permission_kind": kind.analyticsValue,
+                        "step_id": currentStep.analyticsValue,
+                        "to_status": new ? "ready" : "pending",
+                    ]
+                )
+            }
+        }
+
+        previousPermissionStatuses = statuses
     }
 
     private func startPolling() {
@@ -231,37 +692,80 @@ struct PermissionsOnboardingView: View {
         pollTimer = nil
     }
 
-    private func handlePrimaryAction() {
-        guard primaryAction.isEnabled else { return }
-        completeOnboarding(startFirstDictation: primaryAction.shouldStartDictation)
-    }
-
-    private func completeOnboarding(startFirstDictation: Bool = false) {
-        guard hasRequiredPermissions else { return }
-        stopPolling()
+    private func trackShownIfNeeded() {
+        guard !trackedShown else { return }
+        trackedShown = true
         AnalyticsReporter.track(
-            "onboarding_completed",
+            "onboarding_shown",
             properties: [
-                "anonymous_usage_enabled": anonymousAnalyticsEnabled ? "true" : "false",
-                "crash_reporting_enabled": crashReportingEnabled ? "true" : "false",
-                "system_audio_recording_enabled": systemAudioRecordingGranted ? "true" : "false",
+                "analytics_available": AnalyticsReporter.isAvailable ? "true" : "false",
+                "crash_reporting_available": CrashReporter.isAvailable ? "true" : "false",
+                "entrypoint": "first_launch",
+                "has_target": canStartDictation ? "true" : "false",
+                "meeting_recording_ready": systemRecordingGranted ? "true" : "false",
+                "mic_status": micGranted ? "ready" : "pending",
+                "model_state": modelStateAnalyticsValue,
+                "pasteback_status": accessibilityGranted ? "ready" : "pending",
             ]
         )
-        if startFirstDictation, let onStartDictation {
-            onStartDictation()
-            return
+    }
+
+    private func trackStepIfNeeded(_ step: FirstRunOnboardingStep) {
+        guard !trackedSteps.contains(step) else { return }
+        trackedSteps.insert(step)
+        AnalyticsReporter.track(
+            "onboarding_step_viewed",
+            properties: [
+                "model_state": modelStateAnalyticsValue,
+                "step_id": step.analyticsValue,
+                "step_index": "\(step.rawValue + 1)",
+            ]
+        )
+    }
+
+    private func trackModelStateIfChanged() {
+        let newState = modelStateAnalyticsValue
+        guard lastTrackedModelState != newState else { return }
+        let oldState = lastTrackedModelState
+        lastTrackedModelState = newState
+        AnalyticsReporter.track(
+            "onboarding_model_state_changed",
+            properties: [
+                "from_status": oldState ?? "unknown",
+                "step_id": currentStep.analyticsValue,
+                "to_status": newState,
+            ]
+        )
+    }
+
+    private func trackPrimaryCTA(_ title: String) {
+        AnalyticsReporter.track(
+            "onboarding_primary_cta_clicked",
+            properties: [
+                "cta": title.analyticsSlug,
+                "model_state": modelStateAnalyticsValue,
+                "step_id": currentStep.analyticsValue,
+            ]
+        )
+    }
+
+    private func permissionStatusValue(_ kind: TranscriptedPermissionKind) -> String {
+        switch kind {
+        case .microphone:
+            return micGranted ? "ready" : "pending"
+        case .accessibility:
+            return accessibilityGranted ? "ready" : "pending"
+        case .systemAudioRecording:
+            return systemRecordingGranted ? "ready" : "pending"
+        case .calendar:
+            return calendarGranted ? "ready" : "pending"
         }
-        onComplete()
     }
 
-    private func updateCrashReportingPreference(_ enabled: Bool) {
-        crashReportingEnabled = enabled
-        CrashReportingPreferences.setEnabled(enabled)
-    }
-
-    private func updateAnalyticsPreference(_ enabled: Bool) {
-        anonymousAnalyticsEnabled = enabled
-        AnalyticsPreferences.setEnabled(enabled)
+    private func copyText(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
     }
 
     static var hasCompleted: Bool {
@@ -276,49 +780,817 @@ struct PermissionsOnboardingView: View {
     }
 }
 
-private struct LocalDictationModelCard: View {
-    let status: FirstRunModelCardState
+private struct OnboardingHeader: View {
+    let steps: [FirstRunOnboardingStep]
+    let currentStep: FirstRunOnboardingStep
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(spacing: 8) {
-                Image(systemName: iconName)
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(iconColor)
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 12) {
+                AppIconPreview(size: 44)
 
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(status.title)
+                    Text("Transcripted")
                         .font(.headline.weight(.semibold))
                         .foregroundStyle(MenuTokens.textPrimary)
 
-                    Text(status.detail)
+                    Text("Step \(currentStep.rawValue + 1) of \(steps.count): \(currentStep.progressTitle)")
                         .font(.footnote)
+                        .foregroundStyle(MenuTokens.textSecondary)
+                }
+
+                Spacer()
+            }
+
+            HStack(spacing: 6) {
+                ForEach(steps) { step in
+                    ProgressStepPill(
+                        title: step.progressTitle,
+                        isCurrent: step == currentStep,
+                        isComplete: step.rawValue < currentStep.rawValue
+                    )
+                }
+            }
+        }
+    }
+}
+
+private struct ProgressStepPill: View {
+    let title: String
+    let isCurrent: Bool
+    let isComplete: Bool
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if isComplete {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 9, weight: .bold))
+            }
+            Text(isCurrent ? title : "")
+                .font(.system(size: 11, weight: .semibold))
+                .lineLimit(1)
+        }
+        .foregroundStyle(isCurrent || isComplete ? MenuTokens.textPrimary : MenuTokens.textMuted)
+        .frame(minWidth: isCurrent ? 104 : 18, minHeight: 22)
+        .padding(.horizontal, isCurrent ? 8 : 2)
+        .background(
+            Capsule()
+                .fill(isCurrent ? Color.accentColor.opacity(0.35) : MenuTokens.pillBackground)
+                .overlay(
+                    Capsule()
+                        .stroke(isCurrent ? Color.accentColor.opacity(0.65) : MenuTokens.pillBorder, lineWidth: 1)
+                )
+        )
+    }
+}
+
+private struct OnboardingFooter: View {
+    let action: FirstRunOnboardingActionState
+    let canGoBack: Bool
+    let onBack: () -> Void
+    let onSecondary: () -> Void
+    let onPrimary: () -> Void
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 14) {
+            Button {
+                onBack()
+            } label: {
+                Label("Back", systemImage: "chevron.left")
+            }
+            .buttonStyle(.bordered)
+            .disabled(!canGoBack)
+
+            Text(action.detail)
+                .font(.footnote)
+                .foregroundStyle(MenuTokens.textSecondary)
+                .lineLimit(3)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: 10)
+
+            if let secondaryTitle = action.secondaryTitle {
+                Button(secondaryTitle) {
+                    onSecondary()
+                }
+                .buttonStyle(.bordered)
+            }
+
+            Button(action.primaryTitle) {
+                onPrimary()
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .disabled(!action.isPrimaryEnabled)
+        }
+    }
+}
+
+private struct HeroStepView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            VStack(alignment: .leading, spacing: 14) {
+                AppIconPreview(size: 78)
+
+                Text(FirstRunOnboardingStep.hero.screenTitle)
+                    .font(.system(size: 34, weight: .semibold))
+                    .foregroundStyle(MenuTokens.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(FirstRunOnboardingCopy.heroDetail)
+                    .font(.title3.weight(.medium))
+                    .foregroundStyle(MenuTokens.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            OnboardingCard {
+                HStack(spacing: 14) {
+                    FlowSymbol(name: "mic.fill", title: "Speak")
+                    FlowArrow()
+                    FlowSymbol(name: "doc.text.fill", title: "Markdown")
+                    FlowArrow()
+                    FlowSymbol(name: "sparkles", title: "Agent")
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+    }
+}
+
+private struct ValueStepView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            ScreenTitle(
+                title: FirstRunOnboardingStep.value.screenTitle,
+                detail: "Transcripted gives you two ways to turn spoken work into notes you can actually use."
+            )
+
+            HStack(spacing: 14) {
+                ValueCard(
+                    icon: "mic.fill",
+                    title: "Dictation",
+                    detail: "Dictate instead of type."
+                )
+
+                ValueCard(
+                    icon: "record.circle.fill",
+                    title: "Meetings",
+                    detail: "Record conversations into notes."
+                )
+            }
+
+            OnboardingCallout(
+                icon: "folder.fill",
+                title: "Local Markdown",
+                detail: FirstRunOnboardingCopy.valueFooter
+            )
+        }
+    }
+}
+
+private struct DictationSetupStepView: View {
+    let micGranted: Bool
+    let accessibilityGranted: Bool
+    let modelStatus: FirstRunModelCardState
+    let onPermissionAction: (TranscriptedPermissionKind) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            ScreenTitle(
+                title: FirstRunOnboardingStep.dictationSetup.screenTitle,
+                detail: "Dictation needs two things: permission to listen and permission to paste your words back where you were typing."
+            )
+
+            SetupRow(
+                icon: "mic.fill",
+                title: "Microphone",
+                detail: "Lets Transcripted listen when you start dictation.",
+                status: micGranted ? "Ready" : "Required",
+                tone: micGranted ? .ready : .needed,
+                buttonTitle: micGranted ? nil : TranscriptedPermissionKind.microphone.actionButtonTitle
+            ) {
+                onPermissionAction(.microphone)
+            }
+
+            SetupRow(
+                icon: "text.cursor",
+                title: "Paste-back",
+                detail: "Lets Transcripted paste the dictation into the app you were using.",
+                status: accessibilityGranted ? "Ready" : "Required",
+                tone: accessibilityGranted ? .ready : .needed,
+                buttonTitle: accessibilityGranted ? nil : TranscriptedPermissionKind.accessibility.actionButtonTitle
+            ) {
+                onPermissionAction(.accessibility)
+            }
+
+            LocalModelSetupRow(status: modelStatus)
+        }
+    }
+}
+
+private struct TestDictationStepView: View {
+    let isRunning: Bool
+    let issue: String?
+    let onStart: () -> Void
+    let onStop: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            ScreenTitle(
+                title: FirstRunOnboardingStep.testDictation.screenTitle,
+                detail: "Let's make sure the whole loop works before moving on."
+            )
+
+            OnboardingCard {
+                VStack(alignment: .leading, spacing: 14) {
+                    Label(FirstRunOnboardingCopy.dictationPrompt, systemImage: "waveform")
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(MenuTokens.textPrimary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text("Start dictation, say the sentence, then click Stop and Save here.")
+                        .font(.callout)
+                        .foregroundStyle(MenuTokens.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if isRunning {
+                        HStack(spacing: 8) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Listening or preparing...")
+                                .font(.footnote.weight(.semibold))
+                                .foregroundStyle(MenuTokens.textSecondary)
+                        }
+                    }
+
+                    if let issue {
+                        OnboardingCallout(
+                            icon: "exclamationmark.triangle.fill",
+                            title: "Try again",
+                            detail: issue,
+                            tone: .warning
+                        )
+                    }
+
+                    Button {
+                        isRunning ? onStop() : onStart()
+                    } label: {
+                        Label(isRunning ? "Stop and Save" : "Start Dictation", systemImage: isRunning ? "stop.fill" : "mic.fill")
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.large)
+                }
+            }
+        }
+    }
+}
+
+private struct FirstDictationResultStepView: View {
+    let entry: SavedDictationEntry?
+    let copied: Bool
+    let onCopy: () -> Void
+    let onOpenFolder: () -> Void
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            ScreenTitle(
+                title: FirstRunOnboardingStep.dictationResult.screenTitle,
+                detail: "This is the core loop: dictate instead of type, and keep a saved Markdown copy."
+            )
+
+            if let entry {
+                OnboardingCard {
+                    VStack(alignment: .leading, spacing: 14) {
+                        Text("Transcript preview")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(MenuTokens.textPrimary)
+
+                        Text(entry.text)
+                            .font(.body)
+                            .foregroundStyle(MenuTokens.textPrimary)
+                            .lineLimit(6)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .padding(12)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                    .fill(MenuTokens.pillBackground)
+                            )
+
+                        HStack(spacing: 10) {
+                            Label(FirstRunOnboardingCopy.savedAsMarkdown, systemImage: "doc.text.fill")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(MenuTokens.textPrimary)
+
+                            Spacer()
+
+                            Text(entry.url.lastPathComponent)
+                                .font(.footnote.monospaced())
+                                .foregroundStyle(MenuTokens.textSecondary)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+
+                OnboardingCallout(
+                    icon: "sparkles",
+                    title: "For your agent",
+                    detail: FirstRunOnboardingCopy.agentDictationNote
+                )
+
+                HStack(spacing: 10) {
+                    Button {
+                        onCopy()
+                    } label: {
+                        Label(copied ? "Copied" : "Copy", systemImage: copied ? "checkmark" : "doc.on.doc")
+                    }
+                    .buttonStyle(.bordered)
+
+                    Button {
+                        onOpenFolder()
+                    } label: {
+                        Label("Open Folder", systemImage: "folder")
+                    }
+                    .buttonStyle(.bordered)
+                }
+            } else {
+                OnboardingCallout(
+                    icon: "exclamationmark.triangle.fill",
+                    title: "No dictation saved yet",
+                    detail: "Try one clear sentence so Transcripted can show you the saved Markdown result.",
+                    tone: .warning
+                )
+
+                Button {
+                    onRetry()
+                } label: {
+                    Label("Try Again", systemImage: "mic.fill")
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+}
+
+private struct MeetingsIntroStepView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            ScreenTitle(
+                title: FirstRunOnboardingStep.meetingsIntro.screenTitle,
+                detail: "Once dictation works, the same idea expands to meetings."
+            )
+
+            OnboardingCard {
+                HStack(spacing: 14) {
+                    FlowSymbol(name: "person.2.wave.2.fill", title: "Conversation")
+                    FlowArrow()
+                    FlowSymbol(name: "waveform", title: "Recording")
+                    FlowArrow()
+                    FlowSymbol(name: "doc.text.fill", title: "Notes")
+                }
+                .frame(maxWidth: .infinity)
+            }
+
+            OnboardingCallout(
+                icon: "record.circle.fill",
+                title: "Meetings become notes",
+                detail: FirstRunOnboardingCopy.meetingsDetail
+            )
+        }
+    }
+}
+
+private struct MeetingSetupStepView: View {
+    let micGranted: Bool
+    let systemRecordingGranted: Bool
+    let calendarGranted: Bool
+    let isDryRunStarting: Bool
+    let isDryRunRunning: Bool
+    let dryRunCompleted: Bool
+    let dryRunIssue: String?
+    let onPermissionAction: (TranscriptedPermissionKind) -> Void
+    let onDryRun: () -> Void
+    let onStopDryRun: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            ScreenTitle(
+                title: FirstRunOnboardingStep.meetingSetup.screenTitle,
+                detail: "Meeting recording needs your microphone plus System Audio Recording for the other side of calls."
+            )
+
+            SetupRow(
+                icon: "mic.fill",
+                title: "Microphone",
+                detail: "Already used for your side of meetings.",
+                status: micGranted ? "Ready" : "Required",
+                tone: micGranted ? .ready : .needed,
+                buttonTitle: micGranted ? nil : TranscriptedPermissionKind.microphone.actionButtonTitle
+            ) {
+                onPermissionAction(.microphone)
+            }
+
+            SetupRow(
+                icon: "speaker.wave.2.fill",
+                title: "System Audio Recording",
+                detail: "Captures the other side of Zoom, Meet, videos, and calls.",
+                status: systemRecordingGranted ? "Ready" : "Needed for meetings",
+                tone: systemRecordingGranted ? .ready : .needed,
+                buttonTitle: systemRecordingGranted ? nil : TranscriptedPermissionKind.systemAudioRecording.actionButtonTitle
+            ) {
+                onPermissionAction(.systemAudioRecording)
+            }
+
+            SetupRow(
+                icon: "calendar",
+                title: "Calendar",
+                detail: "Optional. Helps Transcripted spot meetings and offer a record prompt.",
+                status: calendarGranted ? "Ready" : "Optional",
+                tone: calendarGranted ? .ready : .neutral,
+                buttonTitle: calendarGranted ? nil : TranscriptedPermissionKind.calendar.actionButtonTitle
+            ) {
+                onPermissionAction(.calendar)
+            }
+
+            OnboardingCard {
+                HStack(spacing: 12) {
+                    Image(systemName: dryRunCompleted ? "checkmark.circle.fill" : "record.circle")
+                        .font(.system(size: 26, weight: .semibold))
+                        .foregroundStyle(dryRunCompleted ? MenuTokens.statusGreen : Color.accentColor)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(dryRunCompleted ? "Dry run worked" : "Run a quick dry run")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(MenuTokens.textPrimary)
+
+                        Text(dryRunDetail)
+                            .font(.footnote)
+                            .foregroundStyle(MenuTokens.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Spacer()
+
+                    Button {
+                        isDryRunRunning ? onStopDryRun() : onDryRun()
+                    } label: {
+                        Label(dryRunButtonTitle, systemImage: dryRunButtonIcon)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isDryRunStarting)
+                }
+            }
+
+            if let dryRunIssue {
+                OnboardingCallout(
+                    icon: "exclamationmark.triangle.fill",
+                    title: "Dry run needs another try",
+                    detail: dryRunIssue,
+                    tone: .warning
+                )
+            }
+        }
+    }
+
+    private var dryRunDetail: String {
+        if isDryRunStarting {
+            return "Starting a short recording test..."
+        }
+        if isDryRunRunning {
+            return "Recording test is running. Stop it here when you're ready. Test audio will be discarded."
+        }
+        if dryRunCompleted {
+            return "Meeting capture started and stopped correctly. The test audio was discarded."
+        }
+        return "Start a short meeting recording test, then stop it here. Transcripted discards this test audio."
+    }
+
+    private var dryRunButtonTitle: String {
+        if isDryRunStarting {
+            return "Starting..."
+        }
+        return isDryRunRunning ? "Stop Dry Run" : "Run Dry Run"
+    }
+
+    private var dryRunButtonIcon: String {
+        if isDryRunStarting {
+            return "clock"
+        }
+        return isDryRunRunning ? "stop.fill" : "play.fill"
+    }
+}
+
+private struct AgentPayoffStepView: View {
+    let copiedAgentPrompt: Bool
+    let isInstallingClaude: Bool
+    let installMessage: String?
+    @Binding var crashReportingEnabled: Bool
+    @Binding var anonymousAnalyticsEnabled: Bool
+    let crashReportingAvailable: Bool
+    let analyticsAvailable: Bool
+    let onInstallClaude: () -> Void
+    let onCopyAgentPrompt: () -> Void
+    let onOpenAgentSettings: () -> Void
+    let onCrashToggle: (Bool) -> Void
+    let onAnalyticsToggle: (Bool) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            ScreenTitle(
+                title: FirstRunOnboardingStep.agentPayoff.screenTitle,
+                detail: FirstRunOnboardingCopy.agentDetail
+            )
+
+            OnboardingCard {
+                HStack(spacing: 14) {
+                    FlowSymbol(name: "folder.fill", title: "Markdown")
+                    FlowArrow()
+                    FlowSymbol(name: "magnifyingglass", title: "Search")
+                    FlowArrow()
+                    FlowSymbol(name: "sparkles", title: "Agent")
+                }
+                .frame(maxWidth: .infinity)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                AgentPromptPill(text: "Search my meetings")
+                AgentPromptPill(text: "What am I working on?")
+                AgentPromptPill(text: "Summarize today")
+            }
+
+            HStack(spacing: 10) {
+                Button {
+                    onInstallClaude()
+                } label: {
+                    Label(isInstallingClaude ? "Installing..." : "Install in Claude", systemImage: isInstallingClaude ? "hourglass" : "sparkles")
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isInstallingClaude)
+
+                Button {
+                    onCopyAgentPrompt()
+                } label: {
+                    Label(copiedAgentPrompt ? "Copied" : "Copy for Agent", systemImage: copiedAgentPrompt ? "checkmark" : "doc.on.doc")
+                }
+                .buttonStyle(.bordered)
+
+                Button {
+                    onOpenAgentSettings()
+                } label: {
+                    Label("Agent Settings", systemImage: "gearshape")
+                }
+                .buttonStyle(.bordered)
+            }
+
+            if let installMessage {
+                Text(installMessage)
+                    .font(.footnote)
+                    .foregroundStyle(installMessage.hasPrefix("Ready") ? MenuTokens.statusGreen : Color.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            ReportingConsentCard(
+                crashReportingEnabled: $crashReportingEnabled,
+                anonymousAnalyticsEnabled: $anonymousAnalyticsEnabled,
+                crashReportingAvailable: crashReportingAvailable,
+                analyticsAvailable: analyticsAvailable,
+                onCrashToggle: onCrashToggle,
+                onAnalyticsToggle: onAnalyticsToggle
+            )
+        }
+    }
+}
+
+private struct ReportingConsentCard: View {
+    @Binding var crashReportingEnabled: Bool
+    @Binding var anonymousAnalyticsEnabled: Bool
+    let crashReportingAvailable: Bool
+    let analyticsAvailable: Bool
+    let onCrashToggle: (Bool) -> Void
+    let onAnalyticsToggle: (Bool) -> Void
+
+    var body: some View {
+        OnboardingCard {
+            VStack(alignment: .leading, spacing: 12) {
+                Label("Help improve Transcripted", systemImage: "bolt.shield.fill")
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(MenuTokens.textPrimary)
+
+                Text("Privacy-safe diagnostics help catch setup problems. Transcripted never sends transcript text, audio, meeting titles, speaker names, source app names, emails, file paths, or raw URLs.")
+                    .font(.footnote)
+                    .foregroundStyle(MenuTokens.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                ToggleRow(
+                    title: "Crash and error reports",
+                    detail: crashReportingAvailable ? "Scrubbed reliability events only." : "Unavailable in this build.",
+                    isOn: Binding(get: { crashReportingEnabled }, set: { onCrashToggle($0) }),
+                    isEnabled: crashReportingAvailable
+                )
+
+                ToggleRow(
+                    title: "Anonymous usage stats",
+                    detail: analyticsAvailable ? "Allowlisted product events only." : "Unavailable until PostHog is configured.",
+                    isOn: Binding(get: { anonymousAnalyticsEnabled }, set: { onAnalyticsToggle($0) }),
+                    isEnabled: analyticsAvailable
+                )
+            }
+        }
+    }
+}
+
+private struct ToggleRow: View {
+    let title: String
+    let detail: String
+    @Binding var isOn: Bool
+    let isEnabled: Bool
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(MenuTokens.textPrimary)
+
+                Text(detail)
+                    .font(.footnote)
+                    .foregroundStyle(MenuTokens.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: $isOn)
+                .labelsHidden()
+                .disabled(!isEnabled)
+                .accessibilityLabel(title)
+                .help(detail)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(MenuTokens.pillBackground)
+        )
+    }
+}
+
+private struct ScreenTitle: View {
+    let title: String
+    let detail: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 30, weight: .semibold))
+                .foregroundStyle(MenuTokens.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(detail)
+                .font(.title3.weight(.medium))
+                .foregroundStyle(MenuTokens.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+private struct ValueCard: View {
+    let icon: String
+    let title: String
+    let detail: String
+
+    var body: some View {
+        OnboardingCard {
+            VStack(alignment: .leading, spacing: 12) {
+                Image(systemName: icon)
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+
+                Text(title)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(MenuTokens.textPrimary)
+
+                Text(detail)
+                    .font(.callout)
+                    .foregroundStyle(MenuTokens.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, minHeight: 130, alignment: .leading)
+        }
+    }
+}
+
+private enum SetupTone {
+    case ready
+    case needed
+    case working
+    case warning
+    case neutral
+
+    var color: Color {
+        switch self {
+        case .ready:
+            return MenuTokens.statusGreen
+        case .needed, .warning:
+            return Color.orange
+        case .working:
+            return Color.accentColor
+        case .neutral:
+            return MenuTokens.textSecondary
+        }
+    }
+}
+
+private struct SetupRow: View {
+    let icon: String
+    let title: String
+    let detail: String
+    let status: String
+    let tone: SetupTone
+    let buttonTitle: String?
+    let action: () -> Void
+
+    var body: some View {
+        OnboardingCard {
+            HStack(alignment: .center, spacing: 14) {
+                ZStack {
+                    Circle()
+                        .fill(MenuTokens.pillBackground)
+                        .frame(width: 42, height: 42)
+
+                    Image(systemName: icon)
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(MenuTokens.textPrimary)
+                }
+
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack(spacing: 8) {
+                        Text(title)
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(MenuTokens.textPrimary)
+
+                        StatusBadge(title: status, tone: tone)
+                    }
+
+                    Text(detail)
+                        .font(.callout)
                         .foregroundStyle(MenuTokens.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
                 Spacer(minLength: 8)
 
-                Text(status.status)
-                    .font(.footnote.weight(.semibold))
-                    .foregroundStyle(iconColor)
-            }
-
-            if let progress = status.progress, status.tone != .ready {
-                ProgressView(value: progress)
-                    .progressViewStyle(.linear)
-                    .tint(iconColor)
+                if let buttonTitle {
+                    Button(buttonTitle) {
+                        action()
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
             }
         }
-        .padding(14)
-        .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(cardFill)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .stroke(cardStroke, lineWidth: 1)
-                )
-        )
+    }
+}
+
+private struct LocalModelSetupRow: View {
+    let status: FirstRunModelCardState
+
+    var body: some View {
+        OnboardingCard {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .center, spacing: 14) {
+                    ZStack {
+                        Circle()
+                            .fill(MenuTokens.pillBackground)
+                            .frame(width: 42, height: 42)
+
+                        Image(systemName: iconName)
+                            .font(.system(size: 17, weight: .semibold))
+                            .foregroundStyle(iconColor)
+                    }
+
+                    VStack(alignment: .leading, spacing: 5) {
+                        HStack(spacing: 8) {
+                            Text("Local model")
+                                .font(.headline.weight(.semibold))
+                                .foregroundStyle(MenuTokens.textPrimary)
+
+                            StatusBadge(title: status.status, tone: tone)
+                        }
+
+                        Text(status.detail)
+                            .font(.callout)
+                            .foregroundStyle(MenuTokens.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                if let progress = status.progress, status.tone != .ready {
+                    ProgressView(value: progress)
+                        .progressViewStyle(.linear)
+                        .tint(iconColor)
+                }
+            }
+        }
     }
 
     private var iconName: String {
@@ -332,94 +1604,169 @@ private struct LocalDictationModelCard: View {
         }
     }
 
-    private var iconColor: Color {
+    private var tone: SetupTone {
         switch status.tone {
         case .ready:
-            return MenuTokens.statusGreen
+            return .ready
         case .working:
-            return Color.accentColor
+            return .working
         case .failed:
-            return Color.orange
+            return .warning
         }
     }
 
-    private var cardFill: Color {
-        switch status.tone {
-        case .ready:
-            return MenuTokens.savedBackground
-        case .working, .failed:
-            return MenuTokens.cardBackground
-        }
+    private var iconColor: Color {
+        tone.color
     }
+}
 
-    private var cardStroke: Color {
-        switch status.tone {
-        case .ready:
-            return MenuTokens.savedBorder
-        case .working, .failed:
-            return MenuTokens.cardBorder
+private struct StatusBadge: View {
+    let title: String
+    let tone: SetupTone
+
+    var body: some View {
+        Text(title)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(tone.color)
+            .lineLimit(1)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                Capsule()
+                    .fill(tone == .ready ? MenuTokens.savedBackground : MenuTokens.pillBackground)
+                    .overlay(
+                        Capsule()
+                            .stroke(tone == .ready ? MenuTokens.savedBorder : MenuTokens.pillBorder, lineWidth: 1)
+                    )
+            )
+    }
+}
+
+private enum CalloutTone {
+    case normal
+    case warning
+}
+
+private struct OnboardingCallout: View {
+    let icon: String
+    let title: String
+    let detail: String
+    var tone: CalloutTone = .normal
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(tone == .warning ? Color.orange : Color.accentColor)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(MenuTokens.textPrimary)
+
+                Text(detail)
+                    .font(.callout)
+                    .foregroundStyle(MenuTokens.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(tone == .warning ? Color.orange.opacity(0.12) : MenuTokens.pillBackground)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(tone == .warning ? Color.orange.opacity(0.28) : MenuTokens.pillBorder, lineWidth: 1)
+                )
+        )
+    }
+}
+
+private struct OnboardingCard<Content: View>: View {
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        content()
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(MenuTokens.pillBackground)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(MenuTokens.pillBorder, lineWidth: 1)
+                    )
+            )
+    }
+}
+
+private struct FlowSymbol: View {
+    let name: String
+    let title: String
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(MenuTokens.pillBackground)
+                    .frame(width: 76, height: 58)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(MenuTokens.pillBorder, lineWidth: 1)
+                    )
+
+                Image(systemName: name)
+                    .font(.system(size: 24, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+            }
+
+            Text(title)
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(MenuTokens.textSecondary)
         }
     }
 }
 
-private struct OnboardingHeroCard: View {
+private struct FlowArrow: View {
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(alignment: .top, spacing: 16) {
-                AppIconPreview()
+        Image(systemName: "arrow.right")
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(MenuTokens.textSecondary)
+            .frame(width: 28)
+    }
+}
 
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Welcome to Transcripted")
-                        .font(.system(size: 30, weight: .semibold))
-                        .foregroundStyle(MenuTokens.textPrimary)
+private struct AgentPromptPill: View {
+    let text: String
 
-                    Text("We’ll get the core permissions ready here, then open the menu bar controls so you can start dictating right away.")
-                        .font(.title3.weight(.medium))
-                        .foregroundStyle(MenuTokens.textSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-            }
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
 
-            HStack(spacing: 8) {
-                FeaturePill(icon: "menubar.rectangle", title: "Menu bar utility")
-                FeaturePill(icon: "mic.fill", title: "Dictation first")
-                FeaturePill(icon: "record.circle.fill", title: "Meetings later")
-            }
+            Text(text)
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(MenuTokens.textPrimary)
 
-            HStack(alignment: .top, spacing: 10) {
-                Image(systemName: "sparkles")
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(MenuTokens.textSecondary)
-                    .frame(width: 16)
-
-                Text("After setup, Transcripted lives in your menu bar. Use that icon to start dictation, record a meeting, open settings, or check for updates.")
-                    .font(.footnote)
-                    .foregroundStyle(MenuTokens.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            .padding(14)
-            .background(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(MenuTokens.pillBackground)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .stroke(MenuTokens.pillBorder, lineWidth: 1)
-                    )
-            )
+            Spacer()
         }
-        .padding(18)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
         .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .fill(MenuTokens.cardBackground)
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(MenuTokens.pillBackground)
                 .overlay(
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .stroke(MenuTokens.cardBorder, lineWidth: 1)
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(MenuTokens.pillBorder, lineWidth: 1)
                 )
         )
     }
 }
 
 private struct AppIconPreview: View {
+    let size: CGFloat
+
     private var iconImage: NSImage {
         if let icon = NSApplication.shared.applicationIconImage,
            icon.size.width > 0,
@@ -433,368 +1780,55 @@ private struct AppIconPreview: View {
         Image(nsImage: iconImage)
             .resizable()
             .interpolation(.high)
-            .frame(width: 76, height: 76)
-            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: min(16, size * 0.22), style: .continuous))
             .shadow(color: .black.opacity(0.2), radius: 10, y: 4)
     }
 }
 
-private struct FeaturePill: View {
-    let icon: String
-    let title: String
-
-    var body: some View {
-        HStack(spacing: 6) {
-            Image(systemName: icon)
-                .font(.footnote.weight(.semibold))
-            Text(title)
-                .font(.footnote.weight(.semibold))
+private extension TranscriptedPermissionKind {
+    var analyticsValue: String {
+        switch self {
+        case .microphone:
+            return "microphone"
+        case .accessibility:
+            return "pasteback"
+        case .systemAudioRecording:
+            return "system_recording"
+        case .calendar:
+            return "calendar"
         }
-        .foregroundStyle(MenuTokens.textPrimary)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 7)
-        .background(
-            Capsule()
-                .fill(MenuTokens.pillBackground)
-                .overlay(
-                    Capsule().stroke(MenuTokens.pillBorder, lineWidth: 1)
-                )
-        )
     }
 }
 
-private struct PermissionSetupCard: View {
-    let kind: TranscriptedPermissionKind
-    let granted: Bool
-    let action: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(alignment: .top, spacing: 12) {
-                ZStack {
-                    Circle()
-                        .fill(MenuTokens.pillBackground)
-                        .frame(width: 40, height: 40)
-
-                    Image(systemName: kind.icon)
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(MenuTokens.textPrimary)
-                }
-
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(spacing: 6) {
-                        Text(kind.title)
-                            .font(.headline.weight(.semibold))
-                            .foregroundStyle(MenuTokens.textPrimary)
-
-                        RequirementBadge(title: kind.isRequiredOnFirstLaunch ? "Required" : "Optional")
-                    }
-
-                    Text(kind.summary)
-                        .font(.callout)
-                        .foregroundStyle(MenuTokens.textSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Spacer(minLength: 8)
-
-                StatusBadge(granted: granted)
-            }
-
-            if !granted {
-                Button(kind.actionButtonTitle, action: action)
-                    .buttonStyle(.borderedProminent)
-            }
+private extension FirstRunOnboardingStep {
+    var analyticsValue: String {
+        switch self {
+        case .hero:
+            return "hero"
+        case .value:
+            return "value"
+        case .dictationSetup:
+            return "dictation_setup"
+        case .testDictation:
+            return "test_dictation"
+        case .dictationResult:
+            return "dictation_result"
+        case .meetingsIntro:
+            return "meetings_intro"
+        case .meetingSetup:
+            return "meeting_setup"
+        case .agentPayoff:
+            return "agent_payoff"
         }
-        .padding(14)
-        .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(MenuTokens.cardBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .stroke(MenuTokens.cardBorder, lineWidth: 1)
-                )
-        )
     }
 }
 
-private struct OptionalPermissionsCard: View {
-    let optionalPermissions: [TranscriptedPermissionKind]
-    let isGranted: (TranscriptedPermissionKind) -> Bool
-    let footnote: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Optional later")
-                .font(.headline.weight(.semibold))
-                .foregroundStyle(MenuTokens.textPrimary)
-
-            Text(footnote)
-                .font(.footnote)
-                .foregroundStyle(MenuTokens.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            ForEach(optionalPermissions) { kind in
-                OptionalPermissionRow(kind: kind, granted: isGranted(kind))
-            }
-        }
-        .padding(14)
-        .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(MenuTokens.cardBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .stroke(MenuTokens.cardBorder, lineWidth: 1)
-                )
-        )
-    }
-}
-
-private struct ObservabilityConsentCard: View {
-    @Binding var crashReportingEnabled: Bool
-    @Binding var anonymousAnalyticsEnabled: Bool
-    let crashReportingAvailable: Bool
-    let analyticsAvailable: Bool
-    let onCrashToggle: (Bool) -> Void
-    let onAnalyticsToggle: (Bool) -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Help improve Transcripted")
-                .font(.headline.weight(.semibold))
-                .foregroundStyle(MenuTokens.textPrimary)
-
-            Text("These start on by default for this release, and you can turn either one off right now or later in Settings. Transcripted never sends transcript text, audio, meeting titles, speaker names, source app names, emails, file paths, or raw URLs.")
-                .font(.footnote)
-                .foregroundStyle(MenuTokens.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            ObservabilityQuestionRow(
-                icon: "bolt.shield.fill",
-                title: "Share crash and error reports",
-                detail: crashFootnote,
-                isOn: Binding(
-                    get: { crashReportingEnabled },
-                    set: { onCrashToggle($0) }
-                ),
-                isAvailable: crashReportingAvailable
-            )
-
-            ObservabilityQuestionRow(
-                icon: "chart.bar.xaxis",
-                title: "Share anonymous usage stats",
-                detail: analyticsFootnote,
-                isOn: Binding(
-                    get: { anonymousAnalyticsEnabled },
-                    set: { onAnalyticsToggle($0) }
-                ),
-                isAvailable: analyticsAvailable
-            )
-        }
-        .padding(14)
-        .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(MenuTokens.cardBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .stroke(MenuTokens.cardBorder, lineWidth: 1)
-                )
-        )
-    }
-
-    private var crashFootnote: String {
-        if !crashReportingAvailable {
-            return "This build does not have Sentry configured yet, so crash and error reports stay on this Mac only. You can still change this later from Settings."
-        }
-
-        return crashReportingEnabled
-            ? "On by default. Transcripted will send scrubbed crash logs plus a small allowlist of reliability events to Sentry. You can turn this off now or later from Settings."
-            : "Off. Crash and error details will stay on this Mac unless you turn this back on later."
-    }
-
-    private var analyticsFootnote: String {
-        if !analyticsAvailable {
-            return "This build does not have PostHog configured yet, so anonymous usage statistics stay off until a project key is added."
-        }
-
-        return anonymousAnalyticsEnabled
-            ? "On by default. Transcripted will send only allowlisted, bucketed product events with an anonymous device ID to PostHog."
-            : "Off. Transcripted will stop sending anonymous usage trends unless you turn this back on later."
-    }
-}
-
-private struct ObservabilityQuestionRow: View {
-    let icon: String
-    let title: String
-    let detail: String
-    @Binding var isOn: Bool
-    let isAvailable: Bool
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            ZStack {
-                Circle()
-                    .fill(MenuTokens.pillBackground)
-                    .frame(width: 40, height: 40)
-
-                Image(systemName: icon)
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(MenuTokens.textPrimary)
-            }
-
-            VStack(alignment: .leading, spacing: 6) {
-                Text(title)
-                    .font(.headline.weight(.semibold))
-                    .foregroundStyle(MenuTokens.textPrimary)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                Text(detail)
-                    .font(.footnote)
-                    .foregroundStyle(MenuTokens.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            Spacer(minLength: 12)
-
-            Toggle("", isOn: $isOn)
-                .labelsHidden()
-                .disabled(!isAvailable)
-                .accessibilityLabel(title)
-        }
-        .padding(14)
-        .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(MenuTokens.pillBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
-                        .stroke(MenuTokens.pillBorder, lineWidth: 1)
-                )
-        )
-    }
-}
-
-private struct RequirementBadge: View {
-    let title: String
-
-    var body: some View {
-        Text(title)
-            .font(.system(size: 11, weight: .semibold))
-            .foregroundStyle(MenuTokens.textMuted)
-            .padding(.horizontal, 7)
-            .padding(.vertical, 3)
-            .background(
-                Capsule()
-                    .fill(MenuTokens.pillBackground)
-                    .overlay(
-                        Capsule().stroke(MenuTokens.pillBorder, lineWidth: 1)
-                    )
-            )
-    }
-}
-
-private struct StatusBadge: View {
-    let granted: Bool
-
-    var body: some View {
-        HStack(spacing: 4) {
-            Image(systemName: granted ? "checkmark.circle.fill" : "circle.dashed")
-                .font(.footnote.weight(.semibold))
-            Text(granted ? "Ready" : "Pending")
-                .font(.system(size: 11, weight: .semibold))
-        }
-        .foregroundStyle(granted ? MenuTokens.statusGreen : MenuTokens.textMuted)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(
-            Capsule()
-                .fill(granted ? MenuTokens.savedBackground : MenuTokens.pillBackground)
-                .overlay(
-                    Capsule().stroke(granted ? MenuTokens.savedBorder : MenuTokens.pillBorder, lineWidth: 1)
-                )
-        )
-    }
-}
-
-private struct QuickStartRow: View {
-    let icon: String
-    let title: String
-    let detail: String
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 10) {
-            ZStack {
-                Circle()
-                    .fill(MenuTokens.pillBackground)
-                    .frame(width: 28, height: 28)
-
-                Image(systemName: icon)
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(MenuTokens.textPrimary)
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title)
-                    .font(.callout.weight(.semibold))
-                    .foregroundStyle(MenuTokens.textPrimary)
-                Text(detail)
-                    .font(.footnote)
-                    .foregroundStyle(MenuTokens.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-        .padding(12)
-        .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(MenuTokens.pillBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .stroke(MenuTokens.pillBorder, lineWidth: 1)
-                )
-        )
-    }
-}
-
-private struct OptionalPermissionRow: View {
-    let kind: TranscriptedPermissionKind
-    let granted: Bool
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            ZStack {
-                Circle()
-                    .fill(MenuTokens.pillBackground)
-                    .frame(width: 32, height: 32)
-
-                Image(systemName: kind.icon)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(MenuTokens.textPrimary)
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 6) {
-                    Text(kind.title)
-                        .font(.callout.weight(.semibold))
-                        .foregroundStyle(MenuTokens.textPrimary)
-
-                    Text(granted ? "Ready" : "Later")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(granted ? MenuTokens.statusGreen : MenuTokens.textMuted)
-                }
-
-                Text(kind.summary)
-                    .font(.footnote)
-                    .foregroundStyle(MenuTokens.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-        .padding(12)
-        .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(MenuTokens.pillBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .stroke(MenuTokens.pillBorder, lineWidth: 1)
-                )
-        )
+private extension String {
+    var analyticsSlug: String {
+        lowercased()
+            .replacingOccurrences(of: " ", with: "_")
+            .replacingOccurrences(of: "-", with: "_")
+            .filter { $0.isLetter || $0.isNumber || $0 == "_" }
     }
 }

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -59,6 +59,9 @@ struct PermissionsOnboardingView: View {
     @State private var trackedSteps: Set<FirstRunOnboardingStep> = []
     @State private var trackedShown = false
     @State private var lastTrackedModelState: String?
+    @State private var onboardingStartedAt = Date()
+    @State private var currentStepStartedAt = Date()
+    @State private var didCompleteOnboarding = false
 
     init(
         sttRouter: STTRouter,
@@ -123,6 +126,8 @@ struct PermissionsOnboardingView: View {
         .background(MenuTokens.cardBackground)
         .preferredColorScheme(.dark)
         .onAppear {
+            onboardingStartedAt = Date()
+            currentStepStartedAt = Date()
             checkAllPermissions(trackChanges: false)
             crashReportingEnabled = CrashReportingPreferences.isEnabled()
             anonymousAnalyticsEnabled = AnalyticsPreferences.isEnabled()
@@ -132,6 +137,7 @@ struct PermissionsOnboardingView: View {
             trackModelStateIfChanged()
         }
         .onDisappear {
+            trackDismissedIfNeeded()
             stopMeetingDryRunIfNeeded()
             stopPolling()
         }
@@ -295,7 +301,7 @@ struct PermissionsOnboardingView: View {
     }
 
     private func handlePrimaryAction() {
-        trackPrimaryCTA(currentAction.primaryTitle)
+        trackPrimaryCTA(currentAction.primaryTitle, ctaType: "primary")
 
         switch currentStep {
         case .hero, .value:
@@ -331,7 +337,7 @@ struct PermissionsOnboardingView: View {
 
     private func handleSecondaryAction() {
         guard let title = currentAction.secondaryTitle else { return }
-        trackPrimaryCTA(title)
+        trackPrimaryCTA(title, ctaType: "secondary")
 
         switch currentStep {
         case .testDictation:
@@ -355,6 +361,7 @@ struct PermissionsOnboardingView: View {
 
     private func move(to step: FirstRunOnboardingStep) {
         currentStep = step
+        currentStepStartedAt = Date()
     }
 
     private func requestPermission(_ kind: TranscriptedPermissionKind) {
@@ -595,6 +602,7 @@ struct PermissionsOnboardingView: View {
 
     private func completeOnboarding() {
         stopPolling()
+        didCompleteOnboarding = true
         AnalyticsReporter.track(
             "onboarding_completed",
             properties: [
@@ -603,6 +611,8 @@ struct PermissionsOnboardingView: View {
                 "completion_path": "guided",
                 "crash_reporting_enabled": crashReportingEnabled ? "true" : "false",
                 "first_dictation_saved": firstSavedDictation == nil ? "false" : "true",
+                "flow_elapsed_bucket": flowElapsedBucket,
+                "meeting_dry_run_completed": meetingDryRunCompleted ? "true" : "false",
                 "meeting_recording_ready": systemRecordingGranted ? "true" : "false",
                 "model_state": modelStateAnalyticsValue,
                 "step_id": currentStep.analyticsValue,
@@ -716,6 +726,7 @@ struct PermissionsOnboardingView: View {
         AnalyticsReporter.track(
             "onboarding_step_viewed",
             properties: [
+                "flow_elapsed_bucket": flowElapsedBucket,
                 "model_state": modelStateAnalyticsValue,
                 "step_id": step.analyticsValue,
                 "step_index": "\(step.rawValue + 1)",
@@ -738,15 +749,41 @@ struct PermissionsOnboardingView: View {
         )
     }
 
-    private func trackPrimaryCTA(_ title: String) {
+    private func trackDismissedIfNeeded() {
+        guard trackedShown, !didCompleteOnboarding else { return }
+        AnalyticsReporter.track(
+            "onboarding_dismissed",
+            properties: [
+                "first_dictation_saved": firstSavedDictation == nil ? "false" : "true",
+                "flow_elapsed_bucket": flowElapsedBucket,
+                "meeting_dry_run_completed": meetingDryRunCompleted ? "true" : "false",
+                "model_state": modelStateAnalyticsValue,
+                "step_id": currentStep.analyticsValue,
+                "step_index": "\(currentStep.rawValue + 1)",
+            ]
+        )
+    }
+
+    private func trackPrimaryCTA(_ title: String, ctaType: String) {
         AnalyticsReporter.track(
             "onboarding_primary_cta_clicked",
             properties: [
                 "cta": title.analyticsSlug,
+                "cta_type": ctaType,
+                "flow_elapsed_bucket": flowElapsedBucket,
                 "model_state": modelStateAnalyticsValue,
+                "step_elapsed_bucket": stepElapsedBucket,
                 "step_id": currentStep.analyticsValue,
             ]
         )
+    }
+
+    private var flowElapsedBucket: String {
+        AnalyticsReporter.durationBucket(seconds: Date().timeIntervalSince(onboardingStartedAt))
+    }
+
+    private var stepElapsedBucket: String {
+        AnalyticsReporter.durationBucket(seconds: Date().timeIntervalSince(currentStepStartedAt))
     }
 
     private func permissionStatusValue(_ kind: TranscriptedPermissionKind) -> String {
@@ -1783,21 +1820,6 @@ private struct AppIconPreview: View {
             .frame(width: size, height: size)
             .clipShape(RoundedRectangle(cornerRadius: min(16, size * 0.22), style: .continuous))
             .shadow(color: .black.opacity(0.2), radius: 10, y: 4)
-    }
-}
-
-private extension TranscriptedPermissionKind {
-    var analyticsValue: String {
-        switch self {
-        case .microphone:
-            return "microphone"
-        case .accessibility:
-            return "pasteback"
-        case .systemAudioRecording:
-            return "system_recording"
-        case .calendar:
-            return "calendar"
-        }
     }
 }
 

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -89,21 +89,20 @@ struct PermissionsOnboardingView: View {
                 steps: FirstRunExperience.onboardingSteps(),
                 currentStep: currentStep
             )
-            .padding(.horizontal, 22)
-            .padding(.top, 22)
-            .padding(.bottom, 14)
+            .padding(.horizontal, 28)
+            .padding(.top, 24)
+            .padding(.bottom, 16)
 
-            Divider()
-                .overlay(MenuTokens.cardBorder)
+            OnboardingHairline()
 
             ScrollView {
                 currentScreen
-                    .padding(.horizontal, 22)
-                    .padding(.vertical, 18)
+                    .frame(maxWidth: 720, alignment: .leading)
+                    .padding(.horizontal, 28)
+                    .padding(.vertical, 24)
             }
 
-            Divider()
-                .overlay(MenuTokens.cardBorder)
+            OnboardingHairline()
 
             OnboardingFooter(
                 action: currentAction,
@@ -112,14 +111,14 @@ struct PermissionsOnboardingView: View {
                 onSecondary: handleSecondaryAction,
                 onPrimary: handlePrimaryAction
             )
-            .padding(.horizontal, 22)
-            .padding(.vertical, 16)
+            .padding(.horizontal, 28)
+            .padding(.vertical, 14)
         }
         .frame(
             minWidth: MenuTokens.onboardingWindowWidth,
-            idealWidth: 680,
+            idealWidth: MenuTokens.onboardingWindowWidth,
             maxWidth: .infinity,
-            minHeight: 700,
+            minHeight: 680,
             idealHeight: MenuTokens.onboardingWindowHeight,
             maxHeight: .infinity
         )
@@ -824,60 +823,53 @@ private struct OnboardingHeader: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             HStack(spacing: 12) {
-                AppIconPreview(size: 44)
+                AppIconPreview(size: 38)
 
                 VStack(alignment: .leading, spacing: 3) {
                     Text("Transcripted")
                         .font(.headline.weight(.semibold))
                         .foregroundStyle(MenuTokens.textPrimary)
 
-                    Text("Step \(currentStep.rawValue + 1) of \(steps.count): \(currentStep.progressTitle)")
+                    Text("Step \(currentStep.rawValue + 1) of \(steps.count) - \(currentStep.progressTitle)")
                         .font(.footnote)
                         .foregroundStyle(MenuTokens.textSecondary)
                 }
 
                 Spacer()
+
+                Text(currentStep.phaseTitle)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Color.accentColor)
+                    .frame(minWidth: 72)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(
+                        Capsule()
+                            .fill(Color.accentColor.opacity(0.12))
+                            .overlay(
+                                Capsule()
+                                    .stroke(Color.accentColor.opacity(0.22), lineWidth: 1)
+                            )
+                    )
             }
 
-            HStack(spacing: 6) {
-                ForEach(steps) { step in
-                    ProgressStepPill(
-                        title: step.progressTitle,
-                        isCurrent: step == currentStep,
-                        isComplete: step.rawValue < currentStep.rawValue
-                    )
+            GeometryReader { proxy in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Color.white.opacity(0.08))
+
+                    Capsule()
+                        .fill(Color.accentColor)
+                        .frame(width: max(14, proxy.size.width * progress))
                 }
             }
+            .frame(height: 4)
         }
     }
-}
 
-private struct ProgressStepPill: View {
-    let title: String
-    let isCurrent: Bool
-    let isComplete: Bool
-
-    var body: some View {
-        HStack(spacing: 4) {
-            if isComplete {
-                Image(systemName: "checkmark")
-                    .font(.system(size: 9, weight: .bold))
-            }
-            Text(isCurrent ? title : "")
-                .font(.system(size: 11, weight: .semibold))
-                .lineLimit(1)
-        }
-        .foregroundStyle(isCurrent || isComplete ? MenuTokens.textPrimary : MenuTokens.textMuted)
-        .frame(minWidth: isCurrent ? 104 : 18, minHeight: 22)
-        .padding(.horizontal, isCurrent ? 8 : 2)
-        .background(
-            Capsule()
-                .fill(isCurrent ? Color.accentColor.opacity(0.35) : MenuTokens.pillBackground)
-                .overlay(
-                    Capsule()
-                        .stroke(isCurrent ? Color.accentColor.opacity(0.65) : MenuTokens.pillBorder, lineWidth: 1)
-                )
-        )
+    private var progress: CGFloat {
+        guard !steps.isEmpty else { return 0 }
+        return CGFloat(currentStep.rawValue + 1) / CGFloat(steps.count)
     }
 }
 
@@ -889,7 +881,7 @@ private struct OnboardingFooter: View {
     let onPrimary: () -> Void
 
     var body: some View {
-        HStack(alignment: .center, spacing: 14) {
+        HStack(alignment: .center, spacing: 12) {
             Button {
                 onBack()
             } label: {
@@ -898,13 +890,7 @@ private struct OnboardingFooter: View {
             .buttonStyle(.bordered)
             .disabled(!canGoBack)
 
-            Text(action.detail)
-                .font(.footnote)
-                .foregroundStyle(MenuTokens.textSecondary)
-                .lineLimit(3)
-                .fixedSize(horizontal: false, vertical: true)
-
-            Spacer(minLength: 10)
+            Spacer(minLength: 16)
 
             if let secondaryTitle = action.secondaryTitle {
                 Button(secondaryTitle) {
@@ -940,16 +926,7 @@ private struct HeroStepView: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            OnboardingCard {
-                HStack(spacing: 14) {
-                    FlowSymbol(name: "mic.fill", title: "Speak")
-                    FlowArrow()
-                    FlowSymbol(name: "doc.text.fill", title: "Markdown")
-                    FlowArrow()
-                    FlowSymbol(name: "sparkles", title: "Agent")
-                }
-                .frame(maxWidth: .infinity)
-            }
+            OutcomePreviewCard()
         }
     }
 }
@@ -966,21 +943,17 @@ private struct ValueStepView: View {
                 ValueCard(
                     icon: "mic.fill",
                     title: "Dictation",
-                    detail: "Dictate instead of type."
+                    detail: "Speak a thought, paste it where you were typing, and keep the Markdown."
                 )
 
                 ValueCard(
                     icon: "record.circle.fill",
                     title: "Meetings",
-                    detail: "Record conversations into notes."
+                    detail: "Record calls locally and turn conversations into useful notes."
                 )
             }
 
-            OnboardingCallout(
-                icon: "folder.fill",
-                title: "Local Markdown",
-                detail: FirstRunOnboardingCopy.valueFooter
-            )
+            AgentContextStrip()
         }
     }
 }
@@ -998,29 +971,37 @@ private struct DictationSetupStepView: View {
                 detail: "Dictation needs two things: permission to listen and permission to paste your words back where you were typing."
             )
 
-            SetupRow(
-                icon: "mic.fill",
-                title: "Microphone",
-                detail: "Lets Transcripted listen when you start dictation.",
-                status: micGranted ? "Ready" : "Required",
-                tone: micGranted ? .ready : .needed,
-                buttonTitle: micGranted ? nil : TranscriptedPermissionKind.microphone.actionButtonTitle
-            ) {
-                onPermissionAction(.microphone)
-            }
+            OnboardingCard(padding: 0) {
+                VStack(spacing: 0) {
+                    SetupRow(
+                        icon: "mic.fill",
+                        title: "Microphone",
+                        detail: "Listen when you start dictation.",
+                        status: micGranted ? "Ready" : "Required",
+                        tone: micGranted ? .ready : .needed,
+                        buttonTitle: micGranted ? nil : TranscriptedPermissionKind.microphone.actionButtonTitle
+                    ) {
+                        onPermissionAction(.microphone)
+                    }
 
-            SetupRow(
-                icon: "text.cursor",
-                title: "Paste-back",
-                detail: "Lets Transcripted paste the dictation into the app you were using.",
-                status: accessibilityGranted ? "Ready" : "Required",
-                tone: accessibilityGranted ? .ready : .needed,
-                buttonTitle: accessibilityGranted ? nil : TranscriptedPermissionKind.accessibility.actionButtonTitle
-            ) {
-                onPermissionAction(.accessibility)
-            }
+                    OnboardingHairline()
 
-            LocalModelSetupRow(status: modelStatus)
+                    SetupRow(
+                        icon: "text.cursor",
+                        title: "Paste into other apps",
+                        detail: "Put the finished dictation back where you were typing.",
+                        status: accessibilityGranted ? "Ready" : "Required",
+                        tone: accessibilityGranted ? .ready : .needed,
+                        buttonTitle: accessibilityGranted ? nil : TranscriptedPermissionKind.accessibility.actionButtonTitle
+                    ) {
+                        onPermissionAction(.accessibility)
+                    }
+
+                    OnboardingHairline()
+
+                    LocalModelSetupRow(status: modelStatus)
+                }
+            }
         }
     }
 }
@@ -1039,25 +1020,25 @@ private struct TestDictationStepView: View {
             )
 
             OnboardingCard {
-                VStack(alignment: .leading, spacing: 14) {
-                    Label(FirstRunOnboardingCopy.dictationPrompt, systemImage: "waveform")
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(MenuTokens.textPrimary)
-                        .fixedSize(horizontal: false, vertical: true)
+                VStack(alignment: .leading, spacing: 16) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label("Say this out loud", systemImage: "waveform")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(MenuTokens.textPrimary)
 
-                    Text("Start dictation, say the sentence, then click Stop and Save here.")
-                        .font(.callout)
-                        .foregroundStyle(MenuTokens.textSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
+                        Text("\"Remind me to review the pricing call.\"")
+                            .font(.system(size: 25, weight: .semibold))
+                            .foregroundStyle(MenuTokens.textPrimary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        Text("Then stop the capture. Transcripted will paste the text back and save a Markdown copy.")
+                            .font(.callout)
+                            .foregroundStyle(MenuTokens.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
 
                     if isRunning {
-                        HStack(spacing: 8) {
-                            ProgressView()
-                                .controlSize(.small)
-                            Text("Listening or preparing...")
-                                .font(.footnote.weight(.semibold))
-                                .foregroundStyle(MenuTokens.textSecondary)
-                        }
+                        ListeningStatePill()
                     }
 
                     if let issue {
@@ -1068,14 +1049,6 @@ private struct TestDictationStepView: View {
                             tone: .warning
                         )
                     }
-
-                    Button {
-                        isRunning ? onStop() : onStart()
-                    } label: {
-                        Label(isRunning ? "Stop and Save" : "Start Dictation", systemImage: isRunning ? "stop.fill" : "mic.fill")
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.large)
                 }
             }
         }
@@ -1099,7 +1072,7 @@ private struct FirstDictationResultStepView: View {
             if let entry {
                 OnboardingCard {
                     VStack(alignment: .leading, spacing: 14) {
-                        Text("Transcript preview")
+                        Label("Your words are now Markdown", systemImage: "checkmark.circle.fill")
                             .font(.headline.weight(.semibold))
                             .foregroundStyle(MenuTokens.textPrimary)
 
@@ -1178,22 +1151,7 @@ private struct MeetingsIntroStepView: View {
                 detail: "Once dictation works, the same idea expands to meetings."
             )
 
-            OnboardingCard {
-                HStack(spacing: 14) {
-                    FlowSymbol(name: "person.2.wave.2.fill", title: "Conversation")
-                    FlowArrow()
-                    FlowSymbol(name: "waveform", title: "Recording")
-                    FlowArrow()
-                    FlowSymbol(name: "doc.text.fill", title: "Notes")
-                }
-                .frame(maxWidth: .infinity)
-            }
-
-            OnboardingCallout(
-                icon: "record.circle.fill",
-                title: "Meetings become notes",
-                detail: FirstRunOnboardingCopy.meetingsDetail
-            )
+            MeetingNotePreviewCard()
         }
     }
 }
@@ -1217,37 +1175,45 @@ private struct MeetingSetupStepView: View {
                 detail: "Meeting recording needs your microphone plus System Audio Recording for the other side of calls."
             )
 
-            SetupRow(
-                icon: "mic.fill",
-                title: "Microphone",
-                detail: "Already used for your side of meetings.",
-                status: micGranted ? "Ready" : "Required",
-                tone: micGranted ? .ready : .needed,
-                buttonTitle: micGranted ? nil : TranscriptedPermissionKind.microphone.actionButtonTitle
-            ) {
-                onPermissionAction(.microphone)
-            }
+            OnboardingCard(padding: 0) {
+                VStack(spacing: 0) {
+                    SetupRow(
+                        icon: "mic.fill",
+                        title: "Microphone",
+                        detail: "Already used for your side of meetings.",
+                        status: micGranted ? "Ready" : "Required",
+                        tone: micGranted ? .ready : .needed,
+                        buttonTitle: micGranted ? nil : TranscriptedPermissionKind.microphone.actionButtonTitle
+                    ) {
+                        onPermissionAction(.microphone)
+                    }
 
-            SetupRow(
-                icon: "speaker.wave.2.fill",
-                title: "System Audio Recording",
-                detail: "Captures the other side of Zoom, Meet, videos, and calls.",
-                status: systemRecordingGranted ? "Ready" : "Needed for meetings",
-                tone: systemRecordingGranted ? .ready : .needed,
-                buttonTitle: systemRecordingGranted ? nil : TranscriptedPermissionKind.systemAudioRecording.actionButtonTitle
-            ) {
-                onPermissionAction(.systemAudioRecording)
-            }
+                    OnboardingHairline()
 
-            SetupRow(
-                icon: "calendar",
-                title: "Calendar",
-                detail: "Optional. Helps Transcripted spot meetings and offer a record prompt.",
-                status: calendarGranted ? "Ready" : "Optional",
-                tone: calendarGranted ? .ready : .neutral,
-                buttonTitle: calendarGranted ? nil : TranscriptedPermissionKind.calendar.actionButtonTitle
-            ) {
-                onPermissionAction(.calendar)
+                    SetupRow(
+                        icon: "speaker.wave.2.fill",
+                        title: "System Audio Recording",
+                        detail: "Captures the other side of Zoom, Meet, videos, and calls.",
+                        status: systemRecordingGranted ? "Ready" : "Needed for meetings",
+                        tone: systemRecordingGranted ? .ready : .needed,
+                        buttonTitle: systemRecordingGranted ? nil : TranscriptedPermissionKind.systemAudioRecording.actionButtonTitle
+                    ) {
+                        onPermissionAction(.systemAudioRecording)
+                    }
+
+                    OnboardingHairline()
+
+                    SetupRow(
+                        icon: "calendar",
+                        title: "Calendar",
+                        detail: "Optional. Helps Transcripted spot meetings and offer a record prompt.",
+                        status: calendarGranted ? "Ready" : "Optional",
+                        tone: calendarGranted ? .ready : .neutral,
+                        buttonTitle: calendarGranted ? nil : TranscriptedPermissionKind.calendar.actionButtonTitle
+                    ) {
+                        onPermissionAction(.calendar)
+                    }
+                }
             }
 
             OnboardingCard {
@@ -1339,22 +1305,7 @@ private struct AgentPayoffStepView: View {
                 detail: FirstRunOnboardingCopy.agentDetail
             )
 
-            OnboardingCard {
-                HStack(spacing: 14) {
-                    FlowSymbol(name: "folder.fill", title: "Markdown")
-                    FlowArrow()
-                    FlowSymbol(name: "magnifyingglass", title: "Search")
-                    FlowArrow()
-                    FlowSymbol(name: "sparkles", title: "Agent")
-                }
-                .frame(maxWidth: .infinity)
-            }
-
-            VStack(alignment: .leading, spacing: 8) {
-                AgentPromptPill(text: "Search my meetings")
-                AgentPromptPill(text: "What am I working on?")
-                AgentPromptPill(text: "Summarize today")
-            }
+            AgentContextPreviewCard()
 
             HStack(spacing: 10) {
                 Button {
@@ -1409,29 +1360,41 @@ private struct ReportingConsentCard: View {
 
     var body: some View {
         OnboardingCard {
-            VStack(alignment: .leading, spacing: 12) {
-                Label("Help improve Transcripted", systemImage: "bolt.shield.fill")
-                    .font(.headline.weight(.semibold))
-                    .foregroundStyle(MenuTokens.textPrimary)
+            HStack(alignment: .top, spacing: 14) {
+                Image(systemName: "bolt.shield.fill")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: 36, height: 36)
+                    .background(Circle().fill(Color.accentColor.opacity(0.12)))
 
-                Text("Privacy-safe diagnostics help catch setup problems. Transcripted never sends transcript text, audio, meeting titles, speaker names, source app names, emails, file paths, or raw URLs.")
-                    .font(.footnote)
-                    .foregroundStyle(MenuTokens.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Privacy-safe diagnostics")
+                        .font(.headline.weight(.semibold))
+                        .foregroundStyle(MenuTokens.textPrimary)
 
-                ToggleRow(
-                    title: "Crash and error reports",
-                    detail: crashReportingAvailable ? "Scrubbed reliability events only." : "Unavailable in this build.",
-                    isOn: Binding(get: { crashReportingEnabled }, set: { onCrashToggle($0) }),
-                    isEnabled: crashReportingAvailable
-                )
+                    Text("Helps catch setup problems. Never sends transcript text, audio, meeting titles, speaker names, emails, file paths, or URLs.")
+                        .font(.footnote)
+                        .foregroundStyle(MenuTokens.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
-                ToggleRow(
-                    title: "Anonymous usage stats",
-                    detail: analyticsAvailable ? "Allowlisted product events only." : "Unavailable until PostHog is configured.",
-                    isOn: Binding(get: { anonymousAnalyticsEnabled }, set: { onAnalyticsToggle($0) }),
-                    isEnabled: analyticsAvailable
-                )
+                Spacer(minLength: 16)
+
+                VStack(alignment: .trailing, spacing: 8) {
+                    ToggleRow(
+                        title: "Crash reports",
+                        detail: crashReportingAvailable ? "Scrubbed only" : "Unavailable",
+                        isOn: Binding(get: { crashReportingEnabled }, set: { onCrashToggle($0) }),
+                        isEnabled: crashReportingAvailable
+                    )
+
+                    ToggleRow(
+                        title: "Usage stats",
+                        detail: analyticsAvailable ? "Allowlisted only" : "Unavailable",
+                        isOn: Binding(get: { anonymousAnalyticsEnabled }, set: { onAnalyticsToggle($0) }),
+                        isEnabled: analyticsAvailable
+                    )
+                }
             }
         }
     }
@@ -1447,16 +1410,14 @@ private struct ToggleRow: View {
         HStack(alignment: .center, spacing: 12) {
             VStack(alignment: .leading, spacing: 3) {
                 Text(title)
-                    .font(.subheadline.weight(.semibold))
+                    .font(.footnote.weight(.semibold))
                     .foregroundStyle(MenuTokens.textPrimary)
 
                 Text(detail)
-                    .font(.footnote)
+                    .font(.caption)
                     .foregroundStyle(MenuTokens.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
-
-            Spacer()
 
             Toggle("", isOn: $isOn)
                 .labelsHidden()
@@ -1464,11 +1425,7 @@ private struct ToggleRow: View {
                 .accessibilityLabel(title)
                 .help(detail)
         }
-        .padding(12)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(MenuTokens.pillBackground)
-        )
+        .frame(minHeight: 40)
     }
 }
 
@@ -1479,7 +1436,7 @@ private struct ScreenTitle: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title)
-                .font(.system(size: 30, weight: .semibold))
+                .font(.system(size: 31, weight: .semibold))
                 .foregroundStyle(MenuTokens.textPrimary)
                 .fixedSize(horizontal: false, vertical: true)
 
@@ -1487,6 +1444,212 @@ private struct ScreenTitle: View {
                 .font(.title3.weight(.medium))
                 .foregroundStyle(MenuTokens.textSecondary)
                 .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+private struct OutcomePreviewCard: View {
+    var body: some View {
+        OnboardingCard {
+            HStack(alignment: .top, spacing: 18) {
+                PreviewColumn(
+                    icon: "waveform",
+                    title: "Speak",
+                    detail: "\"Review onboarding before pricing.\""
+                )
+
+                FlowArrow()
+                    .padding(.top, 28)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    PreviewColumnHeader(icon: "doc.text.fill", title: "Markdown")
+
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text("# Dictation")
+                            .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                        Text("Review onboarding before pricing.")
+                            .font(.system(size: 12, design: .monospaced))
+                    }
+                    .foregroundStyle(MenuTokens.textPrimary)
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .fill(Color.black.opacity(0.22))
+                    )
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                FlowArrow()
+                    .padding(.top, 28)
+
+                PreviewColumn(
+                    icon: "sparkles",
+                    title: "Agent",
+                    detail: "Ask: what did I say I should do next?"
+                )
+            }
+        }
+    }
+}
+
+private struct AgentContextStrip: View {
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "folder.fill")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+                .frame(width: 34, height: 34)
+                .background(Circle().fill(Color.accentColor.opacity(0.12)))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Everything lands in local Markdown")
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(MenuTokens.textPrimary)
+
+                Text(FirstRunOnboardingCopy.valueFooter)
+                    .font(.callout)
+                    .foregroundStyle(MenuTokens.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.accentColor.opacity(0.08))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(Color.accentColor.opacity(0.16), lineWidth: 1)
+                )
+        )
+    }
+}
+
+private struct ListeningStatePill: View {
+    var body: some View {
+        HStack(spacing: 9) {
+            ProgressView()
+                .controlSize(.small)
+
+            Text("Listening or preparing...")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(MenuTokens.textSecondary)
+        }
+        .padding(.horizontal, 11)
+        .padding(.vertical, 8)
+        .background(
+            Capsule()
+                .fill(Color.white.opacity(0.07))
+        )
+    }
+}
+
+private struct MeetingNotePreviewCard: View {
+    var body: some View {
+        OnboardingCard {
+            HStack(alignment: .top, spacing: 18) {
+                VStack(alignment: .leading, spacing: 10) {
+                    PreviewColumnHeader(icon: "record.circle.fill", title: "Meeting")
+                    Text("Transcripted records your mic plus system audio. No bot joins the call.")
+                        .font(.callout)
+                        .foregroundStyle(MenuTokens.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    PreviewColumnHeader(icon: "doc.text.fill", title: "Notes")
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("## Decisions")
+                            .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                        Text("- Keep pricing manual this week")
+                            .font(.system(size: 12, design: .monospaced))
+                        Text("## Follow-ups")
+                            .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                        Text("- Review onboarding dropoff")
+                            .font(.system(size: 12, design: .monospaced))
+                    }
+                    .foregroundStyle(MenuTokens.textPrimary)
+                    .padding(10)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .fill(Color.black.opacity(0.22))
+                    )
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+}
+
+private struct AgentContextPreviewCard: View {
+    var body: some View {
+        OnboardingCard {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(alignment: .top, spacing: 14) {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(Color.accentColor)
+                        .frame(width: 40, height: 40)
+                        .background(Circle().fill(Color.accentColor.opacity(0.12)))
+
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text("Your agent gets searchable spoken context")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(MenuTokens.textPrimary)
+
+                        Text("Point an agent at the capture folder and ask across dictations, meetings, and imported audio.")
+                            .font(.callout)
+                            .foregroundStyle(MenuTokens.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                HStack(spacing: 8) {
+                    AgentPromptPill(text: "Search my meetings")
+                    AgentPromptPill(text: "What am I working on?")
+                    AgentPromptPill(text: "Summarize today")
+                }
+            }
+        }
+    }
+}
+
+private struct PreviewColumn: View {
+    let icon: String
+    let title: String
+    let detail: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            PreviewColumnHeader(icon: icon, title: title)
+
+            Text(detail)
+                .font(.callout)
+                .foregroundStyle(MenuTokens.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct PreviewColumnHeader: View {
+    let icon: String
+    let title: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(MenuTokens.textPrimary)
         }
     }
 }
@@ -1502,6 +1665,8 @@ private struct ValueCard: View {
                 Image(systemName: icon)
                     .font(.system(size: 24, weight: .semibold))
                     .foregroundStyle(Color.accentColor)
+                    .frame(width: 42, height: 42)
+                    .background(Circle().fill(Color.accentColor.opacity(0.12)))
 
                 Text(title)
                     .font(.title3.weight(.semibold))
@@ -1512,7 +1677,7 @@ private struct ValueCard: View {
                     .foregroundStyle(MenuTokens.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
-            .frame(maxWidth: .infinity, minHeight: 130, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: 148, alignment: .leading)
         }
     }
 }
@@ -1548,43 +1713,42 @@ private struct SetupRow: View {
     let action: () -> Void
 
     var body: some View {
-        OnboardingCard {
-            HStack(alignment: .center, spacing: 14) {
-                ZStack {
-                    Circle()
-                        .fill(MenuTokens.pillBackground)
-                        .frame(width: 42, height: 42)
+        HStack(alignment: .center, spacing: 14) {
+            ZStack {
+                Circle()
+                    .fill(tone.color.opacity(tone == .neutral ? 0.10 : 0.14))
+                    .frame(width: 42, height: 42)
 
-                    Image(systemName: icon)
-                        .font(.system(size: 17, weight: .semibold))
+                Image(systemName: tone == .ready ? "checkmark" : icon)
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(tone == .ready ? MenuTokens.statusGreen : MenuTokens.textPrimary)
+            }
+
+            VStack(alignment: .leading, spacing: 5) {
+                HStack(spacing: 8) {
+                    Text(title)
+                        .font(.headline.weight(.semibold))
                         .foregroundStyle(MenuTokens.textPrimary)
+
+                    StatusBadge(title: status, tone: tone)
                 }
 
-                VStack(alignment: .leading, spacing: 5) {
-                    HStack(spacing: 8) {
-                        Text(title)
-                            .font(.headline.weight(.semibold))
-                            .foregroundStyle(MenuTokens.textPrimary)
+                Text(detail)
+                    .font(.callout)
+                    .foregroundStyle(MenuTokens.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
 
-                        StatusBadge(title: status, tone: tone)
-                    }
+            Spacer(minLength: 8)
 
-                    Text(detail)
-                        .font(.callout)
-                        .foregroundStyle(MenuTokens.textSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
+            if let buttonTitle {
+                Button(buttonTitle) {
+                    action()
                 }
-
-                Spacer(minLength: 8)
-
-                if let buttonTitle {
-                    Button(buttonTitle) {
-                        action()
-                    }
-                    .buttonStyle(.borderedProminent)
-                }
+                .buttonStyle(.borderedProminent)
             }
         }
+        .padding(16)
     }
 }
 
@@ -1592,42 +1756,41 @@ private struct LocalModelSetupRow: View {
     let status: FirstRunModelCardState
 
     var body: some View {
-        OnboardingCard {
-            VStack(alignment: .leading, spacing: 10) {
-                HStack(alignment: .center, spacing: 14) {
-                    ZStack {
-                        Circle()
-                            .fill(MenuTokens.pillBackground)
-                            .frame(width: 42, height: 42)
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 14) {
+                ZStack {
+                    Circle()
+                        .fill(iconColor.opacity(0.14))
+                        .frame(width: 42, height: 42)
 
-                        Image(systemName: iconName)
-                            .font(.system(size: 17, weight: .semibold))
-                            .foregroundStyle(iconColor)
-                    }
-
-                    VStack(alignment: .leading, spacing: 5) {
-                        HStack(spacing: 8) {
-                            Text("Local model")
-                                .font(.headline.weight(.semibold))
-                                .foregroundStyle(MenuTokens.textPrimary)
-
-                            StatusBadge(title: status.status, tone: tone)
-                        }
-
-                        Text(status.detail)
-                            .font(.callout)
-                            .foregroundStyle(MenuTokens.textSecondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
+                    Image(systemName: iconName)
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(iconColor)
                 }
 
-                if let progress = status.progress, status.tone != .ready {
-                    ProgressView(value: progress)
-                        .progressViewStyle(.linear)
-                        .tint(iconColor)
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack(spacing: 8) {
+                        Text("Local model")
+                            .font(.headline.weight(.semibold))
+                            .foregroundStyle(MenuTokens.textPrimary)
+
+                        StatusBadge(title: status.status, tone: tone)
+                    }
+
+                    Text(status.detail)
+                        .font(.callout)
+                        .foregroundStyle(MenuTokens.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
+
+            if let progress = status.progress, status.tone != .ready {
+                ProgressView(value: progress)
+                    .progressViewStyle(.linear)
+                    .tint(iconColor)
+            }
         }
+        .padding(16)
     }
 
     private var iconName: String {
@@ -1670,10 +1833,10 @@ private struct StatusBadge: View {
             .padding(.vertical, 4)
             .background(
                 Capsule()
-                    .fill(tone == .ready ? MenuTokens.savedBackground : MenuTokens.pillBackground)
+                    .fill(tone.color.opacity(tone == .ready ? 0.16 : 0.10))
                     .overlay(
                         Capsule()
-                            .stroke(tone == .ready ? MenuTokens.savedBorder : MenuTokens.pillBorder, lineWidth: 1)
+                            .stroke(tone.color.opacity(tone == .ready ? 0.24 : 0.18), lineWidth: 1)
                     )
             )
     }
@@ -1721,19 +1884,34 @@ private struct OnboardingCallout: View {
 }
 
 private struct OnboardingCard<Content: View>: View {
+    let padding: CGFloat
     @ViewBuilder let content: () -> Content
+
+    init(padding: CGFloat = 16, @ViewBuilder content: @escaping () -> Content) {
+        self.padding = padding
+        self.content = content
+    }
 
     var body: some View {
         content()
-            .padding(16)
+            .padding(padding)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(MenuTokens.pillBackground)
+                    .fill(Color.white.opacity(0.055))
                     .overlay(
                         RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .stroke(MenuTokens.pillBorder, lineWidth: 1)
+                            .stroke(Color.white.opacity(0.085), lineWidth: 1)
                     )
+                    .shadow(color: .black.opacity(0.14), radius: 14, y: 8)
             )
+    }
+}
+
+private struct OnboardingHairline: View {
+    var body: some View {
+        Rectangle()
+            .fill(Color.white.opacity(0.08))
+            .frame(height: 1)
     }
 }
 
@@ -1783,19 +1961,17 @@ private struct AgentPromptPill: View {
                 .foregroundStyle(Color.accentColor)
 
             Text(text)
-                .font(.callout.weight(.semibold))
+                .font(.footnote.weight(.semibold))
                 .foregroundStyle(MenuTokens.textPrimary)
-
-            Spacer()
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
+        .padding(.horizontal, 11)
+        .padding(.vertical, 8)
         .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(MenuTokens.pillBackground)
+            Capsule()
+                .fill(Color.white.opacity(0.07))
                 .overlay(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(MenuTokens.pillBorder, lineWidth: 1)
+                    Capsule()
+                        .stroke(Color.white.opacity(0.10), lineWidth: 1)
                 )
         )
     }
@@ -1824,6 +2000,19 @@ private struct AppIconPreview: View {
 }
 
 private extension FirstRunOnboardingStep {
+    var phaseTitle: String {
+        switch self {
+        case .hero, .value:
+            return "Value"
+        case .dictationSetup, .testDictation, .dictationResult:
+            return "Dictation"
+        case .meetingsIntro, .meetingSetup:
+            return "Meetings"
+        case .agentPayoff:
+            return "Agent"
+        }
+    }
+
     var analyticsValue: String {
         switch self {
         case .hero:

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -29,7 +29,7 @@ struct PermissionsOnboardingView: View {
 
     @ObservedObject private var sttRouter: STTRouter
     let canStartDictation: Bool
-    var onStartDictation: (() -> Void)?
+    var onStartDictation: ((NSRect?) -> Void)?
     var onStopDictation: (() -> Void)?
     var onStartMeetingDryRun: (() async -> Bool)?
     var onStopMeetingDryRun: (() async -> Bool)?
@@ -62,11 +62,12 @@ struct PermissionsOnboardingView: View {
     @State private var onboardingStartedAt = Date()
     @State private var currentStepStartedAt = Date()
     @State private var didCompleteOnboarding = false
+    @State private var dictationPracticeAnchor: NSRect?
 
     init(
         sttRouter: STTRouter,
         canStartDictation: Bool = false,
-        onStartDictation: (() -> Void)? = nil,
+        onStartDictation: ((NSRect?) -> Void)? = nil,
         onStopDictation: (() -> Void)? = nil,
         onStartMeetingDryRun: (() async -> Bool)? = nil,
         onStopMeetingDryRun: (() async -> Bool)? = nil,
@@ -170,10 +171,8 @@ struct PermissionsOnboardingView: View {
             )
         case .testDictation:
             TestDictationStepView(
-                isRunning: isFirstDictationRunning,
                 issue: firstDictationIssue,
-                onStart: startFirstDictation,
-                onStop: stopFirstDictation
+                onAnchorChange: { dictationPracticeAnchor = $0 }
             )
         case .dictationResult:
             FirstDictationResultStepView(
@@ -405,7 +404,7 @@ struct PermissionsOnboardingView: View {
             return
         }
 
-        onStartDictation()
+        onStartDictation(dictationPracticeAnchor)
     }
 
     private func stopFirstDictation() {
@@ -913,8 +912,6 @@ private struct HeroStepView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 22) {
             VStack(alignment: .leading, spacing: 14) {
-                AppIconPreview(size: 78)
-
                 Text(FirstRunOnboardingStep.hero.screenTitle)
                     .font(.system(size: 34, weight: .semibold))
                     .foregroundStyle(MenuTokens.textPrimary)
@@ -1007,10 +1004,8 @@ private struct DictationSetupStepView: View {
 }
 
 private struct TestDictationStepView: View {
-    let isRunning: Bool
     let issue: String?
-    let onStart: () -> Void
-    let onStop: () -> Void
+    let onAnchorChange: (NSRect?) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -1037,10 +1032,6 @@ private struct TestDictationStepView: View {
                             .fixedSize(horizontal: false, vertical: true)
                     }
 
-                    if isRunning {
-                        ListeningStatePill()
-                    }
-
                     if let issue {
                         OnboardingCallout(
                             icon: "exclamationmark.triangle.fill",
@@ -1051,6 +1042,7 @@ private struct TestDictationStepView: View {
                     }
                 }
             }
+            .background(OnboardingScreenFrameReader(onChange: onAnchorChange))
         }
     }
 }
@@ -1527,25 +1519,6 @@ private struct AgentContextStrip: View {
     }
 }
 
-private struct ListeningStatePill: View {
-    var body: some View {
-        HStack(spacing: 9) {
-            ProgressView()
-                .controlSize(.small)
-
-            Text("Listening or preparing...")
-                .font(.footnote.weight(.semibold))
-                .foregroundStyle(MenuTokens.textSecondary)
-        }
-        .padding(.horizontal, 11)
-        .padding(.vertical, 8)
-        .background(
-            Capsule()
-                .fill(Color.white.opacity(0.07))
-        )
-    }
-}
-
 private struct MeetingNotePreviewCard: View {
     var body: some View {
         OnboardingCard {
@@ -1996,6 +1969,62 @@ private struct AppIconPreview: View {
             .frame(width: size, height: size)
             .clipShape(RoundedRectangle(cornerRadius: min(16, size * 0.22), style: .continuous))
             .shadow(color: .black.opacity(0.2), radius: 10, y: 4)
+    }
+}
+
+private struct OnboardingScreenFrameReader: NSViewRepresentable {
+    let onChange: (NSRect?) -> Void
+
+    func makeNSView(context: Context) -> AnchorTrackingView {
+        let view = AnchorTrackingView()
+        view.onChange = onChange
+        return view
+    }
+
+    func updateNSView(_ nsView: AnchorTrackingView, context: Context) {
+        nsView.onChange = onChange
+        nsView.publishScreenFrame()
+    }
+
+    final class AnchorTrackingView: NSView {
+        var onChange: ((NSRect?) -> Void)?
+        private var lastFrame: NSRect?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            publishScreenFrame()
+        }
+
+        override func layout() {
+            super.layout()
+            publishScreenFrame()
+        }
+
+        override func setFrameSize(_ newSize: NSSize) {
+            super.setFrameSize(newSize)
+            publishScreenFrame()
+        }
+
+        func publishScreenFrame() {
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                guard let window = self.window else {
+                    if self.lastFrame != nil {
+                        self.lastFrame = nil
+                        self.onChange?(nil)
+                    }
+                    return
+                }
+
+                let windowRect = self.convert(self.bounds, to: nil)
+                let screenRect = window.convertToScreen(windowRect)
+                guard screenRect.width > 0, screenRect.height > 0 else { return }
+                if self.lastFrame != screenRect {
+                    self.lastFrame = screenRect
+                    self.onChange?(screenRect)
+                }
+            }
+        }
     }
 }
 

--- a/Sources/UI/Settings/TranscriptedOnboardingWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedOnboardingWindowController.swift
@@ -19,7 +19,7 @@ final class TranscriptedOnboardingWindowController: NSWindowController {
                 width: MenuTokens.onboardingWindowWidth,
                 height: MenuTokens.onboardingWindowHeight
             ),
-            styleMask: [.titled, .closable, .fullSizeContentView],
+            styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
@@ -28,10 +28,10 @@ final class TranscriptedOnboardingWindowController: NSWindowController {
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = true
         window.isReleasedWhenClosed = false
+        window.minSize = NSSize(width: MenuTokens.onboardingWindowWidth, height: 700)
         window.contentViewController = hostingController
         window.center()
         window.standardWindowButton(.miniaturizeButton)?.isHidden = true
-        window.standardWindowButton(.zoomButton)?.isHidden = true
 
         super.init(window: window)
     }

--- a/Sources/UI/Settings/TranscriptedOnboardingWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedOnboardingWindowController.swift
@@ -28,7 +28,7 @@ final class TranscriptedOnboardingWindowController: NSWindowController {
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = true
         window.isReleasedWhenClosed = false
-        window.minSize = NSSize(width: MenuTokens.onboardingWindowWidth, height: 700)
+        window.minSize = NSSize(width: MenuTokens.onboardingWindowWidth, height: 680)
         window.contentViewController = hostingController
         window.center()
         window.standardWindowButton(.miniaturizeButton)?.isHidden = true

--- a/Sources/UI/Settings/TranscriptedSettingsPage.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsPage.swift
@@ -15,6 +15,15 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
+    var analyticsValue: String {
+        switch self {
+        case .connectAgent:
+            return "connect_agent"
+        default:
+            return rawValue
+        }
+    }
+
     var title: String {
         switch self {
         case .home: return "Home"

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -123,9 +123,11 @@ struct TranscriptedSettingsView: View {
         .onAppear(perform: refreshState)
         .task(id: navigation.presentationID) {
             refreshState()
+            trackSettingsPageViewed(navigation.selectedPage, source: "presentation")
         }
-        .onChange(of: navigation.selectedPage) { _, _ in
+        .onChange(of: navigation.selectedPage) { _, page in
             refreshRecentCaptures()
+            trackSettingsPageViewed(page, source: "navigation")
         }
         .onChange(of: meetingSession.lastSavedTranscriptURL) { _, _ in
             refreshRecentCaptures()
@@ -206,7 +208,10 @@ struct TranscriptedSettingsView: View {
                     menuBarVisibility: menuBarVisibilityBinding(for: .startDictation),
                     actionHelp: "Start dictation now.",
                     menuBarVisibilityHelp: "Show or hide Start Dictation in the menu bar popover.",
-                    action: actions.startDictation
+                    action: {
+                        trackSettingsAction("start_dictation", page: .home)
+                        actions.startDictation()
+                    }
                 )
 
                 SettingsActionTile(
@@ -217,7 +222,10 @@ struct TranscriptedSettingsView: View {
                     menuBarVisibility: menuBarVisibilityBinding(for: .startMeeting),
                     actionHelp: "Start a meeting recording now.",
                     menuBarVisibilityHelp: "Show or hide Start Meeting in the menu bar popover.",
-                    action: actions.startMeeting
+                    action: {
+                        trackSettingsAction("start_meeting", page: .home)
+                        actions.startMeeting()
+                    }
                 )
 
                 SettingsActionTile(
@@ -227,7 +235,10 @@ struct TranscriptedSettingsView: View {
                     menuBarVisibility: menuBarVisibilityBinding(for: .pasteLastDictation),
                     actionHelp: "Paste the newest saved dictation into the current app.",
                     menuBarVisibilityHelp: "Show or hide Paste Last Dictation in the menu bar popover.",
-                    action: actions.pasteLastDictation
+                    action: {
+                        trackSettingsAction("paste_last_dictation", page: .home)
+                        actions.pasteLastDictation()
+                    }
                 )
 
                 SettingsActionTile(
@@ -238,6 +249,7 @@ struct TranscriptedSettingsView: View {
                     actionHelp: "Open the Meetings page to browse saved meeting notes.",
                     menuBarVisibilityHelp: "Show or hide Recent Meetings in the menu bar popover.",
                     action: {
+                        trackSettingsAction("open_recent_meetings", page: .home)
                         navigation.selectedPage = .meetings
                     }
                 )
@@ -254,6 +266,7 @@ struct TranscriptedSettingsView: View {
                     actionTitle: activity.transcriptURL == nil ? nil : "Open Transcript",
                     action: activity.transcriptURL.map { transcriptURL in
                         {
+                            trackSettingsAction("open_current_activity", page: .home)
                             NSWorkspace.shared.open(transcriptURL)
                         }
                     }
@@ -310,6 +323,7 @@ struct TranscriptedSettingsView: View {
                     title: "Shortcuts",
                     detail: "Change the keys Transcripted listens for."
                 ) {
+                    trackSettingsAction("quick_link_shortcuts", page: .home)
                     navigation.selectedPage = .shortcuts
                 }
 
@@ -318,6 +332,7 @@ struct TranscriptedSettingsView: View {
                     title: "Meetings",
                     detail: "Record calls and import audio."
                 ) {
+                    trackSettingsAction("quick_link_meetings", page: .home)
                     navigation.selectedPage = .meetings
                 }
 
@@ -326,6 +341,7 @@ struct TranscriptedSettingsView: View {
                     title: "People",
                     detail: "Review saved speakers and duplicates."
                 ) {
+                    trackSettingsAction("quick_link_people", page: .home)
                     navigation.selectedPage = .people
                 }
 
@@ -334,6 +350,7 @@ struct TranscriptedSettingsView: View {
                     title: "Storage",
                     detail: "See where Markdown files live."
                 ) {
+                    trackSettingsAction("quick_link_storage", page: .home)
                     navigation.selectedPage = .storage
                 }
 
@@ -342,6 +359,7 @@ struct TranscriptedSettingsView: View {
                     title: "Privacy",
                     detail: "Review permissions and reporting."
                 ) {
+                    trackSettingsAction("quick_link_privacy", page: .home)
                     navigation.selectedPage = .privacy
                 }
             }
@@ -384,6 +402,7 @@ struct TranscriptedSettingsView: View {
                     get: { autoEnterEnabled },
                     set: { newValue in
                         autoEnterEnabled = newValue
+                        trackSettingsToggle("auto_send", enabled: newValue, page: .shortcuts)
                         DictationAutoSendPreferences.setEnabled(newValue)
                     }
                 ))
@@ -392,6 +411,7 @@ struct TranscriptedSettingsView: View {
                     get: { autoEnterKey },
                     set: { newValue in
                         autoEnterKey = newValue
+                        trackSettingsAction("change_auto_send_key", page: .shortcuts)
                         DictationAutoSendPreferences.setSendKey(newValue)
                     }
                 )) {
@@ -410,10 +430,12 @@ struct TranscriptedSettingsView: View {
                         Spacer()
 
                         Button("Refresh") {
+                            trackSettingsAction("refresh_auto_send_apps", page: .shortcuts)
                             refreshAutoEnterAppCandidates()
                         }
 
                         Button("Add App…") {
+                            trackSettingsAction("add_auto_send_app", page: .shortcuts)
                             chooseAutoEnterApp()
                         }
                     }
@@ -627,6 +649,7 @@ struct TranscriptedSettingsView: View {
                     title: "Start Meeting",
                     detail: "Capture your mic and computer audio."
                 ) {
+                    trackSettingsAction("start_meeting", page: .meetings)
                     actions.startMeeting()
                 }
 
@@ -635,6 +658,7 @@ struct TranscriptedSettingsView: View {
                     title: "Transcribe Audio File",
                     detail: "Turn an audio file into meeting notes."
                 ) {
+                    trackSettingsAction("import_recording", page: .meetings)
                     actions.importAudioFile()
                 }
 
@@ -652,9 +676,11 @@ struct TranscriptedSettingsView: View {
                         SettingsFailedMeetingRow(
                             item: item,
                             retryAction: {
+                                trackSettingsAction("retry_failed_meeting", page: .meetings)
                                 meetingSession.retryFailedMeeting(id: item.id)
                             },
                             secondaryAction: {
+                                trackSettingsAction(item.hasAudioFiles ? "delete_failed_meeting" : "dismiss_failed_meeting", page: .meetings)
                                 if item.hasAudioFiles {
                                     meetingSession.deleteFailedMeeting(id: item.id)
                                 } else {
@@ -681,9 +707,11 @@ struct TranscriptedSettingsView: View {
                             detail: formattedRecentDate(item.date),
                             isCopied: copiedAgentMeetingID == item.id,
                             openAction: {
+                                trackSettingsAction("open_recent_meeting", page: .meetings)
                                 NSWorkspace.shared.open(item.transcriptURL)
                             },
                             copyForAgentAction: {
+                                trackSettingsAction("copy_recent_meeting_for_agent", page: .meetings)
                                 copyMeetingForAgent(item)
                             }
                         )
@@ -720,6 +748,7 @@ struct TranscriptedSettingsView: View {
                     title: "Paste Last Dictation",
                     detail: "Paste into the app you were using."
                 ) {
+                    trackSettingsAction("paste_last_dictation", page: .dictations)
                     actions.pasteLastDictation()
                 }
 
@@ -743,6 +772,7 @@ struct TranscriptedSettingsView: View {
                             title: item.title,
                             detail: "\(formattedRecentDate(item.createdAt)) • \(item.sourceAppName)"
                         ) {
+                            trackSettingsAction("open_recent_dictation", page: .dictations)
                             NSWorkspace.shared.open(item.url)
                         }
                     }
@@ -757,6 +787,7 @@ struct TranscriptedSettingsView: View {
                     get: { uiSoundsEnabled },
                     set: { newValue in
                         uiSoundsEnabled = newValue
+                        trackSettingsToggle("dictation_sounds", enabled: newValue, page: .dictations)
                         UISoundPreferences.setEnabled(newValue)
                     }
                 ))
@@ -788,12 +819,21 @@ struct TranscriptedSettingsView: View {
 
                 HStack {
                     Button("Choose Folder") {
+                        trackSettingsAction("choose_capture_library", page: .storage)
                         chooseCaptureLibrary()
                     }
 
                     Button("Reset to Default") {
+                        trackSettingsAction("reset_capture_library", page: .storage)
                         TranscriptedStoragePreferences.setCaptureLibraryURL(nil)
                         refreshStoragePaths()
+                        AnalyticsReporter.track(
+                            "settings_capture_library_changed",
+                            properties: [
+                                "location_type": "default",
+                                "page_id": TranscriptedSettingsPage.storage.analyticsValue,
+                            ]
+                        )
                     }
                 }
 
@@ -836,6 +876,7 @@ struct TranscriptedSettingsView: View {
             ) {
                 ForEach(TranscriptedPermissionKind.allCases) { kind in
                     PermissionStatusRow(kind: kind, granted: permissionStates[kind] ?? false) {
+                        trackPermissionCTA(kind)
                         TranscriptedPermissionAccess.openSettings(for: kind)
                         refreshPermissions()
                     }
@@ -850,6 +891,7 @@ struct TranscriptedSettingsView: View {
                     get: { crashReportingEnabled },
                     set: { newValue in
                         crashReportingEnabled = newValue
+                        trackSettingsToggle("crash_reporting", enabled: newValue, page: .privacy)
                         CrashReportingPreferences.setEnabled(newValue)
                         sentryTestStatus = nil
                     }
@@ -860,13 +902,20 @@ struct TranscriptedSettingsView: View {
                     get: { anonymousAnalyticsEnabled },
                     set: { newValue in
                         anonymousAnalyticsEnabled = newValue
-                        AnalyticsPreferences.setEnabled(newValue)
+                        if newValue {
+                            AnalyticsPreferences.setEnabled(true)
+                            trackSettingsToggle("anonymous_analytics", enabled: true, page: .privacy)
+                        } else {
+                            trackSettingsToggle("anonymous_analytics", enabled: false, page: .privacy)
+                            AnalyticsPreferences.setEnabled(false)
+                        }
                     }
                 ))
                 .disabled(!AnalyticsReporter.isAvailable)
 
                 HStack {
                     Button("Send Test Sentry Event") {
+                        trackSettingsAction("send_test_sentry_event", page: .privacy)
                         sendTestSentryEvent()
                     }
                     .disabled(!CrashReporter.isAvailable || !crashReportingEnabled)
@@ -920,11 +969,13 @@ struct TranscriptedSettingsView: View {
 
                 HStack {
                     Button(aboutUpdateButtonTitle) {
+                        trackSettingsAction("check_updates", page: .about)
                         actions.checkForUpdates()
                     }
                     .disabled(!sparkleUpdater.updateStatus.canCheckForUpdates)
 
                     Button("Submit Feedback") {
+                        trackSettingsAction("submit_feedback", page: .about)
                         actions.sendFeedback()
                     }
                 }
@@ -1052,6 +1103,48 @@ struct TranscriptedSettingsView: View {
         }
     }
 
+    private func trackSettingsPageViewed(_ page: TranscriptedSettingsPage, source: String) {
+        AnalyticsReporter.track(
+            "settings_page_viewed",
+            properties: [
+                "page_id": page.analyticsValue,
+                "source": source,
+            ]
+        )
+    }
+
+    private func trackSettingsAction(_ actionID: String, page: TranscriptedSettingsPage? = nil) {
+        AnalyticsReporter.track(
+            "settings_action_clicked",
+            properties: [
+                "action_id": actionID,
+                "page_id": (page ?? navigation.selectedPage).analyticsValue,
+            ]
+        )
+    }
+
+    private func trackSettingsToggle(_ settingID: String, enabled: Bool, page: TranscriptedSettingsPage? = nil) {
+        AnalyticsReporter.track(
+            "settings_toggle_changed",
+            properties: [
+                "enabled": enabled ? "true" : "false",
+                "page_id": (page ?? navigation.selectedPage).analyticsValue,
+                "setting_id": settingID,
+            ]
+        )
+    }
+
+    private func trackPermissionCTA(_ kind: TranscriptedPermissionKind) {
+        AnalyticsReporter.track(
+            "settings_permission_cta_clicked",
+            properties: [
+                "page_id": navigation.selectedPage.analyticsValue,
+                "permission_kind": kind.analyticsValue,
+                "prior_status": permissionStates[kind] == true ? "ready" : "pending",
+            ]
+        )
+    }
+
     private func refreshPermissions() {
         permissionStates = PermissionSnapshot.current()
     }
@@ -1083,6 +1176,7 @@ struct TranscriptedSettingsView: View {
     private func updateLaunchAtLogin(_ enabled: Bool) {
         let previousValue = launchAtLoginEnabled
         launchAtLoginEnabled = enabled
+        trackSettingsToggle("launch_at_login", enabled: enabled, page: .general)
 
         do {
             try LaunchAtLoginController.setEnabled(enabled)
@@ -1116,6 +1210,7 @@ struct TranscriptedSettingsView: View {
     private func updatePreferredTranscriptionModel(_ model: TranscriptionModelChoice) {
         preferredTranscriptionModel = model
         showAdvancedModelControls = true
+        trackSettingsAction("switch_model", page: .models)
         TranscriptionModelPreferences.setPreferredModel(model)
         Task { @MainActor in
             await sttRouter.initializeSelectedModel()
@@ -1127,6 +1222,7 @@ struct TranscriptedSettingsView: View {
             get: { menuBarItemVisibility[item] ?? true },
             set: { newValue in
                 menuBarItemVisibility[item] = newValue
+                trackSettingsToggle("menu_bar_\(item.analyticsValue)", enabled: newValue, page: .home)
                 MenuBarVisibilityPreferences.setVisible(item, newValue)
             }
         )
@@ -1164,6 +1260,13 @@ struct TranscriptedSettingsView: View {
         guard panel.runModal() == .OK, let url = panel.url else { return }
         TranscriptedStoragePreferences.setCaptureLibraryURL(url)
         refreshStoragePaths()
+        AnalyticsReporter.track(
+            "settings_capture_library_changed",
+            properties: [
+                "location_type": isUsingDefaultCaptureLibrary ? "default" : "custom",
+                "page_id": TranscriptedSettingsPage.storage.analyticsValue,
+            ]
+        )
     }
 
     private var sortedAutoEnterAllowedBundleIDs: [String] {
@@ -1178,6 +1281,7 @@ struct TranscriptedSettingsView: View {
         } else {
             autoEnterAllowedBundleIDs.remove(bundleID)
         }
+        trackSettingsToggle("auto_send_app_allowed", enabled: isAllowed, page: .shortcuts)
         DictationAutoSendPreferences.setAllowedBundleIDs(autoEnterAllowedBundleIDs)
     }
 

--- a/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
@@ -44,11 +44,18 @@ final class TranscriptedSettingsWindowController: NSWindowController, NSWindowDe
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError() }
 
-    func present(page: TranscriptedSettingsPage = .home) {
+    func present(page: TranscriptedSettingsPage = .home, source: String = "unknown") {
         guard let window else { return }
         speakerPeopleModel.refresh()
         navigationModel.selectedPage = page
         navigationModel.presentationID = UUID()
+        AnalyticsReporter.track(
+            "settings_opened",
+            properties: [
+                "page_id": page.analyticsValue,
+                "source": source,
+            ]
+        )
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
     }

--- a/Sources/UI/Shared/FirstRunExperience.swift
+++ b/Sources/UI/Shared/FirstRunExperience.swift
@@ -34,7 +34,178 @@ struct MenuBarPrimaryActionState: Equatable {
     let subtitle: String
 }
 
+enum FirstRunOnboardingStep: Int, CaseIterable, Identifiable, Equatable {
+    case hero
+    case value
+    case dictationSetup
+    case testDictation
+    case dictationResult
+    case meetingsIntro
+    case meetingSetup
+    case agentPayoff
+
+    var id: Int { rawValue }
+
+    var progressTitle: String {
+        switch self {
+        case .hero:
+            return "Welcome"
+        case .value:
+            return "What it does"
+        case .dictationSetup:
+            return "Dictation setup"
+        case .testDictation:
+            return "First dictation"
+        case .dictationResult:
+            return "Result"
+        case .meetingsIntro:
+            return "Meetings"
+        case .meetingSetup:
+            return "Meeting setup"
+        case .agentPayoff:
+            return "Agent"
+        }
+    }
+
+    var screenTitle: String {
+        switch self {
+        case .hero:
+            return "Speak and get clean local Markdown your agents can use."
+        case .value:
+            return "What Transcripted does"
+        case .dictationSetup:
+            return "Set up dictation"
+        case .testDictation:
+            return "Try your first dictation"
+        case .dictationResult:
+            return "Here's your first dictation"
+        case .meetingsIntro:
+            return "Transcripted also records meetings"
+        case .meetingSetup:
+            return "Set up meeting recording"
+        case .agentPayoff:
+            return "Use your audio context with an agent"
+        }
+    }
+}
+
+struct FirstRunOnboardingActionState: Equatable {
+    let primaryTitle: String
+    let secondaryTitle: String?
+    let detail: String
+    let isPrimaryEnabled: Bool
+}
+
+struct FirstRunOnboardingCopy {
+    static let heroDetail = "Dictations and meetings become private Markdown files on this Mac, ready for search, notes, and agent context."
+    static let valueFooter = "Your spoken context is saved as clean local Markdown."
+    static let dictationPrompt = "Say one sentence you want saved for later."
+    static let savedAsMarkdown = "Saved as local Markdown"
+    static let agentDictationNote = "Your dictations can be searched later to understand what you're thinking and working on."
+    static let meetingsDetail = "Record conversations into notes, then keep them alongside your dictations."
+    static let agentDetail = "Dictations and meetings become local Markdown files your agent can search, summarize, and reference."
+}
+
 enum FirstRunExperience {
+    static func onboardingSteps() -> [FirstRunOnboardingStep] {
+        FirstRunOnboardingStep.allCases
+    }
+
+    static func nextStep(after step: FirstRunOnboardingStep) -> FirstRunOnboardingStep? {
+        FirstRunOnboardingStep(rawValue: step.rawValue + 1)
+    }
+
+    static func previousStep(before step: FirstRunOnboardingStep) -> FirstRunOnboardingStep? {
+        FirstRunOnboardingStep(rawValue: step.rawValue - 1)
+    }
+
+    static func hasRequiredDictationSetup(
+        microphoneGranted: Bool,
+        accessibilityGranted: Bool
+    ) -> Bool {
+        microphoneGranted && accessibilityGranted
+    }
+
+    static func onboardingAction(
+        for step: FirstRunOnboardingStep,
+        microphoneGranted: Bool,
+        accessibilityGranted: Bool,
+        hasFirstDictation: Bool
+    ) -> FirstRunOnboardingActionState {
+        switch step {
+        case .hero:
+            return FirstRunOnboardingActionState(
+                primaryTitle: "Continue",
+                secondaryTitle: nil,
+                detail: FirstRunOnboardingCopy.heroDetail,
+                isPrimaryEnabled: true
+            )
+        case .value:
+            return FirstRunOnboardingActionState(
+                primaryTitle: "Continue",
+                secondaryTitle: nil,
+                detail: FirstRunOnboardingCopy.valueFooter,
+                isPrimaryEnabled: true
+            )
+        case .dictationSetup:
+            let ready = hasRequiredDictationSetup(
+                microphoneGranted: microphoneGranted,
+                accessibilityGranted: accessibilityGranted
+            )
+            return FirstRunOnboardingActionState(
+                primaryTitle: ready ? "Continue" : "Turn on Microphone and Paste-back",
+                secondaryTitle: nil,
+                detail: ready
+                    ? "Dictation is ready. Next, try one short capture."
+                    : "Microphone lets Transcripted listen. Paste-back lets it put the result where you were typing.",
+                isPrimaryEnabled: ready
+            )
+        case .testDictation:
+            let ready = hasRequiredDictationSetup(
+                microphoneGranted: microphoneGranted,
+                accessibilityGranted: accessibilityGranted
+            )
+            return FirstRunOnboardingActionState(
+                primaryTitle: "Start Dictation",
+                secondaryTitle: nil,
+                detail: ready
+                    ? "Transcripted will listen, paste back, and save a local Markdown copy."
+                    : "Finish dictation setup first so this test can paste back.",
+                isPrimaryEnabled: ready
+            )
+        case .dictationResult:
+            return FirstRunOnboardingActionState(
+                primaryTitle: hasFirstDictation ? "Continue" : "Try Again",
+                secondaryTitle: nil,
+                detail: hasFirstDictation
+                    ? "This is the first useful moment: spoken work became a saved dictation."
+                    : "No dictation has been saved yet. Try again with one clear sentence.",
+                isPrimaryEnabled: true
+            )
+        case .meetingsIntro:
+            return FirstRunOnboardingActionState(
+                primaryTitle: "Set up meetings",
+                secondaryTitle: "Skip for now",
+                detail: FirstRunOnboardingCopy.meetingsDetail,
+                isPrimaryEnabled: true
+            )
+        case .meetingSetup:
+            return FirstRunOnboardingActionState(
+                primaryTitle: "Continue",
+                secondaryTitle: "Skip for now",
+                detail: "System Audio Recording captures the other side of calls. Calendar stays optional.",
+                isPrimaryEnabled: true
+            )
+        case .agentPayoff:
+            return FirstRunOnboardingActionState(
+                primaryTitle: "Open Transcripted",
+                secondaryTitle: nil,
+                detail: FirstRunOnboardingCopy.agentDetail,
+                isPrimaryEnabled: true
+            )
+        }
+    }
+
     static func onboardingRequiredPermissions() -> [TranscriptedPermissionKind] {
         [.microphone, .accessibility]
     }

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -1,6 +1,47 @@
 import Foundation
 
 func testAnalyticsEventPolicy() {
+    runSuite("AnalyticsEventPolicy allows explicit onboarding funnel events") {
+        let shown = AnalyticsEventPolicy.policy(forEvent: "onboarding_shown")
+        let stepViewed = AnalyticsEventPolicy.policy(forEvent: "onboarding_step_viewed")
+        let permissionClicked = AnalyticsEventPolicy.policy(forEvent: "onboarding_permission_cta_clicked")
+        let permissionChanged = AnalyticsEventPolicy.policy(forEvent: "onboarding_permission_status_changed")
+        let firstSaved = AnalyticsEventPolicy.policy(forEvent: "onboarding_first_dictation_saved")
+        let meetingDryRun = AnalyticsEventPolicy.policy(forEvent: "onboarding_meeting_dry_run_clicked")
+        let agentClicked = AnalyticsEventPolicy.policy(forEvent: "onboarding_agent_cta_clicked")
+        let completed = AnalyticsEventPolicy.policy(forEvent: "onboarding_completed")
+
+        assertEqual(shown?.allowedProperties.contains("meeting_recording_ready"), true, "onboarding shown should preserve meeting-readiness attribution")
+        assertEqual(stepViewed?.allowedProperties.contains("step_id"), true, "step views should preserve funnel step")
+        assertEqual(permissionClicked?.allowedProperties.contains("permission_kind"), true, "permission clicks should preserve the clicked permission")
+        assertEqual(permissionChanged?.allowedProperties.contains("to_status"), true, "permission status changes should preserve the new status")
+        assertEqual(firstSaved?.allowedProperties.contains("word_count_bucket"), true, "first saved dictation should keep coarse word count")
+        assertEqual(meetingDryRun?.allowedProperties.contains("meeting_recording_ready"), true, "meeting dry runs should keep setup readiness")
+        assertEqual(agentClicked?.allowedProperties.contains("agent_cta"), true, "agent CTAs should preserve the action id")
+        assertEqual(completed?.allowedProperties.contains("first_dictation_saved"), true, "completion should preserve whether first value happened")
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "meeting_recording_ready": "true",
+                "permission_kind": "system_recording",
+                "step_id": "meeting_setup",
+            ],
+            allowedKeys: [
+                "meeting_recording_ready",
+                "permission_kind",
+                "step_id",
+            ]
+        )
+        assertEqual(sanitized["meeting_recording_ready"], "true", "meeting_recording_ready should avoid the audio-key sanitizer drop")
+        assertEqual(sanitized["permission_kind"], "system_recording", "permission kind should survive as a coarse enum")
+        assertEqual(sanitized["step_id"], "meeting_setup", "step id should survive sanitization")
+    }
+
+    runSuite("AnalyticsEventPolicy preserves dictation auto-send attribution") {
+        let dictationCompleted = AnalyticsEventPolicy.policy(forEvent: "dictation_completed")
+        assertEqual(dictationCompleted?.allowedProperties.contains("auto_send"), true, "dictation completion should allow the existing auto_send property")
+    }
+
     runSuite("AnalyticsEventPolicy only permits reviewed analytics events") {
         let dictationCompleted = AnalyticsEventPolicy.policy(forEvent: "dictation_completed")
         let dictationNoSpeech = AnalyticsEventPolicy.policy(forEvent: "dictation_no_speech")

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -10,8 +10,10 @@ func testAnalyticsEventPolicy() {
         let meetingDryRun = AnalyticsEventPolicy.policy(forEvent: "onboarding_meeting_dry_run_clicked")
         let agentClicked = AnalyticsEventPolicy.policy(forEvent: "onboarding_agent_cta_clicked")
         let completed = AnalyticsEventPolicy.policy(forEvent: "onboarding_completed")
+        let dismissed = AnalyticsEventPolicy.policy(forEvent: "onboarding_dismissed")
 
         assertEqual(shown?.allowedProperties.contains("meeting_recording_ready"), true, "onboarding shown should preserve meeting-readiness attribution")
+        assertEqual(stepViewed?.allowedProperties.contains("flow_elapsed_bucket"), true, "step views should preserve coarse elapsed time")
         assertEqual(stepViewed?.allowedProperties.contains("step_id"), true, "step views should preserve funnel step")
         assertEqual(permissionClicked?.allowedProperties.contains("permission_kind"), true, "permission clicks should preserve the clicked permission")
         assertEqual(permissionChanged?.allowedProperties.contains("to_status"), true, "permission status changes should preserve the new status")
@@ -19,14 +21,18 @@ func testAnalyticsEventPolicy() {
         assertEqual(meetingDryRun?.allowedProperties.contains("meeting_recording_ready"), true, "meeting dry runs should keep setup readiness")
         assertEqual(agentClicked?.allowedProperties.contains("agent_cta"), true, "agent CTAs should preserve the action id")
         assertEqual(completed?.allowedProperties.contains("first_dictation_saved"), true, "completion should preserve whether first value happened")
+        assertEqual(completed?.allowedProperties.contains("flow_elapsed_bucket"), true, "completion should preserve coarse time to finish")
+        assertEqual(dismissed?.allowedProperties.contains("step_index"), true, "dismissal should preserve where users dropped")
 
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
             [
                 "meeting_recording_ready": "true",
                 "permission_kind": "system_recording",
+                "flow_elapsed_bucket": "30_119s",
                 "step_id": "meeting_setup",
             ],
             allowedKeys: [
+                "flow_elapsed_bucket",
                 "meeting_recording_ready",
                 "permission_kind",
                 "step_id",
@@ -34,7 +40,42 @@ func testAnalyticsEventPolicy() {
         )
         assertEqual(sanitized["meeting_recording_ready"], "true", "meeting_recording_ready should avoid the audio-key sanitizer drop")
         assertEqual(sanitized["permission_kind"], "system_recording", "permission kind should survive as a coarse enum")
+        assertEqual(sanitized["flow_elapsed_bucket"], "30_119s", "coarse elapsed buckets should survive sanitization")
         assertEqual(sanitized["step_id"], "meeting_setup", "step id should survive sanitization")
+    }
+
+    runSuite("AnalyticsEventPolicy allows menu and settings behavior events") {
+        let menuOpened = AnalyticsEventPolicy.policy(forEvent: "menu_bar_opened")
+        let menuAction = AnalyticsEventPolicy.policy(forEvent: "menu_bar_action_clicked")
+        let settingsOpened = AnalyticsEventPolicy.policy(forEvent: "settings_opened")
+        let settingsPage = AnalyticsEventPolicy.policy(forEvent: "settings_page_viewed")
+        let settingsAction = AnalyticsEventPolicy.policy(forEvent: "settings_action_clicked")
+        let settingsToggle = AnalyticsEventPolicy.policy(forEvent: "settings_toggle_changed")
+        let settingsPermission = AnalyticsEventPolicy.policy(forEvent: "settings_permission_cta_clicked")
+        let captureLibrary = AnalyticsEventPolicy.policy(forEvent: "settings_capture_library_changed")
+
+        assertEqual(menuOpened?.allowedProperties.contains("paste_available"), true, "menu opens should preserve whether paste has value")
+        assertEqual(menuAction?.allowedProperties.contains("action_id"), true, "menu clicks should preserve the clicked action")
+        assertEqual(settingsOpened?.allowedProperties.contains("source"), true, "settings opens should preserve entry source")
+        assertEqual(settingsPage?.allowedProperties.contains("page_id"), true, "settings page views should preserve page id")
+        assertEqual(settingsAction?.allowedProperties.contains("action_id"), true, "settings actions should preserve action id")
+        assertEqual(settingsToggle?.allowedProperties.contains("setting_id"), true, "settings toggles should preserve setting id")
+        assertEqual(settingsPermission?.allowedProperties.contains("permission_kind"), true, "settings permission CTAs should preserve permission kind")
+        assertEqual(captureLibrary?.allowedProperties.contains("location_type"), true, "capture library changes should preserve default-vs-custom only")
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "action_id": "start_dictation",
+                "page_id": "home",
+                "setting_id": "menu_bar_start_dictation",
+                "source": "menu_bar",
+            ],
+            allowedKeys: ["action_id", "page_id", "setting_id", "source"]
+        )
+        assertEqual(sanitized["action_id"], "start_dictation", "action ids should survive sanitization")
+        assertEqual(sanitized["page_id"], "home", "page ids should survive sanitization")
+        assertEqual(sanitized["setting_id"], "menu_bar_start_dictation", "setting ids should survive sanitization")
+        assertEqual(sanitized["source"], "menu_bar", "source enums should survive sanitization")
     }
 
     runSuite("AnalyticsEventPolicy preserves dictation auto-send attribution") {
@@ -86,6 +127,9 @@ func testAnalyticsEventPolicy() {
         let failed = AnalyticsEventPolicy.policy(forEvent: "meeting_transcript_failed")
 
         assertEqual(saved?.allowedProperties.contains("trigger"), true, "meeting saves should preserve trigger attribution")
+        assertEqual(saved?.allowedProperties.contains("duration_bucket"), true, "meeting saves should preserve coarse duration")
+        assertEqual(saved?.allowedProperties.contains("word_count_bucket"), true, "meeting saves should preserve coarse word output")
+        assertEqual(saved?.allowedProperties.contains("participant_count_bucket"), true, "meeting saves should preserve coarse participant count")
         assertEqual(failed?.allowedProperties.contains("trigger"), true, "meeting failures should preserve trigger attribution")
     }
 

--- a/Tests/FirstRunExperienceTests.swift
+++ b/Tests/FirstRunExperienceTests.swift
@@ -1,6 +1,72 @@
 import Foundation
 
 func testFirstRunExperience() {
+    runSuite("FirstRunExperience.onboardingSteps — follows the approved first-value journey") {
+        let steps = FirstRunExperience.onboardingSteps()
+
+        assertEqual(
+            steps,
+            [.hero, .value, .dictationSetup, .testDictation, .dictationResult, .meetingsIntro, .meetingSetup, .agentPayoff],
+            "onboarding should teach value, prove dictation, introduce meetings, then explain agent payoff"
+        )
+        assertEqual(
+            FirstRunOnboardingStep.hero.screenTitle,
+            "Speak and get clean local Markdown your agents can use.",
+            "hero should use the approved value proposition"
+        )
+        assertEqual(
+            FirstRunOnboardingStep.value.screenTitle,
+            "What Transcripted does",
+            "second screen should explain the product instead of asking users to choose a path"
+        )
+    }
+
+    runSuite("FirstRunExperience.onboardingAction — gates first dictation on microphone plus paste-back") {
+        let blocked = FirstRunExperience.onboardingAction(
+            for: .dictationSetup,
+            microphoneGranted: true,
+            accessibilityGranted: false,
+            hasFirstDictation: false
+        )
+        let ready = FirstRunExperience.onboardingAction(
+            for: .dictationSetup,
+            microphoneGranted: true,
+            accessibilityGranted: true,
+            hasFirstDictation: false
+        )
+
+        assertEqual(blocked.primaryTitle, "Turn on Microphone and Paste-back", "blocked setup should name both required dictation capabilities")
+        assertFalse(blocked.isPrimaryEnabled, "dictation setup should block until paste-back is ready")
+        assertEqual(ready.primaryTitle, "Continue", "ready setup should let users reach the first dictation test")
+        assertTrue(ready.isPrimaryEnabled, "ready setup should unlock")
+    }
+
+    runSuite("FirstRunExperience.onboardingAction — presents meetings and agent payoff after first dictation") {
+        let result = FirstRunExperience.onboardingAction(
+            for: .dictationResult,
+            microphoneGranted: true,
+            accessibilityGranted: true,
+            hasFirstDictation: true
+        )
+        let meetings = FirstRunExperience.onboardingAction(
+            for: .meetingsIntro,
+            microphoneGranted: true,
+            accessibilityGranted: true,
+            hasFirstDictation: true
+        )
+        let agent = FirstRunExperience.onboardingAction(
+            for: .agentPayoff,
+            microphoneGranted: true,
+            accessibilityGranted: true,
+            hasFirstDictation: true
+        )
+
+        assertEqual(result.primaryTitle, "Continue", "saved first dictation should move into meetings")
+        assertEqual(meetings.primaryTitle, "Set up meetings", "meeting intro should offer setup")
+        assertEqual(meetings.secondaryTitle, "Skip for now", "meeting intro should not trap dictation-first users")
+        assertEqual(agent.primaryTitle, "Open Transcripted", "last step should land users in the app")
+    }
+
     runSuite("FirstRunExperience.onboardingPermissions — keeps dictation setup separate from later meeting permissions") {
         let required = FirstRunExperience.onboardingRequiredPermissions()
         let optional = FirstRunExperience.onboardingOptionalPermissions()

--- a/Tests/SentryEventPolicyTests.swift
+++ b/Tests/SentryEventPolicyTests.swift
@@ -22,6 +22,14 @@ func testSentryEventPolicy() {
             forEngine: "parakeet",
             event: "model_init_failed"
         )
+        let onboardingStartFailure = SentryEventPolicy.policy(
+            forEngine: "onboarding",
+            event: "first_dictation_start_failed"
+        )
+        let onboardingStopFailure = SentryEventPolicy.policy(
+            forEngine: "onboarding",
+            event: "first_dictation_stop_failed"
+        )
         let unknown = SentryEventPolicy.policy(
             forEngine: "dictation",
             event: "dictation_export_failed"
@@ -32,6 +40,8 @@ func testSentryEventPolicy() {
         assertEqual(audioStartFailure?.summary, "Speech audio engine failed to start.", "audio-start failures should stay allowlisted with a privacy-safe summary")
         assertEqual(microphoneStartTimeout?.summary, "Dictation microphone start timed out.", "microphone start timeouts should be visible in Sentry without raw device names")
         assertEqual(modelInitFailure?.summary, "Speech model initialization failed.", "model-init failures should stay allowlisted with a privacy-safe summary")
+        assertEqual(onboardingStartFailure?.summary, "Onboarding could not start first dictation.", "onboarding start wiring failures should be visible without clickstream data")
+        assertEqual(onboardingStopFailure?.summary, "Onboarding could not stop first dictation.", "onboarding stop wiring failures should be visible without clickstream data")
         assertNil(unknown, "unknown events should stay local-only by default")
     }
 }

--- a/docs/onboarding-deep-dive-report.html
+++ b/docs/onboarding-deep-dive-report.html
@@ -1,0 +1,1406 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Transcripted Onboarding Deep Dive</title>
+  <style>
+    :root {
+      --bg: #111214;
+      --panel: #191b1f;
+      --panel-2: #22252b;
+      --ink: #f3f4f6;
+      --muted: #b9bec7;
+      --dim: #8f96a3;
+      --line: #333842;
+      --blue: #4ea1ff;
+      --green: #59d17c;
+      --yellow: #f5c84c;
+      --orange: #ff9d4d;
+      --red: #ff6b6b;
+      --purple: #ad8cff;
+      --shadow: rgba(0, 0, 0, 0.24);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
+      line-height: 1.55;
+    }
+
+    a {
+      color: var(--blue);
+      text-decoration: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    code {
+      color: #e7eefc;
+      background: #2a2e36;
+      border: 1px solid #3a404c;
+      border-radius: 6px;
+      padding: 0.1rem 0.32rem;
+      font-family: "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+      font-size: 0.9em;
+    }
+
+    .page {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 42px 24px 80px;
+    }
+
+    .hero {
+      padding: 34px;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: linear-gradient(135deg, #1c1f27 0%, #15171b 62%, #121316 100%);
+      box-shadow: 0 18px 60px var(--shadow);
+    }
+
+    .eyebrow {
+      margin: 0 0 10px;
+      color: var(--blue);
+      font-size: 0.82rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 0;
+      max-width: 880px;
+      font-size: clamp(2.1rem, 5vw, 4.2rem);
+      line-height: 1.02;
+      letter-spacing: 0;
+    }
+
+    h2 {
+      margin: 44px 0 14px;
+      font-size: 1.65rem;
+      letter-spacing: 0;
+    }
+
+    h3 {
+      margin: 26px 0 10px;
+      font-size: 1.16rem;
+    }
+
+    p {
+      margin: 0 0 13px;
+      color: var(--muted);
+    }
+
+    ul,
+    ol {
+      color: var(--muted);
+      padding-left: 1.25rem;
+    }
+
+    li {
+      margin: 0.38rem 0;
+    }
+
+    .hero p {
+      max-width: 900px;
+      font-size: 1.08rem;
+    }
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 24px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      min-height: 30px;
+      padding: 6px 10px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: #20242b;
+      color: var(--muted);
+      font-size: 0.9rem;
+      font-weight: 600;
+    }
+
+    .nav {
+      position: sticky;
+      top: 0;
+      z-index: 2;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin: 18px 0 36px;
+      padding: 12px;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: rgba(17, 18, 20, 0.92);
+      backdrop-filter: blur(12px);
+    }
+
+    .nav a {
+      padding: 7px 10px;
+      border: 1px solid #2c313a;
+      border-radius: 8px;
+      color: var(--ink);
+      background: #1a1d22;
+      font-size: 0.9rem;
+      font-weight: 650;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(12, 1fr);
+      gap: 14px;
+    }
+
+    .card {
+      grid-column: span 4;
+      padding: 18px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: var(--panel);
+      box-shadow: 0 10px 30px var(--shadow);
+    }
+
+    .card.wide {
+      grid-column: span 6;
+    }
+
+    .card.full {
+      grid-column: 1 / -1;
+    }
+
+    .card h3 {
+      margin-top: 0;
+    }
+
+    .grade {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 46px;
+      height: 34px;
+      margin-right: 8px;
+      border-radius: 8px;
+      color: #111214;
+      font-weight: 900;
+      letter-spacing: 0;
+    }
+
+    .grade-a { background: var(--green); }
+    .grade-b { background: #8fdf91; }
+    .grade-c { background: var(--yellow); }
+    .grade-d { background: var(--orange); }
+    .grade-f { background: var(--red); }
+
+    .severity {
+      display: inline-flex;
+      min-width: 42px;
+      justify-content: center;
+      padding: 4px 8px;
+      border-radius: 8px;
+      font-size: 0.8rem;
+      font-weight: 800;
+      color: #111214;
+    }
+
+    .p0 { background: var(--red); }
+    .p1 { background: var(--orange); }
+    .p2 { background: var(--yellow); }
+    .p3 { background: var(--blue); color: #06111f; }
+
+    .table-wrap {
+      overflow-x: auto;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: var(--panel);
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 780px;
+    }
+
+    th,
+    td {
+      padding: 12px 13px;
+      border-bottom: 1px solid var(--line);
+      vertical-align: top;
+      text-align: left;
+    }
+
+    th {
+      color: var(--ink);
+      background: #23272f;
+      font-size: 0.88rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    td {
+      color: var(--muted);
+    }
+
+    tr:last-child td {
+      border-bottom: 0;
+    }
+
+    .callout {
+      padding: 16px 18px;
+      border: 1px solid #3f4755;
+      border-left: 5px solid var(--blue);
+      border-radius: 10px;
+      background: #1b2028;
+    }
+
+    .callout strong {
+      color: var(--ink);
+    }
+
+    .danger {
+      border-left-color: var(--red);
+    }
+
+    .warn {
+      border-left-color: var(--orange);
+    }
+
+    .good {
+      border-left-color: var(--green);
+    }
+
+    .quote {
+      color: var(--dim);
+      font-size: 0.95rem;
+    }
+
+    .small {
+      color: var(--dim);
+      font-size: 0.9rem;
+    }
+
+    details {
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: var(--panel);
+      padding: 14px 16px;
+      margin: 12px 0;
+    }
+
+    summary {
+      cursor: pointer;
+      color: var(--ink);
+      font-weight: 800;
+    }
+
+    .ranked {
+      counter-reset: issue;
+      display: grid;
+      gap: 12px;
+    }
+
+    .issue {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 12px;
+      padding: 16px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: var(--panel);
+    }
+
+    .issue h3 {
+      margin: 0 0 6px;
+    }
+
+    .issue p {
+      margin-bottom: 8px;
+    }
+
+    .scoreline {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 12px;
+    }
+
+    .tag {
+      display: inline-flex;
+      padding: 4px 8px;
+      border-radius: 7px;
+      background: #252a33;
+      color: var(--muted);
+      font-size: 0.82rem;
+      font-weight: 700;
+    }
+
+    .two-col {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+    }
+
+    .checklist li {
+      margin-bottom: 0.65rem;
+    }
+
+    @media (max-width: 860px) {
+      .page {
+        padding: 24px 14px 64px;
+      }
+
+      .hero {
+        padding: 24px 18px;
+      }
+
+      .card,
+      .card.wide {
+        grid-column: 1 / -1;
+      }
+
+      .two-col {
+        grid-template-columns: 1fr;
+      }
+
+      .nav {
+        position: static;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <section class="hero">
+      <p class="eyebrow">Transcripted onboarding audit</p>
+      <h1>The current onboarding is clear enough to finish, but not strong enough to create the aha.</h1>
+      <p>
+        The app asks users to complete setup. It does not yet guide them all the way to the emotional payoff:
+        spoken context becomes local Markdown, then an agent can use it. That missing bridge is the main retention risk.
+      </p>
+      <div class="meta">
+        <span class="pill">Generated 2026-04-22</span>
+        <span class="pill">Repo: transcripted-latest</span>
+        <span class="pill">Build verified with signed local app</span>
+        <span class="pill">Computer Use walkthrough included</span>
+        <span class="pill">6 subagent audits included</span>
+      </div>
+    </section>
+
+    <nav class="nav" aria-label="Report sections">
+      <a href="#summary">Summary</a>
+      <a href="#evidence">Evidence</a>
+      <a href="#grades">Grades</a>
+      <a href="#top-fixes">Top Fixes</a>
+      <a href="#journey">Journey</a>
+      <a href="#friction">Friction</a>
+      <a href="#analytics">PostHog</a>
+      <a href="#sentry">Sentry</a>
+      <a href="#tests">Tests</a>
+      <a href="#manual">Manual QA</a>
+      <a href="#file-map">File Map</a>
+    </nav>
+
+    <section id="summary">
+      <h2>Executive Summary</h2>
+      <div class="grid">
+        <article class="card">
+          <h3><span class="grade grade-c">C</span>Overall onboarding</h3>
+          <p>
+            Clear structure, good local-first intent, and a working first-dictation path. But it is too much setup, too little payoff,
+            too little instrumentation, and too much friction before the user has received value.
+          </p>
+        </article>
+        <article class="card">
+          <h3><span class="grade grade-d">D</span>Funnel visibility</h3>
+          <p>
+            PostHog currently sees launch, completion, and later dictation/meeting outcomes. It cannot see the actual onboarding funnel:
+            who saw it, clicked permissions, got stuck, closed it, waited on the model, or reached first value.
+          </p>
+        </article>
+        <article class="card">
+          <h3><span class="grade grade-f">F</span>Menu keyboard access</h3>
+          <p>
+            The immediate post-onboarding popover is built from custom mouse-only rows. Computer Use could not address the rows as controls,
+            and the code has mouse handlers without keyboard or accessibility button semantics.
+          </p>
+        </article>
+        <article class="card wide">
+          <h3>Biggest Product Problem</h3>
+          <p>
+            The app says "Welcome" and asks for permissions. It should say, in substance:
+            "Say one sentence. We will paste it back, save Markdown locally, and show you how your agent can use it."
+          </p>
+          <p>
+            The current flow can end in a no-speech error, a generic menu, or a settings screen. None of those are the aha.
+          </p>
+        </article>
+        <article class="card wide">
+          <h3>Biggest Measurement Problem</h3>
+          <p>
+            The event taxonomy is missing the onboarding funnel. It also has two concrete property-loss bugs:
+            <code>system_audio_recording_enabled</code> likely gets dropped because the sanitizer drops keys containing <code>audio</code>,
+            and <code>dictation_completed.auto_send</code> is sent by code but not allowlisted.
+          </p>
+        </article>
+      </div>
+
+      <div class="callout danger" style="margin-top: 16px;">
+        <strong>Most important recommendation:</strong>
+        turn onboarding into a guided first capture, not a permissions checklist. The product should optimize for first useful dictation,
+        first saved Markdown, and first agent use. Permissions are only supporting steps.
+      </div>
+    </section>
+
+    <section id="evidence">
+      <h2>What I Actually Tested</h2>
+      <div class="two-col">
+        <div class="callout good">
+          <strong>Done</strong>
+          <ul>
+            <li>Read repo docs, UI docs, observability docs, test docs, and storage/build notes.</li>
+            <li>Located first-run routing, window controller, onboarding view, permission helpers, menu bar, settings, analytics, and Sentry code.</li>
+            <li>Built dependencies with <code>bash build-deps.sh --force</code>.</li>
+            <li>Built and launched the signed app with <code>bash build.sh</code>.</li>
+            <li>Forced onboarding with <code>scripts/dev/onboarding.sh force-on</code>.</li>
+            <li>Used Computer Use to inspect onboarding, scroll states, first dictation, post-onboarding popover, Settings Home, and Agent page.</li>
+            <li>Checked local observability logs and credential availability.</li>
+          </ul>
+        </div>
+        <div class="callout warn">
+          <strong>Limits</strong>
+          <ul>
+            <li>No live PostHog or Sentry read queries: <code>POSTHOG_PERSONAL_API_KEY</code>, <code>POSTHOG_PROJECT_ID</code>, and <code>SENTRY_AUTH_TOKEN</code> were unset.</li>
+            <li>No full fresh-user TCC reset for Microphone, Accessibility, Calendar, or System Audio. I audited those via code and existing tests.</li>
+            <li>I did not submit external data or create a PostHog survey. This report is a design and implementation plan.</li>
+          </ul>
+        </div>
+      </div>
+
+      <h3>Computer Use Notes</h3>
+      <ul>
+        <li>First launch initially appeared to show Settings because another Transcripted build from a different worktree was running with the same legacy bundle id. After killing duplicate processes, the intended onboarding appeared.</li>
+        <li>The onboarding window was <code>Welcome to Transcripted</code>, with a visible hero, required permissions, model card, partial "Optional later" content, and a fixed footer CTA.</li>
+        <li>At the first fold, the optional and consent sections were cut off while <code>Start first dictation</code> remained visible. This makes it easy to skip important trust/setup context.</li>
+        <li>Clicking <code>Start first dictation</code> launched the compact overlay. Stopping without speech showed <code>Dictation issue</code> and <code>No speech detected</code>.</li>
+        <li>After completion, the menu popover was visually simple and useful, but Computer Use exposed only the popover as a whole, not the individual rows.</li>
+        <li>The Agent page is functional, but the copy is extremely thin: <code>Agent</code>, <code>Pick one.</code>, <code>Install in Claude</code>, <code>Copy for Agent</code>.</li>
+      </ul>
+
+      <h3>Build Notes</h3>
+      <ul>
+        <li><code>bash build.sh</code> initially failed because dependencies were missing or stale. Running <code>bash build-deps.sh --force</code> fixed that.</li>
+        <li>The final build signed with Developer ID and passed launch smoke.</li>
+        <li>App identifier is still <code>com.justinbetker.draft</code>, which is a support, testing, and permission-state footgun.</li>
+      </ul>
+    </section>
+
+    <section id="grades">
+      <h2>Grades By Screen And Section</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Area</th>
+              <th>Grade</th>
+              <th>Why</th>
+              <th>Best Fix</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Launch and first-run routing</td>
+              <td><span class="grade grade-b">B-</span></td>
+              <td>Onboarding reliably gates the menu until completion, but multiple running builds with the same bundle id confused testing and could confuse support.</td>
+              <td>Rename bundle id to Transcripted, add single-instance handling, and track <code>onboarding_shown</code>.</td>
+            </tr>
+            <tr>
+              <td>Hero</td>
+              <td><span class="grade grade-c">C</span></td>
+              <td>"Welcome" plus "core permissions" starts with admin work. It underplays local Markdown and agent value.</td>
+              <td>Lead with outcome: "Capture spoken context as local Markdown your tools can search."</td>
+            </tr>
+            <tr>
+              <td>Feature pills</td>
+              <td><span class="grade grade-c">C</span></td>
+              <td>"Menu bar utility / Dictation first / Meetings later" makes the app feel smaller than the product promise.</td>
+              <td>Use "Dictate anywhere / Record meetings / Save local Markdown" or similar.</td>
+            </tr>
+            <tr>
+              <td>Required permissions</td>
+              <td><span class="grade grade-c">C+</span></td>
+              <td>Good separation of required versus later permissions, but Accessibility is scary and weakly explained.</td>
+              <td>Add trust copy: "Used only for hotkeys and paste-back. Transcripted does not read your screen."</td>
+            </tr>
+            <tr>
+              <td>Hard block on Accessibility</td>
+              <td><span class="grade grade-d">D</span></td>
+              <td>This can stop users before first value. Dictation could still create value with manual copy or an in-app transcript preview.</td>
+              <td>Allow a "Try dictation without paste-back" path after Microphone is granted.</td>
+            </tr>
+            <tr>
+              <td>Local model card</td>
+              <td><span class="grade grade-b">B-</span></td>
+              <td>Good local-first disclosure and progress, but "Parakeet TDT V3" is too technical for first-run.</td>
+              <td>Lead with "Local voice model"; put Parakeet as secondary detail.</td>
+            </tr>
+            <tr>
+              <td>Optional permissions</td>
+              <td><span class="grade grade-c">C</span></td>
+              <td>"Optional later" is accurate for onboarding but hides that System Audio is required for the full meeting promise.</td>
+              <td>Rename to "For meetings later" and provide explicit grant buttons or a "Set up meetings now" branch.</td>
+            </tr>
+            <tr>
+              <td>Observability consent</td>
+              <td><span class="grade grade-d">D+</span></td>
+              <td>Transparent but heavy. It asks for trust before value and says "for this release," which feels temporary/defensive.</td>
+              <td>Move after first success, or collapse into one simple privacy row with an advanced link.</td>
+            </tr>
+            <tr>
+              <td>Footer CTA</td>
+              <td><span class="grade grade-b">B-</span></td>
+              <td>"Start first dictation" is the right direction. Disabled state and fallback "Continue to Transcripted" are weaker.</td>
+              <td>Make CTA outcome-specific: "Try a 10-second dictation" and "Open menu bar controls."</td>
+            </tr>
+            <tr>
+              <td>First dictation handoff</td>
+              <td><span class="grade grade-c">C</span></td>
+              <td>Technically works, but it can immediately end in "No speech detected" without a guided retry or sample prompt.</td>
+              <td>Show a retry CTA, sample phrase, and success path to saved Markdown.</td>
+            </tr>
+            <tr>
+              <td>No-speech recovery</td>
+              <td><span class="grade grade-d">D</span></td>
+              <td>First value can become an error state. In testing, the inspected overlay showed only the issue, not a clear recovery path.</td>
+              <td>Use first-run-specific recovery: "Try again", "Need help?", "Open menu", and "Use a sample capture."</td>
+            </tr>
+            <tr>
+              <td>Menu bar popover visuals</td>
+              <td><span class="grade grade-c">C+</span></td>
+              <td>Simple and direct. But "Home" has no detail, Connect Agent is below the fold of attention, and first-run coaching ends too soon.</td>
+              <td>Highlight next action after onboarding and add a first-run success state.</td>
+            </tr>
+            <tr>
+              <td>Menu bar popover accessibility</td>
+              <td><span class="grade grade-f">F</span></td>
+              <td>Custom rows appear mouse-only from code and Computer Use accessibility tree.</td>
+              <td>Use real buttons or implement full NSAccessibility button semantics and keyboard activation.</td>
+            </tr>
+            <tr>
+              <td>Settings Home</td>
+              <td><span class="grade grade-c">C+</span></td>
+              <td>Useful, but mixes actions, readiness, visibility toggles, and navigation before the user has value.</td>
+              <td>Hide menu-visibility toggles from first-run context; focus on first capture and agent connection.</td>
+            </tr>
+            <tr>
+              <td>Agent setup page</td>
+              <td><span class="grade grade-c">C</span></td>
+              <td>Functional but under-explained. It should be central to the aha, not just a sparse settings page.</td>
+              <td>After first capture, show "Ask your agent about this capture" with Claude/Codex paths.</td>
+            </tr>
+            <tr>
+              <td>PostHog coverage</td>
+              <td><span class="grade grade-d">D</span></td>
+              <td>Only completion is tracked for onboarding, and even that is biased by analytics opt-out.</td>
+              <td>Add explicit funnel events and property allowlists.</td>
+            </tr>
+            <tr>
+              <td>Sentry coverage</td>
+              <td><span class="grade grade-b">B</span></td>
+              <td>Privacy posture is strong and error forwarding is tightly allowlisted. Onboarding-specific reliability events are missing.</td>
+              <td>Keep clickstream out of Sentry. Add only failure breadcrumbs/events.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="top-fixes">
+      <h2>Most Obvious Things To Fix</h2>
+      <div class="ranked">
+        <article class="issue">
+          <span class="severity p0">P0</span>
+          <div>
+            <h3>Instrument the onboarding funnel before optimizing blind.</h3>
+            <p>
+              Today, the app cannot answer the most basic onboarding questions: who saw it, who clicked a permission CTA,
+              which permission blocked them, who closed it, who waited on the model, who started first dictation, or who got no speech.
+            </p>
+            <p><strong>Fix:</strong> add explicit PostHog events for every section, click, state transition, and exit. Keep properties coarse and allowlisted.</p>
+            <p class="quote">Evidence: <code>AnalyticsEventPolicy.swift:16</code> only allowlists <code>onboarding_completed</code> for onboarding.</p>
+          </div>
+        </article>
+
+        <article class="issue">
+          <span class="severity p0">P0</span>
+          <div>
+            <h3>Make the first value moment explicit.</h3>
+            <p>
+              The product promise is not permission setup. It is spoken context becoming useful. Current onboarding does not show the Markdown result,
+              does not show where it was saved, and does not show how an agent can use it.
+            </p>
+            <p><strong>Fix:</strong> after first dictation, show a success panel: saved text, Markdown location, "Copy for Agent", and "Open capture folder".</p>
+          </div>
+        </article>
+
+        <article class="issue">
+          <span class="severity p1">P1</span>
+          <div>
+            <h3>Replace the setup-first hero with an outcome-first hero.</h3>
+            <p>
+              Current copy says "We will get the core permissions ready." That makes users evaluate cost before value.
+            </p>
+            <p><strong>Fix:</strong> use a concrete one-screen promise: "Turn meetings, dictation, and audio into local Markdown your agents can read."</p>
+          </div>
+        </article>
+
+        <article class="issue">
+          <span class="severity p1">P1</span>
+          <div>
+            <h3>Do not hard-block first value on Accessibility.</h3>
+            <p>
+              Accessibility is useful for hotkeys and paste-back, but it is also the scariest permission. Making it mandatory before any value is risky.
+            </p>
+            <p><strong>Fix:</strong> require Microphone for first dictation, but allow a degraded path: record -> show transcript -> copy manually -> save Markdown.</p>
+            <p class="quote">Evidence: <code>FirstRunExperience.swift:38</code> requires Microphone and Accessibility; <code>PermissionsOnboardingView.swift:239</code> refuses completion without both.</p>
+          </div>
+        </article>
+
+        <article class="issue">
+          <span class="severity p1">P1</span>
+          <div>
+            <h3>Make the post-onboarding menu accessible.</h3>
+            <p>
+              The immediate post-onboarding surface should be rock solid. Right now the custom menu rows are not exposed as individual controls.
+            </p>
+            <p><strong>Fix:</strong> use <code>NSButton</code> rows or implement accessible role, title, value, help, action, focus ring, Space/Return activation, and disabled reason.</p>
+            <p class="quote">Evidence: <code>MenuBarActionRowView.swift:244</code> handles mouse events directly; Computer Use saw only the popover, not rows.</p>
+          </div>
+        </article>
+
+        <article class="issue">
+          <span class="severity p1">P1</span>
+          <div>
+            <h3>Move or compress observability consent.</h3>
+            <p>
+              It is transparent, but it is too much trust negotiation before the user has seen value. It also appears below the fold and can be skipped.
+            </p>
+            <p><strong>Fix:</strong> ask after first success, or collapse to: "Help improve Transcripted with privacy-safe diagnostics" plus two toggles in Settings.</p>
+          </div>
+        </article>
+
+        <article class="issue">
+          <span class="severity p1">P1</span>
+          <div>
+            <h3>Fix analytics property loss.</h3>
+            <p>
+              <code>system_audio_recording_enabled</code> contains <code>audio</code>, and the analytics sanitizer drops any key containing <code>audio</code>.
+              Separately, <code>auto_send</code> is sent on dictation completion but not allowlisted.
+            </p>
+            <p><strong>Fix:</strong> rename properties to safe enum keys or add explicit allowlist precedence before sensitive-fragment dropping.</p>
+          </div>
+        </article>
+
+        <article class="issue">
+          <span class="severity p2">P2</span>
+          <div>
+            <h3>Make first no-speech a recovery flow, not a dead end.</h3>
+            <p>
+              My first Computer Use run ended in <code>No speech detected</code>. That is normal if someone clicks Stop quickly, but it is a bad first experience.
+            </p>
+            <p><strong>Fix:</strong> show "Try again", "Say: remind me to review the pricing call", and "Open Transcripted menu". Track <code>first_capture_empty</code>.</p>
+          </div>
+        </article>
+
+        <article class="issue">
+          <span class="severity p2">P2</span>
+          <div>
+            <h3>Clarify meeting setup instead of burying it.</h3>
+            <p>
+              Meetings are core to the product, but onboarding says "Meetings later" and optional rows have no actions.
+            </p>
+            <p><strong>Fix:</strong> offer a branch: "I mainly want meeting notes" -> set up System Audio now -> run a meeting recording dry run.</p>
+          </div>
+        </article>
+
+        <article class="issue">
+          <span class="severity p2">P2</span>
+          <div>
+            <h3>Rename the bundle id.</h3>
+            <p>
+              The bundle id is still <code>com.justinbetker.draft</code>. This affects TCC, defaults, logs, support screenshots, and testing.
+            </p>
+            <p><strong>Fix:</strong> plan a migration to a Transcripted bundle id with explicit TCC and defaults implications.</p>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="journey">
+      <h2>Current Journey Map</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Step</th>
+              <th>What Happens Now</th>
+              <th>User Risk</th>
+              <th>Recommended Change</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>1. Launch</td>
+              <td>App launches as accessory/menu-bar app, creates status item, then presents onboarding if completion key is false.</td>
+              <td>User may not understand where the app lives or how to get it back if they close the window.</td>
+              <td>Show a short "Transcripted lives here" animation or pointer to the menu bar icon, and track <code>onboarding_shown</code>.</td>
+            </tr>
+            <tr>
+              <td>2. Welcome hero</td>
+              <td>Hero frames onboarding as getting permissions ready.</td>
+              <td>Cost appears before value.</td>
+              <td>Lead with "Capture spoken context as local Markdown your agents can read."</td>
+            </tr>
+            <tr>
+              <td>3. Required permissions</td>
+              <td>Microphone and Accessibility are required. CTA is disabled until both are ready.</td>
+              <td>Accessibility may scare users away before any value.</td>
+              <td>Allow first dictation with Microphone only; explain Accessibility as paste-back/hotkey enhancement.</td>
+            </tr>
+            <tr>
+              <td>4. Model readiness</td>
+              <td>Shows Parakeet state and download/load progress.</td>
+              <td>Technical model name may distract; offline/slow download can feel like app is stuck.</td>
+              <td>Use plain language, estimated wait, retry state, and local-first proof.</td>
+            </tr>
+            <tr>
+              <td>5. Optional later</td>
+              <td>System Audio and Calendar are display-only rows in onboarding.</td>
+              <td>Meeting-first users do not know how to become meeting-ready.</td>
+              <td>Add "Set up meetings now" branch or action buttons.</td>
+            </tr>
+            <tr>
+              <td>6. Consent</td>
+              <td>Crash and analytics toggles are on by default when configured.</td>
+              <td>Trust cost before value; opt-out creates analytics blind spots.</td>
+              <td>Delay, simplify, or make the first launch event wait until after consent.</td>
+            </tr>
+            <tr>
+              <td>7. CTA</td>
+              <td>Starts first dictation when a remembered app exists, otherwise continues to menu.</td>
+              <td>Remembered app may not be a text field; fallback can delay aha.</td>
+              <td>Open a built-in scratch capture if no clear paste target exists.</td>
+            </tr>
+            <tr>
+              <td>8. First dictation</td>
+              <td>Compact overlay listens, then transcribes/pastes/saves or shows error.</td>
+              <td>No-speech or paste failure can become the first emotional result.</td>
+              <td>Use first-run overlay copy, sample prompt, and explicit retry/success screen.</td>
+            </tr>
+            <tr>
+              <td>9. Menu popover</td>
+              <td>Shows Home, Start Dictation, Start Meeting, Paste Last, Recent Meetings, Connect Agent, etc.</td>
+              <td>No first-run coaching; keyboard and VoiceOver users may be blocked.</td>
+              <td>Highlight next action and make rows accessible controls.</td>
+            </tr>
+            <tr>
+              <td>10. Agent connection</td>
+              <td>Agent setup lives in Settings -> Agent and says "Pick one."</td>
+              <td>The agent aha is too far from the first capture.</td>
+              <td>After first saved capture, show "Ask your agent what you just said" and lead to Agent setup.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="friction">
+      <h2>Detailed Friction Inventory</h2>
+
+      <details open>
+        <summary>First impression and trust</summary>
+        <ul>
+          <li>The hero starts with permissions, not the reason the app exists.</li>
+          <li>"Menu bar utility" undersells the product. Transcripted is a memory layer, not merely a utility.</li>
+          <li>"Meetings later" is operationally true but strategically weak because meetings are one of the core use cases.</li>
+          <li>Accessibility copy says "For shortcuts and paste-back", but does not explicitly say what it will not do.</li>
+          <li>The old screenshot at <code>docs/screenshots/onboarding.png</code> still shows a Draft writing-profile onboarding flow. That is stale and misleading for docs or QA.</li>
+        </ul>
+      </details>
+
+      <details open>
+        <summary>Permissions</summary>
+        <ul>
+          <li>Microphone and Accessibility are both mandatory before completion, even though a mic-only first capture could create value.</li>
+          <li>Optional permissions show status but no CTA, so users cannot set up meetings from onboarding.</li>
+          <li>System Audio status is cached in defaults. It can show "Ready" based on cached state until meeting start revalidates.</li>
+          <li>Calendar copy says it is for meeting prompts, but runtime app prompts can happen without calendar.</li>
+          <li>The app still uses the Draft bundle id for TCC/defaults, which can make permission instructions and support logs confusing.</li>
+        </ul>
+      </details>
+
+      <details open>
+        <summary>Layout and hierarchy</summary>
+        <ul>
+          <li>The onboarding window is fixed at <code>620x760</code>, non-resizable, and hides zoom.</li>
+          <li>The first fold cuts into the optional permissions card while the footer CTA remains visible.</li>
+          <li>Consent and "what happens next" are below the fold for many users.</li>
+          <li>Many small labels use muted text on dark/badge backgrounds. Contrast is likely under target for 10-11 point labels.</li>
+          <li>Cards inside cards make the lower half feel dense and repetitive.</li>
+        </ul>
+      </details>
+
+      <details open>
+        <summary>First capture</summary>
+        <ul>
+          <li>The primary CTA says "Start first dictation", but there is no sample phrase or countdown.</li>
+          <li>The app assumes the remembered source app is a useful paste target. It may be Finder, Settings, or another non-text context.</li>
+          <li>If no paste target exists, the fallback tells the user to click into a text field later. That delays the aha.</li>
+          <li>The no-speech state can be the first post-onboarding result.</li>
+          <li>The success path does not teach where Markdown went or how to use it with an agent.</li>
+        </ul>
+      </details>
+
+      <details open>
+        <summary>Post-onboarding surfaces</summary>
+        <ul>
+          <li>The menu popover is visually good but accessibility-poor.</li>
+          <li>"Connect Agent" is present, but not framed as the next step after a saved capture.</li>
+          <li>Settings Home is useful but too admin-heavy for first success: menu visibility toggles, ready checks, and page links compete with the first action.</li>
+          <li>The Agent settings page has very little explanatory copy. "Pick one" is too thin for a core setup step.</li>
+        </ul>
+      </details>
+
+      <details open>
+        <summary>Observability and analytics</summary>
+        <ul>
+          <li><code>app_launched</code> can be sent before the user sees analytics consent because analytics defaults on when configured.</li>
+          <li><code>onboarding_completed</code> is not sent if the user turns analytics off before completing.</li>
+          <li>There is no event for <code>onboarding_shown</code>, so completion rate cannot be calculated reliably.</li>
+          <li>There is no event for permission CTA clicks or permission transitions.</li>
+          <li>There is no event for closing onboarding before completion.</li>
+          <li>There is no event for first-dictation no-speech from onboarding as a first-run funnel exit.</li>
+          <li>Sentry is strong on privacy but missing onboarding-specific failure context.</li>
+        </ul>
+      </details>
+    </section>
+
+    <section id="analytics">
+      <h2>PostHog Plan</h2>
+      <div class="callout">
+        <strong>Principle:</strong>
+        do not use broad autocapture for this native macOS onboarding. Use explicit event calls with stable action ids and coarse properties.
+        The app captures sensitive local work context, and the current transport is a custom direct <code>/capture/</code> client, not the PostHog SDK.
+      </div>
+
+      <h3>Current State</h3>
+      <ul>
+        <li>PostHog config is read from <code>Info.plist</code>, environment, or local overrides in <code>AnalyticsReporter.swift</code>.</li>
+        <li>Transport sends direct capture requests and adds <code>distinct_id</code>, <code>app_version</code>, <code>os_major</code>, and <code>session_id</code>.</li>
+        <li>Allowed events live in <code>AnalyticsEventPolicy.swift</code>.</li>
+        <li>Current onboarding event: <code>onboarding_completed</code> only.</li>
+        <li>Sanitizer drops sensitive property names and redacts sensitive values.</li>
+      </ul>
+
+      <h3>Critical Event Taxonomy</h3>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Event</th>
+              <th>When To Fire</th>
+              <th>Properties</th>
+              <th>Why It Matters</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>onboarding_shown</code></td>
+              <td>When the window is presented.</td>
+              <td><code>entrypoint</code>, <code>has_paste_target</code>, <code>required_missing_count</code>, <code>model_state</code>, <code>analytics_available</code>, <code>crash_reporting_available</code></td>
+              <td>Denominator for all funnels.</td>
+            </tr>
+            <tr>
+              <td><code>onboarding_section_viewed</code></td>
+              <td>When a section first becomes visible or is rendered above fold.</td>
+              <td><code>section</code>, <code>position</code>, <code>scroll_depth_bucket</code></td>
+              <td>Shows whether users ever see optional permissions, consent, and next steps.</td>
+            </tr>
+            <tr>
+              <td><code>onboarding_permission_cta_clicked</code></td>
+              <td>When a permission action button is clicked.</td>
+              <td><code>permission_kind</code>, <code>required</code>, <code>prior_status</code>, <code>destination</code></td>
+              <td>Shows intent and permission friction by kind.</td>
+            </tr>
+            <tr>
+              <td><code>onboarding_permission_status_changed</code></td>
+              <td>When polling detects a status transition.</td>
+              <td><code>permission_kind</code>, <code>from_status</code>, <code>to_status</code>, <code>elapsed_bucket</code></td>
+              <td>Measures success after System Settings handoff.</td>
+            </tr>
+            <tr>
+              <td><code>onboarding_model_state_changed</code></td>
+              <td>When model state changes during onboarding.</td>
+              <td><code>model_kind</code>, <code>from_state</code>, <code>to_state</code>, <code>progress_bucket</code>, <code>failure_kind</code></td>
+              <td>Shows whether local model startup/download causes drop-off.</td>
+            </tr>
+            <tr>
+              <td><code>onboarding_reporting_toggle_changed</code></td>
+              <td>When crash or analytics toggle changes.</td>
+              <td><code>reporting_kind</code>, <code>enabled</code>, <code>available</code></td>
+              <td>Measures trust cost. Note: opt-out events require explicit consent design.</td>
+            </tr>
+            <tr>
+              <td><code>onboarding_primary_cta_clicked</code></td>
+              <td>When footer CTA is clicked.</td>
+              <td><code>cta_kind</code>, <code>should_start_dictation</code>, <code>has_paste_target</code>, <code>model_state</code>, <code>required_missing_count</code></td>
+              <td>Separates permission completion from first action.</td>
+            </tr>
+            <tr>
+              <td><code>onboarding_dismissed</code></td>
+              <td>When the window closes before completion.</td>
+              <td><code>close_source</code>, <code>required_missing_count</code>, <code>model_state</code>, <code>duration_bucket</code></td>
+              <td>Captures abandonments that are invisible today.</td>
+            </tr>
+            <tr>
+              <td><code>onboarding_completed</code></td>
+              <td>When completion is marked.</td>
+              <td><code>completion_path</code>, <code>duration_bucket</code>, <code>mic_status</code>, <code>accessibility_status</code>, <code>meeting_audio_status</code>, <code>calendar_status</code>, <code>model_state</code>, <code>has_paste_target</code></td>
+              <td>Current event should be expanded and property names should avoid sanitizer collisions.</td>
+            </tr>
+            <tr>
+              <td><code>dictation_requested</code></td>
+              <td>When the user asks to start dictation.</td>
+              <td><code>trigger</code>, <code>model_state</code>, <code>has_paste_target</code></td>
+              <td>Current <code>dictation_started</code> fires before audio is necessarily flowing. This separates request from actual start.</td>
+            </tr>
+            <tr>
+              <td><code>dictation_listening_started</code></td>
+              <td>When audio samples are flowing.</td>
+              <td><code>trigger</code>, <code>startup_latency_bucket</code>, <code>input_class</code></td>
+              <td>Measures if first capture actually begins.</td>
+            </tr>
+            <tr>
+              <td><code>first_capture_empty</code></td>
+              <td>When first onboarding dictation yields no speech/text.</td>
+              <td><code>trigger</code>, <code>duration_bucket</code>, <code>model_state</code></td>
+              <td>Important first-run failure path.</td>
+            </tr>
+            <tr>
+              <td><code>first_capture_saved</code></td>
+              <td>When the first dictation or meeting Markdown is saved.</td>
+              <td><code>capture_kind</code>, <code>delivery</code>, <code>word_count_bucket</code>, <code>duration_bucket</code></td>
+              <td>Best practical aha metric.</td>
+            </tr>
+            <tr>
+              <td><code>agent_setup_cta_shown</code></td>
+              <td>After first saved capture or on Agent page.</td>
+              <td><code>surface</code>, <code>capture_kind</code>, <code>agent_option</code></td>
+              <td>Measures transition from capture to agent value.</td>
+            </tr>
+            <tr>
+              <td><code>agent_setup_cta_clicked</code></td>
+              <td>When user chooses Claude install or copy-for-agent.</td>
+              <td><code>surface</code>, <code>agent_option</code>, <code>status</code></td>
+              <td>Connects onboarding to the core "agent can use this" loop.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Funnel Definitions</h3>
+      <ul class="checklist">
+        <li><strong>Dictation activation:</strong> <code>app_launched</code> -> <code>onboarding_shown</code> -> <code>onboarding_completed</code> -> <code>dictation_requested</code> -> <code>dictation_listening_started</code> -> <code>first_capture_saved</code>.</li>
+        <li><strong>Permission success:</strong> <code>onboarding_shown</code> -> <code>onboarding_permission_cta_clicked</code> -> <code>onboarding_permission_status_changed(to_status=granted)</code> -> <code>onboarding_completed</code>, broken down by <code>permission_kind</code>.</li>
+        <li><strong>Model readiness:</strong> <code>onboarding_shown</code> -> <code>onboarding_model_state_changed(to_state=ready)</code> -> <code>onboarding_primary_cta_clicked</code> -> <code>dictation_listening_started</code>.</li>
+        <li><strong>Meeting setup:</strong> <code>onboarding_shown</code> -> <code>meeting_setup_cta_clicked</code> -> <code>meeting_audio_permission_result</code> -> <code>meeting_recording_started</code> -> <code>meeting_transcript_saved</code>.</li>
+        <li><strong>Agent aha:</strong> <code>first_capture_saved</code> -> <code>agent_setup_cta_shown</code> -> <code>agent_setup_cta_clicked</code> -> <code>agent_setup_completed</code>.</li>
+      </ul>
+
+      <h3>Cohorts To Build</h3>
+      <ul>
+        <li>Users stuck on Microphone.</li>
+        <li>Users stuck on Accessibility.</li>
+        <li>Users who completed onboarding but never requested dictation.</li>
+        <li>Users whose first dictation was no-speech.</li>
+        <li>Users who saved first capture but never opened Agent setup.</li>
+        <li>Users who chose meeting path but hit System Audio friction.</li>
+        <li>Users who toggled analytics or crash reporting off during onboarding.</li>
+        <li>Users with model startup/download failure before first capture.</li>
+      </ul>
+
+      <h3>Dashboards</h3>
+      <ul>
+        <li><strong>Onboarding conversion:</strong> shown, completed, first dictation requested, first listening started, first capture saved.</li>
+        <li><strong>Permission friction:</strong> CTA clicks, grant rates, time to grant, abandonments by permission.</li>
+        <li><strong>First value quality:</strong> no-speech, paste failure, saved word count, duration bucket, retry rate.</li>
+        <li><strong>Agent value:</strong> first capture saved to Agent CTA shown/clicked/completed.</li>
+        <li><strong>Meeting readiness:</strong> System Audio unknown/denied/granted, meeting start blocks, first meeting saved.</li>
+      </ul>
+
+      <h3>Privacy Rules For PostHog</h3>
+      <ul>
+        <li>Never send transcript text, audio references, meeting titles, speaker names, emails, source app names, bundle ids, raw URLs, file paths, or raw error messages.</li>
+        <li>Prefer enums and buckets: <code>permission_kind=accessibility</code>, <code>duration_bucket=10_29s</code>, <code>failure_kind=no_speech</code>.</li>
+        <li>Use allowlist-first sanitization. Current sensitive-fragment dropping is good, but it accidentally drops legitimate coarse keys like <code>system_audio_recording_enabled</code>.</li>
+        <li>Do not use broad autocapture for native app setup. PostHog autocapture can collect many interaction types depending on SDK and config. This app should use explicit actions only.</li>
+        <li>Session replay should be opt-in only, sampled, and heavily masked. For this app, explicit events are safer and probably enough.</li>
+      </ul>
+
+      <h3>PostHog Product Features To Use</h3>
+      <ul>
+        <li><strong>Funnels:</strong> use for step-by-step drop-off and time-to-convert analysis.</li>
+        <li><strong>Cohorts:</strong> use to isolate stuck users and compare return behavior.</li>
+        <li><strong>Surveys:</strong> after failure or first success, ask one lightweight question like "What nearly stopped you from finishing setup?"</li>
+        <li><strong>Feature flags:</strong> test consent timing, Microphone-only path, meeting-first branch, and first-capture success panel.</li>
+      </ul>
+
+      <p class="small">
+        Official references: <a href="https://posthog.com/docs/product-analytics/autocapture">PostHog autocapture</a>,
+        <a href="https://posthog.com/docs/product-analytics/funnels">PostHog funnels</a>,
+        <a href="https://posthog.com/docs/data/cohorts">PostHog cohorts</a>,
+        <a href="https://posthog.com/docs/surveys">PostHog surveys</a>.
+      </p>
+    </section>
+
+    <section id="sentry">
+      <h2>Sentry Plan</h2>
+      <div class="callout good">
+        <strong>Current Sentry posture is mostly right.</strong>
+        Sentry is for crashes and reliability failures, not onboarding clickstream. Keep automatic breadcrumbs, screenshots, view hierarchy,
+        request data, and PII off unless there is a very deliberate privacy review.
+      </div>
+
+      <h3>Current State</h3>
+      <ul>
+        <li><code>CrashReporter.swift</code> sets <code>sendDefaultPii=false</code>, disables network breadcrumbs, sets <code>maxBreadcrumbs=0</code>, blocks screenshots/view hierarchy, and sanitizes before send.</li>
+        <li><code>EventReporter.swift</code> forwards only <code>.error</code> events that match <code>SentryEventPolicy</code>.</li>
+        <li><code>SentryEventPolicy.swift</code> covers model/audio/hotkey/paste failures, not onboarding-specific reliability failures.</li>
+      </ul>
+
+      <h3>What To Add</h3>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Sentry Signal</th>
+              <th>Trigger</th>
+              <th>Safe Context</th>
+              <th>Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>onboarding.model_init_failed</code></td>
+              <td>Local model fails before first capture.</td>
+              <td><code>model_kind</code>, <code>failure_stage</code>, <code>bundled_model_present</code></td>
+              <td>Keep raw error out; use failure kind.</td>
+            </tr>
+            <tr>
+              <td><code>onboarding.model_download_failed</code></td>
+              <td>Runtime model download fails during onboarding.</td>
+              <td><code>model_kind</code>, <code>download_source</code>, <code>failure_kind</code></td>
+              <td>No URLs, no file paths.</td>
+            </tr>
+            <tr>
+              <td><code>onboarding.first_dictation_start_failed</code></td>
+              <td>CTA is clicked but dictation cannot start.</td>
+              <td><code>permission_state</code>, <code>model_state</code>, <code>trigger=onboarding</code></td>
+              <td>This is reliability, not product analytics.</td>
+            </tr>
+            <tr>
+              <td><code>onboarding.permission_prompt_failed</code></td>
+              <td>Permission request API fails unexpectedly.</td>
+              <td><code>permission_kind</code>, <code>status_before</code>, <code>prompt_source</code></td>
+              <td>Do not send System Settings URLs or app names.</td>
+            </tr>
+            <tr>
+              <td><code>meeting.system_audio_permission_request_failed</code></td>
+              <td>ScreenCaptureKit permission probe fails in a non-user-cancel way.</td>
+              <td><code>permission_check</code>, <code>failure_kind</code>, <code>macos_major</code></td>
+              <td>Useful because meeting setup is a high-value funnel.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Manual Breadcrumbs If You Ever Enable Them</h3>
+      <p>
+        If Sentry breadcrumbs become useful, keep them manual and allowlisted. Do not enable broad automatic breadcrumbs.
+      </p>
+      <ul>
+        <li><code>onboarding_shown</code></li>
+        <li><code>permission_cta_clicked</code> with <code>permission_kind</code></li>
+        <li><code>permission_status_changed</code> with coarse from/to statuses</li>
+        <li><code>model_state_changed</code></li>
+        <li><code>primary_cta_clicked</code></li>
+        <li><code>dictation_listening_started</code></li>
+      </ul>
+
+      <p class="small">
+        Official references: <a href="https://docs.sentry.io/platforms/apple/configuration/options/">Sentry Apple options</a>.
+      </p>
+    </section>
+
+    <section id="tests">
+      <h2>Automated Test Plan</h2>
+      <p>
+        The current tests are good for extracted policy, but the actual onboarding shell is under-tested. Do not unit-test the SwiftUI body directly.
+        Extract state, completion, and analytics decisions into pure helpers under <code>Sources/UI/Shared/</code>, then test them with the fast runner.
+      </p>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Test</th>
+              <th>Purpose</th>
+              <th>Files To Touch</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>PermissionsOnboardingStateTests</code></td>
+              <td>Rows, granted flags, required/optional grouping, CTA enablement, status labels.</td>
+              <td><code>Sources/UI/Shared/PermissionsOnboardingState.swift</code>, <code>Tests/FastTests.manifest</code>, <code>run-tests.sh</code> source list.</td>
+            </tr>
+            <tr>
+              <td><code>OnboardingCompletionPolicyTests</code></td>
+              <td>Completion key, force override, no-complete unless requirements pass.</td>
+              <td>Extract from <code>PermissionsOnboardingView</code> into a helper.</td>
+            </tr>
+            <tr>
+              <td>Extend <code>FirstRunExperienceTests</code></td>
+              <td>Table-test all model states with paste target yes/no, including progress edges and failed states.</td>
+              <td><code>Tests/FirstRunExperienceTests.swift</code>.</td>
+            </tr>
+            <tr>
+              <td><code>OnboardingAnalyticsPolicyTests</code></td>
+              <td>Ensure every new onboarding event and property is allowlisted and sanitized correctly.</td>
+              <td><code>AnalyticsEventPolicy.swift</code>, <code>AnalyticsPayloadSanitizerTests.swift</code>.</td>
+            </tr>
+            <tr>
+              <td><code>FirstDictationOnboardingFlowTests</code></td>
+              <td>Completion marked, window dismissed, source app activated if present, dictation starts with trigger <code>onboarding</code>.</td>
+              <td>Extract a small coordinator from <code>TranscriptedApp.finishOnboardingAndStartDictation()</code>.</td>
+            </tr>
+            <tr>
+              <td>Accessibility smoke</td>
+              <td>Assert menu rows expose button role/title/action and can be activated by keyboard.</td>
+              <td><code>MenuBarActionRowView</code> or replacement <code>NSButton</code> row component.</td>
+            </tr>
+            <tr>
+              <td>Launch UI smoke</td>
+              <td>After onboarding reset, assert the welcome window appears. After completion, assert main popover appears.</td>
+              <td>New local UI smoke script, probably not fast tests.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Current Coverage Worth Keeping</h3>
+      <ul>
+        <li><code>FirstRunExperienceTests.swift</code> covers required/optional split, CTA states, and model copy.</li>
+        <li><code>TranscriptedPermissionAccessTests.swift</code> covers permission helper behavior.</li>
+        <li><code>MeetingRecordingStartGateTests.swift</code> covers meeting permission copy and gating.</li>
+        <li><code>AnalyticsEventPolicyTests.swift</code>, <code>AnalyticsPayloadSanitizerTests.swift</code>, <code>SentryEventPolicyTests.swift</code>, and <code>SentryPayloadSanitizerTests.swift</code> cover privacy-critical observability policy.</li>
+      </ul>
+    </section>
+
+    <section id="manual">
+      <h2>Manual QA Matrix</h2>
+      <p>
+        Run this on a fresh macOS user or VM where possible. Defaults reset is not enough for TCC.
+      </p>
+      <div class="grid">
+        <article class="card wide">
+          <h3>Fresh Install</h3>
+          <ul>
+            <li>No permissions granted.</li>
+            <li>Microphone grant path.</li>
+            <li>Accessibility grant path.</li>
+            <li>Deny Microphone, then recover.</li>
+            <li>Deny Accessibility, then recover.</li>
+            <li>Close onboarding before completion and reopen from menu bar.</li>
+          </ul>
+        </article>
+        <article class="card wide">
+          <h3>First Dictation Targets</h3>
+          <ul>
+            <li>TextEdit text field.</li>
+            <li>Notes.</li>
+            <li>Safari web input.</li>
+            <li>Slack/Discord/Teams.</li>
+            <li>Finder or non-text foreground app.</li>
+            <li>Secure/password field.</li>
+          </ul>
+        </article>
+        <article class="card wide">
+          <h3>Model Conditions</h3>
+          <ul>
+            <li>Bundled model ready.</li>
+            <li>Runtime download required.</li>
+            <li>Offline while model missing.</li>
+            <li>Slow network.</li>
+            <li>Download failure and retry.</li>
+          </ul>
+        </article>
+        <article class="card wide">
+          <h3>Meetings</h3>
+          <ul>
+            <li>System Audio unknown.</li>
+            <li>System Audio denied.</li>
+            <li>System Audio granted then revoked.</li>
+            <li>Calendar denied.</li>
+            <li>Runtime prompt with Zoom/Meet/Teams active.</li>
+            <li>Meeting prompt timeout versus explicit Not Now.</li>
+          </ul>
+        </article>
+        <article class="card wide">
+          <h3>Accessibility</h3>
+          <ul>
+            <li>Keyboard-only onboarding.</li>
+            <li>VoiceOver through permission cards and toggles.</li>
+            <li>Keyboard-only menu popover.</li>
+            <li>Larger text / display zoom.</li>
+            <li>Reduced motion.</li>
+            <li>High contrast mode.</li>
+          </ul>
+        </article>
+        <article class="card wide">
+          <h3>Analytics Verification</h3>
+          <ul>
+            <li>Tail local <code>events.jsonl</code>.</li>
+            <li>Check PostHog ingestion for each funnel event.</li>
+            <li>Verify opt-out behavior.</li>
+            <li>Verify no sensitive values in PostHog properties.</li>
+            <li>Send test Sentry event from Settings.</li>
+            <li>Verify allowlisted Sentry failures are scrubbed.</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section id="file-map">
+      <h2>File Map And Evidence</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>File</th>
+              <th>Why It Matters</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>Sources/TranscriptedApp.swift:65</code></td>
+              <td>App lifecycle, status item, onboarding presentation, completion, first-dictation handoff.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/UI/Settings/TranscriptedOnboardingWindowController.swift:15</code></td>
+              <td>Fixed onboarding window configuration, closable title window, hidden zoom.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/UI/Settings/PermissionsOnboardingView.swift:26</code></td>
+              <td>Main onboarding screen, state, copy, polling, completion, consent toggles, analytics completion call.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/UI/Shared/FirstRunExperience.swift:37</code></td>
+              <td>Permission policy, CTA copy/state, model card copy, menu action subtitles.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/Support/TranscriptedPermissionKind.swift:5</code></td>
+              <td>Permission names, summaries, buttons, required flags.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/Support/TranscriptedPermissionAccess.swift:23</code></td>
+              <td>Permission status reads, prompts, System Settings deep links, System Audio cache.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/UI/MenuBar/MenuBarActionRowView.swift:244</code></td>
+              <td>Custom mouse-only menu rows.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/UI/MenuBar/MenuBarPanelController.swift:53</code></td>
+              <td>Main popover refresh, action routing, post-onboarding surface.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/UI/Settings/TranscriptedSettingsView.swift:188</code></td>
+              <td>Settings Home, ready check, action tiles, useful pages.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/UI/Settings/TranscriptedSettingsView.swift:1538</code></td>
+              <td>Agent page and setup IA.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/Observability/AnalyticsReporter.swift:82</code></td>
+              <td>Custom PostHog transport, anonymous id, session id, HTTPS enforcement.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/Observability/AnalyticsEventPolicy.swift:11</code></td>
+              <td>Analytics event allowlist.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/Observability/AnalyticsPayloadSanitizer.swift:3</code></td>
+              <td>Analytics privacy rules and property dropping.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/Observability/CrashReporter.swift:23</code></td>
+              <td>Sentry setup and scrub-before-send policy.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/Observability/SentryEventPolicy.swift:12</code></td>
+              <td>Allowlisted non-fatal Sentry forwarding.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/UI/Overlay/DictationSessionController.swift</code></td>
+              <td>Dictation lifecycle, first-run trigger, analytics outcomes, save/paste behavior.</td>
+            </tr>
+            <tr>
+              <td><code>Sources/Meeting/MeetingRecordingStartGate.swift:17</code></td>
+              <td>Meeting permission copy and start blockers.</td>
+            </tr>
+            <tr>
+              <td><code>scripts/dev/onboarding.sh:1</code></td>
+              <td>Onboarding reset/force helper, still targeting legacy bundle id.</td>
+            </tr>
+            <tr>
+              <td><code>Info.plist:11</code></td>
+              <td>Legacy bundle id and permission strings.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="source-links">
+      <h2>External References Used</h2>
+      <ul>
+        <li><a href="https://posthog.com/docs/product-analytics/autocapture">PostHog autocapture docs</a></li>
+        <li><a href="https://posthog.com/docs/product-analytics/funnels">PostHog funnels docs</a></li>
+        <li><a href="https://posthog.com/docs/data/cohorts">PostHog cohorts docs</a></li>
+        <li><a href="https://posthog.com/docs/surveys">PostHog surveys docs</a></li>
+        <li><a href="https://docs.sentry.io/platforms/apple/configuration/options/">Sentry Apple configuration options</a></li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Redesigns first-run onboarding around the value path: welcome, product value, dictation setup, first dictation, meetings, and agent payoff.
- Adds privacy-safe analytics for onboarding funnel progress, menu/settings behavior, and coarse dictation/meeting usage buckets.
- Anchors the first-dictation overlay to the practice card so the recording UI feels intentional during onboarding.
- Removes the duplicate hero icon and duplicate inline listening state from the onboarding UI.

## Validation
- `bash build.sh`
- `bash run-tests.sh` — 732 passed
- Manual onboarding click-through with Computer Use, including first dictation overlay placement
