### PR TITLE
[nightly-agent] Clarify legacy context path docs

### DIFF
--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -19,10 +19,11 @@ By default these commands read:
 - meetings: `~/Library/Application Support/Transcripted/captures/meetings`
 - dictations: `~/Library/Application Support/Transcripted/captures/dictations`
 
-Fallback order when the Transcripted capture folders do not exist yet:
+Read order for default local context:
 
-- legacy Draft exports: `~/Library/Application Support/Draft/{meetings,dictations}/transcripts`
-- older shared layout: `~/Documents/Transcripted`
+- current Transcripted capture folders first
+- legacy Draft exports when they contain capture Markdown: `~/Library/Application Support/Draft/{meetings,dictations}/transcripts`
+- older shared layout when it contains capture Markdown: `~/Documents/Transcripted`
 
 They also honor:
 

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -129,7 +129,7 @@ Example Claude Desktop config:
 Notes:
 
 - `transcripted-mcp` communicates over stdio, not HTTP.
-- By default it resolves Transcripted capture folders first, then falls back to legacy Draft or `~/Documents/Transcripted/` layouts if those are the only artifacts on disk.
+- By default it resolves Transcripted capture folders first, then also reads legacy Draft or `~/Documents/Transcripted/` layouts when those folders still contain capture Markdown.
 - `TRANSCRIPTED_DATA_DIR` can point at a shared root with `meetings/` and `dictations/` subfolders. For `transcripted-mcp`, that shared root also becomes the default SQLite index location unless `TRANSCRIPTED_INDEX_DIR` is set.
 - If needed, override paths with `TRANSCRIPTED_DATA_DIR`,
   `TRANSCRIPTED_MEETINGS_DIR`, `TRANSCRIPTED_DICTATIONS_DIR`, and


### PR DESCRIPTION
## Summary
- Clarify that CLI/MCP default reads start with current Transcripted capture folders
- Note that legacy Draft and ~/Documents/Transcripted folders are also read only when they contain capture Markdown

## Verification
- swift build (Tools/TranscriptedCLI)
- swift test (Tools/TranscriptedCLI)
- swift build -c release (Tools/TranscriptedMCP)
- swift test (Tools/TranscriptedMCP)