### PR TITLE
[codex] Improve update visibility and automatic downloads

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -32,6 +32,10 @@
 	<true/>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
+	<key>SUAllowsAutomaticUpdates</key>
+	<true/>
+	<key>SUScheduledCheckInterval</key>
+	<integer>14400</integer>
 	<key>SUFeedURL</key>
 	<string>https://raw.githubusercontent.com/r3dbars/transcripted/main/docs/appcast.xml</string>
 	<key>SUPublicEDKey</key>

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -169,6 +169,62 @@ struct AnalyticsEventPolicy: Equatable {
                 "paste_available",
             ]
         ),
+        "update_action_clicked": .init(
+            name: "update_action_clicked",
+            allowedProperties: [
+                "action_id",
+                "automatic_downloads_enabled",
+                "state",
+                "surface",
+                "version",
+            ]
+        ),
+        "update_setting_changed": .init(
+            name: "update_setting_changed",
+            allowedProperties: [
+                "enabled",
+                "setting_id",
+            ]
+        ),
+        "update_check_finished": .init(
+            name: "update_check_finished",
+            allowedProperties: [
+                "automatic_downloads_enabled",
+                "result",
+                "state",
+                "version",
+            ]
+        ),
+        "update_download_started": .init(
+            name: "update_download_started",
+            allowedProperties: [
+                "automatic_downloads_enabled",
+                "state",
+                "version",
+            ]
+        ),
+        "update_download_finished": .init(
+            name: "update_download_finished",
+            allowedProperties: [
+                "automatic_downloads_enabled",
+                "state",
+                "version",
+            ]
+        ),
+        "update_ready_to_install": .init(
+            name: "update_ready_to_install",
+            allowedProperties: [
+                "automatic_downloads_enabled",
+                "state",
+                "version",
+            ]
+        ),
+        "update_relaunching": .init(
+            name: "update_relaunching",
+            allowedProperties: [
+                "version",
+            ]
+        ),
         "settings_opened": .init(
             name: "settings_opened",
             allowedProperties: [

--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -4,6 +4,12 @@ import Sparkle
 
 @MainActor
 final class SparkleUpdaterController: NSObject, ObservableObject {
+    struct AutomaticUpdateSettings: Equatable {
+        var automaticChecksEnabled: Bool
+        var automaticDownloadsAllowed: Bool
+        var automaticDownloadsEnabled: Bool
+    }
+
     struct UpdateStatus: Equatable {
         enum State: Equatable {
             case unknown
@@ -11,22 +17,42 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
             case checking
             case noUpdateAvailable
             case updateAvailable(version: String)
+            case downloading(version: String)
+            case readyToInstall(version: String)
         }
 
         var state: State
         var canCheckForUpdates: Bool
 
         var availableUpdateVersion: String? {
-            if case .updateAvailable(let version) = state {
+            switch state {
+            case .updateAvailable(let version), .downloading(let version), .readyToInstall(let version):
                 return version
+            case .unknown, .readyToCheck, .checking, .noUpdateAvailable:
+                return nil
             }
-            return nil
+        }
+
+        var canRunUserUpdateAction: Bool {
+            switch state {
+            case .checking, .downloading:
+                return false
+            case .readyToInstall:
+                return true
+            case .unknown, .readyToCheck, .noUpdateAvailable, .updateAvailable:
+                return canCheckForUpdates
+            }
         }
     }
 
     @Published private(set) var updateStatus = UpdateStatus(
         state: .unknown,
         canCheckForUpdates: false
+    )
+    @Published private(set) var automaticUpdateSettings = AutomaticUpdateSettings(
+        automaticChecksEnabled: false,
+        automaticDownloadsAllowed: false,
+        automaticDownloadsEnabled: false
     )
 
     private lazy var updaterController = SPUStandardUpdaterController(
@@ -35,11 +61,15 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
         userDriverDelegate: self
     )
     private var canCheckObservation: NSKeyValueObservation?
+    private var updaterSettingObservations: [NSKeyValueObservation] = []
     private var hasPerformedStartupCheck = false
+    private var pendingImmediateInstallHandler: (() -> Void)?
+    private var pendingImmediateInstallVersion: String?
 
     override init() {
         super.init()
         observeUpdaterReadiness()
+        observeUpdaterSettings()
     }
 
     func performStartupUpdateCheckIfNeeded() {
@@ -84,6 +114,53 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
         updaterController.updater.checkForUpdateInformation()
     }
 
+    func performUserUpdateAction(surface: String) {
+        let state = updateStatus.state
+        let version = updateStatus.availableUpdateVersion
+        trackUpdateActionClicked(surface: surface, state: state, version: version)
+
+        if case .readyToInstall(let version) = state, let pendingImmediateInstallHandler {
+            pendingImmediateInstallVersion = version
+            pendingImmediateInstallHandler()
+            return
+        }
+
+        checkForUpdates()
+    }
+
+    func setAutomaticallyChecksForUpdates(_ enabled: Bool) {
+        guard hasConfiguredFeedURL else { return }
+        updaterController.updater.automaticallyChecksForUpdates = enabled
+        if !enabled {
+            updaterController.updater.automaticallyDownloadsUpdates = false
+        }
+        syncAutomaticUpdateSettings(from: updaterController.updater)
+        trackUpdateSettingChanged(settingID: "automatic_checks", enabled: enabled)
+
+        if enabled {
+            refreshUpdateStatus()
+        }
+    }
+
+    func setAutomaticallyDownloadsUpdates(_ enabled: Bool) {
+        guard hasConfiguredFeedURL else { return }
+
+        if enabled {
+            updaterController.updater.automaticallyChecksForUpdates = true
+        }
+
+        updaterController.updater.automaticallyDownloadsUpdates = enabled && updaterController.updater.allowsAutomaticUpdates
+        syncAutomaticUpdateSettings(from: updaterController.updater)
+        trackUpdateSettingChanged(
+            settingID: "automatic_downloads",
+            enabled: updaterController.updater.automaticallyDownloadsUpdates
+        )
+
+        guard updaterController.updater.automaticallyDownloadsUpdates, !updaterController.updater.sessionInProgress else { return }
+        beginObservedUpdateCheck()
+        updaterController.updater.checkForUpdatesInBackground()
+    }
+
     private func observeUpdaterReadiness() {
         canCheckObservation = updaterController.updater.observe(
             \.canCheckForUpdates,
@@ -95,9 +172,30 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
         }
     }
 
+    private func observeUpdaterSettings() {
+        let updater = updaterController.updater
+        updaterSettingObservations = [
+            updater.observe(\.automaticallyChecksForUpdates, options: [.initial, .new]) { [weak self] updater, _ in
+                Task { @MainActor [weak self] in
+                    self?.syncAutomaticUpdateSettings(from: updater)
+                }
+            },
+            updater.observe(\.automaticallyDownloadsUpdates, options: [.initial, .new]) { [weak self] updater, _ in
+                Task { @MainActor [weak self] in
+                    self?.syncAutomaticUpdateSettings(from: updater)
+                }
+            },
+            updater.observe(\.allowsAutomaticUpdates, options: [.initial, .new]) { [weak self] updater, _ in
+                Task { @MainActor [weak self] in
+                    self?.syncAutomaticUpdateSettings(from: updater)
+                }
+            },
+        ]
+    }
+
     private func beginObservedUpdateCheck() {
         switch updateStatus.state {
-        case .updateAvailable:
+        case .updateAvailable, .downloading, .readyToInstall:
             syncReadiness(from: updaterController.updater)
         default:
             setUpdateStatus(.checking, canCheckForUpdates: updaterController.updater.canCheckForUpdates)
@@ -116,6 +214,16 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
         }
 
         setUpdateStatus(nextState, canCheckForUpdates: canCheckForUpdates)
+    }
+
+    private func syncAutomaticUpdateSettings(from updater: SPUUpdater) {
+        let nextSettings = AutomaticUpdateSettings(
+            automaticChecksEnabled: updater.automaticallyChecksForUpdates,
+            automaticDownloadsAllowed: updater.allowsAutomaticUpdates,
+            automaticDownloadsEnabled: updater.automaticallyDownloadsUpdates
+        )
+        guard nextSettings != automaticUpdateSettings else { return }
+        automaticUpdateSettings = nextSettings
     }
 
     private func setUpdateStatus(_ state: UpdateStatus.State, canCheckForUpdates: Bool) {
@@ -144,19 +252,132 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
         }
         return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
+
+    private func trackUpdateActionClicked(surface: String, state: UpdateStatus.State, version: String?) {
+        var properties = baseUpdateTelemetryProperties(state: state, version: version)
+        properties["surface"] = surface
+        properties["action_id"] = updateActionID(for: state)
+        AnalyticsReporter.track("update_action_clicked", properties: properties)
+    }
+
+    private func trackUpdateSettingChanged(settingID: String, enabled: Bool) {
+        AnalyticsReporter.track(
+            "update_setting_changed",
+            properties: [
+                "enabled": enabled ? "true" : "false",
+                "setting_id": settingID,
+            ]
+        )
+    }
+
+    private func trackUpdateCheckFinished(result: String, state: UpdateStatus.State, version: String?) {
+        var properties = baseUpdateTelemetryProperties(state: state, version: version)
+        properties["result"] = result
+        AnalyticsReporter.track("update_check_finished", properties: properties)
+    }
+
+    private func trackUpdateLifecycleEvent(_ event: String, state: UpdateStatus.State, version: String) {
+        AnalyticsReporter.track(
+            event,
+            properties: baseUpdateTelemetryProperties(state: state, version: version)
+        )
+    }
+
+    private func baseUpdateTelemetryProperties(state: UpdateStatus.State, version: String?) -> [String: String] {
+        var properties = [
+            "automatic_downloads_enabled": automaticUpdateSettings.automaticDownloadsEnabled ? "true" : "false",
+            "state": analyticsValue(for: state),
+        ]
+        if let version {
+            properties["version"] = version
+        }
+        return properties
+    }
+
+    private func analyticsValue(for state: UpdateStatus.State) -> String {
+        switch state {
+        case .unknown:
+            return "unknown"
+        case .readyToCheck:
+            return "ready"
+        case .checking:
+            return "checking"
+        case .noUpdateAvailable:
+            return "up_to_date"
+        case .updateAvailable:
+            return "available"
+        case .downloading:
+            return "downloading"
+        case .readyToInstall:
+            return "ready_to_install"
+        }
+    }
+
+    private func updateActionID(for state: UpdateStatus.State) -> String {
+        switch state {
+        case .updateAvailable:
+            return "install_update"
+        case .readyToInstall:
+            return "restart_to_update"
+        case .checking, .downloading:
+            return "view_update_progress"
+        case .unknown, .readyToCheck, .noUpdateAvailable:
+            return "check_updates"
+        }
+    }
 }
 
 extension SparkleUpdaterController: SPUUpdaterDelegate {
     func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
-        setUpdateStatus(.updateAvailable(version: versionString(for: item)), canCheckForUpdates: updater.canCheckForUpdates)
+        let version = versionString(for: item)
+        let state = UpdateStatus.State.updateAvailable(version: version)
+        setUpdateStatus(state, canCheckForUpdates: updater.canCheckForUpdates)
+        trackUpdateCheckFinished(result: "available", state: state, version: version)
     }
 
     func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: any Error) {
         setUpdateStatus(.noUpdateAvailable, canCheckForUpdates: updater.canCheckForUpdates)
+        trackUpdateCheckFinished(result: "up_to_date", state: .noUpdateAvailable, version: nil)
     }
 
     func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
         setUpdateStatus(.noUpdateAvailable, canCheckForUpdates: updater.canCheckForUpdates)
+        trackUpdateCheckFinished(result: "up_to_date", state: .noUpdateAvailable, version: nil)
+    }
+
+    func updater(_ updater: SPUUpdater, willDownloadUpdate item: SUAppcastItem, with request: NSMutableURLRequest) {
+        let version = versionString(for: item)
+        let state = UpdateStatus.State.downloading(version: version)
+        setUpdateStatus(state, canCheckForUpdates: updater.canCheckForUpdates)
+        trackUpdateLifecycleEvent("update_download_started", state: state, version: version)
+    }
+
+    func updater(_ updater: SPUUpdater, didDownloadUpdate item: SUAppcastItem) {
+        let version = versionString(for: item)
+        let state = UpdateStatus.State.downloading(version: version)
+        setUpdateStatus(state, canCheckForUpdates: updater.canCheckForUpdates)
+        trackUpdateLifecycleEvent("update_download_finished", state: state, version: version)
+    }
+
+    func updater(_ updater: SPUUpdater, failedToDownloadUpdate item: SUAppcastItem, error: any Error) {
+        let version = versionString(for: item)
+        let state = UpdateStatus.State.updateAvailable(version: version)
+        setUpdateStatus(state, canCheckForUpdates: updater.canCheckForUpdates)
+        trackUpdateCheckFinished(result: "download_failed", state: state, version: version)
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        willInstallUpdateOnQuit item: SUAppcastItem,
+        immediateInstallationBlock immediateInstallHandler: @escaping () -> Void
+    ) -> Bool {
+        let version = versionString(for: item)
+        let state = UpdateStatus.State.readyToInstall(version: version)
+        pendingImmediateInstallHandler = immediateInstallHandler
+        pendingImmediateInstallVersion = version
+        setUpdateStatus(state, canCheckForUpdates: updater.canCheckForUpdates)
+        trackUpdateLifecycleEvent("update_ready_to_install", state: state, version: version)
+        return true
     }
 
     func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor updateCheck: SPUUpdateCheck, error: (any Error)?) {
@@ -169,6 +390,17 @@ extension SparkleUpdaterController: SPUUpdaterDelegate {
         }
 
         setUpdateStatus(fallbackState, canCheckForUpdates: updater.canCheckForUpdates)
+    }
+
+    func updaterWillRelaunchApplication(_ updater: SPUUpdater) {
+        if let pendingImmediateInstallVersion {
+            AnalyticsReporter.track(
+                "update_relaunching",
+                properties: ["version": pendingImmediateInstallVersion]
+            )
+        }
+        pendingImmediateInstallHandler = nil
+        pendingImmediateInstallVersion = nil
     }
 }
 
