### PR TITLE
[nightly-regression] Preserve row-level You speaker naming

### DIFF
--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingPolicy.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingPolicy.swift
@@ -1,18 +1,18 @@
 import Foundation
 
-enum SpeakerNamingPolicy {
-    static func shouldAutoAccept(profile: SpeakerProfile, similarity: Double) -> Bool {
+public enum SpeakerNamingPolicy {
+    public static func shouldAutoAccept(profile: SpeakerProfile, similarity: Double) -> Bool {
         profile.displayName != nil
             && profile.disputeCount == 0
             && similarity > 0.88
             && profile.callCount > 4
     }
 
-    static func confidence(similarity: Double, callCount: Int) -> SpeakerConfidence {
+    public static func confidence(similarity: Double, callCount: Int) -> SpeakerConfidence {
         similarity > 0.85 && callCount > 3 ? .high : .medium
     }
 
-    static func initialMapping(
+    public static func initialMapping(
         speakerId: String,
         profile: SpeakerProfile,
         similarity: Double
@@ -29,5 +29,73 @@ enum SpeakerNamingPolicy {
             confidence: confidence(similarity: similarity, callCount: profile.callCount),
             isConfirmedIdentity: true
         )
+    }
+
+    /// Row-level manual names should stay row-level edits, even when a mic row
+    /// is manually set to "You". Only the sheet-wide "Keep as You" toggle
+    /// should emit `.collapsedToMe`.
+    public static func typedNameUpdate(
+        entry: SpeakerNamingEntry,
+        typedName: String,
+        optionsByLabel: [String: SpeakerIdentityOption]
+    ) -> SpeakerNameUpdate? {
+        let typed = typedName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !typed.isEmpty else { return nil }
+
+        if let option = option(
+            matching: typed,
+            optionsByLabel: optionsByLabel
+        ) {
+            return SpeakerNameUpdate(
+                persistentSpeakerId: entry.id,
+                diarizerSpeakerId: entry.diarizerSpeakerId,
+                channel: entry.channel,
+                newName: option.displayName,
+                action: .merged(targetProfileId: option.id)
+            )
+        }
+
+        let action: SpeakerNameUpdate.NamingAction
+        if entry.suggestedProfileId != nil {
+            action = .named
+        } else if let current = entry.currentName, !current.isEmpty {
+            action = typed.caseInsensitiveCompare(current) == .orderedSame
+                ? .confirmed
+                : .corrected
+        } else {
+            action = .named
+        }
+
+        return SpeakerNameUpdate(
+            persistentSpeakerId: entry.id,
+            diarizerSpeakerId: entry.diarizerSpeakerId,
+            channel: entry.channel,
+            newName: typed,
+            previousName: entry.currentName,
+            action: action
+        )
+    }
+
+    private static func option(
+        matching input: String,
+        optionsByLabel: [String: SpeakerIdentityOption]
+    ) -> SpeakerIdentityOption? {
+        if let exact = optionsByLabel[input] {
+            return exact
+        }
+
+        let normalizedInput = normalizedSearchText(input)
+        let displayMatches = optionsByLabel.values.filter {
+            normalizedSearchText($0.displayName) == normalizedInput
+        }
+        guard displayMatches.count == 1 else { return nil }
+        return displayMatches[0]
+    }
+
+    private static func normalizedSearchText(_ value: String) -> String {
+        value
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
     }
 }

--- a/Sources/UI/Settings/SpeakerNamingSheet.swift
+++ b/Sources/UI/Settings/SpeakerNamingSheet.swift
@@ -694,35 +694,10 @@ final class SpeakerRowView: NSView {
         }
 
         guard !typed.isEmpty else { return nil }
-
-        if let option = knownPeopleOption(matching: typed) {
-            return SpeakerNameUpdate(
-                persistentSpeakerId: entry.id,
-                diarizerSpeakerId: entry.diarizerSpeakerId,
-                channel: entry.channel,
-                newName: option.displayName,
-                action: .merged(targetProfileId: option.id)
-            )
-        }
-
-        let action: SpeakerNameUpdate.NamingAction
-        if entry.suggestedProfileId != nil {
-            action = .named
-        } else if let current = entry.currentName, !current.isEmpty {
-            action = typed.caseInsensitiveCompare(current) == .orderedSame
-                ? .confirmed
-                : .corrected
-        } else {
-            action = .named
-        }
-
-        return SpeakerNameUpdate(
-            persistentSpeakerId: entry.id,
-            diarizerSpeakerId: entry.diarizerSpeakerId,
-            channel: entry.channel,
-            newName: typed,
-            previousName: entry.currentName,
-            action: action
+        return SpeakerNamingPolicy.typedNameUpdate(
+            entry: entry,
+            typedName: typed,
+            optionsByLabel: knownPeopleByLabel
         )
     }
 

--- a/Tests/SpeakerNamingPolicyTests.swift
+++ b/Tests/SpeakerNamingPolicyTests.swift
@@ -70,4 +70,32 @@ func testSpeakerNamingPolicy() {
         assertNil(mapping.identifiedName, "disputed profiles should not auto-apply")
         assertEqual(mapping.displayName, "Speaker 0", "disputed profiles should stay generic until repaired")
     }
+
+    runSuite("SpeakerNamingPolicy keeps row-level You edits as normal mic renames") {
+        let entry = SpeakerNamingEntry(
+            id: UUID(),
+            diarizerSpeakerId: "1",
+            channel: .mic,
+            clipURL: URL(fileURLWithPath: "/tmp/speaker-row.wav"),
+            sampleText: "I am in the room.",
+            currentName: "Speaker 1",
+            matchSimilarity: nil,
+            needsNaming: true,
+            needsConfirmation: false
+        )
+
+        let update = SpeakerNamingPolicy.typedNameUpdate(
+            entry: entry,
+            typedName: "You",
+            optionsByLabel: [:]
+        )
+
+        assertEqual(update?.newName, "You", "row-level owner labels should still save the typed name")
+        assertEqual(update?.previousName, "Speaker 1", "row-level owner labels should preserve the previous mic name")
+        if case .corrected? = update?.action {
+            assertTrue(true, "manually typing You should stay a row-level correction")
+        } else {
+            assertTrue(false, "manually typing You should not collapse the whole local speaker set")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- move row-level speaker rename update building into TranscriptedCore policy
- keep manually typed "You" on a single mic row as a normal rename instead of a collapse-to-me action
- add fast regression coverage for the row-level mic rename path

## Verification
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test