### PR TITLE
Update release metadata for 1.1.26

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.25"
-  sha256 "0a91536b468c96db9d234dfb3d17e9c2c0c28b95637882857e4ca65193dae72d"
+  version "1.1.26"
+  sha256 "14093c55403e7d88aa074e5a5f0ee4293261d81e322fd1a56a8958dac3c5319b"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -1,11 +1,22 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='utf-8'?>
 <rss xmlns:atom="http://www.w3.org/2005/Atom" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
   <channel>
     <title>Transcripted Updates</title>
     <link>https://github.com/r3dbars/transcripted</link>
-    <atom:link href="https://raw.githubusercontent.com/r3dbars/transcripted/main/docs/appcast.xml" rel="self" type="application/rss+xml"/>
+    <atom:link href="https://raw.githubusercontent.com/r3dbars/transcripted/main/docs/appcast.xml" rel="self" type="application/rss+xml" />
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
+    <item>
+      <title>1.1.26</title>
+      <pubDate>Wed, 29 Apr 2026 09:35:07 -0500</pubDate>
+      <sparkle:version>1.1.26</sparkle:version>
+      <sparkle:shortVersionString>1.1.26</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.26/Transcripted-1.1.26.dmg" length="528273936" type="application/octet-stream" sparkle:edSignature="tN3cxOObgbJ1p3fFHRarzoI4GHND3Ia+9wplGzpt9hkzbVqgqP73/gBzDXaR9qZ9tbPiqkT2oGxDfioVtGiQCA==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.26</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.26</sparkle:releaseNotesLink>
+    </item>
     <item>
       <title>Version 1.1.25</title>
       <pubDate>Mon, 27 Apr 2026 21:42:09 GMT</pubDate>
@@ -15,7 +26,7 @@
       <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.25</sparkle:releaseNotesLink>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.25/Transcripted-1.1.25.dmg" length="528085275" type="application/octet-stream" sparkle:edSignature="uKMVX52MNfk1iAIqcw7gi5fFtRmCrib1YCIsM1C8vhtkhLEJ/luxlvt/VooP18VEHsZdzdZ4ESljUANFcU00Bw=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.25/Transcripted-1.1.25.dmg" length="528085275" type="application/octet-stream" sparkle:edSignature="uKMVX52MNfk1iAIqcw7gi5fFtRmCrib1YCIsM1C8vhtkhLEJ/luxlvt/VooP18VEHsZdzdZ4ESljUANFcU00Bw==" />
     </item>
     <item>
       <title>Version 1.1.24</title>
@@ -26,7 +37,7 @@
       <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.24</sparkle:releaseNotesLink>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.24/Transcripted-1.1.24.dmg" length="528065393" type="application/octet-stream" sparkle:edSignature="uIo35PPcM3882Ggz7J4xQbsleTpKzw7sekIThwK9YV/U9rMQ5iBdxRak5bb8IRi72XVu3dd9HkXd/HXBwajvAQ=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.24/Transcripted-1.1.24.dmg" length="528065393" type="application/octet-stream" sparkle:edSignature="uIo35PPcM3882Ggz7J4xQbsleTpKzw7sekIThwK9YV/U9rMQ5iBdxRak5bb8IRi72XVu3dd9HkXd/HXBwajvAQ==" />
     </item>
     <item>
       <title>1.1.23</title>
@@ -37,8 +48,8 @@
       <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.23</sparkle:fullReleaseNotesLink>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <sparkle:criticalUpdate/>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.23/Transcripted-1.1.23.dmg" length="528064411" type="application/octet-stream" sparkle:edSignature="RsIqBbb5KkhYpCXABJ6XSu3cP4EYc8vls37imIP54Rk5YDIgDzM641HlBywdsRvBoBGmfttLEZ7v4C0g5GmOCw=="/>
+      <sparkle:criticalUpdate />
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.23/Transcripted-1.1.23.dmg" length="528064411" type="application/octet-stream" sparkle:edSignature="RsIqBbb5KkhYpCXABJ6XSu3cP4EYc8vls37imIP54Rk5YDIgDzM641HlBywdsRvBoBGmfttLEZ7v4C0g5GmOCw==" />
     </item>
     <item>
       <title>1.1.22</title>
@@ -49,8 +60,8 @@
       <sparkle:fullReleaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.22</sparkle:fullReleaseNotesLink>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <sparkle:criticalUpdate/>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.22/Transcripted-1.1.22.dmg" length="528066662" type="application/octet-stream" sparkle:edSignature="6NFhcrMXH17PMBuhLW7WFpicG0aNaZiKzss6W0vA9DoTsYgo7tQA2nOgKop1CdWPZkeIc2IynNrS/pLDH9rZBQ=="/>
+      <sparkle:criticalUpdate />
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.22/Transcripted-1.1.22.dmg" length="528066662" type="application/octet-stream" sparkle:edSignature="6NFhcrMXH17PMBuhLW7WFpicG0aNaZiKzss6W0vA9DoTsYgo7tQA2nOgKop1CdWPZkeIc2IynNrS/pLDH9rZBQ==" />
     </item>
     <item>
       <title>1.1.21</title>
@@ -61,7 +72,7 @@
       <sparkle:shortVersionString>1.1.21</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.21/Transcripted-1.1.21.dmg" length="528066568" type="application/octet-stream" sparkle:edSignature="h14lCjbd/tlREtn+v0TbQvfmILYpyoahU+fhksxbCHy/wTLMlktod6sh5axmlLFeiHM6uE0Aa2C/4ykIeIqyAQ=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.21/Transcripted-1.1.21.dmg" length="528066568" type="application/octet-stream" sparkle:edSignature="h14lCjbd/tlREtn+v0TbQvfmILYpyoahU+fhksxbCHy/wTLMlktod6sh5axmlLFeiHM6uE0Aa2C/4ykIeIqyAQ==" />
     </item>
     <item>
       <title>1.1.20</title>
@@ -72,7 +83,7 @@
       <sparkle:shortVersionString>1.1.20</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.20/Transcripted-1.1.20.dmg" length="528072685" type="application/octet-stream" sparkle:edSignature="RPpxwPth7L7LHjBa3yL7PuQglOqJvpY2K9X1IYvrUWtFfFa1ZGppm8bN0aeOmygV7KXhI9KLMhr0ArStlSpPDA=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.20/Transcripted-1.1.20.dmg" length="528072685" type="application/octet-stream" sparkle:edSignature="RPpxwPth7L7LHjBa3yL7PuQglOqJvpY2K9X1IYvrUWtFfFa1ZGppm8bN0aeOmygV7KXhI9KLMhr0ArStlSpPDA==" />
     </item>
     <item>
       <title>1.1.19</title>
@@ -83,7 +94,7 @@
       <sparkle:shortVersionString>1.1.19</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.19/Transcripted-1.1.19.dmg" length="527924847" type="application/octet-stream" sparkle:edSignature="EOvTOMK2Zi0DDWAGZS4kJkpFSS7oo3vYQgeIh1WKVSwz2p0VqMm23fX41rqGFz3tNvslwk5mQ5tCrtk7+Wb5Ag=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.19/Transcripted-1.1.19.dmg" length="527924847" type="application/octet-stream" sparkle:edSignature="EOvTOMK2Zi0DDWAGZS4kJkpFSS7oo3vYQgeIh1WKVSwz2p0VqMm23fX41rqGFz3tNvslwk5mQ5tCrtk7+Wb5Ag==" />
     </item>
     <item>
       <title>1.1.18</title>
@@ -94,7 +105,7 @@
       <sparkle:shortVersionString>1.1.18</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.18/Transcripted-1.1.18.dmg" length="527982010" type="application/octet-stream" sparkle:edSignature="KuYF7CLSPFEzkXMtT2Uwarcze401ifkbBHTMNV0eBnB9rIUxwQygSNc3OWp59C5TNVSUpJbt/CoQYhtX7/PfBQ=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.18/Transcripted-1.1.18.dmg" length="527982010" type="application/octet-stream" sparkle:edSignature="KuYF7CLSPFEzkXMtT2Uwarcze401ifkbBHTMNV0eBnB9rIUxwQygSNc3OWp59C5TNVSUpJbt/CoQYhtX7/PfBQ==" />
     </item>
     <item>
       <title>1.1.17</title>
