### PR TITLE
[codex] Restack onboarding redesign on current release

### DIFF
--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -1,10 +1,10 @@
 // PermissionsOnboardingView.swift
-// First-run onboarding for getting users to their first useful Transcripted capture.
+// First-run onboarding for Transcripted's local dictation and meeting capture.
 
 import SwiftUI
+import AppKit
 import AVFoundation
 import ApplicationServices
-import AppKit
 
 extension FirstRunLocalModelState {
     init(_ state: ParakeetModelState) {
@@ -23,43 +23,26 @@ extension FirstRunLocalModelState {
     }
 }
 
+@MainActor
 struct PermissionsOnboardingView: View {
-    @ObservedObject private var sttRouter: STTRouter
-    let canStartDictation: Bool
-    var onStartDictation: ((NSRect?) -> Void)?
-    var onStopDictation: (() -> Void)?
-    var onStartMeetingDryRun: (() async -> Bool)?
-    var onStopMeetingDryRun: (() async -> Bool)?
-    var onOpenAgentSettings: (() -> Void)?
     var onComplete: () -> Void
 
-    @State private var currentStep: FirstRunOnboardingStep = .hero
+    static let preferredSize = NSSize(width: 960, height: 680)
+    private static let defaultDictationShortcut = "Right Option"
+
+    @State private var currentStepIndex = 0
+    @State private var navigationDirection: OnboardingNavigationDirection = .forward
     @State private var micGranted = false
     @State private var accessibilityGranted = false
-    @State private var systemRecordingGranted = false
+    @State private var screenRecordingGranted = false
     @State private var calendarGranted = false
-    @State private var firstSavedDictation: SavedDictationEntry?
-    @State private var firstDictationIssue: String?
-    @State private var isFirstDictationRunning = false
-    @State private var crashReportingEnabled = CrashReportingPreferences.isEnabled()
-    @State private var anonymousAnalyticsEnabled = AnalyticsPreferences.isEnabled()
-    @State private var copiedFirstDictation = false
-    @State private var copiedAgentPrompt = false
-    @State private var isInstallingClaude = false
-    @State private var claudeInstallMessage: String?
-    @State private var isMeetingDryRunStarting = false
-    @State private var isMeetingDryRunRunning = false
-    @State private var meetingDryRunCompleted = false
-    @State private var meetingDryRunIssue: String?
+    @State private var meetingPromptsEnabled = true
+    @State private var diagnosticsEnabled = CrashReportingPreferences.isEnabled() && AnalyticsPreferences.isEnabled()
+    @State private var demoDictationText = ""
+    @State private var copiedAgentItem: AgentCopyItem?
+    @State private var copiedResetTask: Task<Void, Never>?
     @State private var pollTimer: Timer?
-    @State private var previousPermissionStatuses: [TranscriptedPermissionKind: Bool] = [:]
-    @State private var trackedSteps: Set<FirstRunOnboardingStep> = []
-    @State private var trackedShown = false
-    @State private var lastTrackedModelState: String?
-    @State private var onboardingStartedAt = Date()
-    @State private var currentStepStartedAt = Date()
-    @State private var didCompleteOnboarding = false
-    @State private var dictationPracticeAnchor: NSRect?
+    @FocusState private var demoEditorFocused: Bool
 
     init(
         sttRouter: STTRouter,
@@ -71,620 +54,312 @@ struct PermissionsOnboardingView: View {
         onOpenAgentSettings: (() -> Void)? = nil,
         onComplete: @escaping () -> Void
     ) {
-        _sttRouter = ObservedObject(wrappedValue: sttRouter)
-        self.canStartDictation = canStartDictation
-        self.onStartDictation = onStartDictation
-        self.onStopDictation = onStopDictation
-        self.onStartMeetingDryRun = onStartMeetingDryRun
-        self.onStopMeetingDryRun = onStopMeetingDryRun
-        self.onOpenAgentSettings = onOpenAgentSettings
         self.onComplete = onComplete
     }
 
+    private var currentStep: OnboardingStepSpec {
+        Self.steps[currentStepIndex]
+    }
+
+    private var hasRequiredPermissions: Bool {
+        micGranted && accessibilityGranted
+    }
+
+    private var primaryButtonTitle: String {
+        if currentStepIndex == 0 { return "Begin" }
+        if currentStepIndex == Self.steps.count - 1 { return "Open Transcripted" }
+        return "Continue"
+    }
+
+    private var primaryButtonDisabled: Bool {
+        (currentStep.kind == .permissions || currentStep.kind == .done) && !hasRequiredPermissions
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            OnboardingHeader(
-                steps: FirstRunExperience.onboardingSteps(),
-                currentStep: currentStep
-            )
-            .padding(.horizontal, 28)
-            .padding(.top, 24)
-            .padding(.bottom, 16)
-
-            OnboardingHairline()
-
-            ScrollView {
-                currentScreen
-                    .frame(maxWidth: 720, alignment: .leading)
-                    .padding(.horizontal, 28)
-                    .padding(.vertical, 24)
-            }
-
-            OnboardingHairline()
-
-            OnboardingFooter(
-                action: currentAction,
-                canGoBack: FirstRunExperience.previousStep(before: currentStep) != nil,
-                onBack: goBack,
-                onSecondary: handleSecondaryAction,
-                onPrimary: handlePrimaryAction
-            )
-            .padding(.horizontal, 28)
-            .padding(.vertical, 14)
+        OnboardingWindowShell(
+            current: currentStepIndex,
+            total: Self.steps.count,
+            direction: navigationDirection,
+            canGoBack: currentStepIndex > 0,
+            canSkip: currentStep.canSkip,
+            primaryTitle: primaryButtonTitle,
+            primaryDisabled: primaryButtonDisabled,
+            onBack: goBack,
+            onSkip: goNext,
+            onNext: goNextOrComplete
+        ) {
+            stepContent
+                .id(currentStep.kind)
         }
-        .frame(
-            minWidth: MenuTokens.onboardingWindowWidth,
-            idealWidth: MenuTokens.onboardingWindowWidth,
-            maxWidth: .infinity,
-            minHeight: 680,
-            idealHeight: MenuTokens.onboardingWindowHeight,
-            maxHeight: .infinity
-        )
-        .background(MenuTokens.cardBackground)
-        .preferredColorScheme(.dark)
+        .frame(width: Self.preferredSize.width, height: Self.preferredSize.height)
+        .background(OnboardingTheme.canvas)
         .onAppear {
-            onboardingStartedAt = Date()
-            currentStepStartedAt = Date()
-            checkAllPermissions(trackChanges: false)
-            crashReportingEnabled = CrashReportingPreferences.isEnabled()
-            anonymousAnalyticsEnabled = AnalyticsPreferences.isEnabled()
+            HotkeyPreferences.setRightOptionDictation(enabled: true)
+            checkAllPermissions()
             startPolling()
-            trackShownIfNeeded()
-            trackStepIfNeeded(currentStep)
-            trackModelStateIfChanged()
         }
         .onDisappear {
-            trackDismissedIfNeeded()
-            stopMeetingDryRunIfNeeded()
             stopPolling()
-        }
-        .onChange(of: currentStep) { _, step in
-            trackStepIfNeeded(step)
-        }
-        .onChange(of: modelStateAnalyticsValue) { _, _ in
-            trackModelStateIfChanged()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .dictationTranscriptDidSave)) { _ in
-            handleDictationSaved()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .dictationNoSpeechDetected)) { _ in
-            handleNoSpeech()
+            copiedResetTask?.cancel()
         }
     }
 
     @ViewBuilder
-    private var currentScreen: some View {
-        switch currentStep {
-        case .hero:
-            HeroStepView()
-        case .value:
-            ValueStepView()
-        case .dictationSetup:
-            DictationSetupStepView(
-                micGranted: micGranted,
-                accessibilityGranted: accessibilityGranted,
-                modelStatus: modelStatus,
-                onPermissionAction: requestPermission
-            )
-        case .testDictation:
-            TestDictationStepView(
-                issue: firstDictationIssue,
-                onAnchorChange: { dictationPracticeAnchor = $0 }
-            )
-        case .dictationResult:
-            FirstDictationResultStepView(
-                entry: firstSavedDictation,
-                copied: copiedFirstDictation,
-                onCopy: copyFirstDictation,
-                onOpenFolder: openFirstDictationFolder,
-                onRetry: startFirstDictation
-            )
-        case .meetingsIntro:
-            MeetingsIntroStepView()
-        case .meetingSetup:
-            MeetingSetupStepView(
-                micGranted: micGranted,
-                systemRecordingGranted: systemRecordingGranted,
-                calendarGranted: calendarGranted,
-                isDryRunStarting: isMeetingDryRunStarting,
-                isDryRunRunning: isMeetingDryRunRunning,
-                dryRunCompleted: meetingDryRunCompleted,
-                dryRunIssue: meetingDryRunIssue,
-                onPermissionAction: requestPermission,
-                onDryRun: startMeetingDryRun,
-                onStopDryRun: stopMeetingDryRun
-            )
-        case .agentPayoff:
-            AgentPayoffStepView(
-                copiedAgentPrompt: copiedAgentPrompt,
-                isInstallingClaude: isInstallingClaude,
-                installMessage: claudeInstallMessage,
-                crashReportingEnabled: $crashReportingEnabled,
-                anonymousAnalyticsEnabled: $anonymousAnalyticsEnabled,
-                crashReportingAvailable: CrashReporter.isAvailable,
-                analyticsAvailable: AnalyticsReporter.isAvailable,
-                onInstallClaude: installClaude,
-                onCopyAgentPrompt: copyAgentPrompt,
-                onOpenAgentSettings: openAgentSettings,
-                onCrashToggle: updateCrashReportingPreference,
-                onAnalyticsToggle: updateAnalyticsPreference
-            )
-        }
-    }
-
-    private var hasRequiredDictationSetup: Bool {
-        FirstRunExperience.hasRequiredDictationSetup(
-            microphoneGranted: micGranted,
-            accessibilityGranted: accessibilityGranted
-        )
-    }
-
-    private var currentAction: FirstRunOnboardingActionState {
-        if currentStep == .testDictation, isFirstDictationRunning {
-            return FirstRunOnboardingActionState(
-                primaryTitle: "Stop and Save",
-                secondaryTitle: nil,
-                detail: "Stop when you finish the sentence. Transcripted will transcribe and save the result.",
-                isPrimaryEnabled: true
-            )
-        }
-
-        if currentStep == .testDictation, firstDictationIssue != nil {
-            return FirstRunOnboardingActionState(
-                primaryTitle: "Try Again",
-                secondaryTitle: "Continue anyway",
-                detail: "Try again for the best setup check, or keep going and start dictation later from the menu.",
-                isPrimaryEnabled: true
-            )
-        }
-
-        if currentStep == .meetingSetup, isMeetingDryRunStarting {
-            return FirstRunOnboardingActionState(
-                primaryTitle: "Starting...",
-                secondaryTitle: nil,
-                detail: "Starting a short recording test.",
-                isPrimaryEnabled: false
-            )
-        }
-
-        if currentStep == .meetingSetup, isMeetingDryRunRunning {
-            return FirstRunOnboardingActionState(
-                primaryTitle: "Stop Dry Run",
-                secondaryTitle: nil,
-                detail: "Stop the dry run when you see recording is active. Test audio will be discarded.",
-                isPrimaryEnabled: true
-            )
-        }
-
-        if currentStep == .meetingSetup, meetingDryRunCompleted {
-            return FirstRunOnboardingActionState(
-                primaryTitle: "Continue",
-                secondaryTitle: "Skip for now",
-                detail: "Meeting recording is ready. The test audio was discarded.",
-                isPrimaryEnabled: true
-            )
-        }
-
-        return FirstRunExperience.onboardingAction(
-            for: currentStep,
-            microphoneGranted: micGranted,
-            accessibilityGranted: accessibilityGranted,
-            hasFirstDictation: firstSavedDictation != nil
-        )
-    }
-
-    private var modelStatus: FirstRunModelCardState {
-        FirstRunExperience.modelCard(
-            for: FirstRunLocalModelState(sttRouter.modelDownloadState),
-            model: sttRouter.selectedModel
-        )
-    }
-
-    private var modelStateAnalyticsValue: String {
-        switch sttRouter.modelDownloadState {
-        case .notLoaded:
-            return "not_loaded"
-        case .downloading(let progress):
-            return "downloading_\(Int(progress * 100))"
-        case .loading:
-            return "loading"
-        case .ready:
-            return "ready"
-        case .failed:
-            return "failed"
-        }
-    }
-
-    private func handlePrimaryAction() {
-        trackPrimaryCTA(currentAction.primaryTitle, ctaType: "primary")
-
-        switch currentStep {
-        case .hero, .value:
-            moveToNextStep()
-        case .dictationSetup:
-            guard hasRequiredDictationSetup else { return }
-            moveToNextStep()
-        case .testDictation:
-            if isFirstDictationRunning {
-                stopFirstDictation()
-            } else {
-                startFirstDictation()
+    private var stepContent: some View {
+        switch currentStep.kind {
+        case .welcome:
+            CenterStage {
+                Kicker("Transcripted")
+                Headline(primary: "Your voice becomes text.", emphasis: "Every meeting, remembered.")
+                Lede("Talk to type in any app. Record every call. Ask your agent what happened.")
+                HeroWaveCircle()
+                    .padding(.top, 14)
             }
-        case .dictationResult:
-            if firstSavedDictation == nil {
-                startFirstDictation()
-            } else {
-                move(to: .meetingsIntro)
+        case .privacy:
+            CenterStage {
+                Kicker("Before we start")
+                Headline(primary: "Your voice.\nYour files.", emphasis: "Stays on your Mac.")
+                Lede("No accounts. No sign-in. Nothing leaves your computer.", maxWidth: 500)
+                HStack(spacing: 14) {
+                    PrivacyPill("On-device transcription")
+                    PrivacyPill("Stored as markdown")
+                    PrivacyPill("No cloud, no sync")
+                }
+                .padding(.top, 18)
             }
-        case .meetingsIntro:
-            move(to: .meetingSetup)
-        case .meetingSetup:
-            if isMeetingDryRunRunning {
-                stopMeetingDryRun()
-                return
+        case .permissions:
+            CenterStage {
+                Kicker("Two permissions")
+                Headline(primary: "Two yeses and we're set.", size: 42)
+                BodyCopy("macOS will ask. You can change your mind anytime.", maxWidth: 440)
+                VStack(spacing: 12) {
+                    PermissionGrantRow(
+                        title: "Microphone",
+                        reason: "So we can hear you.",
+                        icon: "mic.fill",
+                        granted: micGranted,
+                        actionTitle: "Allow"
+                    ) {
+                        TranscriptedPermissionAccess.openSettings(for: .microphone)
+                        checkAllPermissions()
+                    }
+                    PermissionGrantRow(
+                        title: "Accessibility",
+                        reason: "So your shortcut works everywhere.",
+                        icon: "hand.raised.fill",
+                        granted: accessibilityGranted,
+                        actionTitle: "Allow"
+                    ) {
+                        TranscriptedPermissionAccess.openSettings(for: .accessibility)
+                        checkAllPermissions()
+                    }
+                }
+                .frame(width: 480)
+                .padding(.top, 8)
+                Text(hasRequiredPermissions ? "You're ready to keep going." : "Allow both to continue.")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(OnboardingTheme.muted)
+                    .padding(.top, 4)
             }
-            guard !isMeetingDryRunStarting else { return }
-            move(to: .agentPayoff)
-        case .agentPayoff:
-            completeOnboarding()
-        }
-    }
-
-    private func handleSecondaryAction() {
-        guard let title = currentAction.secondaryTitle else { return }
-        trackPrimaryCTA(title, ctaType: "secondary")
-
-        switch currentStep {
-        case .testDictation:
-            move(to: .meetingsIntro)
-        case .meetingsIntro, .meetingSetup:
-            move(to: .agentPayoff)
-        default:
-            break
+        case .dictation:
+            SplitStage {
+                Kicker("Dictation")
+                Headline(primary: "Talk to type.", emphasis: "In any app.", size: 42, alignment: .leading)
+                BodyCopy("Tap Right Option once to start. Tap it again to stop. Your words land where your cursor is.")
+                BulletList(["Mail, docs, Slack, code, anywhere", "On-device. Fast.", "Never leaves your Mac"])
+            } right: {
+                DictationDemoCard()
+            }
+        case .shortcut:
+            CenterStage {
+                Kicker("Your turn")
+                Headline(primary: "Try dictation\nright now.", size: 42)
+                BodyCopy("Tap Right Option, say what you want, then tap Right Option again. Transcripted will paste it here.", maxWidth: 540)
+                DemoPasteTarget(text: $demoDictationText)
+                    .focused($demoEditorFocused)
+                    .padding(.top, 6)
+                HStack(spacing: 12) {
+                    DictationPill(label: Self.defaultDictationShortcut)
+                    Text("You can change it anytime in Settings.")
+                        .font(.system(size: 12))
+                        .italic()
+                        .foregroundStyle(OnboardingTheme.muted)
+                }
+                .padding(.top, 6)
+                .onAppear {
+                    HotkeyPreferences.setRightOptionDictation(enabled: true)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                        demoEditorFocused = true
+                    }
+                }
+            }
+        case .systemAudio:
+            SplitStage {
+                Kicker("Meeting transcripts")
+                Headline(primary: "Record meetings.\nGet the transcript.", size: 42, alignment: .leading)
+                BodyCopy("Transcripted needs two audio streams to write the whole conversation: your microphone for you, and system audio for everyone else.")
+                BulletList(["macOS calls this Screen Recording", "Used only to hear meeting audio", "Everything stays on your Mac"])
+                Button(screenRecordingGranted ? "System audio enabled" : "Enable system audio") {
+                    TranscriptedPermissionAccess.openSettings(for: .systemAudioRecording)
+                    checkAllPermissions()
+                }
+                .buttonStyle(InkButtonStyle(isSubtle: screenRecordingGranted))
+                .padding(.top, 12)
+                Text("You can skip this now, but meeting transcripts need it to include the other side of the call.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnboardingTheme.muted)
+                    .fixedSize(horizontal: false, vertical: true)
+            } right: {
+                DualStreamVisual(systemReady: screenRecordingGranted)
+            }
+        case .meeting:
+            SplitStage {
+                Kicker("After the call")
+                Headline(primary: "A transcript you can actually use.", size: 42, alignment: .leading)
+                BodyCopy("Every recorded meeting becomes a local Markdown file with timestamps and speaker labels.")
+                BulletList(["Find decisions later", "Copy exact quotes", "Give your agent the right context"])
+            } right: {
+                MeetingDemoCard()
+            }
+        case .calendar:
+            SplitStage {
+                Kicker("Calendar")
+                Headline(primary: "Want meeting\nreminders?", size: 42, alignment: .leading)
+                BodyCopy("Transcripted can look at your calendar and offer a quiet prompt when a call is about to start.")
+                ToggleCard(
+                    title: "Meeting reminders",
+                    detail: "Use read-only calendar access to notice upcoming calls.",
+                    isOn: $meetingPromptsEnabled
+                )
+                .frame(maxWidth: 440)
+                .padding(.top, 4)
+                .onChange(of: meetingPromptsEnabled) { _, newValue in
+                    if !newValue {
+                        calendarGranted = false
+                    }
+                }
+                Button(calendarGranted ? "Calendar connected" : "Allow calendar access") {
+                    TranscriptedPermissionAccess.openSettings(for: .calendar)
+                    checkAllPermissions()
+                }
+                .buttonStyle(InkButtonStyle(isSubtle: calendarGranted || !meetingPromptsEnabled))
+                .disabled(!meetingPromptsEnabled)
+                .padding(.top, 6)
+                Text("Read-only. Events stay on your Mac.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnboardingTheme.muted)
+            } right: {
+                CalendarMock(connected: calendarGranted && meetingPromptsEnabled)
+            }
+        case .memory:
+            CenterStage {
+                Kicker("The payoff")
+                Headline(primary: "Every word you've said,", emphasis: "searchable.", size: 52)
+                Lede("Dictations and meetings flow into one place on your Mac. Your second brain, for your agent to reason over.", maxWidth: 560)
+                MemoryFlowVisual()
+                    .padding(.top, 16)
+            }
+        case .agentDemo:
+            SplitStage {
+                Kicker("Your agent")
+                Headline(primary: "Ask about", emphasis: "last Tuesday.", size: 42, alignment: .leading)
+                BodyCopy("Your agent gets a new skill: your voice history. Answers come back with citations from your own words.")
+            } right: {
+                AgentDemoCard()
+            }
+        case .connectAgent:
+            ConnectAgentStage(
+                copiedItem: copiedAgentItem,
+                onCopy: copyAgentItem
+            )
+        case .diagnostics:
+            CenterStage {
+                Kicker("One last thing")
+                Headline(primary: "Help us make it better?", size: 42)
+                BodyCopy("Anonymous diagnostics help us find bugs and fix them fast.", maxWidth: 480)
+                ToggleCard(
+                    title: "Share anonymous diagnostics",
+                    detail: "Crash reports, feature counts, app version, and macOS version. Never audio, transcripts, or anything you type or say.",
+                    isOn: $diagnosticsEnabled
+                )
+                .frame(width: 480)
+                .padding(.top, 10)
+                .onChange(of: diagnosticsEnabled) { _, newValue in
+                    CrashReportingPreferences.setEnabled(newValue)
+                    AnalyticsPreferences.setEnabled(newValue)
+                }
+            }
+        case .done:
+            CenterStage {
+                Kicker("You're set")
+                Headline(primary: "Dictate. Record. Ask.", size: 52)
+                Lede("Three actions to remember: use your voice anywhere, capture meetings, then ask your agent what happened.", maxWidth: 560)
+                ThreeActionsRecap()
+                    .padding(.top, 22)
+            }
         }
     }
 
     private func goBack() {
-        guard let previous = FirstRunExperience.previousStep(before: currentStep) else { return }
-        move(to: previous)
-    }
-
-    private func moveToNextStep() {
-        guard let next = FirstRunExperience.nextStep(after: currentStep) else { return }
-        move(to: next)
-    }
-
-    private func move(to step: FirstRunOnboardingStep) {
-        currentStep = step
-        currentStepStartedAt = Date()
-    }
-
-    private func requestPermission(_ kind: TranscriptedPermissionKind) {
-        AnalyticsReporter.track(
-            "onboarding_permission_cta_clicked",
-            properties: [
-                "permission_kind": kind.analyticsValue,
-                "prior_status": permissionStatusValue(kind),
-                "required": kind.isRequiredOnFirstLaunch ? "true" : "false",
-                "step_id": currentStep.analyticsValue,
-            ]
-        )
-        TranscriptedPermissionAccess.openSettings(for: kind)
-    }
-
-    private func startFirstDictation() {
-        guard hasRequiredDictationSetup else {
-            move(to: .dictationSetup)
-            return
-        }
-
-        firstDictationIssue = nil
-        isFirstDictationRunning = true
-        AnalyticsReporter.track(
-            "onboarding_first_dictation_started",
-            properties: [
-                "model_state": modelStateAnalyticsValue,
-                "step_id": currentStep.analyticsValue,
-            ]
-        )
-
-        guard let onStartDictation else {
-            isFirstDictationRunning = false
-            firstDictationIssue = "Dictation could not start from onboarding. Open Transcripted and try Start Dictation."
-            EventReporter.shared.capture(
-                level: .error,
-                engine: "onboarding",
-                event: "first_dictation_start_failed",
-                message: "Onboarding first dictation callback was not wired",
-                context: ["step_id": currentStep.analyticsValue]
-            )
-            return
-        }
-
-        onStartDictation(dictationPracticeAnchor)
-    }
-
-    private func stopFirstDictation() {
-        AnalyticsReporter.track(
-            "onboarding_first_dictation_stop_clicked",
-            properties: [
-                "step_id": currentStep.analyticsValue,
-            ]
-        )
-
-        guard let onStopDictation else {
-            firstDictationIssue = "Dictation is running, but onboarding could not stop it. Use the floating control to stop."
-            EventReporter.shared.capture(
-                level: .error,
-                engine: "onboarding",
-                event: "first_dictation_stop_failed",
-                message: "Onboarding first dictation stop callback was not wired",
-                context: ["step_id": currentStep.analyticsValue]
-            )
-            return
-        }
-
-        onStopDictation()
-    }
-
-    private func startMeetingDryRun() {
-        guard !isMeetingDryRunStarting, !isMeetingDryRunRunning else { return }
-        meetingDryRunIssue = nil
-        meetingDryRunCompleted = false
-        isMeetingDryRunStarting = true
-
-        AnalyticsReporter.track(
-            "onboarding_meeting_dry_run_clicked",
-            properties: [
-                "meeting_recording_ready": systemRecordingGranted ? "true" : "false",
-                "step_id": currentStep.analyticsValue,
-            ]
-        )
-
-        guard let onStartMeetingDryRun else {
-            isMeetingDryRunStarting = false
-            meetingDryRunIssue = "Meeting recording could not start from onboarding. You can still start meetings later from the menu."
-            return
-        }
-
-        Task { @MainActor in
-            let started = await onStartMeetingDryRun()
-            isMeetingDryRunStarting = false
-            isMeetingDryRunRunning = started
-            if !started {
-                meetingDryRunIssue = "Meeting recording could not start. Check Microphone and System Audio Recording, then try again."
-            }
+        guard currentStepIndex > 0 else { return }
+        withAnimation(.easeInOut(duration: 0.24)) {
+            navigationDirection = .backward
+            currentStepIndex -= 1
         }
     }
 
-    private func stopMeetingDryRun() {
-        guard isMeetingDryRunStarting || isMeetingDryRunRunning else { return }
-        meetingDryRunIssue = nil
-
-        guard let onStopMeetingDryRun else {
-            isMeetingDryRunStarting = false
-            isMeetingDryRunRunning = false
-            meetingDryRunIssue = "Meeting recording is running, but onboarding could not stop it. Use the meeting overlay stop button."
-            return
-        }
-
-        Task { @MainActor in
-            let stopped = await onStopMeetingDryRun()
-            isMeetingDryRunStarting = false
-            isMeetingDryRunRunning = false
-            meetingDryRunCompleted = stopped
-            if !stopped {
-                meetingDryRunIssue = "Meeting recording had already stopped. You can continue or run the dry run again."
-            }
+    private func goNext() {
+        guard currentStepIndex < Self.steps.count - 1 else { return }
+        withAnimation(.easeInOut(duration: 0.24)) {
+            navigationDirection = .forward
+            currentStepIndex += 1
         }
     }
 
-    private func stopMeetingDryRunIfNeeded() {
-        guard isMeetingDryRunStarting || isMeetingDryRunRunning else { return }
-        guard let onStopMeetingDryRun else { return }
-        Task { @MainActor in
-            _ = await onStopMeetingDryRun()
+    private func goNextOrComplete() {
+        guard !primaryButtonDisabled else { return }
+        if currentStepIndex == Self.steps.count - 1 {
+            completeOnboarding()
+        } else {
+            goNext()
         }
     }
 
-    private func copyFirstDictation() {
-        guard let text = firstSavedDictation?.text else { return }
-        copyText(text)
-        copiedFirstDictation = true
-        Task { @MainActor in
+    private func copyAgentItem(_ item: AgentCopyItem) {
+        let value: String
+        switch item {
+        case .claudePrompt:
+            value = AgentConnectionGuide.starterPrompt(filename: nil)
+        case .mcpConfig:
+            value = """
+            \(AgentConnectionGuide.mcpSetupText)
+
+            \(AgentConnectionGuide.mcpConfigExample)
+            """
+        }
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(value, forType: .string)
+
+        copiedAgentItem = item
+        copiedResetTask?.cancel()
+        copiedResetTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 1_500_000_000)
-            copiedFirstDictation = false
+            guard !Task.isCancelled else { return }
+            copiedAgentItem = nil
         }
     }
 
-    private func openFirstDictationFolder() {
-        guard let url = firstSavedDictation?.url else { return }
-        NSWorkspace.shared.activateFileViewerSelecting([url])
-    }
-
-    private func installClaude() {
-        guard !isInstallingClaude else { return }
-        isInstallingClaude = true
-        claudeInstallMessage = nil
-        AnalyticsReporter.track(
-            "onboarding_agent_cta_clicked",
-            properties: [
-                "agent_cta": "install_claude",
-                "step_id": currentStep.analyticsValue,
-            ]
-        )
-
-        Task {
-            do {
-                _ = try await Task.detached(priority: .userInitiated) {
-                    try ClaudeDesktopIntegrationInstaller.installForClaudeDesktop()
-                }.value
-                claudeInstallMessage = "Ready. Restart Claude Desktop."
-            } catch {
-                claudeInstallMessage = error.localizedDescription
-            }
-            isInstallingClaude = false
-        }
-    }
-
-    private func copyAgentPrompt() {
-        copyText(AgentConnectionGuide.starterPrompt(filename: nil))
-        copiedAgentPrompt = true
-        AnalyticsReporter.track(
-            "onboarding_agent_cta_clicked",
-            properties: [
-                "agent_cta": "copy_for_agent",
-                "step_id": currentStep.analyticsValue,
-            ]
-        )
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 1_500_000_000)
-            copiedAgentPrompt = false
-        }
-    }
-
-    private func openAgentSettings() {
-        AnalyticsReporter.track(
-            "onboarding_agent_cta_clicked",
-            properties: [
-                "agent_cta": "open_agent_settings",
-                "step_id": currentStep.analyticsValue,
-            ]
-        )
-        onOpenAgentSettings?()
-    }
-
-    private func updateCrashReportingPreference(_ enabled: Bool) {
-        crashReportingEnabled = enabled
-        CrashReportingPreferences.setEnabled(enabled)
-        AnalyticsReporter.track(
-            "onboarding_reporting_toggle_changed",
-            properties: [
-                "available": CrashReporter.isAvailable ? "true" : "false",
-                "enabled": enabled ? "true" : "false",
-                "reporting_kind": "crash",
-                "step_id": currentStep.analyticsValue,
-            ]
-        )
-    }
-
-    private func updateAnalyticsPreference(_ enabled: Bool) {
-        if anonymousAnalyticsEnabled {
-            AnalyticsReporter.track(
-                "onboarding_reporting_toggle_changed",
-                properties: [
-                    "available": AnalyticsReporter.isAvailable ? "true" : "false",
-                    "enabled": enabled ? "true" : "false",
-                    "reporting_kind": "analytics",
-                    "step_id": currentStep.analyticsValue,
-                ]
-            )
-        }
-        anonymousAnalyticsEnabled = enabled
-        AnalyticsPreferences.setEnabled(enabled)
-        if enabled {
-            AnalyticsReporter.track(
-                "onboarding_reporting_toggle_changed",
-                properties: [
-                    "available": AnalyticsReporter.isAvailable ? "true" : "false",
-                    "enabled": "true",
-                    "reporting_kind": "analytics",
-                    "step_id": currentStep.analyticsValue,
-                ]
-            )
-        }
-    }
-
-    private func completeOnboarding() {
-        stopPolling()
-        didCompleteOnboarding = true
-        AnalyticsReporter.track(
-            "onboarding_completed",
-            properties: [
-                "anonymous_usage_enabled": anonymousAnalyticsEnabled ? "true" : "false",
-                "calendar_status": calendarGranted ? "ready" : "pending",
-                "completion_path": "guided",
-                "crash_reporting_enabled": crashReportingEnabled ? "true" : "false",
-                "first_dictation_saved": firstSavedDictation == nil ? "false" : "true",
-                "flow_elapsed_bucket": flowElapsedBucket,
-                "meeting_dry_run_completed": meetingDryRunCompleted ? "true" : "false",
-                "meeting_recording_ready": systemRecordingGranted ? "true" : "false",
-                "model_state": modelStateAnalyticsValue,
-                "step_id": currentStep.analyticsValue,
-            ]
-        )
-        onComplete()
-    }
-
-    private func handleDictationSaved() {
-        guard isFirstDictationRunning || currentStep == .testDictation else { return }
-        firstSavedDictation = DictationTranscriptStore.latestSavedDictation()
-        isFirstDictationRunning = false
-        firstDictationIssue = nil
-        NSApp.activate(ignoringOtherApps: true)
-
-        if let firstSavedDictation {
-            AnalyticsReporter.track(
-                "onboarding_first_dictation_saved",
-                properties: [
-                    "delivery": firstSavedDictation.delivery.rawValue,
-                    "step_id": currentStep.analyticsValue,
-                    "word_count_bucket": AnalyticsReporter.wordCountBucket(
-                        firstSavedDictation.text.split(whereSeparator: \.isWhitespace).count
-                    ),
-                ]
-            )
-        }
-        move(to: .dictationResult)
-    }
-
-    private func handleNoSpeech() {
-        guard currentStep == .testDictation || isFirstDictationRunning else { return }
-        isFirstDictationRunning = false
-        firstDictationIssue = "No speech detected. Try one clear sentence, like: remind me to review the pricing call."
-        NSApp.activate(ignoringOtherApps: true)
-        AnalyticsReporter.track(
-            "onboarding_first_dictation_empty",
-            properties: [
-                "step_id": currentStep.analyticsValue,
-            ]
-        )
-    }
-
-    private func checkAllPermissions(trackChanges: Bool = true) {
-        let statuses: [TranscriptedPermissionKind: Bool] = [
-            .microphone: TranscriptedPermissionAccess.isGranted(.microphone),
-            .accessibility: TranscriptedPermissionAccess.isGranted(.accessibility),
-            .systemAudioRecording: TranscriptedPermissionAccess.isGranted(.systemAudioRecording),
-            .calendar: TranscriptedPermissionAccess.isGranted(.calendar),
-        ]
-
-        micGranted = statuses[.microphone] ?? false
-        accessibilityGranted = statuses[.accessibility] ?? false
-        systemRecordingGranted = statuses[.systemAudioRecording] ?? false
-        calendarGranted = statuses[.calendar] ?? false
-
-        if trackChanges, !previousPermissionStatuses.isEmpty {
-            for kind in TranscriptedPermissionKind.allCases {
-                let old = previousPermissionStatuses[kind] ?? false
-                let new = statuses[kind] ?? false
-                guard old != new else { continue }
-                AnalyticsReporter.track(
-                    "onboarding_permission_status_changed",
-                    properties: [
-                        "from_status": old ? "ready" : "pending",
-                        "permission_kind": kind.analyticsValue,
-                        "step_id": currentStep.analyticsValue,
-                        "to_status": new ? "ready" : "pending",
-                    ]
-                )
-            }
-        }
-
-        previousPermissionStatuses = statuses
+    private func checkAllPermissions() {
+        micGranted = TranscriptedPermissionAccess.isGranted(.microphone)
+        accessibilityGranted = TranscriptedPermissionAccess.isGranted(.accessibility)
+        screenRecordingGranted = TranscriptedPermissionAccess.isGranted(.systemAudioRecording)
+        calendarGranted = TranscriptedPermissionAccess.isGranted(.calendar)
     }
 
     private func startPolling() {
+        pollTimer?.invalidate()
         pollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
             Task { @MainActor in
                 checkAllPermissions()
@@ -697,1365 +372,1315 @@ struct PermissionsOnboardingView: View {
         pollTimer = nil
     }
 
-    private func trackShownIfNeeded() {
-        guard !trackedShown else { return }
-        trackedShown = true
-        AnalyticsReporter.track(
-            "onboarding_shown",
-            properties: [
-                "analytics_available": AnalyticsReporter.isAvailable ? "true" : "false",
-                "crash_reporting_available": CrashReporter.isAvailable ? "true" : "false",
-                "entrypoint": "first_launch",
-                "has_target": canStartDictation ? "true" : "false",
-                "meeting_recording_ready": systemRecordingGranted ? "true" : "false",
-                "mic_status": micGranted ? "ready" : "pending",
-                "model_state": modelStateAnalyticsValue,
-                "pasteback_status": accessibilityGranted ? "ready" : "pending",
-            ]
-        )
+    private func completeOnboarding() {
+        guard hasRequiredPermissions else { return }
+        stopPolling()
+        onComplete()
     }
 
-    private func trackStepIfNeeded(_ step: FirstRunOnboardingStep) {
-        guard !trackedSteps.contains(step) else { return }
-        trackedSteps.insert(step)
-        AnalyticsReporter.track(
-            "onboarding_step_viewed",
-            properties: [
-                "flow_elapsed_bucket": flowElapsedBucket,
-                "model_state": modelStateAnalyticsValue,
-                "step_id": step.analyticsValue,
-                "step_index": "\(step.rawValue + 1)",
-            ]
-        )
+    static var hasCompleted: Bool {
+        UserDefaults.standard.bool(forKey: "permissionsOnboardingCompleted")
     }
 
-    private func trackModelStateIfChanged() {
-        let newState = modelStateAnalyticsValue
-        guard lastTrackedModelState != newState else { return }
-        let oldState = lastTrackedModelState
-        lastTrackedModelState = newState
-        AnalyticsReporter.track(
-            "onboarding_model_state_changed",
-            properties: [
-                "from_status": oldState ?? "unknown",
-                "step_id": currentStep.analyticsValue,
-                "to_status": newState,
-            ]
-        )
+    static func markCompleted() {
+        UserDefaults.standard.set(true, forKey: "permissionsOnboardingCompleted")
     }
 
-    private func trackDismissedIfNeeded() {
-        guard trackedShown, !didCompleteOnboarding else { return }
-        AnalyticsReporter.track(
-            "onboarding_dismissed",
-            properties: [
-                "first_dictation_saved": firstSavedDictation == nil ? "false" : "true",
-                "flow_elapsed_bucket": flowElapsedBucket,
-                "meeting_dry_run_completed": meetingDryRunCompleted ? "true" : "false",
-                "model_state": modelStateAnalyticsValue,
-                "step_id": currentStep.analyticsValue,
-                "step_index": "\(currentStep.rawValue + 1)",
-            ]
-        )
-    }
-
-    private func trackPrimaryCTA(_ title: String, ctaType: String) {
-        AnalyticsReporter.track(
-            "onboarding_primary_cta_clicked",
-            properties: [
-                "cta": title.analyticsSlug,
-                "cta_type": ctaType,
-                "flow_elapsed_bucket": flowElapsedBucket,
-                "model_state": modelStateAnalyticsValue,
-                "step_elapsed_bucket": stepElapsedBucket,
-                "step_id": currentStep.analyticsValue,
-            ]
-        )
-    }
-
-    private var flowElapsedBucket: String {
-        AnalyticsReporter.durationBucket(seconds: Date().timeIntervalSince(onboardingStartedAt))
-    }
-
-    private var stepElapsedBucket: String {
-        AnalyticsReporter.durationBucket(seconds: Date().timeIntervalSince(currentStepStartedAt))
-    }
-
-    private func permissionStatusValue(_ kind: TranscriptedPermissionKind) -> String {
-        switch kind {
-        case .microphone:
-            return micGranted ? "ready" : "pending"
-        case .accessibility:
-            return accessibilityGranted ? "ready" : "pending"
-        case .systemAudioRecording:
-            return systemRecordingGranted ? "ready" : "pending"
-        case .calendar:
-            return calendarGranted ? "ready" : "pending"
-        }
-    }
-
-    private func copyText(_ text: String) {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
-    }
-
+    private static let steps: [OnboardingStepSpec] = [
+        .init(kind: .welcome),
+        .init(kind: .privacy),
+        .init(kind: .permissions),
+        .init(kind: .dictation),
+        .init(kind: .shortcut),
+        .init(kind: .systemAudio, canSkip: true),
+        .init(kind: .meeting),
+        .init(kind: .calendar, canSkip: true),
+        .init(kind: .memory),
+        .init(kind: .agentDemo),
+        .init(kind: .connectAgent, canSkip: true),
+        .init(kind: .diagnostics, canSkip: true),
+        .init(kind: .done),
+    ]
 }
 
-private struct OnboardingHeader: View {
-    let steps: [FirstRunOnboardingStep]
-    let currentStep: FirstRunOnboardingStep
+private struct OnboardingStepSpec {
+    let kind: OnboardingStepKind
+    var canSkip = false
+}
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            HStack(spacing: 12) {
-                AppIconPreview(size: 38)
+private enum OnboardingStepKind: Hashable {
+    case welcome
+    case privacy
+    case permissions
+    case dictation
+    case shortcut
+    case systemAudio
+    case meeting
+    case calendar
+    case memory
+    case agentDemo
+    case connectAgent
+    case diagnostics
+    case done
+}
 
-                VStack(alignment: .leading, spacing: 3) {
-                    Text("Transcripted")
-                        .font(.headline.weight(.semibold))
-                        .foregroundStyle(MenuTokens.textPrimary)
+private enum AgentCopyItem: Hashable {
+    case claudePrompt
+    case mcpConfig
+}
 
-                    Text("Step \(currentStep.rawValue + 1) of \(steps.count) - \(currentStep.progressTitle)")
-                        .font(.footnote)
-                        .foregroundStyle(MenuTokens.textSecondary)
-                }
+private enum OnboardingNavigationDirection {
+    case forward
+    case backward
 
-                Spacer()
-
-                Text(currentStep.phaseTitle)
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(Color.accentColor)
-                    .frame(minWidth: 72)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .background(
-                        Capsule()
-                            .fill(Color.accentColor.opacity(0.12))
-                            .overlay(
-                                Capsule()
-                                    .stroke(Color.accentColor.opacity(0.22), lineWidth: 1)
-                            )
-                    )
-            }
-
-            GeometryReader { proxy in
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill(Color.white.opacity(0.08))
-
-                    Capsule()
-                        .fill(Color.accentColor)
-                        .frame(width: max(14, proxy.size.width * progress))
-                }
-            }
-            .frame(height: 4)
+    var transition: AnyTransition {
+        switch self {
+        case .forward:
+            return .asymmetric(
+                insertion: .move(edge: .trailing).combined(with: .opacity),
+                removal: .move(edge: .leading).combined(with: .opacity)
+            )
+        case .backward:
+            return .asymmetric(
+                insertion: .move(edge: .leading).combined(with: .opacity),
+                removal: .move(edge: .trailing).combined(with: .opacity)
+            )
         }
-    }
-
-    private var progress: CGFloat {
-        guard !steps.isEmpty else { return 0 }
-        return CGFloat(currentStep.rawValue + 1) / CGFloat(steps.count)
     }
 }
 
-private struct OnboardingFooter: View {
-    let action: FirstRunOnboardingActionState
+private enum OnboardingTheme {
+    static let canvas = Color(red: 0.89, green: 0.87, blue: 0.84)
+    static let window = Color(red: 0.98, green: 0.98, blue: 0.96)
+    static let card = Color.white
+    static let cardSoft = Color(red: 0.97, green: 0.96, blue: 0.93)
+    static let ink = Color(red: 0.11, green: 0.11, blue: 0.11)
+    static let body = Color(red: 0.16, green: 0.16, blue: 0.15)
+    static let muted = Color(red: 0.42, green: 0.42, blue: 0.41)
+    static let border = Color.black.opacity(0.08)
+    static let success = Color(red: 0.16, green: 0.78, blue: 0.25)
+    static let recording = Color(red: 1.0, green: 0.27, blue: 0.23)
+    static let claude = Color(red: 0.85, green: 0.47, blue: 0.34)
+    static let codex = Color(red: 0.06, green: 0.64, blue: 0.50)
+}
+
+private struct OnboardingWindowShell<Content: View>: View {
+    let current: Int
+    let total: Int
+    let direction: OnboardingNavigationDirection
     let canGoBack: Bool
+    let canSkip: Bool
+    let primaryTitle: String
+    let primaryDisabled: Bool
     let onBack: () -> Void
-    let onSecondary: () -> Void
-    let onPrimary: () -> Void
+    let onSkip: () -> Void
+    let onNext: () -> Void
+    let content: Content
+
+    init(
+        current: Int,
+        total: Int,
+        direction: OnboardingNavigationDirection,
+        canGoBack: Bool,
+        canSkip: Bool,
+        primaryTitle: String,
+        primaryDisabled: Bool,
+        onBack: @escaping () -> Void,
+        onSkip: @escaping () -> Void,
+        onNext: @escaping () -> Void,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.current = current
+        self.total = total
+        self.direction = direction
+        self.canGoBack = canGoBack
+        self.canSkip = canSkip
+        self.primaryTitle = primaryTitle
+        self.primaryDisabled = primaryDisabled
+        self.onBack = onBack
+        self.onSkip = onSkip
+        self.onNext = onNext
+        self.content = content()
+    }
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
+        ZStack {
+            OnboardingTheme.window
+
+            VStack(spacing: 0) {
+                HStack(alignment: .center) {
+                    TrafficLights()
+                    Spacer()
+                    ProgressCounter(current: current, total: total)
+                }
+                .padding(.horizontal, 16)
+                .frame(height: 44)
+
+                ZStack {
+                    content
+                        .transition(direction.transition)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .clipped()
+
+                NavBar(
+                    canGoBack: canGoBack,
+                    canSkip: canSkip,
+                    primaryTitle: primaryTitle,
+                    primaryDisabled: primaryDisabled,
+                    onBack: onBack,
+                    onSkip: onSkip,
+                    onNext: onNext
+                )
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(OnboardingTheme.border, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.22), radius: 45, y: 24)
+    }
+}
+
+private struct TrafficLights: View {
+    var body: some View {
+        HStack(spacing: 8) {
+            Circle().fill(Color(red: 1.0, green: 0.37, blue: 0.34))
+            Circle().fill(Color(red: 1.0, green: 0.74, blue: 0.18))
+            Circle().fill(OnboardingTheme.success)
+        }
+        .frame(width: 52, height: 12)
+    }
+}
+
+private struct ProgressCounter: View {
+    let current: Int
+    let total: Int
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 3) {
+            Text("\(String(format: "%02d", current + 1)) / \(String(format: "%02d", total))")
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .kerning(2)
+                .foregroundStyle(OnboardingTheme.muted)
+            Rectangle()
+                .fill(OnboardingTheme.ink)
+                .frame(width: 28, height: 1)
+        }
+    }
+}
+
+private struct NavBar: View {
+    let canGoBack: Bool
+    let canSkip: Bool
+    let primaryTitle: String
+    let primaryDisabled: Bool
+    let onBack: () -> Void
+    let onSkip: () -> Void
+    let onNext: () -> Void
+
+    var body: some View {
+        HStack {
             Button {
                 onBack()
             } label: {
-                Label("Back", systemImage: "chevron.left")
+                Text("← Back")
+                    .font(.system(size: 13))
+                    .foregroundStyle(OnboardingTheme.muted)
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(.plain)
+            .opacity(canGoBack ? 1 : 0)
             .disabled(!canGoBack)
 
-            Spacer(minLength: 16)
-
-            if let secondaryTitle = action.secondaryTitle {
-                Button(secondaryTitle) {
-                    onSecondary()
-                }
-                .buttonStyle(.bordered)
-            }
-
-            Button(action.primaryTitle) {
-                onPrimary()
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.large)
-            .disabled(!action.isPrimaryEnabled)
-        }
-    }
-}
-
-private struct HeroStepView: View {
-    var body: some View {
-        VStack(alignment: .leading, spacing: 22) {
-            VStack(alignment: .leading, spacing: 14) {
-                Text(FirstRunOnboardingStep.hero.screenTitle)
-                    .font(.system(size: 34, weight: .semibold))
-                    .foregroundStyle(MenuTokens.textPrimary)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                Text(FirstRunOnboardingCopy.heroDetail)
-                    .font(.title3.weight(.medium))
-                    .foregroundStyle(MenuTokens.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            OutcomePreviewCard()
-        }
-    }
-}
-
-private struct ValueStepView: View {
-    var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            ScreenTitle(
-                title: FirstRunOnboardingStep.value.screenTitle,
-                detail: "Transcripted gives you two ways to turn spoken work into notes you can actually use."
-            )
-
-            HStack(spacing: 14) {
-                ValueCard(
-                    icon: "mic.fill",
-                    title: "Dictation",
-                    detail: "Speak a thought, paste it where you were typing, and keep the Markdown."
-                )
-
-                ValueCard(
-                    icon: "record.circle.fill",
-                    title: "Meetings",
-                    detail: "Record calls locally and turn conversations into useful notes."
-                )
-            }
-
-            AgentContextStrip()
-        }
-    }
-}
-
-private struct DictationSetupStepView: View {
-    let micGranted: Bool
-    let accessibilityGranted: Bool
-    let modelStatus: FirstRunModelCardState
-    let onPermissionAction: (TranscriptedPermissionKind) -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            ScreenTitle(
-                title: FirstRunOnboardingStep.dictationSetup.screenTitle,
-                detail: "Dictation needs two things: permission to listen and permission to paste your words back where you were typing."
-            )
-
-            OnboardingCard(padding: 0) {
-                VStack(spacing: 0) {
-                    SetupRow(
-                        icon: "mic.fill",
-                        title: "Microphone",
-                        detail: "Listen when you start dictation.",
-                        status: micGranted ? "Ready" : "Required",
-                        tone: micGranted ? .ready : .needed,
-                        buttonTitle: micGranted ? nil : TranscriptedPermissionKind.microphone.actionButtonTitle
-                    ) {
-                        onPermissionAction(.microphone)
-                    }
-
-                    OnboardingHairline()
-
-                    SetupRow(
-                        icon: "text.cursor",
-                        title: "Paste into other apps",
-                        detail: "Put the finished dictation back where you were typing.",
-                        status: accessibilityGranted ? "Ready" : "Required",
-                        tone: accessibilityGranted ? .ready : .needed,
-                        buttonTitle: accessibilityGranted ? nil : TranscriptedPermissionKind.accessibility.actionButtonTitle
-                    ) {
-                        onPermissionAction(.accessibility)
-                    }
-
-                    OnboardingHairline()
-
-                    LocalModelSetupRow(status: modelStatus)
-                }
-            }
-        }
-    }
-}
-
-private struct TestDictationStepView: View {
-    let issue: String?
-    let onAnchorChange: (NSRect?) -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            ScreenTitle(
-                title: FirstRunOnboardingStep.testDictation.screenTitle,
-                detail: "Let's make sure the whole loop works before moving on."
-            )
-
-            OnboardingCard {
-                VStack(alignment: .leading, spacing: 16) {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Label("Say this out loud", systemImage: "waveform")
-                            .font(.headline.weight(.semibold))
-                            .foregroundStyle(MenuTokens.textPrimary)
-
-                        Text("\"Remind me to review the pricing call.\"")
-                            .font(.system(size: 25, weight: .semibold))
-                            .foregroundStyle(MenuTokens.textPrimary)
-                            .fixedSize(horizontal: false, vertical: true)
-
-                        Text("Then stop the capture. Transcripted will paste the text back and save a Markdown copy.")
-                            .font(.callout)
-                            .foregroundStyle(MenuTokens.textSecondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-
-                    if let issue {
-                        OnboardingCallout(
-                            icon: "exclamationmark.triangle.fill",
-                            title: "Try again",
-                            detail: issue,
-                            tone: .warning
-                        )
-                    }
-                }
-            }
-            .background(OnboardingScreenFrameReader(onChange: onAnchorChange))
-        }
-    }
-}
-
-private struct FirstDictationResultStepView: View {
-    let entry: SavedDictationEntry?
-    let copied: Bool
-    let onCopy: () -> Void
-    let onOpenFolder: () -> Void
-    let onRetry: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            ScreenTitle(
-                title: FirstRunOnboardingStep.dictationResult.screenTitle,
-                detail: "This is the core loop: dictate instead of type, and keep a saved Markdown copy."
-            )
-
-            if let entry {
-                OnboardingCard {
-                    VStack(alignment: .leading, spacing: 14) {
-                        Label("Your words are now Markdown", systemImage: "checkmark.circle.fill")
-                            .font(.headline.weight(.semibold))
-                            .foregroundStyle(MenuTokens.textPrimary)
-
-                        Text(entry.text)
-                            .font(.body)
-                            .foregroundStyle(MenuTokens.textPrimary)
-                            .lineLimit(6)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .padding(12)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(
-                                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                    .fill(MenuTokens.pillBackground)
-                            )
-
-                        HStack(spacing: 10) {
-                            Label(FirstRunOnboardingCopy.savedAsMarkdown, systemImage: "doc.text.fill")
-                                .font(.subheadline.weight(.semibold))
-                                .foregroundStyle(MenuTokens.textPrimary)
-
-                            Spacer()
-
-                            Text(entry.url.lastPathComponent)
-                                .font(.footnote.monospaced())
-                                .foregroundStyle(MenuTokens.textSecondary)
-                                .lineLimit(1)
-                        }
-                    }
-                }
-
-                OnboardingCallout(
-                    icon: "sparkles",
-                    title: "For your agent",
-                    detail: FirstRunOnboardingCopy.agentDictationNote
-                )
-
-                HStack(spacing: 10) {
-                    Button {
-                        onCopy()
-                    } label: {
-                        Label(copied ? "Copied" : "Copy", systemImage: copied ? "checkmark" : "doc.on.doc")
-                    }
-                    .buttonStyle(.bordered)
-
-                    Button {
-                        onOpenFolder()
-                    } label: {
-                        Label("Open Folder", systemImage: "folder")
-                    }
-                    .buttonStyle(.bordered)
-                }
-            } else {
-                OnboardingCallout(
-                    icon: "exclamationmark.triangle.fill",
-                    title: "No dictation saved yet",
-                    detail: "Try one clear sentence so Transcripted can show you the saved Markdown result.",
-                    tone: .warning
-                )
-
-                Button {
-                    onRetry()
-                } label: {
-                    Label("Try Again", systemImage: "mic.fill")
-                }
-                .buttonStyle(.borderedProminent)
-            }
-        }
-    }
-}
-
-private struct MeetingsIntroStepView: View {
-    var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            ScreenTitle(
-                title: FirstRunOnboardingStep.meetingsIntro.screenTitle,
-                detail: "Once dictation works, the same idea expands to meetings."
-            )
-
-            MeetingNotePreviewCard()
-        }
-    }
-}
-
-private struct MeetingSetupStepView: View {
-    let micGranted: Bool
-    let systemRecordingGranted: Bool
-    let calendarGranted: Bool
-    let isDryRunStarting: Bool
-    let isDryRunRunning: Bool
-    let dryRunCompleted: Bool
-    let dryRunIssue: String?
-    let onPermissionAction: (TranscriptedPermissionKind) -> Void
-    let onDryRun: () -> Void
-    let onStopDryRun: () -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            ScreenTitle(
-                title: FirstRunOnboardingStep.meetingSetup.screenTitle,
-                detail: "Meeting recording needs your microphone plus System Audio Recording for the other side of calls."
-            )
-
-            OnboardingCard(padding: 0) {
-                VStack(spacing: 0) {
-                    SetupRow(
-                        icon: "mic.fill",
-                        title: "Microphone",
-                        detail: "Already used for your side of meetings.",
-                        status: micGranted ? "Ready" : "Required",
-                        tone: micGranted ? .ready : .needed,
-                        buttonTitle: micGranted ? nil : TranscriptedPermissionKind.microphone.actionButtonTitle
-                    ) {
-                        onPermissionAction(.microphone)
-                    }
-
-                    OnboardingHairline()
-
-                    SetupRow(
-                        icon: "speaker.wave.2.fill",
-                        title: "System Audio Recording",
-                        detail: "Captures the other side of Zoom, Meet, videos, and calls.",
-                        status: systemRecordingGranted ? "Ready" : "Needed for meetings",
-                        tone: systemRecordingGranted ? .ready : .needed,
-                        buttonTitle: systemRecordingGranted ? nil : TranscriptedPermissionKind.systemAudioRecording.actionButtonTitle
-                    ) {
-                        onPermissionAction(.systemAudioRecording)
-                    }
-
-                    OnboardingHairline()
-
-                    SetupRow(
-                        icon: "calendar",
-                        title: "Calendar",
-                        detail: "Optional. Helps Transcripted spot meetings and offer a record prompt.",
-                        status: calendarGranted ? "Ready" : "Optional",
-                        tone: calendarGranted ? .ready : .neutral,
-                        buttonTitle: calendarGranted ? nil : TranscriptedPermissionKind.calendar.actionButtonTitle
-                    ) {
-                        onPermissionAction(.calendar)
-                    }
-                }
-            }
-
-            OnboardingCard {
-                HStack(spacing: 12) {
-                    Image(systemName: dryRunCompleted ? "checkmark.circle.fill" : "record.circle")
-                        .font(.system(size: 26, weight: .semibold))
-                        .foregroundStyle(dryRunCompleted ? MenuTokens.statusGreen : Color.accentColor)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(dryRunCompleted ? "Dry run worked" : "Run a quick dry run")
-                            .font(.headline.weight(.semibold))
-                            .foregroundStyle(MenuTokens.textPrimary)
-
-                        Text(dryRunDetail)
-                            .font(.footnote)
-                            .foregroundStyle(MenuTokens.textSecondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-
-                    Spacer()
-
-                    Button {
-                        isDryRunRunning ? onStopDryRun() : onDryRun()
-                    } label: {
-                        Label(dryRunButtonTitle, systemImage: dryRunButtonIcon)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(isDryRunStarting)
-                }
-            }
-
-            if let dryRunIssue {
-                OnboardingCallout(
-                    icon: "exclamationmark.triangle.fill",
-                    title: "Dry run needs another try",
-                    detail: dryRunIssue,
-                    tone: .warning
-                )
-            }
-        }
-    }
-
-    private var dryRunDetail: String {
-        if isDryRunStarting {
-            return "Starting a short recording test..."
-        }
-        if isDryRunRunning {
-            return "Recording test is running. Stop it here when you're ready. Test audio will be discarded."
-        }
-        if dryRunCompleted {
-            return "Meeting capture started and stopped correctly. The test audio was discarded."
-        }
-        return "Start a short meeting recording test, then stop it here. Transcripted discards this test audio."
-    }
-
-    private var dryRunButtonTitle: String {
-        if isDryRunStarting {
-            return "Starting..."
-        }
-        return isDryRunRunning ? "Stop Dry Run" : "Run Dry Run"
-    }
-
-    private var dryRunButtonIcon: String {
-        if isDryRunStarting {
-            return "clock"
-        }
-        return isDryRunRunning ? "stop.fill" : "play.fill"
-    }
-}
-
-private struct AgentPayoffStepView: View {
-    let copiedAgentPrompt: Bool
-    let isInstallingClaude: Bool
-    let installMessage: String?
-    @Binding var crashReportingEnabled: Bool
-    @Binding var anonymousAnalyticsEnabled: Bool
-    let crashReportingAvailable: Bool
-    let analyticsAvailable: Bool
-    let onInstallClaude: () -> Void
-    let onCopyAgentPrompt: () -> Void
-    let onOpenAgentSettings: () -> Void
-    let onCrashToggle: (Bool) -> Void
-    let onAnalyticsToggle: (Bool) -> Void
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            ScreenTitle(
-                title: FirstRunOnboardingStep.agentPayoff.screenTitle,
-                detail: FirstRunOnboardingCopy.agentDetail
-            )
-
-            AgentContextPreviewCard()
-
-            HStack(spacing: 10) {
-                Button {
-                    onInstallClaude()
-                } label: {
-                    Label(isInstallingClaude ? "Installing..." : "Install in Claude", systemImage: isInstallingClaude ? "hourglass" : "sparkles")
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(isInstallingClaude)
-
-                Button {
-                    onCopyAgentPrompt()
-                } label: {
-                    Label(copiedAgentPrompt ? "Copied" : "Copy for Agent", systemImage: copiedAgentPrompt ? "checkmark" : "doc.on.doc")
-                }
-                .buttonStyle(.bordered)
-
-                Button {
-                    onOpenAgentSettings()
-                } label: {
-                    Label("Agent Settings", systemImage: "gearshape")
-                }
-                .buttonStyle(.bordered)
-            }
-
-            if let installMessage {
-                Text(installMessage)
-                    .font(.footnote)
-                    .foregroundStyle(installMessage.hasPrefix("Ready") ? MenuTokens.statusGreen : Color.orange)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            ReportingConsentCard(
-                crashReportingEnabled: $crashReportingEnabled,
-                anonymousAnalyticsEnabled: $anonymousAnalyticsEnabled,
-                crashReportingAvailable: crashReportingAvailable,
-                analyticsAvailable: analyticsAvailable,
-                onCrashToggle: onCrashToggle,
-                onAnalyticsToggle: onAnalyticsToggle
-            )
-        }
-    }
-}
-
-private struct ReportingConsentCard: View {
-    @Binding var crashReportingEnabled: Bool
-    @Binding var anonymousAnalyticsEnabled: Bool
-    let crashReportingAvailable: Bool
-    let analyticsAvailable: Bool
-    let onCrashToggle: (Bool) -> Void
-    let onAnalyticsToggle: (Bool) -> Void
-
-    var body: some View {
-        OnboardingCard {
-            HStack(alignment: .top, spacing: 14) {
-                Image(systemName: "bolt.shield.fill")
-                    .font(.system(size: 17, weight: .semibold))
-                    .foregroundStyle(Color.accentColor)
-                    .frame(width: 36, height: 36)
-                    .background(Circle().fill(Color.accentColor.opacity(0.12)))
-
-                VStack(alignment: .leading, spacing: 5) {
-                    Text("Privacy-safe diagnostics")
-                        .font(.headline.weight(.semibold))
-                        .foregroundStyle(MenuTokens.textPrimary)
-
-                    Text("Helps catch setup problems. Never sends transcript text, audio, meeting titles, speaker names, emails, file paths, or URLs.")
-                        .font(.footnote)
-                        .foregroundStyle(MenuTokens.textSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Spacer(minLength: 16)
-
-                VStack(alignment: .trailing, spacing: 8) {
-                    ToggleRow(
-                        title: "Crash reports",
-                        detail: crashReportingAvailable ? "Scrubbed only" : "Unavailable",
-                        isOn: Binding(get: { crashReportingEnabled }, set: { onCrashToggle($0) }),
-                        isEnabled: crashReportingAvailable
-                    )
-
-                    ToggleRow(
-                        title: "Usage stats",
-                        detail: analyticsAvailable ? "Allowlisted only" : "Unavailable",
-                        isOn: Binding(get: { anonymousAnalyticsEnabled }, set: { onAnalyticsToggle($0) }),
-                        isEnabled: analyticsAvailable
-                    )
-                }
-            }
-        }
-    }
-}
-
-private struct ToggleRow: View {
-    let title: String
-    let detail: String
-    @Binding var isOn: Bool
-    let isEnabled: Bool
-
-    var body: some View {
-        HStack(alignment: .center, spacing: 12) {
-            VStack(alignment: .leading, spacing: 3) {
-                Text(title)
-                    .font(.footnote.weight(.semibold))
-                    .foregroundStyle(MenuTokens.textPrimary)
-
-                Text(detail)
-                    .font(.caption)
-                    .foregroundStyle(MenuTokens.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            Toggle("", isOn: $isOn)
-                .labelsHidden()
-                .disabled(!isEnabled)
-                .accessibilityLabel(title)
-                .help(detail)
-        }
-        .frame(minHeight: 40)
-    }
-}
-
-private struct ScreenTitle: View {
-    let title: String
-    let detail: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(title)
-                .font(.system(size: 31, weight: .semibold))
-                .foregroundStyle(MenuTokens.textPrimary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            Text(detail)
-                .font(.title3.weight(.medium))
-                .foregroundStyle(MenuTokens.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-    }
-}
-
-private struct OutcomePreviewCard: View {
-    var body: some View {
-        OnboardingCard {
-            HStack(alignment: .top, spacing: 18) {
-                PreviewColumn(
-                    icon: "waveform",
-                    title: "Speak",
-                    detail: "\"Review onboarding before pricing.\""
-                )
-
-                FlowArrow()
-                    .padding(.top, 28)
-
-                VStack(alignment: .leading, spacing: 8) {
-                    PreviewColumnHeader(icon: "doc.text.fill", title: "Markdown")
-
-                    VStack(alignment: .leading, spacing: 5) {
-                        Text("# Dictation")
-                            .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                        Text("Review onboarding before pricing.")
-                            .font(.system(size: 12, design: .monospaced))
-                    }
-                    .foregroundStyle(MenuTokens.textPrimary)
-                    .padding(10)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6, style: .continuous)
-                            .fill(Color.black.opacity(0.22))
-                    )
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                FlowArrow()
-                    .padding(.top, 28)
-
-                PreviewColumn(
-                    icon: "sparkles",
-                    title: "Agent",
-                    detail: "Ask: what did I say I should do next?"
-                )
-            }
-        }
-    }
-}
-
-private struct AgentContextStrip: View {
-    var body: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "folder.fill")
-                .font(.system(size: 18, weight: .semibold))
-                .foregroundStyle(Color.accentColor)
-                .frame(width: 34, height: 34)
-                .background(Circle().fill(Color.accentColor.opacity(0.12)))
-
-            VStack(alignment: .leading, spacing: 3) {
-                Text("Everything lands in local Markdown")
-                    .font(.headline.weight(.semibold))
-                    .foregroundStyle(MenuTokens.textPrimary)
-
-                Text(FirstRunOnboardingCopy.valueFooter)
-                    .font(.callout)
-                    .foregroundStyle(MenuTokens.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
             Spacer()
-        }
-        .padding(14)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.accentColor.opacity(0.08))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(Color.accentColor.opacity(0.16), lineWidth: 1)
+
+            if canSkip {
+                Button("Skip for now") {
+                    onSkip()
+                }
+                .font(.system(size: 13))
+                .buttonStyle(.plain)
+                .foregroundStyle(OnboardingTheme.muted)
+            }
+
+            Button {
+                onNext()
+            } label: {
+                HStack(spacing: 7) {
+                    Text(primaryTitle)
+                    Text("→")
+                }
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(OnboardingTheme.window)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 12)
+                .background(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(primaryDisabled ? OnboardingTheme.muted.opacity(0.45) : OnboardingTheme.ink)
                 )
-        )
+            }
+            .buttonStyle(.plain)
+            .disabled(primaryDisabled)
+        }
+        .padding(.horizontal, 32)
+        .frame(height: 78)
     }
 }
 
-private struct MeetingNotePreviewCard: View {
+private struct CenterStage<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
     var body: some View {
-        OnboardingCard {
-            HStack(alignment: .top, spacing: 18) {
-                VStack(alignment: .leading, spacing: 10) {
-                    PreviewColumnHeader(icon: "record.circle.fill", title: "Meeting")
-                    Text("Transcripted records your mic plus system audio. No bot joins the call.")
-                        .font(.callout)
-                        .foregroundStyle(MenuTokens.textSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
+        VStack(spacing: 0) {
+            Spacer(minLength: 0)
+            VStack(spacing: 18) {
+                content
+            }
+            .frame(maxWidth: 800)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 60)
+    }
+}
 
-                VStack(alignment: .leading, spacing: 8) {
-                    PreviewColumnHeader(icon: "doc.text.fill", title: "Notes")
+private struct SplitStage<Left: View, Right: View>: View {
+    let left: Left
+    let right: Right
 
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text("## Decisions")
-                            .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                        Text("- Keep pricing manual this week")
-                            .font(.system(size: 12, design: .monospaced))
-                        Text("## Follow-ups")
-                            .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                        Text("- Review onboarding dropoff")
-                            .font(.system(size: 12, design: .monospaced))
-                    }
-                    .foregroundStyle(MenuTokens.textPrimary)
-                    .padding(10)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6, style: .continuous)
-                            .fill(Color.black.opacity(0.22))
-                    )
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
+    init(@ViewBuilder left: () -> Left, @ViewBuilder right: () -> Right) {
+        self.left = left()
+        self.right = right()
+    }
+
+    var body: some View {
+        HStack(spacing: 30) {
+            VStack(alignment: .leading, spacing: 18) {
+                left
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            ZStack {
+                right
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .padding(.horizontal, 60)
+        .padding(.vertical, 28)
+    }
+}
+
+private struct Kicker: View {
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
+            .kerning(2.2)
+            .foregroundStyle(OnboardingTheme.muted)
+    }
+}
+
+private struct Headline: View {
+    let primary: String
+    var emphasis: String?
+    var size: CGFloat = 58
+    var alignment: TextAlignment = .center
+
+    var body: some View {
+        VStack(alignment: alignment == .leading ? .leading : .center, spacing: 2) {
+            Text(primary)
+                .font(.system(size: size, weight: .semibold))
+                .lineSpacing(1)
+            if let emphasis {
+                Text(emphasis)
+                    .font(.custom("Georgia", size: size).italic())
             }
         }
+        .foregroundStyle(OnboardingTheme.ink)
+        .multilineTextAlignment(alignment)
+        .lineLimit(nil)
+        .fixedSize(horizontal: false, vertical: true)
     }
 }
 
-private struct AgentContextPreviewCard: View {
-    var body: some View {
-        OnboardingCard {
-            VStack(alignment: .leading, spacing: 14) {
-                HStack(alignment: .top, spacing: 14) {
-                    Image(systemName: "sparkles")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundStyle(Color.accentColor)
-                        .frame(width: 40, height: 40)
-                        .background(Circle().fill(Color.accentColor.opacity(0.12)))
+private struct Lede: View {
+    let text: String
+    var maxWidth: CGFloat = 540
 
-                    VStack(alignment: .leading, spacing: 5) {
-                        Text("Your agent gets searchable spoken context")
-                            .font(.headline.weight(.semibold))
-                            .foregroundStyle(MenuTokens.textPrimary)
-
-                        Text("Point an agent at the capture folder and ask across dictations, meetings, and imported audio.")
-                            .font(.callout)
-                            .foregroundStyle(MenuTokens.textSecondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-
-                HStack(spacing: 8) {
-                    AgentPromptPill(text: "Search my meetings")
-                    AgentPromptPill(text: "What am I working on?")
-                    AgentPromptPill(text: "Summarize today")
-                }
-            }
-        }
+    init(_ text: String, maxWidth: CGFloat = 540) {
+        self.text = text
+        self.maxWidth = maxWidth
     }
-}
-
-private struct PreviewColumn: View {
-    let icon: String
-    let title: String
-    let detail: String
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            PreviewColumnHeader(icon: icon, title: title)
-
-            Text(detail)
-                .font(.callout)
-                .foregroundStyle(MenuTokens.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        Text(text)
+            .font(.system(size: 17))
+            .lineSpacing(3)
+            .foregroundStyle(OnboardingTheme.body)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: maxWidth)
+            .fixedSize(horizontal: false, vertical: true)
     }
 }
 
-private struct PreviewColumnHeader: View {
-    let icon: String
-    let title: String
+private struct BodyCopy: View {
+    let text: String
+    var maxWidth: CGFloat = 430
+
+    init(_ text: String, maxWidth: CGFloat = 430) {
+        self.text = text
+        self.maxWidth = maxWidth
+    }
 
     var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: icon)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(Color.accentColor)
-
-            Text(title)
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(MenuTokens.textPrimary)
-        }
+        Text(text)
+            .font(.system(size: 15))
+            .lineSpacing(3)
+            .foregroundStyle(OnboardingTheme.body)
+            .frame(maxWidth: maxWidth, alignment: .leading)
+            .fixedSize(horizontal: false, vertical: true)
     }
 }
 
-private struct ValueCard: View {
-    let icon: String
-    let title: String
-    let detail: String
+private struct HeroWaveCircle: View {
+    private let count = 26
 
     var body: some View {
-        OnboardingCard {
-            VStack(alignment: .leading, spacing: 12) {
-                Image(systemName: icon)
-                    .font(.system(size: 24, weight: .semibold))
-                    .foregroundStyle(Color.accentColor)
-                    .frame(width: 42, height: 42)
-                    .background(Circle().fill(Color.accentColor.opacity(0.12)))
-
-                Text(title)
-                    .font(.title3.weight(.semibold))
-                    .foregroundStyle(MenuTokens.textPrimary)
-
-                Text(detail)
-                    .font(.callout)
-                    .foregroundStyle(MenuTokens.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            .frame(maxWidth: .infinity, minHeight: 148, alignment: .leading)
-        }
-    }
-}
-
-private enum SetupTone {
-    case ready
-    case needed
-    case working
-    case warning
-    case neutral
-
-    var color: Color {
-        switch self {
-        case .ready:
-            return MenuTokens.statusGreen
-        case .needed, .warning:
-            return Color.orange
-        case .working:
-            return Color.accentColor
-        case .neutral:
-            return MenuTokens.textSecondary
-        }
-    }
-}
-
-private struct SetupRow: View {
-    let icon: String
-    let title: String
-    let detail: String
-    let status: String
-    let tone: SetupTone
-    let buttonTitle: String?
-    let action: () -> Void
-
-    var body: some View {
-        HStack(alignment: .center, spacing: 14) {
+        TimelineView(.animation) { timeline in
+            let t = timeline.date.timeIntervalSinceReferenceDate
             ZStack {
                 Circle()
-                    .fill(tone.color.opacity(tone == .neutral ? 0.10 : 0.14))
-                    .frame(width: 42, height: 42)
+                    .fill(OnboardingTheme.ink)
+                    .frame(width: 200, height: 200)
+                    .shadow(color: .black.opacity(0.22 + 0.04 * abs(sin(t * 1.4))), radius: 30, y: 20)
 
-                Image(systemName: tone == .ready ? "checkmark" : icon)
-                    .font(.system(size: 17, weight: .semibold))
-                    .foregroundStyle(tone == .ready ? MenuTokens.statusGreen : MenuTokens.textPrimary)
-            }
-
-            VStack(alignment: .leading, spacing: 5) {
-                HStack(spacing: 8) {
-                    Text(title)
-                        .font(.headline.weight(.semibold))
-                        .foregroundStyle(MenuTokens.textPrimary)
-
-                    StatusBadge(title: status, tone: tone)
-                }
-
-                Text(detail)
-                    .font(.callout)
-                    .foregroundStyle(MenuTokens.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            Spacer(minLength: 8)
-
-            if let buttonTitle {
-                Button(buttonTitle) {
-                    action()
-                }
-                .buttonStyle(.borderedProminent)
-            }
-        }
-        .padding(16)
-    }
-}
-
-private struct LocalModelSetupRow: View {
-    let status: FirstRunModelCardState
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .center, spacing: 14) {
-                ZStack {
-                    Circle()
-                        .fill(iconColor.opacity(0.14))
-                        .frame(width: 42, height: 42)
-
-                    Image(systemName: iconName)
-                        .font(.system(size: 17, weight: .semibold))
-                        .foregroundStyle(iconColor)
-                }
-
-                VStack(alignment: .leading, spacing: 5) {
-                    HStack(spacing: 8) {
-                        Text("Local model")
-                            .font(.headline.weight(.semibold))
-                            .foregroundStyle(MenuTokens.textPrimary)
-
-                        StatusBadge(title: status.status, tone: tone)
+                HStack(alignment: .center, spacing: 2) {
+                    ForEach(0..<count, id: \.self) { index in
+                        RoundedRectangle(cornerRadius: 1.2, style: .continuous)
+                            .fill(OnboardingTheme.window)
+                            .frame(width: 2.4, height: barHeight(index: index, time: t))
                     }
-
-                    Text(status.detail)
-                        .font(.callout)
-                        .foregroundStyle(MenuTokens.textSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
                 }
-            }
-
-            if let progress = status.progress, status.tone != .ready {
-                ProgressView(value: progress)
-                    .progressViewStyle(.linear)
-                    .tint(iconColor)
+                .frame(height: 40)
             }
         }
-        .padding(16)
     }
 
-    private var iconName: String {
-        switch status.tone {
-        case .ready:
-            return "checkmark.circle.fill"
-        case .working:
-            return "arrow.down.circle.fill"
-        case .failed:
-            return "exclamationmark.triangle.fill"
-        }
-    }
-
-    private var tone: SetupTone {
-        switch status.tone {
-        case .ready:
-            return .ready
-        case .working:
-            return .working
-        case .failed:
-            return .warning
-        }
-    }
-
-    private var iconColor: Color {
-        tone.color
+    private func barHeight(index: Int, time: TimeInterval) -> CGFloat {
+        let center = Double(count - 1) / 2.0
+        let norm = (Double(index) - center) / center
+        let envelope = pow(max(0, cos(norm * .pi / 2.0)), 1.2)
+        let wave = abs(sin(Double(index) * 0.82 + time * 2.0) + sin(Double(index) * 0.23 + time * 3.2) * 0.5)
+        return CGFloat(max(3.0, wave * 18.0 * envelope + 3.0))
     }
 }
 
-private struct StatusBadge: View {
-    let title: String
-    let tone: SetupTone
+private struct PrivacyPill: View {
+    let label: String
 
-    var body: some View {
-        Text(title)
-            .font(.system(size: 11, weight: .semibold))
-            .foregroundStyle(tone.color)
-            .lineLimit(1)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(
-                Capsule()
-                    .fill(tone.color.opacity(tone == .ready ? 0.16 : 0.10))
-                    .overlay(
-                        Capsule()
-                            .stroke(tone.color.opacity(tone == .ready ? 0.24 : 0.18), lineWidth: 1)
-                    )
-            )
+    init(_ label: String) {
+        self.label = label
     }
-}
-
-private enum CalloutTone {
-    case normal
-    case warning
-}
-
-private struct OnboardingCallout: View {
-    let icon: String
-    let title: String
-    let detail: String
-    var tone: CalloutTone = .normal
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Image(systemName: icon)
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(tone == .warning ? Color.orange : Color.accentColor)
-                .frame(width: 24)
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title)
-                    .font(.headline.weight(.semibold))
-                    .foregroundStyle(MenuTokens.textPrimary)
-
-                Text(detail)
-                    .font(.callout)
-                    .foregroundStyle(MenuTokens.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-        }
-        .padding(14)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(tone == .warning ? Color.orange.opacity(0.12) : MenuTokens.pillBackground)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(tone == .warning ? Color.orange.opacity(0.28) : MenuTokens.pillBorder, lineWidth: 1)
-                )
-        )
-    }
-}
-
-private struct OnboardingCard<Content: View>: View {
-    let padding: CGFloat
-    @ViewBuilder let content: () -> Content
-
-    init(padding: CGFloat = 16, @ViewBuilder content: @escaping () -> Content) {
-        self.padding = padding
-        self.content = content
-    }
-
-    var body: some View {
-        content()
-            .padding(padding)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color.white.opacity(0.055))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .stroke(Color.white.opacity(0.085), lineWidth: 1)
-                    )
-                    .shadow(color: .black.opacity(0.14), radius: 14, y: 8)
-            )
-    }
-}
-
-private struct OnboardingHairline: View {
-    var body: some View {
-        Rectangle()
-            .fill(Color.white.opacity(0.08))
-            .frame(height: 1)
-    }
-}
-
-private struct FlowSymbol: View {
-    let name: String
-    let title: String
-
-    var body: some View {
-        VStack(spacing: 8) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(MenuTokens.pillBackground)
-                    .frame(width: 76, height: 58)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .stroke(MenuTokens.pillBorder, lineWidth: 1)
-                    )
-
-                Image(systemName: name)
-                    .font(.system(size: 24, weight: .semibold))
-                    .foregroundStyle(Color.accentColor)
-            }
-
-            Text(title)
-                .font(.footnote.weight(.semibold))
-                .foregroundStyle(MenuTokens.textSecondary)
-        }
-    }
-}
-
-private struct FlowArrow: View {
-    var body: some View {
-        Image(systemName: "arrow.right")
-            .font(.system(size: 16, weight: .semibold))
-            .foregroundStyle(MenuTokens.textSecondary)
-            .frame(width: 28)
-    }
-}
-
-private struct AgentPromptPill: View {
-    let text: String
 
     var body: some View {
         HStack(spacing: 10) {
-            Image(systemName: "magnifyingglass")
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(Color.accentColor)
-
-            Text(text)
-                .font(.footnote.weight(.semibold))
-                .foregroundStyle(MenuTokens.textPrimary)
+            Image(systemName: "checkmark")
+                .font(.system(size: 11, weight: .bold))
+            Text(label)
+                .font(.system(size: 13, weight: .medium))
         }
-        .padding(.horizontal, 11)
-        .padding(.vertical, 8)
-        .background(
-            Capsule()
-                .fill(Color.white.opacity(0.07))
-                .overlay(
-                    Capsule()
-                        .stroke(Color.white.opacity(0.10), lineWidth: 1)
-                )
-        )
+        .foregroundStyle(OnboardingTheme.ink)
+        .padding(.horizontal, 18)
+        .padding(.vertical, 10)
+        .background(Capsule().fill(OnboardingTheme.card))
+        .overlay(Capsule().stroke(OnboardingTheme.border, lineWidth: 1))
+        .shadow(color: .black.opacity(0.04), radius: 8, y: 4)
     }
 }
 
-private struct AppIconPreview: View {
-    let size: CGFloat
+private struct PermissionGrantRow: View {
+    let title: String
+    let reason: String
+    let icon: String
+    let granted: Bool
+    let actionTitle: String
+    let action: () -> Void
 
-    private var iconImage: NSImage {
-        if let icon = NSApplication.shared.applicationIconImage,
-           icon.size.width > 0,
-           icon.size.height > 0 {
-            return icon
+    var body: some View {
+        HStack(spacing: 16) {
+            ZStack {
+                Circle()
+                    .fill(granted ? OnboardingTheme.success : OnboardingTheme.cardSoft)
+                    .frame(width: 28, height: 28)
+                Image(systemName: granted ? "checkmark" : icon)
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(granted ? OnboardingTheme.ink : OnboardingTheme.muted)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 14, weight: .semibold))
+                Text(reason)
+                    .font(.system(size: 12))
+                    .foregroundStyle(OnboardingTheme.muted)
+            }
+            .foregroundStyle(granted ? OnboardingTheme.window : OnboardingTheme.ink)
+
+            Spacer()
+
+            Button(granted ? "Granted" : actionTitle) {
+                action()
+            }
+            .buttonStyle(InkButtonStyle(isSubtle: granted, compact: true))
+            .disabled(granted)
         }
-        return NSImage(systemSymbolName: "waveform.and.mic", accessibilityDescription: "Transcripted") ?? NSImage()
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(granted ? OnboardingTheme.ink : OnboardingTheme.card)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(OnboardingTheme.border, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.04), radius: 10, y: 5)
+        .animation(.easeInOut(duration: 0.2), value: granted)
+    }
+}
+
+private struct InkButtonStyle: ButtonStyle {
+    var isSubtle = false
+    var compact = false
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: compact ? 12 : 14, weight: .semibold))
+            .foregroundStyle(isSubtle ? OnboardingTheme.ink : OnboardingTheme.window)
+            .padding(.horizontal, compact ? 14 : 22)
+            .padding(.vertical, compact ? 8 : 12)
+            .background(
+                RoundedRectangle(cornerRadius: compact ? 8 : 10, style: .continuous)
+                    .fill(isSubtle ? Color.clear : OnboardingTheme.ink)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: compact ? 8 : 10, style: .continuous)
+                    .stroke(isSubtle ? OnboardingTheme.border : Color.clear, lineWidth: 1)
+            )
+            .opacity(configuration.isPressed ? 0.72 : 1)
+    }
+}
+
+private struct BulletList: View {
+    let items: [String]
+
+    init(_ items: [String]) {
+        self.items = items
     }
 
     var body: some View {
-        Image(nsImage: iconImage)
-            .resizable()
-            .interpolation(.high)
-            .frame(width: size, height: size)
-            .clipShape(RoundedRectangle(cornerRadius: min(16, size * 0.22), style: .continuous))
-            .shadow(color: .black.opacity(0.2), radius: 10, y: 4)
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(items, id: \.self) { item in
+                HStack(alignment: .top, spacing: 12) {
+                    Circle()
+                        .fill(OnboardingTheme.ink)
+                        .frame(width: 4, height: 4)
+                        .padding(.top, 8)
+                    Text(item)
+                        .font(.system(size: 13.5))
+                        .foregroundStyle(OnboardingTheme.body)
+                }
+            }
+        }
+        .padding(.top, 8)
     }
 }
 
-private struct OnboardingScreenFrameReader: NSViewRepresentable {
-    let onChange: (NSRect?) -> Void
+private struct DictationDemoCard: View {
+    private let phrase = "I think we should ship the pricing change before the board meeting."
 
-    func makeNSView(context: Context) -> AnchorTrackingView {
-        let view = AnchorTrackingView()
-        view.onChange = onChange
-        return view
+    var body: some View {
+        VStack(spacing: 18) {
+            MiniWindow(title: "Mail - Reply") {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(phrase)
+                        .font(.system(size: 15))
+                        .lineSpacing(4)
+                        .foregroundStyle(OnboardingTheme.ink)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Rectangle()
+                        .fill(OnboardingTheme.ink)
+                        .frame(width: 2, height: 18)
+                        .opacity(0.7)
+                }
+                .padding(18)
+            }
+            .frame(width: 360, height: 170)
+
+            DictationPill(label: "Listening")
+        }
+    }
+}
+
+private struct MiniWindow<Content: View>: View {
+    let title: String
+    let content: Content
+
+    init(title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
     }
 
-    func updateNSView(_ nsView: AnchorTrackingView, context: Context) {
-        nsView.onChange = onChange
-        nsView.publishScreenFrame()
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 6) {
+                Circle().fill(OnboardingTheme.border).frame(width: 7, height: 7)
+                Circle().fill(OnboardingTheme.border).frame(width: 7, height: 7)
+                Circle().fill(OnboardingTheme.border).frame(width: 7, height: 7)
+                Text(title)
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(OnboardingTheme.muted.opacity(0.7))
+                    .padding(.leading, 6)
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 26)
+            .overlay(Rectangle().fill(OnboardingTheme.border).frame(height: 1), alignment: .bottom)
+
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .background(OnboardingTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(OnboardingTheme.border, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.06), radius: 18, y: 10)
     }
+}
 
-    final class AnchorTrackingView: NSView {
-        var onChange: ((NSRect?) -> Void)?
-        private var lastFrame: NSRect?
+private struct DictationPill: View {
+    let label: String
 
-        override func viewDidMoveToWindow() {
-            super.viewDidMoveToWindow()
-            publishScreenFrame()
+    var body: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(OnboardingTheme.recording)
+                .frame(width: 8, height: 8)
+            Text(label)
+                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+            MiniWaveform(color: OnboardingTheme.ink, width: 54, height: 18)
         }
+        .foregroundStyle(OnboardingTheme.ink)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(Capsule().fill(OnboardingTheme.card))
+        .overlay(Capsule().stroke(OnboardingTheme.border, lineWidth: 1))
+    }
+}
 
-        override func layout() {
-            super.layout()
-            publishScreenFrame()
-        }
+private struct DemoPasteTarget: View {
+    @Binding var text: String
 
-        override func setFrameSize(_ newSize: NSSize) {
-            super.setFrameSize(newSize)
-            publishScreenFrame()
-        }
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(OnboardingTheme.card)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(OnboardingTheme.border, lineWidth: 1)
+                )
+                .shadow(color: .black.opacity(0.05), radius: 14, y: 8)
 
-        func publishScreenFrame() {
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                guard let window = self.window else {
-                    if self.lastFrame != nil {
-                        self.lastFrame = nil
-                        self.onChange?(nil)
-                    }
-                    return
+            TextEditor(text: $text)
+                .font(.system(size: 18))
+                .foregroundStyle(OnboardingTheme.ink)
+                .scrollContentBackground(.hidden)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 14)
+
+            if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Your words will paste here.")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(OnboardingTheme.ink.opacity(0.42))
+                    Text("Tap Right Option once, speak, then tap it again.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(OnboardingTheme.muted)
                 }
-
-                let windowRect = self.convert(self.bounds, to: nil)
-                let screenRect = window.convertToScreen(windowRect)
-                guard screenRect.width > 0, screenRect.height > 0 else { return }
-                if self.lastFrame != screenRect {
-                    self.lastFrame = screenRect
-                    self.onChange?(screenRect)
+                .padding(.horizontal, 22)
+                .padding(.vertical, 20)
+                .allowsHitTesting(false)
+            }
+        }
+        .frame(width: 560, height: 150)
+        .overlay(alignment: .bottomTrailing) {
+            if !text.isEmpty {
+                Button("Clear") {
+                    text = ""
                 }
+                .buttonStyle(.plain)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(OnboardingTheme.muted)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
             }
         }
     }
 }
 
-private extension FirstRunOnboardingStep {
-    var phaseTitle: String {
-        switch self {
-        case .hero, .value:
-            return "Value"
-        case .dictationSetup, .testDictation, .dictationResult:
-            return "Dictation"
-        case .meetingsIntro, .meetingSetup:
-            return "Meetings"
-        case .agentPayoff:
-            return "Agent"
+private struct MiniWaveform: View {
+    let color: Color
+    let width: CGFloat
+    let height: CGFloat
+    private let count = 16
+
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            let t = timeline.date.timeIntervalSinceReferenceDate
+            HStack(alignment: .center, spacing: 1.6) {
+                ForEach(0..<count, id: \.self) { index in
+                    RoundedRectangle(cornerRadius: 1, style: .continuous)
+                        .fill(color)
+                        .frame(width: 2, height: barHeight(index: index, time: t))
+                }
+            }
+            .frame(width: width, height: height)
         }
     }
 
-    var analyticsValue: String {
-        switch self {
-        case .hero:
-            return "hero"
-        case .value:
-            return "value"
-        case .dictationSetup:
-            return "dictation_setup"
-        case .testDictation:
-            return "test_dictation"
-        case .dictationResult:
-            return "dictation_result"
-        case .meetingsIntro:
-            return "meetings_intro"
-        case .meetingSetup:
-            return "meeting_setup"
-        case .agentPayoff:
-            return "agent_payoff"
+    private func barHeight(index: Int, time: TimeInterval) -> CGFloat {
+        let center = Double(count - 1) / 2.0
+        let norm = abs((Double(index) - center) / center)
+        let envelope = 1.0 - norm * 0.55
+        let wave = abs(sin(time * 4.0 + Double(index) * 0.58))
+        return CGFloat(max(3.0, wave * 14.0 * envelope + 2.0))
+    }
+}
+
+private struct DualStreamVisual: View {
+    let systemReady: Bool
+
+    var body: some View {
+        VStack(spacing: 22) {
+            StreamCard(label: "You", subtitle: "Mic", color: Color(red: 0.55, green: 0.65, blue: 1.0), active: true)
+            StreamCard(label: "Everyone else", subtitle: "System audio", color: Color(red: 1.0, green: 0.70, blue: 0.55), active: systemReady)
+            Text("-> local transcript with speaker labels")
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .kerning(1.2)
+                .textCase(.uppercase)
+                .foregroundStyle(OnboardingTheme.muted)
+        }
+        .frame(width: 380)
+    }
+}
+
+private struct StreamCard: View {
+    let label: String
+    let subtitle: String
+    let color: Color
+    let active: Bool
+
+    var body: some View {
+        HStack(spacing: 14) {
+            ZStack {
+                Circle()
+                    .fill(color.opacity(active ? 1 : 0.25))
+                    .frame(width: 32, height: 32)
+                Text(String(label.prefix(1)))
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(OnboardingTheme.ink)
+            }
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(label)
+                    .font(.system(size: 13.5, weight: .semibold))
+                Text(subtitle)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(OnboardingTheme.muted)
+            }
+
+            Spacer()
+            MiniWaveform(color: OnboardingTheme.ink.opacity(active ? 0.85 : 0.25), width: 80, height: 22)
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
+        .background(OnboardingTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(OnboardingTheme.border, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.04), radius: 14, y: 6)
+    }
+}
+
+private struct MeetingDemoCard: View {
+    private let lines = [
+        ("00:00", "You", "Thanks for making time today."),
+        ("00:04", "Alex", "Happy to help. Let's get started."),
+        ("00:08", "You", "Can you walk me through the rollout plan?"),
+        ("00:13", "Alex", "Sure. We staged it in three regions.")
+    ]
+
+    var body: some View {
+        MiniWindow(title: "Transcript.md") {
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(lines, id: \.0) { time, speaker, text in
+                    HStack(alignment: .top, spacing: 10) {
+                        Text(time)
+                            .font(.system(size: 10, weight: .medium, design: .monospaced))
+                            .foregroundStyle(OnboardingTheme.muted)
+                            .frame(width: 42, alignment: .leading)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(speaker)
+                                .font(.system(size: 12, weight: .semibold))
+                            Text(text)
+                                .font(.system(size: 12))
+                                .foregroundStyle(OnboardingTheme.body)
+                        }
+                    }
+                }
+            }
+            .padding(18)
+        }
+        .frame(width: 380, height: 250)
+    }
+}
+
+private struct ToggleCard: View {
+    let title: String
+    let detail: String
+    @Binding var isOn: Bool
+
+    var body: some View {
+        HStack(spacing: 14) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.system(size: 14, weight: .semibold))
+                Text(detail)
+                    .font(.system(size: 12))
+                    .lineSpacing(2)
+                    .foregroundStyle(OnboardingTheme.muted)
+            }
+            Spacer()
+            Toggle("", isOn: $isOn)
+                .toggleStyle(.switch)
+                .labelsHidden()
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .background(OnboardingTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(OnboardingTheme.border, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.04), radius: 12, y: 6)
+    }
+}
+
+private struct CalendarMock: View {
+    let connected: Bool
+    private let events = [
+        ("10:00", "Design review", "45m", Color(red: 0.55, green: 0.65, blue: 1.0)),
+        ("11:30", "Team sync", "30m", Color(red: 1.0, green: 0.70, blue: 0.55)),
+        ("02:00", "1:1 with Priya", "30m", Color(red: 0.55, green: 0.90, blue: 0.76))
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Today")
+                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                .kerning(1.8)
+                .foregroundStyle(OnboardingTheme.muted)
+                .textCase(.uppercase)
+
+            VStack(spacing: 10) {
+                ForEach(events, id: \.1) { time, name, duration, color in
+                    HStack(spacing: 12) {
+                        RoundedRectangle(cornerRadius: 2, style: .continuous)
+                            .fill(color)
+                            .frame(width: 3, height: 32)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(name)
+                                .font(.system(size: 13, weight: .semibold))
+                            Text("\(time) - \(duration)")
+                                .font(.system(size: 11, design: .monospaced))
+                                .foregroundStyle(OnboardingTheme.muted)
+                        }
+                        Spacer()
+                        if connected {
+                            Text("prompt")
+                                .font(.system(size: 10, design: .monospaced))
+                                .foregroundStyle(OnboardingTheme.muted)
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+                    .background(connected ? OnboardingTheme.cardSoft : Color.clear)
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .opacity(connected ? 1 : 0.45)
+                }
+            }
+        }
+        .padding(20)
+        .frame(width: 340)
+        .background(OnboardingTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(OnboardingTheme.border, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.08), radius: 24, y: 12)
+    }
+}
+
+private struct MemoryFlowVisual: View {
+    var body: some View {
+        HStack(spacing: 14) {
+            VStack(spacing: 10) {
+                MemorySourceCard(
+                    label: "Dictation",
+                    title: "Voice notes",
+                    detail: "Ship notes from today"
+                )
+                MemorySourceCard(
+                    label: "Meeting",
+                    title: "Transcript",
+                    detail: "Alex: rollout in 3 regions"
+                )
+            }
+
+            MemoryConnector(label: "saved")
+
+            MemoryIndexCard()
+
+            MemoryConnector(label: "ask")
+
+            VStack(spacing: 10) {
+                MemoryQuestionCard(text: "What did Alex decide?")
+                MemoryQuestionCard(text: "Find the launch notes")
+                MemoryQuestionCard(text: "Summarize last Tuesday")
+            }
+            .frame(width: 170)
+        }
+        .frame(width: 720, height: 210)
+    }
+}
+
+private struct MemorySourceCard: View {
+    let label: String
+    let title: String
+    let detail: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .kerning(1.4)
+                .foregroundStyle(OnboardingTheme.muted)
+                .textCase(.uppercase)
+            Text(title)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(OnboardingTheme.ink)
+            Text(detail)
+                .font(.system(size: 11))
+                .foregroundStyle(OnboardingTheme.muted)
+                .lineLimit(1)
+        }
+        .padding(14)
+        .frame(width: 158, height: 84, alignment: .leading)
+        .background(OnboardingTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(OnboardingTheme.border, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.04), radius: 12, y: 6)
+    }
+}
+
+private struct MemoryConnector: View {
+    let label: String
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text(label)
+                .font(.system(size: 9, weight: .semibold, design: .monospaced))
+                .kerning(1.2)
+                .foregroundStyle(OnboardingTheme.muted)
+                .textCase(.uppercase)
+            Canvas { context, size in
+                var path = Path()
+                path.move(to: CGPoint(x: 0, y: size.height / 2))
+                path.addCurve(
+                    to: CGPoint(x: size.width, y: size.height / 2),
+                    control1: CGPoint(x: size.width * 0.34, y: 0),
+                    control2: CGPoint(x: size.width * 0.66, y: size.height)
+                )
+                context.stroke(
+                    path,
+                    with: .color(OnboardingTheme.ink.opacity(0.28)),
+                    style: StrokeStyle(lineWidth: 1.3, dash: [3, 4])
+                )
+            }
+            .frame(width: 58, height: 34)
+        }
+        .frame(width: 64)
+    }
+}
+
+private struct MemoryIndexCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("LOCAL MEMORY")
+                        .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                        .kerning(1.4)
+                        .foregroundStyle(OnboardingTheme.muted)
+                    Text("on your Mac")
+                        .font(.system(size: 11))
+                        .foregroundStyle(OnboardingTheme.body)
+                }
+                Spacer()
+                Circle()
+                    .fill(OnboardingTheme.codex)
+                    .frame(width: 10, height: 10)
+            }
+
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(OnboardingTheme.muted)
+                Text("search voice history")
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(OnboardingTheme.ink)
+                Spacer()
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 34)
+            .background(OnboardingTheme.cardSoft)
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 8) {
+                MemoryTagRow(label: "decisions", value: "18")
+                MemoryTagRow(label: "people", value: "42")
+                MemoryTagRow(label: "dates", value: "all local")
+            }
+        }
+        .padding(16)
+        .frame(width: 210, height: 174)
+        .background(OnboardingTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(OnboardingTheme.ink.opacity(0.18), lineWidth: 1.3)
+        )
+        .shadow(color: .black.opacity(0.08), radius: 22, y: 12)
+    }
+}
+
+private struct MemoryTagRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(OnboardingTheme.body)
+            Spacer()
+            Text(value)
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(OnboardingTheme.muted)
         }
     }
 }
 
