### PR TITLE
[nightly-retrieval] improve CLI meeting search matching

### DIFF
--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -9,7 +9,7 @@ It does not build or run the app target.
 ### Local Context
 
 - `transcripted-cli context-recent` — list recent meetings and dictations
-- `transcripted-cli context-search <query>` — search across saved meetings and dictations
+- `transcripted-cli context-search <query>` — search across saved meetings and dictations, including meeting titles and speaker names
 - `transcripted-cli list-dictations` — list saved dictation day files
 - `transcripted-cli read-dictation <filename>` — read one dictation day or one entry
 

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -227,11 +227,14 @@ enum CLIContextStore {
                 if let speaker, !meeting.speakers.contains(where: { $0.localizedCaseInsensitiveContains(speaker) }) {
                     return nil
                 }
-                let matches = meeting.utterances.filter { utterance in
+                let textMatch = meeting.utterances.first { utterance in
                     utterance.text.localizedCaseInsensitiveContains(normalizedQuery)
                         && (speaker == nil || speakerMatches(filter: speaker!, speakerName: utterance.speakerId))
                 }
-                guard let firstMatch = matches.first else { return nil }
+                let metadataMatch = meeting.title.localizedCaseInsensitiveContains(normalizedQuery)
+                    || meeting.speakers.contains(where: { $0.localizedCaseInsensitiveContains(normalizedQuery) })
+                guard let preview = textMatch.map({ String($0.text.prefix(220)) })
+                    ?? (metadataMatch ? recentMeetingPreview(for: meeting) : nil) else { return nil }
                 return CLIContextItem(
                     kind: .meeting,
                     title: meeting.title,
@@ -239,7 +242,7 @@ enum CLIContextStore {
                     entryId: nil,
                     date: meeting.date,
                     datetime: meeting.datetime,
-                    preview: String(firstMatch.text.prefix(220)),
+                    preview: preview,
                     wordCount: meeting.wordCount,
                     speakers: meeting.speakers,
                     sourceAppName: nil,

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -131,6 +131,100 @@ final class ContextStoreTests: XCTestCase {
         XCTAssertEqual(items.first?.preview, "I agree, and the product plan still needs a test pass.")
     }
 
+    func testSearchMatchesMeetingTitleWhenTranscriptDoesNotContainQuery() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let meetingsDir = root.appendingPathComponent("meetings", isDirectory: true)
+        let dictationsDir = root.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: meetingsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dictationsDir, withIntermediateDirectories: true)
+
+        let meeting = """
+        ---
+        capture_type: meeting
+        title: Strategy sync
+        date: 2026-04-16
+        time: 09:15:00
+        duration: "0:18"
+        ---
+
+        # Strategy sync
+
+        ## Full Transcript
+
+        [00:03] [Mic/You] We should test the onboarding changes before touching pricing.
+        [00:08] [System/Jenny Wen] Agreed.
+        """
+        try meeting.write(
+            to: meetingsDir.appendingPathComponent("Strategy sync.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let items = CLIContextStore.search(
+            query: "strategy",
+            speaker: nil,
+            in: CLIContextDirectories(meetingsDir: meetingsDir, dictationsDir: dictationsDir),
+            kind: .meeting,
+            count: 5,
+            dateFrom: nil,
+            dateTo: nil
+        )
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.title, "Strategy sync")
+    }
+
+    func testSearchMatchesMeetingSpeakerNameWhenTranscriptDoesNotContainQuery() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let meetingsDir = root.appendingPathComponent("meetings", isDirectory: true)
+        let dictationsDir = root.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: meetingsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dictationsDir, withIntermediateDirectories: true)
+
+        let meeting = """
+        ---
+        capture_type: meeting
+        title: Hardware chat
+        date: 2026-04-16
+        time: 09:15:00
+        duration: "0:18"
+        speakers:
+          - id: "0"
+            name: Linus
+            db_id: "80FB272B-6061-4FC4-8408-3F7A974C59DB"
+        ---
+
+        # Hardware chat
+
+        ## Full Transcript
+
+        [00:03] [System/Linus] Yellow.
+        [00:08] [System/Linus] Touch screen finally shipped.
+        """
+        try meeting.write(
+            to: meetingsDir.appendingPathComponent("Hardware chat.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let items = CLIContextStore.search(
+            query: "Linus",
+            speaker: nil,
+            in: CLIContextDirectories(meetingsDir: meetingsDir, dictationsDir: dictationsDir),
+            kind: .meeting,
+            count: 5,
+            dateFrom: nil,
+            dateTo: nil
+        )
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.title, "Hardware chat")
+    }
+
     func testRecentIncludesLegacyMeetingDirectories() throws {
         let root = makeTempDir()
         defer { try? FileManager.default.removeItem(at: root) }


### PR DESCRIPTION
## What changed
- taught `transcripted-cli context-search` to match meeting titles and speaker names, not just utterance text
- added CLI regression tests for title-only and speaker-name-only meeting queries
- updated the CLI tool doc to reflect the broader search behavior

## Why
Nightly retrieval eval found a live gap in the CLI surface: `context-search Linus --kind meeting` returned no meetings even though local `Meeting with Linus*.md` captures existed. The query only searched utterance text, so agents could miss obvious meetings when the useful clue lived in the title or speaker metadata.

## Impact
Agents using the CLI can now find meetings from common queries like a participant name or meeting title without needing the exact spoken text.

## Verification
- `cd Tools/TranscriptedCLI && swift build`
- `cd Tools/TranscriptedCLI && swift test`
- `cd Tools/TranscriptedCLI && swift run transcripted-cli context-search Linus --kind meeting --count 5 --json`
- `cd Tools/TranscriptedMCP && swift build`
- `cd Tools/TranscriptedMCP && swift test`
- `bash run-tests.sh`
- `bash build-deps.sh --force`
- `bash build.sh`
