### PR TITLE
[codex] Make settings window resizable

### DIFF
--- a/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
@@ -28,13 +28,14 @@ final class TranscriptedSettingsWindowController: NSWindowController, NSWindowDe
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 980, height: 760),
-            styleMask: [.titled, .closable, .miniaturizable, .fullSizeContentView],
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
         window.title = "Transcripted Settings"
         window.titleVisibility = .hidden
         window.contentViewController = hostingController
+        window.contentMinSize = NSSize(width: 880, height: 640)
         window.isReleasedWhenClosed = false
         window.center()
 


### PR DESCRIPTION
## Summary

- Adds the standard macOS resize affordance to the Transcripted Settings window.
- Sets the content minimum size to match the existing SwiftUI layout floor, so the Home/settings pane can grow without collapsing below its intended minimum.

## Why

The Settings/Home window was built without the `.resizable` style mask, so users could not resize it even though the SwiftUI content already supports larger layouts.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (1714 passed)