### PR TITLE
[codex] Update agent docs for current tree

### DIFF
--- a/AGENT_START.md
+++ b/AGENT_START.md
@@ -22,12 +22,17 @@ exist for migration and reference only.
 ## Edit Map
 
 - `Sources/` - macOS app target
+- `Sources/Accessibility/` - focused-editor AX metadata and overlay placement
+- `Sources/Capture/` - global hotkeys and physical dictation trigger routing
+- `Sources/Dictation/` - dictation transcript persistence and timeout helpers
 - `Sources/Speech/` - dictation STT, audio recovery, device handling
 - `Sources/Meeting/` - app-side meeting flow and bridge into core
 - `Sources/TranscriptedCore/` - reusable meeting transcription library
 - `Sources/UI/` - overlay, menu bar, settings, onboarding, agent connect
 - `Sources/Support/` - preferences, permissions, paths, paste, launch behavior
 - `Sources/Observability/` - logs, diagnostics, Sentry, PostHog, Sparkle
+- `Sources/Reliability/` - wake / sleep recovery
+- `Sources/Beta/` - beta-build configuration
 - `Tests/` - fast tests and core package tests
 - `Tools/` - standalone CLI, MCP, and QA packages
 

--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -13,6 +13,7 @@
 - `MeetingCaptureBridge+LivePreview.swift` — bridge extension for recording health snapshots plus mic/system live-preview buffer forwarding
 - `MeetingCaptureSupport.swift` — small support types for meeting capture stop results and pending async-attempt bookkeeping
 - `MeetingFailureCopy.swift` — normalizes `MeetingFailureKind` values into user-facing titles and recovery copy
+- `MeetingFailureExplanation.swift` — maps meeting outcomes into retryability, artifact-retention, user-visible state, and privacy-safe telemetry fields
 - `MeetingFailureKind.swift` — canonical failure taxonomy that classifies raw meeting errors into stable machine-readable kinds
 - `MeetingImportedAudioPreparer.swift` — copies imported recordings into app-managed scratch paths, derives titles, and prepares single-file meeting transcription jobs
 - `MeetingModelDownloader.swift` — loads the selected STT and diarization models together
@@ -43,7 +44,7 @@
 12. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the recent-meetings UI state.
 13. After a transcript is saved, `MeetingAudioStorageManager` compresses retained WAV audio to M4A and applies the user's retention setting. Launch and Settings changes also run a backfill pass over existing Transcripted meeting transcripts.
 14. If the speaker review sheet shows multiple local speakers, the user can either name them individually or collapse them back to a single "You" track via the UI's "Keep as You" path.
-15. Failed meetings can be retried, deleted, or dismissed from the Settings meetings page, with `MeetingFailureKind` providing stable failure categories and `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
+15. Failed meetings can be retried, deleted, or dismissed from the Settings meetings page, with `MeetingFailureKind` providing stable failure categories, `MeetingFailureExplanation` preserving retry/artifact state, and `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
 
 ## Key invariants
 
@@ -57,6 +58,7 @@
 - Prompt dismissals are provider- and source-aware: runtime-only prompts can remind sooner, calendar-linked prompts can stay suppressed until the next relevant window, and Teams gets a longer minimum dismiss interval.
 - Local mic diarization is opt-in and controlled by `Support/LocalSpeakerPreferences.swift`, so default meeting behavior still keeps the mic side as a single "You" speaker unless the user enables review for people in the room.
 - `MeetingRecordingStartGate` is the canonical place for meeting-recording permission policy and reason strings. Keep duplicate permission branching out of overlay code.
+- `MeetingFailureExplanation` owns the answer to "what happened, what was retained, and can the user retry?" Keep support summaries and telemetry aligned through its report fields instead of duplicating outcome logic.
 - `MeetingFailureKind` is the canonical place for stable failed-meeting categories used by presentation and metadata. Keep new classification rules centralized there.
 - `MeetingFailureCopy` is the canonical place for human-facing failed-meeting titles and details. Keep retry messaging centralized there.
 - `MeetingSessionUIPolicy` is the canonical place for deciding whether background meeting work should still surface as an active transcribing/saving state. Speaker review alone should not keep that state visible.
