### PR TITLE
Fix dictation clipboard and meeting menu state

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -40,6 +40,7 @@ final class MeetingSessionController: ObservableObject {
     enum StopReason: String {
         case hotkeyToggle = "hotkey_toggle"
         case overlayStopButton = "overlay_stop_button"
+        case menuBarStopButton = "menu_bar_stop_button"
         case audioInactivityPrompt = "audio_inactivity_prompt"
         case audioInactivityTimeout = "audio_inactivity_timeout"
         case unknown = "unknown"

--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -96,15 +96,7 @@ final class ClipboardRestoringTextPaster {
 
         let changeCountAfterSet = pasteboard.changeCount
         clipboardRestoreTask = Task { @MainActor [weak self] in
-            let startTime = CFAbsoluteTimeGetCurrent()
-            while CFAbsoluteTimeGetCurrent() - startTime < TranscriptedConstants.clipboardRestoreTimeout {
-                try? await Task.sleep(nanoseconds: TranscriptedConstants.clipboardPollInterval)
-                guard !Task.isCancelled else { return }
-                if pasteboard.changeCount != changeCountAfterSet {
-                    return
-                }
-            }
-
+            try? await Task.sleep(nanoseconds: TranscriptedConstants.clipboardRestoreDelay)
             guard !Task.isCancelled else { return }
             self?.restorePasteboardItems(
                 savedItems,

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -114,11 +114,8 @@ enum TranscriptedConstants {
 
     // MARK: - Clipboard
 
-    /// Clipboard restore polling interval (nanoseconds)
-    static let clipboardPollInterval: UInt64 = 50_000_000  // 50ms
-
-    /// Clipboard restore timeout in seconds
-    static let clipboardRestoreTimeout: Double = 2.0
+    /// Delay after posting Cmd+V before restoring the user's clipboard.
+    static let clipboardRestoreDelay: UInt64 = 120_000_000  // 120ms
 
     // MARK: - Dictation Auto Enter
 

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -64,7 +64,8 @@ final class MenuBarPanelController: NSViewController {
         let dictationState = FirstRunExperience.dictationAction(for: modelState)
         let meetingState = FirstRunExperience.meetingAction(
             dictationReady: appState.sttRouter.isModelLoaded,
-            meetingsStatus: warmupStatus.meetingsStatus
+            meetingsStatus: warmupStatus.meetingsStatus,
+            isRecording: appState.meetingSession.isRecording
         )
         let updatePresentation = menuUpdatePresentation(for: appState.sparkleUpdater.updateStatus)
         let menuVisibility = MenuBarVisibilityPreferences.snapshot()
@@ -118,6 +119,13 @@ final class MenuBarPanelController: NSViewController {
 
     private func setupSubscriptions() {
         appState.meetingSession.$warmupStatus
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.refresh()
+            }
+            .store(in: &subscriptions)
+
+        appState.meetingSession.$state
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in
                 self?.refresh()
@@ -186,12 +194,17 @@ final class MenuBarPanelController: NSViewController {
     }
 
     private func startMeetingFromMenu() {
-        trackMenuAction("start_meeting")
+        let isRecording = appState.meetingSession.isRecording
+        trackMenuAction(isRecording ? "stop_meeting" : "start_meeting")
         let sourceApp = resolvedSourceApp()
         dismissPopover()
         sourceApp?.activate(options: [])
-        Task {
-            await appState.meetingSession.startRecording(trigger: .menu)
+        Task { [meetingSession = appState.meetingSession] in
+            if isRecording {
+                await meetingSession.stopRecording(reason: .menuBarStopButton)
+            } else {
+                await meetingSession.startRecording(trigger: .menu)
+            }
         }
     }
 

--- a/Sources/UI/MenuBar/MenuBarPrimaryActionsView.swift
+++ b/Sources/UI/MenuBar/MenuBarPrimaryActionsView.swift
@@ -60,8 +60,8 @@ final class MenuBarPrimaryActionsView: NSView {
 
         dictationRow.isHidden = !showStartDictation
         dictationRow.update(
-            symbolName: "mic.fill",
-            title: "Start Dictation",
+            symbolName: dictationState.symbolName,
+            title: dictationState.title,
             detail: dictationState.subtitle,
             trailingText: dictationKey,
             tone: .accent,
@@ -71,8 +71,8 @@ final class MenuBarPrimaryActionsView: NSView {
 
         meetingRow.isHidden = !showStartMeeting
         meetingRow.update(
-            symbolName: "record.circle.fill",
-            title: "Start Meeting",
+            symbolName: meetingState.symbolName,
+            title: meetingState.title,
             detail: meetingState.subtitle,
             trailingText: meetingKey,
             tone: .accent,

--- a/Sources/UI/MenuBar/MenuBarShortcutsView.swift
+++ b/Sources/UI/MenuBar/MenuBarShortcutsView.swift
@@ -30,8 +30,18 @@ final class MenuBarShortcutsView: NSView {
     private var recordingTarget: RecordingTarget?
     private var pendingDictationModifier: PhysicalDictationTriggerBinding?
     private var pendingDictationModifierKeyCode: UInt32?
-    private var currentDictationState = MenuBarPrimaryActionState(isEnabled: true, subtitle: "Paste spoken text anywhere")
-    private var currentMeetingState = MenuBarPrimaryActionState(isEnabled: true, subtitle: "Capture mic and system audio")
+    private var currentDictationState = MenuBarPrimaryActionState(
+        title: "Start Dictation",
+        symbolName: "mic.fill",
+        isEnabled: true,
+        subtitle: "Paste spoken text anywhere"
+    )
+    private var currentMeetingState = MenuBarPrimaryActionState(
+        title: "Start Meeting",
+        symbolName: "record.circle.fill",
+        isEnabled: true,
+        subtitle: "Capture mic and system audio"
+    )
     private var canImportAudioFiles = true
 
     private enum RecordingTarget {

--- a/Sources/UI/Shared/FirstRunExperience.swift
+++ b/Sources/UI/Shared/FirstRunExperience.swift
@@ -30,8 +30,22 @@ struct FirstRunModelCardState: Equatable {
 }
 
 struct MenuBarPrimaryActionState: Equatable {
+    let title: String
+    let symbolName: String
     let isEnabled: Bool
     let subtitle: String
+
+    init(
+        title: String,
+        symbolName: String,
+        isEnabled: Bool,
+        subtitle: String
+    ) {
+        self.title = title
+        self.symbolName = symbolName
+        self.isEnabled = isEnabled
+        self.subtitle = subtitle
+    }
 }
 
 enum FirstRunOnboardingStep: Int, CaseIterable, Identifiable, Equatable {
@@ -329,12 +343,27 @@ enum FirstRunExperience {
         }
 
         return MenuBarPrimaryActionState(
+            title: "Start Dictation",
+            symbolName: "mic.fill",
             isEnabled: true,
             subtitle: subtitle
         )
     }
 
-    static func meetingAction(dictationReady: Bool, meetingsStatus: String) -> MenuBarPrimaryActionState {
+    static func meetingAction(
+        dictationReady: Bool,
+        meetingsStatus: String,
+        isRecording: Bool = false
+    ) -> MenuBarPrimaryActionState {
+        if isRecording {
+            return MenuBarPrimaryActionState(
+                title: "Stop Meeting",
+                symbolName: "stop.circle.fill",
+                isEnabled: true,
+                subtitle: "Recording now"
+            )
+        }
+
         let subtitle: String
         switch meetingsStatus {
         case "Ready":
@@ -348,6 +377,8 @@ enum FirstRunExperience {
         }
 
         return MenuBarPrimaryActionState(
+            title: "Start Meeting",
+            symbolName: "record.circle.fill",
             isEnabled: true,
             subtitle: subtitle
         )

--- a/Tests/FirstRunExperienceTests.swift
+++ b/Tests/FirstRunExperienceTests.swift
@@ -83,6 +83,25 @@ func testFirstRunExperience() {
         )
     }
 
+    runSuite("FirstRunExperience.meetingAction — switches menu copy while recording") {
+        let idle = FirstRunExperience.meetingAction(
+            dictationReady: true,
+            meetingsStatus: "Ready",
+            isRecording: false
+        )
+        let recording = FirstRunExperience.meetingAction(
+            dictationReady: true,
+            meetingsStatus: "Ready",
+            isRecording: true
+        )
+
+        assertEqual(idle.title, "Start Meeting", "idle menu action should invite starting a meeting")
+        assertEqual(idle.symbolName, "record.circle.fill", "idle menu action should use the record icon")
+        assertEqual(recording.title, "Stop Meeting", "recording menu action should not keep saying Start Meeting")
+        assertEqual(recording.symbolName, "stop.circle.fill", "recording menu action should use the stop icon")
+        assertEqual(recording.subtitle, "Recording now", "recording menu detail should explain the current state")
+    }
+
     runSuite("FirstRunExperience.primaryAction — explains only dictation-critical permissions are required up front") {
         let action = FirstRunExperience.primaryAction(
             hasRequiredPermissions: false,

--- a/Tests/TranscriptedConstantsTests.swift
+++ b/Tests/TranscriptedConstantsTests.swift
@@ -8,6 +8,13 @@ func testTranscriptedConstants() async {
         assertTrue(TranscriptedConstants.hasMinimumParakeetAudioSamples(20_000), "longer audio should still be accepted")
     }
 
+    runSuite("TranscriptedConstants restores borrowed clipboard before auto-enter") {
+        assertTrue(
+            TranscriptedConstants.clipboardRestoreDelay < TranscriptedConstants.dictationAutoEnterDelay,
+            "clipboard restore should happen before follow-up keypresses and before users can easily paste stale dictation text"
+        )
+    }
+
     await runSuite("TranscriptedConstants.withTimeout — returns completed work before deadline") {
         let result = try? await TranscriptedConstants.withTimeout(seconds: 1) {
             "ok"

--- a/docs/meeting-menu-row-preview.html
+++ b/docs/meeting-menu-row-preview.html
@@ -1,0 +1,219 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Transcripted Meeting Menu Row Preview</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #15161a;
+      --panel: #202227;
+      --panel-border: #343740;
+      --row: #2a2d34;
+      --row-hover: #323641;
+      --text: #f3f4f6;
+      --muted: #a6acb8;
+      --key: #d2d6df;
+      --accent: #59b6ff;
+      --stop: #ff6b63;
+      --shadow: 0 18px 50px rgba(0, 0, 0, 0.38);
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      background: #101114;
+      color: var(--text);
+    }
+
+    main {
+      width: min(760px, calc(100vw - 32px));
+      display: grid;
+      gap: 18px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 22px;
+      font-weight: 700;
+      letter-spacing: 0;
+    }
+
+    p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 14px;
+      line-height: 1.45;
+    }
+
+    .panel {
+      width: 360px;
+      max-width: 100%;
+      padding: 12px;
+      background: var(--panel);
+      border: 1px solid var(--panel-border);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+    }
+
+    .stack {
+      display: grid;
+      gap: 10px;
+    }
+
+    .row {
+      display: grid;
+      grid-template-columns: 34px 1fr auto;
+      align-items: center;
+      gap: 12px;
+      min-height: 62px;
+      padding: 10px 12px;
+      border-radius: 7px;
+      background: var(--row);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+    }
+
+    .row:hover {
+      background: var(--row-hover);
+    }
+
+    .icon {
+      width: 30px;
+      height: 30px;
+      display: grid;
+      place-items: center;
+      border-radius: 7px;
+      color: #081018;
+      background: var(--accent);
+    }
+
+    .icon.stop {
+      background: var(--stop);
+    }
+
+    .icon svg {
+      width: 18px;
+      height: 18px;
+      fill: currentColor;
+    }
+
+    .copy {
+      min-width: 0;
+    }
+
+    .title {
+      margin: 0 0 3px;
+      font-size: 15px;
+      font-weight: 700;
+      letter-spacing: 0;
+      color: var(--text);
+    }
+
+    .detail {
+      margin: 0;
+      font-size: 12px;
+      line-height: 1.25;
+      color: var(--muted);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .key {
+      min-width: 54px;
+      padding: 5px 8px;
+      text-align: center;
+      color: var(--key);
+      font-size: 12px;
+      font-weight: 650;
+      border-radius: 6px;
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.09);
+    }
+
+    .comparison {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 18px;
+      align-items: start;
+    }
+
+    .label {
+      margin: 0 0 8px;
+      color: var(--muted);
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    @media (max-width: 760px) {
+      .comparison {
+        grid-template-columns: 1fr;
+      }
+
+      .panel {
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>Meeting Menu Row</h1>
+      <p>The row now changes state while a meeting is recording, so it no longer sits there saying “Start Meeting.”</p>
+    </header>
+
+    <section class="comparison" aria-label="Meeting row states">
+      <div>
+        <p class="label">Idle</p>
+        <div class="panel">
+          <div class="stack">
+            <div class="row">
+              <div class="icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24">
+                  <path d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18Zm0 3.2a5.8 5.8 0 1 1 0 11.6 5.8 5.8 0 0 1 0-11.6Zm0 2.2a3.6 3.6 0 1 0 0 7.2 3.6 3.6 0 0 0 0-7.2Z"/>
+                </svg>
+              </div>
+              <div class="copy">
+                <p class="title">Start Meeting</p>
+                <p class="detail">Capture mic and system audio</p>
+              </div>
+              <div class="key">⌥M</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <p class="label">Recording</p>
+        <div class="panel">
+          <div class="stack">
+            <div class="row">
+              <div class="icon stop" aria-hidden="true">
+                <svg viewBox="0 0 24 24">
+                  <path d="M12 3a9 9 0 1 0 0 18 9 9 0 0 0 0-18Zm-3 6.4c0-.22.18-.4.4-.4h5.2c.22 0 .4.18.4.4v5.2c0 .22-.18.4-.4.4H9.4a.4.4 0 0 1-.4-.4V9.4Z"/>
+                </svg>
+              </div>
+              <div class="copy">
+                <p class="title">Stop Meeting</p>
+                <p class="detail">Recording now</p>
+              </div>
+              <div class="key">⌥M</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restore the previous clipboard quickly after dictation paste-back so immediate manual paste does not reuse dictated text
- make the meeting menu row switch to Stop Meeting while recording and toggle stop from the menu
- add a small HTML preview for the meeting menu row states

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh