### PR TITLE
[nightly-retrieval] Fix CLI speaker preview fallback

### DIFF
--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -250,7 +250,7 @@ enum CLIContextStore {
                 let metadataMatch = meeting.title.localizedCaseInsensitiveContains(normalizedQuery)
                     || meeting.speakers.contains(where: { $0.localizedCaseInsensitiveContains(normalizedQuery) })
                 guard let preview = textMatch.map({ String($0.text.prefix(220)) })
-                    ?? (metadataMatch ? recentMeetingPreview(for: meeting) : nil) else { return nil }
+                    ?? (metadataMatch ? recentMeetingPreview(for: meeting, preferredSpeaker: speaker) : nil) else { return nil }
                 return CLIContextItem(
                     kind: .meeting,
                     title: meeting.title,
@@ -528,7 +528,15 @@ enum CLIContextStore {
         return extractTitle(from: content) ?? filename
     }
 
-    private static func recentMeetingPreview(for meeting: MeetingRecord) -> String {
+    private static func recentMeetingPreview(for meeting: MeetingRecord, preferredSpeaker: String? = nil) -> String {
+        if let preferredSpeaker,
+           let matchingSpeakerUtterance = meeting.utterances.first(where: { utterance in
+               speakerMatches(filter: preferredSpeaker, speakerName: utterance.speakerId)
+                   && !utterance.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+           }) {
+            return String(matchingSpeakerUtterance.text.prefix(220))
+        }
+
         if let firstUtterance = meeting.utterances.first(where: {
             !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }) {

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -225,6 +225,58 @@ final class ContextStoreTests: XCTestCase {
         XCTAssertEqual(items.first?.title, "Hardware chat")
     }
 
+    func testSearchSpeakerMetadataMatchUsesFilteredSpeakerPreview() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let meetingsDir = root.appendingPathComponent("meetings", isDirectory: true)
+        let dictationsDir = root.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: meetingsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dictationsDir, withIntermediateDirectories: true)
+
+        let meeting = """
+        ---
+        capture_type: meeting
+        title: Hardware chat
+        date: 2026-04-16
+        time: 09:15:00
+        duration: "0:18"
+        speakers:
+          - id: "0"
+            name: Speaker 1
+            db_id: "system-1"
+          - id: "1"
+            name: Linus
+            db_id: "linus-1"
+        ---
+
+        # Hardware chat
+
+        ## Full Transcript
+
+        [00:03] [System/Speaker 1] Touch screen finally shipped.
+        [00:08] [Mic/Linus] Yellow.
+        """
+        try meeting.write(
+            to: meetingsDir.appendingPathComponent("Hardware chat.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let items = CLIContextStore.search(
+            query: "Linus",
+            speaker: "Linus",
+            in: CLIContextDirectories(meetingsDir: meetingsDir, dictationsDir: dictationsDir),
+            kind: .meeting,
+            count: 5,
+            dateFrom: nil,
+            dateTo: nil
+        )
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.preview, "Yellow.")
+    }
+
     func testRecentIncludesLegacyMeetingDirectories() throws {
         let root = makeTempDir()
         defer { try? FileManager.default.removeItem(at: root) }


### PR DESCRIPTION
## Summary
- prefer a matching speaker utterance when CLI search falls back to meeting metadata
- keep the old first-utterance fallback when there is no speaker-specific line
- add a regression test for speaker-filtered metadata matches

## Verification
- `cd Tools/TranscriptedCLI && swift build`
- `cd Tools/TranscriptedCLI && swift test`
- `cd Tools/TranscriptedMCP && swift build`
- `cd Tools/TranscriptedMCP && swift test`
- `cd Tools/TranscriptedCLI && swift run transcripted-cli context-recent --kind meeting --count 1`
- `cd Tools/TranscriptedCLI && swift run transcripted-cli context-search Linus --kind meeting --speaker Linus --count 5`
- `cd Tools/TranscriptedCLI && swift run transcripted-cli list-dictations --date-from 2026-05-02 --date-to 2026-05-02`
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`