### PR TITLE
Security audit fixes: HF model integrity, dead beta token, worker proxy route, entitlement docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,6 +43,51 @@ Operational caveats:
 - beta builds can optionally contact the update/log proxy for update checks and diagnostics shipping
 - core dictation and transcription do not require cloud APIs
 
+## Model integrity
+
+Model files come from `https://huggingface.co` only. There is no third-party
+mirror fallback: if huggingface.co is unreachable, the download fails closed
+rather than silently degrading to a less-trusted source whose manifest could
+supply attacker-controlled digests.
+
+LFS-tracked files (weights) are verified against the SHA-256 digest reported by
+the HuggingFace API before being moved into the cache. Non-LFS files
+(tokenizer.json, config.json, etc.) ride on HTTPS to huggingface.co with no
+per-file digest — those are documented but not currently hash-pinned.
+
+## Beta build entitlements
+
+The beta build is intentionally less hardened than a typical sandboxed Mac app.
+`config/entitlements/beta.plist` sets:
+
+- `com.apple.security.app-sandbox` = false
+- `com.apple.security.cs.disable-library-validation` = true
+- `com.apple.security.cs.allow-jit` = true
+
+Combined with the TCC permissions Transcripted asks for (microphone, screen
+recording, accessibility, calendars), this means: anything running as your user
+that can write into `Transcripted.app/Contents/Frameworks/` can load its own
+code into the running app and inherit those permissions, including the ability
+to inject keystrokes into other apps via the paste-back path.
+
+The reason library validation is disabled is that the on-device ML stack (MLX,
+WhisperKit, CoreML model bundles) currently ships dylibs that do not all carry
+the same team-id signing as the app, so strict library validation refuses to
+load them. We treat that as a known cost of running ML locally on macOS today.
+
+Practical implications for users:
+
+- install Transcripted from a trusted source (the signed DMG from GitHub
+  Releases) and verify the Developer ID before granting permissions
+- treat user-level malware as already game-over for these permissions, since
+  it could substitute a framework binary and inherit them
+- the local-test entitlements profile (`config/entitlements/local.plist`) is
+  meant for ad-hoc smoke builds only and shares the sandbox-off posture — it
+  is not the shipping profile
+
+If a future version of the ML stack supports team-id-consistent signing for all
+embedded dylibs, the `disable-library-validation` entitlement will be removed.
+
 ## Supported Versions
 
 | Version | Supported |

--- a/Sources/Beta/BetaConfig.swift
+++ b/Sources/Beta/BetaConfig.swift
@@ -1,22 +1,27 @@
 // BetaConfig.swift
-// Per-user beta configuration — only compiled into beta builds.
-// The token placeholder is replaced by build-beta.sh via sed for each user's DMG.
+// Beta-build compile-time configuration. Currently empty.
+//
+// History: this file used to ship a per-user bearer token baked in at build time
+// via sed/perl substitution in build-beta.sh. That token authenticated the app
+// against the archived proxy worker at draft-proxy.tz427gsydr.workers.dev, which
+// also re-exposed Anthropic's /v1/messages endpoint.
+//
+// The proxy client is no longer part of the app target (BetaTelemetry and the
+// /config update-check flow are gone — Sparkle handles updates, Sentry handles
+// crash reports, PostHog handles analytics). The token was therefore dead code
+// that still ended up recoverable from the Mach-O binary via `strings` for
+// anyone with read access to the bundle. It has been removed.
+//
+// If beta-only auth comes back, generate the secret at first launch into the
+// Keychain rather than baking it into the binary, and pair it to the server via
+// a short-lived enrollment code handed out-of-band.
 
 #if BETA_BUILD
 
 import Foundation
 
 enum BetaConfig {
-    /// Per-user beta token, baked in at build time.
-    /// build-beta.sh replaces BETA_TOKEN_PLACEHOLDER with the actual token.
-    static let userToken: String = {
-        let token = "BETA_TOKEN_PLACEHOLDER"
-        // Crash early in debug/test if build-beta.sh did not substitute the token.
-        assert(token != "BETA_TOKEN_PLACEHOLDER",
-               "BetaConfig.userToken was not substituted — run build-beta.sh before use")
-        return token
-    }()
-
+    // Intentionally empty — see file header.
 }
 
 #endif

--- a/Sources/TranscriptedCore/Services/ModelDownloadService.swift
+++ b/Sources/TranscriptedCore/Services/ModelDownloadService.swift
@@ -65,10 +65,21 @@ public struct ModelDownloadError: Error, LocalizedError {
 
 public enum ModelDownloadService {
 
-    /// HuggingFace mirror URLs, tried in order
+    /// HuggingFace endpoint.
+    ///
+    /// Security: previously this list also contained a third-party mirror
+    /// (`https://hf-mirror.com`) as a fallback. That fallback was removed because the manifest
+    /// served by the mirror is what supplies the per-file SHA-256 used for verification — so a
+    /// compromised mirror could simply hand back a manifest whose `lfs.sha256` matches the
+    /// malicious file it intends to serve, and the integrity check would still pass. The mirror
+    /// also lets non-LFS files (tokenizer.json, config.json, etc.) ride along with no digest
+    /// anywhere in the response.
+    ///
+    /// Treat `huggingface.co` as the only source of truth. If huggingface.co is unreachable,
+    /// fail closed and surface the network error instead of degrading silently to an untrusted
+    /// mirror.
     private static let mirrors: [String] = [
-        "https://huggingface.co",
-        "https://hf-mirror.com"
+        "https://huggingface.co"
     ]
 
     /// Default retry configuration
@@ -231,8 +242,8 @@ public enum ModelDownloadService {
         let size: Int?
         /// SHA-256 hex digest for LFS-tracked files (e.g. model weights).
         /// Populated from the HuggingFace API response when available.
-        /// Security: used to verify file integrity after download from mirrors,
-        /// so a compromised third-party mirror cannot silently serve malicious weights.
+        /// Security: used to verify file integrity end-to-end against the digest
+        /// huggingface.co reports for the file.
         let sha256: String?
     }
 
@@ -307,15 +318,15 @@ public enum ModelDownloadService {
         )
     }
 
-    /// Download a single file with mirror fallback and retry.
+    /// Download a single file with retry. (The previous mirror-fallback loop was reduced to
+    /// huggingface.co only — see `mirrors` above for the security rationale.)
     /// - Parameters:
     ///   - modelId: HuggingFace model identifier
     ///   - filename: Filename within the model repository (pre-validated by isSafeModelFilename)
     ///   - destination: Local destination URL
     ///   - expectedSHA256: SHA-256 hex digest from the HuggingFace API manifest (optional).
-    ///     Security: when provided, the downloaded file is verified against this digest before being
-    ///     moved to its destination. This prevents a compromised third-party mirror (hf-mirror.com)
-    ///     from silently serving malicious model weights in place of the genuine files.
+    ///     Security: when provided, the downloaded file is verified against this digest before
+    ///     being moved to its destination.
     static func downloadFileWithMirrorFallback(
         modelId: String,
         filename: String,

--- a/archive/backend-beta-worker/CLAUDE.md
+++ b/archive/backend-beta-worker/CLAUDE.md
@@ -26,8 +26,6 @@ on `main` does not depend on this worker.
 
 - `GET /`
   Health check.
-- `POST /v1/messages`
-  Token-gated proxy to Anthropic `v1/messages`, including streaming passthrough.
 - `POST /events`
   Stores structured telemetry events from the app.
 - `POST /logs`
@@ -40,14 +38,19 @@ on `main` does not depend on this worker.
 All non-admin endpoints require a bearer token that maps to an active user in
 the D1 `users` table.
 
+The historical `POST /v1/messages` route that proxied to Anthropic has been
+removed from this source. The current app on `main` does not call Anthropic
+through this worker. If the live deployment still serves `/v1/messages`,
+redeploy from this archive and rotate `ANTHROPIC_API_KEY` out of the worker's
+secrets. The `api_calls` D1 table (see `schema.sql`) becomes dead; drop it at
+your leisure.
+
 ## Important Reality Check
 
-This worker still proxies Anthropic for beta paths, while the main app on
-`main` is otherwise local-first. Treat backend docs as beta/distribution
-context, not as the primary app architecture.
-
-The current macOS app on `main` no longer consumes `/config` for DMG
-self-update checks; that endpoint remains backend/beta-ops context.
+The app on `main` is local-first; this worker covers beta telemetry/log/config
+paths only. The current macOS app on `main` does not consume `/config` for DMG
+self-update checks (Sparkle handles updates) — that endpoint remains
+backend/beta-ops context.
 
 ## Data Model
 

--- a/archive/backend-beta-worker/README.md
+++ b/archive/backend-beta-worker/README.md
@@ -17,23 +17,32 @@ The current app's core dictation and meeting flows do not depend on this directo
 
 ## Endpoints in `src/index.ts`
 
-- `POST /v1/messages` — proxy request to Anthropic, log usage
 - `POST /events` — ingest event payloads from the app
 - `POST /logs` — ingest debug log batches
 - `GET /config` — return retained beta config for a user; current macOS app builds on `main` no longer consume its version/update fields
 - `GET /admin/usage` — admin-only usage summary
+
+The historical `POST /v1/messages` route, which proxied to Anthropic using a
+worker-side `ANTHROPIC_API_KEY`, was removed. If you redeploy from this archive,
+the route is gone. The current app on `main` does not chat with Anthropic via
+this worker, so there is no caller to break. If the live worker at
+`draft-proxy.tz427gsydr.workers.dev` still has the old route, redeploy from this
+archive (or take the worker offline) and rotate any `ANTHROPIC_API_KEY` that was
+ever set in the worker's secrets.
 
 ## Environment
 
 The Worker expects bindings / secrets such as:
 
 - `DB`
-- `ANTHROPIC_API_KEY`
 - `ADMIN_TOKEN`
 - `BETA_MESSAGE`
 - `LATEST_VERSION`
 - `DOWNLOAD_URL`
 - `DOWNLOAD_URL_BASE`
+
+`ANTHROPIC_API_KEY` is no longer referenced — remove it from the deployed
+worker's secrets after redeploying.
 
 ## Local commands
 
@@ -47,6 +56,6 @@ npm run deploy
 ## Agent notes
 
 - This directory is isolated from the Swift app build.
-- The current macOS app still uses the worker for beta telemetry/proxy paths, but not for DMG self-update checks.
+- The current macOS app does not consume DMG self-update checks from this worker (Sparkle handles updates) and the historical Anthropic proxy route has been removed.
 - If you touch beta-only Swift code in `Sources/Observability/` or `Sources/Beta/BetaConfig.swift`, verify whether the change also requires a backend change here.
 - There is currently no local test harness documented for the Worker; review the SQL schema and endpoint contracts directly before refactoring.

--- a/archive/backend-beta-worker/src/index.ts
+++ b/archive/backend-beta-worker/src/index.ts
@@ -1,11 +1,13 @@
 // Transcripted Beta Proxy — Cloudflare Worker
-// Sits between the Transcripted app and the Anthropic API.
-// Validates per-user beta tokens, streams responses transparently,
-// logs usage to D1, and supports telemetry + config endpoints.
+// Token-gated telemetry/log/config endpoints for the beta channel.
+// The historical `/v1/messages` route that proxied to Anthropic has been
+// removed: the current app on main does not chat with Anthropic via this
+// worker, and any leaked beta token used to be enough to bill operator-funded
+// LLM spend. ANTHROPIC_API_KEY is no longer read here — rotate it in the
+// Cloudflare dashboard if it is still present.
 
 interface Env {
   DB: D1Database;
-  ANTHROPIC_API_KEY: string;
   ADMIN_TOKEN?: string;
   BETA_MESSAGE?: string;
   LATEST_VERSION?: string;
@@ -37,105 +39,6 @@ async function validateToken(db: D1Database, token: string): Promise<User | null
     .bind(token)
     .first<User>();
   return result;
-}
-
-// POST /v1/messages — Proxy to Anthropic API with streaming passthrough
-async function handleMessages(
-  request: Request,
-  env: Env,
-  user: User
-): Promise<Response> {
-  const startTime = Date.now();
-
-  // Read the request body to inspect it (we need to check for stream flag)
-  const bodyText = await request.text();
-  let parsedBody: Record<string, unknown>;
-  try {
-    parsedBody = JSON.parse(bodyText);
-  } catch {
-    return new Response("Invalid JSON body", { status: 400 });
-  }
-
-  const model = (parsedBody.model as string) ?? "unknown";
-  const isStreaming = parsedBody.stream === true;
-
-  // Forward to Anthropic
-  const anthropicHeaders: Record<string, string> = {
-    "Content-Type": "application/json",
-    "x-api-key": env.ANTHROPIC_API_KEY,
-    "anthropic-version": "2023-06-01",
-  };
-
-  // Pass through beta headers if present
-  const betaHeader = request.headers.get("anthropic-beta");
-  if (betaHeader) {
-    anthropicHeaders["anthropic-beta"] = betaHeader;
-  }
-
-  const anthropicResponse = await fetch(
-    "https://api.anthropic.com/v1/messages",
-    {
-      method: "POST",
-      headers: anthropicHeaders,
-      body: bodyText,
-    }
-  );
-
-  const latencyMs = Date.now() - startTime;
-  const success = anthropicResponse.ok ? 1 : 0;
-
-  // Log the API call to D1 (non-blocking via waitUntil would be ideal,
-  // but we do it inline for simplicity — D1 writes are fast)
-  if (isStreaming && anthropicResponse.ok && anthropicResponse.body) {
-    // For streaming responses, pipe through transparently.
-    // We can't easily parse usage from SSE mid-stream, so log with zeros
-    // and rely on the /events endpoint for detailed tracking.
-    const logPromise = env.DB.prepare(
-      "INSERT INTO api_calls (user_id, model, input_tokens, output_tokens, latency_ms, success) VALUES (?, ?, 0, 0, ?, ?)"
-    )
-      .bind(user.id, model, latencyMs, success)
-      .run();
-
-    // Don't await — let it run in background
-    void logPromise;
-
-    return new Response(anthropicResponse.body, {
-      status: anthropicResponse.status,
-      headers: {
-        "Content-Type":
-          anthropicResponse.headers.get("Content-Type") ?? "text/event-stream",
-        "Cache-Control": "no-cache",
-      },
-    });
-  }
-
-  // Non-streaming: read full response, parse usage, log, return
-  const responseBody = await anthropicResponse.text();
-
-  let inputTokens = 0;
-  let outputTokens = 0;
-  if (anthropicResponse.ok) {
-    try {
-      const parsed = JSON.parse(responseBody);
-      inputTokens = parsed.usage?.input_tokens ?? 0;
-      outputTokens = parsed.usage?.output_tokens ?? 0;
-    } catch {
-      // Ignore parse errors for logging
-    }
-  }
-
-  await env.DB.prepare(
-    "INSERT INTO api_calls (user_id, model, input_tokens, output_tokens, latency_ms, success) VALUES (?, ?, ?, ?, ?, ?)"
-  )
-    .bind(user.id, model, inputTokens, outputTokens, latencyMs, success)
-    .run();
-
-  return new Response(responseBody, {
-    status: anthropicResponse.status,
-    headers: {
-      "Content-Type": anthropicResponse.headers.get("Content-Type") ?? "application/json",
-    },
-  });
 }
 
 // POST /events — Log telemetry events from the app
@@ -368,9 +271,6 @@ export default {
     }
 
     // Route to handlers
-    if (method === "POST" && path === "/v1/messages") {
-      return handleMessages(request, env, user);
-    }
     if (method === "POST" && path === "/events") {
       return handleEvents(request, env, user);
     }

--- a/scripts/entrypoints/build-beta.sh
+++ b/scripts/entrypoints/build-beta.sh
@@ -23,16 +23,19 @@ cd "$REPO_ROOT"
 
 BETA_TOKEN="${1:-}"
 USER_NAME="${2:-beta}"
+
+# BETA_TOKEN is retained as a positional arg for backwards-compatible invocations,
+# but it is no longer injected into the app binary — the app no longer has a beta
+# proxy client. Builds without a token are fine. See Sources/Beta/BetaConfig.swift
+# for the rationale.
 SKIP_NOTARIZATION="${SKIP_NOTARIZATION:-0}"
 REQUIRE_BUNDLED_PARAKEET_MODELS="${REQUIRE_BUNDLED_PARAKEET_MODELS:-1}"
 BUNDLE_PARAKEET_MODELS="${BUNDLE_PARAKEET_MODELS:-0}"
 SWIFTC_NUM_THREADS="${SWIFTC_NUM_THREADS:-$(sysctl -n hw.ncpu 2>/dev/null || printf '8')}"
 APP_VERSION="$(plist_value Info.plist CFBundleShortVersionString)"
 
-if [ -z "$BETA_TOKEN" ]; then
-    echo "Usage: ./build-beta.sh <beta-token> <user-name>"
-    echo "Example: ./build-beta.sh transcripted-beta-nate Nate"
-    exit 1
+if [ -n "$BETA_TOKEN" ]; then
+    echo "ℹ️  BETA_TOKEN passed but no longer injected into the binary. Continuing."
 fi
 
 if [ -z "$APP_VERSION" ]; then
@@ -59,8 +62,6 @@ DMG_BACKGROUND_PATH="scripts/release/assets/dmg-background.png"
 SIGNING_IDENTITY="${SIGNING_IDENTITY:-${SIGN_IDENTITY:-}}"
 SIGNING_DISPLAY_NAME=""
 NOTARY_PROFILE="${NOTARY_PROFILE:-}"
-BETA_CONFIG_PATH="Sources/Beta/BetaConfig.swift"
-BETA_CONFIG_BACKUP="$(mktemp -t transcripted-beta-config)"
 BETA_ENTITLEMENTS="config/entitlements/beta.plist"
 DEPS_BUILD_STAMP="deps-libs/.build-deps-stamp"
 DEPS_FRAMEWORK_ROOT="deps-frameworks"
@@ -110,28 +111,6 @@ mask_secret() {
     fi
 
     printf '%s...%s' "${value:0:4}" "${value: -2}"
-}
-
-escape_for_swift_string_literal() {
-    local value="$1"
-
-    value=${value//\\/\\\\}
-    value=${value//\"/\\\"}
-    value=${value//$'\n'/\\n}
-    value=${value//$'\r'/\\r}
-    value=${value//$'\t'/\\t}
-
-    printf '%s' "$value"
-}
-
-inject_beta_token() {
-    local escaped_token
-    escaped_token="$(escape_for_swift_string_literal "$BETA_TOKEN")"
-
-    BETA_TOKEN_SWIFT_LITERAL="$escaped_token" perl -0pi -e '
-        my $replacement = $ENV{BETA_TOKEN_SWIFT_LITERAL};
-        s/BETA_TOKEN_PLACEHOLDER/$replacement/g;
-    ' "$BETA_CONFIG_PATH"
 }
 
 validate_signed_app() {
@@ -341,15 +320,6 @@ bundle_mcp_server() {
     chmod 755 "$BUNDLED_MCP_BINARY"
 }
 
-cleanup() {
-    if [ -f "$BETA_CONFIG_BACKUP" ]; then
-        cp "$BETA_CONFIG_BACKUP" "$BETA_CONFIG_PATH"
-        rm -f "$BETA_CONFIG_BACKUP"
-    fi
-}
-
-trap cleanup EXIT
-
 if [ ! -f "$BETA_ENTITLEMENTS" ]; then
     echo "❌ Missing entitlements file: $BETA_ENTITLEMENTS"
     exit 1
@@ -422,11 +392,6 @@ if [ -d "Resources" ]; then
 fi
 
 bundle_mcp_server
-
-# Inject the user's beta token after dependency preflight succeeds.
-echo "Injecting token for $USER_NAME..."
-cp "$BETA_CONFIG_PATH" "$BETA_CONFIG_BACKUP"
-inject_beta_token
 
 # Unified dependencies (FluidAudio + mlx-swift-lm + WhisperKit)
 echo "Dependencies found"
@@ -597,7 +562,6 @@ fi
 echo ""
 echo "✅ Done! DMG ready: $BUILD_DIR/$DMG_NAME"
 echo "   Size: $(du -sh "$BUILD_DIR/$DMG_NAME" | cut -f1)"
-echo "   Token: $(mask_secret "$BETA_TOKEN")"
 echo "   User: $USER_NAME"
 if [ "$SKIP_NOTARIZATION" = "1" ] || [[ ! "$SIGNING_DISPLAY_NAME" == Developer\ ID* ]]; then
     echo "   Note: this build is not notarized yet, so Gatekeeper rejection is still expected."


### PR DESCRIPTION
## Summary

Closes four findings from the /cso security audit run on 2026-05-12.

- **HF model integrity** — `ModelDownloadService` no longer falls back to `hf-mirror.com`. The mirror also supplied the manifest SHA-256s used for verification, so a compromised mirror could just hand back a manifest whose `lfs.sha256` matched the malicious file it intended to serve. huggingface.co is now the only source; downloads fail closed instead of silently degrading.
- **Dead beta token** — `BetaConfig.userToken` was no longer consumed by any Swift code but `build-beta.sh` kept baking it into every signed beta binary, where `strings` could recover it. Stripped the constant and the `inject_beta_token` plumbing. `BETA_TOKEN` is retained as an optional positional arg for invocation compat but is no longer substituted into source.
- **Anthropic proxy route in worker archive** — `POST /v1/messages` forwarded to api.anthropic.com using a worker-side `ANTHROPIC_API_KEY`. The app on main no longer uses this route, but any leaked beta token used to be enough to bill operator-funded LLM spend. Removed the route + env field. Docs explicitly call out that the live worker needs to be redeployed and the Anthropic key rotated out of secrets.
- **Entitlement + model integrity docs** — added two sections to `SECURITY.md`. Model integrity section names the huggingface.co-only sourcing and the LFS-vs-non-LFS digest gap (non-LFS files like tokenizer.json are not hash-pinned). Beta entitlement section explains why `app-sandbox`/`disable-library-validation`/`allow-jit` are set, what that means for users, and the practical mitigations.

## Out-of-band action required

The live Cloudflare Worker at `draft-proxy.tz427gsydr.workers.dev` may still serve `POST /v1/messages`. After this lands:

1. Redeploy the worker from `archive/backend-beta-worker/` (or take it offline).
2. Rotate `ANTHROPIC_API_KEY` out of the worker's Cloudflare secrets.
3. Optionally drop the now-dead `api_calls` D1 table.

## Test plan

- [x] `swiftc -parse` clean across `Sources/Beta` + `Sources/TranscriptedCore/Services`
- [x] `bash -n scripts/entrypoints/build-beta.sh` clean
- [x] Worker TS brace-balanced, no orphan `handleMessages` refs, `ANTHROPIC_API_KEY` only present in a deprecation comment
- [ ] `bash build-deps.sh && bash build.sh && bash run-tests.sh && bash run-integration-smoke.sh` — deferred to CI / reviewer (fresh worktree had no prebuilt deps and build-deps is multi-minute)
- [ ] `swift test` — same
- [ ] Smoke beta build: `./build-beta.sh` (no token arg) should succeed end-to-end and the resulting binary should not contain any beta token string when `strings` is run against it

🤖 Generated with [Claude Code](https://claude.com/claude-code)