### PR TITLE
[codex] Serialize meeting audio graph teardown

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -155,6 +155,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
     var engine: AVAudioEngine?
     var inputNode: AVAudioInputNode?
+    private let audioGraphLock = NSRecursiveLock()
     var startTime: Date?
     var timer: Timer?
 
@@ -291,6 +292,12 @@ public class Audio: ObservableObject, @unchecked Sendable {
     var inputChannelCount: AVAudioChannelCount {
         get { formatLock.lock(); defer { formatLock.unlock() }; return _inputChannelCount }
         set { formatLock.lock(); defer { formatLock.unlock() }; _inputChannelCount = newValue }
+    }
+
+    func withAudioGraphLock<T>(_ body: () throws -> T) rethrows -> T {
+        audioGraphLock.lock()
+        defer { audioGraphLock.unlock() }
+        return try body()
     }
 
     // Throttle system audio visualizer updates (skip every other callback)
@@ -545,7 +552,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
     /// capture can keep the shared input device in a processed mode, which can
     /// make other mic apps sound quieter.
     func disarmVoiceProcessing(on inputNode: AVAudioInputNode) {
-        guard voiceProcessingEnabled || inputNode.isVoiceProcessingEnabled else { return }
+        guard voiceProcessingEnabled else { return }
         if let engine, engine.isRunning { return }
 
         do {
@@ -734,19 +741,21 @@ public class Audio: ObservableObject, @unchecked Sendable {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
 
-            if let engineRef, let inputNodeRef {
-                AppLogger.audio.info("Stopping audio capture")
-                if engineRef.isRunning {
-                    inputNodeRef.removeTap(onBus: 0)
-                    engineRef.stop()
+            self.withAudioGraphLock {
+                if let engineRef, let inputNodeRef {
+                    AppLogger.audio.info("Stopping audio capture")
+                    if engineRef.isRunning {
+                        inputNodeRef.removeTap(onBus: 0)
+                        engineRef.stop()
+                    }
+                    self.disarmVoiceProcessing(on: inputNodeRef)
                 }
-                self.disarmVoiceProcessing(on: inputNodeRef)
-            }
 
-            // Drop the RealtimeAGC reference so gain history doesn't
-            // carry into the next recording. Safe here because the
-            // engine has stopped — no more tap callbacks can fire.
-            self.realtimeAGC = nil
+                // Drop the RealtimeAGC reference so gain history doesn't
+                // carry into the next recording. Safe here because the
+                // engine has stopped — no more tap callbacks can fire.
+                self.realtimeAGC = nil
+            }
 
             // System audio capture's `stop()` is non-blocking (vs `stopSync`),
             // but we keep it ordered after engine teardown so a single
@@ -809,23 +818,28 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         AppLogger.audio.info("Starting audio level monitoring")
 
-        let monitorFormat = recordingFormat(for: inputNode)
+        let monitorFormat = withAudioGraphLock {
+            recordingFormat(for: inputNode)
+        }
         guard monitorFormat.sampleRate > 0, monitorFormat.channelCount > 0 else {
             AppLogger.audio.warning("Cannot start monitoring — invalid input format")
             return
         }
 
-        // Install mic tap for level metering only (no file writing)
-        inputNode.removeTap(onBus: 0)
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: monitorFormat) { [weak self] buffer, _ in
-            self?.calculateLevel(buffer: buffer)
-        }
-
         do {
-            try engine.start()
+            try withAudioGraphLock {
+                // Install mic tap for level metering only (no file writing)
+                inputNode.removeTap(onBus: 0)
+                inputNode.installTap(onBus: 0, bufferSize: 4096, format: monitorFormat) { [weak self] buffer, _ in
+                    self?.calculateLevel(buffer: buffer)
+                }
+                try engine.start()
+            }
         } catch {
             AppLogger.audio.warning("Failed to start monitoring engine", ["error": error.localizedDescription])
-            inputNode.removeTap(onBus: 0)
+            withAudioGraphLock {
+                inputNode.removeTap(onBus: 0)
+            }
             return
         }
 
@@ -856,18 +870,20 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         AppLogger.audio.info("Stopping audio level monitoring")
 
-        if let engine = engine, let inputNode = inputNode {
-            if engine.isRunning {
-                inputNode.removeTap(onBus: 0)
-                engine.stop()
+        withAudioGraphLock {
+            if let engine = engine, let inputNode = inputNode {
+                if engine.isRunning {
+                    inputNode.removeTap(onBus: 0)
+                    engine.stop()
+                }
+                disarmVoiceProcessing(on: inputNode)
             }
-            disarmVoiceProcessing(on: inputNode)
-        }
 
-        // Monitoring shares the engine but not the AGC; drop it here so a
-        // monitoring session followed by a recording session both start
-        // with a fresh gain history.
-        realtimeAGC = nil
+            // Monitoring shares the engine but not the AGC; drop it here so a
+            // monitoring session followed by a recording session both start
+            // with a fresh gain history.
+            realtimeAGC = nil
+        }
 
         systemAudioCapture?.stopSync()  // Synchronous — avoids race where delayed cleanup destroys the next recording's tap
 
@@ -892,9 +908,11 @@ public class Audio: ObservableObject, @unchecked Sendable {
         systemAudioCancellable?.cancel()
         systemAudioCapture?.stopSync()
 
-        if let engine, let inputNode, engine.isRunning {
-            inputNode.removeTap(onBus: 0)
-            engine.stop()
+        withAudioGraphLock {
+            if let engine, let inputNode, engine.isRunning {
+                inputNode.removeTap(onBus: 0)
+                engine.stop()
+            }
         }
     }
 }

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -86,20 +86,17 @@ extension Audio {
         recoveryAttemptCount += 1
         AppLogger.audioMic.debug("Recovering from device change", ["switchNumber": "\(deviceSwitchCount)", "maxAttempts": "\(maxRecoveryAttempts)"])
 
-        // Stop engine (but keep recording flag true)
-        inputNode.removeTap(onBus: 0)
-        engine.stop()
-
-        // Reset to system default (ignore UserDefaults preference during recovery)
-        engine.reset()
-        // engine.reset() clears VPIO state on the input node; require re-arm.
-        voiceProcessingEnabled = false
-        self.inputNode = engine.inputNode
-
-        // Get new device format
-        guard let newInputNode = self.inputNode else {
-            AppLogger.audioMic.error("Failed to get input node after reset")
-            return
+        // Stop engine (but keep recording flag true), then reset to system
+        // default. Keep graph mutation serialized with stop/start teardown so
+        // a user stop during device recovery cannot race CoreAudio format
+        // reads or tap replacement.
+        withAudioGraphLock {
+            inputNode.removeTap(onBus: 0)
+            engine.stop()
+            engine.reset()
+            // engine.reset() clears VPIO state on the input node; require re-arm.
+            voiceProcessingEnabled = false
+            self.inputNode = engine.inputNode
         }
 
         // HAL settle time - wait for audio hardware to stabilize after device change
@@ -115,35 +112,45 @@ extension Audio {
             return
         }
 
+        // Get new device format
+        guard let newInputNode = self.inputNode else {
+            AppLogger.audioMic.error("Failed to get input node after reset")
+            return
+        }
+
         // Re-enable VPIO after the HAL settles so setVoiceProcessingEnabled
         // queries a stable device. Skips silently if VPIO can't engage on the
         // new device, in which case recordingFormat(for:) falls back to the
         // hardware format and recording continues without AGC. When VPIO is
         // disabled by preference, this is a no-op and the software
         // RealtimeAGC keeps running across the device change.
-        armVoiceProcessing(on: newInputNode)
+        var recordingFormat = withAudioGraphLock {
+            armVoiceProcessing(on: newInputNode)
 
-        // Re-evaluate software AGC: if VPIO armed (rare here), drop AGC; if
-        // VPIO didn't arm, reset gain history so the new device starts at
-        // unity gain instead of inheriting the previous device's level.
-        if voiceProcessingEnabled {
-            realtimeAGC = nil
-        } else if let existing = realtimeAGC {
-            existing.reset()
-        } else {
-            realtimeAGC = RealtimeAGC()
+            // Re-evaluate software AGC: if VPIO armed (rare here), drop AGC; if
+            // VPIO didn't arm, reset gain history so the new device starts at
+            // unity gain instead of inheriting the previous device's level.
+            if voiceProcessingEnabled {
+                realtimeAGC = nil
+            } else if let existing = realtimeAGC {
+                existing.reset()
+            } else {
+                realtimeAGC = RealtimeAGC()
+            }
+
+            // Read the format the tap will actually deliver (VPIO-aware when
+            // armVoiceProcessing succeeded above, hardware format otherwise).
+            return self.recordingFormat(for: newInputNode)
         }
-
-        // Read the format the tap will actually deliver (VPIO-aware when
-        // armVoiceProcessing succeeded above, hardware format otherwise).
-        var recordingFormat = self.recordingFormat(for: newInputNode)
         if recordingFormat.sampleRate <= 0 || recordingFormat.channelCount <= 0 {
             AppLogger.audioMic.warning("Recovery format invalid after first read, retrying", [
                 "sampleRate": "\(recordingFormat.sampleRate)",
                 "channels": "\(recordingFormat.channelCount)"
             ])
             Thread.sleep(forTimeInterval: 0.3)
-            recordingFormat = self.recordingFormat(for: newInputNode)
+            recordingFormat = withAudioGraphLock {
+                self.recordingFormat(for: newInputNode)
+            }
         }
         guard recordingFormat.sampleRate > 0, recordingFormat.channelCount > 0 else {
             AppLogger.audioMic.error("Recovery format remained invalid", [
@@ -226,11 +233,6 @@ extension Audio {
             }
         }
 
-        // Reinstall tap using shared buffer handler
-        newInputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
-            self?.handleMicBuffer(buffer)
-        }
-
         guard sessionGeneration == recordingSessionGeneration else {
             AppLogger.audioMic.info("Skipping stale recovery before engine restart", [
                 "expectedSession": "\(sessionGeneration)",
@@ -241,7 +243,14 @@ extension Audio {
 
         // Restart engine
         do {
-            try engine.start()
+            try withAudioGraphLock {
+                // Reinstall tap using shared buffer handler
+                newInputNode.removeTap(onBus: 0)
+                newInputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
+                    self?.handleMicBuffer(buffer)
+                }
+                try engine.start()
+            }
             lastBufferTime = CACurrentMediaTime() // Reset watchdog
 
             DispatchQueue.main.async { [weak self] in

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -13,15 +13,18 @@ extension Audio {
     func startAudioCapture() async throws {
         ensureCaptureInfrastructureConfigured()
 
-        let (engine, inputNode) = try ensureEngineInitialized()
-        armVoiceProcessing(on: inputNode)
+        let (engine, inputNode) = try withAudioGraphLock {
+            let initialized = try ensureEngineInitialized()
+            armVoiceProcessing(on: initialized.1)
 
-        // When VPIO is off (the default — see `enableVoiceProcessing`), run
-        // a software AGC in the mic tap callback to recover attenuated
-        // streams (issue #500: Safari/Firefox WebRTC contention). VPIO
-        // would do this in hardware but engages system-wide ducking of
-        // other apps' audio output; software AGC has no such side effect.
-        realtimeAGC = voiceProcessingEnabled ? nil : RealtimeAGC()
+            // When VPIO is off (the default — see `enableVoiceProcessing`), run
+            // a software AGC in the mic tap callback to recover attenuated
+            // streams (issue #500: Safari/Firefox WebRTC contention). VPIO
+            // would do this in hardware but engages system-wide ducking of
+            // other apps' audio output; software AGC has no such side effect.
+            realtimeAGC = voiceProcessingEnabled ? nil : RealtimeAGC()
+            return initialized
+        }
 
         // Use system default microphone (whatever macOS has configured).
         // recordingFormat(for:) returns:
@@ -31,7 +34,9 @@ extension Audio {
         //   - Hardware format via inputFormat(forBus: 1) otherwise — required
         //     because outputFormat(forBus: 0) returns the converter format on
         //     stock AVAudioEngine, which breaks Bluetooth capture.
-        let recordingFormat = self.recordingFormat(for: inputNode)
+        let recordingFormat = withAudioGraphLock {
+            self.recordingFormat(for: inputNode)
+        }
         AppLogger.audioMic.info("Mic input format", [
             "sampleRate": "\(recordingFormat.sampleRate)",
             "channels": "\(recordingFormat.channelCount)",
@@ -252,15 +257,17 @@ extension Audio {
             throw NSError(domain: "Audio", code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to create mic audio file: \(error.localizedDescription)"])
         }
 
-        // Remove any existing tap (safety check)
-        inputNode.removeTap(onBus: 0)
+        try withAudioGraphLock {
+            // Remove any existing tap (safety check)
+            inputNode.removeTap(onBus: 0)
 
-        // Install tap on microphone
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
-            self?.handleMicBuffer(buffer)
+            // Install tap on microphone
+            inputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
+                self?.handleMicBuffer(buffer)
+            }
+
+            try engine.start()
         }
-
-        try engine.start()
 
         let cueHandler = self.onCaptureLifecycleCue
         await MainActor.run {


### PR DESCRIPTION
## Summary
- Serialize AVAudioEngine graph mutations across meeting start, stop, monitoring, and mic device recovery.
- Keep the non-blocking stop path from 1.1.25 while preventing stop teardown from racing device recovery format reads and tap replacement.
- Avoid querying the input node for VPIO state when Transcripted knows VPIO is off.

## Why
Sentry APPLE-MACOS-18 showed a latest-release fatal `EXC_BAD_ACCESS: sampleRate >` shortly after the 1.1.25 release. The likely path was the new background stop teardown overlapping with device-change recovery on another queue.

## Validation
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` — 909 passed
- `bash run-integration-smoke.sh`
- `swift test` — 98 passed

## Notes
Untracked `.wrangler/` was left out of this PR.