### PR TITLE
[nightly-security] Harden auth header sanitization

### DIFF
--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -46,7 +46,10 @@ enum AnalyticsPayloadSanitizer {
     private static let commonSecretRegex = makeRegex(
         #"\b(?:ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|phc_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[A-Za-z0-9-]{10,}|xoxx-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9._-]{10,}\.[A-Za-z0-9._-]{10,})\b"#
     )
-    private static let bearerRegex = makeRegex(#"Bearer\s+[A-Za-z0-9._-]+"#, options: [.caseInsensitive])
+    private static let authSchemeRegex = makeRegex(#"(Bearer|Basic)\s+[A-Za-z0-9._~+\/=-]+"#, options: [.caseInsensitive])
+    private static let authorizationAssignmentRegex = makeRegex(
+        #"(?i)\b((?:proxy-)?authorization)\s*[:=]\s*(?:basic|bearer)\s+[^\s,;]+"#
+    )
     private static let secretAssignmentRegex = makeRegex(
         #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature|password|passphrase|secret|client[_-]?secret|credential|dsn)\s*[:=]\s*([^\s,;]+)"#
     )
@@ -104,7 +107,9 @@ enum AnalyticsPayloadSanitizer {
         range = NSRange(result.startIndex..., in: result)
         result = commonSecretRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)
-        result = bearerRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "Bearer ****")
+        result = authorizationAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
+        range = NSRange(result.startIndex..., in: result)
+        result = authSchemeRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1 ****")
         range = NSRange(result.startIndex..., in: result)
         result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)

--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -46,7 +46,10 @@ enum SentryPayloadSanitizer {
     private static let commonSecretRegex = makeRegex(
         #"\b(?:ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|phc_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[A-Za-z0-9-]{10,}|xoxx-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9._-]{10,}\.[A-Za-z0-9._-]{10,})\b"#
     )
-    private static let bearerRegex = makeRegex(#"Bearer\s+[A-Za-z0-9._-]+"#, options: [.caseInsensitive])
+    private static let authSchemeRegex = makeRegex(#"(Bearer|Basic)\s+[A-Za-z0-9._~+\/=-]+"#, options: [.caseInsensitive])
+    private static let authorizationAssignmentRegex = makeRegex(
+        #"(?i)\b((?:proxy-)?authorization)\s*[:=]\s*(?:basic|bearer)\s+[^\s,;]+"#
+    )
     private static let secretAssignmentRegex = makeRegex(
         #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature|password|passphrase|secret|client[_-]?secret|credential|dsn)\s*[:=]\s*([^\s,;]+)"#
     )
@@ -122,7 +125,9 @@ enum SentryPayloadSanitizer {
         range = NSRange(result.startIndex..., in: result)
         result = commonSecretRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)
-        result = bearerRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "Bearer ****")
+        result = authorizationAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
+        range = NSRange(result.startIndex..., in: result)
+        result = authSchemeRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1 ****")
         range = NSRange(result.startIndex..., in: result)
         result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)

--- a/Tests/AnalyticsPayloadSanitizerTests.swift
+++ b/Tests/AnalyticsPayloadSanitizerTests.swift
@@ -96,6 +96,21 @@ func testAnalyticsPayloadSanitizer() {
         }
     }
 
+    runSuite("AnalyticsPayloadSanitizer redacts basic auth headers and authorization assignments") {
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "failure_kind": "Authorization: Basic dXNlcjpwYXNz Basic ZGVtbzpwYXNz",
+            ],
+            allowedKeys: ["failure_kind"]
+        )
+
+        let value = sanitized["failure_kind"] ?? ""
+        assertFalse(value.contains("dXNlcjpwYXNz"), "basic auth payloads should be redacted")
+        assertFalse(value.contains("ZGVtbzpwYXNz"), "standalone basic auth values should be redacted")
+        assertTrue(value.contains("Authorization=[redacted-secret]"), "authorization assignments should collapse to a redacted marker")
+        assertTrue(value.contains("Basic ****"), "standalone basic auth marker should remain")
+    }
+
     runSuite("AnalyticsPayloadSanitizer.redact scrubs without the analytics length cap") {
         // Build a multi-line log blob longer than maxValueLength (80 chars) so
         // the feedback path can verify redaction happens but length is preserved.

--- a/Tests/SentryPayloadSanitizerTests.swift
+++ b/Tests/SentryPayloadSanitizerTests.swift
@@ -132,8 +132,20 @@ func testSentryPayloadSanitizer() {
             assertFalse(sanitized.lowercased().contains("tokenabc"), "case-insensitive bearer should still redact token part in '\(raw)'")
             assertFalse(sanitized.contains("abc.def_ghi"), "bearer with whitespace variants should redact token in '\(raw)'")
             assertFalse(sanitized.contains("mixed_case_token"), "mixed-case bearer should redact in '\(raw)'")
-            assertTrue(sanitized.contains("Bearer ****"), "sanitized bearer marker should remain in '\(raw)'")
+            assertTrue(sanitized.contains("****"), "sanitized auth marker should remain in '\(raw)'")
         }
+    }
+
+    runSuite("SentryPayloadSanitizer redacts basic auth headers and authorization assignments") {
+        let input = "Authorization: Basic dXNlcjpwYXNz Proxy-Authorization=Bearer abc123 fallback Basic ZGVtbzpwYXNz"
+        let sanitized = SentryPayloadSanitizer.sanitizeText(input)
+
+        assertFalse(sanitized.contains("dXNlcjpwYXNz"), "basic auth payloads should be redacted")
+        assertFalse(sanitized.contains("abc123"), "authorization assignment bearer tokens should be redacted")
+        assertFalse(sanitized.contains("ZGVtbzpwYXNz"), "standalone basic auth values should be redacted")
+        assertTrue(sanitized.contains("Authorization=[redacted-secret]"), "authorization assignments should collapse to a redacted marker")
+        assertTrue(sanitized.contains("Proxy-Authorization=[redacted-secret]"), "proxy authorization assignments should collapse to a redacted marker")
+        assertTrue(sanitized.contains("Basic ****"), "standalone basic auth marker should remain")
     }
 
     runSuite("SentryPayloadSanitizer.sanitizeAnyDictionary redacts nested free-form values") {


### PR DESCRIPTION
## Summary
- redact Basic auth tokens in Sentry and analytics free-form sanitizer paths
- collapse Authorization and Proxy-Authorization assignments to a redacted marker
- add fast-test coverage for the new auth-header scrubbing cases

## Verification
- bash run-tests.sh
- bash build-deps.sh --force
- bash build.sh