### PR TITLE
[nightly-retrieval] Document agent retrieval recipes

### DIFF
--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -71,6 +71,26 @@ swift run transcripted-cli list-dictations --count 5
 swift run transcripted-cli diarize /path/to/audio.wav --json
 ```
 
+## Common Retrieval Recipes
+
+Use the built binary once `swift build` finishes so repeated checks do not wait
+on SwiftPM again:
+
+```bash
+./.build/debug/transcripted-cli context-recent --count 10
+./.build/debug/transcripted-cli context-recent --kind meeting --count 3
+./.build/debug/transcripted-cli context-search "Linus" --kind meeting --speaker "Linus" --count 5
+./.build/debug/transcripted-cli list-dictations --date-from 2026-04-29 --date-to 2026-04-29
+./.build/debug/transcripted-cli read-dictation Dictations_2026-04-29
+```
+
+What these are good for:
+
+- latest mixed context: `context-recent`
+- latest meeting only: `context-recent --kind meeting`
+- meetings by speaker or topic: `context-search <query> --kind meeting --speaker <name>`
+- dictations by day: `list-dictations --date-from YYYY-MM-DD --date-to YYYY-MM-DD`, then `read-dictation`
+
 Binary path after build:
 
 ```text
@@ -90,4 +110,5 @@ instruction to run `bash build-deps.sh` from the repo root before rebuilding.
 - retrieval-only commands should still build and run even when the diarization bundle is absent
 - `swift test` currently covers the agent-facing context path resolver and context-store loading behavior
 - the default context resolver prefers Transcripted capture folders, then falls back to Draft-era exports, then `~/Documents/Transcripted/`
+- `context-recent` is intentionally a mixed feed; if the user asks for the latest meeting specifically, add `--kind meeting`
 - changes here should be verified independently from the app build

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -70,6 +70,15 @@ All tools are read-only.
 | `who_is` | Look up a speaker profile across saved meetings |
 | `recap` | Build a structured digest for a date range |
 
+## Common Agent Retrieval Shapes
+
+Use these tool patterns for the most common questions:
+
+- latest meeting: `list_meetings` with `{"count": 3}` or `recent_context` with `{"kind":"meeting","count":3}`
+- meetings by speaker: `search` with `{"query":"topic","speaker":"Name"}` or `who_is` with `{"speaker":"Name"}`
+- recent mixed context: `recent_context` with `{"count":10}`
+- dictations by day: `list_dictations` with `{"date":"2026-04-29"}`, then `read_dictation` with the returned filename
+
 ## Data Flow
 
 ```text
@@ -142,5 +151,6 @@ The in-app Claude Desktop installer copies that helper into:
 - direct file reads are path-validated and reject traversal or symlink escapes
 - the server auto-creates missing data and index directories
 - the index rebuilds from disk on startup
+- `recent_context` is intentionally mixed; for the latest meeting specifically, prefer `list_meetings` or `recent_context` with `kind: "meeting"`
 - `read_meeting` and `read_dictation` read markdown directly from disk, not from the SQLite index
 - source builds can run the server standalone, but shipped app builds bundle the helper for the one-click Claude Desktop installer


### PR DESCRIPTION
## Summary
- add exact CLI retrieval commands for latest meeting, speaker-scoped meeting search, and dictations by day
- add MCP tool-call shapes for latest meeting, recent context, speaker lookups, and day-scoped dictations
- call out that mixed recent feeds should use meeting-only mode when the user asks for the latest meeting

## Verification
- cd Tools/TranscriptedCLI && swift build
- cd Tools/TranscriptedMCP && swift build
- cd Tools/TranscriptedMCP && swift test
- exercised transcripted-cli against local Transcripted captures with context-recent, context-search, list-dictations, and read-dictation
