### PR TITLE
[nightly-ux] Scrub copied diagnostics key values

### DIFF
--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -61,11 +61,15 @@ enum AnalyticsPayloadSanitizer {
         options: [.caseInsensitive]
     )
     private static let jsonSensitiveAssignmentRegex = makeRegex(
-        #""(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)"\s*:\s*"[^"]*""#,
+        #""(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)"\s*:\s*"(?:\\.|[^"\\])*""#,
         options: [.caseInsensitive]
     )
     private static let inlineSensitiveAssignmentRegex = makeRegex(
         #"\b(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)\s*=\s*.*?(?=\s+[A-Za-z0-9_.$-]+=|$)"#,
+        options: [.caseInsensitive]
+    )
+    private static let engineDeviceLogRegex = makeRegex(
+        #"\((parakeet|whisper),\s*[^)]*\)"#,
         options: [.caseInsensitive]
     )
     private static let secretAssignmentRegex = makeRegex(
@@ -136,6 +140,8 @@ enum AnalyticsPayloadSanitizer {
         result = jsonSensitiveAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "\"$1\":\"[redacted-sensitive-value]\"")
         range = NSRange(result.startIndex..., in: result)
         result = inlineSensitiveAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-sensitive-value]")
+        range = NSRange(result.startIndex..., in: result)
+        result = engineDeviceLogRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "($1, [redacted-sensitive-value])")
         range = NSRange(result.startIndex..., in: result)
         result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)

--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -25,59 +25,6 @@ enum AnalyticsPayloadSanitizer {
         "url",
     ]
 
-    // Security: compile-time regex patterns are built via this helper instead of try! so that a
-    // future malformed pattern triggers an assertionFailure in debug builds and falls back to a
-    // no-op regex in release builds — keeping the crash-scrubbing path alive rather than crashing it.
-    private static func makeRegex(_ pattern: String, options: NSRegularExpression.Options = []) -> NSRegularExpression {
-        if let regex = try? NSRegularExpression(pattern: pattern, options: options) {
-            return regex
-        }
-        assertionFailure("Sanitizer regex failed to compile — pattern will be skipped: \(pattern)")
-        // "(?!)" is a negative lookahead that never matches, so substitution is a no-op.
-        // swiftlint:disable:next force_try
-        return try! NSRegularExpression(pattern: "(?!)")
-    }
-
-    private static let appSupportPathRegex = makeRegex(#"/Users/[^/\s]+/Library/Application Support/(?:Transcripted|Draft)(?:/[^\s"]*)?"#)
-    private static let userPathRegex = makeRegex(#"/Users/[^/\s]+/"#)
-    private static let absolutePathRegex = makeRegex(
-        #"(?<!https:)(?<!http:)/(?:System/Volumes/Data/)?(?:Users|private|var|tmp|Volumes|Applications|Library|opt)[^\s"]*"#
-    )
-    private static let rawURLRegex = makeRegex(#"https?://[^\s"]+"#, options: [.caseInsensitive])
-    private static let apiKeyRegex = makeRegex(#"sk-[A-Za-z0-9_-]+"#)
-    private static let commonSecretRegex = makeRegex(
-        #"\b(?:ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|phc_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[A-Za-z0-9-]{10,}|xoxx-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9._-]{10,}\.[A-Za-z0-9._-]{10,})\b"#
-    )
-    private static let authSchemeRegex = makeRegex(#"(Bearer|Basic)\s+[A-Za-z0-9._~+\/=-]+"#, options: [.caseInsensitive])
-    private static let authorizationAssignmentRegex = makeRegex(
-        #"(?i)\b((?:proxy-)?authorization)\s*[:=]\s*(?:basic|bearer)\s+[^\s,;]+"#
-    )
-    private static let privateKeyBlockRegex = makeRegex(
-        #"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----"#,
-        options: [.caseInsensitive]
-    )
-    private static let privateKeyMarkerRegex = makeRegex(
-        #"-----((?:BEGIN|END)) [A-Z0-9 ]*PRIVATE KEY-----"#,
-        options: [.caseInsensitive]
-    )
-    private static let jsonSensitiveAssignmentRegex = makeRegex(
-        #""(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)"\s*:\s*"(?:\\.|[^"\\])*""#,
-        options: [.caseInsensitive]
-    )
-    private static let inlineSensitiveAssignmentRegex = makeRegex(
-        #"\b(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)\s*=\s*.*?(?=\s+[A-Za-z0-9_.$-]+=|$)"#,
-        options: [.caseInsensitive]
-    )
-    private static let engineDeviceLogRegex = makeRegex(
-        #"\((parakeet|whisper),\s*[^)]*\)"#,
-        options: [.caseInsensitive]
-    )
-    private static let secretAssignmentRegex = makeRegex(
-        #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature|password|passphrase|secret|client[_-]?secret|credential|dsn)\s*[:=]\s*([^\s,;]+)"#
-    )
-    private static let emailRegex = makeRegex(#"[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}"#, options: [.caseInsensitive])
-    private static let localHostnameRegex = makeRegex(#"\b[a-zA-Z0-9._-]+\.local\b"#)
-
     static func sanitizeProperties(
         _ properties: [String: String],
         allowedKeys: Set<String>
@@ -112,44 +59,7 @@ enum AnalyticsPayloadSanitizer {
     /// blobs must be scrubbed but not truncated. `sanitizeText` calls
     /// this and then applies the `maxValueLength` cap.
     static func redact(_ text: String) -> String {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return "" }
-
-        var result = trimmed
-        var range = NSRange(result.startIndex..., in: result)
-        result = appSupportPathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-path]")
-        range = NSRange(result.startIndex..., in: result)
-        result = userPathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "/Users/****/")
-        range = NSRange(result.startIndex..., in: result)
-        result = absolutePathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-path]")
-        range = NSRange(result.startIndex..., in: result)
-        result = rawURLRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-url]")
-        range = NSRange(result.startIndex..., in: result)
-        result = apiKeyRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "sk-****")
-        range = NSRange(result.startIndex..., in: result)
-        result = commonSecretRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
-        range = NSRange(result.startIndex..., in: result)
-        result = authorizationAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
-        range = NSRange(result.startIndex..., in: result)
-        result = authSchemeRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1 ****")
-        range = NSRange(result.startIndex..., in: result)
-        result = privateKeyBlockRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
-        range = NSRange(result.startIndex..., in: result)
-        result = privateKeyMarkerRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
-        range = NSRange(result.startIndex..., in: result)
-        result = jsonSensitiveAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "\"$1\":\"[redacted-sensitive-value]\"")
-        range = NSRange(result.startIndex..., in: result)
-        result = inlineSensitiveAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-sensitive-value]")
-        range = NSRange(result.startIndex..., in: result)
-        result = engineDeviceLogRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "($1, [redacted-sensitive-value])")
-        range = NSRange(result.startIndex..., in: result)
-        result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
-        range = NSRange(result.startIndex..., in: result)
-        result = emailRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-email]")
-        range = NSRange(result.startIndex..., in: result)
-        result = localHostnameRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-host]")
-
-        return result
+        ObservabilityTextRedactor.redact(text)
     }
 
     private static func shouldDrop(key: String) -> Bool {

--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -60,6 +60,14 @@ enum AnalyticsPayloadSanitizer {
         #"-----((?:BEGIN|END)) [A-Z0-9 ]*PRIVATE KEY-----"#,
         options: [.caseInsensitive]
     )
+    private static let jsonSensitiveAssignmentRegex = makeRegex(
+        #""(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)"\s*:\s*"[^"]*""#,
+        options: [.caseInsensitive]
+    )
+    private static let inlineSensitiveAssignmentRegex = makeRegex(
+        #"\b(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)\s*=\s*.*?(?=\s+[A-Za-z0-9_.$-]+=|$)"#,
+        options: [.caseInsensitive]
+    )
     private static let secretAssignmentRegex = makeRegex(
         #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature|password|passphrase|secret|client[_-]?secret|credential|dsn)\s*[:=]\s*([^\s,;]+)"#
     )
@@ -124,6 +132,10 @@ enum AnalyticsPayloadSanitizer {
         result = privateKeyBlockRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)
         result = privateKeyMarkerRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
+        range = NSRange(result.startIndex..., in: result)
+        result = jsonSensitiveAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "\"$1\":\"[redacted-sensitive-value]\"")
+        range = NSRange(result.startIndex..., in: result)
+        result = inlineSensitiveAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-sensitive-value]")
         range = NSRange(result.startIndex..., in: result)
         result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)

