### PR TITLE
[nightly-agent] Document MCP self-test for agents

### DIFF
--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -117,6 +117,7 @@ This lets the server answer both meeting-specific queries (`who_is`, `read_meeti
 cd Tools/TranscriptedMCP
 swift build -c release
 swift test
+./.build/release/transcripted-mcp --self-test
 ```
 
 Binary path after build:
@@ -124,6 +125,9 @@ Binary path after build:
 ```text
 .build/release/transcripted-mcp
 ```
+
+`--self-test` verifies directory resolution, builds the SQLite index, prints a
+JSON status payload, and exits without starting the MCP stdio server.
 
 App builds also bundle a signed copy at:
 

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -106,6 +106,7 @@ the Claude Desktop button in Transcripted Settings.
 ```bash
 cd Tools/TranscriptedMCP
 swift build -c release
+./.build/release/transcripted-mcp --self-test
 ```
 
 Binary path after build:
@@ -129,6 +130,7 @@ Example Claude Desktop config:
 Notes:
 
 - `transcripted-mcp` communicates over stdio, not HTTP.
+- `--self-test` verifies directory resolution, creates missing local data/index directories, and exits without starting the MCP stdio server.
 - By default it follows the capture library chosen in Transcripted Settings, then also reads legacy Draft or `~/Documents/Transcripted/` layouts when those folders still contain capture Markdown.
 - `TRANSCRIPTED_DATA_DIR` can point at a shared root with `meetings/` and `dictations/` subfolders. For `transcripted-mcp`, that shared root also becomes the default SQLite index location unless `TRANSCRIPTED_INDEX_DIR` is set.
 - If needed, override paths with `TRANSCRIPTED_DATA_DIR`,


### PR DESCRIPTION
## Summary

- adds the MCP `--self-test` command to the source-build fallback docs
- mirrors that verification step in the MCP tool guide for agents

## Validation

- `cd Tools/TranscriptedCLI && swift build && swift test`
- `cd Tools/TranscriptedMCP && swift build -c release && swift test`
- isolated `transcripted-mcp --self-test` with temp `TRANSCRIPTED_DATA_DIR` and `TRANSCRIPTED_INDEX_DIR`
- confirmed documented CLI/MCP binary paths exist and are executable
