### PR TITLE
[release] Transcripted 1.1.31

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.30"
-  sha256 "aaee2b12dc1fe87bbf26758215b236b1c72989c88044c89b1c45bbd4991d7e8f"
+  version "1.1.31"
+  sha256 "2bc37184ef1c87673744b2fdde04c3f0ae886fb0e86e9f4b6ac9447c67d955ef"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.30</string>
+	<string>1.1.31</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.30</string>
+	<string>1.1.31</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.31</title>
+      <pubDate>Mon, 04 May 2026 16:31:51 -0500</pubDate>
+      <sparkle:version>1.1.31</sparkle:version>
+      <sparkle:shortVersionString>1.1.31</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.31/Transcripted-1.1.31.dmg" length="528480022" type="application/octet-stream" sparkle:edSignature="IpsQFbRA8PFOe7MYTV2vxOwzG5AeCzAHjaYvbpYYYv5XqoRmtjwFvrieP/0jmPEyT/BIX00Go0W4unHqtxhtAg==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.31</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.31</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.30</title>
       <pubDate>Sun, 03 May 2026 19:52:20 -0500</pubDate>
       <sparkle:version>1.1.30</sparkle:version>


### PR DESCRIPTION
## Summary
- Bump Transcripted to 1.1.31
- Publish Sparkle appcast entry for v1.1.31
- Update Homebrew cask to the v1.1.31 DMG SHA-256

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh (1413 passed)
- bash run-integration-smoke.sh
- swift test (119 passed)
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-public-1.1.31 Transcripted
- xcrun stapler validate build/Transcripted-1.1.31.dmg
- codesign --verify --deep --strict --verbose=2 build/Transcripted.app
- bash scripts/release/verify-sparkle-release.sh 1.1.31