--- a/Sources/Observability/ObservabilityTextRedactor.swift
+++ b/Sources/Observability/ObservabilityTextRedactor.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+enum ObservabilityTextRedactor {
+    // Security: compile-time regex patterns are built via this helper instead of try! so that a
+    // future malformed pattern triggers an assertionFailure in debug builds and falls back to a
+    // no-op regex in release builds, keeping the redaction path alive rather than crashing it.
+    private static func makeRegex(_ pattern: String, options: NSRegularExpression.Options = []) -> NSRegularExpression {
+        if let regex = try? NSRegularExpression(pattern: pattern, options: options) {
+            return regex
+        }
+        assertionFailure("Sanitizer regex failed to compile; pattern will be skipped: \(pattern)")
+        // "(?!)" is a negative lookahead that never matches, so substitution is a no-op.
+        // swiftlint:disable:next force_try
+        return try! NSRegularExpression(pattern: "(?!)")
+    }
+
+    private static let appSupportPathRegex = makeRegex(#"/Users/[^/\s]+/Library/Application Support/(?:Transcripted|Draft)(?:/[^\s"]*)?"#)
+    private static let userPathRegex = makeRegex(#"/Users/[^/\s]+/"#)
+    private static let absolutePathRegex = makeRegex(
+        #"(?<!https:)(?<!http:)/(?:System/Volumes/Data/)?(?:Users|private|var|tmp|Volumes|Applications|Library|opt)[^\s"]*"#
+    )
+    private static let rawURLRegex = makeRegex(#"https?://[^\s"]+"#, options: [.caseInsensitive])
+    private static let apiKeyRegex = makeRegex(#"sk-[A-Za-z0-9_-]+"#)
+    private static let commonSecretRegex = makeRegex(
+        #"\b(?:ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|phc_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[A-Za-z0-9-]{10,}|xoxx-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9._-]{10,}\.[A-Za-z0-9._-]{10,})\b"#
+    )
+    private static let authSchemeRegex = makeRegex(#"(Bearer|Basic)\s+[A-Za-z0-9._~+\/=-]+"#, options: [.caseInsensitive])
+    private static let authorizationAssignmentRegex = makeRegex(
+        #"(?i)\b((?:proxy-)?authorization)\s*[:=]\s*(?:basic|bearer)\s+[^\s,;]+"#
+    )
+    private static let privateKeyBlockRegex = makeRegex(
+        #"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----"#,
+        options: [.caseInsensitive]
+    )
+    private static let privateKeyMarkerRegex = makeRegex(
+        #"-----((?:BEGIN|END)) [A-Z0-9 ]*PRIVATE KEY-----"#,
+        options: [.caseInsensitive]
+    )
+    private static let jsonSensitiveAssignmentRegex = makeRegex(
+        #""(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)"\s*:\s*"(?:\\.|[^"\\])*""#,
+        options: [.caseInsensitive]
+    )
+    private static let inlineSensitiveAssignmentRegex = makeRegex(
+        #"\b(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)\s*=\s*.*?(?=\s+[A-Za-z0-9_.$-]+=|$)"#,
+        options: [.caseInsensitive]
+    )
+    private static let engineDeviceLogRegex = makeRegex(
+        #"\((parakeet|whisper),\s*[^)]*\)"#,
+        options: [.caseInsensitive]
+    )
+    private static let secretAssignmentRegex = makeRegex(
+        #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature|password|passphrase|secret|client[_-]?secret|credential|dsn)\s*[:=]\s*([^\s,;]+)"#
+    )
+    private static let emailRegex = makeRegex(#"[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}"#, options: [.caseInsensitive])
+    private static let localHostnameRegex = makeRegex(#"\b[a-zA-Z0-9._-]+\.local\b"#)
+
+    static func redact(_ text: String) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+
+        var result = trimmed
+        var range = NSRange(result.startIndex..., in: result)
+        result = appSupportPathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-path]")
+        range = NSRange(result.startIndex..., in: result)
+        result = userPathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "/Users/****/")
+        range = NSRange(result.startIndex..., in: result)
+        result = absolutePathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-path]")
+        range = NSRange(result.startIndex..., in: result)
+        result = rawURLRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-url]")
+        range = NSRange(result.startIndex..., in: result)
+        result = apiKeyRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "sk-****")
+        range = NSRange(result.startIndex..., in: result)
+        result = commonSecretRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
+        range = NSRange(result.startIndex..., in: result)
+        result = authorizationAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
+        range = NSRange(result.startIndex..., in: result)
+        result = authSchemeRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1 ****")
+        range = NSRange(result.startIndex..., in: result)
+        result = privateKeyBlockRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
+        range = NSRange(result.startIndex..., in: result)
+        result = privateKeyMarkerRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
+        range = NSRange(result.startIndex..., in: result)
+        result = jsonSensitiveAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "\"$1\":\"[redacted-sensitive-value]\"")
+        range = NSRange(result.startIndex..., in: result)
+        result = inlineSensitiveAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-sensitive-value]")
+        range = NSRange(result.startIndex..., in: result)
+        result = engineDeviceLogRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "($1, [redacted-sensitive-value])")
+        range = NSRange(result.startIndex..., in: result)
+        result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
+        range = NSRange(result.startIndex..., in: result)
+        result = emailRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-email]")
+        range = NSRange(result.startIndex..., in: result)
+        result = localHostnameRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-host]")
+
+        return result
+    }
+}

--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -62,11 +62,15 @@ enum SentryPayloadSanitizer {
         options: [.caseInsensitive]
     )
     private static let jsonSensitiveAssignmentRegex = makeRegex(
-        #""(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)"\s*:\s*"[^"]*""#,
+        #""(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)"\s*:\s*"(?:\\.|[^"\\])*""#,
         options: [.caseInsensitive]
     )
     private static let inlineSensitiveAssignmentRegex = makeRegex(
         #"\b(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)\s*=\s*.*?(?=\s+[A-Za-z0-9_.$-]+=|$)"#,
+        options: [.caseInsensitive]
+    )
+    private static let engineDeviceLogRegex = makeRegex(
+        #"\((parakeet|whisper),\s*[^)]*\)"#,
         options: [.caseInsensitive]
     )
     private static let secretAssignmentRegex = makeRegex(
@@ -155,6 +159,8 @@ enum SentryPayloadSanitizer {
         result = jsonSensitiveAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "\"$1\":\"[redacted-sensitive-value]\"")
         range = NSRange(result.startIndex..., in: result)
         result = inlineSensitiveAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-sensitive-value]")
+        range = NSRange(result.startIndex..., in: result)
+        result = engineDeviceLogRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "($1, [redacted-sensitive-value])")
         range = NSRange(result.startIndex..., in: result)
         result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)

--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -26,59 +26,6 @@ enum SentryPayloadSanitizer {
         "url",
     ]
 
