### PR TITLE
Release 1.1.28

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.27"
-  sha256 "9e680d9cb624b41d5c81ccb8708335767775542c33f6e98f9d6f9a35cd1ae280"
+  version "1.1.28"
+  sha256 "055f65157c05f545ca1c079b7e1b4a90908acc09667b1c47491d967c2ef46e7e"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.27</string>
+	<string>1.1.28</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.27</string>
+	<string>1.1.28</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.28</title>
+      <pubDate>Thu, 30 Apr 2026 13:04:01 -0500</pubDate>
+      <sparkle:version>1.1.28</sparkle:version>
+      <sparkle:shortVersionString>1.1.28</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.28/Transcripted-1.1.28.dmg" length="528254490" type="application/octet-stream" sparkle:edSignature="IQ0zWL5xK2EFz+OqhTGDUx6WQfWf3YeddnmXKqRp2SyLkZGEdEcZHvqZzKP7vd78iW3nr9kTEyWf0y6WAdOBAg==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.28</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.28</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.27</title>
       <pubDate>Wed, 29 Apr 2026 19:48:32 -0500</pubDate>
       <sparkle:version>1.1.27</sparkle:version>


### PR DESCRIPTION
## Summary
- Bump Transcripted to 1.1.28
- Publish Sparkle appcast metadata for v1.1.28
- Update Homebrew cask SHA for the v1.1.28 DMG

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-public-1.1.28 Transcripted
- bash scripts/release/verify-sparkle-release.sh 1.1.28