### PR TITLE
security: nightly security audit findings [automated]

### DIFF
--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -111,6 +111,18 @@ public class FailedTranscriptionManager: ObservableObject {
         systemAudioURL: URL?,
         errorMessage: String
     ) {
+        // Security: validate incoming audio URLs before they ever reach the queue.
+        // The on-disk load path already re-checks sandboxing, but without this guard an
+        // in-memory caller could enqueue an arbitrary file path and trigger deletion before
+        // the next reload.
+        guard isSafeAudioURL(micAudioURL), systemAudioURL.map(isSafeAudioURL) ?? true else {
+            AppLogger.pipeline.error("Rejected failed transcription with out-of-sandbox audio path", [
+                "micURL": micAudioURL.path,
+                "systemURL": systemAudioURL?.path ?? "none"
+            ])
+            return
+        }
+
         let failed = FailedTranscription(
             micAudioURL: micAudioURL,
             systemAudioURL: systemAudioURL,
@@ -223,6 +235,16 @@ public class FailedTranscriptionManager: ObservableObject {
     }
 
     private func removeAudioFile(_ url: URL, label: String) {
+        // Security: re-check containment at deletion time so a mutated in-memory entry cannot
+        // redirect cleanup to arbitrary files outside Transcripted-managed audio directories.
+        guard isSafeAudioURL(url) else {
+            AppLogger.pipeline.error("Refused to delete out-of-sandbox audio file", [
+                "label": label,
+                "path": url.path
+            ])
+            return
+        }
+
         do {
             try FileManager.default.removeItem(at: url)
             AppLogger.pipeline.info("Deleted audio file", [

--- a/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
@@ -97,6 +97,29 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertEqual(persisted, [safeEntry])
     }
 
+    func testAddFailedTranscriptionRejectsOutOfSandboxAudioPaths() throws {
+        let paths = makePaths(root: testRoot)
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+
+        let safeMicURL = paths.audioCaptures.appendingPathComponent("safe-mic.wav")
+        FileManager.default.createFile(atPath: safeMicURL.path, contents: Data("mic".utf8))
+
+        let manager = FailedTranscriptionManager(paths: paths)
+        manager.addFailedTranscription(
+            micAudioURL: URL(fileURLWithPath: "/tmp/transcripted-unsafe-mic.wav"),
+            systemAudioURL: nil,
+            errorMessage: "Temporary transcription failure"
+        )
+        manager.addFailedTranscription(
+            micAudioURL: safeMicURL,
+            systemAudioURL: URL(fileURLWithPath: "/tmp/transcripted-unsafe-system.wav"),
+            errorMessage: "Temporary transcription failure"
+        )
+
+        XCTAssertTrue(manager.failedTranscriptions.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: paths.failedQueue.path))
+    }
+
     func testFailedTranscriptionRetryabilityDoesNotOvermatchGenericMinimumLanguage() {
         let failure = FailedTranscription(
             micAudioURL: testRoot.appendingPathComponent("mic.wav"),


### PR DESCRIPTION
## Summary
Nightly automated security audit found one real issue and applied a minimal security-only fix.

## Findings by severity

### Critical
- None.

### High
- None.

### Medium
- **Failed transcription queue could accept unsafe in-memory audio paths before persistence reload.**
  - `FailedTranscriptionManager` already rejected unsafe paths when loading the on-disk queue, but `addFailedTranscription(...)` did not validate paths before appending new entries in memory.
  - That meant a bad caller could enqueue an out-of-sandbox file path and later reach cleanup code that deletes the referenced file before the next queue reload revalidated it.
  - Fix: validate mic/system audio URLs on insert, reject out-of-sandbox entries, and re-check containment again immediately before file deletion.
  - Added focused regression coverage in `FailedTranscriptionManagerTests`.

### Low
- No additional exploitable issues confirmed in the reviewed areas.
  - SQLite access in `SpeakerDatabase` and `StatsDatabase` uses prepared statements and serialized access.
  - Sparkle is configured with HTTPS appcast delivery and a public Ed25519 update key.
  - Temporary audio handling already restricts saved files to owner-only permissions in the reviewed paths.
  - HuggingFace/model downloads are pinned to HTTPS endpoints and already perform integrity verification when manifests provide digests.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
