### PR TITLE
Enable VPIO on meeting mic to fix Safari/Firefox quietness (#500)

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -132,6 +132,14 @@ public class Audio: ObservableObject, @unchecked Sendable {
     var startTime: Date?
     var timer: Timer?
 
+    // True once setVoiceProcessingEnabled(true) has succeeded on the current
+    // inputNode. Reset whenever engine.reset() runs (device recovery) so we
+    // re-arm VPIO before reinstalling the tap. Issue #500: Safari/Firefox
+    // WebRTC activates AUVoiceProcessingIO on the shared input device which
+    // hands every other reader an attenuated stream; running our own VPIO
+    // gives us our own AGC'd copy.
+    var voiceProcessingEnabled: Bool = false
+
     // Device change watchdog - thread-safe access via lock
     // Uses CACurrentMediaTime() (monotonic clock) to avoid false triggers after sleep/wake.
     // Matches SystemAudioCapture.swift which also uses CACurrentMediaTime().
@@ -404,6 +412,10 @@ public class Audio: ObservableObject, @unchecked Sendable {
             AppLogger.audioMic.info("Using system default microphone")
         }
 
+        if let inputNode {
+            armVoiceProcessing(on: inputNode)
+        }
+
         guard let engine, let inputNode else {
             throw NSError(
                 domain: "Audio",
@@ -413,6 +425,52 @@ public class Audio: ObservableObject, @unchecked Sendable {
         }
 
         return (engine, inputNode)
+    }
+
+    /// Format the mic tap will actually deliver. With VPIO enabled the tap
+    /// receives the VPIO output (mono Float32 at the unit's preferred rate),
+    /// not the raw hardware format. Without VPIO we keep using the hardware
+    /// format read on bus 1 so Bluetooth devices keep working.
+    func recordingFormat(for inputNode: AVAudioInputNode) -> AVAudioFormat {
+        if voiceProcessingEnabled {
+            return inputNode.outputFormat(forBus: 0)
+        }
+        return inputNode.inputFormat(forBus: 1)
+    }
+
+    /// Enable AUVoiceProcessingIO on the meeting input node so Transcripted
+    /// gets its own AGC'd copy of the mic stream rather than reading the raw
+    /// shared device. Issue #500: when Safari/Firefox WebRTC has VPIO active
+    /// on the same physical device, plain AVAudioEngine taps see attenuated
+    /// audio and meeting recordings come out very quiet.
+    ///
+    /// Idempotent and safe to call repeatedly. Skips when the engine is
+    /// already running (toggling VPIO requires a stopped engine). Falls back
+    /// silently when the device cannot host VPIO (rare, e.g. unusual
+    /// aggregate devices) so a VPIO failure never blocks recording.
+    func armVoiceProcessing(on inputNode: AVAudioInputNode) {
+        if voiceProcessingEnabled, inputNode.isVoiceProcessingEnabled {
+            return
+        }
+
+        if let engine, engine.isRunning {
+            // VPIO can only be toggled while the engine is stopped. Defer until
+            // the next start cycle re-enters this path.
+            return
+        }
+
+        do {
+            try inputNode.setVoiceProcessingEnabled(true)
+            voiceProcessingEnabled = true
+            AppLogger.audioMic.info("Voice processing enabled on meeting mic", [
+                "reason": "issue_500_safari_firefox_vpio_contention"
+            ])
+        } catch {
+            voiceProcessingEnabled = false
+            AppLogger.audioMic.warning("Voice processing unavailable, continuing without it", [
+                "error": error.localizedDescription
+            ])
+        }
     }
 
     func prepareForNewRecordingStart() {
@@ -636,15 +694,15 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         AppLogger.audio.info("Starting audio level monitoring")
 
-        let hardwareFormat = inputNode.inputFormat(forBus: 1)
-        guard hardwareFormat.sampleRate > 0, hardwareFormat.channelCount > 0 else {
+        let monitorFormat = recordingFormat(for: inputNode)
+        guard monitorFormat.sampleRate > 0, monitorFormat.channelCount > 0 else {
             AppLogger.audio.warning("Cannot start monitoring — invalid input format")
             return
         }
 
         // Install mic tap for level metering only (no file writing)
         inputNode.removeTap(onBus: 0)
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: hardwareFormat) { [weak self] buffer, _ in
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: monitorFormat) { [weak self] buffer, _ in
             self?.calculateLevel(buffer: buffer)
         }
 

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -92,6 +92,8 @@ extension Audio {
 
         // Reset to system default (ignore UserDefaults preference during recovery)
         engine.reset()
+        // engine.reset() clears VPIO state on the input node; require re-arm.
+        voiceProcessingEnabled = false
         self.inputNode = engine.inputNode
 
         // Get new device format
@@ -113,15 +115,22 @@ extension Audio {
             return
         }
 
-        // Get ACTUAL hardware format (not converter format)
-        var recordingFormat = newInputNode.inputFormat(forBus: 1)
+        // Re-enable VPIO after the HAL settles so setVoiceProcessingEnabled
+        // queries a stable device. Skips silently if VPIO can't engage on the
+        // new device, in which case recordingFormat(for:) falls back to the
+        // hardware format and recording continues without AGC.
+        armVoiceProcessing(on: newInputNode)
+
+        // Read the format the tap will actually deliver (VPIO-aware when
+        // armVoiceProcessing succeeded above, hardware format otherwise).
+        var recordingFormat = self.recordingFormat(for: newInputNode)
         if recordingFormat.sampleRate <= 0 || recordingFormat.channelCount <= 0 {
             AppLogger.audioMic.warning("Recovery format invalid after first read, retrying", [
                 "sampleRate": "\(recordingFormat.sampleRate)",
                 "channels": "\(recordingFormat.channelCount)"
             ])
             Thread.sleep(forTimeInterval: 0.3)
-            recordingFormat = newInputNode.inputFormat(forBus: 1)
+            recordingFormat = self.recordingFormat(for: newInputNode)
         }
         guard recordingFormat.sampleRate > 0, recordingFormat.channelCount > 0 else {
             AppLogger.audioMic.error("Recovery format remained invalid", [

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -16,18 +16,24 @@ extension Audio {
 
         let (engine, inputNode) = try ensureEngineInitialized()
 
-        // Use system default microphone (whatever macOS has configured)
-        // CRITICAL: Must use inputFormat(forBus: 1) to get ACTUAL hardware format
-        // outputFormat(forBus: 0) returns the converter format, not hardware format
-        let hardwareFormat = inputNode.inputFormat(forBus: 1)
-        AppLogger.audioMic.info("Hardware format", ["sampleRate": "\(hardwareFormat.sampleRate)", "channels": "\(hardwareFormat.channelCount)"])
+        // Use system default microphone (whatever macOS has configured).
+        // recordingFormat(for:) returns:
+        //   - VPIO output format when armVoiceProcessing enabled it (mono
+        //     Float32 at the unit's preferred rate), which matches what the
+        //     tap on bus 0 will actually deliver.
+        //   - Hardware format via inputFormat(forBus: 1) otherwise — required
+        //     because outputFormat(forBus: 0) returns the converter format on
+        //     stock AVAudioEngine, which breaks Bluetooth capture.
+        let recordingFormat = self.recordingFormat(for: inputNode)
+        AppLogger.audioMic.info("Mic input format", [
+            "sampleRate": "\(recordingFormat.sampleRate)",
+            "channels": "\(recordingFormat.channelCount)",
+            "voiceProcessing": "\(voiceProcessingEnabled)"
+        ])
 
-        guard hardwareFormat.sampleRate > 0 && hardwareFormat.channelCount > 0 else {
+        guard recordingFormat.sampleRate > 0 && recordingFormat.channelCount > 0 else {
             throw NSError(domain: "Audio", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid input format"])
         }
-
-        // Use the HARDWARE format for the tap (critical for Bluetooth devices)
-        let recordingFormat = hardwareFormat
 
         // Start system audio capture
         // CRITICAL: Create audio file BEFORE starting I/O proc to avoid CPU overload

--- a/Sources/TranscriptedCore/Audio/AudioSignalRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioSignalRecovery.swift
@@ -88,14 +88,25 @@ enum AudioSignalRecovery {
         sampleRate: Double,
         analysis: AudioSignalAnalysis? = nil,
         targetPeak: Float = 0.45,
-        maxGain: Float = 12.0
+        maxGain: Float = 12.0,
+        minPeak: Float = 0.0008
     ) -> AudioNormalizationResult {
         let resolvedAnalysis = analysis ?? analyze(samples: samples, sampleRate: sampleRate)
-        guard resolvedAnalysis.hasSpeechCandidate, resolvedAnalysis.peak > 0.0001 else {
+        // Issue #500: WebRTC-attenuated meeting mic audio routinely peaks below
+        // the legacy hasSpeechCandidate gate (peak >= 0.004). The previous
+        // short-circuit returned gain=1.0 for exactly the case we needed to
+        // recover. Now we only bail when the buffer is essentially silence,
+        // and otherwise let normalizationGain (clamped by maxGain) do its job.
+        guard resolvedAnalysis.peak >= minPeak else {
             return AudioNormalizationResult(samples: samples, analysis: resolvedAnalysis, gain: 1.0)
         }
 
-        let gain = normalizationGain(for: resolvedAnalysis, targetPeak: targetPeak, maxGain: maxGain)
+        let gain = normalizationGain(
+            for: resolvedAnalysis,
+            targetPeak: targetPeak,
+            maxGain: maxGain,
+            minPeak: minPeak
+        )
         guard gain > 1.0 else {
             return AudioNormalizationResult(samples: samples, analysis: resolvedAnalysis, gain: 1.0)
         }
@@ -115,9 +126,10 @@ enum AudioSignalRecovery {
     static func normalizationGain(
         for analysis: AudioSignalAnalysis,
         targetPeak: Float = 0.45,
-        maxGain: Float = 12.0
+        maxGain: Float = 12.0,
+        minPeak: Float = 0.0008
     ) -> Float {
-        guard analysis.hasSpeechCandidate, analysis.peak > 0.0001 else { return 1.0 }
+        guard analysis.peak >= minPeak else { return 1.0 }
         return max(1.0, min(maxGain, targetPeak / analysis.peak))
     }
 

--- a/Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift
@@ -155,6 +155,29 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         XCTAssertEqual(normalized.samples, samples)
     }
 
+    func testAudioSignalRecoveryNormalizesAttenuatedSpeechBelowLegacyGate() {
+        // Issue #500 reproduction: WebRTC attenuation in Safari/Firefox can
+        // pull mic peaks below the old hasSpeechCandidate gate (peak >= 0.004),
+        // and the previous normalizer short-circuited to gain=1.0 on exactly
+        // this case. Now we should still apply gain.
+        var samples = [Float](repeating: 0.0, count: 64_000)
+        let attenuatedSpeech = alternatingSamples(amplitude: 0.002, count: 24_000)
+        samples.replaceSubrange(20_000..<44_000, with: attenuatedSpeech)
+
+        let analysis = AudioSignalRecovery.analyze(samples: samples, sampleRate: 16_000)
+        let normalized = AudioSignalRecovery.normalizeForSpeech(
+            samples: samples,
+            sampleRate: 16_000,
+            analysis: analysis
+        )
+
+        XCTAssertFalse(analysis.hasSpeechCandidate, "Peak 0.002 must remain below the legacy candidate threshold")
+        XCTAssertTrue(normalized.wasNormalized, "Attenuated speech should still be amplified")
+        XCTAssertGreaterThan(normalized.gain, 1.0)
+        XCTAssertLessThanOrEqual(normalized.gain, 12.0)
+        XCTAssertGreaterThan(normalized.samples.map(abs).max() ?? 0, analysis.peak)
+    }
+
     func testPrepareMicSegmentPadsShortQuietSpeechForParakeet() {
         let samples = alternatingSamples(amplitude: 0.006, count: 8_000)
 


### PR DESCRIPTION
## Summary
- Fixes #500. Enables AUVoiceProcessingIO on Transcripted's own meeting AVAudioEngine so we get an AGC'd copy of the mic instead of reading the attenuated shared-device stream Safari/Firefox produce when their WebRTC stack activates VPIO.
- Loosens the \`normalizeForSpeech\` gate from \`hasSpeechCandidate\` to \`peak >= 0.0008\` as a fallback for devices where VPIO can't engage.
- VPIO output format handled via a new \`recordingFormat(for:)\` helper; non-VPIO path keeps the existing \`inputFormat(forBus: 1)\` Bluetooth-friendly read.

## Why PR #505 wasn't enough
The post-processing normalizer short-circuited to gain=1.0 when \`peak < 0.004\`, but WebRTC-attenuated mic audio routinely peaks at 0.001–0.003 — exactly the case it was meant to recover. And it only touched the in-memory copy fed to STT, so the saved WAV stayed quiet either way.

## Why Safari/Firefox only
Chromium browsers do AGC in user space and never touch macOS's voice-processing unit. Safari/WebKit and Firefox use AUVoiceProcessingIO when WebRTC \`getUserMedia\` enables echo-cancellation/AGC/NS (the defaults). VPIO active on a shared input device hands every other reader an attenuated stream until they own a VPIO instance themselves.

## Test plan
- [x] \`bash build.sh\` (clean build)
- [x] \`bash run-tests.sh\` (846/846)
- [x] \`bash run-integration-smoke.sh\`
- [x] \`swift test --filter TranscriptionPipelineHelpersTests\` (13/13, includes new \`testAudioSignalRecoveryNormalizesAttenuatedSpeechBelowLegacyGate\`)
- [ ] Manual repro: open https://meet.google.com/new in **Safari** with mic granted, start a Transcripted meeting recording, speak, stop, verify the saved \`meeting_*_mic.wav\` is at normal volume (compare to a control with Safari closed)
- [ ] Manual repro: same in **Firefox**
- [ ] Sanity: same in Chrome — should still work fine (this was never broken)
- [ ] Bluetooth/AirPods sanity: start a meeting recording with AirPods and verify capture starts cleanly (VPIO falls back to hardware format if it can't engage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)