### PR TITLE
Release Transcripted 1.1.22

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.21"
-  sha256 "01d6f605f4082f03a2b15f6727c621908ae80311637fd70d8acfc4239529e885"
+  version "1.1.22"
+  sha256 "1335a306dca8208750d7ca5b6c9c2113623b32cbebd024bcaab6ef8e5be4460b"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.21</string>
+	<string>1.1.22</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.21</string>
+	<string>1.1.22</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -1,208 +1,220 @@
-<?xml version="1.0" standalone="yes"?>
+<?xml version="1.0" ?>
 <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
-    <channel>
-        <title>Transcripted Updates</title>
-        <link>https://github.com/r3dbars/transcripted</link>
-        <atom:link href="https://raw.githubusercontent.com/r3dbars/transcripted/main/docs/appcast.xml" rel="self" type="application/rss+xml"/>
-        <description>Release feed for Transcripted macOS updates.</description>
-        <language>en</language>
-        <item>
-            <title>1.1.21</title>
-            <pubDate>Fri, 24 Apr 2026 15:19:44 -0500</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.21</link>
-            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.21</sparkle:fullReleaseNotesLink>
-            <sparkle:version>1.1.21</sparkle:version>
-            <sparkle:shortVersionString>1.1.21</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.21/Transcripted-1.1.21.dmg" length="528066568" type="application/octet-stream" sparkle:edSignature="h14lCjbd/tlREtn+v0TbQvfmILYpyoahU+fhksxbCHy/wTLMlktod6sh5axmlLFeiHM6uE0Aa2C/4ykIeIqyAQ=="/>
-        </item>
-        <item>
-            <title>1.1.20</title>
-            <pubDate>Fri, 24 Apr 2026 12:44:17 -0500</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.20</link>
-            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.20</sparkle:fullReleaseNotesLink>
-            <sparkle:version>1.1.20</sparkle:version>
-            <sparkle:shortVersionString>1.1.20</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.20/Transcripted-1.1.20.dmg" length="528072685" type="application/octet-stream" sparkle:edSignature="RPpxwPth7L7LHjBa3yL7PuQglOqJvpY2K9X1IYvrUWtFfFa1ZGppm8bN0aeOmygV7KXhI9KLMhr0ArStlSpPDA=="/>
-        </item>
-        <item>
-            <title>1.1.19</title>
-            <pubDate>Fri, 24 Apr 2026 06:38:28 -0500</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.19</link>
-            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.19</sparkle:fullReleaseNotesLink>
-            <sparkle:version>1.1.19</sparkle:version>
-            <sparkle:shortVersionString>1.1.19</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.19/Transcripted-1.1.19.dmg" length="527924847" type="application/octet-stream" sparkle:edSignature="EOvTOMK2Zi0DDWAGZS4kJkpFSS7oo3vYQgeIh1WKVSwz2p0VqMm23fX41rqGFz3tNvslwk5mQ5tCrtk7+Wb5Ag=="/>
-        </item>
-        <item>
-            <title>1.1.18</title>
-            <pubDate>Wed, 22 Apr 2026 21:00:58 -0500</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.18</link>
-            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.18</sparkle:fullReleaseNotesLink>
-            <sparkle:version>1.1.18</sparkle:version>
-            <sparkle:shortVersionString>1.1.18</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.18/Transcripted-1.1.18.dmg" length="527982010" type="application/octet-stream" sparkle:edSignature="KuYF7CLSPFEzkXMtT2Uwarcze401ifkbBHTMNV0eBnB9rIUxwQygSNc3OWp59C5TNVSUpJbt/CoQYhtX7/PfBQ=="/>
-        </item>
-        <item>
-            <title>1.1.17</title>
-            <pubDate>Wed, 22 Apr 2026 12:12:08 -0500</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.17</link>
-            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.17</sparkle:fullReleaseNotesLink>
-            <sparkle:version>1.1.17</sparkle:version>
-            <sparkle:shortVersionString>1.1.17</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.17/Transcripted-1.1.17.dmg" length="527944947" type="application/octet-stream" sparkle:edSignature="14WAhGieu5//GU3jDtgyhoRK5sHVpHQ9wgb8BX7hysxhMWvPzbEaVHSliFVTBZn//xFXqrrvYy/c+mhfkwmgAA=="/>
-        </item>
-        <item>
-            <title>1.1.16</title>
-            <pubDate>Tue, 21 Apr 2026 21:14:50 -0500</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.16</link>
-            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.16</sparkle:fullReleaseNotesLink>
-            <sparkle:version>1.1.16</sparkle:version>
-            <sparkle:shortVersionString>1.1.16</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.16/Transcripted-1.1.16.dmg" length="527808505" type="application/octet-stream" sparkle:edSignature="AMpY3nl6FgbHI05aKbevDPw05Ja+D419dMKwLPSwCwxEV7dfLFaScLU80t5rN2y7q1oAY630z6w51mugt1EWBQ=="/>
-        </item>
-        <item>
-            <title>1.1.15</title>
-            <pubDate>Tue, 21 Apr 2026 16:18:20 -0500</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.15</link>
-            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.15</sparkle:fullReleaseNotesLink>
-            <sparkle:version>1.1.15</sparkle:version>
-            <sparkle:shortVersionString>1.1.15</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.15/Transcripted-1.1.15.dmg" length="525387622" type="application/octet-stream" sparkle:edSignature="qPXpfEd9Umelrca057dPpTz26cFTnCDhau6+/fqL5f141HWbrEZQVQFfzKCDb56Aj0QoLW9G7x9klb6FDICOBg=="/>
-        </item>
-        <item>
-            <title>1.1.14</title>
-            <pubDate>Tue, 21 Apr 2026 11:38:54 -0500</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.14</link>
-            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.14</sparkle:fullReleaseNotesLink>
-            <sparkle:version>1.1.14</sparkle:version>
-            <sparkle:shortVersionString>1.1.14</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.14/Transcripted-1.1.14.dmg" length="504103210" type="application/octet-stream" sparkle:edSignature="JyTTM3YcuhRlJNfUBh3T+K5VZRt4QZHB8MibdJnhbym8x/AzwY0q2zSO2hHo2Gtvu3HCMW2qDPiJVtLFzK8OBQ=="/>
-        </item>
-        <item>
-            <title>1.1.13</title>
-            <pubDate>Mon, 20 Apr 2026 17:56:58 -0500</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.13</link>
-            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.13</sparkle:fullReleaseNotesLink>
-            <sparkle:version>1.1.13</sparkle:version>
-            <sparkle:shortVersionString>1.1.13</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.13/Transcripted-1.1.13.dmg" length="504141336" type="application/octet-stream" sparkle:edSignature="C/BPy2Mrk3/ELyGKbvLP8lYDqDiUX5Oaw2/CAr+5hz5L5DxaGHkhe6TdtleyxuuI17qeozn3IeKip7lft1jkCg=="/>
-        </item>
-        <item>
-            <title>1.1.12</title>
-            <pubDate>Sun, 19 Apr 2026 02:22:54 GMT</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.12</link>
-            <sparkle:version>1.1.12</sparkle:version>
-            <sparkle:shortVersionString>1.1.12</sparkle:shortVersionString>
-            <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.12</sparkle:releaseNotesLink>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.12/Transcripted-1.1.12.dmg" length="503316542" type="application/octet-stream" sparkle:edSignature="tyMGBXTf61HJp9NL+rHFGn0Kmay2FZ2g5aiJWMAOUFfgjDMeXpaQEt7l7cwMHKuqUFVCr8/TDAto5sAM3K14Cw=="/>
-        </item>
-        <item>
-            <title>1.1.11</title>
-            <pubDate>Sat, 18 Apr 2026 12:00:39 GMT</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.11</link>
-            <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.11</sparkle:releaseNotesLink>
-            <sparkle:version>1.1.11</sparkle:version>
-            <sparkle:shortVersionString>1.1.11</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.11/Transcripted-1.1.11.dmg" length="503193049" type="application/octet-stream" sparkle:edSignature="r3XHWckeyeCU3lkgfIda5c9jDDph9K19xXbQ8ySleY6Y3umG4wS4WqX/e8M7Z4zM5cmFLrIYcqx8oJSrhYuLCw=="/>
-        </item>
-        <item>
-            <title>1.1.10</title>
-            <pubDate>Fri, 17 Apr 2026 19:44:46 GMT</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.10</link>
-            <sparkle:version>1.1.10</sparkle:version>
-            <sparkle:shortVersionString>1.1.10</sparkle:shortVersionString>
-            <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.10</sparkle:releaseNotesLink>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.10/Transcripted-1.1.10.dmg" length="502721532" type="application/octet-stream" sparkle:edSignature="bShxoOEQ6bKgHQGBGiXAQ3BIOmudVrgnbtGS1h9f3yYGE6Yd091mqjR+BD7mg4FJ9jjQlZstE4ZNGugrF3f4DQ=="/>
-        </item>
-        <item>
-            <title>1.0.9</title>
-            <pubDate>Fri, 17 Apr 2026 18:24:06 GMT</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.9</link>
-            <sparkle:version>1.0.9</sparkle:version>
-            <sparkle:shortVersionString>1.0.9</sparkle:shortVersionString>
-            <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.9</sparkle:releaseNotesLink>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.9/Transcripted-1.0.9.dmg" length="502688154" type="application/octet-stream" sparkle:edSignature="w4Cw8zDn/4vfeJbuIq8OPJNs5naALADafyVZSrLsg/W68eBqVw4HRy/8c/lSvB68/sCZgwrfa9vWLPVLEpnZDA=="/>
-        </item>
-        <item>
-            <title>1.0.8</title>
-            <pubDate>Fri, 17 Apr 2026 17:13:16 GMT</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.8</link>
-            <sparkle:version>1.0.8</sparkle:version>
-            <sparkle:shortVersionString>1.0.8</sparkle:shortVersionString>
-            <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.8</sparkle:releaseNotesLink>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.8/Transcripted-1.0.8.dmg" length="502664309" type="application/octet-stream" sparkle:edSignature="l3EA/xoFcRhpjEBPx4BYBQCWWfRd8C95qLd0/bIR0LBj2vQsUNZert5TdjTs9g5Snxm/rTIYymfX/BquXOC2Cg=="/>
-        </item>
-        <item>
-            <title>1.0.7</title>
-            <pubDate>Tue, 14 Apr 2026 05:51:44 -0500</pubDate>
-            <link>https://github.com/r3dbars/transcripted</link>
-            <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.7</sparkle:fullReleaseNotesLink>
-            <sparkle:version>1.0.7</sparkle:version>
-            <sparkle:shortVersionString>1.0.7</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.7/Transcripted-1.0.7.dmg" length="502675765" type="application/octet-stream" sparkle:edSignature="Q98ME9znEwbm2Gy9CyYVe6Bhqel8n6seNBa0xpj2iiYi2WgSruw8FCANBGWkVBsU9gXANw8bBGS+ZfjsykVRBg=="/>
-        </item>
-        <item>
-            <title>1.0.6</title>
-            <pubDate>Mon, 13 Apr 2026 19:50:36 GMT</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.6</link>
-            <sparkle:version>1.0.6</sparkle:version>
-            <sparkle:shortVersionString>1.0.6</sparkle:shortVersionString>
-            <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.6</sparkle:releaseNotesLink>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.6/Transcripted-1.0.6.dmg" length="502646081" type="application/octet-stream" sparkle:edSignature="QWSKxul7wWJBM2GTL8F4xKhp7q/9IfJVvtZJsC63pE5BoL85oRmKSTQRtWzx0DZPmKScQmw8VXMom7E9gQJPCQ=="/>
-        </item>
-        <item>
-            <title>1.0.5</title>
-            <pubDate>Mon, 13 Apr 2026 13:46:48 GMT</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.5</link>
-            <sparkle:version>1.0.5</sparkle:version>
-            <sparkle:shortVersionString>1.0.5</sparkle:shortVersionString>
-            <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.5</sparkle:releaseNotesLink>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.5/Transcripted-1.0.5.dmg" length="502640480" type="application/octet-stream" sparkle:edSignature="kvlnlYL4tbnNLZjIjdJwA+0FCZ8CV4dW55PhYxgEWDJ9kbPrNRYNRlWq887xWhwWJ/R065gqD5WN0JtxvFeUAw=="/>
-        </item>
-        <item>
-            <title>1.0.4</title>
-            <pubDate>Sun, 12 Apr 2026 18:58:26 GMT</pubDate>
-            <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.4</link>
-            <sparkle:version>1.0.4</sparkle:version>
-            <sparkle:shortVersionString>1.0.4</sparkle:shortVersionString>
-            <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.4</sparkle:releaseNotesLink>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-            <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.4/Transcripted-1.0.4.dmg" length="509228201" type="application/octet-stream" sparkle:edSignature="xz6/eZzqaQwyYX79B2ztJ79IZEPSXKrTIf9DXhEP43Aep8RSus6AJgr2WLJj5+Qq34nNWql4ynn8kDyiAjXpBg=="/>
-        </item>
-    </channel>
+  <channel>
+    <title>Transcripted Updates</title>
+    <link>https://github.com/r3dbars/transcripted</link>
+    <atom:link href="https://raw.githubusercontent.com/r3dbars/transcripted/main/docs/appcast.xml" rel="self" type="application/rss+xml"/>
+    <description>Release feed for Transcripted macOS updates.</description>
+    <language>en</language>
+    <item>
+      <title>1.1.22</title>
+      <pubDate>Fri, 24 Apr 2026 20:43:36 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.22</link>
+      <sparkle:version>1.1.22</sparkle:version>
+      <sparkle:shortVersionString>1.1.22</sparkle:shortVersionString>
+      <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.22</sparkle:fullReleaseNotesLink>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <sparkle:criticalUpdate/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.22/Transcripted-1.1.22.dmg" length="528066662" type="application/octet-stream" sparkle:edSignature="6NFhcrMXH17PMBuhLW7WFpicG0aNaZiKzss6W0vA9DoTsYgo7tQA2nOgKop1CdWPZkeIc2IynNrS/pLDH9rZBQ=="/>
+    </item>
+    <item>
+      <title>1.1.21</title>
+      <pubDate>Fri, 24 Apr 2026 15:19:44 -0500</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.21</link>
+      <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.21</sparkle:fullReleaseNotesLink>
+      <sparkle:version>1.1.21</sparkle:version>
+      <sparkle:shortVersionString>1.1.21</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.21/Transcripted-1.1.21.dmg" length="528066568" type="application/octet-stream" sparkle:edSignature="h14lCjbd/tlREtn+v0TbQvfmILYpyoahU+fhksxbCHy/wTLMlktod6sh5axmlLFeiHM6uE0Aa2C/4ykIeIqyAQ=="/>
+    </item>
+    <item>
+      <title>1.1.20</title>
+      <pubDate>Fri, 24 Apr 2026 12:44:17 -0500</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.20</link>
+      <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.20</sparkle:fullReleaseNotesLink>
+      <sparkle:version>1.1.20</sparkle:version>
+      <sparkle:shortVersionString>1.1.20</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.20/Transcripted-1.1.20.dmg" length="528072685" type="application/octet-stream" sparkle:edSignature="RPpxwPth7L7LHjBa3yL7PuQglOqJvpY2K9X1IYvrUWtFfFa1ZGppm8bN0aeOmygV7KXhI9KLMhr0ArStlSpPDA=="/>
+    </item>
+    <item>
+      <title>1.1.19</title>
+      <pubDate>Fri, 24 Apr 2026 06:38:28 -0500</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.19</link>
+      <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.19</sparkle:fullReleaseNotesLink>
+      <sparkle:version>1.1.19</sparkle:version>
+      <sparkle:shortVersionString>1.1.19</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.19/Transcripted-1.1.19.dmg" length="527924847" type="application/octet-stream" sparkle:edSignature="EOvTOMK2Zi0DDWAGZS4kJkpFSS7oo3vYQgeIh1WKVSwz2p0VqMm23fX41rqGFz3tNvslwk5mQ5tCrtk7+Wb5Ag=="/>
+    </item>
+    <item>
+      <title>1.1.18</title>
+      <pubDate>Wed, 22 Apr 2026 21:00:58 -0500</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.18</link>
+      <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.18</sparkle:fullReleaseNotesLink>
+      <sparkle:version>1.1.18</sparkle:version>
+      <sparkle:shortVersionString>1.1.18</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.18/Transcripted-1.1.18.dmg" length="527982010" type="application/octet-stream" sparkle:edSignature="KuYF7CLSPFEzkXMtT2Uwarcze401ifkbBHTMNV0eBnB9rIUxwQygSNc3OWp59C5TNVSUpJbt/CoQYhtX7/PfBQ=="/>
+    </item>
+    <item>
+      <title>1.1.17</title>
+      <pubDate>Wed, 22 Apr 2026 12:12:08 -0500</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.17</link>
+      <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.17</sparkle:fullReleaseNotesLink>
+      <sparkle:version>1.1.17</sparkle:version>
+      <sparkle:shortVersionString>1.1.17</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.17/Transcripted-1.1.17.dmg" length="527944947" type="application/octet-stream" sparkle:edSignature="14WAhGieu5//GU3jDtgyhoRK5sHVpHQ9wgb8BX7hysxhMWvPzbEaVHSliFVTBZn//xFXqrrvYy/c+mhfkwmgAA=="/>
+    </item>
+    <item>
+      <title>1.1.16</title>
+      <pubDate>Tue, 21 Apr 2026 21:14:50 -0500</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.16</link>
+      <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.16</sparkle:fullReleaseNotesLink>
+      <sparkle:version>1.1.16</sparkle:version>
+      <sparkle:shortVersionString>1.1.16</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.16/Transcripted-1.1.16.dmg" length="527808505" type="application/octet-stream" sparkle:edSignature="AMpY3nl6FgbHI05aKbevDPw05Ja+D419dMKwLPSwCwxEV7dfLFaScLU80t5rN2y7q1oAY630z6w51mugt1EWBQ=="/>
+    </item>
+    <item>
+      <title>1.1.15</title>
+      <pubDate>Tue, 21 Apr 2026 16:18:20 -0500</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.15</link>
+      <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.15</sparkle:fullReleaseNotesLink>
+      <sparkle:version>1.1.15</sparkle:version>
+      <sparkle:shortVersionString>1.1.15</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.15/Transcripted-1.1.15.dmg" length="525387622" type="application/octet-stream" sparkle:edSignature="qPXpfEd9Umelrca057dPpTz26cFTnCDhau6+/fqL5f141HWbrEZQVQFfzKCDb56Aj0QoLW9G7x9klb6FDICOBg=="/>
+    </item>
+    <item>
+      <title>1.1.14</title>
+      <pubDate>Tue, 21 Apr 2026 11:38:54 -0500</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.14</link>
+      <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.14</sparkle:fullReleaseNotesLink>
+      <sparkle:version>1.1.14</sparkle:version>
+      <sparkle:shortVersionString>1.1.14</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.14/Transcripted-1.1.14.dmg" length="504103210" type="application/octet-stream" sparkle:edSignature="JyTTM3YcuhRlJNfUBh3T+K5VZRt4QZHB8MibdJnhbym8x/AzwY0q2zSO2hHo2Gtvu3HCMW2qDPiJVtLFzK8OBQ=="/>
+    </item>
+    <item>
+      <title>1.1.13</title>
+      <pubDate>Mon, 20 Apr 2026 17:56:58 -0500</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.13</link>
+      <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.13</sparkle:fullReleaseNotesLink>
+      <sparkle:version>1.1.13</sparkle:version>
+      <sparkle:shortVersionString>1.1.13</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.13/Transcripted-1.1.13.dmg" length="504141336" type="application/octet-stream" sparkle:edSignature="C/BPy2Mrk3/ELyGKbvLP8lYDqDiUX5Oaw2/CAr+5hz5L5DxaGHkhe6TdtleyxuuI17qeozn3IeKip7lft1jkCg=="/>
+    </item>
+    <item>
+      <title>1.1.12</title>
+      <pubDate>Sun, 19 Apr 2026 02:22:54 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.12</link>
+      <sparkle:version>1.1.12</sparkle:version>
+      <sparkle:shortVersionString>1.1.12</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.12</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.12/Transcripted-1.1.12.dmg" length="503316542" type="application/octet-stream" sparkle:edSignature="tyMGBXTf61HJp9NL+rHFGn0Kmay2FZ2g5aiJWMAOUFfgjDMeXpaQEt7l7cwMHKuqUFVCr8/TDAto5sAM3K14Cw=="/>
+    </item>
+    <item>
+      <title>1.1.11</title>
+      <pubDate>Sat, 18 Apr 2026 12:00:39 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.11</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.11</sparkle:releaseNotesLink>
+      <sparkle:version>1.1.11</sparkle:version>
+      <sparkle:shortVersionString>1.1.11</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.11/Transcripted-1.1.11.dmg" length="503193049" type="application/octet-stream" sparkle:edSignature="r3XHWckeyeCU3lkgfIda5c9jDDph9K19xXbQ8ySleY6Y3umG4wS4WqX/e8M7Z4zM5cmFLrIYcqx8oJSrhYuLCw=="/>
+    </item>
+    <item>
+      <title>1.1.10</title>
+      <pubDate>Fri, 17 Apr 2026 19:44:46 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.10</link>
+      <sparkle:version>1.1.10</sparkle:version>
+      <sparkle:shortVersionString>1.1.10</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.10</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.10/Transcripted-1.1.10.dmg" length="502721532" type="application/octet-stream" sparkle:edSignature="bShxoOEQ6bKgHQGBGiXAQ3BIOmudVrgnbtGS1h9f3yYGE6Yd091mqjR+BD7mg4FJ9jjQlZstE4ZNGugrF3f4DQ=="/>
+    </item>
+    <item>
+      <title>1.0.9</title>
+      <pubDate>Fri, 17 Apr 2026 18:24:06 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.9</link>
+      <sparkle:version>1.0.9</sparkle:version>
+      <sparkle:shortVersionString>1.0.9</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.9</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.9/Transcripted-1.0.9.dmg" length="502688154" type="application/octet-stream" sparkle:edSignature="w4Cw8zDn/4vfeJbuIq8OPJNs5naALADafyVZSrLsg/W68eBqVw4HRy/8c/lSvB68/sCZgwrfa9vWLPVLEpnZDA=="/>
+    </item>
+    <item>
+      <title>1.0.8</title>
+      <pubDate>Fri, 17 Apr 2026 17:13:16 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.8</link>
+      <sparkle:version>1.0.8</sparkle:version>
+      <sparkle:shortVersionString>1.0.8</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.8</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.8/Transcripted-1.0.8.dmg" length="502664309" type="application/octet-stream" sparkle:edSignature="l3EA/xoFcRhpjEBPx4BYBQCWWfRd8C95qLd0/bIR0LBj2vQsUNZert5TdjTs9g5Snxm/rTIYymfX/BquXOC2Cg=="/>
+    </item>
+    <item>
+      <title>1.0.7</title>
+      <pubDate>Tue, 14 Apr 2026 05:51:44 -0500</pubDate>
+      <link>https://github.com/r3dbars/transcripted</link>
+      <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.7</sparkle:fullReleaseNotesLink>
+      <sparkle:version>1.0.7</sparkle:version>
+      <sparkle:shortVersionString>1.0.7</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.7/Transcripted-1.0.7.dmg" length="502675765" type="application/octet-stream" sparkle:edSignature="Q98ME9znEwbm2Gy9CyYVe6Bhqel8n6seNBa0xpj2iiYi2WgSruw8FCANBGWkVBsU9gXANw8bBGS+ZfjsykVRBg=="/>
+    </item>
+    <item>
+      <title>1.0.6</title>
+      <pubDate>Mon, 13 Apr 2026 19:50:36 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.6</link>
+      <sparkle:version>1.0.6</sparkle:version>
+      <sparkle:shortVersionString>1.0.6</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.6</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.6/Transcripted-1.0.6.dmg" length="502646081" type="application/octet-stream" sparkle:edSignature="QWSKxul7wWJBM2GTL8F4xKhp7q/9IfJVvtZJsC63pE5BoL85oRmKSTQRtWzx0DZPmKScQmw8VXMom7E9gQJPCQ=="/>
+    </item>
+    <item>
+      <title>1.0.5</title>
+      <pubDate>Mon, 13 Apr 2026 13:46:48 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.5</link>
+      <sparkle:version>1.0.5</sparkle:version>
+      <sparkle:shortVersionString>1.0.5</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.5</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.5/Transcripted-1.0.5.dmg" length="502640480" type="application/octet-stream" sparkle:edSignature="kvlnlYL4tbnNLZjIjdJwA+0FCZ8CV4dW55PhYxgEWDJ9kbPrNRYNRlWq887xWhwWJ/R065gqD5WN0JtxvFeUAw=="/>
+    </item>
+    <item>
+      <title>1.0.4</title>
+      <pubDate>Sun, 12 Apr 2026 18:58:26 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.0.4</link>
+      <sparkle:version>1.0.4</sparkle:version>
+      <sparkle:shortVersionString>1.0.4</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.4</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.4/Transcripted-1.0.4.dmg" length="509228201" type="application/octet-stream" sparkle:edSignature="xz6/eZzqaQwyYX79B2ztJ79IZEPSXKrTIf9DXhEP43Aep8RSus6AJgr2WLJj5+Qq34nNWql4ynn8kDyiAjXpBg=="/>
+    </item>
+  </channel>
 </rss>


### PR DESCRIPTION
## Summary
- bump Transcripted to 1.1.22
- publish Sparkle appcast entry for 1.1.22 as a critical update
- update Homebrew cask to 1.1.22

## Verification
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-public Public
- plutil -lint Info.plist
- xmllint --noout docs/appcast.xml
- ruby -c Casks/transcripted.rb