### PR TITLE
[nightly-security] Harden observability path redaction

### DIFF
--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -40,7 +40,9 @@ enum AnalyticsPayloadSanitizer {
 
     private static let appSupportPathRegex = makeRegex(#"/Users/[^/\s]+/Library/Application Support/(?:Transcripted|Draft)(?:/[^\s"]*)?"#)
     private static let userPathRegex = makeRegex(#"/Users/[^/\s]+/"#)
-    private static let absolutePathRegex = makeRegex(#"(?<!https:)(?<!http:)/(?:Users|private|var|tmp|Volumes|Applications)[^\s"]*"#)
+    private static let absolutePathRegex = makeRegex(
+        #"(?<!https:)(?<!http:)/(?:System/Volumes/Data/)?(?:Users|private|var|tmp|Volumes|Applications|Library|opt)[^\s"]*"#
+    )
     private static let rawURLRegex = makeRegex(#"https?://[^\s"]+"#, options: [.caseInsensitive])
     private static let apiKeyRegex = makeRegex(#"sk-[A-Za-z0-9_-]+"#)
     private static let commonSecretRegex = makeRegex(

--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -40,7 +40,9 @@ enum SentryPayloadSanitizer {
 
     private static let appSupportPathRegex = makeRegex(#"/Users/[^/\s]+/Library/Application Support/(?:Transcripted|Draft)(?:/[^\s"]*)?"#)
     private static let userPathRegex = makeRegex(#"/Users/[^/\s]+/"#)
-    private static let absolutePathRegex = makeRegex(#"(?<!https:)(?<!http:)/(?:Users|private|var|tmp|Volumes|Applications)[^\s"]*"#)
+    private static let absolutePathRegex = makeRegex(
+        #"(?<!https:)(?<!http:)/(?:System/Volumes/Data/)?(?:Users|private|var|tmp|Volumes|Applications|Library|opt)[^\s"]*"#
+    )
     private static let rawURLRegex = makeRegex(#"https?://[^\s"]+"#, options: [.caseInsensitive])
     private static let apiKeyRegex = makeRegex(#"sk-[A-Za-z0-9_-]+"#)
     private static let commonSecretRegex = makeRegex(

--- a/Tests/AnalyticsPayloadSanitizerTests.swift
+++ b/Tests/AnalyticsPayloadSanitizerTests.swift
@@ -36,6 +36,20 @@ func testAnalyticsPayloadSanitizer() {
         assertTrue(value.contains("[redacted-host]"), "host marker should remain")
     }
 
+    runSuite("AnalyticsPayloadSanitizer redacts synthetic-root macOS paths from values") {
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "failure_kind": "Saved to /System/Volumes/Data/Users/redbars/Library/Application Support/Transcripted/logs/app.jsonl before retry",
+            ],
+            allowedKeys: ["failure_kind"]
+        )
+
+        let value = sanitized["failure_kind"] ?? ""
+        assertFalse(value.contains("/System/Volumes/Data/Users/redbars/"), "synthetic-root home paths should be redacted")
+        assertFalse(value.contains("Application Support/Transcripted/logs/app.jsonl"), "synthetic-root app support path should be fully redacted")
+        assertTrue(value.contains("[redacted-path]"), "path marker should remain")
+    }
+
     runSuite("AnalyticsPayloadSanitizer drops authorization-like keys even if allowlisted") {
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
             [

--- a/Tests/SentryPayloadSanitizerTests.swift
+++ b/Tests/SentryPayloadSanitizerTests.swift
@@ -100,6 +100,15 @@ func testSentryPayloadSanitizer() {
         assertTrue(sanitized.contains("[redacted-path]"), "redacted path marker should remain")
     }
 
+    runSuite("SentryPayloadSanitizer.sanitizeText redacts synthetic-root macOS paths") {
+        let input = "Retry after checking /System/Volumes/Data/Users/redbars/Library/Application Support/Transcripted/logs/app.jsonl"
+        let sanitized = SentryPayloadSanitizer.sanitizeText(input)
+
+        assertFalse(sanitized.contains("/System/Volumes/Data/Users/redbars/"), "synthetic-root home paths should be redacted")
+        assertFalse(sanitized.contains("Application Support/Transcripted/logs/app.jsonl"), "synthetic-root app support path should be fully redacted")
+        assertTrue(sanitized.contains("[redacted-path]"), "redacted path marker should remain")
+    }
+
     runSuite("SentryPayloadSanitizer.sanitizeText redacts raw URLs and common token formats") {
         let input = "Download failed at https://example.com/private?token=abc123 with ghp_123456789012345678901234567890123456 phc_abcdefghijklmnopqrstuvwxyz123456 AKIAIOSFODNN7EXAMPLE AIzaSyA-BCDEFGHIJKLMNOPQRSTUVWXYZ123456"
         let sanitized = SentryPayloadSanitizer.sanitizeText(input)


### PR DESCRIPTION
## Summary
- redact synthetic-root macOS paths like `/System/Volumes/Data/Users/...` in Sentry and analytics scrubbers
- extend sanitizer coverage to a few other common absolute-path roots used in local runtime output
- add regression tests for both observability paths

## Verification
- bash run-tests.sh
- bash build-deps.sh --force
- bash build.sh