### PR TITLE
Release Transcripted 1.1.25

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.24</string>
+	<string>1.1.25</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.24</string>
+	<string>1.1.25</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>


### PR DESCRIPTION
## Summary

Bumps `Info.plist` to 1.1.25 after merging the three Slack-reported issue fixes from this morning.

## What's in 1.1.25

- **[#553](https://github.com/r3dbars/transcripted/pull/553) — Zoom audio ducking fix.** VPIO is now opt-in via a Settings toggle (default off). A real-time software AGC in the mic tap callback handles issue #500's Safari/Firefox-WebRTC quietness without engaging macOS voice-comms ducking. Josh: the regression where Zoom audio got ducked while Transcripted was recording is gone.
- **[#554](https://github.com/r3dbars/transcripted/pull/554) — Force-quit visibility.** The app appears in Cmd+Option+Esc whenever a meeting or dictation session is active, then drops back out when idle. Taylor: if the widget freezes mid-meeting, you can now kill the app without opening Activity Monitor.
- **[#555](https://github.com/r3dbars/transcripted/pull/555) — Meeting widget freeze fix.** `Audio.stop()` teardown moved off the main thread, health snapshot reordered so lock-protected reads happen after stop. Should eliminate the few-hundred-ms stutter on stop-click and reduce contention with the audio thread. Surgical fix targeting the highest-confidence blocking sites; if Taylor still sees freezes, an Instruments trace is the next step.

## Verified

Built and tested on the merged main + this version bump:

- [x] `bash build-deps.sh --force`
- [x] `bash build.sh` — green, signed bundle
- [x] `bash run-tests.sh` — 909/909
- [x] `bash run-integration-smoke.sh` — 2/2
- [x] `swift test` — 98/98 (covers the 6 + 5 + 9 + 3 new tests across the three feature PRs)

## After this lands

Following the v1.1.24 release pattern (PR #524 → PR #525):

1. Create the `v1.1.25` git tag at this merge commit.
2. Build, sign, and notarize a DMG.
3. Attach as a GitHub release at `v1.1.25`.
4. Open the appcast/cask follow-up PR updating `docs/appcast.xml` and `Casks/transcripted.rb` with the new download URL and SHA so Sparkle auto-updaters and Homebrew users pick up the release.

## Manual repro that should happen before tagging

The unit/integration tests can't actually verify the user-facing behaviors. Before tagging v1.1.25, please confirm on real hardware:

- Open Zoom → start a meeting recording → other person's voice stays at normal volume (no ducking).
- Start a meeting → press Cmd+Option+Esc → Transcripted listed in dialog. Stop → it's gone.
- Click Stop on a meeting widget mid-session → animates promptly to "Saving…" without a noticeable freeze.

If the manual repro fails on any of the three, we either fix and re-cut, or hold the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)