### PR TITLE
Harden audio device recovery

### DIFF
--- a/Sources/Speech/DictationAudioRecovery.swift
+++ b/Sources/Speech/DictationAudioRecovery.swift
@@ -8,7 +8,7 @@ struct DictationAudioAnalysis: Equatable {
     let activeRatio: Double
 
     var durationSeconds: Double {
-        guard sampleRate > 0 else { return 0 }
+        guard ParakeetAudioFormatReadinessPolicy.isUsableCaptureSampleRate(sampleRate) else { return 0 }
         return Double(sampleCount) / sampleRate
     }
 
@@ -34,7 +34,8 @@ struct DictationAudioAnalysis: Equatable {
 
 enum DictationAudioRecovery {
     static func analyze(samples: [Float], sampleRate: Double) -> DictationAudioAnalysis {
-        guard !samples.isEmpty, sampleRate > 0 else {
+        guard !samples.isEmpty,
+              ParakeetAudioFormatReadinessPolicy.isUsableCaptureSampleRate(sampleRate) else {
             return DictationAudioAnalysis(
                 sampleCount: samples.count,
                 sampleRate: sampleRate,
@@ -74,6 +75,7 @@ enum DictationAudioRecovery {
         analysis: DictationAudioAnalysis? = nil
     ) -> [Float]? {
         let resolvedAnalysis = analysis ?? analyze(samples: samples, sampleRate: sampleRate)
+        guard ParakeetAudioFormatReadinessPolicy.isUsableCaptureSampleRate(sampleRate) else { return nil }
         guard resolvedAnalysis.hasUsableSpeechSignal else { return nil }
 
         let threshold = activeThreshold(forPeak: resolvedAnalysis.peak)

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -333,8 +333,8 @@ struct RecordedSpeechSamples {
 }
 
 private struct ParakeetAudioInputSnapshot {
-    let outputFormat: AVAudioFormat
-    let hwFormat: AVAudioFormat
+    let outputFormat: ParakeetAudioFormatSummary
+    let hwFormat: ParakeetAudioFormatSummary
     let selection: DictationInputDeviceSelection?
     let selectionApplication: ParakeetInputDeviceApplication?
     let engineWasRunning: Bool
@@ -782,11 +782,11 @@ class ParakeetEngine: ObservableObject {
             return
         }
 
-        nativeSampleRate = snapshot.outputFormat.sampleRate
+        updateNativeSampleRate(snapshot.outputFormat.sampleRate)
 
         prewarmRetryCount = 0
         markFormatReadyAndPublish()
-        print("🔥 PARAKEET | input ready (\(inputDeviceName), \(nativeSampleRate)Hz)")
+        print("🔥 PARAKEET | input ready (\(inputDeviceName), \(safeNativeSampleRate())Hz)")
     }
 
     private func canContinuePrewarm(generation: Int) -> Bool {
@@ -1007,9 +1007,9 @@ class ParakeetEngine: ObservableObject {
                     throw NSError(domain: "ParakeetEngine", code: -1,
                         userInfo: [NSLocalizedDescriptionKey: "Audio route not settled after device change"])
                 }
-                self.nativeSampleRate = snapshot.outputFormat.sampleRate
+                self.updateNativeSampleRate(snapshot.outputFormat.sampleRate)
                 self.prewarmRetryCount = 0
-                print("🔄 PARAKEET | audio device changed → \(self.inputDeviceName) (\(snapshot.outputFormat.sampleRate)Hz), input ready")
+                print("🔄 PARAKEET | audio device changed → \(self.inputDeviceName) (\(self.safeNativeSampleRate())Hz), input ready")
 
                 guard !Task.isCancelled else { return }
                 guard self.recoveryState.finishRecovery(success: true, generation: myGeneration) else { return }
@@ -1033,7 +1033,7 @@ class ParakeetEngine: ObservableObject {
                                 message: "Recording recovered after device change",
                                 context: [
                                     "audio_device": self.inputDeviceName,
-                                    "sample_rate": "\(self.nativeSampleRate)",
+                                    "sample_rate": "\(self.safeNativeSampleRate())",
                                     "attempts": "\(attempt)"
                                 ])
                             break
@@ -1138,9 +1138,33 @@ class ParakeetEngine: ObservableObject {
         }
     }
 
+    private nonisolated static func audioFormatSummary(_ format: AVAudioFormat) -> ParakeetAudioFormatSummary {
+        ParakeetAudioFormatSummary(
+            sampleRate: format.sampleRate,
+            channelCount: format.channelCount
+        )
+    }
+
+    private func safeNativeSampleRate() -> Double {
+        ParakeetAudioFormatReadinessPolicy.captureSampleRateOrFallback(nativeSampleRate)
+    }
+
+    private func updateNativeSampleRate(_ sampleRate: Double) {
+        nativeSampleRate = ParakeetAudioFormatReadinessPolicy.captureSampleRateOrFallback(sampleRate)
+    }
+
+    private func reserveNativeSampleBufferCapacity() {
+        sampleBuffer.reserveCapacity(
+            ParakeetAudioFormatReadinessPolicy.bufferCapacitySampleCount(
+                sampleRate: safeNativeSampleRate(),
+                seconds: TranscriptedConstants.audioBufferCapacitySeconds
+            )
+        )
+    }
+
     private func audioFormatReadiness(
-        outputFormat: AVAudioFormat,
-        hwFormat: AVAudioFormat,
+        outputFormat: ParakeetAudioFormatSummary,
+        hwFormat: ParakeetAudioFormatSummary,
         selection: DictationInputDeviceSelection?
     ) -> ParakeetAudioFormatReadiness {
         ParakeetAudioFormatReadinessPolicy.readiness(
@@ -1161,8 +1185,8 @@ class ParakeetEngine: ObservableObject {
     }
 
     private func audioFormatContext(
-        outputFormat: AVAudioFormat,
-        hwFormat: AVAudioFormat,
+        outputFormat: ParakeetAudioFormatSummary,
+        hwFormat: ParakeetAudioFormatSummary,
         selection: DictationInputDeviceSelection?,
         readiness: ParakeetAudioFormatReadiness
     ) -> [String: String] {
@@ -1206,8 +1230,8 @@ class ParakeetEngine: ObservableObject {
             let inputNode = self.audioEngine.inputNode
             let selectionApplication = Self.applyPreferredDictationInputDevice(selection, to: inputNode)
             return ParakeetAudioInputSnapshot(
-                outputFormat: inputNode.outputFormat(forBus: 0),
-                hwFormat: inputNode.inputFormat(forBus: 0),
+                outputFormat: Self.audioFormatSummary(inputNode.outputFormat(forBus: 0)),
+                hwFormat: Self.audioFormatSummary(inputNode.inputFormat(forBus: 0)),
                 selection: selection,
                 selectionApplication: selectionApplication,
                 engineWasRunning: self.audioEngine.isRunning
@@ -1227,6 +1251,9 @@ class ParakeetEngine: ObservableObject {
                       let monoSamples = self.extractMonoSamples(from: buffer) else { return }
                 let frameLength = monoSamples.count
                 guard frameLength > 0 else { return }
+                let bufferFormat = Self.audioFormatSummary(buffer.format)
+                let effectiveSampleRate = ParakeetAudioFormatReadinessPolicy.captureSampleRateOrFallback(bufferFormat.sampleRate)
+                self.nativeSampleRate = effectiveSampleRate
 
                 if !self.didReceiveAudioSamples && frameLength > 0 {
                     self.didReceiveAudioSamples = true
@@ -1234,15 +1261,15 @@ class ParakeetEngine: ObservableObject {
                         EventReporter.shared.capture(level: .info, engine: "parakeet", event: "audio_samples_detected",
                             message: "Audio samples started flowing",
                             context: [
-                                "sample_rate": "\(self.nativeSampleRate)",
-                                "channels": "\(buffer.format.channelCount)",
+                                "sample_rate": "\(effectiveSampleRate)",
+                                "channels": "\(bufferFormat.channelCount)",
                                 "frames": "\(frameLength)"
                             ])
                     }
                 }
 
                 if self.liveDisplayEnabled, let eou = self.eouManager {
-                    let resampled = AudioResampler.resample(monoSamples, from: self.nativeSampleRate, to: 16000)
+                    let resampled = AudioResampler.resample(monoSamples, from: effectiveSampleRate, to: 16000)
                     self.streamingSamplesLock.lock()
                     self.streamingSampleBuffer.append(contentsOf: resampled)
                     var chunk: [Float]? = nil
@@ -1262,8 +1289,12 @@ class ParakeetEngine: ObservableObject {
 
                 self.pendingSamplesLock.lock()
                 self.pendingSamples.append(contentsOf: monoSamples)
-                let maxSamples = Int(self.nativeSampleRate) * TranscriptedConstants.audioBufferCapacitySeconds
-                if self.pendingSamples.count > maxSamples + Int(self.nativeSampleRate) {
+                let maxSamples = ParakeetAudioFormatReadinessPolicy.bufferCapacitySampleCount(
+                    sampleRate: effectiveSampleRate,
+                    seconds: TranscriptedConstants.audioBufferCapacitySeconds
+                )
+                let overflowMargin = Int(effectiveSampleRate)
+                if self.pendingSamples.count > maxSamples + overflowMargin {
                     self.pendingSamples.removeFirst(self.pendingSamples.count - maxSamples)
                 }
                 self.pendingSamplesLock.unlock()
@@ -1512,8 +1543,8 @@ class ParakeetEngine: ObservableObject {
         attempt: Int,
         isRecoveryAttempt: Bool,
         engineWasRunning: Bool,
-        outputFormat: AVAudioFormat,
-        hwFormat: AVAudioFormat,
+        outputFormat: ParakeetAudioFormatSummary,
+        hwFormat: ParakeetAudioFormatSummary,
         error: Error? = nil
     ) -> [String: String] {
         var context = [
@@ -1630,7 +1661,7 @@ class ParakeetEngine: ObservableObject {
             pendingSamples.removeAll(keepingCapacity: true)
         }
         sampleBuffer.removeAll(keepingCapacity: true)
-        sampleBuffer.reserveCapacity(Int(nativeSampleRate * Double(TranscriptedConstants.audioBufferCapacitySeconds)))
+        reserveNativeSampleBufferCapacity()
 
         let maxAttempts = isRecoveryAttempt ? 1 : 1 + TranscriptedConstants.audioStartRecoveryAttempts
         for attempt in 1...maxAttempts {
@@ -1722,8 +1753,8 @@ class ParakeetEngine: ObservableObject {
                 return false
             }
 
-            nativeSampleRate = snapshot.outputFormat.sampleRate
-            sampleBuffer.reserveCapacity(Int(nativeSampleRate * Double(TranscriptedConstants.audioBufferCapacitySeconds)))
+            updateNativeSampleRate(snapshot.outputFormat.sampleRate)
+            reserveNativeSampleBufferCapacity()
 
             do {
                 let startSnapshot = try await installTapAndStartEngine(isRecoveryAttempt: isRecoveryAttempt)
@@ -1852,7 +1883,7 @@ class ParakeetEngine: ObservableObject {
             }
             Task { await eouManager?.reset() }
         }
-        print("🎤 PARAKEET | recording started (\(inputDeviceName), \(nativeSampleRate)Hz)")
+        print("🎤 PARAKEET | recording started (\(inputDeviceName), \(safeNativeSampleRate())Hz)")
 
         // Watchdog: detect zombie audio engine (running but no samples flowing after sleep/wake).
         // Only on first attempt — recovery attempt doesn't re-watchdog to prevent infinite loops.
@@ -1981,7 +2012,8 @@ class ParakeetEngine: ObservableObject {
         drainPendingSamplesIntoSampleBuffer()
         isRecording = false
         audioLevel = 0
-        print("⏹️ PARAKEET | recording stopped (\(sampleBuffer.count) samples, \(String(format: "%.1f", Double(sampleBuffer.count) / nativeSampleRate))s)")
+        let stopSampleRate = safeNativeSampleRate()
+        print("⏹️ PARAKEET | recording stopped (\(sampleBuffer.count) samples, \(String(format: "%.1f", Double(sampleBuffer.count) / stopSampleRate))s)")
     }
 
     // MARK: - EOU Streaming (live display)
@@ -2043,7 +2075,7 @@ class ParakeetEngine: ObservableObject {
         isTranscribing = true
         var samples: [Float] = []
         swap(&samples, &sampleBuffer)
-        let inputRate = nativeSampleRate
+        let inputRate = safeNativeSampleRate()
         let nativeCount = samples.count
         let samplesForResampling = samples
         samples.removeAll(keepingCapacity: false)
@@ -2106,7 +2138,7 @@ class ParakeetEngine: ObservableObject {
         // sampleBuffer is cleared immediately, freeing capacity before resampling.
         var samples: [Float] = []
         swap(&samples, &sampleBuffer)
-        let inputRate = nativeSampleRate
+        let inputRate = safeNativeSampleRate()
 
         let startTime = CFAbsoluteTimeGetCurrent()
 

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -51,6 +51,10 @@ enum ParakeetAudioFormatReadiness: String, Equatable {
 enum ParakeetAudioFormatReadinessPolicy {
     private static let likelyBluetoothSpeechRates: Set<Int> = [8_000, 16_000, 24_000]
     static let audioUnitFormatNotSupportedCode = -10_868
+    static let fallbackCaptureSampleRate: Double = 48_000
+    private static let minimumUsableSampleRate: Double = 8_000
+    private static let maximumUsableSampleRate: Double = 384_000
+    private static let maximumBufferCapacitySampleRate: Double = 96_000
 
     static func readiness(
         outputSampleRate: Double,
@@ -60,8 +64,8 @@ enum ParakeetAudioFormatReadinessPolicy {
         selectedInputClass: String,
         selectionOverrodeDefault: Bool
     ) -> ParakeetAudioFormatReadiness {
-        guard outputSampleRate > 0, outputChannelCount > 0,
-              inputSampleRate > 0, inputChannelCount > 0 else {
+        guard isUsableCaptureSampleRate(outputSampleRate), outputChannelCount > 0,
+              isUsableCaptureSampleRate(inputSampleRate), inputChannelCount > 0 else {
             return .invalid
         }
 
@@ -81,4 +85,28 @@ enum ParakeetAudioFormatReadinessPolicy {
         }
         return .audioEngineStartFailed
     }
+
+    static func isUsableCaptureSampleRate(_ sampleRate: Double) -> Bool {
+        sampleRate.isFinite
+            && sampleRate >= minimumUsableSampleRate
+            && sampleRate <= maximumUsableSampleRate
+    }
+
+    static func captureSampleRateOrFallback(_ sampleRate: Double) -> Double {
+        isUsableCaptureSampleRate(sampleRate) ? sampleRate : fallbackCaptureSampleRate
+    }
+
+    static func bufferCapacitySampleCount(sampleRate: Double, seconds: Int) -> Int {
+        let safeRate = captureSampleRateOrFallback(sampleRate)
+        let sampleCount = safeRate * Double(seconds)
+        guard sampleCount.isFinite, sampleCount > 0 else {
+            return Int(fallbackCaptureSampleRate) * max(seconds, 1)
+        }
+        return min(Int(sampleCount), Int(maximumBufferCapacitySampleRate) * max(seconds, 1))
+    }
+}
+
+struct ParakeetAudioFormatSummary: Equatable {
+    let sampleRate: Double
+    let channelCount: UInt32
 }

--- a/Sources/Speech/RecordedAudioTimeline.swift
+++ b/Sources/Speech/RecordedAudioTimeline.swift
@@ -5,7 +5,7 @@ struct RecordedAudioSegment: Equatable {
     var samples: [Float]
 
     var durationSeconds: Double {
-        guard sampleRate > 0 else { return 0 }
+        guard ParakeetAudioFormatReadinessPolicy.isUsableCaptureSampleRate(sampleRate) else { return 0 }
         return Double(samples.count) / sampleRate
     }
 }
@@ -24,7 +24,8 @@ struct RecordedAudioTimeline {
     }
 
     mutating func append(_ samples: [Float], sampleRate: Double) {
-        guard !samples.isEmpty, sampleRate > 0 else { return }
+        guard !samples.isEmpty,
+              ParakeetAudioFormatReadinessPolicy.isUsableCaptureSampleRate(sampleRate) else { return }
 
         if let lastIndex = segments.indices.last, segments[lastIndex].sampleRate == sampleRate {
             segments[lastIndex].samples.append(contentsOf: samples)

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -155,6 +155,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
     var engine: AVAudioEngine?
     var inputNode: AVAudioInputNode?
+    private let audioGraphLock = NSRecursiveLock()
     var startTime: Date?
     var timer: Timer?
 
@@ -291,6 +292,12 @@ public class Audio: ObservableObject, @unchecked Sendable {
     var inputChannelCount: AVAudioChannelCount {
         get { formatLock.lock(); defer { formatLock.unlock() }; return _inputChannelCount }
         set { formatLock.lock(); defer { formatLock.unlock() }; _inputChannelCount = newValue }
+    }
+
+    func withAudioGraphLock<T>(_ body: () throws -> T) rethrows -> T {
+        audioGraphLock.lock()
+        defer { audioGraphLock.unlock() }
+        return try body()
     }
 
     // Throttle system audio visualizer updates (skip every other callback)
@@ -545,7 +552,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
     /// capture can keep the shared input device in a processed mode, which can
     /// make other mic apps sound quieter.
     func disarmVoiceProcessing(on inputNode: AVAudioInputNode) {
-        guard voiceProcessingEnabled || inputNode.isVoiceProcessingEnabled else { return }
+        guard voiceProcessingEnabled else { return }
         if let engine, engine.isRunning { return }
 
         do {
@@ -734,19 +741,21 @@ public class Audio: ObservableObject, @unchecked Sendable {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
 
-            if let engineRef, let inputNodeRef {
-                AppLogger.audio.info("Stopping audio capture")
-                if engineRef.isRunning {
-                    inputNodeRef.removeTap(onBus: 0)
-                    engineRef.stop()
+            self.withAudioGraphLock {
+                if let engineRef, let inputNodeRef {
+                    AppLogger.audio.info("Stopping audio capture")
+                    if engineRef.isRunning {
+                        inputNodeRef.removeTap(onBus: 0)
+                        engineRef.stop()
+                    }
+                    self.disarmVoiceProcessing(on: inputNodeRef)
                 }
-                self.disarmVoiceProcessing(on: inputNodeRef)
-            }
 
-            // Drop the RealtimeAGC reference so gain history doesn't
-            // carry into the next recording. Safe here because the
-            // engine has stopped — no more tap callbacks can fire.
-            self.realtimeAGC = nil
+                // Drop the RealtimeAGC reference so gain history doesn't
+                // carry into the next recording. Safe here because the
+                // engine has stopped — no more tap callbacks can fire.
+                self.realtimeAGC = nil
+            }
 
             // System audio capture's `stop()` is non-blocking (vs `stopSync`),
             // but we keep it ordered after engine teardown so a single
@@ -809,23 +818,28 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         AppLogger.audio.info("Starting audio level monitoring")
 
-        let monitorFormat = recordingFormat(for: inputNode)
+        let monitorFormat = withAudioGraphLock {
+            recordingFormat(for: inputNode)
+        }
         guard monitorFormat.sampleRate > 0, monitorFormat.channelCount > 0 else {
             AppLogger.audio.warning("Cannot start monitoring — invalid input format")
             return
         }
 
-        // Install mic tap for level metering only (no file writing)
-        inputNode.removeTap(onBus: 0)
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: monitorFormat) { [weak self] buffer, _ in
-            self?.calculateLevel(buffer: buffer)
-        }
-
         do {
-            try engine.start()
+            try withAudioGraphLock {
+                // Install mic tap for level metering only (no file writing)
+                inputNode.removeTap(onBus: 0)
+                inputNode.installTap(onBus: 0, bufferSize: 4096, format: monitorFormat) { [weak self] buffer, _ in
+                    self?.calculateLevel(buffer: buffer)
+                }
+                try engine.start()
+            }
         } catch {
             AppLogger.audio.warning("Failed to start monitoring engine", ["error": error.localizedDescription])
-            inputNode.removeTap(onBus: 0)
+            withAudioGraphLock {
+                inputNode.removeTap(onBus: 0)
+            }
             return
         }
 
@@ -856,18 +870,20 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         AppLogger.audio.info("Stopping audio level monitoring")
 
-        if let engine = engine, let inputNode = inputNode {
-            if engine.isRunning {
-                inputNode.removeTap(onBus: 0)
-                engine.stop()
+        withAudioGraphLock {
+            if let engine = engine, let inputNode = inputNode {
+                if engine.isRunning {
+                    inputNode.removeTap(onBus: 0)
+                    engine.stop()
+                }
+                disarmVoiceProcessing(on: inputNode)
             }
-            disarmVoiceProcessing(on: inputNode)
-        }
 
-        // Monitoring shares the engine but not the AGC; drop it here so a
-        // monitoring session followed by a recording session both start
-        // with a fresh gain history.
-        realtimeAGC = nil
+            // Monitoring shares the engine but not the AGC; drop it here so a
+            // monitoring session followed by a recording session both start
+            // with a fresh gain history.
+            realtimeAGC = nil
+        }
 
         systemAudioCapture?.stopSync()  // Synchronous — avoids race where delayed cleanup destroys the next recording's tap
 
@@ -892,9 +908,11 @@ public class Audio: ObservableObject, @unchecked Sendable {
         systemAudioCancellable?.cancel()
         systemAudioCapture?.stopSync()
 
-        if let engine, let inputNode, engine.isRunning {
-            inputNode.removeTap(onBus: 0)
-            engine.stop()
+        withAudioGraphLock {
+            if let engine, let inputNode, engine.isRunning {
+                inputNode.removeTap(onBus: 0)
+                engine.stop()
+            }
         }
     }
 }

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -350,12 +350,6 @@ public class Audio: ObservableObject, @unchecked Sendable {
         set { formatLock.lock(); defer { formatLock.unlock() }; _inputChannelCount = newValue }
     }
 
-    func withAudioGraphLock<T>(_ body: () throws -> T) rethrows -> T {
-        audioGraphLock.lock()
-        defer { audioGraphLock.unlock() }
-        return try body()
-    }
-
     // Throttle system audio visualizer updates (skip every other callback)
     // Protected by systemLevelLock — accessed from I/O callback thread
     var systemLevelUpdateCounter: Int = 0

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -43,6 +43,56 @@ public enum SystemAudioStatus: Equatable {
     }
 }
 
+struct AudioRecordingFormatSnapshot: Equatable {
+    let sampleRate: Double
+    let channelCount: AVAudioChannelCount
+}
+
+enum AudioRecordingFormatPolicy {
+    private static let minimumUsableSampleRate: Double = 8_000
+    private static let maximumUsableSampleRate: Double = 384_000
+
+    static func snapshot(_ format: AVAudioFormat) -> AudioRecordingFormatSnapshot? {
+        let sampleRate = format.sampleRate
+        let channelCount = format.channelCount
+        guard isUsableSampleRate(sampleRate), channelCount > 0 else {
+            return nil
+        }
+        return AudioRecordingFormatSnapshot(sampleRate: sampleRate, channelCount: channelCount)
+    }
+
+    static func isUsableSampleRate(_ sampleRate: Double) -> Bool {
+        sampleRate.isFinite
+            && sampleRate >= minimumUsableSampleRate
+            && sampleRate <= maximumUsableSampleRate
+    }
+
+    static func displaySampleRate(_ sampleRate: Double) -> String {
+        isUsableSampleRate(sampleRate) ? "\(Int(sampleRate))" : "invalid"
+    }
+
+    static func makeMonoOutputFormat(sampleRate: Double) throws -> AVAudioFormat {
+        guard isUsableSampleRate(sampleRate) else {
+            throw NSError(domain: "AudioRecordingFormatPolicy", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Refusing to create mic format from invalid sample rate"
+            ])
+        }
+
+        guard let monoFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: true
+        ) else {
+            throw NSError(domain: "AudioRecordingFormatPolicy", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Failed to create mono mic format"
+            ])
+        }
+
+        return monoFormat
+    }
+}
+
 /// Main audio recording class that captures microphone and system audio
 /// Note: This class does NOT use @MainActor because it manages AVAudioEngine
 /// which requires synchronous access from audio tap callbacks on audio threads.
@@ -155,6 +205,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
     var engine: AVAudioEngine?
     var inputNode: AVAudioInputNode?
+    private let audioGraphLock = NSRecursiveLock()
     var startTime: Date?
     var timer: Timer?
 
@@ -251,6 +302,12 @@ public class Audio: ObservableObject, @unchecked Sendable {
     }
     let maxRecoveryAttempts = 5
     let recoveryCooldown: TimeInterval = 5.0  // Min seconds between recovery attempts
+
+    func withAudioGraphLock<T>(_ body: () throws -> T) rethrows -> T {
+        audioGraphLock.lock()
+        defer { audioGraphLock.unlock() }
+        return try body()
+    }
 
     // Write error tracking — stop writing after repeated failures
     // Thread-safe: accessed from audio file queues (background) and reset from start() (main thread)
@@ -545,7 +602,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
     /// capture can keep the shared input device in a processed mode, which can
     /// make other mic apps sound quieter.
     func disarmVoiceProcessing(on inputNode: AVAudioInputNode) {
-        guard voiceProcessingEnabled || inputNode.isVoiceProcessingEnabled else { return }
+        guard voiceProcessingEnabled else { return }
         if let engine, engine.isRunning { return }
 
         do {
@@ -734,19 +791,21 @@ public class Audio: ObservableObject, @unchecked Sendable {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
 
-            if let engineRef, let inputNodeRef {
-                AppLogger.audio.info("Stopping audio capture")
-                if engineRef.isRunning {
-                    inputNodeRef.removeTap(onBus: 0)
-                    engineRef.stop()
+            self.withAudioGraphLock {
+                if let engineRef, let inputNodeRef {
+                    AppLogger.audio.info("Stopping audio capture")
+                    if engineRef.isRunning {
+                        inputNodeRef.removeTap(onBus: 0)
+                        engineRef.stop()
+                    }
+                    self.disarmVoiceProcessing(on: inputNodeRef)
                 }
-                self.disarmVoiceProcessing(on: inputNodeRef)
-            }
 
-            // Drop the RealtimeAGC reference so gain history doesn't
-            // carry into the next recording. Safe here because the
-            // engine has stopped — no more tap callbacks can fire.
-            self.realtimeAGC = nil
+                // Drop the RealtimeAGC reference so gain history doesn't
+                // carry into the next recording. Safe here because the
+                // engine has stopped — no more tap callbacks can fire.
+                self.realtimeAGC = nil
+            }
 
             // System audio capture's `stop()` is non-blocking (vs `stopSync`),
             // but we keep it ordered after engine teardown so a single
@@ -809,23 +868,28 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         AppLogger.audio.info("Starting audio level monitoring")
 
-        let monitorFormat = recordingFormat(for: inputNode)
-        guard monitorFormat.sampleRate > 0, monitorFormat.channelCount > 0 else {
+        let monitorFormat = withAudioGraphLock {
+            recordingFormat(for: inputNode)
+        }
+        guard AudioRecordingFormatPolicy.snapshot(monitorFormat) != nil else {
             AppLogger.audio.warning("Cannot start monitoring — invalid input format")
             return
         }
 
-        // Install mic tap for level metering only (no file writing)
-        inputNode.removeTap(onBus: 0)
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: monitorFormat) { [weak self] buffer, _ in
-            self?.calculateLevel(buffer: buffer)
-        }
-
         do {
-            try engine.start()
+            try withAudioGraphLock {
+                // Install mic tap for level metering only (no file writing)
+                inputNode.removeTap(onBus: 0)
+                inputNode.installTap(onBus: 0, bufferSize: 4096, format: monitorFormat) { [weak self] buffer, _ in
+                    self?.calculateLevel(buffer: buffer)
+                }
+                try engine.start()
+            }
         } catch {
             AppLogger.audio.warning("Failed to start monitoring engine", ["error": error.localizedDescription])
-            inputNode.removeTap(onBus: 0)
+            withAudioGraphLock {
+                inputNode.removeTap(onBus: 0)
+            }
             return
         }
 
@@ -856,18 +920,20 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         AppLogger.audio.info("Stopping audio level monitoring")
 
-        if let engine = engine, let inputNode = inputNode {
-            if engine.isRunning {
-                inputNode.removeTap(onBus: 0)
-                engine.stop()
+        withAudioGraphLock {
+            if let engine = engine, let inputNode = inputNode {
+                if engine.isRunning {
+                    inputNode.removeTap(onBus: 0)
+                    engine.stop()
+                }
+                disarmVoiceProcessing(on: inputNode)
             }
-            disarmVoiceProcessing(on: inputNode)
-        }
 
-        // Monitoring shares the engine but not the AGC; drop it here so a
-        // monitoring session followed by a recording session both start
-        // with a fresh gain history.
-        realtimeAGC = nil
+            // Monitoring shares the engine but not the AGC; drop it here so a
+            // monitoring session followed by a recording session both start
+            // with a fresh gain history.
+            realtimeAGC = nil
+        }
 
         systemAudioCapture?.stopSync()  // Synchronous — avoids race where delayed cleanup destroys the next recording's tap
 
@@ -892,9 +958,11 @@ public class Audio: ObservableObject, @unchecked Sendable {
         systemAudioCancellable?.cancel()
         systemAudioCapture?.stopSync()
 
-        if let engine, let inputNode, engine.isRunning {
-            inputNode.removeTap(onBus: 0)
-            engine.stop()
+        withAudioGraphLock {
+            if let engine, let inputNode, engine.isRunning {
+                inputNode.removeTap(onBus: 0)
+                engine.stop()
+            }
         }
     }
 }

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -86,20 +86,17 @@ extension Audio {
         recoveryAttemptCount += 1
         AppLogger.audioMic.debug("Recovering from device change", ["switchNumber": "\(deviceSwitchCount)", "maxAttempts": "\(maxRecoveryAttempts)"])
 
-        // Stop engine (but keep recording flag true)
-        inputNode.removeTap(onBus: 0)
-        engine.stop()
-
-        // Reset to system default (ignore UserDefaults preference during recovery)
-        engine.reset()
-        // engine.reset() clears VPIO state on the input node; require re-arm.
-        voiceProcessingEnabled = false
-        self.inputNode = engine.inputNode
-
-        // Get new device format
-        guard let newInputNode = self.inputNode else {
-            AppLogger.audioMic.error("Failed to get input node after reset")
-            return
+        // Stop engine (but keep recording flag true), then reset to system
+        // default. Keep graph mutation serialized with stop/start teardown so
+        // a user stop during device recovery cannot race CoreAudio format
+        // reads or tap replacement.
+        withAudioGraphLock {
+            inputNode.removeTap(onBus: 0)
+            engine.stop()
+            engine.reset()
+            // engine.reset() clears VPIO state on the input node; require re-arm.
+            voiceProcessingEnabled = false
+            self.inputNode = engine.inputNode
         }
 
         // HAL settle time - wait for audio hardware to stabilize after device change
@@ -115,35 +112,45 @@ extension Audio {
             return
         }
 
+        // Get new device format
+        guard let newInputNode = self.inputNode else {
+            AppLogger.audioMic.error("Failed to get input node after reset")
+            return
+        }
+
         // Re-enable VPIO after the HAL settles so setVoiceProcessingEnabled
         // queries a stable device. Skips silently if VPIO can't engage on the
         // new device, in which case recordingFormat(for:) falls back to the
         // hardware format and recording continues without AGC. When VPIO is
         // disabled by preference, this is a no-op and the software
         // RealtimeAGC keeps running across the device change.
-        armVoiceProcessing(on: newInputNode)
+        var recordingFormat = withAudioGraphLock {
+            armVoiceProcessing(on: newInputNode)
 
-        // Re-evaluate software AGC: if VPIO armed (rare here), drop AGC; if
-        // VPIO didn't arm, reset gain history so the new device starts at
-        // unity gain instead of inheriting the previous device's level.
-        if voiceProcessingEnabled {
-            realtimeAGC = nil
-        } else if let existing = realtimeAGC {
-            existing.reset()
-        } else {
-            realtimeAGC = RealtimeAGC()
+            // Re-evaluate software AGC: if VPIO armed (rare here), drop AGC; if
+            // VPIO didn't arm, reset gain history so the new device starts at
+            // unity gain instead of inheriting the previous device's level.
+            if voiceProcessingEnabled {
+                realtimeAGC = nil
+            } else if let existing = realtimeAGC {
+                existing.reset()
+            } else {
+                realtimeAGC = RealtimeAGC()
+            }
+
+            // Read the format the tap will actually deliver (VPIO-aware when
+            // armVoiceProcessing succeeded above, hardware format otherwise).
+            return self.recordingFormat(for: newInputNode)
         }
-
-        // Read the format the tap will actually deliver (VPIO-aware when
-        // armVoiceProcessing succeeded above, hardware format otherwise).
-        var recordingFormat = self.recordingFormat(for: newInputNode)
         if recordingFormat.sampleRate <= 0 || recordingFormat.channelCount <= 0 {
             AppLogger.audioMic.warning("Recovery format invalid after first read, retrying", [
                 "sampleRate": "\(recordingFormat.sampleRate)",
                 "channels": "\(recordingFormat.channelCount)"
             ])
             Thread.sleep(forTimeInterval: 0.3)
-            recordingFormat = self.recordingFormat(for: newInputNode)
+            recordingFormat = withAudioGraphLock {
+                self.recordingFormat(for: newInputNode)
+            }
         }
         guard recordingFormat.sampleRate > 0, recordingFormat.channelCount > 0 else {
             AppLogger.audioMic.error("Recovery format remained invalid", [
@@ -226,11 +233,6 @@ extension Audio {
             }
         }
 
-        // Reinstall tap using shared buffer handler
-        newInputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
-            self?.handleMicBuffer(buffer)
-        }
-
         guard sessionGeneration == recordingSessionGeneration else {
             AppLogger.audioMic.info("Skipping stale recovery before engine restart", [
                 "expectedSession": "\(sessionGeneration)",
@@ -241,7 +243,14 @@ extension Audio {
 
         // Restart engine
         do {
-            try engine.start()
+            try withAudioGraphLock {
+                // Reinstall tap using shared buffer handler
+                newInputNode.removeTap(onBus: 0)
+                newInputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
+                    self?.handleMicBuffer(buffer)
+                }
+                try engine.start()
+            }
             lastBufferTime = CACurrentMediaTime() // Reset watchdog
 
             DispatchQueue.main.async { [weak self] in

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -86,20 +86,17 @@ extension Audio {
         recoveryAttemptCount += 1
         AppLogger.audioMic.debug("Recovering from device change", ["switchNumber": "\(deviceSwitchCount)", "maxAttempts": "\(maxRecoveryAttempts)"])
 
-        // Stop engine (but keep recording flag true)
-        inputNode.removeTap(onBus: 0)
-        engine.stop()
-
-        // Reset to system default (ignore UserDefaults preference during recovery)
-        engine.reset()
-        // engine.reset() clears VPIO state on the input node; require re-arm.
-        voiceProcessingEnabled = false
-        self.inputNode = engine.inputNode
-
-        // Get new device format
-        guard let newInputNode = self.inputNode else {
-            AppLogger.audioMic.error("Failed to get input node after reset")
-            return
+        // Stop engine (but keep recording flag true), then reset to system
+        // default. Keep graph mutation serialized with stop/start teardown so
+        // a user stop during device recovery cannot race CoreAudio format
+        // reads or tap replacement.
+        withAudioGraphLock {
+            inputNode.removeTap(onBus: 0)
+            engine.stop()
+            engine.reset()
+            // engine.reset() clears VPIO state on the input node; require re-arm.
+            voiceProcessingEnabled = false
+            self.inputNode = engine.inputNode
         }
 
         // HAL settle time - wait for audio hardware to stabilize after device change
@@ -115,37 +112,49 @@ extension Audio {
             return
         }
 
+        // Get new device format
+        guard let newInputNode = self.inputNode else {
+            AppLogger.audioMic.error("Failed to get input node after reset")
+            return
+        }
+
         // Re-enable VPIO after the HAL settles so setVoiceProcessingEnabled
         // queries a stable device. Skips silently if VPIO can't engage on the
         // new device, in which case recordingFormat(for:) falls back to the
         // hardware format and recording continues without AGC. When VPIO is
         // disabled by preference, this is a no-op and the software
         // RealtimeAGC keeps running across the device change.
-        armVoiceProcessing(on: newInputNode)
+        var recordingFormat = withAudioGraphLock {
+            armVoiceProcessing(on: newInputNode)
 
-        // Re-evaluate software AGC: if VPIO armed (rare here), drop AGC; if
-        // VPIO didn't arm, reset gain history so the new device starts at
-        // unity gain instead of inheriting the previous device's level.
-        if voiceProcessingEnabled {
-            realtimeAGC = nil
-        } else if let existing = realtimeAGC {
-            existing.reset()
-        } else {
-            realtimeAGC = RealtimeAGC()
+            // Re-evaluate software AGC: if VPIO armed (rare here), drop AGC; if
+            // VPIO didn't arm, reset gain history so the new device starts at
+            // unity gain instead of inheriting the previous device's level.
+            if voiceProcessingEnabled {
+                realtimeAGC = nil
+            } else if let existing = realtimeAGC {
+                existing.reset()
+            } else {
+                realtimeAGC = RealtimeAGC()
+            }
+
+            // Read the format the tap will actually deliver (VPIO-aware when
+            // armVoiceProcessing succeeded above, hardware format otherwise).
+            return self.recordingFormat(for: newInputNode)
         }
-
-        // Read the format the tap will actually deliver (VPIO-aware when
-        // armVoiceProcessing succeeded above, hardware format otherwise).
-        var recordingFormat = self.recordingFormat(for: newInputNode)
-        if recordingFormat.sampleRate <= 0 || recordingFormat.channelCount <= 0 {
+        var recordingSnapshot = AudioRecordingFormatPolicy.snapshot(recordingFormat)
+        if recordingSnapshot == nil {
             AppLogger.audioMic.warning("Recovery format invalid after first read, retrying", [
                 "sampleRate": "\(recordingFormat.sampleRate)",
                 "channels": "\(recordingFormat.channelCount)"
             ])
             Thread.sleep(forTimeInterval: 0.3)
-            recordingFormat = self.recordingFormat(for: newInputNode)
+            recordingFormat = withAudioGraphLock {
+                self.recordingFormat(for: newInputNode)
+            }
+            recordingSnapshot = AudioRecordingFormatPolicy.snapshot(recordingFormat)
         }
-        guard recordingFormat.sampleRate > 0, recordingFormat.channelCount > 0 else {
+        guard let recordingSnapshot else {
             AppLogger.audioMic.error("Recovery format remained invalid", [
                 "sampleRate": "\(recordingFormat.sampleRate)",
                 "channels": "\(recordingFormat.channelCount)"
@@ -153,20 +162,20 @@ extension Audio {
             return
         }
         let oldChannelCount = self.inputChannelCount
-        AppLogger.audioMic.info("Switched to default device", ["sampleRate": "\(recordingFormat.sampleRate)", "channels": "\(recordingFormat.channelCount)"])
+        AppLogger.audioMic.info("Switched to default device", ["sampleRate": "\(recordingSnapshot.sampleRate)", "channels": "\(recordingSnapshot.channelCount)"])
 
         // ALWAYS update channel count for proper downmix handling
         // This was a bug: if only channel count changed (not sample rate), downmix wouldn't work
-        self.inputChannelCount = recordingFormat.channelCount
-        if recordingFormat.channelCount > 1 && oldChannelCount != recordingFormat.channelCount {
-            AppLogger.audioMic.debug("Recovery: will manually downmix to mono", ["channels": "\(recordingFormat.channelCount)"])
+        self.inputChannelCount = recordingSnapshot.channelCount
+        if recordingSnapshot.channelCount > 1 && oldChannelCount != recordingSnapshot.channelCount {
+            AppLogger.audioMic.debug("Recovery: will manually downmix to mono", ["channels": "\(recordingSnapshot.channelCount)"])
         }
 
         // Rotate files only when the sample rate changes. Channel-count-only changes
         // keep writing into the same mono WAV, which avoids unnecessary segment churn.
         // All micAudioFile accesses wrapped in micAudioFileQueue.sync for thread safety.
-        let sampleRateChanged = micAudioFileQueue.sync { micAudioFile.map { recordingFormat.sampleRate != $0.processingFormat.sampleRate } ?? false }
-        let channelCountChanged = oldChannelCount != recordingFormat.channelCount
+        let sampleRateChanged = micAudioFileQueue.sync { micAudioFile.map { recordingSnapshot.sampleRate != $0.processingFormat.sampleRate } ?? false }
+        let channelCountChanged = oldChannelCount != recordingSnapshot.channelCount
         var recoverySegmentURL: URL?
         var shouldKeepRecoverySegment = false
         defer {
@@ -183,7 +192,7 @@ extension Audio {
         if channelCountChanged && !sampleRateChanged {
             AppLogger.audioMic.info("Input channel count changed, keeping current recording file", [
                 "oldChannels": "\(oldChannelCount)",
-                "newChannels": "\(recordingFormat.channelCount)"
+                "newChannels": "\(recordingSnapshot.channelCount)"
             ])
         }
 
@@ -199,16 +208,9 @@ extension Audio {
             recoverySegmentURL = fileURL
 
             do {
-                // Always create mono format at new sample rate
-                guard let monoFormat = AVAudioFormat(
-                    commonFormat: .pcmFormatFloat32,
-                    sampleRate: recordingFormat.sampleRate,
-                    channels: 1,
-                    interleaved: true
-                ) else {
-                    AppLogger.audioMic.error("Failed to create mono format for recovery")
-                    return
-                }
+                let monoFormat = try AudioRecordingFormatPolicy.makeMonoOutputFormat(
+                    sampleRate: recordingSnapshot.sampleRate
+                )
                 self.monoOutputFormat = monoFormat
 
                 let newFile = try AVAudioFile(
@@ -226,11 +228,6 @@ extension Audio {
             }
         }
 
-        // Reinstall tap using shared buffer handler
-        newInputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
-            self?.handleMicBuffer(buffer)
-        }
-
         guard sessionGeneration == recordingSessionGeneration else {
             AppLogger.audioMic.info("Skipping stale recovery before engine restart", [
                 "expectedSession": "\(sessionGeneration)",
@@ -241,7 +238,14 @@ extension Audio {
 
         // Restart engine
         do {
-            try engine.start()
+            try withAudioGraphLock {
+                // Reinstall tap using shared buffer handler
+                newInputNode.removeTap(onBus: 0)
+                newInputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
+                    self?.handleMicBuffer(buffer)
+                }
+                try engine.start()
+            }
             lastBufferTime = CACurrentMediaTime() // Reset watchdog
 
             DispatchQueue.main.async { [weak self] in

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -13,35 +13,42 @@ extension Audio {
     func startAudioCapture() async throws {
         ensureCaptureInfrastructureConfigured()
 
-        let (engine, inputNode) = try ensureEngineInitialized()
-        armVoiceProcessing(on: inputNode)
+        let (engine, inputNode, recordingFormat, recordingSnapshot) = try withAudioGraphLock { () throws -> (AVAudioEngine, AVAudioInputNode, AVAudioFormat, AudioRecordingFormatSnapshot) in
+            let (engine, inputNode) = try ensureEngineInitialized()
+            armVoiceProcessing(on: inputNode)
 
-        // When VPIO is off (the default — see `enableVoiceProcessing`), run
-        // a software AGC in the mic tap callback to recover attenuated
-        // streams (issue #500: Safari/Firefox WebRTC contention). VPIO
-        // would do this in hardware but engages system-wide ducking of
-        // other apps' audio output; software AGC has no such side effect.
-        realtimeAGC = voiceProcessingEnabled ? nil : RealtimeAGC()
+            // When VPIO is off (the default — see `enableVoiceProcessing`), run
+            // a software AGC in the mic tap callback to recover attenuated
+            // streams (issue #500: Safari/Firefox WebRTC contention). VPIO
+            // would do this in hardware but engages system-wide ducking of
+            // other apps' audio output; software AGC has no such side effect.
+            realtimeAGC = voiceProcessingEnabled ? nil : RealtimeAGC()
 
-        // Use system default microphone (whatever macOS has configured).
-        // recordingFormat(for:) returns:
-        //   - VPIO output format when armVoiceProcessing enabled it (mono
-        //     Float32 at the unit's preferred rate), which matches what the
-        //     tap on bus 0 will actually deliver.
-        //   - Hardware format via inputFormat(forBus: 1) otherwise — required
-        //     because outputFormat(forBus: 0) returns the converter format on
-        //     stock AVAudioEngine, which breaks Bluetooth capture.
-        let recordingFormat = self.recordingFormat(for: inputNode)
+            // Use system default microphone (whatever macOS has configured).
+            // recordingFormat(for:) returns:
+            //   - VPIO output format when armVoiceProcessing enabled it (mono
+            //     Float32 at the unit's preferred rate), which matches what the
+            //     tap on bus 0 will actually deliver.
+            //   - Hardware format via inputFormat(forBus: 1) otherwise — required
+            //     because outputFormat(forBus: 0) returns the converter format on
+            //     stock AVAudioEngine, which breaks Bluetooth capture.
+            let recordingFormat = self.recordingFormat(for: inputNode)
+            guard let recordingSnapshot = AudioRecordingFormatPolicy.snapshot(recordingFormat) else {
+                AppLogger.audioMic.error("Mic input format invalid", [
+                    "sampleRate": "\(recordingFormat.sampleRate)",
+                    "channels": "\(recordingFormat.channelCount)"
+                ])
+                throw NSError(domain: "Audio", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid input format"])
+            }
+
+            return (engine, inputNode, recordingFormat, recordingSnapshot)
+        }
         AppLogger.audioMic.info("Mic input format", [
-            "sampleRate": "\(recordingFormat.sampleRate)",
-            "channels": "\(recordingFormat.channelCount)",
+            "sampleRate": "\(recordingSnapshot.sampleRate)",
+            "channels": "\(recordingSnapshot.channelCount)",
             "voiceProcessing": "\(voiceProcessingEnabled)",
             "softwareAGC": "\(realtimeAGC != nil)"
         ])
-
-        guard recordingFormat.sampleRate > 0 && recordingFormat.channelCount > 0 else {
-            throw NSError(domain: "Audio", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid input format"])
-        }
 
         // Start system audio capture
         // CRITICAL: Create audio file BEFORE starting I/O proc to avoid CPU overload
@@ -95,7 +102,11 @@ extension Audio {
                         throw NSError(domain: "Audio", code: 10, userInfo: [NSLocalizedDescriptionKey: "Failed to get tap format"])
                     }
                     let sampleRate = tapFormat.sampleRate
-                    AppLogger.audioSystem.info("System audio format", ["sampleRate": "\(Int(sampleRate))", "channels": "\(tapFormat.channelCount)", "interleaved": "\(tapFormat.isInterleaved)"])
+                    guard AudioRecordingFormatPolicy.isUsableSampleRate(sampleRate),
+                          tapFormat.channelCount > 0 else {
+                        throw NSError(domain: "Audio", code: 11, userInfo: [NSLocalizedDescriptionKey: "Invalid system audio format"])
+                    }
+                    AppLogger.audioSystem.info("System audio format", ["sampleRate": AudioRecordingFormatPolicy.displaySampleRate(sampleRate), "channels": "\(tapFormat.channelCount)", "interleaved": "\(tapFormat.isInterleaved)"])
 
                     // Step 3: Create audio file BEFORE starting I/O proc (critical!)
                     let settings: [String: Any] = [
@@ -116,7 +127,7 @@ extension Audio {
                     )
                     FileManager.default.restrictToOwnerOnly(atPath: fileURL.path)
                     strongSelf.systemAudioFileQueue.sync { strongSelf.systemAudioFile = file }
-                    AppLogger.audioSystem.info("System audio file created before I/O proc", ["sampleRate": "\(Int(sampleRate))", "channels": "\(tapFormat.channelCount)"])
+                    AppLogger.audioSystem.info("System audio file created before I/O proc", ["sampleRate": AudioRecordingFormatPolicy.displaySampleRate(sampleRate), "channels": "\(tapFormat.channelCount)"])
 
                     guard sessionIsCurrent() else {
                         cleanupAbandonedSetup()
@@ -153,7 +164,8 @@ extension Audio {
                         // Debug: Log format details on first few buffers
                         if currentBufferCount <= 3 {
                             let fmt = bufferForAsyncUse.format
-                            AppLogger.audioSystem.debug("System buffer", ["number": "\(currentBufferCount)", "sampleRate": "\(Int(fmt.sampleRate))", "channels": "\(fmt.channelCount)", "frames": "\(bufferForAsyncUse.frameLength)"])
+                            let bufferSampleRate = AudioRecordingFormatPolicy.displaySampleRate(fmt.sampleRate)
+                            AppLogger.audioSystem.debug("System buffer", ["number": "\(currentBufferCount)", "sampleRate": bufferSampleRate, "channels": "\(fmt.channelCount)", "frames": "\(bufferForAsyncUse.frameLength)"])
                         }
 
                         self.onSystemPCMBuffer?(bufferForAsyncUse)
@@ -223,20 +235,15 @@ extension Audio {
             }
 
             // Always create mono output format at the hardware sample rate
-            guard let monoFormat = AVAudioFormat(
-                commonFormat: .pcmFormatFloat32,
-                sampleRate: recordingFormat.sampleRate,
-                channels: 1,
-                interleaved: true
-            ) else {
-                throw NSError(domain: "Audio", code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to create mono format"])
-            }
+            let monoFormat = try AudioRecordingFormatPolicy.makeMonoOutputFormat(
+                sampleRate: recordingSnapshot.sampleRate
+            )
             self.monoOutputFormat = monoFormat
 
             // Track channel count for manual downmix
-            self.inputChannelCount = recordingFormat.channelCount
-            if recordingFormat.channelCount > 1 {
-                AppLogger.audioMic.debug("Will manually downmix to mono", ["channels": "\(recordingFormat.channelCount)"])
+            self.inputChannelCount = recordingSnapshot.channelCount
+            if recordingSnapshot.channelCount > 1 {
+                AppLogger.audioMic.debug("Will manually downmix to mono", ["channels": "\(recordingSnapshot.channelCount)"])
             }
 
             // Save as mono WAV file
@@ -247,20 +254,22 @@ extension Audio {
                 interleaved: monoFormat.isInterleaved
             )
             FileManager.default.restrictToOwnerOnly(atPath: fileURL.path)
-            AppLogger.audioMic.info("Saving as mono", ["sampleRate": "\(recordingFormat.sampleRate)"])
+            AppLogger.audioMic.info("Saving as mono", ["sampleRate": "\(recordingSnapshot.sampleRate)"])
         } catch {
             throw NSError(domain: "Audio", code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to create mic audio file: \(error.localizedDescription)"])
         }
 
-        // Remove any existing tap (safety check)
-        inputNode.removeTap(onBus: 0)
+        try withAudioGraphLock {
+            // Remove any existing tap (safety check)
+            inputNode.removeTap(onBus: 0)
 
-        // Install tap on microphone
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
-            self?.handleMicBuffer(buffer)
+            // Install tap on microphone
+            inputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
+                self?.handleMicBuffer(buffer)
+            }
+
+            try engine.start()
         }
-
-        try engine.start()
 
         let cueHandler = self.onCaptureLifecycleCue
         await MainActor.run {

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -13,15 +13,18 @@ extension Audio {
     func startAudioCapture() async throws {
         ensureCaptureInfrastructureConfigured()
 
-        let (engine, inputNode) = try ensureEngineInitialized()
-        armVoiceProcessing(on: inputNode)
+        let (engine, inputNode) = try withAudioGraphLock {
+            let initialized = try ensureEngineInitialized()
+            armVoiceProcessing(on: initialized.1)
 
-        // When VPIO is off (the default — see `enableVoiceProcessing`), run
-        // a software AGC in the mic tap callback to recover attenuated
-        // streams (issue #500: Safari/Firefox WebRTC contention). VPIO
-        // would do this in hardware but engages system-wide ducking of
-        // other apps' audio output; software AGC has no such side effect.
-        realtimeAGC = voiceProcessingEnabled ? nil : RealtimeAGC()
+            // When VPIO is off (the default — see `enableVoiceProcessing`), run
+            // a software AGC in the mic tap callback to recover attenuated
+            // streams (issue #500: Safari/Firefox WebRTC contention). VPIO
+            // would do this in hardware but engages system-wide ducking of
+            // other apps' audio output; software AGC has no such side effect.
+            realtimeAGC = voiceProcessingEnabled ? nil : RealtimeAGC()
+            return initialized
+        }
 
         // Use system default microphone (whatever macOS has configured).
         // recordingFormat(for:) returns:
@@ -31,7 +34,9 @@ extension Audio {
         //   - Hardware format via inputFormat(forBus: 1) otherwise — required
         //     because outputFormat(forBus: 0) returns the converter format on
         //     stock AVAudioEngine, which breaks Bluetooth capture.
-        let recordingFormat = self.recordingFormat(for: inputNode)
+        let recordingFormat = withAudioGraphLock {
+            self.recordingFormat(for: inputNode)
+        }
         AppLogger.audioMic.info("Mic input format", [
             "sampleRate": "\(recordingFormat.sampleRate)",
             "channels": "\(recordingFormat.channelCount)",
@@ -252,15 +257,17 @@ extension Audio {
             throw NSError(domain: "Audio", code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to create mic audio file: \(error.localizedDescription)"])
         }
 
-        // Remove any existing tap (safety check)
-        inputNode.removeTap(onBus: 0)
+        try withAudioGraphLock {
+            // Remove any existing tap (safety check)
+            inputNode.removeTap(onBus: 0)
 
-        // Install tap on microphone
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
-            self?.handleMicBuffer(buffer)
+            // Install tap on microphone
+            inputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
+                self?.handleMicBuffer(buffer)
+            }
+
+            try engine.start()
         }
-
-        try engine.start()
 
         let cueHandler = self.onCaptureLifecycleCue
         await MainActor.run {

--- a/Sources/TranscriptedCore/Audio/AudioResampler.swift
+++ b/Sources/TranscriptedCore/Audio/AudioResampler.swift
@@ -12,9 +12,17 @@ public enum AudioResampler {
     /// Uses linear interpolation — sufficient for speech (bandwidth << Nyquist at 16kHz).
     public static func resample(_ samples: [Float], from inputRate: Double, to outputRate: Double = 16000) -> [Float] {
         guard inputRate != outputRate, !samples.isEmpty else { return samples }
+        guard AudioRecordingFormatPolicy.isUsableSampleRate(inputRate),
+              AudioRecordingFormatPolicy.isUsableSampleRate(outputRate) else {
+            return samples
+        }
 
         let ratio = inputRate / outputRate
-        let outputCount = Int(Double(samples.count) / ratio)
+        let rawOutputCount = Double(samples.count) / ratio
+        guard rawOutputCount.isFinite, rawOutputCount > 0, rawOutputCount <= Double(Int.max) else {
+            return []
+        }
+        let outputCount = Int(rawOutputCount)
         guard outputCount > 0 else { return [] }
 
         var output = [Float](repeating: 0, count: outputCount)
@@ -51,6 +59,11 @@ public enum AudioResampler {
 
         let frameLength = Int(buffer.frameLength)
         let channelCount = Int(format.channelCount)
+        guard channelCount > 0 else {
+            throw NSError(domain: "AudioResampler", code: 6, userInfo: [
+                NSLocalizedDescriptionKey: "Audio file has no readable channels"
+            ])
+        }
 
         // Convert to mono Float32 array
         var samples = [Float](repeating: 0, count: frameLength)
@@ -89,12 +102,24 @@ public enum AudioResampler {
     private static func convertToMono(url: URL, targetRate: Double) throws -> [Float] {
         let file = try AVAudioFile(forReading: url)
         let srcFormat = file.processingFormat
-        let srcFrames = AVAudioFrameCount(file.length)
 
         // Guard against empty audio files (e.g., mic device thrashing during recording)
-        guard srcFrames > 0 else {
+        guard file.length > 0 else {
             throw PipelineError.emptyAudioFile
         }
+        guard file.length <= Int64(AVAudioFrameCount.max) else {
+            throw NSError(domain: "AudioResampler", code: 7, userInfo: [
+                NSLocalizedDescriptionKey: "Audio file is too large to resample safely"
+            ])
+        }
+        guard AudioRecordingFormatPolicy.isUsableSampleRate(srcFormat.sampleRate),
+              AudioRecordingFormatPolicy.isUsableSampleRate(targetRate),
+              srcFormat.channelCount > 0 else {
+            throw NSError(domain: "AudioResampler", code: 8, userInfo: [
+                NSLocalizedDescriptionKey: "Audio file has an invalid sample rate or channel count"
+            ])
+        }
+        let srcFrames = AVAudioFrameCount(file.length)
 
         // Short-circuit if already at target format
         if srcFormat.sampleRate == targetRate && srcFormat.channelCount == 1 {
@@ -119,9 +144,17 @@ public enum AudioResampler {
         }
 
         let ratio = targetRate / srcFormat.sampleRate
+        let totalDstFrameCount = Double(srcFrames) * ratio + 64
+        guard totalDstFrameCount.isFinite,
+              totalDstFrameCount > 0,
+              totalDstFrameCount <= Double(AVAudioFrameCount.max) else {
+            throw NSError(domain: "AudioResampler", code: 9, userInfo: [
+                NSLocalizedDescriptionKey: "Converted audio frame count is unsafe"
+            ])
+        }
 
         // Allocate output buffer for the entire converted result
-        let totalDstFrames = AVAudioFrameCount(Double(srcFrames) * ratio) + 64
+        let totalDstFrames = AVAudioFrameCount(totalDstFrameCount)
         guard let dstBuffer = AVAudioPCMBuffer(pcmFormat: dstFormat, frameCapacity: totalDstFrames) else {
             throw NSError(domain: "AudioResampler", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "Failed to create destination audio buffer"
@@ -195,8 +228,23 @@ public enum AudioResampler {
         startTime: Double,
         endTime: Double
     ) -> [Float] {
-        let startSample = max(0, Int(startTime * sampleRate))
-        let endSample = min(samples.count, Int(endTime * sampleRate))
+        guard AudioRecordingFormatPolicy.isUsableSampleRate(sampleRate),
+              startTime.isFinite,
+              endTime.isFinite else {
+            return []
+        }
+        let rawStartSample = startTime * sampleRate
+        let rawEndSample = endTime * sampleRate
+        guard rawStartSample.isFinite,
+              rawEndSample.isFinite,
+              rawStartSample >= Double(Int.min),
+              rawEndSample >= Double(Int.min),
+              rawStartSample <= Double(Int.max),
+              rawEndSample <= Double(Int.max) else {
+            return []
+        }
+        let startSample = max(0, Int(rawStartSample))
+        let endSample = min(samples.count, Int(rawEndSample))
         guard startSample < endSample else { return [] }
         return Array(samples[startSample..<endSample])
     }

--- a/Sources/TranscriptedCore/Audio/AudioSignalRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioSignalRecovery.swift
@@ -8,7 +8,7 @@ struct AudioSignalAnalysis: Equatable {
     let activeRatio: Double
 
     var durationSeconds: Double {
-        guard sampleRate > 0 else { return 0 }
+        guard AudioRecordingFormatPolicy.isUsableSampleRate(sampleRate) else { return 0 }
         return Double(sampleCount) / sampleRate
     }
 
@@ -49,7 +49,7 @@ enum AudioSignalRecovery {
     static let legacySpeechDetectionThreshold: Float = 0.010
 
     static func analyze(samples: [Float], sampleRate: Double) -> AudioSignalAnalysis {
-        guard !samples.isEmpty, sampleRate > 0 else {
+        guard !samples.isEmpty, AudioRecordingFormatPolicy.isUsableSampleRate(sampleRate) else {
             return AudioSignalAnalysis(
                 sampleCount: samples.count,
                 sampleRate: sampleRate,

--- a/Sources/TranscriptedCore/Audio/MicRecordingSegment.swift
+++ b/Sources/TranscriptedCore/Audio/MicRecordingSegment.swift
@@ -6,13 +6,27 @@ struct MicRecordingSegment: Equatable {
 
     init(url: URL, gapBeforeDuration: TimeInterval = 0) {
         self.url = url
-        self.gapBeforeDuration = max(0, gapBeforeDuration)
+        self.gapBeforeDuration = gapBeforeDuration.isFinite ? max(0, gapBeforeDuration) : 0
     }
 }
 
 enum MicRecordingMergePlan {
+    private static let minimumUsableSampleRate: Double = 8_000
+    private static let maximumUsableSampleRate: Double = 384_000
+
     static func silenceSampleCount(before segment: MicRecordingSegment, sampleRate: Double) -> Int {
-        guard sampleRate > 0 else { return 0 }
-        return max(0, Int((segment.gapBeforeDuration * sampleRate).rounded()))
+        guard isUsableSampleRate(sampleRate),
+              segment.gapBeforeDuration.isFinite else { return 0 }
+        let rawSampleCount = (segment.gapBeforeDuration * sampleRate).rounded()
+        guard rawSampleCount.isFinite,
+              rawSampleCount >= Double(Int.min),
+              rawSampleCount <= Double(Int.max) else { return 0 }
+        return max(0, Int(rawSampleCount))
+    }
+
+    private static func isUsableSampleRate(_ sampleRate: Double) -> Bool {
+        sampleRate.isFinite
+            && sampleRate >= minimumUsableSampleRate
+            && sampleRate <= maximumUsableSampleRate
     }
 }

--- a/Sources/TranscriptedCore/Audio/SystemAudioProcessTap.swift
+++ b/Sources/TranscriptedCore/Audio/SystemAudioProcessTap.swift
@@ -72,12 +72,15 @@ extension SystemAudioCapture {
         // Security: avoid force-unwrap — a nil crash here is a denial-of-service.
         // tapStreamDescription was assigned via `try` above, but guard defensively in case
         // code flow ever changes and nil reaches this point.
-        if var currentDesc = tapStreamDescription, deviceNominalRate > 0, deviceNominalRate != currentDesc.mSampleRate {
-            AppLogger.audioSystem.warning("Tap format rate (\(Int(currentDesc.mSampleRate))Hz) differs from device nominal rate (\(Int(deviceNominalRate))Hz) — correcting")
+        if var currentDesc = tapStreamDescription,
+           AudioRecordingFormatPolicy.isUsableSampleRate(deviceNominalRate),
+           AudioRecordingFormatPolicy.isUsableSampleRate(currentDesc.mSampleRate),
+           deviceNominalRate != currentDesc.mSampleRate {
+            AppLogger.audioSystem.warning("Tap format rate (\(AudioRecordingFormatPolicy.displaySampleRate(currentDesc.mSampleRate))Hz) differs from device nominal rate (\(AudioRecordingFormatPolicy.displaySampleRate(deviceNominalRate))Hz) — correcting")
             currentDesc.mSampleRate = deviceNominalRate
             tapStreamDescription = currentDesc
         }
-        AppLogger.audioSystem.info("Aggregate device nominal sample rate", ["rate": "\(Int(deviceNominalRate))"])
+        AppLogger.audioSystem.info("Aggregate device nominal sample rate", ["rate": AudioRecordingFormatPolicy.displaySampleRate(deviceNominalRate)])
     }
 
     // MARK: - Audio Device I/O

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -862,7 +862,8 @@ extension Transcription {
         samples: [Float],
         sampleRate: Double
     ) -> PreparedMicSegment? {
-        guard !samples.isEmpty, sampleRate > 0 else { return nil }
+        guard !samples.isEmpty,
+              AudioRecordingFormatPolicy.isUsableSampleRate(sampleRate) else { return nil }
 
         let analysis = AudioSignalRecovery.analyze(samples: samples, sampleRate: sampleRate)
         if samples.count < AudioSignalRecovery.parakeetMinimumInferenceSamples, !analysis.hasSpeechCandidate {
@@ -902,7 +903,8 @@ extension Transcription {
         samples: [Float],
         sampleRate: Double
     ) -> [SpeechSegment] {
-        guard !samples.isEmpty else { return [] }
+        guard !samples.isEmpty,
+              AudioRecordingFormatPolicy.isUsableSampleRate(sampleRate) else { return [] }
 
         let frameSamples = Int(sampleRate * 0.025)  // 25ms frames (400 samples at 16kHz)
         let hopSamples = Int(sampleRate * 0.010)    // 10ms hop

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -450,7 +450,7 @@ public class TranscriptionTaskManager: ObservableObject {
         guard let file = try? AVAudioFile(forReading: url) else { return nil }
         let frames = Double(file.length)
         let sampleRate = file.processingFormat.sampleRate
-        guard sampleRate > 0 else { return nil }
+        guard AudioRecordingFormatPolicy.isUsableSampleRate(sampleRate) else { return nil }
         return frames / sampleRate
     }
 

--- a/Sources/TranscriptedCore/Speaker/SpeakerClipExtractor.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerClipExtractor.swift
@@ -43,7 +43,7 @@ public enum SpeakerClipExtractor {
         let format = audioFile.processingFormat
         let sampleRate = format.sampleRate
 
-        guard sampleRate > 0 else {
+        guard AudioRecordingFormatPolicy.isUsableSampleRate(sampleRate) else {
             throw ClipError.invalidAudioFormat
         }
 
@@ -207,6 +207,9 @@ public enum SpeakerClipExtractor {
         speakerId: Int,
         channel: UtteranceChannel
     ) throws -> URL {
+        guard AudioRecordingFormatPolicy.isUsableSampleRate(sampleRate) else {
+            throw ClipError.invalidAudioFormat
+        }
 
         let tempDir = defaultClipsDirectory
         // Security: keep temporary speaker clips inside Transcripted's owner-only
@@ -235,15 +238,30 @@ public enum SpeakerClipExtractor {
 
         for segment in segments {
             guard totalFramesWritten < maxClipFrames else { break }
+            guard segment.start.isFinite, segment.end.isFinite else { continue }
 
-            let startFrame = AVAudioFramePosition(segment.start * sampleRate)
-            let endFrame = AVAudioFramePosition(min(segment.end, segment.start + 8.0) * sampleRate)
-            let frameCount = AVAudioFrameCount(endFrame - startFrame)
+            let rawStartFrame = segment.start * sampleRate
+            let rawEndFrame = min(segment.end, segment.start + 8.0) * sampleRate
+            guard rawStartFrame.isFinite,
+                  rawEndFrame.isFinite,
+                  rawStartFrame >= 0,
+                  rawStartFrame <= Double(AVAudioFramePosition.max),
+                  rawEndFrame <= Double(AVAudioFramePosition.max),
+                  rawEndFrame > rawStartFrame else {
+                continue
+            }
+
+            let rawFrameCount = rawEndFrame - rawStartFrame
+            guard rawFrameCount <= Double(AVAudioFrameCount.max) else { continue }
+
+            let startFrame = AVAudioFramePosition(rawStartFrame)
+            let frameCount = AVAudioFrameCount(rawFrameCount)
 
             guard frameCount > 0, startFrame >= 0, startFrame < audioFile.length else { continue }
 
             // Clamp to file length
-            let actualFrameCount = min(frameCount, AVAudioFrameCount(audioFile.length - startFrame))
+            let availableFrames = min(audioFile.length - startFrame, AVAudioFramePosition(AVAudioFrameCount.max))
+            let actualFrameCount = min(frameCount, AVAudioFrameCount(availableFrames))
             let remainingAllowed = maxClipFrames - totalFramesWritten
             let framesToRead = min(actualFrameCount, remainingAllowed)
 

--- a/Tests/DictationAudioRecoveryTests.swift
+++ b/Tests/DictationAudioRecoveryTests.swift
@@ -64,4 +64,19 @@ func testDictationAudioRecovery() {
             "short bursts should not be retried"
         )
     }
+
+    runSuite("DictationAudioRecovery — rejects non-finite sample rates") {
+        let samples = [Float](repeating: 0.02, count: 32_000)
+
+        for sampleRate in [Double.nan, Double.infinity, -Double.infinity, 0.0, 7_999.0, 384_001.0] {
+            let analysis = DictationAudioRecovery.analyze(samples: samples, sampleRate: sampleRate)
+
+            assertEqual(analysis.durationSeconds, 0, "invalid sample rates should not compute duration")
+            assertFalse(analysis.hasUsableSpeechSignal, "invalid sample rates should not look recoverable")
+            assertNil(
+                DictationAudioRecovery.retrySamples(from: samples, sampleRate: sampleRate, analysis: analysis),
+                "invalid sample rates should not request retry samples"
+            )
+        }
+    }
 }

--- a/Tests/DictationReadinessWaitPolicyTests.swift
+++ b/Tests/DictationReadinessWaitPolicyTests.swift
@@ -12,6 +12,15 @@ func testDictationReadinessWaitPolicy() {
         assertEqual(action, .waitForRecovery, "active recovery should not start or refresh")
     }
 
+    runSuite("DictationReadinessWaitPolicy — recovery flag wins over stale ready flag") {
+        let action = DictationReadinessWaitPolicy.action(
+            isRecovering: true,
+            inputFormatReady: true
+        )
+
+        assertEqual(action, .waitForRecovery, "active recovery should block recording even if a stale ready flag leaks through")
+    }
+
     runSuite("DictationReadinessWaitPolicy — refreshes after failed recovery leaves input unready") {
         let action = DictationReadinessWaitPolicy.action(
             isRecovering: false,

--- a/Tests/MicRecordingMergePlanTests.swift
+++ b/Tests/MicRecordingMergePlanTests.swift
@@ -37,10 +37,41 @@ func testMicRecordingMergePlan() {
             gapBeforeDuration: 0.5
         )
 
+        for sampleRate in [0.0, -1.0, Double.nan, Double.infinity, -Double.infinity, 7_999.0, 384_001.0] {
+            assertEqual(
+                MicRecordingMergePlan.silenceSampleCount(before: segment, sampleRate: sampleRate),
+                0,
+                "invalid sample rates should not request silence samples"
+            )
+        }
+    }
+
+    runSuite("MicRecordingSegment — clamps non-finite gap durations") {
+        for gap in [Double.nan, Double.infinity, -Double.infinity] {
+            let segment = MicRecordingSegment(
+                url: URL(fileURLWithPath: "/tmp/recovery.wav"),
+                gapBeforeDuration: gap
+            )
+
+            assertEqual(segment.gapBeforeDuration, 0, "non-finite recovery gaps should clamp to zero")
+            assertEqual(
+                MicRecordingMergePlan.silenceSampleCount(before: segment, sampleRate: 16_000),
+                0,
+                "non-finite gaps should not insert silence"
+            )
+        }
+    }
+
+    runSuite("MicRecordingMergePlan.silenceSampleCount — rejects unsafe gap math") {
+        let segment = MicRecordingSegment(
+            url: URL(fileURLWithPath: "/tmp/recovery.wav"),
+            gapBeforeDuration: Double.greatestFiniteMagnitude
+        )
+
         assertEqual(
-            MicRecordingMergePlan.silenceSampleCount(before: segment, sampleRate: 0),
+            MicRecordingMergePlan.silenceSampleCount(before: segment, sampleRate: 16_000),
             0,
-            "invalid sample rates should not request silence samples"
+            "overflowing silence math should fail closed"
         )
     }
 }

--- a/Tests/ParakeetRecoveryStateTests.swift
+++ b/Tests/ParakeetRecoveryStateTests.swift
@@ -53,6 +53,16 @@ func testParakeetRecoveryState() {
         assertFalse(state.inputFormatReady, "format should still be unready after stale finish")
     }
 
+    runSuite("ParakeetRecoveryState.finishRecovery — stale failure cannot poison newer ready generation") {
+        var state = ParakeetRecoveryState()
+        let staleGeneration = state.beginConfigChange()
+        let currentGeneration = state.beginConfigChange()
+
+        assertTrue(state.finishRecovery(success: true, generation: currentGeneration), "current recovery should mark the graph ready")
+        assertFalse(state.finishRecovery(success: false, generation: staleGeneration), "stale failure must be rejected")
+        assertTrue(state.canStartRecording, "late failure from an old graph must not poison the ready graph")
+    }
+
     runSuite("ParakeetRecoveryState.timeoutRecovery — fails active recovery and supersedes stale tasks") {
         var state = ParakeetRecoveryState()
         let recoveryGeneration = state.beginConfigChange()
@@ -81,6 +91,16 @@ func testParakeetRecoveryState() {
         assertFalse(state.timeoutRecovery(generation: staleGeneration), "stale timeout should not affect newer recovery")
         assertTrue(state.isRecovering, "newer recovery should stay active")
         assertFalse(state.inputFormatReady, "newer recovery should keep input unready")
+    }
+
+    runSuite("ParakeetRecoveryState.timeoutRecovery — stale timeout cannot poison newer ready generation") {
+        var state = ParakeetRecoveryState()
+        let staleGeneration = state.beginConfigChange()
+        let currentGeneration = state.beginConfigChange()
+
+        assertTrue(state.finishRecovery(success: true, generation: currentGeneration), "current recovery should mark input ready")
+        assertFalse(state.timeoutRecovery(generation: staleGeneration), "stale timeout must not apply after newer success")
+        assertTrue(state.canStartRecording, "late timeout from an old graph must not block recording")
     }
 
     runSuite("ParakeetRecoveryState.timeoutRecovery — ignores pristine state") {

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -145,6 +145,60 @@ func testParakeetStartRecordingFailurePolicy() {
         assertEqual(zeroInputChannels.startFailureReason, .invalidAudioFormat, "zero input channels should map to invalidAudioFormat")
     }
 
+    runSuite("ParakeetAudioFormatReadinessPolicy rejects non-finite sample rates") {
+        for sampleRate in [Double.nan, Double.infinity, -Double.infinity] {
+            let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+                outputSampleRate: sampleRate,
+                outputChannelCount: 1,
+                inputSampleRate: 48_000,
+                inputChannelCount: 1,
+                selectedInputClass: "built_in",
+                selectionOverrodeDefault: false
+            )
+
+            assertEqual(readiness, .invalid, "non-finite output sample rates must not become ready")
+        }
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy rejects implausible capture sample rates") {
+        for sampleRate in [-1.0, 1.0, 7_999.0, 384_001.0] {
+            let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+                outputSampleRate: sampleRate,
+                outputChannelCount: 1,
+                inputSampleRate: 48_000,
+                inputChannelCount: 1,
+                selectedInputClass: "built_in",
+                selectionOverrodeDefault: false
+            )
+
+            assertEqual(readiness, .invalid, "implausible output sample rates must wait for recovery")
+        }
+
+        assertTrue(
+            ParakeetAudioFormatReadinessPolicy.isUsableCaptureSampleRate(48_000),
+            "normal capture rates should remain usable"
+        )
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy uses bounded fallback buffer sizing") {
+        let fallbackCapacity = ParakeetAudioFormatReadinessPolicy.bufferCapacitySampleCount(
+            sampleRate: .nan,
+            seconds: 10
+        )
+        let cappedCapacity = ParakeetAudioFormatReadinessPolicy.bufferCapacitySampleCount(
+            sampleRate: 384_000,
+            seconds: 10
+        )
+        let normalCapacity = ParakeetAudioFormatReadinessPolicy.bufferCapacitySampleCount(
+            sampleRate: 48_000,
+            seconds: 10
+        )
+
+        assertEqual(fallbackCapacity, 480_000, "invalid rates should fall back to 48k for buffer math")
+        assertEqual(cappedCapacity, 960_000, "high valid rates should be capped for memory sizing")
+        assertEqual(normalCapacity, 480_000, "normal rates should size buffers normally")
+    }
+
     runSuite("ParakeetAudioFormatReadinessPolicy maps CoreAudio format-not-supported") {
         let error = NSError(
             domain: "com.apple.coreaudio.avfaudio",

--- a/Tests/RecordedAudioTimelineTests.swift
+++ b/Tests/RecordedAudioTimelineTests.swift
@@ -35,4 +35,16 @@ func testRecordedAudioTimeline() {
         assertTrue(timeline.isEmpty, "drain should clear the in-memory timeline")
         assertEqual(timeline.totalSourceSampleCount, 0, "cleared timelines should report zero samples")
     }
+
+    runSuite("RecordedAudioTimeline.append — drops invalid and non-finite sample rates") {
+        var timeline = RecordedAudioTimeline()
+
+        for sampleRate in [0, -1, Double.nan, Double.infinity, -Double.infinity, 1, 7_999, 384_001] {
+            timeline.append([0.1, 0.2], sampleRate: sampleRate)
+        }
+
+        assertTrue(timeline.isEmpty, "invalid sample rates should not create timeline segments")
+        timeline.append([0.3], sampleRate: 48_000)
+        assertEqual(timeline.segments.count, 1, "valid sample rates should still append")
+    }
 }

--- a/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@preconcurrency import AVFoundation
 @testable import TranscriptedCore
 
 @available(macOS 14.0, *)
@@ -48,6 +49,37 @@ final class AudioInitializationTests: XCTestCase {
         // after upgrade unless they explicitly opt in via Settings.
         XCTAssertFalse(audio.enableVoiceProcessing,
                        "enableVoiceProcessing must default to false to avoid the system-wide ducking regression")
+    }
+
+    func testAudioRecordingFormatPolicyRejectsInvalidSampleRatesBeforeCreatingFormats() throws {
+        for sampleRate in [0, -1, Double.nan, Double.infinity, -Double.infinity, 7_999, 384_001] {
+            XCTAssertFalse(
+                AudioRecordingFormatPolicy.isUsableSampleRate(sampleRate),
+                "sample rate \(sampleRate) should not be accepted for CoreAudio format creation"
+            )
+            XCTAssertThrowsError(
+                try AudioRecordingFormatPolicy.makeMonoOutputFormat(sampleRate: sampleRate),
+                "invalid sample rates must throw before AVAudioFormat is asked to build a format"
+            )
+        }
+
+        let monoFormat = try AudioRecordingFormatPolicy.makeMonoOutputFormat(sampleRate: 48_000)
+        XCTAssertEqual(monoFormat.sampleRate, 48_000, accuracy: 0.1)
+        XCTAssertEqual(monoFormat.channelCount, 1)
+    }
+
+    func testAudioRecordingFormatPolicySnapshotsOnlyUsableFormats() throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 2,
+            interleaved: false
+        ))
+
+        let snapshot = try XCTUnwrap(AudioRecordingFormatPolicy.snapshot(format))
+
+        XCTAssertEqual(snapshot.sampleRate, 48_000, accuracy: 0.1)
+        XCTAssertEqual(snapshot.channelCount, 2)
     }
 
     func testStopOnIdleAudioDoesNotCrashAndBumpsGeneration() {

--- a/Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift
@@ -122,6 +122,17 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         XCTAssertEqual(segments[0].end, 1.0, accuracy: 0.000_1)
     }
 
+    func testDetectSpeechSegmentsRejectsInvalidSampleRates() {
+        let samples = alternatingSamples(amplitude: 0.02, count: 16_000)
+
+        for sampleRate in [Double.nan, Double.infinity, -Double.infinity, 0.0, 7_999.0, 384_001.0] {
+            XCTAssertEqual(
+                Transcription.detectSpeechSegments(samples: samples, sampleRate: sampleRate).count,
+                0
+            )
+        }
+    }
+
     func testAudioSignalRecoveryNormalizesQuietSpeechCandidate() {
         var samples = [Float](repeating: 0.0, count: 64_000)
         let quietSpeech = alternatingSamples(amplitude: 0.008, count: 24_000)
@@ -153,6 +164,17 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         XCTAssertFalse(analysis.hasSpeechCandidate)
         XCTAssertFalse(normalized.wasNormalized)
         XCTAssertEqual(normalized.samples, samples)
+    }
+
+    func testAudioSignalRecoveryRejectsInvalidSampleRates() {
+        let samples = alternatingSamples(amplitude: 0.02, count: 16_000)
+
+        for sampleRate in [Double.nan, Double.infinity, -Double.infinity, 0.0, 7_999.0, 384_001.0] {
+            let analysis = AudioSignalRecovery.analyze(samples: samples, sampleRate: sampleRate)
+
+            XCTAssertEqual(analysis.durationSeconds, 0)
+            XCTAssertFalse(analysis.hasSpeechCandidate)
+        }
     }
 
     func testAudioSignalRecoveryNormalizesAttenuatedSpeechBelowLegacyGate() {
@@ -201,6 +223,41 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         )
 
         XCTAssertNil(prepared)
+    }
+
+    func testPrepareMicSegmentRejectsInvalidSampleRates() {
+        let samples = alternatingSamples(amplitude: 0.02, count: 16_000)
+
+        for sampleRate in [Double.nan, Double.infinity, -Double.infinity, 0.0, 7_999.0, 384_001.0] {
+            XCTAssertNil(
+                Transcription.prepareMicSegmentForTranscription(samples: samples, sampleRate: sampleRate)
+            )
+        }
+    }
+
+    func testAudioResamplerRejectsUnsafeSliceMath() {
+        let samples = [Float](repeating: 0.1, count: 16_000)
+
+        XCTAssertEqual(
+            AudioResampler.resample(samples, from: Double.infinity, to: 16_000),
+            samples
+        )
+        XCTAssertEqual(
+            AudioResampler.resample(samples, from: 48_000, to: Double.nan),
+            samples
+        )
+        XCTAssertEqual(
+            AudioResampler.extractSlice(from: samples, sampleRate: Double.infinity, startTime: 0, endTime: 1),
+            []
+        )
+        XCTAssertEqual(
+            AudioResampler.extractSlice(from: samples, sampleRate: 16_000, startTime: Double.nan, endTime: 1),
+            []
+        )
+        XCTAssertEqual(
+            AudioResampler.extractSlice(from: samples, sampleRate: 16_000, startTime: 0, endTime: Double.greatestFiniteMagnitude),
+            []
+        )
     }
 
     private func alternatingSamples(amplitude: Float, count: Int) -> [Float] {


### PR DESCRIPTION
## Summary
- Guard mic, system audio, dictation, and transcription paths against non-finite or implausible CoreAudio sample rates before creating formats or converting frame counts.
- Serialize AVAudioEngine/input-node stop, start, monitoring, and device-recovery graph mutations behind one audio graph lock.
- Make stale recovery failures/timeouts unable to poison newer ready audio generations.
- Add regression coverage for weird sample-rate states, bounded buffer sizing, stale recovery generations, unsafe slice math, and recovery gap math.

## Sentry Context
This targets the latest-release audio reliability failures seen in Sentry, especially APPLE-MACOS-18 (`EXC_BAD_ACCESS: sampleRate >`) and APPLE-MACOS-17 (`parakeet.device_change_rewarm_failed`).

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (960 passed)
- `bash run-integration-smoke.sh`
- `swift test` (104 passed)