### PR TITLE
Document review packet visual artifacts

### DIFF
--- a/docs/agent-issue-orchestration.md
+++ b/docs/agent-issue-orchestration.md
@@ -95,6 +95,8 @@ packet gives Justin review signal without having to pull the branch first:
 - Transcripted QA output from `transcripted-qa check-health`, plus deeper `validate-all` for meeting/storage/core paths
 - an automated PR review pass from Codex
 
+Visual artifacts are embedded from files committed under `.agent-review/visuals/` on the PR branch.
+
 For UI work, the agent should save sanitized screenshots or GIFs in:
 
 ```text


### PR DESCRIPTION
## Summary
- Add a short note that Agent Review Packet visual artifacts come from files committed under `.agent-review/visuals/` on the PR branch.

## Validation
- `git diff --check`

## Notes
- Docs-only change.
- No app code touched.
- No visual artifacts needed because this does not touch UI, visual design, app copy, or user-facing flows.

Closes #610
