### PR TITLE
[nightly-regression] Add meeting health teardown coverage

### DIFF
--- a/Tests/TranscriptedCoreTests/RecordingHealthInfoOverrideTests.swift
+++ b/Tests/TranscriptedCoreTests/RecordingHealthInfoOverrideTests.swift
@@ -1,3 +1,5 @@
+import AVFoundation
+import Combine
 import XCTest
 @testable import TranscriptedCore
 
@@ -93,4 +95,70 @@ final class RecordingHealthInfoOverrideTests: XCTestCase {
         XCTAssertEqual(info.captureQuality, .degraded,
                        "createHealthInfo must forward the override into the factory")
     }
+
+    func testHealthyOverrideCannotRecoverAfterCleanupResetsBufferCounters() {
+        let audio = Audio(paths: makePaths())
+        let capture = MutableStubSystemAudioCapture(successRate: 1.0)
+        audio.systemAudioCapture = capture
+        audio.systemAudioStatus = .healthy
+
+        let preStopInfo = audio.createHealthInfo(overrideSystemAudioStatus: .healthy)
+        XCTAssertEqual(preStopInfo.captureQuality, .excellent,
+                       "healthy pre-stop buffers should report excellent capture quality")
+
+        // Simulate the teardown path that triggered the 1.1.26 meeting-health
+        // bug: stop/cleanup reset the live capture counters before the app read
+        // them, so even a preserved healthy status could no longer recover the
+        // real buffer success rate.
+        capture.bufferSuccessRate = 0.0
+        audio.systemAudioStatus = .unknown
+
+        let postStopInfo = audio.createHealthInfo(overrideSystemAudioStatus: .healthy)
+
+        XCTAssertEqual(postStopInfo.captureQuality, .degraded,
+                       "health must be snapshotted before cleanup resets system buffer counters")
+    }
+
+    func testPipelineDiagnosticsSnapshotMustBeTakenBeforeCleanupResetsBuffers() {
+        let audio = Audio(paths: makePaths())
+        let capture = MutableStubSystemAudioCapture(successRate: 1.0)
+        audio.systemAudioCapture = capture
+        audio.systemAudioStatus = .healthy
+
+        let preStopSnapshot = audio.createPipelineDiagnosticsSnapshot(
+            overrideSystemAudioStatus: .healthy
+        )
+        XCTAssertEqual(preStopSnapshot.systemStatus, "healthy")
+        XCTAssertEqual(preStopSnapshot.bufferSuccessBucket, "98_100",
+                       "healthy pre-stop capture should keep its high buffer bucket")
+
+        capture.bufferSuccessRate = 0.0
+        audio.systemAudioStatus = .unknown
+
+        let postStopSnapshot = audio.createPipelineDiagnosticsSnapshot(
+            overrideSystemAudioStatus: .healthy
+        )
+
+        XCTAssertEqual(postStopSnapshot.systemStatus, "healthy",
+                       "override should preserve the pre-stop status label")
+        XCTAssertEqual(postStopSnapshot.bufferSuccessBucket, "lt_50",
+                       "diagnostics must be captured before cleanup resets buffer-success counters")
+    }
+}
+
+private final class MutableStubSystemAudioCapture: SystemAudioCaptureEngine, @unchecked Sendable {
+    let diagnosticBackendName = "stub"
+    let audioFormat: AVAudioFormat? = nil
+    var bufferSuccessRate: Double
+    let deliversOwnedAudioBuffers = true
+    let errorMessagePublisher = CurrentValueSubject<String?, Never>(nil).eraseToAnyPublisher()
+
+    init(successRate: Double) {
+        self.bufferSuccessRate = successRate
+    }
+
+    func prepare() throws {}
+    func start(bufferCallback: @escaping (AVAudioPCMBuffer) -> Void) throws {}
+    func stop() {}
+    func stopSync() {}
 }


### PR DESCRIPTION
## Summary
- add package regression tests for the meeting health teardown timing bug behind `meeting.recording_capture_degraded`
- prove healthy overrides cannot recover system-audio buffer counters after cleanup resets them
- cover the diagnostics snapshot case so future refactors keep the pre-stop snapshot contract visible

## Verification
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test