### PR TITLE
Release Transcripted 1.1.23

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.22"
-  sha256 "1335a306dca8208750d7ca5b6c9c2113623b32cbebd024bcaab6ef8e5be4460b"
+  version "1.1.23"
+  sha256 "9fcf7ceeaa42518482ce2948cb5cfe3dde042c271ae0329ebaa830233770febd"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.22</string>
+	<string>1.1.23</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.22</string>
+	<string>1.1.23</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,18 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.23</title>
+      <pubDate>Sat, 25 Apr 2026 00:48:58 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.23</link>
+      <sparkle:version>1.1.23</sparkle:version>
+      <sparkle:shortVersionString>1.1.23</sparkle:shortVersionString>
+      <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.23</sparkle:fullReleaseNotesLink>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <sparkle:criticalUpdate/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.23/Transcripted-1.1.23.dmg" length="528064411" type="application/octet-stream" sparkle:edSignature="RsIqBbb5KkhYpCXABJ6XSu3cP4EYc8vls37imIP54Rk5YDIgDzM641HlBywdsRvBoBGmfttLEZ7v4C0g5GmOCw=="/>
+    </item>
+    <item>
       <title>1.1.22</title>
       <pubDate>Fri, 24 Apr 2026 20:43:36 GMT</pubDate>
       <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.22</link>


### PR DESCRIPTION
## Summary
- bump Transcripted to 1.1.23
- add 1.1.23 Sparkle appcast entry
- update Homebrew cask checksum

## Verification
- xmllint --noout docs/appcast.xml
- notarized/stapled Transcripted-1.1.23.dmg published in GitHub Releases