### PR TITLE
Rename agent review label to human review

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -7,7 +7,7 @@ tracker:
     - agent in progress
   todo_label: agent todo
   in_progress_label: agent in progress
-  review_label: agent review
+  review_label: human review
   blocked_label: agent blocked
   done_label: agent done
   allowed_authors:
@@ -57,7 +57,7 @@ Use the issue as the source of truth. If the issue is too vague to implement saf
 9. Stage only your own changes, commit, and push.
 10. Open a draft PR against `main` with `gh pr create --draft`.
 11. Link the PR in the issue workpad and add a short verification summary.
-12. Remove `agent in progress` and add `agent review` when the PR is ready for Justin to review.
+12. Remove `agent in progress` and add `human review` when the PR is ready for Justin to review.
 
 ## Guardrails
 

--- a/docs/agent-issue-orchestration.md
+++ b/docs/agent-issue-orchestration.md
@@ -13,7 +13,7 @@ The runner treats labels as state:
 
 - `agent todo` - ready for Codex
 - `agent in progress` - Codex claimed it
-- `agent review` - draft PR is ready for human review
+- `human review` - draft PR is ready for Justin to review
 - `agent blocked` - Codex hit a real blocker
 - `agent done` - optional final state after merge or manual closeout
 
@@ -84,7 +84,7 @@ bash scripts/ops/agent-todo-launchagent.sh restart
 - Moves new work from `agent todo` to `agent in progress`.
 - Launches Codex in that issue workspace.
 
-Codex is expected to commit, push, open a draft PR, update the workpad, and move the issue to `agent review`.
+Codex is expected to commit, push, open a draft PR, update the workpad, and move the issue to `human review`.
 
 ## Safety Notes
 

--- a/scripts/ops/agent-todo-runner.rb
+++ b/scripts/ops/agent-todo-runner.rb
@@ -13,7 +13,7 @@ class AgentTodoRunner
   LABELS = {
     "agent todo" => ["5319e7", "Ready for the local Codex issue runner"],
     "agent in progress" => ["f9d0c4", "Claimed by the local Codex issue runner"],
-    "agent review" => ["0e8a16", "Codex opened a PR for human review"],
+    "human review" => ["0e8a16", "Codex opened a PR for human review"],
     "agent blocked" => ["d93f0b", "Codex needs human input before continuing"],
     "agent done" => ["cfd3d7", "Agent task is complete"]
   }.freeze
@@ -421,7 +421,7 @@ class AgentTodoRunner
   end
 
   def review_label
-    @review_label ||= @tracker.fetch("review_label", "agent review")
+    @review_label ||= @tracker.fetch("review_label", "human review")
   end
 
   def blocked_label


### PR DESCRIPTION
## Summary
- rename the completed-agent state from `agent review` to `human review` in the runner contract and docs
- keep the label description focused on PRs ready for Justin to review

## Verification
- ruby -c scripts/ops/agent-todo-runner.rb
- ruby scripts/ops/agent-todo-runner.rb --labels-only --dry-run
- git diff --check
- renamed the live GitHub label from `agent review` to `human review`
- restarted the local LaunchAgent watcher