### PR TITLE
[nightly-regression] Lock runtime diagnostics context keys

### DIFF
--- a/Tests/RuntimeDiagnosticsStoreTests.swift
+++ b/Tests/RuntimeDiagnosticsStoreTests.swift
@@ -29,6 +29,25 @@ func testRuntimeDiagnosticsStore() {
         assertEqual(context["session_duration_bucket"], "1_4m", "context should bucket previous session duration")
         assertEqual(context["session_kind"], "dictation", "context should keep coarse session kind")
         assertEqual(context["session_stage"], "recording", "context should keep coarse session stage")
+        assertEqual(
+            Set(context.keys),
+            [
+                "app_version",
+                "build_version",
+                "heartbeat_age_bucket",
+                "last_event",
+                "os_major",
+                "session_active",
+                "session_duration_bucket",
+                "session_kind",
+                "session_stage",
+            ],
+            "unclean shutdown context should stay limited to previous-session runtime keys"
+        )
+        assertNil(context["previous_clean_shutdown"], "unclean shutdown context should not include current-session-only clean state")
+        assertNil(context["launch_id"], "launch IDs should not leak into unclean shutdown context")
+        assertNil(context["started_at"], "raw start timestamps should not leak into unclean shutdown context")
+        assertNil(context["updated_at"], "raw heartbeat timestamps should not leak into unclean shutdown context")
     }
 
     runSuite("RuntimeDiagnosticsStore builds current Sentry runtime context") {


### PR DESCRIPTION
## Summary
- add exact key-shape coverage for unclean-shutdown runtime diagnostics context
- assert previous_clean_shutdown stays current-session-only and raw marker fields stay out of analytics context

## Nightly review findings
1. Recent runtime diagnostics refactor was intentional, but unclean-shutdown context lacked an exact regression guard after sharing the common context builder.
2. PostHog still shows unclean shutdown detections in the last week, so this signal should stay stable and privacy-safe.
3. Open issue #500 remains the main product watch item, but recent meeting transcript failures are low after 1.1.33 and did not justify a same-night behavior patch.

## Live evidence
- Recent merged PRs reviewed: #697, #696, #695, #694, plus current origin/main.
- Open GitHub issue reviewed: #500.
- Latest release checked: v1.1.33, published 2026-05-08, release asset live.
- PostHog 7-day spot check: 1.1.33 launch traffic is current; meeting transcript failures were 0 on 2026-05-09 and 2026-05-10 UTC at check time.
- Sentry MCP and local env-token paths were unavailable in this run, so Sentry was not used as evidence.

## Verification
- bash run-tests.sh
- bash build-deps.sh --force
- bash build.sh

Note: the first build.sh attempt correctly failed before dependency rebuild because local deps were missing/stale.