### PR TITLE
Give Transcripted a permanent Dock icon

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -29,7 +29,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>26.0</string>
 	<key>LSUIElement</key>
-	<true/>
+	<false/>
 	<key>SUEnableAutomaticChecks</key>
 	<true/>
 	<key>SUAllowsAutomaticUpdates</key>

--- a/Sources/Support/ActivationPolicyController.swift
+++ b/Sources/Support/ActivationPolicyController.swift
@@ -1,20 +1,14 @@
 // Support/ActivationPolicyController.swift
-// Dynamically switches NSApp's activation policy so an active recording
-// session shows up in the macOS force-quit dialog (Cmd+Option+Esc).
+// Locks NSApp's activation policy to `.regular` so the app has a
+// permanent Dock presence (and shows up in Cmd+Option+Esc).
 //
-// Background: Transcripted is a menubar app, so it normally runs with
-// activation policy `.accessory` and `LSUIElement = true`. macOS hides
-// `.accessory` apps from the force-quit dialog; if the app freezes during
-// a recording, the user has to open Activity Monitor to kill it. Reported
-// pain: Taylor's meeting widget froze and the only recovery was Activity
-// Monitor.
-//
-// Fix shape: while a recording is active (meeting OR dictation), switch
-// to `.regular` so the app appears in the force-quit dialog. When all
-// sessions stop, switch back to `.accessory`. The Dock icon flickers in
-// for the duration of the recording — acceptable trade for a recovery
-// path. The menubar `NSStatusItem` is independent of activation policy
-// and stays visible the whole time.
+// History: this controller used to flip between `.accessory` (menubar
+// only) and `.regular` (during a recording) so the app would appear in
+// the force-quit dialog only when needed. The product now ships with a
+// permanent Dock icon, so the dynamic flip is gone and the recording
+// flags are no-ops. Force-quit visibility comes for free as a side
+// effect of the always-regular policy. The menubar `NSStatusItem` is
+// independent of activation policy and stays visible the whole time.
 //
 // Thread-safety: this type is `@MainActor` because `NSApplication`
 // state is main-thread-only. Callers update the recording flags from
@@ -29,17 +23,16 @@ import Foundation
 /// policy the app should have.
 enum ActivationPolicyDecision {
 
-    /// Returns `.regular` if any session is active so the app shows in
-    /// the force-quit dialog. Otherwise returns `.accessory` to keep
-    /// the Dock clean.
+    /// Always `.regular` — the app keeps a permanent Dock presence
+    /// regardless of recording state. The recording-flag parameters are
+    /// retained so existing callers and tests continue to compile.
     static func desiredPolicy(
         isMeetingRecording: Bool,
         isDictationRecording: Bool
     ) -> NSApplication.ActivationPolicy {
-        if isMeetingRecording || isDictationRecording {
-            return .regular
-        }
-        return .accessory
+        _ = isMeetingRecording
+        _ = isDictationRecording
+        return .regular
     }
 }
 