@@ -103,6 +105,7 @@ See `docs/storage-paths.md` for the full map.
 Relevant direct coverage:
 
 - `Tests/FailedMeetingPresentationTests.swift`
+- `Tests/MeetingFailureExplanationTests.swift`
 - `Tests/MeetingFailureKindTests.swift`
 - `Tests/MeetingPromptHeuristicsTests.swift`
 - `Tests/MeetingRecordingStartGateTests.swift`

--- a/Sources/Observability/CLAUDE.md
+++ b/Sources/Observability/CLAUDE.md
@@ -63,6 +63,7 @@ Relevant direct coverage:
 - `Tests/SentryPayloadSanitizerTests.swift`
 - `Tests/SentryRuntimeConfigurationTests.swift`
 - `Tests/ObservabilityLogWriterTests.swift`
+- `Tests/ReliabilityPacketRecorderTests.swift`
 - `Tests/RuntimeDiagnosticsStoreTests.swift`
 - `Tests/UpdateFailureKindTests.swift`
 

--- a/Sources/Support/CLAUDE.md
+++ b/Sources/Support/CLAUDE.md
@@ -4,7 +4,7 @@
 
 `Sources/Support/` holds app-wide helpers that do not belong to a single UI or pipeline surface. These types mostly wrap persisted preferences, shared constants, permission access, storage paths, or low-level paste / launch behavior used across dictation and meetings.
 
-## Files (20 Swift files)
+## Files (21 Swift files)
 
 - `ActivationPolicyController.swift` — combines the Dock toggle with live-recording safety so Transcripted can idle as menu-bar-only but still surface itself in the macOS force-quit dialog during active capture
 - `AudioStoragePreferences.swift` — persisted meeting-audio retention window for Settings and background retained-audio maintenance
@@ -21,6 +21,7 @@
 - `MicrophoneProcessingPreferences.swift` — persisted meeting-mic processing mode, toggling between default software AGC and optional Apple voice processing (VPIO) for users who need the WebRTC-specific recovery path
 - `PermissionsOnboardingPreferences.swift` — persisted completion and forced-rerun state for the first-run permissions onboarding flow
 - `PhysicalDictationTriggerPreferences.swift` — canonical physical key / modifier trigger bindings for push-to-talk, hands-free dictation, and meeting shortcuts, including migration from older right-Option settings
+- `SpeakerNameSelectionPolicy.swift` — shared speaker-name matching, duplicate-label disambiguation, and owner-label policy used by people/review UI
 - `TranscriptedConstants.swift` — shared timing thresholds and app-wide behavior constants
 - `TranscriptedPermissionAccess.swift` — shared permission status, prompting, and Settings-deep-link helpers for microphone, accessibility, system-audio recording, and calendar access
 - `TranscriptedPermissionKind.swift` — shared permission metadata, onboarding requirements, copy, icons, and action labels used by onboarding and Settings
@@ -34,6 +35,7 @@
 - `TranscriptionModelPreferences` is the shared switch between `Parakeet` and the available local Whisper variants. Model-specific runtime behavior still belongs in `Sources/Speech/` and `Sources/Meeting/`.
 - `CustomDictionaryPreferences` and `DictationAutoSendPreferences` back the Settings `General` and `Dictation` pages. If you change parsing rules or policy thresholds, update the relevant tests.
 - `TranscriptedPermissionAccess` plus `TranscriptedPermissionKind` are the app-level permission seams. UI flows should call into them instead of duplicating TCC branching, metadata, or user-facing permission copy.
