### PR TITLE
[nightly-simplify] Simplify speaker naming cleanup

### DIFF
--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -57,11 +57,12 @@ extension TranscriptionTaskManager {
                 transcriptURL,
                 transcriptId: transcriptId
             ) else {
-                self?.cleanupSpeakerClips(clips)
-                if shouldRemoveTemporaryAudio {
-                    self?.removeManagedCleanupFile(micURL, label: "mic audio")
-                    self?.removeManagedCleanupFile(systemURL, label: "system audio")
-                }
+                self?.cleanupNamingArtifacts(
+                    clips: clips,
+                    micURL: micURL,
+                    systemURL: systemURL,
+                    shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio
+                )
 
                 Task { @MainActor in
                     self?.finishNamingFlow(
@@ -79,11 +80,12 @@ extension TranscriptionTaskManager {
                 clipsBySpeakerId: clipsBySpeakerId,
                 speakerDB: speakerDB
             ) else {
-                self?.cleanupSpeakerClips(clips)
-                if shouldRemoveTemporaryAudio {
-                    self?.removeManagedCleanupFile(micURL, label: "mic audio")
-                    self?.removeManagedCleanupFile(systemURL, label: "system audio")
-                }
+                self?.cleanupNamingArtifacts(
+                    clips: clips,
+                    micURL: micURL,
+                    systemURL: systemURL,
+                    shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio
+                )
 
                 Task { @MainActor in
                     self?.finishNamingFlow(
@@ -134,11 +136,12 @@ extension TranscriptionTaskManager {
                 )
             }
 
-            self?.cleanupSpeakerClips(clips)
-            if shouldRemoveTemporaryAudio {
-                self?.removeManagedCleanupFile(micURL, label: "mic audio")
-                self?.removeManagedCleanupFile(systemURL, label: "system audio")
-            }
+            self?.cleanupNamingArtifacts(
+                clips: clips,
+                micURL: micURL,
+                systemURL: systemURL,
+                shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio
+            )
 
             Task { @MainActor in
                 self?.finishNamingFlow(
@@ -163,6 +166,18 @@ extension TranscriptionTaskManager {
             speakerNamingRequest = nil
             AppLogger.pipeline.info("Cleaned up pending naming on shutdown")
         }
+    }
+
+    nonisolated private func cleanupNamingArtifacts(
+        clips: [SpeakerNamingEntry],
+        micURL: URL?,
+        systemURL: URL,
+        shouldRemoveTemporaryAudio: Bool
+    ) {
+        cleanupSpeakerClips(clips)
+        guard shouldRemoveTemporaryAudio else { return }
+        removeManagedCleanupFile(micURL, label: "mic audio")
+        removeManagedCleanupFile(systemURL, label: "system audio")
     }
 
     nonisolated private func cleanupSpeakerClips(_ clips: [SpeakerNamingEntry]) {


### PR DESCRIPTION
## What changed

- Extracted repeated speaker naming cleanup into one private helper.
- Kept the existing cleanup order: clips first, then temporary mic/system audio when enabled.

## Why

This keeps the speaker naming completion path easier to read without changing product behavior.

## Verification

- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