-    // Security: compile-time regex patterns are built via this helper instead of try! so that a
-    // future malformed pattern triggers an assertionFailure in debug builds and falls back to a
-    // no-op regex in release builds — keeping the crash-scrubbing path alive rather than crashing it.
-    private static func makeRegex(_ pattern: String, options: NSRegularExpression.Options = []) -> NSRegularExpression {
-        if let regex = try? NSRegularExpression(pattern: pattern, options: options) {
-            return regex
-        }
-        assertionFailure("Sanitizer regex failed to compile — pattern will be skipped: \(pattern)")
-        // "(?!)" is a negative lookahead that never matches, so substitution is a no-op.
-        // swiftlint:disable:next force_try
-        return try! NSRegularExpression(pattern: "(?!)")
-    }
-
-    private static let appSupportPathRegex = makeRegex(#"/Users/[^/\s]+/Library/Application Support/(?:Transcripted|Draft)(?:/[^\s"]*)?"#)
-    private static let userPathRegex = makeRegex(#"/Users/[^/\s]+/"#)
-    private static let absolutePathRegex = makeRegex(
-        #"(?<!https:)(?<!http:)/(?:System/Volumes/Data/)?(?:Users|private|var|tmp|Volumes|Applications|Library|opt)[^\s"]*"#
-    )
-    private static let rawURLRegex = makeRegex(#"https?://[^\s"]+"#, options: [.caseInsensitive])
-    private static let apiKeyRegex = makeRegex(#"sk-[A-Za-z0-9_-]+"#)
-    private static let commonSecretRegex = makeRegex(
-        #"\b(?:ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|phc_[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|AIza[0-9A-Za-z\-_]{35}|xox[baprs]-[A-Za-z0-9-]{10,}|xoxx-[A-Za-z0-9-]{10,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9._-]{10,}\.[A-Za-z0-9._-]{10,})\b"#
-    )
-    private static let authSchemeRegex = makeRegex(#"(Bearer|Basic)\s+[A-Za-z0-9._~+\/=-]+"#, options: [.caseInsensitive])
-    private static let authorizationAssignmentRegex = makeRegex(
-        #"(?i)\b((?:proxy-)?authorization)\s*[:=]\s*(?:basic|bearer)\s+[^\s,;]+"#
-    )
-    private static let privateKeyBlockRegex = makeRegex(
-        #"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----"#,
-        options: [.caseInsensitive]
-    )
-    private static let privateKeyMarkerRegex = makeRegex(
-        #"-----((?:BEGIN|END)) [A-Z0-9 ]*PRIVATE KEY-----"#,
-        options: [.caseInsensitive]
-    )
-    private static let jsonSensitiveAssignmentRegex = makeRegex(
-        #""(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)"\s*:\s*"(?:\\.|[^"\\])*""#,
-        options: [.caseInsensitive]
-    )
-    private static let inlineSensitiveAssignmentRegex = makeRegex(
-        #"\b(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)\s*=\s*.*?(?=\s+[A-Za-z0-9_.$-]+=|$)"#,
-        options: [.caseInsensitive]
-    )
-    private static let engineDeviceLogRegex = makeRegex(
-        #"\((parakeet|whisper),\s*[^)]*\)"#,
-        options: [.caseInsensitive]
-    )
-    private static let secretAssignmentRegex = makeRegex(
-        #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature|password|passphrase|secret|client[_-]?secret|credential|dsn)\s*[:=]\s*([^\s,;]+)"#
-    )
-    private static let emailRegex = makeRegex(#"[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}"#, options: [.caseInsensitive])
-    private static let localHostnameRegex = makeRegex(#"\b[a-zA-Z0-9._-]+\.local\b"#)
-
     static func sanitizeTags(_ tags: [String: String]) -> [String: String] {
         var sanitized: [String: String] = [:]
 
@@ -131,42 +78,8 @@ enum SentryPayloadSanitizer {
     }
 
     static func sanitizeText(_ text: String) -> String {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return "" }
-
-        var result = trimmed
-        var range = NSRange(result.startIndex..., in: result)
-        result = appSupportPathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-path]")
-        range = NSRange(result.startIndex..., in: result)
-        result = userPathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "/Users/****/")
-        range = NSRange(result.startIndex..., in: result)
-        result = absolutePathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-path]")
-        range = NSRange(result.startIndex..., in: result)
-        result = rawURLRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-url]")
-        range = NSRange(result.startIndex..., in: result)
-        result = apiKeyRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "sk-****")
-        range = NSRange(result.startIndex..., in: result)
-        result = commonSecretRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
-        range = NSRange(result.startIndex..., in: result)
-        result = authorizationAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
-        range = NSRange(result.startIndex..., in: result)
-        result = authSchemeRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1 ****")
-        range = NSRange(result.startIndex..., in: result)
-        result = privateKeyBlockRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
-        range = NSRange(result.startIndex..., in: result)
-        result = privateKeyMarkerRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
-        range = NSRange(result.startIndex..., in: result)
-        result = jsonSensitiveAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "\"$1\":\"[redacted-sensitive-value]\"")
-        range = NSRange(result.startIndex..., in: result)
-        result = inlineSensitiveAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-sensitive-value]")
-        range = NSRange(result.startIndex..., in: result)
-        result = engineDeviceLogRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "($1, [redacted-sensitive-value])")
-        range = NSRange(result.startIndex..., in: result)
-        result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
-        range = NSRange(result.startIndex..., in: result)
-        result = emailRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-email]")
-        range = NSRange(result.startIndex..., in: result)
-        result = localHostnameRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-host]")
+        let result = ObservabilityTextRedactor.redact(text)
+        guard !result.isEmpty else { return "" }
 
         if result.count > maxValueLength {
             return String(result.prefix(maxValueLength)) + "..."

--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -61,6 +61,14 @@ enum SentryPayloadSanitizer {
         #"-----((?:BEGIN|END)) [A-Z0-9 ]*PRIVATE KEY-----"#,
         options: [.caseInsensitive]
     )
+    private static let jsonSensitiveAssignmentRegex = makeRegex(
+        #""(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)"\s*:\s*"[^"]*""#,
+        options: [.caseInsensitive]
+    )
+    private static let inlineSensitiveAssignmentRegex = makeRegex(
+        #"\b(audio_device|bundle_id|device_name|file_path|input_device_name|meeting_name|meeting_title|microphone_name|output_device_name|raw_url|source_app|source_app_bundle_id|source_app_name|speaker_name|transcript_text|transcript_title)\s*=\s*.*?(?=\s+[A-Za-z0-9_.$-]+=|$)"#,
+        options: [.caseInsensitive]
+    )
     private static let secretAssignmentRegex = makeRegex(
         #"(?i)\b((?:access_)?token|refresh_token|api[_-]?key|x-api-key|signature|x-amz-signature|password|passphrase|secret|client[_-]?secret|credential|dsn)\s*[:=]\s*([^\s,;]+)"#
     )
@@ -143,6 +151,10 @@ enum SentryPayloadSanitizer {
         result = privateKeyBlockRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)
         result = privateKeyMarkerRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-secret]")
