### PR TITLE
[nightly-simplify] Remove unused meeting audio helper

### DIFF
--- a/Sources/Meeting/MeetingAudioStorageManager.swift
+++ b/Sources/Meeting/MeetingAudioStorageManager.swift
@@ -465,13 +465,6 @@ enum MeetingAudioStorageManager {
         return UUID(uuidString: uuidString) != nil
     }
 
-    private static func hasNonEmptyFile(at url: URL, fileManager: FileManager) -> Bool {
-        guard fileManager.fileExists(atPath: url.path) else { return false }
-        guard !isSymbolicLink(url, fileManager: fileManager) else { return false }
-        let values = try? url.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
-        return values?.isRegularFile == true && (values?.fileSize ?? 0) > 0
-    }
-
     private static func isSafeNonSymlinkDirectory(_ url: URL, fileManager: FileManager) -> Bool {
         guard !isSymbolicLink(url, fileManager: fileManager) else { return false }
         var isDirectory: ObjCBool = false


### PR DESCRIPTION
## Summary
- Remove an unused private helper from MeetingAudioStorageManager
- Keep retained-audio behavior unchanged; AVFoundationMeetingAudioValidator still owns non-empty file validation

## Verification
- scripts/dev/agent-preflight.sh
- bash run-tests.sh
- bash build-deps.sh --force
- bash run-integration-smoke.sh
- bash build.sh