### PR TITLE
[codex] Harden queued meeting model recovery

### DIFF
--- a/Sources/Meeting/MeetingModelDownloader.swift
+++ b/Sources/Meeting/MeetingModelDownloader.swift
@@ -25,8 +25,13 @@ final class MeetingModelDownloader {
     /// first meeting recording starts. Safe to call multiple times - each
     /// underlying engine is idempotent after first successful load.
     func ensureModelsReady() async throws {
+        try await ensureModelsReady(sttModel: stt.selectedModel)
+    }
+
+    func ensureModelsReady(sttModel: TranscriptionModelChoice) async throws {
         // Fast path: both already loaded.
-        if stt.isReady && diarization.modelState == .ready {
+        if stt.isReady(for: sttModel) && diarization.isReady {
+            stt.selectPreparedModel(sttModel)
             return
         }
 
@@ -35,17 +40,17 @@ final class MeetingModelDownloader {
         // Kick both initializers in parallel. Each is idempotent and each owns
         // its own progress reporting via @Published properties on the engines.
         do {
-            async let sttReady: Void = stt.initialize()
+            async let sttReady: Void = stt.prepare(model: sttModel)
             async let diarReady: Void = diarization.initialize()
             _ = await (sttReady, diarReady)
 
             // After both returns, confirm they actually reached a usable state.
-            guard stt.isReady else {
+            guard stt.isReady(for: sttModel) else {
                 throw NSError(domain: "MeetingModelDownloader", code: 2, userInfo: [
                     NSLocalizedDescriptionKey: "Selected speech model failed to load."
                 ])
             }
-            guard diarization.modelState == .ready else {
+            guard diarization.isReady else {
                 let detail: String
                 switch diarization.modelState {
                 case .failed(let msg): detail = msg

--- a/Sources/Meeting/MeetingSTTAdapter.swift
+++ b/Sources/Meeting/MeetingSTTAdapter.swift
@@ -23,6 +23,10 @@ final class MeetingSTTAdapter: ObservableObject, SpeechToTextEngine {
         router.isModelLoaded(for: preparedModel ?? router.selectedModel)
     }
 
+    var selectedModel: TranscriptionModelChoice {
+        router.selectedModel
+    }
+
     var transcriptionEngineDescriptor: SpeechTranscriptionEngineDescriptor {
         let model = preparedModel ?? router.selectedModel
         return SpeechTranscriptionEngineDescriptor(
@@ -31,8 +35,12 @@ final class MeetingSTTAdapter: ObservableObject, SpeechToTextEngine {
         )
     }
 
+    func isReady(for model: TranscriptionModelChoice) -> Bool {
+        router.isModelLoaded(for: model)
+    }
+
     func initialize() async {
-        await prepare(model: router.selectedModel)
+        await prepare(model: selectedModel)
     }
 
     func prepare(model: TranscriptionModelChoice) async {

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -84,6 +84,7 @@ final class MeetingSessionController: ObservableObject {
             )
         }
 
+        let id = UUID()
         let kind: Kind
         let startTrigger: StartTrigger
         let sttModel: TranscriptionModelChoice
@@ -1335,6 +1336,8 @@ final class MeetingSessionController: ObservableObject {
 
     private func prepareAndStartQueuedTranscription(_ job: QueuedTranscriptionJob) async {
         let modelsReady = await ensureModelsReadyForQueuedTranscription(job)
+        guard preparingQueuedTranscriptionJob?.id == job.id else { return }
+
         queuedTranscriptionStartTask = nil
         preparingQueuedTranscriptionJob = nil
 

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -168,6 +168,8 @@ final class MeetingSessionController: ObservableObject {
     private var modelPreparationTask: Task<Result<Void, Error>, Never>?
     private var retryingFailedMeetingIDs: Set<UUID> = []
     private var queuedTranscriptionJobs: [QueuedTranscriptionJob] = []
+    private var preparingQueuedTranscriptionJob: QueuedTranscriptionJob?
+    private var queuedTranscriptionStartTask: Task<Void, Never>?
     private var lastTerminalTranscriptionOutcome: TerminalTranscriptionOutcome?
     private var activeRecordingTrigger: StartTrigger = .unknown
     private var activeTranscriptionTrigger: StartTrigger = .unknown
@@ -878,10 +880,14 @@ final class MeetingSessionController: ObservableObject {
     func cancelActiveTranscription(reason: TranscriptionCancelReason = .unknown) {
         let queuedJobs = queuedTranscriptionJobs
         queuedTranscriptionJobs.removeAll()
+        let preparingJob = preparingQueuedTranscriptionJob
+        queuedTranscriptionStartTask?.cancel()
+        queuedTranscriptionStartTask = nil
+        preparingQueuedTranscriptionJob = nil
         lastTerminalTranscriptionOutcome = nil
         activeTranscriptionTrigger = .unknown
 
-        for job in queuedJobs {
+        for job in queuedJobs + [preparingJob].compactMap({ $0 }) {
             switch job.kind {
             case .recorded(let micURL, let systemURL, _):
                 failedManager.addFailedTranscription(
@@ -1226,7 +1232,10 @@ final class MeetingSessionController: ObservableObject {
     }
 
     private var hasBackgroundTranscriptionWork: Bool {
-        taskManager.activeCount > 0 || taskManager.speakerNamingRequest != nil || !queuedTranscriptionJobs.isEmpty
+        taskManager.activeCount > 0
+            || taskManager.speakerNamingRequest != nil
+            || isPreparingQueuedTranscriptionStart
+            || !queuedTranscriptionJobs.isEmpty
     }
 
     var hasRuntimeDiagnosticsWork: Bool {
@@ -1235,7 +1244,7 @@ final class MeetingSessionController: ObservableObject {
 
     private var hasVisibleBackgroundTranscriptionWork: Bool {
         MeetingSessionUIPolicy.shouldShowTranscribing(
-            activeTranscriptions: taskManager.activeCount,
+            activeTranscriptions: taskManager.activeCount + (isPreparingQueuedTranscriptionStart ? 1 : 0),
             queuedTranscriptions: queuedTranscriptionJobs.count
         )
     }
@@ -1246,7 +1255,11 @@ final class MeetingSessionController: ObservableObject {
     }
 
     private var canStartQueuedTranscriptionImmediately: Bool {
-        taskManager.activeCount == 0 && taskManager.speakerNamingRequest == nil
+        taskManager.activeCount == 0 && taskManager.speakerNamingRequest == nil && !isPreparingQueuedTranscriptionStart
+    }
+
+    private var isPreparingQueuedTranscriptionStart: Bool {
+        preparingQueuedTranscriptionJob != nil || queuedTranscriptionStartTask != nil
     }
 
     private var isCaptureSessionActive: Bool {
@@ -1306,10 +1319,96 @@ final class MeetingSessionController: ObservableObject {
         lastTerminalTranscriptionOutcome = nil
         activeTranscriptionTrigger = job.startTrigger
         sttAdapter.selectPreparedModel(job.sttModel)
+        preparingQueuedTranscriptionJob = job
 
         if !isCaptureSessionActive {
             state = .transcribing
         }
+
+        displayStatus = .gettingReady
+        queuedTranscriptionStartTask?.cancel()
+        queuedTranscriptionStartTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.prepareAndStartQueuedTranscription(job)
+        }
+    }
+
+    private func prepareAndStartQueuedTranscription(_ job: QueuedTranscriptionJob) async {
+        let modelsReady = await ensureModelsReadyForQueuedTranscription(job)
+        queuedTranscriptionStartTask = nil
+        preparingQueuedTranscriptionJob = nil
+
+        guard !Task.isCancelled else { return }
+
+        guard modelsReady else {
+            failQueuedTranscriptionJobAfterModelRecovery(job)
+            handleBackgroundTranscriptionWorkChanged()
+            return
+        }
+
+        runPreparedQueuedTranscription(job)
+    }
+
+    private func ensureModelsReadyForQueuedTranscription(_ job: QueuedTranscriptionJob) async -> Bool {
+        sttAdapter.selectPreparedModel(job.sttModel)
+
+        if sttAdapter.isReady && diarization.isReady {
+            return true
+        }
+
+        DiagnosticsTrail.record(
+            engine: "meeting",
+            event: "meeting_transcription_model_recovery_started",
+            message: "Meeting transcription is loading models before starting queued audio",
+            context: baseDiagnosticsContext(
+                extra: [
+                    "trigger": job.startTrigger.rawValue,
+                    "queued_stt_model": job.sttModel.rawValue
+                ]
+            )
+        )
+
+        do {
+            try await downloader.ensureModelsReady(sttModel: job.sttModel)
+            sttAdapter.selectPreparedModel(job.sttModel)
+        } catch {
+            DiagnosticsTrail.record(
+                level: .error,
+                engine: "meeting",
+                event: "meeting_transcription_model_recovery_failed",
+                message: "Meeting transcription models could not be loaded before queued audio started",
+                context: baseDiagnosticsContext(
+                    extra: [
+                        "error": error.localizedDescription,
+                        "trigger": job.startTrigger.rawValue,
+                        "queued_stt_model": job.sttModel.rawValue
+                    ]
+                )
+            )
+            return false
+        }
+
+        let ready = sttAdapter.isReady && diarization.isReady
+        if !ready {
+            DiagnosticsTrail.record(
+                level: .error,
+                engine: "meeting",
+                event: "meeting_transcription_model_recovery_failed",
+                message: "Meeting transcription models were still unavailable after reload",
+                context: baseDiagnosticsContext(
+                    extra: [
+                        "trigger": job.startTrigger.rawValue,
+                        "queued_stt_model": job.sttModel.rawValue
+                    ]
+                )
+            )
+        }
+
+        return ready
+    }
+
+    private func runPreparedQueuedTranscription(_ job: QueuedTranscriptionJob) {
+        sttAdapter.selectPreparedModel(job.sttModel)
 
         switch job.kind {
         case .recorded(let micURL, let systemURL, let healthInfo):
@@ -1326,6 +1425,24 @@ final class MeetingSessionController: ObservableObject {
                 outputFolder: MeetingStoragePaths.transcriptsFolder,
                 meetingTitle: suggestedTitle
             )
+        }
+    }
+
+    private func failQueuedTranscriptionJobAfterModelRecovery(_ job: QueuedTranscriptionJob) {
+        let message = "Meeting transcription models were not ready. Try again after models finish loading."
+        lastTerminalTranscriptionOutcome = .failed(message)
+        state = .error(message)
+        displayStatus = .failed(message: message)
+
+        switch job.kind {
+        case .recorded(let micURL, let systemURL, _):
+            failedManager.addFailedTranscription(
+                micAudioURL: micURL,
+                systemAudioURL: systemURL,
+                errorMessage: message
+            )
+        case .imported(let audioURL, _):
+            try? FileManager.default.removeItem(at: audioURL)
         }
     }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -340,8 +340,9 @@ func testRepoCommandContract() {
         )
         assertTrue(
             controllerContents.contains("preparingQueuedTranscriptionJob")
-                && controllerContents.contains("isPreparingQueuedTranscriptionStart"),
-            "model recovery should count as active background work so the queue cannot double-start"
+                && controllerContents.contains("isPreparingQueuedTranscriptionStart")
+                && controllerContents.contains("preparingQueuedTranscriptionJob?.id == job.id"),
+            "model recovery should count as active background work and stale prep tasks must not clear newer queued work"
         )
         assertTrue(
             downloaderContents.contains("func ensureModelsReady(sttModel: TranscriptionModelChoice) async throws")

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -325,6 +325,31 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - queued meetings recover unloaded models before transcription") {
+        let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let downloaderContents = readRepoTextFile("Sources/Meeting/MeetingModelDownloader.swift")
+
+        assertTrue(
+            controllerContents.contains("await ensureModelsReadyForQueuedTranscription(job)")
+                && controllerContents.contains("runPreparedQueuedTranscription(job)"),
+            "queued meeting jobs should load models before entering TranscriptionTaskManager"
+        )
+        assertTrue(
+            controllerContents.contains("downloader.ensureModelsReady(sttModel: job.sttModel)"),
+            "queued meeting jobs should reload the STT model selected when the audio was queued"
+        )
+        assertTrue(
+            controllerContents.contains("preparingQueuedTranscriptionJob")
+                && controllerContents.contains("isPreparingQueuedTranscriptionStart"),
+            "model recovery should count as active background work so the queue cannot double-start"
+        )
+        assertTrue(
+            downloaderContents.contains("func ensureModelsReady(sttModel: TranscriptionModelChoice) async throws")
+                && downloaderContents.contains("stt.prepare(model: sttModel)"),
+            "meeting model loading should support a queued job's stored speech model"
+        )
+    }
+
     runSuite("Repo command contract - dictation joins existing model downloads") {
         let overlayContents = readRepoTextFile("Sources/UI/Overlay/DictationSessionController.swift")
         let engineContents = readRepoTextFile("Sources/Speech/ParakeetEngine.swift")


### PR DESCRIPTION
## Summary

- reload the queued meeting job's selected STT model plus diarization before entering the core transcription pipeline
- keep queued model recovery counted as active background work so the queue cannot double-start
- add a repo contract test for queued meeting model recovery

## Root Cause

`meeting_transcript_failed` was caused when a queued or just-finished meeting recording entered `TranscriptionTaskManager` while meeting models were not actually loaded. The start path prepared models before recording, but the queued transcription start path only selected the stored STT model and immediately started the core pipeline. If the STT or diarization model had been unloaded, stale, or failed at that moment, core hit model-not-loaded and surfaced the generic meeting transcript failure.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (`1756 passed`)
- `bash run-integration-smoke.sh`
