### PR TITLE
[nightly-telemetry] Add Sentry runtime crash context

### DIFF
--- a/Sources/Observability/CrashReporter.swift
+++ b/Sources/Observability/CrashReporter.swift
@@ -74,6 +74,17 @@ final class CrashReporter {
         )
     }
 
+    static func setRuntimeDiagnosticsContext(_ context: [String: String]) {
+        guard Self.isAvailable, CrashReportingPreferences.isEnabled() else { return }
+
+        let sanitizedContext = SentryPayloadSanitizer.sanitizeContext(context)
+        guard !sanitizedContext.isEmpty else { return }
+
+        SentrySDK.configureScope { scope in
+            scope.setContext(value: sanitizedContext, key: "runtime")
+        }
+    }
+
     @discardableResult
     func captureSupportDiagnosticEvent(extra: [String: String]) -> String? {
         captureMessageEvent(

--- a/Sources/Observability/RuntimeDiagnostics.swift
+++ b/Sources/Observability/RuntimeDiagnostics.swift
@@ -42,6 +42,9 @@ final class RuntimeDiagnostics {
         marker.lastEvent = "clean_shutdown"
         self.marker = marker
         RuntimeDiagnosticsStore.save(marker, to: markerURL)
+        CrashReporter.setRuntimeDiagnosticsContext(
+            RuntimeDiagnosticsStore.contextForCurrentSession(marker: marker)
+        )
         heartbeatTimer?.invalidate()
         heartbeatTimer = nil
     }
@@ -139,5 +142,8 @@ final class RuntimeDiagnostics {
         marker.updatedAt = Date()
         self.marker = marker
         RuntimeDiagnosticsStore.save(marker, to: markerURL)
+        CrashReporter.setRuntimeDiagnosticsContext(
+            RuntimeDiagnosticsStore.contextForCurrentSession(marker: marker)
+        )
     }
 }

--- a/Sources/Observability/RuntimeDiagnosticsStore.swift
+++ b/Sources/Observability/RuntimeDiagnosticsStore.swift
@@ -92,4 +92,21 @@ enum RuntimeDiagnosticsStore {
             "session_stage": marker.sessionStage,
         ]
     }
+
+    static func contextForCurrentSession(
+        marker: RuntimeDiagnosticsMarker,
+        now: Date = Date()
+    ) -> [String: String] {
+        [
+            "app_version": marker.appVersion,
+            "build_version": marker.buildVersion,
+            "heartbeat_age_bucket": heartbeatAgeBucket(previousUpdate: marker.updatedAt, now: now),
+            "last_event": marker.lastEvent,
+            "os_major": "\(marker.osMajor)",
+            "previous_clean_shutdown": "\(marker.cleanShutdown)",
+            "session_active": "\(marker.sessionActive)",
+            "session_kind": marker.sessionKind,
+            "session_stage": marker.sessionStage,
+        ]
+    }
 }

--- a/Tests/RuntimeDiagnosticsStoreTests.swift
+++ b/Tests/RuntimeDiagnosticsStoreTests.swift
@@ -30,6 +30,36 @@ func testRuntimeDiagnosticsStore() {
         assertEqual(context["session_stage"], "recording", "context should keep coarse session stage")
     }
 
+    runSuite("RuntimeDiagnosticsStore builds current Sentry runtime context") {
+        let marker = RuntimeDiagnosticsMarker(
+            launchID: "launch-2",
+            appVersion: "1.2.4",
+            buildVersion: "457",
+            osMajor: 26,
+            cleanShutdown: false,
+            startedAt: Date(timeIntervalSince1970: 2_000),
+            updatedAt: Date(timeIntervalSince1970: 2_010),
+            lastEvent: "meeting_transcribing",
+            sessionKind: "meeting",
+            sessionStage: "transcribing",
+            sessionActive: true
+        )
+
+        let context = RuntimeDiagnosticsStore.contextForCurrentSession(
+            marker: marker,
+            now: Date(timeIntervalSince1970: 2_040)
+        )
+
+        assertEqual(context["app_version"], "1.2.4", "context should keep app version")
+        assertEqual(context["build_version"], "457", "context should keep build version")
+        assertEqual(context["heartbeat_age_bucket"], "15_59s", "context should bucket heartbeat age")
+        assertEqual(context["last_event"], "meeting_transcribing", "context should keep last runtime event")
+        assertEqual(context["previous_clean_shutdown"], "false", "context should keep current marker clean flag")
+        assertEqual(context["session_active"], "true", "context should keep whether a session is active")
+        assertEqual(context["session_kind"], "meeting", "context should keep coarse session kind")
+        assertEqual(context["session_stage"], "transcribing", "context should keep coarse session stage")
+    }
+
     runSuite("RuntimeDiagnosticsStore round-trips marker files") {
         let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("RuntimeDiagnosticsStoreTests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary
- Adds the existing privacy-safe runtime diagnostics marker to the Sentry scope.
- Future fatal crashes should include app version, heartbeat age, last runtime event, and coarse session kind/stage.
- Adds coverage for the current-session runtime context shape.

## Ranked artifact
Top candidate: fatal `1.1.32` crash lacks usable runtime state when Sentry has no stacktrace.
Score: 85/100.
Why it matters: `APPLE-MACOS-1M` is current-release, fatal, and has no stacktrace, so the next event needs coarse state like idle/dictation/meeting/transcribing.
Why others lost: unclean shutdown already reaches both Sentry and PostHog with runtime context; meeting short-recording failures are visible in PostHog and look concentrated to one device.
Smallest safe move: reuse the existing runtime marker as sanitized Sentry context.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`