### PR TITLE
[nightly-release] Prepare 1.1.26 release candidate

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.25</string>
+	<string>1.1.26</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.25</string>
+	<string>1.1.26</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>


### PR DESCRIPTION
## Summary
- bump release metadata from `1.1.25` to `1.1.26` so the next public cut has a clean version boundary
- stage a release candidate only; do not publish a GitHub release, update `docs/appcast.xml`, or update the Homebrew cask in this PR

## Why now
- `v1.1.25` was published on April 27, 2026
- meaningful user-facing work landed after that tag: audio device recovery hardening, meeting audio graph teardown safety, restart-ready Sparkle UX, redesigned Settings Home, and permanent Dock presence
- current repo verification is green on this branch tip after a fresh dependency rebuild

## Release watch items
- latest-release Sentry still shows unresolved `APPLE-MACOS-17`, `APPLE-MACOS-14`, and `APPLE-MACOS-18` on `release:transcripted@1.1.25`, but current live signal is low-volume and showed `0` users in this pass rather than a new high-severity blocker
- build/test still emit existing `ActivationPolicyController` main-actor warnings; they are not failing the release gate in this run

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `swift test`

## Notes
Sparkle users will **not** see `1.1.26` from this PR alone. A real public release still needs a published GitHub release artifact plus an updated `docs/appcast.xml` pushed to `main`.