### PR TITLE
[nightly-review] Sanitize support diagnostics sections

### DIFF
--- a/Sources/UI/Shared/SupportDiagnosticsBundle.swift
+++ b/Sources/UI/Shared/SupportDiagnosticsBundle.swift
@@ -109,8 +109,9 @@ enum SupportDiagnosticsBundle {
     }
 
     private static func render(_ values: [String: String]) -> String {
-        guard !values.isEmpty else { return "Unavailable" }
-        return values
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeDiagnosticContextForDisplay(values)
+        guard !sanitized.isEmpty else { return "Unavailable" }
+        return sanitized
             .sorted { $0.key < $1.key }
             .map { "\($0.key): \($0.value)" }
             .joined(separator: "\n")

--- a/Tests/SupportDiagnosticsBundleTests.swift
+++ b/Tests/SupportDiagnosticsBundleTests.swift
@@ -15,14 +15,18 @@ func testSupportDiagnosticsBundle() {
             pastebackGranted: true,
             calendarGranted: false,
             audioRoute: [
+                "audio_device": "MacBook Pro Microphone",
                 "input_device_class": "bluetooth",
                 "input_rate_hz": "24000",
+                "raw_url": "https://meet.example.com/private-room",
                 "route_shape": "bluetooth_input_to_built_in_output",
             ],
             runtime: [
+                "file_path": "/Users/redbars/private-runtime.json",
                 "session_kind": "dictation",
                 "session_stage": "recording",
                 "session_active": "true",
+                "transcript_title": "Private Customer Call",
             ],
             meetingState: "ready",
             meetingRecording: false,
@@ -54,6 +58,9 @@ func testSupportDiagnosticsBundle() {
         assertFalse(text.contains("com.openai.codex"), "diagnostics should redact source app bundle IDs from recent logs")
         assertFalse(text.contains("source_app_name=Codex"), "diagnostics should redact source app names from recent logs")
         assertFalse(text.contains("MacBook Pro Microphone"), "diagnostics should redact raw device names from recent logs")
+        assertFalse(text.contains("https://meet.example.com/private-room"), "diagnostics should redact raw route URLs")
+        assertFalse(text.contains("private-runtime.json"), "diagnostics should redact runtime file paths")
+        assertFalse(text.contains("Private Customer Call"), "diagnostics should redact runtime transcript titles")
     }
 
     runSuite("SupportDiagnosticsBundle Sentry context avoids sanitizer-dropped audio keys") {


### PR DESCRIPTION
## Summary

- Sanitizes the Support Diagnostics `Runtime` and `Audio Route` sections before rendering copied diagnostics text.
- Adds a regression that raw route/runtime values like device names, URLs, paths, and transcript titles do not appear in the diagnostics body.

## Nightly risk ranking

1. Support diagnostics privacy boundary: recent log redaction was tightened, but rendered snapshot sections still trusted their input dictionaries. This PR fixes that boundary.
2. Dictation/audio lifecycle: PostHog still shows last-24h `app_unclean_shutdown_detected` and `dictation_audio_route_recovery_timeout` events for one user, so the start/cancel and recovery paths stay the next review target.
3. Release/update plumbing: v1.1.33 appcast, cask, and release asset line up, but open performance PR #707 changes model packaging and will need a release-path check before merge.

## Evidence

- No open `[nightly-review]` or `[nightly-regression]` PRs existed before this PR.
- GitHub open issues: #500 remains the only open issue.
- PostHog error tracking: no active issues in the last 24h.
- PostHog workflow events in the last 24h: `app_unclean_shutdown_detected` 7 events / 1 user, `dictation_audio_route_recovery_timeout` 5 events / 1 user, `dictation_no_speech` 3 events / 2 users, `dictation_cancelled` 1 event / 1 user.
- Sentry CLI health probe was unavailable because `SENTRY_AUTH_TOKEN` is not set; Sentry MCP returned a transport error.

## Validation

- `bash run-tests.sh --filter SupportDiagnosticsBundleTests` -> 1,561 passed
- `bash build-deps.sh --force`
- `bash build.sh`
