### PR TITLE
refactor: nightly simplification sweep [automated]

### DIFF
--- a/Sources/TranscriptedCore/Logging/FileLogger.swift
+++ b/Sources/TranscriptedCore/Logging/FileLogger.swift
@@ -37,7 +37,7 @@ final class FileLogger: @unchecked Sendable {
         // Security: embedders may inject a custom logs directory outside the default
         // Transcripted-owned path, so tighten it here as well to avoid world-readable log folders.
         try? FileManager.default.createDirectory(at: logsDir, withIntermediateDirectories: true)
-        try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: logsDir.path)
+        FileManager.default.restrictDirectoryToOwnerOnly(atPath: logsDir.path)
 
         logFileURL = logsDir.appendingPathComponent("app.jsonl")
 

--- a/Sources/TranscriptedCore/Speaker/SpeakerClipExtractor.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerClipExtractor.swift
@@ -213,7 +213,7 @@ public enum SpeakerClipExtractor {
         // app tmp directory instead of the process-wide temp folder, so sensitive
         // voice samples do not spill into a broader shared scratch location.
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: tempDir.path)
+        FileManager.default.restrictDirectoryToOwnerOnly(atPath: tempDir.path)
         let clipFilename = "speaker_\(channel.rawValue)_\(speakerId)_\(UUID().uuidString.prefix(8)).wav"
         let clipURL = tempDir.appendingPathComponent(clipFilename)
 

--- a/Sources/TranscriptedCore/Storage/RecordingAudioArchiver.swift
+++ b/Sources/TranscriptedCore/Storage/RecordingAudioArchiver.swift
@@ -61,7 +61,7 @@ enum RecordingAudioArchiver {
 
     private static func createPrivateDirectory(at url: URL, fileManager: FileManager) throws {
         try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
-        try? fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: url.path)
+        fileManager.restrictDirectoryToOwnerOnly(atPath: url.path)
     }
 
     private static func fileExtension(for url: URL) -> String {

--- a/Sources/TranscriptedCore/Utilities/FilePermissions.swift
+++ b/Sources/TranscriptedCore/Utilities/FilePermissions.swift
@@ -8,6 +8,13 @@ extension FileManager {
         try? setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
     }
 
+    /// Restrict directory to owner-only access (chmod 700).
+    /// Directories holding sensitive captures (logs, speaker clips, recording archives)
+    /// use this so siblings on multi-user systems cannot list or traverse the contents.
+    func restrictDirectoryToOwnerOnly(atPath path: String) {
+        try? setAttributes([.posixPermissions: 0o700], ofItemAtPath: path)
+    }
+
     /// SQLite writes sensitive state into `-wal` and `-shm` sidecars alongside the
     /// main database file. Harden all three artifacts together so write-ahead data
     /// does not drift to broader default permissions than the primary database.


### PR DESCRIPTION
## Summary

Nightly simplification sweep. Found one duplication in `Sources/TranscriptedCore/`:

Three call sites repeated `createDirectory + setAttributes([.posixPermissions: 0o700], ...)` after the previous nightly security tightening landed. Added a directory-symmetric helper to `FilePermissions.swift` and routed all three through it.

- New: `FileManager.restrictDirectoryToOwnerOnly(atPath:)` mirrors the existing `restrictToOwnerOnly(atPath:)` (0o600) for files.
- Updated callers: `FileLogger.init`, `SpeakerClipExtractor.extractClip`, `RecordingAudioArchiver.createPrivateDirectory`.
- The 0o700 magic number now lives in one place; behavior is unchanged (`try?` semantics preserved).

## Why this and not a wider dedupe

The app target (`Sources/Support/TranscriptedStoragePaths.swift`) already exposes `createPrivateDirectory(at: URL)` / `restrictFileToOwnerOnly(at: URL)` extensions on `FileManager` for app-layer call sites. Merging them with the Core-layer string-path helpers would entail renames across many call sites and tests. Out of scope for a nightly sweep — kept the change minimal and focused on the new duplication introduced today.

## Test plan

- [x] `bash build-deps.sh`
- [x] `bash build.sh` (signed build, smoke launch passed)
- [x] `bash run-tests.sh` — 895/895 passed
- [x] `bash run-integration-smoke.sh` — passed
- [x] `swift test` — 82/82 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)