### PR TITLE
Release 1.1.30

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.29"
-  sha256 "e6095b9409f30750af4fefa2fa9687d75e5cc881a1d47515c6e466e7cb50a8c4"
+  version "1.1.30"
+  sha256 "aaee2b12dc1fe87bbf26758215b236b1c72989c88044c89b1c45bbd4991d7e8f"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.29</string>
+	<string>1.1.30</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.29</string>
+	<string>1.1.30</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.30</title>
+      <pubDate>Sun, 03 May 2026 19:52:20 -0500</pubDate>
+      <sparkle:version>1.1.30</sparkle:version>
+      <sparkle:shortVersionString>1.1.30</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.30/Transcripted-1.1.30.dmg" length="528478581" type="application/octet-stream" sparkle:edSignature="tW+ZCoQOggjyHcVyY/wOka6zzqkx6mI4d/7ab3ZWdv4UUsPANL5Sui2ISUoGrsBuIIEj8zZHK5cMh0siKy0TCw==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.30</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.30</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.29</title>
       <pubDate>Sat, 02 May 2026 06:54:42 -0500</pubDate>
       <sparkle:version>1.1.29</sparkle:version>


### PR DESCRIPTION
## Summary
- bumps Transcripted to 1.1.30
- publishes the 1.1.30 Sparkle appcast entry
- updates the Homebrew cask hash for the 1.1.30 DMG

## Verification
- bash build.sh
- bash run-tests.sh (1351 passed)
- bash run-integration-smoke.sh
- swift test (118 passed)
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-public-1.1.30 Transcripted
- bash scripts/release/verify-sparkle-release.sh 1.1.30