### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -83,10 +83,21 @@ public class TranscriptionTaskManager: ObservableObject {
         }
 
 
-        // Gate: reject recordings shorter than 2 seconds (they'll fail in Parakeet anyway)
+        // Gate: reject only when every available capture track is too short.
+        // Meeting recovery can produce a very short mic stub while system audio is still
+        // intact and fully transcribable, so don't throw away the whole recording just
+        // because the mic side is below Parakeet's minimum length.
         let minDuration: TimeInterval = 2.0
-        if let micDuration = audioDuration(url: micURL), micDuration < minDuration {
-            AppLogger.pipeline.info("Recording too short, skipping transcription", ["duration": String(format: "%.1fs", micDuration)])
+        let micDuration = audioDuration(url: micURL)
+        let systemDuration = systemURL.flatMap { audioDuration(url: $0) }
+        let hasUsableMicAudio = (micDuration ?? 0) >= minDuration
+        let hasUsableSystemAudio = (systemDuration ?? 0) >= minDuration
+
+        guard hasUsableMicAudio || hasUsableSystemAudio else {
+            AppLogger.pipeline.info("Recording too short, skipping transcription", [
+                "micDuration": micDuration.map { String(format: "%.1fs", $0) } ?? "unknown",
+                "systemDuration": systemDuration.map { String(format: "%.1fs", $0) } ?? "none"
+            ])
 
             removeRecordingFile(micURL, label: "short mic recording")
             if let systemURL {
@@ -96,6 +107,13 @@ public class TranscriptionTaskManager: ObservableObject {
             self.displayStatus = .failed(message: "Recording too short")
             self.scheduleStatusReset(delay: 3)
             return
+        }
+
+        if !hasUsableMicAudio, hasUsableSystemAudio {
+            AppLogger.pipeline.warning("Proceeding with short mic capture because system audio is still usable", [
+                "micDuration": micDuration.map { String(format: "%.1fs", $0) } ?? "unknown",
+                "systemDuration": systemDuration.map { String(format: "%.1fs", $0) } ?? "unknown"
+            ])
         }
 
         let task = TranscriptionTask(


### PR DESCRIPTION
## Summary
- keep meeting transcription running when the microphone capture is shorter than Parakeet's minimum but the system track is still long enough to transcribe
- tighten short-audio logging so both mic and system durations are visible when a capture is rejected

## Findings fixed
### Transcription pipeline
- `TranscriptionTaskManager.startTranscription` rejected the entire meeting whenever the mic file was under 2 seconds, even if the system audio capture was valid.
- This could drop otherwise recoverable meeting transcripts after mic recovery edge cases, because the short mic stub caused both recordings to be deleted before transcription started.
- The gate now only rejects captures when every available track is too short, and it explicitly logs when we continue with usable system audio.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
