### PR TITLE
Release Transcripted 1.1.35

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.34"
-  sha256 "0cf7d0894cf0ac9290b110763e0ab5266f195111f6213704c1864d361b685f23"
+  version "1.1.35"
+  sha256 "f4dc048526b969c130180663be6d3bd7f3fe2e3c7b337a29a46b9d35f7ec5a94"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.34</string>
+	<string>1.1.35</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.34</string>
+	<string>1.1.35</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.35</title>
+      <pubDate>Wed, 13 May 2026 09:06:03 -0500</pubDate>
+      <sparkle:version>1.1.35</sparkle:version>
+      <sparkle:shortVersionString>1.1.35</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.35/Transcripted-1.1.35.dmg" length="30777248" type="application/octet-stream" sparkle:edSignature="gbJDhN+wf5GnPBFtPHDog144MTWDyrM403vw6yRe0A0m+l7Wb+wQA78UktsTYHeviNJyRnwPEJqlNsWm3ItjCQ==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.35</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.35</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.34</title>
       <pubDate>Mon, 11 May 2026 06:34:58 -0500</pubDate>
       <sparkle:version>1.1.34</sparkle:version>


### PR DESCRIPTION
Publishes Transcripted 1.1.35 release metadata.\n\n- Bumps Info.plist to 1.1.35\n- Adds the 1.1.35 Sparkle appcast entry for the GitHub DMG\n- Updates the Homebrew cask version and sha256\n\nVerification:\n- bash build-deps.sh --force\n- bash build.sh\n- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh\n- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh\n- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift test\n- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-beta-justin Justin\n- bash scripts/release/verify-sparkle-release.sh 1.1.35