### PR TITLE
fix: reapply hidden Dock visibility preference

### DIFF
--- a/Sources/Support/ActivationPolicyController.swift
+++ b/Sources/Support/ActivationPolicyController.swift
@@ -66,7 +66,10 @@ final class ActivationPolicyController {
     }
 
     func setShowInDock(_ visible: Bool) {
-        guard showInDock != visible else { return }
+        guard showInDock != visible else {
+            applyIfDrifted(currentPolicy)
+            return
+        }
         showInDock = visible
         reconcile()
     }

--- a/Sources/Support/ActivationPolicyController.swift
+++ b/Sources/Support/ActivationPolicyController.swift
@@ -41,15 +41,18 @@ final class ActivationPolicyController {
     private var isMeetingRecording: Bool = false
     private var isDictationRecording: Bool = false
 
-    /// Indirection so tests can capture policy changes without touching
-    /// NSApp.
+    /// Indirections so tests can capture policy changes without touching
+    /// NSApp, and so the controller can correct AppKit/updater drift even
+    /// when its cached desired policy has not changed.
+    private let actualPolicy: (@MainActor () -> NSApplication.ActivationPolicy)?
     private let applyPolicy: @MainActor (NSApplication.ActivationPolicy) -> Void
 
     init(
         showInDock: Bool = DockVisibilityPreferences.isVisible(),
         applyPolicy: @escaping @MainActor (NSApplication.ActivationPolicy) -> Void = { policy in
             NSApp.setActivationPolicy(policy)
-        }
+        },
+        actualPolicy: (@MainActor () -> NSApplication.ActivationPolicy)? = nil
     ) {
         self.showInDock = showInDock
         self.currentPolicy = ActivationPolicyDecision.desiredPolicy(
@@ -57,6 +60,7 @@ final class ActivationPolicyController {
             isMeetingRecording: false,
             isDictationRecording: false
         )
+        self.actualPolicy = actualPolicy
         self.applyPolicy = applyPolicy
         applyPolicy(currentPolicy)
     }
@@ -79,14 +83,30 @@ final class ActivationPolicyController {
         reconcile()
     }
 
+    /// Re-enforces the currently desired policy without changing user state.
+    /// Sparkle relaunches, SwiftUI scene activation, and AppKit focus changes
+    /// can leave the process `.regular` even though the cached user setting is
+    /// hidden-Dock/accessory. This gives app lifecycle hooks a safe repair path.
+    func reapplyCurrentPolicy() {
+        applyIfDrifted(currentPolicy)
+    }
+
     private func reconcile() {
         let desired = ActivationPolicyDecision.desiredPolicy(
             showInDock: showInDock,
             isMeetingRecording: isMeetingRecording,
             isDictationRecording: isDictationRecording
         )
-        guard desired != currentPolicy else { return }
+        guard desired != currentPolicy else {
+            applyIfDrifted(desired)
+            return
+        }
         currentPolicy = desired
+        applyPolicy(desired)
+    }
+
+    private func applyIfDrifted(_ desired: NSApplication.ActivationPolicy) {
+        guard let actualPolicy, desired != actualPolicy() else { return }
         applyPolicy(desired)
     }
 }

--- a/Sources/Support/ActivationPolicyController.swift
+++ b/Sources/Support/ActivationPolicyController.swift
@@ -75,13 +75,19 @@ final class ActivationPolicyController {
     }
 
     func setMeetingRecording(_ active: Bool) {
-        guard isMeetingRecording != active else { return }
+        guard isMeetingRecording != active else {
+            applyIfDrifted(currentPolicy)
+            return
+        }
         isMeetingRecording = active
         reconcile()
     }
 
     func setDictationRecording(_ active: Bool) {
-        guard isDictationRecording != active else { return }
+        guard isDictationRecording != active else {
+            applyIfDrifted(currentPolicy)
+            return
+        }
         isDictationRecording = active
         reconcile()
     }

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -88,6 +88,9 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         let activationController = ActivationPolicyController()
         activationPolicyController = activationController
         wireActivationPolicy(controller: activationController)
+        DispatchQueue.main.async { [weak activationController] in
+            activationController?.reapplyCurrentPolicy()
+        }
 
         // Wire session controller
         sessionController.appState = appState
@@ -454,6 +457,14 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             .receive(on: DispatchQueue.main)
             .sink { [weak controller] _ in
                 controller?.setShowInDock(DockVisibilityPreferences.isVisible())
+                controller?.reapplyCurrentPolicy()
+            }
+            .store(in: &activationPolicySubscriptions)
+
+        NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak controller] _ in
+                controller?.reapplyCurrentPolicy()
             }
             .store(in: &activationPolicySubscriptions)
 

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -85,7 +85,9 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         // Crash reporting
         CrashReporter.setup()
 
