### PR TITLE
Release Transcripted 1.1.34

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.33"
-  sha256 "9b83563a39fd92e222819be26ea01af8319d2043d3da3e82e31e57113d00f9f6"
+  version "1.1.34"
+  sha256 "0cf7d0894cf0ac9290b110763e0ab5266f195111f6213704c1864d361b685f23"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.33</string>
+	<string>1.1.34</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.33</string>
+	<string>1.1.34</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.34</title>
+      <pubDate>Mon, 11 May 2026 06:34:58 -0500</pubDate>
+      <sparkle:version>1.1.34</sparkle:version>
+      <sparkle:shortVersionString>1.1.34</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.34/Transcripted-1.1.34.dmg" length="30732248" type="application/octet-stream" sparkle:edSignature="XvSRlVyz7mfENZiPpRTk7JjtJsGoapC0cmY3TmheWI4hzSfKDHdRBEeI7yWbfJ/s5pJ+SklsMj0Bjczsm7oFCw==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.34</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.34</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.33</title>
       <pubDate>Fri, 08 May 2026 16:27:38 -0500</pubDate>
       <sparkle:version>1.1.33</sparkle:version>


### PR DESCRIPTION
Publishes Transcripted 1.1.34 release metadata.

- bumps Info.plist to 1.1.34
- adds the 1.1.34 Sparkle appcast item
- updates the Homebrew cask checksum for the published DMG

Verification:
- bash build-deps.sh --force
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift test
- NOTARY_PROFILE=Transcripted TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build-beta.sh transcripted-public-1.1.34 Transcripted
- bash scripts/release/verify-sparkle-release.sh 1.1.34
- bash scripts/release/update-cask.sh 1.1.34