### PR TITLE
Refresh release metadata for 1.1.17

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.16"
-  sha256 "a928175a158e13ac9fac04737d555b9d939ba58cd8dcd7b58d06bd0beaf85c44"
+  version "1.1.17"
+  sha256 "6b88c4a1ab1b1da10676fe07d230ead5a61f734554a8edfae31960bff6aeca32"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
         <description>Release feed for Transcripted macOS updates.</description>
         <language>en</language>
         <item>
+            <title>1.1.17</title>
+            <pubDate>Wed, 22 Apr 2026 12:12:08 -0500</pubDate>
+            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.17</link>
+            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.17</sparkle:fullReleaseNotesLink>
+            <sparkle:version>1.1.17</sparkle:version>
+            <sparkle:shortVersionString>1.1.17</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.17/Transcripted-1.1.17.dmg" length="527944947" type="application/octet-stream" sparkle:edSignature="14WAhGieu5//GU3jDtgyhoRK5sHVpHQ9wgb8BX7hysxhMWvPzbEaVHSliFVTBZn//xFXqrrvYy/c+mhfkwmgAA=="/>
+        </item>
+        <item>
             <title>1.1.16</title>
             <pubDate>Tue, 21 Apr 2026 21:14:50 -0500</pubDate>
             <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.16</link>


### PR DESCRIPTION
Updates the Sparkle appcast and Homebrew cask for Transcripted 1.1.17.