### PR TITLE
Redesign settings home dashboard

### DIFF
--- a/Sources/Dictation/DictationTranscriptStore.swift
+++ b/Sources/Dictation/DictationTranscriptStore.swift
@@ -23,6 +23,12 @@ struct SavedDictationEntry: Identifiable, Sendable {
     }
 }
 
+struct DictationTranscriptCounts: Sendable {
+    let total: Int
+    let today: Int
+    let totalWords: Int
+}
+
 enum DictationTranscriptStore {
     private static let dictationDayPrefix = "Dictations_"
 
@@ -62,6 +68,36 @@ enum DictationTranscriptStore {
 
     static func latestSavedDictation(directory: URL? = nil) -> SavedDictationEntry? {
         recentSavedDictations(limit: 1, directory: directory).first
+    }
+
+    static func savedDictationCounts(directory: URL? = nil, today: Date = Date()) -> DictationTranscriptCounts {
+        let folder = directory ?? DictationStoragePaths.transcriptsFolder
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: folder.path, isDirectory: &isDirectory),
+              isDirectory.boolValue,
+              let files = try? FileManager.default.contentsOfDirectory(
+                at: folder,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+              ) else {
+            return DictationTranscriptCounts(total: 0, today: 0, totalWords: 0)
+        }
+
+        let todayURL = DictationTranscriptWriter.dailyFileURL(for: today, in: folder)
+        var total = 0
+        var todayCount = 0
+        var totalWords = 0
+
+        for file in files where isDictationDayFile(file) {
+            let stats = fileStats(in: file)
+            total += stats.entries
+            totalWords += stats.words
+            if file.lastPathComponent == todayURL.lastPathComponent {
+                todayCount = stats.entries
+            }
+        }
+
+        return DictationTranscriptCounts(total: total, today: todayCount, totalWords: totalWords)
     }
 
     static func recentSavedDictations(limit: Int = 5, directory: URL? = nil) -> [SavedDictationEntry] {
@@ -143,16 +179,55 @@ enum DictationTranscriptStore {
             return []
         }
 
-        let sections = splitSections(in: content)
-        let limitedSections: ArraySlice<String>
         if let limit, limit > 0 {
-            limitedSections = sections.suffix(limit)
-        } else {
-            limitedSections = sections[...]
+            return splitRecentSections(in: content, limit: limit)
+                .compactMap { parseEntry(from: $0, in: url) }
         }
 
-        return limitedSections
+        return splitSections(in: content)
             .compactMap { parseEntry(from: $0, in: url) }
+    }
+
+    private struct DictationFileStats {
+        let entries: Int
+        let words: Int
+    }
+
+    private static func fileStats(in url: URL) -> DictationFileStats {
+        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+            return DictationFileStats(entries: 0, words: 0)
+        }
+
+        var entries = 0
+        var words = 0
+        var scanningMetadata = false
+        var sawMetadataLine = false
+
+        for line in content.components(separatedBy: "\n") {
+            if isEntryHeading(line) {
+                entries += 1
+                scanningMetadata = true
+                sawMetadataLine = false
+                continue
+            }
+
+            guard scanningMetadata else { continue }
+
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                if sawMetadataLine {
+                    scanningMetadata = false
+                }
+                continue
+            }
+
+            sawMetadataLine = true
+            if trimmed.hasPrefix("Words:") {
+                words += intMetadataValue(from: trimmed, prefix: "Words:")
+            }
+        }
+
+        return DictationFileStats(entries: entries, words: words)
     }
 
     private static func splitSections(in content: String) -> [String] {
@@ -176,6 +251,35 @@ enum DictationTranscriptStore {
         }
 
         return sections
+    }
+
+    private static func splitRecentSections(in content: String, limit: Int) -> [String] {
+        let lines = content.components(separatedBy: "\n")
+        var recentSections: [String] = []
+        var currentSection: [String] = []
+
+        for line in lines {
+            if isEntryHeading(line) {
+                if !currentSection.isEmpty {
+                    recentSections.append(currentSection.joined(separator: "\n"))
+                    if recentSections.count > limit {
+                        recentSections.removeFirst(recentSections.count - limit)
+                    }
+                }
+                currentSection = [line]
+            } else if !currentSection.isEmpty {
+                currentSection.append(line)
+            }
+        }
+
+        if !currentSection.isEmpty {
+            recentSections.append(currentSection.joined(separator: "\n"))
+            if recentSections.count > limit {
+                recentSections.removeFirst(recentSections.count - limit)
+            }
+        }
+
+        return recentSections
     }
 
     private static func isEntryHeading(_ line: String) -> Bool {
@@ -271,6 +375,12 @@ enum DictationTranscriptStore {
         line
             .replacingOccurrences(of: prefix, with: "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func intMetadataValue(from line: String, prefix: String) -> Int {
+        let value = metadataValue(from: line, prefix: prefix)
+            .replacingOccurrences(of: ",", with: "")
+        return Int(value) ?? 0
     }
 
     private static func parseCreatedAt(_ value: String) -> Date? {

--- a/Sources/Dictation/DictationTranscriptStore.swift
+++ b/Sources/Dictation/DictationTranscriptStore.swift
@@ -85,7 +85,8 @@ enum DictationTranscriptStore {
 
         var collectedEntries: [SavedDictationEntry] = []
         for file in dayFiles {
-            collectedEntries.append(contentsOf: entries(in: file))
+            let remaining = limit - collectedEntries.count
+            collectedEntries.append(contentsOf: entries(in: file, limit: remaining))
             if collectedEntries.count >= limit {
                 break
             }
@@ -137,12 +138,20 @@ enum DictationTranscriptStore {
         return joined.isEmpty ? "" : joined + "\n\n"
     }
 
-    private static func entries(in url: URL) -> [SavedDictationEntry] {
+    private static func entries(in url: URL, limit: Int? = nil) -> [SavedDictationEntry] {
         guard let content = try? String(contentsOf: url, encoding: .utf8) else {
             return []
         }
 
-        return splitSections(in: content)
+        let sections = splitSections(in: content)
+        let limitedSections: ArraySlice<String>
+        if let limit, limit > 0 {
+            limitedSections = sections.suffix(limit)
+        } else {
+            limitedSections = sections[...]
+        }
+
+        return limitedSections
             .compactMap { parseEntry(from: $0, in: url) }
     }
 

--- a/Sources/Dictation/DictationTranscriptStore.swift
+++ b/Sources/Dictation/DictationTranscriptStore.swift
@@ -102,6 +102,41 @@ enum DictationTranscriptStore {
         url.pathExtension == "md" && url.lastPathComponent.hasPrefix(dictationDayPrefix)
     }
 
+    /// Removes a single dictation entry by matching on `createdAt` within its day file.
+    /// If the day file has no remaining entries, the file is deleted.
+    static func deleteEntry(_ entry: SavedDictationEntry) throws {
+        let url = entry.url
+        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+            throw NSError(domain: "DictationTranscriptStore", code: 1, userInfo: [NSLocalizedDescriptionKey: "Could not read \(url.lastPathComponent)."])
+        }
+
+        let sections = splitSections(in: content)
+        let kept: [String] = sections.filter { section in
+            guard let parsed = parseEntry(from: section, in: url) else { return true }
+            return parsed.createdAt != entry.createdAt
+        }
+
+        if kept.isEmpty {
+            try FileManager.default.removeItem(at: url)
+        } else {
+            let header = headerPreface(in: content)
+            let rebuilt = (header + kept.joined(separator: "\n\n")).trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
+            try rebuilt.write(to: url, atomically: true, encoding: .utf8)
+        }
+
+        NotificationCenter.default.post(name: .dictationTranscriptDidSave, object: url)
+    }
+
+    private static func headerPreface(in content: String) -> String {
+        var preface: [String] = []
+        for line in content.components(separatedBy: "\n") {
+            if isEntryHeading(line) { break }
+            preface.append(line)
+        }
+        let joined = preface.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        return joined.isEmpty ? "" : joined + "\n\n"
+    }
+
     private static func entries(in url: URL) -> [SavedDictationEntry] {
         guard let content = try? String(contentsOf: url, encoding: .utf8) else {
             return []

--- a/Sources/Dictation/DictationTranscriptStore.swift
+++ b/Sources/Dictation/DictationTranscriptStore.swift
@@ -11,6 +11,7 @@ extension Notification.Name {
 
 struct SavedDictationEntry: Identifiable, Sendable {
     let url: URL
+    let entryID: String?
     let title: String
     let text: String
     let createdAt: Date
@@ -19,7 +20,10 @@ struct SavedDictationEntry: Identifiable, Sendable {
     let sourceAppBundleID: String?
 
     var id: String {
-        "\(url.path)#\(createdAt.timeIntervalSince1970)#\(title)"
+        if let entryID, !entryID.isEmpty {
+            return "\(url.path)#\(entryID)"
+        }
+        return "\(url.path)#\(createdAt.timeIntervalSince1970)#\(title)"
     }
 }
 
@@ -139,7 +143,7 @@ enum DictationTranscriptStore {
         url.pathExtension == "md" && url.lastPathComponent.hasPrefix(dictationDayPrefix)
     }
 
-    /// Removes a single dictation entry by matching on `createdAt` within its day file.
+    /// Removes a single dictation entry by matching on its stable saved entry ID.
     /// If the day file has no remaining entries, the file is deleted.
     static func deleteEntry(_ entry: SavedDictationEntry) throws {
         let url = entry.url
@@ -148,9 +152,22 @@ enum DictationTranscriptStore {
         }
 
         let sections = splitSections(in: content)
+        var removedCount = 0
         let kept: [String] = sections.filter { section in
             guard let parsed = parseEntry(from: section, in: url) else { return true }
-            return parsed.createdAt != entry.createdAt
+            if isSameEntry(parsed, as: entry) {
+                removedCount += 1
+                return false
+            }
+            return true
+        }
+
+        guard removedCount > 0 else {
+            throw NSError(
+                domain: "DictationTranscriptStore",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Could not find the dictation entry to delete."]
+            )
         }
 
         if kept.isEmpty {
@@ -162,6 +179,16 @@ enum DictationTranscriptStore {
         }
 
         NotificationCenter.default.post(name: .dictationTranscriptDidSave, object: url)
+    }
+
+    private static func isSameEntry(_ lhs: SavedDictationEntry, as rhs: SavedDictationEntry) -> Bool {
+        if let lhsEntryID = lhs.entryID, let rhsEntryID = rhs.entryID {
+            return lhs.url == rhs.url && lhsEntryID == rhsEntryID
+        }
+
+        return lhs.url == rhs.url
+            && lhs.createdAt == rhs.createdAt
+            && lhs.title == rhs.title
     }
 
     private static func headerPreface(in content: String) -> String {
@@ -296,6 +323,7 @@ enum DictationTranscriptStore {
         }
 
         let title = parseTitle(from: heading)
+        var entryID: String?
         var createdAtText = ""
         var sourceAppName = "Unknown"
         var sourceAppBundleID: String?
@@ -320,7 +348,11 @@ enum DictationTranscriptStore {
                 continue
             }
 
-            if trimmed.hasPrefix("Captured:") {
+            if trimmed.hasPrefix("Entry ID:") {
+                sawMetadata = true
+                entryID = metadataValue(from: trimmed, prefix: "Entry ID:")
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "`"))
+            } else if trimmed.hasPrefix("Captured:") {
                 sawMetadata = true
                 createdAtText = metadataValue(from: trimmed, prefix: "Captured:")
             } else if trimmed.hasPrefix("Timestamp:") {
@@ -337,7 +369,7 @@ enum DictationTranscriptStore {
                 sawMetadata = true
                 let rawDelivery = metadataValue(from: trimmed, prefix: "Delivery:")
                 delivery = DictationDelivery(rawValue: rawDelivery) ?? .failed
-            } else if trimmed.hasPrefix("Entry ID:") || trimmed.hasPrefix("Words:") || trimmed.hasPrefix("Characters:") {
+            } else if trimmed.hasPrefix("Words:") || trimmed.hasPrefix("Characters:") {
                 sawMetadata = true
             } else if !sawMetadata {
                 inBody = true
@@ -353,6 +385,7 @@ enum DictationTranscriptStore {
 
         return SavedDictationEntry(
             url: url,
+            entryID: entryID,
             title: title,
             text: text,
             createdAt: createdAt,

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -63,7 +63,8 @@ final class HomeViewModel: ObservableObject {
         refreshTask = Task { @MainActor in
             let snapshot = await RecentCaptureLoader.load(
                 dictationLimit: requestedDictationLimit + 1,
-                meetingLimit: requestedMeetingLimit + 1
+                meetingLimit: requestedMeetingLimit + 1,
+                includeDictationCounts: true
             )
             guard !Task.isCancelled else { return }
             let visibleDictations = Array(snapshot.dictations.prefix(requestedDictationLimit))
@@ -143,6 +144,12 @@ struct HomeDeleteConfirmation: Identifiable {
     let title: String
     let message: String
     let perform: () -> Void
+}
+
+struct HomeDeleteFailure: Identifiable {
+    let id = UUID()
+    let title: String
+    let message: String
 }
 
 enum HomeActivityTab: String, CaseIterable, Identifiable {

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -13,12 +13,18 @@ final class HomeViewModel: ObservableObject {
     @Published private(set) var todayDictationCount: Int = 0
     @Published private(set) var todayMeetingCount: Int = 0
     @Published private(set) var isLoading: Bool = false
+    @Published private(set) var isLoadingMore: Bool = false
+    @Published private(set) var canLoadMoreDictations: Bool = false
+    @Published private(set) var canLoadMoreMeetings: Bool = false
 
     private var refreshTask: Task<Void, Never>?
+    private var dictationLimit = 40
+    private var meetingLimit = 25
 
     // Settings Home must open instantly, even for users with thousands of dictations.
     // Keep the dashboard to a small recent slice and leave deep history to the dedicated pages/files.
-    private let listLimit = 40
+    private let initialDictationLimit = 40
+    private let initialMeetingLimit = 25
 
     var welcomeName: String {
         let full = NSFullUserName().trimmingCharacters(in: .whitespacesAndNewlines)
@@ -28,19 +34,49 @@ final class HomeViewModel: ObservableObject {
 
     func refresh() {
         refreshTask?.cancel()
+        dictationLimit = initialDictationLimit
+        meetingLimit = initialMeetingLimit
         isLoading = true
-        let limit = listLimit
+        loadCurrentLimits(isInitialLoad: true)
+    }
+
+    func loadMoreDictations() {
+        guard !isLoading, !isLoadingMore, canLoadMoreDictations else { return }
+        dictationLimit += initialDictationLimit
+        loadCurrentLimits(isInitialLoad: false)
+    }
+
+    func loadMoreMeetings() {
+        guard !isLoading, !isLoadingMore, canLoadMoreMeetings else { return }
+        meetingLimit += initialMeetingLimit
+        loadCurrentLimits(isInitialLoad: false)
+    }
+
+    private func loadCurrentLimits(isInitialLoad: Bool) {
+        refreshTask?.cancel()
+        isLoading = isInitialLoad
+        isLoadingMore = !isInitialLoad
+        let requestedDictationLimit = dictationLimit
+        let requestedMeetingLimit = meetingLimit
         refreshTask = Task { @MainActor in
-            let snapshot = await RecentCaptureLoader.load(limit: limit)
+            let snapshot = await RecentCaptureLoader.load(
+                dictationLimit: requestedDictationLimit + 1,
+                meetingLimit: requestedMeetingLimit + 1
+            )
             guard !Task.isCancelled else { return }
+            let visibleDictations = Array(snapshot.dictations.prefix(requestedDictationLimit))
+            let visibleMeetings = Array(snapshot.meetings.prefix(requestedMeetingLimit))
             let calendar = Calendar.current
-            self.recentDictationCount = snapshot.dictations.count
-            self.recentMeetingCount = snapshot.meetings.count
-            self.todayDictationCount = snapshot.dictations.lazy.filter { calendar.isDateInToday($0.createdAt) }.count
-            self.todayMeetingCount = snapshot.meetings.lazy.filter { calendar.isDateInToday($0.date) }.count
-            self.dictationDaySections = Self.groupByDay(snapshot.dictations, dateForItem: \.createdAt)
-            self.meetingDaySections = Self.groupByDay(snapshot.meetings, dateForItem: \.date)
+            self.recentDictationCount = visibleDictations.count
+            self.recentMeetingCount = visibleMeetings.count
+            self.todayDictationCount = visibleDictations.lazy.filter { calendar.isDateInToday($0.createdAt) }.count
+            self.todayMeetingCount = visibleMeetings.lazy.filter { calendar.isDateInToday($0.date) }.count
+            self.dictationDaySections = Self.groupByDay(visibleDictations, dateForItem: \.createdAt)
+            self.meetingDaySections = Self.groupByDay(visibleMeetings, dateForItem: \.date)
+            self.canLoadMoreDictations = snapshot.dictations.count > requestedDictationLimit
+            self.canLoadMoreMeetings = snapshot.meetings.count > requestedMeetingLimit
             self.isLoading = false
+            self.isLoadingMore = false
         }
     }
 
@@ -570,6 +606,9 @@ struct HomeActivityTabsCard: View {
     let dictationSections: [HomeDaySection<SavedDictationEntry>]
     let meetingSections: [HomeDaySection<RecentMeetingItem>]
     let isLoading: Bool
+    let isLoadingMore: Bool
+    let canLoadMoreDictations: Bool
+    let canLoadMoreMeetings: Bool
     let copiedRowID: String?
     let onOpenDictation: (SavedDictationEntry) -> Void
     let onCopyDictation: (SavedDictationEntry) -> Void
@@ -579,6 +618,8 @@ struct HomeActivityTabsCard: View {
     let onCopyMeeting: (RecentMeetingItem) -> Void
     let onFlagMeeting: (RecentMeetingItem) -> Void
     let meetingMenuItems: (RecentMeetingItem) -> [HomeRowMenuItem]
+    let onLoadMoreDictations: () -> Void
+    let onLoadMoreMeetings: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -604,37 +645,57 @@ struct HomeActivityTabsCard: View {
             } else {
                 switch selectedTab {
                 case .dictations:
-                    HomeDayGroupedList(
-                        sections: dictationSections,
-                        emptyMessage: "No recent dictations.",
-                        getID: { AnyHashable($0.id) },
-                        row: { entry in
-                            HomeDictationRow(
-                                entry: entry,
-                                isCopied: copiedRowID == entry.id,
-                                onOpen: { onOpenDictation(entry) },
-                                onCopy: { onCopyDictation(entry) },
-                                onFlag: { onFlagDictation(entry) },
-                                menuItems: dictationMenuItems(entry)
+                    VStack(spacing: 12) {
+                        HomeDayGroupedList(
+                            sections: dictationSections,
+                            emptyMessage: "No recent dictations.",
+                            getID: { AnyHashable($0.id) },
+                            row: { entry in
+                                HomeDictationRow(
+                                    entry: entry,
+                                    isCopied: copiedRowID == entry.id,
+                                    onOpen: { onOpenDictation(entry) },
+                                    onCopy: { onCopyDictation(entry) },
+                                    onFlag: { onFlagDictation(entry) },
+                                    menuItems: dictationMenuItems(entry)
+                                )
+                            }
+                        )
+
+                        if canLoadMoreDictations {
+                            HomeLoadMoreButton(
+                                title: "Load more dictations",
+                                isLoading: isLoadingMore,
+                                action: onLoadMoreDictations
                             )
                         }
-                    )
+                    }
                 case .meetings:
-                    HomeDayGroupedList(
-                        sections: meetingSections,
-                        emptyMessage: "No recent meetings.",
-                        getID: { AnyHashable($0.id) },
-                        row: { item in
-                            HomeMeetingRow(
-                                item: item,
-                                isCopied: copiedRowID == item.id,
-                                onOpen: { onOpenMeeting(item) },
-                                onCopy: { onCopyMeeting(item) },
-                                onFlag: { onFlagMeeting(item) },
-                                menuItems: meetingMenuItems(item)
+                    VStack(spacing: 12) {
+                        HomeDayGroupedList(
+                            sections: meetingSections,
+                            emptyMessage: "No recent meetings.",
+                            getID: { AnyHashable($0.id) },
+                            row: { item in
+                                HomeMeetingRow(
+                                    item: item,
+                                    isCopied: copiedRowID == item.id,
+                                    onOpen: { onOpenMeeting(item) },
+                                    onCopy: { onCopyMeeting(item) },
+                                    onFlag: { onFlagMeeting(item) },
+                                    menuItems: meetingMenuItems(item)
+                                )
+                            }
+                        )
+
+                        if canLoadMoreMeetings {
+                            HomeLoadMoreButton(
+                                title: "Load more meetings",
+                                isLoading: isLoadingMore,
+                                action: onLoadMoreMeetings
                             )
                         }
-                    )
+                    }
                 }
             }
         }
@@ -648,6 +709,30 @@ struct HomeActivityTabsCard: View {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .stroke(Color.primary.opacity(0.08), lineWidth: 1)
         )
+    }
+}
+
+struct HomeLoadMoreButton: View {
+    let title: String
+    let isLoading: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+
+                Text(isLoading ? "Loading" : title)
+                    .font(.subheadline.weight(.medium))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+        }
+        .buttonStyle(.borderless)
+        .disabled(isLoading)
     }
 }
 

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -20,13 +20,13 @@ final class HomeViewModel: ObservableObject {
     @Published private(set) var canLoadMoreMeetings: Bool = false
 
     private var refreshTask: Task<Void, Never>?
-    private var dictationLimit = 40
-    private var meetingLimit = 25
+    private var dictationLimit = 10
+    private var meetingLimit = 10
 
     // Settings Home must open instantly, even for users with thousands of dictations.
     // Keep the dashboard to a small recent slice and leave deep history to the dedicated pages/files.
-    private let initialDictationLimit = 40
-    private let initialMeetingLimit = 25
+    private let initialDictationLimit = 10
+    private let initialMeetingLimit = 10
 
     var welcomeName: String {
         let full = NSFullUserName().trimmingCharacters(in: .whitespacesAndNewlines)
@@ -197,20 +197,20 @@ struct HomeHeroCard: View {
     let secondaryAction: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            HStack(alignment: .top, spacing: 14) {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top, spacing: 12) {
                 ZStack {
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
                         .fill(Color.accentColor.opacity(0.16))
                     Image(systemName: "mic.fill")
-                        .font(.system(size: 18, weight: .semibold))
+                        .font(.system(size: 16, weight: .semibold))
                         .foregroundStyle(Color.accentColor)
                 }
-                .frame(width: 44, height: 44)
+                .frame(width: 38, height: 38)
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(title)
-                        .font(.system(size: 22, weight: .semibold))
+                        .font(.system(size: 20, weight: .semibold))
                         .foregroundStyle(Color.primary)
                         .fixedSize(horizontal: false, vertical: true)
                     Text(subtitle)
@@ -224,11 +224,11 @@ struct HomeHeroCard: View {
                 Button(action: primaryAction) {
                     Label(primaryTitle, systemImage: "mic.fill")
                         .font(.system(size: 13, weight: .semibold))
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 8)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 7)
                 }
                 .buttonStyle(.borderedProminent)
-                .controlSize(.large)
+                .controlSize(.regular)
 
                 Button(action: secondaryAction) {
                     Label(secondaryTitle, systemImage: "waveform")
@@ -238,7 +238,7 @@ struct HomeHeroCard: View {
                 .buttonStyle(.plain)
             }
         }
-        .padding(22)
+        .padding(18)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
@@ -268,14 +268,14 @@ struct HomeStatsRail: View {
     let streak: Int?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
+        VStack(alignment: .leading, spacing: 16) {
             Text(header)
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
                 .textCase(.uppercase)
                 .tracking(0.6)
 
-            VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 12) {
                 ForEach(stats) { stat in
                     HStack(alignment: .top, spacing: 10) {
                         ZStack {
@@ -290,7 +290,7 @@ struct HomeStatsRail: View {
 
                         VStack(alignment: .leading, spacing: 2) {
                             Text(stat.value)
-                                .font(.system(size: 22, weight: .semibold))
+                                .font(.system(size: 20, weight: .semibold))
                                 .foregroundStyle(Color.primary)
                             Text(stat.label)
                                 .font(.caption)
@@ -316,7 +316,7 @@ struct HomeStatsRail: View {
                 }
             }
         }
-        .padding(18)
+        .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
@@ -661,7 +661,7 @@ struct HomeActivityTabsCard: View {
     let onLoadMoreMeetings: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 14) {
             HStack(alignment: .center, spacing: 16) {
                 VStack(alignment: .leading, spacing: 3) {
                     Text("Recent activity")
@@ -752,7 +752,7 @@ struct HomeActivityTabsCard: View {
                 }
             }
         }
-        .padding(20)
+        .padding(18)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
@@ -767,9 +767,9 @@ struct HomeActivityTabsCard: View {
     private var activitySubtitle: String {
         switch selectedTab {
         case .dictations:
-            return canLoadMoreDictations ? "Showing the latest 40 dictations" : "Latest dictations"
+            return canLoadMoreDictations ? "Showing the latest 10 dictations" : "Latest dictations"
         case .meetings:
-            return canLoadMoreMeetings ? "Showing the latest 25 meetings" : "Latest meetings"
+            return canLoadMoreMeetings ? "Showing the latest 10 meetings" : "Latest meetings"
         }
     }
 }

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -10,6 +10,8 @@ final class HomeViewModel: ObservableObject {
     @Published private(set) var meetingDaySections: [HomeDaySection<RecentMeetingItem>] = []
     @Published private(set) var recentDictationCount: Int = 0
     @Published private(set) var recentMeetingCount: Int = 0
+    @Published private(set) var totalDictationCount: Int = 0
+    @Published private(set) var totalDictationWordCount: Int = 0
     @Published private(set) var todayDictationCount: Int = 0
     @Published private(set) var todayMeetingCount: Int = 0
     @Published private(set) var isLoading: Bool = false
@@ -69,7 +71,9 @@ final class HomeViewModel: ObservableObject {
             let calendar = Calendar.current
             self.recentDictationCount = visibleDictations.count
             self.recentMeetingCount = visibleMeetings.count
-            self.todayDictationCount = visibleDictations.lazy.filter { calendar.isDateInToday($0.createdAt) }.count
+            self.totalDictationCount = snapshot.dictationCounts.total
+            self.totalDictationWordCount = snapshot.dictationCounts.totalWords
+            self.todayDictationCount = snapshot.dictationCounts.today
             self.todayMeetingCount = visibleMeetings.lazy.filter { calendar.isDateInToday($0.date) }.count
             self.dictationDaySections = Self.groupByDay(visibleDictations, dateForItem: \.createdAt)
             self.meetingDaySections = Self.groupByDay(visibleMeetings, dateForItem: \.date)
@@ -645,7 +649,7 @@ struct HomeActivityTabsCard: View {
             } else {
                 switch selectedTab {
                 case .dictations:
-                    VStack(spacing: 12) {
+                    VStack(alignment: .leading, spacing: 12) {
                         HomeDayGroupedList(
                             sections: dictationSections,
                             emptyMessage: "No recent dictations.",
@@ -670,8 +674,9 @@ struct HomeActivityTabsCard: View {
                             )
                         }
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 case .meetings:
-                    VStack(spacing: 12) {
+                    VStack(alignment: .leading, spacing: 12) {
                         HomeDayGroupedList(
                             sections: meetingSections,
                             emptyMessage: "No recent meetings.",
@@ -696,6 +701,7 @@ struct HomeActivityTabsCard: View {
                             )
                         }
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
         }

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -6,50 +6,24 @@ import TranscriptedCore
 
 @MainActor
 final class HomeViewModel: ObservableObject {
-    @Published private(set) var dictations: [SavedDictationEntry] = []
-    @Published private(set) var meetings: [RecentMeetingItem] = []
+    @Published private(set) var dictationDaySections: [HomeDaySection<SavedDictationEntry>] = []
+    @Published private(set) var meetingDaySections: [HomeDaySection<RecentMeetingItem>] = []
+    @Published private(set) var recentDictationCount: Int = 0
+    @Published private(set) var recentMeetingCount: Int = 0
+    @Published private(set) var todayDictationCount: Int = 0
+    @Published private(set) var todayMeetingCount: Int = 0
     @Published private(set) var isLoading: Bool = false
 
     private var refreshTask: Task<Void, Never>?
 
-    // Generous: dictation files are one per day with multiple entries, parsing is cheap.
-    // This gives us full lifetime aggregates plus enough history for the timeline.
-    private let listLimit = 5000
+    // Settings Home must open instantly, even for users with thousands of dictations.
+    // Keep the dashboard to a small recent slice and leave deep history to the dedicated pages/files.
+    private let listLimit = 40
 
     var welcomeName: String {
         let full = NSFullUserName().trimmingCharacters(in: .whitespacesAndNewlines)
         guard !full.isEmpty else { return "there" }
         return full.split(separator: " ").first.map(String.init) ?? full
-    }
-
-    var todayDictationCount: Int {
-        dictations.lazy.filter { Calendar.current.isDateInToday($0.createdAt) }.count
-    }
-
-    var todayMeetingCount: Int {
-        meetings.lazy.filter { Calendar.current.isDateInToday($0.date) }.count
-    }
-
-    var todayWordCount: Int {
-        dictations
-            .lazy
-            .filter { Calendar.current.isDateInToday($0.createdAt) }
-            .map { Self.wordCount(in: $0.text) }
-            .reduce(0, +)
-    }
-
-    var totalDictationCount: Int { dictations.count }
-
-    var totalDictationWordCount: Int {
-        dictations.lazy.map { Self.wordCount(in: $0.text) }.reduce(0, +)
-    }
-
-    var dictationDaySections: [HomeDaySection<SavedDictationEntry>] {
-        Self.groupByDay(dictations, dateForItem: \.createdAt)
-    }
-
-    var meetingDaySections: [HomeDaySection<RecentMeetingItem>] {
-        Self.groupByDay(meetings, dateForItem: \.date)
     }
 
     func refresh() {
@@ -59,8 +33,13 @@ final class HomeViewModel: ObservableObject {
         refreshTask = Task { @MainActor in
             let snapshot = await RecentCaptureLoader.load(limit: limit)
             guard !Task.isCancelled else { return }
-            self.meetings = snapshot.meetings
-            self.dictations = snapshot.dictations
+            let calendar = Calendar.current
+            self.recentDictationCount = snapshot.dictations.count
+            self.recentMeetingCount = snapshot.meetings.count
+            self.todayDictationCount = snapshot.dictations.lazy.filter { calendar.isDateInToday($0.createdAt) }.count
+            self.todayMeetingCount = snapshot.meetings.lazy.filter { calendar.isDateInToday($0.date) }.count
+            self.dictationDaySections = Self.groupByDay(snapshot.dictations, dateForItem: \.createdAt)
+            self.meetingDaySections = Self.groupByDay(snapshot.meetings, dateForItem: \.date)
             self.isLoading = false
         }
     }
@@ -71,12 +50,6 @@ final class HomeViewModel: ObservableObject {
     }
 
     // MARK: - Helpers
-
-    private static func wordCount(in text: String) -> Int {
-        text
-            .split(whereSeparator: { $0.isWhitespace || $0.isNewline })
-            .count
-    }
 
     private static func groupByDay<Item>(
         _ items: [Item],
@@ -564,7 +537,7 @@ struct HomeDayGroupedList<Item, Row: View>: View {
             .padding(.vertical, 28)
             .padding(.horizontal, 4)
         } else {
-            VStack(alignment: .leading, spacing: 18) {
+            LazyVStack(alignment: .leading, spacing: 18) {
                 ForEach(sections) { section in
                     VStack(alignment: .leading, spacing: 4) {
                         Text(section.label)
@@ -596,6 +569,7 @@ struct HomeActivityTabsCard: View {
     @Binding var selectedTab: HomeActivityTab
     let dictationSections: [HomeDaySection<SavedDictationEntry>]
     let meetingSections: [HomeDaySection<RecentMeetingItem>]
+    let isLoading: Bool
     let copiedRowID: String?
     let onOpenDictation: (SavedDictationEntry) -> Void
     let onCopyDictation: (SavedDictationEntry) -> Void
@@ -617,39 +591,51 @@ struct HomeActivityTabsCard: View {
             .labelsHidden()
             .frame(maxWidth: 320, alignment: .leading)
 
-            switch selectedTab {
-            case .dictations:
-                HomeDayGroupedList(
-                    sections: dictationSections,
-                    emptyMessage: "No dictations saved yet.",
-                    getID: { AnyHashable($0.id) },
-                    row: { entry in
-                        HomeDictationRow(
-                            entry: entry,
-                            isCopied: copiedRowID == entry.id,
-                            onOpen: { onOpenDictation(entry) },
-                            onCopy: { onCopyDictation(entry) },
-                            onFlag: { onFlagDictation(entry) },
-                            menuItems: dictationMenuItems(entry)
-                        )
-                    }
-                )
-            case .meetings:
-                HomeDayGroupedList(
-                    sections: meetingSections,
-                    emptyMessage: "No meetings captured yet.",
-                    getID: { AnyHashable($0.id) },
-                    row: { item in
-                        HomeMeetingRow(
-                            item: item,
-                            isCopied: copiedRowID == item.id,
-                            onOpen: { onOpenMeeting(item) },
-                            onCopy: { onCopyMeeting(item) },
-                            onFlag: { onFlagMeeting(item) },
-                            menuItems: meetingMenuItems(item)
-                        )
-                    }
-                )
+            if isLoading {
+                HStack {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Loading recent activity")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .padding(.vertical, 28)
+            } else {
+                switch selectedTab {
+                case .dictations:
+                    HomeDayGroupedList(
+                        sections: dictationSections,
+                        emptyMessage: "No recent dictations.",
+                        getID: { AnyHashable($0.id) },
+                        row: { entry in
+                            HomeDictationRow(
+                                entry: entry,
+                                isCopied: copiedRowID == entry.id,
+                                onOpen: { onOpenDictation(entry) },
+                                onCopy: { onCopyDictation(entry) },
+                                onFlag: { onFlagDictation(entry) },
+                                menuItems: dictationMenuItems(entry)
+                            )
+                        }
+                    )
+                case .meetings:
+                    HomeDayGroupedList(
+                        sections: meetingSections,
+                        emptyMessage: "No recent meetings.",
+                        getID: { AnyHashable($0.id) },
+                        row: { item in
+                            HomeMeetingRow(
+                                item: item,
+                                isCopied: copiedRowID == item.id,
+                                onOpen: { onOpenMeeting(item) },
+                                onCopy: { onCopyMeeting(item) },
+                                onFlag: { onFlagMeeting(item) },
+                                menuItems: meetingMenuItems(item)
+                            )
+                        }
+                    )
+                }
             }
         }
         .padding(20)

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -163,6 +163,7 @@ enum HomeActivityTab: String, CaseIterable, Identifiable {
 
 struct HomeStatItem: Identifiable {
     let id = UUID()
+    let symbolName: String
     let value: String
     let label: String
 }
@@ -196,15 +197,27 @@ struct HomeHeroCard: View {
     let secondaryAction: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            VStack(alignment: .leading, spacing: 6) {
-                Text(title)
-                    .font(.system(size: 22, weight: .semibold))
-                    .foregroundStyle(Color.primary)
-                Text(subtitle)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(alignment: .top, spacing: 14) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(Color.accentColor.opacity(0.16))
+                    Image(systemName: "mic.fill")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(Color.accentColor)
+                }
+                .frame(width: 44, height: 44)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(title)
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(Color.primary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text(subtitle)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
 
             HStack(spacing: 14) {
@@ -218,7 +231,7 @@ struct HomeHeroCard: View {
                 .controlSize(.large)
 
                 Button(action: secondaryAction) {
-                    Text(secondaryTitle)
+                    Label(secondaryTitle, systemImage: "waveform")
                         .font(.system(size: 13, weight: .medium))
                         .foregroundStyle(.secondary)
                 }
@@ -232,8 +245,8 @@ struct HomeHeroCard: View {
                 .fill(
                     LinearGradient(
                         colors: [
-                            Color.accentColor.opacity(0.18),
-                            Color.accentColor.opacity(0.05)
+                            Color(nsColor: .controlBackgroundColor).opacity(0.94),
+                            Color.accentColor.opacity(0.11)
                         ],
                         startPoint: .topLeading,
                         endPoint: .bottomTrailing
@@ -264,13 +277,25 @@ struct HomeStatsRail: View {
 
             VStack(alignment: .leading, spacing: 14) {
                 ForEach(stats) { stat in
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(stat.value)
-                            .font(.system(size: 22, weight: .semibold))
-                            .foregroundStyle(Color.primary)
-                        Text(stat.label)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                    HStack(alignment: .top, spacing: 10) {
+                        ZStack {
+                            Circle()
+                                .fill(Color.primary.opacity(0.06))
+                            Image(systemName: stat.symbolName)
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(.secondary)
+                        }
+                        .frame(width: 26, height: 26)
+                        .padding(.top, 1)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(stat.value)
+                                .font(.system(size: 22, weight: .semibold))
+                                .foregroundStyle(Color.primary)
+                            Text(stat.label)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                 }
             }
@@ -314,7 +339,7 @@ struct HomeStatsStrip: View {
         HStack(spacing: 22) {
             ForEach(stats) { stat in
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(stat.value)
+                    Label(stat.value, systemImage: stat.symbolName)
                         .font(.system(size: 18, weight: .semibold))
                     Text(stat.label)
                         .font(.caption)
@@ -473,7 +498,12 @@ struct HomeDictationRow: View {
             .opacity(isHovering ? 1 : 0.55)
             .animation(.easeOut(duration: 0.12), value: isHovering)
         }
-        .padding(.vertical, 10)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 9)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(isHovering ? Color.primary.opacity(0.035) : Color.clear)
+        )
         .onHover { isHovering = $0 }
     }
 
@@ -542,7 +572,12 @@ struct HomeMeetingRow: View {
             .opacity(isHovering ? 1 : 0.55)
             .animation(.easeOut(duration: 0.12), value: isHovering)
         }
-        .padding(.vertical, 10)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 9)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(isHovering ? Color.primary.opacity(0.035) : Color.clear)
+        )
         .onHover { isHovering = $0 }
     }
 
@@ -626,15 +661,27 @@ struct HomeActivityTabsCard: View {
     let onLoadMoreMeetings: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Picker("", selection: $selectedTab) {
-                ForEach(HomeActivityTab.allCases) { tab in
-                    Text(tab.label).tag(tab)
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .center, spacing: 16) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Recent activity")
+                        .font(.system(size: 15, weight: .semibold))
+                    Text(activitySubtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
+
+                Spacer(minLength: 12)
+
+                Picker("", selection: $selectedTab) {
+                    ForEach(HomeActivityTab.allCases) { tab in
+                        Text(tab.label).tag(tab)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 190, alignment: .trailing)
             }
-            .pickerStyle(.segmented)
-            .labelsHidden()
-            .frame(maxWidth: 320, alignment: .leading)
 
             if isLoading {
                 HStack {
@@ -715,6 +762,15 @@ struct HomeActivityTabsCard: View {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .stroke(Color.primary.opacity(0.08), lineWidth: 1)
         )
+    }
+
+    private var activitySubtitle: String {
+        switch selectedTab {
+        case .dictations:
+            return canLoadMoreDictations ? "Showing the latest 40 dictations" : "Latest dictations"
+        case .meetings:
+            return canLoadMoreMeetings ? "Showing the latest 25 meetings" : "Latest meetings"
+        }
     }
 }
 

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -1,0 +1,724 @@
+import AppKit
+import SwiftUI
+import TranscriptedCore
+
+// MARK: - View model
+
+@MainActor
+final class HomeViewModel: ObservableObject {
+    @Published private(set) var dictations: [SavedDictationEntry] = []
+    @Published private(set) var meetings: [RecentMeetingItem] = []
+    @Published private(set) var isLoading: Bool = false
+
+    private var refreshTask: Task<Void, Never>?
+
+    // Generous: dictation files are one per day with multiple entries, parsing is cheap.
+    // This gives us full lifetime aggregates plus enough history for the timeline.
+    private let listLimit = 5000
+
+    var welcomeName: String {
+        let full = NSFullUserName().trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !full.isEmpty else { return "there" }
+        return full.split(separator: " ").first.map(String.init) ?? full
+    }
+
+    var todayDictationCount: Int {
+        dictations.lazy.filter { Calendar.current.isDateInToday($0.createdAt) }.count
+    }
+
+    var todayMeetingCount: Int {
+        meetings.lazy.filter { Calendar.current.isDateInToday($0.date) }.count
+    }
+
+    var todayWordCount: Int {
+        dictations
+            .lazy
+            .filter { Calendar.current.isDateInToday($0.createdAt) }
+            .map { Self.wordCount(in: $0.text) }
+            .reduce(0, +)
+    }
+
+    var totalDictationCount: Int { dictations.count }
+
+    var totalDictationWordCount: Int {
+        dictations.lazy.map { Self.wordCount(in: $0.text) }.reduce(0, +)
+    }
+
+    var dictationDaySections: [HomeDaySection<SavedDictationEntry>] {
+        Self.groupByDay(dictations, dateForItem: \.createdAt)
+    }
+
+    var meetingDaySections: [HomeDaySection<RecentMeetingItem>] {
+        Self.groupByDay(meetings, dateForItem: \.date)
+    }
+
+    func refresh() {
+        refreshTask?.cancel()
+        isLoading = true
+        let limit = listLimit
+        refreshTask = Task { @MainActor in
+            let snapshot = await RecentCaptureLoader.load(limit: limit)
+            guard !Task.isCancelled else { return }
+            self.meetings = snapshot.meetings
+            self.dictations = snapshot.dictations
+            self.isLoading = false
+        }
+    }
+
+    func cancel() {
+        refreshTask?.cancel()
+        refreshTask = nil
+    }
+
+    // MARK: - Helpers
+
+    private static func wordCount(in text: String) -> Int {
+        text
+            .split(whereSeparator: { $0.isWhitespace || $0.isNewline })
+            .count
+    }
+
+    private static func groupByDay<Item>(
+        _ items: [Item],
+        dateForItem: (Item) -> Date
+    ) -> [HomeDaySection<Item>] {
+        let calendar = Calendar.current
+        var buckets: [(day: Date, items: [Item])] = []
+
+        for item in items {
+            let day = calendar.startOfDay(for: dateForItem(item))
+            if let lastIndex = buckets.indices.last, buckets[lastIndex].day == day {
+                buckets[lastIndex].items.append(item)
+            } else if let existing = buckets.firstIndex(where: { $0.day == day }) {
+                buckets[existing].items.append(item)
+            } else {
+                buckets.append((day: day, items: [item]))
+            }
+        }
+
+        return buckets.map { bucket in
+            HomeDaySection(day: bucket.day, label: dayLabel(for: bucket.day), items: bucket.items)
+        }
+    }
+
+    private static func dayLabel(for day: Date) -> String {
+        let calendar = Calendar.current
+        if calendar.isDateInToday(day) { return "Today" }
+        if calendar.isDateInYesterday(day) { return "Yesterday" }
+        let formatter = Self.daySectionFormatter
+        return formatter.string(from: day)
+    }
+
+    private static let daySectionFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = .current
+        f.dateFormat = "EEEE, MMM d"
+        return f
+    }()
+}
+
+struct HomeDaySection<Item>: Identifiable {
+    let day: Date
+    let label: String
+    let items: [Item]
+
+    var id: TimeInterval { day.timeIntervalSinceReferenceDate }
+}
+
+struct HomeDeleteConfirmation: Identifiable {
+    let id = UUID()
+    let title: String
+    let message: String
+    let perform: () -> Void
+}
+
+enum HomeActivityTab: String, CaseIterable, Identifiable {
+    case dictations
+    case meetings
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .dictations: return "Dictations"
+        case .meetings: return "Meetings"
+        }
+    }
+}
+
+// MARK: - Stats summary
+
+struct HomeStatItem: Identifiable {
+    let id = UUID()
+    let value: String
+    let label: String
+}
+
+// MARK: - Welcome header
+
+struct HomeWelcomeHeader: View {
+    let name: String
+    let summary: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Welcome back, \(name)")
+                .font(.system(size: 28, weight: .semibold))
+            Text(summary)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+// MARK: - Hero card
+
+struct HomeHeroCard: View {
+    let title: String
+    let subtitle: String
+    let primaryTitle: String
+    let primaryAction: () -> Void
+    let secondaryTitle: String
+    let secondaryAction: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title)
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(Color.primary)
+                Text(subtitle)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: 14) {
+                Button(action: primaryAction) {
+                    Label(primaryTitle, systemImage: "mic.fill")
+                        .font(.system(size: 13, weight: .semibold))
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+
+                Button(action: secondaryAction) {
+                    Text(secondaryTitle)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(22)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            Color.accentColor.opacity(0.18),
+                            Color.accentColor.opacity(0.05)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.accentColor.opacity(0.22), lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Stats rail
+
+struct HomeStatsRail: View {
+    let header: String
+    let stats: [HomeStatItem]
+    let streak: Int?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text(header)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+                .tracking(0.6)
+
+            VStack(alignment: .leading, spacing: 14) {
+                ForEach(stats) { stat in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(stat.value)
+                            .font(.system(size: 22, weight: .semibold))
+                            .foregroundStyle(Color.primary)
+                        Text(stat.label)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            if let streak, streak > 0 {
+                Divider()
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "flame.fill")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(.orange)
+                        Text("\(streak) day streak")
+                            .font(.subheadline.weight(.semibold))
+                    }
+                    Text(streak == 1 ? "Keep it going tomorrow." : "Nice run.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.78))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Inline stats strip (narrow layout fallback)
+
+struct HomeStatsStrip: View {
+    let stats: [HomeStatItem]
+    let streak: Int?
+
+    var body: some View {
+        HStack(spacing: 22) {
+            ForEach(stats) { stat in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(stat.value)
+                        .font(.system(size: 18, weight: .semibold))
+                    Text(stat.label)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if let streak, streak > 0 {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "flame.fill")
+                            .foregroundStyle(.orange)
+                        Text("\(streak)")
+                            .font(.system(size: 18, weight: .semibold))
+                    }
+                    Text("day streak")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.6))
+        )
+    }
+}
+
+// MARK: - Row action buttons
+
+struct HomeRowMenuItem: Identifiable {
+    let id = UUID()
+    let title: String
+    let symbolName: String
+    let isDestructive: Bool
+    let action: () -> Void
+
+    init(title: String, symbolName: String, isDestructive: Bool = false, action: @escaping () -> Void) {
+        self.title = title
+        self.symbolName = symbolName
+        self.isDestructive = isDestructive
+        self.action = action
+    }
+}
+
+struct HomeRowActionButtons: View {
+    let isCopied: Bool
+    let onCopy: () -> Void
+    let onFlag: () -> Void
+    let menuItems: [HomeRowMenuItem]
+
+    var body: some View {
+        HStack(spacing: 4) {
+            iconButton(
+                systemName: isCopied ? "checkmark" : "square.on.square",
+                help: isCopied ? "Copied" : "Copy",
+                action: onCopy
+            )
+
+            iconButton(
+                systemName: "flag",
+                help: "Send feedback",
+                action: onFlag
+            )
+
+            if !menuItems.isEmpty {
+                Menu {
+                    ForEach(menuItems) { item in
+                        if item.isDestructive {
+                            Button(role: .destructive, action: item.action) {
+                                Label(item.title, systemImage: item.symbolName)
+                            }
+                        } else {
+                            Button(action: item.action) {
+                                Label(item.title, systemImage: item.symbolName)
+                            }
+                        }
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 26, height: 26)
+                        .contentShape(Rectangle())
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .help("More options")
+            }
+        }
+    }
+
+    private func iconButton(systemName: String, help: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 26, height: 26)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(help)
+    }
+}
+
+// MARK: - Activity rows
+
+struct HomeDictationRow: View {
+    let entry: SavedDictationEntry
+    let isCopied: Bool
+    let onOpen: () -> Void
+    let onCopy: () -> Void
+    let onFlag: () -> Void
+    let menuItems: [HomeRowMenuItem]
+
+    @State private var isHovering = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Button(action: onOpen) {
+                HStack(alignment: .top, spacing: 14) {
+                    Text(timeString)
+                        .font(.system(size: 12, weight: .medium, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 64, alignment: .leading)
+                        .padding(.top, 2)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(preview)
+                            .font(.system(size: 13))
+                            .foregroundStyle(Color.primary)
+                            .lineLimit(3)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        if !entry.sourceAppName.isEmpty, entry.sourceAppName != "Unknown" {
+                            Text(entry.sourceAppName)
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            HomeRowActionButtons(
+                isCopied: isCopied,
+                onCopy: onCopy,
+                onFlag: onFlag,
+                menuItems: menuItems
+            )
+            .opacity(isHovering ? 1 : 0.55)
+            .animation(.easeOut(duration: 0.12), value: isHovering)
+        }
+        .padding(.vertical, 10)
+        .onHover { isHovering = $0 }
+    }
+
+    private var timeString: String {
+        Self.timeFormatter.string(from: entry.createdAt)
+    }
+
+    private var preview: String {
+        let trimmed = entry.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return entry.title }
+        return trimmed
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = .current
+        f.dateFormat = "h:mm a"
+        return f
+    }()
+}
+
+struct HomeMeetingRow: View {
+    let item: RecentMeetingItem
+    let isCopied: Bool
+    let onOpen: () -> Void
+    let onCopy: () -> Void
+    let onFlag: () -> Void
+    let menuItems: [HomeRowMenuItem]
+
+    @State private var isHovering = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Button(action: onOpen) {
+                HStack(alignment: .top, spacing: 14) {
+                    Text(timeString)
+                        .font(.system(size: 12, weight: .medium, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 64, alignment: .leading)
+                        .padding(.top, 2)
+
+                    HStack(alignment: .top, spacing: 10) {
+                        Image(systemName: "person.2.wave.2.fill")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                            .padding(.top, 2)
+
+                        Text(item.title)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(Color.primary)
+                            .lineLimit(2)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            HomeRowActionButtons(
+                isCopied: isCopied,
+                onCopy: onCopy,
+                onFlag: onFlag,
+                menuItems: menuItems
+            )
+            .opacity(isHovering ? 1 : 0.55)
+            .animation(.easeOut(duration: 0.12), value: isHovering)
+        }
+        .padding(.vertical, 10)
+        .onHover { isHovering = $0 }
+    }
+
+    private var timeString: String {
+        Self.timeFormatter.string(from: item.date)
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = .current
+        f.dateFormat = "h:mm a"
+        return f
+    }()
+}
+
+// MARK: - Day-grouped list
+
+struct HomeDayGroupedList<Item, Row: View>: View {
+    let sections: [HomeDaySection<Item>]
+    let emptyMessage: String
+    let getID: (Item) -> AnyHashable
+    @ViewBuilder let row: (Item) -> Row
+
+    var body: some View {
+        if sections.isEmpty {
+            HStack {
+                Text(emptyMessage)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                Spacer()
+            }
+            .padding(.vertical, 28)
+            .padding(.horizontal, 4)
+        } else {
+            VStack(alignment: .leading, spacing: 18) {
+                ForEach(sections) { section in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(section.label)
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .textCase(.uppercase)
+                            .tracking(0.6)
+                            .padding(.bottom, 2)
+
+                        VStack(alignment: .leading, spacing: 0) {
+                            ForEach(Array(section.items.enumerated()), id: \.offset) { index, item in
+                                row(item)
+                                    .id(getID(item))
+                                if index < section.items.count - 1 {
+                                    Divider()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Activity tabs container
+
+struct HomeActivityTabsCard: View {
+    @Binding var selectedTab: HomeActivityTab
+    let dictationSections: [HomeDaySection<SavedDictationEntry>]
+    let meetingSections: [HomeDaySection<RecentMeetingItem>]
+    let copiedRowID: String?
+    let onOpenDictation: (SavedDictationEntry) -> Void
+    let onCopyDictation: (SavedDictationEntry) -> Void
+    let onFlagDictation: (SavedDictationEntry) -> Void
+    let dictationMenuItems: (SavedDictationEntry) -> [HomeRowMenuItem]
+    let onOpenMeeting: (RecentMeetingItem) -> Void
+    let onCopyMeeting: (RecentMeetingItem) -> Void
+    let onFlagMeeting: (RecentMeetingItem) -> Void
+    let meetingMenuItems: (RecentMeetingItem) -> [HomeRowMenuItem]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Picker("", selection: $selectedTab) {
+                ForEach(HomeActivityTab.allCases) { tab in
+                    Text(tab.label).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(maxWidth: 320, alignment: .leading)
+
+            switch selectedTab {
+            case .dictations:
+                HomeDayGroupedList(
+                    sections: dictationSections,
+                    emptyMessage: "No dictations saved yet.",
+                    getID: { AnyHashable($0.id) },
+                    row: { entry in
+                        HomeDictationRow(
+                            entry: entry,
+                            isCopied: copiedRowID == entry.id,
+                            onOpen: { onOpenDictation(entry) },
+                            onCopy: { onCopyDictation(entry) },
+                            onFlag: { onFlagDictation(entry) },
+                            menuItems: dictationMenuItems(entry)
+                        )
+                    }
+                )
+            case .meetings:
+                HomeDayGroupedList(
+                    sections: meetingSections,
+                    emptyMessage: "No meetings captured yet.",
+                    getID: { AnyHashable($0.id) },
+                    row: { item in
+                        HomeMeetingRow(
+                            item: item,
+                            isCopied: copiedRowID == item.id,
+                            onOpen: { onOpenMeeting(item) },
+                            onCopy: { onCopyMeeting(item) },
+                            onFlag: { onFlagMeeting(item) },
+                            menuItems: meetingMenuItems(item)
+                        )
+                    }
+                )
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.78))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
+    }
+}
+
+// MARK: - Needs-attention card
+
+struct HomeNeedsAttentionCard: View {
+    struct Issue: Identifiable {
+        let id = UUID()
+        let title: String
+        let detail: String
+    }
+
+    let issues: [Issue]
+    let onOpenPrivacy: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.system(size: 14, weight: .semibold))
+                Text("Needs attention")
+                    .font(.headline)
+                Spacer()
+                Button("Review", action: onOpenPrivacy)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(issues) { issue in
+                    HStack(alignment: .top, spacing: 8) {
+                        Circle()
+                            .fill(Color.orange)
+                            .frame(width: 5, height: 5)
+                            .padding(.top, 7)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(issue.title)
+                                .font(.subheadline.weight(.semibold))
+                            Text(issue.detail)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.orange.opacity(0.07))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.orange.opacity(0.32), lineWidth: 1)
+        )
+    }
+}

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -297,60 +297,61 @@ struct TranscriptedSettingsView: View {
                         )
                     }
 
-                    HomeActivityTabsCard(
-                        selectedTab: $homeActivityTab,
-                        dictationSections: homeViewModel.dictationDaySections,
-                        meetingSections: homeViewModel.meetingDaySections,
-                        isLoading: homeViewModel.isLoading,
-                        isLoadingMore: homeViewModel.isLoadingMore,
-                        canLoadMoreDictations: homeViewModel.canLoadMoreDictations,
-                        canLoadMoreMeetings: homeViewModel.canLoadMoreMeetings,
-                        copiedRowID: homeCopiedRowID,
-                        onOpenDictation: { entry in
-                            trackSettingsAction("open_recent_dictation", page: .home)
-                            NSWorkspace.shared.open(entry.url)
-                        },
-                        onCopyDictation: { entry in
-                            handleCopyDictation(entry)
-                        },
-                        onFlagDictation: { _ in
-                            trackSettingsAction("flag_dictation", page: .home)
-                            actions.sendFeedback()
-                        },
-                        dictationMenuItems: { entry in
-                            dictationRowMenuItems(for: entry)
-                        },
-                        onOpenMeeting: { item in
-                            trackSettingsAction("open_recent_meeting", page: .home)
-                            NSWorkspace.shared.open(item.transcriptURL)
-                        },
-                        onCopyMeeting: { item in
-                            handleCopyMeeting(item)
-                        },
-                        onFlagMeeting: { _ in
-                            trackSettingsAction("flag_meeting", page: .home)
-                            actions.sendFeedback()
-                        },
-                        meetingMenuItems: { item in
-                            meetingRowMenuItems(for: item)
-                        },
-                        onLoadMoreDictations: {
-                            trackSettingsAction("load_more_dictations", page: .home)
-                            homeViewModel.loadMoreDictations()
-                        },
-                        onLoadMoreMeetings: {
-                            trackSettingsAction("load_more_meetings", page: .home)
-                            homeViewModel.loadMoreMeetings()
-                        }
-                    )
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 if useWideLayout {
-                    HomeStatsRail(header: "Total", stats: stats, streak: homeStreak)
+                    HomeStatsRail(header: "Overall", stats: stats, streak: homeStreak)
                         .frame(width: 200, alignment: .topLeading)
                 }
             }
+
+            HomeActivityTabsCard(
+                selectedTab: $homeActivityTab,
+                dictationSections: homeViewModel.dictationDaySections,
+                meetingSections: homeViewModel.meetingDaySections,
+                isLoading: homeViewModel.isLoading,
+                isLoadingMore: homeViewModel.isLoadingMore,
+                canLoadMoreDictations: homeViewModel.canLoadMoreDictations,
+                canLoadMoreMeetings: homeViewModel.canLoadMoreMeetings,
+                copiedRowID: homeCopiedRowID,
+                onOpenDictation: { entry in
+                    trackSettingsAction("open_recent_dictation", page: .home)
+                    NSWorkspace.shared.open(entry.url)
+                },
+                onCopyDictation: { entry in
+                    handleCopyDictation(entry)
+                },
+                onFlagDictation: { _ in
+                    trackSettingsAction("flag_dictation", page: .home)
+                    actions.sendFeedback()
+                },
+                dictationMenuItems: { entry in
+                    dictationRowMenuItems(for: entry)
+                },
+                onOpenMeeting: { item in
+                    trackSettingsAction("open_recent_meeting", page: .home)
+                    NSWorkspace.shared.open(item.transcriptURL)
+                },
+                onCopyMeeting: { item in
+                    handleCopyMeeting(item)
+                },
+                onFlagMeeting: { _ in
+                    trackSettingsAction("flag_meeting", page: .home)
+                    actions.sendFeedback()
+                },
+                meetingMenuItems: { item in
+                    meetingRowMenuItems(for: item)
+                },
+                onLoadMoreDictations: {
+                    trackSettingsAction("load_more_dictations", page: .home)
+                    homeViewModel.loadMoreDictations()
+                },
+                onLoadMoreMeetings: {
+                    trackSettingsAction("load_more_meetings", page: .home)
+                    homeViewModel.loadMoreMeetings()
+                }
+            )
         }
         .animation(.snappy(duration: 0.22), value: homeTranscriptionActivity)
         .onChange(of: homeActivityTab) { _, newValue in
@@ -478,41 +479,42 @@ struct TranscriptedSettingsView: View {
 
     private var homeWelcomeSummary: String {
         let dictations = homeViewModel.todayDictationCount
-        let meetings = homeViewModel.todayMeetingCount
-        if dictations == 0 && meetings == 0 {
-            return "Ready to capture. Recent activity stays light so this screen opens fast."
-        }
-
-        var parts: [String] = []
-        if dictations > 0 {
-            parts.append("\(dictations) dictation\(dictations == 1 ? "" : "s")")
-        }
-        if meetings > 0 {
-            parts.append("\(meetings) meeting\(meetings == 1 ? "" : "s")")
-        }
-        return "\(parts.joined(separator: " and ")) today."
+        let meetings = statsService.todayRecordings
+        let dictationLabel = dictations == 1 ? "dictation" : "dictations"
+        let meetingLabel = meetings == 1 ? "meeting" : "meetings"
+        return "\(formattedInteger(dictations)) \(dictationLabel) today, \(formattedInteger(meetings)) \(meetingLabel) today."
     }
 
     private var homeStatItems: [HomeStatItem] {
         [
             HomeStatItem(
-                value: "\(homeViewModel.recentDictationCount)",
-                label: "recent dictations"
+                value: formattedInteger(homeViewModel.totalDictationCount),
+                label: homeViewModel.totalDictationCount == 1 ? "dictation" : "dictations"
             ),
             HomeStatItem(
-                value: "\(homeViewModel.recentMeetingCount)",
-                label: "recent meetings"
+                value: formattedInteger(homeViewModel.totalDictationWordCount),
+                label: "words dictated"
             ),
             HomeStatItem(
-                value: "\(statsService.totalRecordings)",
+                value: formattedInteger(statsService.totalRecordings),
                 label: statsService.totalRecordings == 1 ? "meeting" : "meetings"
             ),
             HomeStatItem(
                 value: statsService.formattedTotalHours,
-                label: "transcribed"
+                label: "meeting hours"
             )
         ]
     }
+
+    private func formattedInteger(_ value: Int) -> String {
+        Self.homeIntegerFormatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+
+    private static let homeIntegerFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        return formatter
+    }()
 
     private var homeStreak: Int? {
         let streak = statsService.currentStreak

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -488,18 +488,22 @@ struct TranscriptedSettingsView: View {
     private var homeStatItems: [HomeStatItem] {
         [
             HomeStatItem(
+                symbolName: "text.bubble.fill",
                 value: formattedInteger(homeViewModel.totalDictationCount),
                 label: homeViewModel.totalDictationCount == 1 ? "dictation" : "dictations"
             ),
             HomeStatItem(
+                symbolName: "textformat",
                 value: formattedInteger(homeViewModel.totalDictationWordCount),
                 label: "words dictated"
             ),
             HomeStatItem(
+                symbolName: "person.2.wave.2.fill",
                 value: formattedInteger(statsService.totalRecordings),
                 label: statsService.totalRecordings == 1 ? "meeting" : "meetings"
             ),
             HomeStatItem(
+                symbolName: "clock.fill",
                 value: statsService.formattedTotalHours,
                 label: "meeting hours"
             )

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -58,6 +58,7 @@ struct TranscriptedSettingsView: View {
     @State private var homeActivityTab: HomeActivityTab = .dictations
     @State private var homeCopiedRowID: String?
     @State private var homeDeleteConfirmation: HomeDeleteConfirmation?
+    @State private var homeDeleteFailure: HomeDeleteFailure?
 
     init(
         appState: TranscriptedAppState,
@@ -367,6 +368,13 @@ struct TranscriptedSettingsView: View {
                 secondaryButton: .cancel()
             )
         }
+        .alert(item: $homeDeleteFailure) { failure in
+            Alert(
+                title: Text(failure.title),
+                message: Text(failure.message),
+                dismissButton: .default(Text("OK"))
+            )
+        }
     }
 
     private func handleCopyDictation(_ entry: SavedDictationEntry) {
@@ -421,9 +429,12 @@ struct TranscriptedSettingsView: View {
                     trackSettingsAction("delete_dictation_confirm", page: .home)
                     do {
                         try DictationTranscriptStore.deleteEntry(entry)
-                        homeViewModel.refresh()
+                        refreshRecentCaptures()
                     } catch {
-                        NSSound.beep()
+                        presentHomeDeleteFailure(
+                            title: "Could not delete dictation",
+                            error: error
+                        )
                     }
                 }
             }
@@ -464,13 +475,31 @@ struct TranscriptedSettingsView: View {
     }
 
     private func deleteMeeting(_ item: RecentMeetingItem) {
-        let fm = FileManager.default
-        try? fm.removeItem(at: item.transcriptURL)
-        if let audio = item.audio {
-            try? fm.removeItem(at: audio.directoryURL)
+        do {
+            try removeItemIfPresent(at: item.transcriptURL)
+            if let audio = item.audio {
+                try removeItemIfPresent(at: audio.directoryURL)
+            }
+            refreshRecentCaptures()
+        } catch {
+            presentHomeDeleteFailure(
+                title: "Could not delete meeting",
+                error: error
+            )
         }
-        homeViewModel.refresh()
-        refreshRecentCaptures()
+    }
+
+    private func removeItemIfPresent(at url: URL) throws {
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        try FileManager.default.removeItem(at: url)
+    }
+
+    private func presentHomeDeleteFailure(title: String, error: Error) {
+        NSSound.beep()
+        homeDeleteFailure = HomeDeleteFailure(
+            title: title,
+            message: error.localizedDescription
+        )
     }
 
     private var homeShouldUseWideLayout: Bool {
@@ -1453,9 +1482,12 @@ struct TranscriptedSettingsView: View {
             recentDictations = snapshot.dictations
             recentCapturesLoading = false
         }
-        homeViewModel.refresh()
-        Task { @MainActor in
-            await StatsService.shared.refreshStats()
+
+        if navigation.selectedPage == .home {
+            homeViewModel.refresh()
+            Task { @MainActor in
+                await StatsService.shared.refreshStats()
+            }
         }
     }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -241,9 +241,9 @@ struct TranscriptedSettingsView: View {
         let needsAttention = homeNeedsAttentionIssues
         let useWideLayout = homeShouldUseWideLayout
 
-        return VStack(alignment: .leading, spacing: 24) {
-            HStack(alignment: .top, spacing: 24) {
-                VStack(alignment: .leading, spacing: 22) {
+        return VStack(alignment: .leading, spacing: 20) {
+            HStack(alignment: .top, spacing: 20) {
+                VStack(alignment: .leading, spacing: 18) {
                     HomeWelcomeHeader(
                         name: homeViewModel.welcomeName,
                         summary: homeWelcomeSummary

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -23,6 +23,7 @@ struct TranscriptedSettingsView: View {
     @ObservedObject private var sttRouter: STTRouter
     @ObservedObject private var meetingSession: MeetingSessionController
     @ObservedObject private var sparkleUpdater: SparkleUpdaterController
+    @ObservedObject private var statsService: StatsService = .shared
 
     private let actions: TranscriptedSettingsActions
     private let sidebarSections = SettingsSidebarSection.defaultSections
@@ -53,6 +54,10 @@ struct TranscriptedSettingsView: View {
     @State private var showSupportFolders = false
     @State private var copiedAgentMeetingID: String?
     @State private var meetingVoiceProcessingEnabled = MicrophoneProcessingPreferences.isVoiceProcessingEnabled()
+    @StateObject private var homeViewModel = HomeViewModel()
+    @State private var homeActivityTab: HomeActivityTab = .dictations
+    @State private var homeCopiedRowID: String?
+    @State private var homeDeleteConfirmation: HomeDeleteConfirmation?
 
     init(
         appState: TranscriptedAppState,
@@ -148,6 +153,7 @@ struct TranscriptedSettingsView: View {
         .onDisappear {
             recentCaptureRefreshTask?.cancel()
             recentCaptureRefreshTask = nil
+            homeViewModel.cancel()
         }
     }
 
@@ -231,183 +237,320 @@ struct TranscriptedSettingsView: View {
     }
 
     private var homePage: some View {
-        VStack(alignment: .leading, spacing: 24) {
-            SettingsPageIntro(
-                title: "Home",
-                summary: "Start capture and fix anything marked orange."
-            )
+        let stats = homeStatItems
+        let needsAttention = homeNeedsAttentionIssues
+        let useWideLayout = homeShouldUseWideLayout
 
-            let columns = [
-                GridItem(.flexible(minimum: 260), spacing: 14),
-                GridItem(.flexible(minimum: 260), spacing: 14)
-            ]
+        return VStack(alignment: .leading, spacing: 24) {
+            HStack(alignment: .top, spacing: 24) {
+                VStack(alignment: .leading, spacing: 22) {
+                    HomeWelcomeHeader(
+                        name: homeViewModel.welcomeName,
+                        summary: homeWelcomeSummary
+                    )
 
-            LazyVGrid(columns: columns, alignment: .leading, spacing: 14) {
-                SettingsActionTile(
-                    symbolName: "mic.fill",
-                    title: "Start Dictation",
-                    detail: "Speak into the app you were using.",
-                    tone: .accent,
-                    menuBarVisibility: menuBarVisibilityBinding(for: .startDictation),
-                    actionHelp: "Start dictation now.",
-                    menuBarVisibilityHelp: "Show or hide Start Dictation in the menu bar popover.",
-                    action: {
-                        trackSettingsAction("start_dictation", page: .home)
-                        actions.startDictation()
+                    if !useWideLayout {
+                        HomeStatsStrip(stats: stats, streak: homeStreak)
                     }
-                )
 
-                SettingsActionTile(
-                    symbolName: "record.circle.fill",
-                    title: "Start Meeting",
-                    detail: "Record your mic and computer audio.",
-                    tone: .accent,
-                    menuBarVisibility: menuBarVisibilityBinding(for: .startMeeting),
-                    actionHelp: "Start a meeting recording now.",
-                    menuBarVisibilityHelp: "Show or hide Start Meeting in the menu bar popover.",
-                    action: {
-                        trackSettingsAction("start_meeting", page: .home)
-                        actions.startMeeting()
-                    }
-                )
-
-                SettingsActionTile(
-                    symbolName: "arrow.turn.down.right",
-                    title: "Paste Last Dictation",
-                    detail: "Paste the newest saved dictation.",
-                    menuBarVisibility: menuBarVisibilityBinding(for: .pasteLastDictation),
-                    actionHelp: "Paste the newest saved dictation into the current app.",
-                    menuBarVisibilityHelp: "Show or hide Paste Last Dictation in the menu bar popover.",
-                    action: {
-                        trackSettingsAction("paste_last_dictation", page: .home)
-                        actions.pasteLastDictation()
-                    }
-                )
-
-                SettingsActionTile(
-                    symbolName: "clock.arrow.circlepath",
-                    title: "Recent Meetings",
-                    detail: "Open saved meeting notes.",
-                    menuBarVisibility: menuBarVisibilityBinding(for: .recentMeetings),
-                    actionHelp: "Open the Meetings page to browse saved meeting notes.",
-                    menuBarVisibilityHelp: "Show or hide Recent Meetings in the menu bar popover.",
-                    action: {
-                        trackSettingsAction("open_recent_meetings", page: .home)
-                        navigation.selectedPage = .meetings
-                    }
-                )
-            }
-
-            if let activity = homeTranscriptionActivity {
-                SettingsActivityCard(
-                    symbolName: activity.symbolName,
-                    title: activity.title,
-                    status: activity.status,
-                    detail: activity.detail,
-                    tone: activity.tone,
-                    progress: activity.progress,
-                    actionTitle: activity.transcriptURL == nil ? nil : "Open Transcript",
-                    action: activity.transcriptURL.map { transcriptURL in
-                        {
-                            trackSettingsAction("open_current_activity", page: .home)
-                            NSWorkspace.shared.open(transcriptURL)
+                    HomeHeroCard(
+                        title: "Capture what you say, anywhere you write",
+                        subtitle: "Press your dictation shortcut and speak. Transcripted pastes the text into the app you were using.",
+                        primaryTitle: "Start Dictation",
+                        primaryAction: {
+                            trackSettingsAction("start_dictation", page: .home)
+                            actions.startDictation()
+                        },
+                        secondaryTitle: "Record a meeting",
+                        secondaryAction: {
+                            trackSettingsAction("start_meeting", page: .home)
+                            actions.startMeeting()
                         }
+                    )
+
+                    if let activity = homeTranscriptionActivity {
+                        SettingsActivityCard(
+                            symbolName: activity.symbolName,
+                            title: activity.title,
+                            status: activity.status,
+                            detail: activity.detail,
+                            tone: activity.tone,
+                            progress: activity.progress,
+                            actionTitle: activity.transcriptURL == nil ? nil : "Open Transcript",
+                            action: activity.transcriptURL.map { transcriptURL in
+                                {
+                                    trackSettingsAction("open_current_activity", page: .home)
+                                    NSWorkspace.shared.open(transcriptURL)
+                                }
+                            }
+                        )
+                        .transition(.move(edge: .top).combined(with: .opacity))
                     }
-                )
-                .transition(.move(edge: .top).combined(with: .opacity))
-            }
 
-            SettingsSection(
-                title: "Ready Check",
-                detail: "Green is ready. Orange needs attention."
-            ) {
-                let modelCard = FirstRunExperience.modelCard(
-                    for: FirstRunLocalModelState(sttRouter.modelDownloadState),
-                    model: effectiveTranscriptionModel
-                )
+                    if !needsAttention.isEmpty {
+                        HomeNeedsAttentionCard(
+                            issues: needsAttention,
+                            onOpenPrivacy: {
+                                trackSettingsAction("open_needs_attention", page: .home)
+                                navigation.selectedPage = .privacy
+                            }
+                        )
+                    }
 
-                SettingsStatusCard(
-                    title: "Voice model",
-                    status: modelCard.status,
-                    detail: homeModelDetail(from: modelCard),
-                    tone: preferredTranscriptionModel == effectiveTranscriptionModel ? tone(for: modelCard.tone) : .caution
-                )
-
-                SettingsStatusCard(
-                    title: "Meeting tools",
-                    status: meetingSession.warmupStatus.subtitle,
-                    detail: meetingSession.warmupStatus.detail.isEmpty
-                        ? "Ready for live meetings and audio imports."
-                        : meetingSession.warmupStatus.detail,
-                    tone: meetingSession.warmupStatus == .ready ? .ready : .working
-                )
-
-                SettingsStatusCard(
-                    title: "Permissions",
-                    status: permissionsStatusLine,
-                    detail: permissionsDetailLine,
-                    tone: missingRequiredPermissions.isEmpty ? .ready : .caution
-                )
-
-                SettingsStatusCard(
-                    title: "Capture library",
-                    status: isUsingDefaultCaptureLibrary ? "Default location" : "Custom location",
-                    detail: (captureLibraryURL.path as NSString).abbreviatingWithTildeInPath,
-                    tone: .ready
-                )
-            }
-
-            SettingsSection(
-                title: "Useful Pages",
-                detail: "The settings people usually need first."
-            ) {
-                SettingsQuickLinkRow(
-                    symbolName: "keyboard",
-                    title: "Shortcuts",
-                    detail: "Change the keys Transcripted listens for."
-                ) {
-                    trackSettingsAction("quick_link_shortcuts", page: .home)
-                    navigation.selectedPage = .shortcuts
+                    HomeActivityTabsCard(
+                        selectedTab: $homeActivityTab,
+                        dictationSections: homeViewModel.dictationDaySections,
+                        meetingSections: homeViewModel.meetingDaySections,
+                        copiedRowID: homeCopiedRowID,
+                        onOpenDictation: { entry in
+                            trackSettingsAction("open_recent_dictation", page: .home)
+                            NSWorkspace.shared.open(entry.url)
+                        },
+                        onCopyDictation: { entry in
+                            handleCopyDictation(entry)
+                        },
+                        onFlagDictation: { _ in
+                            trackSettingsAction("flag_dictation", page: .home)
+                            actions.sendFeedback()
+                        },
+                        dictationMenuItems: { entry in
+                            dictationRowMenuItems(for: entry)
+                        },
+                        onOpenMeeting: { item in
+                            trackSettingsAction("open_recent_meeting", page: .home)
+                            NSWorkspace.shared.open(item.transcriptURL)
+                        },
+                        onCopyMeeting: { item in
+                            handleCopyMeeting(item)
+                        },
+                        onFlagMeeting: { _ in
+                            trackSettingsAction("flag_meeting", page: .home)
+                            actions.sendFeedback()
+                        },
+                        meetingMenuItems: { item in
+                            meetingRowMenuItems(for: item)
+                        }
+                    )
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-                SettingsQuickLinkRow(
-                    symbolName: "person.2.wave.2.fill",
-                    title: "Meetings",
-                    detail: "Record calls and import audio."
-                ) {
-                    trackSettingsAction("quick_link_meetings", page: .home)
-                    navigation.selectedPage = .meetings
-                }
-
-                SettingsQuickLinkRow(
-                    symbolName: "person.2.fill",
-                    title: "People",
-                    detail: "Review saved speakers and duplicates."
-                ) {
-                    trackSettingsAction("quick_link_people", page: .home)
-                    navigation.selectedPage = .people
-                }
-
-                SettingsQuickLinkRow(
-                    symbolName: "externaldrive.fill",
-                    title: "Storage",
-                    detail: "See where Markdown files live."
-                ) {
-                    trackSettingsAction("quick_link_storage", page: .home)
-                    navigation.selectedPage = .storage
-                }
-
-                SettingsQuickLinkRow(
-                    symbolName: "lock.shield.fill",
-                    title: "Privacy",
-                    detail: "Review permissions and reporting."
-                ) {
-                    trackSettingsAction("quick_link_privacy", page: .home)
-                    navigation.selectedPage = .privacy
+                if useWideLayout {
+                    HomeStatsRail(header: "Total", stats: stats, streak: homeStreak)
+                        .frame(width: 200, alignment: .topLeading)
                 }
             }
         }
         .animation(.snappy(duration: 0.22), value: homeTranscriptionActivity)
+        .onChange(of: homeActivityTab) { _, newValue in
+            trackSettingsAction("home_tab_\(newValue.rawValue)", page: .home)
+        }
+        .alert(item: $homeDeleteConfirmation) { confirmation in
+            Alert(
+                title: Text(confirmation.title),
+                message: Text(confirmation.message),
+                primaryButton: .destructive(Text("Delete")) {
+                    confirmation.perform()
+                },
+                secondaryButton: .cancel()
+            )
+        }
+    }
+
+    private func handleCopyDictation(_ entry: SavedDictationEntry) {
+        trackSettingsAction("copy_dictation", page: .home)
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(entry.text, forType: .string)
+        flashCopied(rowID: entry.id)
+    }
+
+    private func handleCopyMeeting(_ item: RecentMeetingItem) {
+        trackSettingsAction("copy_meeting", page: .home)
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        if let bundle = AgentConnectionGuide.portableMeetingBundle(
+            title: item.title,
+            date: item.date,
+            transcriptURL: item.transcriptURL
+        ) {
+            pasteboard.setString(bundle, forType: .string)
+        } else if let raw = try? String(contentsOf: item.transcriptURL, encoding: .utf8) {
+            pasteboard.setString(raw, forType: .string)
+        } else {
+            NSSound.beep()
+            return
+        }
+        flashCopied(rowID: item.id)
+    }
+
+    private func flashCopied(rowID: String) {
+        homeCopiedRowID = rowID
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_200_000_000)
+            if homeCopiedRowID == rowID {
+                homeCopiedRowID = nil
+            }
+        }
+    }
+
+    private func dictationRowMenuItems(for entry: SavedDictationEntry) -> [HomeRowMenuItem] {
+        [
+            HomeRowMenuItem(title: "Reveal in Finder", symbolName: "folder") {
+                trackSettingsAction("reveal_dictation_in_finder", page: .home)
+                NSWorkspace.shared.activateFileViewerSelecting([entry.url])
+            },
+            HomeRowMenuItem(title: "Delete dictation", symbolName: "trash", isDestructive: true) {
+                trackSettingsAction("delete_dictation_request", page: .home)
+                homeDeleteConfirmation = HomeDeleteConfirmation(
+                    title: "Delete this dictation?",
+                    message: "This removes the entry from \(entry.url.lastPathComponent). This cannot be undone."
+                ) {
+                    trackSettingsAction("delete_dictation_confirm", page: .home)
+                    do {
+                        try DictationTranscriptStore.deleteEntry(entry)
+                        homeViewModel.refresh()
+                    } catch {
+                        NSSound.beep()
+                    }
+                }
+            }
+        ]
+    }
+
+    private func meetingRowMenuItems(for item: RecentMeetingItem) -> [HomeRowMenuItem] {
+        var items: [HomeRowMenuItem] = [
+            HomeRowMenuItem(title: "Reveal in Finder", symbolName: "folder") {
+                trackSettingsAction("reveal_meeting_in_finder", page: .home)
+                NSWorkspace.shared.activateFileViewerSelecting([item.transcriptURL])
+            }
+        ]
+
+        if let audio = item.audio, let firstAudio = audio.urls.first {
+            items.append(
+                HomeRowMenuItem(title: "Show audio in Finder", symbolName: "waveform") {
+                    trackSettingsAction("reveal_meeting_audio_in_finder", page: .home)
+                    NSWorkspace.shared.activateFileViewerSelecting([firstAudio])
+                }
+            )
+        }
+
+        items.append(
+            HomeRowMenuItem(title: "Delete meeting", symbolName: "trash", isDestructive: true) {
+                trackSettingsAction("delete_meeting_request", page: .home)
+                homeDeleteConfirmation = HomeDeleteConfirmation(
+                    title: "Delete this meeting?",
+                    message: "This removes the transcript and any retained audio. This cannot be undone."
+                ) {
+                    trackSettingsAction("delete_meeting_confirm", page: .home)
+                    deleteMeeting(item)
+                }
+            }
+        )
+
+        return items
+    }
+
+    private func deleteMeeting(_ item: RecentMeetingItem) {
+        let fm = FileManager.default
+        try? fm.removeItem(at: item.transcriptURL)
+        if let audio = item.audio {
+            try? fm.removeItem(at: audio.directoryURL)
+        }
+        homeViewModel.refresh()
+        refreshRecentCaptures()
+    }
+
+    private var homeShouldUseWideLayout: Bool {
+        true
+    }
+
+    private var homeWelcomeSummary: String {
+        let dictations = homeViewModel.todayDictationCount
+        let meetings = homeViewModel.todayMeetingCount
+        if dictations == 0 && meetings == 0 {
+            return "Nothing captured yet today. Start a dictation or record a meeting to fill the timeline."
+        }
+
+        var parts: [String] = []
+        if dictations > 0 {
+            parts.append("\(dictations) dictation\(dictations == 1 ? "" : "s")")
+        }
+        if meetings > 0 {
+            parts.append("\(meetings) meeting\(meetings == 1 ? "" : "s")")
+        }
+        return "\(parts.joined(separator: " and ")) today."
+    }
+
+    private var homeStatItems: [HomeStatItem] {
+        [
+            HomeStatItem(
+                value: homeFormattedWords(homeViewModel.totalDictationWordCount),
+                label: "total words"
+            ),
+            HomeStatItem(
+                value: "\(homeViewModel.totalDictationCount)",
+                label: homeViewModel.totalDictationCount == 1 ? "dictation" : "dictations"
+            ),
+            HomeStatItem(
+                value: "\(statsService.totalRecordings)",
+                label: statsService.totalRecordings == 1 ? "meeting" : "meetings"
+            ),
+            HomeStatItem(
+                value: statsService.formattedTotalHours,
+                label: "transcribed"
+            )
+        ]
+    }
+
+    private var homeStreak: Int? {
+        let streak = statsService.currentStreak
+        return streak > 0 ? streak : nil
+    }
+
+    private func homeFormattedWords(_ count: Int) -> String {
+        if count >= 1000 {
+            let thousands = Double(count) / 1000.0
+            if thousands >= 10 {
+                return "\(Int(thousands.rounded()))K"
+            }
+            return String(format: "%.1fK", thousands)
+        }
+        return "\(count)"
+    }
+
+    private var homeNeedsAttentionIssues: [HomeNeedsAttentionCard.Issue] {
+        var issues: [HomeNeedsAttentionCard.Issue] = []
+
+        if !missingRequiredPermissions.isEmpty {
+            issues.append(
+                HomeNeedsAttentionCard.Issue(
+                    title: "Permissions",
+                    detail: permissionsDetailLine
+                )
+            )
+        }
+
+        let modelCard = FirstRunExperience.modelCard(
+            for: FirstRunLocalModelState(sttRouter.modelDownloadState),
+            model: effectiveTranscriptionModel
+        )
+        if modelCard.tone == .failed {
+            issues.append(
+                HomeNeedsAttentionCard.Issue(
+                    title: "Voice model",
+                    detail: modelCard.detail
+                )
+            )
+        } else if preferredTranscriptionModel != effectiveTranscriptionModel {
+            issues.append(
+                HomeNeedsAttentionCard.Issue(
+                    title: "Voice model",
+                    detail: "\(preferredTranscriptionModel.title) is selected but \(effectiveTranscriptionModel.title) is being used."
+                )
+            )
+        }
+
+        return issues
     }
 
     private var shortcutsPage: some View {
@@ -1302,6 +1445,10 @@ struct TranscriptedSettingsView: View {
             recentMeetings = snapshot.meetings
             recentDictations = snapshot.dictations
             recentCapturesLoading = false
+        }
+        homeViewModel.refresh()
+        Task { @MainActor in
+            await StatsService.shared.refreshStats()
         }
     }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -301,6 +301,7 @@ struct TranscriptedSettingsView: View {
                         selectedTab: $homeActivityTab,
                         dictationSections: homeViewModel.dictationDaySections,
                         meetingSections: homeViewModel.meetingDaySections,
+                        isLoading: homeViewModel.isLoading,
                         copiedRowID: homeCopiedRowID,
                         onOpenDictation: { entry in
                             trackSettingsAction("open_recent_dictation", page: .home)
@@ -468,7 +469,7 @@ struct TranscriptedSettingsView: View {
         let dictations = homeViewModel.todayDictationCount
         let meetings = homeViewModel.todayMeetingCount
         if dictations == 0 && meetings == 0 {
-            return "Nothing captured yet today. Start a dictation or record a meeting to fill the timeline."
+            return "Ready to capture. Recent activity stays light so this screen opens fast."
         }
 
         var parts: [String] = []
@@ -484,12 +485,12 @@ struct TranscriptedSettingsView: View {
     private var homeStatItems: [HomeStatItem] {
         [
             HomeStatItem(
-                value: homeFormattedWords(homeViewModel.totalDictationWordCount),
-                label: "total words"
+                value: "\(homeViewModel.recentDictationCount)",
+                label: "recent dictations"
             ),
             HomeStatItem(
-                value: "\(homeViewModel.totalDictationCount)",
-                label: homeViewModel.totalDictationCount == 1 ? "dictation" : "dictations"
+                value: "\(homeViewModel.recentMeetingCount)",
+                label: "recent meetings"
             ),
             HomeStatItem(
                 value: "\(statsService.totalRecordings)",
@@ -505,17 +506,6 @@ struct TranscriptedSettingsView: View {
     private var homeStreak: Int? {
         let streak = statsService.currentStreak
         return streak > 0 ? streak : nil
-    }
-
-    private func homeFormattedWords(_ count: Int) -> String {
-        if count >= 1000 {
-            let thousands = Double(count) / 1000.0
-            if thousands >= 10 {
-                return "\(Int(thousands.rounded()))K"
-            }
-            return String(format: "%.1fK", thousands)
-        }
-        return "\(count)"
     }
 
     private var homeNeedsAttentionIssues: [HomeNeedsAttentionCard.Issue] {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -302,6 +302,9 @@ struct TranscriptedSettingsView: View {
                         dictationSections: homeViewModel.dictationDaySections,
                         meetingSections: homeViewModel.meetingDaySections,
                         isLoading: homeViewModel.isLoading,
+                        isLoadingMore: homeViewModel.isLoadingMore,
+                        canLoadMoreDictations: homeViewModel.canLoadMoreDictations,
+                        canLoadMoreMeetings: homeViewModel.canLoadMoreMeetings,
                         copiedRowID: homeCopiedRowID,
                         onOpenDictation: { entry in
                             trackSettingsAction("open_recent_dictation", page: .home)
@@ -330,6 +333,14 @@ struct TranscriptedSettingsView: View {
                         },
                         meetingMenuItems: { item in
                             meetingRowMenuItems(for: item)
+                        },
+                        onLoadMoreDictations: {
+                            trackSettingsAction("load_more_dictations", page: .home)
+                            homeViewModel.loadMoreDictations()
+                        },
+                        onLoadMoreMeetings: {
+                            trackSettingsAction("load_more_meetings", page: .home)
+                            homeViewModel.loadMoreMeetings()
                         }
                     )
                 }

--- a/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
@@ -33,6 +33,7 @@ final class TranscriptedSettingsWindowController: NSWindowController, NSWindowDe
             defer: false
         )
         window.title = "Transcripted Settings"
+        window.titleVisibility = .hidden
         window.contentViewController = hostingController
         window.isReleasedWhenClosed = false
         window.center()

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -16,10 +16,14 @@ struct RecentCaptureSnapshot: Sendable {
 
 enum RecentCaptureLoader {
     static func load(limit: Int = 5) async -> RecentCaptureSnapshot {
+        await load(dictationLimit: limit, meetingLimit: limit)
+    }
+
+    static func load(dictationLimit: Int, meetingLimit: Int) async -> RecentCaptureSnapshot {
         await Task.detached(priority: .utility) {
             RecentCaptureSnapshot(
-                meetings: RecentMeetingsScanner.loadRecent(limit: limit),
-                dictations: DictationTranscriptStore.recentSavedDictations(limit: limit)
+                meetings: RecentMeetingsScanner.loadRecent(limit: meetingLimit),
+                dictations: DictationTranscriptStore.recentSavedDictations(limit: dictationLimit)
             )
         }.value
     }

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -17,15 +17,21 @@ struct RecentCaptureSnapshot: Sendable {
 
 enum RecentCaptureLoader {
     static func load(limit: Int = 5) async -> RecentCaptureSnapshot {
-        await load(dictationLimit: limit, meetingLimit: limit)
+        await load(dictationLimit: limit, meetingLimit: limit, includeDictationCounts: false)
     }
 
-    static func load(dictationLimit: Int, meetingLimit: Int) async -> RecentCaptureSnapshot {
+    static func load(
+        dictationLimit: Int,
+        meetingLimit: Int,
+        includeDictationCounts: Bool = false
+    ) async -> RecentCaptureSnapshot {
         await Task.detached(priority: .utility) {
             RecentCaptureSnapshot(
                 meetings: RecentMeetingsScanner.loadRecent(limit: meetingLimit),
                 dictations: DictationTranscriptStore.recentSavedDictations(limit: dictationLimit),
-                dictationCounts: DictationTranscriptStore.savedDictationCounts()
+                dictationCounts: includeDictationCounts
+                    ? DictationTranscriptStore.savedDictationCounts()
+                    : DictationTranscriptCounts(total: 0, today: 0, totalWords: 0)
             )
         }.value
     }

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -12,6 +12,7 @@ struct RecentMeetingItem: Identifiable, Sendable {
 struct RecentCaptureSnapshot: Sendable {
     let meetings: [RecentMeetingItem]
     let dictations: [SavedDictationEntry]
+    let dictationCounts: DictationTranscriptCounts
 }
 
 enum RecentCaptureLoader {
@@ -23,7 +24,8 @@ enum RecentCaptureLoader {
         await Task.detached(priority: .utility) {
             RecentCaptureSnapshot(
                 meetings: RecentMeetingsScanner.loadRecent(limit: meetingLimit),
-                dictations: DictationTranscriptStore.recentSavedDictations(limit: dictationLimit)
+                dictations: DictationTranscriptStore.recentSavedDictations(limit: dictationLimit),
+                dictationCounts: DictationTranscriptStore.savedDictationCounts()
             )
         }.value
     }

--- a/Tests/DictationTranscriptStoreTests.swift
+++ b/Tests/DictationTranscriptStoreTests.swift
@@ -139,6 +139,36 @@ func testDictationTranscriptStore() {
             "body headings should not split one saved dictation into multiple entries"
         )
     }
+
+    runSuite("DictationTranscriptStore.savedDictationCounts — totals entries and dictated words") {
+        let fm = FileManager.default
+        let tempRoot = fm.temporaryDirectory.appendingPathComponent("DraftDictationStoreTests-\(UUID().uuidString)", isDirectory: true)
+        let outputDir = tempRoot.appendingPathComponent("dictations", isDirectory: true)
+        try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempRoot) }
+
+        let today = isoDate("2026-04-11T12:00:00-0500")
+        _ = try? DictationTranscriptStore.save(
+            text: "one two three",
+            sourceApp: nil,
+            delivery: .pasted,
+            createdAt: isoDate("2026-04-10T11:20:00-0500"),
+            directory: outputDir
+        )
+        _ = try? DictationTranscriptStore.save(
+            text: "four five",
+            sourceApp: nil,
+            delivery: .pasted,
+            createdAt: today,
+            directory: outputDir
+        )
+
+        let counts = DictationTranscriptStore.savedDictationCounts(directory: outputDir, today: today)
+
+        assertEqual(counts.total, 2, "total dictation count")
+        assertEqual(counts.today, 1, "today dictation count")
+        assertEqual(counts.totalWords, 5, "total dictated word count")
+    }
 }
 
 private func isoDate(_ string: String) -> Date {

--- a/Tests/DictationTranscriptStoreTests.swift
+++ b/Tests/DictationTranscriptStoreTests.swift
@@ -64,7 +64,9 @@ func testDictationTranscriptStore() {
         """
         try? legacyMarkdown.write(to: legacyFile, atomically: true, encoding: .utf8)
 
-        assertEqual(DictationTranscriptStore.latestSavedText(directory: outputDir), "legacy text", "legacy dictation text")
+        let latest = DictationTranscriptStore.latestSavedDictation(directory: outputDir)
+        assertEqual(latest?.text, "legacy text", "legacy dictation text")
+        assertEqual(latest?.entryID, "dictation-legacy", "legacy dictation entry ID")
     }
 
     runSuite("DictationTranscriptStore.recentSavedDictations — returns the newest entries across day files and same-day sections") {
@@ -168,6 +170,66 @@ func testDictationTranscriptStore() {
         assertEqual(counts.total, 2, "total dictation count")
         assertEqual(counts.today, 1, "today dictation count")
         assertEqual(counts.totalWords, 5, "total dictated word count")
+    }
+
+    runSuite("DictationTranscriptStore.deleteEntry — removes only the matching entry ID") {
+        let fm = FileManager.default
+        let tempRoot = fm.temporaryDirectory.appendingPathComponent("DraftDictationStoreTests-\(UUID().uuidString)", isDirectory: true)
+        let outputDir = tempRoot.appendingPathComponent("dictations", isDirectory: true)
+        try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: tempRoot) }
+
+        let dayFile = outputDir.appendingPathComponent("Dictations_2026-04-12.md")
+        let markdown = """
+        ---
+        title: "Dictations for April 12, 2026"
+        date: 2026-04-12
+        capture_type: dictation_day
+        ---
+
+        # Dictations for April 12, 2026
+
+        ## 10:05 AM - First duplicate timestamp
+
+        Entry ID: `dictation-first`
+        Captured: 2026-04-12T10:05:00Z
+        Source app: Notes
+        Delivery: pasted
+        Words: 2
+        Characters: 11
+
+        first text
+
+        ## 10:05 AM - Second duplicate timestamp
+
+        Entry ID: `dictation-second`
+        Captured: 2026-04-12T10:05:00Z
+        Source app: Notes
+        Delivery: pasted
+        Words: 2
+        Characters: 12
+
+        second text
+        """
+        try? markdown.write(to: dayFile, atomically: true, encoding: .utf8)
+
+        let entries = DictationTranscriptStore.recentSavedDictations(limit: 2, directory: outputDir)
+        guard let second = entries.first(where: { $0.entryID == "dictation-second" }) else {
+            assertionFailure("Expected second dictation entry")
+            return
+        }
+
+        do {
+            try DictationTranscriptStore.deleteEntry(second)
+        } catch {
+            assertionFailure("deleteEntry should not throw: \(error)")
+        }
+
+        let remainingContent = (try? String(contentsOf: dayFile, encoding: .utf8)) ?? ""
+        assertTrue(remainingContent.contains("dictation-first"), "first entry ID remains")
+        assertTrue(remainingContent.contains("first text"), "first entry body remains")
+        assertFalse(remainingContent.contains("dictation-second"), "second entry ID removed")
+        assertFalse(remainingContent.contains("second text"), "second entry body removed")
     }
 }
 


### PR DESCRIPTION
## Summary
- redesign Settings Home around today counts, overall stats, and recent activity
- keep Home fast by loading a small recent slice with load-more controls
- add total dictation and dictated-word counts for the overview rail

## Verification
- bash build.sh
- bash run-tests.sh
- verified Settings Home visually with Computer Use