+        range = NSRange(result.startIndex..., in: result)
+        result = jsonSensitiveAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "\"$1\":\"[redacted-sensitive-value]\"")
+        range = NSRange(result.startIndex..., in: result)
+        result = inlineSensitiveAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-sensitive-value]")
         range = NSRange(result.startIndex..., in: result)
         result = secretAssignmentRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "$1=[redacted-secret]")
         range = NSRange(result.startIndex..., in: result)

--- a/Tests/Fixtures/ObservabilitySanitizerCorpus.json
+++ b/Tests/Fixtures/ObservabilitySanitizerCorpus.json
@@ -82,6 +82,20 @@
       "must_contain": [
         "[redacted-secret]"
       ]
+    },
+    {
+      "id": "diagnostic-key-values",
+      "input": "DIAG source_app_bundle_id=com.openai.codex source_app_name=Codex trigger=physical_key audio_device=MacBook Pro Microphone",
+      "must_not_contain": [
+        "com.openai.codex",
+        "source_app_name=Codex",
+        "MacBook Pro Microphone"
+      ],
+      "must_contain": [
+        "source_app_bundle_id=[redacted-sensitive-value]",
+        "source_app_name=[redacted-sensitive-value]",
+        "audio_device=[redacted-sensitive-value]"
+      ]
     }
   ]
 }

--- a/Tests/Fixtures/ObservabilitySanitizerCorpus.json
+++ b/Tests/Fixtures/ObservabilitySanitizerCorpus.json
@@ -96,6 +96,29 @@
         "source_app_name=[redacted-sensitive-value]",
         "audio_device=[redacted-sensitive-value]"
       ]
+    },
+    {
+      "id": "json-sensitive-values-with-escaped-quotes",
+      "input": "{\"meeting_title\":\"Customer \\\"ACME\\\" Call\",\"source_app_name\":\"Codex\"}",
+      "must_not_contain": [
+        "Customer",
+        "ACME",
+        "Codex"
+      ],
+      "must_contain": [
+        "\"meeting_title\":\"[redacted-sensitive-value]\"",
+        "\"source_app_name\":\"[redacted-sensitive-value]\""
+      ]
+    },
+    {
+      "id": "plain-engine-device-log",
+      "input": "DICTATION | started after 120ms wait (parakeet, MacBook Pro Microphone)",
+      "must_not_contain": [
+        "MacBook Pro Microphone"
+      ],
+      "must_contain": [
+        "(parakeet, [redacted-sensitive-value])"
+      ]
     }
   ]
 }

