### PR TITLE
[nightly-agent] Filter non-capture agent artifacts

### DIFF
--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -105,7 +105,7 @@ struct CLIContextDirectories {
         var directories = [primary]
         var seen = Set([primary.standardizedFileURL.path])
 
-        for candidate in legacyCandidates where directoryHasMarkdownFiles(candidate, fileManager: fileManager) {
+        for candidate in legacyCandidates where directoryHasCaptureMarkdownFiles(candidate, fileManager: fileManager) {
             let path = candidate.standardizedFileURL.path
             guard !seen.contains(path) else { continue }
             seen.insert(path)
@@ -115,7 +115,7 @@ struct CLIContextDirectories {
         return directories
     }
 
-    private static func directoryHasMarkdownFiles(_ directory: URL, fileManager: FileManager) -> Bool {
+    private static func directoryHasCaptureMarkdownFiles(_ directory: URL, fileManager: FileManager) -> Bool {
         guard let contents = try? fileManager.contentsOfDirectory(
             at: directory,
             includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
@@ -130,8 +130,24 @@ struct CLIContextDirectories {
             else {
                 return false
             }
-            return values.isRegularFile == true && values.isSymbolicLink != true
+            guard values.isRegularFile == true, values.isSymbolicLink != true else {
+                return false
+            }
+            return looksLikeCaptureMarkdown(url)
         }
+    }
+
+    private static func looksLikeCaptureMarkdown(_ url: URL) -> Bool {
+        let filename = url.deletingPathExtension().lastPathComponent
+        if filename.hasPrefix("Dictations_") {
+            return true
+        }
+
+        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+            return false
+        }
+
+        return content.hasPrefix("---\n") && content.contains("\n---\n")
     }
 }
 
@@ -433,10 +449,24 @@ enum CLIContextStore {
         return files.compactMap { url in
             guard url.pathExtension == "md" else { return nil }
             switch CLIPathSecurity.validateExistingFile(url, under: directory) {
-            case .valid(let safeURL): return safeURL
+            case .valid(let safeURL):
+                return looksLikeCaptureMarkdown(safeURL) ? safeURL : nil
             case .missing, .invalid: return nil
             }
         }
+    }
+
+    private static func looksLikeCaptureMarkdown(_ url: URL) -> Bool {
+        let filename = url.deletingPathExtension().lastPathComponent
+        if filename.hasPrefix("Dictations_") {
+            return true
+        }
+
+        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+            return false
+        }
+
+        return content.hasPrefix("---\n") && content.contains("\n---\n")
     }
 
     private static func loadDictationDay(at url: URL) -> (payload: CLIAgentDictationDay, entries: [CLIClientDictationEntry])? {

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextDirectoriesTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextDirectoriesTests.swift
@@ -33,8 +33,31 @@ final class ContextDirectoriesTests: XCTestCase {
             .appendingPathComponent("transcripts", isDirectory: true)
         try FileManager.default.createDirectory(at: legacyDraftMeetings, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: legacyDraftDictations, withIntermediateDirectories: true)
-        try "# Old meeting".write(to: legacyDraftMeetings.appendingPathComponent("Call_old.md"), atomically: true, encoding: .utf8)
-        try "# Old dictation".write(to: legacyDraftDictations.appendingPathComponent("Dictations_2026-04-07.md"), atomically: true, encoding: .utf8)
+        try """
+        ---
+        capture_type: meeting
+        date: 2026-04-07
+        time: 09:00:00
+        ---
+
+        # Old meeting
+        """.write(
+            to: legacyDraftMeetings.appendingPathComponent("Call_old.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        ---
+        capture_type: dictation_day
+        date: 2026-04-07
+        ---
+
+        # Old dictation
+        """.write(
+            to: legacyDraftDictations.appendingPathComponent("Dictations_2026-04-07.md"),
+            atomically: true,
+            encoding: .utf8
+        )
 
         let directories = CLIContextDirectories.resolve(
             dataDir: nil,
@@ -110,7 +133,19 @@ final class ContextDirectoriesTests: XCTestCase {
             .appendingPathComponent("meetings", isDirectory: true)
             .appendingPathComponent("transcripts", isDirectory: true)
         try FileManager.default.createDirectory(at: legacyDraftMeetings, withIntermediateDirectories: true)
-        try "# Old meeting".write(to: legacyDraftMeetings.appendingPathComponent("Call_old.md"), atomically: true, encoding: .utf8)
+        try """
+        ---
+        capture_type: meeting
+        date: 2026-04-07
+        time: 09:00:00
+        ---
+
+        # Old meeting
+        """.write(
+            to: legacyDraftMeetings.appendingPathComponent("Call_old.md"),
+            atomically: true,
+            encoding: .utf8
+        )
 
         let directories = CLIContextDirectories.resolve(
             dataDir: nil,
@@ -128,6 +163,65 @@ final class ContextDirectoriesTests: XCTestCase {
             overrideDictations.standardizedFileURL.path,
         ])
     }
+
+    func testResolveSkipsLegacySharedFolderWithoutCaptureMarkdown() throws {
+        let tempHome = makeTempDir()
+        defer { removeTempDir(tempHome) }
+
+        let legacyShared = tempHome
+            .appendingPathComponent("Documents", isDirectory: true)
+            .appendingPathComponent("Transcripted", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyShared, withIntermediateDirectories: true)
+        try "# Notes".write(to: legacyShared.appendingPathComponent("CLAUDE.md"), atomically: true, encoding: .utf8)
+
+        let directories = CLIContextDirectories.resolve(
+            dataDir: nil,
+            meetingsDir: nil,
+            dictationsDir: nil,
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertFalse(directories.meetingDirs.map(\.standardizedFileURL.path).contains(legacyShared.standardizedFileURL.path))
+        XCTAssertFalse(directories.dictationDirs.map(\.standardizedFileURL.path).contains(legacyShared.standardizedFileURL.path))
+    }
+
+    func testResolveIncludesLegacySharedFolderWithCaptureMarkdown() throws {
+        let tempHome = makeTempDir()
+        defer { removeTempDir(tempHome) }
+
+        let legacyShared = tempHome
+            .appendingPathComponent("Documents", isDirectory: true)
+            .appendingPathComponent("Transcripted", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyShared, withIntermediateDirectories: true)
+        try """
+        ---
+        capture_type: meeting
+        date: 2026-04-20
+        time: 09:00:00
+        ---
+
+        # Shared meeting
+        """.write(
+            to: legacyShared.appendingPathComponent("Shared meeting.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let directories = CLIContextDirectories.resolve(
+            dataDir: nil,
+            meetingsDir: nil,
+            dictationsDir: nil,
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertTrue(directories.meetingDirs.map(\.standardizedFileURL.path).contains(legacyShared.standardizedFileURL.path))
+        XCTAssertTrue(directories.dictationDirs.map(\.standardizedFileURL.path).contains(legacyShared.standardizedFileURL.path))
+    }
+
     private func makeTempDir() -> URL {
         let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -161,6 +161,34 @@ final class ContextStoreTests: XCTestCase {
         XCTAssertEqual(items.map(\.title), ["Current meeting", "Legacy meeting"])
     }
 
+    func testRecentSkipsNonCaptureMarkdownInMeetingsDirectory() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let meetingsDir = root.appendingPathComponent("meetings", isDirectory: true)
+        let dictationsDir = root.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: meetingsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dictationsDir, withIntermediateDirectories: true)
+
+        try "# Notes".write(
+            to: meetingsDir.appendingPathComponent("CLAUDE.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try makeMeetingMarkdown(title: "Current meeting", date: "2026-04-18", body: "[00:03] [Mic/You] Current note.")
+            .write(to: meetingsDir.appendingPathComponent("Call_current.md"), atomically: true, encoding: .utf8)
+
+        let items = CLIContextStore.recent(
+            in: CLIContextDirectories(meetingsDir: meetingsDir, dictationsDir: dictationsDir),
+            kind: .meeting,
+            count: 5,
+            dateFrom: nil,
+            dateTo: nil
+        )
+
+        XCTAssertEqual(items.map(\.title), ["Current meeting"])
+    }
+
     func testRecentMeetingWithDuplicateSpeakerNamesDoesNotCrash() throws {
         let root = makeTempDir()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/DataDirectories.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/DataDirectories.swift
@@ -117,7 +117,7 @@ struct TranscriptedDataDirectories {
         var directories = [primary]
         var seen = Set([primary.standardizedFileURL.path])
 
-        for candidate in legacyCandidates where directoryHasMarkdownFiles(candidate, fileManager: fileManager) {
+        for candidate in legacyCandidates where directoryHasCaptureMarkdownFiles(candidate, fileManager: fileManager) {
             let path = candidate.standardizedFileURL.path
             guard !seen.contains(path) else { continue }
             seen.insert(path)
@@ -127,7 +127,7 @@ struct TranscriptedDataDirectories {
         return directories
     }
 
-    private static func directoryHasMarkdownFiles(_ directory: URL, fileManager: FileManager) -> Bool {
+    private static func directoryHasCaptureMarkdownFiles(_ directory: URL, fileManager: FileManager) -> Bool {
         guard let contents = try? fileManager.contentsOfDirectory(
             at: directory,
             includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
@@ -142,7 +142,23 @@ struct TranscriptedDataDirectories {
             else {
                 return false
             }
-            return values.isRegularFile == true && values.isSymbolicLink != true
+            guard values.isRegularFile == true, values.isSymbolicLink != true else {
+                return false
+            }
+            return looksLikeCaptureMarkdown(url)
         }
+    }
+
+    private static func looksLikeCaptureMarkdown(_ url: URL) -> Bool {
+        let filename = url.deletingPathExtension().lastPathComponent
+        if filename.hasPrefix("Dictations_") {
+            return true
+        }
+
+        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+            return false
+        }
+
+        return content.hasPrefix("---\n") && content.contains("\n---\n")
     }
 }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
@@ -151,7 +151,7 @@ enum TranscriptLoader {
     }
 
     static func artifactKind(for url: URL) -> ContextArtifactKind? {
-        guard url.pathExtension == "md" else { return nil }
+        guard url.pathExtension == "md", looksLikeCaptureMarkdown(url) else { return nil }
 
         let filename = url.deletingPathExtension().lastPathComponent
         if filename.hasPrefix("Dictations_") {
@@ -176,6 +176,19 @@ enum TranscriptLoader {
                 .contentModificationDate?.timeIntervalSince1970) ?? 0
             return ContextArtifactFile(url: safeURL, modDate: modDate, kind: kind)
         }
+    }
+
+    private static func looksLikeCaptureMarkdown(_ url: URL) -> Bool {
+        let filename = url.deletingPathExtension().lastPathComponent
+        if filename.hasPrefix("Dictations_") {
+            return true
+        }
+
+        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+            return false
+        }
+
+        return content.hasPrefix("---\n") && content.contains("\n---\n")
     }
 
     static func speakerLookup(from transcript: AgentTranscript) -> [String: (name: String, persistentId: String?)] {

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/DataDirectoriesTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/DataDirectoriesTests.swift
@@ -76,8 +76,31 @@ final class DataDirectoriesTests: XCTestCase {
             .appendingPathComponent("transcripts", isDirectory: true)
         try FileManager.default.createDirectory(at: legacyDraftMeetings, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: legacyDraftDictations, withIntermediateDirectories: true)
-        try "# Old meeting".write(to: legacyDraftMeetings.appendingPathComponent("Call_old.md"), atomically: true, encoding: .utf8)
-        try "# Old dictation".write(to: legacyDraftDictations.appendingPathComponent("Dictations_2026-04-07.md"), atomically: true, encoding: .utf8)
+        try """
+        ---
+        capture_type: meeting
+        date: 2026-04-07
+        time: 09:00:00
+        ---
+
+        # Old meeting
+        """.write(
+            to: legacyDraftMeetings.appendingPathComponent("Call_old.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        ---
+        capture_type: dictation_day
+        date: 2026-04-07
+        ---
+
+        # Old dictation
+        """.write(
+            to: legacyDraftDictations.appendingPathComponent("Dictations_2026-04-07.md"),
+            atomically: true,
+            encoding: .utf8
+        )
 
         let directories = TranscriptedDataDirectories.resolve(
             environment: [:],
@@ -105,7 +128,19 @@ final class DataDirectoriesTests: XCTestCase {
             .appendingPathComponent("meetings", isDirectory: true)
             .appendingPathComponent("transcripts", isDirectory: true)
         try FileManager.default.createDirectory(at: legacyDraftMeetings, withIntermediateDirectories: true)
-        try "# Old meeting".write(to: legacyDraftMeetings.appendingPathComponent("Call_old.md"), atomically: true, encoding: .utf8)
+        try """
+        ---
+        capture_type: meeting
+        date: 2026-04-07
+        time: 09:00:00
+        ---
+
+        # Old meeting
+        """.write(
+            to: legacyDraftMeetings.appendingPathComponent("Call_old.md"),
+            atomically: true,
+            encoding: .utf8
+        )
 
         let directories = TranscriptedDataDirectories.resolve(
             environment: [
@@ -122,5 +157,51 @@ final class DataDirectoriesTests: XCTestCase {
         XCTAssertEqual(directories.dictationDirs.map(\.standardizedFileURL.path), [
             overrideDictations.standardizedFileURL.path,
         ])
+    }
+
+    func testResolveSkipsLegacySharedFolderWithoutCaptureMarkdown() throws {
+        let legacyShared = tempHome
+            .appendingPathComponent("Documents", isDirectory: true)
+            .appendingPathComponent("Transcripted", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyShared, withIntermediateDirectories: true)
+        try "# Notes".write(to: legacyShared.appendingPathComponent("CLAUDE.md"), atomically: true, encoding: .utf8)
+
+        let directories = TranscriptedDataDirectories.resolve(
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertFalse(directories.meetingDirs.map(\.standardizedFileURL.path).contains(legacyShared.standardizedFileURL.path))
+        XCTAssertFalse(directories.dictationDirs.map(\.standardizedFileURL.path).contains(legacyShared.standardizedFileURL.path))
+    }
+
+    func testResolveIncludesLegacySharedFolderWithCaptureMarkdown() throws {
+        let legacyShared = tempHome
+            .appendingPathComponent("Documents", isDirectory: true)
+            .appendingPathComponent("Transcripted", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyShared, withIntermediateDirectories: true)
+        try """
+        ---
+        capture_type: meeting
+        date: 2026-04-20
+        time: 09:00:00
+        ---
+
+        # Shared meeting
+        """.write(
+            to: legacyShared.appendingPathComponent("Shared meeting.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let directories = TranscriptedDataDirectories.resolve(
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertTrue(directories.meetingDirs.map(\.standardizedFileURL.path).contains(legacyShared.standardizedFileURL.path))
+        XCTAssertTrue(directories.dictationDirs.map(\.standardizedFileURL.path).contains(legacyShared.standardizedFileURL.path))
     }
 }

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptLoaderTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptLoaderTests.swift
@@ -62,6 +62,7 @@ final class TranscriptLoaderTests: XCTestCase {
         try writeFixture(makeDictationDayJSON(), filename: "Dictations_2026-04-07", to: tempDir)
         try "other file".data(using: .utf8)!.write(to: tempDir.appendingPathComponent("notes.json"))
         try "not json".data(using: .utf8)!.write(to: tempDir.appendingPathComponent("readme.txt"))
+        try "# Notes".write(to: tempDir.appendingPathComponent("CLAUDE.md"), atomically: true, encoding: .utf8)
 
         let artifacts = TranscriptLoader.enumerateArtifacts(in: tempDir)
         XCTAssertEqual(artifacts.count, 3)


### PR DESCRIPTION
## Summary
- ignore non-capture markdown when CLI and MCP discover fallback or capture artifacts
- keep legacy shared fallback only when it contains real frontmatter-based Transcripted captures
- add coverage for legacy shared fallback and stray markdown inside capture folders

## Verification
- cd Tools/TranscriptedCLI && swift build && swift test
- cd Tools/TranscriptedMCP && swift build -c release && swift test && .build/release/transcripted-mcp --self-test