### PR TITLE
Update release metadata for 1.1.24

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.23"
-  sha256 "9fcf7ceeaa42518482ce2948cb5cfe3dde042c271ae0329ebaa830233770febd"
+  version "1.1.24"
+  sha256 "a0ad9ee739fd1e59675d366f0e93d3ddd2f070353d051dcb9da102ebbc76b810"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>Version 1.1.24</title>
+      <pubDate>Sat, 25 Apr 2026 02:34:53 GMT</pubDate>
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.24</link>
+      <sparkle:version>1.1.24</sparkle:version>
+      <sparkle:shortVersionString>1.1.24</sparkle:shortVersionString>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.24</sparkle:releaseNotesLink>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.24/Transcripted-1.1.24.dmg" length="528065393" type="application/octet-stream" sparkle:edSignature="uIo35PPcM3882Ggz7J4xQbsleTpKzw7sekIThwK9YV/U9rMQ5iBdxRak5bb8IRi72XVu3dd9HkXd/HXBwajvAQ=="/>
+    </item>
+    <item>
       <title>1.1.23</title>
       <pubDate>Sat, 25 Apr 2026 00:48:58 GMT</pubDate>
       <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.23</link>


### PR DESCRIPTION
Updates Sparkle appcast and Homebrew cask for Transcripted 1.1.24.\n\nRelease asset:\nhttps://github.com/r3dbars/transcripted/releases/download/v1.1.24/Transcripted-1.1.24.dmg\n\nVerified:\n- appcast XML parses\n- cask SHA was generated from the published GitHub release asset