### PR TITLE
Publish Transcripted 1.1.33 metadata

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.32"
-  sha256 "d69c0a734375620a4a2d71d80e414be4ed5190a905a34ce58c52687765c861a4"
+  version "1.1.33"
+  sha256 "9b83563a39fd92e222819be26ea01af8319d2043d3da3e82e31e57113d00f9f6"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.33</title>
+      <pubDate>Fri, 08 May 2026 16:27:38 -0500</pubDate>
+      <sparkle:version>1.1.33</sparkle:version>
+      <sparkle:shortVersionString>1.1.33</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.33/Transcripted-1.1.33.dmg" length="524144094" type="application/octet-stream" sparkle:edSignature="4buRVfhMeUPh08NynKnIDo3sZPt8uGP2AkNeuINgAqG2tIlwajjMyN10diozb4c21xqxGceRDFBa/8BgpawKDA==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.33</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.33</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.32</title>
       <pubDate>Wed, 06 May 2026 09:02:15 -0500</pubDate>
       <sparkle:version>1.1.32</sparkle:version>


### PR DESCRIPTION
## Summary
- add Transcripted 1.1.33 to the Sparkle appcast
- update the Homebrew cask to 1.1.33 with the published DMG checksum

## Verification
- gh release create v1.1.33 build/Transcripted-1.1.33.dmg
- bash scripts/release/generate-sparkle-appcast.sh build/sparkle-updates-1.1.33
- bash scripts/release/update-cask.sh 1.1.33
- bash scripts/release/verify-sparkle-release.sh 1.1.33