### PR TITLE
security: nightly security audit findings [automated]

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -230,6 +230,7 @@ final class MeetingSessionController: ObservableObject {
             diarization: services.diarization,
             speakerStore: services.speakerStore,
             speakerClipsDirectory: storagePaths.speakerClips,
+            cleanupDirectories: [storagePaths.audioCaptures, storagePaths.speakerClips],
             retainedAudioDirectoryProvider: { MeetingStoragePaths.audioArchiveFolder },
             statsStore: statsDatabase
         )

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -484,7 +484,7 @@ public class TranscriptionTaskManager: ObservableObject {
         notifier.notifyTranscriptionFailed(errorMessage: errorMessage)
     }
 
-    private func removeRecordingFile(_ url: URL, label: String) {
+    nonisolated private func removeRecordingFile(_ url: URL, label: String) {
         // Security: only delete scratch files inside Transcripted-managed cleanup roots.
         // `startImportedTranscription` accepts a URL from the caller, so without a containment
         // check a misuse or tampered in-memory request could unlink arbitrary user files.
@@ -511,31 +511,31 @@ public class TranscriptionTaskManager: ObservableObject {
         retainedAudioDirectoryProvider?() ?? retainedAudioDirectory
     }
 
-    func removeManagedCleanupFile(_ url: URL?, label: String) {
+    nonisolated func removeManagedCleanupFile(_ url: URL?, label: String) {
         guard let url else { return }
         removeRecordingFile(url, label: label)
     }
 
-    private func isSafeCleanupURL(_ url: URL) -> Bool {
-        let canonicalURL = Self.canonicalFileURL(url)
+    nonisolated private func isSafeCleanupURL(_ url: URL) -> Bool {
+        let canonicalURL = Self.canonicalURL(url)
         return cleanupDirectories.contains { root in
             Self.isFile(canonicalURL, containedIn: root)
         }
     }
 
-    private static func canonicalFileURL(_ url: URL) -> URL {
+    private static func canonicalURL(_ url: URL) -> URL {
         url.standardizedFileURL.resolvingSymlinksInPath()
     }
 
     private static func canonicalDirectoryURL(_ url: URL) -> URL {
-        url.standardizedFileURL.resolvingSymlinksInPath()
+        canonicalURL(url)
     }
 
     private static func isFile(_ fileURL: URL, containedIn directoryURL: URL) -> Bool {
-        let filePath = canonicalFileURL(fileURL).path
+        let filePath = canonicalURL(fileURL).path
         let directoryPath = canonicalDirectoryURL(directoryURL).path
         let normalizedDirectoryPath = directoryPath.hasSuffix("/") ? directoryPath : directoryPath + "/"
-        return filePath == directoryPath || filePath.hasPrefix(normalizedDirectoryPath)
+        return filePath.hasPrefix(normalizedDirectoryPath)
     }
 
     private func archiveFailedRecordingAudioIfConfigured(

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -25,6 +25,7 @@ public class TranscriptionTaskManager: ObservableObject {
     public let statsStore: (any StatsStore)?
     let retainedAudioDirectory: URL?
     private let retainedAudioDirectoryProvider: (() -> URL?)?
+    private let cleanupDirectories: [URL]
 
     /// Embedder-supplied notifier for transcript-saved and failure events. Optional — when
     /// `nil`, notification hooks become no-ops, which keeps Core usable from headless contexts
@@ -37,6 +38,7 @@ public class TranscriptionTaskManager: ObservableObject {
         diarization: any DiarizationEngine,
         speakerStore: any SpeakerStore,
         speakerClipsDirectory: URL = CoreStoragePaths.default.speakerClips,
+        cleanupDirectories: [URL]? = nil,
         retainedAudioDirectory: URL? = nil,
         retainedAudioDirectoryProvider: (() -> URL?)? = nil,
         statsStore: (any StatsStore)? = nil,
@@ -47,6 +49,8 @@ public class TranscriptionTaskManager: ObservableObject {
         self.notifier = notifier
         self.retainedAudioDirectory = retainedAudioDirectory
         self.retainedAudioDirectoryProvider = retainedAudioDirectoryProvider
+        self.cleanupDirectories = (cleanupDirectories ?? [speakerClipsDirectory])
+            .map(Self.canonicalDirectoryURL)
         self.transcription = Transcription(
             speechToText: speechToText,
             diarization: diarization,
@@ -481,6 +485,17 @@ public class TranscriptionTaskManager: ObservableObject {
     }
 
     private func removeRecordingFile(_ url: URL, label: String) {
+        // Security: only delete scratch files inside Transcripted-managed cleanup roots.
+        // `startImportedTranscription` accepts a URL from the caller, so without a containment
+        // check a misuse or tampered in-memory request could unlink arbitrary user files.
+        guard isSafeCleanupURL(url) else {
+            AppLogger.pipeline.error("Refused to delete out-of-sandbox recording file", [
+                "label": label,
+                "path": url.path
+            ])
+            return
+        }
+
         do {
             try FileManager.default.removeItem(at: url)
         } catch {
@@ -494,6 +509,33 @@ public class TranscriptionTaskManager: ObservableObject {
 
     func resolvedRetainedAudioDirectory() -> URL? {
         retainedAudioDirectoryProvider?() ?? retainedAudioDirectory
+    }
+
+    func removeManagedCleanupFile(_ url: URL?, label: String) {
+        guard let url else { return }
+        removeRecordingFile(url, label: label)
+    }
+
+    private func isSafeCleanupURL(_ url: URL) -> Bool {
+        let canonicalURL = Self.canonicalFileURL(url)
+        return cleanupDirectories.contains { root in
+            Self.isFile(canonicalURL, containedIn: root)
+        }
+    }
+
+    private static func canonicalFileURL(_ url: URL) -> URL {
+        url.standardizedFileURL.resolvingSymlinksInPath()
+    }
+
+    private static func canonicalDirectoryURL(_ url: URL) -> URL {
+        url.standardizedFileURL.resolvingSymlinksInPath()
+    }
+
+    private static func isFile(_ fileURL: URL, containedIn directoryURL: URL) -> Bool {
+        let filePath = canonicalFileURL(fileURL).path
+        let directoryPath = canonicalDirectoryURL(directoryURL).path
+        let normalizedDirectoryPath = directoryPath.hasSuffix("/") ? directoryPath : directoryPath + "/"
+        return filePath == directoryPath || filePath.hasPrefix(normalizedDirectoryPath)
     }
 
     private func archiveFailedRecordingAudioIfConfigured(

--- a/Sources/TranscriptedCore/Speaker/SpeakerClipExtractor.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerClipExtractor.swift
@@ -149,21 +149,6 @@ public enum SpeakerClipExtractor {
         removeClipFile(url, label: "persisted clip")
     }
 
-    // MARK: - Temporary Clip Cleanup
-
-    /// Clean up temporary clip files
-    static func cleanupClips(_ clips: [ClipResult]) {
-        for clip in clips {
-            removeClipFile(clip.clipURL, label: "temporary clip")
-        }
-    }
-
-    static func cleanupClips(_ entries: [SpeakerNamingEntry]) {
-        for entry in entries {
-            removeClipFile(entry.clipURL, label: "speaker naming clip")
-        }
-    }
-
     // MARK: - Private
 
     /// Select which utterance segments to use for the clip.

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -57,10 +57,10 @@ extension TranscriptionTaskManager {
                 transcriptURL,
                 transcriptId: transcriptId
             ) else {
-                SpeakerClipExtractor.cleanupClips(clips)
+                self?.cleanupSpeakerClips(clips)
                 if shouldRemoveTemporaryAudio {
-                    Self.removeTemporaryAudioFile(micURL, label: "mic audio")
-                    Self.removeTemporaryAudioFile(systemURL, label: "system audio")
+                    self?.removeManagedCleanupFile(micURL, label: "mic audio")
+                    self?.removeManagedCleanupFile(systemURL, label: "system audio")
                 }
 
                 Task { @MainActor in
@@ -79,10 +79,10 @@ extension TranscriptionTaskManager {
                 clipsBySpeakerId: clipsBySpeakerId,
                 speakerDB: speakerDB
             ) else {
-                SpeakerClipExtractor.cleanupClips(clips)
+                self?.cleanupSpeakerClips(clips)
                 if shouldRemoveTemporaryAudio {
-                    Self.removeTemporaryAudioFile(micURL, label: "mic audio")
-                    Self.removeTemporaryAudioFile(systemURL, label: "system audio")
+                    self?.removeManagedCleanupFile(micURL, label: "mic audio")
+                    self?.removeManagedCleanupFile(systemURL, label: "system audio")
                 }
 
                 Task { @MainActor in
@@ -134,10 +134,10 @@ extension TranscriptionTaskManager {
                 )
             }
 
-            SpeakerClipExtractor.cleanupClips(clips)
+            self?.cleanupSpeakerClips(clips)
             if shouldRemoveTemporaryAudio {
-                Self.removeTemporaryAudioFile(micURL, label: "mic audio")
-                Self.removeTemporaryAudioFile(systemURL, label: "system audio")
+                self?.removeManagedCleanupFile(micURL, label: "mic audio")
+                self?.removeManagedCleanupFile(systemURL, label: "system audio")
             }
 
             Task { @MainActor in
@@ -156,12 +156,24 @@ extension TranscriptionTaskManager {
     public func cleanupPendingNaming() {
         if let request = speakerNamingRequest {
             if request.shouldRemoveTemporaryAudioOnCleanup {
-                Self.removeTemporaryAudioFile(request.micAudioURL, label: "pending mic audio")
-                Self.removeTemporaryAudioFile(request.systemAudioURL, label: "pending system audio")
+                removeManagedCleanupFile(request.micAudioURL, label: "pending mic audio")
+                removeManagedCleanupFile(request.systemAudioURL, label: "pending system audio")
             }
-            SpeakerClipExtractor.cleanupClips(request.speakers)
+            cleanupSpeakerClips(request.speakers)
             speakerNamingRequest = nil
             AppLogger.pipeline.info("Cleaned up pending naming on shutdown")
+        }
+    }
+
+    private func cleanupSpeakerClips(_ clips: [SpeakerNamingEntry]) {
+        for clip in clips {
+            removeManagedCleanupFile(clip.clipURL, label: "speaker naming clip")
+        }
+    }
+
+    private func cleanupSpeakerClips(_ clips: [ClipResult]) {
+        for clip in clips {
+            removeManagedCleanupFile(clip.clipURL, label: "temporary clip")
         }
     }
 
@@ -376,19 +388,6 @@ extension TranscriptionTaskManager {
             }
             .sorted { $0.callCount > $1.callCount }
             .first
-    }
-
-    nonisolated private static func removeTemporaryAudioFile(_ url: URL?, label: String) {
-        guard let url else { return }
-        do {
-            try FileManager.default.removeItem(at: url)
-        } catch {
-            AppLogger.pipeline.warning("Failed to remove temporary audio file", [
-                "label": label,
-                "file": url.lastPathComponent,
-                "error": error.localizedDescription
-            ])
-        }
     }
 
     nonisolated private static func normalizeSpeakerName(_ name: String?) -> String {

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -165,15 +165,9 @@ extension TranscriptionTaskManager {
         }
     }
 
-    private func cleanupSpeakerClips(_ clips: [SpeakerNamingEntry]) {
+    nonisolated private func cleanupSpeakerClips(_ clips: [SpeakerNamingEntry]) {
         for clip in clips {
             removeManagedCleanupFile(clip.clipURL, label: "speaker naming clip")
-        }
-    }
-
-    private func cleanupSpeakerClips(_ clips: [ClipResult]) {
-        for clip in clips {
-            removeManagedCleanupFile(clip.clipURL, label: "temporary clip")
         }
     }
 

--- a/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
@@ -62,6 +62,47 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testCleanupPendingNamingDoesNotDeleteOutOfSandboxFiles() throws {
+        let harness = try makeHarness()
+        let externalClipURL = tempDirectory.appendingPathComponent("outside-clip.wav")
+        let externalMicURL = tempDirectory.appendingPathComponent("outside-mic.wav")
+        let externalSystemURL = tempDirectory.appendingPathComponent("outside-system.wav")
+        try Data().write(to: externalClipURL)
+        try Data().write(to: externalMicURL)
+        try Data().write(to: externalSystemURL)
+
+        harness.manager.speakerNamingRequest = SpeakerNamingRequest(
+            speakers: [
+                SpeakerNamingEntry(
+                    id: UUID(),
+                    diarizerSpeakerId: "1",
+                    channel: .system,
+                    clipURL: externalClipURL,
+                    sampleText: "hello",
+                    currentName: nil,
+                    matchSimilarity: nil,
+                    needsNaming: true,
+                    needsConfirmation: false,
+                    sessionEmbedding: nil,
+                    matchedProfileSnapshot: nil
+                )
+            ],
+            transcriptURL: harness.paths.transcripts.appendingPathComponent("Call.md"),
+            transcriptId: UUID(),
+            systemAudioURL: externalSystemURL,
+            micAudioURL: externalMicURL,
+            shouldRemoveTemporaryAudioOnCleanup: true,
+            onComplete: { _ in }
+        )
+
+        harness.manager.cleanupPendingNaming()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: externalClipURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: externalMicURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: externalSystemURL.path))
+    }
+
+    @MainActor
     func testHandleNamingCompletePublishesSuccessAfterTranscriptRewrite() async throws {
         let harness = try makeHarness()
         let transcriptId = UUID()
@@ -1533,7 +1574,8 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             failedTranscriptionManager: failedManager,
             speechToText: StubSpeechToTextEngine(),
             diarization: StubDiarizationEngine(),
-            speakerStore: speakerDB
+            speakerStore: speakerDB,
+            cleanupDirectories: [paths.audioCaptures, paths.speakerClips]
         )
 
         return TestHarness(paths: paths, speakerDB: speakerDB, manager: manager)

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -101,6 +101,20 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertEqual(message, "System audio required")
     }
 
+    func testStartImportedTranscriptionDoesNotDeleteOutOfSandboxFileWhenRejected() throws {
+        let manager = makeManager()
+        let externalURL = tempDirectory.appendingPathComponent("outside.wav")
+        try writeMonoWAV(to: externalURL, duration: 2.5)
+
+        manager.activeTasks[UUID()] = Task {}
+        manager.startImportedTranscription(
+            audioURL: externalURL,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts")
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: externalURL.path))
+    }
+
     private func makeManager(
         retainedAudioDirectory: URL? = nil,
         retainedAudioDirectoryProvider: (() -> URL?)? = nil
@@ -124,6 +138,7 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             speechToText: MetadataStubSpeechToTextEngine(),
             diarization: MetadataStubDiarizationEngine(),
             speakerStore: SpeakerDatabase(path: paths.speakerDB.path),
+            cleanupDirectories: [paths.audioCaptures, paths.speakerClips],
             retainedAudioDirectory: retainedAudioDirectory,
             retainedAudioDirectoryProvider: retainedAudioDirectoryProvider
         )


### PR DESCRIPTION
## Summary
- guard cleanup-time file deletion so Transcripted only unlinks app-managed scratch audio and speaker clip files
- add regression tests covering imported-audio rejection and pending speaker-naming cleanup for out-of-sandbox paths
- verified with `bash build-deps.sh --force`, `bash build.sh`, and `bash run-tests.sh`

## Findings
### Critical
- None.

### High
- None.

### Medium
- **Out-of-sandbox cleanup deletion in transcription cleanup paths**
  - `TranscriptionTaskManager` and speaker-naming cleanup previously removed whichever file URLs were carried in request state.
  - In failure or shutdown paths, a caller-supplied imported audio URL or tampered in-memory naming request could cause Transcripted to delete files outside its managed scratch directories.
  - Fixed by canonicalizing URLs and refusing cleanup unless the target is contained inside explicit Transcripted-managed cleanup roots.

### Low
- None.

## Audit notes
Reviewed and found no confirmed vulnerabilities in:
- path sandboxing for failed transcription storage and app-owned directories
- SQL handling in `SpeakerDatabase` and `StatsDatabase`
- Sparkle feed/signing configuration
- model download HTTPS/integrity checks
- hardcoded secret scanning
- unsafe-operation and race-condition hotspots inspected during this audit