@@ -188,10 +420,13 @@ extension SparkleUpdaterController: SPUStandardUserDriverDelegate {
         state: SPUUserUpdateState
     ) {
         let version = Self.displayVersionString(for: update)
+        let updateState: UpdateStatus.State = state.stage == .downloaded
+            ? .readyToInstall(version: version)
+            : .updateAvailable(version: version)
         Task { @MainActor [weak self] in
             guard let self else { return }
             self.setUpdateStatus(
-                .updateAvailable(version: version),
+                updateState,
                 canCheckForUpdates: self.updaterController.updater.canCheckForUpdates
             )
         }

--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -87,6 +87,7 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
             // Sparkle recommends forcing launch-time background checks, if
             // desired, immediately after the updater has started and only when
             // automatic checks are enabled.
+            guard !updaterController.updater.sessionInProgress else { return }
             updaterController.updater.checkForUpdatesInBackground()
         } else {
             refreshUpdateStatus()
@@ -100,6 +101,7 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
         }
 
         beginObservedUpdateCheck()
+        guard updaterController.updater.canCheckForUpdates else { return }
         updaterController.checkForUpdates(nil)
     }
 
@@ -108,9 +110,12 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
             setUpdateStatus(.unknown, canCheckForUpdates: false)
             return
         }
-        guard updaterController.updater.canCheckForUpdates else { return }
 
         beginObservedUpdateCheck()
