### PR TITLE
[nightly-docs] Refresh docs drift guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,20 +34,22 @@
 5. `CLAUDE.md`
 6. `Sources/CLAUDE.md`
 7. the nearest local `CLAUDE.md` for the area you are changing
-8. `Sources/Dictation/CLAUDE.md` when touching dictation persistence
-9. `Sources/Meeting/CLAUDE.md` when touching meeting capture or meeting UI
-10. `Sources/TranscriptedCore/CLAUDE.md` when touching the shared library
-11. `Sources/Speech/CLAUDE.md` when touching dictation STT, audio recovery, or device handling
-12. `Sources/Support/CLAUDE.md` when touching shared preferences, permissions, paths, or Claude Desktop install flow
-13. `Sources/UI/CLAUDE.md` when touching overlay, menubar, onboarding, settings, or agent-connect UI
-14. `Sources/Capture/CLAUDE.md` when touching hotkeys or physical dictation trigger routing
-15. `Tests/README.md`
-16. `docs/storage-paths.md`
-17. `Sources/Reliability/CLAUDE.md` when touching wake / sleep recovery or hotkey recovery
-18. `Sources/Observability/CLAUDE.md` when touching crash reporting, event forwarding, anonymous analytics, or app updates
-19. `docs/release-packaging.md` when touching packaging, signing, notarization, or user-facing releases
-20. `docs/sparkle-updates.md` when touching app updates or cutting a release users should receive in-app
-21. `Tools/*/CLAUDE.md` when touching standalone CLI, MCP, or QA tools
+8. `Sources/Accessibility/CLAUDE.md` when touching focused-editor AX metadata, overlay placement, or paste-back context
+9. `Sources/Beta/CLAUDE.md` when touching beta-build configuration
+10. `Sources/Dictation/CLAUDE.md` when touching dictation persistence
+11. `Sources/Meeting/CLAUDE.md` when touching meeting capture or meeting UI
+12. `Sources/TranscriptedCore/CLAUDE.md` when touching the shared library
+13. `Sources/Speech/CLAUDE.md` when touching dictation STT, audio recovery, or device handling
+14. `Sources/Support/CLAUDE.md` when touching shared preferences, permissions, paths, or Claude Desktop install flow
+15. `Sources/UI/CLAUDE.md` when touching overlay, menubar, onboarding, settings, or agent-connect UI
+16. `Sources/Capture/CLAUDE.md` when touching hotkeys or physical dictation trigger routing
+17. `Tests/README.md`
+18. `docs/storage-paths.md`
+19. `Sources/Reliability/CLAUDE.md` when touching wake / sleep recovery or hotkey recovery
+20. `Sources/Observability/CLAUDE.md` when touching crash reporting, event forwarding, anonymous analytics, or app updates
+21. `docs/release-packaging.md` when touching packaging, signing, notarization, or user-facing releases
+22. `docs/sparkle-updates.md` when touching app updates or cutting a release users should receive in-app
+23. `Tools/*/CLAUDE.md` when touching standalone CLI, MCP, or QA tools
 
 Use `docs/repo-layout.md` as the canonical directory map and doc hierarchy.
 

--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -61,6 +61,8 @@ app target entirely. If a historical doc still mentions `Sources/Text/` or
 - touching app-wide support utilities: `Sources/Support/CLAUDE.md`
 - touching overlay, menubar, onboarding, settings, or agent-connect UI: `Sources/UI/CLAUDE.md`
 - touching hotkeys or physical dictation trigger routing: `Sources/Capture/CLAUDE.md`
+- touching focused-editor AX metadata, overlay placement, or paste-back context: `Sources/Accessibility/CLAUDE.md`
+- touching beta-build configuration: `Sources/Beta/CLAUDE.md`
 - touching tests or package boundaries: `Tests/README.md`
 
 Prefer the local doc plus the actual Swift file list before assuming an older

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -13,7 +13,7 @@ The directory is grouped by surface so the live UI tree is easier to scan:
 
 Draft-mode UI is not an active product path in this worktree.
 
-## Files (49 Swift files)
+## Files (51 Swift files)
 
 ### Overlay/
 
@@ -67,6 +67,7 @@ The current agent-connect surfaces should keep one simple mental model:
 
 ### Settings/
 
