### PR TITLE
Fix release blocker QA findings

### DIFF
--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -88,9 +88,7 @@ final class MeetingCaptureBridge: ObservableObject {
                 self.errorMessage = AudioCaptureStartState.timeoutFailureMessage(
                     existingErrorMessage: self.errorMessage
                 )
-                if self.audio.isRecording {
-                    self.audio.stop()
-                }
+                self.audio.stop()
                 continuation.resume(returning: false)
             })
         }

--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -71,6 +71,8 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
     private var pendingImmediateInstallHandler: (() -> Void)?
     private var pendingImmediateInstallVersion: String?
     private var didTrackCurrentUpdateCycleFailure = false
+    private var observedUpdateCheckTimeoutTask: Task<Void, Never>?
+    private static let observedUpdateCheckTimeoutNanoseconds: UInt64 = 30_000_000_000
 
     override init() {
         super.init()
@@ -200,9 +202,11 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
     private func beginObservedUpdateCheck() {
         switch updateStatus.state {
         case .updateAvailable, .downloading, .readyToInstall:
+            cancelObservedUpdateCheckTimeout()
             syncReadiness(from: updaterController.updater)
         default:
             setUpdateStatus(.checking, canCheckForUpdates: updaterController.updater.canCheckForUpdates)
+            scheduleObservedUpdateCheckTimeout()
         }
     }
 
@@ -258,6 +262,7 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
     }
 
     private func markNoUpdateAvailable(from updater: SPUUpdater) {
+        cancelObservedUpdateCheckTimeout()
         if updateStatus.availableUpdateVersion != nil {
             trackUpdateCheckFinished(
                 result: "no_change",
@@ -277,6 +282,7 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
     }
 
     private func markUpdateCheckFailed(from updater: SPUUpdater, error: (any Error)?) {
+        cancelObservedUpdateCheckTimeout()
         if error != nil {
             didTrackCurrentUpdateCycleFailure = true
         }
@@ -295,6 +301,7 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
     }
 
     private func markUpdaterIdle(from updater: SPUUpdater) {
+        cancelObservedUpdateCheckTimeout()
         guard updateStatus.availableUpdateVersion == nil else {
             syncReadiness(from: updater)
             return
@@ -306,6 +313,20 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
 
     private func versionString(for item: SUAppcastItem) -> String {
         Self.displayVersionString(for: item)
+    }
+
+    private func scheduleObservedUpdateCheckTimeout() {
+        observedUpdateCheckTimeoutTask?.cancel()
+        observedUpdateCheckTimeoutTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: Self.observedUpdateCheckTimeoutNanoseconds)
+            guard let self, !Task.isCancelled, self.updateStatus.state == .checking else { return }
+            self.markUpdateCheckFailed(from: self.updaterController.updater, error: nil)
+        }
+    }
+
+    private func cancelObservedUpdateCheckTimeout() {
+        observedUpdateCheckTimeoutTask?.cancel()
+        observedUpdateCheckTimeoutTask = nil
     }
 
     nonisolated private static func displayVersionString(for item: SUAppcastItem) -> String {
@@ -436,6 +457,7 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
 
 extension SparkleUpdaterController: SPUUpdaterDelegate {
     func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        cancelObservedUpdateCheckTimeout()
         let version = versionString(for: item)
         let state = UpdateStatus.State.updateAvailable(version: version)
         setUpdateStatus(state, canCheckForUpdates: updater.canCheckForUpdates)
@@ -498,6 +520,7 @@ extension SparkleUpdaterController: SPUUpdaterDelegate {
     }
 
     func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor updateCheck: SPUUpdateCheck, error: (any Error)?) {
+        cancelObservedUpdateCheckTimeout()
         if let error {
             guard !didTrackCurrentUpdateCycleFailure else { return }
             markUpdateCheckFailed(from: updater, error: error)

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -705,6 +705,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
             return
         }
         prepareForNewRecordingStart()
+        let startGeneration = recordingSessionGeneration
 
         AppLogger.audio.info("Starting audio capture")
 
@@ -714,8 +715,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
             do {
                 try await startAudioCapture()
                 await MainActor.run {
-                    self.isRecording = true
-                    self.isStarting = false
+                    self.finishSuccessfulStartIfCurrent(startGeneration)
                 }
             } catch {
                 await MainActor.run {
@@ -734,6 +734,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // Set isStarting to prevent double-start during async setup
         isStarting = true
         prepareForNewRecordingStart()
+        let startGeneration = recordingSessionGeneration
 
         AppLogger.audio.info("Starting audio capture")
 
@@ -743,8 +744,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
             do {
                 try await startAudioCapture()
                 await MainActor.run {
-                    self.isRecording = true
-                    self.isStarting = false
+                    self.finishSuccessfulStartIfCurrent(startGeneration)
                 }
             } catch {
                 await MainActor.run {
@@ -755,6 +755,23 @@ public class Audio: ObservableObject, @unchecked Sendable {
                 }
             }
         }
+    }
+
+    @MainActor
+    private func finishSuccessfulStartIfCurrent(_ startGeneration: UInt64) {
+        guard recordingSessionGeneration == startGeneration, isStarting else {
+            AppLogger.audio.warning("Audio capture start finished after session was cancelled; tearing down stale capture", [
+                "startGeneration": "\(startGeneration)",
+                "currentGeneration": "\(recordingSessionGeneration)"
+            ])
+            isRecording = false
+            isStarting = false
+            stop()
+            return
+        }
+
+        isRecording = true
+        isStarting = false
     }
 
     // MARK: - Stop Recording
@@ -786,6 +803,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // — the freeze Taylor reported on the meeting widget.
         DispatchQueue.main.async {
             self.isRecording = false
+            self.isStarting = false
             self.audioLevel = 0.0
             self.systemAudioStatus = .unknown  // Reset status when not recording
             self.stopTimer()

--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -35,7 +35,7 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
     var bufferSuccessRate: Double {
         statsLock.lock()
         defer { statsLock.unlock() }
-        guard _totalBuffers > 0 else { return 1.0 }
+        guard _totalBuffers > 0 else { return 0.0 }
         return Double(_buffersWithData) / Double(_totalBuffers)
     }
 

--- a/Sources/TranscriptedCore/Audio/SystemAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SystemAudioCapture.swift
@@ -129,12 +129,12 @@ class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchecked
     var _buffersDropped: Int = 0
     let statsLock = NSLock()
 
-    /// Public getter for buffer success rate (Phase 3: Transcript Metadata)
-    /// Returns 1.0 if no buffers received yet (assume success until proven otherwise)
+    /// Public getter for buffer success rate (Phase 3: Transcript Metadata).
+    /// A started capture that reports no buffers is degraded, not excellent.
     var bufferSuccessRate: Double {
         statsLock.lock()
         defer { statsLock.unlock() }
-        guard _totalBuffers > 0 else { return 1.0 }
+        guard _totalBuffers > 0 else { return 0.0 }
         return Double(_buffersWithData) / Double(_totalBuffers)
     }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -46,6 +46,18 @@ func testRepoCommandContract() {
             "build.sh should not bundle the legacy Parakeet directory as a second 461 MB copy"
         )
     }
+
+    runSuite("Repo command contract - agent todo runner cleans unauthorized queued issues") {
+        let contents = readRepoTextFile("scripts/ops/agent-todo-runner.rb")
+        assertTrue(
+            contents.contains("issues.select { |issue| active_issue?(issue) || unauthorized_active_issue?(issue) }"),
+            "runner should fetch unauthorized active issues so handle_issue can remove agent labels"
+        )
+        assertTrue(
+            contents.contains("def unauthorized_active_issue?(issue)"),
+            "runner should keep unauthorized active issue detection explicit"
+        )
+    }
 }
 
 private func repoRootURL() -> URL {

--- a/Tests/TranscriptedCoreTests/TranscriptMetadataBuilderTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptMetadataBuilderTests.swift
@@ -1,4 +1,6 @@
 import XCTest
+import AVFoundation
+import Combine
 @testable import TranscriptedCore
 
 @available(macOS 14.0, *)
@@ -41,6 +43,15 @@ final class RecordingHealthInfoTests: XCTestCase {
         XCTAssertEqual(health.gapDescriptions, ["sleep_wake: 1.5s"])
     }
 
+    func testHealthInfoTreatsZeroSystemBuffersAsDegraded() {
+        let audio = Audio(paths: makePaths())
+        let capture = StubSystemAudioCapture(successRate: 0.0)
+
+        let health = RecordingHealthInfo.from(audio: audio, systemCapture: capture)
+
+        XCTAssertEqual(health.captureQuality, .degraded)
+    }
+
     private func makePaths() -> CoreStoragePaths {
         CoreStoragePaths(
             transcripts: tempRoot.appendingPathComponent("transcripts", isDirectory: true),
@@ -52,4 +63,21 @@ final class RecordingHealthInfoTests: XCTestCase {
             logs: tempRoot.appendingPathComponent("logs", isDirectory: true)
         )
     }
+}
+
+private final class StubSystemAudioCapture: SystemAudioCaptureEngine {
+    let diagnosticBackendName = "stub"
+    let audioFormat: AVAudioFormat? = nil
+    let bufferSuccessRate: Double
+    let deliversOwnedAudioBuffers = true
+    let errorMessagePublisher = Just<String?>(nil).eraseToAnyPublisher()
+
+    init(successRate: Double) {
+        self.bufferSuccessRate = successRate
+    }
+
+    func prepare() throws {}
+    func start(bufferCallback: @escaping (AVAudioPCMBuffer) -> Void) throws {}
+    func stop() {}
+    func stopSync() {}
 }

--- a/scripts/ops/agent-todo-runner.rb
+++ b/scripts/ops/agent-todo-runner.rb
@@ -102,7 +102,7 @@ class AgentTodoRunner
       "--json", "number,title,body,labels,url,assignees,author,createdAt,updatedAt"
     )
 
-    issues.select { |issue| active_issue?(issue) }
+    issues.select { |issue| active_issue?(issue) || unauthorized_active_issue?(issue) }
   end
 
   def fetch_issue(number)
@@ -116,6 +116,11 @@ class AgentTodoRunner
   def active_issue?(issue)
     labels = label_names(issue)
     (labels & active_labels).any? && (labels & terminal_labels).empty? && allowed_author?(issue)
+  end
+
+  def unauthorized_active_issue?(issue)
+    labels = label_names(issue)
+    (labels & active_labels).any? && (labels & terminal_labels).empty? && !allowed_author?(issue)
   end
 
   def handle_issue(issue)


### PR DESCRIPTION
## Summary
- cancel stale meeting audio starts so timeout paths cannot publish a hidden recording later
- add an update-check watchdog so the About UI returns to an actionable state if Sparkle never finishes a cycle
- mark zero-buffer system audio captures as degraded, and clean unauthorized agent todo labels instead of leaving stale queue items

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run transcripted-qa validate-all --format json
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run transcripted-qa round-trip
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run transcripted-qa check-health
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run transcripted-qa validate-logs
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run transcripted-qa validate-database
- Computer Use: relaunched patched app, checked About update fallback, Meetings, Models, and Agent screens

## Notes
`validate-all` still reports the known local stale artifact drift for `Call_2026-04-18_14-43-40.json` / `transcripted.json`; fresh round-trip fixtures pass.
