### PR TITLE
[nightly-maintenance] Simplify dictation test temp roots

### DIFF
--- a/Tests/DictationTranscriptStoreTests.swift
+++ b/Tests/DictationTranscriptStoreTests.swift
@@ -6,7 +6,7 @@ import Foundation
 func testDictationTranscriptStore() {
     runSuite("DictationTranscriptStore.latestSavedText — returns the newest saved dictation across days") {
         let fm = FileManager.default
-        let tempRoot = fm.temporaryDirectory.appendingPathComponent("DraftDictationStoreTests-\(UUID().uuidString)", isDirectory: true)
+        let tempRoot = temporaryDictationStoreTestRoot(fileManager: fm)
         let outputDir = tempRoot.appendingPathComponent("dictations", isDirectory: true)
         try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: tempRoot) }
@@ -36,7 +36,7 @@ func testDictationTranscriptStore() {
 
     runSuite("DictationTranscriptStore.latestSavedText — reads older Timestamp metadata too") {
         let fm = FileManager.default
-        let tempRoot = fm.temporaryDirectory.appendingPathComponent("DraftDictationStoreTests-\(UUID().uuidString)", isDirectory: true)
+        let tempRoot = temporaryDictationStoreTestRoot(fileManager: fm)
         let outputDir = tempRoot.appendingPathComponent("dictations", isDirectory: true)
         try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: tempRoot) }
@@ -71,7 +71,7 @@ func testDictationTranscriptStore() {
 
     runSuite("DictationTranscriptStore.recentSavedDictations — returns the newest entries across day files and same-day sections") {
         let fm = FileManager.default
-        let tempRoot = fm.temporaryDirectory.appendingPathComponent("DraftDictationStoreTests-\(UUID().uuidString)", isDirectory: true)
+        let tempRoot = temporaryDictationStoreTestRoot(fileManager: fm)
         let outputDir = tempRoot.appendingPathComponent("dictations", isDirectory: true)
         try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: tempRoot) }
@@ -116,7 +116,7 @@ func testDictationTranscriptStore() {
 
     runSuite("DictationTranscriptStore.latestSavedText — preserves markdown headings inside dictation body") {
         let fm = FileManager.default
-        let tempRoot = fm.temporaryDirectory.appendingPathComponent("DraftDictationStoreTests-\(UUID().uuidString)", isDirectory: true)
+        let tempRoot = temporaryDictationStoreTestRoot(fileManager: fm)
         let outputDir = tempRoot.appendingPathComponent("dictations", isDirectory: true)
         try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: tempRoot) }
@@ -144,7 +144,7 @@ func testDictationTranscriptStore() {
 
     runSuite("DictationTranscriptStore.savedDictationCounts — totals entries and dictated words") {
         let fm = FileManager.default
-        let tempRoot = fm.temporaryDirectory.appendingPathComponent("DraftDictationStoreTests-\(UUID().uuidString)", isDirectory: true)
+        let tempRoot = temporaryDictationStoreTestRoot(fileManager: fm)
         let outputDir = tempRoot.appendingPathComponent("dictations", isDirectory: true)
         try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: tempRoot) }
@@ -174,7 +174,7 @@ func testDictationTranscriptStore() {
 
     runSuite("DictationTranscriptStore.deleteEntry — removes only the matching entry ID") {
         let fm = FileManager.default
-        let tempRoot = fm.temporaryDirectory.appendingPathComponent("DraftDictationStoreTests-\(UUID().uuidString)", isDirectory: true)
+        let tempRoot = temporaryDictationStoreTestRoot(fileManager: fm)
         let outputDir = tempRoot.appendingPathComponent("dictations", isDirectory: true)
         try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: tempRoot) }
@@ -234,7 +234,7 @@ func testDictationTranscriptStore() {
 
     runSuite("DictationTranscriptStore.deleteEntry — same-timestamp saved entries keep distinct IDs") {
         let fm = FileManager.default
-        let tempRoot = fm.temporaryDirectory.appendingPathComponent("DraftDictationStoreTests-\(UUID().uuidString)", isDirectory: true)
+        let tempRoot = temporaryDictationStoreTestRoot(fileManager: fm)
         let outputDir = tempRoot.appendingPathComponent("dictations", isDirectory: true)
         try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: tempRoot) }
@@ -275,6 +275,13 @@ func testDictationTranscriptStore() {
         assertEqual(remainingEntries.count, 1, "deleting one same-timestamp entry should keep the other")
         assertEqual(remainingEntries.first?.text, "first saved text", "first same-timestamp entry should remain")
     }
+}
+
+private func temporaryDictationStoreTestRoot(fileManager: FileManager) -> URL {
+    fileManager.temporaryDirectory.appendingPathComponent(
+        "TranscriptedDictationStoreTests-\(UUID().uuidString)",
+        isDirectory: true
+    )
 }
 
 private func isoDate(_ string: String) -> Date {

--- a/Tests/DictationTranscriptWriterTests.swift
+++ b/Tests/DictationTranscriptWriterTests.swift
@@ -6,7 +6,7 @@ import Foundation
 func testDictationTranscriptWriter() {
     runSuite("DictationTranscriptWriter.save — groups dictations by day") {
         let fm = FileManager.default
-        let tempRoot = fm.temporaryDirectory.appendingPathComponent("DraftDictationTests-\(UUID().uuidString)", isDirectory: true)
+        let tempRoot = temporaryDictationWriterTestRoot(fileManager: fm)
         let outputDir = tempRoot.appendingPathComponent("dictations", isDirectory: true)
         try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: tempRoot) }
@@ -43,7 +43,7 @@ func testDictationTranscriptWriter() {
 
     runSuite("DictationTranscriptWriter.save — separates different days") {
         let fm = FileManager.default
-        let tempRoot = fm.temporaryDirectory.appendingPathComponent("DraftDictationTests-\(UUID().uuidString)", isDirectory: true)
+        let tempRoot = temporaryDictationWriterTestRoot(fileManager: fm)
         let outputDir = tempRoot.appendingPathComponent("dictations", isDirectory: true)
         try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
         defer { try? fm.removeItem(at: tempRoot) }
@@ -69,6 +69,13 @@ func testDictationTranscriptWriter() {
         assertTrue(firstSaved?.url.lastPathComponent == "Dictations_2026-04-07.md", "first day filename")
         assertTrue(secondSaved?.url.lastPathComponent == "Dictations_2026-04-08.md", "second day filename")
     }
+}
+
+private func temporaryDictationWriterTestRoot(fileManager: FileManager) -> URL {
+    fileManager.temporaryDirectory.appendingPathComponent(
+        "TranscriptedDictationWriterTests-\(UUID().uuidString)",
+        isDirectory: true
+    )
 }
 
 private func isoDate(_ string: String) -> Date {


### PR DESCRIPTION
## Summary
- Added small helpers for dictation test temp roots.
- Replaced stale Draft-named temp directories with Transcripted-named roots.
- Kept the legacy markdown/path coverage unchanged.

## Verification
- scripts/dev/agent-preflight.sh
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh (1558 passed)

## Notes
- First build.sh stopped because dependency artifacts were missing/stale, so build-deps.sh --force was run before rerunning the required checks.