### PR TITLE
[codex] Use GPT-5.5 for agent runner

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -21,7 +21,7 @@ polling:
 agent:
   max_concurrent_agents: 1
 codex:
-  command: codex exec -m gpt-5.4 --dangerously-bypass-approvals-and-sandbox --output-last-message .codex-agent-last-message.md -
+  command: codex exec -m gpt-5.5 -c model_reasoning_effort=medium --dangerously-bypass-approvals-and-sandbox --output-last-message .codex-agent-last-message.md -
 ---
 
 You are Codex working unattended on GitHub Issue #{{ issue.number }} in {{ repo }}.

--- a/scripts/ops/agent-todo-runner.rb
+++ b/scripts/ops/agent-todo-runner.rb
@@ -390,7 +390,7 @@ class AgentTodoRunner
   end
 
   def codex_command
-    @codex_command ||= @codex_config.fetch("command", "codex exec -m gpt-5.4 --dangerously-bypass-approvals-and-sandbox -").to_s
+    @codex_command ||= @codex_config.fetch("command", "codex exec -m gpt-5.5 -c model_reasoning_effort=medium --dangerously-bypass-approvals-and-sandbox -").to_s
   end
 
   def max_concurrent_agents


### PR DESCRIPTION
## Summary
- Updates the local issue runner config to use `gpt-5.5` with medium reasoning.
- Updates the runner fallback command to match the same model and effort.

## Validation
- `codex --version` reports `codex-cli 0.125.0`
- `codex exec -m gpt-5.5 -c model_reasoning_effort=medium ...` returned `OK`
- `ruby -c scripts/ops/agent-todo-runner.rb` passed
