### PR TITLE
[codex] Harden startup recovery diagnostics

### DIFF
--- a/Sources/Meeting/MeetingFailureExplanation.swift
+++ b/Sources/Meeting/MeetingFailureExplanation.swift
@@ -153,6 +153,7 @@ struct MeetingFailureExplanation: Equatable {
             return .audioStart
         case .modelDownloadFailed,
              .modelNotLoaded,
+             .pipelineFailed,
              .transcriptionInferenceFailed,
              .emptyAudio,
              .invalidAudioFormat,

--- a/Sources/Meeting/MeetingFailureKind.swift
+++ b/Sources/Meeting/MeetingFailureKind.swift
@@ -14,6 +14,7 @@ enum MeetingFailureKind: String {
     case transcriptionInferenceFailed = "transcription_inference_failed"
     case diarizationFailed = "diarization_failed"
     case pipelineBusy = "pipeline_busy"
+    case pipelineFailed = "pipeline_failed"
     case stopTimeout = "stop_timeout"
     case unexpectedError = "unexpected_error"
 
@@ -95,8 +96,14 @@ enum MeetingFailureKind: String {
             return .saveFailed
         }
 
-        if normalized.contains("transcription already in progress") {
+        if normalized.contains(anyOf: [
+            "transcription already in progress",
+        ]) {
             return .pipelineBusy
+        }
+
+        if normalized.contains("retry failed") {
+            return .pipelineFailed
         }
 
         if normalized.contains("model not loaded") {
@@ -117,7 +124,16 @@ enum MeetingFailureKind: String {
         }
 
         if normalized.contains(anyOf: [
+            "asr",
+            "core ml",
+            "coreml",
+            "failed to transcribe",
+            "fluid",
+            "mlmodel",
+            "multiarray",
             "parakeet",
+            "prediction",
+            "preprocessor",
             "inference failed",
             "transcription failed",
         ]) {

--- a/Sources/Observability/CrashReporter.swift
+++ b/Sources/Observability/CrashReporter.swift
@@ -108,15 +108,22 @@ final class CrashReporter {
         message: String,
         context: [String: String]
     ) {
+        let diagnosticTags = SentryEventPolicy.diagnosticTags(
+            forEngine: engine,
+            event: event,
+            context: context
+        )
+        let tags = [
+            "source": "observability",
+            "engine": engine,
+            "event": event,
+        ].merging(diagnosticTags) { current, _ in current }
+
         _ = captureMessageEvent(
             level: sentryLevel(for: level),
             title: "\(engine).\(event)",
             message: message,
-            tags: [
-                "source": "observability",
-                "engine": engine,
-                "event": event,
-            ],
+            tags: tags,
             extra: context,
             fingerprint: [engine, event]
         )

--- a/Sources/Observability/SentryEventPolicy.swift
+++ b/Sources/Observability/SentryEventPolicy.swift
@@ -9,6 +9,67 @@ struct SentryEventPolicy: Equatable {
         allowedPolicies["\(engine).\(event)"]
     }
 
+    static func diagnosticTags(
+        forEngine engine: String,
+        event: String,
+        context: [String: String]
+    ) -> [String: String] {
+        guard policy(forEngine: engine, event: event) != nil else { return [:] }
+
+        var tags = context.filter { allowedDiagnosticTagKeys.contains($0.key) }
+        if let waitBucket = durationBucket(fromMilliseconds: context["wait_ms"]) {
+            tags["wait_bucket"] = waitBucket
+        }
+
+        return SentryPayloadSanitizer.sanitizeTags(tags)
+    }
+
+    private static let allowedDiagnosticTagKeys: Set<String> = [
+        "capture_quality",
+        "default_input_class",
+        "default_output_class",
+        "duration_bucket",
+        "failure_kind",
+        "forced_readiness_recoveries",
+        "format_ready",
+        "gap_count_bucket",
+        "hfp_suspected",
+        "input_channels",
+        "input_device_class",
+        "input_rate_hz",
+        "output_channels",
+        "output_device_class",
+        "output_rate_hz",
+        "queue_depth_bucket",
+        "readiness_refreshes",
+        "recovering",
+        "recovery_start_attempts",
+        "route_change_count_bucket",
+        "route_shape",
+        "sample_flow_started",
+        "selected_input_class",
+        "selection_overrode_default",
+        "selection_reason",
+        "session_active",
+        "session_kind",
+        "session_stage",
+        "stall_kind",
+        "stall_stage",
+        "start_attempts",
+        "stt_model",
+        "system_status",
+        "trigger",
+        "was_recording",
+    ]
+
+    private static func durationBucket(fromMilliseconds value: String?) -> String? {
+        guard let value,
+              let milliseconds = Double(value) else {
+            return nil
+        }
+        return AnalyticsReporter.durationBucket(seconds: milliseconds / 1000)
+    }
+
     private static let allowedPolicies: [String: SentryEventPolicy] = [
         "app.session_stall_detected": .init(
             engine: "app",

--- a/Sources/Speech/DictationReadinessWaitPolicy.swift
+++ b/Sources/Speech/DictationReadinessWaitPolicy.swift
@@ -14,6 +14,7 @@ enum DictationReadinessWaitAction: Equatable {
 
 struct DictationReadinessWaitPolicy {
     private static let refreshesBeforeRecoveryStart = 4
+    private static let maxRecoveryStartAttempts = 2
 
     static func action(
         isRecovering: Bool,
@@ -33,12 +34,17 @@ struct DictationReadinessWaitPolicy {
             return .startRecording
         }
 
-        if readinessRefreshTimedOut, recoveryStartAttempts == 0 {
+        let shouldTryRecoveryStart = readinessRefreshTimedOut
+            || readinessRefreshes >= refreshesBeforeRecoveryStart
+        if shouldTryRecoveryStart,
+           recoveryStartAttempts == 0 {
             return .startRecoveryRecording
         }
 
-        if readinessRefreshes >= refreshesBeforeRecoveryStart,
-           recoveryStartAttempts == 0 {
+        if shouldTryRecoveryStart,
+           forcedRecoveryAttempts > 0,
+           forcedRecoveryAttempts < maxForcedRecoveryAttempts,
+           recoveryStartAttempts < maxRecoveryStartAttempts {
             return .startRecoveryRecording
         }
 

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -563,6 +563,7 @@ class DictationSessionController: ObservableObject {
                 extra: [
                     "wait_ms": "\(waited)",
                     "audio_device": appState.sttRouter.inputDeviceName,
+                    "failure_kind": "microphone_start_timeout",
                     "is_recovering": "\(appState.sttRouter.isRecovering)",
                     "format_ready": "\(appState.sttRouter.inputFormatReady)",
                     "start_attempts": "\(startAttempts)",
@@ -577,10 +578,16 @@ class DictationSessionController: ObservableObject {
             kind: "dictation",
             stage: "microphone_start_timeout",
             durationSeconds: TranscriptedConstants.dictationRecoveryBudget,
-            extra: [
+            extra: dictationAnalyticsProperties(extra: [
+                "failure_kind": "microphone_start_timeout",
                 "format_ready": "\(appState.sttRouter.inputFormatReady)",
-                "recovering": "\(appState.sttRouter.isRecovering)"
-            ]
+                "forced_readiness_recoveries": "\(forcedReadinessRecoveries)",
+                "readiness_refreshes": "\(readinessRefreshes)",
+                "recovering": "\(appState.sttRouter.isRecovering)",
+                "recovery_start_attempts": "\(recoveryStartAttempts)",
+                "start_attempts": "\(startAttempts)",
+                "trigger": currentDictationTrigger.rawValue,
+            ])
         )
         appState.runtimeDiagnostics.clearSession(kind: "dictation", outcome: "microphone_start_timeout")
         isDictating = false

--- a/Tests/DictationReadinessWaitPolicyTests.swift
+++ b/Tests/DictationReadinessWaitPolicyTests.swift
@@ -125,7 +125,19 @@ func testDictationReadinessWaitPolicy() {
         assertEqual(action, .startRecoveryRecording, "one stale readiness refresh should unblock the guarded recovery start")
     }
 
-    runSuite("DictationReadinessWaitPolicy — recovery start is bounded") {
+    runSuite("DictationReadinessWaitPolicy — forced recovery unlocks one more recovery start") {
+        let action = DictationReadinessWaitPolicy.action(
+            isRecovering: false,
+            inputFormatReady: false,
+            readinessRefreshes: 4,
+            forcedRecoveryAttempts: 1,
+            recoveryStartAttempts: 1
+        )
+
+        assertEqual(action, .startRecoveryRecording, "after a hard input recovery, one more guarded recovery start should be allowed")
+    }
+
+    runSuite("DictationReadinessWaitPolicy — recovery start is bounded before forced recovery") {
         let action = DictationReadinessWaitPolicy.action(
             isRecovering: false,
             inputFormatReady: false,
@@ -133,7 +145,19 @@ func testDictationReadinessWaitPolicy() {
             recoveryStartAttempts: 1
         )
 
-        assertEqual(action, .refreshInputReadiness, "after one recovery start attempt the loop should go back to readiness refreshes")
+        assertEqual(action, .refreshInputReadiness, "after one recovery start attempt the loop should refresh until a hard recovery is attempted")
+    }
+
+    runSuite("DictationReadinessWaitPolicy — second recovery start is bounded") {
+        let action = DictationReadinessWaitPolicy.action(
+            isRecovering: false,
+            inputFormatReady: false,
+            readinessRefreshes: 4,
+            forcedRecoveryAttempts: 1,
+            recoveryStartAttempts: 2
+        )
+
+        assertEqual(action, .refreshInputReadiness, "the post-rebuild recovery start should not loop forever")
     }
 
     runSuite("DictationReadinessWaitPolicy — timed-out refresh recovery start is bounded") {

--- a/Tests/MeetingFailureKindTests.swift
+++ b/Tests/MeetingFailureKindTests.swift
@@ -57,6 +57,22 @@ func testMeetingFailureKind() {
         assertEqual(kind, .pipelineBusy, "pipeline-busy rejections from TranscriptionTaskManager should not fall to unexpected_error")
     }
 
+    runSuite("MeetingFailureKind classifies retry pipeline failures") {
+        let kind = MeetingFailureKind.classify(
+            message: "Retry failed"
+        )
+
+        assertEqual(kind, .pipelineFailed, "retry orchestration failures should stay out of unexpected_error")
+    }
+
+    runSuite("MeetingFailureKind classifies model runtime wording") {
+        let kind = MeetingFailureKind.classify(
+            message: "ASR preprocessor failed while running CoreML prediction"
+        )
+
+        assertEqual(kind, .transcriptionInferenceFailed, "model runtime failures should land in the inference bucket")
+    }
+
     runSuite("MeetingFailureKind classifies stop-timeout errors") {
         let kind = MeetingFailureKind.classify(
             message: "Recording stop timed out before audio files were finalized."

--- a/Tests/SentryEventPolicyTests.swift
+++ b/Tests/SentryEventPolicyTests.swift
@@ -84,4 +84,70 @@ func testSentryEventPolicy() {
         assertEqual(onboardingStopFailure?.summary, "Onboarding could not stop first dictation.", "onboarding stop wiring failures should be visible without clickstream data")
         assertNil(unknown, "unknown events should stay local-only by default")
     }
+
+    runSuite("SentryEventPolicy diagnosticTags keeps timeout triage searchable and safe") {
+        let tags = SentryEventPolicy.diagnosticTags(
+            forEngine: "dictation",
+            event: "microphone_start_timeout",
+            context: [
+                "audio_device": "Justin's AirPods",
+                "failure_kind": "microphone_start_timeout",
+                "forced_readiness_recoveries": "2",
+                "format_ready": "false",
+                "input_device_class": "bluetooth",
+                "readiness_refreshes": "8",
+                "recovering": "false",
+                "recovery_start_attempts": "2",
+                "route_shape": "bluetooth_input_to_built_in_output",
+                "start_attempts": "4",
+                "transcript_text": "private words",
+                "trigger": "physical_key",
+                "wait_ms": "6000",
+            ]
+        )
+
+        assertEqual(tags["failure_kind"], "microphone_start_timeout", "failure kind should be queryable")
+        assertEqual(tags["format_ready"], "false", "format readiness should be queryable")
+        assertEqual(tags["recovering"], "false", "recovery state should be queryable")
+        assertEqual(tags["input_device_class"], "bluetooth", "coarse device class should be queryable")
+        assertEqual(tags["route_shape"], "bluetooth_input_to_built_in_output", "coarse route shape should be queryable")
+        assertEqual(tags["start_attempts"], "4", "bounded retry count should be queryable")
+        assertEqual(tags["readiness_refreshes"], "8", "readiness refresh count should be queryable")
+        assertEqual(tags["recovery_start_attempts"], "2", "recovery start count should be queryable")
+        assertEqual(tags["forced_readiness_recoveries"], "2", "forced recovery count should be queryable")
+        assertEqual(tags["trigger"], "physical_key", "coarse trigger should be queryable")
+        assertEqual(tags["wait_bucket"], "lt_10s", "raw wait time should be bucketed")
+        assertNil(tags["audio_device"], "raw device names should stay out of Sentry tags")
+        assertNil(tags["transcript_text"], "transcript text should stay out of Sentry tags")
+    }
+
+    runSuite("SentryEventPolicy diagnosticTags keeps meeting failure triage searchable") {
+        let tags = SentryEventPolicy.diagnosticTags(
+            forEngine: "meeting",
+            event: "meeting_transcript_failed",
+            context: [
+                "failure_kind": "transcription_inference_failed",
+                "input_device_class": "usb",
+                "queue_depth_bucket": "zero",
+                "system_status": "healthy",
+                "trigger": "hotkey",
+            ]
+        )
+
+        assertEqual(tags["failure_kind"], "transcription_inference_failed", "meeting failure kind should be searchable")
+        assertEqual(tags["input_device_class"], "usb", "coarse input class should be searchable")
+        assertEqual(tags["queue_depth_bucket"], "zero", "queue depth should stay bucketed")
+        assertEqual(tags["system_status"], "healthy", "system capture status should be queryable")
+        assertEqual(tags["trigger"], "hotkey", "trigger should be queryable")
+    }
+
+    runSuite("SentryEventPolicy diagnosticTags ignores non-allowlisted events") {
+        let tags = SentryEventPolicy.diagnosticTags(
+            forEngine: "dictation",
+            event: "dictation_export_failed",
+            context: ["format_ready": "false"]
+        )
+
+        assertTrue(tags.isEmpty, "local-only events should not get Sentry diagnostic tags")
+    }
 }


### PR DESCRIPTION
## Summary
- allow one bounded post-rebuild dictation recovery start before reporting microphone timeout
- attach safe Sentry diagnostic tags and paired runtime-stall context for startup and meeting failures
- classify meeting retry/model runtime failures into stable buckets instead of `unexpected_error`

## Why
The latest Sentry/PostHog pass showed a small but real latest-release cluster around dictation startup timeouts/stalls, plus meeting failures that were too vague to triage quickly.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`