### PR TITLE
Release 1.1.29

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.28"
-  sha256 "055f65157c05f545ca1c079b7e1b4a90908acc09667b1c47491d967c2ef46e7e"
+  version "1.1.29"
+  sha256 "e6095b9409f30750af4fefa2fa9687d75e5cc881a1d47515c6e466e7cb50a8c4"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.28</string>
+	<string>1.1.29</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.28</string>
+	<string>1.1.29</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.29</title>
+      <pubDate>Sat, 02 May 2026 06:54:42 -0500</pubDate>
+      <sparkle:version>1.1.29</sparkle:version>
+      <sparkle:shortVersionString>1.1.29</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.29/Transcripted-1.1.29.dmg" length="528464399" type="application/octet-stream" sparkle:edSignature="vEuYsnXktdVRnQHRn9ukVtitla7J0/syzTILiBlTdgSoMkbb685b1EG5NGz0ERVzPhmQ0qcH2f11GQRSXTkXCw==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.29</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.29</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.28</title>
       <pubDate>Thu, 30 Apr 2026 13:04:01 -0500</pubDate>
       <sparkle:version>1.1.28</sparkle:version>


### PR DESCRIPTION
## Summary
- Bump Transcripted to 1.1.29
- Add the 1.1.29 Sparkle appcast item
- Update the Homebrew cask sha256 for the published DMG

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-public-1.1.29 Transcripted
- bash scripts/release/verify-sparkle-release.sh 1.1.29