### PR TITLE
[operator] Sync observability allowlist docs

### DIFF
--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -1,6 +1,19 @@
 import Foundation
 
 func testAnalyticsEventPolicy() {
+    runSuite("AnalyticsEventPolicy docs list matches the source allowlist") {
+        let documentedEvents = documentedAnalyticsEvents().sorted()
+        let policyEvents = sourceAnalyticsPolicyEvents().sorted()
+
+        assertFalse(documentedEvents.isEmpty, "privacy observability doc should list analytics events")
+        assertFalse(policyEvents.isEmpty, "analytics event policy source should expose parseable policy events")
+        assertEqual(
+            documentedEvents,
+            policyEvents,
+            "docs/privacy-first-observability.md should list the same analytics events as AnalyticsEventPolicy.swift"
+        )
+    }
+
     runSuite("AnalyticsEventPolicy allows explicit onboarding funnel events") {
         let shown = AnalyticsEventPolicy.policy(forEvent: "onboarding_shown")
         let stepViewed = AnalyticsEventPolicy.policy(forEvent: "onboarding_step_viewed")
@@ -359,5 +372,76 @@ func testAnalyticsEventPolicy() {
         )
         assertEqual(sanitized["prompt_reason"], "calendar_plus_runtime_match", "prompt reason should survive sanitization")
         assertEqual(sanitized["backoff_kind"], "calendar_teams_extended", "dismiss backoff kind should survive sanitization")
+    }
+}
+
+private func documentedAnalyticsEvents() -> [String] {
+    let text = loadRepoText("docs/privacy-first-observability.md")
+    let section = markdownSection(
+        named: "## Allowlisted analytics events",
+        in: text
+    )
+
+    return section.split(separator: "\n").compactMap { line in
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("- `"), trimmed.hasSuffix("`") else {
+            return nil
+        }
+
+        return String(trimmed.dropFirst(3).dropLast())
+    }
+}
+
+private func sourceAnalyticsPolicyEvents() -> [String] {
+    let text = loadRepoText("Sources/Observability/AnalyticsEventPolicy.swift")
+    guard let start = text.range(of: "private static let allowedPolicies: [String: AnalyticsEventPolicy] = [") else {
+        return []
+    }
+
+    let sourceAfterStart = String(text[start.upperBound...])
+    guard let end = sourceAfterStart.range(of: "\n    ]") else {
+        return []
+    }
+
+    let policyBody = String(sourceAfterStart[..<end.lowerBound])
+    return policyBody.split(separator: "\n").compactMap { line in
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("\""), trimmed.contains("\": .init(") else {
+            return nil
+        }
+
+        let withoutLeadingQuote = trimmed.dropFirst()
+        guard let closingQuote = withoutLeadingQuote.firstIndex(of: "\"") else {
+            return nil
+        }
+
+        return String(withoutLeadingQuote[..<closingQuote])
+    }
+}
+
+private func markdownSection(named heading: String, in text: String) -> String {
+    guard let start = text.range(of: heading) else {
+        return ""
+    }
+
+    let sourceAfterHeading = String(text[start.upperBound...])
+    guard let end = sourceAfterHeading.range(of: "\n## ") else {
+        return sourceAfterHeading
+    }
+
+    return String(sourceAfterHeading[..<end.lowerBound])
+}
+
+private func loadRepoText(_ relativePath: String, file: String = #file, line: Int = #line) -> String {
+    let url = repoFixtureURL(relativePath)
+
+    do {
+        return try String(contentsOf: url, encoding: .utf8)
+    } catch {
+        failedTests += 1
+        totalTests += 1
+        let loc = "\(URL(fileURLWithPath: file).lastPathComponent):\(line)"
+        print("  FAIL [\(loc)] could not load \(relativePath): \(error)")
+        return ""
     }
 }

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -72,22 +72,63 @@ transport.
 
 ## Allowlisted analytics events
 
+This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
+
 - `app_launched`
+- `app_unclean_shutdown_detected`
+- `app_session_stall_detected`
+- `support_diagnostics_copied`
+- `support_diagnostic_event_sent`
+- `onboarding_shown`
+- `onboarding_step_viewed`
+- `onboarding_permission_cta_clicked`
+- `onboarding_permission_status_changed`
+- `onboarding_model_state_changed`
+- `onboarding_primary_cta_clicked`
+- `onboarding_first_dictation_started`
+- `onboarding_first_dictation_saved`
+- `onboarding_first_dictation_stop_clicked`
+- `onboarding_first_dictation_empty`
+- `onboarding_meeting_dry_run_clicked`
+- `onboarding_agent_cta_clicked`
+- `onboarding_reporting_toggle_changed`
 - `onboarding_completed`
+- `onboarding_dismissed`
+- `menu_bar_opened`
+- `menu_bar_action_clicked`
+- `update_action_clicked`
+- `update_setting_changed`
+- `update_check_finished`
+- `update_download_started`
+- `update_download_finished`
+- `update_ready_to_install`
+- `update_relaunching`
+- `settings_opened`
+- `settings_page_viewed`
+- `settings_action_clicked`
+- `settings_toggle_changed`
+- `settings_permission_cta_clicked`
+- `settings_capture_library_changed`
 - `dictation_started`
 - `dictation_start_failed`
 - `dictation_completed`
 - `dictation_cancelled`
 - `dictation_no_speech`
+- `dictation_audio_route_changed`
+- `dictation_audio_route_recovery_finished`
+- `dictation_audio_route_recovery_timeout`
+- `meeting_recording_started`
+- `meeting_recording_start_failed`
 - `meeting_prompt_shown`
 - `meeting_prompt_dismissed`
 - `meeting_prompt_record_selected`
-- `meeting_recording_started`
 - `meeting_recording_stopped`
+- `meeting_capture_health_snapshot`
 - `meeting_recording_cancelled`
 - `meeting_file_imported`
 - `meeting_transcript_saved`
 - `meeting_transcript_failed`
+- `meeting_transcript_skipped`
 
 ## Allowed property style
 


### PR DESCRIPTION
## Summary

- Syncs the privacy observability docs with the current analytics event allowlist in `AnalyticsEventPolicy.swift`.
- Keeps the doc explicit about the source of truth so future telemetry reviews compare against policy instead of stale prose.

## Operator lane

Execute: docs-only observability trust fix.

## Why this is safe

- No runtime behavior changed.
- No analytics payloads expanded.
- Avoids overlap with open draft PRs #706, #707, #708, and #709.

## Verification

- Ruby doc-vs-policy comparison: `policy=55 doc=55`, no missing or extra events.
- `git diff --check`
- `bash scripts/dev/agent-preflight.sh`
