### PR TITLE
[nightly-agent] Clarify shared agent data-dir behavior

### DIFF
--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextDirectoriesTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextDirectoriesTests.swift
@@ -164,6 +164,33 @@ final class ContextDirectoriesTests: XCTestCase {
         ])
     }
 
+    func testResolveSharedDataDirUsesMeetingsAndDictationsSubfolders() throws {
+        let tempHome = makeTempDir()
+        defer { removeTempDir(tempHome) }
+
+        let sharedRoot = tempHome.appendingPathComponent("shared-context", isDirectory: true)
+        let sharedMeetings = sharedRoot.appendingPathComponent("meetings", isDirectory: true)
+        let sharedDictations = sharedRoot.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: sharedMeetings, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: sharedDictations, withIntermediateDirectories: true)
+
+        let directories = CLIContextDirectories.resolve(
+            dataDir: nil,
+            meetingsDir: nil,
+            dictationsDir: nil,
+            environment: ["TRANSCRIPTED_DATA_DIR": sharedRoot.path],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(directories.meetingDirs.map(\.standardizedFileURL.path), [
+            sharedMeetings.standardizedFileURL.path,
+        ])
+        XCTAssertEqual(directories.dictationDirs.map(\.standardizedFileURL.path), [
+            sharedDictations.standardizedFileURL.path,
+        ])
+    }
+
     func testResolveSkipsLegacySharedFolderWithoutCaptureMarkdown() throws {
         let tempHome = makeTempDir()
         defer { removeTempDir(tempHome) }

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -24,6 +24,11 @@ Path overrides:
 - `TRANSCRIPTED_DICTATIONS_DIR` — dictations directory override
 - `TRANSCRIPTED_INDEX_DIR` — SQLite index directory override
 
+When `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
+`dictations/` subfolders, the server uses those subfolders automatically. In
+that mode the SQLite index also defaults to the shared root unless
+`TRANSCRIPTED_INDEX_DIR` is set.
+
 ## Package Layout (15 Swift files)
 
 - `Package.swift` — Swift package manifest for the standalone MCP server

--- a/Tools/TranscriptedMCP/README.md
+++ b/Tools/TranscriptedMCP/README.md
@@ -43,3 +43,7 @@ The server reads:
 
 Override paths with `TRANSCRIPTED_DATA_DIR`, `TRANSCRIPTED_MEETINGS_DIR`,
 `TRANSCRIPTED_DICTATIONS_DIR`, or `TRANSCRIPTED_INDEX_DIR`.
+If `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
+`dictations/` subfolders, `transcripted-mcp` uses those subfolders
+automatically and stores its SQLite index in that shared root unless
+`TRANSCRIPTED_INDEX_DIR` is also set.

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/DataDirectoriesTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/DataDirectoriesTests.swift
@@ -159,6 +159,54 @@ final class DataDirectoriesTests: XCTestCase {
         ])
     }
 
