### PR TITLE
[codex] Fix cached model readiness state

### DIFF
--- a/Sources/Meeting/MeetingWarmupStatusPolicy.swift
+++ b/Sources/Meeting/MeetingWarmupStatusPolicy.swift
@@ -8,6 +8,12 @@ struct MeetingWarmupStatus: Equatable {
     let dictationStatus: String
     let meetingsStatus: String
 
+    var isReadyForMenuHeader: Bool {
+        guard progress >= 1.0 else { return false }
+        return !Self.blockingDictationStatuses.contains(dictationStatus)
+            && !Self.blockingMeetingStatuses.contains(meetingsStatus)
+    }
+
     static let ready = MeetingWarmupStatus(
         title: "Transcripted is ready",
         subtitle: "Dictation and meetings are available",
@@ -34,6 +40,19 @@ struct MeetingWarmupStatus: Equatable {
         dictationStatus: "On demand",
         meetingsStatus: "On demand"
     )
+
+    private static let blockingDictationStatuses: Set<String> = [
+        "Downloading",
+        "Loading",
+        "Failed",
+    ]
+
+    private static let blockingMeetingStatuses: Set<String> = [
+        "Waiting",
+        "Loading",
+        "Starting",
+        "Failed",
+    ]
 }
 
 enum MeetingWarmupDictationState: Equatable {

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -430,6 +430,7 @@ class ParakeetEngine: ObservableObject {
     }
 
     init() {
+        markCachedRuntimeModelIfAvailable()
         scheduleInputDeviceNameRefresh()
     }
 
@@ -533,6 +534,7 @@ class ParakeetEngine: ObservableObject {
         defer { modelInitializationTask = nil }
         guard !isShuttingDown, !Task.isCancelled else { return }
         scheduleInputDeviceNameRefresh()
+        markCachedRuntimeModelIfAvailable()
 
         guard asrManager == nil else {
             EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "already_initialized",
@@ -592,16 +594,21 @@ class ParakeetEngine: ObservableObject {
                 // verification stub would be worse than no check at all.
                 failureStage = .downloadModels
                 loadSource = .download
-                print("🌐 PARAKEET | models not bundled, downloading (~600MB)...")
-                modelDownloadState = .downloading(progress: 0.0)
                 let downloadedPath: URL
                 if let modelFilePrefetchTask {
+                    print("🌐 PARAKEET | waiting for background Parakeet model cache...")
+                    modelDownloadState = .downloading(progress: 0.0)
                     downloadedPath = try await modelFilePrefetchTask.value
                     prefetchedModelPath = downloadedPath
                     self.modelFilePrefetchTask = nil
                 } else if let prefetchedModelPath {
                     downloadedPath = prefetchedModelPath
+                } else if let cachedModelPath = ModelCacheInventory.activeParakeetModelDirectory() {
+                    prefetchedModelPath = cachedModelPath
+                    downloadedPath = cachedModelPath
                 } else {
+                    print("🌐 PARAKEET | models not bundled, downloading (~600MB)...")
+                    modelDownloadState = .downloading(progress: 0.0)
                     downloadedPath = try await AsrModels.download(version: .v3)
                     prefetchedModelPath = downloadedPath
                 }
@@ -662,6 +669,10 @@ class ParakeetEngine: ObservableObject {
             return
         }
 
+        if markCachedRuntimeModelIfAvailable() {
+            return
+        }
+
         switch modelDownloadState {
         case .downloading, .cached, .loading, .ready:
             return
@@ -683,6 +694,12 @@ class ParakeetEngine: ObservableObject {
         do {
             let downloadedPath = try await task.value
             guard !Task.isCancelled, !isShuttingDown else { return }
+            guard modelInitializationTask == nil, asrManager == nil, !asrManagerReady else {
+                if modelFilePrefetchTask != nil {
+                    modelFilePrefetchTask = nil
+                }
+                return
+            }
             prefetchedModelPath = downloadedPath
             modelDownloadState = .cached
             if modelFilePrefetchTask != nil {
@@ -709,6 +726,19 @@ class ParakeetEngine: ObservableObject {
                 message: error.localizedDescription
             )
         }
+    }
+
+    @discardableResult
+    private func markCachedRuntimeModelIfAvailable() -> Bool {
+        guard let cachedModelPath = ModelCacheInventory.activeParakeetModelDirectory() else {
+            return false
+        }
+
+        prefetchedModelPath = cachedModelPath
+        if !asrManagerReady {
+            modelDownloadState = .cached
+        }
+        return true
     }
 
     /// Load Parakeet EOU 120M for streaming live display.

--- a/Sources/Support/ModelCacheInventory.swift
+++ b/Sources/Support/ModelCacheInventory.swift
@@ -71,6 +71,8 @@ struct ModelCacheCleanupResult: Equatable {
 }
 
 enum ModelCacheInventory {
+    static let activeParakeetModelDirectoryName = "parakeet-tdt-0.6b-v3-coreml"
+
     static let knownStaleFluidAudioModelDirectories: Set<String> = [
         "parakeet-tdt-0.6b-v2",
         "parakeet-tdt-0.6b-v2-coreml",
@@ -107,6 +109,21 @@ enum ModelCacheInventory {
         formatter.countStyle = .file
         formatter.allowedUnits = [.useKB, .useMB, .useGB]
         return formatter.string(fromByteCount: bytes)
+    }
+
+    static func activeParakeetModelDirectory(
+        fileManager: FileManager = .default,
+        fluidAudioModelsDirectory: URL = defaultFluidAudioModelsDirectory()
+    ) -> URL? {
+        let candidate = fluidAudioModelsDirectory
+            .appendingPathComponent(activeParakeetModelDirectoryName, isDirectory: true)
+            .standardizedFileURL
+
+        guard hasCompleteParakeetModel(at: candidate, fileManager: fileManager) else {
+            return nil
+        }
+
+        return candidate
     }
 
     static func removeKnownStaleFluidAudioModels(
@@ -226,6 +243,48 @@ enum ModelCacheInventory {
         let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
         guard values?.isRegularFile == true else { return 0 }
         return Int64(values?.fileSize ?? 0)
+    }
+
+    private static func hasCompleteParakeetModel(at directory: URL, fileManager: FileManager) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+              isDirectory.boolValue,
+              !isSymbolicLink(at: directory, fileManager: fileManager)
+        else {
+            return false
+        }
+
+        let requiredDirectories = [
+            "Encoder.mlmodelc",
+            "JointDecision.mlmodelc",
+            "Decoder.mlmodelc",
+            "Preprocessor.mlmodelc",
+        ]
+
+        for name in requiredDirectories {
+            let modelDirectory = directory.appendingPathComponent(name, isDirectory: true)
+            guard fileManager.fileExists(atPath: modelDirectory.path, isDirectory: &isDirectory),
+                  isDirectory.boolValue,
+                  !isSymbolicLink(at: modelDirectory, fileManager: fileManager)
+            else {
+                return false
+            }
+
+            let coreMLData = modelDirectory.appendingPathComponent("coremldata.bin")
+            guard fileManager.fileExists(atPath: coreMLData.path) else {
+                return false
+            }
+        }
+
+        let requiredFiles = [
+            "config.json",
+            "parakeet_v3_vocab.json",
+            "parakeet_vocab.json",
+        ]
+
+        return requiredFiles.allSatisfy { name in
+            fileManager.fileExists(atPath: directory.appendingPathComponent(name).path)
+        }
     }
 
     private static func resolvedDirectoryIsInsideAppCache(

--- a/Sources/UI/MenuBar/MenuBarHeaderView.swift
+++ b/Sources/UI/MenuBar/MenuBarHeaderView.swift
@@ -65,7 +65,7 @@ final class MenuBarHeaderView: NSView {
     override func layout() {
         super.layout()
 
-        let isReady = currentWarmupStatus == .ready
+        let isReady = currentWarmupStatus.isReadyForMenuHeader
         let hasWarning = currentHotkeyError?.isEmpty == false
 
         if isReady && !hasWarning {
@@ -104,7 +104,7 @@ final class MenuBarHeaderView: NSView {
         currentWarmupStatus = warmupStatus
         currentHotkeyError = hotkeyError
 
-        let isReady = warmupStatus == .ready
+        let isReady = warmupStatus.isReadyForMenuHeader
         statusDot.layer?.backgroundColor = (isReady ? MenuTokens.statusGreenNS : MenuTokens.statusOrangeNS).cgColor
         statusLabel.stringValue = isReady ? "Ready" : warmupStatus.subtitle
         progressBar.doubleValue = warmupStatus.progress
@@ -116,7 +116,7 @@ final class MenuBarHeaderView: NSView {
     }
 
     var intrinsicHeight: CGFloat {
-        let isReady = currentWarmupStatus == .ready
+        let isReady = currentWarmupStatus.isReadyForMenuHeader
         let hasWarning = currentHotkeyError?.isEmpty == false
         if isReady {
             return hasWarning ? 56 : 0

--- a/Tests/MeetingWarmupStatusPolicyTests.swift
+++ b/Tests/MeetingWarmupStatusPolicyTests.swift
@@ -60,6 +60,7 @@ func testMeetingWarmupStatusPolicy() {
 
         assertEqual(status.title, "Transcripted is ready", "lazy default launch should not look like stuck startup work")
         assertEqual(status.subtitle, "Dictation and meetings load when started", "lazy model loading should be explicit")
+        assertTrue(status.isReadyForMenuHeader, "lazy model loading should not make the menu header look stuck")
         assertTrue(
             status.detail.contains("outside app updates"),
             "lazy model copy should explain the one-time cache survives normal app updates"
@@ -77,6 +78,7 @@ func testMeetingWarmupStatusPolicy() {
         )
 
         assertEqual(status.dictationStatus, "Downloading", "zero-progress Parakeet downloads should not pretend to have exact percent progress")
+        assertFalse(status.isReadyForMenuHeader, "real downloads should still surface as in-progress work")
         assertTrue(
             status.detail.contains("future app updates should reuse the cached model"),
             "download copy should explain update-safe model caching"
@@ -92,6 +94,7 @@ func testMeetingWarmupStatusPolicy() {
         )
 
         assertEqual(status.dictationStatus, "Cached", "cached dictation files should have their own status")
+        assertTrue(status.isReadyForMenuHeader, "cached files should not make the menu header look stuck or not ready")
         assertTrue(
             status.detail.contains("load them into memory on first use"),
             "cached copy should not claim the speech model is already loaded"

--- a/Tests/ModelCacheInventoryTests.swift
+++ b/Tests/ModelCacheInventoryTests.swift
@@ -28,6 +28,33 @@ func testModelCacheInventory() {
         assertEqual(snapshot.reclaimableBytes(includeWhisper: true), 40, "reclaimable total with Whisper should include stale and optional Whisper models")
     }
 
+    runSuite("ModelCacheInventory active Parakeet cache requires complete CoreML files") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ModelCacheInventoryTests-\(UUID().uuidString)", isDirectory: true)
+        let fluid = root.appendingPathComponent("FluidAudio/Models", isDirectory: true)
+        let active = fluid.appendingPathComponent("parakeet-tdt-0.6b-v3-coreml", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        assertNil(
+            ModelCacheInventory.activeParakeetModelDirectory(fluidAudioModelsDirectory: fluid),
+            "missing active Parakeet cache should not be treated as cached"
+        )
+
+        writeTestFile(active.appendingPathComponent("Encoder.mlmodelc/coremldata.bin"), bytes: 11)
+        writeTestFile(active.appendingPathComponent("JointDecision.mlmodelc/coremldata.bin"), bytes: 11)
+        writeTestFile(active.appendingPathComponent("Decoder.mlmodelc/coremldata.bin"), bytes: 11)
+        writeTestFile(active.appendingPathComponent("Preprocessor.mlmodelc/coremldata.bin"), bytes: 11)
+        writeTestFile(active.appendingPathComponent("config.json"), bytes: 2)
+        writeTestFile(active.appendingPathComponent("parakeet_v3_vocab.json"), bytes: 2)
+        writeTestFile(active.appendingPathComponent("parakeet_vocab.json"), bytes: 2)
+
+        assertEqual(
+            ModelCacheInventory.activeParakeetModelDirectory(fluidAudioModelsDirectory: fluid)?.path,
+            active.standardizedFileURL.path,
+            "complete active Parakeet cache should be reusable without showing a new download"
+        )
+    }
+
     runSuite("ModelCacheInventory diagnostics avoid raw paths") {
         let snapshot = ModelCacheSnapshot(
             fluidAudioModelsBytes: 10,


### PR DESCRIPTION
## Summary
- Detect the existing FluidAudio Parakeet cache on launch and before prefetch/download work.
- Mark cached model files as `.cached` without showing a fake download state.
- Keep background prefetch from overwriting a real loading/ready transition.
- Treat cached/on-demand model states as healthy in the menu header instead of showing a warning-style waiting state.

## Root Cause
After the thin-DMG changes, cached Parakeet files on disk were not reconciled into the app's runtime model state. Existing-install prefetch could show `.downloading` even when FluidAudio already had `parakeet-tdt-0.6b-v3-coreml` locally. Starting dictation or a meeting forced model initialization, which is why the warning disappeared only after capture started.

## Validation
- `bash run-tests.sh` — 1,757 passed
- `bash build-deps.sh --force`
- `bash build.sh` — passed, thin app 104.8 MiB
- `bash run-integration-smoke.sh` — passed