### PR TITLE
[nightly-artifact] add automation fingerprints to QA JSON

### DIFF
--- a/Tools/TranscriptedQA/CLAUDE.md
+++ b/Tools/TranscriptedQA/CLAUDE.md
@@ -104,6 +104,10 @@ swift run transcripted-qa stress-test --transcripts 100 --speakers-per-transcrip
 
 `ValidationReport` wraps all rows, computes a pass/fail/warn summary, exposes the CLI exit code, and can print either aligned text output or pretty JSON.
 
+For agent and automation use, the JSON form also includes:
+- `automation` - overall status, exit code, generated timestamp, and grouped-fingerprint count
+- `failureFingerprints` - grouped non-pass checks with stable ids, counts, and affected targets
+
 ## Key Features
 
 - **Health checks**: Quick system status before deep validation

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Models/ValidationResult.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Models/ValidationResult.swift
@@ -44,6 +44,8 @@ struct ValidationResult: Codable {
 struct ValidationReport: Codable {
     let results: [ValidationResult]
     let summary: Summary
+    let automation: AutomationSummary
+    let failureFingerprints: [FailureFingerprint]
 
     struct Summary: Codable {
         let passed: Int
@@ -51,12 +53,38 @@ struct ValidationReport: Codable {
         let warnings: Int
     }
 
-    init(results: [ValidationResult]) {
+    struct AutomationSummary: Codable {
+        let status: ValidationStatus
+        let exitCode: Int
+        let generatedAt: String
+        let resultCount: Int
+        let failureFingerprintCount: Int
+    }
+
+    struct FailureFingerprint: Codable {
+        let id: String
+        let status: ValidationStatus
+        let check: String
+        let detail: String?
+        let count: Int
+        let targets: [String]
+    }
+
+    init(results: [ValidationResult], generatedAt: Date = Date()) {
         self.results = results
         self.summary = Summary(
             passed: results.filter { $0.status == .pass }.count,
             failed: results.filter { $0.status == .fail }.count,
             warnings: results.filter { $0.status == .warn }.count
+        )
+        self.failureFingerprints = FailureFingerprint.build(from: results)
+        let exitCode = summary.failed > 0 ? 1 : 0
+        self.automation = AutomationSummary(
+            status: ValidationReport.overallStatus(for: summary),
+            exitCode: exitCode,
+            generatedAt: ISO8601DateFormatter().string(from: generatedAt),
+            resultCount: results.count,
+            failureFingerprintCount: failureFingerprints.count
         )
     }
 
@@ -86,5 +114,72 @@ struct ValidationReport: Codable {
             FileHandle.standardError.write(Data("Error: Failed to encode JSON report: \(error)\n".utf8))
             Foundation.exit(1)
         }
+    }
+
+    private static func overallStatus(for summary: Summary) -> ValidationStatus {
+        if summary.failed > 0 {
+            return .fail
+        }
+        if summary.warnings > 0 {
+            return .warn
+        }
+        return .pass
+    }
+}
+
+private extension ValidationReport.FailureFingerprint {
+    static func build(from results: [ValidationResult]) -> [Self] {
+        let grouped = Dictionary(grouping: results.filter { $0.status != .pass }) { result in
+            FingerprintKey(status: result.status, check: result.check, detail: result.detail)
+        }
+
+        return grouped.map { key, group in
+            let targets = Array(Set(group.map(\.target))).sorted()
+            return ValidationReport.FailureFingerprint(
+                id: "fp-\(stableFingerprint(for: key.material))",
+                status: key.status,
+                check: key.check,
+                detail: key.detail,
+                count: group.count,
+                targets: targets
+            )
+        }
+        .sorted {
+            if statusRank($0.status) != statusRank($1.status) {
+                return statusRank($0.status) < statusRank($1.status)
+            }
+            if $0.check != $1.check {
+                return $0.check < $1.check
+            }
+            return ($0.detail ?? "") < ($1.detail ?? "")
+        }
+    }
+
+    private struct FingerprintKey: Hashable {
+        let status: ValidationStatus
+        let check: String
+        let detail: String?
+
+        var material: String {
+            [status.rawValue, check, detail ?? ""].joined(separator: "|")
+        }
+    }
+
+    private static func statusRank(_ status: ValidationStatus) -> Int {
+        switch status {
+        case .fail: return 0
+        case .warn: return 1
+        case .pass: return 2
+        }
+    }
+
+    private static func stableFingerprint(for value: String) -> String {
+        var hash: UInt64 = 14695981039346656037
+        let prime: UInt64 = 1099511628211
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= prime
+        }
+        return String(format: "%016llx", hash)
     }
 }

--- a/Tools/TranscriptedQA/Tests/TranscriptedQATests/ValidatorTests.swift
+++ b/Tools/TranscriptedQA/Tests/TranscriptedQATests/ValidatorTests.swift
@@ -105,4 +105,46 @@ final class ValidatorTests: XCTestCase {
             1
         )
     }
