### PR TITLE
Show typing time saved on Home

### DIFF
--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -524,9 +524,9 @@ struct TranscriptedSettingsView: View {
                 label: homeViewModel.totalDictationCount == 1 ? "dictation" : "dictations"
             ),
             HomeStatItem(
-                symbolName: "textformat",
-                value: formattedInteger(homeViewModel.totalDictationWordCount),
-                label: "words dictated"
+                symbolName: "keyboard",
+                value: formattedTypingTimeSaved(forDictatedWords: homeViewModel.totalDictationWordCount),
+                label: "typing saved"
             ),
             HomeStatItem(
                 symbolName: "person.2.wave.2.fill",
@@ -543,6 +543,23 @@ struct TranscriptedSettingsView: View {
 
     private func formattedInteger(_ value: Int) -> String {
         Self.homeIntegerFormatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+
+    private func formattedTypingTimeSaved(forDictatedWords wordCount: Int) -> String {
+        guard wordCount > 0 else { return "0h" }
+
+        let hours = Double(wordCount) / 40.0 / 60.0
+        guard hours >= 1 else { return "<1h" }
+
+        if hours < 10 {
+            let roundedTenths = (hours * 10).rounded() / 10
+            if roundedTenths >= 10 {
+                return "\(Int(roundedTenths.rounded()))h"
+            }
+            return String(format: "%.1fh", roundedTenths)
+        }
+
+        return "\(Int(hours.rounded()))h"
     }
 
     private static let homeIntegerFormatter: NumberFormatter = {


### PR DESCRIPTION
## Summary
- replace the Home raw word-count stat with estimated typing time saved
- calculate from the existing dictated word total at 40 words per minute
- format as `0h`, `<1h`, one decimal under 10h, and whole hours at 10h+

## Validation
- `bash run-tests.sh` passed: 1072 tests
- `bash build.sh` passed after `bash build-deps.sh --force` refreshed missing/stale dependency artifacts

Closes #597