--- a/Tests/SupportDiagnosticsBundleTests.swift
+++ b/Tests/SupportDiagnosticsBundleTests.swift
@@ -34,6 +34,7 @@ func testSupportDiagnosticsBundle() {
                 "Opened /Users/redbars/Library/Application Support/Transcripted/logs/app.jsonl",
                 "DIAG | capture.dictation_toggle_requested | source_app_bundle_id=com.openai.codex source_app_name=Codex trigger=physical_key",
                 "DIAG | dictation.dictation_started | audio_device=MacBook Pro Microphone route_shape=built_in_input_to_built_in_output",
+                "DICTATION | started after 120ms wait (parakeet, MacBook Pro Microphone)",
                 "Email person@example.com should not leak",
             ]
         )

--- a/Tests/SupportDiagnosticsBundleTests.swift
+++ b/Tests/SupportDiagnosticsBundleTests.swift
@@ -32,6 +32,8 @@ func testSupportDiagnosticsBundle() {
             ],
             recentLogLines: [
                 "Opened /Users/redbars/Library/Application Support/Transcripted/logs/app.jsonl",
+                "DIAG | capture.dictation_toggle_requested | source_app_bundle_id=com.openai.codex source_app_name=Codex trigger=physical_key",
+                "DIAG | dictation.dictation_started | audio_device=MacBook Pro Microphone route_shape=built_in_input_to_built_in_output",
                 "Email person@example.com should not leak",
             ]
         )
@@ -48,6 +50,9 @@ func testSupportDiagnosticsBundle() {
         assertFalse(text.contains("/Users/redbars"), "diagnostics should redact home paths")
         assertFalse(text.contains("person@example.com"), "diagnostics should redact emails")
         assertFalse(text.contains("Application Support/Transcripted"), "diagnostics should redact app support paths")
+        assertFalse(text.contains("com.openai.codex"), "diagnostics should redact source app bundle IDs from recent logs")
+        assertFalse(text.contains("source_app_name=Codex"), "diagnostics should redact source app names from recent logs")
+        assertFalse(text.contains("MacBook Pro Microphone"), "diagnostics should redact raw device names from recent logs")
     }
 
     runSuite("SupportDiagnosticsBundle Sentry context avoids sanitizer-dropped audio keys") {

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -159,6 +159,7 @@ APP_SOURCES=(
     "Sources/Observability/AnalyticsReporter.swift"
     "Sources/Observability/LockedFileAppender.swift"
     "Sources/Observability/AnalyticsEventPolicy.swift"
+    "Sources/Observability/ObservabilityTextRedactor.swift"
     "Sources/Observability/AnalyticsPayloadSanitizer.swift"
     "Sources/Observability/AnalyticsPreferences.swift"
     "Sources/Observability/CrashReportingPreferences.swift"


### PR DESCRIPTION
## Summary
- redact source-app and raw device key-value pairs from copied support diagnostic log text
- keep Analytics and Sentry sanitizer parity through the shared corpus
- add support diagnostics coverage for recent log lines that include source app and microphone names

## Evidence
- Sentry current-release 1.1.33: 2 microphone_start_timeout events and 2 session_stall_detected events in the last 7d
- PostHog current-release 1.1.33: 170 app launches, 104 dictation starts, 99 completions, 21 unclean shutdown events, 9 route recovery timeouts
- Local current logs showed support-copied recent-event candidates with audio_device=MacBook Pro Microphone and source_app_name=Codex

## Candidate scoring
- winner: copied support diagnostics can leak source app/device key values, 93/100
- next: microphone timeout overlay copy under-explains Bluetooth/output route failures, 79/100, lost because privacy trust leak is safer and broader to fix
- next: route recovery timeout telemetry lacks a failure_kind breakdown, 73/100, lost because current data is one-device and below patch threshold

## Verification
- bash build-deps.sh --force
- bash build.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh (1517 passed)