### PR TITLE
Remove dead retroactivelyMergeSpeaker and collapse update overloads

### DIFF
--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -10,50 +10,24 @@ extension TranscriptSaver {
     /// Thread-safe: serialized via fileUpdateQueue to prevent concurrent file corruption.
     /// Satisfies the `TranscriptStorage` protocol — uses `defaultSaveDirectory`.
     public static func retroactivelyUpdateSpeaker(dbId: UUID, newName: String) {
-        retroactivelyUpdateSpeaker(
-            dbId: dbId,
-            newName: newName,
-            directory: nil,
-            speakerStoreForIndex: nil
-        )
+        fileUpdateQueue.sync {
+            _retroactivelyUpdateSpeakerImpl(dbId: dbId, newName: newName, directory: defaultSaveDirectory)
+        }
     }
 
     /// Internal overload for tests — scans a specific directory instead of `defaultSaveDirectory`.
     static func retroactivelyUpdateSpeaker(dbId: UUID, newName: String, in directory: URL) {
-        retroactivelyUpdateSpeaker(
-            dbId: dbId,
-            newName: newName,
-            directory: directory,
-            speakerStoreForIndex: nil
-        )
-    }
-
-    /// Extended overload for app embedders that supply an explicit directory.
-    /// Not part of the `TranscriptStorage` protocol.
-    public static func retroactivelyUpdateSpeaker(
-        dbId: UUID,
-        newName: String,
-        directory: URL? = nil,
-        speakerStoreForIndex _: (any SpeakerStore)? = nil
-    ) {
         fileUpdateQueue.sync {
-            _retroactivelyUpdateSpeakerImpl(
-                dbId: dbId,
-                newName: newName,
-                directory: directory ?? defaultSaveDirectory,
-                speakerStoreForIndex: nil
-            )
+            _retroactivelyUpdateSpeakerImpl(dbId: dbId, newName: newName, directory: directory)
         }
     }
 
     private static func _retroactivelyUpdateSpeakerImpl(
         dbId: UUID,
         newName: String,
-        directory: URL,
-        speakerStoreForIndex _: (any SpeakerStore)?
+        directory: URL
     ) {
-        let dir = directory
-        guard let files = try? FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
+        guard let files = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
             .filter({ $0.pathExtension == "md" }) else { return }
 
         let dbIdString = dbId.uuidString
@@ -100,90 +74,6 @@ extension TranscriptSaver {
                 ["dbId": dbIdString, "name": newName, "files": "\(updatedCount)"])
         }
     }
-
-    /// When two speaker profiles are merged in Settings, rewrite all transcripts that referenced
-    /// the source speaker so they use the target's name instead.
-    /// Thread-safe: serialized via fileUpdateQueue.
-    public static func retroactivelyMergeSpeaker(
-        sourceDbId: UUID,
-        into targetDbId: UUID,
-        newName: String,
-        directory: URL? = nil,
-        speakerStoreForIndex _: (any SpeakerStore)? = nil
-    ) {
-        fileUpdateQueue.sync {
-            _retroactivelyMergeSpeakerImpl(
-                sourceDbId: sourceDbId,
-                targetDbId: targetDbId,
-                newName: newName,
-                directory: directory ?? defaultSaveDirectory,
-                speakerStoreForIndex: nil
-            )
-        }
-    }
-
-    private static func _retroactivelyMergeSpeakerImpl(
-        sourceDbId: UUID,
-        targetDbId: UUID,
-        newName: String,
-        directory: URL,
-        speakerStoreForIndex _: (any SpeakerStore)?
-    ) {
-        guard let files = try? FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
-            .filter({ $0.pathExtension == "md" }) else { return }
-
-        let sourceDbIdString = sourceDbId.uuidString
-        let targetDbIdString = targetDbId.uuidString
-        var updatedCount = 0
-
-        for fileURL in files {
-            guard var content = try? String(contentsOf: fileURL, encoding: .utf8),
-                  content.contains(#"db_id: "\#(sourceDbIdString)""#) else { continue }
-
-            let lines = content.components(separatedBy: "\n")
-            var oldNames: [String] = []
-            for (index, line) in lines.enumerated() {
-                guard line.contains(#"db_id: "\#(sourceDbIdString)""#) else { continue }
-                if index + 1 < lines.count {
-                    let nameLine = lines[index + 1]
-                    if let oldName = extractYAMLQuotedString(from: nameLine, prefix: "name: "),
-                       oldName != newName,
-                       !oldNames.contains(oldName) {
-                        oldNames.append(oldName)
-                    }
-                }
-            }
-
-            content = content.replacingOccurrences(
-                of: #"db_id: "\#(sourceDbIdString)""#,
-                with: #"db_id: "\#(targetDbIdString)""#
-            )
-            for oldName in oldNames {
-                applyNameReplacement(in: &content, oldName: oldName, newName: newName, updateSpeakerTag: true)
-            }
-
-            do {
-                try content.write(to: fileURL, atomically: true, encoding: .utf8)
-                updatedCount += 1
-            } catch {
-                AppLogger.pipeline.warning("Failed to merge speaker in transcript", [
-                    "file": fileURL.lastPathComponent,
-                    "error": error.localizedDescription
-                ])
-            }
-        }
-
-        if updatedCount > 0 {
-            AppLogger.pipeline.info("Retroactively merged speaker in transcripts", [
-                "sourceDbId": sourceDbIdString,
-                "targetDbId": targetDbIdString,
-                "name": newName,
-                "files": "\(updatedCount)"
-            ])
-        }
-    }
-
-    // MARK: - Retroactive Title Update
 
     // MARK: - Speaker Name Updating (Post-Naming Flow)
 


### PR DESCRIPTION
## Summary

- **Delete `retroactivelyMergeSpeaker` + `_retroactivelyMergeSpeakerImpl`** — no callers anywhere in `Sources/` or `Tests/`. The actual speaker-merge flow runs `speakerDatabase.mergeProfiles(sourceId:into:)` then `retroactivelyUpdateSpeaker(dbId:newName:)` (see [`SpeakerPeopleSettingsSection.swift:207-219`](https://github.com/r3dbars/transcripted/blob/main/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift#L207-L219)). The unused merge variant was ~80 LOC of dead code.
- **Collapse `retroactivelyUpdateSpeaker` from 3 overloads to 2.** The middle overload (`directory:speakerStoreForIndex:`) was only called by the other two with all-defaults; inlined the queue dispatch directly into the protocol-required and test-only entry points.
- **Drop unused `speakerStoreForIndex` parameter.** Declared as `_:` everywhere it appeared, threaded through 4 entry points, never read.

Net: **-110 LOC** in one file, no behavior change.

## Test plan

- [x] `swift test --filter RetroactiveSpeakerUpdaterTests` — 14/14 pass
- [x] `bash build-deps.sh --force` — clean rebuild
- [x] `bash build.sh` — app builds and launches
- [x] `bash run-tests.sh` — 846/846 pass
- [x] `bash run-integration-smoke.sh` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)