### PR TITLE
Fix build freshness check SIGPIPE

### DIFF
--- a/scripts/entrypoints/build-beta.sh
+++ b/scripts/entrypoints/build-beta.sh
@@ -84,7 +84,7 @@ dependency_input_listing() {
 }
 
 newest_dependency_input() {
-    dependency_input_listing | sort -nr | head -1
+    dependency_input_listing | awk 'NR == 1 || $1 > max { max = $1; line = $0 } END { if (line != "") print line }'
 }
 
 deps_build_stamp_info() {

--- a/scripts/entrypoints/build.sh
+++ b/scripts/entrypoints/build.sh
@@ -40,7 +40,7 @@ dependency_input_listing() {
 }
 
 newest_dependency_input() {
-    dependency_input_listing | sort -nr | head -1
+    dependency_input_listing | awk 'NR == 1 || $1 > max { max = $1; line = $0 } END { if (line != "") print line }'
 }
 
 deps_build_stamp_info() {


### PR DESCRIPTION
## Summary
- replace the build dependency freshness sort/head pipeline with an awk max scan
- apply the same fix to local and beta build entrypoints so pipefail cannot abort on SIGPIPE after deps are present

## Verification
- bash -n scripts/entrypoints/build.sh scripts/entrypoints/build-beta.sh
- bash build.sh
- bash run-tests.sh: 1116 tests passed
- bash run-integration-smoke.sh
- swift test: 106 tests passed
- swift run transcripted-qa round-trip: clean 87/87, corruption 22/22
