### PR TITLE
[release] Transcripted 1.1.32

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.31"
-  sha256 "2bc37184ef1c87673744b2fdde04c3f0ae886fb0e86e9f4b6ac9447c67d955ef"
+  version "1.1.32"
+  sha256 "d69c0a734375620a4a2d71d80e414be4ed5190a905a34ce58c52687765c861a4"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.31</string>
+	<string>1.1.32</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.31</string>
+	<string>1.1.32</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.32</title>
+      <pubDate>Wed, 06 May 2026 09:02:15 -0500</pubDate>
+      <sparkle:version>1.1.32</sparkle:version>
+      <sparkle:shortVersionString>1.1.32</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.32/Transcripted-1.1.32.dmg" length="528528783" type="application/octet-stream" sparkle:edSignature="XtvoybEU0DGH7D0CIHUcK9HyPJV6GR8h0yxeMbNx4gTnKaJnZdx2yJWDZCYHRK/3kqlD4Suv2wndE8SkP0JlAA==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.32</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.32</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.31</title>
       <pubDate>Mon, 04 May 2026 16:31:51 -0500</pubDate>
       <sparkle:version>1.1.31</sparkle:version>


### PR DESCRIPTION
## Summary
- bump Transcripted to 1.1.32
- publish Sparkle appcast entry for the 1.1.32 DMG
- update the Homebrew cask sha256 for the published artifact

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-public-1.1.32 Transcripted
- bash scripts/release/verify-sparkle-release.sh 1.1.32