### PR TITLE
[nightly-agent] Add CLI meeting read command

### DIFF
--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -10,6 +10,7 @@ It does not build or run the app target.
 
 - `transcripted-cli context-recent` — list recent meetings and dictations
 - `transcripted-cli context-search <query>` — search across saved meetings and dictations, including meeting titles and speaker names
+- `transcripted-cli read-meeting <filename>` — read one saved meeting transcript
 - `transcripted-cli list-dictations` — list saved dictation day files
 - `transcripted-cli read-dictation <filename>` — read one dictation day or one entry
 
@@ -43,7 +44,7 @@ They also honor:
 |------|---------|
 | `Package.swift` | Swift package manifest; links against repo dependency artifacts |
 | `TranscriptedCLI.swift` | `@main` command root and subcommand registration |
-| `ContextCommands.swift` | CLI entry points for recent/search/dictation commands |
+| `ContextCommands.swift` | CLI entry points for recent/search/read context commands |
 | `ContextStore.swift` | Shared file-loading and filtering logic for local context |
 | `ContextModels.swift` | Codable models used by the context commands |
 | `DiarizeCommand.swift` | Single-file diarization command |
@@ -67,6 +68,7 @@ swift build
 swift test
 swift run transcripted-cli context-recent
 swift run transcripted-cli context-search "roadmap"
+swift run transcripted-cli read-meeting "Product review"
 swift run transcripted-cli list-dictations --count 5
 swift run transcripted-cli diarize /path/to/audio.wav --json
 ```
@@ -80,6 +82,7 @@ on SwiftPM again:
 ./.build/debug/transcripted-cli context-recent --count 10
 ./.build/debug/transcripted-cli context-recent --kind meeting --count 3
 ./.build/debug/transcripted-cli context-search "Linus" --kind meeting --speaker "Linus" --count 5
+./.build/debug/transcripted-cli read-meeting "Call_2026-04-29_09-15-00"
 ./.build/debug/transcripted-cli list-dictations --date-from 2026-04-29 --date-to 2026-04-29
 ./.build/debug/transcripted-cli read-dictation Dictations_2026-04-29
 ```
@@ -88,6 +91,7 @@ What these are good for:
 
 - latest mixed context: `context-recent`
 - latest meeting only: `context-recent --kind meeting`
+- full meeting markdown: `read-meeting` with the filename returned by `context-recent --kind meeting`
 - meetings by speaker or topic: `context-search <query> --kind meeting --speaker <name>`
 - dictations by day: `list-dictations --date-from YYYY-MM-DD --date-to YYYY-MM-DD`, then `read-dictation`
 

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextCommands.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextCommands.swift
@@ -123,6 +123,22 @@ struct ListDictations: ParsableCommand {
     }
 }
 
+struct ReadMeeting: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "read-meeting",
+        abstract: "Read a saved meeting transcript."
+    )
+
+    @Argument(help: "Meeting filename, with or without .md.")
+    var filename: String
+
+    @OptionGroup var paths: CLIContextPathOptions
+
+    func run() throws {
+        print(try CLIContextStore.readMeeting(filename: filename, in: paths.resolved))
+    }
+}
+
 struct ReadDictation: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "read-dictation",

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -295,6 +295,36 @@ enum CLIContextStore {
         return Array(items.sorted { $0.datetime > $1.datetime }.prefix(count))
     }
 
+    static func readMeeting(filename: String, in directories: CLIContextDirectories) throws -> String {
+        let requestedName = filename.hasSuffix(".md") ? filename : filename + ".md"
+        var invalidPathRequested = false
+        var markdownURL: URL?
+        for directory in directories.meetingDirs {
+            switch CLIPathSecurity.resolveReadableFile(named: requestedName, in: directory) {
+            case .valid(let safeURL):
+                markdownURL = safeURL
+            case .missing:
+                continue
+            case .invalid:
+                invalidPathRequested = true
+            }
+            if markdownURL != nil { break }
+        }
+
+        if invalidPathRequested && markdownURL == nil {
+            throw ValidationError("Invalid meeting filename: \(filename)")
+        }
+
+        guard let markdownURL,
+              let content = try? String(contentsOf: markdownURL, encoding: .utf8),
+              looksLikeCaptureMarkdown(markdownURL),
+              !markdownURL.deletingPathExtension().lastPathComponent.hasPrefix("Dictations_") else {
+            throw ValidationError("Meeting not found: \(filename)")
+        }
+
+        return content
+    }
+
     static func readDictation(filename: String, entryId: String?, in directories: CLIContextDirectories) throws -> String {
         let requestedName = filename.hasSuffix(".md") ? filename : filename + ".md"
         var invalidPathRequested = false

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/TranscriptedCLI.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/TranscriptedCLI.swift
@@ -11,6 +11,7 @@ struct TranscriptedCLI: AsyncParsableCommand {
             Batch.self,
             ContextRecent.self,
             ContextSearch.self,
+            ReadMeeting.self,
             ListDictations.self,
             ReadDictation.self,
         ]

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -353,6 +353,49 @@ final class ContextStoreTests: XCTestCase {
         ))
     }
 
+    func testReadMeetingReturnsMarkdownFromAllowedMeetingDirectory() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let meetingsDir = root.appendingPathComponent("meetings", isDirectory: true)
+        let dictationsDir = root.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: meetingsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dictationsDir, withIntermediateDirectories: true)
+
+        let markdown = makeMeetingMarkdown(title: "Product review", date: "2026-04-18", body: "[00:03] [Mic/You] Ship the agent path.")
+        try markdown.write(
+            to: meetingsDir.appendingPathComponent("Product review.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let content = try CLIContextStore.readMeeting(
+            filename: "Product review",
+            in: CLIContextDirectories(meetingsDir: meetingsDir, dictationsDir: dictationsDir)
+        )
+
+        XCTAssertEqual(content, markdown)
+    }
+
+    func testReadMeetingRejectsParentTraversal() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let meetingsDir = root.appendingPathComponent("meetings", isDirectory: true)
+        let outsideDir = root.appendingPathComponent("outside", isDirectory: true)
+        let dictationsDir = root.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: meetingsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outsideDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dictationsDir, withIntermediateDirectories: true)
+        try makeMeetingMarkdown(title: "Escaped", date: "2026-04-18", body: "[00:03] [Mic/You] escaped content")
+            .write(to: outsideDir.appendingPathComponent("Escaped.md"), atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(try CLIContextStore.readMeeting(
+            filename: "../outside/Escaped.md",
+            in: CLIContextDirectories(meetingsDir: meetingsDir, dictationsDir: dictationsDir)
+        ))
+    }
+
     func testReadDictationRejectsSymlinkEscape() throws {
         let root = makeTempDir()
         defer { try? FileManager.default.removeItem(at: root) }


### PR DESCRIPTION
## Summary
- add `transcripted-cli read-meeting` for full meeting Markdown reads
- reuse existing path-safety checks for meeting filenames
- document the new agent retrieval command

## Verification
- `swift build` in `Tools/TranscriptedCLI`
- `swift test` in `Tools/TranscriptedCLI`
- `swift build -c release` in `Tools/TranscriptedMCP`
- `swift test` in `Tools/TranscriptedMCP`
- `transcripted-mcp --self-test` with temp `TRANSCRIPTED_DATA_DIR` and `TRANSCRIPTED_INDEX_DIR`
