### PR TITLE
[nightly-retrieval] Fix CLI speaker-filtered search

### DIFF
--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -181,6 +181,7 @@ enum CLIContextStore {
                 }
                 let matches = meeting.utterances.filter { utterance in
                     utterance.text.localizedCaseInsensitiveContains(normalizedQuery)
+                        && (speaker == nil || speakerMatches(filter: speaker!, speakerName: utterance.speakerId))
                 }
                 guard let firstMatch = matches.first else { return nil }
                 return CLIContextItem(
@@ -380,6 +381,10 @@ enum CLIContextStore {
         if let dateFrom, date < dateFrom { return false }
         if let dateTo, date > dateTo { return false }
         return true
+    }
+
+    private static func speakerMatches(filter: String, speakerName: String) -> Bool {
+        speakerName.localizedCaseInsensitiveContains(filter)
     }
 
     private struct ParsedFrontmatter {

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -87,6 +87,50 @@ final class ContextStoreTests: XCTestCase {
         XCTAssertEqual(items.first?.preview, "No transcript captured.")
     }
 
+    func testSearchSpeakerFilterUsesMatchingSpeakerUtterance() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let meetingsDir = root.appendingPathComponent("meetings", isDirectory: true)
+        let dictationsDir = root.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: meetingsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dictationsDir, withIntermediateDirectories: true)
+
+        let meeting = """
+        ---
+        capture_type: meeting
+        date: 2026-04-16
+        time: 09:15:00
+        duration: "0:18"
+        ---
+
+        # Product review
+
+        ## Full Transcript
+
+        [00:03] [System/Speaker 2] The product plan needs review.
+        [00:08] [Mic/You] I agree, and the product plan still needs a test pass.
+        """
+        try meeting.write(
+            to: meetingsDir.appendingPathComponent("Product review.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let items = CLIContextStore.search(
+            query: "product",
+            speaker: "You",
+            in: CLIContextDirectories(meetingsDir: meetingsDir, dictationsDir: dictationsDir),
+            kind: .meeting,
+            count: 5,
+            dateFrom: nil,
+            dateTo: nil
+        )
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.preview, "I agree, and the product plan still needs a test pass.")
+    }
+
     private func makeTempDir() -> URL {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)


### PR DESCRIPTION
## Summary
- make `transcripted-cli context-search --speaker` only surface matching utterances from the requested speaker
- add a regression test that fails if the CLI shows another speaker's line for a speaker-filtered hit
- keep nightly retrieval verification green across CLI, MCP, app build, and repo fast tests

## Verification
- cd Tools/TranscriptedCLI && swift build && swift test
- cd Tools/TranscriptedMCP && swift build
- cd Tools/TranscriptedMCP && swift test
- cd Tools/TranscriptedCLI && ./.build/debug/transcripted-cli context-recent --count 8 --meetings-dir "$HOME/Library/Application Support/Transcripted/captures/meetings" --dictations-dir "$HOME/Library/Application Support/Transcripted/captures/dictations"
- cd Tools/TranscriptedCLI && ./.build/debug/transcripted-cli context-recent --kind meeting --count 5 --meetings-dir "$HOME/Library/Application Support/Transcripted/captures/meetings"
- cd Tools/TranscriptedCLI && ./.build/debug/transcripted-cli list-dictations --count 5 --dictations-dir "$HOME/Library/Application Support/Transcripted/captures/dictations"
- cd Tools/TranscriptedCLI && ./.build/debug/transcripted-cli context-search pricing --count 5 --meetings-dir "$HOME/Library/Application Support/Transcripted/captures/meetings" --dictations-dir "$HOME/Library/Application Support/Transcripted/captures/dictations"
- cd Tools/TranscriptedCLI && ./.build/debug/transcripted-cli context-search testing --kind meeting --speaker You --count 5 --meetings-dir "$HOME/Library/Application Support/Transcripted/captures/meetings"
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh