### PR TITLE
[nightly-agent] Add JSON output for CLI read commands

### DIFF
--- a/Sources/Capture/ContextCaptureEngine.swift
+++ b/Sources/Capture/ContextCaptureEngine.swift
@@ -18,9 +18,12 @@ private var _sharedMeetingToggle: (() -> Void)?
 // Carbon hotkeys can fire back-to-back before Transcripted finishes updating its
 // session state. Ignore rapid repeats so start/stop/cancel transitions stay
 // single-shot and predictable.
-private var _lastAcceptedHotkeyTime: CFAbsoluteTime = 0
+// Use systemUptime (monotonic) instead of CFAbsoluteTimeGetCurrent (wall clock)
+// so NTP adjustments, manual time changes, or DST transitions can't make a
+// backward clock jump silently drop all subsequent hotkey presses.
+private var _lastAcceptedHotkeyTime: TimeInterval = 0
 
-private func shouldAcceptHotkeyAction(now: CFAbsoluteTime = CFAbsoluteTimeGetCurrent()) -> Bool {
+private func shouldAcceptHotkeyAction(now: TimeInterval = ProcessInfo.processInfo.systemUptime) -> Bool {
     let elapsed = now - _lastAcceptedHotkeyTime
     guard elapsed >= TranscriptedConstants.hotkeyActionDebounceInterval else { return false }
     _lastAcceptedHotkeyTime = now

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -70,6 +70,10 @@ class DictationSessionController: ObservableObject {
     /// Max duration for a listening session before auto-cancel (5 minutes).
     /// Prevents stuck sessions when the user walks away from the computer.
     private static let sessionTimeoutNanos: UInt64 = 5 * 60 * 1_000_000_000
+    private static let sessionTimeoutInterval: TimeInterval = 5 * 60
+    /// Cap on each polling sleep so a wake from system sleep gets a chance to
+    /// re-evaluate the uptime-based deadline before firing the cancel branch.
+    private static let sessionTimeoutPollIntervalNanos: UInt64 = 30 * 1_000_000_000
 
     deinit {
         startupTask?.cancel()
@@ -1161,12 +1165,25 @@ class DictationSessionController: ObservableObject {
         overlayController?.resizePanelToCompact()
     }
 
-    /// Install a timeout that auto-cancels the session after 5 minutes.
-    /// Prevents stuck sessions if the user walks away from the computer.
+    /// Install a timeout that auto-cancels the session after 5 minutes of
+    /// *active* uptime. Tracks the deadline against `ProcessInfo.systemUptime`
+    /// so Mac sleep does not consume the session's remaining record window —
+    /// otherwise a session that sees the Mac sleep for hours would auto-cancel
+    /// immediately on wake when Task.sleep's wall-clock deadline expires.
     private func installSessionTimeout() {
         sessionTimeoutTask?.cancel()
+        var timeout = DictationSessionTimeout(timeoutInterval: Self.sessionTimeoutInterval)
+        timeout.start(at: ProcessInfo.processInfo.systemUptime)
         sessionTimeoutTask = Task { [weak self] in
-            try? await Task.sleep(nanoseconds: Self.sessionTimeoutNanos)
+            while !Task.isCancelled {
+                let now = ProcessInfo.processInfo.systemUptime
+                if timeout.isExpired(at: now) { break }
+                let remainingSeconds = timeout.remaining(at: now) ?? 0
+                let remainingNanos = UInt64((remainingSeconds * 1_000_000_000).rounded(.up))
+                let sleepNanos = min(remainingNanos, Self.sessionTimeoutPollIntervalNanos)
+                if sleepNanos == 0 { break }
+                try? await Task.sleep(nanoseconds: sleepNanos)
+            }
             guard !Task.isCancelled, let self = self else { return }
             if self.isInSession {
                 self.appState?.logger.log("SESSION | auto-cancelled after timeout")

--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -84,9 +84,9 @@ on SwiftPM again:
 ./.build/debug/transcripted-cli context-recent --count 10
 ./.build/debug/transcripted-cli context-recent --kind meeting --count 3
 ./.build/debug/transcripted-cli context-search "Linus" --kind meeting --speaker "Linus" --count 5
-./.build/debug/transcripted-cli read-meeting "Call_2026-04-29_09-15-00"
+./.build/debug/transcripted-cli read-meeting "Call_2026-04-29_09-15-00" --json
 ./.build/debug/transcripted-cli list-dictations --date-from 2026-04-29 --date-to 2026-04-29
-./.build/debug/transcripted-cli read-dictation Dictations_2026-04-29
+./.build/debug/transcripted-cli read-dictation Dictations_2026-04-29 --json
 ```
 
 What these are good for:
@@ -96,6 +96,7 @@ What these are good for:
 - full meeting markdown: `read-meeting` with the filename returned by `context-recent --kind meeting`
 - meetings by speaker or topic: `context-search <query> --kind meeting --speaker <name>`
 - dictations by day: `list-dictations --date-from YYYY-MM-DD --date-to YYYY-MM-DD`, then `read-dictation`
+- machine-readable full reads: add `--json` to `read-meeting` or `read-dictation`
 
 Binary path after build:
 

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextCommands.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextCommands.swift
@@ -134,8 +134,18 @@ struct ReadMeeting: ParsableCommand {
 
     @OptionGroup var paths: CLIContextPathOptions
 
+    @Flag(name: .long, help: "Output JSON instead of raw Markdown.")
+    var json: Bool = false
+
     func run() throws {
-        print(try CLIContextStore.readMeeting(filename: filename, in: paths.resolved))
+        let markdown = try CLIContextStore.readMeeting(filename: filename, in: paths.resolved)
+        try printReadMarkdown(
+            kind: .meeting,
+            filename: filename,
+            entryId: nil,
+            markdown: markdown,
+            asJSON: json
+        )
     }
 }
 
@@ -153,8 +163,18 @@ struct ReadDictation: ParsableCommand {
     @Option(name: .long, help: "Optional entry ID to read a single dictation.")
     var entryId: String?
 
+    @Flag(name: .long, help: "Output JSON instead of raw Markdown.")
+    var json: Bool = false
+
     func run() throws {
-        print(try CLIContextStore.readDictation(filename: filename, entryId: entryId, in: paths.resolved))
+        let markdown = try CLIContextStore.readDictation(filename: filename, entryId: entryId, in: paths.resolved)
+        try printReadMarkdown(
+            kind: .dictation,
+            filename: filename,
+            entryId: entryId,
+            markdown: markdown,
+            asJSON: json
+        )
     }
 }
 
@@ -176,4 +196,33 @@ private func printContextItems(_ items: [CLIContextItem], asJSON: Bool) throws {
         }
         print("  \(item.preview)")
     }
+}
+
+private func printReadMarkdown(
+    kind: CLIContextKind,
+    filename: String,
+    entryId: String?,
+    markdown: String,
+    asJSON: Bool
+) throws {
+    guard asJSON else {
+        print(markdown)
+        return
+    }
+
+    let document = CLIReadMarkdownDocument(
+        kind: kind,
+        filename: normalizedMarkdownFilename(filename),
+        entryId: entryId,
+        markdown: markdown
+    )
+    let data = try JSONEncoder.contextPretty.encode(document)
+    print(String(data: data, encoding: .utf8) ?? "{}")
+}
+
+private func normalizedMarkdownFilename(_ filename: String) -> String {
+    if filename.hasSuffix(".md") {
+        return String(filename.dropLast(3))
+    }
+    return filename
 }

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextModels.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextModels.swift
@@ -129,6 +129,18 @@ struct CLIDictationDaySummary: Codable {
     }
 }
 
+struct CLIReadMarkdownDocument: Codable {
+    let kind: CLIContextKind
+    let filename: String
+    let entryId: String?
+    let markdown: String
+
+    enum CodingKeys: String, CodingKey {
+        case kind, filename, markdown
+        case entryId = "entry_id"
+    }
+}
+
 extension JSONEncoder {
     static let contextPretty: JSONEncoder = {
         let encoder = JSONEncoder()

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -430,6 +430,47 @@ final class ContextStoreTests: XCTestCase {
         XCTAssertEqual(content, markdown)
     }
 
+    func testReadMeetingCommandAcceptsJSONFlag() throws {
+        let command = try ReadMeeting.parse([
+            "Product review",
+            "--meetings-dir", "/tmp/meetings",
+            "--dictations-dir", "/tmp/dictations",
+            "--json",
+        ])
+
+        XCTAssertTrue(command.json)
+        XCTAssertEqual(command.filename, "Product review")
+    }
+
+    func testReadDictationCommandAcceptsJSONFlag() throws {
+        let command = try ReadDictation.parse([
+            "Dictations_2026-04-07",
+            "--dictations-dir", "/tmp/dictations",
+            "--entry-id", "dictation-20260407-091500-000",
+            "--json",
+        ])
+
+        XCTAssertTrue(command.json)
+        XCTAssertEqual(command.filename, "Dictations_2026-04-07")
+        XCTAssertEqual(command.entryId, "dictation-20260407-091500-000")
+    }
+
+    func testReadMarkdownDocumentEncodesStableJSONKeys() throws {
+        let document = CLIReadMarkdownDocument(
+            kind: .dictation,
+            filename: "Dictations_2026-04-07",
+            entryId: "dictation-20260407-091500-000",
+            markdown: "# Morning note\n\nShip the agent path."
+        )
+
+        let data = try JSONEncoder.contextPretty.encode(document)
+        let json = String(data: data, encoding: .utf8)
+
+        XCTAssertTrue(json?.contains("\"kind\" : \"dictation\"") == true)
+        XCTAssertTrue(json?.contains("\"entry_id\" : \"dictation-20260407-091500-000\"") == true)
+        XCTAssertTrue(json?.contains("\"markdown\" :") == true)
+    }
+
     func testReadMeetingRejectsParentTraversal() throws {
         let root = makeTempDir()
         defer { try? FileManager.default.removeItem(at: root) }


### PR DESCRIPTION
## Summary
- Add --json support to transcripted-cli read-meeting and read-dictation.
- Wrap full-read Markdown with kind, filename, optional entry_id, and markdown fields.
- Update CLI agent docs and tests for the new machine-readable read mode.

## Verification
- swift test --package-path Tools/TranscriptedCLI
- swift test --package-path Tools/TranscriptedMCP
- cd Tools/TranscriptedMCP && swift build -c release
- TRANSCRIPTED_DATA_DIR=... TRANSCRIPTED_INDEX_DIR=... transcripted-mcp --self-test
- transcripted-mcp --self-test
- Manual CLI JSON checks for context-recent, context-search, list-dictations, read-meeting, and read-dictation against local captures
