### PR TITLE
Quiet noisy health events

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1395,6 +1395,36 @@ final class MeetingSessionController: ObservableObject {
         case .failed(let message):
             lastTerminalTranscriptionOutcome = .failed(message)
             let transcriptionTrigger = activeTranscriptionTrigger
+            let failureKind = MeetingFailureKind.classify(message: message)
+            if failureKind == .recordingTooShort {
+                DiagnosticsTrail.record(
+                    engine: "meeting",
+                    event: "meeting_transcript_skipped",
+                    message: "Meeting transcription skipped because the recording was too short",
+                    context: baseDiagnosticsContext(
+                        extra: [
+                            "failure_kind": failureKind.rawValue,
+                            "queue_depth": "\(queuedTranscriptionJobs.count)",
+                            "trigger": transcriptionTrigger.rawValue
+                        ]
+                    )
+                )
+                AnalyticsReporter.track(
+                    "meeting_transcript_skipped",
+                    properties: meetingCaptureAnalyticsProperties(snapshot: capture.pipelineDiagnosticsSnapshot()).merging(
+                        [
+                            "failure_kind": failureKind.rawValue,
+                            "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
+                            "trigger": transcriptionTrigger.rawValue,
+                        ],
+                        uniquingKeysWith: { _, new in new }
+                    )
+                )
+                Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "recording_too_short")
+                finalizeBackgroundTranscriptionStateIfNeeded()
+                return
+            }
+
             DiagnosticsTrail.record(
                 level: .error,
                 engine: "meeting",

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -503,6 +503,14 @@ struct AnalyticsEventPolicy: Equatable {
                 "trigger",
             ]))
         ),
