### PR TITLE
Add GitHub issue agent workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent_task.md
+++ b/.github/ISSUE_TEMPLATE/agent_task.md
@@ -1,0 +1,21 @@
+---
+name: Codex agent task
+about: Ask Codex to turn an issue into a reviewable PR
+title: "[agent] "
+labels: agent todo, codex
+assignees: ""
+---
+
+## Goal
+
+
+## Acceptance criteria
+
+- [ ]
+
+## Notes or constraints
+
+
+## Verification
+
+- [ ]

--- a/.github/ISSUE_TEMPLATE/agent_task.md
+++ b/.github/ISSUE_TEMPLATE/agent_task.md
@@ -2,7 +2,7 @@
 name: Codex agent task
 about: Ask Codex to turn an issue into a reviewable PR
 title: "[agent] "
-labels: agent todo, codex
+labels: codex
 assignees: ""
 ---
 

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -10,6 +10,9 @@ tracker:
   review_label: agent review
   blocked_label: agent blocked
   done_label: agent done
+  allowed_authors:
+    - r3dbars
+    - justinbetker
 workspace:
   root: /Users/redbars/code/symphony-workspaces
   clone_url: git@github.com:r3dbars/transcripted.git

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,98 @@
+---
+tracker:
+  kind: github
+  repo: r3dbars/transcripted
+  active_labels:
+    - agent todo
+    - agent in progress
+  todo_label: agent todo
+  in_progress_label: agent in progress
+  review_label: agent review
+  blocked_label: agent blocked
+  done_label: agent done
+workspace:
+  root: /Users/redbars/code/symphony-workspaces
+  clone_url: git@github.com:r3dbars/transcripted.git
+polling:
+  interval_ms: 30000
+agent:
+  max_concurrent_agents: 1
+codex:
+  command: codex exec --dangerously-bypass-approvals-and-sandbox --search --output-last-message .codex-agent-last-message.md -
+---
+
+You are Codex working unattended on GitHub Issue #{{ issue.number }} in {{ repo }}.
+
+Issue URL: {{ issue.url }}
+Title: {{ issue.title }}
+Labels: {{ issue.labels }}
+
+Issue body:
+
+{{ issue.body }}
+
+Workspace:
+
+{{ workspace.path }}
+
+## Job
+
+Take this GitHub issue from `agent todo` or `agent in progress` to a reviewable pull request.
+
+Use the issue as the source of truth. If the issue is too vague to implement safely, stop only after writing the exact blocker into the issue workpad and applying `agent blocked`.
+
+## Required Flow
+
+1. Work only in the workspace shown above.
+2. Read the repo docs required by `AGENTS.md` before changing files.
+3. Reuse existing work in this workspace if present. Do not restart from scratch unless the workspace is empty or broken.
+4. Keep exactly one issue comment headed `## Codex Workpad`. Update it as the run progresses.
+5. Before editing, sync with `origin/main` and record the resulting short `HEAD` SHA in the workpad.
+6. Create or reuse a branch named like `codex/issue-{{ issue.number }}-short-slug`.
+7. Make the smallest change that satisfies the issue.
+8. Run the verification required by the files you changed.
+9. Stage only your own changes, commit, and push.
+10. Open a draft PR against `main` with `gh pr create --draft`.
+11. Link the PR in the issue workpad and add a short verification summary.
+12. Remove `agent in progress` and add `agent review` when the PR is ready for Justin to review.
+
+## Guardrails
+
+- Never force-push.
+- Never merge your own PR unless the issue explicitly says to land it.
+- Never stage unrelated pre-existing changes.
+- Never edit files outside this workspace.
+- Preserve Transcripted privacy boundaries.
+- If you touch Swift source, run `bash build.sh` and `bash run-tests.sh`.
+- If you touch `Sources/Meeting/` or `Sources/TranscriptedCore/`, also run `bash run-integration-smoke.sh`.
+- If you touch `Package.swift`, `Sources/TranscriptedCore/`, or the public core seam, also run `swift test`.
+
+## Workpad Shape
+
+Keep the issue workpad short:
+
+```md
+## Codex Workpad
+
+State: In Progress | Human Review | Blocked
+Workspace: ...
+Branch: ...
+PR: ...
+
+### Plan
+- ...
+
+### Acceptance
+- ...
+
+### Validation
+- ...
+
+### Notes
+- ...
+
+### Blockers
+- None
+```
+
+Final message must report completed actions and blockers only.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -18,7 +18,7 @@ polling:
 agent:
   max_concurrent_agents: 1
 codex:
-  command: codex exec --dangerously-bypass-approvals-and-sandbox --output-last-message .codex-agent-last-message.md -
+  command: codex exec -m gpt-5.4 --dangerously-bypass-approvals-and-sandbox --output-last-message .codex-agent-last-message.md -
 ---
 
 You are Codex working unattended on GitHub Issue #{{ issue.number }} in {{ repo }}.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -18,7 +18,7 @@ polling:
 agent:
   max_concurrent_agents: 1
 codex:
-  command: codex exec --dangerously-bypass-approvals-and-sandbox --search --output-last-message .codex-agent-last-message.md -
+  command: codex exec --dangerously-bypass-approvals-and-sandbox --output-last-message .codex-agent-last-message.md -
 ---
 
 You are Codex working unattended on GitHub Issue #{{ issue.number }} in {{ repo }}.

--- a/docs/agent-issue-orchestration.md
+++ b/docs/agent-issue-orchestration.md
@@ -21,7 +21,7 @@ The runner treats labels as state:
 Create the labels once:
 
 ```bash
-ruby scripts/ops/agent-todo-runner.rb --ensure-labels
+ruby scripts/ops/agent-todo-runner.rb --labels-only
 ```
 
 Run one pass:
@@ -40,6 +40,25 @@ Run a specific issue:
 
 ```bash
 ruby scripts/ops/agent-todo-runner.rb --issue 123
+```
+
+## Run It In The Background
+
+Install the macOS LaunchAgent:
+
+```bash
+bash scripts/ops/agent-todo-launchagent.sh install
+```
+
+After that, your Mac watches GitHub in the background. To hand work to Codex,
+add `agent todo` to an issue.
+
+Useful commands:
+
+```bash
+bash scripts/ops/agent-todo-launchagent.sh status
+bash scripts/ops/agent-todo-launchagent.sh logs
+bash scripts/ops/agent-todo-launchagent.sh uninstall
 ```
 
 ## What The Runner Does

--- a/docs/agent-issue-orchestration.md
+++ b/docs/agent-issue-orchestration.md
@@ -4,9 +4,10 @@ This repo can use GitHub Issues as a small Symphony-style queue for Codex.
 
 ## How To Queue Work
 
-1. Create a GitHub issue with the `Codex agent task` template.
-2. Make sure it has the `agent todo` label.
-3. Keep the issue small enough that a draft PR is a good review unit.
+1. Check that the background watcher is running.
+2. Create a GitHub issue with the `Codex agent task` template.
+3. If Justin wants the agent to take it, add the `agent todo` label.
+4. Keep the issue small enough that a draft PR is a good review unit.
 
 The runner treats labels as state:
 
@@ -57,8 +58,21 @@ Useful commands:
 
 ```bash
 bash scripts/ops/agent-todo-launchagent.sh status
+bash scripts/ops/agent-todo-launchagent.sh restart
 bash scripts/ops/agent-todo-launchagent.sh logs
 bash scripts/ops/agent-todo-launchagent.sh uninstall
+```
+
+Before creating or labeling an `agent todo` issue for Justin, check:
+
+```bash
+bash scripts/ops/agent-todo-launchagent.sh status
+```
+
+If it is not running, restart it:
+
+```bash
+bash scripts/ops/agent-todo-launchagent.sh restart
 ```
 
 ## What The Runner Does
@@ -75,5 +89,7 @@ Codex is expected to commit, push, open a draft PR, update the workpad, and move
 ## Safety Notes
 
 This is a trusted local runner. Codex runs in an isolated clone, but the default command in `WORKFLOW.md` uses unattended execution so it can finish without prompts.
+
+Only allowed issue authors can trigger the runner. The allowlist lives in `WORKFLOW.md` under `tracker.allowed_authors`. The public issue template does not auto-apply `agent todo`; add that label only after checking the issue is really work Justin wants to run.
 
 Review the draft PR before merging. Do not put secrets or private customer data in issues.

