### PR TITLE
Show recording sessions in the macOS force-quit dialog

### DIFF
--- a/Sources/Support/ActivationPolicyController.swift
+++ b/Sources/Support/ActivationPolicyController.swift
@@ -1,0 +1,97 @@
+// Support/ActivationPolicyController.swift
+// Dynamically switches NSApp's activation policy so an active recording
+// session shows up in the macOS force-quit dialog (Cmd+Option+Esc).
+//
+// Background: Transcripted is a menubar app, so it normally runs with
+// activation policy `.accessory` and `LSUIElement = true`. macOS hides
+// `.accessory` apps from the force-quit dialog; if the app freezes during
+// a recording, the user has to open Activity Monitor to kill it. Reported
+// pain: Taylor's meeting widget froze and the only recovery was Activity
+// Monitor.
+//
+// Fix shape: while a recording is active (meeting OR dictation), switch
+// to `.regular` so the app appears in the force-quit dialog. When all
+// sessions stop, switch back to `.accessory`. The Dock icon flickers in
+// for the duration of the recording — acceptable trade for a recovery
+// path. The menubar `NSStatusItem` is independent of activation policy
+// and stays visible the whole time.
+//
+// Thread-safety: this type is `@MainActor` because `NSApplication`
+// state is main-thread-only. Callers update the recording flags from
+// the main thread; subscribers running on other threads should hop
+// before calling `update(...)`.
+
+import AppKit
+import Foundation
+
+/// Pure policy decision so we can unit-test it without an `NSApp`
+/// instance. Given the current recording flags, returns the activation
+/// policy the app should have.
+enum ActivationPolicyDecision {
+
+    /// Returns `.regular` if any session is active so the app shows in
+    /// the force-quit dialog. Otherwise returns `.accessory` to keep
+    /// the Dock clean.
+    static func desiredPolicy(
+        isMeetingRecording: Bool,
+        isDictationRecording: Bool
+    ) -> NSApplication.ActivationPolicy {
+        if isMeetingRecording || isDictationRecording {
+            return .regular
+        }
+        return .accessory
+    }
+}
+
+@MainActor
+final class ActivationPolicyController {
+
+    /// Most-recently applied policy. Used so we don't redundantly call
+    /// `setActivationPolicy(_:)` (which has side effects on the Dock
+    /// tile and key-window state).
+    private(set) var currentPolicy: NSApplication.ActivationPolicy
+
+    private var isMeetingRecording: Bool = false
+    private var isDictationRecording: Bool = false
+
+    /// Indirection so tests can capture policy changes without touching
+    /// NSApp.
+    private let applyPolicy: (NSApplication.ActivationPolicy) -> Void
+
+    init(
+        initialPolicy: NSApplication.ActivationPolicy = .accessory,
+        applyPolicy: @escaping (NSApplication.ActivationPolicy) -> Void = { policy in
+            NSApp.setActivationPolicy(policy)
+        }
+    ) {
+        self.currentPolicy = initialPolicy
+        self.applyPolicy = applyPolicy
+        applyPolicy(initialPolicy)
+    }
+
+    /// Update the meeting-recording flag. Recomputes and applies the
+    /// desired policy if it changed.
+    func setMeetingRecording(_ active: Bool) {
+        guard isMeetingRecording != active else { return }
+        isMeetingRecording = active
+        reconcile()
+    }
+
+    /// Update the dictation-recording flag. Recomputes and applies the
+    /// desired policy if it changed.
+    func setDictationRecording(_ active: Bool) {
+        guard isDictationRecording != active else { return }
+        isDictationRecording = active
+        reconcile()
+    }
+
+    private func reconcile() {
+        let desired = ActivationPolicyDecision.desiredPolicy(
+            isMeetingRecording: isMeetingRecording,
+            isDictationRecording: isDictationRecording
+        )
+        guard desired != currentPolicy else { return }
+        currentPolicy = desired
+        applyPolicy(desired)
+    }
+}

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -66,12 +66,23 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     private var workspaceObservers: [NSObjectProtocol] = []
     private var terminationCleanupStarted = false
 
+    /// Switches NSApp's activation policy between `.accessory` (idle) and
+    /// `.regular` (during a meeting/dictation recording) so the app appears
+    /// in the macOS force-quit dialog while a session is active. Initialized
+    /// in `applicationDidFinishLaunching` after AppKit is ready.
+    private var activationPolicyController: ActivationPolicyController?
+    private var activationPolicySubscriptions: Set<AnyCancellable> = []
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Crash reporting
         CrashReporter.setup()
 
-        // Dock icon + menubar
-        NSApp.setActivationPolicy(.accessory)
+        // Dock icon + menubar — start `.accessory` for the menubar-only
+        // feel; the controller will swap to `.regular` while a recording
+        // session runs so the app shows up in Cmd+Option+Esc.
+        let activationController = ActivationPolicyController()
+        activationPolicyController = activationController
+        wireActivationPolicy(controller: activationController)
 
         // Wire session controller
         sessionController.appState = appState
@@ -425,6 +436,32 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         }
 
         return nil