+- `SpeakerNameSelectionPolicy` keeps speaker search and "You" matching consistent across settings and review UI. Keep duplicate-name disambiguation here instead of in individual SwiftUI controls.
 - `PermissionsOnboardingPreferences` is the canonical completion flag for the guided first-run permissions flow. Keep onboarding state out of view-local storage so forced reruns and completion state stay consistent.
 - `TranscriptedStoragePaths` should stay as the canonical path resolver for the app target. `Sources/TranscriptedCore/Services/CoreStoragePaths.swift` is the injected library-side seam.
 - `ClaudeDesktopIntegrationInstaller` owns the Claude Desktop config merge. Preserve existing MCP servers and back up invalid JSON instead of overwriting blindly.
@@ -65,6 +67,7 @@ Relevant direct coverage includes:
 - `Tests/MicrophoneProcessingPreferencesTests.swift`
 - `Tests/PermissionsOnboardingPreferencesTests.swift`
 - `Tests/PhysicalDictationTriggerPreferencesTests.swift`
+- `Tests/SpeakerNameSelectionPolicyTests.swift`
 - `Tests/TranscriptedConstantsTests.swift`
 - `Tests/TranscriptedPermissionAccessTests.swift`
 - `Tests/TranscriptedStoragePathsTests.swift`

--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -4,9 +4,9 @@
 
 `Sources/TranscriptedCore/` is the reusable meeting transcription library embedded in this repo. It is consumed by the app through `Sources/Meeting/`, and it can also be tested as a standalone Swift package through the root `Package.swift`.
 
-## Subsystems (62 Swift files)
+## Subsystems (63 Swift files)
 
-- `Audio/` (17 files) — mic + system audio capture, imported-audio prep helpers, capture start-state gating, device recovery, signal analysis and normalization helpers, real-time AGC, resampling, level metering, process tap, ScreenCaptureKit-backed system-audio capture, backend selection, buffer writing, merge helpers, and privacy-safe pipeline diagnostics snapshots
+- `Audio/` (18 files) — mic + system audio capture, imported-audio prep helpers, capture start-state gating, device recovery, Bluetooth-input avoidance for meetings, signal analysis and normalization helpers, real-time AGC, resampling, level metering, process tap, ScreenCaptureKit-backed system-audio capture, backend selection, buffer writing, merge helpers, and privacy-safe pipeline diagnostics snapshots
 - `Logging/` (2 files) — shared app logger and JSONL file logger
 - `Models/` (5 files) — public data types: `TranscriptionResult`, `DisplayStatus`, `FailedTranscription`, `SpeakerMapping`, and recording-health metadata builders
 - `Pipeline/` (4 files) — transcription orchestration, pipeline runner, and task queue
@@ -31,6 +31,7 @@ These seams exist specifically so the app can embed the library without adopting
 
 - `Audio` can switch between the legacy CoreAudio path and the newer ScreenCaptureKit system-audio path through `SystemAudioCaptureEngine`.
 - `AudioCaptureStartState` is the canonical readiness policy for live meeting capture. Meeting capture should not report success until mic recording is running and the system-audio file exists.
+- `MeetingInputDeviceSelectionPolicy` avoids using Bluetooth headset input for meeting capture when a built-in mic fallback is available, so WebRTC-style playback downgrades do not get worse.
 - `AudioSignalRecovery` is the shared low-level signal-analysis helper used when recorded audio needs peak / RMS / active-ratio checks or gain-normalized recovery clips before later transcription work.
 - `RealtimeAGC` is the default meeting-mic cleanup path for attenuated shared-device input. It avoids the playback-ducking side effects of Apple voice processing while still boosting quiet WebRTC-contended captures.
 - `SCKAudioCapture` is the macOS 26+ backend for audio-only ScreenCaptureKit capture, which keeps system-audio recording on the lighter permission tier and avoids full screen-pixel capture.
@@ -82,11 +83,13 @@ Also run when the package seam changes:
 Current direct core coverage includes:
 
 - `Tests/TranscriptedCoreTests/AudioInitializationTests.swift`
