### PR TITLE
[nightly-ux] Clarify physical key no-speech copy

### DIFF
--- a/Sources/UI/Overlay/DictationNoSpeechPresentationPolicy.swift
+++ b/Sources/UI/Overlay/DictationNoSpeechPresentationPolicy.swift
@@ -3,7 +3,7 @@ import Foundation
 enum DictationNoSpeechPresentationPolicy {
     static func message(trigger: String) -> String {
         if trigger == "physical_key" {
-            return "No speech caught. Hold the key while you talk."
+            return "Transcripted didn't catch your voice. Hold the dictation key while you talk."
         }
         return "No speech heard. Try speaking a little longer."
     }

--- a/Tests/DictationNoSpeechPresentationPolicyTests.swift
+++ b/Tests/DictationNoSpeechPresentationPolicyTests.swift
@@ -6,7 +6,7 @@ func testDictationNoSpeechPresentationPolicy() {
 
         assertEqual(
             message,
-            "No speech caught. Hold the key while you talk.",
+            "Transcripted didn't catch your voice. Hold the dictation key while you talk.",
             "physical key no-speech copy should explain the press-and-talk behavior"
         )
     }


### PR DESCRIPTION
## Summary
- Clarifies the physical-key no-speech overlay recovery message.
- Keeps the focused presentation-policy test aligned with the new copy.

## Evidence
- PostHog last 7 days: `dictation_no_speech` had 113 events across 13 devices, almost all from `physical_key` with `lt_10s` duration.
- Sentry latest release check: no unresolved production issues found for `release:transcripted@1.1.33` via `sentry-cli` after MCP transport closed.

## Verification
- `bash run-tests.sh` — 1491 passed
- `bash build-deps.sh --force`
- `bash build.sh` — build, signing, and launch smoke completed