### PR TITLE
[nightly-maintenance] Track fast test manifest in preflight

### DIFF
--- a/.agents/test-matrix.yml
+++ b/.agents/test-matrix.yml
@@ -8,6 +8,7 @@ rules:
   - paths:
       - "Sources/**/*.swift"
       - "Tests/*.swift"
+      - "Tests/FastTests.manifest"
     checks:
       - "bash build.sh"
       - "bash run-tests.sh"

--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -79,7 +79,7 @@ matches_any() {
 
 if [ -n "$changed_paths" ]; then
     while IFS= read -r path; do
-        if matches_any "$path" "Sources/*.swift" "Sources/*/*.swift" "Tests/*.swift"; then
+        if matches_any "$path" "Sources/*.swift" "Sources/*/*.swift" "Tests/*.swift" "Tests/FastTests.manifest"; then
             add_command "bash build.sh"
             add_command "bash run-tests.sh"
         fi


### PR DESCRIPTION
## Summary
- add `Tests/FastTests.manifest` to the agent verification matrix
- make `scripts/dev/agent-preflight.sh` suggest `bash build.sh` and `bash run-tests.sh` when that manifest changes

## Why
`run-tests.sh` compiles the fast-test files listed in `Tests/FastTests.manifest`, so manifest edits should trigger the same checks as root fast-test Swift edits.

## Verification
- `scripts/dev/agent-preflight.sh`
- `bash -n scripts/dev/agent-preflight.sh`
- `git diff --check`
- temporary manifest diff proof: preflight suggested `bash build.sh` and `bash run-tests.sh`, then the temp line was removed before commit