### PR TITLE
[nightly-security] Harden support diagnostics context

### DIFF
--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -84,6 +84,20 @@ enum AnalyticsPayloadSanitizer {
         return sanitized
     }
 
+    static func sanitizeDiagnosticContextForDisplay(_ context: [String: String]) -> [String: String] {
+        var sanitized: [String: String] = [:]
+
+        for (key, value) in context {
+            guard !shouldDrop(key: key) else { continue }
+
+            let cleaned = sanitizeText(value)
+            guard !cleaned.isEmpty else { continue }
+            sanitized[key] = cleaned
+        }
+
+        return sanitized
+    }
+
     static func sanitizeText(_ text: String) -> String {
         let redacted = redact(text)
         guard !redacted.isEmpty else { return "" }

--- a/Sources/Observability/DiagnosticsTrail.swift
+++ b/Sources/Observability/DiagnosticsTrail.swift
@@ -13,7 +13,7 @@ enum DiagnosticsTrail {
         let trimmedContext = context.filter { !$0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
 
         if let logger {
-            let detail = trimmedContext
+            let detail = AnalyticsPayloadSanitizer.sanitizeDiagnosticContextForDisplay(trimmedContext)
                 .sorted(by: { $0.key < $1.key })
                 .map { "\($0.key)=\($0.value)" }
                 .joined(separator: " ")

--- a/Tests/AnalyticsPayloadSanitizerTests.swift
+++ b/Tests/AnalyticsPayloadSanitizerTests.swift
@@ -67,6 +67,26 @@ func testAnalyticsPayloadSanitizer() {
         assertEqual(sanitized["duration_bucket"], "10_29s", "unrelated coarse properties should remain")
     }
 
+    runSuite("AnalyticsPayloadSanitizer scrubs support-facing diagnostic context") {
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeDiagnosticContextForDisplay([
+            "audio_device": "Private AirPods",
+            "duration_bucket": "10_29s",
+            "error": "Failed on /Users/redbars/private.md for person@example.com",
+            "input_device_class": "bluetooth",
+            "title": "Private customer call",
+            "trigger": "hotkey",
+            "url": "https://example.com/private",
+        ])
+
+        assertEqual(sanitized["duration_bucket"], "10_29s", "coarse duration buckets should remain")
+        assertEqual(sanitized["input_device_class"], "bluetooth", "coarse device class should remain")
+        assertEqual(sanitized["trigger"], "hotkey", "stable trigger enums should remain")
+        assertNil(sanitized["audio_device"], "raw device names should not enter support-facing diagnostics")
+        assertNil(sanitized["error"], "free-form errors should not enter support-facing diagnostics")
+        assertNil(sanitized["title"], "meeting titles should not enter support-facing diagnostics")
+        assertNil(sanitized["url"], "raw URLs should not enter support-facing diagnostics")
+    }
+
     runSuite("AnalyticsPayloadSanitizer redacts raw URLs and common secret values") {
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
             [


### PR DESCRIPTION
## Summary
- Drops sensitive context keys before DiagnosticsTrail writes support-facing app log details.
- Reuses the analytics scrubber so copied/emailed diagnostics keep coarse facts while excluding raw device names, free-form errors, titles, and URLs.
- Adds sanitizer coverage for support-facing diagnostic context.

## Verification
- python3 scripts/ops/nightly-security-check.py --write-report build/nightly-security-report.json
- bash build-deps.sh
- bash build.sh
- python3 scripts/ops/nightly-security-check.py --app-bundle build/Transcripted.app --write-report build/nightly-security-report.json
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh
- bash scripts/release/verify-sparkle-release.sh 1.1.33