### PR TITLE
Harden release QA reliability paths

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -230,6 +230,7 @@ final class MeetingSessionController: ObservableObject {
             speakerStore: services.speakerStore,
             speakerClipsDirectory: storagePaths.speakerClips,
             retainedAudioDirectory: MeetingStoragePaths.audioArchiveFolder,
+            retainedAudioDirectoryProvider: { MeetingStoragePaths.audioArchiveFolder },
             statsStore: statsDatabase
         )
 
@@ -772,6 +773,44 @@ final class MeetingSessionController: ObservableObject {
         )
     }
 
+    func prepareForTermination() async {
+        guard case .recording = state else { return }
+        guard !isFinishingRecording else { return }
+        isFinishingRecording = true
+        defer { isFinishingRecording = false }
+
+        _ = audioInactivityDetector.stopRecording()
+        audioInactivityWarning = nil
+
+        let recordingTrigger = activeRecordingTrigger
+        let files = await capture.stopAndAwaitFiles()
+        activeRecordingTrigger = .unknown
+
+        if let micURL = files.micURL {
+            failedManager.addFailedTranscription(
+                micAudioURL: micURL,
+                systemAudioURL: files.systemURL,
+                errorMessage: "Transcripted quit before this meeting could be transcribed."
+            )
+            refreshFailedMeetings()
+        }
+
+        state = .ready
+        DiagnosticsTrail.record(
+            level: .warning,
+            engine: "meeting",
+            event: "meeting_recording_saved_for_shutdown",
+            message: "Meeting recording was preserved during app termination",
+            context: baseDiagnosticsContext(
+                extra: [
+                    "trigger": recordingTrigger.rawValue,
+                    "mic_file_present": boolString(files.micURL != nil),
+                    "system_file_present": boolString(files.systemURL != nil)
+                ]
+            )
+        )
+    }
+
     func retryFailedMeeting(id: UUID) {
         guard !isRecording, !hasBackgroundTranscriptionWork else { return }
         guard !retryingFailedMeetingIDs.contains(id) else { return }
@@ -784,7 +823,7 @@ final class MeetingSessionController: ObservableObject {
             guard let self else { return }
             _ = await self.taskManager.retryFailedTranscription(
                 failedId: id,
-                outputFolder: self.storagePaths.transcripts
+                outputFolder: MeetingStoragePaths.transcriptsFolder
             )
             self.retryingFailedMeetingIDs.remove(id)
             self.refreshFailedMeetings()
@@ -1118,14 +1157,14 @@ final class MeetingSessionController: ObservableObject {
             taskManager.startTranscription(
                 micURL: micURL,
                 systemURL: systemURL,
-                outputFolder: storagePaths.transcripts,
+                outputFolder: MeetingStoragePaths.transcriptsFolder,
                 healthInfo: healthInfo,
                 splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()
             )
         case .imported(let audioURL, let suggestedTitle):
             taskManager.startImportedTranscription(
                 audioURL: audioURL,
-                outputFolder: storagePaths.transcripts,
+                outputFolder: MeetingStoragePaths.transcriptsFolder,
                 meetingTitle: suggestedTitle
             )
         }

--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -305,7 +305,7 @@ enum MeetingTranscriptStyler {
         return entries
     }
 
-    private static let transcriptEntryRegex = try? NSRegularExpression(pattern: #"^\[?([0-9:]+)\]?\s+\[(.+?)\](.*)$"#)
+    private static let transcriptTimestampRegex = try? NSRegularExpression(pattern: #"^\[?([0-9:]+)\]?\s+"#)
 
     private static func parseTranscriptEntry(from chunk: String) -> TranscriptEntry? {
         let lines = chunk
@@ -318,24 +318,72 @@ enum MeetingTranscriptStyler {
             .replacingOccurrences(of: "**", with: "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
-        guard let regex = transcriptEntryRegex else {
+        guard let regex = transcriptTimestampRegex else {
             return nil
         }
 
         let nsHeader = normalizedHeader as NSString
         let range = NSRange(location: 0, length: nsHeader.length)
         guard let match = regex.firstMatch(in: normalizedHeader, range: range),
-              match.numberOfRanges >= 4 else {
+              match.numberOfRanges >= 2 else {
             return nil
         }
 
         let timestamp = nsHeader.substring(with: match.range(at: 1))
-        let label = nsHeader.substring(with: match.range(at: 2))
-        let inlineTail = nsHeader.substring(with: match.range(at: 3)).trimmingCharacters(in: .whitespaces)
+        let headerTailStart = normalizedHeader.index(
+            normalizedHeader.startIndex,
+            offsetBy: match.range.location + match.range.length
+        )
+        guard let parsedLabel = parseBracketedSpeakerLabel(in: String(normalizedHeader[headerTailStart...])) else {
+            return nil
+        }
+
+        let label = parsedLabel.label
+        let inlineTail = parsedLabel.tail.trimmingCharacters(in: .whitespaces)
         let textLines = (inlineTail.isEmpty ? Array(lines.dropFirst()) : [inlineTail] + Array(lines.dropFirst()))
         let text = textLines.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return nil }
         return TranscriptEntry(timestamp: timestamp, label: label, text: text)
+    }
+
+    private static func parseBracketedSpeakerLabel(in value: String) -> (label: String, tail: String)? {
+        let characters = Array(value)
+        guard characters.first == "[" else { return nil }
+
+        var label = ""
+        var index = 1
+        var wikiLinkDepth = 0
+
+        while index < characters.count {
+            let character = characters[index]
+            let next = index + 1 < characters.count ? characters[index + 1] : nil
+
+            if character == "[", next == "[" {
+                wikiLinkDepth += 1
+                label.append(character)
+                label.append(next!)
+                index += 2
+                continue
+            }
+
+            if character == "]", next == "]", wikiLinkDepth > 0 {
+                wikiLinkDepth -= 1
+                label.append(character)
+                label.append(next!)
+                index += 2
+                continue
+            }
+
+            if character == "]", wikiLinkDepth == 0 {
+                let tail = String(characters.dropFirst(index + 1))
+                return (label, tail)
+            }
+
+            label.append(character)
+            index += 1
+        }
+
+        return nil
     }
 
     private static func formatDuration(_ seconds: Int, fallback: String) -> String {

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -64,6 +64,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     @available(macOS 14.0, *)
     lazy var meetingPromptDetector = MeetingPromptDetector()
     private var workspaceObservers: [NSObjectProtocol] = []
+    private var terminationCleanupStarted = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Crash reporting
@@ -191,6 +192,26 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             meetingPromptDetector.stop()
         }
         appState.shutdown()
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard !terminationCleanupStarted else { return .terminateNow }
+        terminationCleanupStarted = true
+
+        Task { @MainActor [weak self, sender] in
+            guard let self else {
+                sender.reply(toApplicationShouldTerminate: true)
+                return
+            }
+
+            await self.sessionController.finishDictationForTermination()
+            if #available(macOS 14.0, *) {
+                await self.appState.meetingSession.prepareForTermination()
+            }
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+
+        return .terminateLater
     }
 
     @objc func togglePopover() {
@@ -331,6 +352,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
 
     private func finishOnboarding() {
         PermissionsOnboardingPreferences.markCompleted()
+        appState.recoverHotkeysAfterPermissionChange()
         onboardingWindowController.dismiss()
         closePopover()
 
@@ -344,6 +366,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     private func finishOnboardingAndStartDictation() {
         let sourceApp = resolvedSourceApp()
         PermissionsOnboardingPreferences.markCompleted()
+        appState.recoverHotkeysAfterPermissionChange()
         onboardingWindowController.dismiss()
         closePopover()
         sourceApp?.activate(options: [])
@@ -423,8 +446,8 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                 "entrypoint": entrypoint,
                 "meeting_recording_ready": TranscriptedPermissionAccess.isGranted(.systemAudioRecording) ? "true" : "false",
                 "model_state": modelState,
-                "paste_available": DictationTranscriptStore.latestSavedDictation() == nil ? "false" : "true",
-                "recent_meetings_available": RecentMeetingsScanner.loadRecent(limit: 1).isEmpty ? "false" : "true",
+                "paste_available": "unknown",
+                "recent_meetings_available": "unknown",
                 "update_state": updateState,
             ]
         )

--- a/Sources/TranscriptedAppState.swift
+++ b/Sources/TranscriptedAppState.swift
@@ -126,6 +126,13 @@ class TranscriptedAppState: ObservableObject {
         )
     }
 
+    func recoverHotkeysAfterPermissionChange() {
+        logger.log("HOTKEY | refreshing hotkeys after onboarding permissions")
+        contextCapture.unregisterHotkey()
+        contextCapture.registerHotkey()
+        contextCapture.refreshShortcutStatus()
+    }
+
     func shutdown() {
         wakeRecoveryCoordinator.cancel()
         runtimeReadinessTask?.cancel()

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -24,6 +24,7 @@ public class TranscriptionTaskManager: ObservableObject {
     public let failedTranscriptionManager: FailedTranscriptionManager
     public let statsStore: (any StatsStore)?
     let retainedAudioDirectory: URL?
+    private let retainedAudioDirectoryProvider: (() -> URL?)?
 
     /// Embedder-supplied notifier for transcript-saved and failure events. Optional — when
     /// `nil`, notification hooks become no-ops, which keeps Core usable from headless contexts
@@ -37,6 +38,7 @@ public class TranscriptionTaskManager: ObservableObject {
         speakerStore: any SpeakerStore,
         speakerClipsDirectory: URL = CoreStoragePaths.default.speakerClips,
         retainedAudioDirectory: URL? = nil,
+        retainedAudioDirectoryProvider: (() -> URL?)? = nil,
         statsStore: (any StatsStore)? = nil,
         notifier: TranscriptNotifier? = nil
     ) {
@@ -44,6 +46,7 @@ public class TranscriptionTaskManager: ObservableObject {
         self.statsStore = statsStore
         self.notifier = notifier
         self.retainedAudioDirectory = retainedAudioDirectory
+        self.retainedAudioDirectoryProvider = retainedAudioDirectoryProvider
         self.transcription = Transcription(
             speechToText: speechToText,
             diarization: diarization,
@@ -458,7 +461,7 @@ public class TranscriptionTaskManager: ObservableObject {
         systemURL: URL?,
         taskId: UUID
     ) {
-        guard let retainedAudioDirectory else { return }
+        guard let retainedAudioDirectory = retainedAudioDirectoryProvider?() ?? retainedAudioDirectory else { return }
 
         let failedStem = "Failed_\(DateFormattingHelper.formatFilename(Date()))_\(String(taskId.uuidString.prefix(8)))"
         let placeholderTranscriptURL = retainedAudioDirectory

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -14,6 +14,9 @@ final class MenuBarPanelController: NSViewController {
 
     private var contentView: MenuBarContentView?
     private var subscriptions = Set<AnyCancellable>()
+    private var latestDictation: SavedDictationEntry?
+    private var latestDictationLoaded = false
+    private var latestDictationTask: Task<Void, Never>?
 
     init(
         appState: TranscriptedAppState,
@@ -63,7 +66,6 @@ final class MenuBarPanelController: NSViewController {
             dictationReady: appState.sttRouter.isModelLoaded,
             meetingsStatus: warmupStatus.meetingsStatus
         )
-        let latestDictation = DictationTranscriptStore.latestSavedDictation()
         let updatePresentation = menuUpdatePresentation(for: appState.sparkleUpdater.updateStatus)
         let menuVisibility = MenuBarVisibilityPreferences.snapshot()
 
@@ -111,6 +113,7 @@ final class MenuBarPanelController: NSViewController {
         content.needsLayout = true
         content.layoutSubtreeIfNeeded()
         preferredContentSize = content.preferredPanelSize
+        refreshLatestDictationIfNeeded()
     }
 
     private func setupSubscriptions() {
@@ -153,6 +156,14 @@ final class MenuBarPanelController: NSViewController {
         NotificationCenter.default.publisher(for: .menuBarVisibilityPreferencesDidChange)
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
+                self?.refresh()
+            }
+            .store(in: &subscriptions)
+
+        NotificationCenter.default.publisher(for: .dictationTranscriptDidSave)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.latestDictationLoaded = false
                 self?.refresh()
             }
             .store(in: &subscriptions)
@@ -216,9 +227,23 @@ final class MenuBarPanelController: NSViewController {
                 "action_id": actionID,
                 "dictation_ready": appState.sttRouter.isModelLoaded ? "true" : "false",
                 "meeting_recording_ready": TranscriptedPermissionAccess.isGranted(.systemAudioRecording) ? "true" : "false",
-                "paste_available": DictationTranscriptStore.latestSavedDictation() == nil ? "false" : "true",
+                "paste_available": latestDictation == nil ? "false" : "true",
             ]
         )
+    }
+
+    private func refreshLatestDictationIfNeeded() {
+        guard !latestDictationLoaded else { return }
+        latestDictationTask?.cancel()
+        latestDictationTask = Task { @MainActor [weak self] in
+            let latest = await Task.detached(priority: .utility) {
+                DictationTranscriptStore.latestSavedDictation()
+            }.value
+            guard let self, !Task.isCancelled else { return }
+            self.latestDictation = latest
+            self.latestDictationLoaded = true
+            self.refresh()
+        }
     }
 
     private func resolvedSourceApp() -> NSRunningApplication? {

--- a/Sources/UI/MenuBar/MenuBarUtilityActionsView.swift
+++ b/Sources/UI/MenuBar/MenuBarUtilityActionsView.swift
@@ -122,7 +122,7 @@ final class MenuBarUtilityActionsView: NSView {
                 "action_id": actionID,
                 "dictation_ready": appState?.sttRouter.isModelLoaded == true ? "true" : "false",
                 "meeting_recording_ready": TranscriptedPermissionAccess.isGranted(.systemAudioRecording) ? "true" : "false",
-                "paste_available": DictationTranscriptStore.latestSavedDictation() == nil ? "false" : "true",
+                "paste_available": "unknown",
             ]
         )
     }

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -652,6 +652,24 @@ class DictationSessionController: ObservableObject {
         )
     }
 
+    func finishDictationForTermination() async {
+        if isInSession {
+            cancelSession()
+        }
+
+        guard isDictating else { return }
+        stopDictationAndPaste(trigger: .unknown)
+
+        for _ in 0..<100 {
+            if !isDictating { return }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        if isDictating {
+            cancelDictation()
+        }
+    }
+
     // MARK: - Private
 
     private func startDictationAfterWarmup(sourceApp: NSRunningApplication?) {

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -85,6 +85,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
     private var duplicateCountsByProfileID: [UUID: Int] = [:]
     private var mergeTargetsByProfileID: [UUID: [SpeakerProfile]] = [:]
     private var clipURLsByProfileID: [UUID: URL] = [:]
+    private var refreshGeneration = 0
 
     private struct Snapshot {
         let profiles: [SpeakerProfile]
@@ -135,6 +136,8 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
     }
 
     func refresh() {
+        refreshGeneration += 1
+        let generation = refreshGeneration
         let speakerDatabase = self.speakerDatabase
         let preferredClipsDirectory = self.preferredClipsDirectory
         let legacyClipsDirectory = self.legacyClipsDirectory
@@ -145,7 +148,8 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
                 legacyClipsDirectory: legacyClipsDirectory
             )
             DispatchQueue.main.async {
-                self?.applySnapshot(snapshot)
+                guard let self, self.refreshGeneration == generation else { return }
+                self.applySnapshot(snapshot)
             }
         }
     }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -47,6 +47,7 @@ struct TranscriptedSettingsView: View {
     @State private var captureLibraryURL = FileManager.default.transcriptedCaptureLibraryDir
     @State private var recentMeetings: [RecentMeetingItem] = []
     @State private var recentDictations: [SavedDictationEntry] = []
+    @State private var recentCapturesLoading = false
     @State private var recentCaptureRefreshTask: Task<Void, Never>?
     @State private var menuBarItemVisibility = MenuBarVisibilityPreferences.snapshot()
     @State private var showSupportFolders = false
@@ -737,7 +738,11 @@ struct TranscriptedSettingsView: View {
                 title: "Recent",
                 detail: "The last five saved meeting transcripts."
             ) {
-                if recentMeetings.isEmpty {
+                if recentCapturesLoading && recentMeetings.isEmpty {
+                    Text("Loading recent meetings...")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if recentMeetings.isEmpty {
                     Text("No meeting transcripts saved yet.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -802,7 +807,11 @@ struct TranscriptedSettingsView: View {
                 title: "Recent",
                 detail: "The newest saved dictations."
             ) {
-                if recentDictations.isEmpty {
+                if recentCapturesLoading && recentDictations.isEmpty {
+                    Text("Loading recent dictations...")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if recentDictations.isEmpty {
                     Text("No dictations saved yet.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -1260,11 +1269,13 @@ struct TranscriptedSettingsView: View {
 
     private func refreshRecentCaptures() {
         recentCaptureRefreshTask?.cancel()
+        recentCapturesLoading = true
         recentCaptureRefreshTask = Task { @MainActor in
             let snapshot = await RecentCaptureLoader.load(limit: 5)
             guard !Task.isCancelled else { return }
             recentMeetings = snapshot.meetings
             recentDictations = snapshot.dictations
+            recentCapturesLoading = false
         }
     }
 

--- a/Tests/MeetingTranscriptStylerTests.swift
+++ b/Tests/MeetingTranscriptStylerTests.swift
@@ -7,6 +7,7 @@ func testMeetingTranscriptStyler() {
         testMeetingTranscriptStylerIsIdempotent()
         testMeetingTranscriptStylerPreservesExplicitTitle()
         testMeetingTranscriptStylerRenamesRetainedAudioDirectory()
+        testMeetingTranscriptStylerPreservesObsidianSpeakerLinks()
     }
 }
 
@@ -96,6 +97,20 @@ private func testMeetingTranscriptStylerRenamesRetainedAudioDirectory() {
     assertFalse(FileManager.default.fileExists(atPath: audioDirectory.path), "Original retained audio directory should be replaced")
 }
 
+private func testMeetingTranscriptStylerPreservesObsidianSpeakerLinks() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Call_2026-04-07_09-14-00.md")
+    try? sampleObsidianTranscript().write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+    let styled = MeetingTranscriptStyler.restyleTranscript(at: transcriptURL)
+    let updatedMarkdown = try? String(contentsOf: styled.url, encoding: .utf8)
+
+    assertTrue(updatedMarkdown?.contains("[System/[[Alex]]]") == true, "Styler should preserve Obsidian speaker links")
+    assertTrue(updatedMarkdown?.contains("Linked speaker text should stay intact.") == true, "Styler should keep the transcript text attached to the right speaker")
+}
+
 private func sampleMeetingTranscript() -> String {
     """
     ---
@@ -136,6 +151,24 @@ private func sampleImportedTranscript() -> String {
 
     **[00:04] [System/Speaker 1]**
     Happy to help.
+    """
+}
+
+private func sampleObsidianTranscript() -> String {
+    """
+    ---
+    date: "2026-04-07"
+    time: "09:14:00"
+    duration: "12:30"
+    total_word_count: "42"
+    mic_utterances: "0"
+    system_utterances: "1"
+    ---
+
+    ## Full Transcript
+
+    **[00:04] [System/[[Alex]]]**
+    Linked speaker text should stay intact.
     """
 }
 

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/CLIPathSecurity.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/CLIPathSecurity.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+enum CLIPathResolutionStatus {
+    case valid(URL)
+    case missing
+    case invalid
+}
+
+enum CLIPathSecurity {
+    static func resolveReadableFile(named requestedName: String, in baseDirectory: URL) -> CLIPathResolutionStatus {
+        let candidateURL = baseDirectory
+            .appendingPathComponent(requestedName)
+            .standardizedFileURL
+        let standardizedBase = baseDirectory.standardizedFileURL
+
+        guard candidateURL.path.hasPrefix(standardizedBase.path + "/") else {
+            return .invalid
+        }
+
+        return validateExistingFile(candidateURL, under: baseDirectory)
+    }
+
+    static func validateExistingFile(_ url: URL, under baseDirectory: URL) -> CLIPathResolutionStatus {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return .missing
+        }
+
+        guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
+              values.isRegularFile == true,
+              values.isSymbolicLink != true else {
+            return .invalid
+        }
+
+        let resolvedBase = baseDirectory.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedURL = url.resolvingSymlinksInPath().standardizedFileURL
+        guard resolvedURL.path == resolvedBase.path || resolvedURL.path.hasPrefix(resolvedBase.path + "/") else {
+            return .invalid
+        }
+
+        return .valid(resolvedURL)
+    }
+}

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -278,9 +278,25 @@ enum CLIContextStore {
 
     static func readDictation(filename: String, entryId: String?, in directories: CLIContextDirectories) throws -> String {
         let requestedName = filename.hasSuffix(".md") ? filename : filename + ".md"
-        guard let markdownURL = directories.dictationDirs
-            .map({ $0.appendingPathComponent(requestedName) })
-            .first(where: { FileManager.default.fileExists(atPath: $0.path) }) else {
+        var invalidPathRequested = false
+        var markdownURL: URL?
+        for directory in directories.dictationDirs {
+            switch CLIPathSecurity.resolveReadableFile(named: requestedName, in: directory) {
+            case .valid(let safeURL):
+                markdownURL = safeURL
+            case .missing:
+                continue
+            case .invalid:
+                invalidPathRequested = true
+            }
+            if markdownURL != nil { break }
+        }
+
+        if invalidPathRequested && markdownURL == nil {
+            throw ValidationError("Invalid dictation filename: \(filename)")
+        }
+
+        guard let markdownURL else {
             throw ValidationError("Dictation not found: \(filename)")
         }
 
@@ -339,7 +355,7 @@ enum CLIContextStore {
     }
 
     private static func loadMeetings(from directory: URL) -> [MeetingRecord] {
-        let files = (try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)) ?? []
+        let files = safeMarkdownFiles(in: directory)
         return files.compactMap { url in
             let filename = url.deletingPathExtension().lastPathComponent
             guard url.pathExtension == "md",
@@ -372,7 +388,7 @@ enum CLIContextStore {
     }
 
     private static func loadDictationDays(from directory: URL) -> [DictationDayRecord] {
-        let files = (try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)) ?? []
+        let files = safeMarkdownFiles(in: directory)
         return files.compactMap { url in
             guard url.pathExtension == "md", url.deletingPathExtension().lastPathComponent.hasPrefix("Dictations_") else { return nil }
             guard let day = loadDictationDay(at: url) else { return nil }
@@ -405,6 +421,22 @@ enum CLIContextStore {
         }
 
         return deduplicated
+    }
+
+    private static func safeMarkdownFiles(in directory: URL) -> [URL] {
+        let files = (try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+
+        return files.compactMap { url in
+            guard url.pathExtension == "md" else { return nil }
+            switch CLIPathSecurity.validateExistingFile(url, under: directory) {
+            case .valid(let safeURL): return safeURL
+            case .missing, .invalid: return nil
+            }
+        }
     }
 
     private static func loadDictationDay(at url: URL) -> (payload: CLIAgentDictationDay, entries: [CLIClientDictationEntry])? {

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -211,6 +211,52 @@ final class ContextStoreTests: XCTestCase {
         XCTAssertEqual(items.first?.title, "Duplicate names")
     }
 
+    func testReadDictationRejectsParentTraversal() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let dictationsDir = root.appendingPathComponent("dictations", isDirectory: true)
+        let outsideDir = root.appendingPathComponent("outside", isDirectory: true)
+        let meetingsDir = root.appendingPathComponent("meetings", isDirectory: true)
+        try FileManager.default.createDirectory(at: dictationsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outsideDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: meetingsDir, withIntermediateDirectories: true)
+        try makeDictationMarkdown(text: "escaped content")
+            .write(to: outsideDir.appendingPathComponent("Dictations_2026-04-07.md"), atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(try CLIContextStore.readDictation(
+            filename: "../outside/Dictations_2026-04-07.md",
+            entryId: nil,
+            in: CLIContextDirectories(meetingsDir: meetingsDir, dictationsDir: dictationsDir)
+        ))
+    }
+
+    func testReadDictationRejectsSymlinkEscape() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let dictationsDir = root.appendingPathComponent("dictations", isDirectory: true)
+        let outsideDir = root.appendingPathComponent("outside", isDirectory: true)
+        let meetingsDir = root.appendingPathComponent("meetings", isDirectory: true)
+        try FileManager.default.createDirectory(at: dictationsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outsideDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: meetingsDir, withIntermediateDirectories: true)
+
+        let outsideFile = outsideDir.appendingPathComponent("Dictations_2026-04-07.md")
+        try makeDictationMarkdown(text: "escaped content")
+            .write(to: outsideFile, atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            at: dictationsDir.appendingPathComponent("Dictations_2026-04-07.md"),
+            withDestinationURL: outsideFile
+        )
+
+        XCTAssertThrowsError(try CLIContextStore.readDictation(
+            filename: "Dictations_2026-04-07.md",
+            entryId: nil,
+            in: CLIContextDirectories(meetingsDir: meetingsDir, dictationsDir: dictationsDir)
+        ))
+    }
+
     private func makeTempDir() -> URL {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
@@ -232,6 +278,29 @@ final class ContextStoreTests: XCTestCase {
         ## Full Transcript
 
         \(body)
+        """
+    }
+
+    private func makeDictationMarkdown(text: String) -> String {
+        """
+        ---
+        title: "Dictations for 2026-04-07"
+        date: 2026-04-07
+        capture_type: dictation_day
+        ---
+
+        # Dictations for 2026-04-07
+
+        ## 9:15 AM - Morning note
+
+        Entry ID: `dictation-20260407-091500-000`
+        Captured: 2026-04-07T09:15:00-0500
+        Source app: Slack
+        Delivery: copied
+        Words: 2
+        Characters: \(text.count)
+
+        \(text)
         """
     }
 }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/FileWatcher.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/FileWatcher.swift
@@ -5,11 +5,11 @@ final class FileWatcher: @unchecked Sendable {
     private var timer: DispatchSourceTimer?
     private var pendingScan: DispatchWorkItem?
     private let directory: URL
-    private let onChange: (URL) -> Void
+    private let onChange: () -> Void
     private var knownModTimes: [String: TimeInterval] = [:]
     private let watchQueue = DispatchQueue(label: "com.transcripted.mcp.watcher", qos: .utility)
 
-    init(directory: URL, onChange: @escaping (URL) -> Void) {
+    init(directory: URL, onChange: @escaping () -> Void) {
         self.directory = directory
         self.onChange = onChange
     }
@@ -64,16 +64,26 @@ final class FileWatcher: @unchecked Sendable {
         self.timer = timer
     }
 
-    private func scanForChanges() {
+    func scanForChanges() {
         let files = TranscriptLoader.enumerateArtifacts(in: directory)
+        var currentModTimes: [String: TimeInterval] = [:]
+        var changed = false
 
         for file in files {
             let filename = file.url.deletingPathExtension().lastPathComponent
             let modDate = file.modDate
+            currentModTimes[filename] = modDate
             if knownModTimes[filename] != modDate {
-                knownModTimes[filename] = modDate
-                onChange(file.url)
+                changed = true
             }
         }
+
+        if Set(knownModTimes.keys) != Set(currentModTimes.keys) {
+            changed = true
+        }
+
+        guard changed else { return }
+        knownModTimes = currentModTimes
+        onChange()
     }
 }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
@@ -39,11 +39,11 @@ struct TranscriptedMCP {
         }
 
         let watchers = directories.watchedDirectories.map { directory in
-            FileWatcher(directory: directory) { changedURL in
+            FileWatcher(directory: directory) {
                 do {
-                    try index.indexSingleFile(changedURL, allowedRoots: directories.watchedDirectories)
+                    try index.reconcile(meetingDirs: directories.meetingDirs, dictationDirs: directories.dictationDirs)
                 } catch {
-                    log("Failed to index \(changedURL.lastPathComponent): \(error.localizedDescription)")
+                    log("Failed to reconcile watched directories: \(error.localizedDescription)")
                 }
             }
         }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -221,9 +221,8 @@ final class TranscriptIndex: @unchecked Sendable {
 
     func indexSingleFile(_ url: URL, allowedRoots: [URL]) throws {
         try queue.sync {
-            guard let kind = TranscriptLoader.artifactKind(for: url) else { return }
             let standardizedURL = url.standardizedFileURL
-            guard let containingRoot = allowedRoots.first(where: { root in
+            guard allowedRoots.contains(where: { root in
                 let basePath = root.standardizedFileURL.path
                 return standardizedURL.path == basePath
                     || standardizedURL.path.hasPrefix(basePath + "/")
@@ -233,15 +232,23 @@ final class TranscriptIndex: @unchecked Sendable {
             }
 
             let filename = standardizedURL.deletingPathExtension().lastPathComponent
-            switch PathSecurity.validateExistingFile(standardizedURL, under: containingRoot) {
-            case .valid(let safeURL):
-                try reindex(file: safeURL, filename: filename, kind: kind)
-            case .missing:
-                try removeFromIndex(filename: filename)
-            case .invalid:
-                log("Skipping invalid or unsafe file change: \(url.path)")
-                try removeFromIndex(filename: filename)
+            let requestedName = standardizedURL.lastPathComponent
+
+            for root in allowedRoots {
+                switch PathSecurity.resolveReadableFile(named: requestedName, in: root) {
+                case .valid(let safeURL):
+                    guard let kind = TranscriptLoader.artifactKind(for: safeURL) else { continue }
+                    try reindex(file: safeURL, filename: filename, kind: kind)
+                    return
+                case .missing:
+                    continue
+                case .invalid:
+                    log("Skipping invalid or unsafe file change: \(root.appendingPathComponent(requestedName).path)")
+                    continue
+                }
             }
+
+            try removeFromIndex(filename: filename)
         }
     }
 

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptIndexTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptIndexTests.swift
@@ -95,6 +95,56 @@ final class TranscriptIndexTests: XCTestCase {
         XCTAssertEqual(try index.listRecentMeetings(count: 10).count, 0)
     }
 
+    func testIndexSingleFileKeepsHigherPriorityDuplicateBasename() throws {
+        let currentDir = makeTempDir()
+        let legacyDir = makeTempDir()
+        defer {
+            removeTempDir(currentDir)
+            removeTempDir(legacyDir)
+        }
+
+        let filename = "Call_2026-03-29_10-00-00"
+        try writeFixture(
+            makeFixtureJSON(utterances: [("mic_0", 0.0, 3.0, "Current root content")]),
+            filename: filename,
+            to: currentDir
+        )
+        try writeFixture(
+            makeFixtureJSON(utterances: [("mic_0", 0.0, 3.0, "Legacy root content")]),
+            filename: filename,
+            to: legacyDir
+        )
+
+        try index.reconcile(meetingDirs: [currentDir, legacyDir], dictationDirs: [])
+        try index.indexSingleFile(
+            legacyDir.appendingPathComponent("\(filename).md"),
+            allowedRoots: [currentDir, legacyDir]
+        )
+
+        let currentResults = try index.searchUtterances(query: "Current", speaker: nil, dateFrom: nil, dateTo: nil)
+        let legacyResults = try index.searchUtterances(query: "Legacy", speaker: nil, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(currentResults.results.count, 1)
+        XCTAssertTrue(legacyResults.results.isEmpty)
+    }
+
+    func testFileWatcherSignalsDeletes() throws {
+        let directory = makeTempDir()
+        defer { removeTempDir(directory) }
+
+        var changeCount = 0
+        let watcher = FileWatcher(directory: directory) {
+            changeCount += 1
+        }
+
+        try writeFixture(makeFixtureJSON(), filename: "Call_2026-03-29_10-00-00", to: directory)
+        watcher.scanForChanges()
+        XCTAssertEqual(changeCount, 1)
+
+        try FileManager.default.removeItem(at: directory.appendingPathComponent("Call_2026-03-29_10-00-00.md"))
+        watcher.scanForChanges()
+        XCTAssertEqual(changeCount, 2)
+    }
+
     func testMalformedMarkdownIsSkipped() throws {
         try "not markdown".write(to: tempDir.appendingPathComponent("Call_2026-03-29_10-00-00.md"), atomically: true, encoding: .utf8)
         try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)

--- a/Tools/TranscriptedQA/Package.swift
+++ b/Tools/TranscriptedQA/Package.swift
@@ -16,5 +16,10 @@ let package = Package(
             path: "Sources/TranscriptedQA",
             linkerSettings: [.linkedLibrary("sqlite3")]
         ),
+        .testTarget(
+            name: "TranscriptedQATests",
+            dependencies: ["transcripted-qa"],
+            path: "Tests/TranscriptedQATests"
+        ),
     ]
 )

--- a/Tools/TranscriptedQA/Tests/TranscriptedQATests/ValidatorTests.swift
+++ b/Tools/TranscriptedQA/Tests/TranscriptedQATests/ValidatorTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import transcripted_qa
+
+final class ValidatorTests: XCTestCase {
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedQATests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+    }
+
+    func testYAMLParserReadsInlineAndBlockLists() {
+        let parser = YAMLParser(content: """
+        ---
+        title: "Release QA"
+        transcription_engine: parakeet_local
+        sources:
+          - mic
+          - system_audio
+        tags: [release, qa]
+        ---
+        ## Transcript
+        Body
+        """)
+
+        XCTAssertTrue(parser.hasFrontmatter)
+        XCTAssertEqual(parser.value(for: "title"), "Release QA")
+        XCTAssertEqual(parser.value(for: "sources"), "mic, system_audio")
+        XCTAssertEqual(parser.value(for: "tags"), "release, qa")
+        XCTAssertTrue(parser.body.contains("## Transcript"))
+    }
+
+    func testIndexValidatorFailsMissingMarkdownForLegacyIndexEntry() throws {
+        try """
+        {
+          "transcript_count": 1,
+          "transcripts": [
+            { "filename": "Call_2026-04-18_14-43-40" }
+          ],
+          "known_speakers": []
+        }
+        """.write(
+            to: tempRoot.appendingPathComponent("transcripted.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "{}".write(
+            to: tempRoot.appendingPathComponent("Call_2026-04-18_14-43-40.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let results = IndexValidator(directory: tempRoot).validate()
+
+        XCTAssertTrue(results.contains {
+            $0.status == .fail
+                && $0.check == "index/markdown-on-disk"
+                && ($0.detail ?? "").contains("Call_2026-04-18_14-43-40.md not found")
+        })
+    }
+
+    func testJSONSidecarValidatorFailsEmptyUtterances() throws {
+        try """
+        {
+          "version": "1.0",
+          "recording": {
+            "duration_seconds": 12,
+            "engines": {
+              "stt": "parakeet-tdt-v3",
+              "diarization": "pyannote-offline"
+            }
+          },
+          "speakers": [],
+          "utterances": []
+        }
+        """.write(
+            to: tempRoot.appendingPathComponent("Call_2026-04-18_14-43-40.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let results = JSONSidecarValidator(directory: tempRoot).validate()
+
+        XCTAssertTrue(results.contains {
+            $0.status == .fail
+                && $0.check == "artifact/json-utterances-present"
+                && ($0.detail ?? "").contains("No utterances found")
+        })
+    }
+
+    func testValidationReportExitsNonZeroOnlyForFailures() {
+        XCTAssertEqual(
+            ValidationReport(results: [.pass("ok", target: "fixture"), .warn("warn", target: "fixture", detail: "heads up")]).exitCode,
+            0
+        )
+        XCTAssertEqual(
+            ValidationReport(results: [.fail("bad", target: "fixture", detail: "broken")]).exitCode,
+            1
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- preserve active dictation and meeting captures during app shutdown
- refresh hotkeys after onboarding permission changes and retarget meeting storage dynamically
- harden MCP/CLI transcript file handling and add focused regression tests
- smooth menu/settings loading states before release

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- swift test (Tools/TranscriptedMCP)
- swift test (Tools/TranscriptedCLI)
- swift test (Tools/TranscriptedQA)
- Computer Use smoke of Transcripted Settings/Home/Storage