### PR TITLE
Release Transcripted 1.1.19

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.18"
-  sha256 "696288fa1e82cc4711f3bcc842371455935974cb70189746d8b2217a1be3e4aa"
+  version "1.1.19"
+  sha256 "544ac77113f4982acef94ed1767794b0f25f10e12e6075d4073c10a54c1a6a40"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.18</string>
+	<string>1.1.19</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.18</string>
+	<string>1.1.19</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
         <description>Release feed for Transcripted macOS updates.</description>
         <language>en</language>
         <item>
+            <title>1.1.19</title>
+            <pubDate>Fri, 24 Apr 2026 06:38:28 -0500</pubDate>
+            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.19</link>
+            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.19</sparkle:fullReleaseNotesLink>
+            <sparkle:version>1.1.19</sparkle:version>
+            <sparkle:shortVersionString>1.1.19</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.19/Transcripted-1.1.19.dmg" length="527924847" type="application/octet-stream" sparkle:edSignature="EOvTOMK2Zi0DDWAGZS4kJkpFSS7oo3vYQgeIh1WKVSwz2p0VqMm23fX41rqGFz3tNvslwk5mQ5tCrtk7+Wb5Ag=="/>
+        </item>
+        <item>
             <title>1.1.18</title>
             <pubDate>Wed, 22 Apr 2026 21:00:58 -0500</pubDate>
             <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.18</link>


### PR DESCRIPTION
## Summary
- bump Transcripted to 1.1.19
- publish appcast entry for v1.1.19
- update Homebrew cask hash for the v1.1.19 DMG

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- NOTARY_PROFILE=Transcripted bash build-beta.sh <generated-token> Public
- xcrun stapler validate build/Transcripted-1.1.19.dmg
- GitHub release asset size/hash verified