### PR TITLE
[codex] Harden AirPods dictation mic start

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -681,7 +681,7 @@ class ParakeetEngine: ObservableObject {
         }
 
         let inputNode = audioEngine.inputNode
-        applyPreferredDictationInputDevice(to: inputNode, operation: "prewarm")
+        let selection = applyPreferredDictationInputDevice(to: inputNode, operation: "prewarm")
         let outputFormat = inputNode.outputFormat(forBus: 0)
         let hwFormat = inputNode.inputFormat(forBus: 0)
 
@@ -690,16 +690,24 @@ class ParakeetEngine: ObservableObject {
         // the upsample and the tap delivers at the output bus rate. Both must be
         // valid before declaring the engine ready — input alone or output alone
         // can transiently report zero during device transitions.
-        guard outputFormat.sampleRate > 0, outputFormat.channelCount > 0,
-              hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
+        let readiness = audioFormatReadiness(
+            outputFormat: outputFormat,
+            hwFormat: hwFormat,
+            selection: selection
+        )
+        guard readiness == .ready else {
             EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "prewarm_invalid_format",
                 message: "Audio format invalid during prewarm",
-                context: [
-                    "output_rate": "\(outputFormat.sampleRate)",
-                    "output_channels": "\(outputFormat.channelCount)",
-                    "hw_rate": "\(hwFormat.sampleRate)",
-                    "hw_channels": "\(hwFormat.channelCount)"
-                ])
+                context: audioFormatContext(
+                    outputFormat: outputFormat,
+                    hwFormat: hwFormat,
+                    selection: selection,
+                    readiness: readiness
+                ))
+            if readiness == .routeNotSettled {
+                rebuildAudioEngine(reason: "audio_route_not_settled")
+            }
+            markFormatUnreadyAndPublish()
             schedulePrewarmRetry()
             return
         }
