### PR TITLE
Fix stale dictation mic start recovery

### DIFF
--- a/Sources/Speech/DictationReadinessWaitPolicy.swift
+++ b/Sources/Speech/DictationReadinessWaitPolicy.swift
@@ -6,16 +6,29 @@ enum DictationReadinessWaitAction: Equatable {
     case waitForRecovery
     case refreshInputReadiness
     case startRecording
+    case startRecoveryRecording
 }
 
 struct DictationReadinessWaitPolicy {
-    static func action(isRecovering: Bool, inputFormatReady: Bool) -> DictationReadinessWaitAction {
+    private static let refreshesBeforeRecoveryStart = 4
+
+    static func action(
+        isRecovering: Bool,
+        inputFormatReady: Bool,
+        readinessRefreshes: Int = 0,
+        recoveryStartAttempts: Int = 0
+    ) -> DictationReadinessWaitAction {
         if isRecovering {
             return .waitForRecovery
         }
 
         if inputFormatReady {
             return .startRecording
+        }
+
+        if readinessRefreshes >= refreshesBeforeRecoveryStart,
+           recoveryStartAttempts == 0 {
+            return .startRecoveryRecording
         }
 
         return .refreshInputReadiness

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -97,6 +97,11 @@ class STTRouter: ObservableObject {
         return await parakeetEngine.startRecording()
     }
 
+    func startRecordingRecoveryAttempt() async -> Bool {
+        activeRecordingModel = selectedModel
+        return await parakeetEngine.startRecording(isRecoveryAttempt: true)
+    }
+
     func refreshInputReadiness() async {
         await parakeetEngine.prewarm()
     }

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -296,6 +296,7 @@ class DictationSessionController: ObservableObject {
         let startedAt = CFAbsoluteTimeGetCurrent()
         let deadline = startedAt + TranscriptedConstants.dictationRecoveryBudget
         var startAttempts = 0
+        var recoveryStartAttempts = 0
         var readinessRefreshes = 0
         var nextReadinessRefreshAt = startedAt
 
@@ -323,7 +324,12 @@ class DictationSessionController: ObservableObject {
                 anchorRect: sessionAnchorRect
             )
 
-            switch DictationReadinessWaitPolicy.action(isRecovering: isRecovering, inputFormatReady: inputFormatReady) {
+            switch DictationReadinessWaitPolicy.action(
+                isRecovering: isRecovering,
+                inputFormatReady: inputFormatReady,
+                readinessRefreshes: readinessRefreshes,
+                recoveryStartAttempts: recoveryStartAttempts
+            ) {
             case .waitForRecovery:
                 break
 
@@ -333,6 +339,58 @@ class DictationSessionController: ObservableObject {
                     readinessRefreshes += 1
                     nextReadinessRefreshAt = CFAbsoluteTimeGetCurrent() + TranscriptedConstants.dictationReadinessRefreshInterval
                 }
+
+            case .startRecoveryRecording:
+                startAttempts += 1
+                recoveryStartAttempts += 1
+                DiagnosticsTrail.record(
+                    logger: appState.logger,
+                    level: .warning,
+                    engine: "dictation",
+                    event: "dictation_recording_recovery_start",
+                    message: "Dictation forcing one recovery recording start after stale readiness refreshes",
+                    context: dictationContext(
+                        extra: [
+                            "attempt": "\(startAttempts)",
+                            "readiness_refreshes": "\(readinessRefreshes)",
+                            "is_recovering": "\(appState.sttRouter.isRecovering)",
+                            "format_ready": "\(appState.sttRouter.inputFormatReady)"
+                        ]
+                    )
+                )
+                let started = await appState.sttRouter.startRecordingRecoveryAttempt()
+                guard !Task.isCancelled, isDictating else {
+                    if started {
+                        await appState.sttRouter.stopRecording()
+                    }
+                    return
+                }
+                if started {
+                    overlayController.state = .listening
+                    resizePanelToCompact()
+                    let waited = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
+                    appState.logger.log("DICTATION | started after forced recovery start and \(waited)ms wait (parakeet, \(appState.sttRouter.inputDeviceName))")
+                    DiagnosticsTrail.record(
+                        logger: appState.logger,
+                        engine: "dictation",
+                        event: "dictation_started_after_wait",
+                        message: "Dictation started after forcing a recovery recording start",
+                        context: dictationContext(
+                            extra: [
+                                "wait_ms": "\(waited)",
+                                "start_attempts": "\(startAttempts)",
+                                "readiness_refreshes": "\(readinessRefreshes)"
+                            ]
+                        )
+                    )
+                    AppSoundPlayer.shared.play(.dictationStart)
+                    installSessionTimeout()
+                    return
+                }
+
+                await appState.sttRouter.refreshInputReadiness()
+                readinessRefreshes += 1
+                nextReadinessRefreshAt = CFAbsoluteTimeGetCurrent() + TranscriptedConstants.dictationReadinessRefreshInterval
 
             case .startRecording:
                 startAttempts += 1
@@ -408,6 +466,7 @@ class DictationSessionController: ObservableObject {
                     "is_recovering": "\(appState.sttRouter.isRecovering)",
                     "format_ready": "\(appState.sttRouter.inputFormatReady)",
                     "start_attempts": "\(startAttempts)",
+                    "recovery_start_attempts": "\(recoveryStartAttempts)",
                     "readiness_refreshes": "\(readinessRefreshes)"
                 ]
             )

--- a/Tests/DictationReadinessWaitPolicyTests.swift
+++ b/Tests/DictationReadinessWaitPolicyTests.swift
@@ -24,7 +24,9 @@ func testDictationReadinessWaitPolicy() {
     runSuite("DictationReadinessWaitPolicy — refreshes after failed recovery leaves input unready") {
         let action = DictationReadinessWaitPolicy.action(
             isRecovering: false,
-            inputFormatReady: false
+            inputFormatReady: false,
+            readinessRefreshes: 0,
+            recoveryStartAttempts: 0
         )
 
         assertEqual(action, .refreshInputReadiness, "failed recovery should trigger another readiness refresh")
@@ -56,5 +58,27 @@ func testDictationReadinessWaitPolicy() {
             inputFormatReady: recovery.inputFormatReady
         )
         assertEqual(postTimeoutAction, .refreshInputReadiness, "timeout should unblock dictation into a refresh path")
+    }
+
+    runSuite("DictationReadinessWaitPolicy — stale unready input gets one recovery start") {
+        let action = DictationReadinessWaitPolicy.action(
+            isRecovering: false,
+            inputFormatReady: false,
+            readinessRefreshes: 4,
+            recoveryStartAttempts: 0
+        )
+
+        assertEqual(action, .startRecoveryRecording, "repeated stale readiness refreshes should force one guarded recovery start")
+    }
+
+    runSuite("DictationReadinessWaitPolicy — recovery start is bounded") {
+        let action = DictationReadinessWaitPolicy.action(
+            isRecovering: false,
+            inputFormatReady: false,
+            readinessRefreshes: 8,
+            recoveryStartAttempts: 1
+        )
+
+        assertEqual(action, .refreshInputReadiness, "after one recovery start attempt the loop should go back to readiness refreshes")
     }
 }


### PR DESCRIPTION
## Summary
- add a bounded recovery recording start after stale mic readiness refreshes
- route the recovery attempt through Parakeet's guarded recovery-start path
- cover the stale-readiness and bounded-retry policy cases

## Verification
- bash run-tests.sh
- bash build-deps.sh --force
- bash build.sh

Fixes APPLE-MACOS-14