+
+    func testValidationReportJSONIncludesAutomationSummaryAndFingerprints() throws {
+        let generatedAt = Date(timeIntervalSince1970: 1_777_777_777)
+        let report = ValidationReport(
+            results: [
+                .warn("transcript/yaml-capture-quality", target: "one.md", detail: "capture_quality key not present — check skipped"),
+                .warn("transcript/yaml-capture-quality", target: "two.md", detail: "capture_quality key not present — check skipped"),
+                .fail("artifact/md-match", target: "Call_2026-04-18_14-43-40.json", detail: "No corresponding .md file"),
+            ],
+            generatedAt: generatedAt
+        )
+
+        let data = try JSONEncoder().encode(report)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let automation = try XCTUnwrap(object["automation"] as? [String: Any])
+        XCTAssertEqual(automation["status"] as? String, "FAIL")
+        XCTAssertEqual(automation["exitCode"] as? Int, 1)
+        XCTAssertEqual(automation["resultCount"] as? Int, 3)
+        XCTAssertEqual(automation["failureFingerprintCount"] as? Int, 2)
+        XCTAssertEqual(automation["generatedAt"] as? String, "2026-05-03T03:09:37Z")
+
+        let fingerprints = try XCTUnwrap(object["failureFingerprints"] as? [[String: Any]])
+        XCTAssertEqual(fingerprints.count, 2)
+
+        let groupedWarning = try XCTUnwrap(
+            fingerprints.first { $0["check"] as? String == "transcript/yaml-capture-quality" }
+        )
+        XCTAssertEqual(groupedWarning["status"] as? String, "WARN")
+        XCTAssertEqual(groupedWarning["count"] as? Int, 2)
+        XCTAssertEqual(
+            Set((groupedWarning["targets"] as? [String]) ?? []),
+            Set(["one.md", "two.md"])
+        )
+        XCTAssertNotNil(groupedWarning["id"] as? String)
+
+        let groupedFailure = try XCTUnwrap(
+            fingerprints.first { $0["check"] as? String == "artifact/md-match" }
+        )
+        XCTAssertEqual(groupedFailure["status"] as? String, "FAIL")
+        XCTAssertEqual(groupedFailure["count"] as? Int, 1)
+        XCTAssertEqual(groupedFailure["detail"] as? String, "No corresponding .md file")
+    }
 }


### PR DESCRIPTION
## Summary
- add an `automation` block to TranscriptedQA JSON reports
- add grouped `failureFingerprints` with stable ids for non-pass results
- cover the JSON schema in package tests and document it in the QA tool guide

## Verification
- `cd Tools/TranscriptedQA && swift test`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run transcripted-qa check-health --format json`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run transcripted-qa validate-all --format json`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run transcripted-qa round-trip`

## Notes
- The live data still shows the long-lived local drift around `Call_2026-04-18_14-43-40` and stale `transcripted.json` references.
- Full `bash build.sh` / `bash run-tests.sh` verification is currently blocked by `bash build-deps.sh --force` failing with `No space left on device` while writing `deps-libs/libDraftDeps.a`.