-        let activationController = ActivationPolicyController()
+        let activationController = ActivationPolicyController(
+            actualPolicy: { NSApp.activationPolicy() }
+        )
         activationPolicyController = activationController
         wireActivationPolicy(controller: activationController)
         DispatchQueue.main.async { [weak activationController] in
@@ -457,7 +459,6 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             .receive(on: DispatchQueue.main)
             .sink { [weak controller] _ in
                 controller?.setShowInDock(DockVisibilityPreferences.isVisible())
-                controller?.reapplyCurrentPolicy()
             }
             .store(in: &activationPolicySubscriptions)
 

--- a/Tests/ActivationPolicyControllerTests.swift
+++ b/Tests/ActivationPolicyControllerTests.swift
@@ -207,6 +207,30 @@ func testActivationPolicyController() async {
         )
         assertEqual(controller.currentPolicy, .accessory, "same-value repair should not mutate the cached policy")
     }
+
+    runSuite("ActivationPolicyController repairs drift back to regular while recording") {
+        let recorder = PolicyRecorder()
+        var actualPolicy = NSApplication.ActivationPolicy.regular
+        let controller = ActivationPolicyController(
+            showInDock: false,
+            applyPolicy: { policy in
+                actualPolicy = policy
+                recorder.append(policy)
+            },
+            actualPolicy: { actualPolicy }
+        )
+
+        controller.setMeetingRecording(true)
+        actualPolicy = .accessory
+        controller.setMeetingRecording(true)
+
+        assertEqual(
+            recorder.history,
+            [.accessory, .regular, .regular],
+            "repeated recording-state updates should repair drift so active capture stays force-quit-visible"
+        )
+        assertEqual(controller.currentPolicy, .regular, "cached policy should stay regular while recording")
+    }
 }
 
 /// Captures the sequence of activation policies applied by a controller.

--- a/Tests/ActivationPolicyControllerTests.swift
+++ b/Tests/ActivationPolicyControllerTests.swift
@@ -184,6 +184,29 @@ func testActivationPolicyController() async {
         )
         assertEqual(controller.currentPolicy, .accessory, "cached policy should remain the user's hidden-Dock preference")
     }
+
+    runSuite("ActivationPolicyController repairs drift when the Dock preference notification repeats the same value") {
+        let recorder = PolicyRecorder()
+        var actualPolicy = NSApplication.ActivationPolicy.regular
+        let controller = ActivationPolicyController(
+            showInDock: false,
+            applyPolicy: { policy in
+                actualPolicy = policy
+                recorder.append(policy)
+            },
+            actualPolicy: { actualPolicy }
+        )
+
+        actualPolicy = .regular
+        controller.setShowInDock(false)
+
+        assertEqual(
+            recorder.history,
+            [.accessory, .accessory],
+            "same-value Dock preference notifications should still repair activation-policy drift"
+        )
+        assertEqual(controller.currentPolicy, .accessory, "same-value repair should not mutate the cached policy")
+    }
 }
 
 /// Captures the sequence of activation policies applied by a controller.

--- a/Tests/ActivationPolicyControllerTests.swift
+++ b/Tests/ActivationPolicyControllerTests.swift
@@ -161,6 +161,29 @@ func testActivationPolicyController() async {
 
         assertEqual(recorder.history, [.accessory, .regular], "redundant updates should not re-apply policy")
     }
+
+    runSuite("ActivationPolicyController reapplies hidden Dock preference when AppKit drifts back to regular") {
+        let recorder = PolicyRecorder()
+        var actualPolicy = NSApplication.ActivationPolicy.regular
+        let controller = ActivationPolicyController(
+            showInDock: false,
+            applyPolicy: { policy in
+                actualPolicy = policy
+                recorder.append(policy)
+            },
+            actualPolicy: { actualPolicy }
+        )
+
+        actualPolicy = .regular
+        controller.reapplyCurrentPolicy()
+
+        assertEqual(
+            recorder.history,
+            [.accessory, .accessory],
+            "hidden-Dock preference should be enforced again if AppKit or an updater makes the app regular"
+        )
+        assertEqual(controller.currentPolicy, .accessory, "cached policy should remain the user's hidden-Dock preference")
+    }
 }
 
 /// Captures the sequence of activation policies applied by a controller.


### PR DESCRIPTION
## Summary
- lets ActivationPolicyController detect when AppKit/updater lifecycle drifts away from the cached desired policy
- reapplies the hidden-Dock/accessory policy on next run loop, Dock preference changes, and app activation
- adds a regression test for the “toggle is off but app is back in the Dock” case

## Test Plan
- [x] bash run-tests.sh
- [x] bash build.sh

User feedback: after updating, Transcripted can show in the Dock even though “Show Transcripted in Dock” remains unchecked.