-private extension String {
-    var analyticsSlug: String {
-        lowercased()
-            .replacingOccurrences(of: " ", with: "_")
-            .replacingOccurrences(of: "-", with: "_")
-            .filter { $0.isLetter || $0.isNumber || $0 == "_" }
+private struct MemoryQuestionCard: View {
+    let text: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(OnboardingTheme.claude)
+                .frame(width: 7, height: 7)
+            Text(text)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(OnboardingTheme.ink)
+                .lineLimit(1)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 42)
+        .background(OnboardingTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(OnboardingTheme.border, lineWidth: 1)
+        )
+    }
+}
+
+private struct AgentDemoCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            ChatBubble(role: "You", text: "What did Alex say last Tuesday?")
+            ChatBubble(role: "Agent", text: "Alex wanted the rollout staged in three regions. Source: Design review transcript.", accent: OnboardingTheme.codex)
+            HStack(spacing: 8) {
+                Image(systemName: "quote.bubble")
+                Text("Cited from your local transcript")
+            }
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(OnboardingTheme.muted)
+        }
+        .padding(18)
+        .frame(width: 380)
+        .background(OnboardingTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(OnboardingTheme.border, lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.06), radius: 20, y: 10)
+    }
+}
+
+private struct ChatBubble: View {
+    let role: String
+    let text: String
+    var accent: Color = OnboardingTheme.ink
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(role)
+                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                .kerning(1.2)
+                .foregroundStyle(OnboardingTheme.muted)
+                .textCase(.uppercase)
+            Text(text)
+                .font(.system(size: 13))
+                .lineSpacing(2)
+                .foregroundStyle(OnboardingTheme.body)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(accent.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+    }
+}
+
+private struct ConnectAgentStage: View {
+    let copiedItem: AgentCopyItem?
+    let onCopy: (AgentCopyItem) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Kicker("Connect an agent")
+            Headline(primary: "Give your agent a memory.", size: 42, alignment: .leading)
+
+            HStack(spacing: 16) {
+                AgentOptionCard(
+                    eyebrow: "Option 1 - Start here",
+                    title: "Claude Desktop",
+                    detail: "Copy one prompt for Claude Desktop. It can use Transcripted MCP when available, or fall back to local folders.",
+                    glyph: "◆",
+                    color: OnboardingTheme.claude,
+                    buttonTitle: copiedItem == .claudePrompt ? "Copied" : "Copy prompt"
+                ) {
+                    onCopy(.claudePrompt)
+                }
+
+                AgentOptionCard(
+                    eyebrow: "Option 2 - Other apps",
+                    title: "OpenClaw, Claude Code, Codex",
+                    detail: "Copy one MCP config for OpenClaw, Claude Code, Codex, and other tools that can read local MCP config.",
+                    glyph: "●",
+                    color: OnboardingTheme.codex,
+                    buttonTitle: copiedItem == .mcpConfig ? "Copied" : "Copy config"
+                ) {
+                    onCopy(.mcpConfig)
+                }
+            }
+            .frame(height: 300)
+            .padding(.top, 28)
+
+            Text("Or skip. Everything still works without an agent.")
+                .font(.system(size: 12))
+                .italic()
+                .foregroundStyle(OnboardingTheme.muted)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.top, 12)
+        }
+        .padding(.horizontal, 60)
+        .padding(.vertical, 34)
+    }
+}
+
+private struct AgentOptionCard: View {
+    let eyebrow: String
+    let title: String
+    let detail: String
+    let glyph: String
+    let color: Color
+    let buttonTitle: String
+    var inverted = false
+    let action: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(eyebrow.uppercased())
+                .font(.system(size: 10.5, weight: .semibold, design: .monospaced))
+                .kerning(2)
+                .foregroundStyle(inverted ? OnboardingTheme.window.opacity(0.62) : OnboardingTheme.muted)
+
+            HStack(spacing: 12) {
+                AgentGlyph(glyph: glyph, color: color)
+                Text(title)
+                    .font(.system(size: 20, weight: .semibold))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Text(detail)
+                .font(.system(size: 13))
+                .lineSpacing(3)
+                .foregroundStyle(inverted ? OnboardingTheme.window.opacity(0.72) : OnboardingTheme.body)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer()
+
+            Button(buttonTitle) {
+                action()
+            }
+            .buttonStyle(InkButtonStyle(isSubtle: inverted))
+        }
+        .foregroundStyle(inverted ? OnboardingTheme.window : OnboardingTheme.ink)
+        .padding(22)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(inverted ? OnboardingTheme.ink : OnboardingTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(OnboardingTheme.border, lineWidth: 1)
+        )
+    }
+}
+
+private struct AgentGlyph: View {
+    let glyph: String
+    let color: Color
+    var size: CGFloat = 36
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: size * 0.22, style: .continuous)
+                .fill(color)
+                .frame(width: size, height: size)
+            Text(glyph)
+                .font(.system(size: size * 0.48, weight: .bold))
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+private struct ThreeActionsRecap: View {
+    var body: some View {
+        HStack(spacing: 14) {
+            ActionStepCard(
+                number: "1",
+                title: "Dictate",
+                command: "Right Option",
+                detail: "Tap once to talk. Tap again to paste.",
+                color: OnboardingTheme.codex,
+                icon: "keyboard"
+            )
+            ActionStepCard(
+                number: "2",
+                title: "Record",
+                command: "Option-M",
+                detail: "Start or stop a meeting recording.",
+                color: OnboardingTheme.recording,
+                icon: "record.circle"
+            )
+            ActionStepCard(
+                number: "3",
+                title: "Ask",
+                command: "Ask your agent",
+                detail: "Use your saved voice memory as context.",
+                color: OnboardingTheme.claude,
+                icon: "magnifyingglass"
+            )
+        }
+    }
+}
+
+private struct ActionStepCard: View {
+    let number: String
+    let label: String
+    let command: String
+    let detail: String
+    let color: Color
+    let icon: String
+
+    init(number: String, title: String, command: String, detail: String, color: Color, icon: String) {
+        self.number = number
+        self.label = title
+        self.command = command
+        self.detail = detail
+        self.color = color
+        self.icon = icon
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(number)
+                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(OnboardingTheme.window)
+                    .frame(width: 26, height: 26)
+                    .background(Circle().fill(color))
+                Spacer()
+                Image(systemName: icon)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(color)
+            }
+
+            Text(label.uppercased())
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .kerning(1.8)
+                .foregroundStyle(OnboardingTheme.muted)
+
+            Text(command)
+                .font(.system(size: 17, weight: .semibold, design: .monospaced))
+                .foregroundStyle(OnboardingTheme.ink)
+                .lineLimit(1)
+
+            Text(detail)
+                .font(.system(size: 11.5))
+                .foregroundStyle(OnboardingTheme.body)
+                .lineSpacing(2)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+        .frame(width: 190, height: 150, alignment: .leading)
+        .background(OnboardingTheme.card)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(OnboardingTheme.border, lineWidth: 1)
+        )
+        .shadow(color: color.opacity(0.12), radius: 18, y: 10)
     }
 }

