### PR TITLE
refactor: nightly simplification sweep [automated]

### DIFF
--- a/Sources/Speech/DictationAudioRecovery.swift
+++ b/Sources/Speech/DictationAudioRecovery.swift
@@ -54,8 +54,9 @@ enum DictationAudioRecovery {
 
         let rms = Float(sqrt(sumOfSquares / Double(samples.count)))
         let activityThreshold = activeThreshold(forPeak: peak)
-        let activeCount = samples.reduce(0) { count, sample in
-            count + (abs(sample) >= activityThreshold ? 1 : 0)
+        var activeCount = 0
+        for sample in samples {
+            if abs(sample) >= activityThreshold { activeCount += 1 }
         }
 
         return DictationAudioAnalysis(
@@ -94,7 +95,8 @@ enum DictationAudioRecovery {
             return nil
         }
 
-        let focusedPeak = focused.reduce(Float(0)) { max($0, abs($1)) }
+        var focusedPeak: Float = 0
+        for sample in focused { focusedPeak = max(focusedPeak, abs(sample)) }
         guard focusedPeak > 0.0001 else { return nil }
 
         let gain = max(1.0, min(12.0, 0.45 / focusedPeak))

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -1798,6 +1798,10 @@ class ParakeetEngine: ObservableObject {
     }
 
     func finishExternalTranscription() {
+        finishTranscription()
+    }
+
+    private func finishTranscription() {
         isTranscribing = false
         sampleBuffer.removeAll(keepingCapacity: true)
     }
@@ -1854,8 +1858,7 @@ class ParakeetEngine: ObservableObject {
                 message: shortAudioDecision.message ?? "Dictation audio too short for transcription",
                 context: shortAudioDecision.context
             )
-            isTranscribing = false
-            sampleBuffer.removeAll(keepingCapacity: true)
+            finishTranscription()
             return nil
         }
 
@@ -1914,8 +1917,7 @@ class ParakeetEngine: ObservableObject {
                                     "chars": "\(retryCorrected.count)",
                                     "input_samples": "\(nativeCount)",
                                 ]) { current, _ in current })
-                            isTranscribing = false
-                            sampleBuffer.removeAll(keepingCapacity: true)
+                            finishTranscription()
                             return retryCorrected
                         }
 
@@ -1938,13 +1940,11 @@ class ParakeetEngine: ObservableObject {
                 EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "transcription_empty",
                     message: "Parakeet returned no text after \(String(format: "%.1f", elapsed))s inference",
                     context: emptyContext)
-                isTranscribing = false
-                sampleBuffer.removeAll(keepingCapacity: true)
+                finishTranscription()
                 return nil
             }
 
-            isTranscribing = false
-            sampleBuffer.removeAll(keepingCapacity: true)
+            finishTranscription()
 
             EventReporter.shared.capture(level: .info, engine: "parakeet", event: "transcription_complete",
                 message: "Transcribed in \(String(format: "%.2f", elapsed))s",
@@ -1972,8 +1972,7 @@ class ParakeetEngine: ObservableObject {
                     message: fallbackDecision.message ?? "Dictation audio too short for transcription",
                     context: fallbackContext
                 )
-                isTranscribing = false
-                sampleBuffer.removeAll(keepingCapacity: true)
+                finishTranscription()
                 return nil
             }
 
@@ -1981,8 +1980,7 @@ class ParakeetEngine: ObservableObject {
             EventReporter.shared.capture(level: .error, engine: "parakeet", event: "transcription_failed",
                 message: error.localizedDescription,
                 context: ["samples": "\(nativeCount)", "elapsed": String(format: "%.2f", elapsed)])
-            isTranscribing = false
-            sampleBuffer.removeAll(keepingCapacity: true)
+            finishTranscription()
             return nil
         }
     }

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -735,12 +735,8 @@ final class MeetingOverlayRootView: NSView {
             closeButton.setAccessibilityLabel(dismissPromptTooltip)
             closeButton.setAccessibilityHelp("Dismisses this meeting recording prompt.")
             closeButton.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.10).cgColor
-            remindButton.attributedTitle = buttonTitle("Remind me soon", size: 11, weight: .semibold)
             remindButton.setAccessibilityLabel(remindPromptTooltip)
             remindButton.setAccessibilityHelp("Dismisses this prompt and asks again in a little bit.")
-            remindButton.layer?.backgroundColor = MeetingOverlayTokens.quietActionBg.cgColor
-            remindButton.layer?.borderWidth = 0.5
-            remindButton.layer?.borderColor = MeetingOverlayTokens.quietActionBorder.cgColor
         case .recording:
             titleLabel.stringValue = self.isRecordingMinimized ? "Rec" : "Recording meeting"
             updateStatusDot(color: MeetingOverlayTokens.dotRecording, haloOpacity: 0.24, haloRadius: 3)


### PR DESCRIPTION
## Summary

- **DictationAudioRecovery**: Two `.reduce` closures in `analyze()` and `retrySamples()` were computing `activeCount` and `focusedPeak` with closure overhead on every empty-transcription event. Replaced with plain `for` loops — same two-pass logic, no closure allocation or `Int`-boxing per sample.
- **ParakeetEngine**: `isTranscribing = false; sampleBuffer.removeAll(keepingCapacity: true)` appeared at 6 separate return sites inside `transcribe()`. Extracted a private `finishTranscription()` helper; `finishExternalTranscription()` now delegates to it as well.
- **MeetingOverlayController**: The `.prompt` state-update case re-applied four `remindButton` layer properties (`attributedTitle`, `backgroundColor`, `borderWidth`, `borderColor`) that `applyBaseVisualStyle()` had already set on the line immediately above. Removed the four redundant assignments; the two accessibility-label lines that are actually state-specific are kept.

## Test plan

- [x] `bash build.sh` — clean build + signature valid
- [x] `bash run-tests.sh` — 764/764 passed
- [x] `bash run-integration-smoke.sh` — core + wake smoke passed
- [x] `swift test` — 71/71 TranscriptedCore package tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)