### PR TITLE
[reliability] Fix dictation ready-start retry race

### DIFF
--- a/Sources/Capture/ContextCaptureEngine.swift
+++ b/Sources/Capture/ContextCaptureEngine.swift
@@ -58,6 +58,7 @@ private func overlayStateName(_ state: FloatingOverlayController.OverlayState?) 
     guard let state else { return "unknown" }
     switch state {
     case .idle: return "idle"
+    case .starting: return "starting"
     case .loading: return "loading"
     case .listening: return "listening"
     case .drafting: return "drafting"

--- a/Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift
+++ b/Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift
@@ -13,3 +13,28 @@ struct DictationRecordingStartOverlayPolicy {
         return .showLoadingWhileWaiting
     }
 }
+
+struct DictationRecordingStartLifecyclePolicy {
+    enum StopDecision: Equatable {
+        case cancelPendingStart
+        case stopRecording
+        case ignoreInactive
+    }
+
+    static func stopDecision(
+        isLoadingOverlay: Bool,
+        isListeningOverlay: Bool,
+        hasRecordingStartTask: Bool,
+        sttIsRecording: Bool
+    ) -> StopDecision {
+        if !sttIsRecording, (isLoadingOverlay || hasRecordingStartTask) {
+            return .cancelPendingStart
+        }
+
+        if isListeningOverlay || sttIsRecording {
+            return .stopRecording
+        }
+
+        return .ignoreInactive
+    }
+}

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -282,6 +282,7 @@ class DictationSessionController: ObservableObject {
                     await self.waitForEngineAndStart(sourceApp: sourceApp)
                 }
             }
