### PR TITLE
[codex] Use calendar titles for meeting transcripts

### DIFF
--- a/Sources/Meeting/MeetingPromptDetector.swift
+++ b/Sources/Meeting/MeetingPromptDetector.swift
@@ -15,6 +15,7 @@ final class MeetingPromptDetector {
         let startDate: Date
         let endDate: Date
         let meetingURL: URL?
+        let suggestedTranscriptTitle: String?
     }
 
     private struct ScoredCandidate {
@@ -272,7 +273,8 @@ final class MeetingPromptDetector {
                     source: .runtimeApp,
                     startDate: now,
                     endDate: now.addingTimeInterval(MeetingPromptHeuristics.runtimeReminderSnoozeInterval),
-                    meetingURL: nil
+                    meetingURL: nil,
+                    suggestedTranscriptTitle: nil
                 ),
                 score: presentation.score
             )
@@ -324,7 +326,8 @@ final class MeetingPromptDetector {
         )
         guard genericWindow else { return nil }
 
-        let eventTitle = trimmedTitle(from: event)
+        let eventTitle = displayTitle(from: event)
+        let transcriptTitle = suggestedTranscriptTitle(from: event)
         let detail = buildDetail(eventTitle: eventTitle, startsIn: startsIn, runtimeReason: runtimeReason)
         let score = scoreForCandidate(startsIn: startsIn, runtimeReason: runtimeReason)
 
@@ -341,15 +344,20 @@ final class MeetingPromptDetector {
                 source: .calendarEvent,
                 startDate: event.startDate,
                 endDate: event.endDate,
-                meetingURL: meetingURL
+                meetingURL: meetingURL,
+                suggestedTranscriptTitle: transcriptTitle
             ),
             score: score
         )
     }
 
