### PR TITLE
Reliability: stop-timeout routing + I/O proc real-time safety

### DIFF
--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -19,6 +19,16 @@ import Combine
 import Foundation
 import TranscriptedCore
 
+/// Result of a stop request. `didTimeOut == true` means we did not receive
+/// `Audio.onRecordingComplete` within `meetingStopTimeout`, so the WAV files
+/// at the returned URLs may not be fully finalized — the controller should
+/// route the audio to the failed queue rather than enqueuing for transcription.
+struct CaptureStopResult {
+    let micURL: URL?
+    let systemURL: URL?
+    let didTimeOut: Bool
+}
+
 @available(macOS 14.0, *)
 @MainActor
 final class MeetingCaptureBridge: ObservableObject {
@@ -42,7 +52,7 @@ final class MeetingCaptureBridge: ObservableObject {
 
     /// Fulfilled when Core's Audio reports recording completed. Cleared each
     /// time `startRecording` runs so back-to-back sessions do not leak state.
-    private var completionContinuation: CheckedContinuation<(micURL: URL?, systemURL: URL?), Never>?
+    private var completionContinuation: CheckedContinuation<CaptureStopResult, Never>?
     private var completionAttemptID: UUID?
     private var completionTimeoutTask: Task<Void, Never>?
     private var startContinuation: CheckedContinuation<Bool, Never>?
@@ -59,7 +69,11 @@ final class MeetingCaptureBridge: ObservableObject {
         startTimeoutTask?.cancel()
         startContinuation?.resume(returning: false)
         completionTimeoutTask?.cancel()
-        completionContinuation?.resume(returning: (audio.micAudioFileURL, audio.systemAudioFileURL))
+        completionContinuation?.resume(returning: CaptureStopResult(
+            micURL: audio.micAudioFileURL,
+            systemURL: audio.systemAudioFileURL,
+            didTimeOut: false
+        ))
         // Combine cancellables auto-release. Audio's own deinit tears down CoreAudio.
     }
 
@@ -73,7 +87,11 @@ final class MeetingCaptureBridge: ObservableObject {
             completionAttemptID = nil
             completionTimeoutTask?.cancel()
             completionTimeoutTask = nil
-            continuation.resume(returning: (audio.micAudioFileURL, audio.systemAudioFileURL))
+            continuation.resume(returning: CaptureStopResult(
+                micURL: audio.micAudioFileURL,
+                systemURL: audio.systemAudioFileURL,
+                didTimeOut: false
+            ))
         }
         if audio.isRecording { return true }
 
@@ -109,11 +127,18 @@ final class MeetingCaptureBridge: ObservableObject {
     }
 
     /// Stop the current recording and wait for Core's Audio to finish writing
-    /// the mic + system WAV files to disk. Returns the URLs of both files (system
-    /// may be nil if capture failed or was disabled).
-    func stopAndAwaitFiles() async -> (micURL: URL?, systemURL: URL?) {
+    /// the mic + system WAV files to disk. Returns a result that distinguishes
+    /// natural completion (`didTimeOut == false`) from `meetingStopTimeout`
+    /// expiry (`didTimeOut == true`). On timeout the WAV header may not be
+    /// fully patched, so the caller should treat the audio as failed-but-
+    /// recoverable rather than enqueuing it for transcription directly.
+    func stopAndAwaitFiles() async -> CaptureStopResult {
         guard audio.isRecording else {
-            return (audio.micAudioFileURL, audio.systemAudioFileURL)
+            return CaptureStopResult(
+                micURL: audio.micAudioFileURL,
+                systemURL: audio.systemAudioFileURL,
+                didTimeOut: false
+            )
         }
 
         return await withCheckedContinuation { continuation in
@@ -142,7 +167,11 @@ final class MeetingCaptureBridge: ObservableObject {
                         "system_file_available": "\(self.audio.systemAudioFileURL != nil)",
                     ]
                 )
-                continuation.resume(returning: (self.audio.micAudioFileURL, self.audio.systemAudioFileURL))
+                continuation.resume(returning: CaptureStopResult(
+                    micURL: self.audio.micAudioFileURL,
+                    systemURL: self.audio.systemAudioFileURL,
+                    didTimeOut: true
+                ))
             }
         }
     }
@@ -150,11 +179,11 @@ final class MeetingCaptureBridge: ObservableObject {
     /// Stop the current recording, wait for file handles to close, then remove
     /// the just-captured scratch audio instead of handing it to transcription.
     func stopAndDiscardFiles() async -> (micURL: URL?, systemURL: URL?) {
-        let files = await stopAndAwaitFiles()
-        MeetingRecordingCleanup.discardFiles(micURL: files.micURL, systemURL: files.systemURL)
+        let result = await stopAndAwaitFiles()
+        MeetingRecordingCleanup.discardFiles(micURL: result.micURL, systemURL: result.systemURL)
         audio.micAudioFileURL = nil
         audio.systemAudioFileURL = nil
-        return files
+        return (result.micURL, result.systemURL)
     }
 
     /// Snapshot of Core's recording health metadata for transcript frontmatter.
@@ -227,7 +256,11 @@ final class MeetingCaptureBridge: ObservableObject {
                 self.completionAttemptID = nil
                 self.completionTimeoutTask?.cancel()
                 self.completionTimeoutTask = nil
-                continuation?.resume(returning: (micURL, systemURL))
+                continuation?.resume(returning: CaptureStopResult(
+                    micURL: micURL,
+                    systemURL: systemURL,
+                    didTimeOut: false
+                ))
             }
         }
     }

