### PR TITLE
[nightly-ux] clarify short meeting failures on the home card

### DIFF
--- a/Sources/UI/Settings/HomeTranscriptionActivityPresentation.swift
+++ b/Sources/UI/Settings/HomeTranscriptionActivityPresentation.swift
@@ -77,11 +77,16 @@ struct HomeTranscriptionActivityPresentation: Equatable {
                 transcriptURL: transcriptURL
             )
         case .failed(let message):
+            let copy = MeetingFailureCopy.make(
+                forMessage: message,
+                shortErrorMessage: message,
+                isRetryable: true
+            )
             return HomeTranscriptionActivityPresentation(
                 symbolName: "exclamationmark.triangle.fill",
-                title: "Transcription didn't finish",
+                title: copy.title,
                 status: "Needs attention",
-                detail: message,
+                detail: copy.detail,
                 tone: .caution,
                 progress: nil,
                 transcriptURL: nil


### PR DESCRIPTION
## Why
PostHog shows `meeting_transcript_failed` is low-volume but real in the last 7 days, and `recording_too_short` is the top failure kind (4 of 7 failures). The home transcription activity card was still showing the generic `Transcription didn't finish` copy for that path.

## What changed
- reuse `MeetingFailureCopy` for failed home transcription activity cards
- show the existing user-facing short-recording explanation instead of the raw failure string

## Verification
- `bash run-tests.sh`
- `bash build-deps.sh --force`
- `bash build.sh`