--- a/docs/agent-issue-orchestration.md
+++ b/docs/agent-issue-orchestration.md
@@ -1,0 +1,60 @@
+# GitHub Issue Agent Workflow
+
+This repo can use GitHub Issues as a small Symphony-style queue for Codex.
+
+## How To Queue Work
+
+1. Create a GitHub issue with the `Codex agent task` template.
+2. Make sure it has the `agent todo` label.
+3. Keep the issue small enough that a draft PR is a good review unit.
+
+The runner treats labels as state:
+
+- `agent todo` - ready for Codex
+- `agent in progress` - Codex claimed it
+- `agent review` - draft PR is ready for human review
+- `agent blocked` - Codex hit a real blocker
+- `agent done` - optional final state after merge or manual closeout
+
+## Run It Locally
+
+Create the labels once:
+
+```bash
+ruby scripts/ops/agent-todo-runner.rb --ensure-labels
+```
+
+Run one pass:
+
+```bash
+ruby scripts/ops/agent-todo-runner.rb --once
+```
+
+Watch continuously:
+
+```bash
+ruby scripts/ops/agent-todo-runner.rb --watch
+```
+
+Run a specific issue:
+
+```bash
+ruby scripts/ops/agent-todo-runner.rb --issue 123
+```
+
+## What The Runner Does
+
+- Reads `WORKFLOW.md`.
+- Finds open issues labeled `agent todo` or `agent in progress`.
+- Creates or reuses `/Users/redbars/code/symphony-workspaces/GH-<issue-number>`.
+- Creates a single `## Codex Workpad` issue comment if one does not exist.
+- Moves new work from `agent todo` to `agent in progress`.
+- Launches Codex in that issue workspace.
+
+Codex is expected to commit, push, open a draft PR, update the workpad, and move the issue to `agent review`.
+
+## Safety Notes
+
+This is a trusted local runner. Codex runs in an isolated clone, but the default command in `WORKFLOW.md` uses unattended execution so it can finish without prompts.
+
+Review the draft PR before merging. Do not put secrets or private customer data in issues.

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -70,8 +70,10 @@ Use these docs for these jobs:
 - `README.md` — public product overview and quick start
 - `CONTRIBUTING.md` — contributor setup and contribution norms
 - `AGENTS.md` — Codex-specific workflow rules
+- `WORKFLOW.md` - local GitHub Issues to Codex agent workflow contract
 - `CLAUDE.md` — Claude-specific repo orientation
 - `docs/agent-onboarding.md` — how to interpret the repo’s doc layers
+- `docs/agent-issue-orchestration.md` - how to queue GitHub issues for the local Codex runner
 - `docs/storage-paths.md` — canonical storage and fallback path map
 - `docs/release-packaging.md` — release packaging flow
 - `docs/sparkle-updates.md` — Sparkle update contract

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -37,6 +37,11 @@ not have to carry the full operational logic:
 - `scripts/ops/health-probe.sh` — run health checks for observability lanes (Sentry, PostHog, GitHub, Cloudflare)
   - Usage: `bash scripts/ops/health-probe.sh <github|sentry|posthog|cloudflare|all>`
   - See `docs/ops-credentials.md` for credential setup and privacy guidelines
+- `scripts/ops/agent-todo-runner.rb` - local GitHub Issues queue runner for Codex agent tasks
+  - Usage: `ruby scripts/ops/agent-todo-runner.rb --ensure-labels`
+  - Usage: `ruby scripts/ops/agent-todo-runner.rb --once`
+  - Usage: `ruby scripts/ops/agent-todo-runner.rb --watch`
+  - Reads `WORKFLOW.md` and watches issues labeled `agent todo` or `agent in progress`
 - `scripts/ops/qa-gate-check.sh` — one-shot check for the BET-88 QA gate comment on `#428` using the same strict owner + first-line PASS/FAIL rules as the auto-close workflow
   - Usage: `bash scripts/ops/qa-gate-check.sh [--json] [repo] [issue_number] [owner_login]`
   - Returns JSON and exits `0` for `pass`/`fail`, `3` for `PENDING`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,10 +38,14 @@ not have to carry the full operational logic:
   - Usage: `bash scripts/ops/health-probe.sh <github|sentry|posthog|cloudflare|all>`
   - See `docs/ops-credentials.md` for credential setup and privacy guidelines
 - `scripts/ops/agent-todo-runner.rb` - local GitHub Issues queue runner for Codex agent tasks
-  - Usage: `ruby scripts/ops/agent-todo-runner.rb --ensure-labels`
+  - Usage: `ruby scripts/ops/agent-todo-runner.rb --labels-only`
   - Usage: `ruby scripts/ops/agent-todo-runner.rb --once`
   - Usage: `ruby scripts/ops/agent-todo-runner.rb --watch`
   - Reads `WORKFLOW.md` and watches issues labeled `agent todo` or `agent in progress`
+- `scripts/ops/agent-todo-launchagent.sh` - install, restart, inspect, or remove the macOS background watcher
+  - Usage: `bash scripts/ops/agent-todo-launchagent.sh install`
+  - Usage: `bash scripts/ops/agent-todo-launchagent.sh status`
+  - Usage: `bash scripts/ops/agent-todo-launchagent.sh logs`
 - `scripts/ops/qa-gate-check.sh` — one-shot check for the BET-88 QA gate comment on `#428` using the same strict owner + first-line PASS/FAIL rules as the auto-close workflow
   - Usage: `bash scripts/ops/qa-gate-check.sh [--json] [repo] [issue_number] [owner_login]`
   - Returns JSON and exits `0` for `pass`/`fail`, `3` for `PENDING`