+- `Settings/HomeMeetingPreviewFormatter.swift` — formats recent meeting preview metadata for the Settings home dashboard
 - `Settings/HomeTranscriptionActivityPresentation.swift` — presentation model derived from `MeetingSessionController` state for the home page's live transcription activity card (tone, progress, transcript URL)
 - `Settings/HomeView.swift` — redesigned Settings home dashboard with fast recent activity loading, grouped recent dictations/meetings, summary stats, and lightweight copy/feedback/delete affordances
 - `Settings/HotkeyRecorderAppKitView.swift` — AppKit view for recording custom hotkey bindings

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -12,18 +12,20 @@ historical, and which local doc to read before editing a subsystem.
 4. `docs/agent-onboarding.md`
 5. `Sources/CLAUDE.md`
 6. the nearest local `CLAUDE.md`
-7. `Sources/Speech/CLAUDE.md` when touching STT, audio recovery, or device handling
-8. `Sources/Support/CLAUDE.md` when touching shared preferences, paths, permissions, or install flows
-9. `Sources/UI/CLAUDE.md` when touching overlay, menubar, onboarding, settings, or agent-connect UI
-10. `Sources/Capture/CLAUDE.md` when touching hotkeys or physical dictation trigger routing
-11. `Tests/README.md` when touching verification or package seams
-12. `docs/storage-paths.md` when touching persisted output or path resolution
-13. `docs/release-packaging.md` and `docs/sparkle-updates.md` when touching packaging, notarization, releases, or in-app updates
-14. `Sources/Observability/CLAUDE.md` when touching crash reporting, analytics, or Sparkle plumbing
-15. `Sources/Reliability/CLAUDE.md` when touching wake / sleep recovery or hotkey recovery
-16. `Tools/*/CLAUDE.md` when touching standalone CLI, MCP, or QA tools
-17. `scripts/README.md` when touching the shell entrypoints or release helpers
-18. source comments
+7. `Sources/Accessibility/CLAUDE.md` when touching focused-editor AX metadata, overlay placement, or paste-back context
+8. `Sources/Beta/CLAUDE.md` when touching beta-build configuration
+9. `Sources/Speech/CLAUDE.md` when touching STT, audio recovery, or device handling
+10. `Sources/Support/CLAUDE.md` when touching shared preferences, paths, permissions, or install flows
+11. `Sources/UI/CLAUDE.md` when touching overlay, menubar, onboarding, settings, or agent-connect UI
+12. `Sources/Capture/CLAUDE.md` when touching hotkeys or physical dictation trigger routing
+13. `Tests/README.md` when touching verification or package seams
+14. `docs/storage-paths.md` when touching persisted output or path resolution
+15. `docs/release-packaging.md` and `docs/sparkle-updates.md` when touching packaging, notarization, releases, or in-app updates
+16. `Sources/Observability/CLAUDE.md` when touching crash reporting, analytics, or Sparkle plumbing
+17. `Sources/Reliability/CLAUDE.md` when touching wake / sleep recovery or hotkey recovery
+18. `Tools/*/CLAUDE.md` when touching standalone CLI, MCP, or QA tools
+19. `scripts/README.md` when touching the shell entrypoints or release helpers
+20. source comments
 
 For the active directory map and command surface, prefer `docs/repo-layout.md`.
 
@@ -87,6 +89,10 @@ Rule of thumb:
 
 - `Sources/CLAUDE.md`
   App boot order and shared state wiring.
+- `Sources/Accessibility/CLAUDE.md`
+  Focused-editor AX metadata, overlay placement, and paste-back context.
+- `Sources/Beta/CLAUDE.md`
+  Beta-build configuration and archived beta-worker boundaries.
 - `Sources/Meeting/CLAUDE.md`
   App/Core bridge, meeting storage, runtime lifecycle.
 - `Sources/TranscriptedCore/CLAUDE.md`


### PR DESCRIPTION
## Summary
- add the existing Accessibility and Beta subsystem docs to agent read-order guidance
- update the UI subsystem doc to match the current Settings file list and Swift file count

## Verification
- docs-only sweep; no Swift build run
- checked current repo tree, root command wrappers, storage paths, Sparkle/Sentry plist settings, and open [nightly-docs] PR state