### PR TITLE
[nightly-retrieval] Follow app-selected CLI capture paths

### DIFF
--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -16,11 +16,12 @@ It does not build or run the app target.
 
 By default these commands read:
 
-- meetings: `~/Library/Application Support/Transcripted/captures/meetings`
-- dictations: `~/Library/Application Support/Transcripted/captures/dictations`
+- meetings: the app-selected capture library when available, otherwise `~/Library/Application Support/Transcripted/captures/meetings`
+- dictations: the app-selected capture library when available, otherwise `~/Library/Application Support/Transcripted/captures/dictations`
 
 Read order for default local context:
 
+- app-selected capture library first when Transcripted has written `~/Library/Application Support/Transcripted/mcp-directories.json` or a saved `transcriptSaveLocation` preference
 - current Transcripted capture folders first
 - legacy Draft exports when they contain capture Markdown: `~/Library/Application Support/Draft/{meetings,dictations}/transcripts`
 - older shared layout when it contains capture Markdown: `~/Documents/Transcripted`
@@ -114,6 +115,7 @@ instruction to run `bash build-deps.sh` from the repo root before rebuilding.
 - the diarization commands depend on repo-level artifacts, so run `bash build-deps.sh` first when those are missing
 - retrieval-only commands should still build and run even when the diarization bundle is absent
 - `swift test` currently covers the agent-facing context path resolver and context-store loading behavior
-- the default context resolver prefers Transcripted capture folders, then falls back to Draft-era exports, then `~/Documents/Transcripted/`
+- the default context resolver prefers the app-selected capture library when Transcripted has one, then falls back to the current Transcripted capture folders, then Draft-era exports, then `~/Documents/Transcripted/`
+- when the user moved the capture library in Transcripted Settings, the CLI should follow that app-selected path before defaulting back to `~/Library/Application Support/Transcripted/captures`
 - `context-recent` is intentionally a mixed feed; if the user asks for the latest meeting specifically, add `--kind meeting`
 - changes here should be verified independently from the app build

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -1,6 +1,18 @@
 import ArgumentParser
 import Foundation
 
