### PR TITLE
Release 1.1.27 metadata

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.26"
-  sha256 "14093c55403e7d88aa074e5a5f0ee4293261d81e322fd1a56a8958dac3c5319b"
+  version "1.1.27"
+  sha256 "9e680d9cb624b41d5c81ccb8708335767775542c33f6e98f9d6f9a35cd1ae280"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.26</string>
+	<string>1.1.27</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.26</string>
+	<string>1.1.27</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.27</title>
+      <pubDate>Wed, 29 Apr 2026 19:48:32 -0500</pubDate>
+      <sparkle:version>1.1.27</sparkle:version>
+      <sparkle:shortVersionString>1.1.27</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.27/Transcripted-1.1.27.dmg" length="528219855" type="application/octet-stream" sparkle:edSignature="+mc/KYb5FdP0Md/CyyiI09qG8ov9OeX3t0C84HlrLg6dfPzlX7e7A+az/6EXmTnHOvifowCvX98MI+6KzH+bBg==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.27</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.27</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.26</title>
       <pubDate>Wed, 29 Apr 2026 09:35:07 -0500</pubDate>
       <sparkle:version>1.1.26</sparkle:version>


### PR DESCRIPTION
## Summary
- Bump Transcripted to 1.1.27
- Add Sparkle appcast entry for the notarized 1.1.27 DMG
- Update Homebrew cask checksum for 1.1.27

## Verification
- bash build-deps.sh --force
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-public-1.1.27 Transcripted
- bash scripts/release/verify-sparkle-release.sh 1.1.27