### PR TITLE
[nightly-agent] Clarify agent CLI surface docs

### DIFF
--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -86,6 +86,6 @@ instruction to run `bash build-deps.sh` from the repo root before rebuilding.
 - the context commands and the diarization commands serve different users, do not describe the whole package as diarization-only
 - the diarization commands depend on repo-level artifacts, so run `bash build-deps.sh` first when those are missing
 - retrieval-only commands should still build and run even when the diarization bundle is absent
-- `swift test` currently covers the agent-facing context path resolver only
+- `swift test` currently covers the agent-facing context path resolver and context-store loading behavior
 - the default context resolver prefers Transcripted capture folders, then falls back to Draft-era exports, then `~/Documents/Transcripted/`
 - changes here should be verified independently from the app build

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -82,7 +82,7 @@ Rule of thumb:
 - `Sources/TranscriptedCore/CLAUDE.md`
   Library boundary, pipeline layout, embedder seams.
 - `Tools/TranscriptedCLI/CLAUDE.md`
-  Standalone diarization CLI.
+  Standalone local-context and offline diarization CLI.
 
 ## Historical Zones
 


### PR DESCRIPTION
## Summary
- clarify that `Tools/TranscriptedCLI` is a local-context CLI as well as an offline diarization CLI
- fix the CLI doc note so `swift test` coverage matches the current package tests

## Verification
- `cd Tools/TranscriptedCLI && swift build && swift test`
- `cd Tools/TranscriptedMCP && swift build -c release && swift test`