--- a/Sources/Meeting/MeetingFailureCopy.swift
+++ b/Sources/Meeting/MeetingFailureCopy.swift
@@ -50,6 +50,13 @@ struct MeetingFailureCopy: Equatable {
             )
         }
 
+        if message.contains("stop timed out") {
+            return MeetingFailureCopy(
+                title: "Recording didn't close cleanly",
+                detail: "The audio files may be incomplete. Retry to transcribe what was captured, or delete to discard."
+            )
+        }
+
         return MeetingFailureCopy(
             title: isRetryable ? "Transcript needs another pass" : "Recording needs attention",
             detail: shortErrorMessage

--- a/Sources/Meeting/MeetingFailureKind.swift
+++ b/Sources/Meeting/MeetingFailureKind.swift
@@ -14,6 +14,7 @@ enum MeetingFailureKind: String {
     case transcriptionInferenceFailed = "transcription_inference_failed"
     case diarizationFailed = "diarization_failed"
     case pipelineBusy = "pipeline_busy"
+    case stopTimeout = "stop_timeout"
     case unexpectedError = "unexpected_error"
 
     static func isRecordingTooShortMessage(_ message: String) -> Bool {
@@ -31,6 +32,11 @@ enum MeetingFailureKind: String {
 
     static func classify(message: String) -> MeetingFailureKind {
         let normalized = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        if normalized.contains("stop timed out")
+            || normalized.contains("recording stop timed out") {
+            return .stopTimeout
+        }
 
         if normalized.contains("system audio is required")
             || normalized.contains("system audio recording")

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -497,7 +497,8 @@ final class MeetingSessionController: ObservableObject {
         // Snapshot capture health before stop resets system-audio status/stats during cleanup.
         let healthInfo = capture.healthInfo()
         let finalSystemAudioStatus = capture.systemAudioStatus
-        let files = await capture.stopAndAwaitFiles()
+        let stopResult = await capture.stopAndAwaitFiles()
+        let files = (micURL: stopResult.micURL, systemURL: stopResult.systemURL)
         let durationMs = Int(recordingDuration * 1000)
         activeRecordingTrigger = .unknown
         state = .transcribing
@@ -514,6 +515,7 @@ final class MeetingSessionController: ObservableObject {
                     "duration_ms": "\(durationMs)",
                     "mic_file_present": boolString(files.micURL != nil),
                     "system_file_present": boolString(files.systemURL != nil),
+                    "stop_timed_out": boolString(stopResult.didTimeOut),
                     "capture_quality": healthInfo.captureQuality.rawValue,
                     "audio_gaps": "\(healthInfo.audioGaps)",
                     "device_switches": "\(healthInfo.deviceSwitches)"
@@ -531,6 +533,28 @@ final class MeetingSessionController: ObservableObject {
                 context: baseDiagnosticsContext(extra: ["reason": reason.rawValue])
             )
             state = .error("No microphone audio was captured.")
+            return
+        }
+
+        // Stop timeout means Audio.onRecordingComplete never fired. The WAV
+        // header may not be fully patched, so route the audio to the failed
+        // queue rather than enqueuing for transcription. The user can retry
+        // from Settings → Meetings, where the pipeline will either succeed
+        // on a now-finalized file or fail cleanly.
+        if stopResult.didTimeOut {
+            failedManager.addFailedTranscription(
+                micAudioURL: micURL,
+                systemAudioURL: files.systemURL,
+                errorMessage: "Recording stop timed out before audio files were finalized."
+            )
+            DiagnosticsTrail.record(
+                level: .warning,
+                engine: "meeting",
+                event: "meeting_recording_stop_timeout_failed",
+                message: "Meeting routed to failed queue due to stop timeout",
+                context: baseDiagnosticsContext(extra: ["reason": reason.rawValue])
+            )
+            state = .error("Recording didn't close cleanly. Open Settings → Meetings to retry.")
             return
         }
 

--- a/Sources/TranscriptedCore/Audio/SystemAudioProcessTap.swift
+++ b/Sources/TranscriptedCore/Audio/SystemAudioProcessTap.swift
@@ -91,64 +91,48 @@ extension SystemAudioCapture {
             throw "Failed to create AVAudioFormat from tap description"
         }
 
-        // Track callback count for debugging (thread-safe via atomic-like access)
-        var callbackCount = 0
-
-        // Create I/O proc to receive audio buffers
+        // Create I/O proc to receive audio buffers.
+        //
+        // CRITICAL: this closure runs on the CoreAudio I/O thread. It must be
+        // real-time safe — NO logging, NO allocations beyond AVAudioPCMBuffer
+        // wrapper construction, NO blocking work. Counter increments use short
+        // NSLock acquisitions which are acceptable here; anything heavier must
+        // be deferred. cleanup()/logStats() surface counters off the RT thread.
         var err = AudioDeviceCreateIOProcIDWithBlock(&deviceProcID, aggregateDeviceID, queue) { [weak self] inNow, inInputData, inInputTime, outOutputData, inOutputTime in
             guard let self = self, let bufferCallback = self.bufferCallback else {
-                AppLogger.audioSystem.warning("I/O Proc: self or bufferCallback is nil")
                 return
             }
 
-            callbackCount += 1
-            if callbackCount <= 3 {
-                AppLogger.audioSystem.debug("I/O Proc callback", ["count": "\(callbackCount)"])
+            guard let buffer = AVAudioPCMBuffer(pcmFormat: format, bufferListNoCopy: inInputData, deallocator: nil) else {
+                return
             }
 
-            do {
-                guard let buffer = AVAudioPCMBuffer(pcmFormat: format, bufferListNoCopy: inInputData, deallocator: nil) else {
-                    AppLogger.audioSystem.error("I/O Proc: Failed to create PCM buffer")
-                    throw "Failed to create PCM buffer"
-                }
+            // Track total buffers received
+            self.incrementStats(hasData: false)
 
-                // Track total buffers received
-                self.incrementStats(hasData: false)
-
-                // CRITICAL FIX: Check for zero-frame buffers BEFORE updating watchdog
-                // Zero-frame buffers were defeating the watchdog by updating lastBufferTime
-                // even though no actual audio was being captured (device switch scenario)
-                let frameLength = buffer.frameLength
-                if frameLength == 0 {
-                    // Log throttled: first 10, then every 100th
-                    if callbackCount <= 10 || callbackCount % 100 == 0 {
-                        AppLogger.audioSystem.warning("Zero-frame buffer", ["callbackCount": "\(callbackCount)"])
-                    }
-                    self.incrementDropped()
-                    // Do NOT update lastBufferTime - let watchdog detect silence
-                    return
-                }
-
-                if callbackCount <= 3 {
-                    AppLogger.audioSystem.debug("Buffer created", ["frames": "\(frameLength)"])
-                }
-
-                // Only update watchdog timestamp for buffers with actual data
-                // CACurrentMediaTime() is allocation-free and safe for real-time threads
-                self.lastBufferTime = CACurrentMediaTime()
-                if !self.hasReceivedFirstBuffer {
-                    self.hasReceivedFirstBuffer = true
-                }
-                if self.recoveryAttempts > 0 {
-                    self.recoveryAttempts = 0
-                }
-                self.markBufferHasData()
-
-                // Send buffer to callback
-                bufferCallback(buffer)
-            } catch {
-                AppLogger.audioSystem.error("I/O Proc error", ["error": "\(error)"])
+            // CRITICAL FIX: Check for zero-frame buffers BEFORE updating watchdog.
+            // Zero-frame buffers were defeating the watchdog by updating lastBufferTime
+            // even though no actual audio was being captured (device switch scenario).
+            let frameLength = buffer.frameLength
+            if frameLength == 0 {
+                self.incrementDropped()
+                // Do NOT update lastBufferTime — let watchdog detect silence
+                return
             }
+
+            // Only update watchdog timestamp for buffers with actual data.
+            // CACurrentMediaTime() is allocation-free and safe for real-time threads.
+            self.lastBufferTime = CACurrentMediaTime()
+            if !self.hasReceivedFirstBuffer {
+                self.hasReceivedFirstBuffer = true
+            }
+            if self.recoveryAttempts > 0 {
+                self.recoveryAttempts = 0
+            }
+            self.markBufferHasData()
+
+            // Send buffer to callback
+            bufferCallback(buffer)
         }
 
         guard err == noErr else {

--- a/Tests/MeetingFailureKindTests.swift
+++ b/Tests/MeetingFailureKindTests.swift
@@ -49,6 +49,24 @@ func testMeetingFailureKind() {
         assertEqual(kind, .pipelineBusy, "pipeline-busy rejections from TranscriptionTaskManager should not fall to unexpected_error")
     }
 
+    runSuite("MeetingFailureKind classifies stop-timeout errors") {
+        let kind = MeetingFailureKind.classify(
+            message: "Recording stop timed out before audio files were finalized."
+        )
+
+        assertEqual(kind, .stopTimeout, "stop-timeout failures should keep their own bucket so retry copy can target them")
+    }
+
+    runSuite("MeetingFailureCopy surfaces stop-timeout retry guidance") {
+        let copy = MeetingFailureCopy.make(
+            forMessage: "Recording stop timed out before audio files were finalized.",
+            shortErrorMessage: "Recording stop timed out.",
+            isRetryable: true
+        )
+
+        assertEqual(copy.title, "Recording didn't close cleanly", "stop-timeout users should see specific copy, not generic retry phrasing")
+    }
+
     runSuite("MeetingFailureKind falls back to an explicit unexpected bucket") {
         let kind = MeetingFailureKind.classify(
             message: "Something odd happened while processing the meeting"


### PR DESCRIPTION
## Summary

Two independent reliability fixes uncovered in a focused audit of the meeting capture path.

**1. Route stop-timeout meetings to the failed queue** ([8fde23a](https://github.com/r3dbars/transcripted/commit/8fde23a))

`MeetingCaptureBridge.stopAndAwaitFiles` resolves with whatever URLs `Audio` exposes when `meetingStopTimeout` (30s) fires, regardless of whether `onRecordingComplete` ever ran. The controller was feeding those URLs directly into transcription, risking a corrupt transcript from a half-finalized WAV. The bridge now returns a `CaptureStopResult` carrying `didTimeOut`; on timeout the controller writes the audio into the failed queue (with retry available from Settings) and surfaces a clear error instead of attempting to transcribe.

Adds a new `MeetingFailureKind.stopTimeout` + matching `MeetingFailureCopy` so retry messaging is user-friendly. Also adds `stop_timed_out` to the existing `meeting_recording_stopped` diagnostics event for visibility.

**2. Drop logging from the system audio I/O proc** ([32fa75b](https://github.com/r3dbars/transcripted/commit/32fa75b))

`SystemAudioProcessTap.startAudioDevice` was running debug/warning/error logs from the CoreAudio I/O block — even with `callbackCount`-based throttling, that's logging on the real-time audio callback thread. Strip the logs, remove the now-dead `callbackCount` capture, and document the RT-safety contract. Stats counters still capture the same data (success rate, dropped buffers); `cleanup()` logs them off-thread.

## Test plan

- [x] `bash build.sh` — clean
- [x] `bash run-tests.sh` — 848/848 (added 2 new cases for `stopTimeout` classification + copy)
- [x] `bash run-integration-smoke.sh` — clean
- [ ] Manual verification of the timeout path is hard without forcing a 30s+ stall on `onRecordingComplete`. The branch is logically verified but not empirically reproduced.

## Follow-ups deliberately not in this PR

- Protocol seam for `MeetingCaptureBridge` so the controller's timeout branch can be unit-tested with a mock
- Larger Fix #2 phases (consolidate the per-scalar `NSLock`s in `Audio.swift`, pre-allocate or pool the per-callback `AVAudioPCMBuffer` wrapper) — both real concerns but should land behind a benchmark
- Other audit findings: STT model-switch race in `STTRouter`, failed-transcription persistence crash window, `MeetingPromptDetector` polling cost, transcript styler I/O on `@MainActor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)