### PR TITLE
[nightly-agent] Clarify local agent direct tools prompt

### DIFF
--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -125,7 +125,18 @@ enum AgentConnectionGuide {
         var prompt = """
         I use Transcripted on this Mac.
 
-        Read my saved Transcripted Markdown files directly:
+        Use Transcripted direct tools first if they are connected:
+        - recent_context
+        - search_context
+        - list_meetings
+        - read_meeting
+        - list_dictations
+        - read_dictation
+        - search
+        - who_is
+        - recap
+
+        If direct tools are not connected, read my saved Transcripted Markdown files directly:
 
         Meetings:
         - \(meetingsFolder.path)
@@ -136,11 +147,12 @@ enum AgentConnectionGuide {
         Use these files as the source of truth.
 
         Rules:
-        - Search meetings and dictations together when useful.
+        - Prefer Transcripted direct tools when available; otherwise search meetings and dictations together from files.
         - Cite filenames, dates, speakers, and timestamps when useful.
         - For relative dates like today or yesterday, state the exact dates searched.
-        - If you cannot read a folder, tell me which folder failed.
-        - Do not suggest Claude Desktop or MCP unless I ask.
+        - If a direct tool fails, fall back to the folders.
+        - If you cannot use direct tools or read a folder, say exactly what failed.
+        - Do not suggest installing Claude Desktop or MCP unless I ask.
         """
 
         if let filename {

--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -117,24 +117,31 @@ enum AgentConnectionGuide {
         agentSkillsFolder.appendingPathComponent("manifest.json", isDirectory: false)
     }
 
+    static let directToolNames = [
+        "recent_context",
+        "search_context",
+        "list_meetings",
+        "read_meeting",
+        "list_dictations",
+        "read_dictation",
+        "search",
+        "who_is",
+        "recap",
+    ]
+
     static func skillFileURL(for skill: AgentConnectionStarterSkill) -> URL {
         agentSkillsFolder.appendingPathComponent(skill.relativeSkillPath, isDirectory: false)
     }
 
     static func starterPrompt(filename: String?) -> String {
+        let directToolsList = directToolNames
+            .map { "- \($0)" }
+            .joined(separator: "\n")
         var prompt = """
         I use Transcripted on this Mac.
 
         Use Transcripted direct tools first if they are connected:
-        - recent_context
-        - search_context
-        - list_meetings
-        - read_meeting
-        - list_dictations
-        - read_dictation
-        - search
-        - who_is
-        - recap
+        \(directToolsList)
 
         If direct tools are not connected, read my saved Transcripted Markdown files directly:
 

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -23,12 +23,16 @@ func testAgentConnectionGuide() {
         let prompt = AgentConnectionGuide.starterPrompt(filename: "Planning Sync")
 
         assertTrue(
-            prompt.contains("Read my saved Transcripted Markdown files directly:"),
-            "prompt should tell local agents to read Transcripted files directly"
+            prompt.contains("Use Transcripted direct tools first if they are connected:"),
+            "prompt should tell local agents to use direct tools when available"
         )
         assertTrue(
-            prompt.contains("Use these files as the source of truth."),
-            "prompt should ground answers in saved Markdown files"
+            prompt.contains("recent_context") && prompt.contains("search_context") && prompt.contains("read_meeting"),
+            "prompt should name the main Transcripted direct tools"
+        )
+        assertTrue(
+            prompt.contains("If direct tools are not connected, read my saved Transcripted Markdown files directly:"),
+            "prompt should keep saved Markdown as the fallback path"
         )
         assertTrue(
             !prompt.contains("Install for Claude Desktop"),
@@ -39,20 +43,24 @@ func testAgentConnectionGuide() {
             "local agent prompt should not include web/Cowork routing"
         )
         assertTrue(
-            prompt.contains("Search meetings and dictations together when useful."),
-            "prompt should support combined meeting and dictation searches"
+            prompt.contains("Prefer Transcripted direct tools when available; otherwise search meetings and dictations together from files."),
+            "prompt should support direct-tool retrieval and folder fallback"
         )
         assertTrue(
             prompt.contains("For relative dates like today or yesterday, state the exact dates searched."),
             "prompt should force exact dates for relative-date work"
         )
         assertTrue(
-            prompt.contains("If you cannot read a folder, tell me which folder failed."),
-            "prompt should name the folder failure when blocked"
+            prompt.contains("If a direct tool fails, fall back to the folders."),
+            "prompt should recover from direct-tool failures"
         )
         assertTrue(
-            prompt.contains("Do not suggest Claude Desktop or MCP unless I ask."),
-            "prompt should keep local-agent flow separate from Claude Desktop setup"
+            prompt.contains("If you cannot use direct tools or read a folder, say exactly what failed."),
+            "prompt should name the failed access path when blocked"
+        )
+        assertTrue(
+            prompt.contains("Do not suggest installing Claude Desktop or MCP unless I ask."),
+            "prompt should avoid pushing setup work unless the user asks"
         )
         assertTrue(
             prompt.contains("Meetings:\n- \(AgentConnectionGuide.meetingsFolder.path)"),

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -27,8 +27,29 @@ func testAgentConnectionGuide() {
             "prompt should tell local agents to use direct tools when available"
         )
         assertTrue(
-            prompt.contains("recent_context") && prompt.contains("search_context") && prompt.contains("read_meeting"),
-            "prompt should name the main Transcripted direct tools"
+            AgentConnectionGuide.directToolNames.count == 9,
+            "prompt should track the full Transcripted MCP direct tool set"
+        )
+        for toolName in AgentConnectionGuide.directToolNames {
+            assertTrue(
+                prompt.contains("- \(toolName)"),
+                "prompt should name the \(toolName) direct tool"
+            )
+        }
+        assertEqual(
+            Set(AgentConnectionGuide.directToolNames),
+            Set([
+                "recent_context",
+                "search_context",
+                "list_meetings",
+                "read_meeting",
+                "list_dictations",
+                "read_dictation",
+                "search",
+                "who_is",
+                "recap",
+            ]),
+            "direct tool list should mirror Tools/TranscriptedMCP tool registration"
         )
         assertTrue(
             prompt.contains("If direct tools are not connected, read my saved Transcripted Markdown files directly:"),


### PR DESCRIPTION
## Summary

- Updates the copied local-agent prompt to use Transcripted direct tools first when MCP is connected.
- Keeps the saved Markdown folders as the fallback path and tells agents to report exactly what failed.
- Updates the prompt contract test for the new direct-tools-first behavior.

## Verification

- swift test --package-path Tools/TranscriptedCLI
- swift test --package-path Tools/TranscriptedMCP
- cd Tools/TranscriptedMCP && swift build -c release
- Tools/TranscriptedMCP/.build/release/transcripted-mcp --self-test
- CLI context-recent/context-search/list-dictations/read-meeting/read-dictation exercised against local artifacts with redacted metadata-only output
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
