### PR TITLE
[nightly-retrieval] Quiet transcripted-mcp self-test logs

### DIFF
--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
@@ -78,8 +78,10 @@ struct TranscriptedMCP {
             }
         }
 
-        let index = try TranscriptIndex(indexDir: directories.indexDir)
-        try index.reconcile(meetingDirs: directories.meetingDirs, dictationDirs: directories.dictationDirs)
+        try withLogsSuppressed {
+            let index = try TranscriptIndex(indexDir: directories.indexDir)
+            try index.reconcile(meetingDirs: directories.meetingDirs, dictationDirs: directories.dictationDirs)
+        }
 
         let result = TranscriptedMCPSelfTestResult(
             ok: true,

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+private let logSuppressionLock = NSLock()
+private var logSuppressionDepth = 0
+
 enum ContextArtifactKind {
     case meeting
     case dictationDay
@@ -546,5 +549,24 @@ enum TranscriptLoader {
 
 /// Log to stderr (stdout is reserved for MCP JSON-RPC).
 func log(_ message: String) {
+    logSuppressionLock.lock()
+    let isSuppressed = logSuppressionDepth > 0
+    logSuppressionLock.unlock()
+
+    guard !isSuppressed else { return }
     fputs("[transcripted-mcp] \(message)\n", stderr)
+}
+
+func withLogsSuppressed<T>(_ body: () throws -> T) rethrows -> T {
+    logSuppressionLock.lock()
+    logSuppressionDepth += 1
+    logSuppressionLock.unlock()
+
+    defer {
+        logSuppressionLock.lock()
+        logSuppressionDepth = max(0, logSuppressionDepth - 1)
+        logSuppressionLock.unlock()
+    }
+
+    return try body()
 }

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/LoggingTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/LoggingTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import XCTest
+@testable import transcripted_mcp
+
+final class LoggingTests: XCTestCase {
+    func testLogWritesToStderrByDefault() {
+        let output = captureStandardError {
+            log("default logging still works")
+        }
+
+        XCTAssertTrue(output.contains("default logging still works"))
+    }
+
+    func testWithLogsSuppressedSkipsStderrOutput() {
+        let output = captureStandardError {
+            withLogsSuppressed {
+                log("self-test should stay quiet")
+            }
+        }
+
+        XCTAssertEqual(output.trimmingCharacters(in: .whitespacesAndNewlines), "")
+    }
+
+    private func captureStandardError(_ body: () -> Void) -> String {
+        let pipe = Pipe()
+        let original = dup(STDERR_FILENO)
+        XCTAssertNotEqual(original, -1)
+
+        fflush(stderr)
+        dup2(pipe.fileHandleForWriting.fileDescriptor, STDERR_FILENO)
+
+        body()
+
+        fflush(stderr)
+        dup2(original, STDERR_FILENO)
+        close(original)
+        pipe.fileHandleForWriting.closeFile()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(decoding: data, as: UTF8.self)
+    }
+}


### PR DESCRIPTION
## Summary
- suppress transcripted-mcp stderr logging during `--self-test` so stdout stays machine-readable JSON
- keep normal MCP runtime logging unchanged
- add MCP logging tests for default stderr output and suppression

## Verification
- `cd Tools/TranscriptedCLI && swift build`
- `cd Tools/TranscriptedMCP && swift build`
- `cd Tools/TranscriptedMCP && swift test`
- `cd Tools/TranscriptedMCP && ./.build/debug/transcripted-mcp --self-test` with stdout/stderr split check
- `bash run-tests.sh`

## Notes
- `bash build.sh` is still blocked in this worktree because repo dependency artifacts are missing; it asks for `bash build-deps.sh --force`.
- Nightly retrieval probes on local data were otherwise healthy: recent context, latest meeting, speaker search, dictations by day, and explicit data-dir/index overrides all worked.