### PR TITLE
Release Transcripted 1.1.20

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.19"
-  sha256 "544ac77113f4982acef94ed1767794b0f25f10e12e6075d4073c10a54c1a6a40"
+  version "1.1.20"
+  sha256 "2d170059d8e0c3ad7805dca328a131f98ead801bfaaf809674e66122f05d529a"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.19</string>
+	<string>1.1.20</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.19</string>
+	<string>1.1.20</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
         <description>Release feed for Transcripted macOS updates.</description>
         <language>en</language>
         <item>
+            <title>1.1.20</title>
+            <pubDate>Fri, 24 Apr 2026 12:44:17 -0500</pubDate>
+            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.20</link>
+            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.20</sparkle:fullReleaseNotesLink>
+            <sparkle:version>1.1.20</sparkle:version>
+            <sparkle:shortVersionString>1.1.20</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.20/Transcripted-1.1.20.dmg" length="528072685" type="application/octet-stream" sparkle:edSignature="RPpxwPth7L7LHjBa3yL7PuQglOqJvpY2K9X1IYvrUWtFfFa1ZGppm8bN0aeOmygV7KXhI9KLMhr0ArStlSpPDA=="/>
+        </item>
+        <item>
             <title>1.1.19</title>
             <pubDate>Fri, 24 Apr 2026 06:38:28 -0500</pubDate>
             <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.19</link>


### PR DESCRIPTION
## Summary
- bump Transcripted version metadata to 1.1.20
- publish Sparkle appcast entry for v1.1.20
- update Homebrew cask sha256 for the published DMG

## Release artifact
- GitHub release: https://github.com/r3dbars/transcripted/releases/tag/v1.1.20
- DMG: Transcripted-1.1.20.dmg
- SHA256: 2d170059d8e0c3ad7805dca328a131f98ead801bfaaf809674e66122f05d529a

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-public-release-1-1-20 Public
- xcrun stapler validate build/Transcripted-1.1.20.dmg
- scripts/release/update-cask.sh 1.1.20