### PR TITLE
[nightly-simplify] Simplify meeting failure copy routing

### DIFF
--- a/Sources/Meeting/MeetingFailureCopy.swift
+++ b/Sources/Meeting/MeetingFailureCopy.swift
@@ -9,57 +9,54 @@ struct MeetingFailureCopy: Equatable {
         shortErrorMessage: String,
         isRetryable: Bool
     ) -> MeetingFailureCopy {
-        let message = errorMessage.lowercased()
+        let message = errorMessage.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
 
-        if message.contains("system audio is required")
-            || message.contains("system audio recording")
-            || message.contains("screen recording") {
-            return MeetingFailureCopy(
-                title: "Turn on System Audio Recording",
-                detail: "Turn on System Audio Recording in System Settings, then retry the meeting."
-            )
-        }
-
-        if message.contains("microphone access")
-            || message.contains("microphone permission")
-            || message.contains("mic_not_authorized") {
+        // Keep the broader "microphone access" wording that some meeting-start
+        // errors use even though the analytics classifier keys off more specific
+        // permission phrases.
+        if message.contains("microphone access") {
             return MeetingFailureCopy(
                 title: "Turn on Microphone",
                 detail: "Turn on Microphone access in System Settings, then retry the meeting."
             )
         }
 
-        if MeetingFailureKind.isRecordingTooShortMessage(message) {
+        switch MeetingFailureKind.classify(message: message) {
+        case .systemAudioPermission:
+            return MeetingFailureCopy(
+                title: "Turn on System Audio Recording",
+                detail: "Turn on System Audio Recording in System Settings, then retry the meeting."
+            )
+        case .microphonePermission:
+            return MeetingFailureCopy(
+                title: "Turn on Microphone",
+                detail: "Turn on Microphone access in System Settings, then retry the meeting."
+            )
+        case .recordingTooShort:
             return MeetingFailureCopy(
                 title: "Recording ended too soon",
                 detail: "Nothing broke - there just was not enough audio to transcribe. Record at least two seconds before stopping."
             )
-        }
-
-        if message.contains("no samples recorded") || message.contains("empty audio") {
+        case .emptyAudio:
             return MeetingFailureCopy(
                 title: "No audio was captured",
                 detail: "Transcripted kept the recording, but there was not enough audio signal to transcribe."
             )
-        }
-
-        if message.contains("failed to save") {
+        case .saveFailed:
             return MeetingFailureCopy(
                 title: "Couldn't save the transcript",
                 detail: shortErrorMessage
             )
-        }
-
-        if message.contains("stop timed out") {
+        case .stopTimeout:
             return MeetingFailureCopy(
                 title: "Recording didn't close cleanly",
                 detail: "The audio files may be incomplete. Retry to transcribe what was captured, or delete to discard."
             )
+        default:
+            return MeetingFailureCopy(
+                title: isRetryable ? "Transcript needs another pass" : "Recording needs attention",
+                detail: shortErrorMessage
+            )
         }
-
-        return MeetingFailureCopy(
-            title: isRetryable ? "Transcript needs another pass" : "Recording needs attention",
-            detail: shortErrorMessage
-        )
     }
 }

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -56,4 +56,15 @@ func testFailedMeetingPresentation() {
             "microphone failures should point to the recovery step"
         )
     }
+
+    runSuite("FailedMeetingPresentation save failures keep the short error detail") {
+        let copy = MeetingFailureCopy.make(
+            forMessage: "Failed to save transcript: Could not write transcript to meetings",
+            shortErrorMessage: "Could not write transcript to meetings",
+            isRetryable: false
+        )
+
+        assertEqual(copy.title, "Couldn't save the transcript", "save failures should keep the save-specific title")
+        assertEqual(copy.detail, "Could not write transcript to meetings", "save failures should preserve the short write error")
+    }
 }


### PR DESCRIPTION
## Summary
- route meeting failure copy through `MeetingFailureKind` instead of re-parsing most error strings in `MeetingFailureCopy`
- keep the existing broad `microphone access` copy path intact for meeting-start permission errors
- add a regression test that save failures still preserve the short write error

## Verification
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