--- a/Sources/UI/Settings/TranscriptedOnboardingWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedOnboardingWindowController.swift
@@ -16,8 +16,8 @@ final class TranscriptedOnboardingWindowController: NSWindowController {
             contentRect: NSRect(
                 x: 0,
                 y: 0,
-                width: MenuTokens.onboardingWindowWidth,
-                height: MenuTokens.onboardingWindowHeight
+                width: PermissionsOnboardingView.preferredSize.width,
+                height: PermissionsOnboardingView.preferredSize.height
             ),
             styleMask: [.titled, .closable, .resizable, .fullSizeContentView],
             backing: .buffered,
@@ -28,7 +28,7 @@ final class TranscriptedOnboardingWindowController: NSWindowController {
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = true
         window.isReleasedWhenClosed = false
-        window.minSize = NSSize(width: MenuTokens.onboardingWindowWidth, height: 680)
+        window.minSize = PermissionsOnboardingView.preferredSize
         window.contentViewController = hostingController
         window.center()
         window.standardWindowButton(.miniaturizeButton)?.isHidden = true


### PR DESCRIPTION
## Summary

- Restacks the reviewed onboarding redesign onto current `origin/main` / Transcripted `1.1.19`.
- Replaces the older dark first-run flow with the lighter carousel-style onboarding the user reviewed.
- Carries over the requested copy and UX changes: Right Option dictation demo, clearer meeting/system-audio explanation, combined calendar reminders, richer memory payoff, simplified agent options, and Dictate / Record / Ask recap.
- Updates the onboarding window size to match the redesigned 960x680 experience.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` — 819 passed, 0 failed
- Verified built app bundle reports `CFBundleShortVersionString` / `CFBundleVersion` as `1.1.19`.
- Launched `/Users/redbars/.codex/worktrees/transcripted-onboarding-current/build/Transcripted.app` after resetting onboarding completion.
