### PR TITLE
[codex] Keep onboarding dictation shortcuts fully off

### DIFF
--- a/Sources/Support/HotkeyPreferences.swift
+++ b/Sources/Support/HotkeyPreferences.swift
@@ -153,7 +153,11 @@ enum HotkeyPreferences {
     }
 
     static func setDictationShortcutsEnabled(_ enabled: Bool, userDefaults: UserDefaults = .standard) {
-        userDefaults.set(enabled, forKey: dictationShortcutsEnabledKey)
+        let ud = userDefaults
+        ud.set(enabled, forKey: dictationShortcutsEnabledKey)
+        if !enabled {
+            ud.set(false, forKey: rightOptionDictationKey)
+        }
         NotificationCenter.default.post(name: .hotkeysDidChange, object: nil)
     }
 
@@ -167,6 +171,7 @@ enum HotkeyPreferences {
         ud.removeObject(forKey: meetingModifiersKey)
         ud.removeObject(forKey: dictationShortcutModeKey)
         ud.removeObject(forKey: dictationShortcutsEnabledKey)
+        ud.removeObject(forKey: rightOptionDictationKey)
         NotificationCenter.default.post(name: .hotkeysDidChange, object: nil)
     }
 

--- a/Sources/Support/OnboardingDictationShortcutPolicy.swift
+++ b/Sources/Support/OnboardingDictationShortcutPolicy.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum OnboardingDictationShortcutPolicy {
+    enum UseCase {
+        case meetings
+        case dictation
+    }
+
+    static func apply(
+        useCase: UseCase,
+        leaveDictationShortcutsOff: Bool,
+        userDefaults: UserDefaults = .standard
+    ) {
+        switch useCase {
+        case .meetings:
+            HotkeyPreferences.setDictationShortcutsEnabled(!leaveDictationShortcutsOff, userDefaults: userDefaults)
+        case .dictation:
+            HotkeyPreferences.setDictationShortcutsEnabled(true, userDefaults: userDefaults)
+        }
+    }
+}

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -446,12 +446,10 @@ struct PermissionsOnboardingView: View {
     }
 
     private func applySelectedUseCasePreferences() {
-        switch selectedUseCase {
-        case .meetings:
-            HotkeyPreferences.setDictationShortcutsEnabled(!leaveDictationShortcutsOff)
-        case .dictation:
-            HotkeyPreferences.setDictationShortcutsEnabled(true)
-        }
+        OnboardingDictationShortcutPolicy.apply(
+            useCase: selectedUseCase.shortcutPolicyUseCase,
+            leaveDictationShortcutsOff: leaveDictationShortcutsOff
+        )
     }
 
     private func copyAgentItem(_ item: AgentCopyItem) {
@@ -584,6 +582,15 @@ private enum OnboardingStepKind: Hashable {
 private enum OnboardingUseCase: Hashable {
     case meetings
     case dictation
+
+    var shortcutPolicyUseCase: OnboardingDictationShortcutPolicy.UseCase {
+        switch self {
+        case .meetings:
+            return .meetings
+        case .dictation:
+            return .dictation
+        }
+    }
 }
 
 private enum AgentCopyItem: Hashable {

--- a/Tests/HotkeyPreferencesTests.swift
+++ b/Tests/HotkeyPreferencesTests.swift
@@ -44,12 +44,46 @@ func testHotkeyPreferences() {
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
+        HotkeyPreferences.setRightOptionDictation(enabled: true, userDefaults: defaults)
         HotkeyPreferences.setDictationShortcutsEnabled(false, userDefaults: defaults)
 
         assertEqual(
             HotkeyPreferences.dictationShortcutsEnabled(userDefaults: defaults),
             false,
             "users should be able to turn off accidental dictation triggers"
+        )
+        assertEqual(
+            HotkeyPreferences.rightOptionDictationEnabled(userDefaults: defaults),
+            false,
+            "turning dictation shortcuts off should also keep the legacy Right Option trigger off"
+        )
+    }
+
+    runSuite("Onboarding keeps Daniel Goncalves's meeting-only setup fully off") {
+        let suiteName = "HotkeyPreferencesTests.danielMeetingOnly.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        OnboardingDictationShortcutPolicy.apply(
+            useCase: .meetings,
+            leaveDictationShortcutsOff: true,
+            userDefaults: defaults
+        )
+
+        assertEqual(
+            HotkeyPreferences.dictationShortcutsEnabled(userDefaults: defaults),
+            false,
+            "meeting-only onboarding should let users leave dictation shortcuts off"
+        )
+        assertEqual(
+            HotkeyPreferences.rightOptionDictationEnabled(userDefaults: defaults),
+            false,
+            "meeting-only onboarding should not leave Right Option armed behind the master switch"
+        )
+        assertEqual(
+            PhysicalDictationTriggerPreferences.meetingBinding(userDefaults: defaults),
+            PhysicalDictationTriggerPreferences.defaultMeetingBinding,
+            "meeting capture should still keep its app shortcut path available"
         )
     }
 
@@ -85,6 +119,11 @@ func testHotkeyPreferences() {
             HotkeyPreferences.dictationShortcutsEnabled(userDefaults: defaults),
             true,
             "reset should re-enable dictation shortcuts"
+        )
+        assertEqual(
+            HotkeyPreferences.rightOptionDictationEnabled(userDefaults: defaults),
+            true,
+            "reset should restore the default Right Option behavior"
         )
     }
 }

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -120,6 +120,7 @@ APP_SOURCES=(
     "Sources/Support/MenuBarVisibilityPreferences.swift"
     "Sources/Support/PermissionsOnboardingPreferences.swift"
     "Sources/Support/HotkeyPreferences.swift"
+    "Sources/Support/OnboardingDictationShortcutPolicy.swift"
     "Sources/Support/PhysicalDictationTriggerPreferences.swift"
     "Sources/Support/CustomDictionaryPreferences.swift"
     "Sources/Support/DockVisibilityPreferences.swift"


### PR DESCRIPTION
## Summary

- Keep meeting-only onboarding from re-arming dictation shortcuts.
- Route onboarding shortcut writes through a small policy helper.
- When dictation shortcuts are turned off, also clear the legacy Right Option dictation flag so the old trigger cannot come back behind the master switch.
- Add a regression test for Daniel Goncalves's May 5 support case: meeting notes started from app clicks, with dictation fully off.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (`1814 passed`)