+    func testResolveSharedDataDirUsesMeetingsAndDictationsSubfoldersAndSharedIndex() throws {
+        let sharedRoot = tempHome.appendingPathComponent("shared-context", isDirectory: true)
+        let sharedMeetings = sharedRoot.appendingPathComponent("meetings", isDirectory: true)
+        let sharedDictations = sharedRoot.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: sharedMeetings, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: sharedDictations, withIntermediateDirectories: true)
+
+        let directories = TranscriptedDataDirectories.resolve(
+            environment: ["TRANSCRIPTED_DATA_DIR": sharedRoot.path],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(directories.meetingDirs.map(\.standardizedFileURL.path), [
+            sharedMeetings.standardizedFileURL.path,
+        ])
+        XCTAssertEqual(directories.dictationDirs.map(\.standardizedFileURL.path), [
+            sharedDictations.standardizedFileURL.path,
+        ])
+        XCTAssertEqual(directories.indexDir.standardizedFileURL.path, sharedRoot.standardizedFileURL.path)
+    }
+
+    func testResolveSharedDataDirHonorsExplicitIndexOverride() throws {
+        let sharedRoot = tempHome.appendingPathComponent("shared-context", isDirectory: true)
+        let sharedMeetings = sharedRoot.appendingPathComponent("meetings", isDirectory: true)
+        let sharedDictations = sharedRoot.appendingPathComponent("dictations", isDirectory: true)
+        let customIndex = tempHome.appendingPathComponent("custom-index", isDirectory: true)
+        try FileManager.default.createDirectory(at: sharedMeetings, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: sharedDictations, withIntermediateDirectories: true)
+
+        let directories = TranscriptedDataDirectories.resolve(
+            environment: [
+                "TRANSCRIPTED_DATA_DIR": sharedRoot.path,
+                "TRANSCRIPTED_INDEX_DIR": customIndex.path,
+            ],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(directories.meetingDirs.map(\.standardizedFileURL.path), [
+            sharedMeetings.standardizedFileURL.path,
+        ])
+        XCTAssertEqual(directories.dictationDirs.map(\.standardizedFileURL.path), [
+            sharedDictations.standardizedFileURL.path,
+        ])
+        XCTAssertEqual(directories.indexDir.standardizedFileURL.path, customIndex.standardizedFileURL.path)
+    }
+
     func testResolveSkipsLegacySharedFolderWithoutCaptureMarkdown() throws {
         let legacyShared = tempHome
             .appendingPathComponent("Documents", isDirectory: true)

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -130,6 +130,7 @@ Notes:
 
 - `transcripted-mcp` communicates over stdio, not HTTP.
 - By default it resolves Transcripted capture folders first, then falls back to legacy Draft or `~/Documents/Transcripted/` layouts if those are the only artifacts on disk.
+- `TRANSCRIPTED_DATA_DIR` can point at a shared root with `meetings/` and `dictations/` subfolders. For `transcripted-mcp`, that shared root also becomes the default SQLite index location unless `TRANSCRIPTED_INDEX_DIR` is set.
 - If needed, override paths with `TRANSCRIPTED_DATA_DIR`,
   `TRANSCRIPTED_MEETINGS_DIR`, `TRANSCRIPTED_DICTATIONS_DIR`, and
   `TRANSCRIPTED_INDEX_DIR`.

--- a/docs/storage-paths.md
+++ b/docs/storage-paths.md
@@ -89,5 +89,5 @@ can follow the user-selected capture library.
 The standalone tools do not all resolve paths the same way:
 
 - `TranscriptedCLI` reads `~/Library/Application Support/Transcripted/captures/{meetings,dictations}/` first, then also merges legacy Draft `.../transcripts/` folders and `~/Documents/Transcripted/` when those folders still contain Markdown captures
-- `TranscriptedMCP` follows the same current-plus-legacy read order and keeps its SQLite index under `~/Library/Application Support/Transcripted/cache/` by default
+- `TranscriptedMCP` follows the same current-plus-legacy read order and keeps its SQLite index under `~/Library/Application Support/Transcripted/cache/` by default; if `TRANSCRIPTED_DATA_DIR` is set, it instead keeps the index in that shared root unless `TRANSCRIPTED_INDEX_DIR` is also set
 - `TranscriptedQA` now defaults to the current Transcripted meetings/state/log layout, uses `~/Library/Application Support/Transcripted/logs/app.jsonl` for log validation, falls back to legacy Draft and then `~/Documents/Transcripted/`, and accepts explicit `--path`, `--state-dir`, and `--log-path` overrides for nonstandard setups


### PR DESCRIPTION
## Summary
- document that `TRANSCRIPTED_DATA_DIR` can point at a shared root with `meetings/` and `dictations/` subfolders
- document that `transcripted-mcp` uses that shared root for its SQLite index unless `TRANSCRIPTED_INDEX_DIR` is set
- add CLI and MCP resolver tests so the shared-dir behavior stays locked in

## Verification
- `swift test` in `Tools/TranscriptedCLI`
- `swift test` in `Tools/TranscriptedMCP`
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`