### PR TITLE
[nightly-notes] Clarify no-candidate nightly release notes

### DIFF
--- a/docs/release-notes-template.md
+++ b/docs/release-notes-template.md
@@ -8,6 +8,7 @@ Keep it short. Focus on what a user would notice or care about.
 ## Candidate summary
 
 - One sentence on what this candidate is trying to improve.
+- If `Info.plist`, GitHub Releases, Sparkle, and Homebrew already match and there is no meaningful merged work after that release, say plainly that there is no new candidate tonight.
 - If `HEAD` is ahead of the latest shipped tag but `Info.plist` and GitHub Releases still match, say plainly that this is post-release `main` work and not a versioned candidate yet.
 - Say whether Sparkle and Homebrew already point at this version, or still lag.
 
@@ -34,3 +35,4 @@ Keep it short. Focus on what a user would notice or care about.
 
 - Ship when the user-facing value is clear and the reliability fixes match live pain.
 - Wait when the branch is mostly internal cleanup, docs sync, or automation work.
+- Wait when the latest version already shipped and there is nothing new for users yet.


### PR DESCRIPTION
## Summary
- clarify the nightly release-notes template for nights when the latest version already shipped and there is nothing new to draft
- make the wait case explicit so the nightly pass can say there is no candidate instead of forcing filler

## Why
Tonight hit the exact already-shipped state: `Info.plist`, GitHub Releases, Sparkle, and Homebrew all match `1.1.32`, with no new user-facing candidate after that release.

## Validation
- docs-only change
- nightly release-notes pass rerun against live repo and release state