### PR TITLE
[nightly-compat] Remove unused Draft storage helper

### DIFF
--- a/Sources/Support/TranscriptedStoragePaths.swift
+++ b/Sources/Support/TranscriptedStoragePaths.swift
@@ -103,11 +103,6 @@ extension FileManager {
         ensuredPrivateDirectory(at: transcriptedAppSupportRootURL, context: "Transcripted app support root")
     }
 
-    /// Historic Draft compatibility root, retained only for migration / cleanup flows.
-    var draftAppSupportDir: URL {
-        userApplicationSupportDir.appendingPathComponent("Draft", isDirectory: true)
-    }
-
     var transcriptedDefaultCaptureLibraryDir: URL {
         let url = transcriptedAppSupportDir.appendingPathComponent("captures", isDirectory: true)
         return ensuredPrivateDirectory(at: url, context: "Transcripted capture library parent")


### PR DESCRIPTION
## Summary
- remove the unused app-side `draftAppSupportDir` helper from `TranscriptedStoragePaths`
- keep all documented legacy Draft fallback behavior in CLI/MCP/QA tools unchanged

## Verification
- `bash run-tests.sh`
- `bash build-deps.sh`
- `bash build.sh`