+        guard updaterController.updater.canCheckForUpdates,
+              !updaterController.updater.sessionInProgress else {
+            return
+        }
         updaterController.updater.checkForUpdateInformation()
     }
 
@@ -232,6 +237,34 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
         updateStatus = nextStatus
     }
 
+    private func markNoUpdateAvailable(from updater: SPUUpdater) {
+        if updateStatus.availableUpdateVersion != nil {
+            trackUpdateCheckFinished(
+                result: "no_change",
+                state: updateStatus.state,
+                version: updateStatus.availableUpdateVersion
+            )
+            return
+        }
+
+        let state = UpdateStatus.State.noUpdateAvailable
+        setUpdateStatus(state, canCheckForUpdates: updater.canCheckForUpdates)
+        trackUpdateCheckFinished(result: "up_to_date", state: state, version: nil)
+    }
+
+    private func markUpdateCheckFailed(from updater: SPUUpdater) {
+        if updateStatus.availableUpdateVersion == nil {
+            let state: UpdateStatus.State = updater.canCheckForUpdates ? .readyToCheck : .unknown
+            setUpdateStatus(state, canCheckForUpdates: updater.canCheckForUpdates)
+        }
+
+        trackUpdateCheckFinished(
+            result: "error",
+            state: updateStatus.state,
+            version: updateStatus.availableUpdateVersion
+        )
+    }
+
     private func versionString(for item: SUAppcastItem) -> String {
         Self.displayVersionString(for: item)
     }
