### PR TITLE
Fix failed transcription test fixture path

### DIFF
--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -75,7 +75,7 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
 
     func testStartTranscriptionRejectsMissingSystemAudioBeforeBackgroundWorkStarts() throws {
         let manager = makeManager()
-        let micURL = tempDirectory.appendingPathComponent("mic.wav")
+        let micURL = tempDirectory.appendingPathComponent("audio/mic.wav")
         try writeMonoWAV(to: micURL, duration: 2.5)
 
         manager.startTranscription(


### PR DESCRIPTION
## Summary\n- Put the missing-system-audio test mic fixture under the injected audio capture root\n- Keeps the test aligned with failed-transcription path hardening\n\n## Verification\n- swift test