### PR TITLE
[codex] Fix meeting mic tap teardown order

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -99,6 +99,19 @@ enum AudioRecordingFormatPolicy {
     }
 }
 
+enum AudioInputTapTeardownStep: Equatable {
+    case stopEngine
+    case removeInputTap
+}
+
+enum AudioInputTapTeardownPolicy {
+    static func steps(engineIsRunning: Bool) -> [AudioInputTapTeardownStep] {
+        engineIsRunning
+            ? [.stopEngine, .removeInputTap]
+            : [.removeInputTap]
+    }
+}
+
 /// Main audio recording class that captures microphone and system audio
 /// Note: This class does NOT use @MainActor because it manages AVAudioEngine
 /// which requires synchronous access from audio tap callbacks on audio threads.
@@ -313,6 +326,25 @@ public class Audio: ObservableObject, @unchecked Sendable {
         audioGraphLock.lock()
         defer { audioGraphLock.unlock() }
         return try body()
+    }
+
+    func tearDownInputTapSafely(
+        engine: AVAudioEngine,
+        inputNode: AVAudioInputNode,
+        operation: String
+    ) {
+        let steps = AudioInputTapTeardownPolicy.steps(engineIsRunning: engine.isRunning)
+        for step in steps {
+            switch step {
+            case .stopEngine:
+                AppLogger.audioMic.info("Stopping mic engine before removing input tap", [
+                    "operation": operation
+                ])
+                engine.stop()
+            case .removeInputTap:
+                inputNode.removeTap(onBus: 0)
+            }
+        }
     }
 
     // Write error tracking — stop writing after repeated failures
@@ -927,10 +959,11 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
                 if let engineRef, let inputNodeRef {
                     AppLogger.audio.info("Stopping audio capture")
-                    inputNodeRef.removeTap(onBus: 0)
-                    if engineRef.isRunning {
-                        engineRef.stop()
-                    }
+                    self.tearDownInputTapSafely(
+                        engine: engineRef,
+                        inputNode: inputNodeRef,
+                        operation: "recording_stop"
+                    )
                     self.disarmVoiceProcessing(on: inputNodeRef)
                 }
 
