### PR TITLE
[codex] Improve settings performance refreshes

### DIFF
--- a/Sources/Dictation/DictationTranscriptStore.swift
+++ b/Sources/Dictation/DictationTranscriptStore.swift
@@ -9,7 +9,7 @@ extension Notification.Name {
     static let dictationNoSpeechDetected = Notification.Name("Transcripted.DictationNoSpeechDetected")
 }
 
-struct SavedDictationEntry: Identifiable {
+struct SavedDictationEntry: Identifiable, Sendable {
     let url: URL
     let title: String
     let text: String
@@ -35,6 +35,7 @@ enum DictationTranscriptStore {
 
         return [fractional, standard]
     }()
+    private static let iso8601FormatterQueue = DispatchQueue(label: "Transcripted.DictationTranscriptStore.iso8601Formatters")
 
     @discardableResult
     static func save(
@@ -233,12 +234,13 @@ enum DictationTranscriptStore {
             return nil
         }
 
-        for formatter in iso8601Formatters {
-            if let parsed = formatter.date(from: value) {
-                return parsed
+        return iso8601FormatterQueue.sync { () -> Date? in
+            for formatter in iso8601Formatters {
+                if let parsed = formatter.date(from: value) {
+                    return parsed
+                }
             }
+            return nil
         }
-
-        return nil
     }
 }

--- a/Sources/Dictation/DictationTranscriptWriter.swift
+++ b/Sources/Dictation/DictationTranscriptWriter.swift
@@ -4,12 +4,12 @@
 import AppKit
 import Foundation
 
-struct SavedDictationTranscript {
+struct SavedDictationTranscript: Sendable {
     let url: URL
     let title: String
 }
 
-enum DictationDelivery: String {
+enum DictationDelivery: String, Sendable {
     case pasted
     case copied
     case failed

--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -27,6 +27,7 @@ enum MeetingTranscriptStyler {
         formatter.timeStyle = .short
         return formatter
     }()
+    private static let formatterQueue = DispatchQueue(label: "Transcripted.MeetingTranscriptStyler.formatters")
 
     static func restyleTranscript(at url: URL) -> StyledMeetingTranscript {
         styledTranscript(at: url, persistChanges: true)
@@ -150,7 +151,7 @@ enum MeetingTranscriptStyler {
     private static func parseRecordedAt(values: [String: String], fallbackURL: URL) -> Date {
         if let date = values["date"],
            let time = values["time"],
-           let parsed = parseFormatter.date(from: "\(date) \(time)") {
+           let parsed = parsedRecordedAt(from: "\(date) \(time)") {
             return parsed
         }
 
@@ -187,7 +188,7 @@ enum MeetingTranscriptStyler {
 
     private static func renderBody(document: ParsedDocument, title: String) -> String {
         var detailParts = [
-            "Recorded \(detailFormatter.string(from: document.recordedAt))",
+            "Recorded \(detailString(from: document.recordedAt))",
             formatDuration(document.durationSeconds, fallback: document.duration)
         ]
         if document.totalWords > 0 {
@@ -256,7 +257,25 @@ enum MeetingTranscriptStyler {
             return "Quick notes"
         }
 
-        return titleFormatter.string(from: document.recordedAt)
+        return titleString(from: document.recordedAt)
+    }
+
+    private static func parsedRecordedAt(from value: String) -> Date? {
+        formatterQueue.sync {
+            parseFormatter.date(from: value)
+        }
+    }
+
+    private static func titleString(from date: Date) -> String {
+        formatterQueue.sync {
+            titleFormatter.string(from: date)
+        }
+    }
+
+    private static func detailString(from date: Date) -> String {
+        formatterQueue.sync {
+            detailFormatter.string(from: date)
+        }
     }
 
     private static func parseDurationSeconds(_ duration: String) -> Int {

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -80,6 +80,20 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
     private let speakerDatabase: SpeakerDatabase
     private let preferredClipsDirectory: URL
     private let legacyClipsDirectory: URL
+    private(set) var duplicateCandidates: [SpeakerDuplicateCandidate] = []
+    private var duplicateProfileIDs: Set<UUID> = []
+    private var duplicateCountsByProfileID: [UUID: Int] = [:]
+    private var mergeTargetsByProfileID: [UUID: [SpeakerProfile]] = [:]
+    private var clipURLsByProfileID: [UUID: URL] = [:]
+
+    private struct Snapshot {
+        let profiles: [SpeakerProfile]
+        let duplicateCandidates: [SpeakerDuplicateCandidate]
+        let duplicateProfileIDs: Set<UUID>
+        let duplicateCountsByProfileID: [UUID: Int]
+        let mergeTargetsByProfileID: [UUID: [SpeakerProfile]]
+        let clipURLsByProfileID: [UUID: URL]
+    }
 
     init(
         speakerDatabase: SpeakerDatabase,
@@ -90,10 +104,6 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         self.preferredClipsDirectory = preferredClipsDirectory
         self.legacyClipsDirectory = legacyClipsDirectory
         refresh()
-    }
-
-    var duplicateCandidates: [SpeakerDuplicateCandidate] {
-        Self.duplicateCandidates(from: profiles)
     }
 
     var filteredProfiles: [SpeakerProfile] {
@@ -124,31 +134,24 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         }
     }
 
-    var duplicateProfileIDs: Set<UUID> {
-        var ids = Set<UUID>()
-        for candidate in duplicateCandidates {
-            ids.insert(candidate.source.id)
-            ids.insert(candidate.target.id)
-        }
-        return ids
-    }
-
     func refresh() {
         let speakerDatabase = self.speakerDatabase
+        let preferredClipsDirectory = self.preferredClipsDirectory
+        let legacyClipsDirectory = self.legacyClipsDirectory
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            let profiles = Self.sortedProfiles(from: speakerDatabase)
+            let snapshot = Self.snapshot(
+                from: speakerDatabase,
+                preferredClipsDirectory: preferredClipsDirectory,
+                legacyClipsDirectory: legacyClipsDirectory
+            )
             DispatchQueue.main.async {
-                self?.profiles = profiles
+                self?.applySnapshot(snapshot)
             }
         }
     }
 
     func clipURL(for speakerId: UUID) -> URL? {
-        Self.clipURL(
-            for: speakerId,
-            preferredClipsDirectory: preferredClipsDirectory,
-            legacyClipsDirectory: legacyClipsDirectory
-        )
+        clipURLsByProfileID[speakerId]
     }
 
     func playSample(for speakerId: UUID) {
@@ -162,13 +165,19 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
 
         let profileId = profile.id
         let speakerDatabase = self.speakerDatabase
+        let preferredClipsDirectory = self.preferredClipsDirectory
+        let legacyClipsDirectory = self.legacyClipsDirectory
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             speakerDatabase.setDisplayName(id: profileId, name: trimmed, source: NameSource.userManual)
             speakerDatabase.resetDisputeCount(id: profileId)
             TranscriptSaver.retroactivelyUpdateSpeaker(dbId: profileId, newName: trimmed)
-            let profiles = Self.sortedProfiles(from: speakerDatabase)
+            let snapshot = Self.snapshot(
+                from: speakerDatabase,
+                preferredClipsDirectory: preferredClipsDirectory,
+                legacyClipsDirectory: legacyClipsDirectory
+            )
             DispatchQueue.main.async {
-                self?.profiles = profiles
+                self?.applySnapshot(snapshot)
             }
         }
     }
@@ -204,9 +213,13 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
                 ?? "Speaker \(targetId.uuidString.prefix(8))"
 
             TranscriptSaver.retroactivelyUpdateSpeaker(dbId: sourceId, newName: resolvedName)
-            let profiles = Self.sortedProfiles(from: speakerDatabase)
+            let snapshot = Self.snapshot(
+                from: speakerDatabase,
+                preferredClipsDirectory: preferredClipsDirectory,
+                legacyClipsDirectory: legacyClipsDirectory
+            )
             DispatchQueue.main.async {
-                self?.profiles = profiles
+                self?.applySnapshot(snapshot)
             }
         }
     }
@@ -224,27 +237,105 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
                 preferredClipsDirectory: preferredClipsDirectory,
                 legacyClipsDirectory: legacyClipsDirectory
             )
-            let profiles = Self.sortedProfiles(from: speakerDatabase)
+            let snapshot = Self.snapshot(
+                from: speakerDatabase,
+                preferredClipsDirectory: preferredClipsDirectory,
+                legacyClipsDirectory: legacyClipsDirectory
+            )
             DispatchQueue.main.async {
-                self?.profiles = profiles
+                self?.applySnapshot(snapshot)
             }
         }
     }
 
     func duplicateCount(for profile: SpeakerProfile) -> Int {
-        duplicateCandidates.filter { candidate in
-            candidate.source.id == profile.id || candidate.target.id == profile.id
-        }.count
+        duplicateCountsByProfileID[profile.id] ?? 0
     }
 
     func mergeTargets(for profile: SpeakerProfile) -> [SpeakerProfile] {
-        let duplicatePeerIds = Set(duplicateCandidates.compactMap { candidate -> UUID? in
-            if candidate.source.id == profile.id { return candidate.target.id }
-            if candidate.target.id == profile.id { return candidate.source.id }
-            return nil
-        })
+        mergeTargetsByProfileID[profile.id] ?? []
+    }
 
-        return profiles.filter { $0.id != profile.id }.sorted { lhs, rhs in
+    private func applySnapshot(_ snapshot: Snapshot) {
+        duplicateCandidates = snapshot.duplicateCandidates
+        duplicateProfileIDs = snapshot.duplicateProfileIDs
+        duplicateCountsByProfileID = snapshot.duplicateCountsByProfileID
+        mergeTargetsByProfileID = snapshot.mergeTargetsByProfileID
+        clipURLsByProfileID = snapshot.clipURLsByProfileID
+        profiles = snapshot.profiles
+    }
+
+    nonisolated private static func snapshot(
+        from speakerDatabase: SpeakerDatabase,
+        preferredClipsDirectory: URL,
+        legacyClipsDirectory: URL
+    ) -> Snapshot {
+        snapshot(
+            from: sortedProfiles(from: speakerDatabase),
+            preferredClipsDirectory: preferredClipsDirectory,
+            legacyClipsDirectory: legacyClipsDirectory
+        )
+    }
+
+    nonisolated private static func snapshot(
+        from profiles: [SpeakerProfile],
+        preferredClipsDirectory: URL,
+        legacyClipsDirectory: URL
+    ) -> Snapshot {
+        let duplicateCandidates = duplicateCandidates(from: profiles)
+        var duplicateCountsByProfileID: [UUID: Int] = [:]
+        var duplicatePeerIDsByProfileID: [UUID: Set<UUID>] = [:]
+
+        for candidate in duplicateCandidates {
+            let sourceID = candidate.source.id
+            let targetID = candidate.target.id
+            duplicateCountsByProfileID[sourceID, default: 0] += 1
+            duplicateCountsByProfileID[targetID, default: 0] += 1
+            duplicatePeerIDsByProfileID[sourceID, default: []].insert(targetID)
+            duplicatePeerIDsByProfileID[targetID, default: []].insert(sourceID)
+        }
+
+        let duplicateProfileIDs = Set(duplicateCountsByProfileID.keys)
+        let mergeTargetsByProfileID = Dictionary(
+            uniqueKeysWithValues: profiles.map { profile in
+                (
+                    profile.id,
+                    sortedMergeTargets(
+                        for: profile,
+                        in: profiles,
+                        duplicatePeerIds: duplicatePeerIDsByProfileID[profile.id] ?? []
+                    )
+                )
+            }
+        )
+
+        var clipURLsByProfileID: [UUID: URL] = [:]
+        for profile in profiles {
+            if let url = clipURL(
+                for: profile.id,
+                preferredClipsDirectory: preferredClipsDirectory,
+                legacyClipsDirectory: legacyClipsDirectory
+            ) {
+                clipURLsByProfileID[profile.id] = url
+            }
+        }
+
+        return Snapshot(
+            profiles: profiles,
+            duplicateCandidates: duplicateCandidates,
+            duplicateProfileIDs: duplicateProfileIDs,
+            duplicateCountsByProfileID: duplicateCountsByProfileID,
+            mergeTargetsByProfileID: mergeTargetsByProfileID,
+            clipURLsByProfileID: clipURLsByProfileID
+        )
+    }
+
+    nonisolated private static func sortedMergeTargets(
+        for profile: SpeakerProfile,
+        in profiles: [SpeakerProfile],
+        duplicatePeerIds: Set<UUID>
+    ) -> [SpeakerProfile] {
+        profiles.filter { $0.id != profile.id }.sorted { lhs, rhs in
             let lhsIsDuplicate = duplicatePeerIds.contains(lhs.id)
             let rhsIsDuplicate = duplicatePeerIds.contains(rhs.id)
             if lhsIsDuplicate != rhsIsDuplicate {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -45,8 +45,9 @@ struct TranscriptedSettingsView: View {
     @State private var sentryTestStatus: String?
     @State private var permissionStates = PermissionSnapshot.current()
     @State private var captureLibraryURL = FileManager.default.transcriptedCaptureLibraryDir
-    @State private var recentMeetings = RecentMeetingsScanner.loadRecent(limit: 5)
-    @State private var recentDictations = DictationTranscriptStore.recentSavedDictations(limit: 5)
+    @State private var recentMeetings: [RecentMeetingItem] = []
+    @State private var recentDictations: [SavedDictationEntry] = []
+    @State private var recentCaptureRefreshTask: Task<Void, Never>?
     @State private var menuBarItemVisibility = MenuBarVisibilityPreferences.snapshot()
     @State private var showSupportFolders = false
     @State private var copiedAgentMeetingID: String?
@@ -141,6 +142,10 @@ struct TranscriptedSettingsView: View {
             refreshPermissions()
             refreshRecentCaptures()
             refreshShortcutState()
+        }
+        .onDisappear {
+            recentCaptureRefreshTask?.cancel()
+            recentCaptureRefreshTask = nil
         }
     }
 
@@ -1254,8 +1259,13 @@ struct TranscriptedSettingsView: View {
     }
 
     private func refreshRecentCaptures() {
-        recentMeetings = RecentMeetingsScanner.loadRecent(limit: 5)
-        recentDictations = DictationTranscriptStore.recentSavedDictations(limit: 5)
+        recentCaptureRefreshTask?.cancel()
+        recentCaptureRefreshTask = Task { @MainActor in
+            let snapshot = await RecentCaptureLoader.load(limit: 5)
+            guard !Task.isCancelled else { return }
+            recentMeetings = snapshot.meetings
+            recentDictations = snapshot.dictations
+        }
     }
 
     private func refreshShortcutState() {

--- a/Sources/UI/Shared/MeetingAudioArchiveResolver.swift
+++ b/Sources/UI/Shared/MeetingAudioArchiveResolver.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct MeetingAudioAttachment: Equatable {
+struct MeetingAudioAttachment: Equatable, Sendable {
     let directoryURL: URL
     let urls: [URL]
 

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct RecentMeetingItem: Identifiable {
+struct RecentMeetingItem: Identifiable, Sendable {
     let title: String
     let date: Date
     let transcriptURL: URL
@@ -9,7 +9,22 @@ struct RecentMeetingItem: Identifiable {
     var id: String { transcriptURL.path }
 }
 
-@MainActor
+struct RecentCaptureSnapshot: Sendable {
+    let meetings: [RecentMeetingItem]
+    let dictations: [SavedDictationEntry]
+}
+
+enum RecentCaptureLoader {
+    static func load(limit: Int = 5) async -> RecentCaptureSnapshot {
+        await Task.detached(priority: .utility) {
+            RecentCaptureSnapshot(
+                meetings: RecentMeetingsScanner.loadRecent(limit: limit),
+                dictations: DictationTranscriptStore.recentSavedDictations(limit: limit)
+            )
+        }.value
+    }
+}
+
 enum RecentMeetingsScanner {
     private static let excludedMarkdownFilenames: Set<String> = ["AGENT.md", "CLAUDE.md"]
 


### PR DESCRIPTION
## Summary

- Move recent meeting and dictation capture loading off the main Settings render path.
- Guard shared transcript date formatters so background parsing stays safe.
- Cache People settings duplicate candidates, duplicate counts, merge targets, and clip URLs in the view model instead of recomputing them from SwiftUI rows.

## Why

Settings was doing file scans and repeated speaker duplicate analysis from UI-facing paths. That can make the Settings window feel heavier as capture history and saved speakers grow.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`