+private struct CLIAppDirectoryManifest: Decodable {
+    let version: Int
+    let captureLibraryDirectory: String
+    let meetingsDirectory: String
+    let dictationsDirectory: String
+}
+
+private struct CLIConfiguredCaptureDirectories {
+    let meetings: URL
+    let dictations: URL
+}
+
 struct CLIContextDirectories {
     let meetingDirs: [URL]
     let dictationDirs: [URL]
@@ -78,17 +90,35 @@ struct CLIContextDirectories {
             .appendingPathComponent("Documents", isDirectory: true)
             .appendingPathComponent("Transcripted", isDirectory: true)
 
+        let appConfiguredCaptureDirectories = configuredCaptureDirectories(
+            homeDirectory: home,
+            fileManager: fileManager
+        )
         let meetingsURL = meetingsDir.map(URL.init(fileURLWithPath:))
             ?? environment["TRANSCRIPTED_MEETINGS_DIR"].map(URL.init(fileURLWithPath:))
         let dictationsURL = dictationsDir.map(URL.init(fileURLWithPath:))
             ?? environment["TRANSCRIPTED_DICTATIONS_DIR"].map(URL.init(fileURLWithPath:))
         let meetingDirs = meetingsURL.map { [$0] }
+            ?? appConfiguredCaptureDirectories.map {
+                captureDirectories(
+                    primary: $0.meetings,
+                    legacyCandidates: [legacyDraftMeetings, legacyShared],
+                    fileManager: fileManager
+                )
+            }
             ?? captureDirectories(
                 primary: defaultMeetings,
                 legacyCandidates: [legacyDraftMeetings, legacyShared],
                 fileManager: fileManager
             )
         let dictationDirs = dictationsURL.map { [$0] }
+            ?? appConfiguredCaptureDirectories.map {
+                captureDirectories(
+                    primary: $0.dictations,
+                    legacyCandidates: [legacyDraftDictations, legacyShared],
+                    fileManager: fileManager
+                )
+            }
             ?? captureDirectories(
                 primary: defaultDictations,
                 legacyCandidates: [legacyDraftDictations, legacyShared],
@@ -148,6 +178,83 @@ struct CLIContextDirectories {
         }
 
         return content.hasPrefix("---\n") && content.contains("\n---\n")
+    }
+
+    private static func configuredCaptureDirectories(
+        homeDirectory home: URL,
+        fileManager: FileManager
+    ) -> CLIConfiguredCaptureDirectories? {
+        manifestCaptureDirectories(homeDirectory: home, fileManager: fileManager)
+            ?? appPreferenceCaptureDirectories(homeDirectory: home)
+    }
+
+    private static func manifestCaptureDirectories(
+        homeDirectory home: URL,
+        fileManager: FileManager
+    ) -> CLIConfiguredCaptureDirectories? {
+        let manifestURL = home
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Transcripted", isDirectory: true)
+            .appendingPathComponent("mcp-directories.json", isDirectory: false)
+
+        guard fileManager.fileExists(atPath: manifestURL.path),
+              let data = try? Data(contentsOf: manifestURL),
+              let manifest = try? JSONDecoder().decode(CLIAppDirectoryManifest.self, from: data),
+              manifest.version >= 1,
+              let meetings = validatedConfiguredDirectory(manifest.meetingsDirectory, homeDirectory: home),
+              let dictations = validatedConfiguredDirectory(manifest.dictationsDirectory, homeDirectory: home) else {
+            return nil
+        }
+
+        return CLIConfiguredCaptureDirectories(meetings: meetings, dictations: dictations)
+    }
+
+    private static func appPreferenceCaptureDirectories(homeDirectory home: URL) -> CLIConfiguredCaptureDirectories? {
+        for domain in appPreferenceDomains {
+            let preferenceURL = home
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("Preferences", isDirectory: true)
+                .appendingPathComponent("\(domain).plist", isDirectory: false)
+
+            guard let data = try? Data(contentsOf: preferenceURL),
+                  let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
+                  let values = plist as? [String: Any],
+                  let rawPath = values["transcriptSaveLocation"] as? String,
+                  let captureLibrary = validatedConfiguredDirectory(rawPath, homeDirectory: home) else {
+                continue
+            }
+
+            return CLIConfiguredCaptureDirectories(
+                meetings: captureLibrary.appendingPathComponent("meetings", isDirectory: true),
+                dictations: captureLibrary.appendingPathComponent("dictations", isDirectory: true)
+            )
+        }
+
+        return nil
+    }
+
+    private static var appPreferenceDomains: [String] {
+        [
+            "com.justinbetker.draft",
+            "app.transcripted.Transcripted",
+        ]
+    }
+
+    private static func validatedConfiguredDirectory(_ rawPath: String, homeDirectory home: URL) -> URL? {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.hasPrefix("/") else {
+            return nil
+        }
+
+        let configuredURL = URL(fileURLWithPath: trimmed, isDirectory: true)
+        let standardizedPath = configuredURL.standardizedFileURL.path
+        let homePath = home.standardizedFileURL.path
+        guard standardizedPath.hasPrefix(homePath) else {
+            return nil
+        }
+
+        return configuredURL
     }
 }
 

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextDirectoriesTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextDirectoriesTests.swift
@@ -191,6 +191,86 @@ final class ContextDirectoriesTests: XCTestCase {
         ])
     }
 
