### PR TITLE
[nightly-docs] refresh docs drift notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,10 +110,11 @@ Rules:
 2. Runtime Sentry config lives in `Info.plist` under:
    - `TranscriptedSentryDSN`
    - `TranscriptedSentryEnvironment`
-   - `TranscriptedSentryAppHangTrackingEnabled`
+   - optional: `TranscriptedSentryAppHangTrackingEnabled`
 3. Local overrides for testing can come from process environment:
    - `SENTRY_DSN`
    - `SENTRY_ENVIRONMENT`
+   - `SENTRY_ENABLE_APP_HANG_TRACKING`
 4. Runtime PostHog config lives in `Info.plist` under:
    - `TranscriptedPostHogAPIKey`
    - `TranscriptedPostHogHost`

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -13,7 +13,7 @@ The directory is grouped by surface so the live UI tree is easier to scan:
 
 Draft-mode UI is not an active product path in this worktree.
 
-## Files (47 Swift files)
+## Files (48 Swift files)
 
 ### Overlay/
 
@@ -68,6 +68,7 @@ The current agent-connect surfaces should keep one simple mental model:
 ### Settings/
 
 - `Settings/HomeTranscriptionActivityPresentation.swift` — presentation model derived from `MeetingSessionController` state for the home page's live transcription activity card (tone, progress, transcript URL)
+- `Settings/HomeView.swift` — SwiftUI home page with first-run guidance, permission status, quick actions, and live transcription activity
 - `Settings/HotkeyRecorderAppKitView.swift` — AppKit view for recording custom hotkey bindings
 - `Settings/PermissionsOnboardingView.swift` — first-launch permissions walkthrough
 - `Settings/SpeakerNamingSheet.swift` — sheet for reviewing speakers in a completed meeting, grouped into local room speakers vs remote participants, with a "Keep as You" escape hatch for local mic splits


### PR DESCRIPTION
## Summary
- fix the AGENTS Sentry config note to match the live optional app-hang flag and env override
- update the UI subsystem doc count and add the missing `Settings/HomeView.swift` entry

## Verification
- docs-only repo sweep against current tree, Info.plist keys, wrapper scripts, and subsystem file lists