### PR TITLE
[nightly-simplify] Remove unused onboarding start helper

### DIFF
--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -364,16 +364,6 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         }
     }
 
-    private func finishOnboardingAndStartDictation() {
-        let sourceApp = resolvedSourceApp()
-        PermissionsOnboardingPreferences.markCompleted()
-        appState.recoverHotkeysAfterPermissionChange()
-        onboardingWindowController.dismiss()
-        closePopover()
-        sourceApp?.activate(options: [])
-        sessionController.startDictation(sourceApp: sourceApp, trigger: .onboarding)
-    }
-
     private func showMainPopover(
         relativeTo button: NSStatusBarButton,
         popover: NSPopover,


### PR DESCRIPTION
## Summary
- remove the unused private `finishOnboardingAndStartDictation()` helper from `TranscriptedAppDelegate`
- keep onboarding completion and dictation startup behavior unchanged by deleting only the dead duplicate path
- note the build-space cleanup: cleared stale `transcripted-deps-build.*` temp folders so required verification could complete

## Verification
- `bash run-tests.sh`
- `bash build-deps.sh --force`
- `bash build.sh`