### PR TITLE
[nightly-compat] Remove unused beta proxy URL

### DIFF
--- a/Sources/Beta/BetaConfig.swift
+++ b/Sources/Beta/BetaConfig.swift
@@ -17,8 +17,6 @@ enum BetaConfig {
         return token
     }()
 
-    /// Proxy base URL for beta-only proxy traffic.
-    static let proxyBaseURL = "https://draft-proxy.tz427gsydr.workers.dev"
 }
 
 #endif

--- a/Sources/Beta/CLAUDE.md
+++ b/Sources/Beta/CLAUDE.md
@@ -2,11 +2,11 @@
 
 ## Current status
 
-`Sources/Beta/` currently contains only beta-build configuration.
+`Sources/Beta/` currently contains only beta-build token configuration.
 
 ## Important file
 
-- `BetaConfig.swift` — `#if BETA_BUILD` constants for proxy token and proxy base URL
+- `BetaConfig.swift` — `#if BETA_BUILD` token placeholder replaced by `build-beta.sh`
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Removed the unused beta proxy base URL pointing at the old Draft worker
- Updated the Beta subsystem note to describe the remaining token-only config

## Verification
- scripts/dev/agent-preflight.sh
- bash run-tests.sh (1491 passed)
- bash build-deps.sh --force
- bash build.sh
