### PR TITLE
[nightly-review] Preserve meeting cancel stop timeouts

### DIFF
--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -134,12 +134,12 @@ final class MeetingCaptureBridge: ObservableObject {
 
     /// Stop the current recording, wait for file handles to close, then remove
     /// the just-captured scratch audio instead of handing it to transcription.
-    func stopAndDiscardFiles() async -> (micURL: URL?, systemURL: URL?) {
+    func stopAndDiscardFiles() async -> CaptureStopResult {
         let result = await stopAndAwaitFiles()
         MeetingRecordingCleanup.discardFiles(micURL: result.micURL, systemURL: result.systemURL)
         audio.micAudioFileURL = nil
         audio.systemAudioFileURL = nil
-        return (result.micURL, result.systemURL)
+        return result
     }
 
     func pipelineDiagnosticsSnapshot(

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -708,7 +708,8 @@ final class MeetingSessionController: ObservableObject {
             )
         )
 
-        let files = await capture.stopAndDiscardFiles()
+        let stopResult = await capture.stopAndDiscardFiles()
+        let files = (micURL: stopResult.micURL, systemURL: stopResult.systemURL)
         activeRecordingTrigger = .unknown
         restoreStateAfterRecordingEndedWithoutNewWork()
         AppSoundPlayer.shared.play(.dictationCancelled)
@@ -723,7 +724,8 @@ final class MeetingSessionController: ObservableObject {
                     "reason": reason.rawValue,
                     "duration_ms": "\(durationMs)",
                     "mic_file_present": boolString(files.micURL != nil),
-                    "system_file_present": boolString(files.systemURL != nil)
+                    "system_file_present": boolString(files.systemURL != nil),
+                    "stop_timed_out": boolString(stopResult.didTimeOut)
                 ]
             )
         )
@@ -733,6 +735,7 @@ final class MeetingSessionController: ObservableObject {
                 [
                     "duration_bucket": AnalyticsReporter.durationBucket(seconds: Double(durationMs) / 1000),
                     "reason": reason.rawValue,
+                    "stop_timed_out": boolString(stopResult.didTimeOut),
                     "system_stream_present": boolString(files.systemURL != nil),
                     "trigger": recordingTrigger.rawValue,
                 ],
@@ -748,7 +751,7 @@ final class MeetingSessionController: ObservableObject {
                 reason: reason.rawValue,
                 durationSeconds: Double(durationMs) / 1000,
                 systemStreamPresent: files.systemURL != nil,
-                stopTimedOut: false
+                stopTimedOut: stopResult.didTimeOut
             )
         )
     }

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -401,6 +401,7 @@ struct AnalyticsEventPolicy: Equatable {
             allowedProperties: meetingCaptureDiagnosticProperties.union(Set([
                 "duration_bucket",
                 "reason",
+                "stop_timed_out",
                 "system_stream_present",
                 "trigger",
             ]))

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -205,6 +205,7 @@ func testAnalyticsEventPolicy() {
         assertEqual(policy?.allowedProperties.contains("duration_bucket"), true, "meeting cancellation should only keep bucketed duration")
         assertEqual(policy?.allowedProperties.contains("mic_processing"), true, "meeting cancellation should preserve the coarse mic processing mode")
         assertEqual(policy?.allowedProperties.contains("reason"), true, "meeting cancellation should preserve coarse reason")
+        assertEqual(policy?.allowedProperties.contains("stop_timed_out"), true, "meeting cancellation should preserve stop timeout state")
         assertEqual(policy?.allowedProperties.contains("system_stream_present"), true, "meeting cancellation should preserve system stream presence")
         assertEqual(policy?.allowedProperties.contains("trigger"), true, "meeting cancellation should preserve trigger attribution")
         assertEqual(policy?.allowedProperties.contains("voice_processing"), true, "meeting cancellation should preserve whether VPIO was requested")


### PR DESCRIPTION
## Summary
- preserve CaptureStopResult.didTimeOut when cancelling a meeting recording
- include the timeout state in local diagnostics, health snapshot analytics, and cancellation analytics
- allowlist stop_timed_out for meeting cancellation telemetry and cover it in fast tests

## Review focus
This fixes the highest-confidence nightly finding: explicit meeting discard was collapsing stop timeout state to false, so a cancellation during an audio-close timeout looked clean in diagnostics.

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh