### PR TITLE
[nightly-retrieval] Deduplicate retrieval speaker names

### DIFF
--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -389,7 +389,7 @@ enum CLIContextStore {
                 date: String(transcript.recording.date.prefix(10)),
                 datetime: transcript.recording.date,
                 wordCount: transcript.speakers.reduce(0) { $0 + $1.wordCount },
-                speakers: transcript.speakers.map(\.name),
+                speakers: uniqueSpeakerNames(from: transcript.speakers.map(\.name)),
                 utterances: transcript.utterances.map { utterance in
                     CLIUtterance(
                         start: utterance.start,
@@ -530,6 +530,19 @@ enum CLIContextStore {
 
     private static func speakerMatches(filter: String, speakerName: String) -> Bool {
         speakerName.localizedCaseInsensitiveContains(filter)
+    }
+
+    private static func uniqueSpeakerNames(from names: [String]) -> [String] {
+        var seen: Set<String> = []
+        var ordered: [String] = []
+
+        for name in names {
+            let normalized = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !normalized.isEmpty, seen.insert(normalized).inserted else { continue }
+            ordered.append(name)
+        }
+
+        return ordered
     }
 
     private struct ParsedFrontmatter {

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -331,6 +331,7 @@ final class ContextStoreTests: XCTestCase {
 
         XCTAssertEqual(items.count, 1)
         XCTAssertEqual(items.first?.title, "Duplicate names")
+        XCTAssertEqual(items.first?.speakers, ["Alex"])
     }
 
     func testReadDictationRejectsParentTraversal() throws {

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -786,7 +786,7 @@ final class TranscriptIndex: @unchecked Sendable {
                     datetime: $0.datetime,
                     preview: firstUtterance.isEmpty ? "No transcript captured." : String(firstUtterance.prefix(220)),
                     wordCount: $0.wordCount,
-                    speakers: $0.speakers.map(\.name),
+                    speakers: uniqueSpeakerNames(from: $0.speakers.map(\.name)),
                     sourceAppName: nil,
                     delivery: nil
                 )
@@ -799,6 +799,19 @@ final class TranscriptIndex: @unchecked Sendable {
 
         items.sort { $0.datetime > $1.datetime }
         return RecentContextResult(items: Array(items.prefix(max(1, min(count, 50)))))
+    }
+
+    private func uniqueSpeakerNames(from names: [String]) -> [String] {
+        var seen: Set<String> = []
+        var ordered: [String] = []
+
+        for name in names {
+            let normalized = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !normalized.isEmpty, seen.insert(normalized).inserted else { continue }
+            ordered.append(name)
+        }
+
+        return ordered
     }
 
     func getSpeakerHistory(speaker: String) throws -> SpeakerHistoryResult {

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptIndexTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptIndexTests.swift
@@ -283,6 +283,30 @@ final class TranscriptIndexTests: XCTestCase {
         XCTAssertEqual(result.items.first?.preview, "Good morning everyone")
     }
 
+    func testRecentContextDeduplicatesSpeakerNames() throws {
+        try writeFixture(
+            makeFixtureJSON(
+                date: "2026-03-29T10:00:00-0500",
+                speakers: [
+                    ("system_0", "Alex", "80FB272B-6061-4FC4-8408-3F7A974C59DB"),
+                    ("system_1", "Alex", "4F57C98D-B6B7-449F-95B9-3521FA99D7DA"),
+                ],
+                utterances: [
+                    ("system_0", 0.0, 5.0, "First shared name"),
+                    ("system_1", 5.0, 10.0, "Second shared name"),
+                ]
+            ),
+            filename: "Call_2026-03-29_10-00-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try index.listRecentContext(kind: .meeting, count: 10)
+
+        XCTAssertEqual(result.items.count, 1)
+        XCTAssertEqual(result.items.first?.speakers, ["Alex"])
+    }
+
     func testRecentContextEmptyMeetingUsesExplicitPreview() throws {
         try writeFixture(
             makeFixtureJSON(


### PR DESCRIPTION
## Summary
- deduplicate repeated speaker names in CLI recent/search meeting results
- deduplicate repeated speaker names in MCP recent_context meeting items
- cover both paths with regression tests

## Verification
- cd Tools/TranscriptedCLI && swift build && swift test
- cd Tools/TranscriptedMCP && swift build && swift test
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- ./Tools/TranscriptedCLI/.build/debug/transcripted-cli context-search Linus --kind meeting --count 5 --json