+            return
         case .showLoadingWhileWaiting:
             // Slow path — engine is settling after a device change. Wait for it.
             overlayController.showLoadingState(

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -254,6 +254,10 @@ class DictationSessionController: ObservableObject {
         case .skipLoadingAndStartRecording:
             // Fast path — engine is ready right now. The actual CoreAudio start
             // still runs asynchronously so a slow device graph never blocks UI.
+            overlayController.state = .starting
+            if !overlayController.isVisible {
+                overlayController.showPanel(near: sourceApp, anchorRect: sessionAnchorRect)
+            }
             recordingStartRetryTask?.cancel()
             recordingStartRetryTask = Task { @MainActor [weak self] in
                 guard let self,
@@ -659,13 +663,19 @@ class DictationSessionController: ObservableObject {
             )
             return
         }
-        if overlayController.state == .loading && !appState.sttRouter.isRecording {
+        let stopDecision = DictationRecordingStartLifecyclePolicy.stopDecision(
+            isLoadingOverlay: overlayController.state == .loading,
+            isListeningOverlay: overlayController.state == .listening,
+            hasRecordingStartTask: recordingStartRetryTask != nil,
+            sttIsRecording: appState.sttRouter.isRecording
+        )
+
+        if stopDecision == .cancelPendingStart {
             cancelDictation()
             return
         }
 
-        let canStopRecording = overlayController.state == .listening || appState.sttRouter.isRecording
-        guard canStopRecording else {
+        guard stopDecision == .stopRecording else {
             DiagnosticsTrail.record(
                 logger: appState.logger,
                 level: .warning,
@@ -1110,6 +1120,7 @@ class DictationSessionController: ObservableObject {
     private func overlayStateName(_ state: FloatingOverlayController.OverlayState) -> String {
         switch state {
         case .idle: return "idle"
+        case .starting: return "starting"
         case .loading: return "loading"
         case .listening: return "listening"
         case .drafting: return "drafting"
@@ -1123,12 +1134,15 @@ class DictationSessionController: ObservableObject {
         streamingTask?.cancel()
         streamingTask = nil
         textPaster.cancelPendingClipboardRestore()
+        let recordingStartWasInFlight = recordingStartRetryTask != nil
         recordingStartRetryTask?.cancel()
         recordingStartRetryTask = nil
         sessionTimeoutTask?.cancel()
         sessionTimeoutTask = nil
 
-        guard cancelRecording, let appState, appState.sttRouter.isRecording else { return }
+        guard cancelRecording,
+              let appState,
+              appState.sttRouter.isRecording || recordingStartWasInFlight else { return }
         appState.sttRouter.cancel()
     }
 

--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -27,6 +27,7 @@ class FloatingOverlayController {
 
     enum OverlayState {
         case idle
+        case starting     // Microphone start requested — cancellable before recording flips on
         case loading      // Voice model still loading — waiting for readiness
         case listening    // Recording dictation
         case drafting     // Processing dictation
@@ -547,7 +548,7 @@ class FloatingOverlayController {
             guard event.keyCode == 53 else { return }
             Task { @MainActor [weak self] in
                 guard let self = self else { return }
-                guard self.state == .loading || self.state == .listening || self.state == .drafting else { return }
+                guard self.state == .starting || self.state == .loading || self.state == .listening || self.state == .drafting else { return }
                 self.onEscapeDuringSession?()
             }
         }
@@ -590,7 +591,7 @@ class FloatingOverlayController {
             return NSSize(width: OverlayTokens.panelWidth, height: OverlayTokens.panelLoadingHeight)
         case .drafting where !errorMessage.isEmpty:
             return errorPanelSize()
-        case .idle, .listening, .drafting, .success:
+        case .idle, .starting, .listening, .drafting, .success:
             return NSSize(width: OverlayTokens.panelCompactWidth, height: OverlayTokens.panelCompactHeight)
         }
     }

--- a/Sources/UI/Overlay/OverlayHeaderView.swift
+++ b/Sources/UI/Overlay/OverlayHeaderView.swift
@@ -243,6 +243,9 @@ final class OverlayHeaderView: NSView {
     ) {
         // Mode label text + color
         switch state {
+        case .starting:
+            modeLabel.stringValue = "Starting"
+            modeLabel.textColor = OverlayTokens.textSecondary
         case .listening:
             modeLabel.stringValue = "Listening"
             modeLabel.textColor = OverlayTokens.textPrimary
@@ -261,7 +264,7 @@ final class OverlayHeaderView: NSView {
         }
 
         // Spinner visibility
-        let showSpinner = (state == .drafting && !isError) || state == .loading
+        let showSpinner = state == .starting || (state == .drafting && !isError) || state == .loading
         spinner.isHidden = !showSpinner
         if showSpinner { spinner.startAnimation(nil) } else { spinner.stopAnimation(nil) }
 
@@ -279,7 +282,7 @@ final class OverlayHeaderView: NSView {
         case .success:
             shortcutHint.stringValue = ""
             shortcutHint.textColor = OverlayTokens.textMuted
-        case .loading:
+        case .starting, .loading:
             shortcutHint.stringValue = "Cancel: \(dictationShortcutHint)"
             shortcutHint.textColor = OverlayTokens.textSecondary
         case .drafting:

--- a/Tests/DictationRecordingStartOverlayPolicyTests.swift
+++ b/Tests/DictationRecordingStartOverlayPolicyTests.swift
@@ -39,4 +39,49 @@ func testDictationRecordingStartOverlayPolicy() {
             "an unready input format should still wait instead of pretending the mic is live"
         )
     }
+
+    runSuite("DictationRecordingStartLifecyclePolicy cancels a fast start that is still in flight") {
+        let decision = DictationRecordingStartLifecyclePolicy.stopDecision(
+            isLoadingOverlay: false,
+            isListeningOverlay: false,
+            hasRecordingStartTask: true,
+            sttIsRecording: false
+        )
+
+        assertEqual(
+            decision,
+            .cancelPendingStart,
+            "a quick push-to-talk release before CoreAudio flips recording on should cancel the pending start"
+        )
+    }
+
+    runSuite("DictationRecordingStartLifecyclePolicy stops once recording is active") {
+        let decision = DictationRecordingStartLifecyclePolicy.stopDecision(
+            isLoadingOverlay: false,
+            isListeningOverlay: false,
+            hasRecordingStartTask: true,
+            sttIsRecording: true
+        )
+
+        assertEqual(
+            decision,
+            .stopRecording,
+            "once CoreAudio is recording the same stop request should transcribe instead of cancelling"
+        )
+    }
+
+    runSuite("DictationRecordingStartLifecyclePolicy ignores inactive compact overlay stops") {
+        let decision = DictationRecordingStartLifecyclePolicy.stopDecision(
+            isLoadingOverlay: false,
+            isListeningOverlay: false,
+            hasRecordingStartTask: false,
+            sttIsRecording: false
+        )
+
+        assertEqual(
+            decision,
+            .ignoreInactive,
+            "idle compact overlay stops should stay ignored"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes a ready-microphone control-flow race where the fast start path immediately fell through into the wait/retry loop.
- This avoids duplicate start attempts and `audio_start_deferred` retry noise when the input format is already ready.

## Evidence
- Latest-release Sentry signal showed `dictation.microphone_start_timeout` and `app.session_stall_detected` on `transcripted@1.1.33`.
- Local `events.jsonl` showed normal dictations producing repeated `audio_start_deferred`, `dictation_recording_retry`, and `dictation_started_after_wait`, matching the fallthrough path.

## Verification
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 1502 passed.
- `bash build-deps.sh --force` — passed.
- `bash build.sh` — passed and launch smoke completed.

## Safety
- No release was published.
- No telemetry policy widened.
- No user data or production settings changed.