### PR TITLE
[nightly-security] Harden private key payload redaction

### DIFF
--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -52,6 +52,14 @@ enum AnalyticsPayloadSanitizer {
     private static let authorizationAssignmentRegex = makeRegex(
         #"(?i)\b((?:proxy-)?authorization)\s*[:=]\s*(?:basic|bearer)\s+[^\s,;]+"#
     )
+    private static let privateKeyBlockRegex = makeRegex(
+        #"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----"#,
+        options: [.caseInsensitive]
+    )
+    private static let privateKeyMarkerRegex = makeRegex(
+        #"-----((?:BEGIN|END)) [A-Z0-9 ]*PRIVATE KEY-----"#,
+        options: [.caseInsensitive]
+    )
     private static let secretAssignmentRegex = makeRegex(
         #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature|password|passphrase|secret|client[_-]?secret|credential|dsn)\s*[:=]\s*([^\s,;]+)"#
     )
@@ -112,6 +120,10 @@ enum AnalyticsPayloadSanitizer {
         result = authorizationAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)
         result = authSchemeRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1 ****")
+        range = NSRange(result.startIndex..., in: result)
+        result = privateKeyBlockRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
+        range = NSRange(result.startIndex..., in: result)
+        result = privateKeyMarkerRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)
         result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)

--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -52,6 +52,14 @@ enum SentryPayloadSanitizer {
     private static let authorizationAssignmentRegex = makeRegex(
         #"(?i)\b((?:proxy-)?authorization)\s*[:=]\s*(?:basic|bearer)\s+[^\s,;]+"#
     )
+    private static let privateKeyBlockRegex = makeRegex(
+        #"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----"#,
+        options: [.caseInsensitive]
+    )
+    private static let privateKeyMarkerRegex = makeRegex(
+        #"-----((?:BEGIN|END)) [A-Z0-9 ]*PRIVATE KEY-----"#,
+        options: [.caseInsensitive]
+    )
     private static let secretAssignmentRegex = makeRegex(
         #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature|password|passphrase|secret|client[_-]?secret|credential|dsn)\s*[:=]\s*([^\s,;]+)"#
     )
@@ -130,6 +138,10 @@ enum SentryPayloadSanitizer {
         result = authorizationAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)
         result = authSchemeRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1 ****")
+        range = NSRange(result.startIndex..., in: result)
+        result = privateKeyBlockRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
+        range = NSRange(result.startIndex..., in: result)
+        result = privateKeyMarkerRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)
         result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)

--- a/Tests/AnalyticsPayloadSanitizerTests.swift
+++ b/Tests/AnalyticsPayloadSanitizerTests.swift
@@ -125,6 +125,26 @@ func testAnalyticsPayloadSanitizer() {
         assertTrue(value.contains("Basic ****"), "standalone basic auth marker should remain")
     }
 
+    runSuite("AnalyticsPayloadSanitizer redacts PEM private key material") {
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "failure_kind": """
+                Failure included:
+                -----BEGIN RSA PRIVATE KEY-----
+                MIIEpAIBAAKCAQEAz7i9W5tQ3k3FdemoKeyMaterial
+                -----END RSA PRIVATE KEY-----
+                """,
+            ],
+            allowedKeys: ["failure_kind"]
+        )
+
+        let value = sanitized["failure_kind"] ?? ""
+        assertFalse(value.contains("BEGIN RSA PRIVATE KEY"), "private key header should be redacted")
+        assertFalse(value.contains("MIIEpAIBAAKCAQEA"), "private key body should be redacted")
+        assertFalse(value.contains("END RSA PRIVATE KEY"), "private key footer should be redacted")
+        assertTrue(value.contains("[redacted-secret]"), "private key content should collapse to a secret marker")
+    }
+
     runSuite("AnalyticsPayloadSanitizer.redact scrubs without the analytics length cap") {
         // Build a multi-line log blob longer than maxValueLength (80 chars) so
         // the feedback path can verify redaction happens but length is preserved.

--- a/Tests/SentryPayloadSanitizerTests.swift
+++ b/Tests/SentryPayloadSanitizerTests.swift
@@ -157,6 +157,21 @@ func testSentryPayloadSanitizer() {
         assertTrue(sanitized.contains("Basic ****"), "standalone basic auth marker should remain")
     }
 
+    runSuite("SentryPayloadSanitizer redacts PEM private key material") {
+        let input = """
+        Failed to parse key:
+        -----BEGIN OPENSSH PRIVATE KEY-----
+        b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAlwAAAAdzc2gtcn
+        -----END OPENSSH PRIVATE KEY-----
+        """
+        let sanitized = SentryPayloadSanitizer.sanitizeText(input)
+
+        assertFalse(sanitized.contains("BEGIN OPENSSH PRIVATE KEY"), "private key header should be redacted")
+        assertFalse(sanitized.contains("b3BlbnNzaC1rZXkt"), "private key body should be redacted")
+        assertFalse(sanitized.contains("END OPENSSH PRIVATE KEY"), "private key footer should be redacted")
+        assertTrue(sanitized.contains("[redacted-secret]"), "private key content should collapse to a secret marker")
+    }
+
     runSuite("SentryPayloadSanitizer.sanitizeAnyDictionary redacts nested free-form values") {
         let sanitized = SentryPayloadSanitizer.sanitizeAnyDictionary([
             "safe_count": 3,


### PR DESCRIPTION
## Summary
- redact PEM private key blocks in the Sentry payload sanitizer
- redact PEM private key blocks in the analytics payload sanitizer
- add fast tests for both scrubbers so private key material cannot regress into off-device payloads

## Verification
- bash run-tests.sh
- bash build-deps.sh --force
- bash build.sh