+- `Tests/TranscriptedCoreTests/AudioDiagnosticsSnapshotTests.swift`
 - `Tests/TranscriptedCoreTests/CoreStoragePathsTests.swift`
 - `Tests/TranscriptedCoreTests/DatabaseFilePermissionsTests.swift`
 - `Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift`
 - `Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift`
 - `Tests/TranscriptedCoreTests/FileLoggerTests.swift`
+- `Tests/TranscriptedCoreTests/MeetingInputDeviceSelectionPolicyTests.swift`
 - `Tests/TranscriptedCoreTests/MicRecordingFileMergerTests.swift`
 - `Tests/TranscriptedCoreTests/RealtimeAGCTests.swift`
 - `Tests/TranscriptedCoreTests/RecordingAudioArchiverTests.swift`

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -13,11 +13,14 @@ The directory is grouped by surface so the live UI tree is easier to scan:
 
 Draft-mode UI is not an active product path in this worktree.
 
-## Files (51 Swift files)
+## Files (54 Swift files)
 
 ### Overlay/
 
 - `Overlay/DictationMeterPolicy.swift` — tiny presentation policy that decides when the dictation waveform meter should render and clamps its displayed level
+- `Overlay/DictationMicrophoneLoadingPresentationPolicy.swift` — copy and timing policy for the microphone-starting / device-switching overlay state
+- `Overlay/DictationNoSpeechPresentationPolicy.swift` — user-facing no-speech copy for hotkey and non-hotkey dictation attempts
+- `Overlay/DictationRecordingStartOverlayPolicy.swift` — decides whether recording can skip the loading UI or should wait for microphone recovery
 - `Overlay/DictationSessionController.swift` — dictation session orchestration; removed draft-mode methods are stubs
 - `Overlay/FloatingOverlayController.swift` — owns the dictation overlay panel lifecycle and Combine subscriptions
 - `Overlay/FloatingOverlayPanel.swift` — non-activating NSPanel for the dictation overlay
@@ -34,6 +37,8 @@ dictation overlay and the meeting prompt / recording overlay.
 `DictationMeterPolicy` keeps the live meter visibility rule out of view code, so
 UI tweaks to when the waveform shows up should land there instead of being
 re-implemented in controllers or views.
+The other dictation overlay policy files own startup/loading and no-speech copy
+so tiny transient states do not get duplicated inside controllers.
 `OverlayHeaderView` owns the inline dictation stop affordance and centered
 listening layout, while `OverlayRootView` decides when the pill should expand
 into a taller loading or error state.
@@ -143,3 +148,18 @@ Manual checks:
 - permissions onboarding and first-run onboarding window still open correctly
 - first-run CTA copy updates correctly as permissions and local-model state change
 - settings window still opens correctly
+
+Relevant direct coverage:
+
+- `Tests/AgentConnectionGuideTests.swift`
+- `Tests/DictationMeterPolicyTests.swift`
+- `Tests/DictationMicrophoneLoadingPresentationPolicyTests.swift`
+- `Tests/DictationNoSpeechPresentationPolicyTests.swift`
+- `Tests/DictationRecordingStartOverlayPolicyTests.swift`
+- `Tests/DictationSoundsTests.swift`
+- `Tests/FeedbackIssueBuilderTests.swift`
+- `Tests/FirstRunExperienceTests.swift`
+- `Tests/HomeMeetingPreviewFormatterTests.swift`
+- `Tests/MeetingAudioArchiveResolverTests.swift`
+- `Tests/SettingsRecentCaptureRefreshPolicyTests.swift`
+- `Tests/SupportDiagnosticsBundleTests.swift`

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -31,9 +31,10 @@ The current compiled fast test set lives in `Tests/FastTests.manifest`.
 
 ## Core Package Tests
 