@@ -59,7 +52,7 @@ final class ActivationPolicyController {
     private let applyPolicy: (NSApplication.ActivationPolicy) -> Void
 
     init(
-        initialPolicy: NSApplication.ActivationPolicy = .accessory,
+        initialPolicy: NSApplication.ActivationPolicy = .regular,
         applyPolicy: @escaping (NSApplication.ActivationPolicy) -> Void = { policy in
             NSApp.setActivationPolicy(policy)
         }

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -191,7 +191,19 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        togglePopover()
+        if flag {
+            // Let AppKit do its default handling (bring an existing
+            // window to the front).
+            return true
+        }
+
+        if !PermissionsOnboardingPreferences.hasCompleted() {
+            _ = resolvedSourceApp()
+            onboardingWindowController.present()
+            return false
+        }
+
+        showSettingsWindow(page: .home, source: "dock_icon")
         return false
     }
 

--- a/Tests/ActivationPolicyControllerTests.swift
+++ b/Tests/ActivationPolicyControllerTests.swift
@@ -3,12 +3,12 @@ import Foundation
 
 @MainActor
 func testActivationPolicyController() async {
-    runSuite("ActivationPolicyDecision returns .accessory when both sessions are idle") {
+    runSuite("ActivationPolicyDecision returns .regular when both sessions are idle") {
         let policy = ActivationPolicyDecision.desiredPolicy(
             isMeetingRecording: false,
             isDictationRecording: false
         )
-        assertEqual(policy, .accessory, "idle app stays a menubar agent")
+        assertEqual(policy, .regular, "app keeps a permanent Dock presence even when idle")
     }
 
     runSuite("ActivationPolicyDecision returns .regular when a meeting is recording") {
@@ -16,7 +16,7 @@ func testActivationPolicyController() async {
             isMeetingRecording: true,
             isDictationRecording: false
         )
-        assertEqual(policy, .regular, "meeting session promotes the app to .regular for force-quit visibility")
+        assertEqual(policy, .regular, "meeting session keeps the app visible in force-quit / Dock")
     }
 
     runSuite("ActivationPolicyDecision returns .regular when a dictation is recording") {
@@ -24,7 +24,7 @@ func testActivationPolicyController() async {
             isMeetingRecording: false,
             isDictationRecording: true
         )
-        assertEqual(policy, .regular, "dictation session promotes the app the same way")
+        assertEqual(policy, .regular, "dictation session keeps the app visible in force-quit / Dock")
     }
 
     runSuite("ActivationPolicyDecision returns .regular when both sessions are recording") {
@@ -32,76 +32,76 @@ func testActivationPolicyController() async {
             isMeetingRecording: true,
             isDictationRecording: true
         )
-        assertEqual(policy, .regular, "any active session keeps us in .regular")
+        assertEqual(policy, .regular, "any combination of session flags resolves to .regular")
     }
 
-    await runSuite("ActivationPolicyController applies initial policy at init") {
+    await runSuite("ActivationPolicyController applies initial .regular policy at init") {
         let recorder = PolicyRecorder()
         _ = ActivationPolicyController(
-            initialPolicy: .accessory,
+            initialPolicy: .regular,
             applyPolicy: { policy in recorder.append(policy) }
         )
-        assertEqual(recorder.history, [.accessory], "init applies initial policy exactly once")
+        assertEqual(recorder.history, [.regular], "init applies initial policy exactly once")
     }
 
-    await runSuite("ActivationPolicyController switches to .regular when a meeting starts") {
+    await runSuite("ActivationPolicyController stays .regular when a meeting starts") {
         let recorder = PolicyRecorder()
         let controller = ActivationPolicyController(
-            initialPolicy: .accessory,
+            initialPolicy: .regular,
             applyPolicy: { policy in recorder.append(policy) }
         )
 
         controller.setMeetingRecording(true)
 
-        assertEqual(recorder.history, [.accessory, .regular], "meeting on flips to .regular")
-        assertEqual(controller.currentPolicy, .regular, "controller tracks current policy")
+        assertEqual(recorder.history, [.regular], "meeting on does not bounce the activation policy")
+        assertEqual(controller.currentPolicy, .regular, "controller stays .regular")
     }
 
-    await runSuite("ActivationPolicyController returns to .accessory when meeting stops with no other session") {
+    await runSuite("ActivationPolicyController stays .regular when meeting stops") {
         let recorder = PolicyRecorder()
         let controller = ActivationPolicyController(
-            initialPolicy: .accessory,
+            initialPolicy: .regular,
             applyPolicy: { policy in recorder.append(policy) }
         )
 
         controller.setMeetingRecording(true)
         controller.setMeetingRecording(false)
 
-        assertEqual(recorder.history, [.accessory, .regular, .accessory], "stop without overlapping session restores .accessory")
+        assertEqual(recorder.history, [.regular], "session lifecycle never demotes the app from .regular")
     }
 
-    await runSuite("ActivationPolicyController stays .regular while either session is active") {
+    await runSuite("ActivationPolicyController stays .regular across overlapping sessions") {
         let recorder = PolicyRecorder()
         let controller = ActivationPolicyController(
-            initialPolicy: .accessory,
+            initialPolicy: .regular,
             applyPolicy: { policy in recorder.append(policy) }
         )
 
-        controller.setMeetingRecording(true)        // accessory -> regular
-        controller.setDictationRecording(true)      // already regular, no apply
-        controller.setMeetingRecording(false)       // dictation still active, stays regular
-        controller.setDictationRecording(false)     // both off, back to accessory
+        controller.setMeetingRecording(true)
+        controller.setDictationRecording(true)
+        controller.setMeetingRecording(false)
+        controller.setDictationRecording(false)
 
         assertEqual(
             recorder.history,
-            [.accessory, .regular, .accessory],
-            "policy only changes when the OR of sessions flips; intermediate flag changes do not bounce the Dock"
+            [.regular],
+            "no combination of overlapping session flags should demote the activation policy"
         )
     }
 
     await runSuite("ActivationPolicyController coalesces redundant flag updates") {
         let recorder = PolicyRecorder()
         let controller = ActivationPolicyController(
-            initialPolicy: .accessory,
+            initialPolicy: .regular,
             applyPolicy: { policy in recorder.append(policy) }
         )
 
-        controller.setMeetingRecording(false)    // already false; no apply
-        controller.setDictationRecording(false)  // already false; no apply
-        controller.setMeetingRecording(true)     // accessory -> regular
-        controller.setMeetingRecording(true)     // already true; no apply
+        controller.setMeetingRecording(false)
+        controller.setDictationRecording(false)
+        controller.setMeetingRecording(true)
+        controller.setMeetingRecording(true)
 
-        assertEqual(recorder.history, [.accessory, .regular], "redundant updates do not re-apply policy")
+        assertEqual(recorder.history, [.regular], "redundant updates do not re-apply policy")
     }
 }
 


### PR DESCRIPTION
## Summary
- Flip `LSUIElement` to `false` so Transcripted shows a permanent Dock icon instead of being a menubar-only `.accessory` app that only briefly appeared in the Dock during recordings.
- Route Dock-icon clicks (via `applicationShouldHandleReopen`) to the Settings window on the Home page when no window is already visible; otherwise let AppKit bring the existing window to the front.
- Simplify `ActivationPolicyController` to always report `.regular`. Its original purpose — making the app appear in the force-quit dialog during a recording — is now satisfied for free by the always-regular policy. The recording-flag wiring is kept as a no-op to avoid churning callers, and the unit tests are updated to assert the new always-`.regular` behavior.

The menubar status item and its existing quick-action popover are unchanged — left-click still opens the popover, exactly as before.

## Test plan
- [x] `bash build.sh` passes.
- [x] `bash run-tests.sh` — 909/909 pass.
- [ ] Manually verify: Transcripted appears in the Dock at launch (no longer hides as `.accessory`).
- [ ] Click the Dock icon with no window open → Settings window opens on Home.
- [ ] Click the Dock icon with the Settings window already visible → existing window comes to the front.
- [ ] Left-click the menubar icon → quick-action popover appears (unchanged behavior).
- [ ] First-run: clicking the Dock icon before onboarding completion routes to the onboarding window.
- [ ] Start and stop a meeting / dictation → Dock icon stays put (no flicker between accessory and regular).

🤖 Generated with [Claude Code](https://claude.com/claude-code)