+    }
+
+    /// Subscribe to meeting and dictation `isRecording` flags so the
+    /// activation-policy controller can swap the app between `.accessory`
+    /// (idle) and `.regular` (recording) — the latter makes the app appear
+    /// in the macOS force-quit dialog so a frozen recording session can be
+    /// killed without Activity Monitor.
+    private func wireActivationPolicy(controller: ActivationPolicyController) {
+        // Dictation: STTRouter publishes its own isRecording flag.
+        appState.sttRouter.$isRecording
+            .receive(on: DispatchQueue.main)
+            .sink { [weak controller] isRecording in
+                controller?.setDictationRecording(isRecording)
+            }
+            .store(in: &activationPolicySubscriptions)
+
+        // Meeting: the @MainActor MeetingSessionController owns the flag.
+        // Only available on macOS 14+, matching where MeetingSession lives.
+        if #available(macOS 14.0, *) {
+            appState.meetingSession.$isRecording
+                .receive(on: DispatchQueue.main)
+                .sink { [weak controller] isRecording in
+                    controller?.setMeetingRecording(isRecording)
+                }
+                .store(in: &activationPolicySubscriptions)
+        }
     }
 
     private func startDictationFromSettings() {

--- a/Tests/ActivationPolicyControllerTests.swift
+++ b/Tests/ActivationPolicyControllerTests.swift
@@ -1,0 +1,118 @@
+import AppKit
+import Foundation
+
+@MainActor
+func testActivationPolicyController() async {
+    runSuite("ActivationPolicyDecision returns .accessory when both sessions are idle") {
+        let policy = ActivationPolicyDecision.desiredPolicy(
+            isMeetingRecording: false,
+            isDictationRecording: false
+        )
+        assertEqual(policy, .accessory, "idle app stays a menubar agent")
+    }
+
+    runSuite("ActivationPolicyDecision returns .regular when a meeting is recording") {
+        let policy = ActivationPolicyDecision.desiredPolicy(
+            isMeetingRecording: true,
+            isDictationRecording: false
+        )
+        assertEqual(policy, .regular, "meeting session promotes the app to .regular for force-quit visibility")
+    }
+
+    runSuite("ActivationPolicyDecision returns .regular when a dictation is recording") {
+        let policy = ActivationPolicyDecision.desiredPolicy(
+            isMeetingRecording: false,
+            isDictationRecording: true
+        )
+        assertEqual(policy, .regular, "dictation session promotes the app the same way")
+    }
+
+    runSuite("ActivationPolicyDecision returns .regular when both sessions are recording") {
+        let policy = ActivationPolicyDecision.desiredPolicy(
+            isMeetingRecording: true,
+            isDictationRecording: true
+        )
+        assertEqual(policy, .regular, "any active session keeps us in .regular")
+    }
+
+    await runSuite("ActivationPolicyController applies initial policy at init") {
+        let recorder = PolicyRecorder()
+        _ = ActivationPolicyController(
+            initialPolicy: .accessory,
+            applyPolicy: { policy in recorder.append(policy) }
+        )
+        assertEqual(recorder.history, [.accessory], "init applies initial policy exactly once")
+    }
+
+    await runSuite("ActivationPolicyController switches to .regular when a meeting starts") {
+        let recorder = PolicyRecorder()
+        let controller = ActivationPolicyController(
+            initialPolicy: .accessory,
+            applyPolicy: { policy in recorder.append(policy) }
+        )
+
+        controller.setMeetingRecording(true)
+
+        assertEqual(recorder.history, [.accessory, .regular], "meeting on flips to .regular")
+        assertEqual(controller.currentPolicy, .regular, "controller tracks current policy")
+    }
+
+    await runSuite("ActivationPolicyController returns to .accessory when meeting stops with no other session") {
+        let recorder = PolicyRecorder()
+        let controller = ActivationPolicyController(
+            initialPolicy: .accessory,
+            applyPolicy: { policy in recorder.append(policy) }
+        )
+
+        controller.setMeetingRecording(true)
+        controller.setMeetingRecording(false)
+
+        assertEqual(recorder.history, [.accessory, .regular, .accessory], "stop without overlapping session restores .accessory")
+    }
+
+    await runSuite("ActivationPolicyController stays .regular while either session is active") {
+        let recorder = PolicyRecorder()
+        let controller = ActivationPolicyController(
+            initialPolicy: .accessory,
+            applyPolicy: { policy in recorder.append(policy) }
+        )
+
+        controller.setMeetingRecording(true)        // accessory -> regular
+        controller.setDictationRecording(true)      // already regular, no apply
+        controller.setMeetingRecording(false)       // dictation still active, stays regular
+        controller.setDictationRecording(false)     // both off, back to accessory
+
+        assertEqual(
+            recorder.history,
+            [.accessory, .regular, .accessory],
+            "policy only changes when the OR of sessions flips; intermediate flag changes do not bounce the Dock"
+        )
+    }
+
+    await runSuite("ActivationPolicyController coalesces redundant flag updates") {
+        let recorder = PolicyRecorder()
+        let controller = ActivationPolicyController(
+            initialPolicy: .accessory,
+            applyPolicy: { policy in recorder.append(policy) }
+        )
+
+        controller.setMeetingRecording(false)    // already false; no apply
+        controller.setDictationRecording(false)  // already false; no apply
+        controller.setMeetingRecording(true)     // accessory -> regular
+        controller.setMeetingRecording(true)     // already true; no apply
+
+        assertEqual(recorder.history, [.accessory, .regular], "redundant updates do not re-apply policy")
+    }
+}
+
+/// Captures the sequence of activation policies applied by a controller.
+/// `@MainActor` because the controller is `@MainActor` and synchronously
+/// invokes the `applyPolicy` closure during init/updates.
+@MainActor
+private final class PolicyRecorder {
+    private(set) var history: [NSApplication.ActivationPolicy] = []
+
+    func append(_ policy: NSApplication.ActivationPolicy) {
+        history.append(policy)
+    }
+}

--- a/Tests/FastTests.manifest
+++ b/Tests/FastTests.manifest
@@ -1,6 +1,7 @@
 # Fast test manifest
 # Format: <TestFile.swift>:<top-level entry function>
 
+ActivationPolicyControllerTests.swift:testActivationPolicyController
 AgentConnectionGuideTests.swift:testAgentConnectionGuide
 ClaudeDesktopIntegrationInstallerTests.swift:testClaudeDesktopIntegrationInstaller
 AnalyticsEventPolicyTests.swift:testAnalyticsEventPolicy

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -111,6 +111,7 @@ $manifest_entries
 EOF
 
 APP_SOURCES=(
+    "Sources/Support/ActivationPolicyController.swift"
     "Sources/Support/TranscriptedPermissionKind.swift"
     "Sources/Support/TranscriptedPermissionAccess.swift"
     "Sources/Support/TranscriptedStoragePaths.swift"


### PR DESCRIPTION
## Summary

- Add `ActivationPolicyController` that switches `NSApp` between `.accessory` (idle) and `.regular` (recording) so a frozen recording session shows up in Cmd+Option+Esc.
- Subscribe to `STTRouter.$isRecording` (dictation) and `MeetingSessionController.$isRecording` (meeting); the OR of the two drives policy.
- Tests: 9 unit cases covering the pure decision matrix and the controller's coalescing/init behavior.

## Why

Transcripted runs as `LSUIElement = true` with `setActivationPolicy(.accessory)`, so it's deliberately hidden from the macOS force-quit dialog. Taylor reported on Slack that the meeting widget freezes occasionally during a session, and his only recovery path was opening Activity Monitor — that's a bad UX for a stuck recording. macOS only shows `.regular` apps in Cmd+Opt+Esc, so the cleanest way to make Transcripted force-quittable is to flip activation policy while a session is running and revert when it stops.

## What stayed the same

- Idle state is unchanged: `.accessory` policy, `LSUIElement = true` in Info.plist, no Dock icon, no force-quit visibility.
- The menubar `NSStatusItem` is independent of activation policy and stays visible the whole time — users won't see anything different in the menubar.

## What changes during a recording

- Dock icon flickers in for the duration of the session. (Trade-off accepted: this is the only way to get force-quit visibility, and it's only visible while the session is live.)
- App shows up in Cmd+Opt+Esc; users can force-quit it without opening Activity Monitor.
- Reverts to `.accessory` (Dock icon disappears, force-quit hidden again) when the session stops.

## Files

- New `Sources/Support/ActivationPolicyController.swift` — pure decision enum + `@MainActor` controller with injectable apply closure for tests.
- `Sources/TranscriptedApp.swift` — replaces the static `setActivationPolicy(.accessory)` call with the controller; subscribes to both recording flags via Combine.
- New `Tests/ActivationPolicyControllerTests.swift` — 9 cases:
  - decision returns `.accessory` when both off
  - decision returns `.regular` for meeting alone, dictation alone, both
  - init applies initial policy exactly once
  - meeting on flips policy
  - meeting stop with no other session restores `.accessory`
  - overlapping session keeps `.regular` while either is active (no Dock bouncing)
  - redundant flag updates don't re-apply policy

## Test plan

- [x] `bash build.sh` (signed bundle)
- [x] `bash run-tests.sh` — 905/905 (was 899; 6 new tests)
- [x] `bash run-integration-smoke.sh` — 2/2
- [x] `swift test` — 82/82
- [ ] Manual: idle app should stay menubar-only (no Dock icon).
- [ ] Manual: start a meeting → confirm Dock icon appears AND app shows up in Cmd+Opt+Esc.
- [ ] Manual: stop meeting → confirm Dock icon disappears AND app drops out of force-quit dialog.
- [ ] Manual: same flow but with dictation instead of meeting.
- [ ] Manual: start meeting + dictation overlap (if reachable) → verify policy stays `.regular` until both stop.

## Out of scope

- The Zoom-ducking fix (#553) and the meeting widget freeze fix (separate PR) are not part of this change. This PR only addresses the recovery path; it does not stop the freeze from happening in the first place. The widget-freeze PR will land alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)