### PR TITLE
Fix meeting stop timeout diagnostics snapshot

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -616,9 +616,9 @@ final class MeetingSessionController: ObservableObject {
             Self.runtimeDiagnosticsRecorder?.recordStall(
                 kind: "meeting",
                 stage: "recording_stop_timeout",
-                durationSeconds: finalRecordingDuration,
+                durationSeconds: recordingSnapshot.durationSeconds,
                 extra: [
-                    "trigger": recordingTrigger.rawValue,
+                    "trigger": recordingSnapshot.trigger.rawValue,
                     "reason": reason.rawValue
                 ]
             )


### PR DESCRIPTION
## Summary
- use the recording stop snapshot for stop-timeout diagnostics after the meeting stop refactor

## Verification
- bash run-tests.sh
- bash build.sh