### PR TITLE
[nightly-telemetry] Clear inactive runtime heartbeat context

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1211,6 +1211,10 @@ final class MeetingSessionController: ObservableObject {
         taskManager.activeCount > 0 || taskManager.speakerNamingRequest != nil || !queuedTranscriptionJobs.isEmpty
     }
 
+    var hasRuntimeDiagnosticsWork: Bool {
+        isCaptureSessionActive || isFinishingRecording || hasBackgroundTranscriptionWork
+    }
+
     private var hasVisibleBackgroundTranscriptionWork: Bool {
         MeetingSessionUIPolicy.shouldShowTranscribing(
             activeTranscriptions: taskManager.activeCount,

--- a/Sources/Observability/RuntimeDiagnostics.swift
+++ b/Sources/Observability/RuntimeDiagnostics.swift
@@ -132,6 +132,9 @@ final class RuntimeDiagnostics {
     private func persist(event: String) {
         updateMarker { marker in
             marker.lastEvent = event
+            if event == "heartbeat" {
+                RuntimeDiagnosticsStore.clearInactiveSessionContextForHeartbeat(&marker)
+            }
         }
     }
 

--- a/Sources/Observability/RuntimeDiagnostics.swift
+++ b/Sources/Observability/RuntimeDiagnostics.swift
@@ -5,6 +5,7 @@ final class RuntimeDiagnostics {
     private let markerURL: URL
     private var marker: RuntimeDiagnosticsMarker?
     private var heartbeatTimer: Timer?
+    private var activeWorkProvider: (() -> Bool)?
 
     init(markerURL: URL = RuntimeDiagnosticsStore.defaultMarkerURL()) {
         self.markerURL = markerURL
@@ -47,6 +48,10 @@ final class RuntimeDiagnostics {
         )
         heartbeatTimer?.invalidate()
         heartbeatTimer = nil
+    }
+
+    func setActiveWorkProvider(_ provider: (() -> Bool)?) {
+        activeWorkProvider = provider
     }
 
     func recordSession(kind: String, stage: String, active: Bool = true) {
@@ -133,7 +138,10 @@ final class RuntimeDiagnostics {
         updateMarker { marker in
             marker.lastEvent = event
             if event == "heartbeat" {
-                RuntimeDiagnosticsStore.clearInactiveSessionContextForHeartbeat(&marker)
+                RuntimeDiagnosticsStore.clearInactiveSessionContextForHeartbeat(
+                    &marker,
+                    runtimeWorkActive: activeWorkProvider?() ?? false
+                )
             }
         }
     }

--- a/Sources/Observability/RuntimeDiagnostics.swift
+++ b/Sources/Observability/RuntimeDiagnostics.swift
@@ -6,12 +6,18 @@ final class RuntimeDiagnostics {
     private var marker: RuntimeDiagnosticsMarker?
     private var heartbeatTimer: Timer?
     private var activeWorkProvider: (() -> Bool)?
+    private let isDisabled: Bool
 
-    init(markerURL: URL = RuntimeDiagnosticsStore.defaultMarkerURL()) {
+    init(
+        markerURL: URL = RuntimeDiagnosticsStore.defaultMarkerURL(),
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
         self.markerURL = markerURL
+        self.isDisabled = environment["TRANSCRIPTED_DISABLE_RUNTIME_DIAGNOSTICS"] == "1"
     }
 
     func start() {
+        guard !isDisabled else { return }
         guard marker == nil else { return }
 
         if let previous = RuntimeDiagnosticsStore.load(from: markerURL),
@@ -37,6 +43,7 @@ final class RuntimeDiagnostics {
     }
 
     func markCleanShutdown() {
+        guard !isDisabled else { return }
         guard var marker else { return }
         marker.cleanShutdown = true
         marker.updatedAt = Date()
@@ -55,6 +62,7 @@ final class RuntimeDiagnostics {
     }
 
     func recordSession(kind: String, stage: String, active: Bool = true) {
+        guard !isDisabled else { return }
         if marker == nil {
             start()
         }
@@ -68,6 +76,7 @@ final class RuntimeDiagnostics {
     }
 
     func clearSession(kind: String, outcome: String) {
+        guard !isDisabled else { return }
         if marker == nil {
             start()
         }
@@ -86,6 +95,7 @@ final class RuntimeDiagnostics {
         durationSeconds: Double,
         extra: [String: String] = [:]
     ) {
+        guard !isDisabled else { return }
         recordSession(kind: kind, stage: stage, active: true)
         var context = currentAnalyticsContext()
         context["duration_bucket"] = AnalyticsReporter.durationBucket(seconds: durationSeconds)

--- a/Sources/Observability/RuntimeDiagnosticsStore.swift
+++ b/Sources/Observability/RuntimeDiagnosticsStore.swift
@@ -152,8 +152,12 @@ enum RuntimeDiagnosticsStore {
         return heartbeatAgeBucket(previousUpdate: marker.updatedAt, now: now) != "lt_15s"
     }
 
-    static func clearInactiveSessionContextForHeartbeat(_ marker: inout RuntimeDiagnosticsMarker) {
+    static func clearInactiveSessionContextForHeartbeat(
+        _ marker: inout RuntimeDiagnosticsMarker,
+        runtimeWorkActive: Bool = false
+    ) {
         guard !marker.sessionActive else { return }
+        guard !runtimeWorkActive else { return }
 
         marker.sessionKind = "none"
         marker.sessionStage = "idle"

--- a/Sources/Observability/RuntimeDiagnosticsStore.swift
+++ b/Sources/Observability/RuntimeDiagnosticsStore.swift
@@ -151,4 +151,11 @@ enum RuntimeDiagnosticsStore {
 
         return heartbeatAgeBucket(previousUpdate: marker.updatedAt, now: now) != "lt_15s"
     }
+
+    static func clearInactiveSessionContextForHeartbeat(_ marker: inout RuntimeDiagnosticsMarker) {
+        guard !marker.sessionActive else { return }
+
+        marker.sessionKind = "none"
+        marker.sessionStage = "idle"
+    }
 }

--- a/Sources/TranscriptedAppState.swift
+++ b/Sources/TranscriptedAppState.swift
@@ -82,6 +82,14 @@ class TranscriptedAppState: ObservableObject {
 
         logger.log("APP LAUNCHED | modes: dictation + meetings")
         AnalyticsReporter.track("app_launched")
+        runtimeDiagnostics.setActiveWorkProvider { [weak self] in
+            guard let self else { return false }
+            var workActive = self.sttRouter.isRecording || self.sttRouter.isTranscribing
+            if #available(macOS 14.0, *) {
+                workActive = workActive || self.meetingSession.hasRuntimeDiagnosticsWork
+            }
+            return workActive
+        }
         runtimeDiagnostics.start()
         if #available(macOS 14.0, *) {
             MeetingSessionController.runtimeDiagnosticsRecorder = runtimeDiagnostics
@@ -155,6 +163,7 @@ class TranscriptedAppState: ObservableObject {
         if #available(macOS 14.0, *) {
             MeetingSessionController.runtimeDiagnosticsRecorder = nil
         }
+        runtimeDiagnostics.setActiveWorkProvider(nil)
         runtimeDiagnostics.markCleanShutdown()
     }
 

--- a/Tests/RuntimeDiagnosticsStoreTests.swift
+++ b/Tests/RuntimeDiagnosticsStoreTests.swift
@@ -231,6 +231,64 @@ func testRuntimeDiagnosticsStore() {
         assertEqual(marker.sessionStage, "idle", "inactive completed work should reset to idle after the next heartbeat")
     }
 
+    runSuite("RuntimeDiagnosticsStore suppresses cleaned heartbeat-only shutdown markers") {
+        var marker = RuntimeDiagnosticsMarker(
+            launchID: "completed-dictation-heartbeat",
+            appVersion: "1.2.3",
+            buildVersion: "456",
+            osMajor: 26,
+            cleanShutdown: false,
+            startedAt: Date(timeIntervalSince1970: 1_000),
+            updatedAt: Date(timeIntervalSince1970: 1_100),
+            lastEvent: "heartbeat",
+            sessionKind: "dictation",
+            sessionStage: "completed",
+            sessionActive: false
+        )
+
+        RuntimeDiagnosticsStore.clearInactiveSessionContextForHeartbeat(
+            &marker,
+            runtimeWorkActive: false
+        )
+
+        let shouldReport = RuntimeDiagnosticsStore.shouldReportUncleanShutdown(
+            previous: marker,
+            now: Date(timeIntervalSince1970: 1_220)
+        )
+
+        assertEqual(shouldReport, false, "idle heartbeat-only markers should stay suppressed after cleanup")
+    }
+
+    runSuite("RuntimeDiagnosticsStore keeps queued work attribution across heartbeat cleanup") {
+        var marker = RuntimeDiagnosticsMarker(
+            launchID: "queued-meeting",
+            appVersion: "1.2.3",
+            buildVersion: "456",
+            osMajor: 26,
+            cleanShutdown: false,
+            startedAt: Date(timeIntervalSince1970: 1_000),
+            updatedAt: Date(timeIntervalSince1970: 1_100),
+            lastEvent: "heartbeat",
+            sessionKind: "meeting",
+            sessionStage: "transcript_saved",
+            sessionActive: false
+        )
+
+        RuntimeDiagnosticsStore.clearInactiveSessionContextForHeartbeat(
+            &marker,
+            runtimeWorkActive: true
+        )
+
+        let shouldReport = RuntimeDiagnosticsStore.shouldReportUncleanShutdown(
+            previous: marker,
+            now: Date(timeIntervalSince1970: 1_220)
+        )
+
+        assertEqual(marker.sessionKind, "meeting", "queued meeting work should keep its attribution across heartbeats")
+        assertEqual(marker.sessionStage, "transcript_saved", "queued meeting stage should survive heartbeat cleanup")
+        assertEqual(shouldReport, true, "queued work interrupted after a heartbeat should still report unclean shutdown")
+    }
+
     runSuite("RuntimeDiagnosticsStore keeps active session context on heartbeat") {
         var marker = RuntimeDiagnosticsMarker(
             launchID: "active-dictation",

--- a/Tests/RuntimeDiagnosticsStoreTests.swift
+++ b/Tests/RuntimeDiagnosticsStoreTests.swift
@@ -209,4 +209,46 @@ func testRuntimeDiagnosticsStore() {
 
         assertEqual(shouldReport, true, "active meeting shutdowns should stay visible")
     }
+
+    runSuite("RuntimeDiagnosticsStore clears inactive session context on heartbeat") {
+        var marker = RuntimeDiagnosticsMarker(
+            launchID: "completed-dictation",
+            appVersion: "1.2.3",
+            buildVersion: "456",
+            osMajor: 26,
+            cleanShutdown: false,
+            startedAt: Date(timeIntervalSince1970: 1_000),
+            updatedAt: Date(timeIntervalSince1970: 1_100),
+            lastEvent: "heartbeat",
+            sessionKind: "dictation",
+            sessionStage: "completed",
+            sessionActive: false
+        )
+
+        RuntimeDiagnosticsStore.clearInactiveSessionContextForHeartbeat(&marker)
+
+        assertEqual(marker.sessionKind, "none", "inactive completed work should stop polluting later shutdown reports")
+        assertEqual(marker.sessionStage, "idle", "inactive completed work should reset to idle after the next heartbeat")
+    }
+
+    runSuite("RuntimeDiagnosticsStore keeps active session context on heartbeat") {
+        var marker = RuntimeDiagnosticsMarker(
+            launchID: "active-dictation",
+            appVersion: "1.2.3",
+            buildVersion: "456",
+            osMajor: 26,
+            cleanShutdown: false,
+            startedAt: Date(timeIntervalSince1970: 1_000),
+            updatedAt: Date(timeIntervalSince1970: 1_100),
+            lastEvent: "heartbeat",
+            sessionKind: "dictation",
+            sessionStage: "recording",
+            sessionActive: true
+        )
+
+        RuntimeDiagnosticsStore.clearInactiveSessionContextForHeartbeat(&marker)
+
+        assertEqual(marker.sessionKind, "dictation", "active work should stay attributed across heartbeats")
+        assertEqual(marker.sessionStage, "recording", "active session stage should survive heartbeat persistence")
+    }
 }


### PR DESCRIPTION
## Summary

- Clears inactive runtime session context on the next heartbeat after a workflow completes.
- Keeps active dictation/meeting session context intact across heartbeats.
- Adds runtime marker tests for inactive vs active heartbeat behavior.

## Nightly evidence

- Sentry current-release 7d signal for `transcripted@1.1.33`: `dictation.microphone_start_timeout` 2 events and `app.session_stall_detected` 2 events.
- PostHog current-release 7d signal: 281 launches, 119 dictation starts, 111 completions, 6 start failures, 27 `app_unclean_shutdown_detected`, 4 meeting starts, 4 meeting transcript saves, 0 meeting transcript failures.
- The top telemetry distortion was the unclean-shutdown stream: all 27 events were `session_active=false`, all had `last_event=heartbeat`, and session stages were only successful terminal states (`completed` 23, `transcript_saved` 4).
- That makes the reliability view look scarier than the workflow evidence supports. The app was preserving the last completed workflow forever, so a later idle kill/restart could still look like a dictation or meeting shutdown.

## Candidate scores

1. Runtime heartbeat keeps stale completed workflow context in unclean-shutdown telemetry: 88/100. High repeat count, current release, tiny localized fix, privacy-safe.
2. Permission-denied dictation starts need clearer recovery copy: 79/100. Real current-release friction, but only 4 events and the app already shows a settings action.
3. Mic start timeout Sentry/PostHog context follow-up: 76/100. Real Sentry issue, but only 2 current-release events and current PostHog route fields are already present.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` -> 1,562 passed
- `git diff --check`
