### PR TITLE
Polish menubar and overlay UI papercuts

### DIFF
--- a/Sources/UI/MenuBar/MenuBarActionRowView.swift
+++ b/Sources/UI/MenuBar/MenuBarActionRowView.swift
@@ -29,7 +29,10 @@ final class MenuBarActionRowView: NSControl {
     private var currentHeight: CGFloat = 26
 
     override var isEnabled: Bool {
-        didSet { updateAppearance() }
+        didSet {
+            updateAppearance()
+            window?.invalidateCursorRects(for: self)
+        }
     }
 
     override init(frame: NSRect) {
@@ -181,7 +184,7 @@ final class MenuBarActionRowView: NSControl {
             titleLabel.frame = NSRect(x: textX, y: centeredY, width: textWidth, height: 16)
             detailLabel.frame = .zero
         } else {
-            let titleY: CGFloat = rowSize == .primary ? 1 : 1
+            let titleY: CGFloat = 1
             titleLabel.frame = NSRect(x: textX, y: titleY, width: textWidth, height: 16)
             detailLabel.frame = NSRect(x: textX, y: titleLabel.frame.maxY + 1, width: textWidth, height: 13)
         }
@@ -229,6 +232,13 @@ final class MenuBarActionRowView: NSControl {
         )
         addTrackingArea(area)
         trackingAreaRef = area
+        window?.invalidateCursorRects(for: self)
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        guard isEnabled else { return }
+        addCursorRect(bounds, cursor: .pointingHand)
     }
 
     override func mouseEntered(with event: NSEvent) {

--- a/Sources/UI/Overlay/OverlayDraftingView.swift
+++ b/Sources/UI/Overlay/OverlayDraftingView.swift
@@ -101,7 +101,7 @@ final class OverlayDraftingView: NSView {
         // Error icon
         if let image = NSImage(systemSymbolName: "exclamationmark.triangle", accessibilityDescription: "Error") {
             errorIcon.image = image
-            errorIcon.contentTintColor = NSColor.systemYellow
+            errorIcon.contentTintColor = OverlayTokens.warningColor
             let config = NSImage.SymbolConfiguration(pointSize: 18, weight: .regular)
             errorIcon.symbolConfiguration = config
         }

--- a/Sources/UI/Overlay/OverlayHeaderView.swift
+++ b/Sources/UI/Overlay/OverlayHeaderView.swift
@@ -128,9 +128,8 @@ final class OverlayHeaderView: NSView {
         if isCenteredListeningLayout {
             let compactPad: CGFloat = 10
             let spacing: CGFloat = 6
-            let preferredWaveWidth: CGFloat = 124
             let availableWaveWidth = max(0, bounds.width - compactPad * 2 - labelSize.width - stopSize.width - spacing * 2)
-            let waveWidth = min(preferredWaveWidth, availableWaveWidth)
+            let waveWidth = min(OverlayTokens.preferredWaveformWidth, availableWaveWidth)
             let groupWidth = labelSize.width + spacing + waveWidth + spacing + stopSize.width
             let groupOriginX = max(compactPad, (bounds.width - groupWidth) / 2)
 

--- a/Sources/UI/Overlay/OverlayRootView.swift
+++ b/Sources/UI/Overlay/OverlayRootView.swift
@@ -53,11 +53,11 @@ final class OverlayRootView: NSView {
     private func setupViews() {
         // Dividers
         topDivider.wantsLayer = true
-        topDivider.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.06).cgColor
+        topDivider.layer?.backgroundColor = OverlayTokens.dividerColor.cgColor
         addSubview(topDivider)
 
         bottomDivider.wantsLayer = true
-        bottomDivider.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.06).cgColor
+        bottomDivider.layer?.backgroundColor = OverlayTokens.dividerColor.cgColor
         addSubview(bottomDivider)
 
         addSubview(headerView)

--- a/Sources/UI/Overlay/OverlayTokens.swift
+++ b/Sources/UI/Overlay/OverlayTokens.swift
@@ -27,4 +27,9 @@ enum OverlayTokens {
     static let headerHeight: CGFloat = 32
     static let toolbarHeight: CGFloat = 28
     static let dividerHeight: CGFloat = 1
+    static let preferredWaveformWidth: CGFloat = 124
+
+    // Status + surfaces
+    static let warningColor = NSColor.systemOrange
+    static let dividerColor = NSColor.white.withAlphaComponent(0.06)
 }


### PR DESCRIPTION
## Summary

Small UI-polish pass. No behavior changes, no new features.

- **MenuBarActionRowView:** clickable rows in the popover (Connect Agent, Settings, Feedback, Quit, etc.) now switch the cursor to `.pointingHand` on hover when enabled, so they actually feel clickable.
- **MenuBarActionRowView:** collapsed a dead `rowSize == .primary ? 1 : 1` ternary into a plain constant.
- **OverlayTokens:** added `warningColor`, `dividerColor`, and `preferredWaveformWidth` so callers don't reach for raw `.systemYellow` / `NSColor.white.withAlphaComponent(0.06)` / `124`.
- **OverlayDraftingView:** error icon uses `OverlayTokens.warningColor` (system orange) instead of `.systemYellow`, matching the warning hue used elsewhere in the app.
- **OverlayRootView:** top/bottom dividers use `OverlayTokens.dividerColor` instead of the inline alpha literal.
- **OverlayHeaderView:** centered-listening layout reads the waveform width from `OverlayTokens.preferredWaveformWidth` instead of an inline `124`.

## Test plan

- [x] `bash build.sh` clean
- [x] `bash run-tests.sh` — 1752/1752 passing
- [ ] Open the menubar popover, hover any row, confirm the cursor switches to the pointing hand
- [ ] Trigger a dictation error and confirm the warning icon is orange (not yellow)
- [ ] Start a dictation and confirm the listening waveform still sits between the "Listening" label and the Stop button as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)