### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Tools/TranscriptedQA/CLAUDE.md
+++ b/Tools/TranscriptedQA/CLAUDE.md
@@ -118,9 +118,7 @@ swift run transcripted-qa stress-test --transcripts 100 --speakers-per-transcrip
 
 ## Gotchas
 
-- The current implementation is consolidated into one source file, so keep the
-  subcommand list in `TranscriptedQA.configuration` in sync with the validator
-  types defined below it.
+- The package is now split across `Commands/`, `Validators/`, `Utilities/`, `Generators/`, and `Models/`, so keep `TranscriptedQA.configuration` in sync when adding or removing subcommands.
 - All validators run synchronously on background threads
 - SQLite readers use dedicated utility queues for thread safety
 - Validation results are structured for programmatic consumption and can be emitted as aligned text or pretty JSON via `ValidationReport`


### PR DESCRIPTION
## Summary
- update `Tools/TranscriptedQA/CLAUDE.md` to reflect the current multi-file package layout
- replace the stale note that still described the QA CLI as a single-source-file implementation

## Why
Recent QA CLI changes split the package across commands, validators, utilities, generators, and models. The local CLAUDE.md had drifted and no longer matched the actual code structure.

## Files updated
- `Tools/TranscriptedQA/CLAUDE.md`