@@ -105,7 +116,7 @@
       <sparkle:shortVersionString>1.1.17</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.17/Transcripted-1.1.17.dmg" length="527944947" type="application/octet-stream" sparkle:edSignature="14WAhGieu5//GU3jDtgyhoRK5sHVpHQ9wgb8BX7hysxhMWvPzbEaVHSliFVTBZn//xFXqrrvYy/c+mhfkwmgAA=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.17/Transcripted-1.1.17.dmg" length="527944947" type="application/octet-stream" sparkle:edSignature="14WAhGieu5//GU3jDtgyhoRK5sHVpHQ9wgb8BX7hysxhMWvPzbEaVHSliFVTBZn//xFXqrrvYy/c+mhfkwmgAA==" />
     </item>
     <item>
       <title>1.1.16</title>
@@ -116,7 +127,7 @@
       <sparkle:shortVersionString>1.1.16</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.16/Transcripted-1.1.16.dmg" length="527808505" type="application/octet-stream" sparkle:edSignature="AMpY3nl6FgbHI05aKbevDPw05Ja+D419dMKwLPSwCwxEV7dfLFaScLU80t5rN2y7q1oAY630z6w51mugt1EWBQ=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.16/Transcripted-1.1.16.dmg" length="527808505" type="application/octet-stream" sparkle:edSignature="AMpY3nl6FgbHI05aKbevDPw05Ja+D419dMKwLPSwCwxEV7dfLFaScLU80t5rN2y7q1oAY630z6w51mugt1EWBQ==" />
     </item>
     <item>
       <title>1.1.15</title>
@@ -127,7 +138,7 @@
       <sparkle:shortVersionString>1.1.15</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.15/Transcripted-1.1.15.dmg" length="525387622" type="application/octet-stream" sparkle:edSignature="qPXpfEd9Umelrca057dPpTz26cFTnCDhau6+/fqL5f141HWbrEZQVQFfzKCDb56Aj0QoLW9G7x9klb6FDICOBg=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.15/Transcripted-1.1.15.dmg" length="525387622" type="application/octet-stream" sparkle:edSignature="qPXpfEd9Umelrca057dPpTz26cFTnCDhau6+/fqL5f141HWbrEZQVQFfzKCDb56Aj0QoLW9G7x9klb6FDICOBg==" />
     </item>
     <item>
       <title>1.1.14</title>
@@ -138,7 +149,7 @@
       <sparkle:shortVersionString>1.1.14</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.14/Transcripted-1.1.14.dmg" length="504103210" type="application/octet-stream" sparkle:edSignature="JyTTM3YcuhRlJNfUBh3T+K5VZRt4QZHB8MibdJnhbym8x/AzwY0q2zSO2hHo2Gtvu3HCMW2qDPiJVtLFzK8OBQ=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.14/Transcripted-1.1.14.dmg" length="504103210" type="application/octet-stream" sparkle:edSignature="JyTTM3YcuhRlJNfUBh3T+K5VZRt4QZHB8MibdJnhbym8x/AzwY0q2zSO2hHo2Gtvu3HCMW2qDPiJVtLFzK8OBQ==" />
     </item>
     <item>
       <title>1.1.13</title>
@@ -149,7 +160,7 @@
       <sparkle:shortVersionString>1.1.13</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.13/Transcripted-1.1.13.dmg" length="504141336" type="application/octet-stream" sparkle:edSignature="C/BPy2Mrk3/ELyGKbvLP8lYDqDiUX5Oaw2/CAr+5hz5L5DxaGHkhe6TdtleyxuuI17qeozn3IeKip7lft1jkCg=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.13/Transcripted-1.1.13.dmg" length="504141336" type="application/octet-stream" sparkle:edSignature="C/BPy2Mrk3/ELyGKbvLP8lYDqDiUX5Oaw2/CAr+5hz5L5DxaGHkhe6TdtleyxuuI17qeozn3IeKip7lft1jkCg==" />
     </item>
     <item>
       <title>1.1.12</title>
