### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -2346,6 +2346,14 @@ class ParakeetEngine: ObservableObject {
         cancelAudioWatchdog()
         prewarmRetryTask?.cancel()
         prewarmRetryTask = nil
+        configChangeDebounceTask?.cancel()
+        configChangeDebounceTask = nil
+        configRecoveryTask?.cancel()
+        configRecoveryTask = nil
+        cancelConfigRecoveryTimeout()
+        configChangeWasRecording = false
+        recoveryState.reset()
+        publishRecoveryState()
         pendingSamplesLock.withLock {
             pendingSamples.removeAll(keepingCapacity: true)
         }

--- a/Sources/Speech/ParakeetRecoveryState.swift
+++ b/Sources/Speech/ParakeetRecoveryState.swift
@@ -32,6 +32,12 @@ struct ParakeetRecoveryState: Equatable {
         inputFormatReady = true
     }
 
+    mutating func reset() {
+        generation &+= 1
+        isRecovering = false
+        inputFormatReady = true
+    }
+
     mutating func finishRecovery(success: Bool, generation: UInt64) -> Bool {
         guard generation == self.generation else { return false }
         isRecovering = false

--- a/Tests/ParakeetRecoveryStateTests.swift
+++ b/Tests/ParakeetRecoveryStateTests.swift
@@ -174,6 +174,18 @@ func testParakeetRecoveryState() {
         assertTrue(state.canStartRecording, "format-ready should unblock recording after a failed start")
     }
 
+    runSuite("ParakeetRecoveryState.reset — clears cancellation leftovers and supersedes older recovery tasks") {
+        var state = ParakeetRecoveryState()
+        let staleGeneration = state.beginConfigChange()
+
+        state.reset()
+
+        assertFalse(state.isRecovering, "reset should clear recovering state")
+        assertTrue(state.inputFormatReady, "reset should restore ready state for a fresh start")
+        assertTrue(state.canStartRecording, "reset should allow a new start attempt")
+        assertTrue(state.isStale(generation: staleGeneration), "reset should supersede in-flight recovery tasks")
+    }
+
     runSuite("ParakeetAudioStartRecoveryPolicy.shouldRetryStartFailure — retries only normal first failures") {
         assertTrue(
             ParakeetAudioStartRecoveryPolicy.shouldRetryStartFailure(isRecoveryAttempt: false, failedAttempts: 1, retryBudget: 1),


### PR DESCRIPTION
## Summary
- fix stale dictation recovery work continuing after a user-cancelled session
- supersede in-flight recovery generations on cancel so future starts are not blocked by stale recovery state
- cover the reset behavior with a focused recovery-state regression test

## Findings fixed

### Dictation / audio recovery
- `ParakeetEngine.cancel()` cleaned up recording buffers but did not cancel the recently added config-change debounce, recovery, or timeout tasks. If a device-change recovery was in flight when the user cancelled dictation, stale recovery work could continue in the background, publish late interruption state, or leave the next start attempt stuck behind an obsolete recovery generation.
- Fixed by cancelling those recovery tasks during `cancel()`, clearing the inherited `configChangeWasRecording` flag, and resetting `ParakeetRecoveryState` so pending work is superseded and a fresh dictation start is allowed.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`