### PR TITLE
[docs] Update beta build docs

### DIFF
--- a/Sources/Beta/CLAUDE.md
+++ b/Sources/Beta/CLAUDE.md
@@ -2,15 +2,21 @@
 
 ## Current status
 
-`Sources/Beta/` currently contains only beta-build token configuration.
+`Sources/Beta/` currently contains only the `BETA_BUILD` compile-time
+configuration shell. There is no embedded beta token or beta proxy client in
+the app target.
 
 ## Important file
 
-- `BetaConfig.swift` — `#if BETA_BUILD` token placeholder replaced by `build-beta.sh`
+- `BetaConfig.swift` — intentionally empty `#if BETA_BUILD` enum. The old
+  per-user bearer token used by the archived proxy worker has been removed; see
+  the file header for rationale and the keychain-based path if beta-only auth
+  ever comes back.
 
 ## Notes
 
 - the core dictation and meeting flows do not depend on a live app-side API client here
-- the current app no longer consumes `/config`-driven version or update fields from the archived beta worker
+- the current app no longer consumes `/config`, `/events`, or `/logs` from the archived beta worker; Sparkle handles updates, Sentry handles crash and non-fatal reports, and PostHog handles anonymous analytics
+- `build-beta.sh` still accepts a positional beta-token argument for backwards-compatible invocations, but the value is not injected into the binary
 - if you need beta distribution or backend context, read `archive/backend-beta-worker/README.md`
 - older docs mentioning `GeminiEngine`, keychain helpers, or chat-drafting HTTP paths do not match the current tree

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -25,12 +25,11 @@ swift scripts/release/generate-dmg-background.swift
 the built-in Finder-layout fallback, so polished install windows no longer
 depend on `create-dmg` being present just to avoid a blank DMG.
 
-`build-beta.sh` also treats the per-user beta token as sensitive build input:
-it escapes the token before injecting it into `Sources/Beta/BetaConfig.swift`
-and only prints a masked preview in build logs.
-The packaged release archive is still versioned from `Info.plist`, so published
-artifacts keep the stable `Transcripted-<version>.dmg` name expected by Sparkle
-and Homebrew even when the embedded beta token is per-user.
+`build-beta.sh` still accepts a positional beta-token argument for
+backwards-compatible invocations, but the value is no longer injected into the
+binary. See `Sources/Beta/BetaConfig.swift` for the rationale. The packaged
+release archive is versioned from `Info.plist`, so published artifacts keep the
+stable `Transcripted-<version>.dmg` name expected by Sparkle and Homebrew.
 
 Transcripted's Sparkle update plumbing is documented in `docs/sparkle-updates.md`.
 `build-deps.sh` now downloads the pinned Sparkle framework and release tools,


### PR DESCRIPTION
## Summary
- update beta local docs now that BetaConfig no longer embeds a token
- update release packaging docs to say build-beta accepts but ignores the token argument

## Verification
- bash scripts/dev/agent-preflight.sh
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- SKIP_NOTARIZATION=1 bash build-beta.sh dummy-token Codex

## Notes
- SECURITY.md still has a stale beta proxy caveat, but this lane allowed only agent/docs surfaces and local CLAUDE docs, so I left it untouched.