### PR TITLE
[operator] Clarify first-value Markdown proof

### DIFF
--- a/Sources/UI/Shared/FirstRunExperience.swift
+++ b/Sources/UI/Shared/FirstRunExperience.swift
@@ -197,7 +197,7 @@ enum FirstRunExperience {
                 primaryTitle: hasFirstDictation ? "Continue" : "Try Again",
                 secondaryTitle: nil,
                 detail: hasFirstDictation
-                    ? "This is the first useful moment: spoken work became a saved dictation."
+                    ? "This is the first useful moment: spoken work became a saved local Markdown file."
                     : "No dictation has been saved yet. Try again with one clear sentence.",
                 isPrimaryEnabled: true
             )

--- a/Tests/FirstRunExperienceTests.swift
+++ b/Tests/FirstRunExperienceTests.swift
@@ -62,6 +62,10 @@ func testFirstRunExperience() {
         )
 
         assertEqual(result.primaryTitle, "Continue", "saved first dictation should move into meetings")
+        assertTrue(
+            result.detail.contains("saved local Markdown file"),
+            "saved first dictation should prove the local Markdown artifact"
+        )
         assertEqual(meetings.primaryTitle, "Set up meetings", "meeting intro should offer setup")
         assertEqual(meetings.secondaryTitle, "Skip for now", "meeting intro should not trap dictation-first users")
         assertEqual(agent.primaryTitle, "Open Transcripted", "last step should land users in the app")


### PR DESCRIPTION
## Summary
- clarify the first successful onboarding dictation as a saved local Markdown file
- add a regression assertion so the first-value copy keeps proving the local artifact

## Verification
- bash run-tests.sh FirstRunExperienceTests.swift (runner executed full fast suite: 1715 passed)
- bash build-deps.sh --force
- bash build.sh

## Nightly operator context
Chosen lane: Execute. This is a tiny first-value onboarding copy/test fix that avoids the open audio/reliability PR surfaces and does not add telemetry or touch capture behavior.