### PR TITLE
Fix onboarding init drop, retained-audio staleness, and analytics gaps

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -47,7 +47,6 @@ final class MeetingSessionController: ObservableObject {
 
     enum RecordingCancelReason: String {
         case discardButton = "discard_button"
-        case onboardingDryRun = "onboarding_dry_run"
         case unknown = "unknown"
     }
 
@@ -229,7 +228,6 @@ final class MeetingSessionController: ObservableObject {
             diarization: services.diarization,
             speakerStore: services.speakerStore,
             speakerClipsDirectory: storagePaths.speakerClips,
-            retainedAudioDirectory: MeetingStoragePaths.audioArchiveFolder,
             retainedAudioDirectoryProvider: { MeetingStoragePaths.audioArchiveFolder },
             statsStore: statsDatabase
         )

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -313,31 +313,9 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     }
 
     private func makeOnboardingView() -> PermissionsOnboardingView {
-        let hasPasteTarget = resolvedSourceApp() != nil
-        return PermissionsOnboardingView(
-            sttRouter: appState.sttRouter,
-            canStartDictation: hasPasteTarget,
-            onStartDictation: { [weak self] anchorRect in
-                self?.startOnboardingDictationTest(anchorRect: anchorRect)
-            },
-            onStopDictation: { [weak self] in
-                self?.stopOnboardingDictationTest()
-            },
-            onStartMeetingDryRun: { [weak self] in
-                guard let self else { return false }
-                return await self.startOnboardingMeetingDryRun()
-            },
-            onStopMeetingDryRun: { [weak self] in
-                guard let self else { return false }
-                return await self.stopOnboardingMeetingDryRun()
-            },
-            onOpenAgentSettings: { [weak self] in
-                self?.showSettingsWindow(page: .connectAgent, source: "onboarding")
-            },
-            onComplete: { [weak self] in
-                self?.finishOnboarding()
-            }
-        )
+        PermissionsOnboardingView { [weak self] in
+            self?.finishOnboarding()
+        }
     }
 
     private func presentInitialOnboardingIfNeeded() {
@@ -371,25 +349,6 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         closePopover()
         sourceApp?.activate(options: [])
         sessionController.startDictation(sourceApp: sourceApp, trigger: .onboarding)
-    }
-
-    private func startOnboardingDictationTest(anchorRect: NSRect?) {
-        NSApp.activate(ignoringOtherApps: true)
-        sessionController.startDictation(sourceApp: nil, trigger: .onboarding, anchorRect: anchorRect)
-    }
-
-    private func stopOnboardingDictationTest() {
-        sessionController.stopDictationAndPaste(trigger: .onboarding)
-    }
-
-    private func startOnboardingMeetingDryRun() async -> Bool {
-        await appState.meetingSession.startRecording(trigger: .onboarding)
-    }
-
-    private func stopOnboardingMeetingDryRun() async -> Bool {
-        guard case .recording = appState.meetingSession.state else { return false }
-        await appState.meetingSession.cancelRecording(reason: .onboardingDryRun)
-        return true
     }
 
     private func showMainPopover(

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -424,7 +424,7 @@ extension TranscriptionTaskManager {
         systemURL: URL,
         savedURL: URL
     ) async -> Bool {
-        let retainedAudioDirectory = await MainActor.run { self.retainedAudioDirectory }
+        let retainedAudioDirectory = await MainActor.run { self.resolvedRetainedAudioDirectory() }
         guard let retainedAudioDirectory else { return true }
 
         do {

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -456,12 +456,16 @@ public class TranscriptionTaskManager: ObservableObject {
         }
     }
 
+    func resolvedRetainedAudioDirectory() -> URL? {
+        retainedAudioDirectoryProvider?() ?? retainedAudioDirectory
+    }
+
     private func archiveFailedRecordingAudioIfConfigured(
         micURL: URL?,
         systemURL: URL?,
         taskId: UUID
     ) {
-        guard let retainedAudioDirectory = retainedAudioDirectoryProvider?() ?? retainedAudioDirectory else { return }
+        guard let retainedAudioDirectory = resolvedRetainedAudioDirectory() else { return }
 
         let failedStem = "Failed_\(DateFormattingHelper.formatFilename(Date()))_\(String(taskId.uuidString.prefix(8)))"
         let placeholderTranscriptURL = retainedAudioDirectory

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -97,6 +97,7 @@ final class MenuBarPanelController: NSViewController {
             isEnabled: appState.sparkleUpdater.updateStatus.canRunUserUpdateAction
         )
 
+        content.utilityActionsView.pasteAvailable = latestDictationLoaded ? (latestDictation != nil) : nil
         content.utilityActionsView.update(
             updateTitle: updatePresentation.title,
             updateDetail: updatePresentation.detail,

--- a/Sources/UI/MenuBar/MenuBarUtilityActionsView.swift
+++ b/Sources/UI/MenuBar/MenuBarUtilityActionsView.swift
@@ -3,6 +3,7 @@ import AppKit
 @MainActor
 final class MenuBarUtilityActionsView: NSView {
     weak var appState: TranscriptedAppState?
+    var pasteAvailable: Bool?
 
     var onOpenConnectAgent: (() -> Void)?
     var onCheckForUpdates: (() -> Void)?
@@ -122,7 +123,7 @@ final class MenuBarUtilityActionsView: NSView {
                 "action_id": actionID,
                 "dictation_ready": appState?.sttRouter.isModelLoaded == true ? "true" : "false",
                 "meeting_recording_ready": TranscriptedPermissionAccess.isGranted(.systemAudioRecording) ? "true" : "false",
-                "paste_available": "unknown",
+                "paste_available": pasteAvailable.map { $0 ? "true" : "false" } ?? "unknown",
             ]
         )
     }

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -41,19 +41,10 @@ struct PermissionsOnboardingView: View {
     @State private var demoDictationText = ""
     @State private var copiedAgentItem: AgentCopyItem?
     @State private var copiedResetTask: Task<Void, Never>?
-    @State private var pollTimer: Timer?
+    @State private var pollTask: Task<Void, Never>?
     @FocusState private var demoEditorFocused: Bool
 
-    init(
-        sttRouter: STTRouter,
-        canStartDictation: Bool = false,
-        onStartDictation: ((NSRect?) -> Void)? = nil,
-        onStopDictation: (() -> Void)? = nil,
-        onStartMeetingDryRun: (() async -> Bool)? = nil,
-        onStopMeetingDryRun: (() async -> Bool)? = nil,
-        onOpenAgentSettings: (() -> Void)? = nil,
-        onComplete: @escaping () -> Void
-    ) {
+    init(onComplete: @escaping () -> Void) {
         self.onComplete = onComplete
     }
 
@@ -94,7 +85,6 @@ struct PermissionsOnboardingView: View {
         .frame(width: Self.preferredSize.width, height: Self.preferredSize.height)
         .background(OnboardingTheme.canvas)
         .onAppear {
-            HotkeyPreferences.setRightOptionDictation(enabled: true)
             checkAllPermissions()
             startPolling()
         }
@@ -187,7 +177,6 @@ struct PermissionsOnboardingView: View {
                 }
                 .padding(.top, 6)
                 .onAppear {
-                    HotkeyPreferences.setRightOptionDictation(enabled: true)
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
                         demoEditorFocused = true
                     }
@@ -359,17 +348,18 @@ struct PermissionsOnboardingView: View {
     }
 
     private func startPolling() {
-        pollTimer?.invalidate()
-        pollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
-            Task { @MainActor in
+        pollTask?.cancel()
+        pollTask = Task { @MainActor in
+            while !Task.isCancelled {
                 checkAllPermissions()
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
             }
         }
     }
 
     private func stopPolling() {
-        pollTimer?.invalidate()
-        pollTimer = nil
+        pollTask?.cancel()
+        pollTask = nil
     }
 
     private func completeOnboarding() {

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -47,7 +47,35 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertEqual(manager.lastSavedSpeakerCount, 5)
     }
 
-    private func makeManager() -> TranscriptionTaskManager {
+    func testResolvedRetainedAudioDirectoryFollowsProvider() {
+        var providerCallCount = 0
+        var nextDirectory = tempDirectory.appendingPathComponent("first")
+        let manager = makeManager(retainedAudioDirectoryProvider: {
+            providerCallCount += 1
+            return nextDirectory
+        })
+
+        XCTAssertEqual(manager.resolvedRetainedAudioDirectory(), tempDirectory.appendingPathComponent("first"))
+        XCTAssertEqual(providerCallCount, 1, "resolver should call provider on each lookup")
+
+        nextDirectory = tempDirectory.appendingPathComponent("second")
+        XCTAssertEqual(manager.resolvedRetainedAudioDirectory(), tempDirectory.appendingPathComponent("second"),
+                       "resolver should reflect provider changes between calls (e.g. user moves capture library)")
+        XCTAssertEqual(providerCallCount, 2)
+    }
+
+    func testResolvedRetainedAudioDirectoryFallsBackToStaticValue() {
+        let staticDirectory = tempDirectory.appendingPathComponent("static")
+        let manager = makeManager(retainedAudioDirectory: staticDirectory)
+
+        XCTAssertEqual(manager.resolvedRetainedAudioDirectory(), staticDirectory,
+                       "embedders that pass only the static value should still get a valid resolver result")
+    }
+
+    private func makeManager(
+        retainedAudioDirectory: URL? = nil,
+        retainedAudioDirectoryProvider: (() -> URL?)? = nil
+    ) -> TranscriptionTaskManager {
         let paths = CoreStoragePaths(
             transcripts: tempDirectory.appendingPathComponent("transcripts"),
             speakerDB: tempDirectory.appendingPathComponent("speakers.sqlite"),
@@ -66,7 +94,9 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             failedTranscriptionManager: FailedTranscriptionManager(paths: paths),
             speechToText: MetadataStubSpeechToTextEngine(),
             diarization: MetadataStubDiarizationEngine(),
-            speakerStore: SpeakerDatabase(path: paths.speakerDB.path)
+            speakerStore: SpeakerDatabase(path: paths.speakerDB.path),
+            retainedAudioDirectory: retainedAudioDirectory,
+            retainedAudioDirectoryProvider: retainedAudioDirectoryProvider
         )
     }
 }


### PR DESCRIPTION
## Summary

- **Onboarding init drops 7 callbacks (P1).** [`PermissionsOnboardingView.init`](Sources/UI/Settings/PermissionsOnboardingView.swift) accepted `sttRouter`, `canStartDictation`, `onStartDictation`, `onStopDictation`, `onStartMeetingDryRun`, `onStopMeetingDryRun`, `onOpenAgentSettings` but only stored `onComplete`. The redesign uses static demo cards plus the global Right-Option hotkey — the wired-up callbacks were never read. Removed the params, the 4 dead methods in `TranscriptedApp`, and the orphaned `RecordingCancelReason.onboardingDryRun`.
- **Retained-audio dir staleness in live recordings (P2).** [`TranscriptionPipelineRunner`](Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift) read the static `retainedAudioDirectory` field while the imported-audio path used the dynamic provider closure. Embedders that change capture library mid-session would archive live meetings to the original folder. Added `resolvedRetainedAudioDirectory()` helper on `TranscriptionTaskManager`, used it in both paths, dropped the now-redundant static arg from `MeetingSessionController`. Two new unit tests cover dynamic provider + static fallback.
- **Inconsistent `paste_available` analytics (P2).** Wired `latestDictation` cache from `MenuBarPanelController` through to `MenuBarUtilityActionsView` so utility action clicks no longer hard-code `"unknown"`.
- **Onboarding force-overrode dictation hotkey on every appear (P2).** Removed both `HotkeyPreferences.setRightOptionDictation(enabled: true)` calls — default-on already covers fresh installs and re-opening shouldn't undo a user's later choice.
- **Polling Task leak (P3).** Replaced the `Timer`-based polling that spawned untracked Tasks every tick with a single stored `Task` running a `while !Task.isCancelled` loop, cancelled cleanly on `.onDisappear`.

## Test plan

- [x] `bash run-tests.sh` — 846/846 pass
- [x] `swift test --filter TranscriptionTaskManagerMetadataTests` — 3/3 pass (incl. 2 new resolver tests)
- [x] `bash build.sh` — clean: no errors, no warnings, signed binary
- [ ] Manual: open onboarding window → ensure step polling still picks up newly granted permissions within ~1s
- [ ] Manual: start a live meeting recording, change capture library in Settings, stop the recording → verify retained audio lands in the new folder
- [ ] Manual: open menubar → click an action → check `paste_available` in analytics is `"true"` or `"false"` (not `"unknown"`) once the dictation cache has loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)