### PR TITLE
[codex] Avoid cancelling active dictation inference

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -2918,12 +2918,19 @@ class ParakeetEngine: ObservableObject {
             wakeObserver = nil
         }
         removeInputDeviceChangeListener()
+        let cleanupDecision = ParakeetASRManagerCleanupPolicy.decision(isTranscribing: isTranscribing)
         let mgr = asrManager
-        asrManager = nil
+        if cleanupDecision == .cleanupNow {
+            asrManager = nil
+        }
         asrManagerReady = false
         eouManager = nil
         modelDownloadState = .notLoaded
-        Task { mgr?.cleanup() }
+        if cleanupDecision == .cleanupNow {
+            Task { mgr?.cleanup() }
+        } else {
+            print("ℹ️ PARAKEET | deferring ASR manager cleanup while transcription is active")
+        }
     }
 
     deinit {

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -72,6 +72,17 @@ enum ParakeetAudioEngineRetirementPolicy {
     static let deferredReleaseDelayNanoseconds: UInt64 = 3_000_000_000
 }
 
+enum ParakeetASRManagerCleanupDecision: Equatable {
+    case cleanupNow
+    case deferUntilProcessExit
+}
+
+enum ParakeetASRManagerCleanupPolicy {
+    static func decision(isTranscribing: Bool) -> ParakeetASRManagerCleanupDecision {
+        isTranscribing ? .deferUntilProcessExit : .cleanupNow
+    }
+}
+
 enum ParakeetAudioFormatReadiness: String, Equatable {
     case ready
     case invalid

--- a/Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift
+++ b/Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift
@@ -56,3 +56,24 @@ struct DictationRecordingStartFailurePolicy {
         )
     }
 }