@@ -160,7 +171,7 @@
       <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.12</sparkle:releaseNotesLink>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.12/Transcripted-1.1.12.dmg" length="503316542" type="application/octet-stream" sparkle:edSignature="tyMGBXTf61HJp9NL+rHFGn0Kmay2FZ2g5aiJWMAOUFfgjDMeXpaQEt7l7cwMHKuqUFVCr8/TDAto5sAM3K14Cw=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.12/Transcripted-1.1.12.dmg" length="503316542" type="application/octet-stream" sparkle:edSignature="tyMGBXTf61HJp9NL+rHFGn0Kmay2FZ2g5aiJWMAOUFfgjDMeXpaQEt7l7cwMHKuqUFVCr8/TDAto5sAM3K14Cw==" />
     </item>
     <item>
       <title>1.1.11</title>
@@ -171,7 +182,7 @@
       <sparkle:shortVersionString>1.1.11</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.11/Transcripted-1.1.11.dmg" length="503193049" type="application/octet-stream" sparkle:edSignature="r3XHWckeyeCU3lkgfIda5c9jDDph9K19xXbQ8ySleY6Y3umG4wS4WqX/e8M7Z4zM5cmFLrIYcqx8oJSrhYuLCw=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.11/Transcripted-1.1.11.dmg" length="503193049" type="application/octet-stream" sparkle:edSignature="r3XHWckeyeCU3lkgfIda5c9jDDph9K19xXbQ8ySleY6Y3umG4wS4WqX/e8M7Z4zM5cmFLrIYcqx8oJSrhYuLCw==" />
     </item>
     <item>
       <title>1.1.10</title>
@@ -182,7 +193,7 @@
       <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.10</sparkle:releaseNotesLink>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.10/Transcripted-1.1.10.dmg" length="502721532" type="application/octet-stream" sparkle:edSignature="bShxoOEQ6bKgHQGBGiXAQ3BIOmudVrgnbtGS1h9f3yYGE6Yd091mqjR+BD7mg4FJ9jjQlZstE4ZNGugrF3f4DQ=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.10/Transcripted-1.1.10.dmg" length="502721532" type="application/octet-stream" sparkle:edSignature="bShxoOEQ6bKgHQGBGiXAQ3BIOmudVrgnbtGS1h9f3yYGE6Yd091mqjR+BD7mg4FJ9jjQlZstE4ZNGugrF3f4DQ==" />
     </item>
     <item>
       <title>1.0.9</title>
@@ -193,7 +204,7 @@
       <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.9</sparkle:releaseNotesLink>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.9/Transcripted-1.0.9.dmg" length="502688154" type="application/octet-stream" sparkle:edSignature="w4Cw8zDn/4vfeJbuIq8OPJNs5naALADafyVZSrLsg/W68eBqVw4HRy/8c/lSvB68/sCZgwrfa9vWLPVLEpnZDA=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.9/Transcripted-1.0.9.dmg" length="502688154" type="application/octet-stream" sparkle:edSignature="w4Cw8zDn/4vfeJbuIq8OPJNs5naALADafyVZSrLsg/W68eBqVw4HRy/8c/lSvB68/sCZgwrfa9vWLPVLEpnZDA==" />
     </item>
     <item>
       <title>1.0.8</title>
@@ -204,7 +215,7 @@
       <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.8</sparkle:releaseNotesLink>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.8/Transcripted-1.0.8.dmg" length="502664309" type="application/octet-stream" sparkle:edSignature="l3EA/xoFcRhpjEBPx4BYBQCWWfRd8C95qLd0/bIR0LBj2vQsUNZert5TdjTs9g5Snxm/rTIYymfX/BquXOC2Cg=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.8/Transcripted-1.0.8.dmg" length="502664309" type="application/octet-stream" sparkle:edSignature="l3EA/xoFcRhpjEBPx4BYBQCWWfRd8C95qLd0/bIR0LBj2vQsUNZert5TdjTs9g5Snxm/rTIYymfX/BquXOC2Cg==" />
     </item>
     <item>
       <title>1.0.7</title>
