### PR TITLE
[codex] Fix built-in mic Bluetooth recovery

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -1474,6 +1474,7 @@ class ParakeetEngine: ObservableObject {
             inputSampleRate: hwFormat.sampleRate,
             inputChannelCount: hwFormat.channelCount,
             selectedInputClass: selectedInputClass(for: selection),
+            outputDeviceClass: defaultOutputClass(for: selection),
             selectionOverrodeDefault: selection?.didOverrideDefault ?? false
         )
     }
@@ -1483,6 +1484,10 @@ class ParakeetEngine: ObservableObject {
             return DictationInputDeviceSelectionPolicy.deviceClass(for: selection.selectedInput)
         }
         return inputDeviceClass(for: inputDeviceName)
+    }
+
+    private func defaultOutputClass(for selection: DictationInputDeviceSelection?) -> String {
+        selection?.defaultOutput.map(DictationInputDeviceSelectionPolicy.deviceClass(for:)) ?? "unknown"
     }
 
     private func audioFormatContext(
@@ -1554,7 +1559,7 @@ class ParakeetEngine: ObservableObject {
             "default_input_class": defaultInputClass,
             "default_output_class": defaultOutputClass,
             "format_ready": "\(recoveryState.inputFormatReady)",
-            "hfp_suspected": "\(isLikelyBluetoothHandsFreeProfile(inputClass: selectedClass, inputRate: inputRate, outputRate: outputRate))",
+            "hfp_suspected": "\(isLikelyBluetoothHandsFreeProfile(inputClass: selectedClass, outputDeviceClass: defaultOutputClass, inputRate: inputRate, outputRate: outputRate))",
             "input_device_class": selectedClass,
             "output_device_class": defaultOutputClass,
             "recovering": "\(recoveryState.isRecovering)",
@@ -1584,12 +1589,18 @@ class ParakeetEngine: ObservableObject {
 
     private func isLikelyBluetoothHandsFreeProfile(
         inputClass: String,
+        outputDeviceClass: String,
         inputRate: Double?,
         outputRate: Double?
     ) -> Bool {
-        guard inputClass == "bluetooth" else { return false }
         guard let inputRate, let outputRate else { return false }
-        return inputRate <= 24_000 && outputRate >= 44_100
+        if inputClass == "bluetooth" {
+            return inputRate <= 24_000 && outputRate >= 44_100
+        }
+        if outputDeviceClass == "bluetooth" {
+            return outputRate <= 24_000 && inputRate >= 44_100
+        }
+        return false
     }
 
     private func audioInputSnapshot(

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -103,6 +103,7 @@ enum ParakeetAudioFormatReadinessPolicy {
         inputSampleRate: Double,
         inputChannelCount: UInt32,
         selectedInputClass: String,
+        outputDeviceClass: String,
         selectionOverrodeDefault: Bool
     ) -> ParakeetAudioFormatReadiness {
         guard isUsableCaptureSampleRate(outputSampleRate), outputChannelCount > 0,
@@ -112,6 +113,7 @@ enum ParakeetAudioFormatReadinessPolicy {
 
         if selectionOverrodeDefault,
            selectedInputClass != "bluetooth",
+           outputDeviceClass != "bluetooth",
            inputSampleRate >= 44_100,
            likelyBluetoothSpeechRates.contains(Int(outputSampleRate.rounded())) {
             return .routeNotSettled

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -108,6 +108,7 @@ func testParakeetStartRecordingFailurePolicy() {
             inputSampleRate: 48_000,
             inputChannelCount: 1,
             selectedInputClass: "built_in",
+            outputDeviceClass: "built_in",
             selectionOverrodeDefault: true
         )
 
@@ -121,10 +122,25 @@ func testParakeetStartRecordingFailurePolicy() {
             inputSampleRate: 24_000,
             inputChannelCount: 1,
             selectedInputClass: "bluetooth",
+            outputDeviceClass: "bluetooth",
             selectionOverrodeDefault: false
         )
 
         assertEqual(readiness, .ready, "AirPods HFP 24k hardware to 48k output should remain valid")
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy accepts built-in mic with Bluetooth output speech bus") {
+        let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: 24_000,
+            outputChannelCount: 1,
+            inputSampleRate: 48_000,
+            inputChannelCount: 1,
+            selectedInputClass: "built_in",
+            outputDeviceClass: "bluetooth",
+            selectionOverrodeDefault: true
+        )
+
+        assertEqual(readiness, .ready, "built-in mic with Bluetooth output can capture at the 24k bus and resample")
     }
 
     runSuite("ParakeetAudioFormatReadinessPolicy defers stale AirPods-to-built-in switch formats") {
@@ -134,6 +150,7 @@ func testParakeetStartRecordingFailurePolicy() {
             inputSampleRate: 48_000,
             inputChannelCount: 1,
             selectedInputClass: "built_in",
+            outputDeviceClass: "built_in",
             selectionOverrodeDefault: true
         )
 
@@ -148,6 +165,7 @@ func testParakeetStartRecordingFailurePolicy() {
             inputSampleRate: 48_000,
             inputChannelCount: 1,
             selectedInputClass: "built_in",
+            outputDeviceClass: "built_in",
             selectionOverrodeDefault: true
         )
 
@@ -162,6 +180,7 @@ func testParakeetStartRecordingFailurePolicy() {
             inputSampleRate: 0,
             inputChannelCount: 1,
             selectedInputClass: "built_in",
+            outputDeviceClass: "built_in",
             selectionOverrodeDefault: true
         )
         let zeroInputChannels = ParakeetAudioFormatReadinessPolicy.readiness(
@@ -170,6 +189,7 @@ func testParakeetStartRecordingFailurePolicy() {
             inputSampleRate: 48_000,
             inputChannelCount: 0,
             selectedInputClass: "built_in",
+            outputDeviceClass: "built_in",
             selectionOverrodeDefault: true
         )
 
@@ -187,6 +207,7 @@ func testParakeetStartRecordingFailurePolicy() {
                 inputSampleRate: 48_000,
                 inputChannelCount: 1,
                 selectedInputClass: "built_in",
+                outputDeviceClass: "built_in",
                 selectionOverrodeDefault: false
             )
 
@@ -202,6 +223,7 @@ func testParakeetStartRecordingFailurePolicy() {
                 inputSampleRate: 48_000,
                 inputChannelCount: 1,
                 selectedInputClass: "built_in",
+                outputDeviceClass: "built_in",
                 selectionOverrodeDefault: false
             )
 


### PR DESCRIPTION
## Summary
- Allow built-in mic + Bluetooth output 24k speech-bus routes to recover instead of being treated as still unsettled.
- Keep the stale-route guard for non-Bluetooth outputs.
- Add a regression test for the exact built-in-input-to-Bluetooth-output shape.

## Root Cause
The format-readiness policy treated a 24k output bus with 48k built-in input as stale whenever dictation overrode the default Bluetooth input. For Bluetooth output, that 24k bus can be valid and capturable, so recovery could loop into rewarm failure or timeout.

## Validation
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` — 1791 passed
- `bash run-daily-audio-reliability.sh --synthetic` — PASS, 72 checks passed

## Confidence
Medium-high. The patch covers the Sentry route shape and the deterministic tests are green. Remaining gap: no live Bluetooth hardware churn pass yet.