### PR TITLE
[codex] Bump Transcripted to 1.1.18

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.17</string>
+	<string>1.1.18</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.17</string>
+	<string>1.1.18</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>


### PR DESCRIPTION
## Summary
- Bump Transcripted app version metadata to 1.1.18.

## Testing
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh — 764 passed
- bash run-integration-smoke.sh