-    private func trimmedTitle(from event: EKEvent) -> String {
+    private func displayTitle(from event: EKEvent) -> String {
+        suggestedTranscriptTitle(from: event) ?? "Upcoming meeting"
+    }
+
+    private func suggestedTranscriptTitle(from event: EKEvent) -> String? {
         let trimmed = (event.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? "Upcoming meeting" : trimmed
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private func buildDetail(eventTitle: String, startsIn: TimeInterval, runtimeReason: String?) -> String {

--- a/Sources/Meeting/MeetingPromptDetector.swift
+++ b/Sources/Meeting/MeetingPromptDetector.swift
@@ -169,6 +169,19 @@ final class MeetingPromptDetector {
         pendingUntil[candidate.id] = until
     }
 
+    func currentSuggestedTranscriptTitle(now: Date = Date()) -> String? {
+        guard TranscriptedPermissionAccess.calendarAccessGranted() else { return nil }
+        return upcomingCalendarCandidates(
+            now: now,
+            runningBundleIDs: [],
+            frontmostBundleID: nil
+        )
+        .sorted(by: sortCandidates)
+        .lazy
+        .compactMap(\.candidate.suggestedTranscriptTitle)
+        .first
+    }
+
     private func evaluate() async {
         let now = Date()
         let runningApplications = NSWorkspace.shared.runningApplications

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -171,6 +171,7 @@ final class MeetingSessionController: ObservableObject {
     private let speakerDatabase: SpeakerDatabase
     private let statsDatabase: StatsDatabase
     private let downloader: MeetingModelDownloader
+    var calendarSuggestedTitleProvider: (() -> String?)?
 
     private var cancellables: Set<AnyCancellable> = []
     private var modelPreparationTask: Task<Result<Void, Error>, Never>?
@@ -390,7 +391,10 @@ final class MeetingSessionController: ObservableObject {
         }
 
         activeRecordingTrigger = trigger
-        activeRecordingSuggestedTitle = Self.normalizedSuggestedTitle(suggestedTitle)
+        activeRecordingSuggestedTitle = MeetingRecordingTitlePolicy.resolve(
+            explicitTitle: suggestedTitle,
+            calendarTitle: calendarSuggestedTitleProvider?()
+        )
         state = .recording
         Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "recording")
         let pipelineSnapshot = capture.pipelineDiagnosticsSnapshot()
@@ -1841,15 +1845,6 @@ final class MeetingSessionController: ObservableObject {
             ),
             suggestedTitle: activeRecordingSuggestedTitle
         )
-    }
-
-    private static func normalizedSuggestedTitle(_ title: String?) -> String? {
-        guard let title else { return nil }
-        let normalized = title
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "\r", with: " ")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return normalized.isEmpty ? nil : normalized
     }
 
     private func baseDiagnosticsContext(extra: [String: String] = [:]) -> [String: String] {

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -76,7 +76,8 @@ final class MeetingSessionController: ObservableObject {
             case recorded(
                 micURL: URL,
                 systemURL: URL?,
-                healthInfo: RecordingHealthInfo
+                healthInfo: RecordingHealthInfo,
+                meetingTitle: String?
             )
             case imported(
                 audioURL: URL,
@@ -102,6 +103,7 @@ final class MeetingSessionController: ObservableObject {
         var durationMilliseconds: Int { Int(durationSeconds * 1000) }
         let healthInfo: RecordingHealthInfo
         let pipelineSnapshot: AudioPipelineDiagnosticsSnapshot
+        let suggestedTitle: String?
     }
 
     private struct BackgroundTranscriptionWorkSnapshot {
@@ -178,6 +180,7 @@ final class MeetingSessionController: ObservableObject {
     private var queuedTranscriptionStartTask: Task<Void, Never>?
     private var lastTerminalTranscriptionOutcome: TerminalTranscriptionOutcome?
     private var activeRecordingTrigger: StartTrigger = .unknown
+    private var activeRecordingSuggestedTitle: String?
     private var activeTranscriptionTrigger: StartTrigger = .unknown
     private var isFinishingRecording = false
     private var shouldSurfaceMeetingWarmupFailure = false
@@ -309,7 +312,7 @@ final class MeetingSessionController: ObservableObject {
     /// meeting is still transcribing, the new capture starts immediately and
     /// the older transcript continues in the background.
     @discardableResult
-    func startRecording(trigger: StartTrigger = .unknown) async -> Bool {
+    func startRecording(trigger: StartTrigger = .unknown, suggestedTitle: String? = nil) async -> Bool {
         Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "start_requested")
         DiagnosticsTrail.record(
             engine: "meeting",
@@ -387,6 +390,7 @@ final class MeetingSessionController: ObservableObject {
         }
 
         activeRecordingTrigger = trigger
+        activeRecordingSuggestedTitle = Self.normalizedSuggestedTitle(suggestedTitle)
         state = .recording
         Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "recording")
         let pipelineSnapshot = capture.pipelineDiagnosticsSnapshot()
@@ -547,6 +551,7 @@ final class MeetingSessionController: ObservableObject {
             afterStopContext: afterStopVolumeContext
         )
         activeRecordingTrigger = .unknown
+        activeRecordingSuggestedTitle = nil
         state = .transcribing
         Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "transcribing")
         let stopDiagnosticsContext = stopCaptureDiagnostics.merging(
@@ -659,6 +664,7 @@ final class MeetingSessionController: ObservableObject {
             micURL: micURL,
             systemURL: files.systemURL,
             healthInfo: recordingSnapshot.healthInfo,
+            meetingTitle: recordingSnapshot.suggestedTitle,
             startTrigger: recordingSnapshot.trigger
         )
 
@@ -749,6 +755,7 @@ final class MeetingSessionController: ObservableObject {
             afterStopContext: afterStopVolumeContext
         )
         activeRecordingTrigger = .unknown
+        activeRecordingSuggestedTitle = nil
         restoreStateAfterRecordingEndedWithoutNewWork()
         AppSoundPlayer.shared.play(.dictationCancelled)
         Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "cancelled")
@@ -894,7 +901,7 @@ final class MeetingSessionController: ObservableObject {
 
         for job in queuedJobs + [preparingJob].compactMap({ $0 }) {
             switch job.kind {
-            case .recorded(let micURL, let systemURL, _):
+            case .recorded(let micURL, let systemURL, _, _):
                 failedManager.addFailedTranscription(
                     micAudioURL: micURL,
                     systemAudioURL: systemURL,
@@ -929,6 +936,7 @@ final class MeetingSessionController: ObservableObject {
         let recordingTrigger = activeRecordingTrigger
         let files = await capture.stopAndAwaitFiles()
         activeRecordingTrigger = .unknown
+        activeRecordingSuggestedTitle = nil
 
         if let micURL = files.micURL {
             failedManager.addFailedTranscription(
@@ -1287,13 +1295,15 @@ final class MeetingSessionController: ObservableObject {
         micURL: URL,
         systemURL: URL?,
         healthInfo: RecordingHealthInfo,
+        meetingTitle: String?,
         startTrigger: StartTrigger
     ) -> QueueInsertionOutcome {
         let job = QueuedTranscriptionJob(
             kind: .recorded(
                 micURL: micURL,
                 systemURL: systemURL,
-                healthInfo: healthInfo
+                healthInfo: healthInfo,
+                meetingTitle: meetingTitle
             ),
             startTrigger: startTrigger,
             sttModel: sttRouter.selectedModel
@@ -1427,12 +1437,13 @@ final class MeetingSessionController: ObservableObject {
         sttAdapter.selectPreparedModel(job.sttModel)
 
         switch job.kind {
-        case .recorded(let micURL, let systemURL, let healthInfo):
+        case .recorded(let micURL, let systemURL, let healthInfo, let meetingTitle):
             taskManager.startTranscription(
                 micURL: micURL,
                 systemURL: systemURL,
                 outputFolder: MeetingStoragePaths.transcriptsFolder,
                 healthInfo: healthInfo,
+                meetingTitle: meetingTitle,
                 splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()
             )
         case .imported(let audioURL, let suggestedTitle):
@@ -1451,7 +1462,7 @@ final class MeetingSessionController: ObservableObject {
         displayStatus = .failed(message: message)
 
         switch job.kind {
-        case .recorded(let micURL, let systemURL, _):
+        case .recorded(let micURL, let systemURL, _, _):
             failedManager.addFailedTranscription(
                 micAudioURL: micURL,
                 systemAudioURL: systemURL,
@@ -1827,8 +1838,18 @@ final class MeetingSessionController: ObservableObject {
             healthInfo: capture.healthInfo(overrideSystemAudioStatus: systemAudioStatus),
             pipelineSnapshot: capture.pipelineDiagnosticsSnapshot(
                 overrideSystemAudioStatus: systemAudioStatus
-            )
+            ),
+            suggestedTitle: activeRecordingSuggestedTitle
         )
+    }
+
+    private static func normalizedSuggestedTitle(_ title: String?) -> String? {
+        guard let title else { return nil }
+        let normalized = title
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? nil : normalized
     }
 
     private func baseDiagnosticsContext(extra: [String: String] = [:]) -> [String: String] {

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -104,6 +104,11 @@ final class MeetingSessionController: ObservableObject {
         let pipelineSnapshot: AudioPipelineDiagnosticsSnapshot
     }
 
+    private struct BackgroundTranscriptionWorkSnapshot {
+        let activeCount: Int
+        let speakerNamingRequest: SpeakerNamingRequest?
+    }
+
     // MARK: - Published state (for meeting UI bindings)
 
     /// High-level session state for the meeting UI.
@@ -1064,8 +1069,13 @@ final class MeetingSessionController: ObservableObject {
 
         taskManager.$activeCount
             .combineLatest(taskManager.$speakerNamingRequest)
-            .sink { [weak self] _, _ in
-                self?.handleBackgroundTranscriptionWorkChanged()
+            .sink { [weak self] activeCount, speakerNamingRequest in
+                self?.handleBackgroundTranscriptionWorkChanged(
+                    snapshot: BackgroundTranscriptionWorkSnapshot(
+                        activeCount: activeCount,
+                        speakerNamingRequest: speakerNamingRequest
+                    )
+                )
             }
             .store(in: &cancellables)
 
@@ -1243,10 +1253,7 @@ final class MeetingSessionController: ObservableObject {
     }
 
     private var hasVisibleBackgroundTranscriptionWork: Bool {
-        MeetingSessionUIPolicy.shouldShowTranscribing(
-            activeTranscriptions: taskManager.activeCount + (isPreparingQueuedTranscriptionStart ? 1 : 0),
-            queuedTranscriptions: queuedTranscriptionJobs.count
-        )
+        hasVisibleBackgroundTranscriptionWork(snapshot: currentBackgroundTranscriptionWorkSnapshot)
     }
 
     private var isSpeechModelPreparedForSelection: Bool {
@@ -1255,11 +1262,18 @@ final class MeetingSessionController: ObservableObject {
     }
 
     private var canStartQueuedTranscriptionImmediately: Bool {
-        taskManager.activeCount == 0 && taskManager.speakerNamingRequest == nil && !isPreparingQueuedTranscriptionStart
+        canStartQueuedTranscriptionImmediately(snapshot: currentBackgroundTranscriptionWorkSnapshot)
     }
 
     private var isPreparingQueuedTranscriptionStart: Bool {
         preparingQueuedTranscriptionJob != nil || queuedTranscriptionStartTask != nil
+    }
+
+    private var currentBackgroundTranscriptionWorkSnapshot: BackgroundTranscriptionWorkSnapshot {
+        BackgroundTranscriptionWorkSnapshot(
+            activeCount: taskManager.activeCount,
+            speakerNamingRequest: taskManager.speakerNamingRequest
+        )
     }
 
     private var isCaptureSessionActive: Bool {
@@ -1448,19 +1462,44 @@ final class MeetingSessionController: ObservableObject {
         }
     }
 
+    private func canStartQueuedTranscriptionImmediately(
+        snapshot: BackgroundTranscriptionWorkSnapshot
+    ) -> Bool {
+        MeetingSessionUIPolicy.canStartQueuedTranscription(
+            activeTranscriptions: snapshot.activeCount,
+            isSpeakerReviewPending: snapshot.speakerNamingRequest != nil,
+            isPreparingQueuedTranscriptionStart: isPreparingQueuedTranscriptionStart
+        )
+    }
+
+    private func hasVisibleBackgroundTranscriptionWork(
+        snapshot: BackgroundTranscriptionWorkSnapshot
+    ) -> Bool {
+        MeetingSessionUIPolicy.shouldShowTranscribing(
+            activeTranscriptions: snapshot.activeCount + (isPreparingQueuedTranscriptionStart ? 1 : 0),
+            queuedTranscriptions: queuedTranscriptionJobs.count
+        )
+    }
+
     private func handleBackgroundTranscriptionWorkChanged() {
-        if canStartQueuedTranscriptionImmediately {
+        handleBackgroundTranscriptionWorkChanged(snapshot: currentBackgroundTranscriptionWorkSnapshot)
+    }
+
+    private func handleBackgroundTranscriptionWorkChanged(
+        snapshot: BackgroundTranscriptionWorkSnapshot
+    ) {
+        if canStartQueuedTranscriptionImmediately(snapshot: snapshot) {
             if let nextJob = popNextQueuedTranscriptionJob() {
                 startQueuedTranscription(nextJob)
                 return
             }
 
-            finalizeBackgroundTranscriptionStateIfNeeded()
+            finalizeBackgroundTranscriptionStateIfNeeded(snapshot: snapshot)
             return
         }
 
-        if !hasVisibleBackgroundTranscriptionWork {
-            finalizeBackgroundTranscriptionStateIfNeeded()
+        if !hasVisibleBackgroundTranscriptionWork(snapshot: snapshot) {
+            finalizeBackgroundTranscriptionStateIfNeeded(snapshot: snapshot)
             return
         }
 
@@ -1475,7 +1514,13 @@ final class MeetingSessionController: ObservableObject {
     }
 
     private func finalizeBackgroundTranscriptionStateIfNeeded() {
-        guard !hasVisibleBackgroundTranscriptionWork else { return }
+        finalizeBackgroundTranscriptionStateIfNeeded(snapshot: currentBackgroundTranscriptionWorkSnapshot)
+    }
+
+    private func finalizeBackgroundTranscriptionStateIfNeeded(
+        snapshot: BackgroundTranscriptionWorkSnapshot
+    ) {
+        guard !hasVisibleBackgroundTranscriptionWork(snapshot: snapshot) else { return }
         guard !isCaptureSessionActive else { return }
         activeTranscriptionTrigger = .unknown
 

--- a/Sources/Meeting/MeetingSessionUIPolicy.swift
+++ b/Sources/Meeting/MeetingSessionUIPolicy.swift
@@ -7,4 +7,14 @@ enum MeetingSessionUIPolicy {
     ) -> Bool {
         activeTranscriptions > 0 || queuedTranscriptions > 0
     }
+
+    static func canStartQueuedTranscription(
+        activeTranscriptions: Int,
+        isSpeakerReviewPending: Bool,
+        isPreparingQueuedTranscriptionStart: Bool
+    ) -> Bool {
+        activeTranscriptions == 0
+            && !isSpeakerReviewPending
+            && !isPreparingQueuedTranscriptionStart
+    }
 }

--- a/Sources/Meeting/MeetingSessionUIPolicy.swift
+++ b/Sources/Meeting/MeetingSessionUIPolicy.swift
@@ -18,3 +18,18 @@ enum MeetingSessionUIPolicy {
             && !isPreparingQueuedTranscriptionStart
     }
 }
+
+enum MeetingRecordingTitlePolicy {
+    static func resolve(explicitTitle: String?, calendarTitle: String?) -> String? {
+        normalized(explicitTitle) ?? normalized(calendarTitle)
+    }
+
+    static func normalized(_ title: String?) -> String? {
+        guard let title else { return nil }
+        let normalized = title
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? nil : normalized
+    }
+}

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -120,7 +120,10 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                 )
                 Task { @MainActor [weak self] in
                     guard let self else { return }
-                    let started = await self.appState.meetingSession.startRecording(trigger: .detectedPrompt)
+                    let started = await self.appState.meetingSession.startRecording(
+                        trigger: .detectedPrompt,
+                        suggestedTitle: candidate.suggestedTranscriptTitle
+                    )
                     if started {
                         self.meetingPromptDetector.markAccepted(candidate: candidate)
                     }

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -111,6 +111,9 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         // Meeting overlay + hotkey + speaker naming — Lane C wiring.
         if #available(macOS 14.0, *) {
             let meetingSession = appState.meetingSession
+            meetingSession.calendarSuggestedTitleProvider = { [weak self] in
+                self?.meetingPromptDetector.currentSuggestedTranscriptTitle()
+            }
             meetingOverlayController.setup(meetingSession: meetingSession)
             meetingOverlayController.onPromptRecord = { [weak self] candidate in
                 guard let self else { return }

--- a/Sources/TranscriptedCore/Models/DisplayStatus.swift
+++ b/Sources/TranscriptedCore/Models/DisplayStatus.swift
@@ -87,13 +87,15 @@ public struct TranscriptionTask: Identifiable {
     public let startTime: Date
     public let healthInfo: RecordingHealthInfo?
     public let splitLocalSpeakers: Bool
+    public let meetingTitle: String?
 
     public init(
         micURL: URL,
         systemURL: URL?,
         outputFolder: URL,
         healthInfo: RecordingHealthInfo? = nil,
-        splitLocalSpeakers: Bool = false
+        splitLocalSpeakers: Bool = false,
+        meetingTitle: String? = nil
     ) {
         self.id = UUID()
         self.micURL = micURL
@@ -102,5 +104,6 @@ public struct TranscriptionTask: Identifiable {
         self.startTime = Date()
         self.healthInfo = healthInfo
         self.splitLocalSpeakers = splitLocalSpeakers
+        self.meetingTitle = meetingTitle
     }
 }

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -70,6 +70,7 @@ public class TranscriptionTaskManager: ObservableObject {
         systemURL: URL?,
         outputFolder: URL,
         healthInfo: RecordingHealthInfo? = nil,
+        meetingTitle: String? = nil,
         splitLocalSpeakers: Bool = false
     ) {
 
@@ -147,7 +148,8 @@ public class TranscriptionTaskManager: ObservableObject {
             systemURL: systemURL,
             outputFolder: outputFolder,
             healthInfo: healthInfo,
-            splitLocalSpeakers: splitLocalSpeakers
+            splitLocalSpeakers: splitLocalSpeakers,
+            meetingTitle: meetingTitle
         )
 
         activeCount += 1
@@ -172,7 +174,8 @@ public class TranscriptionTaskManager: ObservableObject {
                     outputFolder: outputFolder,
                     taskId: task.id,
                     healthInfo: task.healthInfo,
-                    splitLocalSpeakers: task.splitLocalSpeakers
+                    splitLocalSpeakers: task.splitLocalSpeakers,
+                    meetingTitle: task.meetingTitle
                 )
 
                 await MainActor.run {

--- a/Tests/MeetingPromptDetectorTests.swift
+++ b/Tests/MeetingPromptDetectorTests.swift
@@ -17,7 +17,8 @@ private func makeMeetingPromptCandidate(
         source: source,
         startDate: startDate,
         endDate: startDate.addingTimeInterval(30 * 60),
-        meetingURL: nil
+        meetingURL: nil,
+        suggestedTranscriptTitle: source == .calendarEvent ? "Design review" : nil
     )
 }
 
@@ -85,6 +86,21 @@ func testMeetingPromptDetector() async {
         assertTrue(
             decision.until.timeIntervalSince(Date()) > 25 * 60,
             "Not now should remain meaningfully longer than Remind me soon"
+        )
+    }
+
+    runSuite("MeetingPromptDetector.Candidate — calendar prompts carry a transcript title hint") {
+        let calendarCandidate = makeMeetingPromptCandidate(id: "calendar:title", source: .calendarEvent)
+        let runtimeCandidate = makeMeetingPromptCandidate(id: "runtime:title", source: .runtimeApp)
+
+        assertEqual(
+            calendarCandidate.suggestedTranscriptTitle,
+            "Design review",
+            "calendar-backed prompts should carry the event title into the recording path"
+        )
+        assertNil(
+            runtimeCandidate.suggestedTranscriptTitle,
+            "runtime-only prompts should not invent a transcript title"
         )
     }
 }

--- a/Tests/MeetingSessionUIPolicyTests.swift
+++ b/Tests/MeetingSessionUIPolicyTests.swift
@@ -30,4 +30,45 @@ func testMeetingSessionUIPolicy() {
             "queued meeting work should keep the saving state visible until it starts"
         )
     }
+
+    runSuite("MeetingSessionUIPolicy.canStartQueuedTranscription — waits while speaker review is pending") {
+        assertFalse(
+            MeetingSessionUIPolicy.canStartQueuedTranscription(
+                activeTranscriptions: 0,
+                isSpeakerReviewPending: true,
+                isPreparingQueuedTranscriptionStart: false
+            ),
+            "speaker review should keep the next queued transcription from starting until the transcript is finalized"
+        )
+    }
+
+    runSuite("MeetingSessionUIPolicy.canStartQueuedTranscription — starts once speaker review clears") {
+        assertTrue(
+            MeetingSessionUIPolicy.canStartQueuedTranscription(
+                activeTranscriptions: 0,
+                isSpeakerReviewPending: false,
+                isPreparingQueuedTranscriptionStart: false
+            ),
+            "a queued meeting should start as soon as the old speaker review publishes nil"
+        )
+    }
+
+    runSuite("MeetingSessionUIPolicy.canStartQueuedTranscription — blocks duplicate starts") {
+        assertFalse(
+            MeetingSessionUIPolicy.canStartQueuedTranscription(
+                activeTranscriptions: 1,
+                isSpeakerReviewPending: false,
+                isPreparingQueuedTranscriptionStart: false
+            ),
+            "active transcription work should remain single-flight"
+        )
+        assertFalse(
+            MeetingSessionUIPolicy.canStartQueuedTranscription(
+                activeTranscriptions: 0,
+                isSpeakerReviewPending: false,
+                isPreparingQueuedTranscriptionStart: true
+            ),
+            "a queued start already being prepared should not be started twice"
+        )
+    }
 }

--- a/Tests/MeetingSessionUIPolicyTests.swift
+++ b/Tests/MeetingSessionUIPolicyTests.swift
@@ -71,4 +71,44 @@ func testMeetingSessionUIPolicy() {
             "a queued start already being prepared should not be started twice"
         )
     }
+
+    runSuite("MeetingRecordingTitlePolicy — explicit prompt title wins over calendar fallback") {
+        assertEqual(
+            MeetingRecordingTitlePolicy.resolve(
+                explicitTitle: "Prompt Title",
+                calendarTitle: "Calendar Title"
+            ),
+            "Prompt Title",
+            "explicit prompt context should not be overwritten by a later calendar lookup"
+        )
+    }
+
+    runSuite("MeetingRecordingTitlePolicy — manual starts can use the calendar title") {
+        assertEqual(
+            MeetingRecordingTitlePolicy.resolve(
+                explicitTitle: nil,
+                calendarTitle: "Transcripted Calendar Smoke Live"
+            ),
+            "Transcripted Calendar Smoke Live",
+            "manual, menu, and hotkey starts should still get the active calendar event title"
+        )
+    }
+
+    runSuite("MeetingRecordingTitlePolicy — blank titles are ignored") {
+        assertEqual(
+            MeetingRecordingTitlePolicy.resolve(
+                explicitTitle: " \n ",
+                calendarTitle: "Calendar Title"
+            ),
+            "Calendar Title",
+            "blank prompt titles should not block the calendar fallback"
+        )
+        assertNil(
+            MeetingRecordingTitlePolicy.resolve(
+                explicitTitle: nil,
+                calendarTitle: " \r\n "
+            ),
+            "blank calendar titles should not become transcript titles"
+        )
+    }
 }

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -73,6 +73,45 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
                        "embedders that pass only the static value should still get a valid resolver result")
     }
 
+    func testTranscriptionTaskCarriesCalendarMeetingTitle() {
+        let task = TranscriptionTask(
+            micURL: tempDirectory.appendingPathComponent("mic.wav"),
+            systemURL: tempDirectory.appendingPathComponent("system.wav"),
+            outputFolder: tempDirectory.appendingPathComponent("transcripts"),
+            meetingTitle: "Customer Discovery Sync"
+        )
+
+        XCTAssertEqual(task.meetingTitle, "Customer Discovery Sync")
+    }
+
+    func testTranscriptFormatterWritesCalendarMeetingTitle() {
+        let result = TranscriptionResult(
+            micUtterances: [],
+            systemUtterances: [
+                TranscriptionUtterance(
+                    start: 0,
+                    end: 2,
+                    channel: 1,
+                    speakerId: 0,
+                    persistentSpeakerId: nil,
+                    matchSimilarity: nil,
+                    transcript: "Thanks for joining."
+                )
+            ],
+            duration: 2,
+            processingTime: 0.5
+        )
+
+        let markdown = TranscriptSaver.formatTranscriptMarkdown(
+            result: result,
+            transcriptId: UUID(uuidString: "00000000-0000-0000-0000-000000000123")!,
+            date: Date(timeIntervalSince1970: 0),
+            meetingTitle: "Customer Discovery Sync"
+        )
+
+        XCTAssertTrue(markdown.contains("title: \"Customer Discovery Sync\""))
+    }
+
     func testStartTranscriptionRejectsMissingSystemAudioBeforeBackgroundWorkStarts() throws {
         let manager = makeManager()
         let micScratchDirectory = tempDirectory.appendingPathComponent("audio")


### PR DESCRIPTION
## Summary
- Fix queued meeting saves so the status bar clears when a second recording starts before speaker review is saved.
- Carry Apple Calendar event titles into meeting transcript metadata and filenames.
- Use the active Calendar title for prompt-started, manual, menu, and hotkey meeting recordings.

## Why
Customer feedback showed two related problems: the save bar could get stuck after back-to-back recordings, and meeting titles were too generic even when the calendar already had the call topic.

## Validation
- `bash build.sh`
- `bash run-tests.sh` (`1809 tests, 1809 passed`)
- `bash run-integration-smoke.sh`
- `swift test` (`172 tests, 0 failures`)
- Live Apple Calendar smoke: created a temporary Calendar event titled `Transcripted Calendar Smoke Live`, recorded a meeting, and verified the saved Markdown frontmatter title and document heading matched that Calendar title.