### PR TITLE
[codex] Tune VPIO for meeting recording

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -474,8 +474,17 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         do {
             try inputNode.setVoiceProcessingEnabled(true)
+            inputNode.isVoiceProcessingAGCEnabled = true
+            if #available(macOS 14.0, *) {
+                inputNode.voiceProcessingOtherAudioDuckingConfiguration = AVAudioVoiceProcessingOtherAudioDuckingConfiguration(
+                    enableAdvancedDucking: false,
+                    duckingLevel: .min
+                )
+            }
             voiceProcessingEnabled = true
             AppLogger.audioMic.info("Voice processing enabled on meeting mic", [
+                "agc": "\(inputNode.isVoiceProcessingAGCEnabled)",
+                "ducking": "min",
                 "reason": "issue_500_safari_firefox_vpio_contention"
             ])
         } catch {


### PR DESCRIPTION
## Summary
- keep meeting mic VPIO enabled but explicitly keep AGC on
- set VPIO other-audio ducking to minimum so Transcripted does not lower the system audio it is recording
- add coarse logging for AGC and ducking state

## Why
Issue #500 showed Safari/Firefox/WebRTC can attenuate the shared mic when another meeting app is using it. VPIO is still the right mic-side tool, but Transcripted is a recorder, not the call app, so Apple's default voice-chat ducking behavior is risky for captured meeting audio.

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
