### PR TITLE
[operator] Align README install requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Download the latest `.dmg`:
 Requirements:
 
 - macOS 26+
-- Apple Silicon Mac recommended
+- Apple Silicon Mac required
 
 ### Homebrew
 


### PR DESCRIPTION
## Summary
- update README install requirements to say Apple Silicon is required
- align the public repo docs with the Sparkle appcast and Homebrew cask arm64 requirement

## Why
The README said Apple Silicon was recommended, while the shipped appcast and Homebrew cask require arm64. This removes install confusion without changing app behavior.

## Verification
- scripts/dev/agent-preflight.sh
- rg -n "Apple Silicon|arm64|macOS 26" README.md Casks/transcripted.rb docs/appcast.xml Info.plist
- git diff --check