### PR TITLE
[codex] Fix meeting audio stop race

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -48,6 +48,12 @@ struct AudioRecordingFormatSnapshot: Equatable {
     let channelCount: AVAudioChannelCount
 }
 
+struct AudioCaptureStaleSessionError: LocalizedError {
+    var errorDescription: String? {
+        "Recording start was cancelled before audio capture finished"
+    }
+}
+
 enum AudioRecordingFormatPolicy {
     private static let minimumUsableSampleRate: Double = 8_000
     private static let maximumUsableSampleRate: Double = 384_000
@@ -773,12 +779,20 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         Task {
             do {
-                try await startAudioCapture()
+                try await startAudioCapture(sessionGeneration: startGeneration)
                 await MainActor.run {
                     self.finishSuccessfulStartIfCurrent(startGeneration)
                 }
             } catch {
                 await MainActor.run {
+                    guard self.recordingSessionGeneration == startGeneration else {
+                        AppLogger.audio.info("Skipping stale start failure after session boundary", [
+                            "startGeneration": "\(startGeneration)",
+                            "currentGeneration": "\(self.recordingSessionGeneration)"
+                        ])
+                        return
+                    }
+
                     self.error = "Recording failed to start: \(error.localizedDescription). Try quitting and reopening Transcripted."
                     self.isRecording = false
                     self.isStarting = false
@@ -802,12 +816,20 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         Task {
             do {
-                try await startAudioCapture()
+                try await startAudioCapture(sessionGeneration: startGeneration)
                 await MainActor.run {
                     self.finishSuccessfulStartIfCurrent(startGeneration)
                 }
             } catch {
                 await MainActor.run {
+                    guard self.recordingSessionGeneration == startGeneration else {
+                        AppLogger.audio.info("Skipping stale start failure after session boundary", [
+                            "startGeneration": "\(startGeneration)",
+                            "currentGeneration": "\(self.recordingSessionGeneration)"
+                        ])
+                        return
+                    }
+
                     self.error = "Recording failed to start: \(error.localizedDescription). Try quitting and reopening Transcripted."
                     self.isRecording = false
                     self.isStarting = false
@@ -824,9 +846,10 @@ public class Audio: ObservableObject, @unchecked Sendable {
                 "startGeneration": "\(startGeneration)",
                 "currentGeneration": "\(recordingSessionGeneration)"
             ])
-            isRecording = false
-            isStarting = false
-            stop()
+            if recordingSessionGeneration == startGeneration {
+                isRecording = false
+                isStarting = false
+            }
             return
         }
 
@@ -841,6 +864,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // concurrent recovery work that checks the generation immediately
         // sees the new session boundary.
         recordingSessionGeneration &+= 1
+        let stopGeneration = recordingSessionGeneration
 
         // Snapshot every reference the teardown will need so the
         // background queue closure isn't reading mutable instance state
@@ -848,6 +872,8 @@ public class Audio: ObservableObject, @unchecked Sendable {
         let engineRef = self.engine
         let inputNodeRef = self.inputNode
         let systemCaptureRef = self.systemAudioCapture
+        let micAudioFileRef = micAudioFileQueue.sync { self.micAudioFile }
+        let systemAudioFileRef = systemAudioFileQueue.sync { self.systemAudioFile }
         // Use the original mic URL (set at recording start), not the potentially-overwritten
         // recovery URL. Device recovery creates a new WAV segment but the original file
         // contains the bulk of the recording.
@@ -862,6 +888,13 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // hundreds of ms while AVAudioEngine drains in-flight callbacks
         // — the freeze Taylor reported on the meeting widget.
         DispatchQueue.main.async {
+            guard self.recordingSessionGeneration == stopGeneration else {
+                AppLogger.audio.info("Skipping stale stop UI reset because a newer session exists", [
+                    "stopGeneration": "\(stopGeneration)",
+                    "currentGeneration": "\(self.recordingSessionGeneration)"
+                ])
+                return
+            }
             self.isRecording = false
             self.isStarting = false
             self.audioLevel = 0.0
@@ -881,11 +914,21 @@ public class Audio: ObservableObject, @unchecked Sendable {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
 
+            var didTeardownCurrentSession = false
             self.withAudioGraphLock {
+                guard self.recordingSessionGeneration == stopGeneration else {
+                    AppLogger.audio.info("Skipping stale audio graph teardown because a newer session exists", [
+                        "stopGeneration": "\(stopGeneration)",
+                        "currentGeneration": "\(self.recordingSessionGeneration)"
+                    ])
+                    return
+                }
+                didTeardownCurrentSession = true
+
                 if let engineRef, let inputNodeRef {
                     AppLogger.audio.info("Stopping audio capture")
+                    inputNodeRef.removeTap(onBus: 0)
                     if engineRef.isRunning {
-                        inputNodeRef.removeTap(onBus: 0)
                         engineRef.stop()
                     }
                     self.disarmVoiceProcessing(on: inputNodeRef)
@@ -897,20 +940,25 @@ public class Audio: ObservableObject, @unchecked Sendable {
                 self.realtimeAGC = nil
             }
 
-            // System audio capture's `stop()` is non-blocking (vs `stopSync`),
-            // but we keep it ordered after engine teardown so a single
-            // "stopping" log block stays readable.
-            systemCaptureRef?.stop()
+            // This closure already runs off-main, so use the synchronous system
+            // capture stop. It keeps onRecordingComplete behind backend teardown
+            // and avoids stale ScreenCaptureKit cleanup racing the next start.
+            if didTeardownCurrentSession {
+                systemCaptureRef?.stopSync()
+            }
 
             // Coordinate file close. With the engine fully stopped above,
             // no new buffers will arrive on these queues — closing here is
-            // safe and the cleanup notify will fire onRecordingComplete.
+            // safe. If this stop is stale, only clear the file handles that
+            // belonged to the stopped generation.
             let cleanupGroup = DispatchGroup()
 
             cleanupGroup.enter()
             self.micAudioFileQueue.async { [weak self] in
-                if let self, self.micAudioFile != nil {
-                    self.micAudioFile = nil
+                if let self, let micAudioFileRef {
+                    if let currentMicFile = self.micAudioFile, currentMicFile === micAudioFileRef {
+                        self.micAudioFile = nil
+                    }
                     AppLogger.audioMic.info("Audio file closed", ["file": primaryMicURL?.lastPathComponent ?? self.micAudioFileURL?.lastPathComponent ?? "unknown"])
                 }
                 cleanupGroup.leave()
@@ -918,8 +966,10 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
             cleanupGroup.enter()
             self.systemAudioFileQueue.async { [weak self] in
-                if self?.systemAudioFile != nil {
-                    self?.systemAudioFile = nil
+                if let self, let systemAudioFileRef {
+                    if let currentSystemFile = self.systemAudioFile, currentSystemFile === systemAudioFileRef {
+                        self.systemAudioFile = nil
+                    }
                     AppLogger.audioSystem.info("Audio file closed", ["file": finalSystemURL?.lastPathComponent ?? "unknown"])
                 }
                 cleanupGroup.leave()
@@ -929,9 +979,16 @@ public class Audio: ObservableObject, @unchecked Sendable {
                 guard let self else { return }
                 let finalMicURL = self.finalizeMicRecording(primaryURL: primaryMicURL, segments: micSegmentsSnapshot)
                 DispatchQueue.main.async {
-                    self.originalMicAudioFileURL = nil
-                    self.micSegments = []
-                    self.micAudioFileURL = finalMicURL
+                    if self.recordingSessionGeneration == stopGeneration {
+                        self.originalMicAudioFileURL = nil
+                        self.micSegments = []
+                        self.micAudioFileURL = finalMicURL
+                    } else {
+                        AppLogger.audio.info("Recording completion belongs to stale stop; preserving current capture state", [
+                            "stopGeneration": "\(stopGeneration)",
+                            "currentGeneration": "\(self.recordingSessionGeneration)"
+                        ])
+                    }
                     self.onRecordingComplete?(finalMicURL, finalSystemURL)
                 }
             }

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -90,13 +90,25 @@ extension Audio {
         // default. Keep graph mutation serialized with stop/start teardown so
         // a user stop during device recovery cannot race CoreAudio format
         // reads or tap replacement.
+        var didResetGraph = false
         withAudioGraphLock {
+            guard sessionGeneration == recordingSessionGeneration else {
+                AppLogger.audioMic.info("Skipping stale recovery before graph reset", [
+                    "expectedSession": "\(sessionGeneration)",
+                    "currentSession": "\(recordingSessionGeneration)"
+                ])
+                return
+            }
             inputNode.removeTap(onBus: 0)
             engine.stop()
             engine.reset()
             // engine.reset() clears VPIO state on the input node; require re-arm.
             voiceProcessingEnabled = false
             self.inputNode = engine.inputNode
+            didResetGraph = true
+        }
+        guard didResetGraph else {
+            return
         }
 
         // HAL settle time - wait for audio hardware to stabilize after device change
@@ -240,12 +252,22 @@ extension Audio {
         // Restart engine
         do {
             try withAudioGraphLock {
+                guard sessionGeneration == recordingSessionGeneration else {
+                    throw AudioCaptureStaleSessionError()
+                }
                 // Reinstall tap using shared buffer handler
                 newInputNode.removeTap(onBus: 0)
                 newInputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
                     self?.handleMicBuffer(buffer)
                 }
-                try engine.start()
+                do {
+                    engine.prepare()
+                    try engine.start()
+                } catch {
+                    newInputNode.removeTap(onBus: 0)
+                    engine.stop()
+                    throw error
+                }
             }
             lastBufferTime = CACurrentMediaTime() // Reset watchdog
 
@@ -276,6 +298,13 @@ extension Audio {
             recoveryAttemptCount = 0
             AppLogger.audioMic.info("Device recovery complete, recording continues", ["gap": gap.description])
         } catch {
+            if error is AudioCaptureStaleSessionError {
+                AppLogger.audioMic.info("Skipping stale recovery restart", [
+                    "expectedSession": "\(sessionGeneration)",
+                    "currentSession": "\(recordingSessionGeneration)"
+                ])
+                return
+            }
             AppLogger.audioMic.error("Failed to restart engine", ["error": error.localizedDescription])
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -10,13 +10,34 @@ extension Audio {
 
     // MARK: - Audio Capture Setup
 
-    func startAudioCapture() async throws {
+    func startAudioCapture(sessionGeneration: UInt64) async throws {
         ensureCaptureInfrastructureConfigured()
 
+        func sessionIsCurrent() -> Bool {
+            sessionGeneration == recordingSessionGeneration
+        }
+
+        guard sessionIsCurrent() else {
+            throw AudioCaptureStaleSessionError()
+        }
+
         let (engine, inputNode, recordingFormat, recordingSnapshot) = try withAudioGraphLock { () throws -> (AVAudioEngine, AVAudioInputNode, AVAudioFormat, AudioRecordingFormatSnapshot) in
+            guard sessionIsCurrent() else {
+                throw AudioCaptureStaleSessionError()
+            }
             let (engine, inputNode) = try ensureEngineInitialized()
-            applyPreferredMeetingInputDevice(to: inputNode, operation: "start_recording")
-            armVoiceProcessing(on: inputNode)
+            if engine.isRunning {
+                inputNode.removeTap(onBus: 0)
+                engine.stop()
+                engine.reset()
+                voiceProcessingEnabled = false
+                self.inputNode = engine.inputNode
+            }
+            guard let activeInputNode = self.inputNode else {
+                throw NSError(domain: "Audio", code: 1, userInfo: [NSLocalizedDescriptionKey: "Engine input node unavailable"])
+            }
+            applyPreferredMeetingInputDevice(to: activeInputNode, operation: "start_recording")
+            armVoiceProcessing(on: activeInputNode)
 
             // When VPIO is off (the default — see `enableVoiceProcessing`), run
             // a software AGC in the mic tap callback to recover attenuated
@@ -33,7 +54,7 @@ extension Audio {
             //   - Hardware format via inputFormat(forBus: 1) otherwise — required
             //     because outputFormat(forBus: 0) returns the converter format on
             //     stock AVAudioEngine, which breaks Bluetooth capture.
-            let recordingFormat = self.recordingFormat(for: inputNode)
+            let recordingFormat = self.recordingFormat(for: activeInputNode)
             guard let recordingSnapshot = AudioRecordingFormatPolicy.snapshot(recordingFormat) else {
                 AppLogger.audioMic.error("Mic input format invalid", [
                     "sampleRate": "\(recordingFormat.sampleRate)",
@@ -42,7 +63,7 @@ extension Audio {
                 throw NSError(domain: "Audio", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid input format"])
             }
 
-            return (engine, inputNode, recordingFormat, recordingSnapshot)
+            return (engine, activeInputNode, recordingFormat, recordingSnapshot)
         }
         AppLogger.audioMic.info("Mic input format", [
             "sampleRate": "\(recordingSnapshot.sampleRate)",
@@ -60,7 +81,6 @@ extension Audio {
             try? FileManager.default.createDirectory(at: captureDir, withIntermediateDirectories: true)
             let timestamp = DateFormattingHelper.formatFilenamePrecise(Date())
             let fileURL = captureDir.appendingPathComponent("meeting_\(timestamp)_system.wav")
-            let sessionGeneration = recordingSessionGeneration
             AppLogger.audioSystem.info("System audio file URL", ["file": fileURL.lastPathComponent])
 
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
@@ -229,9 +249,14 @@ extension Audio {
             let timestamp = DateFormattingHelper.formatFilenamePrecise(Date())
             let fileURL = captureDir.appendingPathComponent("meeting_\(timestamp)_mic.wav")
 
+            guard sessionIsCurrent() else {
+                throw AudioCaptureStaleSessionError()
+            }
+
             self.originalMicAudioFileURL = fileURL
             self.micSegments = [MicRecordingSegment(url: fileURL)]
             DispatchQueue.main.async {
+                guard sessionGeneration == self.recordingSessionGeneration else { return }
                 self.micAudioFileURL = fileURL
             }
 
@@ -261,6 +286,9 @@ extension Audio {
         }
 
         try withAudioGraphLock {
+            guard sessionIsCurrent() else {
+                throw AudioCaptureStaleSessionError()
+            }
             // Remove any existing tap (safety check)
             inputNode.removeTap(onBus: 0)
 
@@ -269,11 +297,19 @@ extension Audio {
                 self?.handleMicBuffer(buffer)
             }
 
-            try engine.start()
+            do {
+                engine.prepare()
+                try engine.start()
+            } catch {
+                inputNode.removeTap(onBus: 0)
+                engine.stop()
+                throw error
+            }
         }
 
         let cueHandler = self.onCaptureLifecycleCue
         await MainActor.run {
+            guard sessionGeneration == self.recordingSessionGeneration else { return }
             // isRecording already set in start()
             self.startTime = Date()
             self.recordingDuration = 0.0

--- a/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
+++ b/Sources/TranscriptedCore/Audio/SCKAudioCapture.swift
@@ -21,6 +21,8 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
     private var _audioFormat: AVAudioFormat?
     private var _isCapturing = false
     private var bufferCallback: ((AVAudioPCMBuffer) -> Void)?
+    private var _generation: UInt64 = 0
+    private let generationLock = NSLock()
 
     var diagnosticBackendName: String { "screen_capture_kit" }
 
@@ -47,6 +49,8 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
 
     func prepare() throws {
         AppLogger.audioSystem.info("SCKAudioCapture: preparing ScreenCaptureKit audio stream")
+        stopSync()
+        let prepareGeneration = incrementGeneration()
 
         // Fetch shareable content — triggers the system permission dialog on first use.
         // Called from a background thread (AudioFileManager dispatches to .userInitiated),
@@ -87,16 +91,26 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
         config.height = 2
         config.minimumFrameInterval = CMTime(value: 1, timescale: 1)
 
+        guard currentGeneration() == prepareGeneration else {
+            throw AudioCaptureStaleSessionError()
+        }
+
         // Pre-create the format the WAV file will use. ScreenCaptureKit delivers
         // float32 non-interleaved audio matching the configured rate/channels.
-        _audioFormat = AVAudioFormat(
+        let audioFormat = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
             sampleRate: 48000,
             channels: 2,
             interleaved: false
         )
 
-        stream = SCStream(filter: filter, configuration: config, delegate: nil)
+        let preparedStream = SCStream(filter: filter, configuration: config, delegate: nil)
+        guard currentGeneration() == prepareGeneration else {
+            stopStreamSynchronously(preparedStream)
+            throw AudioCaptureStaleSessionError()
+        }
+        _audioFormat = audioFormat
+        stream = preparedStream
 
         AppLogger.audioSystem.info("SCKAudioCapture: stream prepared", [
             "sampleRate": "48000",
@@ -111,6 +125,7 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
             guard self.stream != nil else { throw "SCKAudioCapture: prepare failed silently" }
             return try start(bufferCallback: bufferCallback)
         }
+        let startGeneration = currentGeneration()
 
         self.bufferCallback = bufferCallback
         publishErrorMessage(nil)
@@ -118,6 +133,7 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
         // Output handler converts CMSampleBuffer → AVAudioPCMBuffer
         let output = SCKAudioStreamOutput { [weak self] buffer in
             guard let self = self else { return }
+            guard self.currentGeneration() == startGeneration else { return }
             self.statsLock.lock()
             self._totalBuffers += 1
             self._buffersWithData += 1
@@ -143,11 +159,15 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
                 throw error
             }
 
+            guard currentGeneration() == startGeneration, self.stream === stream else {
+                stopStreamSynchronously(stream)
+                throw AudioCaptureStaleSessionError()
+            }
             _isCapturing = true
             AppLogger.audioSystem.info("SCKAudioCapture: now capturing system audio")
         } catch {
             AppLogger.audioSystem.error("SCKAudioCapture: start failed", ["error": error.localizedDescription])
-            cleanup()
+            cleanupIfCurrent(generation: startGeneration, stream: stream)
             publishErrorMessage(error.localizedDescription)
             throw error
         }
@@ -155,34 +175,66 @@ final class SCKAudioCapture: ObservableObject, SystemAudioCaptureEngine, @unchec
 
     func stop() {
         guard let stream = stream else { return }
+        let stopGeneration = currentGeneration()
         guard _isCapturing else {
-            cleanup()
+            cleanupIfCurrent(generation: stopGeneration, stream: stream)
             return
         }
 
         _isCapturing = false
-        stream.stopCapture { [weak self] error in
+        stream.stopCapture { [weak self, stream] error in
             if let error = error {
                 AppLogger.audioSystem.warning("SCKAudioCapture: stop error", ["error": error.localizedDescription])
             }
-            self?.cleanup()
+            self?.cleanupIfCurrent(generation: stopGeneration, stream: stream)
         }
     }
 
     func stopSync() {
         guard let stream = stream else { return }
+        let stopGeneration = currentGeneration()
         guard _isCapturing else {
-            cleanup()
+            cleanupIfCurrent(generation: stopGeneration, stream: stream)
             return
         }
 
         _isCapturing = false
+        stopStreamSynchronously(stream)
+        cleanupIfCurrent(generation: stopGeneration, stream: stream)
+    }
+
+    private func incrementGeneration() -> UInt64 {
+        generationLock.lock()
+        defer { generationLock.unlock() }
+        _generation &+= 1
+        return _generation
+    }
+
+    private func currentGeneration() -> UInt64 {
+        generationLock.lock()
+        defer { generationLock.unlock() }
+        return _generation
+    }
+
+    private func cleanupIfCurrent(generation: UInt64, stream expectedStream: SCStream) {
+        guard currentGeneration() == generation,
+              let currentStream = stream,
+              currentStream === expectedStream else {
+            AppLogger.audioSystem.info("SCKAudioCapture: skipping stale cleanup")
+            return
+        }
+        cleanup()
+    }
+
+    private func stopStreamSynchronously(_ stream: SCStream) {
         let semaphore = DispatchSemaphore(value: 0)
-        stream.stopCapture { _ in
+        stream.stopCapture { error in
+            if let error = error {
+                AppLogger.audioSystem.warning("SCKAudioCapture: stop error", ["error": error.localizedDescription])
+            }
             semaphore.signal()
         }
         semaphore.wait()
-        cleanup()
     }
 
     private func cleanup() {

--- a/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
@@ -179,6 +179,93 @@ final class AudioInitializationTests: XCTestCase {
         wait(for: [stopFinished], timeout: 1.0)
     }
 
+    func testStaleStopDoesNotOverwriteNewSessionArtifactsOrFileHandles() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioInitializationTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let paths = CoreStoragePaths(
+            transcripts: root.appendingPathComponent("captures/meetings", isDirectory: true),
+            speakerDB: root.appendingPathComponent("state/speakers.sqlite"),
+            statsDB: root.appendingPathComponent("state/stats.sqlite"),
+            failedQueue: root.appendingPathComponent("state/failed_transcriptions.json"),
+            speakerClips: root.appendingPathComponent("tmp/recordings/speaker_clips", isDirectory: true),
+            audioCaptures: root.appendingPathComponent("tmp/recordings", isDirectory: true),
+            logs: root.appendingPathComponent("logs", isDirectory: true)
+        )
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+
+        let audio = Audio(paths: paths)
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        ))
+
+        let oldMicURL = paths.audioCaptures.appendingPathComponent("old-mic.wav")
+        let oldSystemURL = paths.audioCaptures.appendingPathComponent("old-system.wav")
+        let newMicURL = paths.audioCaptures.appendingPathComponent("new-mic.wav")
+        let newSystemURL = paths.audioCaptures.appendingPathComponent("new-system.wav")
+        let oldMicFile = try AVAudioFile(forWriting: oldMicURL, settings: format.settings)
+        let oldSystemFile = try AVAudioFile(forWriting: oldSystemURL, settings: format.settings)
+        let newMicFile = try AVAudioFile(forWriting: newMicURL, settings: format.settings)
+        let newSystemFile = try AVAudioFile(forWriting: newSystemURL, settings: format.settings)
+
+        audio.originalMicAudioFileURL = oldMicURL
+        audio.micSegments = [MicRecordingSegment(url: oldMicURL)]
+        audio.micAudioFileURL = oldMicURL
+        audio.systemAudioFileURL = oldSystemURL
+        audio.micAudioFileQueue.sync { audio.micAudioFile = oldMicFile }
+        audio.systemAudioFileQueue.sync { audio.systemAudioFile = oldSystemFile }
+
+        let lockHeld = expectation(description: "audio graph lock held")
+        let releaseLock = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            audio.withAudioGraphLock {
+                lockHeld.fulfill()
+                _ = releaseLock.wait(timeout: .now() + 2)
+            }
+        }
+        wait(for: [lockHeld], timeout: 1.0)
+
+        let stopFinished = expectation(description: "stale stop completion fired")
+        var completedMicURL: URL?
+        var completedSystemURL: URL?
+        audio.onRecordingComplete = { micURL, systemURL in
+            completedMicURL = micURL
+            completedSystemURL = systemURL
+            stopFinished.fulfill()
+        }
+
+        audio.stop()
+        audio.prepareForNewRecordingStart()
+        let newGeneration = audio.recordingSessionGeneration
+        audio.originalMicAudioFileURL = newMicURL
+        audio.micSegments = [MicRecordingSegment(url: newMicURL)]
+        audio.micAudioFileURL = newMicURL
+        audio.systemAudioFileURL = newSystemURL
+        audio.micAudioFileQueue.sync { audio.micAudioFile = newMicFile }
+        audio.systemAudioFileQueue.sync { audio.systemAudioFile = newSystemFile }
+
+        releaseLock.signal()
+        wait(for: [stopFinished], timeout: 1.0)
+
+        XCTAssertEqual(completedMicURL, oldMicURL)
+        XCTAssertEqual(completedSystemURL, oldSystemURL)
+        XCTAssertEqual(audio.recordingSessionGeneration, newGeneration)
+        XCTAssertEqual(audio.originalMicAudioFileURL, newMicURL)
+        XCTAssertEqual(audio.micAudioFileURL, newMicURL)
+        XCTAssertEqual(audio.systemAudioFileURL, newSystemURL)
+
+        let activeMicFile = audio.micAudioFileQueue.sync { audio.micAudioFile }
+        let activeSystemFile = audio.systemAudioFileQueue.sync { audio.systemAudioFile }
+        XCTAssertNotNil(activeMicFile)
+        XCTAssertNotNil(activeSystemFile)
+        XCTAssertTrue(activeMicFile === newMicFile)
+        XCTAssertTrue(activeSystemFile === newSystemFile)
+    }
+
     func testPrepareForNewRecordingStartClearsStaleCaptureArtifacts() {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("AudioInitializationTests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary
- Guard meeting audio stop cleanup so stale teardown cannot overwrite a newer recording session.
- Stop ScreenCaptureKit system audio synchronously before recording completion fires.
- Add generation checks around mic tap start/recovery and SCK cleanup.
- Add regression coverage for stale stop cleanup preserving new session files.

## Root Cause
A meeting stop could finish its asynchronous CoreAudio and ScreenCaptureKit cleanup after a new meeting had already started. That stale cleanup could remove the new mic tap, stop the new engine, or clear the new stream/file handles, matching the native CoreAudio assertion seen in `APPLE-MACOS-1P` and the related transcript failures.

## Validation
- `swift test --filter AudioInitializationTests`
- `bash build.sh`
- `bash run-tests.sh` (1790/1790)
- `bash run-integration-smoke.sh`
- `swift test`
- `bash run-daily-audio-reliability.sh --synthetic`