### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -82,6 +82,24 @@ public class TranscriptionTaskManager: ObservableObject {
             return
         }
 
+        guard systemURL != nil else {
+            let errorMessage = PipelineError.missingSystemAudio.localizedDescription
+            AppLogger.pipeline.warning("Rejecting transcription — system audio capture is missing")
+            archiveFailedRecordingAudioIfConfigured(
+                micURL: micURL,
+                systemURL: nil,
+                taskId: UUID()
+            )
+            failedTranscriptionManager.addFailedTranscription(
+                micAudioURL: micURL,
+                systemAudioURL: nil,
+                errorMessage: errorMessage
+            )
+            displayStatus = .failed(message: "System audio required")
+            sendFailureNotification(errorMessage: errorMessage)
+            scheduleStatusReset(delay: 4)
+            return
+        }
 
         // Gate: reject only when every available capture track is too short.
         // Meeting recovery can produce a very short mic stub while system audio is still

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Combine
+import AVFoundation
 import FluidAudio
 @testable import TranscriptedCore
 
@@ -72,6 +73,32 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
                        "embedders that pass only the static value should still get a valid resolver result")
     }
 
+    func testStartTranscriptionRejectsMissingSystemAudioBeforeBackgroundWorkStarts() throws {
+        let manager = makeManager()
+        let micURL = tempDirectory.appendingPathComponent("mic.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+
+        manager.startTranscription(
+            micURL: micURL,
+            systemURL: nil,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts")
+        )
+
+        XCTAssertEqual(manager.activeCount, 0)
+        XCTAssertEqual(manager.backgroundTaskCount, 0)
+        XCTAssertEqual(manager.activeTasks.count, 0)
+        XCTAssertEqual(manager.failedTranscriptionManager.failedTranscriptions.count, 1)
+        XCTAssertEqual(
+            manager.failedTranscriptionManager.failedTranscriptions.first?.errorMessage,
+            PipelineError.missingSystemAudio.localizedDescription
+        )
+
+        guard case .failed(let message) = manager.displayStatus else {
+            return XCTFail("Expected failed display status when system audio is missing")
+        }
+        XCTAssertEqual(message, "System audio required")
+    }
+
     private func makeManager(
         retainedAudioDirectory: URL? = nil,
         retainedAudioDirectoryProvider: (() -> URL?)? = nil
@@ -98,6 +125,40 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             retainedAudioDirectory: retainedAudioDirectory,
             retainedAudioDirectoryProvider: retainedAudioDirectoryProvider
         )
+    }
+
+    private func writeMonoWAV(to url: URL, duration: TimeInterval, sampleRate: Double = 16_000) throws {
+        let frameCount = Int(duration * sampleRate)
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        ) else {
+            return XCTFail("Failed to create test audio format")
+        }
+
+        let file = try AVAudioFile(
+            forWriting: url,
+            settings: format.settings,
+            commonFormat: format.commonFormat,
+            interleaved: format.isInterleaved
+        )
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(frameCount)
+        ) else {
+            return XCTFail("Failed to create test audio buffer")
+        }
+
+        buffer.frameLength = AVAudioFrameCount(frameCount)
+        if let channelData = buffer.floatChannelData?[0] {
+            for index in 0..<frameCount {
+                channelData[index] = 0.25
+            }
+        }
+
+        try file.write(from: buffer)
     }
 }
 


### PR DESCRIPTION
## Summary
- fail fast when a meeting reaches transcription without a system-audio file
- preserve the failure in the failed-transcription queue instead of starting a doomed background task
- cover the regression with a focused task-manager test

## Findings fixed

### Transcription pipeline
- `TranscriptionTaskManager.startTranscription` could start a background transcription when the mic recording was long enough but the required system-audio file was missing.
- The pipeline would then fail later with `missingSystemAudio`, after moving through active-task state and notification paths that made the failure slower and less deterministic.
- The manager now rejects that case up front, archives the failed capture when configured, records the failure in the retry queue, and surfaces a clear user-visible failure immediately.

### Tests
- Added coverage proving a mic-only recording is rejected before any background task starts and is stored as a failed transcription with the expected error.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
