### PR TITLE
[nightly-agent] Clarify agent setup choices

### DIFF
--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -3103,7 +3103,7 @@ private struct AgentConnectionSettingsPage: View {
         VStack(alignment: .leading, spacing: 24) {
             SettingsPageIntro(
                 title: "Agent",
-                summary: "Pick one."
+                summary: "Install direct tools for Claude Desktop, or copy a prompt for local coding agents."
             )
 
             agentActionSection


### PR DESCRIPTION
## Summary
- Clarifies the Settings > Agent intro so users see the two actual setup paths.
- Keeps the nightly agent surface fix scoped to setup copy only.

## Verification
- swift test --package-path Tools/TranscriptedCLI
- swift test --package-path Tools/TranscriptedMCP
- cd Tools/TranscriptedMCP && swift build -c release
- transcripted-mcp --help
- transcripted-mcp --self-test with default manifest paths and explicit TRANSCRIPTED_DATA_DIR
- transcripted-cli context-recent/context-search/list-dictations/read-meeting/read-dictation with explicit local directory overrides
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh