### PR TITLE
fix: nightly code review findings [automated]

### DIFF
--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -113,7 +113,7 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
         }
 
         self.bufferCallback = bufferCallback
-        errorMessage = nil
+        publishErrorMessage(nil)
 
         // Output handler converts CMSampleBuffer → AVAudioPCMBuffer
         let output = SCKAudioStreamOutput { [weak self] buffer in
@@ -148,7 +148,7 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
         } catch {
             AppLogger.audioSystem.error("SCKAudioCapture: start failed", ["error": error.localizedDescription])
             cleanup()
-            DispatchQueue.main.async { self.errorMessage = error.localizedDescription }
+            publishErrorMessage(error.localizedDescription)
             throw error
         }
     }
@@ -212,6 +212,16 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
         _totalBuffers = 0
         _buffersWithData = 0
         statsLock.unlock()
+    }
+
+    private func publishErrorMessage(_ message: String?) {
+        if Thread.isMainThread {
+            errorMessage = message
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.errorMessage = message
+            }
+        }
     }
 }
 

--- a/Sources/TranscriptedCore/Audio/SystemAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SystemAudioCapture.swift
@@ -194,7 +194,7 @@ class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchecked
         }
 
         self.bufferCallback = bufferCallback
-        errorMessage = nil
+        publishErrorMessage(nil)
 
         do {
             // Setup tap if not already prepared
@@ -216,7 +216,7 @@ class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchecked
             let errMsg = "Failed to start system audio capture: \(error.localizedDescription)"
             AppLogger.audioSystem.error("Start failed", ["error": errMsg])
             cleanup()
-            errorMessage = errMsg
+            publishErrorMessage(errMsg)
             throw error
         }
     }
@@ -280,6 +280,16 @@ class SystemAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchecked
         }
 
         cleanup()
+    }
+
+    private func publishErrorMessage(_ message: String?) {
+        if Thread.isMainThread {
+            errorMessage = message
+        } else {
+            DispatchQueue.main.async { [weak self] in
+                self?.errorMessage = message
+            }
+        }
     }
 
     deinit {

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -28,7 +28,6 @@ public class FailedTranscriptionManager: ObservableObject {
         self.allowedAudioRoots = [
             paths.audioCaptures,
             paths.transcripts
-                .deletingLastPathComponent()
                 .appendingPathComponent("audio", isDirectory: true),
         ].map(Self.canonicalDirectoryURL)
 

--- a/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
@@ -120,6 +120,46 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: paths.failedQueue.path))
     }
 
+    func testAddFailedTranscriptionAcceptsRetainedMeetingAudioArchivePaths() throws {
+        let paths = makePaths(root: testRoot)
+        let archiveRoot = paths.transcripts.appendingPathComponent("audio", isDirectory: true)
+        let archivedDirectory = archiveRoot.appendingPathComponent("Failed_Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: archivedDirectory, withIntermediateDirectories: true)
+
+        let archivedMicURL = archivedDirectory.appendingPathComponent("microphone.wav")
+        let archivedSystemURL = archivedDirectory.appendingPathComponent("system_audio.wav")
+        FileManager.default.createFile(atPath: archivedMicURL.path, contents: Data("mic".utf8))
+        FileManager.default.createFile(atPath: archivedSystemURL.path, contents: Data("system".utf8))
+
+        let manager = FailedTranscriptionManager(paths: paths)
+        manager.addFailedTranscription(
+            micAudioURL: archivedMicURL,
+            systemAudioURL: archivedSystemURL,
+            errorMessage: "Temporary transcription failure"
+        )
+
+        XCTAssertEqual(manager.failedTranscriptions.count, 1)
+        XCTAssertEqual(manager.failedTranscriptions.first?.micAudioURL, archivedMicURL)
+        XCTAssertEqual(manager.failedTranscriptions.first?.systemAudioURL, archivedSystemURL)
+
+        let siblingArchiveURL = paths.transcripts
+            .deletingLastPathComponent()
+            .appendingPathComponent("audio/sibling.wav")
+        try FileManager.default.createDirectory(
+            at: siblingArchiveURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        FileManager.default.createFile(atPath: siblingArchiveURL.path, contents: Data("sibling".utf8))
+
+        manager.addFailedTranscription(
+            micAudioURL: siblingArchiveURL,
+            systemAudioURL: nil,
+            errorMessage: "Temporary transcription failure"
+        )
+
+        XCTAssertEqual(manager.failedTranscriptions.count, 1)
+    }
+
     func testFailedTranscriptionRetryabilityDoesNotOvermatchGenericMinimumLanguage() {
         let failure = FailedTranscription(
             micAudioURL: testRoot.appendingPathComponent("mic.wav"),


### PR DESCRIPTION
## Summary
Nightly automated code review focused on commits from the last 7 days, with extra attention on transcription, audio capture, meeting capture, threading, and failed-transcription recovery paths.

## Fixed
### Threading
- Marshaled `SystemAudioCapture.errorMessage` updates onto the main thread so `@Published` UI state is not mutated from non-main capture/startup paths.

### Failed transcription recovery
- Fixed `FailedTranscriptionManager`'s retained-audio allowlist to accept archived meeting audio stored under `transcripts/audio/...`.
- Added a regression test covering accepted retained archive paths and rejection of a sibling `audio/` directory outside the intended root.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
