### PR TITLE
[nightly-simplify] Simplify runtime diagnostics context

### DIFF
--- a/Sources/Observability/RuntimeDiagnosticsStore.swift
+++ b/Sources/Observability/RuntimeDiagnosticsStore.swift
@@ -101,22 +101,21 @@ enum RuntimeDiagnosticsStore {
         previous marker: RuntimeDiagnosticsMarker,
         now: Date = Date()
     ) -> [String: String] {
-        [
-            "app_version": marker.appVersion,
-            "build_version": marker.buildVersion,
-            "heartbeat_age_bucket": heartbeatAgeBucket(previousUpdate: marker.updatedAt, now: now),
-            "last_event": marker.lastEvent,
-            "os_major": "\(marker.osMajor)",
-            "session_active": "\(marker.sessionActive)",
-            "session_duration_bucket": sessionDurationBucket(startedAt: marker.startedAt, now: now),
-            "session_kind": marker.sessionKind,
-            "session_stage": marker.sessionStage,
-        ]
+        runtimeContext(for: marker, now: now)
     }
 
     static func contextForCurrentSession(
         marker: RuntimeDiagnosticsMarker,
         now: Date = Date()
+    ) -> [String: String] {
+        var context = runtimeContext(for: marker, now: now)
+        context["previous_clean_shutdown"] = "\(marker.cleanShutdown)"
+        return context
+    }
+
+    private static func runtimeContext(
+        for marker: RuntimeDiagnosticsMarker,
+        now: Date
     ) -> [String: String] {
         [
             "app_version": marker.appVersion,
@@ -124,7 +123,6 @@ enum RuntimeDiagnosticsStore {
             "heartbeat_age_bucket": heartbeatAgeBucket(previousUpdate: marker.updatedAt, now: now),
             "last_event": marker.lastEvent,
             "os_major": "\(marker.osMajor)",
-            "previous_clean_shutdown": "\(marker.cleanShutdown)",
             "session_active": "\(marker.sessionActive)",
             "session_duration_bucket": sessionDurationBucket(startedAt: marker.startedAt, now: now),
             "session_kind": marker.sessionKind,


### PR DESCRIPTION
## Summary
- share the common runtime diagnostics context dictionary between unclean-shutdown and current-session reporting
- keep the current-session-only previous_clean_shutdown key layered on top

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh