### PR TITLE
[nightly-telemetry] Track failed dictation starts

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -277,6 +277,13 @@ struct AnalyticsEventPolicy: Equatable {
                 "trigger",
             ]
         ),
+        "dictation_start_failed": .init(
+            name: "dictation_start_failed",
+            allowedProperties: [
+                "failure_kind",
+                "trigger",
+            ]
+        ),
         "dictation_completed": .init(
             name: "dictation_completed",
             allowedProperties: [

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -195,6 +195,31 @@ class DictationSessionController: ObservableObject {
         )
     }
 
+    private func trackDictationStartFailed(_ failureKind: String) {
+        AnalyticsReporter.track(
+            "dictation_start_failed",
+            properties: [
+                "failure_kind": failureKind,
+                "trigger": currentDictationTrigger.rawValue,
+            ]
+        )
+    }
+
+    private func dictationStartFailureKind(for status: AVAuthorizationStatus) -> String {
+        switch status {
+        case .denied:
+            return "microphone_permission_denied"
+        case .restricted:
+            return "microphone_permission_restricted"
+        case .notDetermined:
+            return "microphone_permission_not_determined"
+        case .authorized:
+            return "microphone_unavailable"
+        @unknown default:
+            return "microphone_permission_unknown"
+        }
+    }
+
     private func continueDictationStart(
         appState: TranscriptedAppState,
         overlayController: FloatingOverlayController,
@@ -387,6 +412,7 @@ class DictationSessionController: ObservableObject {
                 ]
             )
         )
+        trackDictationStartFailed("microphone_start_timeout")
         isDictating = false
         overlayController.showError(
             microphoneTimeoutMessage(
@@ -421,6 +447,7 @@ class DictationSessionController: ObservableObject {
                 ]
             )
         )
+        trackDictationStartFailed(dictationStartFailureKind(for: status))
         if !overlayController.isVisible {
             overlayController.showPanel(near: sourceApp, anchorRect: sessionAnchorRect)
         }

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -99,12 +99,31 @@ func testAnalyticsEventPolicy() {
         assertEqual(dictationCompleted?.allowedProperties.contains("auto_send"), true, "dictation completion should allow the existing auto_send property")
     }
 
+    runSuite("AnalyticsEventPolicy allows dictation start failures with coarse attribution") {
+        let dictationStartFailed = AnalyticsEventPolicy.policy(forEvent: "dictation_start_failed")
+
+        assertEqual(dictationStartFailed?.allowedProperties.contains("failure_kind"), true, "dictation start failures should preserve normalized failure kinds")
+        assertEqual(dictationStartFailed?.allowedProperties.contains("trigger"), true, "dictation start failures should preserve trigger attribution")
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "failure_kind": "microphone_start_timeout",
+                "trigger": "hotkey",
+            ],
+            allowedKeys: ["failure_kind", "trigger"]
+        )
+        assertEqual(sanitized["failure_kind"], "microphone_start_timeout", "dictation start failure kind should survive sanitization")
+        assertEqual(sanitized["trigger"], "hotkey", "dictation start trigger should survive sanitization")
+    }
+
     runSuite("AnalyticsEventPolicy only permits reviewed analytics events") {
+        let dictationStartFailed = AnalyticsEventPolicy.policy(forEvent: "dictation_start_failed")
         let dictationCompleted = AnalyticsEventPolicy.policy(forEvent: "dictation_completed")
         let dictationNoSpeech = AnalyticsEventPolicy.policy(forEvent: "dictation_no_speech")
         let meetingFailed = AnalyticsEventPolicy.policy(forEvent: "meeting_transcript_failed")
         let unknown = AnalyticsEventPolicy.policy(forEvent: "raw_transcript_uploaded")
 
+        assertEqual(dictationStartFailed?.allowedProperties.contains("failure_kind"), true, "dictation start failures should allow normalized failure kinds")
         assertEqual(dictationCompleted?.allowedProperties.contains("word_count_bucket"), true, "dictation completion should allow bucketed word counts")
         assertEqual(dictationNoSpeech?.allowedProperties.contains("duration_bucket"), true, "dictation no-speech should keep a coarse duration bucket")
         assertEqual(dictationNoSpeech?.allowedProperties.contains("trigger"), true, "dictation no-speech should preserve trigger attribution")

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -75,6 +75,7 @@ transport.
 - `app_launched`
 - `onboarding_completed`
 - `dictation_started`
+- `dictation_start_failed`
 - `dictation_completed`
 - `dictation_cancelled`
 - `dictation_no_speech`


### PR DESCRIPTION
## Summary
- add a reviewed `dictation_start_failed` analytics event
- track coarse failure kinds for microphone permission failures and microphone start timeouts
- document and test the new allowlisted event

## Why
Sentry already shows dictation startup failures, but PostHog only saw successful starts and later outcomes. That made startup failures disappear from the product funnel.