### PR TITLE
Release Transcripted 1.1.36

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.35"
-  sha256 "f4dc048526b969c130180663be6d3bd7f3fe2e3c7b337a29a46b9d35f7ec5a94"
+  version "1.1.36"
+  sha256 "90f98a36295b8352e037f5b7dc1ea4df632cc268e5331f1ac7348ede7f8bc6e2"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.35</string>
+	<string>1.1.36</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.35</string>
+	<string>1.1.36</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.36</title>
+      <pubDate>Thu, 14 May 2026 06:58:36 -0500</pubDate>
+      <sparkle:version>1.1.36</sparkle:version>
+      <sparkle:shortVersionString>1.1.36</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.36/Transcripted-1.1.36.dmg" length="503951580" type="application/octet-stream" sparkle:edSignature="3FhsdJVffo3j9UvSjmQnE1D+OIXOaNrBMfWKtdTpe5cuCuaxok4nt1BImh2usXiw0XgGXRxLujGGm1UQq0LsDA==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.36</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.36</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.35</title>
       <pubDate>Wed, 13 May 2026 09:06:03 -0500</pubDate>
       <sparkle:version>1.1.35</sparkle:version>

--- a/docs/release-candidate-1.1.36.md
+++ b/docs/release-candidate-1.1.36.md
@@ -1,12 +1,9 @@
-# Transcripted 1.1.36 Release Candidate Notes
+# Transcripted 1.1.36 Release Notes
 
-This is prep only. No GitHub release, Sparkle appcast, or Homebrew cask entry
-exists for 1.1.36 yet.
+## Summary
 
-## Candidate summary
-
-Transcripted 1.1.36 is a reliability hotfix candidate for meeting audio teardown
-and dictation recovery issues seen after 1.1.35 shipped.
+Transcripted 1.1.36 is a reliability and polish release for meeting capture,
+dictation recovery, onboarding, and the Settings home experience.
 
 ## User-visible changes
 
@@ -18,6 +15,12 @@ and dictation recovery issues seen after 1.1.35 shipped.
   dictation recording GIFs.
 - Meeting-only onboarding keeps dictation shortcuts fully off when the user
   chose that path.
+- The Settings home screen has cleaner Meetings and Dictation tabs and a fixed
+  collapsed-sidebar header layout.
+- The feedback issue picker now stays within the report sheet instead of
+  stretching the settings window.
+- The Agent setup page explains the Claude Desktop tools path and local-agent
+  prompt path more clearly.
 
 ## Reliability and ops changes
 
@@ -29,32 +32,20 @@ and dictation recovery issues seen after 1.1.35 shipped.
   speech-bus routes.
 - Avoids cancelling active dictation inference while CoreML transcription is in
   flight.
+- Preserves meeting start trigger attribution through speaker review so saved
+  and failed meeting telemetry keeps its original source.
 - Makes CLI and MCP legacy transcript reads skip malformed rows instead of
   crashing.
 - Keeps beta/distribution builds from accidentally shipping thin artifacts
   without bundled Parakeet models unless both opt-outs are explicit.
+- Keeps every health-probe lane running even when one provider is missing local
+  credentials.
+- Aligns the root Claude read order with the current agent onboarding docs.
 
 ## Known caveats
 
 - Open issue #500 still needs the focused manual browser/app/device audio
   matrix.
-- The latest 1.1.35 Sentry meeting crash and transcript-failure events happened
-  before the post-release audio fixes, so the fix needs release-side validation.
-- Sparkle users will not see 1.1.36 until a real artifact is published and
-  `docs/appcast.xml` is updated.
-- Homebrew users will not see 1.1.36 until `Casks/transcripted.rb` is updated
-  after the GitHub release asset exists.
-
-## Release blockers
-
-- Build and notarize the 1.1.36 DMG.
-- Verify Sparkle metadata against the real published artifact.
-- Update and verify the Homebrew cask from the published DMG.
-- Confirm `https://transcripted.app/download` resolves to the 1.1.36 asset only
-  after approval to publish.
-
-## Publish next step
-
-If approved, run the full release flow from `docs/release-packaging.md`: build
-the notarized artifact, publish the GitHub release, generate and verify the
-Sparkle appcast entry, update the cask, then verify the live download route.
+- The latest 1.1.35 meeting crash and transcript-failure events happened before
+  the post-release audio fixes, so this build still needs normal live-release
+  monitoring after publication.


### PR DESCRIPTION
## Summary
- bump Transcripted to 1.1.36
- publish Sparkle appcast metadata for the notarized 1.1.36 DMG
- update the Homebrew cask to the 1.1.36 GitHub release asset

## Verification
- bash build-deps.sh --force
- bash build.sh
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-public-1.1.36 Transcripted
- bash scripts/release/verify-sparkle-release.sh 1.1.36
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift test