### PR TITLE
[nightly-artifact] report missing markdown for empty JSON sidecars

### DIFF
--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Validators/JSONSidecarValidator.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Validators/JSONSidecarValidator.swift
@@ -68,38 +68,38 @@ struct JSONSidecarValidator {
             if let utterances = json["utterances"] as? [[String: Any]] {
                 if utterances.isEmpty {
                     results.append(.fail("artifact/json-utterances-present", target: name, detail: "No utterances found"))
-                    continue
-                }
-
-                var sorted = true
-                var prevStart: Double = -1
-                var missingStartCount = 0
-                for utt in utterances {
-                    if let start = utt["start"] as? Double {
-                        if start < prevStart { sorted = false; break }
-                        prevStart = start
-                    } else {
-                        missingStartCount += 1
+                } else {
+                    var sorted = true
+                    var prevStart: Double = -1
+                    var missingStartCount = 0
+                    for utt in utterances {
+                        if let start = utt["start"] as? Double {
+                            if start < prevStart { sorted = false; break }
+                            prevStart = start
+                        } else {
+                            missingStartCount += 1
+                        }
                     }
-                }
-                if missingStartCount > 0 {
-                    results.append(.warn("artifact/json-utterance-start-times", target: name, detail: "\(missingStartCount) utterance(s) missing start time"))
-                }
-                if sorted {
-                    results.append(.pass("artifact/json-utterances-sorted", target: name))
-                } else {
-                    results.append(.fail("artifact/json-utterances-sorted", target: name, detail: "Utterances not sorted by start time"))
-                }
 
-                // Speaker refs valid
-                let speakers = json["speakers"] as? [[String: Any]] ?? []
-                let speakerIds = Set(speakers.compactMap { $0["id"] as? String })
-                let uttSpeakerIds = Set(utterances.compactMap { $0["speaker_id"] as? String })
-                let missing = uttSpeakerIds.subtracting(speakerIds)
-                if missing.isEmpty {
-                    results.append(.pass("artifact/json-speaker-refs", target: name))
-                } else {
-                    results.append(.fail("artifact/json-speaker-refs", target: name, detail: "Utterances reference unknown speakers: \(missing)"))
+                    if missingStartCount > 0 {
+                        results.append(.warn("artifact/json-utterance-start-times", target: name, detail: "\(missingStartCount) utterance(s) missing start time"))
+                    }
+                    if sorted {
+                        results.append(.pass("artifact/json-utterances-sorted", target: name))
+                    } else {
+                        results.append(.fail("artifact/json-utterances-sorted", target: name, detail: "Utterances not sorted by start time"))
+                    }
+
+                    // Speaker refs valid
+                    let speakers = json["speakers"] as? [[String: Any]] ?? []
+                    let speakerIds = Set(speakers.compactMap { $0["id"] as? String })
+                    let uttSpeakerIds = Set(utterances.compactMap { $0["speaker_id"] as? String })
+                    let missing = uttSpeakerIds.subtracting(speakerIds)
+                    if missing.isEmpty {
+                        results.append(.pass("artifact/json-speaker-refs", target: name))
+                    } else {
+                        results.append(.fail("artifact/json-speaker-refs", target: name, detail: "Utterances reference unknown speakers: \(missing)"))
+                    }
                 }
             } else {
                 results.append(.warn("artifact/json-utterances", target: name, detail: "utterances block missing — sort and speaker ref checks skipped"))


### PR DESCRIPTION
## What changed
- keep `artifact/md-match` running even when a JSON sidecar has an empty `utterances` array
- preserve the existing empty-utterance failure instead of short-circuiting the rest of sidecar validation

## Nightly artifact QA
- `swift run transcripted-qa check-health` passed on the local Transcripted paths
- `swift run transcripted-qa validate-all` now reports the orphan JSON/Markdown pairing directly

## Current local data failures
- `Call_2026-04-18_14-43-40.json`: empty `utterances`
- `Call_2026-04-18_14-43-40.json`: missing matching `Call_2026-04-18_14-43-40.md`
- `transcripted.json`: stale index entry still points at missing `Call_2026-04-18_14-43-40.md`

## Verification
- `cd Tools/TranscriptedQA && swift build`
- `cd Tools/TranscriptedQA && TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run transcripted-qa validate-all | rg "^(FAIL|WARN|Summary:)"`
- `bash run-tests.sh`
- `bash build-deps.sh --force`
- `bash build.sh`