+
+struct DictationActiveTaskCancellationPlan: Equatable {
+    let cancelStreamingTask: Bool
+    let cancelSpeechEngine: Bool
+}
+
+enum DictationActiveTaskCancellationPolicy {
+    static func plan(
+        cancelRecording: Bool,
+        recordingStartWasInFlight: Bool,
+        sttIsRecording: Bool,
+        sttIsTranscribing: Bool
+    ) -> DictationActiveTaskCancellationPlan {
+        DictationActiveTaskCancellationPlan(
+            cancelStreamingTask: !sttIsTranscribing,
+            cancelSpeechEngine: cancelRecording
+                && !sttIsTranscribing
+                && (sttIsRecording || recordingStartWasInFlight)
+        )
+    }
+}

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -66,6 +66,7 @@ class DictationSessionController: ObservableObject {
     private var sessionTimeoutTask: Task<Void, Never>?
     private var sessionStartTime: CFAbsoluteTime = 0
     private var currentDictationTrigger: DictationTrigger = .unknown
+    private var currentDictationSessionID = UUID()
 
     /// Max duration for a listening session before auto-cancel (5 minutes).
     /// Prevents stuck sessions when the user walks away from the computer.
@@ -122,7 +123,12 @@ class DictationSessionController: ObservableObject {
     ) {
         guard let (appState, overlayController) = readyState() else { return }
         guard !isDictating, !isInSession else { return }
+        guard !appState.sttRouter.isTranscribing else {
+            overlayController.showError("Still finishing the last dictation. Try again in a moment.")
+            return
+        }
         isDictating = true
+        currentDictationSessionID = UUID()
         sessionSourceApp = sourceApp
         sessionAnchorRect = anchorRect
         sessionStartTime = CFAbsoluteTimeGetCurrent()
@@ -797,9 +803,13 @@ class DictationSessionController: ObservableObject {
         recordingStartRetryTask = nil
 
         streamingTask?.cancel()
+        let taskSessionID = currentDictationSessionID
         streamingTask = Task {
             appState.runtimeDiagnostics.recordSession(kind: "dictation", stage: "stop_requested")
             await appState.sttRouter.stopRecording()
+            guard !Task.isCancelled,
+                  self.isDictating,
+                  self.currentDictationSessionID == taskSessionID else { return }
 
             // Surface model warmup honestly instead of calling it "Transcribing"
             // before the local dictation model is actually ready.
@@ -807,11 +817,15 @@ class DictationSessionController: ObservableObject {
                 appState.logger.log("DICTATION | waiting for voice model before transcribe…")
                 self.updateLoadingOverlay(sourceApp: self.sessionSourceApp)
                 for _ in 0..<TranscriptedConstants.modelLoadMaxIterations {
-                    guard !Task.isCancelled else { return }
+                    guard !Task.isCancelled,
+                          self.isDictating,
+                          self.currentDictationSessionID == taskSessionID else { return }
                     if appState.sttRouter.isModelLoaded { break }
                     self.updateLoadingOverlay(sourceApp: self.sessionSourceApp)
                     try? await Task.sleep(nanoseconds: TranscriptedConstants.modelLoadPollInterval)
                 }
+                guard self.isDictating,
+                      self.currentDictationSessionID == taskSessionID else { return }
                 guard appState.sttRouter.isModelLoaded else {
                     appState.logger.log("DICTATION | voice model failed to load for transcription")
                     overlayController.showError("Voice model failed to load")
@@ -823,7 +837,9 @@ class DictationSessionController: ObservableObject {
             overlayController.state = .drafting
             appState.runtimeDiagnostics.recordSession(kind: "dictation", stage: "transcribing")
             let voiceText = await appState.sttRouter.transcribe()
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled,
+                  self.isDictating,
+                  self.currentDictationSessionID == taskSessionID else { return }
 
             guard let text = voiceText, !text.isEmpty else {
                 appState.logger.log("DICTATION | no transcription, cancelling")
@@ -1211,20 +1227,30 @@ class DictationSessionController: ObservableObject {
     }
 
     private func cancelActiveTasks(cancelRecording: Bool) {
+        let recordingStartWasInFlight = recordingStartRetryTask != nil
+        let sttIsRecording = appState?.sttRouter.isRecording ?? false
+        let sttIsTranscribing = appState?.sttRouter.isTranscribing ?? false
+        let cancellationPlan = DictationActiveTaskCancellationPolicy.plan(
+            cancelRecording: cancelRecording,
+            recordingStartWasInFlight: recordingStartWasInFlight,
+            sttIsRecording: sttIsRecording,
+            sttIsTranscribing: sttIsTranscribing
+        )
+
         startupTask?.cancel()
         startupTask = nil
-        streamingTask?.cancel()
-        streamingTask = nil
+        if cancellationPlan.cancelStreamingTask {
+            streamingTask?.cancel()
+            streamingTask = nil
+        }
         textPaster.cancelPendingClipboardRestore()
-        let recordingStartWasInFlight = recordingStartRetryTask != nil
         recordingStartRetryTask?.cancel()
         recordingStartRetryTask = nil
         sessionTimeoutTask?.cancel()
         sessionTimeoutTask = nil
 
-        guard cancelRecording,
-              let appState,
-              appState.sttRouter.isRecording || recordingStartWasInFlight else { return }
+        guard cancellationPlan.cancelSpeechEngine,
+              let appState else { return }
         appState.sttRouter.cancel()
     }
 

--- a/Tests/DictationRecordingStartOverlayPolicyTests.swift
+++ b/Tests/DictationRecordingStartOverlayPolicyTests.swift
@@ -93,4 +93,35 @@ func testDictationRecordingStartOverlayPolicy() {
         assertTrue(plan.resetSpeechEngine, "failed startup should release the partial audio graph")
         assertFalse(plan.reportRuntimeStall, "the timeout event already reports this failure; it should not also emit app.session_stall_detected")
     }
+
+    runSuite("DictationActiveTaskCancellationPolicy leaves active inference alone") {
+        let plan = DictationActiveTaskCancellationPolicy.plan(
+            cancelRecording: true,
+            recordingStartWasInFlight: false,
+            sttIsRecording: false,
+            sttIsTranscribing: true
+        )
+
+        assertFalse(plan.cancelStreamingTask, "active CoreML transcription should be allowed to finish")
+        assertFalse(plan.cancelSpeechEngine, "active CoreML transcription should not race engine cleanup")
+    }
+
+    runSuite("DictationActiveTaskCancellationPolicy still cancels recording and pending starts") {
+        let recordingPlan = DictationActiveTaskCancellationPolicy.plan(
+            cancelRecording: true,
+            recordingStartWasInFlight: false,
+            sttIsRecording: true,
+            sttIsTranscribing: false
+        )
+        let pendingStartPlan = DictationActiveTaskCancellationPolicy.plan(
+            cancelRecording: true,
+            recordingStartWasInFlight: true,
+            sttIsRecording: false,
+            sttIsTranscribing: false
+        )
+
+        assertTrue(recordingPlan.cancelStreamingTask, "non-transcribing work can still be cancelled")
+        assertTrue(recordingPlan.cancelSpeechEngine, "active recording cancel should still stop the speech engine")
+        assertTrue(pendingStartPlan.cancelSpeechEngine, "pending CoreAudio starts should still be cancelled")
+    }
 }

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -101,6 +101,19 @@ func testParakeetStartRecordingFailurePolicy() {
         )
     }
 
+    runSuite("ParakeetASRManagerCleanupPolicy defers cleanup during active inference") {
+        assertEqual(
+            ParakeetASRManagerCleanupPolicy.decision(isTranscribing: true),
+            .deferUntilProcessExit,
+            "shutdown must not clean up CoreML ASR objects while prediction is active"
+        )
+        assertEqual(
+            ParakeetASRManagerCleanupPolicy.decision(isTranscribing: false),
+            .cleanupNow,
+            "idle shutdown can still release ASR objects normally"
+        )
+    }
+
     runSuite("ParakeetAudioFormatReadinessPolicy accepts normal built-in formats") {
         let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
             outputSampleRate: 48_000,


### PR DESCRIPTION
## Summary
- Avoid cancelling the dictation streaming task once Parakeet/CoreML inference is already active.
- Skip speech-engine cancellation during active inference, while still cancelling pending starts and active recording normally.
- Defer Parakeet ASR manager cleanup during shutdown if transcription is in flight.

## Root Cause
Sentry issue `APPLE-MACOS-S` had a fresh `transcripted@1.1.34` fatal `objc_release` crash during `dictation/transcribing`, with another thread in CoreML prediction. The app could cancel the outer dictation task or clean up the ASR manager while CoreML inference was still alive.

## Validation
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (`1797/1797` passed)
- `git diff --check`

I did not fully reproduce the native crash locally because the Sentry stack was thinly symbolicated, but the runtime context and thread shape match the patched race.