--- a/scripts/ops/agent-todo-launchagent.sh
+++ b/scripts/ops/agent-todo-launchagent.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LABEL="com.r3dbars.transcripted.agent-todo-runner"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$REPO_ROOT/scripts/ops/agent-todo-runner.rb"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+LOG_DIR="$HOME/Library/Logs/TranscriptedAgentTodoRunner"
+OUT_LOG="$LOG_DIR/stdout.log"
+ERR_LOG="$LOG_DIR/stderr.log"
+DOMAIN="gui/$(id -u)"
+
+xml_escape() {
+  sed \
+    -e 's/&/\&amp;/g' \
+    -e 's/</\&lt;/g' \
+    -e 's/>/\&gt;/g' \
+    -e 's/"/\&quot;/g'
+}
+
+write_plist() {
+  local escaped_repo_root escaped_runner escaped_home
+  escaped_repo_root="$(printf '%s' "$REPO_ROOT" | xml_escape)"
+  escaped_runner="$(printf '%s' "$RUNNER" | xml_escape)"
+  escaped_home="$(printf '%s' "$HOME" | xml_escape)"
+
+  mkdir -p "$(dirname "$PLIST")" "$LOG_DIR"
+
+  cat > "$PLIST" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/ruby</string>
+    <string>$escaped_runner</string>
+    <string>--watch</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>$escaped_repo_root</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>$OUT_LOG</string>
+  <key>StandardErrorPath</key>
+  <string>$ERR_LOG</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>$escaped_home</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
+</dict>
+</plist>
+PLIST
+}
+
+install_agent() {
+  ruby "$RUNNER" --labels-only
+  write_plist
+  launchctl bootout "$DOMAIN" "$PLIST" >/dev/null 2>&1 || true
+  launchctl bootstrap "$DOMAIN" "$PLIST"
+  launchctl enable "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
+  launchctl kickstart -k "$DOMAIN/$LABEL"
+  echo "Installed and started $LABEL"
+  echo "Logs: $LOG_DIR"
+}
+
+uninstall_agent() {
+  launchctl bootout "$DOMAIN" "$PLIST" >/dev/null 2>&1 || true
+  rm -f "$PLIST"
+  echo "Uninstalled $LABEL"
+}
+
+status_agent() {
+  launchctl print "$DOMAIN/$LABEL"
+}
+
+logs_agent() {
+  echo "== stdout =="
+  tail -n 80 "$OUT_LOG" 2>/dev/null || true
+  echo "== stderr =="
+  tail -n 80 "$ERR_LOG" 2>/dev/null || true
+}
+
+case "${1:-install}" in
+  install)
+    install_agent
+    ;;
+  uninstall)
+    uninstall_agent
+    ;;
+  restart)
+    uninstall_agent
+    install_agent
+    ;;
+  status)
+    status_agent
+    ;;
+  logs)
+    logs_agent
+    ;;
+  *)
+    echo "Usage: $0 [install|uninstall|restart|status|logs]" >&2
+    exit 64
+    ;;
+esac

--- a/scripts/ops/agent-todo-runner.rb
+++ b/scripts/ops/agent-todo-runner.rb
@@ -369,7 +369,7 @@ class AgentTodoRunner
   end
 
   def codex_command
-    @codex_command ||= @codex_config.fetch("command", "codex exec --dangerously-bypass-approvals-and-sandbox --search -").to_s
+    @codex_command ||= @codex_config.fetch("command", "codex exec --dangerously-bypass-approvals-and-sandbox -").to_s
   end
 
   def max_concurrent_agents

--- a/scripts/ops/agent-todo-runner.rb
+++ b/scripts/ops/agent-todo-runner.rb
@@ -369,7 +369,7 @@ class AgentTodoRunner
   end
 
   def codex_command
-    @codex_command ||= @codex_config.fetch("command", "codex exec --dangerously-bypass-approvals-and-sandbox -").to_s
+    @codex_command ||= @codex_config.fetch("command", "codex exec -m gpt-5.4 --dangerously-bypass-approvals-and-sandbox -").to_s
   end
 
   def max_concurrent_agents

--- a/scripts/ops/agent-todo-runner.rb
+++ b/scripts/ops/agent-todo-runner.rb
@@ -99,7 +99,7 @@ class AgentTodoRunner
       "--repo", repo,
       "--state", "open",
       "--limit", "100",
-      "--json", "number,title,body,labels,url,assignees,createdAt,updatedAt"
+      "--json", "number,title,body,labels,url,assignees,author,createdAt,updatedAt"
     )
 
     issues.select { |issue| active_issue?(issue) }
