### PR TITLE
[nightly-ux] Clarify update ready copy

### DIFF
--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -2308,7 +2308,7 @@ struct TranscriptedSettingsView: View {
             if sparkleUpdater.automaticUpdateSettings.automaticDownloadsEnabled {
                 return "Transcripted is preparing version \(version). You only need to restart when it is ready."
             }
-            return "Version \(version) is ready."
+            return "Version \(version) is ready to install."
         case .downloading(let version):
             return "Version \(version) is downloading."
         case .readyToInstall(let version):


### PR DESCRIPTION
## Summary
- Clarifies the About > Updates status detail when an update is available but not auto-downloading.
- Changes "Version X is ready" to "Version X is ready to install" so the status matches the Install button.

## Evidence
- Latest local app version: 1.1.32.
- PostHog last 7d: update surface is active: install_update 57 clicks from 5 people; check_updates 8 clicks from 6 people.
- Sentry 1.1.32 issues were either mostly single-device unclean shutdown signal or one single-event crash, so they were not safe UX patch targets tonight.

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh: 1450 passed
