### PR TITLE
[codex] Speed up recent meeting previews

### DIFF
--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -37,6 +37,30 @@ enum MeetingTranscriptStyler {
         styledTranscript(at: url, persistChanges: false)
     }
 
+    static func displayTranscriptPreview(at url: URL) -> StyledMeetingTranscript? {
+        let raw: String
+        do {
+            raw = try previewString(at: url)
+        } catch {
+            logFailure(
+                event: "meeting_transcript_preview_read_failed",
+                message: "Failed to read meeting transcript preview",
+                context: [
+                    "file": url.lastPathComponent,
+                    "error": error.localizedDescription
+                ]
+            )
+            return nil
+        }
+
+        guard isMeetingTranscript(raw) else { return nil }
+        guard let document = parseDocument(raw, fallbackURL: url) else {
+            return StyledMeetingTranscript(url: url, title: fallbackTitle(for: url))
+        }
+
+        return StyledMeetingTranscript(url: url, title: buildTitle(for: document))
+    }
+
     private static func styledTranscript(at url: URL, persistChanges: Bool) -> StyledMeetingTranscript {
         let raw: String
         do {
@@ -105,6 +129,18 @@ enum MeetingTranscriptStyler {
         }
         return stripFrontmatter(from: raw)?.trimmingCharacters(in: .whitespacesAndNewlines)
             ?? raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func previewString(at url: URL, byteLimit: Int = 64 * 1024) throws -> String {
+        let data = try Data(contentsOf: url, options: [.mappedIfSafe])
+        guard data.count > byteLimit else {
+            return String(decoding: data, as: UTF8.self)
+        }
+        return String(decoding: data.prefix(byteLimit), as: UTF8.self)
+    }
+
+    private static func isMeetingTranscript(_ raw: String) -> Bool {
+        raw.hasPrefix("---\n") && (raw.contains("\n## Full Transcript") || raw.contains("\n## Transcript"))
     }
 
     private static func parseDocument(_ raw: String, fallbackURL: URL) -> ParsedDocument? {

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -114,8 +114,9 @@ enum RecentMeetingsScanner {
 
         var recentItems: [RecentMeetingItem] = []
         for entry in candidates.sorted(by: { $0.date > $1.date }) {
-            guard isMeetingTranscript(entry.url) else { continue }
-            let styled = MeetingTranscriptStyler.displayTranscript(at: entry.url)
+            guard let styled = MeetingTranscriptStyler.displayTranscriptPreview(at: entry.url) else {
+                continue
+            }
             recentItems.append(
                 RecentMeetingItem(
                     title: styled.title,
@@ -143,10 +144,5 @@ enum RecentMeetingsScanner {
         }
 
         return true
-    }
-
-    private static func isMeetingTranscript(_ url: URL) -> Bool {
-        guard let raw = try? String(contentsOf: url, encoding: .utf8) else { return false }
-        return raw.hasPrefix("---\n") && (raw.contains("\n## Full Transcript") || raw.contains("\n## Transcript"))
     }
 }

--- a/Tests/MeetingTranscriptStylerTests.swift
+++ b/Tests/MeetingTranscriptStylerTests.swift
@@ -6,6 +6,8 @@ func testMeetingTranscriptStyler() {
         testMeetingTranscriptStylerDoesNotCreateSiblingArtifacts()
         testMeetingTranscriptStylerIsIdempotent()
         testMeetingTranscriptStylerPreservesExplicitTitle()
+        testMeetingTranscriptStylerPreviewReadsBoundedMeetingMetadata()
+        testMeetingTranscriptStylerPreviewRejectsPlainMarkdown()
         testMeetingTranscriptStylerRenamesRetainedAudioDirectory()
         testMeetingTranscriptStylerPreservesObsidianSpeakerLinks()
     }
@@ -73,6 +75,30 @@ private func testMeetingTranscriptStylerPreservesExplicitTitle() {
     assertEqual(styled.title, "Customer Interview April", "Styler should respect an explicit imported transcript title")
     assertEqual(styled.url.lastPathComponent, "Customer Interview April.md", "Explicit titles should drive the final transcript filename")
     assertTrue(updatedMarkdown?.contains("# Customer Interview April") == true, "Explicit titles should be written back into the rendered markdown")
+}
+
+private func testMeetingTranscriptStylerPreviewReadsBoundedMeetingMetadata() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Call_2026-04-07_09-14-00.md")
+    let oversizedBody = String(repeating: "extra transcript text\n", count: 8_000)
+    try? (sampleImportedTranscript() + "\n" + oversizedBody).write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+    let preview = MeetingTranscriptStyler.displayTranscriptPreview(at: transcriptURL)
+
+    assertEqual(preview?.title, "Customer Interview April", "Preview should derive the same title without requiring a full restyle pass")
+    assertEqual(preview?.url, transcriptURL, "Preview should not rename or rewrite the transcript")
+}
+
+private func testMeetingTranscriptStylerPreviewRejectsPlainMarkdown() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let noteURL = directory.appendingPathComponent("notes.md")
+    try? "# Notes\n\nNot a Transcripted meeting.".write(to: noteURL, atomically: true, encoding: .utf8)
+
+    assertNil(MeetingTranscriptStyler.displayTranscriptPreview(at: noteURL), "Preview should skip non-meeting markdown files")
 }
 
 private func testMeetingTranscriptStylerRenamesRetainedAudioDirectory() {


### PR DESCRIPTION
## What changed

- Added a lightweight meeting transcript preview path for recent meeting lists.
- Updated the Home/recent capture scanner to use that preview instead of reading and parsing each full transcript twice.
- Added tests for bounded preview parsing and skipping non-meeting Markdown.

## Why

The Home dashboard and menu-adjacent recent meeting surfaces should stay fast even as the local meeting library grows. They only need a title and a meeting/not-meeting decision, not the whole transcript body.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` — 1206 passed
- `bash run-integration-smoke.sh`