+        "meeting_transcript_skipped": .init(
+            name: "meeting_transcript_skipped",
+            allowedProperties: meetingCaptureDiagnosticProperties.union(Set([
+                "failure_kind",
+                "queue_depth_bucket",
+                "trigger",
+            ]))
+        ),
         "meeting_file_imported": .init(
             name: "meeting_file_imported",
             allowedProperties: [

--- a/Sources/Observability/ReliabilityPacketRecorder.swift
+++ b/Sources/Observability/ReliabilityPacketRecorder.swift
@@ -160,6 +160,8 @@ enum ReliabilityPacketRecorder {
             return .init(feature: "meeting", stage: "stop", defaultOutcome: "cancelled")
         case ("meeting", "meeting_transcript_saved"):
             return .init(feature: "meeting", stage: "save", defaultOutcome: "success")
+        case ("meeting", "meeting_transcript_skipped"):
+            return .init(feature: "meeting", stage: "transcribe", defaultOutcome: "skipped_expected")
         case ("meeting", "meeting_transcript_failed"):
             return .init(feature: "meeting", stage: "transcribe", defaultOutcome: "failed_retryable")
         case ("dictation", "dictation_started"):

--- a/Sources/Observability/RuntimeDiagnostics.swift
+++ b/Sources/Observability/RuntimeDiagnostics.swift
@@ -14,10 +14,10 @@ final class RuntimeDiagnostics {
         guard marker == nil else { return }
 
         if let previous = RuntimeDiagnosticsStore.load(from: markerURL),
-           !previous.cleanShutdown {
+           RuntimeDiagnosticsStore.shouldReportUncleanShutdown(previous: previous) {
             let context = RuntimeDiagnosticsStore.contextForUncleanShutdown(previous: previous)
             EventReporter.shared.capture(
-                level: .error,
+                level: .warning,
                 engine: "app",
                 event: "unclean_shutdown_detected",
                 message: "Previous app session did not shut down cleanly",

--- a/Sources/Observability/RuntimeDiagnosticsStore.swift
+++ b/Sources/Observability/RuntimeDiagnosticsStore.swift
@@ -92,4 +92,26 @@ enum RuntimeDiagnosticsStore {
             "session_stage": marker.sessionStage,
         ]
     }
+
+    static func shouldReportUncleanShutdown(
+        previous marker: RuntimeDiagnosticsMarker,
+        now: Date = Date()
+    ) -> Bool {
+        guard !marker.cleanShutdown else { return false }
+
+        if marker.sessionActive {
+            return true
+        }
+
+        if marker.sessionKind != "none" || marker.sessionStage != "idle" {
+            return true
+        }
+
+        let launchOnlyEvents: Set<String> = ["app_launched", "heartbeat"]
+        if launchOnlyEvents.contains(marker.lastEvent) {
+            return false
+        }
+
+        return heartbeatAgeBucket(previousUpdate: marker.updatedAt, now: now) != "lt_15s"
+    }
 }

--- a/Sources/Observability/SentryEventPolicy.swift
+++ b/Sources/Observability/SentryEventPolicy.swift
@@ -10,11 +10,6 @@ struct SentryEventPolicy: Equatable {
     }
 
     private static let allowedPolicies: [String: SentryEventPolicy] = [
-        "app.unclean_shutdown_detected": .init(
-            engine: "app",
-            event: "unclean_shutdown_detected",
-            summary: "Previous app session did not shut down cleanly."
-        ),
         "app.session_stall_detected": .init(
             engine: "app",
             event: "session_stall_detected",

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -198,6 +198,7 @@ func testAnalyticsEventPolicy() {
         let dictationCompleted = AnalyticsEventPolicy.policy(forEvent: "dictation_completed")
         let dictationNoSpeech = AnalyticsEventPolicy.policy(forEvent: "dictation_no_speech")
         let meetingFailed = AnalyticsEventPolicy.policy(forEvent: "meeting_transcript_failed")
+        let meetingSkipped = AnalyticsEventPolicy.policy(forEvent: "meeting_transcript_skipped")
         let unknown = AnalyticsEventPolicy.policy(forEvent: "raw_transcript_uploaded")
 
         assertEqual(dictationStartFailed?.allowedProperties.contains("failure_kind"), true, "dictation start failures should allow normalized failure kinds")
@@ -205,6 +206,7 @@ func testAnalyticsEventPolicy() {
         assertEqual(dictationNoSpeech?.allowedProperties.contains("duration_bucket"), true, "dictation no-speech should keep a coarse duration bucket")
         assertEqual(dictationNoSpeech?.allowedProperties.contains("trigger"), true, "dictation no-speech should preserve trigger attribution")
         assertEqual(meetingFailed?.allowedProperties.contains("failure_kind"), true, "meeting failures should allow normalized failure kinds")
+        assertEqual(meetingSkipped?.allowedProperties.contains("failure_kind"), true, "skipped meeting transcripts should allow normalized reasons")
         assertNil(unknown, "unreviewed analytics events should not be allowed")
     }
 
@@ -319,12 +321,14 @@ func testAnalyticsEventPolicy() {
     runSuite("AnalyticsEventPolicy allows meeting outcome trigger attribution") {
         let saved = AnalyticsEventPolicy.policy(forEvent: "meeting_transcript_saved")
         let failed = AnalyticsEventPolicy.policy(forEvent: "meeting_transcript_failed")
+        let skipped = AnalyticsEventPolicy.policy(forEvent: "meeting_transcript_skipped")
 
         assertEqual(saved?.allowedProperties.contains("trigger"), true, "meeting saves should preserve trigger attribution")
         assertEqual(saved?.allowedProperties.contains("duration_bucket"), true, "meeting saves should preserve coarse duration")
         assertEqual(saved?.allowedProperties.contains("word_count_bucket"), true, "meeting saves should preserve coarse word output")
         assertEqual(saved?.allowedProperties.contains("participant_count_bucket"), true, "meeting saves should preserve coarse participant count")
         assertEqual(failed?.allowedProperties.contains("trigger"), true, "meeting failures should preserve trigger attribution")
+        assertEqual(skipped?.allowedProperties.contains("trigger"), true, "skipped meeting transcripts should preserve trigger attribution")
     }
 
     runSuite("AnalyticsEventPolicy allows meeting_file_imported with queue depth") {

--- a/Tests/ReliabilityPacketRecorderTests.swift
+++ b/Tests/ReliabilityPacketRecorderTests.swift
@@ -65,6 +65,33 @@ func testReliabilityPacketRecorder() {
         assertNil(ReliabilityPacketRecorder.packet(from: event), "boring app launch should not create a packet")
     }
 
+    runSuite("ReliabilityPacketRecorder maps short meetings as expected skips") {
+        let event = ObservabilityEvent(
+            timestamp: "2026-05-03T01:15:11.605Z",
+            level: "info",
+            engine: "meeting",
+            event: "meeting_transcript_skipped",
+            message: "Meeting transcription skipped because the recording was too short",
+            context: [
+                "error": "private raw error should not be copied",
+                "failure_kind": "recording_too_short",
+                "queue_depth": "0",
+                "trigger": "hotkey",
+            ],
+            appVersion: "1.1.32",
+            osVersion: "Version 26.4.1"
+        )
+
+        let packet = ReliabilityPacketRecorder.packet(from: event)
+
+        assertNotNil(packet, "short meeting skips should produce a reliability packet")
+        assertEqual(packet?.feature, "meeting", "packet feature should classify the flow")
+        assertEqual(packet?.stage, "transcribe", "packet stage should classify the skip")
+        assertEqual(packet?.outcome, "skipped_expected", "too-short meetings should not look like failures")
+        assertEqual(packet?.context["failure_kind"], "recording_too_short", "skip reason should stay normalized")
+        assertNil(packet?.context["error"], "raw error text should not be copied into reliability packets")
+    }
+
     runSuite("ReliabilityPacketRecorder renders recent packet summaries from JSONL") {
         let packets = [
             ReliabilityPacket(

--- a/Tests/RuntimeDiagnosticsStoreTests.swift
+++ b/Tests/RuntimeDiagnosticsStoreTests.swift
@@ -49,4 +49,50 @@ func testRuntimeDiagnosticsStore() {
 
         assertEqual(loaded, marker, "runtime diagnostics marker should round-trip through JSON")
     }
+
+    runSuite("RuntimeDiagnosticsStore suppresses idle launch-only shutdown markers") {
+        let marker = RuntimeDiagnosticsMarker(
+            launchID: "launch-only",
+            appVersion: "1.2.3",
+            buildVersion: "456",
+            osMajor: 26,
+            cleanShutdown: false,
+            startedAt: Date(timeIntervalSince1970: 1_000),
+            updatedAt: Date(timeIntervalSince1970: 1_001),
+            lastEvent: "app_launched",
+            sessionKind: "none",
+            sessionStage: "idle",
+            sessionActive: false
+        )
+
+        let shouldReport = RuntimeDiagnosticsStore.shouldReportUncleanShutdown(
+            previous: marker,
+            now: Date(timeIntervalSince1970: 1_002)
+        )
+
+        assertEqual(shouldReport, false, "idle launch-only markers should not pollute shutdown health")
+    }
+
+    runSuite("RuntimeDiagnosticsStore reports unclean shutdowns during active work") {
+        let marker = RuntimeDiagnosticsMarker(
+            launchID: "active-session",
+            appVersion: "1.2.3",
+            buildVersion: "456",
+            osMajor: 26,
+            cleanShutdown: false,
+            startedAt: Date(timeIntervalSince1970: 1_000),
+            updatedAt: Date(timeIntervalSince1970: 1_100),
+            lastEvent: "meeting_recording",
+            sessionKind: "meeting",
+            sessionStage: "recording",
+            sessionActive: true
+        )
+
+        let shouldReport = RuntimeDiagnosticsStore.shouldReportUncleanShutdown(
+            previous: marker,
+            now: Date(timeIntervalSince1970: 1_120)
+        )
+
+        assertEqual(shouldReport, true, "active meeting shutdowns should stay visible")
+    }
 }

--- a/Tests/SentryEventPolicyTests.swift
+++ b/Tests/SentryEventPolicyTests.swift
@@ -68,7 +68,7 @@ func testSentryEventPolicy() {
         )
 
         assertEqual(transcriptionFailure?.summary, "Speech transcription failed.", "transcription failure should use the normalized summary")
-        assertEqual(uncleanShutdown?.summary, "Previous app session did not shut down cleanly.", "unclean shutdown reports should be visible in Sentry")
+        assertNil(uncleanShutdown, "unclean shutdown markers should stay local and analytics-only")
         assertEqual(sessionStall?.summary, "Transcripted detected a stalled runtime session.", "session stalls should be visible in Sentry")
         assertEqual(hotkeyFailure?.summary, "Transcripted could not register a keyboard shortcut.", "capture failure should stay allowlisted")
         assertEqual(audioStartFailure?.summary, "Speech audio engine failed to start.", "audio-start failures should stay allowlisted with a privacy-safe summary")


### PR DESCRIPTION
## Summary
- keep idle launch-only unclean shutdown markers out of Sentry and PostHog health noise
- downgrade reportable unclean shutdowns to local warning/analytics signal instead of Sentry errors
- route too-short meeting recordings through `meeting_transcript_skipped` instead of `meeting_transcript_failed`

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`