### PR TITLE
[nightly-maintenance] Include Info.plist in preflight checks

### DIFF
--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -84,6 +84,11 @@ if [ -n "$changed_paths" ]; then
             add_command "bash run-tests.sh"
         fi
 
+        if matches_any "$path" "Info.plist"; then
+            add_command "bash build.sh"
+            add_command "bash run-tests.sh"
+        fi
+
         if matches_any "$path" "Sources/Meeting/*" "Sources/TranscriptedCore/*" "Tests/Integration/*"; then
             add_command "bash build.sh"
             add_command "bash run-tests.sh"


### PR DESCRIPTION
## Summary
- update agent preflight so Info.plist changes suggest the build and fast-test checks from .agents/test-matrix.yml

## Verification
- scripts/dev/agent-preflight.sh before editing
- bash -n scripts/dev/agent-preflight.sh
- git diff --check
- scripts/dev/agent-preflight.sh
- temporary Info.plist diff confirmed preflight suggests bash build.sh and bash run-tests.sh; temporary diff was removed before commit