### PR TITLE
[nightly-regression] Lock Sentry runtime crash context

### DIFF
--- a/Tests/RuntimeDiagnosticsStoreTests.swift
+++ b/Tests/RuntimeDiagnosticsStoreTests.swift
@@ -60,6 +60,47 @@ func testRuntimeDiagnosticsStore() {
         assertEqual(context["session_stage"], "transcribing", "context should keep coarse session stage")
     }
 
+    runSuite("RuntimeDiagnosticsStore current Sentry context stays privacy-safe and stable") {
+        let marker = RuntimeDiagnosticsMarker(
+            launchID: "launch-secret",
+            appVersion: "1.2.5",
+            buildVersion: "458",
+            osMajor: 26,
+            cleanShutdown: true,
+            startedAt: Date(timeIntervalSince1970: 3_000),
+            updatedAt: Date(timeIntervalSince1970: 3_015),
+            lastEvent: "clean_shutdown",
+            sessionKind: "none",
+            sessionStage: "idle",
+            sessionActive: false
+        )
+
+        let context = RuntimeDiagnosticsStore.contextForCurrentSession(
+            marker: marker,
+            now: Date(timeIntervalSince1970: 3_020)
+        )
+
+        assertEqual(
+            Set(context.keys),
+            [
+                "app_version",
+                "build_version",
+                "heartbeat_age_bucket",
+                "last_event",
+                "os_major",
+                "previous_clean_shutdown",
+                "session_active",
+                "session_kind",
+                "session_stage",
+            ],
+            "current Sentry context should stay limited to coarse runtime keys"
+        )
+        assertEqual(context["previous_clean_shutdown"], "true", "clean shutdown state should survive as a coarse boolean")
+        assertNil(context["launch_id"], "launch IDs should not leak into crash context")
+        assertNil(context["started_at"], "raw start timestamps should not leak into crash context")
+        assertNil(context["updated_at"], "raw heartbeat timestamps should not leak into crash context")
+    }
+
     runSuite("RuntimeDiagnosticsStore round-trips marker files") {
         let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("RuntimeDiagnosticsStoreTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/SentryPayloadSanitizerTests.swift
+++ b/Tests/SentryPayloadSanitizerTests.swift
@@ -95,6 +95,34 @@ func testSentryPayloadSanitizer() {
         assertNil(sanitized["source_app"], "source app identifiers should be dropped")
     }
 
+    runSuite("SentryPayloadSanitizer.sanitizeContext keeps runtime crash context coarse") {
+        let sanitized = SentryPayloadSanitizer.sanitizeContext([
+            "app_version": "1.2.5",
+            "build_version": "458",
+            "heartbeat_age_bucket": "15_59s",
+            "last_event": "clean_shutdown",
+            "os_major": "26",
+            "previous_clean_shutdown": "true",
+            "session_active": "false",
+            "session_kind": "none",
+            "session_stage": "idle",
+            "transcript_path": "/Users/redbars/Library/Application Support/Transcripted/captures/meetings/private.md",
+            "error": "private raw failure",
+        ])
+
+        assertEqual(sanitized["app_version"], "1.2.5", "app version should remain")
+        assertEqual(sanitized["build_version"], "458", "build version should remain")
+        assertEqual(sanitized["heartbeat_age_bucket"], "15_59s", "heartbeat bucket should remain")
+        assertEqual(sanitized["last_event"], "clean_shutdown", "last event should remain")
+        assertEqual(sanitized["os_major"], "26", "OS major should remain")
+        assertEqual(sanitized["previous_clean_shutdown"], "true", "clean shutdown state should remain")
+        assertEqual(sanitized["session_active"], "false", "session activity should remain")
+        assertEqual(sanitized["session_kind"], "none", "session kind should remain")
+        assertEqual(sanitized["session_stage"], "idle", "session stage should remain")
+        assertNil(sanitized["transcript_path"], "transcript paths should still be dropped")
+        assertNil(sanitized["error"], "free-form runtime errors should still be dropped")
+    }
+
     runSuite("SentryPayloadSanitizer.sanitizeText redacts emails hostnames and non-home paths") {
         let input = "Contact me at person@example.com from Redbarss-MacBook-Pro.local and inspect /private/var/folders/demo/file.txt"
         let sanitized = SentryPayloadSanitizer.sanitizeText(input)


### PR DESCRIPTION
## Summary
- add a fast regression test that locks the current Sentry runtime-context key set to coarse privacy-safe fields
- add a sanitizer regression test that keeps the runtime crash context while still dropping accidental sensitive fields

## Verification
- bash build.sh
- bash run-tests.sh