### PR TITLE
[codex] Clean up failed dictation mic starts

### DIFF
--- a/Sources/Observability/RuntimeDiagnostics.swift
+++ b/Sources/Observability/RuntimeDiagnostics.swift
@@ -75,17 +75,22 @@ final class RuntimeDiagnostics {
         }
     }
 
-    func clearSession(kind: String, outcome: String) {
+    func clearSession(kind: String, outcome: String, resetToIdle: Bool = false) {
         guard !isDisabled else { return }
         if marker == nil {
             start()
         }
         guard marker != nil else { return }
         updateMarker { marker in
-            marker.sessionKind = kind
-            marker.sessionStage = outcome
             marker.sessionActive = false
             marker.lastEvent = "\(kind)_\(outcome)"
+            if resetToIdle {
+                marker.sessionKind = "none"
+                marker.sessionStage = "idle"
+            } else {
+                marker.sessionKind = kind
+                marker.sessionStage = outcome
+            }
         }
     }
 

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -2680,6 +2680,38 @@ class ParakeetEngine: ObservableObject {
 
     // MARK: - Cleanup
 
+    func resetAfterFailedRecordingStart() async {
+        cancelAudioWatchdog()
+        prewarmRetryTask?.cancel()
+        prewarmRetryTask = nil
+        configChangeDebounceTask?.cancel()
+        configChangeDebounceTask = nil
+        configRecoveryTask?.cancel()
+        configRecoveryTask = nil
+        cancelConfigRecoveryTimeout()
+        configChangeWasRecording = false
+        recoveryState.reset()
+        recoveryState.markFormatUnready()
+        publishRecoveryState()
+        pendingSamplesLock.withLock {
+            pendingSamples.removeAll(keepingCapacity: true)
+        }
+        streamingSamplesLock.withLock {
+            streamingSampleBuffer.removeAll(keepingCapacity: true)
+        }
+        await eouManager?.reset()
+        isRecording = false
+        isTranscribing = false
+        audioLevel = 0
+        didReceiveAudioSamples = false
+        sampleBuffer.removeAll(keepingCapacity: true)
+        liveTranscript = ""
+        committedStreamText = ""
+        audioGraphGeneration += 1
+        let cleanupGeneration = audioGraphGeneration
+        await releaseIdleAudioHardware(removeTap: true, expectedGeneration: cleanupGeneration)
+    }
+
     func cancel() {
         cancelAudioWatchdog()
         prewarmRetryTask?.cancel()

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -123,6 +123,11 @@ class STTRouter: ObservableObject {
         await parakeetEngine.stopRecording()
     }
 
+    func resetAfterFailedRecordingStart() async {
+        activeRecordingModel = nil
+        await parakeetEngine.resetAfterFailedRecordingStart()
+    }
+
     func transcribe() async -> String? {
         let model = activeRecordingModel ?? selectedModel
         defer {

--- a/Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift
+++ b/Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift
@@ -38,3 +38,21 @@ struct DictationRecordingStartLifecyclePolicy {
         return .ignoreInactive
     }
 }
+
+struct DictationRecordingStartFailureCleanupPlan: Equatable {
+    let outcome: String
+    let resetRuntimeSessionToIdle: Bool
+    let resetSpeechEngine: Bool
+    let reportRuntimeStall: Bool
+}
+
+struct DictationRecordingStartFailurePolicy {
+    static func cleanupPlan(for failureKind: String) -> DictationRecordingStartFailureCleanupPlan {
+        DictationRecordingStartFailureCleanupPlan(
+            outcome: failureKind,
+            resetRuntimeSessionToIdle: true,
+            resetSpeechEngine: true,
+            reportRuntimeStall: false
+        )
+    }
+}

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -553,6 +553,8 @@ class DictationSessionController: ObservableObject {
         readinessRefresher.cancel()
 
         let waited = Int(TranscriptedConstants.dictationRecoveryBudget * 1000)
+        let cleanupPlan = DictationRecordingStartFailurePolicy.cleanupPlan(for: "microphone_start_timeout")
+        await finishFailedDictationStart(appState: appState, cleanupPlan: cleanupPlan)
         DiagnosticsTrail.record(
             logger: appState.logger,
             level: .error,
@@ -572,18 +574,18 @@ class DictationSessionController: ObservableObject {
                 ]
             )
         )
-        trackDictationStartFailed("microphone_start_timeout")
-        appState.runtimeDiagnostics.recordStall(
-            kind: "dictation",
-            stage: "microphone_start_timeout",
-            durationSeconds: TranscriptedConstants.dictationRecoveryBudget,
-            extra: [
-                "format_ready": "\(appState.sttRouter.inputFormatReady)",
-                "recovering": "\(appState.sttRouter.isRecovering)"
-            ]
-        )
-        appState.runtimeDiagnostics.clearSession(kind: "dictation", outcome: "microphone_start_timeout")
-        isDictating = false
+        trackDictationStartFailed(cleanupPlan.outcome)
+        if cleanupPlan.reportRuntimeStall {
+            appState.runtimeDiagnostics.recordStall(
+                kind: "dictation",
+                stage: cleanupPlan.outcome,
+                durationSeconds: TranscriptedConstants.dictationRecoveryBudget,
+                extra: [
+                    "format_ready": "\(appState.sttRouter.inputFormatReady)",
+                    "recovering": "\(appState.sttRouter.isRecovering)"
+                ]
+            )
+        }
         overlayController.showError(
             microphoneTimeoutMessage(
                 deviceName: appState.sttRouter.inputDeviceName,
@@ -596,6 +598,24 @@ class DictationSessionController: ObservableObject {
                 self.startDictation(sourceApp: sourceApp, trigger: self.currentDictationTrigger)
             }
         )
+    }
+
+    private func finishFailedDictationStart(
+        appState: TranscriptedAppState,
+        cleanupPlan: DictationRecordingStartFailureCleanupPlan
+    ) async {
+        recordingStartRetryTask = nil
+        sessionTimeoutTask?.cancel()
+        sessionTimeoutTask = nil
+        if cleanupPlan.resetSpeechEngine {
+            await appState.sttRouter.resetAfterFailedRecordingStart()
+        }
+        appState.runtimeDiagnostics.clearSession(
+            kind: "dictation",
+            outcome: cleanupPlan.outcome,
+            resetToIdle: cleanupPlan.resetRuntimeSessionToIdle
+        )
+        isDictating = false
     }
 
     private func presentMicrophonePermissionError(

--- a/Tests/DictationRecordingStartOverlayPolicyTests.swift
+++ b/Tests/DictationRecordingStartOverlayPolicyTests.swift
@@ -84,4 +84,13 @@ func testDictationRecordingStartOverlayPolicy() {
             "idle compact overlay stops should stay ignored"
         )
     }
+
+    runSuite("DictationRecordingStartFailurePolicy treats microphone timeout as a handled startup failure") {
+        let plan = DictationRecordingStartFailurePolicy.cleanupPlan(for: "microphone_start_timeout")
+
+        assertEqual(plan.outcome, "microphone_start_timeout", "cleanup should keep the concrete failure outcome")
+        assertTrue(plan.resetRuntimeSessionToIdle, "handled mic-start failures should not leave an active runtime session")
+        assertTrue(plan.resetSpeechEngine, "failed startup should release the partial audio graph")
+        assertFalse(plan.reportRuntimeStall, "the timeout event already reports this failure; it should not also emit app.session_stall_detected")
+    }
 }


### PR DESCRIPTION
## Summary

- Treat dictation microphone start timeout as a handled startup failure instead of a live runtime stall.
- Reset the Parakeet startup graph after a failed mic start so partial taps, pending buffers, recovery tasks, and audio hardware state do not linger.
- Add focused policy coverage to keep the timeout path from emitting a duplicate `app.session_stall_detected` event.

## Root Cause

The production path already reported `dictation.microphone_start_timeout`, but then also recorded a runtime stall for the same dictation session before fully settling the failed startup state. On routes like `built_in_input_to_bluetooth_output`, a route that never became ready could therefore look like both a mic-start failure and a still-live stalled session.

The Bluetooth heuristic itself still looks right: choosing the built-in mic while Bluetooth output is active avoids forcing headset/HFP input mode. The fix is cleanup and attribution when that preferred route never settles.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (`1718 tests, 1718 passed`)
- Fresh recheck before PR:
  - `bash build.sh`
  - `bash run-tests.sh` (`1718 tests, 1718 passed`)
