### PR TITLE
[operator] Report first-value PostHog probe counts

### DIFF
--- a/docs/ops-credentials.md
+++ b/docs/ops-credentials.md
@@ -7,7 +7,7 @@ This document describes the observability lanes used by Transcripted and how to 
 | Lane | What it Reports | Required Env Vars | Required Scopes | How to Obtain Credential | Probe Command |
 |------|-----------------|-------------------|-----------------|--------------------------|---------------|
 | **Sentry** | Crash and reliability diagnostics | `SENTRY_AUTH_TOKEN` | `project:read` | Create an auth token at [Sentry API Tokens](https://sentry.io/settings/account/api/auth-tokens/) with `project:read` scope | `curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" "https://sentry.io/api/0/projects/r3dbars/apple-macos/issues/?query=is:unresolved&limit=10"` |
-| **PostHog** | Anonymous usage statistics | `POSTHOG_PERSONAL_API_KEY`, `POSTHOG_PROJECT_ID` | Personal API key | Create a Personal API Key in PostHog project settings (Settings -> Personal API keys) | `curl -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" "https://us.i.posthog.com/api/projects/$POSTHOG_PROJECT_ID/query/" -d '{"query":"select uniq(distinct_id) as devices_7d, sum(case when event in (\"app_launched\",\"app_unclean_shutdown_detected\",\"app_session_stall_detected\",\"onboarding_completed\",\"dictation_started\",\"dictation_start_failed\",\"dictation_completed\",\"dictation_cancelled\",\"dictation_no_speech\",\"dictation_audio_route_recovery_timeout\",\"meeting_recording_started\",\"meeting_recording_start_failed\",\"meeting_recording_stopped\",\"meeting_recording_cancelled\",\"meeting_transcript_saved\",\"meeting_transcript_failed\",\"meeting_transcript_skipped\") then 1 else 0 end) as workflow_events_7d from events where timestamp >= now() - interval 7 day"}'` |
+| **PostHog** | Anonymous usage statistics | `POSTHOG_PERSONAL_API_KEY`, `POSTHOG_PROJECT_ID` | Personal API key | Create a Personal API Key in PostHog project settings (Settings -> Personal API keys) | `bash scripts/ops/health-probe.sh posthog` |
 | **GitHub** | Release metadata, traffic stats | None (uses `gh auth`) | None (uses authenticated CLI) | Run `gh auth login` in your terminal | `gh api repos/r3dbars/transcripted` |
 | **Cloudflare** | Pages deployment status | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` | Account-level `Zone:Read` | Create an API Token at [Cloudflare Tokens](https://dash.cloudflare.com/profile/api-tokens) with Account permissions for `Zone:Read` | See `scripts/ops/health-probe.sh cloudflare` |
 
@@ -33,6 +33,10 @@ When running health checks or operational probes, **never** log or expose:
 - Full event payloads or user identifiers
 
 Only report aggregate counts, status codes, deployment IDs, and issue titles. For the full privacy contract, see [`privacy-first-observability.md`](./privacy-first-observability.md).
+
+### PostHog Probe Shape
+
+The PostHog probe reports aggregate 7-day counts for active devices, workflow events, onboarding events, and first-value events. First-value events are limited to `onboarding_first_dictation_saved` and `onboarding_agent_cta_clicked`, so the health lane can see whether users reached a saved Markdown artifact or agent payoff without exposing transcript text, file paths, titles, or user identifiers.
 
 ## Quick Start
 

--- a/scripts/ops/health-probe.sh
+++ b/scripts/ops/health-probe.sh
@@ -83,24 +83,31 @@ probe_posthog() {
   fi
 
   echo "PostHog health check..."
+  local workflow_events onboarding_events first_value_events query payload
+  workflow_events="'app_launched','app_unclean_shutdown_detected','app_session_stall_detected','onboarding_completed','dictation_started','dictation_start_failed','dictation_completed','dictation_cancelled','dictation_no_speech','dictation_audio_route_recovery_timeout','meeting_recording_started','meeting_recording_start_failed','meeting_recording_stopped','meeting_recording_cancelled','meeting_transcript_saved','meeting_transcript_failed','meeting_transcript_skipped'"
+  onboarding_events="'onboarding_shown','onboarding_step_viewed','onboarding_permission_cta_clicked','onboarding_permission_status_changed','onboarding_model_state_changed','onboarding_primary_cta_clicked','onboarding_first_dictation_started','onboarding_first_dictation_saved','onboarding_first_dictation_stop_clicked','onboarding_first_dictation_empty','onboarding_meeting_dry_run_clicked','onboarding_agent_cta_clicked','onboarding_reporting_toggle_changed','onboarding_completed','onboarding_dismissed'"
+  first_value_events="'onboarding_first_dictation_saved','onboarding_agent_cta_clicked'"
+  query="select uniq(distinct_id) as devices_7d, sum(case when event in ($workflow_events) then 1 else 0 end) as workflow_events_7d, sum(case when event in ($onboarding_events) then 1 else 0 end) as onboarding_events_7d, sum(case when event in ($first_value_events) then 1 else 0 end) as first_value_events_7d from events where timestamp >= now() - interval 7 day"
+  payload=$(jq -cn --arg query "$query" '{query: $query}')
+
   local response
   response=$(curl -s -f -X POST \
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
     -H "Content-Type: application/json" \
     "https://us.i.posthog.com/api/projects/$POSTHOG_PROJECT_ID/query/" \
-    -d '{
-      "query": "select uniq(distinct_id) as devices_7d, sum(case when event in (\"app_launched\",\"app_unclean_shutdown_detected\",\"app_session_stall_detected\",\"onboarding_completed\",\"dictation_started\",\"dictation_start_failed\",\"dictation_completed\",\"dictation_cancelled\",\"dictation_no_speech\",\"dictation_audio_route_recovery_timeout\",\"meeting_recording_started\",\"meeting_recording_start_failed\",\"meeting_recording_stopped\",\"meeting_recording_cancelled\",\"meeting_transcript_saved\",\"meeting_transcript_failed\",\"meeting_transcript_skipped\") then 1 else 0 end) as workflow_events_7d from events where timestamp >= now() - interval 7 day"
-    }')
+    -d "$payload")
 
   if [[ -z "$response" ]]; then
     echo "PostHog: query failed"
     return 1
   fi
 
-  local devices events
+  local devices events onboarding first_value
   devices=$(echo "$response" | jq -r '.data[0][0]')
   events=$(echo "$response" | jq -r '.data[0][1]')
-  echo "PostHog (last 7d): devices=$devices, workflow_events=$events"
+  onboarding=$(echo "$response" | jq -r '.data[0][2] // 0')
+  first_value=$(echo "$response" | jq -r '.data[0][3] // 0')
+  echo "PostHog (last 7d): devices=$devices, workflow_events=$events, onboarding_events=$onboarding, first_value_events=$first_value"
 }
 
 probe_cloudflare() {


### PR DESCRIPTION
## Summary
- expands the PostHog health probe to report aggregate onboarding and first-value event counts
- documents the probe shape and points ops docs at the maintained script instead of a stale inline curl query

## Verification
- bash -n scripts/ops/health-probe.sh
- bash scripts/ops/health-probe.sh posthog (skips cleanly without POSTHOG_PERSONAL_API_KEY)
- scripts/dev/agent-preflight.sh
- git diff --check

## Notes
- no app telemetry payloads changed
- first-value counts are limited to onboarding_first_dictation_saved and onboarding_agent_cta_clicked