+    func testResolveUsesAppDirectoryManifestBeforeDefaultCaptures() throws {
+        let tempHome = makeTempDir()
+        defer { removeTempDir(tempHome) }
+
+        let transcriptedRoot = tempHome
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Transcripted", isDirectory: true)
+        let manifestMeetings = tempHome.appendingPathComponent("custom-captures/meetings", isDirectory: true)
+        let manifestDictations = tempHome.appendingPathComponent("custom-captures/dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: transcriptedRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: manifestMeetings, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: manifestDictations, withIntermediateDirectories: true)
+
+        let manifestURL = transcriptedRoot.appendingPathComponent("mcp-directories.json", isDirectory: false)
+        try """
+        {
+          "version": 1,
+          "captureLibraryDirectory": "\(tempHome.appendingPathComponent("custom-captures", isDirectory: true).path)",
+          "meetingsDirectory": "\(manifestMeetings.path)",
+          "dictationsDirectory": "\(manifestDictations.path)"
+        }
+        """.write(to: manifestURL, atomically: true, encoding: .utf8)
+
+        let directories = CLIContextDirectories.resolve(
+            dataDir: nil,
+            meetingsDir: nil,
+            dictationsDir: nil,
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(directories.meetingDirs.map(\.standardizedFileURL.path), [
+            manifestMeetings.standardizedFileURL.path,
+        ])
+        XCTAssertEqual(directories.dictationDirs.map(\.standardizedFileURL.path), [
+            manifestDictations.standardizedFileURL.path,
+        ])
+    }
+
+    func testResolveUsesAppCaptureLibraryPreferenceWhenManifestIsMissing() throws {
+        let tempHome = makeTempDir()
+        defer { removeTempDir(tempHome) }
+
+        let preferencesDir = tempHome
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Preferences", isDirectory: true)
+        let customCaptureLibrary = tempHome.appendingPathComponent("preferred-captures", isDirectory: true)
+        let customMeetings = customCaptureLibrary.appendingPathComponent("meetings", isDirectory: true)
+        let customDictations = customCaptureLibrary.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: preferencesDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: customMeetings, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: customDictations, withIntermediateDirectories: true)
+
+        let plistURL = preferencesDir.appendingPathComponent("app.transcripted.Transcripted.plist", isDirectory: false)
+        let plistData = try PropertyListSerialization.data(
+            fromPropertyList: ["transcriptSaveLocation": customCaptureLibrary.path],
+            format: .xml,
+            options: 0
+        )
+        try plistData.write(to: plistURL)
+
+        let directories = CLIContextDirectories.resolve(
+            dataDir: nil,
+            meetingsDir: nil,
+            dictationsDir: nil,
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(directories.meetingDirs.map(\.standardizedFileURL.path), [
+            customMeetings.standardizedFileURL.path,
+        ])
+        XCTAssertEqual(directories.dictationDirs.map(\.standardizedFileURL.path), [
+            customDictations.standardizedFileURL.path,
+        ])
+    }
+
     func testResolveSkipsLegacySharedFolderWithoutCaptureMarkdown() throws {
         let tempHome = makeTempDir()
         defer { removeTempDir(tempHome) }

--- a/docs/storage-paths.md
+++ b/docs/storage-paths.md
@@ -101,6 +101,6 @@ can follow the user-selected capture library.
 
 The standalone tools do not all resolve paths the same way:
 
-- `TranscriptedCLI` reads `~/Library/Application Support/Transcripted/captures/{meetings,dictations}/` first, then also merges legacy Draft `.../transcripts/` folders and `~/Documents/Transcripted/` when those folders still contain Markdown captures
+- `TranscriptedCLI` first follows the app-selected capture library from `mcp-directories.json` or the app's `transcriptSaveLocation` preference, then falls back to the current Transcripted capture folders, then legacy Draft `.../transcripts/`, then `~/Documents/Transcripted/`; explicit `--data-dir`, `--meetings-dir`, `--dictations-dir`, or matching env vars still override this
 - `TranscriptedMCP` first follows the app-selected capture library from `mcp-directories.json` or the app's `transcriptSaveLocation` preference, then falls back to the current-plus-legacy read order. It keeps its SQLite index under `~/Library/Application Support/Transcripted/cache/` by default; if `TRANSCRIPTED_DATA_DIR` is set, it instead keeps the index in that shared root unless `TRANSCRIPTED_INDEX_DIR` is also set
 - `TranscriptedQA` now defaults to the current Transcripted meetings/state/log layout, uses `~/Library/Application Support/Transcripted/logs/app.jsonl` for log validation, falls back to legacy Draft and then `~/Documents/Transcripted/`, and accepts explicit `--path`, `--state-dir`, and `--log-path` overrides for nonstandard setups


### PR DESCRIPTION
## Why
Nightly retrieval eval found that `transcripted-cli` still defaulted to the hardcoded Transcripted capture folders, so local-agent retrieval could miss the real library after a user moved it in Settings.

## What changed
- make `TranscriptedCLI` follow `mcp-directories.json` first
- fall back to the saved `transcriptSaveLocation` app preference when the manifest is missing
- keep existing explicit overrides and legacy fallback order
- add resolver tests and update the CLI/storage docs

## Verification
- `cd Tools/TranscriptedCLI && swift build`
- `cd Tools/TranscriptedCLI && swift test`
- `cd Tools/TranscriptedMCP && swift build`
- `cd Tools/TranscriptedMCP && swift test`
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
- `cd Tools/TranscriptedCLI && ./.build/debug/transcripted-cli context-recent --kind meeting --count 2`