### PR TITLE
Test storage-refactor save-directory and capture-id seams

### DIFF
--- a/Sources/TranscriptedCore/Services/RecordingValidator.swift
+++ b/Sources/TranscriptedCore/Services/RecordingValidator.swift
@@ -112,7 +112,7 @@ public enum RecordingValidator {
         }
     }
 
-    private static func resolvedSaveDirectory(paths: CoreStoragePaths) -> URL {
+    static func resolvedSaveDirectory(paths: CoreStoragePaths) -> URL {
         if let customPath = normalizedCustomSavePath(),
            !customPath.isEmpty {
             if validateRawSavePath(customPath) != nil {

--- a/Sources/TranscriptedCore/Storage/TranscriptScanner.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptScanner.swift
@@ -78,7 +78,7 @@ public enum TranscriptScanner {
 
     /// Parse a transcript file and extract metadata
     /// Returns tuple of (metadata, actionItemsCount) or nil if parsing failed
-    private static func parseTranscriptFile(_ fileURL: URL) -> (RecordingMetadata, Int)? {
+    static func parseTranscriptFile(_ fileURL: URL) -> (RecordingMetadata, Int)? {
         guard let content = try? String(contentsOf: fileURL, encoding: .utf8) else {
             AppLogger.pipeline.warning("TranscriptScanner could not read file", ["file": fileURL.lastPathComponent])
             return nil

--- a/Tests/TranscriptedCoreTests/RecordingValidatorResolvedSaveDirectoryTests.swift
+++ b/Tests/TranscriptedCoreTests/RecordingValidatorResolvedSaveDirectoryTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import TranscriptedCore
+
+/// Pins how `RecordingValidator` resolves the directory it probes for disk space
+/// and write permissions. The markdown-first refactor treats the
+/// `transcriptSaveLocation` preference as a capture-library root, so the validator
+/// must probe `<custom>/meetings`, not the bare custom path — otherwise the
+/// permission preflight file ends up in the wrong directory.
+@available(macOS 14.0, *)
+final class RecordingValidatorResolvedSaveDirectoryTests: XCTestCase {
+
+    private let preferenceKey = "transcriptSaveLocation"
+    private var originalPreference: Any?
+    private var paths: CoreStoragePaths!
+
+    override func setUp() {
+        super.setUp()
+        originalPreference = UserDefaults.standard.object(forKey: preferenceKey)
+        UserDefaults.standard.removeObject(forKey: preferenceKey)
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RecordingValidatorResolvedSaveDirectoryTests-\(UUID().uuidString)", isDirectory: true)
+        paths = CoreStoragePaths(
+            transcripts: root.appendingPathComponent("transcripts"),
+            speakerDB: root.appendingPathComponent("s.sqlite"),
+            statsDB: root.appendingPathComponent("st.sqlite"),
+            failedQueue: root.appendingPathComponent("fq.json"),
+            speakerClips: root.appendingPathComponent("clips"),
+            audioCaptures: root.appendingPathComponent("caps"),
+            logs: root.appendingPathComponent("logs")
+        )
+    }
+
+    override func tearDown() {
+        if let originalPreference {
+            UserDefaults.standard.set(originalPreference, forKey: preferenceKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: preferenceKey)
+        }
+        super.tearDown()
+    }
+
+    func testReturnsPathsTranscriptsWhenNoCustomLocation() {
+        XCTAssertEqual(
+            RecordingValidator.resolvedSaveDirectory(paths: paths),
+            paths.transcripts
+        )
+    }
+
+    func testReturnsPathsTranscriptsWhenCustomLocationBlank() {
+        UserDefaults.standard.set("   ", forKey: preferenceKey)
+
+        XCTAssertEqual(
+            RecordingValidator.resolvedSaveDirectory(paths: paths),
+            paths.transcripts
+        )
+    }
+
+    func testAppendsMeetingsSubdirectoryForCustomLocation() {
+        let customRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RecordingValidatorResolvedSaveDirectoryTests-custom-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: customRoot) }
+        try? FileManager.default.createDirectory(at: customRoot, withIntermediateDirectories: true)
+
+        UserDefaults.standard.set(customRoot.path, forKey: preferenceKey)
+
+        XCTAssertEqual(
+            RecordingValidator.resolvedSaveDirectory(paths: paths),
+            customRoot.appendingPathComponent("meetings", isDirectory: true)
+        )
+    }
+
+    func testRelativeCustomLocationFallsBackToPathsTranscripts() {
+        UserDefaults.standard.set("relative/path", forKey: preferenceKey)
+
+        XCTAssertEqual(
+            RecordingValidator.resolvedSaveDirectory(paths: paths),
+            paths.transcripts
+        )
+    }
+
+    func testTraversalCustomLocationFallsBackToPathsTranscripts() {
+        UserDefaults.standard.set("/tmp/foo/../../etc", forKey: preferenceKey)
+
+        XCTAssertEqual(
+            RecordingValidator.resolvedSaveDirectory(paths: paths),
+            paths.transcripts
+        )
+    }
+
+    func testSystemCustomLocationFallsBackToPathsTranscripts() {
+        UserDefaults.standard.set("/System/Library/Transcripted", forKey: preferenceKey)
+
+        XCTAssertEqual(
+            RecordingValidator.resolvedSaveDirectory(paths: paths),
+            paths.transcripts
+        )
+    }
+}

--- a/Tests/TranscriptedCoreTests/TranscriptSaverDefaultSaveDirectoryTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptSaverDefaultSaveDirectoryTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import TranscriptedCore
+
+/// Pins the behaviour of `TranscriptSaver.defaultSaveDirectory` so a future revert
+/// of the markdown-first storage refactor is loud. Pre-refactor, a custom
+/// `transcriptSaveLocation` was used as the literal save directory; post-refactor it
+/// is treated as a capture-library root and meetings land under `<custom>/meetings`.
+@available(macOS 14.0, *)
+final class TranscriptSaverDefaultSaveDirectoryTests: XCTestCase {
+
+    private let preferenceKey = "transcriptSaveLocation"
+    private var originalPreference: Any?
+
+    override func setUp() {
+        super.setUp()
+        originalPreference = UserDefaults.standard.object(forKey: preferenceKey)
+        UserDefaults.standard.removeObject(forKey: preferenceKey)
+    }
+
+    override func tearDown() {
+        if let originalPreference {
+            UserDefaults.standard.set(originalPreference, forKey: preferenceKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: preferenceKey)
+        }
+        super.tearDown()
+    }
+
+    func testReturnsDefaultTranscriptsWhenNoCustomPathSet() {
+        XCTAssertEqual(
+            TranscriptSaver.defaultSaveDirectory,
+            CoreStoragePaths.default.transcripts
+        )
+    }
+
+    func testReturnsDefaultTranscriptsWhenCustomPathIsBlank() {
+        UserDefaults.standard.set("   ", forKey: preferenceKey)
+
+        XCTAssertEqual(
+            TranscriptSaver.defaultSaveDirectory,
+            CoreStoragePaths.default.transcripts
+        )
+    }
+
+    func testCustomAbsolutePathAppendsMeetingsSubdirectory() {
+        let customRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptSaverDefaultSaveDirectoryTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: customRoot) }
+        try? FileManager.default.createDirectory(at: customRoot, withIntermediateDirectories: true)
+
+        UserDefaults.standard.set(customRoot.path, forKey: preferenceKey)
+
+        XCTAssertEqual(
+            TranscriptSaver.defaultSaveDirectory,
+            customRoot.appendingPathComponent("meetings", isDirectory: true)
+        )
+    }
+
+    func testRelativeCustomPathFallsBackToDefault() {
+        UserDefaults.standard.set("relative/path", forKey: preferenceKey)
+
+        XCTAssertEqual(
+            TranscriptSaver.defaultSaveDirectory,
+            CoreStoragePaths.default.transcripts
+        )
+    }
+
+    func testTraversalCustomPathFallsBackToDefault() {
+        UserDefaults.standard.set("/Users/someone/../../etc/passwd", forKey: preferenceKey)
+
+        XCTAssertEqual(
+            TranscriptSaver.defaultSaveDirectory,
+            CoreStoragePaths.default.transcripts
+        )
+    }
+
+    func testSystemCustomPathFallsBackToDefault() {
+        UserDefaults.standard.set("/System/Library/Transcripted", forKey: preferenceKey)
+
+        XCTAssertEqual(
+            TranscriptSaver.defaultSaveDirectory,
+            CoreStoragePaths.default.transcripts
+        )
+    }
+}

--- a/Tests/TranscriptedCoreTests/TranscriptScannerCaptureIDTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptScannerCaptureIDTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import TranscriptedCore
+
+/// Pins the capture-id parsing introduced by the markdown-first storage refactor.
+/// The scanner must round-trip the `capture_id` / `transcript_id` frontmatter field
+/// into `RecordingMetadata.id`, mint a UUID when absent, and cap adversarial values
+/// at 256 characters before they reach the stats database.
+@available(macOS 14.0, *)
+final class TranscriptScannerCaptureIDTests: XCTestCase {
+
+    private var workingDirectory: URL!
+
+    override func setUp() {
+        super.setUp()
+        workingDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptScannerCaptureIDTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: workingDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: workingDirectory)
+        workingDirectory = nil
+        super.tearDown()
+    }
+
+    func testParsesCaptureIDFromFrontmatter() throws {
+        let captureID = "cap_abc123"
+        let url = try writeTranscript(captureIDField: "capture_id", captureID: captureID)
+
+        let parsed = TranscriptScanner.parseTranscriptFile(url)
+
+        XCTAssertEqual(parsed?.0.id, captureID)
+    }
+
+    func testParsesLegacyTranscriptIDField() throws {
+        let captureID = "legacy_xyz"
+        let url = try writeTranscript(captureIDField: "transcript_id", captureID: captureID)
+
+        let parsed = TranscriptScanner.parseTranscriptFile(url)
+
+        XCTAssertEqual(parsed?.0.id, captureID)
+    }
+
+    func testFallsBackToFreshUUIDWhenCaptureIDMissing() throws {
+        let url = try writeTranscript(captureIDField: nil, captureID: nil)
+
+        let parsed = TranscriptScanner.parseTranscriptFile(url)
+
+        let id = try XCTUnwrap(parsed?.0.id)
+        XCTAssertFalse(id.isEmpty)
+        XCTAssertNotNil(UUID(uuidString: id), "fallback id should be a valid UUID")
+    }
+
+    func testOversizedCaptureIDIsTruncatedTo256Characters() throws {
+        let oversizedID = String(repeating: "a", count: 1024)
+        let url = try writeTranscript(captureIDField: "capture_id", captureID: oversizedID)
+
+        let parsed = TranscriptScanner.parseTranscriptFile(url)
+
+        XCTAssertEqual(parsed?.0.id.count, 256)
+        XCTAssertEqual(parsed?.0.id, String(repeating: "a", count: 256))
+    }
+
+    func testCaptureIDPrefersTranscriptIDOverCaptureIDWhenBothPresent() throws {
+        let transcriptID = "legacy_first"
+        let captureID = "should_not_win"
+        let raw = """
+        ---
+        capture_type: meeting
+        title: "Mixed Fields"
+        date: 2026-04-22
+        time: "13:14:15"
+        duration: "00:30"
+        transcript_id: \(transcriptID)
+        capture_id: \(captureID)
+        ---
+
+        ## Transcript
+
+        Hello.
+        """
+        let url = workingDirectory.appendingPathComponent("mixed.md")
+        try raw.write(to: url, atomically: true, encoding: .utf8)
+
+        let parsed = TranscriptScanner.parseTranscriptFile(url)
+
+        XCTAssertEqual(parsed?.0.id, transcriptID, "transcript_id takes precedence (left side of `??`)")
+    }
+
+    private func writeTranscript(captureIDField: String?, captureID: String?) throws -> URL {
+        var frontmatter = """
+        ---
+        capture_type: meeting
+        title: "Sample"
+        date: 2026-04-22
+        time: "13:14:15"
+        duration: "00:30"
+        total_word_count: 3
+        """
+        if let captureIDField, let captureID {
+            frontmatter += "\n\(captureIDField): \(captureID)"
+        }
+        frontmatter += "\n---\n\n## Transcript\n\nHello world here.\n"
+
+        let url = workingDirectory.appendingPathComponent("sample-\(UUID().uuidString).md")
+        try frontmatter.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+}


### PR DESCRIPTION
## Summary
- Pin `TranscriptSaver.defaultSaveDirectory` behaviour: custom path → `<custom>/meetings`, and relative/traversal/system paths fall back to the default. Catches a future revert of the markdown-first refactor.
- Pin `RecordingValidator.resolvedSaveDirectory` behaviour: disk-space and permission preflight probe `<custom>/meetings` (not the bare custom path) when a capture-library override is set, with matching fallbacks for tampered preferences.
- Pin `TranscriptScanner.parseTranscriptFile` capture-id parsing: round-trip `capture_id` + legacy `transcript_id`, mint a UUID when absent, and truncate adversarial values at 256 chars before they reach the stats database.
- Promote `resolvedSaveDirectory` and `parseTranscriptFile` from `private` to `internal` for `@testable` access, matching the convention used by other Core helpers (`normalizedCustomSavePath`, `validateRawSavePath`, `diskSpaceProbeURL`).

Adds 17 tests across 3 new files in the `TranscriptedCoreTests` package target; no source-behaviour change.

## Test plan
- [x] `swift test` — 153 tests, 0 failures
- [x] `bash build.sh` — app builds cleanly, smoke check + performance budget pass
- [x] `bash run-tests.sh` — 1752 tests, 0 failures
- [x] `bash run-integration-smoke.sh` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)