### PR TITLE
[nightly-compat] remove unused overlay drafting hook

### DIFF
--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -297,11 +297,6 @@ class FloatingOverlayController {
         installEscapeMonitor()
     }
 
-    func enterDraftingState() {
-        state = .drafting
-        resizePanelToCompact()
-    }
-
     func resizePanelToCompact() {
         resizePanelInstant(to: NSSize(width: OverlayTokens.panelCompactWidth, height: OverlayTokens.panelCompactHeight))
     }


### PR DESCRIPTION
## What changed
- Removed the unused `enterDraftingState()` helper from `FloatingOverlayController`.

## Why
- This was a Draft-era overlay hook with no remaining callers, so keeping it around only added dead compatibility surface.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
