### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Sources/Observability/CLAUDE.md
+++ b/Sources/Observability/CLAUDE.md
@@ -9,7 +9,8 @@ anonymous analytics, and Sparkle update plumbing.
 
 - `AppLogger.swift` — developer-facing debug log writer
 - `EventReporter.swift` — structured event capture
-- `JSONLWriter.swift` — shared append-only JSONL writer
+- `JSONLWriter.swift` — shared append-only JSONL writer that reuses file handles and falls back cleanly if log files are rotated or recreated
+- `LockedFileAppender.swift` — cross-process-safe file append helper that serializes writes and uses `flock` so concurrent JSONL/debug-log writers do not interleave records
 - `DiagnosticsTrail.swift` — lightweight high-signal diagnostics helper
 - `CrashReporter.swift` — crash reporting setup
 - `CrashReportingPreferences.swift` — Settings-backed crash reporting preference
@@ -20,12 +21,14 @@ anonymous analytics, and Sparkle update plumbing.
 - `SentryEventPolicy.swift` — explicit allowlist of non-fatal events permitted to reach Sentry
 - `SentryPayloadSanitizer.swift` — strips obvious sensitive values before Sentry sends
 - `SentryRuntimeConfiguration.swift` — resolves Sentry DSN, environment, release, and dist from `Info.plist` or process environment
-- `SparkleUpdaterController.swift` — live Sparkle update controller used by the menubar app
+- `SparkleUpdaterController.swift` — live Sparkle update controller used by the menubar app, including update-state telemetry and ready-to-install restart flows
+- `UpdateFailureKind.swift` — canonical Sparkle/update failure taxonomy used to normalize network, appcast, download, signature, install, and busy-session errors for analytics
 
 ## Current Notes
 
 - Treat this directory as shared infrastructure for the current dictation + meetings app
 - Sparkle is the live in-app update path on `main`; the older beta DMG self-update flow is no longer part of the app target
+- `LockedFileAppender` is the canonical append path for local debug and JSONL logs. Keep concurrent file writes funneled through it so app and helper processes do not splice records together.
 - Do not assume older draft/style/analysis event flows are still active just because they appear in historical docs or event logs
 - `build.sh` and beta behavior can affect logs, signing, and permissions during local testing
 - `TRANSCRIPTED_DISABLE_FILE_LOGGER=1` disables `app.jsonl` writes for test and smoke runs so local production logs stay clean
@@ -33,6 +36,7 @@ anonymous analytics, and Sparkle update plumbing.
 - `SentryRuntimeConfiguration` rejects non-HTTPS DSNs, so insecure local overrides fail closed instead of downgrading crash transport
 - PostHog config is read from `Info.plist` (`TranscriptedPostHogAPIKey`, `TranscriptedPostHogHost`) or process environment (`POSTHOG_API_KEY`, `POSTHOG_HOST`), and anonymous analytics must stay event-allowlisted and bucketed rather than sending raw payloads
 - Non-fatal error forwarding to Sentry is allowlisted. New `.error` events should not automatically assume they are safe to send off-device.
+- Update telemetry should keep using `UpdateFailureKind` instead of ad hoc string parsing so dashboards stay stable across Sparkle error wording changes.
 
 ## Verification
 
@@ -52,6 +56,8 @@ Relevant direct coverage:
 - `Tests/SentryEventPolicyTests.swift`
 - `Tests/SentryPayloadSanitizerTests.swift`
 - `Tests/SentryRuntimeConfigurationTests.swift`
+- `Tests/ObservabilityLogWriterTests.swift`
+- `Tests/UpdateFailureKindTests.swift`
 
 Useful files while testing:
 

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -13,7 +13,7 @@ The directory is grouped by surface so the live UI tree is easier to scan:
 
 Draft-mode UI is not an active product path in this worktree.
 
-## Files (47 Swift files)
+## Files (48 Swift files)
 
 ### Overlay/
 
@@ -68,6 +68,7 @@ The current agent-connect surfaces should keep one simple mental model:
 ### Settings/
 
 - `Settings/HomeTranscriptionActivityPresentation.swift` — presentation model derived from `MeetingSessionController` state for the home page's live transcription activity card (tone, progress, transcript URL)
+- `Settings/HomeView.swift` — redesigned Settings home dashboard with fast recent activity loading, grouped recent dictations/meetings, summary stats, and lightweight copy/feedback/delete affordances
 - `Settings/HotkeyRecorderAppKitView.swift` — AppKit view for recording custom hotkey bindings
 - `Settings/PermissionsOnboardingView.swift` — first-launch permissions walkthrough
 - `Settings/SpeakerNamingSheet.swift` — sheet for reviewing speakers in a completed meeting, grouped into local room speakers vs remote participants, with a "Keep as You" escape hatch for local mic splits
@@ -101,6 +102,11 @@ Cross-cutting local-speaker behavior is split between settings and review UI:
 while `SpeakerNamingSheet` is where users confirm local-vs-remote speakers or
 collapse the local side back into a single "You" track.
 
+The redesigned Settings home surface is intentionally a fast dashboard rather
+than a full archive browser. `HomeView` keeps recent dictations and meetings to
+small paged slices so the settings window still opens quickly for users with
+large capture libraries.
+
 Keep user-visible TCC prompts user-initiated. Background warmup paths should
 not request microphone, system-audio-recording, or calendar access on their own;
 onboarding and Settings own those prompts so the dialogs appear in context.
@@ -129,6 +135,7 @@ Manual checks:
 - speaker settings can preview clips, surface duplicates, toggle local-speaker splitting, and rename / merge people cleanly
 - completed meeting review cleanly separates "People in the room" from remote participants, can resolve retained meeting audio playback, and "Keep as You" restores the single-speaker local path when needed
 - recent meetings in Settings can play retained audio attachments without losing sync between transcript rows and playback state
+- the Settings home dashboard opens quickly, shows grouped recent dictations and meetings, and its load-more actions keep working on large libraries
 - permissions onboarding and first-run onboarding window still open correctly
 - first-run CTA copy updates correctly as permissions and local-model state change
 - settings window still opens correctly


### PR DESCRIPTION
## Summary
- sync `Sources/Observability/CLAUDE.md` with the current logging and update-observability files
- document `LockedFileAppender.swift` and `UpdateFailureKind.swift`, plus their direct tests
- sync `Sources/UI/CLAUDE.md` with the redesigned Settings home dashboard and current Swift file count

## Why
Recent app changes added new observability helpers and a new Settings home surface, so the local CLAUDE docs had drifted from the live codebase.