### PR TITLE
[nightly-review] Reject malformed frontmatter durations

### DIFF
--- a/Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift
@@ -103,7 +103,11 @@ public enum TranscriptFrontmatter {
     public static func durationSeconds(from value: String?) -> Int? {
         guard let value else { return nil }
 
-        let parts = value.split(separator: ":").compactMap { Int($0) }
+        let rawParts = value.split(separator: ":", omittingEmptySubsequences: false)
+        let parts = rawParts.compactMap { Int($0) }
+        guard parts.count == rawParts.count else { return nil }
+        guard parts.allSatisfy({ $0 >= 0 }) else { return nil }
+
         switch parts.count {
         case 1:
             return parts[0]

--- a/Tests/TranscriptedCoreTests/TranscriptFrontmatterTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptFrontmatterTests.swift
@@ -35,6 +35,10 @@ final class TranscriptFrontmatterTests: XCTestCase {
         XCTAssertEqual(TranscriptFrontmatter.durationSeconds(from: "12:34"), 754)
         XCTAssertEqual(TranscriptFrontmatter.durationSeconds(from: "1:02:03"), 3723)
         XCTAssertNil(TranscriptFrontmatter.durationSeconds(from: "not a duration"))
+        XCTAssertNil(TranscriptFrontmatter.durationSeconds(from: "1:bad"))
+        XCTAssertNil(TranscriptFrontmatter.durationSeconds(from: "1:02:bad"))
+        XCTAssertNil(TranscriptFrontmatter.durationSeconds(from: "1:"))
+        XCTAssertNil(TranscriptFrontmatter.durationSeconds(from: "-1:02"))
     }
 
     func testParsesRecordedAt() throws {


### PR DESCRIPTION
## Summary
- Reject malformed duration frontmatter instead of compacting away bad components
- Cover bad text, dangling separators, and negative duration parts

## Verification
- bash build-deps.sh --force
- swiftc -typecheck Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift
- bash run-tests.sh
- swift test --filter TranscriptFrontmatterTests
- bash build.sh
- swift test
- bash run-integration-smoke.sh