-`swift test` currently exercises the standalone package seam, including:
-
-- `Tests/TranscriptedCoreTests/CoreStoragePathsTests.swift`
+`swift test` currently exercises the standalone package seam under
+`Tests/TranscriptedCoreTests/`, including storage paths, audio startup,
+meeting-input selection, file logging, failed-transcription persistence,
+recording archiving, stats, speaker reconciliation, and transcript metadata.
 
 Use this when changing:
 

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -14,18 +14,21 @@ historical, and which local doc to read before editing a subsystem.
 6. the nearest local `CLAUDE.md`
 7. `Sources/Accessibility/CLAUDE.md` when touching focused-editor AX metadata, overlay placement, or paste-back context
 8. `Sources/Beta/CLAUDE.md` when touching beta-build configuration
-9. `Sources/Speech/CLAUDE.md` when touching STT, audio recovery, or device handling
-10. `Sources/Support/CLAUDE.md` when touching shared preferences, paths, permissions, or install flows
-11. `Sources/UI/CLAUDE.md` when touching overlay, menubar, onboarding, settings, or agent-connect UI
-12. `Sources/Capture/CLAUDE.md` when touching hotkeys or physical dictation trigger routing
-13. `Tests/README.md` when touching verification or package seams
-14. `docs/storage-paths.md` when touching persisted output or path resolution
-15. `docs/release-packaging.md` and `docs/sparkle-updates.md` when touching packaging, notarization, releases, or in-app updates
-16. `Sources/Observability/CLAUDE.md` when touching crash reporting, analytics, or Sparkle plumbing
-17. `Sources/Reliability/CLAUDE.md` when touching wake / sleep recovery or hotkey recovery
-18. `Tools/*/CLAUDE.md` when touching standalone CLI, MCP, or QA tools
-19. `scripts/README.md` when touching the shell entrypoints or release helpers
-20. source comments
+9. `Sources/Dictation/CLAUDE.md` when touching dictation persistence
+10. `Sources/Meeting/CLAUDE.md` when touching meeting capture, imported-audio transcription, or meeting UI
+11. `Sources/TranscriptedCore/CLAUDE.md` when touching the reusable meeting library or public core seam
+12. `Sources/Speech/CLAUDE.md` when touching STT, audio recovery, or device handling
+13. `Sources/Support/CLAUDE.md` when touching shared preferences, paths, permissions, or install flows
+14. `Sources/UI/CLAUDE.md` when touching overlay, menubar, onboarding, settings, or agent-connect UI
+15. `Sources/Capture/CLAUDE.md` when touching hotkeys or physical dictation trigger routing
+16. `Tests/README.md` when touching verification or package seams
+17. `docs/storage-paths.md` when touching persisted output or path resolution
+18. `docs/release-packaging.md` and `docs/sparkle-updates.md` when touching packaging, notarization, releases, or in-app updates
+19. `Sources/Observability/CLAUDE.md` when touching crash reporting, analytics, or Sparkle plumbing
+20. `Sources/Reliability/CLAUDE.md` when touching wake / sleep recovery or hotkey recovery
+21. `Tools/*/CLAUDE.md` when touching standalone CLI, MCP, or QA tools
+22. `scripts/README.md` when touching the shell entrypoints or release helpers
+23. source comments
 
 For the active directory map and command surface, prefer `docs/repo-layout.md`.
 
@@ -98,6 +101,8 @@ Rule of thumb:
   Focused-editor AX metadata, overlay placement, and paste-back context.
 - `Sources/Beta/CLAUDE.md`
   Beta-build configuration and archived beta-worker boundaries.
+- `Sources/Dictation/CLAUDE.md`
+  Dictation persistence, daily Markdown files, and timeout helpers.
 - `Sources/Meeting/CLAUDE.md`
   App/Core bridge, meeting storage, runtime lifecycle.
 - `Sources/TranscriptedCore/CLAUDE.md`


### PR DESCRIPTION
## Summary

- Refresh agent entrypoint and onboarding read order for the current Transcripted repo layout.
- Update subsystem CLAUDE files for new meeting, UI, support, observability, and TranscriptedCore policy/test surfaces.
- Tighten the Tests guide so core package coverage reflects the current suite.

## Validation

- `scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` — 1450 passed
- `bash run-integration-smoke.sh`
- `swift test` — 122 passed
