### PR TITLE
[nightly-notes] Clarify post-release notes template

### DIFF
--- a/docs/release-notes-template.md
+++ b/docs/release-notes-template.md
@@ -8,7 +8,7 @@ Keep it short. Focus on what a user would notice or care about.
 ## Candidate summary
 
 - One sentence on what this candidate is trying to improve.
-- Call out the version gap plainly if `Info.plist` and GitHub Releases still match.
+- If `HEAD` is ahead of the latest shipped tag but `Info.plist` and GitHub Releases still match, say plainly that this is post-release `main` work and not a versioned candidate yet.
 - Say whether Sparkle and Homebrew already point at this version, or still lag.
 
 ## User-visible changes


### PR DESCRIPTION
## What changed
- Clarifies the release-notes template for the common nightly case where `HEAD` is ahead of the latest shipped tag but `Info.plist` still matches the current release.
- Tells the writer to say plainly that this is post-release `main` work, not a versioned candidate yet.

## Why
- Keeps nightly notes from sounding like a new release exists when the branch has moved but release metadata has not.

## Validation
- Docs-only change.
- Reviewed the rendered Markdown diff locally.