### PR TITLE
[nightly-notes] Add release notes template

### DIFF
--- a/docs/release-notes-template.md
+++ b/docs/release-notes-template.md
@@ -1,0 +1,34 @@
+# Release Notes Template
+
+Use this when drafting the next Transcripted release note from `main` after the
+latest shipped tag.
+
+Keep it short. Focus on what a user would notice or care about.
+
+## Candidate summary
+
+- One sentence on what this candidate is trying to improve.
+- Call out the version gap plainly if `Info.plist` and GitHub Releases still match.
+
+## User-visible changes
+
+- New UI surfaces or workflow changes.
+- Better update/install behavior users may notice.
+- Search or agent-connect improvements people can actually use.
+
+## Reliability and ops changes
+
+- Crash, freeze, audio, or data-safety fixes.
+- Privacy or logging hardening that protects real usage.
+- Keep this in normal language, not Sentry shorthand.
+
+## Known caveats
+
+- Things that still need manual QA.
+- Things that are better but not fully proven yet.
+- Anything that is still docs-only and should not be oversold.
+
+## Good reason to ship or wait
+
+- Ship when the user-facing value is clear and the reliability fixes match live pain.
+- Wait when the branch is mostly internal cleanup, docs sync, or automation work.

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -96,6 +96,7 @@ Before you publish a user-facing release note, sanity-check the release state:
 - compare `Info.plist` `CFBundleShortVersionString` against the latest GitHub release tag
 - review the merged PRs since that latest published release so the note reflects shipped changes, not just local branch state
 - if `docs/appcast.xml` still points at the older release, say plainly that existing installs will not discover the new build in-app yet
+- if you want a clean starting point, use `docs/release-notes-template.md`
 
 If you expect existing installs of Transcripted to discover the new version
 inside the app, do not stop after the DMG is built. You must also complete the


### PR DESCRIPTION
## Summary
- add a short release notes template for nightly drafting passes
- link the packaging doc to the template so release-note prep starts from the same shape each time

## Verification
- git diff --check