### PR TITLE
[codex] Refresh release metadata for 1.1.18

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.17"
-  sha256 "6b88c4a1ab1b1da10676fe07d230ead5a61f734554a8edfae31960bff6aeca32"
+  version "1.1.18"
+  sha256 "696288fa1e82cc4711f3bcc842371455935974cb70189746d8b2217a1be3e4aa"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
         <description>Release feed for Transcripted macOS updates.</description>
         <language>en</language>
         <item>
+            <title>1.1.18</title>
+            <pubDate>Wed, 22 Apr 2026 21:00:58 -0500</pubDate>
+            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.18</link>
+            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.18</sparkle:fullReleaseNotesLink>
+            <sparkle:version>1.1.18</sparkle:version>
+            <sparkle:shortVersionString>1.1.18</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.18/Transcripted-1.1.18.dmg" length="527982010" type="application/octet-stream" sparkle:edSignature="KuYF7CLSPFEzkXMtT2Uwarcze401ifkbBHTMNV0eBnB9rIUxwQygSNc3OWp59C5TNVSUpJbt/CoQYhtX7/PfBQ=="/>
+        </item>
+        <item>
             <title>1.1.17</title>
             <pubDate>Wed, 22 Apr 2026 12:12:08 -0500</pubDate>
             <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.17</link>


### PR DESCRIPTION
## Summary
- Add the Sparkle appcast entry for v1.1.18.
- Update the Homebrew cask to v1.1.18 and the GitHub asset SHA.

## Verification
- xmllint --noout docs/appcast.xml
- ruby -c Casks/transcripted.rb
- GitHub release v1.1.18 published with notarized DMG
- Cask SHA computed by downloading the published GitHub asset