### PR TITLE
[nightly-security] Harden Sentry DSN config

### DIFF
--- a/Sources/Observability/CLAUDE.md
+++ b/Sources/Observability/CLAUDE.md
@@ -30,6 +30,7 @@ anonymous analytics, and Sparkle update plumbing.
 - `build.sh` and beta behavior can affect logs, signing, and permissions during local testing
 - `TRANSCRIPTED_DISABLE_FILE_LOGGER=1` disables `app.jsonl` writes for test and smoke runs so local production logs stay clean
 - Sentry runtime config is resolved by `SentryRuntimeConfiguration` from `Info.plist` (`TranscriptedSentryDSN`, `TranscriptedSentryEnvironment`) or process environment (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`), and crash reports must stay scrubbed of transcript/audio/title/path data
+- `SentryRuntimeConfiguration` rejects non-HTTPS DSNs, so insecure local overrides fail closed instead of downgrading crash transport
 - PostHog config is read from `Info.plist` (`TranscriptedPostHogAPIKey`, `TranscriptedPostHogHost`) or process environment (`POSTHOG_API_KEY`, `POSTHOG_HOST`), and anonymous analytics must stay event-allowlisted and bucketed rather than sending raw payloads
 - Non-fatal error forwarding to Sentry is allowlisted. New `.error` events should not automatically assume they are safe to send off-device.
 

--- a/Sources/Observability/SentryRuntimeConfiguration.swift
+++ b/Sources/Observability/SentryRuntimeConfiguration.swift
@@ -12,7 +12,7 @@ enum SentryRuntimeConfiguration {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         infoDictionary: [String: Any]? = Bundle.main.infoDictionary
     ) -> String? {
-        firstNonEmpty(
+        firstValidHTTPSValue(
             environment[dsnEnvironmentKey],
             infoDictionary?[dsnInfoKey] as? String
         )
@@ -61,6 +61,27 @@ enum SentryRuntimeConfiguration {
         candidates
             .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
             .first(where: { !$0.isEmpty })
+    }
+
+    private static func firstValidHTTPSValue(_ candidates: String?...) -> String? {
+        candidates
+            .compactMap { normalizedHTTPSValue($0) }
+            .first
+    }
+
+    private static func normalizedHTTPSValue(_ candidate: String?) -> String? {
+        guard let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+
+        // Security: fail closed on non-HTTPS DSNs so a tampered env var or Info.plist
+        // cannot downgrade crash reports to plaintext transport.
+        guard trimmed.lowercased().hasPrefix("https://") else {
+            return nil
+        }
+
+        return trimmed
     }
 
     private static func parseBoolean(_ value: String) -> Bool? {

--- a/Tests/SentryRuntimeConfigurationTests.swift
+++ b/Tests/SentryRuntimeConfigurationTests.swift
@@ -23,6 +23,35 @@ func testSentryRuntimeConfiguration() {
         )
     }
 
+    runSuite("SentryRuntimeConfiguration rejects insecure DSNs and falls back to a secure source") {
+        let info: [String: Any] = [
+            SentryRuntimeConfiguration.dsnInfoKey: "https://plist@example.invalid/1",
+        ]
+        let environment = [
+            SentryRuntimeConfiguration.dsnEnvironmentKey: "http://local@example.invalid/2",
+        ]
+
+        assertEqual(
+            SentryRuntimeConfiguration.dsn(environment: environment, infoDictionary: info),
+            "https://plist@example.invalid/1",
+            "non-HTTPS env DSNs should be ignored so crash reports do not downgrade to plaintext transport"
+        )
+    }
+
+    runSuite("SentryRuntimeConfiguration returns nil when every DSN source is insecure") {
+        let info: [String: Any] = [
+            SentryRuntimeConfiguration.dsnInfoKey: "ftp://plist@example.invalid/1",
+        ]
+        let environment = [
+            SentryRuntimeConfiguration.dsnEnvironmentKey: "http://local@example.invalid/2",
+        ]
+
+        assertNil(
+            SentryRuntimeConfiguration.dsn(environment: environment, infoDictionary: info),
+            "Sentry should stay disabled when only insecure DSN values are available"
+        )
+    }
+
     runSuite("SentryRuntimeConfiguration falls back to plist then production defaults") {
         let info: [String: Any] = [
             SentryRuntimeConfiguration.dsnInfoKey: "https://plist@example.invalid/1",

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -13,6 +13,10 @@ There is no separate beta-only off-device telemetry path anymore. Beta builds
 keep the updater flow, but diagnostics still go through the same Sentry and
 PostHog controls described below.
 
+Sentry DSNs should stay on `https://`. Non-HTTPS overrides are ignored so local
+or bundled config cannot silently downgrade crash reports to plaintext
+transport.
+
 ## Privacy contract
 
 - never send transcript text


### PR DESCRIPTION
## Summary
- reject non-HTTPS Sentry DSNs instead of accepting insecure overrides
- fall back to the next secure DSN source when a local override is malformed
- document the HTTPS-only behavior and cover it with fast tests

## Verification
- bash run-tests.sh
- bash build-deps.sh --force
- bash build.sh