### PR TITLE
Disable Sentry app hang noise

### DIFF
--- a/Sources/Observability/CrashReporter.swift
+++ b/Sources/Observability/CrashReporter.swift
@@ -31,6 +31,7 @@ final class CrashReporter {
         options.sendDefaultPii = false
         options.enableCrashHandler = true
         options.enableUncaughtNSExceptionReporting = true
+        options.enableAppHangTracking = SentryRuntimeConfiguration.appHangTrackingEnabled()
         options.enableAutoSessionTracking = false
         options.enableNetworkBreadcrumbs = false
         options.maxBreadcrumbs = 0

--- a/Sources/Observability/SentryRuntimeConfiguration.swift
+++ b/Sources/Observability/SentryRuntimeConfiguration.swift
@@ -3,8 +3,10 @@ import Foundation
 enum SentryRuntimeConfiguration {
     static let dsnInfoKey = "TranscriptedSentryDSN"
     static let environmentInfoKey = "TranscriptedSentryEnvironment"
+    static let appHangTrackingInfoKey = "TranscriptedSentryAppHangTrackingEnabled"
     static let dsnEnvironmentKey = "SENTRY_DSN"
     static let environmentEnvironmentKey = "SENTRY_ENVIRONMENT"
+    static let appHangTrackingEnvironmentKey = "SENTRY_ENABLE_APP_HANG_TRACKING"
 
     static func dsn(
         environment: [String: String] = ProcessInfo.processInfo.environment,
@@ -35,9 +37,40 @@ enum SentryRuntimeConfiguration {
         firstNonEmpty(infoDictionary?["CFBundleVersion"] as? String)
     }
 
+    static func appHangTrackingEnabled(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        infoDictionary: [String: Any]? = Bundle.main.infoDictionary
+    ) -> Bool {
+        if let override = firstNonEmpty(environment[appHangTrackingEnvironmentKey]) {
+            return parseBoolean(override) ?? false
+        }
+
+        if let configured = infoDictionary?[appHangTrackingInfoKey] {
+            if let enabled = configured as? Bool {
+                return enabled
+            }
+            if let configuredString = configured as? String {
+                return parseBoolean(configuredString) ?? false
+            }
+        }
+
+        return false
+    }
+
     private static func firstNonEmpty(_ candidates: String?...) -> String? {
         candidates
             .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
             .first(where: { !$0.isEmpty })
+    }
+
+    private static func parseBoolean(_ value: String) -> Bool? {
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        case "0", "false", "no", "off":
+            return false
+        default:
+            return nil
+        }
     }
 }

--- a/Tests/SentryRuntimeConfigurationTests.swift
+++ b/Tests/SentryRuntimeConfigurationTests.swift
@@ -57,4 +57,35 @@ func testSentryRuntimeConfiguration() {
             "dist should still mirror CFBundleVersion"
         )
     }
+
+    runSuite("SentryRuntimeConfiguration disables app hang tracking by default") {
+        assertFalse(
+            SentryRuntimeConfiguration.appHangTrackingEnabled(environment: [:], infoDictionary: [:]),
+            "automatic app hang tracking should default off because modal system alerts can look like hangs"
+        )
+    }
+
+    runSuite("SentryRuntimeConfiguration allows explicit app hang tracking opt in") {
+        assertTrue(
+            SentryRuntimeConfiguration.appHangTrackingEnabled(
+                environment: [SentryRuntimeConfiguration.appHangTrackingEnvironmentKey: "true"],
+                infoDictionary: [:]
+            ),
+            "local validation can opt into app hang tracking through environment"
+        )
+        assertTrue(
+            SentryRuntimeConfiguration.appHangTrackingEnabled(
+                environment: [:],
+                infoDictionary: [SentryRuntimeConfiguration.appHangTrackingInfoKey: true]
+            ),
+            "bundle config can opt into app hang tracking when we intentionally want it"
+        )
+        assertFalse(
+            SentryRuntimeConfiguration.appHangTrackingEnabled(
+                environment: [SentryRuntimeConfiguration.appHangTrackingEnvironmentKey: "not-a-bool"],
+                infoDictionary: [SentryRuntimeConfiguration.appHangTrackingInfoKey: true]
+            ),
+            "invalid environment override should fail closed"
+        )
+    }
 }

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -24,6 +24,8 @@ PostHog controls described below.
 - never send emails, tokens, or raw URLs
 - keep analytics to allowlisted events and coarse buckets only
 - keep crash reporting separately user-controllable from anonymous analytics
+- keep Sentry automatic app-hang tracking off by default; modal macOS update,
+  permission, and confirmation dialogs can otherwise be misreported as hangs
 
 ## Current rollout checklist
 
@@ -59,6 +61,9 @@ PostHog controls described below.
 9. Use `Send Test Sentry Event` to verify Sentry wiring.
 10. Leave anonymous usage statistics on and verify only allowlisted events arrive
    in PostHog.
+11. If intentionally testing Sentry app-hang tracking, launch locally with
+    `SENTRY_ENABLE_APP_HANG_TRACKING=true`. Do not enable it in release builds
+    without a specific review of modal dialog false positives.
 
 ## Allowlisted analytics events
 


### PR DESCRIPTION
## Summary
- Disable Sentry automatic app-hang tracking by default because modal macOS alerts can be misreported as hangs.
- Keep crash reporting, NSException reporting, Sentry scrubbing, and allowlisted manual/non-fatal events enabled.
- Add explicit env/plist opt-in for local app-hang tracking validation.

Fixes APPLE-MACOS-4 for future releases.

## Validation
- bash run-tests.sh — 846 passed
- bash build-deps.sh --force
- bash build.sh