@@ -887,22 +895,40 @@ class ParakeetEngine: ObservableObject {
                 // sample rate on first read after device change, even past the
                 // initial settle delay. One extra wait + re-read is enough.
                 let inputNode = self.audioEngine.inputNode
-                self.applyPreferredDictationInputDevice(to: inputNode, operation: "device_recovery")
+                var selection = self.applyPreferredDictationInputDevice(to: inputNode, operation: "device_recovery")
                 var newFormat = inputNode.outputFormat(forBus: 0)
                 var hwFormat = inputNode.inputFormat(forBus: 0)
-                if newFormat.sampleRate == 0 || newFormat.channelCount == 0 ||
-                   hwFormat.sampleRate == 0 || hwFormat.channelCount == 0 {
+                if self.audioFormatReadiness(outputFormat: newFormat, hwFormat: hwFormat, selection: selection) != .ready {
                     try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
                     guard !self.recoveryState.isStale(generation: myGeneration) else { return }
                     let refreshedInputNode = self.audioEngine.inputNode
-                    self.applyPreferredDictationInputDevice(to: refreshedInputNode, operation: "device_recovery_retry")
+                    selection = self.applyPreferredDictationInputDevice(to: refreshedInputNode, operation: "device_recovery_retry")
                     newFormat = refreshedInputNode.outputFormat(forBus: 0)
                     hwFormat = refreshedInputNode.inputFormat(forBus: 0)
                 }
-                guard newFormat.sampleRate > 0, newFormat.channelCount > 0,
-                      hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
+                let readiness = self.audioFormatReadiness(
+                    outputFormat: newFormat,
+                    hwFormat: hwFormat,
+                    selection: selection
+                )
+                guard readiness == .ready else {
+                    EventReporter.shared.capture(
+                        level: .warning,
+                        engine: "parakeet",
+                        event: "device_change_rewarm_deferred",
+                        message: "Audio route still settling after device change",
+                        context: self.audioFormatContext(
+                            outputFormat: newFormat,
+                            hwFormat: hwFormat,
+                            selection: selection,
+                            readiness: readiness
+                        )
+                    )
+                    self.rebuildAudioEngine(reason: "device_change_route_not_settled")
+                    self.prewarmRetryCount = 0
+                    self.schedulePrewarmRetry()
                     throw NSError(domain: "ParakeetEngine", code: -1,
-                        userInfo: [NSLocalizedDescriptionKey: "Invalid audio format after device change (output \(newFormat.sampleRate)Hz/\(newFormat.channelCount)ch, input \(hwFormat.sampleRate)Hz/\(hwFormat.channelCount)ch)"])
+                        userInfo: [NSLocalizedDescriptionKey: "Audio route not settled after device change"])
                 }
                 self.nativeSampleRate = newFormat.sampleRate
                 self.prewarmRetryCount = 0
@@ -986,6 +1012,59 @@ class ParakeetEngine: ObservableObject {
             recoveryState.markFormatReady()
             publishRecoveryState()
         }
+    }
+
+    private func audioFormatReadiness(
+        outputFormat: AVAudioFormat,
+        hwFormat: AVAudioFormat,
+        selection: DictationInputDeviceSelection?
+    ) -> ParakeetAudioFormatReadiness {
+        ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: outputFormat.sampleRate,
+            outputChannelCount: outputFormat.channelCount,
+            inputSampleRate: hwFormat.sampleRate,
+            inputChannelCount: hwFormat.channelCount,
+            selectedInputClass: selectedInputClass(for: selection),
+            selectionOverrodeDefault: selection?.didOverrideDefault ?? false
+        )
+    }
+
+    private func selectedInputClass(for selection: DictationInputDeviceSelection?) -> String {
+        if let selection {
+            return DictationInputDeviceSelectionPolicy.deviceClass(for: selection.selectedInput)
+        }
+        return inputDeviceClass(for: inputDeviceName)
+    }
+
+    private func audioFormatContext(
+        outputFormat: AVAudioFormat,
+        hwFormat: AVAudioFormat,
+        selection: DictationInputDeviceSelection?,
+        readiness: ParakeetAudioFormatReadiness
+    ) -> [String: String] {
+        var context = [
+            "format_readiness": readiness.rawValue,
+            "output_rate_hz": String(format: "%.0f", outputFormat.sampleRate),
+            "output_channels": "\(outputFormat.channelCount)",
+            "input_rate_hz": String(format: "%.0f", hwFormat.sampleRate),
+            "hw_channels": "\(hwFormat.channelCount)",
+            "input_device_class": selectedInputClass(for: selection),
+            "selection_overrode_default": "\(selection?.didOverrideDefault ?? false)",
+            "recovering": "\(recoveryState.isRecovering)",
+            "format_ready": "\(recoveryState.inputFormatReady)",
+            "generation": "\(recoveryState.generation)",
+        ]
+
+        if let selection {
+            context["selection_reason"] = selection.reason.rawValue
+            context["default_input_class"] = DictationInputDeviceSelectionPolicy.deviceClass(for: selection.defaultInput)
+            context["selected_input_class"] = DictationInputDeviceSelectionPolicy.deviceClass(for: selection.selectedInput)
+            if let defaultOutput = selection.defaultOutput {
+                context["default_output_class"] = DictationInputDeviceSelectionPolicy.deviceClass(for: defaultOutput)
+            }
+        }
+
+        return context
     }
 
     private func removeRecordingTap(force: Bool = false) {
@@ -1259,7 +1338,7 @@ class ParakeetEngine: ObservableObject {
         let maxAttempts = isRecoveryAttempt ? 1 : 1 + TranscriptedConstants.audioStartRecoveryAttempts
         for attempt in 1...maxAttempts {
             let inputNode = audioEngine.inputNode
-            applyPreferredDictationInputDevice(to: inputNode, operation: "start_recording")
+            let selection = applyPreferredDictationInputDevice(to: inputNode, operation: "start_recording")
             // The tap is installed with format: nil, which means buffers arrive at the
             // node's OUTPUT bus format. On AirPods HFP the hw input is 24kHz but the
             // node's output bus is 48kHz (CoreAudio's internal converter handles the
@@ -1268,28 +1347,41 @@ class ParakeetEngine: ObservableObject {
             // both so we don't proceed when the device graph is still settling.
             let outputFormat = inputNode.outputFormat(forBus: 0)
             let hwFormat = inputNode.inputFormat(forBus: 0)
-            guard outputFormat.sampleRate > 0, outputFormat.channelCount > 0,
-                  hwFormat.sampleRate > 0, hwFormat.channelCount > 0 else {
+            let readiness = audioFormatReadiness(
+                outputFormat: outputFormat,
+                hwFormat: hwFormat,
+                selection: selection
+            )
+            guard readiness == .ready else {
                 let startFailureAction = ParakeetStartRecordingFailurePolicy.action(
-                    for: .invalidAudioFormat,
+                    for: readiness.startFailureReason ?? .invalidAudioFormat,
                     isRecoveryAttempt: isRecoveryAttempt
                 )
-                print("⚠️ PARAKEET | input format unavailable: output=\(outputFormat.sampleRate)Hz/\(outputFormat.channelCount)ch hw=\(hwFormat.sampleRate)Hz/\(hwFormat.channelCount)ch")
+                print("⚠️ PARAKEET | input format unavailable (\(readiness.rawValue)): output=\(outputFormat.sampleRate)Hz/\(outputFormat.channelCount)ch hw=\(hwFormat.sampleRate)Hz/\(hwFormat.channelCount)ch")
+                var context = audioStartContext(
+                    attempt: attempt,
+                    isRecoveryAttempt: isRecoveryAttempt,
+                    engineWasRunning: audioEngine.isRunning,
+                    outputFormat: outputFormat,
+                    hwFormat: hwFormat
+                )
+                context.merge(
+                    audioFormatContext(
+                        outputFormat: outputFormat,
+                        hwFormat: hwFormat,
+                        selection: selection,
+                        readiness: readiness
+                    )
+                ) { current, _ in current }
                 EventReporter.shared.capture(
                     level: .warning,
                     engine: "parakeet",
                     event: "audio_format_unavailable",
                     message: "Audio hardware format not ready while starting dictation",
-                    context: audioStartContext(
-                        attempt: attempt,
-                        isRecoveryAttempt: isRecoveryAttempt,
-                        engineWasRunning: audioEngine.isRunning,
-                        outputFormat: outputFormat,
-                        hwFormat: hwFormat
-                    )
+                    context: context
                 )
                 resetAudioGraphAfterStartFailure(
-                    reason: "invalid_audio_format",
+                    reason: readiness == .routeNotSettled ? "audio_route_not_settled" : "invalid_audio_format",
                     rebuildEngine: startFailureAction.rebuildAudioEngine
                 )
                 if startFailureAction.markFormatUnready {
@@ -1398,12 +1490,14 @@ class ParakeetEngine: ObservableObject {
                         hwFormat: hwFormat,
                         error: error
                     )
-                    let shouldRetry = ParakeetAudioStartRecoveryPolicy.shouldRetryStartFailure(
+                    let failureReason = ParakeetAudioFormatReadinessPolicy.startFailureReason(for: error as NSError)
+                    let shouldRetry = failureReason == .audioEngineStartFailed
+                        && ParakeetAudioStartRecoveryPolicy.shouldRetryStartFailure(
                         isRecoveryAttempt: isRecoveryAttempt,
                         failedAttempts: attempt
                     )
                     resetAudioGraphAfterStartFailure(
-                        reason: "audio_engine_start_failed",
+                        reason: failureReason == .audioRouteNotSettled ? "audio_route_not_settled" : "audio_engine_start_failed",
                         rebuildEngine: true
                     )
 
@@ -1417,6 +1511,28 @@ class ParakeetEngine: ObservableObject {
                             context: context
                         )
                         continue
+                    }
+
+                    if failureReason == .audioRouteNotSettled {
+                        print("⚠️ PARAKEET | audio route format unsupported while starting; waiting for CoreAudio to settle")
+                        EventReporter.shared.capture(
+                            level: .warning,
+                            engine: "parakeet",
+                            event: "audio_route_not_settled",
+                            message: "Audio route format was not ready while starting dictation",
+                            context: context
+                        )
+                        let startFailureAction = ParakeetStartRecordingFailurePolicy.action(
+                            for: failureReason,
+                            isRecoveryAttempt: isRecoveryAttempt
+                        )
+                        if startFailureAction.markFormatUnready {
+                            markStartFailedAndPublish()
+                        }
+                        if startFailureAction.schedulePrewarmRetry {
+                            schedulePrewarmRetry()
+                        }
+                        return false
                     }
 
                     print("❌ PARAKEET | audio engine failed after \(attempt) attempt(s): \(error.localizedDescription)")

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum ParakeetStartRecordingFailureReason: Equatable {
     case invalidAudioFormat
+    case audioRouteNotSettled
     case audioEngineStartFailed
 }
 
@@ -18,7 +19,7 @@ enum ParakeetStartRecordingFailurePolicy {
     ) -> ParakeetStartRecordingFailureAction {
         let shouldScheduleRetry: Bool
         switch reason {
-        case .invalidAudioFormat, .audioEngineStartFailed:
+        case .invalidAudioFormat, .audioRouteNotSettled, .audioEngineStartFailed:
             shouldScheduleRetry = !isRecoveryAttempt
         }
 
@@ -27,5 +28,57 @@ enum ParakeetStartRecordingFailurePolicy {
             schedulePrewarmRetry: shouldScheduleRetry,
             rebuildAudioEngine: true
         )
+    }
+}
+
+enum ParakeetAudioFormatReadiness: String, Equatable {
+    case ready
+    case invalid
+    case routeNotSettled
+
+    var startFailureReason: ParakeetStartRecordingFailureReason? {
+        switch self {
+        case .ready:
+            return nil
+        case .invalid:
+            return .invalidAudioFormat
+        case .routeNotSettled:
+            return .audioRouteNotSettled
+        }
+    }
+}
+
+enum ParakeetAudioFormatReadinessPolicy {
+    private static let likelyBluetoothSpeechRates: Set<Int> = [8_000, 16_000, 24_000]
+    static let audioUnitFormatNotSupportedCode = -10_868
+
+    static func readiness(
+        outputSampleRate: Double,
+        outputChannelCount: UInt32,
+        inputSampleRate: Double,
+        inputChannelCount: UInt32,
+        selectedInputClass: String,
+        selectionOverrodeDefault: Bool
+    ) -> ParakeetAudioFormatReadiness {
+        guard outputSampleRate > 0, outputChannelCount > 0,
+              inputSampleRate > 0, inputChannelCount > 0 else {
+            return .invalid
+        }
+
+        if selectionOverrodeDefault,
+           selectedInputClass != "bluetooth",
+           inputSampleRate >= 44_100,
+           likelyBluetoothSpeechRates.contains(Int(outputSampleRate.rounded())) {
+            return .routeNotSettled
+        }
+
+        return .ready
+    }
+
+    static func startFailureReason(for error: NSError) -> ParakeetStartRecordingFailureReason {
+        if error.code == audioUnitFormatNotSupportedCode {
+            return .audioRouteNotSettled
+        }
+        return .audioEngineStartFailed
     }
 }

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -340,14 +340,19 @@ class DictationSessionController: ObservableObject {
                 ]
             )
         )
+        isDictating = false
         overlayController.showError(
             microphoneTimeoutMessage(
                 deviceName: appState.sttRouter.inputDeviceName,
                 startAttempts: startAttempts,
                 inputFormatReady: appState.sttRouter.inputFormatReady
-            )
+            ),
+            actionTitle: "Try Again",
+            action: { [weak self] in
+                guard let self else { return }
+                self.startDictation(sourceApp: sourceApp, trigger: self.currentDictationTrigger)
+            }
         )
-        isDictating = false
     }
 
     private func presentMicrophonePermissionError(

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -44,4 +44,82 @@ func testParakeetStartRecordingFailurePolicy() {
         assertTrue(action.schedulePrewarmRetry, "initial start failures should schedule retry")
         assertTrue(action.rebuildAudioEngine, "engine start failure should rebuild the stale audio engine")
     }
+
+    runSuite("ParakeetStartRecordingFailurePolicy route-not-settled schedules prewarm") {
+        let action = ParakeetStartRecordingFailurePolicy.action(
+            for: .audioRouteNotSettled,
+            isRecoveryAttempt: false
+        )
+
+        assertTrue(action.markFormatUnready, "stale route formats should hold recording starts")
+        assertTrue(action.schedulePrewarmRetry, "stale route formats should wait for the next prewarm")
+        assertTrue(action.rebuildAudioEngine, "stale route formats should rebuild the audio engine")
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy accepts normal built-in formats") {
+        let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: 48_000,
+            outputChannelCount: 1,
+            inputSampleRate: 48_000,
+            inputChannelCount: 1,
+            selectedInputClass: "built_in",
+            selectionOverrodeDefault: true
+        )
+
+        assertEqual(readiness, .ready, "built-in mic 48k/48k should be ready")
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy accepts AirPods HFP upsample path") {
+        let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: 48_000,
+            outputChannelCount: 1,
+            inputSampleRate: 24_000,
+            inputChannelCount: 1,
+            selectedInputClass: "bluetooth",
+            selectionOverrodeDefault: false
+        )
+
+        assertEqual(readiness, .ready, "AirPods HFP 24k hardware to 48k output should remain valid")
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy defers stale AirPods-to-built-in switch formats") {
+        let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: 24_000,
+            outputChannelCount: 1,
+            inputSampleRate: 48_000,
+            inputChannelCount: 1,
+            selectedInputClass: "built_in",
+            selectionOverrodeDefault: true
+        )
+
+        assertEqual(readiness, .routeNotSettled, "24k output against a 48k built-in override is the stale route seen in Sentry")
+        assertEqual(readiness.startFailureReason, .audioRouteNotSettled, "route-not-settled should map to the matching start failure")
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy rejects zero formats") {
+        let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: 0,
+            outputChannelCount: 1,
+            inputSampleRate: 48_000,
+            inputChannelCount: 1,
+            selectedInputClass: "built_in",
+            selectionOverrodeDefault: true
+        )
+
+        assertEqual(readiness, .invalid, "zero output rate should still be invalid")
+        assertEqual(readiness.startFailureReason, .invalidAudioFormat, "invalid format should map to invalidAudioFormat")
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy maps CoreAudio format-not-supported") {
+        let error = NSError(
+            domain: "com.apple.coreaudio.avfaudio",
+            code: ParakeetAudioFormatReadinessPolicy.audioUnitFormatNotSupportedCode
+        )
+
+        assertEqual(
+            ParakeetAudioFormatReadinessPolicy.startFailureReason(for: error),
+            .audioRouteNotSettled,
+            "CoreAudio -10868 should be treated as a settling route instead of a terminal engine failure"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Treat stale AirPods-to-built-in CoreAudio route formats as still settling instead of ready.
- Rebuild and prewarm the Parakeet audio engine when the route reports the Sentry shape: built-in input at 48 kHz with a stale 24 kHz output bus.
- Keep a visible `Try Again` action on dictation microphone startup timeout.

## Why
Sentry showed the visible user failure as `APPLE-MACOS-14` (`dictation.microphone_start_timeout`) on `transcripted@1.1.16`. The underlying failures were `APPLE-MACOS-V` (`parakeet.audio_engine_start_failed`) with CoreAudio `-10868` / `kAudioUnitErr_FormatNotSupported`.

The key event had `input_device_class=built_in`, `input_rate_hz=48000`, `output_rate_hz=24000`, `format_ready=true`, and 22 start attempts. That means the app had switched away from AirPods to the built-in mic, but the output bus still looked like the Bluetooth speech route. We were treating that as ready and repeatedly calling `AVAudioEngine.start()`.

## Impact
First-run users with AirPods/AirPods Max should get a better recovery path: wait/retry while CoreAudio settles, rather than a dead-end microphone failure after repeated failed starts.

## Verification
- `bash run-tests.sh` passed: 705/705
- `bash build-deps.sh --force` completed to populate missing deps in this worktree
- `bash build.sh` passed and signed the app