### PR TITLE
[codex] Score reliability and harden Sentry diagnostics

### DIFF
--- a/Sources/Observability/CrashReporter.swift
+++ b/Sources/Observability/CrashReporter.swift
@@ -108,15 +108,22 @@ final class CrashReporter {
         message: String,
         context: [String: String]
     ) {
+        let diagnosticTags = SentryEventPolicy.diagnosticTags(
+            forEngine: engine,
+            event: event,
+            context: context
+        )
+        let tags = [
+            "source": "observability",
+            "engine": engine,
+            "event": event,
+        ].merging(diagnosticTags) { current, _ in current }
+
         _ = captureMessageEvent(
             level: sentryLevel(for: level),
             title: "\(engine).\(event)",
             message: message,
-            tags: [
-                "source": "observability",
-                "engine": engine,
-                "event": event,
-            ],
+            tags: tags,
             extra: context,
             fingerprint: [engine, event]
         )

--- a/Sources/Observability/SentryEventPolicy.swift
+++ b/Sources/Observability/SentryEventPolicy.swift
@@ -9,6 +9,62 @@ struct SentryEventPolicy: Equatable {
         allowedPolicies["\(engine).\(event)"]
     }
 
+    static func diagnosticTags(
+        forEngine engine: String,
+        event: String,
+        context: [String: String]
+    ) -> [String: String] {
+        guard policy(forEngine: engine, event: event) != nil else { return [:] }
+
+        var tags = context.filter { allowedDiagnosticTagKeys.contains($0.key) }
+        if let waitBucket = durationBucket(fromMilliseconds: context["wait_ms"]) {
+            tags["wait_bucket"] = waitBucket
+        }
+
+        return SentryPayloadSanitizer.sanitizeTags(tags)
+    }
+
+    private static let allowedDiagnosticTagKeys: Set<String> = [
+        "default_input_class",
+        "default_output_class",
+        "duration_bucket",
+        "failure_kind",
+        "forced_readiness_recoveries",
+        "format_ready",
+        "hfp_suspected",
+        "input_channels",
+        "input_device_class",
+        "input_rate_hz",
+        "output_channels",
+        "output_device_class",
+        "output_rate_hz",
+        "readiness_refreshes",
+        "recovering",
+        "recovery_start_attempts",
+        "route_shape",
+        "sample_flow_started",
+        "selected_input_class",
+        "selection_overrode_default",
+        "selection_reason",
+        "session_active",
+        "session_kind",
+        "session_stage",
+        "stall_kind",
+        "stall_stage",
+        "start_attempts",
+        "stt_model",
+        "trigger",
+        "was_recording",
+    ]
+
+    private static func durationBucket(fromMilliseconds value: String?) -> String? {
+        guard let value,
+              let milliseconds = Double(value) else {
+            return nil
+        }
+        return AnalyticsReporter.durationBucket(seconds: milliseconds / 1000)
+    }
+
     private static let allowedPolicies: [String: SentryEventPolicy] = [
         "app.session_stall_detected": .init(
             engine: "app",

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -563,6 +563,7 @@ class DictationSessionController: ObservableObject {
                 extra: [
                     "wait_ms": "\(waited)",
                     "audio_device": appState.sttRouter.inputDeviceName,
+                    "failure_kind": "microphone_start_timeout",
                     "is_recovering": "\(appState.sttRouter.isRecovering)",
                     "format_ready": "\(appState.sttRouter.inputFormatReady)",
                     "start_attempts": "\(startAttempts)",
@@ -577,10 +578,16 @@ class DictationSessionController: ObservableObject {
             kind: "dictation",
             stage: "microphone_start_timeout",
             durationSeconds: TranscriptedConstants.dictationRecoveryBudget,
-            extra: [
+            extra: dictationAnalyticsProperties(extra: [
+                "failure_kind": "microphone_start_timeout",
                 "format_ready": "\(appState.sttRouter.inputFormatReady)",
-                "recovering": "\(appState.sttRouter.isRecovering)"
-            ]
+                "forced_readiness_recoveries": "\(forcedReadinessRecoveries)",
+                "readiness_refreshes": "\(readinessRefreshes)",
+                "recovering": "\(appState.sttRouter.isRecovering)",
+                "recovery_start_attempts": "\(recoveryStartAttempts)",
+                "start_attempts": "\(startAttempts)",
+                "trigger": currentDictationTrigger.rawValue,
+            ])
         )
         appState.runtimeDiagnostics.clearSession(kind: "dictation", outcome: "microphone_start_timeout")
         isDictating = false

--- a/Tests/SentryEventPolicyTests.swift
+++ b/Tests/SentryEventPolicyTests.swift
@@ -84,4 +84,48 @@ func testSentryEventPolicy() {
         assertEqual(onboardingStopFailure?.summary, "Onboarding could not stop first dictation.", "onboarding stop wiring failures should be visible without clickstream data")
         assertNil(unknown, "unknown events should stay local-only by default")
     }
+
+    runSuite("SentryEventPolicy diagnosticTags keeps timeout triage searchable and safe") {
+        let tags = SentryEventPolicy.diagnosticTags(
+            forEngine: "dictation",
+            event: "microphone_start_timeout",
+            context: [
+                "audio_device": "Justin's AirPods",
+                "forced_readiness_recoveries": "2",
+                "format_ready": "false",
+                "input_device_class": "bluetooth",
+                "readiness_refreshes": "8",
+                "recovering": "false",
+                "recovery_start_attempts": "1",
+                "route_shape": "bluetooth_input_to_builtin_output",
+                "start_attempts": "3",
+                "transcript_text": "private words",
+                "trigger": "hands_free",
+                "wait_ms": "6000",
+            ]
+        )
+
+        assertEqual(tags["format_ready"], "false", "format readiness should be queryable")
+        assertEqual(tags["recovering"], "false", "recovery state should be queryable")
+        assertEqual(tags["input_device_class"], "bluetooth", "coarse device class should be queryable")
+        assertEqual(tags["route_shape"], "bluetooth_input_to_builtin_output", "coarse route shape should be queryable")
+        assertEqual(tags["start_attempts"], "3", "bounded retry count should be queryable")
+        assertEqual(tags["readiness_refreshes"], "8", "readiness refresh count should be queryable")
+        assertEqual(tags["recovery_start_attempts"], "1", "recovery start count should be queryable")
+        assertEqual(tags["forced_readiness_recoveries"], "2", "forced recovery count should be queryable")
+        assertEqual(tags["trigger"], "hands_free", "coarse trigger should be queryable")
+        assertEqual(tags["wait_bucket"], "lt_10s", "raw wait time should be bucketed")
+        assertNil(tags["audio_device"], "raw device names should stay out of Sentry tags")
+        assertNil(tags["transcript_text"], "transcript text should stay out of Sentry tags")
+    }
+
+    runSuite("SentryEventPolicy diagnosticTags ignores non-allowlisted events") {
+        let tags = SentryEventPolicy.diagnosticTags(
+            forEngine: "dictation",
+            event: "dictation_export_failed",
+            context: ["format_ready": "false"]
+        )
+
+        assertTrue(tags.isEmpty, "local-only events should not get Sentry diagnostic tags")
+    }
 }

--- a/docs/reliability-trust-performance-score-2026-05-11.md
+++ b/docs/reliability-trust-performance-score-2026-05-11.md
@@ -1,0 +1,118 @@
+# Transcripted Reliability, Trust, and Performance Score
+
+Date: 2026-05-11
+Branch: `codex/reliability-trust-score-20260511`
+Base: `origin/main` at `29925428`
+
+This score is current-state evidence, not vibes. A category cannot be A+ if the
+proof is missing, live production still shows current-release failures, or the
+latest fix is not shipped.
+
+## Summary
+
+| Area | Weight | Score | Grade | A+ status |
+| --- | ---: | ---: | --- | --- |
+| Reliability | 45 | 39 | B+ | Blocked |
+| Trustworthiness | 40 | 36 | A- | Blocked |
+| Performance | 15 | 14 | A | Close |
+| Total | 100 | 89 | B+ | Blocked |
+
+## Hard A+ Gates
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| Local build passes | Pass | `bash build.sh` passed; signed app, launch smoke, performance budget OK |
+| Fast tests pass | Pass | `bash run-tests.sh` passed, 1727/1727 |
+| Integration smoke passes | Pass | `bash run-integration-smoke.sh` passed |
+| Core package tests pass | Pass | `swift test` passed, 135/135 |
+| Synthetic audio reliability passes | Pass | `bash run-daily-audio-reliability.sh --synthetic --skip-build --no-launch` passed, 72/72 |
+| Live release surfaces agree | Pass | `Info.plist`, GitHub latest release, `docs/appcast.xml`, cask, and website download all point at `1.1.34` |
+| No current-release production failures | Fail | Sentry has 2 `dictation.microphone_start_timeout` and 2 matching `app.session_stall_detected` events on `transcripted@1.1.34` in the last 24h |
+| Product-success telemetry available | Blocked | `POSTHOG_PERSONAL_API_KEY is required` |
+| Known open reliability issues closed | Fail | GitHub issue #500 is still open: mic audio recording is quieter |
+| Live manual device-change/sleep/wake proof current | Blocked | Only deterministic synthetic audio proof was run in this pass |
+
+## Reliability - 39/45
+
+Strong:
+
+- App build and all automated test layers are green.
+- Dictation recovery policy has direct fast-test coverage.
+- Wake recovery smoke passed.
+- Synthetic failure-state matrix passed 72/72 and answers the required retry/artifact/user-state questions.
+- Release `1.1.34` is live and coherent across GitHub, Sparkle, Homebrew, and the website.
+
+Blocked:
+
+- Current release still has a production microphone-start timeout cluster.
+- The matching runtime-stall events mean users can still hit a stuck start path.
+- Issue #500 remains open for quieter mic audio.
+- Manual Bluetooth, input-device change, and sleep/wake checks were not rerun live in this pass.
+
+Patch made:
+
+- Sentry observability events now add safe diagnostic tags for allowlisted events.
+- Future timeout/stall events will be searchable by coarse fields like `format_ready`, `recovering`, `start_attempts`, `readiness_refreshes`, `recovery_start_attempts`, `forced_readiness_recoveries`, `input_device_class`, `route_shape`, `trigger`, and bucketed wait time.
+- Raw device names, transcript text, audio paths, secrets, URLs, and similar sensitive values stay out of Sentry tags.
+
+## Trustworthiness - 36/40
+
+Strong:
+
+- Local-first storage contract is clear and tested.
+- Sentry and analytics payload sanitizers are covered by tests.
+- Crash reporting and analytics preferences default on but remain user-controllable.
+- Release truth is coherent for `1.1.34`: app metadata, appcast, cask, GitHub release asset, and website download agree.
+- Support diagnostics and reliability packets are privacy-safe and coarse.
+
+Blocked:
+
+- PostHog live usage/product-success proof could not be pulled without `POSTHOG_PERSONAL_API_KEY`.
+- Current production Sentry failures mean the public app cannot honestly be called fully trustworthy yet.
+- The latest observability fix is only on this branch until it is merged and released.
+
+## Performance - 14/15
+
+Strong:
+
+- `bash build.sh` performance budget passed.
+- Thin app build is 104.8 MiB expanded.
+- Latest release DMG is about 30.7 MB and defaults to runtime model download instead of bundling the large Parakeet model.
+- Website download page serves the latest `Transcripted-1.1.34.dmg`.
+
+Gap:
+
+- I did not rerun live UI CPU/RSS sampling or a real meeting transcription RTF benchmark in this pass.
+
+## Commands Run
+
+```bash
+git status --short --branch
+git log --oneline --decorate -n 12
+gh release view --repo r3dbars/transcripted --json tagName,name,publishedAt,assets,url,targetCommitish,isPrerelease,isDraft
+gh pr list --repo r3dbars/transcripted --state open --json number,title,headRefName,isDraft,mergeable,reviewDecision,statusCheckRollup,updatedAt,url
+/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" Info.plist
+/usr/libexec/PlistBuddy -c "Print CFBundleVersion" Info.plist
+/usr/libexec/PlistBuddy -c "Print SUFeedURL" Info.plist
+curl -ILs https://transcripted.app/download
+curl -Ls https://transcripted.app/download | rg -n "1\\.1\\.34|Transcripted-1\\.1\\.34|github.com/r3dbars/transcripted/releases|Download"
+python3 /Users/redbars/.codex/skills/transcripted-health/scripts/github_snapshot.py
+python3 /Users/redbars/.codex/skills/transcripted-health/scripts/cloudflare_pages_snapshot.py
+python3 /Users/redbars/.codex/skills/transcripted-health/scripts/posthog_snapshot.py
+scripts/dev/agent-preflight.sh
+bash build-deps.sh --force
+bash build.sh
+bash run-tests.sh
+bash run-integration-smoke.sh
+swift test
+bash run-daily-audio-reliability.sh --synthetic --skip-build --no-launch
+```
+
+## Current Next Loop
+
+1. Merge and release the safe Sentry diagnostic-tag patch so the next production timeout is actually diagnosable.
+2. Rerun Sentry after enough `1.1.34+` usage exists; A+ reliability requires zero current-release timeout/stall events.
+3. Provide `POSTHOG_PERSONAL_API_KEY` and rerun product-success scoring.
+4. Run the live daily audio reliability matrix, especially Bluetooth/input-device change and sleep/wake.
+5. Triage issue #500 with fresh retained-audio diagnostics and close or downgrade it with proof.
+

--- a/docs/reliability-trust-performance-score-2026-05-11.md
+++ b/docs/reliability-trust-performance-score-2026-05-11.md
@@ -53,6 +53,7 @@ Patch made:
 
 - Sentry observability events now add safe diagnostic tags for allowlisted events.
 - Future timeout/stall events will be searchable by coarse fields like `format_ready`, `recovering`, `start_attempts`, `readiness_refreshes`, `recovery_start_attempts`, `forced_readiness_recoveries`, `input_device_class`, `route_shape`, `trigger`, and bucketed wait time.
+- The dictation timeout path now attaches the same coarse route/retry shape to the paired runtime-stall event, so Sentry can connect the two symptoms without raw device names or transcript/audio content.
 - Raw device names, transcript text, audio paths, secrets, URLs, and similar sensitive values stay out of Sentry tags.
 
 ## Trustworthiness - 36/40
@@ -115,4 +116,3 @@ bash run-daily-audio-reliability.sh --synthetic --skip-build --no-launch
 3. Provide `POSTHOG_PERSONAL_API_KEY` and rerun product-success scoring.
 4. Run the live daily audio reliability matrix, especially Bluetooth/input-device change and sleep/wake.
 5. Triage issue #500 with fresh retained-audio diagnostics and close or downgrade it with proof.
-


### PR DESCRIPTION
## Summary
- add a reliability/trust/performance scorecard for the current Transcripted state
- add safe, searchable Sentry diagnostic tags for allowlisted observability events
- attach coarse timeout route/retry context to paired runtime-stall diagnostics

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- bash run-daily-audio-reliability.sh --synthetic --skip-build --no-launch
- git diff --check

## Current blockers to A+
- current release 1.1.34 still has production microphone-start timeout and runtime-stall events in Sentry
- PostHog product-success scoring is blocked by missing POSTHOG_PERSONAL_API_KEY
- issue #500 still needs live WebRTC/WhatsApp audio repro before another audio-volume fix
- live Bluetooth/input-device-change/sleep-wake reliability matrix was not rerun in this pass