@@ -1026,7 +1059,11 @@ public class Audio: ObservableObject, @unchecked Sendable {
         do {
             try withAudioGraphLock {
                 // Install mic tap for level metering only (no file writing)
-                inputNode.removeTap(onBus: 0)
+                tearDownInputTapSafely(
+                    engine: engine,
+                    inputNode: inputNode,
+                    operation: "monitoring_start"
+                )
                 inputNode.installTap(onBus: 0, bufferSize: 4096, format: monitorFormat) { [weak self] buffer, _ in
                     self?.calculateLevel(buffer: buffer)
                 }
@@ -1035,7 +1072,11 @@ public class Audio: ObservableObject, @unchecked Sendable {
         } catch {
             AppLogger.audio.warning("Failed to start monitoring engine", ["error": error.localizedDescription])
             withAudioGraphLock {
-                inputNode.removeTap(onBus: 0)
+                tearDownInputTapSafely(
+                    engine: engine,
+                    inputNode: inputNode,
+                    operation: "monitoring_start_failed"
+                )
             }
             return
         }
@@ -1069,10 +1110,11 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         withAudioGraphLock {
             if let engine = engine, let inputNode = inputNode {
-                if engine.isRunning {
-                    inputNode.removeTap(onBus: 0)
-                    engine.stop()
-                }
+                tearDownInputTapSafely(
+                    engine: engine,
+                    inputNode: inputNode,
+                    operation: "monitoring_stop"
+                )
                 disarmVoiceProcessing(on: inputNode)
             }
 
@@ -1106,9 +1148,12 @@ public class Audio: ObservableObject, @unchecked Sendable {
         systemAudioCapture?.stopSync()
 
         withAudioGraphLock {
-            if let engine, let inputNode, engine.isRunning {
-                inputNode.removeTap(onBus: 0)
-                engine.stop()
+            if let engine, let inputNode {
+                tearDownInputTapSafely(
+                    engine: engine,
+                    inputNode: inputNode,
+                    operation: "deinit"
+                )
             }
         }
     }

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -99,8 +99,11 @@ extension Audio {
                 ])
                 return
             }
-            inputNode.removeTap(onBus: 0)
-            engine.stop()
+            tearDownInputTapSafely(
+                engine: engine,
+                inputNode: inputNode,
+                operation: "device_recovery_reset"
+            )
             engine.reset()
             // engine.reset() clears VPIO state on the input node; require re-arm.
             voiceProcessingEnabled = false
@@ -256,7 +259,11 @@ extension Audio {
                     throw AudioCaptureStaleSessionError()
                 }
                 // Reinstall tap using shared buffer handler
-                newInputNode.removeTap(onBus: 0)
+                tearDownInputTapSafely(
+                    engine: engine,
+                    inputNode: newInputNode,
+                    operation: "device_recovery_restart"
+                )
                 newInputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
                     self?.handleMicBuffer(buffer)
                 }
@@ -264,8 +271,11 @@ extension Audio {
                     engine.prepare()
                     try engine.start()
                 } catch {
-                    newInputNode.removeTap(onBus: 0)
-                    engine.stop()
+                    tearDownInputTapSafely(
+                        engine: engine,
+                        inputNode: newInputNode,
+                        operation: "device_recovery_restart_failed"
+                    )
                     throw error
                 }
             }

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -27,8 +27,11 @@ extension Audio {
             }
             let (engine, inputNode) = try ensureEngineInitialized()
             if engine.isRunning {
-                inputNode.removeTap(onBus: 0)
-                engine.stop()
+                tearDownInputTapSafely(
+                    engine: engine,
+                    inputNode: inputNode,
+                    operation: "start_recording_reset"
+                )
                 engine.reset()
                 voiceProcessingEnabled = false
                 self.inputNode = engine.inputNode
@@ -290,7 +293,11 @@ extension Audio {
                 throw AudioCaptureStaleSessionError()
             }
             // Remove any existing tap (safety check)
-            inputNode.removeTap(onBus: 0)
+            tearDownInputTapSafely(
+                engine: engine,
+                inputNode: inputNode,
+                operation: "start_recording_install"
+            )
 
             // Install tap on microphone
             inputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
@@ -301,8 +308,11 @@ extension Audio {
                 engine.prepare()
                 try engine.start()
             } catch {
-                inputNode.removeTap(onBus: 0)
-                engine.stop()
+                tearDownInputTapSafely(
+                    engine: engine,
+                    inputNode: inputNode,
+                    operation: "start_recording_failed"
+                )
                 throw error
             }
         }

--- a/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
@@ -82,6 +82,19 @@ final class AudioInitializationTests: XCTestCase {
         XCTAssertEqual(snapshot.channelCount, 2)
     }
 
+    func testInputTapTeardownStopsRunningEngineBeforeRemovingTap() {
+        XCTAssertEqual(
+            AudioInputTapTeardownPolicy.steps(engineIsRunning: true),
+            [.stopEngine, .removeInputTap],
+            "Running AVAudioEngine graphs must be stopped before the input tap is removed so CoreAudio never receives input with tap == nil"
+        )
+        XCTAssertEqual(
+            AudioInputTapTeardownPolicy.steps(engineIsRunning: false),
+            [.removeInputTap],
+            "Stopped engines can remove the tap directly"
+        )
+    }
+
     func testStopOnIdleAudioDoesNotCrashAndBumpsGeneration() {
         // The stop refactor moves engine teardown to a background queue.
         // On a fresh Audio with no engine, stop() should still:


### PR DESCRIPTION
## Summary

- stop the meeting mic `AVAudioEngine` before removing its input tap
- apply the safer teardown order across start reset, stop, monitoring, and device recovery paths
- add package coverage for the teardown-order policy

## Root Cause

Sentry `APPLE-MACOS-1P` showed CoreAudio aborting during an active meeting recording with `required condition is false: isSink || tap != nullptr`. The likely race was removing the input tap while the engine was still running, leaving CoreAudio's input callback with no tap. The later `APPLE-MACOS-1H` failures on the same Seattle session look downstream of that broken capture.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (`1809 passed`)
- `bash run-integration-smoke.sh`
- `swift test` (`174 passed`)
- `bash /Users/redbars/.codex/skills/transcripted-repro-lab/scripts/run_daily_audio_reliability.sh --synthetic` (`72 passed`)