### PR TITLE
[codex] Avoid bundling duplicate Parakeet models

### DIFF
--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -34,6 +34,18 @@ func testRepoCommandContract() {
 
         assertEqual(disallowedMatches, [], "live docs/scripts should reference bash build.sh, not the historical Xcode project")
     }
+
+    runSuite("Repo command contract - build bundles only the runtime Parakeet model") {
+        let contents = readRepoTextFile("scripts/entrypoints/build.sh")
+        assertTrue(
+            contents.contains("PARAKEET_MODEL_DIR=\"parakeet-tdt-0.6b-v3-coreml\""),
+            "build.sh should bundle the CoreML Parakeet directory loaded by ParakeetEngine"
+        )
+        assertFalse(
+            contents.contains("\"parakeet-tdt-0.6b-v3\""),
+            "build.sh should not bundle the legacy Parakeet directory as a second 461 MB copy"
+        )
+    }
 }
 
 private func repoRootURL() -> URL {

--- a/scripts/entrypoints/build.sh
+++ b/scripts/entrypoints/build.sh
@@ -210,27 +210,20 @@ mkdir -p "$APP_BUNDLE/Contents/Resources"
 mkdir -p "$APP_BUNDLE/Contents/Frameworks"
 mkdir -p "$APP_BUNDLE/Contents/Helpers"
 
-# Bundle Parakeet model directories used by FluidAudio.
-# The runtime loader can resolve files from both the `-coreml` and legacy
-# `parakeet-tdt-0.6b-v3` layouts, so ship both when present.
+# Bundle the Parakeet model directory used by the runtime loader.
 PARAKEET_MODELS_ROOT="$HOME/Library/Application Support/FluidAudio/Models"
 PARAKEET_BUNDLE_DIR="$APP_BUNDLE/Contents/Resources/parakeet-models"
-PARAKEET_MODEL_DIRS=(
-    "parakeet-tdt-0.6b-v3-coreml"
-    "parakeet-tdt-0.6b-v3"
-)
+PARAKEET_MODEL_DIR="parakeet-tdt-0.6b-v3-coreml"
 
 bundled_parakeet_models=false
 mkdir -p "$PARAKEET_BUNDLE_DIR"
-for model_dir in "${PARAKEET_MODEL_DIRS[@]}"; do
-    model_src="$PARAKEET_MODELS_ROOT/$model_dir"
-    if [ -d "$model_src/Encoder.mlmodelc" ]; then
-        echo "Bundling Parakeet models from $model_dir..."
-        rm -rf "$PARAKEET_BUNDLE_DIR/$model_dir"
-        ditto "$model_src" "$PARAKEET_BUNDLE_DIR/$model_dir"
-        bundled_parakeet_models=true
-    fi
-done
+model_src="$PARAKEET_MODELS_ROOT/$PARAKEET_MODEL_DIR"
+if [ -d "$model_src/Encoder.mlmodelc" ]; then
+    echo "Bundling Parakeet models from $PARAKEET_MODEL_DIR..."
+    rm -rf "$PARAKEET_BUNDLE_DIR/$PARAKEET_MODEL_DIR"
+    ditto "$model_src" "$PARAKEET_BUNDLE_DIR/$PARAKEET_MODEL_DIR"
+    bundled_parakeet_models=true
+fi
 
 if [ "$bundled_parakeet_models" = false ]; then
     echo "Parakeet models not found — Parakeet engine will attempt runtime download"


### PR DESCRIPTION
## What changed

- Stop local `build.sh` from bundling both Parakeet model layouts.
- Keep only `parakeet-tdt-0.6b-v3-coreml`, which is the runtime path loaded by `ParakeetEngine`.
- Add a fast regression test so the legacy duplicate directory does not get reintroduced.

## Why

Local builds were copying two 461 MB Parakeet directories into the app bundle. The app only loads the CoreML directory, so the legacy copy made the expanded app about 461 MB larger without improving first-run behavior.

This should not change runtime behavior. Users still get bundled Parakeet and should not need a first-run model download.

Note: release packaging uses `build-beta.sh`, which already bundles the CoreML path only. This PR mainly fixes the local `build.sh` artifact and prevents future drift.

## Verified

- `bash run-tests.sh` passed: 864 tests
- `bash build.sh` passed, signed, and launch smoke passed
- Built app size dropped from about 1.0 GB to 590 MB
- `Contents/Resources/parakeet-models` now contains only `parakeet-tdt-0.6b-v3-coreml`
