### PR TITLE
[nightly-release] Prepare 1.1.33 release candidate

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.32</string>
+	<string>1.1.33</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.32</string>
+	<string>1.1.33</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>


### PR DESCRIPTION
## Summary
- bump `Info.plist` from `1.1.32` to `1.1.33` for nightly RC prep only
- keep `docs/appcast.xml` untouched until a real approved release is cut

## Why this exists
- `v1.1.32` was published on May 6, 2026, so this is not a recommendation to ship another public release immediately
- there is meaningful user-facing work on `main` after `v1.1.32`, including the row-level `You` speaker fix, clearer update-ready copy, and CLI/MCP capture-path correctness
- repo verification is green after rebuilding deps: `bash build-deps.sh --force`, `bash build.sh`, `bash run-tests.sh`, `bash run-integration-smoke.sh`, and `swift test` all passed on May 7, 2026

## Important
- this PR does **not** publish a GitHub release
- Sparkle users will only see an update after a real release artifact exists and `docs/appcast.xml` is updated and pushed to `main`
- Homebrew users will only see it after the cask is updated in the real release flow