### PR TITLE
[nightly-agent] Follow external capture libraries in CLI

### DIFF
--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -250,14 +250,25 @@ struct CLIContextDirectories {
             return nil
         }
 
-        let configuredURL = URL(fileURLWithPath: trimmed, isDirectory: true)
-        let standardizedPath = configuredURL.standardizedFileURL.path
-        let homePath = home.standardizedFileURL.path
-        guard standardizedPath.hasPrefix(homePath) else {
+        let directory = URL(fileURLWithPath: trimmed, isDirectory: true).standardizedFileURL
+        guard directory.path != "/", !directory.pathComponents.contains("..") else {
             return nil
         }
 
-        return configuredURL
+        let resolvedDirectory = directory.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedHome = home.resolvingSymlinksInPath().standardizedFileURL
+        let isUnderHome = resolvedDirectory.path == resolvedHome.path
+            || resolvedDirectory.path.hasPrefix(resolvedHome.path + "/")
+        let forbiddenPrefixes = ["/System", "/Library", "/usr", "/bin", "/sbin", "/private"]
+        let isForbidden = forbiddenPrefixes.contains { prefix in
+            resolvedDirectory.path == prefix || resolvedDirectory.path.hasPrefix(prefix + "/")
+        }
+
+        guard !isForbidden || isUnderHome else {
+            return nil
+        }
+
+        return directory
     }
 
     private static func isManifestDirectory(_ directory: URL, named name: String, under captureLibrary: URL) -> Bool {

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextDirectoriesTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextDirectoriesTests.swift
@@ -232,6 +232,51 @@ final class ContextDirectoriesTests: XCTestCase {
         ])
     }
 
+    func testResolveUsesAppDirectoryManifestOutsideHome() throws {
+        let tempHome = makeTempDir()
+        let externalCaptureLibrary = makeTempDir()
+        defer {
+            removeTempDir(tempHome)
+            removeTempDir(externalCaptureLibrary)
+        }
+
+        let transcriptedRoot = tempHome
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Transcripted", isDirectory: true)
+        let manifestMeetings = externalCaptureLibrary.appendingPathComponent("meetings", isDirectory: true)
+        let manifestDictations = externalCaptureLibrary.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: transcriptedRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: manifestMeetings, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: manifestDictations, withIntermediateDirectories: true)
+
+        let manifestURL = transcriptedRoot.appendingPathComponent("mcp-directories.json", isDirectory: false)
+        try """
+        {
+          "version": 1,
+          "captureLibraryDirectory": "\(externalCaptureLibrary.path)",
+          "meetingsDirectory": "\(manifestMeetings.path)",
+          "dictationsDirectory": "\(manifestDictations.path)"
+        }
+        """.write(to: manifestURL, atomically: true, encoding: .utf8)
+
+        let directories = CLIContextDirectories.resolve(
+            dataDir: nil,
+            meetingsDir: nil,
+            dictationsDir: nil,
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(directories.meetingDirs.map(\.standardizedFileURL.path), [
+            manifestMeetings.standardizedFileURL.path,
+        ])
+        XCTAssertEqual(directories.dictationDirs.map(\.standardizedFileURL.path), [
+            manifestDictations.standardizedFileURL.path,
+        ])
+    }
+
     func testResolveIgnoresManifestWhenDirectoriesDoNotMatchCaptureLibrary() throws {
         let tempHome = makeTempDir()
         defer { removeTempDir(tempHome) }
@@ -292,6 +337,48 @@ final class ContextDirectoriesTests: XCTestCase {
         let plistURL = preferencesDir.appendingPathComponent("app.transcripted.Transcripted.plist", isDirectory: false)
         let plistData = try PropertyListSerialization.data(
             fromPropertyList: ["transcriptSaveLocation": customCaptureLibrary.path],
+            format: .xml,
+            options: 0
+        )
+        try plistData.write(to: plistURL)
+
+        let directories = CLIContextDirectories.resolve(
+            dataDir: nil,
+            meetingsDir: nil,
+            dictationsDir: nil,
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(directories.meetingDirs.map(\.standardizedFileURL.path), [
+            customMeetings.standardizedFileURL.path,
+        ])
+        XCTAssertEqual(directories.dictationDirs.map(\.standardizedFileURL.path), [
+            customDictations.standardizedFileURL.path,
+        ])
+    }
+
+    func testResolveUsesAppCaptureLibraryPreferenceOutsideHome() throws {
+        let tempHome = makeTempDir()
+        let externalCaptureLibrary = makeTempDir()
+        defer {
+            removeTempDir(tempHome)
+            removeTempDir(externalCaptureLibrary)
+        }
+
+        let preferencesDir = tempHome
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Preferences", isDirectory: true)
+        let customMeetings = externalCaptureLibrary.appendingPathComponent("meetings", isDirectory: true)
+        let customDictations = externalCaptureLibrary.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: preferencesDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: customMeetings, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: customDictations, withIntermediateDirectories: true)
+
+        let plistURL = preferencesDir.appendingPathComponent("app.transcripted.Transcripted.plist", isDirectory: false)
+        let plistData = try PropertyListSerialization.data(
+            fromPropertyList: ["transcriptSaveLocation": externalCaptureLibrary.path],
             format: .xml,
             options: 0
         )


### PR DESCRIPTION
## Summary
- allow TranscriptedCLI to follow app-selected capture libraries outside the user home, matching the MCP/app safety model
- keep rejecting root/traversal/system-prefix configured paths
- add CLI resolver tests for manifest and preference capture libraries outside the fake home

## Verification
- swift test --package-path Tools/TranscriptedCLI
- swift test --package-path Tools/TranscriptedMCP
- cd Tools/TranscriptedMCP && swift build -c release
- transcripted-mcp --self-test with default resolution
- transcripted-mcp --self-test with explicit TRANSCRIPTED_DATA_DIR
- transcripted-cli context-recent/context-search/list-dictations/read-meeting/read-dictation with explicit local directory overrides