### PR TITLE
docs: sync CLAUDE.md files with recent codebase changes

### DIFF
--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ## Subsystems (62 Swift files)
 
-- `Audio/` (17 files) — mic + system audio capture, imported-audio prep helpers, capture start-state gating, device recovery, signal analysis and normalization helpers, real-time AGC, resampling, level metering, process tap, ScreenCaptureKit-backed system-audio capture, backend selection, buffer writing, and merge helpers
+- `Audio/` (17 files) — mic + system audio capture, imported-audio prep helpers, capture start-state gating, device recovery, signal analysis and normalization helpers, privacy-safe pipeline diagnostics snapshots, real-time AGC, resampling, level metering, process tap, ScreenCaptureKit-backed system-audio capture, backend selection, buffer writing, and merge helpers
 - `Logging/` (2 files) — shared app logger and JSONL file logger
 - `Models/` (5 files) — public data types: `TranscriptionResult`, `DisplayStatus`, `FailedTranscription`, `SpeakerMapping`, and recording-health metadata builders
 - `Pipeline/` (4 files) — transcription orchestration, pipeline runner, and task queue
@@ -34,6 +34,7 @@ These seams exist specifically so the app can embed the library without adopting
 - `AudioSignalRecovery` is the shared low-level signal-analysis helper used when recorded audio needs peak / RMS / active-ratio checks or gain-normalized recovery clips before later transcription work.
 - `RealtimeAGC` is the default meeting-mic cleanup path for attenuated shared-device input. It avoids the playback-ducking side effects of Apple voice processing while still boosting quiet WebRTC-contended captures.
 - `SCKAudioCapture` is the macOS 26+ backend for audio-only ScreenCaptureKit capture, which keeps system-audio recording on the lighter permission tier and avoids full screen-pixel capture.
+- `AudioPipelineDiagnosticsSnapshot` is the privacy-safe route and buffer-health summary used for analytics and Sentry context. Keep it limited to bucketed device classes, rates, channel counts, and recovery state, never raw device names, transcript text, titles, file paths, or audio.
 - Hosts embedding `TranscriptedCore` should keep app-specific permission UX outside this directory, but they should understand that system-audio capture backend behavior now depends on OS availability.
 - Imported meeting audio is funneled through the same pipeline primitives as live captures so transcript formatting, stats, speaker naming, and retry behavior stay aligned.
 

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -71,7 +71,7 @@ The current agent-connect surfaces should keep one simple mental model:
 - `Settings/HomeView.swift` — redesigned Settings home dashboard with fast recent activity loading, grouped recent dictations/meetings, summary stats, and lightweight copy/feedback/delete affordances
 - `Settings/HotkeyRecorderAppKitView.swift` — AppKit view for recording custom hotkey bindings
 - `Settings/PermissionsOnboardingView.swift` — first-launch permissions walkthrough
-- `Settings/SettingsRecentCaptureRefreshPolicy.swift` — small routing policy that decides whether the current Settings page should live-refresh the home dashboard, recent capture lists, or neither
+- `Settings/SettingsRecentCaptureRefreshPolicy.swift` — central policy for whether Settings should refresh the home dashboard, the recent meetings/dictations lists, or neither when navigation changes
 - `Settings/SpeakerNamingSheet.swift` — sheet for reviewing speakers in a completed meeting, grouped into local room speakers vs remote participants, with a "Keep as You" escape hatch for local mic splits
 - `Settings/SpeakerPeopleSettingsSection.swift` — settings section and view model for browsing, naming, merging, previewing, and deleting saved speaker profiles, plus the toggle for identifying multiple local speakers on the mic track
 - `Settings/TranscriptedOnboardingWindowController.swift` — dedicated first-launch window that hosts onboarding before users drop into the menubar flow
@@ -106,7 +106,8 @@ collapse the local side back into a single "You" track.
 The redesigned Settings home surface is intentionally a fast dashboard rather
 than a full archive browser. `HomeView` keeps recent dictations and meetings to
 small paged slices so the settings window still opens quickly for users with
-large capture libraries.
+large capture libraries, and `SettingsRecentCaptureRefreshPolicy` keeps those
+refreshes scoped to the pages that actually need them.
 
 Keep user-visible TCC prompts user-initiated. Background warmup paths should
 not request microphone, system-audio-recording, or calendar access on their own;


### PR DESCRIPTION
## Summary
- refresh `Sources/UI/CLAUDE.md` to describe the new settings refresh policy and its role in page-scoped recent-capture updates
- refresh `Sources/TranscriptedCore/CLAUDE.md` to call out the new privacy-safe audio pipeline diagnostics snapshot in the audio subsystem docs

## Why
Recent Swift changes added `SettingsRecentCaptureRefreshPolicy.swift` and `AudioPipelineDiagnosticsSnapshot.swift`, so the local CLAUDE docs needed a small sync to match the current codebase.