### PR TITLE
Code review cleanups: TranscriptedCore boundary, onboarding poll, EOU lookup, stale TODO

### DIFF
--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -14,6 +14,7 @@
 //   3. Keeping the bridge isolated from the pipeline lets Lane C swap in a mock
 //      for preview/testing without touching CoreAudio.
 
+import AppKit
 import AVFoundation
 import Combine
 import Foundation
@@ -228,6 +229,23 @@ final class MeetingCaptureBridge: ObservableObject {
                 self.completionTimeoutTask?.cancel()
                 self.completionTimeoutTask = nil
                 continuation?.resume(returning: (micURL, systemURL))
+            }
+        }
+
+        // Capture-lifecycle cues used to live inside Core (NSSound("Tink") on
+        // start, NSSound("Pop") on stop). Core no longer depends on AppKit for
+        // cosmetic UI; the host plays the sounds here. Audio fires the cue from
+        // the main queue (via DispatchQueue.main.async / MainActor.run inside
+        // the lifecycle helpers), but we still bounce through Task @MainActor
+        // to match the rest of the bridge's threading discipline.
+        audio.onCaptureLifecycleCue = { cue in
+            Task { @MainActor in
+                switch cue {
+                case .recordingStarted:
+                    NSSound(named: "Tink")?.play()
+                case .recordingStopped:
+                    NSSound(named: "Pop")?.play()
+                }
             }
         }
     }

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -208,11 +208,12 @@ final class MeetingSessionController: ObservableObject {
         self.statsDatabase = StatsDatabase(path: storagePaths.statsDB.path)
 
         // Failed-queue manager: takes CoreStoragePaths so its JSON file lives
-        // under app-owned state, not the capture library.
-        // TODO: Phase 2 ships without failed-transcription recovery for meeting
-        // mode — we construct the manager because TranscriptionTaskManager
-        // requires it, but nothing in the app currently drains the failed queue
-        // or exposes retry UI. Follow-up work lands in a later phase.
+        // under app-owned state, not the capture library. The queue is drained
+        // by `refreshFailedMeetings()` (subscribed to
+        // `failedManager.$failedTranscriptions`) and surfaced in Settings →
+        // Meetings → "Needs Attention", with retry / dismiss / delete actions
+        // wired through `retryFailedMeeting`, `dismissFailedMeeting`, and
+        // `deleteFailedMeeting`.
         self.failedManager = FailedTranscriptionManager(paths: storagePaths)
 
         // DI container — the protocol-typed "what Core sees" surface.

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -624,8 +624,17 @@ class ParakeetEngine: ObservableObject {
             } else {
                 // Download from HuggingFace (~120MB) and cache locally
                 // DownloadUtils nests inside <directory>/<repo.folderName>/, so we use the parent
-                let cacheBase = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-                    .appendingPathComponent("FluidAudio/Models", isDirectory: true)
+                guard let appSupportRoot = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+                    print("⚠️ PARAKEET EOU | application support directory unavailable")
+                    EventReporter.shared.capture(
+                        level: .warning,
+                        engine: "parakeet",
+                        event: "eou_app_support_unavailable",
+                        message: "Application support directory lookup returned no results; cannot resolve EOU model cache"
+                    )
+                    return
+                }
+                let cacheBase = appSupportRoot.appendingPathComponent("FluidAudio/Models", isDirectory: true)
                 let expectedDir = cacheBase.appendingPathComponent("parakeet-eou-streaming/320ms", isDirectory: true)
                 let checkFile = expectedDir.appendingPathComponent("streaming_encoder.mlmodelc")
                 if FileManager.default.fileExists(atPath: checkFile.path) {

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -5,6 +5,13 @@ import AppKit
 import CoreAudio
 import Combine
 
+/// Cosmetic lifecycle cues emitted by `Audio` so embedders can play start /
+/// stop UI feedback without `Audio` itself depending on AppKit / NSSound.
+public enum CaptureLifecycleCue: Sendable {
+    case recordingStarted
+    case recordingStopped
+}
+
 /// Status of system audio capture for UI feedback
 /// Used to show warnings when device switching or audio loss occurs
 public enum SystemAudioStatus: Equatable {
@@ -296,6 +303,12 @@ public class Audio: ObservableObject, @unchecked Sendable {
     // Callback for when recording starts (used for pre-loading models)
     public var onRecordingStart: (() -> Void)?
 
+    // Cosmetic capture lifecycle cues. Embedders decide how (or whether) to
+    // surface these — typically a UI sound. Fires from whichever queue the
+    // underlying lifecycle event runs on; the host should hop to the main
+    // actor before touching UI.
+    public var onCaptureLifecycleCue: ((CaptureLifecycleCue) -> Void)?
+
     // MARK: - Live PCM buffer hooks (host app live-preview integration)
     //
     // These callbacks let an embedder tap the raw PCM buffers as they arrive
@@ -571,6 +584,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         // Update UI immediately - don't wait for file cleanup
         // This makes the app feel instant
+        let cueHandler = self.onCaptureLifecycleCue
         DispatchQueue.main.async {
             self.isRecording = false
             self.audioLevel = 0.0
@@ -578,7 +592,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
             self.stopTimer()
             self.stopWatchdog()
             self.isMicRecovering = false
-            NSSound(named: "Pop")?.play()
+            cueHandler?(.recordingStopped)
         }
 
         // Close audio files asynchronously - use DispatchGroup to coordinate

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -1,6 +1,5 @@
 import Foundation
 @preconcurrency import AVFoundation
-import AppKit
 import QuartzCore
 
 // MARK: - Audio File Creation & Buffer Management
@@ -248,13 +247,14 @@ extension Audio {
 
         try engine.start()
 
+        let cueHandler = self.onCaptureLifecycleCue
         await MainActor.run {
             // isRecording already set in start()
             self.startTime = Date()
             self.recordingDuration = 0.0
             self.startTimer()
             self.startWatchdog()
-            NSSound(named: "Tink")?.play()
+            cueHandler?(.recordingStarted)
         }
     }
 

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -41,7 +41,7 @@ struct PermissionsOnboardingView: View {
     @State private var demoDictationText = ""
     @State private var copiedAgentItem: AgentCopyItem?
     @State private var copiedResetTask: Task<Void, Never>?
-    @State private var pollTimer: Timer?
+    @State private var pollTask: Task<Void, Never>?
     @FocusState private var demoEditorFocused: Bool
 
     init(
@@ -359,17 +359,23 @@ struct PermissionsOnboardingView: View {
     }
 
     private func startPolling() {
-        pollTimer?.invalidate()
-        pollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
-            Task { @MainActor in
+        pollTask?.cancel()
+        pollTask = Task { @MainActor in
+            // Foundation Timers run in .default mode and pause during menu
+            // tracking, so onboarding could miss a permission flip while the
+            // user has the System Settings menu open. A Task-driven loop keeps
+            // polling regardless and dies cleanly when onDisappear cancels it.
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard !Task.isCancelled else { return }
                 checkAllPermissions()
             }
         }
     }
 
     private func stopPolling() {
-        pollTimer?.invalidate()
-        pollTimer = nil
+        pollTask?.cancel()
+        pollTask = nil
     }
 
     private func completeOnboarding() {


### PR DESCRIPTION
## Summary

Four low-risk fixes flagged in a code review of `main`:

- **TranscriptedCore boundary** — `Audio.swift` and `AudioFileManager.swift` were dragging `import AppKit` into the reusable library to play two `NSSound` cues on recording start/stop. Replaced with a `CaptureLifecycleCue` callback on `Audio`; the host (`MeetingCaptureBridge`) now plays the sounds. `AudioFileManager.swift` no longer imports AppKit. `Audio.swift` still imports AppKit because of `NSWorkspace` sleep/wake notifications — that's a real OS API and a separate concern from cosmetic UI cues.
- **Onboarding polling** — `PermissionsOnboardingView` was using `Timer.scheduledTimer` plus a nested `Task { @MainActor in checkAllPermissions() }`. Foundation timers run in `.default` mode and pause during menu tracking, so the loop could miss a permission flip while System Settings was open. Replaced with a single cancellable `Task` that awaits `Task.sleep` — same `onDisappear` cleanup, but polling continues regardless of UI run-loop state.
- **EOU model cache lookup** — `ParakeetEngine.initializeEouModel()` had `urls(for:.applicationSupportDirectory, in:.userDomainMask).first!`. Replaced with `guard let` + a structured `EventReporter` warning + clean return. Almost-impossible to hit in practice, but a hard force-unwrap on a deep init path was a hard crash if it ever did fail.
- **Stale Phase-2 TODO** — `MeetingSessionController` carried a comment claiming meetings shipped without failed-transcription retry UI. That stopped being true some time ago: the queue is drained by `refreshFailedMeetings()` (subscribed to `failedManager.$failedTranscriptions`), surfaced in Settings → Meetings → "Needs Attention" via `SettingsFailedMeetingRow`, and `retryFailedMeeting` / `dismissFailedMeeting` / `deleteFailedMeeting` wire the actions through. Comment-only change; rewritten to describe current reality.

No user-visible change for #1, #2, #4. #3 converts a rare crash into a logged warning.

## Test plan

- [x] `bash build.sh` — clean
- [x] `bash run-tests.sh` — 846 / 846 passed
- [x] `bash run-integration-smoke.sh` — passed (Audio + AudioFileManager touched)
- [x] `swift test` — 77 / 77 passed (TranscriptedCore package seam)
- [ ] Manual: meeting recording start/stop still plays Tink/Pop sounds
- [ ] Manual: permissions onboarding still flips green when permissions are granted while System Settings is in the foreground

🤖 Generated with [Claude Code](https://claude.com/claude-code)