### PR TITLE
[codex] Share transcript frontmatter parsing

### DIFF
--- a/Sources/Meeting/MeetingAudioStorageManager.swift
+++ b/Sources/Meeting/MeetingAudioStorageManager.swift
@@ -1,5 +1,8 @@
 import AVFoundation
 import Foundation
+#if canImport(TranscriptedCore)
+import TranscriptedCore
+#endif
 
 protocol MeetingAudioFileConverting {
     func convertWAVToM4A(sourceURL: URL, destinationURL: URL) async throws
@@ -55,12 +58,6 @@ enum MeetingAudioStorageManager {
     private static let frontmatterPreviewByteLimit = 64 * 1024
     private static let staleTemporaryM4AAge: TimeInterval = 10 * 60
     private static let managedAudioStems = ["microphone", "system_audio", "recording", "playback"]
-    private static let transcriptDateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return formatter
-    }()
 
     @discardableResult
     static func processExistingRetainedAudio(
@@ -356,7 +353,7 @@ enum MeetingAudioStorageManager {
 
     private static func isTranscriptedMeetingTranscript(_ raw: String) -> Bool {
         guard raw.contains("\n## Full Transcript") || raw.contains("\n## Transcript"),
-              let values = frontmatterValues(in: raw),
+              let values = TranscriptFrontmatter.values(in: raw),
               values["capture_type"]?.lowercased() == "meeting" else {
             return false
         }
@@ -366,7 +363,7 @@ enum MeetingAudioStorageManager {
     }
 
     private static func transcriptReferenceDate(for url: URL, raw: String) -> Date {
-        if let frontmatterDate = frontmatterRecordedDate(in: raw) {
+        if let frontmatterDate = TranscriptFrontmatter.recordedAt(in: raw) {
             return frontmatterDate
         }
 
@@ -374,41 +371,9 @@ enum MeetingAudioStorageManager {
         return values?.creationDate ?? values?.contentModificationDate ?? Date()
     }
 
-    private static func frontmatterRecordedDate(in raw: String) -> Date? {
-        guard let values = frontmatterValues(in: raw) else { return nil }
-        guard let date = values["date"], let time = values["time"] else { return nil }
-        return transcriptDateFormatter.date(from: "\(date) \(time)")
-    }
-
-    private static func frontmatterValues(in raw: String) -> [String: String]? {
-        guard let lines = frontmatterLines(in: raw) else { return nil }
-        var values: [String: String] = [:]
-        for line in lines {
-            let parts = line.split(separator: ":", maxSplits: 1).map(String.init)
-            guard parts.count == 2 else { continue }
-            values[parts[0].trimmingCharacters(in: .whitespaces)] = parts[1]
-                .trimmingCharacters(in: .whitespaces)
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-        }
-        return values
-    }
-
     private static func isValidTranscriptIdentifier(_ value: String?) -> Bool {
         guard let value else { return false }
         return UUID(uuidString: value) != nil
-    }
-
-    private static func frontmatterLines(in raw: String) -> [String]? {
-        guard raw.hasPrefix("---\n"),
-              let endRange = raw.range(
-                of: "\n---\n",
-                range: raw.index(raw.startIndex, offsetBy: 4)..<raw.endIndex
-              ) else {
-            return nil
-        }
-
-        let frontmatterText = String(raw[raw.index(raw.startIndex, offsetBy: 4)..<endRange.lowerBound])
-        return frontmatterText.components(separatedBy: "\n")
     }
 
     private static func isWAVFile(_ url: URL, fileManager: FileManager) -> Bool {

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1573,14 +1573,14 @@ final class MeetingSessionController: ObservableObject {
     private func savedTranscriptAnalyticsProperties() -> [String: String] {
         guard let url = taskManager.lastSavedTranscriptURL ?? lastSavedTranscriptURL,
               let raw = try? String(contentsOf: url, encoding: .utf8),
-              let values = transcriptFrontmatterValues(from: raw) else {
+              let values = TranscriptFrontmatter.values(in: raw) else {
             return [:]
         }
 
         var properties: [String: String] = [:]
 
         if let duration = values["duration"],
-           let durationSeconds = transcriptDurationSeconds(from: duration) {
+           let durationSeconds = TranscriptFrontmatter.durationSeconds(from: duration) {
             properties["duration_bucket"] = AnalyticsReporter.durationBucket(seconds: Double(durationSeconds))
         }
 
@@ -1595,39 +1595,6 @@ final class MeetingSessionController: ObservableObject {
         }
 
         return properties
-    }
-
-    private func transcriptFrontmatterValues(from raw: String) -> [String: String]? {
-        guard raw.hasPrefix("---\n"),
-              let endRange = raw.range(
-                of: "\n---\n",
-                range: raw.index(raw.startIndex, offsetBy: 4)..<raw.endIndex
-              ) else {
-            return nil
-        }
-
-        let frontmatter = String(raw[raw.index(raw.startIndex, offsetBy: 4)..<endRange.lowerBound])
-        var values: [String: String] = [:]
-        for line in frontmatter.components(separatedBy: "\n") {
-            let parts = line.split(separator: ":", maxSplits: 1).map(String.init)
-            guard parts.count == 2 else { continue }
-            values[parts[0].trimmingCharacters(in: .whitespaces)] = parts[1]
-                .trimmingCharacters(in: .whitespaces)
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-        }
-        return values
-    }
-
-    private func transcriptDurationSeconds(from value: String) -> Int? {
-        let parts = value.split(separator: ":").compactMap { Int($0) }
-        switch parts.count {
-        case 2:
-            return parts[0] * 60 + parts[1]
-        case 3:
-            return parts[0] * 3600 + parts[1] * 60 + parts[2]
-        default:
-            return nil
-        }
     }
 
     /// Snapshot capture health before the stop call, since the system-audio

--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(TranscriptedCore)
+import TranscriptedCore
+#endif
 
 struct StyledMeetingTranscript {
     let url: URL
@@ -7,13 +10,6 @@ struct StyledMeetingTranscript {
 
 enum MeetingTranscriptStyler {
     private static let frontmatterPreviewByteLimit = 64 * 1024
-
-    private static let parseFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        return formatter
-    }()
 
     private static let titleFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -133,7 +129,7 @@ enum MeetingTranscriptStyler {
             )
             return nil
         }
-        return stripFrontmatter(from: raw)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return TranscriptFrontmatter.body(in: raw)?.trimmingCharacters(in: .whitespacesAndNewlines)
             ?? raw.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
@@ -149,27 +145,25 @@ enum MeetingTranscriptStyler {
     }
 
     private static func parseDocument(_ raw: String, fallbackURL: URL) -> ParsedDocument? {
-        guard let body = stripFrontmatter(from: raw),
-              raw.hasPrefix("---\n"),
-              let frontmatterLines = frontmatterLines(in: raw) else {
+        guard let frontmatter = TranscriptFrontmatter.document(in: raw) else {
             return nil
         }
 
-        let values = frontmatterValues(from: frontmatterLines)
+        let values = frontmatter.values
 
         let recordedAt = parseRecordedAt(values: values, fallbackURL: fallbackURL)
-        let transcriptEntries = extractTranscriptEntries(from: body)
+        let transcriptEntries = extractTranscriptEntries(from: frontmatter.body)
 
         let duration = values["duration"] ?? "0:00"
         let words = Int(values["total_word_count"] ?? "") ?? 0
         let utterances = (Int(values["mic_utterances"] ?? "") ?? 0) + (Int(values["system_utterances"] ?? "") ?? 0)
 
         return ParsedDocument(
-            frontmatterLines: frontmatterLines,
+            frontmatterLines: frontmatter.lines,
             explicitTitle: values["title"]?.trimmingCharacters(in: .whitespacesAndNewlines),
             recordedAt: recordedAt,
             duration: duration,
-            durationSeconds: parseDurationSeconds(duration),
+            durationSeconds: TranscriptFrontmatter.durationSeconds(from: duration) ?? 0,
             totalWords: words,
             totalUtterances: utterances,
             transcriptEntries: transcriptEntries
@@ -177,45 +171,20 @@ enum MeetingTranscriptStyler {
     }
 
     private static func frontmatterTitle(at url: URL) -> String? {
-        guard let raw = try? previewString(at: url, byteLimit: frontmatterPreviewByteLimit),
-              let frontmatterLines = frontmatterLines(in: raw) else {
+        guard let values = try? TranscriptFrontmatter.readValues(
+            from: url,
+            byteLimit: frontmatterPreviewByteLimit
+        ) else {
             return nil
         }
 
-        let title = frontmatterValues(from: frontmatterLines)["title"]?
+        let title = values["title"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return title?.isEmpty == false ? title : nil
     }
 
-    private static func frontmatterLines(in raw: String) -> [String]? {
-        guard raw.hasPrefix("---\n"),
-              let endRange = raw.range(
-                of: "\n---\n",
-                range: raw.index(raw.startIndex, offsetBy: 4)..<raw.endIndex
-              ) else {
-            return nil
-        }
-
-        let frontmatterText = String(raw[raw.index(raw.startIndex, offsetBy: 4)..<endRange.lowerBound])
-        return frontmatterText.components(separatedBy: "\n")
-    }
-
-    private static func frontmatterValues(from lines: [String]) -> [String: String] {
-        var values: [String: String] = [:]
-        for line in lines {
-            let parts = line.split(separator: ":", maxSplits: 1).map(String.init)
-            guard parts.count == 2 else { continue }
-            values[parts[0].trimmingCharacters(in: .whitespaces)] = parts[1]
-                .trimmingCharacters(in: .whitespaces)
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-        }
-        return values
-    }
-
     private static func parseRecordedAt(values: [String: String], fallbackURL: URL) -> Date {
-        if let date = values["date"],
-           let time = values["time"],
-           let parsed = parsedRecordedAt(from: "\(date) \(time)") {
+        if let parsed = TranscriptFrontmatter.recordedAt(values: values) {
             return parsed
         }
 
@@ -282,18 +251,6 @@ enum MeetingTranscriptStyler {
         """
     }
 
-    private static func stripFrontmatter(from raw: String) -> String? {
-        guard raw.hasPrefix("---\n"),
-              let endRange = raw.range(
-                of: "\n---\n",
-                range: raw.index(raw.startIndex, offsetBy: 4)..<raw.endIndex
-              ) else {
-            return nil
-        }
-
-        return String(raw[endRange.upperBound...])
-    }
-
     private static func buildTitle(for document: ParsedDocument) -> String {
         if let explicitTitle = document.explicitTitle,
            !explicitTitle.isEmpty {
@@ -324,12 +281,6 @@ enum MeetingTranscriptStyler {
         return titleString(from: document.recordedAt)
     }
 
-    private static func parsedRecordedAt(from value: String) -> Date? {
-        formatterQueue.sync {
-            parseFormatter.date(from: value)
-        }
-    }
-
     private static func titleString(from date: Date) -> String {
         formatterQueue.sync {
             titleFormatter.string(from: date)
@@ -340,18 +291,6 @@ enum MeetingTranscriptStyler {
         formatterQueue.sync {
             detailFormatter.string(from: date)
         }
-    }
-
-    private static func parseDurationSeconds(_ duration: String) -> Int {
-        let components = duration.split(separator: ":").compactMap { Int($0) }
-        guard !components.isEmpty else { return 0 }
-        if components.count == 2 {
-            return components[0] * 60 + components[1]
-        }
-        if components.count == 3 {
-            return components[0] * 3600 + components[1] * 60 + components[2]
-        }
-        return components[0]
     }
 
     private static func parseTranscriptEntries(from block: String) -> [TranscriptEntry] {

--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -4,7 +4,7 @@
 
 `Sources/TranscriptedCore/` is the reusable meeting transcription library embedded in this repo. It is consumed by the app through `Sources/Meeting/`, and it can also be tested as a standalone Swift package through the root `Package.swift`.
 
-## Subsystems (62 Swift files)
+## Subsystems (64 Swift files)
 
 - `Audio/` (17 files) — mic + system audio capture, imported-audio prep helpers, capture start-state gating, device recovery, signal analysis and normalization helpers, real-time AGC, resampling, level metering, process tap, ScreenCaptureKit-backed system-audio capture, backend selection, buffer writing, merge helpers, and privacy-safe pipeline diagnostics snapshots
 - `Logging/` (2 files) — shared app logger and JSONL file logger
@@ -14,7 +14,7 @@
 - `Services/` (7 files) — DI container (`AppServices`), model bundle / download management, path indirection, recording validation, diarization, and failed-transcription persistence
 - `Speaker/` (10 files) — speaker DB, embedding matching / clustering, clip extraction, naming policy / coordinator, profile merging, retroactive transcript updates
 - `Stats/` (4 files) — recording stats database, models, queries, and service
-- `Storage/` (4 files) — transcript save, scanner, formatter, and retained-recording audio archiving
+- `Storage/` (5 files) — transcript save, scanner, formatter, shared frontmatter parsing, and retained-recording audio archiving
 - `Utilities/` (2 files) — date formatting and file permission helpers
 
 ## The seams embedders should know

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -418,42 +418,14 @@ public class TranscriptionTaskManager: ObservableObject {
         lastSavedTranscriptURL = url
         let name = url.deletingPathExtension().lastPathComponent
         lastSavedTitle = name.replacingOccurrences(of: "_", with: " ").replacingOccurrences(of: "-", with: " ")
-        guard let yaml = readYAMLFrontmatter(from: url) else { return }
-        var speakers = 0
-        for line in yaml.components(separatedBy: "\n") {
-            let parts = line.split(separator: ":", maxSplits: 1).map { String($0).trimmingCharacters(in: .whitespaces) }
-            guard parts.count == 2 else { continue }
-            switch parts[0] {
-            case "title": lastSavedTitle = parts[1].trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            case "duration": lastSavedDuration = parts[1].trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            case "mic_speakers", "system_speakers": speakers += Int(parts[1]) ?? 0
-            default: break
-            }
+        guard let values = try? TranscriptFrontmatter.readValues(from: url) else { return }
+
+        if let title = values["title"] {
+            lastSavedTitle = title
         }
-        lastSavedSpeakerCount = speakers
-    }
-
-    private func readYAMLFrontmatter(from url: URL, chunkSize: Int = 2048, maxBytes: Int = 64 * 1024) -> String? {
-        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
-        defer { try? handle.close() }
-
-        var data = Data()
-        let closingMarker = Data("\n---\n".utf8)
-
-        while data.count < maxBytes {
-            let remaining = maxBytes - data.count
-            let chunk = handle.readData(ofLength: min(chunkSize, remaining))
-            guard !chunk.isEmpty else { break }
-            data.append(chunk)
-
-            if data.starts(with: Data("---".utf8)),
-               let endRange = data.range(of: closingMarker, in: 3..<data.count),
-               let raw = String(data: data[..<endRange.lowerBound], encoding: .utf8) {
-                return String(raw.dropFirst(4))
-            }
-        }
-
-        return nil
+        lastSavedDuration = values["duration"]
+        lastSavedSpeakerCount = (Int(values["mic_speakers"] ?? "") ?? 0)
+            + (Int(values["system_speakers"] ?? "") ?? 0)
     }
 
     func scheduleStatusReset(delay: TimeInterval = 3) {

--- a/Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+/// Small, shared parser for Transcripted's Markdown YAML frontmatter.
+///
+/// This is intentionally not a general YAML parser. It handles the flat
+/// `key: value` fields Transcripted writes and leaves richer blocks, like
+/// `speakers:`, to callers that need the original frontmatter lines.
+public struct TranscriptFrontmatterDocument: Sendable {
+    public let lines: [String]
+    public let values: [String: String]
+    public let body: String
+
+    public init(lines: [String], values: [String: String], body: String) {
+        self.lines = lines
+        self.values = values
+        self.body = body
+    }
+}
+
+public enum TranscriptFrontmatter {
+    public static let previewByteLimit = 64 * 1024
+
+    private static let recordedAtFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return formatter
+    }()
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    private static let formatterQueue = DispatchQueue(label: "TranscriptedCore.TranscriptFrontmatter.formatters")
+
+    public static func document(in raw: String) -> TranscriptFrontmatterDocument? {
+        guard raw.hasPrefix("---\n"),
+              let endRange = raw.range(
+                of: "\n---\n",
+                range: raw.index(raw.startIndex, offsetBy: 4)..<raw.endIndex
+              ) else {
+            return nil
+        }
+
+        let frontmatterText = String(raw[raw.index(raw.startIndex, offsetBy: 4)..<endRange.lowerBound])
+        let lines = frontmatterText.components(separatedBy: "\n")
+        return TranscriptFrontmatterDocument(
+            lines: lines,
+            values: values(from: lines),
+            body: String(raw[endRange.upperBound...])
+        )
+    }
+
+    public static func body(in raw: String) -> String? {
+        document(in: raw)?.body
+    }
+
+    public static func lines(in raw: String) -> [String]? {
+        document(in: raw)?.lines
+    }
+
+    public static func values(in raw: String) -> [String: String]? {
+        document(in: raw)?.values
+    }
+
+    public static func values(from lines: [String]) -> [String: String] {
+        var values: [String: String] = [:]
+
+        for line in lines {
+            guard line.first?.isWhitespace != true else { continue }
+
+            let parts = line.split(separator: ":", maxSplits: 1).map(String.init)
+            guard parts.count == 2 else { continue }
+
+            values[parts[0].trimmingCharacters(in: .whitespaces)] = normalizeValue(parts[1])
+        }
+
+        return values
+    }
+
+    public static func readDocument(
+        from url: URL,
+        byteLimit: Int = previewByteLimit
+    ) throws -> TranscriptFrontmatterDocument? {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+
+        let data = try handle.read(upToCount: byteLimit) ?? Data()
+        let raw = String(decoding: data, as: UTF8.self)
+        return document(in: raw)
+    }
+
+    public static func readValues(
+        from url: URL,
+        byteLimit: Int = previewByteLimit
+    ) throws -> [String: String]? {
+        try readDocument(from: url, byteLimit: byteLimit)?.values
+    }
+
+    public static func durationSeconds(from value: String?) -> Int? {
+        guard let value else { return nil }
+
+        let parts = value.split(separator: ":").compactMap { Int($0) }
+        switch parts.count {
+        case 1:
+            return parts[0]
+        case 2:
+            return parts[0] * 60 + parts[1]
+        case 3:
+            return parts[0] * 3600 + parts[1] * 60 + parts[2]
+        default:
+            return nil
+        }
+    }
+
+    public static func recordedAt(values: [String: String]) -> Date? {
+        guard let date = values["date"] else { return nil }
+        let time = values["time"] ?? "00:00:00"
+
+        return formatterQueue.sync {
+            recordedAtFormatter.date(from: "\(date) \(time)")
+        }
+    }
+
+    public static func recordedAt(in raw: String) -> Date? {
+        guard let values = values(in: raw) else { return nil }
+        return recordedAt(values: values)
+    }
+
+    public static func date(values: [String: String]) -> Date? {
+        guard let date = values["date"] else { return nil }
+
+        return formatterQueue.sync {
+            dateFormatter.date(from: date)
+        }
+    }
+
+    public static func date(in raw: String) -> Date? {
+        guard let values = values(in: raw) else { return nil }
+        return date(values: values)
+    }
+
+    private static func normalizeValue(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespaces)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+    }
+}

--- a/Sources/TranscriptedCore/Storage/TranscriptScanner.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptScanner.swift
@@ -94,84 +94,54 @@ public enum TranscriptScanner {
         var actionItemsCount = 0
         var captureID: String?
 
-        // Check for YAML frontmatter
-        if content.hasPrefix("---") {
-            if let endIndex = content.range(of: "---", range: content.index(content.startIndex, offsetBy: 3)..<content.endIndex) {
-                let yaml = String(content[content.index(content.startIndex, offsetBy: 3)..<endIndex.lowerBound])
+        if let values = TranscriptFrontmatter.values(in: content) {
+            if let parsedDate = TranscriptFrontmatter.date(values: values) {
+                date = parsedDate
+            }
 
-                // Parse YAML fields
-                let lines = yaml.components(separatedBy: .newlines)
-                for line in lines {
-                    let parts = line.split(separator: ":", maxSplits: 1)
-                    guard parts.count == 2 else { continue }
-
-                    let key = String(parts[0]).trimmingCharacters(in: .whitespaces)
-                    // Security: trim only surrounding quotes rather than stripping all quotes (avoids mangling embedded escaped-quote values)
-                    let value = String(parts[1]).trimmingCharacters(in: .whitespaces)
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-
-                    switch key {
-                    case "date":
-                        let dateFormatter = DateFormatter()
-                        dateFormatter.dateFormat = "yyyy-MM-dd"
-                        if let parsedDate = dateFormatter.date(from: value) {
-                            date = parsedDate
-                        }
-
-                    case "time":
-                        // Combine with existing date
-                        let timeFormatter = DateFormatter()
-                        timeFormatter.dateFormat = "HH:mm:ss"
-                        if let time = timeFormatter.date(from: value) {
-                            let calendar = Calendar.current
-                            let timeComponents = calendar.dateComponents([.hour, .minute, .second], from: time)
-                            date = calendar.date(bySettingHour: timeComponents.hour ?? 0,
-                                                minute: timeComponents.minute ?? 0,
-                                                second: timeComponents.second ?? 0,
-                                                of: date) ?? date
-                        }
-
-                    case "duration":
-                        // Parse "MM:SS" format
-                        let durationParts = value.split(separator: ":")
-                        if durationParts.count == 2 {
-                            let minutes = Int(durationParts[0]) ?? 0
-                            let seconds = Int(durationParts[1]) ?? 0
-                            durationSeconds = minutes * 60 + seconds
-                        }
-
-                    case "total_word_count":
-                        wordCount = Int(value) ?? 0
-
-                    case "mic_speakers", "system_speakers":
-                        speakerCount += Int(value) ?? 0
-
-                    case "processing_time":
-                        // Parse "X.Xs" format
-                        let numStr = value.replacingOccurrences(of: "s", with: "")
-                        if let seconds = Double(numStr) {
-                            processingTimeMs = Int(seconds * 1000)
-                        }
-
-                    case "action_items":
-                        actionItemsCount = Int(value) ?? 0
-
-                    case "capture_id", "transcript_id":
-                        // Security: cap length to prevent unbounded strings from an adversarially
-                        // crafted transcript file from being stored in the stats database.
-                        // A legitimate UUID is 36 chars; 256 gives generous slack for any future formats.
-                        if value.count > 256 {
-                            AppLogger.pipeline.warning("TranscriptScanner: oversized capture_id truncated", [
-                                "path": fileURL.lastPathComponent,
-                                "length": "\(value.count)"
-                            ])
-                        }
-                        captureID = String(value.prefix(256))
-
-                    default:
-                        break
-                    }
+            if let timeValue = values["time"] {
+                let timeFormatter = DateFormatter()
+                timeFormatter.dateFormat = "HH:mm:ss"
+                if let time = timeFormatter.date(from: timeValue) {
+                    let calendar = Calendar.current
+                    let timeComponents = calendar.dateComponents([.hour, .minute, .second], from: time)
+                    date = calendar.date(
+                        bySettingHour: timeComponents.hour ?? 0,
+                        minute: timeComponents.minute ?? 0,
+                        second: timeComponents.second ?? 0,
+                        of: date
+                    ) ?? date
                 }
+            }
+
+            if let duration = TranscriptFrontmatter.durationSeconds(from: values["duration"]) {
+                durationSeconds = duration
+            }
+
+            wordCount = Int(values["total_word_count"] ?? "") ?? wordCount
+            speakerCount = (Int(values["mic_speakers"] ?? "") ?? 0)
+                + (Int(values["system_speakers"] ?? "") ?? 0)
+
+            if let processingTime = values["processing_time"] {
+                let numStr = processingTime.replacingOccurrences(of: "s", with: "")
+                if let seconds = Double(numStr) {
+                    processingTimeMs = Int(seconds * 1000)
+                }
+            }
+
+            actionItemsCount = Int(values["action_items"] ?? "") ?? actionItemsCount
+
+            if let rawCaptureID = values["transcript_id"] ?? values["capture_id"] {
+                // Security: cap length to prevent unbounded strings from an adversarially
+                // crafted transcript file from being stored in the stats database.
+                // A legitimate UUID is 36 chars; 256 gives generous slack for any future formats.
+                if rawCaptureID.count > 256 {
+                    AppLogger.pipeline.warning("TranscriptScanner: oversized capture_id truncated", [
+                        "path": fileURL.lastPathComponent,
+                        "length": "\(rawCaptureID.count)"
+                    ])
+                }
+                captureID = String(rawCaptureID.prefix(256))
             }
         }
 

--- a/Tests/TranscriptedCoreTests/TranscriptFrontmatterTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptFrontmatterTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import TranscriptedCore
+
+final class TranscriptFrontmatterTests: XCTestCase {
+    func testParsesFlatValuesAndBody() throws {
+        let raw = """
+        ---
+        capture_type: meeting
+        title: "Product Review: Follow-up"
+        duration: "1:02:03"
+        total_word_count: 42
+        speakers:
+          - id: "system_0"
+            name: "Alex"
+        ---
+
+        ## Transcript
+
+        Hello.
+        """
+
+        let document = try XCTUnwrap(TranscriptFrontmatter.document(in: raw))
+
+        XCTAssertEqual(document.values["capture_type"], "meeting")
+        XCTAssertEqual(document.values["title"], "Product Review: Follow-up")
+        XCTAssertEqual(document.values["duration"], "1:02:03")
+        XCTAssertEqual(document.values["total_word_count"], "42")
+        XCTAssertNil(document.values["name"])
+        XCTAssertEqual(document.body.trimmingCharacters(in: .whitespacesAndNewlines), "## Transcript\n\nHello.")
+        XCTAssertTrue(document.lines.contains("speakers:"))
+    }
+
+    func testParsesDurationShapes() {
+        XCTAssertEqual(TranscriptFrontmatter.durationSeconds(from: "45"), 45)
+        XCTAssertEqual(TranscriptFrontmatter.durationSeconds(from: "12:34"), 754)
+        XCTAssertEqual(TranscriptFrontmatter.durationSeconds(from: "1:02:03"), 3723)
+        XCTAssertNil(TranscriptFrontmatter.durationSeconds(from: "not a duration"))
+    }
+
+    func testParsesRecordedAt() throws {
+        let date = try XCTUnwrap(
+            TranscriptFrontmatter.recordedAt(
+                values: [
+                    "date": "2026-04-22",
+                    "time": "13:14:15"
+                ]
+            )
+        )
+
+        let components = Calendar(identifier: .gregorian)
+            .dateComponents(in: TimeZone.current, from: date)
+        XCTAssertEqual(components.year, 2026)
+        XCTAssertEqual(components.month, 4)
+        XCTAssertEqual(components.day, 22)
+        XCTAssertEqual(components.hour, 13)
+        XCTAssertEqual(components.minute, 14)
+        XCTAssertEqual(components.second, 15)
+    }
+
+    func testReadValuesUsesBoundedPrefix() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptFrontmatterTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let url = directory.appendingPathComponent("meeting.md")
+        let raw = """
+        ---
+        title: "Large Meeting"
+        duration: "42:17"
+        ---
+
+        \(String(repeating: "body\n", count: 1_000))
+        """
+        try raw.write(to: url, atomically: true, encoding: .utf8)
+
+        let values = try XCTUnwrap(try TranscriptFrontmatter.readValues(from: url))
+
+        XCTAssertEqual(values["title"], "Large Meeting")
+        XCTAssertEqual(values["duration"], "42:17")
+    }
+}

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -175,6 +175,7 @@ APP_SOURCES=(
     "Sources/TranscriptedCore/Models/TranscriptionTypes.swift"
     "Sources/TranscriptedCore/Speaker/SpeakerProfile.swift"
     "Sources/TranscriptedCore/Speaker/SpeakerNamingPolicy.swift"
+    "Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift"
     "Sources/Support/SpeakerNameSelectionPolicy.swift"
     "Sources/UI/Shared/AgentConnectionGuide.swift"
     "Sources/UI/Shared/FeedbackIssueBuilder.swift"


### PR DESCRIPTION
## Summary

- Add a shared `TranscriptFrontmatter` helper in `TranscriptedCore` for Transcripted markdown frontmatter parsing.
- Move meeting transcript styling, retained-audio cleanup, saved-metadata, scanner, and analytics metadata reads onto the shared helper.
- Add package tests for flat value parsing, bounded reads, durations, and recorded timestamps.

## Why

Transcript frontmatter parsing had become scattered across app and core code. This keeps the transcript metadata seam in one Core-owned place and removes repeated ad hoc parser logic.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (`1450/1450`)
- `bash run-integration-smoke.sh`
- `swift test` (`126/126`)