### PR TITLE
[nightly-review] Harden MCP manifest directory resolution

### DIFF
--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/DataDirectories.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/DataDirectories.swift
@@ -215,8 +215,11 @@ struct TranscriptedDataDirectories {
               let data = try? Data(contentsOf: manifestURL),
               let manifest = try? JSONDecoder().decode(AppDirectoryManifest.self, from: data),
               manifest.version >= 1,
+              let captureLibrary = validatedConfiguredDirectory(manifest.captureLibraryDirectory, homeDirectory: home),
               let meetings = validatedConfiguredDirectory(manifest.meetingsDirectory, homeDirectory: home),
-              let dictations = validatedConfiguredDirectory(manifest.dictationsDirectory, homeDirectory: home) else {
+              let dictations = validatedConfiguredDirectory(manifest.dictationsDirectory, homeDirectory: home),
+              isManifestDirectory(meetings, named: "meetings", under: captureLibrary),
+              isManifestDirectory(dictations, named: "dictations", under: captureLibrary) else {
             return nil
         }
 
@@ -279,5 +282,18 @@ struct TranscriptedDataDirectories {
         }
 
         return directory
+    }
+
+    private static func isManifestDirectory(_ directory: URL, named name: String, under captureLibrary: URL) -> Bool {
+        let expected = captureLibrary
+            .appendingPathComponent(name, isDirectory: true)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let actual = directory
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        return actual.path == expected.path
     }
 }

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/DataDirectoriesTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/DataDirectoriesTests.swift
@@ -252,6 +252,47 @@ final class DataDirectoriesTests: XCTestCase {
         ])
     }
 
+    func testResolveIgnoresManifestWhenDirectoriesDoNotMatchCaptureLibrary() throws {
+        let manifestRoot = tempHome.appendingPathComponent("manifest-captures", isDirectory: true)
+        let unrelatedMeetings = tempHome.appendingPathComponent("unrelated-meetings", isDirectory: true)
+        let unrelatedDictations = tempHome.appendingPathComponent("unrelated-dictations", isDirectory: true)
+        let defaultCaptures = tempHome
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Transcripted", isDirectory: true)
+            .appendingPathComponent("captures", isDirectory: true)
+        let defaultMeetings = defaultCaptures.appendingPathComponent("meetings", isDirectory: true)
+        let defaultDictations = defaultCaptures.appendingPathComponent("dictations", isDirectory: true)
+        let manifestURL = tempHome
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Transcripted", isDirectory: true)
+            .appendingPathComponent("mcp-directories.json", isDirectory: false)
+        try FileManager.default.createDirectory(at: manifestURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try """
+        {
+          "version": 1,
+          "captureLibraryDirectory": "\(manifestRoot.path)",
+          "meetingsDirectory": "\(unrelatedMeetings.path)",
+          "dictationsDirectory": "\(unrelatedDictations.path)",
+          "updatedAt": "2026-05-06T00:00:00Z"
+        }
+        """.write(to: manifestURL, atomically: true, encoding: .utf8)
+
+        let directories = TranscriptedDataDirectories.resolve(
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(directories.meetingDirs.map(\.standardizedFileURL.path), [
+            defaultMeetings.standardizedFileURL.path,
+        ])
+        XCTAssertEqual(directories.dictationDirs.map(\.standardizedFileURL.path), [
+            defaultDictations.standardizedFileURL.path,
+        ])
+    }
+
     func testResolveUsesAppCaptureLibraryPreferenceWhenManifestIsMissing() throws {
         let customRoot = tempHome.appendingPathComponent("preference-captures", isDirectory: true)
         let preferencesURL = tempHome


### PR DESCRIPTION
## Summary
- Require MCP directory manifests to keep meetings and dictations under the declared capture library
- Fall back to default/preference resolution when a manifest has split or stale directories
- Add regression coverage for mismatched manifest roots

## Verification
- `bash run-tests.sh`
- `bash scripts/release/verify-sparkle-release.sh 1.1.32`
- `python3 scripts/ops/nightly-security-check.py --write-report build/nightly-security-report.json`
- `cd Tools/TranscriptedMCP && swift test`