### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -9,7 +9,7 @@
 - `FailedMeetingPresentation.swift` — maps `FailedTranscription` into `FailedMeetingItem` view-models with human-readable titles and retry metadata
 - `MeetingAudioInactivityDetector.swift` — detects prolonged audio silence during meetings and emits warning/cleared events so the UI can prompt the user to confirm the recording is still needed
 - `MeetingCaptureBridge.swift` — `@MainActor` wrapper around core `Audio`, converts callback-based stop into `async`
-- `MeetingFailureCopy.swift` — normalizes `MeetingFailureKind` values into user-facing titles and recovery copy
+- `MeetingFailureCopy.swift` — takes raw error messages, classifies them through `MeetingFailureKind`, and produces user-facing titles and recovery copy
 - `MeetingFailureKind.swift` — canonical failure taxonomy that classifies raw meeting errors into stable machine-readable kinds
 - `MeetingImportedAudioPreparer.swift` — copies imported recordings into app-managed scratch paths, derives titles, and prepares single-file meeting transcription jobs
 - `MeetingModelDownloader.swift` — loads the selected STT and diarization models together
@@ -102,6 +102,7 @@ Relevant direct coverage:
 - `Tests/MeetingRecordingCleanupTests.swift`
 - `Tests/MeetingWarmupStatusPolicyTests.swift`
 - `Tests/MeetingAudioInactivityDetectorTests.swift`
+- `Tests/MeetingPromptDetectorTests.swift`
 - `Tests/MeetingSessionUIPolicyTests.swift`
 - `Tests/MeetingTranscriptStylerTests.swift`
 - `Tests/SpeakerNamingPolicyTests.swift`

--- a/Sources/Observability/CLAUDE.md
+++ b/Sources/Observability/CLAUDE.md
@@ -43,6 +43,16 @@ bash build.sh
 bash run-tests.sh
 ```
 
+Relevant direct coverage:
+
+- `Tests/AnalyticsEventPolicyTests.swift`
+- `Tests/AnalyticsPayloadSanitizerTests.swift`
+- `Tests/AnalyticsReporterTests.swift`
+- `Tests/ObservabilityPreferencesTests.swift`
+- `Tests/SentryEventPolicyTests.swift`
+- `Tests/SentryPayloadSanitizerTests.swift`
+- `Tests/SentryRuntimeConfigurationTests.swift`
+
 Useful files while testing:
 
 - `~/Library/Application Support/Transcripted/logs/debug.log`

--- a/Sources/Reliability/CLAUDE.md
+++ b/Sources/Reliability/CLAUDE.md
@@ -29,6 +29,11 @@ bash build.sh
 bash run-tests.sh
 ```
 
+Relevant direct coverage:
+
+- `Tests/WakeRecoveryCoordinatorTests.swift`
+- `Tests/Integration/WakeRecoveryIntegrationSmoke.swift`
+
 Manual check:
 
 - sleep and wake the Mac, then confirm hotkeys still work and the app does not enter duplicate recovery loops

--- a/Sources/Speech/CLAUDE.md
+++ b/Sources/Speech/CLAUDE.md
@@ -57,6 +57,7 @@ Relevant direct coverage:
 - `Tests/DictationAudioLevelMeterTests.swift`
 - `Tests/DictationAudioRecoveryTests.swift`
 - `Tests/DictationInputDeviceSelectionPolicyTests.swift`
+- `Tests/DictationReadinessWaitPolicyTests.swift`
 - `Tests/ParakeetModelInitDiagnosticsTests.swift`
 - `Tests/ParakeetPrewarmPolicyTests.swift`
 - `Tests/ParakeetRecoveryStateTests.swift`


### PR DESCRIPTION
## Summary

- **Meeting CLAUDE.md**: Updated `MeetingFailureCopy.swift` description to reflect the centralized classification refactor (now takes raw error messages and classifies through `MeetingFailureKind` internally). Added missing `MeetingPromptDetectorTests.swift` to the test coverage section.
- **Speech CLAUDE.md**: Added missing `DictationReadinessWaitPolicyTests.swift` to the test coverage section.
- **Observability CLAUDE.md**: Added test coverage section listing all 7 existing test files that were previously undocumented.
- **Reliability CLAUDE.md**: Added test coverage section with `WakeRecoveryCoordinatorTests.swift` and `WakeRecoveryIntegrationSmoke.swift`.

## Audit notes

All file counts, file index tables, and subsystem descriptions verified against current codebase. AGENTS.md and root CLAUDE.md are accurate — no changes needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)