### PR TITLE
[nightly-artifact] tighten empty sidecar validation

### DIFF
--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/RoundTrip.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/RoundTrip.swift
@@ -96,6 +96,22 @@ struct RoundTrip: ParsableCommand {
                 }
             }),
 
+            ("Remove all utterances from JSON sidecar", {
+                try corruptionTest(cleanDir: cleanDir, tmpBase: tmpBase, name: "empty-utterances") { dir in
+                    let jsonFile = dir.appendingPathComponent("Call_2026-03-26_10-30-00.json")
+                    let data = try Data(contentsOf: jsonFile)
+                    guard var json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                        return false
+                    }
+                    json["utterances"] = [[String: Any]]()
+                    let newData = try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+                    try newData.write(to: jsonFile)
+
+                    let results = JSONSidecarValidator(directory: dir).validate()
+                    return results.contains { $0.status == .fail && $0.check == "artifact/json-utterances-present" }
+                }
+            }),
+
             ("Set negative duration_seconds in JSON", {
                 try corruptionTest(cleanDir: cleanDir, tmpBase: tmpBase, name: "negative-duration") { dir in
                     let jsonFile = dir.appendingPathComponent("Call_2026-03-26_10-30-00.json")

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Generators/TestDataGenerator.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Generators/TestDataGenerator.swift
@@ -11,7 +11,7 @@ struct TestDataGenerator {
         try fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
 
         let transcripts: [(name: String, utterances: Int, speakers: Int, duration: Int)] = [
-            ("Call_2026-03-26_00-00-00", 0, 0, 0),       // empty
+            ("Call_2026-03-26_00-00-00", 1, 1, 6),       // minimal valid artifact
             ("Call_2026-03-26_10-30-00", 5, 2, 120),      // small
             ("Call_2026-03-26_14-00-00", 50, 5, 3600),    // large
         ]

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Validators/JSONSidecarValidator.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Validators/JSONSidecarValidator.swift
@@ -66,6 +66,11 @@ struct JSONSidecarValidator {
 
             // Utterances sorted by start
             if let utterances = json["utterances"] as? [[String: Any]] {
+                if utterances.isEmpty {
+                    results.append(.fail("artifact/json-utterances-present", target: name, detail: "No utterances found"))
+                    continue
+                }
+
                 var sorted = true
                 var prevStart: Double = -1
                 var missingStartCount = 0


### PR DESCRIPTION
## Summary
- fail legacy JSON sidecars when they contain no utterances
- add a round-trip corruption case for empty sidecars
- keep generated clean fixtures aligned with the stricter validator

## Nightly artifact QA
- check-health: 6 passed, 0 failed, 0 warnings
- validate-all: 824 passed, 2 failed, 5 warnings after the validator fix
- remaining failures are local data drift in ~/Library/Application Support/Transcripted/captures/meetings: one empty orphan JSON sidecar and one stale transcripted.json markdown entry

## Verification
- swift build in Tools/TranscriptedQA
- swift run transcripted-qa round-trip
- swift run transcripted-qa validate-all
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
