### PR TITLE
Release Transcripted 1.1.21

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.20"
-  sha256 "2d170059d8e0c3ad7805dca328a131f98ead801bfaaf809674e66122f05d529a"
+  version "1.1.21"
+  sha256 "01d6f605f4082f03a2b15f6727c621908ae80311637fd70d8acfc4239529e885"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.20</string>
+	<string>1.1.21</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.20</string>
+	<string>1.1.21</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
         <description>Release feed for Transcripted macOS updates.</description>
         <language>en</language>
         <item>
+            <title>1.1.21</title>
+            <pubDate>Fri, 24 Apr 2026 15:19:44 -0500</pubDate>
+            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.21</link>
+            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.21</sparkle:fullReleaseNotesLink>
+            <sparkle:version>1.1.21</sparkle:version>
+            <sparkle:shortVersionString>1.1.21</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.21/Transcripted-1.1.21.dmg" length="528066568" type="application/octet-stream" sparkle:edSignature="h14lCjbd/tlREtn+v0TbQvfmILYpyoahU+fhksxbCHy/wTLMlktod6sh5axmlLFeiHM6uE0Aa2C/4ykIeIqyAQ=="/>
+        </item>
+        <item>
             <title>1.1.20</title>
             <pubDate>Fri, 24 Apr 2026 12:44:17 -0500</pubDate>
             <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.20</link>


### PR DESCRIPTION
## Summary
- bump Transcripted app version to 1.1.21
- publish Sparkle appcast metadata for 1.1.21
- update Homebrew cask to the 1.1.21 DMG sha256

## Release
- GitHub release: https://github.com/r3dbars/transcripted/releases/tag/v1.1.21
- DMG: Transcripted-1.1.21.dmg
- SHA256: 01d6f605f4082f03a2b15f6727c621908ae80311637fd70d8acfc4239529e885

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-public-release-1.1.21 Release
- xcrun stapler validate build/Transcripted-1.1.21.dmg
- codesign --verify --deep --strict build/Transcripted.app