### PR TITLE
[codex] Guard meeting transcription model readiness

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -954,6 +954,20 @@ final class MeetingSessionController: ObservableObject {
 
         Task { [weak self] in
             guard let self else { return }
+            await self.prepareModels()
+            guard case .ready = self.state else {
+                DiagnosticsTrail.record(
+                    level: .warning,
+                    engine: "meeting",
+                    event: "meeting_failed_retry_blocked_models",
+                    message: "Failed meeting retry blocked because models were not ready",
+                    context: self.baseDiagnosticsContext(extra: ["failed_id": id.uuidString])
+                )
+                self.retryingFailedMeetingIDs.remove(id)
+                self.refreshFailedMeetings()
+                return
+            }
+
             _ = await self.taskManager.retryFailedTranscription(
                 failedId: id,
                 outputFolder: MeetingStoragePaths.transcriptsFolder

--- a/Sources/TranscriptedCore/Pipeline/Transcription.swift
+++ b/Sources/TranscriptedCore/Pipeline/Transcription.swift
@@ -33,12 +33,42 @@ public class Transcription: ObservableObject {
 
     /// Initialize local models. Call once at app startup.
     public func initializeModels() async {
-        guard !hasInitialized else {
+        do {
+            try await ensureModelsReadyForPipeline()
+        } catch {
+            AppLogger.transcription.error("Model initialization finished without ready models", [
+                "error": error.localizedDescription
+            ])
+        }
+    }
+
+    func ensureModelsReadyForPipeline() async throws {
+        if parakeet.isReady && diarization.isReady {
+            hasInitialized = true
             AppLogger.transcription.debug("Models already initialized, skipping")
             return
         }
+
+        if hasInitialized {
+            AppLogger.transcription.warning("Reloading local transcription models before pipeline", [
+                "speechReady": "\(parakeet.isReady)",
+                "diarizationReady": "\(diarization.isReady)"
+            ])
+        }
+
         hasInitialized = true
-        await parakeet.initialize()
-        await diarization.initialize()
+        if !parakeet.isReady {
+            await parakeet.initialize()
+        }
+        if !diarization.isReady {
+            await diarization.initialize()
+        }
+
+        guard parakeet.isReady else {
+            throw PipelineError.modelNotLoaded(model: parakeet.transcriptionEngineDescriptor.displayName)
+        }
+        guard diarization.isReady else {
+            throw PipelineError.modelNotLoaded(model: "Diarization")
+        }
     }
 }

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -67,6 +67,7 @@ extension TranscriptionTaskManager {
     ) async throws -> URL {
 
         let transcription = await MainActor.run { self.transcription }
+        try await transcription.ensureModelsReadyForPipeline()
 
         let speechEngine = await MainActor.run {
             transcription.parakeet.transcriptionEngineDescriptor

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -146,7 +146,32 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: externalURL.path))
     }
 
+    func testPipelineModelReadinessReloadsModelsAfterCleanup() async throws {
+        let speech = MetadataStubSpeechToTextEngine(isReady: false)
+        let diarization = MetadataStubDiarizationEngine(isReady: false)
+        let manager = makeManager(speechToText: speech, diarization: diarization)
+
+        try await manager.transcription.ensureModelsReadyForPipeline()
+
+        XCTAssertTrue(speech.isReady)
+        XCTAssertTrue(diarization.isReady)
+        XCTAssertEqual(speech.initializeCallCount, 1)
+        XCTAssertEqual(diarization.initializeCallCount, 1)
+
+        speech.cleanup()
+        diarization.cleanup()
+
+        try await manager.transcription.ensureModelsReadyForPipeline()
+
+        XCTAssertTrue(speech.isReady)
+        XCTAssertTrue(diarization.isReady)
+        XCTAssertEqual(speech.initializeCallCount, 2)
+        XCTAssertEqual(diarization.initializeCallCount, 2)
+    }
+
     private func makeManager(
+        speechToText: (any SpeechToTextEngine)? = nil,
+        diarization: (any DiarizationEngine)? = nil,
         retainedAudioDirectory: URL? = nil,
         retainedAudioDirectoryProvider: (() -> URL?)? = nil
     ) -> TranscriptionTaskManager {
@@ -164,10 +189,13 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         try? FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
         try? FileManager.default.createDirectory(at: paths.logs, withIntermediateDirectories: true)
 
+        let resolvedSpeechToText = speechToText ?? MetadataStubSpeechToTextEngine()
+        let resolvedDiarization = diarization ?? MetadataStubDiarizationEngine()
+
         return TranscriptionTaskManager(
             failedTranscriptionManager: FailedTranscriptionManager(paths: paths),
-            speechToText: MetadataStubSpeechToTextEngine(),
-            diarization: MetadataStubDiarizationEngine(),
+            speechToText: resolvedSpeechToText,
+            diarization: resolvedDiarization,
             speakerStore: SpeakerDatabase(path: paths.speakerDB.path),
             cleanupDirectories: [paths.audioCaptures, paths.speakerClips],
             retainedAudioDirectory: retainedAudioDirectory,
@@ -214,21 +242,41 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
 @MainActor
 private final class MetadataStubSpeechToTextEngine: SpeechToTextEngine {
     nonisolated let objectWillChange = ObservableObjectPublisher()
-    var isReady: Bool = true
+    var isReady: Bool
+    var initializeCallCount = 0
 
-    func initialize() async {}
+    init(isReady: Bool = true) {
+        self.isReady = isReady
+    }
+
+    func initialize() async {
+        initializeCallCount += 1
+        isReady = true
+    }
     func transcribeSegment(samples: [Float], source: AudioSource) async throws -> String { "" }
-    func cleanup() {}
+    func cleanup() {
+        isReady = false
+    }
 }
 
 @available(macOS 14.0, *)
 @MainActor
 private final class MetadataStubDiarizationEngine: DiarizationEngine {
     nonisolated let objectWillChange = ObservableObjectPublisher()
-    var isReady: Bool = true
+    var isReady: Bool
+    var initializeCallCount = 0
 
-    func initialize() async {}
+    init(isReady: Bool = true) {
+        self.isReady = isReady
+    }
+
+    func initialize() async {
+        initializeCallCount += 1
+        isReady = true
+    }
     func diarizeOffline(samples: [Float], sampleRate: Int) async throws -> [SpeakerSegment] { [] }
     func diarizeOffline(audioURL: URL) async throws -> [SpeakerSegment] { [] }
-    func cleanup() {}
+    func cleanup() {
+        isReady = false
+    }
 }


### PR DESCRIPTION
## Summary
- Warm meeting models before retrying a failed meeting transcription.
- Add a core pipeline readiness guard that reloads STT and diarization models if they were cleaned up before background transcription starts.
- Add regression coverage for reload-after-cleanup behavior.

## Root cause
Sentry issue APPLE-MACOS-1H showed `meeting_transcript_failed` on release `1.1.34` while the meeting UI was already `transcribing`, but both model signals were unloaded (`meeting_model_state: not_loaded`, `stt_model_loaded: false`). The failed-meeting retry path could jump straight into `TranscriptionTaskManager.retryFailedTranscription(...)` without first calling `MeetingSessionController.prepareModels()`. The core pipeline also assumed the host had kept models resident.

## Validation
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `swift test`
- `swift test --filter TranscriptionTaskManagerMetadataTests/testPipelineModelReadinessReloadsModelsAfterCleanup`
- `git diff --check origin/main...HEAD`