### PR TITLE
[codex] Normalize quiet meeting mic audio

### DIFF
--- a/Sources/TranscriptedCore/Audio/AudioSignalRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioSignalRecovery.swift
@@ -46,6 +46,7 @@ struct AudioNormalizationResult: Equatable {
 enum AudioSignalRecovery {
     static let parakeetSampleRate: Double = 16_000
     static let parakeetMinimumInferenceSamples = 16_000
+    static let legacySpeechDetectionThreshold: Float = 0.010
 
     static func analyze(samples: [Float], sampleRate: Double) -> AudioSignalAnalysis {
         guard !samples.isEmpty, sampleRate > 0 else {
@@ -122,12 +123,12 @@ enum AudioSignalRecovery {
 
     static func speechDetectionThreshold(for analysis: AudioSignalAnalysis) -> Float {
         guard analysis.hasSpeechCandidate else {
-            return activeThreshold(forPeak: analysis.peak)
+            return min(legacySpeechDetectionThreshold, activeThreshold(forPeak: analysis.peak))
         }
 
         let peakBased = activeThreshold(forPeak: analysis.peak)
         let rmsBased = max(0.003, min(0.020, analysis.rms * 0.8))
-        return min(peakBased, rmsBased)
+        return min(legacySpeechDetectionThreshold, peakBased, rmsBased)
     }
 
     static func activeThreshold(forPeak peak: Float) -> Float {

--- a/Sources/TranscriptedCore/Audio/AudioSignalRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioSignalRecovery.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+struct AudioSignalAnalysis: Equatable {
+    let sampleCount: Int
+    let sampleRate: Double
+    let peak: Float
+    let rms: Float
+    let activeRatio: Double
+
+    var durationSeconds: Double {
+        guard sampleRate > 0 else { return 0 }
+        return Double(sampleCount) / sampleRate
+    }
+
+    var activeDurationSeconds: Double {
+        durationSeconds * activeRatio
+    }
+
+    var hasSpeechCandidate: Bool {
+        peak >= 0.004 && rms >= 0.0005 && activeRatio >= 0.005 && activeDurationSeconds >= 0.20
+    }
+
+    var context: [String: String] {
+        [
+            "sample_count": "\(sampleCount)",
+            "duration_s": String(format: "%.2f", durationSeconds),
+            "peak": String(format: "%.5f", peak),
+            "rms": String(format: "%.5f", rms),
+            "active_ratio": String(format: "%.3f", activeRatio),
+            "active_duration_s": String(format: "%.2f", activeDurationSeconds),
+            "has_speech_candidate": "\(hasSpeechCandidate)",
+        ]
+    }
+}
+
+struct AudioNormalizationResult: Equatable {
+    let samples: [Float]
+    let analysis: AudioSignalAnalysis
+    let gain: Float
+
+    var wasNormalized: Bool {
+        gain > 1.0001
+    }
+}
+
+enum AudioSignalRecovery {
+    static let parakeetSampleRate: Double = 16_000
+    static let parakeetMinimumInferenceSamples = 16_000
+
+    static func analyze(samples: [Float], sampleRate: Double) -> AudioSignalAnalysis {
+        guard !samples.isEmpty, sampleRate > 0 else {
+            return AudioSignalAnalysis(
+                sampleCount: samples.count,
+                sampleRate: sampleRate,
+                peak: 0,
+                rms: 0,
+                activeRatio: 0
+            )
+        }
+
+        var peak: Float = 0
+        var sumOfSquares: Double = 0
+        for sample in samples {
+            let magnitude = abs(sample)
+            peak = max(peak, magnitude)
+            sumOfSquares += Double(sample * sample)
+        }
+
+        let rms = Float(sqrt(sumOfSquares / Double(samples.count)))
+        let threshold = activeThreshold(forPeak: peak)
+        var activeCount = 0
+        for sample in samples {
+            if abs(sample) >= threshold { activeCount += 1 }
+        }
+
+        return AudioSignalAnalysis(
+            sampleCount: samples.count,
+            sampleRate: sampleRate,
+            peak: peak,
+            rms: rms,
+            activeRatio: Double(activeCount) / Double(samples.count)
+        )
+    }
+
+    static func normalizeForSpeech(
+        samples: [Float],
+        sampleRate: Double,
+        analysis: AudioSignalAnalysis? = nil,
+        targetPeak: Float = 0.45,
+        maxGain: Float = 12.0
+    ) -> AudioNormalizationResult {
+        let resolvedAnalysis = analysis ?? analyze(samples: samples, sampleRate: sampleRate)
+        guard resolvedAnalysis.hasSpeechCandidate, resolvedAnalysis.peak > 0.0001 else {
+            return AudioNormalizationResult(samples: samples, analysis: resolvedAnalysis, gain: 1.0)
+        }
+
+        let gain = normalizationGain(for: resolvedAnalysis, targetPeak: targetPeak, maxGain: maxGain)
+        guard gain > 1.0 else {
+            return AudioNormalizationResult(samples: samples, analysis: resolvedAnalysis, gain: 1.0)
+        }
+
+        let normalized = samples.map { sample in
+            max(-1.0, min(1.0, sample * gain))
+        }
+
+        return AudioNormalizationResult(samples: normalized, analysis: resolvedAnalysis, gain: gain)
+    }
+
+    static func padForParakeet(samples: [Float]) -> [Float] {
+        guard samples.count < parakeetMinimumInferenceSamples else { return samples }
+        return samples + [Float](repeating: 0, count: parakeetMinimumInferenceSamples - samples.count)
+    }
+
+    static func normalizationGain(
+        for analysis: AudioSignalAnalysis,
+        targetPeak: Float = 0.45,
+        maxGain: Float = 12.0
+    ) -> Float {
+        guard analysis.hasSpeechCandidate, analysis.peak > 0.0001 else { return 1.0 }
+        return max(1.0, min(maxGain, targetPeak / analysis.peak))
+    }
+
+    static func speechDetectionThreshold(for analysis: AudioSignalAnalysis) -> Float {
+        guard analysis.hasSpeechCandidate else {
+            return activeThreshold(forPeak: analysis.peak)
+        }
+
+        let peakBased = activeThreshold(forPeak: analysis.peak)
+        let rmsBased = max(0.003, min(0.020, analysis.rms * 0.8))
+        return min(peakBased, rmsBased)
+    }
+
+    static func activeThreshold(forPeak peak: Float) -> Float {
+        max(0.003, min(0.020, peak * 0.08))
+    }
+}

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -79,6 +79,17 @@ extension Transcription {
                 AppLogger.transcription.debug("Mic: skipped for system-audio-only transcription")
             }
 
+            let micSignalAnalysis: AudioSignalAnalysis?
+            if micURL != nil, !micSamples.isEmpty {
+                let rawMicAnalysis = AudioSignalRecovery.analyze(samples: micSamples, sampleRate: 16000)
+                var context = rawMicAnalysis.context
+                context["suggested_gain"] = String(format: "%.2f", AudioSignalRecovery.normalizationGain(for: rawMicAnalysis))
+                AppLogger.transcription.info("Analyzed meeting mic signal", context)
+                micSignalAnalysis = rawMicAnalysis
+            } else {
+                micSignalAnalysis = nil
+            }
+
             // Validate system audio has meaningful content (at least 1 second at 16kHz).
             // Without this, a failed system audio capture produces an empty transcript.
             guard systemSamples.count >= 16000 else {
@@ -110,7 +121,9 @@ extension Transcription {
                     micEnergyPerFrame[i] = sqrt(sumSquares / Float(micFrameSize))
                 }
             }
-            let micActiveThreshold: Float = 0.02  // matches isSilent threshold
+            let micActiveThreshold = AudioSignalRecovery.speechDetectionThreshold(
+                for: micSignalAnalysis ?? AudioSignalRecovery.analyze(samples: [], sampleRate: 16000)
+            )
 
             /// Returns the fraction of a time range where the local mic was active (0.0-1.0).
             func micActiveFraction(startTime: Double, endTime: Double) -> Double {
@@ -429,8 +442,13 @@ extension Transcription {
 
                 if splitLocalSpeakers {
                     // B) Mic diarization path
-                    let micResult = try await Self.processMicChannelWithDiarization(
+                    let diarizationMicSamples = AudioSignalRecovery.normalizeForSpeech(
                         samples: micSamples,
+                        sampleRate: 16000,
+                        analysis: micSignalAnalysis
+                    ).samples
+                    let micResult = try await Self.processMicChannelWithDiarization(
+                        samples: diarizationMicSamples,
                         diarization: diarization,
                         parakeet: parakeet,
                         speakerDB: speakerDB,
@@ -461,11 +479,23 @@ extension Transcription {
                             endTime: segment.end
                         )
 
-                        // Skip segments shorter than 1s — Parakeet requires at least 16,000 samples
-                        guard segmentSamples.count >= 16000 else { droppedSegments += 1; continue }
+                        guard let preparedSegment = Self.prepareMicSegmentForTranscription(
+                            samples: segmentSamples,
+                            sampleRate: 16000
+                        ) else {
+                            droppedSegments += 1
+                            continue
+                        }
 
-                        let text = try await parakeet.transcribeSegment(samples: segmentSamples, source: .microphone)
-                        guard !text.isEmpty else { continue }
+                        let text = try await parakeet.transcribeSegment(samples: preparedSegment.samples, source: .microphone)
+                        guard !text.isEmpty else {
+                            var context = preparedSegment.analysis.context
+                            context["segment_index"] = "\(index)"
+                            context["gain"] = String(format: "%.2f", preparedSegment.gain)
+                            context["padded_samples"] = "\(preparedSegment.paddedSampleCount)"
+                            AppLogger.transcription.warning("Mic segment returned empty transcription", context)
+                            continue
+                        }
 
                         micUtterances.append(TranscriptionUtterance(
                             start: segment.start,
@@ -706,10 +736,23 @@ extension Transcription {
                 startTime: segment.startTime,
                 endTime: segment.endTime
             )
-            guard segmentSamples.count >= 16000 else { droppedSegments += 1; continue }
+            guard let preparedSegment = Self.prepareMicSegmentForTranscription(
+                samples: segmentSamples,
+                sampleRate: 16000
+            ) else {
+                droppedSegments += 1
+                continue
+            }
 
-            let text = try await parakeet.transcribeSegment(samples: segmentSamples, source: .microphone)
-            guard !text.isEmpty else { continue }
+            let text = try await parakeet.transcribeSegment(samples: preparedSegment.samples, source: .microphone)
+            guard !text.isEmpty else {
+                var context = preparedSegment.analysis.context
+                context["segment_index"] = "\(index)"
+                context["gain"] = String(format: "%.2f", preparedSegment.gain)
+                context["padded_samples"] = "\(preparedSegment.paddedSampleCount)"
+                AppLogger.transcription.warning("Mic diarization segment returned empty transcription", context)
+                continue
+            }
 
             let effectiveSpeakerId = speakerIdRemap[segment.speakerId] ?? segment.speakerId
             let persistentId: UUID?
@@ -808,6 +851,35 @@ extension Transcription {
 
     // MARK: - Silence-Based Speech Segmentation
 
+    struct PreparedMicSegment {
+        let samples: [Float]
+        let analysis: AudioSignalAnalysis
+        let gain: Float
+        let paddedSampleCount: Int
+    }
+
+    nonisolated static func prepareMicSegmentForTranscription(
+        samples: [Float],
+        sampleRate: Double
+    ) -> PreparedMicSegment? {
+        guard !samples.isEmpty, sampleRate > 0 else { return nil }
+
+        let analysis = AudioSignalRecovery.analyze(samples: samples, sampleRate: sampleRate)
+        let normalization = AudioSignalRecovery.normalizeForSpeech(
+            samples: samples,
+            sampleRate: sampleRate,
+            analysis: analysis
+        )
+        let padded = AudioSignalRecovery.padForParakeet(samples: normalization.samples)
+
+        return PreparedMicSegment(
+            samples: padded,
+            analysis: analysis,
+            gain: normalization.gain,
+            paddedSampleCount: padded.count - normalization.samples.count
+        )
+    }
+
     /// A time range representing a speech segment in the audio.
     struct SpeechSegment {
         let start: Double   // seconds
@@ -830,7 +902,8 @@ extension Transcription {
 
         let frameSamples = Int(sampleRate * 0.025)  // 25ms frames (400 samples at 16kHz)
         let hopSamples = Int(sampleRate * 0.010)    // 10ms hop
-        let silenceThreshold: Float = 0.01          // RMS below this = silence
+        let analysis = AudioSignalRecovery.analyze(samples: samples, sampleRate: sampleRate)
+        let silenceThreshold = AudioSignalRecovery.speechDetectionThreshold(for: analysis)
         let minSilenceDuration: Double = 0.4        // 400ms gap to split
         let minSegmentDuration: Double = 0.5        // Don't create segments shorter than this
 

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -865,6 +865,10 @@ extension Transcription {
         guard !samples.isEmpty, sampleRate > 0 else { return nil }
 
         let analysis = AudioSignalRecovery.analyze(samples: samples, sampleRate: sampleRate)
+        if samples.count < AudioSignalRecovery.parakeetMinimumInferenceSamples, !analysis.hasSpeechCandidate {
+            return nil
+        }
+
         let normalization = AudioSignalRecovery.normalizeForSpeech(
             samples: samples,
             sampleRate: sampleRate,

--- a/Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift
@@ -98,6 +98,20 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         XCTAssertEqual(segments[1].end, 2.5, accuracy: 0.05)
     }
 
+    func testDetectSpeechSegmentsDoesNotRaiseThresholdAboveLegacyValue() {
+        let voiced = alternatingSamples(amplitude: 0.011, count: 16_000)
+        let silence = [Float](repeating: 0.0, count: 8_000)
+        let samples = voiced + silence + voiced
+
+        let segments = Transcription.detectSpeechSegments(samples: samples, sampleRate: 16_000)
+
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments[0].start, 0.0, accuracy: 0.02)
+        XCTAssertEqual(segments[0].end, 1.0, accuracy: 0.05)
+        XCTAssertEqual(segments[1].start, 1.5, accuracy: 0.05)
+        XCTAssertEqual(segments[1].end, 2.5, accuracy: 0.05)
+    }
+
     func testDetectSpeechSegmentsFallsBackToWholeTrackForSilentInput() {
         let samples = [Float](repeating: 0.0, count: 16_000)
 
@@ -153,6 +167,17 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         XCTAssertEqual(prepared?.samples.count, 16_000)
         XCTAssertEqual(prepared?.paddedSampleCount, 8_000)
         XCTAssertGreaterThan(prepared?.gain ?? 1, 1)
+    }
+
+    func testPrepareMicSegmentSkipsShortSilenceInsteadOfPaddingNoise() {
+        let samples = [Float](repeating: 0.0, count: 8_000)
+
+        let prepared = Transcription.prepareMicSegmentForTranscription(
+            samples: samples,
+            sampleRate: 16_000
+        )
+
+        XCTAssertNil(prepared)
     }
 
     private func alternatingSamples(amplitude: Float, count: Int) -> [Float] {

--- a/Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift
@@ -84,6 +84,20 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         XCTAssertEqual(segments[1].end, 2.5, accuracy: 0.05)
     }
 
+    func testDetectSpeechSegmentsFindsAttenuatedSpeechBelowOldFixedThreshold() {
+        let voiced = alternatingSamples(amplitude: 0.006, count: 16_000)
+        let silence = [Float](repeating: 0.0, count: 8_000)
+        let samples = voiced + silence + voiced
+
+        let segments = Transcription.detectSpeechSegments(samples: samples, sampleRate: 16_000)
+
+        XCTAssertEqual(segments.count, 2)
+        XCTAssertEqual(segments[0].start, 0.0, accuracy: 0.02)
+        XCTAssertEqual(segments[0].end, 1.0, accuracy: 0.05)
+        XCTAssertEqual(segments[1].start, 1.5, accuracy: 0.05)
+        XCTAssertEqual(segments[1].end, 2.5, accuracy: 0.05)
+    }
+
     func testDetectSpeechSegmentsFallsBackToWholeTrackForSilentInput() {
         let samples = [Float](repeating: 0.0, count: 16_000)
 
@@ -92,6 +106,57 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         XCTAssertEqual(segments.count, 1)
         XCTAssertEqual(segments[0].start, 0.0, accuracy: 0.000_1)
         XCTAssertEqual(segments[0].end, 1.0, accuracy: 0.000_1)
+    }
+
+    func testAudioSignalRecoveryNormalizesQuietSpeechCandidate() {
+        var samples = [Float](repeating: 0.0, count: 64_000)
+        let quietSpeech = alternatingSamples(amplitude: 0.008, count: 24_000)
+        samples.replaceSubrange(20_000..<44_000, with: quietSpeech)
+
+        let analysis = AudioSignalRecovery.analyze(samples: samples, sampleRate: 16_000)
+        let normalized = AudioSignalRecovery.normalizeForSpeech(
+            samples: samples,
+            sampleRate: 16_000,
+            analysis: analysis
+        )
+
+        XCTAssertTrue(analysis.hasSpeechCandidate)
+        XCTAssertTrue(normalized.wasNormalized)
+        XCTAssertEqual(normalized.samples.count, samples.count)
+        XCTAssertGreaterThan(normalized.samples.map(abs).max() ?? 0, analysis.peak)
+    }
+
+    func testAudioSignalRecoveryDoesNotNormalizeSilence() {
+        let samples = [Float](repeating: 0.0, count: 16_000)
+
+        let analysis = AudioSignalRecovery.analyze(samples: samples, sampleRate: 16_000)
+        let normalized = AudioSignalRecovery.normalizeForSpeech(
+            samples: samples,
+            sampleRate: 16_000,
+            analysis: analysis
+        )
+
+        XCTAssertFalse(analysis.hasSpeechCandidate)
+        XCTAssertFalse(normalized.wasNormalized)
+        XCTAssertEqual(normalized.samples, samples)
+    }
+
+    func testPrepareMicSegmentPadsShortQuietSpeechForParakeet() {
+        let samples = alternatingSamples(amplitude: 0.006, count: 8_000)
+
+        let prepared = Transcription.prepareMicSegmentForTranscription(
+            samples: samples,
+            sampleRate: 16_000
+        )
+
+        XCTAssertNotNil(prepared)
+        XCTAssertEqual(prepared?.samples.count, 16_000)
+        XCTAssertEqual(prepared?.paddedSampleCount, 8_000)
+        XCTAssertGreaterThan(prepared?.gain ?? 1, 1)
+    }
+
+    private func alternatingSamples(amplitude: Float, count: Int) -> [Float] {
+        (0..<count).map { $0.isMultiple(of: 2) ? amplitude : -amplitude }
     }
 
     private func utterance(


### PR DESCRIPTION
## Summary

Fixes #500.

This makes meeting mic transcription more tolerant when Google Meet, WhatsApp, or macOS makes the shared mic stream much quieter.

## What changed

- Added `AudioSignalRecovery` in `TranscriptedCore` to measure mic peak/RMS/activity, choose an adaptive speech threshold, apply bounded gain, and pad short segments to Parakeet's minimum length.
- Updated meeting mic transcription to use adaptive silence detection instead of a fixed `0.01` RMS threshold.
- Normalizes only the mic segments sent to Parakeet, keeping the saved raw mic WAV untouched.
- Logs privacy-safe mic signal stats and empty mic segment diagnostics.
- Covers attenuated speech, silence, normalization, and short-segment padding in package tests.

## Validation

- `bash build-deps.sh`
- `swift test --filter TranscriptionPipelineHelpersTests`
- `swift test`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`