### PR TITLE
[codex] Fix bug hunt findings

### DIFF
--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -235,8 +235,12 @@ func testRepoCommandContract() {
             "beta release build should support an intentional thin distribution variant"
         )
         assertTrue(
-            betaBuildScript.contains("BUNDLE_PARAKEET_MODELS=\"${BUNDLE_PARAKEET_MODELS:-0}\""),
-            "beta release build should default to the lightweight model-download distribution"
+            betaBuildScript.contains("BUNDLE_PARAKEET_MODELS=\"${BUNDLE_PARAKEET_MODELS:-1}\""),
+            "beta release build should bundle Parakeet by default for first-launch trust"
+        )
+        assertTrue(
+            betaBuildScript.contains("BUNDLE_PARAKEET_MODELS=0 requires REQUIRE_BUNDLED_PARAKEET_MODELS=0"),
+            "beta release build should not allow thin distribution unless the model requirement is explicitly disabled"
         )
         assertTrue(
             betaBuildScript.contains("SWIFTC_NUM_THREADS")

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -932,7 +932,9 @@ enum CLIContextStore {
         guard trimmed.hasPrefix("["),
               let timestampEnd = trimmed.firstIndex(of: "]") else { return nil }
         let timestamp = String(trimmed[trimmed.index(after: trimmed.startIndex)..<timestampEnd])
-        let sourceStart = trimmed.index(timestampEnd, offsetBy: 3)
+        let afterTimestamp = trimmed[trimmed.index(after: timestampEnd)...]
+        guard afterTimestamp.hasPrefix(" ["),
+              let sourceStart = trimmed.index(timestampEnd, offsetBy: 3, limitedBy: trimmed.endIndex) else { return nil }
         guard let labelEnd = trimmed.range(of: "] ", range: sourceStart..<trimmed.endIndex) else { return nil }
         let sourceLabel = trimmed[sourceStart..<labelEnd.lowerBound]
         guard let separator = sourceLabel.firstIndex(of: "/") else { return nil }

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -88,6 +88,51 @@ final class ContextStoreTests: XCTestCase {
         XCTAssertEqual(items.first?.preview, "No transcript captured.")
     }
 
+    func testRecentMeetingSkipsMalformedLegacyTranscriptRows() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let meetingsDir = root.appendingPathComponent("meetings", isDirectory: true)
+        let dictationsDir = root.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: meetingsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dictationsDir, withIntermediateDirectories: true)
+
+        let meeting = """
+        ---
+        capture_type: meeting
+        title: Parser fixture
+        date: 2026-04-18
+        time: 09:15:00
+        duration: "0:18"
+        ---
+
+        # Parser fixture
+
+        ## Full Transcript
+
+        [00:00]
+        [00:01]x
+        [00:02] [
+        [00:03] [Mic/You] Still works.
+        """
+        try meeting.write(
+            to: meetingsDir.appendingPathComponent("Parser fixture.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let items = CLIContextStore.recent(
+            in: CLIContextDirectories(meetingsDir: meetingsDir, dictationsDir: dictationsDir),
+            kind: .meeting,
+            count: 5,
+            dateFrom: nil,
+            dateTo: nil
+        )
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.preview, "Still works.")
+    }
+
     func testSearchSpeakerFilterUsesMatchingSpeakerUtterance() throws {
         let root = makeTempDir()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
@@ -336,7 +336,11 @@ enum TranscriptLoader {
         }
 
         let timestamp = String(trimmed[trimmed.index(after: trimmed.startIndex)..<timestampEnd])
-        let sourceStart = trimmed.index(timestampEnd, offsetBy: 3)
+        let afterTimestamp = trimmed[trimmed.index(after: timestampEnd)...]
+        guard afterTimestamp.hasPrefix(" ["),
+              let sourceStart = trimmed.index(timestampEnd, offsetBy: 3, limitedBy: trimmed.endIndex) else {
+            return nil
+        }
         guard let labelEnd = trimmed.range(of: "] ", range: sourceStart..<trimmed.endIndex) else {
             return nil
         }

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptLoaderTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptLoaderTests.swift
@@ -51,6 +51,33 @@ final class TranscriptLoaderTests: XCTestCase {
         XCTAssertNil(transcript)
     }
 
+    func testLoadMeetingSkipsMalformedLegacyTranscriptRows() throws {
+        let markdown = """
+        ---
+        capture_type: meeting
+        date: 2026-04-18
+        time: 09:15:00
+        duration: "0:18"
+        ---
+
+        # Parser fixture
+
+        ## Full Transcript
+
+        [00:00]
+        [00:01]x
+        [00:02] [
+        [00:03] [Mic/You] Still works.
+        """
+        try markdown.write(to: tempDir.appendingPathComponent("Call_malformed_legacy.md"), atomically: true, encoding: .utf8)
+
+        let transcript = TranscriptLoader.load(tempDir.appendingPathComponent("Call_malformed_legacy.md"))
+
+        XCTAssertNotNil(transcript)
+        XCTAssertEqual(transcript?.utterances.count, 1)
+        XCTAssertEqual(transcript?.utterances.first?.text, "Still works.")
+    }
+
     func testLoadMissingFileReturnsNil() {
         let transcript = TranscriptLoader.load(tempDir.appendingPathComponent("Call_missing.md"))
         XCTAssertNil(transcript)

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -56,9 +56,9 @@ also require the app binary to exist before signature validation runs.
 1. Install a `Developer ID Application` certificate.
 2. Store a notarytool profile in the login keychain.
 3. Build the unified dependency bundle once with exact pinned versions.
-4. Decide whether this release should be thin or full/offline. Thin is the
-   default and downloads the Parakeet model on first use. Full/offline requires
-   the local Parakeet models so `build-beta.sh` can bundle them into the app.
+4. Make sure the local Parakeet models are installed. Distribution builds
+   bundle them by default so first launch does not depend on a runtime model
+   download.
 
 Useful checks:
 
@@ -74,13 +74,13 @@ SIGN_IDENTITY=<sha-or-name-fragment> bash build.sh
 SIGNING_IDENTITY=<sha-or-name-fragment> bash build-beta.sh <beta-token> <user-name>
 ```
 
-`build-beta.sh` now defaults to a thin distribution so the DMG stays lightweight.
-The app still downloads the local speech model on first dictation/meeting use.
+`build-beta.sh` bundles Parakeet by default for distribution builds. That keeps
+the first dictation/meeting path local after install.
 
-If you deliberately want a full offline artifact, opt into model bundling:
+If you deliberately want a thin local test artifact, make both opt-outs explicit:
 
 ```bash
-BUNDLE_PARAKEET_MODELS=1 REQUIRE_BUNDLED_PARAKEET_MODELS=1 bash build-beta.sh <beta-token> <user-name>
+REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 bash build-beta.sh <beta-token> <user-name>
 ```
 
 ## Release Flow

--- a/scripts/entrypoints/build-beta.sh
+++ b/scripts/entrypoints/build-beta.sh
@@ -30,7 +30,7 @@ USER_NAME="${2:-beta}"
 # for the rationale.
 SKIP_NOTARIZATION="${SKIP_NOTARIZATION:-0}"
 REQUIRE_BUNDLED_PARAKEET_MODELS="${REQUIRE_BUNDLED_PARAKEET_MODELS:-1}"
-BUNDLE_PARAKEET_MODELS="${BUNDLE_PARAKEET_MODELS:-0}"
+BUNDLE_PARAKEET_MODELS="${BUNDLE_PARAKEET_MODELS:-1}"
 SWIFTC_NUM_THREADS="${SWIFTC_NUM_THREADS:-$(sysctl -n hw.ncpu 2>/dev/null || printf '8')}"
 APP_VERSION="$(plist_value Info.plist CFBundleShortVersionString)"
 
@@ -40,6 +40,15 @@ fi
 
 if [ -z "$APP_VERSION" ]; then
     echo "❌ Could not read CFBundleShortVersionString from Info.plist"
+    exit 1
+fi
+
+if [ "$BUNDLE_PARAKEET_MODELS" = "0" ] && [ "$REQUIRE_BUNDLED_PARAKEET_MODELS" != "0" ]; then
+    echo "❌ BUNDLE_PARAKEET_MODELS=0 requires REQUIRE_BUNDLED_PARAKEET_MODELS=0"
+    echo "   Distribution builds bundle Parakeet by default so first launch does not"
+    echo "   depend on a runtime model download."
+    echo "   If you intentionally want a thin local test build, rerun with:"
+    echo "   REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 bash build-beta.sh <beta-token> <user-name>"
     exit 1
 fi
 
@@ -378,7 +387,7 @@ else
         echo "   build-beta.sh now requires bundled Parakeet models by default so"
         echo "   distribution builds do not fall back to a runtime download on first launch."
         echo "   If you intentionally want a thin local test build, rerun with:"
-        echo "   REQUIRE_BUNDLED_PARAKEET_MODELS=0 bash build-beta.sh <beta-token> <user-name>"
+        echo "   REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 bash build-beta.sh <beta-token> <user-name>"
         exit 1
     fi
 fi


### PR DESCRIPTION
## Summary

- Bundle Parakeet by default in beta/distribution builds and require an explicit double opt-out for thin test artifacts.
- Harden MCP and CLI legacy transcript parsing so malformed rows are skipped instead of crashing.
- Add regression coverage for malformed legacy transcript rows and update release/build contract docs.

## Validation

- `swift test --filter TranscriptLoaderTests/testLoadMeetingSkipsMalformedLegacyTranscriptRows` in `Tools/TranscriptedMCP`
- `swift test --filter ContextStoreTests/testRecentMeetingSkipsMalformedLegacyTranscriptRows` in `Tools/TranscriptedCLI`
- `BUNDLE_PARAKEET_MODELS=0 bash build-beta.sh bug-hunt Codex` fails fast with the new guard
- `swift test` in `Tools/TranscriptedMCP`
- `swift test` in `Tools/TranscriptedCLI`
- `bash run-tests.sh --filter RepoCommandContractTests`
- `bash build.sh --no-open`
- `SKIP_NOTARIZATION=1 bash build-beta.sh bug-hunt Codex`