### PR TITLE
[nightly-security] Harden Sentry context scrubbing

### DIFF
--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -7,6 +7,7 @@ enum SentryPayloadSanitizer {
         "authorization",
         "bearer",
         "bundle",
+        "context",
         "credential",
         "dsn",
         "email",

--- a/Tests/SentryPayloadSanitizerTests.swift
+++ b/Tests/SentryPayloadSanitizerTests.swift
@@ -16,6 +16,7 @@ func testSentryPayloadSanitizer() {
     runSuite("SentryPayloadSanitizer.sanitizeContext drops obviously sensitive keys") {
         let sanitized = SentryPayloadSanitizer.sanitizeContext([
             "client_secret": "plain-secret",
+            "context": "Customer transcript line that should stay local",
             "dsn": "https://example@sentry.invalid/1",
             "duration_ms": "123",
             "meeting_state": "transcribing",
@@ -31,6 +32,7 @@ func testSentryPayloadSanitizer() {
         assertEqual(sanitized["duration_ms"], "123", "coarse numeric values should remain")
         assertEqual(sanitized["meeting_state"], "transcribing", "non-sensitive state should remain")
         assertNil(sanitized["client_secret"], "client secrets should be dropped")
+        assertNil(sanitized["context"], "free-form context strings should be dropped")
         assertNil(sanitized["dsn"], "DSNs should be dropped")
         assertNil(sanitized["meeting_name"], "meeting names should be dropped")
         assertNil(sanitized["name"], "generic names should be dropped")

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -25,6 +25,7 @@ transport.
 - never send speaker names
 - never send source app names or bundle IDs
 - never send absolute file paths
+- never send free-form context strings
 - never send emails, tokens, or raw URLs
 - keep analytics to allowlisted events and coarse buckets only
 - keep crash reporting separately user-controllable from anonymous analytics


### PR DESCRIPTION
## Summary
- treat generic Sentry `context` payload keys as sensitive and drop them before off-device send
- add a regression test for free-form context strings in the Sentry sanitizer
- note the free-form context rule in the privacy-first observability doc

## Verification
- bash run-tests.sh
- bash build-deps.sh --force
- bash build.sh