@@ -109,18 +109,23 @@ class AgentTodoRunner
     capture_json(
       "gh", "issue", "view", number.to_s,
       "--repo", repo,
-      "--json", "number,title,body,labels,url,assignees,createdAt,updatedAt"
+      "--json", "number,title,body,labels,url,assignees,author,createdAt,updatedAt"
     )
   end
 
   def active_issue?(issue)
     labels = label_names(issue)
-    (labels & active_labels).any? && (labels & terminal_labels).empty?
+    (labels & active_labels).any? && (labels & terminal_labels).empty? && allowed_author?(issue)
   end
 
   def handle_issue(issue)
     number = issue.fetch("number")
     workspace = workspace_path(number)
+
+    unless allowed_author?(issue)
+      skip_unauthorized_issue(issue)
+      return
+    end
 
     puts "Claiming #{repo}##{number}: #{issue.fetch("title")}"
     claim_issue(issue)
@@ -248,6 +253,7 @@ class AgentTodoRunner
         "title" => issue.fetch("title", ""),
         "body" => issue.fetch("body", "") || "",
         "url" => issue.fetch("url", ""),
+        "author" => issue_author(issue),
         "labels" => label_names(issue).join(", ")
       },
       "workspace" => {
@@ -302,6 +308,21 @@ class AgentTodoRunner
       ```text
       #{message}
       ```
+    MD
+    run_command("gh", "issue", "comment", number.to_s, "--repo", repo, "--body", body)
+  end
+
+  def skip_unauthorized_issue(issue)
+    number = issue.fetch("number")
+    author = issue_author(issue)
+    puts "Skipping ##{number}: author #{author} is not in allowed_authors"
+    return if @dry_run
+
+    edit_labels(number, [], [todo_label, in_progress_label])
+    body = <<~MD
+      Agent handoff skipped.
+
+      `agent todo` is restricted to repository operators. This issue was opened by `#{author}`, which is not in the runner allowlist.
     MD
     run_command("gh", "issue", "comment", number.to_s, "--repo", repo, "--body", body)
   end
@@ -409,6 +430,24 @@ class AgentTodoRunner
 
   def done_label
     @done_label ||= @tracker.fetch("done_label", "agent done")
+  end
+
+  def allowed_author?(issue)
+    authors = allowed_authors
+    return true if authors.empty?
+
+    authors.include?(issue_author(issue))
+  end
+
+  def allowed_authors
+    @allowed_authors ||= Array(@tracker.fetch("allowed_authors", [])).map(&:to_s)
+  end
+
+  def issue_author(issue)
+    author = issue.fetch("author", nil)
+    return author.fetch("login", "unknown").to_s if author.is_a?(Hash)
+
+    "unknown"
   end
 
   def label_names(issue)

--- a/scripts/ops/agent-todo-runner.rb
+++ b/scripts/ops/agent-todo-runner.rb
@@ -25,6 +25,7 @@ class AgentTodoRunner
     @watch = options[:watch]
     @issue_number = options[:issue]
     @ensure_labels_requested = options[:ensure_labels]
+    @labels_only = options[:labels_only]
 
     @config, @template = load_workflow(@workflow_path)
     @tracker = @config.fetch("tracker", {})
@@ -37,6 +38,7 @@ class AgentTodoRunner
   def run
     validate!
     ensure_labels if @ensure_labels_requested
+    return if @labels_only
 
     loop do
       count = run_once
@@ -428,6 +430,10 @@ parser = OptionParser.new do |opts|
   opts.on("--once", "Run one polling pass. This is the default.") { options[:watch] = false }
   opts.on("--watch", "Poll forever.") { options[:watch] = true }
   opts.on("--ensure-labels", "Create missing agent labels.") { options[:ensure_labels] = true }
+  opts.on("--labels-only", "Create missing agent labels and exit.") do
+    options[:ensure_labels] = true
+    options[:labels_only] = true
+  end
   opts.on("--dry-run", "Print actions without changing GitHub or launching Codex.") { options[:dry_run] = true }
 end
 

--- a/scripts/ops/agent-todo-runner.rb
+++ b/scripts/ops/agent-todo-runner.rb
@@ -1,0 +1,436 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+require "json"
+require "open3"
+require "optparse"
+require "shellwords"
+require "time"
+require "yaml"
+
+class AgentTodoRunner
+  LABELS = {
+    "agent todo" => ["5319e7", "Ready for the local Codex issue runner"],
+    "agent in progress" => ["f9d0c4", "Claimed by the local Codex issue runner"],
+    "agent review" => ["0e8a16", "Codex opened a PR for human review"],
+    "agent blocked" => ["d93f0b", "Codex needs human input before continuing"],
+    "agent done" => ["cfd3d7", "Agent task is complete"]
+  }.freeze
+
+  def initialize(options)
+    @repo_root = File.expand_path("../..", __dir__)
+    @workflow_path = File.expand_path(options[:workflow] || File.join(@repo_root, "WORKFLOW.md"))
+    @dry_run = options[:dry_run]
+    @watch = options[:watch]
+    @issue_number = options[:issue]
+    @ensure_labels_requested = options[:ensure_labels]
+
+    @config, @template = load_workflow(@workflow_path)
+    @tracker = @config.fetch("tracker", {})
+    @workspace_config = @config.fetch("workspace", {})
+    @agent_config = @config.fetch("agent", {})
+    @codex_config = @config.fetch("codex", {})
+    @polling_config = @config.fetch("polling", {})
+  end
+
+  def run
+    validate!
+    ensure_labels if @ensure_labels_requested
+
+    loop do
+      count = run_once
+      break unless @watch
+
+      puts "No matching issues." if count.zero?
+      puts "Sleeping #{poll_interval_seconds}s..."
+      sleep poll_interval_seconds
+    end
+  end
+
+  private
+
+  def load_workflow(path)
+    body = File.read(path)
+    unless body.start_with?("---\n")
+      return [{}, body.strip]
+    end
+
+    _, yaml, prompt = body.split(/^---\s*$/, 3)
+    raise "Could not parse YAML front matter in #{path}" if yaml.nil? || prompt.nil?
+
+    [YAML.safe_load(yaml) || {}, prompt.strip]
+  end
+
+  def validate!
+    raise "WORKFLOW.md must set tracker.kind: github" unless @tracker["kind"] == "github"
+    raise "WORKFLOW.md must set tracker.repo" if repo.empty?
+    raise "WORKFLOW.md must set workspace.root" if workspace_root.empty?
+    raise "WORKFLOW.md has an empty Codex prompt body" if @template.empty?
+
+    assert_command!("gh")
+    assert_command!("git")
+    assert_command!("codex")
+  end
+
+  def assert_command!(command)
+    _, _, status = Open3.capture3("which", command)
+    raise "Missing required command: #{command}" unless status.success?
+  end
+
+  def run_once
+    issues = @issue_number ? [fetch_issue(@issue_number)] : fetch_candidates
+    issues = issues.first(max_concurrent_agents)
+
+    issues.each do |issue|
+      with_issue_lock(issue) do
+        handle_issue(issue)
+      end
+    end
+
+    issues.length
+  end
+
+  def fetch_candidates
+    issues = capture_json(
+      "gh", "issue", "list",
+      "--repo", repo,
+      "--state", "open",
+      "--limit", "100",
+      "--json", "number,title,body,labels,url,assignees,createdAt,updatedAt"
+    )
+
+    issues.select { |issue| active_issue?(issue) }
+  end
+
+  def fetch_issue(number)
+    capture_json(
+      "gh", "issue", "view", number.to_s,
+      "--repo", repo,
+      "--json", "number,title,body,labels,url,assignees,createdAt,updatedAt"
+    )
+  end
+
+  def active_issue?(issue)
+    labels = label_names(issue)
+    (labels & active_labels).any? && (labels & terminal_labels).empty?
+  end
+
+  def handle_issue(issue)
+    number = issue.fetch("number")
+    workspace = workspace_path(number)
+
+    puts "Claiming #{repo}##{number}: #{issue.fetch("title")}"
+    claim_issue(issue)
+    prepare_workspace(number, workspace)
+    ensure_workpad(issue, workspace)
+    run_codex(issue, workspace)
+  rescue StandardError => error
+    warn "Issue ##{number || "?"} failed: #{error.message}"
+    mark_blocked(number, error.message) if number
+  end
+
+  def claim_issue(issue)
+    labels = label_names(issue)
+    additions = []
+    removals = []
+    additions << in_progress_label unless labels.include?(in_progress_label)
+    removals << todo_label if labels.include?(todo_label)
+    edit_labels(issue.fetch("number"), additions, removals)
+  end
+
+  def prepare_workspace(number, path)
+    if File.directory?(File.join(path, ".git"))
+      puts "Reusing #{path}"
+      return
+    end
+
+    if File.exist?(path) && !Dir.empty?(path)
+      raise "Workspace exists but is not a git checkout: #{path}"
+    end
+
+    puts "Creating #{path}"
+    return if @dry_run
+
+    FileUtils.mkdir_p(path)
+    run_command("git", "clone", clone_url, ".", chdir: path)
+  end
+
+  def ensure_workpad(issue, workspace)
+    comments = capture_json(
+      "gh", "issue", "view", issue.fetch("number").to_s,
+      "--repo", repo,
+      "--json", "comments"
+    ).fetch("comments")
+
+    return if comments.any? { |comment| comment.fetch("body", "").include?("## Codex Workpad") }
+
+    body = <<~MD
+      ## Codex Workpad
+
+      State: In Progress
+      Workspace: `#{workspace}`
+      Branch: Pending
+      PR: Pending
+
+      ### Plan
+      - [ ] Read the issue and required repo docs.
+      - [ ] Sync with `origin/main`.
+      - [ ] Implement the smallest safe change.
+      - [ ] Run required verification.
+      - [ ] Open a draft PR.
+
+      ### Acceptance
+      - Follow the issue body.
+
+      ### Validation
+      - Pending.
+
+      ### Notes
+      - Runner claimed this issue at #{Time.now.iso8601}.
+
+      ### Blockers
+      - None.
+    MD
+
+    puts "Creating workpad comment"
+    return if @dry_run
+
+    run_command("gh", "issue", "comment", issue.fetch("number").to_s, "--repo", repo, "--body", body)
+  end
+
+  def run_codex(issue, workspace)
+    prompt = render_prompt(issue, workspace)
+    log_path = log_path_for(issue.fetch("number"))
+    FileUtils.mkdir_p(File.dirname(log_path)) unless @dry_run
+
+    puts "Starting Codex in #{workspace}"
+    puts "Log: #{log_path}"
+    if @dry_run
+      puts "--- prompt preview ---"
+      puts prompt.lines.first(40).join
+      puts "--- end preview ---"
+      return
+    end
+
+    command = Shellwords.split(codex_command)
+    env = {
+      "AGENT_ISSUE_NUMBER" => issue.fetch("number").to_s,
+      "AGENT_ISSUE_URL" => issue.fetch("url").to_s,
+      "AGENT_WORKSPACE" => workspace,
+      "AGENT_REPO" => repo
+    }
+
+    File.open(log_path, "w") do |log|
+      Open3.popen2e(env, *command, chdir: workspace) do |stdin, output, wait_thread|
+        stdin.write(prompt)
+        stdin.close
+
+        output.each do |line|
+          print line
+          log.write(line)
+        end
+
+        status = wait_thread.value
+        raise "Codex exited with status #{status.exitstatus}. See #{log_path}" unless status.success?
+      end
+    end
+  end
+
+  def render_prompt(issue, workspace)
+    context = {
+      "repo" => repo,
+      "issue" => {
+        "number" => issue.fetch("number").to_s,
+        "identifier" => "GH-#{issue.fetch("number")}",
+        "title" => issue.fetch("title", ""),
+        "body" => issue.fetch("body", "") || "",
+        "url" => issue.fetch("url", ""),
+        "labels" => label_names(issue).join(", ")
+      },
+      "workspace" => {
+        "path" => workspace
+      }
+    }
+
+    @template.gsub(/\{\{\s*([A-Za-z0-9_.]+)\s*\}\}/) do
+      lookup(context, Regexp.last_match(1))
+    end
+  end
+
+  def lookup(context, key)
+    value = key.split(".").reduce(context) do |current, part|
+      raise "Unknown template variable: #{key}" unless current.is_a?(Hash) && current.key?(part)
+
+      current.fetch(part)
+    end
+    value.to_s
+  end
+
+  def with_issue_lock(issue)
+    FileUtils.mkdir_p(lock_root) unless @dry_run
+    lock_path = File.join(lock_root, "GH-#{issue.fetch("number")}.lock")
+
+    if @dry_run
+      yield
+      return
+    end
+
+    begin
+      Dir.mkdir(lock_path)
+    rescue Errno::EEXIST
+      puts "Skipping ##{issue.fetch("number")} because #{lock_path} exists"
+      return
+    end
+
+    begin
+      yield
+    ensure
+      FileUtils.rm_rf(lock_path)
+    end
+  end
+
+  def mark_blocked(number, message)
+    edit_labels(number, [blocked_label], [todo_label, in_progress_label])
+    return if @dry_run
+
+    body = <<~MD
+      Codex runner stopped on a blocker.
+
+      ```text
+      #{message}
+      ```
+    MD
+    run_command("gh", "issue", "comment", number.to_s, "--repo", repo, "--body", body)
+  end
+
+  def edit_labels(number, additions, removals)
+    return if additions.empty? && removals.empty?
+
+    args = ["gh", "issue", "edit", number.to_s, "--repo", repo]
+    args += ["--add-label", additions.join(",")] unless additions.empty?
+    args += ["--remove-label", removals.join(",")] unless removals.empty?
+    puts args.shelljoin
+    run_command(*args) unless @dry_run
+  end
+
+  def ensure_labels
+    label_names = capture_json("gh", "label", "list", "--repo", repo, "--limit", "200", "--json", "name").map { |label| label["name"] }
+
+    LABELS.each do |name, (color, description)|
+      next if label_names.include?(name)
+
+      puts "Creating label #{name}"
+      run_command("gh", "label", "create", name, "--repo", repo, "--color", color, "--description", description) unless @dry_run
+    end
+  end
+
+  def capture_json(*command)
+    stdout, stderr, status = Open3.capture3(*command)
+    raise "Command failed: #{command.shelljoin}\n#{stderr}" unless status.success?
+
+    JSON.parse(stdout)
+  end
+
+  def run_command(*command, chdir: nil)
+    options = {}
+    options[:chdir] = chdir if chdir
+    stdout, stderr, status = Open3.capture3(*command, **options)
+    raise "Command failed: #{command.shelljoin}\n#{stdout}\n#{stderr}" unless status.success?
+
+    stdout
+  end
+
+  def repo
+    @repo ||= @tracker.fetch("repo", "").to_s
+  end
+
+  def clone_url
+    @clone_url ||= @workspace_config.fetch("clone_url", "git@github.com:#{repo}.git").to_s
+  end
+
+  def workspace_root
+    @workspace_root ||= File.expand_path(@workspace_config.fetch("root", "").to_s)
+  end
+
+  def workspace_path(number)
+    File.join(workspace_root, "GH-#{number}")
+  end
+
+  def lock_root
+    File.join(workspace_root, "_locks")
+  end
+
+  def log_path_for(number)
+    timestamp = Time.now.utc.strftime("%Y%m%dT%H%M%SZ")
+    File.join(workspace_root, "_logs", "GH-#{number}-#{timestamp}.log")
+  end
+
+  def codex_command
+    @codex_command ||= @codex_config.fetch("command", "codex exec --dangerously-bypass-approvals-and-sandbox --search -").to_s
+  end
+
+  def max_concurrent_agents
+    value = @agent_config.fetch("max_concurrent_agents", 1).to_i
+    value.positive? ? value : 1
+  end
+
+  def poll_interval_seconds
+    value = @polling_config.fetch("interval_ms", 30_000).to_i / 1000.0
+    value.positive? ? value : 30
+  end
+
+  def active_labels
+    configured = @tracker["active_labels"]
+    @active_labels ||= Array(configured.nil? ? [todo_label, in_progress_label] : configured)
+  end
+
+  def terminal_labels
+    @terminal_labels ||= [review_label, blocked_label, done_label]
+  end
+
+  def todo_label
+    @todo_label ||= @tracker.fetch("todo_label", "agent todo")
+  end
+
+  def in_progress_label
+    @in_progress_label ||= @tracker.fetch("in_progress_label", "agent in progress")
+  end
+
+  def review_label
+    @review_label ||= @tracker.fetch("review_label", "agent review")
+  end
+
+  def blocked_label
+    @blocked_label ||= @tracker.fetch("blocked_label", "agent blocked")
+  end
+
+  def done_label
+    @done_label ||= @tracker.fetch("done_label", "agent done")
+  end
+
+  def label_names(issue)
+    issue.fetch("labels", []).map { |label| label.fetch("name") }
+  end
+end
+
+options = {
+  dry_run: ENV["DRY_RUN"] == "1",
+  watch: false,
+  ensure_labels: false
+}
+
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: ruby scripts/ops/agent-todo-runner.rb [options]"
+
+  opts.on("--workflow PATH", "Workflow file path. Defaults to WORKFLOW.md.") { |value| options[:workflow] = value }
+  opts.on("--issue NUMBER", Integer, "Run a specific GitHub issue.") { |value| options[:issue] = value }
+  opts.on("--once", "Run one polling pass. This is the default.") { options[:watch] = false }
+  opts.on("--watch", "Poll forever.") { options[:watch] = true }
+  opts.on("--ensure-labels", "Create missing agent labels.") { options[:ensure_labels] = true }
+  opts.on("--dry-run", "Print actions without changing GitHub or launching Codex.") { options[:dry_run] = true }
+end
+
+parser.parse!
+
+AgentTodoRunner.new(options).run


### PR DESCRIPTION
## Summary
- add WORKFLOW.md for a GitHub Issues to Codex flow
- add an agent task issue template and docs
- add a local runner that watches agent labels and launches Codex in per-issue workspaces

## Verification
- ruby -c scripts/ops/agent-todo-runner.rb
- ruby scripts/ops/agent-todo-runner.rb --once --dry-run
- ruby scripts/ops/agent-todo-runner.rb --issue 500 --dry-run
- git diff --check
- created GitHub labels: agent todo, agent in progress, agent review, agent blocked, agent done