@@ -336,13 +369,11 @@ extension SparkleUpdaterController: SPUUpdaterDelegate {
     }
 
     func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: any Error) {
-        setUpdateStatus(.noUpdateAvailable, canCheckForUpdates: updater.canCheckForUpdates)
-        trackUpdateCheckFinished(result: "up_to_date", state: .noUpdateAvailable, version: nil)
+        markUpdateCheckFailed(from: updater)
     }
 
     func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
-        setUpdateStatus(.noUpdateAvailable, canCheckForUpdates: updater.canCheckForUpdates)
-        trackUpdateCheckFinished(result: "up_to_date", state: .noUpdateAvailable, version: nil)
+        markNoUpdateAvailable(from: updater)
     }
 
     func updater(_ updater: SPUUpdater, willDownloadUpdate item: SUAppcastItem, with request: NSMutableURLRequest) {
@@ -420,9 +451,15 @@ extension SparkleUpdaterController: SPUStandardUserDriverDelegate {
         state: SPUUserUpdateState
     ) {
         let version = Self.displayVersionString(for: update)
-        let updateState: UpdateStatus.State = state.stage == .downloaded
-            ? .readyToInstall(version: version)
-            : .updateAvailable(version: version)
+        let updateState: UpdateStatus.State
+        switch state.stage {
+        case .downloaded, .installing:
+            updateState = .readyToInstall(version: version)
+        case .notDownloaded:
+            updateState = .updateAvailable(version: version)
+        @unknown default:
+            updateState = .updateAvailable(version: version)
+        }
         Task { @MainActor [weak self] in
             guard let self else { return }
             self.setUpdateStatus(

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -260,7 +260,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         statusItemUpdateBadge.isHidden = updateVersion == nil
 
         if let updateVersion {
-            statusItem?.button?.toolTip = "Transcripted - update \(updateVersion) available"
+            statusItem?.button?.toolTip = "Transcripted - update \(updateVersion) ready"
         } else {
             statusItem?.button?.toolTip = "Transcripted"
         }
@@ -410,6 +410,10 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             updateState = "up_to_date"
         case .updateAvailable:
             updateState = "available"
+        case .downloading:
+            updateState = "downloading"
+        case .readyToInstall:
+            updateState = "ready_to_install"
         }
 
         AnalyticsReporter.track(

--- a/Sources/UI/MenuBar/MenuBarContentView.swift
+++ b/Sources/UI/MenuBar/MenuBarContentView.swift
@@ -12,8 +12,17 @@ final class MenuBarContentView: NSView {
     private var documentHeight: CGFloat = MenuTokens.panelHeight
 
     let headerView = MenuBarHeaderView(frame: .zero)
+    let updateCalloutRow = MenuBarActionRowView(frame: .zero)
     let primaryActionsView = MenuBarPrimaryActionsView(frame: .zero)
     let utilityActionsView = MenuBarUtilityActionsView(frame: .zero)
+
+    var onUpdateAction: (() -> Void)? {
+        didSet {
+            updateCalloutRow.onPress = { [weak self] in
+                self?.onUpdateAction?()
+            }
+        }
+    }
 
     weak var appState: TranscriptedAppState? {
         didSet {
@@ -52,7 +61,8 @@ final class MenuBarContentView: NSView {
             documentView.addSubview($0)
         }
 
-        [headerView, primaryActionsView, utilityActionsView].forEach(documentView.addSubview(_:))
+        updateCalloutRow.isHidden = true
+        [headerView, updateCalloutRow, primaryActionsView, utilityActionsView].forEach(documentView.addSubview(_:))
     }
 
     override func layout() {
@@ -78,6 +88,14 @@ final class MenuBarContentView: NSView {
             headerDivider.frame = .zero
         }
 
+        if !updateCalloutRow.isHidden {
+            let updateHeight = updateCalloutRow.intrinsicContentSize.height
+            updateCalloutRow.frame = NSRect(x: pad, y: y, width: width, height: updateHeight)
+            y += updateHeight + 7
+        } else {
+            updateCalloutRow.frame = .zero
+        }
+
         let primaryHeight = primaryActionsView.intrinsicHeight
         primaryActionsView.frame = NSRect(x: pad, y: y, width: width, height: primaryHeight)
         y += primaryHeight + MenuTokens.sectionSpacing
@@ -96,6 +114,30 @@ final class MenuBarContentView: NSView {
     func scrollToTop() {
         scrollView.contentView.scroll(to: .zero)
         scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
+    func updateProminentUpdate(
+        symbolName: String,
+        title: String,
+        detail: String,
+        trailingText: String?,
+        tone: MenuBarActionRowView.Tone,
+        isVisible: Bool,
+        isEnabled: Bool
+    ) {
+        updateCalloutRow.isHidden = !isVisible
+        if isVisible {
+            updateCalloutRow.update(
+                symbolName: symbolName,
+                title: title,
+                detail: detail,
+                trailingText: trailingText,
+                tone: tone,
+                size: .primary,
+                isEnabled: isEnabled
+            )
+        }
+        needsLayout = true
     }
 
     var preferredPanelSize: NSSize {

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -40,8 +40,9 @@ final class MenuBarPanelController: NSViewController {
         content.primaryActionsView.onPasteLastDictation = { [weak self] in self?.pasteLastDictationFromMenu() }
         content.primaryActionsView.onOpenRecentMeetings = { [weak self] in self?.openSettingsFromMenu(.meetings) }
         content.utilityActionsView.onOpenSettings = { [weak self] in self?.openSettingsFromMenu(.home) }
-        content.utilityActionsView.onCheckForUpdates = { [weak self] in self?.checkForUpdatesFromMenu() }
+        content.utilityActionsView.onCheckForUpdates = { [weak self] in self?.performUpdateActionFromMenu() }
         content.utilityActionsView.onOpenConnectAgent = { [weak self] in self?.openSettingsFromMenu(.connectAgent) }
+        content.onUpdateAction = { [weak self] in self?.performUpdateActionFromMenu() }
         view = content
         contentView = content
         view.appearance = NSAppearance(named: .darkAqua)
@@ -84,12 +85,23 @@ final class MenuBarPanelController: NSViewController {
             showRecentMeetings: menuVisibility[.recentMeetings] ?? true
         )
 
+        content.updateProminentUpdate(
+            symbolName: updatePresentation.symbolName,
+            title: updatePresentation.title,
+            detail: updatePresentation.detail,
+            trailingText: updatePresentation.trailingText,
+            tone: updatePresentation.tone,
+            isVisible: updatePresentation.isProminent,
+            isEnabled: appState.sparkleUpdater.updateStatus.canRunUserUpdateAction
+        )
+
         content.utilityActionsView.update(
             updateTitle: updatePresentation.title,
             updateDetail: updatePresentation.detail,
-            updateVersion: updatePresentation.version,
+            updateVersion: updatePresentation.trailingText,
             updateTone: updatePresentation.tone,
-            updateEnabled: appState.sparkleUpdater.updateStatus.canCheckForUpdates
+            updateEnabled: appState.sparkleUpdater.updateStatus.canRunUserUpdateAction,
+            showUpdateRow: !updatePresentation.isProminent
         )
 
         if case .unknown = appState.sparkleUpdater.updateStatus.state {
@@ -191,10 +203,10 @@ final class MenuBarPanelController: NSViewController {
         openSettingsWindow(page)
     }
 
-    private func checkForUpdatesFromMenu() {
-        trackMenuAction("check_updates")
+    private func performUpdateActionFromMenu() {
+        trackMenuAction(menuUpdateActionID(for: appState.sparkleUpdater.updateStatus.state))
         dismissPopover()
-        appState.sparkleUpdater.checkForUpdates()
+        appState.sparkleUpdater.performUserUpdateAction(surface: "menu_bar")
     }
 
     private func trackMenuAction(_ actionID: String) {
@@ -217,36 +229,82 @@ final class MenuBarPanelController: NSViewController {
 
     private func menuUpdatePresentation(
         for status: SparkleUpdaterController.UpdateStatus
-    ) -> (title: String, detail: String, version: String?, tone: MenuBarActionRowView.Tone) {
+    ) -> (
+        symbolName: String,
+        title: String,
+        detail: String,
+        trailingText: String?,
+        tone: MenuBarActionRowView.Tone,
+        isProminent: Bool
+    ) {
         switch status.state {
         case .unknown, .readyToCheck:
             return (
+                "arrow.triangle.2.circlepath.circle",
                 "Check for Updates",
                 "",
                 nil,
-                .standard
+                .standard,
+                false
             )
         case .checking:
             return (
+                "arrow.triangle.2.circlepath.circle",
                 "Checking for Updates…",
                 "",
                 nil,
-                .standard
+                .standard,
+                false
             )
         case .noUpdateAvailable:
             return (
+                "arrow.triangle.2.circlepath.circle",
                 "Check for Updates",
                 "",
                 nil,
-                .standard
+                .standard,
+                false
             )
         case .updateAvailable(let version):
             return (
-                "Update Available",
-                "Version \(version) ready",
+                "arrow.down.circle.fill",
+                "Install \(version)",
+                "Update ready",
                 "Install",
-                .accent
+                .warning,
+                true
             )
+        case .downloading(let version):
+            return (
+                "arrow.down.circle",
+                "Downloading \(version)",
+                "Update will be ready soon",
+                nil,
+                .warning,
+                true
+            )
+        case .readyToInstall(let version):
+            return (
+                "arrow.clockwise.circle.fill",
+                "Restart to Update",
+                "Version \(version) downloaded",
+                "Restart",
+                .warning,
+                true
+            )
+        }
+    }
+
+    private func menuUpdateActionID(for state: SparkleUpdaterController.UpdateStatus.State) -> String {
+        switch state {
+        case .updateAvailable:
+            return "install_update"
+        case .readyToInstall:
+            return "restart_to_update"
+        case .checking, .downloading:
+            return "view_update_progress"
+        case .unknown, .readyToCheck, .noUpdateAvailable:
+            return "check_updates"
         }
     }
 

--- a/Sources/UI/MenuBar/MenuBarUtilityActionsView.swift
+++ b/Sources/UI/MenuBar/MenuBarUtilityActionsView.swift
@@ -45,7 +45,8 @@ final class MenuBarUtilityActionsView: NSView {
         updateDetail: String,
         updateVersion: String?,
         updateTone: MenuBarActionRowView.Tone,
-        updateEnabled: Bool
+        updateEnabled: Bool,
+        showUpdateRow: Bool = true
     ) {
         connectAgentRow.update(
             symbolName: "sparkles",
@@ -72,6 +73,7 @@ final class MenuBarUtilityActionsView: NSView {
             size: .utility,
             isEnabled: updateEnabled
         )
+        updatesRow.isHidden = !showUpdateRow
 
         settingsRow.update(
             symbolName: "gearshape",
@@ -98,10 +100,14 @@ final class MenuBarUtilityActionsView: NSView {
         super.layout()
 
         var y: CGFloat = 0
-        for row in allRows {
+        for row in visibleRows {
             let rowHeight = row.intrinsicContentSize.height
             row.frame = NSRect(x: 0, y: y, width: bounds.width, height: rowHeight)
             y += rowHeight + 1
+        }
+
+        for row in allRows where row.isHidden {
+            row.frame = .zero
         }
     }
 
@@ -124,7 +130,7 @@ final class MenuBarUtilityActionsView: NSView {
     func dismissTransientUI() {}
 
     var intrinsicHeight: CGFloat {
-        let rows = allRows
+        let rows = visibleRows
         let rowSpacing = max(0, rows.count - 1)
         return rows
             .map { $0.intrinsicContentSize.height }
@@ -133,5 +139,9 @@ final class MenuBarUtilityActionsView: NSView {
 
     private var allRows: [MenuBarActionRowView] {
         [connectAgentRow, feedbackRow, updatesRow, settingsRow, quitRow]
+    }
+
+    private var visibleRows: [MenuBarActionRowView] {
+        allRows.filter { !$0.isHidden }
     }
 }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -154,7 +154,8 @@ struct TranscriptedSettingsView: View {
 
     private var settingsSidebarFooter: some View {
         Button {
-            actions.checkForUpdates()
+            trackSettingsAction(settingsUpdateActionID, page: .about)
+            sparkleUpdater.performUserUpdateAction(surface: "settings_footer")
         } label: {
             HStack(spacing: 8) {
                 if sparkleUpdater.updateStatus.availableUpdateVersion != nil {
@@ -182,7 +183,7 @@ struct TranscriptedSettingsView: View {
                 Image(systemName: settingsFooterIsUpdateAvailable ? "arrow.down.circle.fill" : "arrow.triangle.2.circlepath")
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(settingsFooterIsUpdateAvailable ? Color.accentColor : Color.secondary)
-                    .opacity(sparkleUpdater.updateStatus.canCheckForUpdates ? 1 : 0.45)
+                    .opacity(sparkleUpdater.updateStatus.canRunUserUpdateAction ? 1 : 0.45)
             }
             .padding(.horizontal, 14)
             .padding(.vertical, settingsFooterIsUpdateAvailable ? 8 : 10)
@@ -190,7 +191,7 @@ struct TranscriptedSettingsView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(!sparkleUpdater.updateStatus.canCheckForUpdates)
+        .disabled(!sparkleUpdater.updateStatus.canRunUserUpdateAction)
         .help(settingsFooterHelp)
     }
 
@@ -1002,12 +1003,36 @@ struct TranscriptedSettingsView: View {
                     tone: aboutUpdateStatusTone
                 )
 
+                VStack(alignment: .leading, spacing: 8) {
+                    Toggle("Check automatically", isOn: Binding(
+                        get: { sparkleUpdater.automaticUpdateSettings.automaticChecksEnabled },
+                        set: { newValue in
+                            trackSettingsToggle("automatic_update_checks", enabled: newValue, page: .about)
+                            sparkleUpdater.setAutomaticallyChecksForUpdates(newValue)
+                        }
+                    ))
+
+                    Toggle("Download automatically", isOn: Binding(
+                        get: { sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled },
+                        set: { newValue in
+                            trackSettingsToggle("automatic_update_downloads", enabled: newValue, page: .about)
+                            sparkleUpdater.setAutomaticallyDownloadsUpdates(newValue)
+                        }
+                    ))
+                    .disabled(!sparkleUpdater.automaticUpdateSettings.automaticDownloadsAllowed)
+
+                    Text(automaticUpdatesDetail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
                 HStack {
                     Button(aboutUpdateButtonTitle) {
-                        trackSettingsAction("check_updates", page: .about)
-                        actions.checkForUpdates()
+                        trackSettingsAction(settingsUpdateActionID, page: .about)
+                        sparkleUpdater.performUserUpdateAction(surface: "settings_about")
                     }
-                    .disabled(!sparkleUpdater.updateStatus.canCheckForUpdates)
+                    .disabled(!sparkleUpdater.updateStatus.canRunUserUpdateAction)
 
                     Button("Submit Feedback") {
                         trackSettingsAction("submit_feedback", page: .about)
@@ -1030,6 +1055,10 @@ struct TranscriptedSettingsView: View {
         switch sparkleUpdater.updateStatus.state {
         case .checking:
             return "Checking for updates"
+        case .downloading(let version):
+            return "Downloading \(version)"
+        case .readyToInstall(let version):
+            return "Restart to update \(version)"
         case .noUpdateAvailable, .unknown, .readyToCheck:
             return TranscriptedSupportActions.appVersionDescription
         case .updateAvailable:
@@ -1046,6 +1075,9 @@ struct TranscriptedSettingsView: View {
 
     private var settingsFooterHelp: String {
         if let version = sparkleUpdater.updateStatus.availableUpdateVersion {
+            if case .readyToInstall = sparkleUpdater.updateStatus.state {
+                return "Restart to install update \(version)."
+            }
             return "Install update \(version)."
         }
         return "Check for updates."
@@ -1400,6 +1432,10 @@ struct TranscriptedSettingsView: View {
             return "Up to date"
         case .updateAvailable(let version):
             return "Update available (\(version))"
+        case .downloading(let version):
+            return "Downloading update (\(version))"
+        case .readyToInstall(let version):
+            return "Ready to restart (\(version))"
         }
     }
 
@@ -1413,6 +1449,10 @@ struct TranscriptedSettingsView: View {
             return "This Mac is on the newest visible version."
         case .updateAvailable(let version):
             return "Version \(version) is ready."
+        case .downloading(let version):
+            return "Version \(version) is downloading."
+        case .readyToInstall(let version):
+            return "Version \(version) is downloaded."
         }
     }
 
@@ -1424,19 +1464,47 @@ struct TranscriptedSettingsView: View {
             return .working
         case .noUpdateAvailable:
             return .ready
-        case .updateAvailable:
+        case .updateAvailable, .downloading, .readyToInstall:
             return .caution
         }
     }
 
     private var aboutUpdateButtonTitle: String {
         switch sparkleUpdater.updateStatus.state {
-        case .updateAvailable:
-            return "Update Available"
+        case .updateAvailable(let version):
+            return "Install \(version)"
+        case .downloading:
+            return "Downloading…"
+        case .readyToInstall:
+            return "Restart to Update"
         case .checking:
             return "Checking for Updates…"
         case .unknown, .readyToCheck, .noUpdateAvailable:
             return "Check for Updates"
+        }
+    }
+
+    private var automaticUpdatesDetail: String {
+        let settings = sparkleUpdater.automaticUpdateSettings
+        if settings.automaticDownloadsEnabled {
+            return "Transcripted will download updates in the background. When one is ready, you only need to restart."
+        }
+        if settings.automaticChecksEnabled {
+            return "Transcripted will check in the background and show an update badge when one is ready."
+        }
+        return "Turn on automatic checks to see updates sooner."
+    }
+
+    private var settingsUpdateActionID: String {
+        switch sparkleUpdater.updateStatus.state {
+        case .updateAvailable:
+            return "install_update"
+        case .readyToInstall:
+            return "restart_to_update"
+        case .checking, .downloading:
+            return "view_update_progress"
+        case .unknown, .readyToCheck, .noUpdateAvailable:
+            return "check_updates"
         }
     }
 

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -53,6 +53,9 @@ func testAnalyticsEventPolicy() {
         let settingsToggle = AnalyticsEventPolicy.policy(forEvent: "settings_toggle_changed")
         let settingsPermission = AnalyticsEventPolicy.policy(forEvent: "settings_permission_cta_clicked")
         let captureLibrary = AnalyticsEventPolicy.policy(forEvent: "settings_capture_library_changed")
+        let updateAction = AnalyticsEventPolicy.policy(forEvent: "update_action_clicked")
+        let updateSetting = AnalyticsEventPolicy.policy(forEvent: "update_setting_changed")
+        let updateCheckFinished = AnalyticsEventPolicy.policy(forEvent: "update_check_finished")
 
         assertEqual(menuOpened?.allowedProperties.contains("paste_available"), true, "menu opens should preserve whether paste has value")
         assertEqual(menuAction?.allowedProperties.contains("action_id"), true, "menu clicks should preserve the clicked action")
@@ -62,20 +65,30 @@ func testAnalyticsEventPolicy() {
         assertEqual(settingsToggle?.allowedProperties.contains("setting_id"), true, "settings toggles should preserve setting id")
         assertEqual(settingsPermission?.allowedProperties.contains("permission_kind"), true, "settings permission CTAs should preserve permission kind")
         assertEqual(captureLibrary?.allowedProperties.contains("location_type"), true, "capture library changes should preserve default-vs-custom only")
+        assertEqual(updateAction?.allowedProperties.contains("surface"), true, "update clicks should preserve whether menu or settings drove the action")
+        assertEqual(updateAction?.allowedProperties.contains("automatic_downloads_enabled"), true, "update clicks should preserve auto-download state")
+        assertEqual(updateSetting?.allowedProperties.contains("setting_id"), true, "update settings should preserve the changed toggle")
+        assertEqual(updateCheckFinished?.allowedProperties.contains("result"), true, "update checks should preserve the coarse outcome")
 
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
             [
                 "action_id": "start_dictation",
+                "automatic_downloads_enabled": "true",
                 "page_id": "home",
                 "setting_id": "menu_bar_start_dictation",
                 "source": "menu_bar",
+                "state": "ready_to_install",
+                "surface": "settings_about",
             ],
-            allowedKeys: ["action_id", "page_id", "setting_id", "source"]
+            allowedKeys: ["action_id", "automatic_downloads_enabled", "page_id", "setting_id", "source", "state", "surface"]
         )
         assertEqual(sanitized["action_id"], "start_dictation", "action ids should survive sanitization")
+        assertEqual(sanitized["automatic_downloads_enabled"], "true", "automatic update download state should survive sanitization")
         assertEqual(sanitized["page_id"], "home", "page ids should survive sanitization")
         assertEqual(sanitized["setting_id"], "menu_bar_start_dictation", "setting ids should survive sanitization")
         assertEqual(sanitized["source"], "menu_bar", "source enums should survive sanitization")
+        assertEqual(sanitized["state"], "ready_to_install", "update state should survive sanitization")
+        assertEqual(sanitized["surface"], "settings_about", "update surface should survive sanitization")
     }
 
     runSuite("AnalyticsEventPolicy preserves dictation auto-send attribution") {

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -17,13 +17,21 @@ Future agents should treat this as a release requirement:
 
 - `Info.plist` points Sparkle at `https://raw.githubusercontent.com/r3dbars/transcripted/main/docs/appcast.xml`
 - `SUEnableAutomaticChecks` is enabled by default
+- `SUScheduledCheckInterval` is set to 4 hours so automatic checks happen
+  more often than Sparkle's default daily cadence
+- `SUAllowsAutomaticUpdates` is enabled so users can opt in to background
+  downloads from Settings
 - the app triggers a background update check on launch when automatic checks are enabled
 - scheduled update reminders are handled quietly inside Transcripted instead of
   showing automatic Sparkle pop-ups
-- the menu bar footer includes a manual `Check for updates` action and changes
-  to an update-ready action when Sparkle finds a newer release
+- the menu bar footer includes a manual `Check for updates` action; when
+  Sparkle finds a newer release, a prominent update action appears near the top
+  of the menu
 - the settings sidebar footer also becomes an update-ready action when Sparkle
   finds a newer release
+- the About settings page exposes `Check automatically` and `Download
+  automatically`; if Sparkle has already downloaded an update, the primary
+  action becomes `Restart to Update`
 
 ## Local tooling
 


### PR DESCRIPTION
## Summary
- Makes Sparkle checks more frequent and enables automatic update downloads.
- Adds clearer update states in the menu bar and Settings, including download and restart-ready states.
- Adds safe update funnel analytics and documents the update behavior.
- Fixes a Sparkle session race so an active update is not incorrectly shown as up to date.

## Validation
- `bash build.sh`
- `bash run-tests.sh` (`819/819` passing)
- Local Sparkle appcast simulation: fake signed `1.1.99` update was fetched, downloaded, and staged/extracted by Sparkle.

## Notes
- Opened as draft because the local visual UI automation for the menu-bar accessory window was flaky, even though the real Sparkle download/staging path was verified.