### PR TITLE
[nightly-security] Harden Sentry name scrubbing

### DIFF
--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -12,6 +12,7 @@ enum SentryPayloadSanitizer {
         "email",
         "error",
         "file",
+        "name",
         "password",
         "path",
         "speaker",

--- a/Tests/SentryPayloadSanitizerTests.swift
+++ b/Tests/SentryPayloadSanitizerTests.swift
@@ -19,6 +19,8 @@ func testSentryPayloadSanitizer() {
             "dsn": "https://example@sentry.invalid/1",
             "duration_ms": "123",
             "meeting_state": "transcribing",
+            "meeting_name": "Weekly roadmap call",
+            "name": "Customer name",
             "password": "hunter2",
             "title": "Private customer call",
             "transcript_url": "/Users/redbars/Library/Application Support/Draft/meetings/demo.md",
@@ -30,6 +32,8 @@ func testSentryPayloadSanitizer() {
         assertEqual(sanitized["meeting_state"], "transcribing", "non-sensitive state should remain")
         assertNil(sanitized["client_secret"], "client secrets should be dropped")
         assertNil(sanitized["dsn"], "DSNs should be dropped")
+        assertNil(sanitized["meeting_name"], "meeting names should be dropped")
+        assertNil(sanitized["name"], "generic names should be dropped")
         assertNil(sanitized["password"], "password fields should be dropped")
         assertNil(sanitized["title"], "title should be dropped")
         assertNil(sanitized["transcript_url"], "transcript path should be dropped")


### PR DESCRIPTION
## Summary
- Drop generic `name`-bearing Sentry context keys before off-device reporting.
- Extend Sentry sanitizer coverage for `meeting_name` and plain `name` fields.

## Why
Transcripted treats names and meeting labels as private user context. Analytics already filters generic name keys; this brings Sentry scrubbing in line with that privacy boundary.

## Validation
- `bash run-tests.sh`
- `bash build-deps.sh --force`
- `bash build.sh`

## Sweep notes
- No open `[nightly-security]` draft PR existed before this branch.
- Latest GitHub release, `Info.plist`, Homebrew cask, and top appcast entry all point at `1.1.18`.
