### PR TITLE
[nightly-telemetry] Preserve meeting outcome trigger attribution

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1537,7 +1537,11 @@ final class MeetingSessionController: ObservableObject {
     ) {
         guard !hasVisibleBackgroundTranscriptionWork(snapshot: snapshot) else { return }
         guard !isCaptureSessionActive else { return }
-        activeTranscriptionTrigger = .unknown
+        if MeetingSessionUIPolicy.shouldClearTranscriptionTriggerWhenIdle(
+            isSpeakerReviewPending: snapshot.speakerNamingRequest != nil
+        ) {
+            activeTranscriptionTrigger = .unknown
+        }
 
         switch lastTerminalTranscriptionOutcome {
         case .failed(let message):

--- a/Sources/Meeting/MeetingSessionUIPolicy.swift
+++ b/Sources/Meeting/MeetingSessionUIPolicy.swift
@@ -17,6 +17,12 @@ enum MeetingSessionUIPolicy {
             && !isSpeakerReviewPending
             && !isPreparingQueuedTranscriptionStart
     }
+
+    static func shouldClearTranscriptionTriggerWhenIdle(
+        isSpeakerReviewPending: Bool
+    ) -> Bool {
+        !isSpeakerReviewPending
+    }
 }
 
 enum MeetingRecordingTitlePolicy {

--- a/Tests/MeetingSessionUIPolicyTests.swift
+++ b/Tests/MeetingSessionUIPolicyTests.swift
@@ -72,6 +72,22 @@ func testMeetingSessionUIPolicy() {
         )
     }
 
+    runSuite("MeetingSessionUIPolicy.shouldClearTranscriptionTriggerWhenIdle — keeps trigger through speaker review") {
+        assertFalse(
+            MeetingSessionUIPolicy.shouldClearTranscriptionTriggerWhenIdle(
+                isSpeakerReviewPending: true
+            ),
+            "speaker review can publish the terminal saved or failed status after active transcription work clears"
+        )
+
+        assertTrue(
+            MeetingSessionUIPolicy.shouldClearTranscriptionTriggerWhenIdle(
+                isSpeakerReviewPending: false
+            ),
+            "completed work without speaker review should clear the last start trigger"
+        )
+    }
+
     runSuite("MeetingRecordingTitlePolicy — explicit prompt title wins over calendar fallback") {
         assertEqual(
             MeetingRecordingTitlePolicy.resolve(


### PR DESCRIPTION
## Summary
- Preserve meeting start trigger attribution while speaker review is still pending.
- Add a focused policy test for the delayed terminal saved/failed status path.

## Nightly sweep evidence
- PostHog last 7 days: 139/141 meeting_transcript_saved and 16/18 meeting_transcript_failed events had trigger=unknown.
- Sentry APPLE-MACOS-1H current release events also show trigger=unknown on meeting_transcript_failed.
- The reset happened before speaker review could publish the terminal saved/failed status.

## Score
Winner: meeting outcome trigger attribution blind spot, 88/100.
- User pain/workflow distortion: 24/30
- Debugging/confusion severity: 24/25
- Current-release relevance: 14/15
- Small-patch safety: 14/15
- Privacy/payload confidence: 12/15

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh