### PR TITLE
[nightly-regression] Guard meeting warmup header readiness

### DIFF
--- a/Tests/MeetingWarmupStatusPolicyTests.swift
+++ b/Tests/MeetingWarmupStatusPolicyTests.swift
@@ -11,6 +11,7 @@ func testMeetingWarmupStatusPolicy() {
 
         assertEqual(status.subtitle, "Meetings load when started", "background startup failures should not become visible meeting errors")
         assertEqual(status.meetingsStatus, "On demand", "quiet meeting warmup failures should fall back to lazy meeting copy")
+        assertTrue(status.isReadyForMenuHeader, "quiet meeting warmup failures should not make the menu header look broken")
     }
 
     runSuite("MeetingWarmupStatusPolicy.status — surfaces user-requested meeting warmup failures") {
@@ -23,6 +24,7 @@ func testMeetingWarmupStatusPolicy() {
 
         assertEqual(status.subtitle, "Meeting transcription models failed to load", "explicit meeting setup should show the failure")
         assertEqual(status.meetingsStatus, "Failed", "the meeting action should offer retry copy after visible failure")
+        assertFalse(status.isReadyForMenuHeader, "visible meeting failures should not let the menu header claim Transcripted is ready")
     }
 
     runSuite("MeetingWarmupStatusPolicy.status — shows meeting loading while warmup is visible") {


### PR DESCRIPTION
## Nightly review

Top risks from the last 24h:

1. Meeting model recovery now does more async queued-start work. A visible meeting-model failure must not let the menu header keep claiming the app is ready.
2. Bluetooth/CoreAudio recovery now abandons blocked audio graphs. The policy coverage is good, but this remains the runtime path to watch with live Sentry once credentials are available.
3. Issue #500 meeting-volume diagnostics landed and are allowlisted, but live PostHog/Sentry checks were unavailable in this environment, so production confirmation is still pending.

Chosen action: tests-only regression. Product behavior looked correct, so this pins the fragile readiness contract in `MeetingWarmupStatusPolicyTests` without changing runtime code.

## Verification

- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (`1790 tests, 1790 passed`)
- `git diff --check`

Live evidence notes:

- GitHub snapshot: latest release `v1.1.34` has 80 downloads; recent merged PRs #724-#734 landed after yesterday's run.
- Open issues: #500 remains the only open product bug found by `gh issue list`.
- Sentry was unavailable because `SENTRY_AUTH_TOKEN` is not set in this environment.
- PostHog was unavailable because `POSTHOG_PERSONAL_API_KEY` is not set in this environment.