@@ -215,7 +226,7 @@
       <sparkle:shortVersionString>1.0.7</sparkle:shortVersionString>
       <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.7/Transcripted-1.0.7.dmg" length="502675765" type="application/octet-stream" sparkle:edSignature="Q98ME9znEwbm2Gy9CyYVe6Bhqel8n6seNBa0xpj2iiYi2WgSruw8FCANBGWkVBsU9gXANw8bBGS+ZfjsykVRBg=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.7/Transcripted-1.0.7.dmg" length="502675765" type="application/octet-stream" sparkle:edSignature="Q98ME9znEwbm2Gy9CyYVe6Bhqel8n6seNBa0xpj2iiYi2WgSruw8FCANBGWkVBsU9gXANw8bBGS+ZfjsykVRBg==" />
     </item>
     <item>
       <title>1.0.6</title>
@@ -226,7 +237,7 @@
       <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.6</sparkle:releaseNotesLink>
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.6/Transcripted-1.0.6.dmg" length="502646081" type="application/octet-stream" sparkle:edSignature="QWSKxul7wWJBM2GTL8F4xKhp7q/9IfJVvtZJsC63pE5BoL85oRmKSTQRtWzx0DZPmKScQmw8VXMom7E9gQJPCQ=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.6/Transcripted-1.0.6.dmg" length="502646081" type="application/octet-stream" sparkle:edSignature="QWSKxul7wWJBM2GTL8F4xKhp7q/9IfJVvtZJsC63pE5BoL85oRmKSTQRtWzx0DZPmKScQmw8VXMom7E9gQJPCQ==" />
     </item>
     <item>
       <title>1.0.5</title>
@@ -237,7 +248,7 @@
       <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.5</sparkle:releaseNotesLink>
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.5/Transcripted-1.0.5.dmg" length="502640480" type="application/octet-stream" sparkle:edSignature="kvlnlYL4tbnNLZjIjdJwA+0FCZ8CV4dW55PhYxgEWDJ9kbPrNRYNRlWq887xWhwWJ/R065gqD5WN0JtxvFeUAw=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.5/Transcripted-1.0.5.dmg" length="502640480" type="application/octet-stream" sparkle:edSignature="kvlnlYL4tbnNLZjIjdJwA+0FCZ8CV4dW55PhYxgEWDJ9kbPrNRYNRlWq887xWhwWJ/R065gqD5WN0JtxvFeUAw==" />
     </item>
     <item>
       <title>1.0.4</title>
@@ -248,7 +259,7 @@
       <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.0.4</sparkle:releaseNotesLink>
       <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
       <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
-      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.4/Transcripted-1.0.4.dmg" length="509228201" type="application/octet-stream" sparkle:edSignature="xz6/eZzqaQwyYX79B2ztJ79IZEPSXKrTIf9DXhEP43Aep8RSus6AJgr2WLJj5+Qq34nNWql4ynn8kDyiAjXpBg=="/>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.0.4/Transcripted-1.0.4.dmg" length="509228201" type="application/octet-stream" sparkle:edSignature="xz6/eZzqaQwyYX79B2ztJ79IZEPSXKrTIf9DXhEP43Aep8RSus6AJgr2WLJj5+Qq34nNWql4ynn8kDyiAjXpBg==" />
     </item>
   </channel>
 </rss>

--- a/scripts/release/generate-sparkle-appcast.sh
+++ b/scripts/release/generate-sparkle-appcast.sh
@@ -146,7 +146,9 @@ for existing in existing_items:
     if item_version(existing) == version:
         repo_channel.remove(existing)
 
-repo_channel.insert(0, latest_item)
+children = list(repo_channel)
+insert_index = next((index for index, child in enumerate(children) if child.tag == "item"), len(children))
+repo_channel.insert(insert_index, latest_item)
 
 if hasattr(ET, "indent"):
     ET.indent(repo_tree, space="  ")


### PR DESCRIPTION
## Summary
- add the Sparkle appcast entry for Transcripted 1.1.26
- update the Homebrew cask to the 1.1.26 DMG SHA256
- keep generated appcast items after channel metadata when merging a new release item

## Verification
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-beta-justin Justin
- xcrun stapler validate build/Transcripted-1.1.26.dmg
- gh release create v1.1.26 build/Transcripted-1.1.26.dmg
- bash scripts/release/generate-sparkle-appcast.sh /tmp/transcripted-sparkle-1.1.26
- bash scripts/release/update-cask.sh 1.1.26
- bash scripts/release/verify-sparkle-release.sh 1.1.26
- bash run-tests.sh
