### PR TITLE
security: nightly security audit findings [automated]

### DIFF
--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -319,10 +319,31 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
     }
 
     private var hasConfiguredFeedURL: Bool {
-        guard let value = Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String else {
+        guard let value = Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String,
+              let feedURL = normalizedHTTPSURL(value) else {
             return false
         }
-        return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+
+        // Security: require an HTTPS Sparkle feed with a non-empty EdDSA public key.
+        // If a tampered Info.plist swaps in HTTP or removes SUPublicEDKey, fail closed
+        // instead of letting update checks proceed against an unsigned/plaintext channel.
+        guard let publicKey = Bundle.main.object(forInfoDictionaryKey: "SUPublicEDKey") as? String,
+              !publicKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return false
+        }
+
+        return feedURL.host != nil
+    }
+
+    private func normalizedHTTPSURL(_ rawValue: String) -> URL? {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let url = URL(string: trimmed),
+              let scheme = url.scheme,
+              scheme.caseInsensitiveCompare("https") == .orderedSame else {
+            return nil
+        }
+        return url
     }
 
     private func trackUpdateActionClicked(surface: String, state: UpdateStatus.State, version: String?) {


### PR DESCRIPTION
## Summary
Nightly automated security audit for Transcripted found one confirmed low-severity hardening issue in updater configuration.

## Findings
### Critical
- None.

### High
- None.

### Medium
- None.

### Low
- Hardened Sparkle update configuration handling in `SparkleUpdaterController`.
  - Vulnerability: the app previously treated any non-empty `SUFeedURL` as configured, without locally requiring HTTPS or verifying that `SUPublicEDKey` was present before enabling update checks.
  - Impact: if a bundled configuration were tampered with, update checks could be pointed at an insecure or unsigned channel instead of failing closed.
  - Fix: require a valid HTTPS `SUFeedURL` and a non-empty `SUPublicEDKey` before considering Sparkle configured.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
