### PR TITLE
Add contributor mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+r3dbars <r3dbars@users.noreply.github.com> r3dbars <tz427gsydr@privaterelay.appleid.com>
+r3dbars <r3dbars@users.noreply.github.com> r3dbars <239240273+r3dbars@users.noreply.github.com>
+r3dbars <r3dbars@users.noreply.github.com> Justin Betker <jbetker91@gmail.com>
+r3dbars <r3dbars@users.noreply.github.com> justinbetker <Justin.betker@jamf.com>


### PR DESCRIPTION
## Summary
- add a root .mailmap for contributor identity cleanup
- map old Justin Betker, jbetker91, and r3dbars email aliases to r3dbars

## Validation
- git check-mailmap for each mapped identity
- git shortlog -sne --all confirms the old identities now group under r3dbars
- no app tests run; metadata-only change