### PR TITLE
[nightly-docs] Align docs drift sweep notes

### DIFF
--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -7,28 +7,30 @@ historical, and which local doc to read before editing a subsystem.
 ## Read Order
 
 1. `AGENT_START.md`
-2. `AGENTS.md` or root `CLAUDE.md`
-3. `docs/repo-layout.md`
-4. `docs/agent-onboarding.md`
-5. `Sources/CLAUDE.md`
-6. the nearest local `CLAUDE.md`
-7. `Sources/Accessibility/CLAUDE.md` when touching focused-editor AX metadata, overlay placement, or paste-back context
-8. `Sources/Beta/CLAUDE.md` when touching beta-build configuration
-9. `Sources/Dictation/CLAUDE.md` when touching dictation persistence
-10. `Sources/Meeting/CLAUDE.md` when touching meeting capture, imported-audio transcription, or meeting UI
-11. `Sources/TranscriptedCore/CLAUDE.md` when touching the reusable meeting library or public core seam
-12. `Sources/Speech/CLAUDE.md` when touching STT, audio recovery, or device handling
-13. `Sources/Support/CLAUDE.md` when touching shared preferences, paths, permissions, or install flows
-14. `Sources/UI/CLAUDE.md` when touching overlay, menubar, onboarding, settings, or agent-connect UI
-15. `Sources/Capture/CLAUDE.md` when touching hotkeys or physical dictation trigger routing
-16. `Tests/README.md` when touching verification or package seams
-17. `docs/storage-paths.md` when touching persisted output or path resolution
-18. `docs/release-packaging.md` and `docs/sparkle-updates.md` when touching packaging, notarization, releases, or in-app updates
-19. `Sources/Observability/CLAUDE.md` when touching crash reporting, analytics, or Sparkle plumbing
+2. `README.md`
+3. `AGENTS.md`
+4. `docs/repo-layout.md`
+5. `docs/agent-onboarding.md`
+6. `CLAUDE.md`
+7. `Sources/CLAUDE.md`
+8. the nearest local `CLAUDE.md`
+9. `Sources/Accessibility/CLAUDE.md` when touching focused-editor AX metadata, overlay placement, or paste-back context
+10. `Sources/Beta/CLAUDE.md` when touching beta-build configuration
+11. `Sources/Dictation/CLAUDE.md` when touching dictation persistence
+12. `Sources/Meeting/CLAUDE.md` when touching meeting capture, imported-audio transcription, or meeting UI
+13. `Sources/TranscriptedCore/CLAUDE.md` when touching the reusable meeting library or public core seam
+14. `Sources/Speech/CLAUDE.md` when touching STT, audio recovery, or device handling
+15. `Sources/Support/CLAUDE.md` when touching shared preferences, paths, permissions, or install flows
+16. `Sources/UI/CLAUDE.md` when touching overlay, menubar, onboarding, settings, or agent-connect UI
+17. `Sources/Capture/CLAUDE.md` when touching hotkeys or physical dictation trigger routing
+18. `Tests/README.md` when touching verification or package seams
+19. `docs/storage-paths.md` when touching persisted output or path resolution
 20. `Sources/Reliability/CLAUDE.md` when touching wake / sleep recovery or hotkey recovery
-21. `Tools/*/CLAUDE.md` when touching standalone CLI, MCP, or QA tools
-22. `scripts/README.md` when touching the shell entrypoints or release helpers
-23. source comments
+21. `Sources/Observability/CLAUDE.md` when touching crash reporting, analytics, or Sparkle plumbing
+22. `docs/release-packaging.md` and `docs/sparkle-updates.md` when touching packaging, notarization, releases, or in-app updates
+23. `Tools/*/CLAUDE.md` when touching standalone CLI, MCP, or QA tools
+24. `scripts/README.md` when touching the shell entrypoints or release helpers
+25. source comments
 
 For the active directory map and command surface, prefer `docs/repo-layout.md`.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,7 @@ stable and the docs can keep pointing at the same commands:
 - `build-beta.sh` — signed beta/distribution build
 - `run-tests.sh` — curated fast test runner
 - `run-integration-smoke.sh` — app/core smoke verification
+- `run-daily-audio-reliability.sh` — interactive or synthetic daily audio reliability check
 
 ## Entrypoint implementations
 


### PR DESCRIPTION
## Summary
- align docs/agent-onboarding.md read order with AGENTS.md
- add the active run-daily-audio-reliability.sh root wrapper to scripts/README.md

## Verification
- scripts/dev/agent-preflight.sh
- swift test --package-path Tools/TranscriptedQA