### PR TITLE
[codex] Harden audio startup and meeting failure diagnostics

### DIFF
--- a/Sources/Meeting/MeetingFailureKind.swift
+++ b/Sources/Meeting/MeetingFailureKind.swift
@@ -102,11 +102,12 @@ enum MeetingFailureKind: String {
             return .pipelineBusy
         }
 
-        if normalized.contains("retry failed") {
-            return .pipelineFailed
-        }
-
-        if normalized.contains("model not loaded") {
+        if normalized.contains(anyOf: [
+            "model not loaded",
+            "models were not ready",
+            "model failed to load",
+            "speech model failed to load",
+        ]) {
             return .modelNotLoaded
         }
 
@@ -138,6 +139,15 @@ enum MeetingFailureKind: String {
             "transcription failed",
         ]) {
             return .transcriptionInferenceFailed
+        }
+
+        if normalized.contains(anyOf: [
+            "pipeline failed",
+            "pipeline error",
+            "retry failed",
+            "transcription pipeline",
+        ]) {
+            return .pipelineFailed
         }
 
         return .unexpectedError

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -179,6 +179,7 @@ final class MeetingSessionController: ObservableObject {
     private var queuedTranscriptionJobs: [QueuedTranscriptionJob] = []
     private var preparingQueuedTranscriptionJob: QueuedTranscriptionJob?
     private var queuedTranscriptionStartTask: Task<Void, Never>?
+    private var isDeferringPendingSpeakerReview = false
     private var lastTerminalTranscriptionOutcome: TerminalTranscriptionOutcome?
     private var activeRecordingTrigger: StartTrigger = .unknown
     private var activeRecordingSuggestedTitle: String?
@@ -1264,6 +1265,14 @@ final class MeetingSessionController: ObservableObject {
         isCaptureSessionActive || isFinishingRecording || hasBackgroundTranscriptionWork
     }
 
+    var queuedTranscriptionCount: Int {
+        queuedTranscriptionJobs.count
+    }
+
+    var isSpeakerReviewPending: Bool {
+        taskManager.speakerNamingRequest != nil
+    }
+
     private var hasVisibleBackgroundTranscriptionWork: Bool {
         hasVisibleBackgroundTranscriptionWork(snapshot: currentBackgroundTranscriptionWorkSnapshot)
     }
@@ -1340,6 +1349,7 @@ final class MeetingSessionController: ObservableObject {
         }
 
         queuedTranscriptionJobs.append(job)
+        deferPendingSpeakerReviewForQueuedTranscriptionIfNeeded()
         return .queued(position: queuedTranscriptionJobs.count)
     }
 
@@ -1503,6 +1513,14 @@ final class MeetingSessionController: ObservableObject {
     private func handleBackgroundTranscriptionWorkChanged(
         snapshot: BackgroundTranscriptionWorkSnapshot
     ) {
+        if snapshot.speakerNamingRequest == nil {
+            isDeferringPendingSpeakerReview = false
+        }
+
+        if deferPendingSpeakerReviewForQueuedTranscriptionIfNeeded(snapshot: snapshot) {
+            return
+        }
+
         if canStartQueuedTranscriptionImmediately(snapshot: snapshot) {
             if let nextJob = popNextQueuedTranscriptionJob() {
                 startQueuedTranscription(nextJob)
@@ -1521,6 +1539,37 @@ final class MeetingSessionController: ObservableObject {
         if !isCaptureSessionActive {
             state = .transcribing
         }
+    }
+
+    @discardableResult
+    private func deferPendingSpeakerReviewForQueuedTranscriptionIfNeeded(
+        snapshot: BackgroundTranscriptionWorkSnapshot? = nil
+    ) -> Bool {
+        let snapshot = snapshot ?? currentBackgroundTranscriptionWorkSnapshot
+        guard !isDeferringPendingSpeakerReview,
+              snapshot.activeCount == 0,
+              snapshot.speakerNamingRequest != nil,
+              !queuedTranscriptionJobs.isEmpty,
+              !isPreparingQueuedTranscriptionStart else {
+            return false
+        }
+
+        guard taskManager.deferPendingSpeakerNamingReview(reason: "queued_transcription") else {
+            return false
+        }
+
+        isDeferringPendingSpeakerReview = true
+        DiagnosticsTrail.record(
+            engine: "meeting",
+            event: "meeting_speaker_review_deferred_for_queue",
+            message: "Speaker review was moved to Review Later so queued meeting transcription can start",
+            context: baseDiagnosticsContext(
+                extra: [
+                    "queue_depth": "\(queuedTranscriptionJobs.count)"
+                ]
+            )
+        )
+        return true
     }
 
     private func popNextQueuedTranscriptionJob() -> QueuedTranscriptionJob? {

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -179,7 +179,6 @@ final class MeetingSessionController: ObservableObject {
     private var queuedTranscriptionJobs: [QueuedTranscriptionJob] = []
     private var preparingQueuedTranscriptionJob: QueuedTranscriptionJob?
     private var queuedTranscriptionStartTask: Task<Void, Never>?
-    private var isDeferringPendingSpeakerReview = false
     private var lastTerminalTranscriptionOutcome: TerminalTranscriptionOutcome?
     private var activeRecordingTrigger: StartTrigger = .unknown
     private var activeRecordingSuggestedTitle: String?
@@ -621,15 +620,30 @@ final class MeetingSessionController: ObservableObject {
         )
 
         guard let micURL = files.micURL else {
-            MeetingRecordingCleanup.discardFiles(micURL: nil, systemURL: files.systemURL)
+            let preserved = taskManager.addFailedTranscriptionRetainingAvailableAudio(
+                micAudioURL: nil,
+                systemAudioURL: files.systemURL,
+                errorMessage: "Recording stopped without microphone audio."
+            )
             DiagnosticsTrail.record(
                 level: .error,
                 engine: "meeting",
                 event: "meeting_recording_missing_mic_audio",
                 message: "Meeting recording stopped without a microphone file",
-                context: baseDiagnosticsContext(extra: ["reason": reason.rawValue])
+                context: baseDiagnosticsContext(
+                    extra: [
+                        "reason": reason.rawValue,
+                        "system_file_present": boolString(files.systemURL != nil),
+                        "preserved_for_retry": boolString(preserved)
+                    ]
+                )
             )
-            state = .error("No microphone audio was captured.")
+            if preserved {
+                refreshFailedMeetings()
+            }
+            state = files.systemURL == nil
+                ? .error("No meeting audio was captured.")
+                : .error("Microphone audio was missing. Open Settings → Meetings to retry the system audio.")
             return
         }
 
@@ -930,42 +944,87 @@ final class MeetingSessionController: ObservableObject {
     }
 
     func prepareForTermination() async {
-        guard case .recording = state else { return }
-        guard !isFinishingRecording else { return }
-        isFinishingRecording = true
-        defer { isFinishingRecording = false }
+        var didPreserveRecording = false
+        var recordingTrigger = activeRecordingTrigger
+        var stoppedFiles: (micURL: URL?, systemURL: URL?) = (nil, nil)
 
-        _ = audioInactivityDetector.stopRecording()
-        audioInactivityWarning = nil
+        if case .recording = state, !isFinishingRecording {
+            isFinishingRecording = true
+            defer { isFinishingRecording = false }
 
-        let recordingTrigger = activeRecordingTrigger
-        let files = await capture.stopAndAwaitFiles()
-        activeRecordingTrigger = .unknown
-        activeRecordingSuggestedTitle = nil
+            _ = audioInactivityDetector.stopRecording()
+            audioInactivityWarning = nil
 
-        if let micURL = files.micURL {
-            taskManager.addFailedTranscriptionRetainingAudio(
-                micAudioURL: micURL,
-                systemAudioURL: files.systemURL,
-                errorMessage: "Transcripted quit before this meeting could be transcribed."
-            )
-            refreshFailedMeetings()
+            let files = await capture.stopAndAwaitFiles()
+            stoppedFiles = (micURL: files.micURL, systemURL: files.systemURL)
+            activeRecordingTrigger = .unknown
+            activeRecordingSuggestedTitle = nil
+
+            if files.micURL != nil || files.systemURL != nil {
+                didPreserveRecording = taskManager.addFailedTranscriptionRetainingAvailableAudio(
+                    micAudioURL: files.micURL,
+                    systemAudioURL: files.systemURL,
+                    errorMessage: "Transcripted quit before this meeting could be transcribed."
+                )
+            }
+        } else {
+            recordingTrigger = .unknown
         }
 
+        let queuedPreserved = preserveQueuedTranscriptionJobsForShutdown(
+            errorMessage: "Transcripted quit before this queued meeting could be transcribed."
+        )
+        let activePreserved = taskManager.preserveActiveTranscriptionsForShutdown(
+            errorMessage: "Transcripted quit while this meeting was being transcribed."
+        )
+
+        guard didPreserveRecording || queuedPreserved > 0 || activePreserved > 0 else { return }
+
+        refreshFailedMeetings()
         state = .ready
         DiagnosticsTrail.record(
             level: .warning,
             engine: "meeting",
             event: "meeting_recording_saved_for_shutdown",
-            message: "Meeting recording was preserved during app termination",
+            message: "Meeting audio was preserved during app termination",
             context: baseDiagnosticsContext(
                 extra: [
                     "trigger": recordingTrigger.rawValue,
-                    "mic_file_present": boolString(files.micURL != nil),
-                    "system_file_present": boolString(files.systemURL != nil)
+                    "mic_file_present": boolString(stoppedFiles.micURL != nil),
+                    "system_file_present": boolString(stoppedFiles.systemURL != nil),
+                    "active_preserved": "\(activePreserved)",
+                    "queued_preserved": "\(queuedPreserved)"
                 ]
             )
         )
+    }
+
+    private func preserveQueuedTranscriptionJobsForShutdown(errorMessage: String) -> Int {
+        let preparingJob = preparingQueuedTranscriptionJob
+        let jobs = queuedTranscriptionJobs + [preparingJob].compactMap { $0 }
+        guard !jobs.isEmpty else { return 0 }
+
+        queuedTranscriptionStartTask?.cancel()
+        queuedTranscriptionStartTask = nil
+        preparingQueuedTranscriptionJob = nil
+        queuedTranscriptionJobs.removeAll()
+
+        var preservedCount = 0
+        for job in jobs {
+            switch job.kind {
+            case .recorded(let micURL, let systemURL, _, _):
+                if taskManager.addFailedTranscriptionRetainingAvailableAudio(
+                    micAudioURL: micURL,
+                    systemAudioURL: systemURL,
+                    errorMessage: errorMessage
+                ) {
+                    preservedCount += 1
+                }
+            case .imported(let audioURL, _):
+                try? FileManager.default.removeItem(at: audioURL)
+            }
+        }
+        return preservedCount
     }
 
     func retryFailedMeeting(id: UUID) {
@@ -1256,7 +1315,6 @@ final class MeetingSessionController: ObservableObject {
 
     private var hasBackgroundTranscriptionWork: Bool {
         taskManager.activeCount > 0
-            || taskManager.speakerNamingRequest != nil
             || isPreparingQueuedTranscriptionStart
             || !queuedTranscriptionJobs.isEmpty
     }
@@ -1349,7 +1407,6 @@ final class MeetingSessionController: ObservableObject {
         }
 
         queuedTranscriptionJobs.append(job)
-        deferPendingSpeakerReviewForQueuedTranscriptionIfNeeded()
         return .queued(position: queuedTranscriptionJobs.count)
     }
 
@@ -1492,7 +1549,6 @@ final class MeetingSessionController: ObservableObject {
     ) -> Bool {
         MeetingSessionUIPolicy.canStartQueuedTranscription(
             activeTranscriptions: snapshot.activeCount,
-            isSpeakerReviewPending: snapshot.speakerNamingRequest != nil,
             isPreparingQueuedTranscriptionStart: isPreparingQueuedTranscriptionStart
         )
     }
@@ -1513,14 +1569,6 @@ final class MeetingSessionController: ObservableObject {
     private func handleBackgroundTranscriptionWorkChanged(
         snapshot: BackgroundTranscriptionWorkSnapshot
     ) {
-        if snapshot.speakerNamingRequest == nil {
-            isDeferringPendingSpeakerReview = false
-        }
-
-        if deferPendingSpeakerReviewForQueuedTranscriptionIfNeeded(snapshot: snapshot) {
-            return
-        }
-
         if canStartQueuedTranscriptionImmediately(snapshot: snapshot) {
             if let nextJob = popNextQueuedTranscriptionJob() {
                 startQueuedTranscription(nextJob)
@@ -1541,37 +1589,6 @@ final class MeetingSessionController: ObservableObject {
         }
     }
 
-    @discardableResult
-    private func deferPendingSpeakerReviewForQueuedTranscriptionIfNeeded(
-        snapshot: BackgroundTranscriptionWorkSnapshot? = nil
-    ) -> Bool {
-        let snapshot = snapshot ?? currentBackgroundTranscriptionWorkSnapshot
-        guard !isDeferringPendingSpeakerReview,
-              snapshot.activeCount == 0,
-              snapshot.speakerNamingRequest != nil,
-              !queuedTranscriptionJobs.isEmpty,
-              !isPreparingQueuedTranscriptionStart else {
-            return false
-        }
-
-        guard taskManager.deferPendingSpeakerNamingReview(reason: "queued_transcription") else {
-            return false
-        }
-
-        isDeferringPendingSpeakerReview = true
-        DiagnosticsTrail.record(
-            engine: "meeting",
-            event: "meeting_speaker_review_deferred_for_queue",
-            message: "Speaker review was moved to Review Later so queued meeting transcription can start",
-            context: baseDiagnosticsContext(
-                extra: [
-                    "queue_depth": "\(queuedTranscriptionJobs.count)"
-                ]
-            )
-        )
-        return true
-    }
-
     private func popNextQueuedTranscriptionJob() -> QueuedTranscriptionJob? {
         guard !queuedTranscriptionJobs.isEmpty else { return nil }
         return queuedTranscriptionJobs.removeFirst()
@@ -1586,11 +1603,7 @@ final class MeetingSessionController: ObservableObject {
     ) {
         guard !hasVisibleBackgroundTranscriptionWork(snapshot: snapshot) else { return }
         guard !isCaptureSessionActive else { return }
-        if MeetingSessionUIPolicy.shouldClearTranscriptionTriggerWhenIdle(
-            isSpeakerReviewPending: snapshot.speakerNamingRequest != nil
-        ) {
-            activeTranscriptionTrigger = .unknown
-        }
+        activeTranscriptionTrigger = .unknown
 
         switch lastTerminalTranscriptionOutcome {
         case .failed(let message):

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -647,7 +647,7 @@ final class MeetingSessionController: ObservableObject {
                     "reason": reason.rawValue
                 ]
             )
-            failedManager.addFailedTranscription(
+            taskManager.addFailedTranscriptionRetainingAudio(
                 micAudioURL: micURL,
                 systemAudioURL: files.systemURL,
                 errorMessage: "Recording stop timed out before audio files were finalized."
@@ -906,7 +906,7 @@ final class MeetingSessionController: ObservableObject {
         for job in queuedJobs + [preparingJob].compactMap({ $0 }) {
             switch job.kind {
             case .recorded(let micURL, let systemURL, _, _):
-                failedManager.addFailedTranscription(
+                taskManager.addFailedTranscriptionRetainingAudio(
                     micAudioURL: micURL,
                     systemAudioURL: systemURL,
                     errorMessage: "Transcription cancelled"
@@ -943,7 +943,7 @@ final class MeetingSessionController: ObservableObject {
         activeRecordingSuggestedTitle = nil
 
         if let micURL = files.micURL {
-            failedManager.addFailedTranscription(
+            taskManager.addFailedTranscriptionRetainingAudio(
                 micAudioURL: micURL,
                 systemAudioURL: files.systemURL,
                 errorMessage: "Transcripted quit before this meeting could be transcribed."
@@ -1467,7 +1467,7 @@ final class MeetingSessionController: ObservableObject {
 
         switch job.kind {
         case .recorded(let micURL, let systemURL, _, _):
-            failedManager.addFailedTranscription(
+            taskManager.addFailedTranscriptionRetainingAudio(
                 micAudioURL: micURL,
                 systemAudioURL: systemURL,
                 errorMessage: message
@@ -1600,7 +1600,8 @@ final class MeetingSessionController: ObservableObject {
         case .failed(let message):
             lastTerminalTranscriptionOutcome = .failed(message)
             let transcriptionTrigger = activeTranscriptionTrigger
-            let failureKind = MeetingFailureKind.classify(message: message)
+            let diagnosticMessage = taskManager.lastFailureDiagnosticMessage ?? message
+            let failureKind = MeetingFailureKind.classify(message: diagnosticMessage)
             if failureKind == .recordingTooShort {
                 DiagnosticsTrail.record(
                     engine: "meeting",
@@ -1638,7 +1639,8 @@ final class MeetingSessionController: ObservableObject {
                 context: baseDiagnosticsContext(
                     extra: [
                         "error": message,
-                        "failure_kind": analyticsFailureKind(from: message),
+                        "diagnostic_error": diagnosticMessage,
+                        "failure_kind": failureKind.rawValue,
                         "queue_depth": "\(queuedTranscriptionJobs.count)",
                         "trigger": transcriptionTrigger.rawValue
                     ]
@@ -1647,11 +1649,11 @@ final class MeetingSessionController: ObservableObject {
             AnalyticsReporter.track(
                 "meeting_transcript_failed",
                 properties: meetingCaptureAnalyticsProperties(snapshot: capture.pipelineDiagnosticsSnapshot()).merging(
-                    [
-                        "failure_kind": analyticsFailureKind(from: message),
+                        [
+                        "failure_kind": failureKind.rawValue,
                         "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
                         "trigger": transcriptionTrigger.rawValue,
-                    ],
+                        ],
                     uniquingKeysWith: { _, new in new }
                 )
             )
@@ -1722,10 +1724,6 @@ final class MeetingSessionController: ObservableObject {
             status.meetingsStatus,
             "\(Int(status.progress * 10))"
         ].joined(separator: "|")
-    }
-
-    private func analyticsFailureKind(from message: String) -> String {
-        MeetingFailureKind.classify(message: message).rawValue
     }
 
     private func meetingStartFailureKind(from message: String) -> String {

--- a/Sources/Meeting/MeetingSessionUIPolicy.swift
+++ b/Sources/Meeting/MeetingSessionUIPolicy.swift
@@ -10,18 +10,10 @@ enum MeetingSessionUIPolicy {
 
     static func canStartQueuedTranscription(
         activeTranscriptions: Int,
-        isSpeakerReviewPending: Bool,
         isPreparingQueuedTranscriptionStart: Bool
     ) -> Bool {
         activeTranscriptions == 0
-            && !isSpeakerReviewPending
             && !isPreparingQueuedTranscriptionStart
-    }
-
-    static func shouldClearTranscriptionTriggerWhenIdle(
-        isSpeakerReviewPending: Bool
-    ) -> Bool {
-        !isSpeakerReviewPending
     }
 }
 

--- a/Sources/Speech/DictationInputDeviceSelectionPolicy.swift
+++ b/Sources/Speech/DictationInputDeviceSelectionPolicy.swift
@@ -87,12 +87,15 @@ enum DictationInputDeviceSelectionPolicy {
             return "built_in"
         }
 
-        if transport == .usb
-            || normalized.contains("usb")
-            || normalized.contains("scarlett")
-            || normalized.contains("rode")
-            || normalized.contains("shure")
-            || normalized.contains("yeti") {
+        if transport == .aggregate {
+            return "aggregate"
+        }
+
+        if transport == .virtual {
+            return "virtual"
+        }
+
+        if isExternalMicrophoneName(normalized, transport: transport) {
             return "external"
         }
 
@@ -195,6 +198,27 @@ enum DictationInputDeviceSelectionPolicy {
             || normalized.contains("built-in")
             || normalized.contains("built in")
             || normalized.contains("studio display")
+    }
+
+    private static func isExternalMicrophoneName(
+        _ normalized: String,
+        transport: DictationAudioTransport
+    ) -> Bool {
+        transport == .usb
+            || normalized.contains("usb")
+            || normalized.contains("audio interface")
+            || normalized.contains("camera")
+            || normalized.contains("c920")
+            || normalized.contains("elgato")
+            || normalized.contains("external")
+            || normalized.contains("interface")
+            || normalized.contains("logitech")
+            || normalized.contains("mv7")
+            || normalized.contains("rode")
+            || normalized.contains("scarlett")
+            || normalized.contains("shure")
+            || normalized.contains("webcam")
+            || normalized.contains("yeti")
     }
 
     private static func normalize(_ value: String) -> String {

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -24,6 +24,28 @@ private enum InputDeviceLookupError: Error {
     case unknownDevice
 }
 
+private enum ParakeetAudioEngineWorkError: LocalizedError {
+    case timedOut(operation: String, timeoutMs: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .timedOut(let operation, let timeoutMs):
+            return "Audio engine \(operation) timed out after \(timeoutMs)ms"
+        }
+    }
+}
+
+private enum ParakeetDeviceRecoveryError: LocalizedError {
+    case routeNotSettled
+
+    var errorDescription: String? {
+        switch self {
+        case .routeNotSettled:
+            return "Audio route not settled after device change"
+        }
+    }
+}
+
 private enum CoreAudioInputDeviceLookup {
     static func preferredDictationInputSelection() throws -> DictationInputDeviceSelection {
         let defaultInputID = try defaultInputDeviceID()
@@ -503,6 +525,53 @@ class ParakeetEngine: ObservableObject {
                 } catch {
                     continuation.resume(throwing: error)
                 }
+            }
+        }
+    }
+
+    private func runTimedAudioEngineWork<T>(
+        operation: String,
+        timeoutNanoseconds: UInt64 = TranscriptedConstants.audioStartOperationTimeout,
+        _ work: @escaping (AVAudioEngine) throws -> T
+    ) async throws -> T {
+        let queue = audioEngineQueue
+        let engine = audioEngine
+        let timeoutMs = Int(timeoutNanoseconds / 1_000_000)
+        let resumeLock = NSLock()
+        var didResume = false
+
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
+            func resumeOnce(_ result: Result<T, Error>) {
+                var shouldResume = false
+                resumeLock.withLock {
+                    if !didResume {
+                        didResume = true
+                        shouldResume = true
+                    }
+                }
+                guard shouldResume else { return }
+                continuation.resume(with: result)
+            }
+
+            queue.async {
+                do {
+                    resumeOnce(.success(try work(engine)))
+                } catch {
+                    resumeOnce(.failure(error))
+                }
+            }
+
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(
+                deadline: .now() + .nanoseconds(Int(timeoutNanoseconds))
+            ) {
+                resumeOnce(
+                    .failure(
+                        ParakeetAudioEngineWorkError.timedOut(
+                            operation: operation,
+                            timeoutMs: timeoutMs
+                        )
+                    )
+                )
             }
         }
     }
@@ -1204,11 +1273,7 @@ class ParakeetEngine: ObservableObject {
                             readiness: readiness
                         )
                     )
-                    await self.rebuildAudioEngine(reason: "device_change_route_not_settled")
-                    self.prewarmRetryCount = 0
-                    self.schedulePrewarmRetry()
-                    throw NSError(domain: "ParakeetEngine", code: -1,
-                        userInfo: [NSLocalizedDescriptionKey: "Audio route not settled after device change"])
+                    throw ParakeetDeviceRecoveryError.routeNotSettled
                 }
                 self.updateNativeSampleRate(snapshot.outputFormat.sampleRate)
                 self.prewarmRetryCount = 0
@@ -1329,7 +1394,10 @@ class ParakeetEngine: ObservableObject {
                             ]
                         ))
                 }
-                await self.rebuildAudioEngine(reason: "device_change_rewarm_failed")
+                let rebuildReason = error is ParakeetDeviceRecoveryError
+                    ? "device_change_route_not_settled"
+                    : "device_change_rewarm_failed"
+                await self.rebuildAudioEngine(reason: rebuildReason)
                 if failureAction.schedulePrewarmRetry {
                     self.prewarmRetryCount = 0
                     self.schedulePrewarmRetry()
@@ -1609,7 +1677,7 @@ class ParakeetEngine: ObservableObject {
     ) async throws -> ParakeetAudioInputSnapshot {
         let selection = Self.loadDictationInputDeviceSelection()
         if let selection, selection.didOverrideDefault {
-            let shouldApplyOverride = await runAudioEngineWork { engine in
+            let shouldApplyOverride = try await runTimedAudioEngineWork(operation: "\(operation)_device_check") { engine in
                 engine.inputNode.auAudioUnit.deviceID != selection.selectedInput.id
             }
             if let recoveryGeneration, recoveryState.isStale(generation: recoveryGeneration) {
@@ -1624,7 +1692,7 @@ class ParakeetEngine: ObservableObject {
             throw CancellationError()
         }
         let snapshotGraphGeneration = audioGraphGeneration
-        let snapshot = await runAudioEngineWork { audioEngine in
+        let snapshot = try await runTimedAudioEngineWork(operation: "\(operation)_snapshot") { audioEngine in
             let inputNode = audioEngine.inputNode
             let selectionApplication = Self.applyPreferredDictationInputDevice(selection, to: inputNode)
             return ParakeetAudioInputSnapshot(
@@ -1641,12 +1709,58 @@ class ParakeetEngine: ObservableObject {
         if snapshotGraphGeneration == audioGraphGeneration {
             recordInputSelection(snapshot.selectionApplication, operation: operation)
         }
-        return snapshot
+
+        guard snapshot.selectionApplication?.didApplyOverride == true else {
+            return snapshot
+        }
+
+        try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
+        if let recoveryGeneration, recoveryState.isStale(generation: recoveryGeneration) {
+            throw CancellationError()
+        }
+
+        let settledGraphGeneration = audioGraphGeneration
+        let settledSnapshot = try await runTimedAudioEngineWork(operation: "\(operation)_settled_snapshot") { audioEngine in
+            let inputNode = audioEngine.inputNode
+            return ParakeetAudioInputSnapshot(
+                outputFormat: Self.audioFormatSummary(inputNode.outputFormat(forBus: 0)),
+                hwFormat: Self.audioFormatSummary(inputNode.inputFormat(forBus: 0)),
+                selection: selection,
+                selectionApplication: snapshot.selectionApplication,
+                engineWasRunning: audioEngine.isRunning
+            )
+        }
+        if let recoveryGeneration, recoveryState.isStale(generation: recoveryGeneration) {
+            throw CancellationError()
+        }
+        if settledGraphGeneration == audioGraphGeneration {
+            let readiness = audioFormatReadiness(
+                outputFormat: settledSnapshot.outputFormat,
+                hwFormat: settledSnapshot.hwFormat,
+                selection: settledSnapshot.selection
+            )
+            EventReporter.shared.capture(
+                level: .info,
+                engine: "parakeet",
+                event: "dictation_input_device_override_settled",
+                message: "Dictation input override settled before reading microphone format",
+                context: audioFormatContext(
+                    outputFormat: settledSnapshot.outputFormat,
+                    hwFormat: settledSnapshot.hwFormat,
+                    selection: settledSnapshot.selection,
+                    readiness: readiness
+                ).merging(
+                    ["operation": operation],
+                    uniquingKeysWith: { current, _ in current }
+                )
+            )
+        }
+        return settledSnapshot
     }
 
     private func installTapAndStartEngine(isRecoveryAttempt: Bool) async throws -> ParakeetAudioStartSnapshot {
         let wasPrewarmed = isEnginePrewarmed
-        return try await runAudioEngineWork { audioEngine in
+        return try await runTimedAudioEngineWork(operation: "start_recording") { audioEngine in
             let inputNode = audioEngine.inputNode
             inputNode.removeTap(onBus: 0)
             inputNode.installTap(onBus: 0, bufferSize: TranscriptedConstants.audioTapBufferSize, format: nil) { [weak self] buffer, _ in
@@ -2114,18 +2228,25 @@ class ParakeetEngine: ObservableObject {
             do {
                 snapshot = try await audioInputSnapshot(operation: "start_recording")
             } catch {
+                let operationTimedOut = error is ParakeetAudioEngineWorkError
                 EventReporter.shared.capture(
-                    level: .warning,
+                    level: operationTimedOut ? .error : .warning,
                     engine: "parakeet",
-                    event: "audio_format_unavailable",
-                    message: "Audio hardware format could not be read while starting dictation",
+                    event: operationTimedOut ? "audio_format_read_timeout" : "audio_format_unavailable",
+                    message: operationTimedOut
+                        ? "Audio hardware format read timed out while starting dictation"
+                        : "Audio hardware format could not be read while starting dictation",
                     context: [
                         "attempt": "\(attempt)",
                         "start_mode": isRecoveryAttempt ? "recovery" : "normal",
                         "error": error.localizedDescription
                     ]
                 )
-                await resetAudioGraphAfterStartFailure(reason: "audio_format_read_failed", rebuildEngine: true)
+                if operationTimedOut {
+                    abandonBlockedAudioEngine(reason: "audio_format_read_timeout")
+                } else {
+                    await resetAudioGraphAfterStartFailure(reason: "audio_format_read_failed", rebuildEngine: true)
+                }
                 markFormatUnreadyAndPublish()
                 schedulePrewarmRetry()
                 return false
@@ -2218,6 +2339,7 @@ class ParakeetEngine: ObservableObject {
                         ])
                 }
             } catch {
+                let operationTimedOut = error is ParakeetAudioEngineWorkError
                 let context = audioStartContext(
                     attempt: attempt,
                     isRecoveryAttempt: isRecoveryAttempt,
@@ -2226,16 +2348,23 @@ class ParakeetEngine: ObservableObject {
                     hwFormat: snapshot.hwFormat,
                     error: error
                 )
-                let failureReason = ParakeetAudioFormatReadinessPolicy.startFailureReason(for: error as NSError)
-                let shouldRetry = failureReason == .audioEngineStartFailed
+                let failureReason = operationTimedOut
+                    ? ParakeetStartRecordingFailureReason.audioEngineStartFailed
+                    : ParakeetAudioFormatReadinessPolicy.startFailureReason(for: error as NSError)
+                let shouldRetry = !operationTimedOut
+                    && failureReason == .audioEngineStartFailed
                     && ParakeetAudioStartRecoveryPolicy.shouldRetryStartFailure(
                     isRecoveryAttempt: isRecoveryAttempt,
                     failedAttempts: attempt
                 )
-                await resetAudioGraphAfterStartFailure(
-                    reason: failureReason == .audioRouteNotSettled ? "audio_route_not_settled" : "audio_engine_start_failed",
-                    rebuildEngine: true
-                )
+                if operationTimedOut {
+                    abandonBlockedAudioEngine(reason: "audio_engine_start_timeout")
+                } else {
+                    await resetAudioGraphAfterStartFailure(
+                        reason: failureReason == .audioRouteNotSettled ? "audio_route_not_settled" : "audio_engine_start_failed",
+                        rebuildEngine: true
+                    )
+                }
 
                 if shouldRetry {
                     startGeneration = audioGraphGeneration
@@ -2261,6 +2390,28 @@ class ParakeetEngine: ObservableObject {
                     )
                     let startFailureAction = ParakeetStartRecordingFailurePolicy.action(
                         for: failureReason,
+                        isRecoveryAttempt: isRecoveryAttempt
+                    )
+                    if startFailureAction.markFormatUnready {
+                        markStartFailedAndPublish()
+                    }
+                    if startFailureAction.schedulePrewarmRetry {
+                        schedulePrewarmRetry()
+                    }
+                    return false
+                }
+
+                if operationTimedOut {
+                    print("❌ PARAKEET | audio engine start timed out after \(attempt) attempt(s): \(error.localizedDescription)")
+                    EventReporter.shared.capture(
+                        level: .error,
+                        engine: "parakeet",
+                        event: "audio_engine_start_timeout",
+                        message: "Audio engine start timed out; abandoned blocked microphone graph",
+                        context: context
+                    )
+                    let startFailureAction = ParakeetStartRecordingFailurePolicy.action(
+                        for: .audioEngineStartFailed,
                         isRecoveryAttempt: isRecoveryAttempt
                     )
                     if startFailureAction.markFormatUnready {
@@ -2840,6 +2991,37 @@ class ParakeetEngine: ObservableObject {
         audioGraphGeneration += 1
         let cleanupGeneration = audioGraphGeneration
         await releaseIdleAudioHardware(removeTap: true, expectedGeneration: cleanupGeneration)
+    }
+
+    func abandonBlockedRecordingStart(reason: String) {
+        cancelAudioWatchdog()
+        prewarmRetryTask?.cancel()
+        prewarmRetryTask = nil
+        configChangeDebounceTask?.cancel()
+        configChangeDebounceTask = nil
+        configRecoveryTask?.cancel()
+        configRecoveryTask = nil
+        cancelConfigRecoveryTimeout()
+        configChangeWasRecording = false
+        recoveryState.reset()
+        recoveryState.markFormatUnready()
+        publishRecoveryState()
+        pendingSamplesLock.withLock {
+            pendingSamples.removeAll(keepingCapacity: true)
+        }
+        streamingSamplesLock.withLock {
+            streamingSampleBuffer.removeAll(keepingCapacity: true)
+        }
+        Task { await eouManager?.reset() }
+        isRecording = false
+        isTranscribing = false
+        audioStartInProgress = false
+        audioLevel = 0
+        didReceiveAudioSamples = false
+        sampleBuffer.removeAll(keepingCapacity: true)
+        liveTranscript = ""
+        committedStreamText = ""
+        abandonBlockedAudioEngine(reason: reason)
     }
 
     func cancel() {

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -532,6 +532,7 @@ class ParakeetEngine: ObservableObject {
     private func runTimedAudioEngineWork<T>(
         operation: String,
         timeoutNanoseconds: UInt64 = TranscriptedConstants.audioStartOperationTimeout,
+        cleanupAfterLateCompletion: ((AVAudioEngine) -> Void)? = nil,
         _ work: @escaping (AVAudioEngine) throws -> T
     ) async throws -> T {
         let queue = audioEngineQueue
@@ -554,10 +555,28 @@ class ParakeetEngine: ObservableObject {
             }
 
             queue.async {
+                let shouldRun = resumeLock.withLock { !didResume }
+                guard shouldRun else { return }
+
+                let result: Result<T, Error>
                 do {
-                    resumeOnce(.success(try work(engine)))
+                    result = .success(try work(engine))
                 } catch {
-                    resumeOnce(.failure(error))
+                    result = .failure(error)
+                }
+
+                var completedBeforeTimeout = false
+                resumeLock.withLock {
+                    if !didResume {
+                        didResume = true
+                        completedBeforeTimeout = true
+                    }
+                }
+
+                if completedBeforeTimeout {
+                    continuation.resume(with: result)
+                } else {
+                    cleanupAfterLateCompletion?(engine)
                 }
             }
 
@@ -574,6 +593,14 @@ class ParakeetEngine: ObservableObject {
                 )
             }
         }
+    }
+
+    private static func cleanUpLateAudioStart(on audioEngine: AVAudioEngine) {
+        audioEngine.inputNode.removeTap(onBus: 0)
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+        audioEngine.reset()
     }
 
     private func runAudioEngineWork<T>(_ work: @escaping (AVAudioEngine) -> T) async -> T {
@@ -1760,7 +1787,10 @@ class ParakeetEngine: ObservableObject {
 
     private func installTapAndStartEngine(isRecoveryAttempt: Bool) async throws -> ParakeetAudioStartSnapshot {
         let wasPrewarmed = isEnginePrewarmed
-        return try await runTimedAudioEngineWork(operation: "start_recording") { audioEngine in
+        return try await runTimedAudioEngineWork(
+            operation: "start_recording",
+            cleanupAfterLateCompletion: Self.cleanUpLateAudioStart(on:)
+        ) { audioEngine in
             let inputNode = audioEngine.inputNode
             inputNode.removeTap(onBus: 0)
             inputNode.installTap(onBus: 0, bufferSize: TranscriptedConstants.audioTapBufferSize, format: nil) { [weak self] buffer, _ in

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -69,7 +69,7 @@ enum ParakeetDeviceRecoveryTimeoutPolicy {
 enum ParakeetAudioEngineRetirementPolicy {
     /// CoreAudio can still deliver queued AVAudioIOUnit property-listener blocks
     /// after Transcripted has stopped and replaced an AVAudioEngine during route churn.
-    static let deferredReleaseDelayNanoseconds: UInt64 = 3_000_000_000
+    static let deferredReleaseDelayNanoseconds: UInt64 = 5_000_000_000
 }
 
 enum ParakeetASRManagerCleanupDecision: Equatable {
@@ -122,8 +122,7 @@ enum ParakeetAudioFormatReadinessPolicy {
             return .invalid
         }
 
-        if selectionOverrodeDefault,
-           selectedInputClass != "bluetooth",
+        if selectedInputClass != "bluetooth",
            outputDeviceClass != "bluetooth",
            inputSampleRate >= 44_100,
            likelyBluetoothSpeechRates.contains(Int(outputSampleRate.rounded())) {

--- a/Sources/Speech/STTRouter.swift
+++ b/Sources/Speech/STTRouter.swift
@@ -128,6 +128,11 @@ class STTRouter: ObservableObject {
         await parakeetEngine.resetAfterFailedRecordingStart()
     }
 
+    func abandonBlockedRecordingStart(reason: String) {
+        activeRecordingModel = nil
+        parakeetEngine.abandonBlockedRecordingStart(reason: reason)
+    }
+
     func transcribe() async -> String? {
         let model = activeRecordingModel ?? selectedModel
         defer {

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -68,7 +68,11 @@ enum TranscriptedConstants {
     /// Max time a device-change recovery may stay active before being marked
     /// failed. This leaves room inside `dictationRecoveryBudget` for a fallback
     /// prewarm/start attempt.
-    static let audioDeviceRecoveryTimeout: UInt64 = 2_000_000_000  // 2 seconds
+    static let audioDeviceRecoveryTimeout: UInt64 = 4_000_000_000  // 4 seconds
+
+    /// Max time a single CoreAudio startup operation may sit on the audio-engine
+    /// worker before Transcripted treats the graph as blocked and rebuilds it.
+    static let audioStartOperationTimeout: UInt64 = 1_500_000_000  // 1.5 seconds
 
     /// Total budget for dictation to wait on engine readiness after a device change.
     /// Sized to cover slower USB/Bluetooth CoreAudio graph rebuilds without trapping

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -380,7 +380,7 @@ extension TranscriptionTaskManager {
 
             let capturedEntries = namingEntries
             await MainActor.run {
-                self.speakerNamingRequest = SpeakerNamingRequest(
+                self.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
                     speakers: capturedEntries,
                     knownPeople: knownPeople,
                     transcriptURL: savedURL,
@@ -400,7 +400,7 @@ extension TranscriptionTaskManager {
                             clips: capturedEntries
                         )
                     }
-                )
+                ))
             }
 
             AppLogger.pipeline.info("Speaker naming requested", [

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -189,13 +189,7 @@ public class TranscriptionTaskManager: ObservableObject {
                 )
 
                 await MainActor.run {
-                    if self.speakerNamingRequest == nil {
-                        self.populateSavedMetadata(from: transcriptURL)
-                        self.publishNonFailureStatus(.transcriptSaved)
-                        self.scheduleStatusReset(delay: 4)
-                    } else {
-                        self.publishNonFailureStatus(.finishing)
-                    }
+                    self.publishTranscriptSaved(from: transcriptURL)
                     self.handleTaskCompletion(taskId: task.id)
                 }
 
@@ -289,13 +283,7 @@ public class TranscriptionTaskManager: ObservableObject {
                 )
 
                 await MainActor.run {
-                    if self.speakerNamingRequest == nil {
-                        self.populateSavedMetadata(from: transcriptURL)
-                        self.publishNonFailureStatus(.transcriptSaved)
-                        self.scheduleStatusReset(delay: 4)
-                    } else {
-                        self.publishNonFailureStatus(.finishing)
-                    }
+                    self.publishTranscriptSaved(from: transcriptURL)
                     self.handleTaskCompletion(taskId: taskId)
                 }
             } catch {
@@ -443,6 +431,12 @@ public class TranscriptionTaskManager: ObservableObject {
         displayStatus = status
     }
 
+    func publishTranscriptSaved(from transcriptURL: URL) {
+        populateSavedMetadata(from: transcriptURL)
+        publishNonFailureStatus(.transcriptSaved)
+        scheduleStatusReset(delay: 4)
+    }
+
     public func addFailedTranscriptionRetainingAudio(
         micAudioURL: URL,
         systemAudioURL: URL?,
@@ -532,13 +526,7 @@ public class TranscriptionTaskManager: ObservableObject {
                 self.activeTasks.removeValue(forKey: failedId)
                 self.activeCount = max(0, self.activeCount - 1)
                 self.backgroundTaskCount = max(0, self.backgroundTaskCount - 1)
-                if self.speakerNamingRequest == nil {
-                    self.populateSavedMetadata(from: transcriptURL)
-                    self.publishNonFailureStatus(.transcriptSaved)
-                    self.scheduleStatusReset(delay: 4)
-                } else {
-                    self.publishNonFailureStatus(.finishing)
-                }
+                self.publishTranscriptSaved(from: transcriptURL)
             }
 
             return true
@@ -609,9 +597,12 @@ public class TranscriptionTaskManager: ObservableObject {
         Task { [weak self] in
             try? await Task.sleep(for: .seconds(delay))
             guard let self else { return }
-            // Don't reset if speaker naming is in progress —
-            // SpeakerNamingCoordinator will re-publish .transcriptSaved when done
-            guard self.speakerNamingRequest == nil else { return }
+            if self.speakerNamingRequest != nil {
+                if case .transcriptSaved = self.displayStatus {
+                    self.publishNonFailureStatus(.idle)
+                }
+                return
+            }
             switch self.displayStatus {
             case .transcriptSaved, .failed:
                 self.publishNonFailureStatus(.idle)

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -19,7 +19,11 @@ public class TranscriptionTaskManager: ObservableObject {
     @Published public var lastSavedSpeakerCount: Int? = nil
     @Published public private(set) var lastFailureDiagnosticMessage: String? = nil
 
+    var lastSavedTranscriptId: UUID?
     var activeTasks: [UUID: Task<Void, Never>] = [:]
+    private var activeTaskAudio: [UUID: (micURL: URL, systemURL: URL?)] = [:]
+    private var preservedTaskIdsForShutdown: Set<UUID> = []
+    var pendingSpeakerNamingRequests: [SpeakerNamingRequest] = []
     public let transcription: Transcription
 
     public let failedTranscriptionManager: FailedTranscriptionManager
@@ -78,7 +82,7 @@ public class TranscriptionTaskManager: ObservableObject {
         // Guard: reject concurrent pipelines to prevent model contention
         if !activeTasks.isEmpty {
             AppLogger.pipeline.warning("Rejecting transcription — another pipeline is already active", ["activeCount": "\(activeTasks.count)"])
-            failedTranscriptionManager.addFailedTranscription(
+            addFailedTranscriptionRetainingAudio(
                 micAudioURL: micURL,
                 systemAudioURL: systemURL,
                 errorMessage: "Transcription already in progress"
@@ -94,17 +98,8 @@ public class TranscriptionTaskManager: ObservableObject {
         guard systemURL != nil else {
             let errorMessage = PipelineError.missingSystemAudio.localizedDescription
             AppLogger.pipeline.warning("Rejecting transcription — system audio capture is missing")
-            let retainedAudio = archiveFailedRecordingAudioIfConfigured(
-                micURL: micURL,
-                systemURL: nil,
-                taskId: UUID()
-            )
-            let failedMicURL = retainedAudio?.micURL ?? micURL
-            if retainedAudio?.micURL != nil {
-                removeManagedCleanupFile(micURL, label: "archived failed mic scratch")
-            }
-            failedTranscriptionManager.addFailedTranscription(
-                micAudioURL: failedMicURL,
+            addFailedTranscriptionRetainingAudio(
+                micAudioURL: micURL,
                 systemAudioURL: nil,
                 errorMessage: errorMessage
             )
@@ -124,10 +119,11 @@ public class TranscriptionTaskManager: ObservableObject {
         let minDuration: TimeInterval = 2.0
         let micDuration = audioDuration(url: micURL)
         let systemDuration = systemURL.flatMap { audioDuration(url: $0) }
-        let hasUsableMicAudio = (micDuration ?? 0) >= minDuration
-        let hasUsableSystemAudio = (systemDuration ?? 0) >= minDuration
+        let hasUsableMicAudio = micDuration.map { $0 >= minDuration } ?? false
+        let hasUsableSystemAudio = systemDuration.map { $0 >= minDuration } ?? false
+        let hasUnknownDuration = micDuration == nil || (systemURL != nil && systemDuration == nil)
 
-        guard hasUsableMicAudio || hasUsableSystemAudio else {
+        guard hasUsableMicAudio || hasUsableSystemAudio || hasUnknownDuration else {
             AppLogger.pipeline.info("Recording too short, skipping transcription", [
                 "micDuration": micDuration.map { String(format: "%.1fs", $0) } ?? "unknown",
                 "systemDuration": systemDuration.map { String(format: "%.1fs", $0) } ?? "none"
@@ -144,6 +140,13 @@ public class TranscriptionTaskManager: ObservableObject {
             )
             self.scheduleStatusReset(delay: 3)
             return
+        }
+
+        if hasUnknownDuration {
+            AppLogger.pipeline.warning("Recording duration could not be verified; preserving retry path instead of treating it as short", [
+                "micDuration": micDuration.map { String(format: "%.1fs", $0) } ?? "unknown",
+                "systemDuration": systemDuration.map { String(format: "%.1fs", $0) } ?? (systemURL == nil ? "none" : "unknown")
+            ])
         }
 
         if !hasUsableMicAudio, hasUsableSystemAudio {
@@ -164,6 +167,7 @@ public class TranscriptionTaskManager: ObservableObject {
 
         activeCount += 1
         backgroundTaskCount += 1
+        activeTaskAudio[task.id] = (micURL: micURL, systemURL: systemURL)
         publishNonFailureStatus(.gettingReady)
 
         AppLogger.pipeline.info("Starting transcription task", [
@@ -197,27 +201,20 @@ public class TranscriptionTaskManager: ObservableObject {
                 AppLogger.pipeline.error("Transcription task failed", ["taskId": "\(task.id)", "error": "\(error.localizedDescription)"])
 
                 await MainActor.run {
-                    let retainedAudio = self.archiveFailedRecordingAudioIfConfigured(
-                        micURL: micURL,
-                        systemURL: systemURL,
-                        taskId: task.id
-                    )
-                    let failedMicURL = retainedAudio?.micURL ?? micURL
-                    let failedSystemURL = retainedAudio?.systemURL ?? systemURL
-                    if retainedAudio?.micURL != nil {
-                        self.removeManagedCleanupFile(micURL, label: "archived failed mic scratch")
+                    if self.preservedTaskIdsForShutdown.remove(task.id) != nil {
+                        self.handleTaskCompletion(taskId: task.id)
+                        return
                     }
-                    if retainedAudio?.systemURL != nil {
-                        self.removeManagedCleanupFile(systemURL, label: "archived failed system scratch")
-                    }
+
                     self.publishFailure(
                         displayMessage: "Transcription failed",
                         diagnosticMessage: Self.safeFailureDiagnosticMessage(for: error)
                     )
-                    self.failedTranscriptionManager.addFailedTranscription(
-                        micAudioURL: failedMicURL,
-                        systemAudioURL: failedSystemURL,
-                        errorMessage: error.localizedDescription
+                    self.addFailedTranscriptionRetainingAvailableAudio(
+                        micAudioURL: micURL,
+                        systemAudioURL: systemURL,
+                        errorMessage: error.localizedDescription,
+                        taskId: task.id
                     )
                     self.sendFailureNotification(errorMessage: error.localizedDescription)
                     self.handleTaskCompletion(taskId: task.id)
@@ -443,24 +440,129 @@ public class TranscriptionTaskManager: ObservableObject {
         errorMessage: String,
         taskId: UUID = UUID()
     ) {
+        _ = addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: micAudioURL,
+            systemAudioURL: systemAudioURL,
+            errorMessage: errorMessage,
+            taskId: taskId
+        )
+    }
+
+    @discardableResult
+    public func addFailedTranscriptionRetainingAvailableAudio(
+        micAudioURL: URL?,
+        systemAudioURL: URL?,
+        errorMessage: String,
+        taskId: UUID = UUID()
+    ) -> Bool {
+        guard micAudioURL != nil || systemAudioURL != nil else {
+            AppLogger.pipeline.error("No audio files available to retain for failed transcription", [
+                "taskId": taskId.uuidString
+            ])
+            return false
+        }
+
         let retainedAudio = archiveFailedRecordingAudioIfConfigured(
             micURL: micAudioURL,
             systemURL: systemAudioURL,
             taskId: taskId
         )
-        let failedMicURL = retainedAudio?.micURL ?? micAudioURL
-        let failedSystemURL = retainedAudio?.systemURL ?? systemAudioURL
-        if retainedAudio?.micURL != nil {
-            removeManagedCleanupFile(micAudioURL, label: "archived failed mic scratch")
+        return enqueueFailedTranscriptionAfterRetainingAudio(
+            retainedAudio: retainedAudio,
+            originalMicURL: micAudioURL,
+            originalSystemURL: systemAudioURL,
+            errorMessage: errorMessage
+        )
+    }
+
+    @discardableResult
+    private func enqueueFailedTranscriptionAfterRetainingAudio(
+        retainedAudio: RetainedRecordingAudio?,
+        originalMicURL: URL?,
+        originalSystemURL: URL?,
+        errorMessage: String
+    ) -> Bool {
+        let failedSystemURL = retainedAudio?.systemURL ?? originalSystemURL
+        let placeholderMicURL = makeSilentMicPlaceholderIfNeeded(
+            retainedAudio: retainedAudio,
+            hasOriginalMic: originalMicURL != nil,
+            failedSystemURL: failedSystemURL
+        )
+        guard let failedMicURL = retainedAudio?.micURL ?? originalMicURL ?? placeholderMicURL else {
+            AppLogger.pipeline.error("Failed transcription was not queued because no microphone track or placeholder is available")
+            return false
         }
-        if retainedAudio?.systemURL != nil {
-            removeManagedCleanupFile(systemAudioURL, label: "archived failed system scratch")
-        }
-        failedTranscriptionManager.addFailedTranscription(
+
+        let didPersist = failedTranscriptionManager.addFailedTranscription(
             micAudioURL: failedMicURL,
             systemAudioURL: failedSystemURL,
             errorMessage: errorMessage
         )
+        guard didPersist else { return false }
+
+        if retainedAudio?.micURL != nil {
+            removeManagedCleanupFile(originalMicURL, label: "archived failed mic scratch")
+        } else if placeholderMicURL != nil {
+            removeManagedCleanupFile(originalMicURL, label: "missing failed mic scratch")
+        }
+        if retainedAudio?.systemURL != nil {
+            removeManagedCleanupFile(originalSystemURL, label: "archived failed system scratch")
+        }
+        return true
+    }
+
+    private func makeSilentMicPlaceholderIfNeeded(
+        retainedAudio: RetainedRecordingAudio?,
+        hasOriginalMic: Bool,
+        failedSystemURL: URL?
+    ) -> URL? {
+        guard !hasOriginalMic,
+              let failedSystemURL else {
+            return nil
+        }
+
+        let placeholderDirectory = retainedAudio?.directory ?? failedSystemURL.deletingLastPathComponent()
+        let placeholderURL = placeholderDirectory
+            .appendingPathComponent("microphone_placeholder")
+            .appendingPathExtension("wav")
+        do {
+            try FileManager.default.createDirectory(
+                at: placeholderDirectory,
+                withIntermediateDirectories: true
+            )
+            try Self.writeSilentWAV(to: placeholderURL, duration: 2.5)
+            FileManager.default.restrictToOwnerOnly(atPath: placeholderURL.path)
+            AppLogger.pipeline.warning("Created silent microphone placeholder for system-only failed meeting audio")
+            return placeholderURL
+        } catch {
+            AppLogger.pipeline.error("Failed to create silent microphone placeholder", [
+                "error": error.localizedDescription
+            ])
+            return nil
+        }
+    }
+
+    private static func writeSilentWAV(to url: URL, duration: TimeInterval) throws {
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw PipelineError.invalidAudioFormat(detail: "Could not create placeholder audio format")
+        }
+        let frameCount = AVAudioFrameCount((duration * format.sampleRate).rounded(.up))
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount) else {
+            throw PipelineError.invalidAudioFormat(detail: "Could not create placeholder audio buffer")
+        }
+        buffer.frameLength = frameCount
+        let file = try AVAudioFile(
+            forWriting: url,
+            settings: format.settings,
+            commonFormat: format.commonFormat,
+            interleaved: format.isInterleaved
+        )
+        try file.write(from: buffer)
     }
 
     /// Retry a failed transcription by its ID
@@ -551,6 +653,8 @@ public class TranscriptionTaskManager: ObservableObject {
 
     func handleTaskCompletion(taskId: UUID) {
         activeTasks.removeValue(forKey: taskId)
+        activeTaskAudio.removeValue(forKey: taskId)
+        preservedTaskIdsForShutdown.remove(taskId)
         activeCount = max(0, activeCount - 1)
         backgroundTaskCount = max(0, backgroundTaskCount - 1)
 
@@ -571,9 +675,47 @@ public class TranscriptionTaskManager: ObservableObject {
             AppLogger.pipeline.info("Cancelled task", ["taskId": "\(taskId)"])
         }
         activeTasks.removeAll()
+        activeTaskAudio.removeAll()
+        preservedTaskIdsForShutdown.removeAll()
         activeCount = 0
         backgroundTaskCount = 0
         publishNonFailureStatus(.idle)
+    }
+
+    @discardableResult
+    public func preserveActiveTranscriptionsForShutdown(errorMessage: String) -> Int {
+        let activeAudio = activeTaskAudio
+        guard !activeAudio.isEmpty else { return 0 }
+
+        for taskId in activeAudio.keys {
+            preservedTaskIdsForShutdown.insert(taskId)
+        }
+
+        for (taskId, task) in activeTasks {
+            task.cancel()
+            AppLogger.pipeline.warning("Preserving active transcription audio during shutdown", [
+                "taskId": taskId.uuidString
+            ])
+        }
+
+        activeTasks.removeAll()
+        activeTaskAudio.removeAll()
+        activeCount = 0
+        backgroundTaskCount = 0
+        publishNonFailureStatus(.idle)
+
+        var preservedCount = 0
+        for (taskId, audio) in activeAudio {
+            if addFailedTranscriptionRetainingAvailableAudio(
+                micAudioURL: audio.micURL,
+                systemAudioURL: audio.systemURL,
+                errorMessage: errorMessage,
+                taskId: taskId
+            ) {
+                preservedCount += 1
+            }
+        }
+        return preservedCount
     }
 
     /// Populate saved transcript metadata from the file's YAML frontmatter.
@@ -581,10 +723,14 @@ public class TranscriptionTaskManager: ObservableObject {
     /// (many speakers, gap events, etc.) still parse without reading the whole file.
     func populateSavedMetadata(from url: URL) {
         lastSavedTranscriptURL = url
+        lastSavedTranscriptId = nil
         let name = url.deletingPathExtension().lastPathComponent
         lastSavedTitle = name.replacingOccurrences(of: "_", with: " ").replacingOccurrences(of: "-", with: " ")
         guard let values = try? TranscriptFrontmatter.readValues(from: url) else { return }
 
+        if let transcriptId = values["transcript_id"] {
+            lastSavedTranscriptId = UUID(uuidString: transcriptId)
+        }
         if let title = values["title"] {
             lastSavedTitle = title
         }

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -17,6 +17,7 @@ public class TranscriptionTaskManager: ObservableObject {
     @Published public var lastSavedTitle: String? = nil
     @Published public var lastSavedDuration: String? = nil
     @Published public var lastSavedSpeakerCount: Int? = nil
+    @Published public private(set) var lastFailureDiagnosticMessage: String? = nil
 
     var activeTasks: [UUID: Task<Void, Never>] = [:]
     public let transcription: Transcription
@@ -82,7 +83,10 @@ public class TranscriptionTaskManager: ObservableObject {
                 systemAudioURL: systemURL,
                 errorMessage: "Transcription already in progress"
             )
-            displayStatus = .failed(message: "Transcription already in progress")
+            publishFailure(
+                displayMessage: "Transcription already in progress",
+                diagnosticMessage: "Transcription already in progress"
+            )
             scheduleStatusReset(delay: 4)
             return
         }
@@ -104,7 +108,10 @@ public class TranscriptionTaskManager: ObservableObject {
                 systemAudioURL: nil,
                 errorMessage: errorMessage
             )
-            displayStatus = .failed(message: "System audio required")
+            publishFailure(
+                displayMessage: "System audio required",
+                diagnosticMessage: errorMessage
+            )
             sendFailureNotification(errorMessage: errorMessage)
             scheduleStatusReset(delay: 4)
             return
@@ -131,7 +138,10 @@ public class TranscriptionTaskManager: ObservableObject {
                 removeRecordingFile(systemURL, label: "short system recording")
             }
 
-            self.displayStatus = .failed(message: "Recording too short")
+            self.publishFailure(
+                displayMessage: "Recording too short",
+                diagnosticMessage: "Recording too short"
+            )
             self.scheduleStatusReset(delay: 3)
             return
         }
@@ -206,7 +216,10 @@ public class TranscriptionTaskManager: ObservableObject {
                     if retainedAudio?.systemURL != nil {
                         self.removeManagedCleanupFile(systemURL, label: "archived failed system scratch")
                     }
-                    self.displayStatus = .failed(message: "Transcription failed")
+                    self.publishFailure(
+                        displayMessage: "Transcription failed",
+                        diagnosticMessage: Self.safeFailureDiagnosticMessage(for: error)
+                    )
                     self.failedTranscriptionManager.addFailedTranscription(
                         micAudioURL: failedMicURL,
                         systemAudioURL: failedSystemURL,
@@ -232,7 +245,10 @@ public class TranscriptionTaskManager: ObservableObject {
         if !activeTasks.isEmpty {
             AppLogger.pipeline.warning("Rejecting imported transcription — another pipeline is already active", ["activeCount": "\(activeTasks.count)"])
             removeRecordingFile(audioURL, label: "rejected imported recording")
-            displayStatus = .failed(message: "Transcription already in progress")
+            publishFailure(
+                displayMessage: "Transcription already in progress",
+                diagnosticMessage: "Transcription already in progress"
+            )
             scheduleStatusReset(delay: 4)
             return
         }
@@ -241,7 +257,10 @@ public class TranscriptionTaskManager: ObservableObject {
         if let audioDuration = audioDuration(url: audioURL), audioDuration < minDuration {
             AppLogger.pipeline.info("Imported recording too short, skipping transcription", ["duration": String(format: "%.1fs", audioDuration)])
             removeRecordingFile(audioURL, label: "short imported recording")
-            displayStatus = .failed(message: "Recording too short")
+            publishFailure(
+                displayMessage: "Recording too short",
+                diagnosticMessage: "Recording too short"
+            )
             scheduleStatusReset(delay: 3)
             return
         }
@@ -287,7 +306,10 @@ public class TranscriptionTaskManager: ObservableObject {
 
                 await MainActor.run {
                     self.removeRecordingFile(audioURL, label: "failed imported recording")
-                    self.displayStatus = .failed(message: "Transcription failed")
+                    self.publishFailure(
+                        displayMessage: "Transcription failed",
+                        diagnosticMessage: Self.safeFailureDiagnosticMessage(for: error)
+                    )
                     self.sendFailureNotification(errorMessage: error.localizedDescription)
                     self.handleTaskCompletion(taskId: taskId)
                     self.scheduleStatusReset(delay: 4)
@@ -296,6 +318,150 @@ public class TranscriptionTaskManager: ObservableObject {
         }
 
         activeTasks[taskId] = asyncTask
+    }
+
+    public static func safeFailureDiagnosticMessage(for error: Error) -> String {
+        if let pipelineError = error as? PipelineError {
+            switch pipelineError {
+            case .emptyAudioFile:
+                return "Empty audio file"
+            case .recordingTooShort:
+                return "Recording too short"
+            case .invalidAudioFormat:
+                return "Invalid audio format"
+            case .missingSystemAudio:
+                return PipelineError.missingSystemAudio.localizedDescription
+            case .modelNotLoaded(let model):
+                return "\(model) model not loaded"
+            case .modelInferenceFailed(let model, _):
+                return "\(model) inference failed"
+            case .saveFailed:
+                return "Failed to save transcript"
+            case .unknown(let underlying):
+                return safeFailureDiagnosticMessage(forText: underlying)
+            }
+        }
+
+        return safeFailureDiagnosticMessage(forText: error.localizedDescription)
+    }
+
+    private static func safeFailureDiagnosticMessage(forText message: String) -> String {
+        let normalized = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        if normalized.contains("transcription already in progress") {
+            return "Transcription already in progress"
+        }
+
+        if normalized.contains(anyOf: [
+            "system audio is required",
+            "system audio recording",
+            "screen recording",
+        ]) {
+            return PipelineError.missingSystemAudio.localizedDescription
+        }
+
+        if normalized.contains(anyOf: [
+            "recording too short",
+            "at least 1 second",
+            "at least 2 seconds",
+            "at least one second",
+            "at least two seconds",
+        ]) && (normalized.contains("audio") || normalized.contains("recording")) {
+            return "Recording too short"
+        }
+
+        if normalized.contains(anyOf: [
+            "empty audio",
+            "empty audio file",
+            "no samples recorded",
+        ]) {
+            return "Empty audio file"
+        }
+
+        if normalized.contains(anyOf: [
+            "invalid audio",
+            "invalid audio data",
+            "invalid audio format",
+        ]) {
+            return "Invalid audio format"
+        }
+
+        if normalized.contains(anyOf: [
+            "failed to save",
+            "could not write transcript",
+            "permission denied",
+        ]) {
+            return "Failed to save transcript"
+        }
+
+        if normalized.contains(anyOf: [
+            "model not loaded",
+            "models were not ready",
+            "model failed to load",
+            "speech model failed to load",
+        ]) {
+            return "Model not loaded"
+        }
+
+        if normalized.contains(anyOf: [
+            "pyannote",
+            "sortformer",
+            "wespeaker",
+            "diarization",
+        ]) {
+            return "Diarization failed"
+        }
+
+        if normalized.contains(anyOf: [
+            "asr",
+            "core ml",
+            "coreml",
+            "failed to transcribe",
+            "fluid",
+            "inference",
+            "mlmodel",
+            "multiarray",
+            "parakeet",
+            "prediction",
+            "preprocessor",
+            "transcription failed",
+            "whisper",
+        ]) {
+            return "Transcription inference failed"
+        }
+
+        return "Pipeline failed"
+    }
+
+    private func publishFailure(displayMessage: String, diagnosticMessage: String) {
+        lastFailureDiagnosticMessage = diagnosticMessage
+        displayStatus = .failed(message: displayMessage)
+    }
+
+    public func addFailedTranscriptionRetainingAudio(
+        micAudioURL: URL,
+        systemAudioURL: URL?,
+        errorMessage: String,
+        taskId: UUID = UUID()
+    ) {
+        let retainedAudio = archiveFailedRecordingAudioIfConfigured(
+            micURL: micAudioURL,
+            systemURL: systemAudioURL,
+            taskId: taskId
+        )
+        let failedMicURL = retainedAudio?.micURL ?? micAudioURL
+        let failedSystemURL = retainedAudio?.systemURL ?? systemAudioURL
+        if retainedAudio?.micURL != nil {
+            removeManagedCleanupFile(micAudioURL, label: "archived failed mic scratch")
+        }
+        if retainedAudio?.systemURL != nil {
+            removeManagedCleanupFile(systemAudioURL, label: "archived failed system scratch")
+        }
+        failedTranscriptionManager.addFailedTranscription(
+            micAudioURL: failedMicURL,
+            systemAudioURL: failedSystemURL,
+            errorMessage: errorMessage
+        )
     }
 
     /// Retry a failed transcription by its ID
@@ -378,7 +544,10 @@ public class TranscriptionTaskManager: ObservableObject {
                 self.activeTasks.removeValue(forKey: failedId)
                 self.activeCount = max(0, self.activeCount - 1)
                 self.backgroundTaskCount = max(0, self.backgroundTaskCount - 1)
-                self.displayStatus = .failed(message: "Retry failed")
+                self.publishFailure(
+                    displayMessage: "Retry failed",
+                    diagnosticMessage: "Retry failed: \(Self.safeFailureDiagnosticMessage(for: error))"
+                )
                 self.scheduleStatusReset(delay: 8)
             }
             return false
@@ -556,5 +725,11 @@ public class TranscriptionTaskManager: ObservableObject {
             ])
             return nil
         }
+    }
+}
+
+private extension String {
+    func contains(anyOf fragments: [String]) -> Bool {
+        fragments.contains(where: contains)
     }
 }

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -164,7 +164,7 @@ public class TranscriptionTaskManager: ObservableObject {
 
         activeCount += 1
         backgroundTaskCount += 1
-        displayStatus = .gettingReady
+        publishNonFailureStatus(.gettingReady)
 
         AppLogger.pipeline.info("Starting transcription task", [
             "taskId": "\(task.id)",
@@ -175,7 +175,7 @@ public class TranscriptionTaskManager: ObservableObject {
         let asyncTask = Task {
             do {
                 await MainActor.run {
-                    self.displayStatus = .transcribing(progress: 0.0)
+                    self.publishNonFailureStatus(.transcribing(progress: 0.0))
                 }
 
                 let transcriptURL = try await self.transcribeWithSpeakerIdentification(
@@ -191,10 +191,10 @@ public class TranscriptionTaskManager: ObservableObject {
                 await MainActor.run {
                     if self.speakerNamingRequest == nil {
                         self.populateSavedMetadata(from: transcriptURL)
-                        self.displayStatus = .transcriptSaved
+                        self.publishNonFailureStatus(.transcriptSaved)
                         self.scheduleStatusReset(delay: 4)
                     } else {
-                        self.displayStatus = .finishing
+                        self.publishNonFailureStatus(.finishing)
                     }
                     self.handleTaskCompletion(taskId: task.id)
                 }
@@ -268,7 +268,7 @@ public class TranscriptionTaskManager: ObservableObject {
         let taskId = UUID()
         activeCount += 1
         backgroundTaskCount += 1
-        displayStatus = .gettingReady
+        publishNonFailureStatus(.gettingReady)
 
         AppLogger.pipeline.info("Starting imported transcription task", [
             "taskId": taskId.uuidString,
@@ -278,7 +278,7 @@ public class TranscriptionTaskManager: ObservableObject {
         let asyncTask = Task {
             do {
                 await MainActor.run {
-                    self.displayStatus = .transcribing(progress: 0.0)
+                    self.publishNonFailureStatus(.transcribing(progress: 0.0))
                 }
 
                 let transcriptURL = try await self.transcribeImportedAudio(
@@ -291,10 +291,10 @@ public class TranscriptionTaskManager: ObservableObject {
                 await MainActor.run {
                     if self.speakerNamingRequest == nil {
                         self.populateSavedMetadata(from: transcriptURL)
-                        self.displayStatus = .transcriptSaved
+                        self.publishNonFailureStatus(.transcriptSaved)
                         self.scheduleStatusReset(delay: 4)
                     } else {
-                        self.displayStatus = .finishing
+                        self.publishNonFailureStatus(.finishing)
                     }
                     self.handleTaskCompletion(taskId: taskId)
                 }
@@ -438,6 +438,11 @@ public class TranscriptionTaskManager: ObservableObject {
         displayStatus = .failed(message: displayMessage)
     }
 
+    private func publishNonFailureStatus(_ status: DisplayStatus) {
+        lastFailureDiagnosticMessage = nil
+        displayStatus = status
+    }
+
     public func addFailedTranscriptionRetainingAudio(
         micAudioURL: URL,
         systemAudioURL: URL?,
@@ -504,7 +509,7 @@ public class TranscriptionTaskManager: ObservableObject {
             failedTranscriptionManager.incrementRetryCount(id: failedId)
             self.activeCount += 1
             self.backgroundTaskCount += 1
-            self.displayStatus = .gettingReady
+            self.publishNonFailureStatus(.gettingReady)
         }
 
         do {
@@ -529,10 +534,10 @@ public class TranscriptionTaskManager: ObservableObject {
                 self.backgroundTaskCount = max(0, self.backgroundTaskCount - 1)
                 if self.speakerNamingRequest == nil {
                     self.populateSavedMetadata(from: transcriptURL)
-                    self.displayStatus = .transcriptSaved
+                    self.publishNonFailureStatus(.transcriptSaved)
                     self.scheduleStatusReset(delay: 4)
                 } else {
-                    self.displayStatus = .finishing
+                    self.publishNonFailureStatus(.finishing)
                 }
             }
 
@@ -580,7 +585,7 @@ public class TranscriptionTaskManager: ObservableObject {
         activeTasks.removeAll()
         activeCount = 0
         backgroundTaskCount = 0
-        displayStatus = .idle
+        publishNonFailureStatus(.idle)
     }
 
     /// Populate saved transcript metadata from the file's YAML frontmatter.
@@ -609,7 +614,7 @@ public class TranscriptionTaskManager: ObservableObject {
             guard self.speakerNamingRequest == nil else { return }
             switch self.displayStatus {
             case .transcriptSaved, .failed:
-                self.displayStatus = .idle
+                self.publishNonFailureStatus(.idle)
             default:
                 break
             }

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -93,23 +93,27 @@ public class FailedTranscriptionManager: ObservableObject {
     }
 
     /// Saves failed transcriptions to disk
-    private func saveFailedTranscriptions() {
+    @discardableResult
+    private func saveFailedTranscriptions() -> Bool {
         do {
             let data = try encoder.encode(failedTranscriptions)
             try data.write(to: storageURL, options: .atomic)
             FileManager.default.restrictToOwnerOnly(atPath: storageURL.path)
             AppLogger.pipeline.info("Saved failed transcriptions", ["count": "\(failedTranscriptions.count)"])
+            return true
         } catch {
             AppLogger.pipeline.error("Error saving failed transcriptions", ["error": "\(error)"])
+            return false
         }
     }
 
     /// Adds a new failed transcription to the queue
+    @discardableResult
     public func addFailedTranscription(
         micAudioURL: URL,
         systemAudioURL: URL?,
         errorMessage: String
-    ) {
+    ) -> Bool {
         // Security: validate incoming audio URLs before they ever reach the queue.
         // The on-disk load path already re-checks sandboxing, but without this guard an
         // in-memory caller could enqueue an arbitrary file path and trigger deletion before
@@ -119,7 +123,7 @@ public class FailedTranscriptionManager: ObservableObject {
                 "micURL": micAudioURL.path,
                 "systemURL": systemAudioURL?.path ?? "none"
             ])
-            return
+            return false
         }
 
         let failed = FailedTranscription(
@@ -129,9 +133,16 @@ public class FailedTranscriptionManager: ObservableObject {
         )
 
         failedTranscriptions.append(failed)
-        saveFailedTranscriptions()
+        let didPersist = saveFailedTranscriptions()
+        if !didPersist {
+            failedTranscriptions.removeAll { $0.id == failed.id }
+        }
 
-        AppLogger.pipeline.info("Added failed transcription", ["id": "\(failed.id)"])
+        AppLogger.pipeline.info("Added failed transcription", [
+            "id": "\(failed.id)",
+            "persisted": "\(didPersist)"
+        ])
+        return didPersist
     }
 
     /// Removes a failed transcription from the queue

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -195,20 +195,43 @@ extension TranscriptionTaskManager {
     /// Clean up any tasks stuck in pendingNaming state.
     /// Called from applicationWillTerminate to prevent orphaned audio files.
     public func cleanupPendingNaming() {
-        if let request = speakerNamingRequest {
-            if request.shouldRemoveTemporaryAudioOnCleanup {
-                removeManagedCleanupFile(request.micAudioURL, label: "pending mic audio")
-                removeManagedCleanupFile(request.systemAudioURL, label: "pending system audio")
-            }
-            cleanupSpeakerClips(request.speakers)
-            speakerNamingRequest = nil
-            AppLogger.pipeline.info("Cleaned up pending naming on shutdown")
+        let requests = [speakerNamingRequest].compactMap { $0 } + pendingSpeakerNamingRequests
+        guard !requests.isEmpty else { return }
+
+        for request in requests {
+            cleanupSpeakerNamingRequest(request)
         }
+        speakerNamingRequest = nil
+        pendingSpeakerNamingRequests.removeAll()
+        AppLogger.pipeline.info("Cleaned up pending naming on shutdown", [
+            "count": "\(requests.count)"
+        ])
+    }
+
+    func enqueueSpeakerNamingRequest(_ request: SpeakerNamingRequest) {
+        if speakerNamingRequest?.transcriptId == request.transcriptId
+            || pendingSpeakerNamingRequests.contains(where: { $0.transcriptId == request.transcriptId }) {
+            AppLogger.pipeline.warning("Ignoring duplicate speaker naming request", [
+                "transcriptId": request.transcriptId.uuidString
+            ])
+            return
+        }
+
+        guard speakerNamingRequest != nil else {
+            speakerNamingRequest = request
+            return
+        }
+
+        pendingSpeakerNamingRequests.append(request)
+        AppLogger.pipeline.info("Queued speaker naming request behind active review", [
+            "pending": "\(pendingSpeakerNamingRequests.count)"
+        ])
     }
 
     @discardableResult
     public func deferPendingSpeakerNamingReview(reason: String) -> Bool {
         guard let request = speakerNamingRequest else { return false }
+        speakerNamingRequest = nil
 
         AppLogger.pipeline.info("Deferring pending speaker review", [
             "reason": reason,
@@ -216,6 +239,27 @@ extension TranscriptionTaskManager {
         ])
         request.onComplete([])
         return true
+    }
+
+    private func cleanupSpeakerNamingRequest(_ request: SpeakerNamingRequest) {
+        if request.shouldRemoveTemporaryAudioOnCleanup {
+            removeManagedCleanupFile(request.micAudioURL, label: "pending mic audio")
+            removeManagedCleanupFile(request.systemAudioURL, label: "pending system audio")
+        }
+        cleanupSpeakerClips(request.speakers)
+    }
+
+    private func clearCompletedSpeakerNamingRequest(transcriptId: UUID) {
+        if speakerNamingRequest?.transcriptId == transcriptId {
+            speakerNamingRequest = nil
+        }
+        pendingSpeakerNamingRequests.removeAll { $0.transcriptId == transcriptId }
+        promoteNextSpeakerNamingRequestIfNeeded()
+    }
+
+    private func promoteNextSpeakerNamingRequestIfNeeded() {
+        guard speakerNamingRequest == nil, !pendingSpeakerNamingRequests.isEmpty else { return }
+        speakerNamingRequest = pendingSpeakerNamingRequests.removeFirst()
     }
 
     nonisolated private func cleanupNamingArtifacts(
@@ -545,7 +589,8 @@ extension TranscriptionTaskManager {
                 "named": "\(updatesCount)",
                 "transcript": resolvedURL.lastPathComponent
             ])
-            let didAlreadyPublishSavedTranscript = lastSavedTranscriptURL == resolvedURL
+            let didAlreadyPublishSavedTranscript = lastSavedTranscriptId == transcriptId
+                || lastSavedTranscriptURL == resolvedURL
             populateSavedMetadata(from: resolvedURL)
             if !didAlreadyPublishSavedTranscript {
                 displayStatus = .transcriptSaved
@@ -560,6 +605,6 @@ extension TranscriptionTaskManager {
             scheduleStatusReset(delay: 8)
         }
 
-        speakerNamingRequest = nil
+        clearCompletedSpeakerNamingRequest(transcriptId: transcriptId)
     }
 }

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -206,6 +206,18 @@ extension TranscriptionTaskManager {
         }
     }
 
+    @discardableResult
+    public func deferPendingSpeakerNamingReview(reason: String) -> Bool {
+        guard let request = speakerNamingRequest else { return false }
+
+        AppLogger.pipeline.info("Deferring pending speaker review", [
+            "reason": reason,
+            "speakers": "\(request.speakers.count)"
+        ])
+        request.onComplete([])
+        return true
+    }
+
     nonisolated private func cleanupNamingArtifacts(
         clips: [SpeakerNamingEntry],
         micURL: URL?,
@@ -533,17 +545,21 @@ extension TranscriptionTaskManager {
                 "named": "\(updatesCount)",
                 "transcript": resolvedURL.lastPathComponent
             ])
+            let didAlreadyPublishSavedTranscript = lastSavedTranscriptURL == resolvedURL
             populateSavedMetadata(from: resolvedURL)
-            displayStatus = .transcriptSaved
+            if !didAlreadyPublishSavedTranscript {
+                displayStatus = .transcriptSaved
+                scheduleStatusReset(delay: 8)
+            }
         } else {
             AppLogger.pipeline.error("Speaker naming finalization failed", [
                 "transcriptId": transcriptId.uuidString,
                 "transcript": resolvedURL.lastPathComponent
             ])
             displayStatus = .failed(message: "Failed to finalize speaker names")
+            scheduleStatusReset(delay: 8)
         }
 
-        scheduleStatusReset(delay: 8)
         speakerNamingRequest = nil
     }
 }

--- a/Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift
+++ b/Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift
@@ -43,15 +43,20 @@ struct DictationRecordingStartFailureCleanupPlan: Equatable {
     let outcome: String
     let resetRuntimeSessionToIdle: Bool
     let resetSpeechEngine: Bool
+    let hardResetSpeechEngine: Bool
+    let reportBeforeCleanup: Bool
     let reportRuntimeStall: Bool
 }
 
 struct DictationRecordingStartFailurePolicy {
     static func cleanupPlan(for failureKind: String) -> DictationRecordingStartFailureCleanupPlan {
-        DictationRecordingStartFailureCleanupPlan(
+        let isMicStartTimeout = failureKind == "microphone_start_timeout"
+        return DictationRecordingStartFailureCleanupPlan(
             outcome: failureKind,
             resetRuntimeSessionToIdle: true,
             resetSpeechEngine: true,
+            hardResetSpeechEngine: isMicStartTimeout,
+            reportBeforeCleanup: isMicStartTimeout,
             reportRuntimeStall: false
         )
     }

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -359,7 +359,7 @@ class DictationSessionController: ObservableObject {
             return
         }
 
-        let startedAt = CFAbsoluteTimeGetCurrent()
+        let startedAt = ProcessInfo.processInfo.systemUptime
         let deadline = startedAt + TranscriptedConstants.dictationRecoveryBudget
         var startAttempts = 0
         var recoveryStartAttempts = 0
@@ -376,13 +376,13 @@ class DictationSessionController: ObservableObject {
             if readinessRefresher.start(appState: appState) {
                 readinessRefreshes += 1
             }
-            nextReadinessRefreshAt = CFAbsoluteTimeGetCurrent() + TranscriptedConstants.dictationReadinessRefreshInterval
+            nextReadinessRefreshAt = ProcessInfo.processInfo.systemUptime + TranscriptedConstants.dictationReadinessRefreshInterval
         }
 
-        while CFAbsoluteTimeGetCurrent() < deadline {
+        while ProcessInfo.processInfo.systemUptime < deadline {
             guard isDictating, !Task.isCancelled else { return }
 
-            let now = CFAbsoluteTimeGetCurrent()
+            let now = ProcessInfo.processInfo.systemUptime
             if let staleRefresh = readinessRefresher.cancelIfTimedOut(now: now) {
                 readinessRefreshTimedOut = true
                 DiagnosticsTrail.record(
@@ -430,11 +430,11 @@ class DictationSessionController: ObservableObject {
                 break
 
             case .refreshInputReadiness:
-                if CFAbsoluteTimeGetCurrent() >= nextReadinessRefreshAt {
+                if now >= nextReadinessRefreshAt {
                     if readinessRefresher.start(appState: appState) {
                         readinessRefreshes += 1
                     }
-                    nextReadinessRefreshAt = CFAbsoluteTimeGetCurrent() + TranscriptedConstants.dictationReadinessRefreshInterval
+                    nextReadinessRefreshAt = ProcessInfo.processInfo.systemUptime + TranscriptedConstants.dictationReadinessRefreshInterval
                 }
 
             case .forceInputRecovery:
@@ -444,7 +444,7 @@ class DictationSessionController: ObservableObject {
                 ) {
                     forcedReadinessRecoveries += 1
                     readinessRefreshes = 0
-                    nextReadinessRefreshAt = CFAbsoluteTimeGetCurrent() + TranscriptedConstants.dictationReadinessRefreshInterval
+                    nextReadinessRefreshAt = ProcessInfo.processInfo.systemUptime + TranscriptedConstants.dictationReadinessRefreshInterval
                 }
 
             case .startRecoveryRecording:
@@ -476,7 +476,7 @@ class DictationSessionController: ObservableObject {
                 if started {
                     overlayController.state = .listening
                     resizePanelToCompact()
-                    let waited = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
+                    let waited = Int((ProcessInfo.processInfo.systemUptime - startedAt) * 1000)
                     appState.logger.log("DICTATION | started after forced recovery start and \(waited)ms wait (parakeet, \(appState.sttRouter.inputDeviceName))")
                     DiagnosticsTrail.record(
                         logger: appState.logger,
@@ -496,9 +496,10 @@ class DictationSessionController: ObservableObject {
                     return
                 }
 
-                await appState.sttRouter.refreshInputReadiness()
-                readinessRefreshes += 1
-                nextReadinessRefreshAt = CFAbsoluteTimeGetCurrent() + TranscriptedConstants.dictationReadinessRefreshInterval
+                if readinessRefresher.start(appState: appState) {
+                    readinessRefreshes += 1
+                }
+                nextReadinessRefreshAt = ProcessInfo.processInfo.systemUptime + TranscriptedConstants.dictationReadinessRefreshInterval
 
             case .startRecording:
                 startAttempts += 1
@@ -513,7 +514,7 @@ class DictationSessionController: ObservableObject {
                     overlayController.state = .listening
                     resizePanelToCompact()
                     appState.runtimeDiagnostics.recordSession(kind: "dictation", stage: "recording_after_wait")
-                    let waited = Int((CFAbsoluteTimeGetCurrent() - startedAt) * 1000)
+                    let waited = Int((ProcessInfo.processInfo.systemUptime - startedAt) * 1000)
                     appState.logger.log("DICTATION | started after \(waited)ms wait (parakeet, \(appState.sttRouter.inputDeviceName))")
                     DiagnosticsTrail.record(
                         logger: appState.logger,
@@ -550,9 +551,10 @@ class DictationSessionController: ObservableObject {
                     )
                 )
                 if !appState.sttRouter.isRecovering {
-                    await appState.sttRouter.refreshInputReadiness()
-                    readinessRefreshes += 1
-                    nextReadinessRefreshAt = CFAbsoluteTimeGetCurrent() + TranscriptedConstants.dictationReadinessRefreshInterval
+                    if readinessRefresher.start(appState: appState) {
+                        readinessRefreshes += 1
+                    }
+                    nextReadinessRefreshAt = ProcessInfo.processInfo.systemUptime + TranscriptedConstants.dictationReadinessRefreshInterval
                 }
             }
 
@@ -564,7 +566,9 @@ class DictationSessionController: ObservableObject {
 
         let waited = Int(TranscriptedConstants.dictationRecoveryBudget * 1000)
         let cleanupPlan = DictationRecordingStartFailurePolicy.cleanupPlan(for: "microphone_start_timeout")
-        await finishFailedDictationStart(appState: appState, cleanupPlan: cleanupPlan)
+        if !cleanupPlan.reportBeforeCleanup {
+            await finishFailedDictationStart(appState: appState, cleanupPlan: cleanupPlan)
+        }
         DiagnosticsTrail.record(
             logger: appState.logger,
             level: .error,
@@ -603,6 +607,9 @@ class DictationSessionController: ObservableObject {
                 ])
             )
         }
+        if cleanupPlan.reportBeforeCleanup {
+            await finishFailedDictationStart(appState: appState, cleanupPlan: cleanupPlan)
+        }
         overlayController.showError(
             microphoneTimeoutMessage(
                 deviceName: appState.sttRouter.inputDeviceName,
@@ -625,7 +632,11 @@ class DictationSessionController: ObservableObject {
         sessionTimeoutTask?.cancel()
         sessionTimeoutTask = nil
         if cleanupPlan.resetSpeechEngine {
-            await appState.sttRouter.resetAfterFailedRecordingStart()
+            if cleanupPlan.hardResetSpeechEngine {
+                appState.sttRouter.abandonBlockedRecordingStart(reason: cleanupPlan.outcome)
+            } else {
+                await appState.sttRouter.resetAfterFailedRecordingStart()
+            }
         }
         appState.runtimeDiagnostics.clearSession(
             kind: "dictation",
@@ -1467,7 +1478,7 @@ private final class DictationReadinessRefreshRunner {
         generation &+= 1
         let taskGeneration = generation
         operation = operationName
-        startedAt = CFAbsoluteTimeGetCurrent()
+        startedAt = ProcessInfo.processInfo.systemUptime
         task = Task { @MainActor [weak self] in
             await body()
             guard !Task.isCancelled else { return }

--- a/Sources/UI/Settings/SpeakerNamingSheet.swift
+++ b/Sources/UI/Settings/SpeakerNamingSheet.swift
@@ -31,7 +31,11 @@ final class SpeakerNamingSheet {
         subscription = taskManager.$speakerNamingRequest
             .receive(on: RunLoop.main)
             .sink { [weak self] request in
-                guard let self, let request else { return }
+                guard let self else { return }
+                guard let request else {
+                    self.dismissCurrentWindowBecauseRequestCleared()
+                    return
+                }
                 self.present(request: request)
             }
     }
@@ -48,6 +52,11 @@ final class SpeakerNamingSheet {
         controller.window?.center()
         controller.window?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func dismissCurrentWindowBecauseRequestCleared() {
+        currentWindowController?.closeWithoutCompleting()
+        currentWindowController = nil
     }
 }
 
@@ -101,6 +110,11 @@ final class NamingWindowController: NSWindowController, NSWindowDelegate {
         }
         SpeakerClipPlayback.stop()
         onClose()
+    }
+
+    func closeWithoutCompleting() {
+        didComplete = true
+        close()
     }
 
     private func finish(with updates: [SpeakerNameUpdate]) {

--- a/Sources/UI/Shared/SupportDiagnosticsBundle.swift
+++ b/Sources/UI/Shared/SupportDiagnosticsBundle.swift
@@ -18,6 +18,10 @@ struct SupportDiagnosticsSnapshot: Equatable {
     var meetingState: String
     var meetingRecording: Bool
     var meetingDurationBucket: String
+    var meetingDisplayStatus: String = "unknown"
+    var speakerReviewPending: Bool = false
+    var queuedMeetingCount: Int = 0
+    var meetingShortcut: String = "unknown"
     var reliabilityPackets: [String]
     var recentLogLines: [String]
 }
@@ -66,8 +70,12 @@ enum SupportDiagnosticsBundle {
 
         Meeting
         State: \(snapshot.meetingState)
+        Display status: \(snapshot.meetingDisplayStatus)
         Recording: \(bool(snapshot.meetingRecording))
         Duration: \(snapshot.meetingDurationBucket)
+        Speaker review pending: \(bool(snapshot.speakerReviewPending))
+        Queued meetings: \(snapshot.queuedMeetingCount)
+        Meeting shortcut: \(snapshot.meetingShortcut)
 
         Reliability Packets
         \(reliabilityPackets.isEmpty ? "No recent reliability packets." : reliabilityPackets.joined(separator: "\n"))
@@ -89,11 +97,15 @@ enum SupportDiagnosticsBundle {
             "calendar_granted": bool(snapshot.calendarGranted),
             "crash_reporting_available": bool(snapshot.crashReportingAvailable),
             "crash_reporting_enabled": bool(snapshot.crashReportingEnabled),
+            "meeting_display_status": snapshot.meetingDisplayStatus,
             "meeting_duration_bucket": snapshot.meetingDurationBucket,
             "meeting_recording": bool(snapshot.meetingRecording),
+            "meeting_review_pending": bool(snapshot.speakerReviewPending),
+            "meeting_shortcut": snapshot.meetingShortcut,
             "meeting_state": snapshot.meetingState,
             "microphone_status": snapshot.microphoneStatus,
             "pasteback_granted": bool(snapshot.pastebackGranted),
+            "queued_meeting_count": "\(snapshot.queuedMeetingCount)",
             "reliability_packet_count": "\(min(snapshot.reliabilityPackets.count, maxReliabilityPackets))",
             "system_audio_recording_granted": bool(snapshot.systemAudioRecordingGranted),
         ]

--- a/Sources/UI/Shared/TranscriptedSupportActions.swift
+++ b/Sources/UI/Shared/TranscriptedSupportActions.swift
@@ -1,6 +1,7 @@
 import AppKit
 import AVFoundation
 import Foundation
+import TranscriptedCore
 
 @MainActor
 enum TranscriptedSupportActions {
@@ -70,14 +71,26 @@ enum TranscriptedSupportActions {
         let meetingState: String
         let meetingRecording: Bool
         let meetingDurationBucket: String
+        let meetingDisplayStatus: String
+        let speakerReviewPending: Bool
+        let queuedMeetingCount: Int
+        let meetingShortcut: String
         if #available(macOS 14.0, *) {
             meetingState = meetingStateName(appState.meetingSession.state)
             meetingRecording = appState.meetingSession.isRecording
             meetingDurationBucket = AnalyticsReporter.durationBucket(seconds: appState.meetingSession.recordingDuration)
+            meetingDisplayStatus = displayStatusName(appState.meetingSession.displayStatus)
+            speakerReviewPending = appState.meetingSession.isSpeakerReviewPending
+            queuedMeetingCount = appState.meetingSession.queuedTranscriptionCount
+            meetingShortcut = appState.contextCapture.meetingShortcutDisplay
         } else {
             meetingState = "unavailable"
             meetingRecording = false
             meetingDurationBucket = "lt_10s"
+            meetingDisplayStatus = "unavailable"
+            speakerReviewPending = false
+            queuedMeetingCount = 0
+            meetingShortcut = "unavailable"
         }
 
         return SupportDiagnosticsSnapshot(
@@ -98,6 +111,10 @@ enum TranscriptedSupportActions {
             meetingState: meetingState,
             meetingRecording: meetingRecording,
             meetingDurationBucket: meetingDurationBucket,
+            meetingDisplayStatus: meetingDisplayStatus,
+            speakerReviewPending: speakerReviewPending,
+            queuedMeetingCount: queuedMeetingCount,
+            meetingShortcut: meetingShortcut,
             reliabilityPackets: ReliabilityPacketRecorder.recentPacketSummaries(),
             recentLogLines: appState.logger.entries
         )
@@ -127,6 +144,23 @@ enum TranscriptedSupportActions {
         case .recording: return "recording"
         case .transcribing: return "transcribing"
         case .error: return "error"
+        }
+    }
+
+    private static func displayStatusName(_ status: DisplayStatus) -> String {
+        switch status {
+        case .idle:
+            return "idle"
+        case .gettingReady:
+            return "getting_ready"
+        case .transcribing:
+            return "transcribing"
+        case .finishing:
+            return "finishing"
+        case .transcriptSaved:
+            return "transcript_saved"
+        case .failed:
+            return "failed"
         }
     }
 }

--- a/Tests/DictationInputDeviceSelectionPolicyTests.swift
+++ b/Tests/DictationInputDeviceSelectionPolicyTests.swift
@@ -75,6 +75,32 @@ func testDictationInputDeviceSelectionPolicy() {
         assertEqual(selection.selectedInput, airPodsInput, "without a local mic fallback, dictation should still work")
         assertEqual(selection.reason, .noBuiltInFallbackAvailable, "missing fallback should be explicit")
     }
+
+    runSuite("DictationInputDeviceSelectionPolicy classifies non-USB external mics") {
+        assertEqual(
+            DictationInputDeviceSelectionPolicy.deviceClass(forName: "Logitech C920 Camera Microphone"),
+            "external",
+            "webcam mics should not collapse to unknown"
+        )
+        assertEqual(
+            DictationInputDeviceSelectionPolicy.deviceClass(forName: "Universal Audio Interface"),
+            "external",
+            "audio interface names should produce a stable route class"
+        )
+    }
+
+    runSuite("DictationInputDeviceSelectionPolicy preserves aggregate and virtual route classes") {
+        assertEqual(
+            DictationInputDeviceSelectionPolicy.deviceClass(forName: "Multi-Output Aggregate", transport: .aggregate),
+            "aggregate",
+            "aggregate devices should be visible in route-shape analytics"
+        )
+        assertEqual(
+            DictationInputDeviceSelectionPolicy.deviceClass(forName: "BlackHole 2ch", transport: .virtual),
+            "virtual",
+            "virtual devices should be visible in route-shape analytics"
+        )
+    }
 }
 
 private func device(

--- a/Tests/DictationRecordingStartOverlayPolicyTests.swift
+++ b/Tests/DictationRecordingStartOverlayPolicyTests.swift
@@ -91,6 +91,8 @@ func testDictationRecordingStartOverlayPolicy() {
         assertEqual(plan.outcome, "microphone_start_timeout", "cleanup should keep the concrete failure outcome")
         assertTrue(plan.resetRuntimeSessionToIdle, "handled mic-start failures should not leave an active runtime session")
         assertTrue(plan.resetSpeechEngine, "failed startup should release the partial audio graph")
+        assertTrue(plan.hardResetSpeechEngine, "mic-start timeout cleanup must abandon the blocked CoreAudio graph instead of queuing behind it")
+        assertTrue(plan.reportBeforeCleanup, "mic-start timeout telemetry should fire before audio cleanup can block")
         assertFalse(plan.reportRuntimeStall, "the timeout event already reports this failure; it should not also emit app.session_stall_detected")
     }
 

--- a/Tests/MeetingFailureKindTests.swift
+++ b/Tests/MeetingFailureKindTests.swift
@@ -65,6 +65,30 @@ func testMeetingFailureKind() {
         assertEqual(kind, .pipelineFailed, "retry orchestration failures should stay out of unexpected_error")
     }
 
+    runSuite("MeetingFailureKind preserves retry root causes") {
+        let kind = MeetingFailureKind.classify(
+            message: "Retry failed: Parakeet inference failed"
+        )
+
+        assertEqual(kind, .transcriptionInferenceFailed, "retry wrappers should not hide the concrete model failure")
+    }
+
+    runSuite("MeetingFailureKind classifies model-not-ready wording") {
+        let kind = MeetingFailureKind.classify(
+            message: "Meeting transcription models were not ready. Try again after models finish loading."
+        )
+
+        assertEqual(kind, .modelNotLoaded, "model warmup failures should not fall to unexpected_error")
+    }
+
+    runSuite("MeetingFailureKind classifies generic pipeline failures") {
+        let kind = MeetingFailureKind.classify(
+            message: "Pipeline failed"
+        )
+
+        assertEqual(kind, .pipelineFailed, "generic pipeline failures should have a stable bucket")
+    }
+
     runSuite("MeetingFailureKind classifies model runtime wording") {
         let kind = MeetingFailureKind.classify(
             message: "ASR preprocessor failed while running CoreML prediction"

--- a/Tests/MeetingSessionUIPolicyTests.swift
+++ b/Tests/MeetingSessionUIPolicyTests.swift
@@ -31,25 +31,23 @@ func testMeetingSessionUIPolicy() {
         )
     }
 
-    runSuite("MeetingSessionUIPolicy.canStartQueuedTranscription — waits while speaker review is pending") {
-        assertFalse(
-            MeetingSessionUIPolicy.canStartQueuedTranscription(
-                activeTranscriptions: 0,
-                isSpeakerReviewPending: true,
-                isPreparingQueuedTranscriptionStart: false
-            ),
-            "speaker review should keep the next queued transcription from starting until the transcript is finalized"
-        )
-    }
-
-    runSuite("MeetingSessionUIPolicy.canStartQueuedTranscription — starts once speaker review clears") {
+    runSuite("MeetingSessionUIPolicy.canStartQueuedTranscription — speaker review does not block next meeting") {
         assertTrue(
             MeetingSessionUIPolicy.canStartQueuedTranscription(
                 activeTranscriptions: 0,
-                isSpeakerReviewPending: false,
                 isPreparingQueuedTranscriptionStart: false
             ),
-            "a queued meeting should start as soon as the old speaker review publishes nil"
+            "speaker review should stay open while the next queued meeting starts"
+        )
+    }
+
+    runSuite("MeetingSessionUIPolicy.canStartQueuedTranscription — starts when no pipeline is active") {
+        assertTrue(
+            MeetingSessionUIPolicy.canStartQueuedTranscription(
+                activeTranscriptions: 0,
+                isPreparingQueuedTranscriptionStart: false
+            ),
+            "a queued meeting should start as soon as prior transcription work clears"
         )
     }
 
@@ -57,7 +55,6 @@ func testMeetingSessionUIPolicy() {
         assertFalse(
             MeetingSessionUIPolicy.canStartQueuedTranscription(
                 activeTranscriptions: 1,
-                isSpeakerReviewPending: false,
                 isPreparingQueuedTranscriptionStart: false
             ),
             "active transcription work should remain single-flight"
@@ -65,26 +62,9 @@ func testMeetingSessionUIPolicy() {
         assertFalse(
             MeetingSessionUIPolicy.canStartQueuedTranscription(
                 activeTranscriptions: 0,
-                isSpeakerReviewPending: false,
                 isPreparingQueuedTranscriptionStart: true
             ),
             "a queued start already being prepared should not be started twice"
-        )
-    }
-
-    runSuite("MeetingSessionUIPolicy.shouldClearTranscriptionTriggerWhenIdle — keeps trigger through speaker review") {
-        assertFalse(
-            MeetingSessionUIPolicy.shouldClearTranscriptionTriggerWhenIdle(
-                isSpeakerReviewPending: true
-            ),
-            "speaker review can publish the terminal saved or failed status after active transcription work clears"
-        )
-
-        assertTrue(
-            MeetingSessionUIPolicy.shouldClearTranscriptionTriggerWhenIdle(
-                isSpeakerReviewPending: false
-            ),
-            "completed work without speaker review should clear the last start trigger"
         )
     }
 

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -171,6 +171,48 @@ func testParakeetStartRecordingFailurePolicy() {
         assertEqual(readiness.startFailureReason, .audioRouteNotSettled, "route-not-settled should map to the matching start failure")
     }
 
+    runSuite("ParakeetAudioFormatReadinessPolicy defers stale external-input formats") {
+        let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: 24_000,
+            outputChannelCount: 1,
+            inputSampleRate: 48_000,
+            inputChannelCount: 1,
+            selectedInputClass: "external",
+            outputDeviceClass: "built_in",
+            selectionOverrodeDefault: false
+        )
+
+        assertEqual(readiness, .routeNotSettled, "external mics can see the same stale 24k output bus during route churn")
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy allows Bluetooth speech output routes") {
+        let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: 24_000,
+            outputChannelCount: 1,
+            inputSampleRate: 48_000,
+            inputChannelCount: 1,
+            selectedInputClass: "external",
+            outputDeviceClass: "bluetooth",
+            selectionOverrodeDefault: false
+        )
+
+        assertEqual(readiness, .ready, "Bluetooth output speech buses should not be deferred when that is the active route")
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy allows native low-rate external capture") {
+        let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: 24_000,
+            outputChannelCount: 1,
+            inputSampleRate: 24_000,
+            inputChannelCount: 1,
+            selectedInputClass: "external",
+            outputDeviceClass: "built_in",
+            selectionOverrodeDefault: false
+        )
+
+        assertEqual(readiness, .ready, "native 24k external capture should stay usable when input and output agree")
+    }
+
     runSuite("ParakeetAudioFormatReadinessPolicy rejects zero formats") {
         let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
             outputSampleRate: 0,

--- a/Tests/SupportDiagnosticsBundleTests.swift
+++ b/Tests/SupportDiagnosticsBundleTests.swift
@@ -35,6 +35,10 @@ func testSupportDiagnosticsBundle() {
             meetingState: "ready",
             meetingRecording: false,
             meetingDurationBucket: "lt_10s",
+            meetingDisplayStatus: "finishing",
+            speakerReviewPending: true,
+            queuedMeetingCount: 1,
+            meetingShortcut: "⌥C",
             reliabilityPackets: [
                 "2026-05-03T01:15:11Z meeting.stop recovered event=meeting_recording_stopped route_change_count_bucket=2_3 path=/Users/redbars/private.txt"
             ],
@@ -56,6 +60,10 @@ func testSupportDiagnosticsBundle() {
         assertTrue(text.contains("input_device_class: bluetooth"), "diagnostics should include coarse route facts")
         assertTrue(text.contains("session_stage: recording"), "diagnostics should include runtime session stage")
         assertTrue(text.contains("model_cache_total: 3 GB"), "diagnostics should include coarse model cache size")
+        assertTrue(text.contains("Display status: finishing"), "diagnostics should include meeting display status")
+        assertTrue(text.contains("Speaker review pending: true"), "diagnostics should include pending speaker review state")
+        assertTrue(text.contains("Queued meetings: 1"), "diagnostics should include queued meeting count")
+        assertTrue(text.contains("Meeting shortcut: ⌥C"), "diagnostics should include the active meeting shortcut")
         assertTrue(text.contains("meeting.stop recovered"), "diagnostics should include recent reliability packet summaries")
         assertFalse(text.contains("/Users/redbars"), "diagnostics should redact home paths")
         assertFalse(text.contains("person@example.com"), "diagnostics should redact emails")
@@ -87,6 +95,10 @@ func testSupportDiagnosticsBundle() {
             meetingState: "recording",
             meetingRecording: true,
             meetingDurationBucket: "2_9m",
+            meetingDisplayStatus: "transcribing",
+            speakerReviewPending: false,
+            queuedMeetingCount: 2,
+            meetingShortcut: "⌥M",
             reliabilityPackets: [
                 "2026-05-03T01:15:11Z meeting.stop recovered event=meeting_recording_stopped"
             ],
@@ -98,6 +110,10 @@ func testSupportDiagnosticsBundle() {
 
         assertEqual(sanitized["route_input_device_class"], "bluetooth", "route context should survive Sentry key sanitization")
         assertEqual(sanitized["storage_known_stale_model_count"], "1", "storage context should survive Sentry key sanitization")
+        assertEqual(sanitized["meeting_display_status"], "transcribing", "display status should survive Sentry key sanitization")
+        assertEqual(sanitized["meeting_review_pending"], "false", "speaker review state should survive under a privacy-safe key")
+        assertEqual(sanitized["queued_meeting_count"], "2", "queued meeting count should survive Sentry key sanitization")
+        assertEqual(sanitized["meeting_shortcut"], "⌥M", "meeting shortcut should survive Sentry key sanitization")
         assertEqual(sanitized["reliability_packet_count"], "1", "support diagnostics should include packet count")
         assertNil(sanitized["audio_input_device_class"], "support diagnostics should not use audio-prefixed Sentry keys")
     }

--- a/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
@@ -160,6 +160,25 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertEqual(manager.failedTranscriptions.count, 1)
     }
 
+    func testAddFailedTranscriptionRollsBackMemoryWhenPersistenceFails() throws {
+        let paths = makePaths(root: testRoot)
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+        let micURL = paths.audioCaptures.appendingPathComponent("safe-mic.wav")
+        FileManager.default.createFile(atPath: micURL.path, contents: Data("mic".utf8))
+        let manager = FailedTranscriptionManager(paths: paths)
+        try FileManager.default.createDirectory(at: paths.failedQueue, withIntermediateDirectories: true)
+
+        let didPersist = manager.addFailedTranscription(
+            micAudioURL: micURL,
+            systemAudioURL: nil,
+            errorMessage: "Temporary transcription failure"
+        )
+
+        XCTAssertFalse(didPersist)
+        XCTAssertTrue(manager.failedTranscriptions.isEmpty)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
+    }
+
     func testFailedTranscriptionRetryabilityDoesNotOvermatchGenericMinimumLanguage() {
         let failure = FailedTranscription(
             micAudioURL: testRoot.appendingPathComponent("mic.wav"),

--- a/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
@@ -198,6 +198,106 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testHandleNamingCompleteDoesNotRepublishSavedStatusAfterRenamedTranscriptAlreadyPublished() async throws {
+        let harness = try makeHarness()
+        let transcriptId = UUID()
+        let persistentSpeakerId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.25, count: 256),
+            existingId: nil
+        ).id
+        let originalURL = harness.paths.transcripts.appendingPathComponent("Call_2026-04-10_15-01-23.md")
+        let renamedURL = harness.paths.transcripts.appendingPathComponent("Customer_Call.md")
+        let clipURL = harness.paths.speakerClips.appendingPathComponent("speaker-renamed.wav")
+        let micURL = harness.paths.audioCaptures.appendingPathComponent("mic-renamed.wav")
+        let systemURL = harness.paths.audioCaptures.appendingPathComponent("system-renamed.wav")
+        let speakers = [
+            MarkdownSpeaker(
+                id: "1",
+                persistentSpeakerId: persistentSpeakerId,
+                name: "Speaker 1",
+                confidence: "unknown",
+                source: "db_pending"
+            )
+        ]
+        let utterances = [
+            MarkdownUtterance(
+                timestamp: "00:01",
+                source: "System",
+                label: "Speaker 1",
+                text: "Thanks for joining."
+            )
+        ]
+
+        try sampleTranscript(
+            transcriptId: transcriptId,
+            speakers: speakers,
+            utterances: utterances,
+            breakdownEntries: [
+                BreakdownEntry(name: "Speaker 1", utterances: 1, wordCount: 5, duration: "00:03")
+            ]
+        ).write(to: originalURL, atomically: true, encoding: .utf8)
+        harness.manager.publishTranscriptSaved(from: originalURL)
+        harness.manager.displayStatus = .idle
+        try FileManager.default.moveItem(at: originalURL, to: renamedURL)
+        let transcriptionResult = sampleTranscriptionResult(speakers: speakers, utterances: utterances)
+        try Data().write(to: clipURL)
+        try Data().write(to: micURL)
+        try Data().write(to: systemURL)
+
+        harness.manager.speakerNamingRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: originalURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: micURL,
+            onComplete: { _ in }
+        )
+
+        harness.manager.handleNamingComplete(
+            updates: [
+                SpeakerNameUpdate(
+                    persistentSpeakerId: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    newName: "Sarah Graham",
+                    previousName: nil,
+                    action: .named
+                )
+            ],
+            transcriptURL: originalURL,
+            transcriptId: transcriptId,
+            transcriptionResult: transcriptionResult,
+            micURL: micURL,
+            systemURL: systemURL,
+            clips: [
+                SpeakerNamingEntry(
+                    id: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    clipURL: clipURL,
+                    sampleText: "Thanks for joining.",
+                    currentName: nil,
+                    matchSimilarity: nil,
+                    needsNaming: true,
+                    needsConfirmation: false,
+                    sessionEmbedding: [Float](repeating: 0.25, count: 256)
+                )
+            ]
+        )
+
+        try await waitUntil {
+            harness.manager.speakerNamingRequest == nil
+        }
+
+        XCTAssertEqual(harness.manager.displayStatus, .idle)
+        XCTAssertEqual(harness.manager.lastSavedTranscriptURL, renamedURL)
+        XCTAssertEqual(harness.manager.lastSavedTranscriptId, transcriptId)
+        let savedTranscript = try String(contentsOf: renamedURL, encoding: .utf8)
+        XCTAssertTrue(savedTranscript.contains("Sarah Graham"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: clipURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path))
+    }
+
+    @MainActor
     func testDeferringSpeakerReviewKeepsUnnamedProfileAndSampleForPeopleSettings() async throws {
         let harness = try makeHarness()
         let transcriptId = UUID()

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -171,6 +171,31 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: archivedDirectory.path), "delete should remove the empty failed-audio directory")
     }
 
+    func testManualFailedQueueRetainsAudioBeforeRemovingScratch() throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(retainedAudioDirectory: retainedAudioDirectory)
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        try FileManager.default.createDirectory(at: scratchDirectory, withIntermediateDirectories: true)
+        let micURL = scratchDirectory.appendingPathComponent("mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        manager.addFailedTranscriptionRetainingAudio(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: "Recording stop timed out before audio files were finalized."
+        )
+
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertTrue(failed.micAudioURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(failed.systemAudioURL?.path.hasPrefix(retainedAudioDirectory.path + "/") ?? false)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path), "scratch mic audio should be removed after archive")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path), "scratch system audio should be removed after archive")
+    }
+
     func testStartImportedTranscriptionDoesNotDeleteOutOfSandboxFileWhenRejected() throws {
         let manager = makeManager()
         let externalURL = tempDirectory.appendingPathComponent("outside.wav")
@@ -206,6 +231,27 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertTrue(diarization.isReady)
         XCTAssertEqual(speech.initializeCallCount, 2)
         XCTAssertEqual(diarization.initializeCallCount, 2)
+    }
+
+    func testSafeFailureDiagnosticMessageKeepsTypedRootCause() {
+        XCTAssertEqual(
+            TranscriptionTaskManager.safeFailureDiagnosticMessage(
+                for: PipelineError.modelInferenceFailed(model: "Parakeet", underlying: "/Users/redbars/private/path")
+            ),
+            "Parakeet inference failed"
+        )
+        XCTAssertEqual(
+            TranscriptionTaskManager.safeFailureDiagnosticMessage(
+                for: PipelineError.saveFailed(detail: "/Users/redbars/private/transcript.md")
+            ),
+            "Failed to save transcript"
+        )
+        XCTAssertEqual(
+            TranscriptionTaskManager.safeFailureDiagnosticMessage(
+                for: PipelineError.unknown(underlying: "PyAnnote failed while reading /Users/redbars/audio.wav")
+            ),
+            "Diarization failed"
+        )
     }
 
     private func makeManager(

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -73,6 +73,58 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
                        "embedders that pass only the static value should still get a valid resolver result")
     }
 
+    func testPublishTranscriptSavedDoesNotStayFinishingWhenSpeakerReviewIsPending() throws {
+        let manager = makeManager()
+        let transcriptURL = tempDirectory.appendingPathComponent("Customer_Call.md")
+        try """
+        ---
+        title: "Customer Call"
+        duration: "10:03"
+        mic_speakers: 1
+        system_speakers: 2
+        ---
+
+        # Meeting Recording
+        """.write(to: transcriptURL, atomically: true, encoding: .utf8)
+        manager.displayStatus = .finishing
+        manager.speakerNamingRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: UUID(),
+            systemAudioURL: tempDirectory.appendingPathComponent("system.wav"),
+            micAudioURL: nil,
+            onComplete: { _ in }
+        )
+
+        manager.publishTranscriptSaved(from: transcriptURL)
+
+        XCTAssertEqual(manager.displayStatus, .transcriptSaved)
+        XCTAssertEqual(manager.lastSavedTitle, "Customer Call")
+        XCTAssertEqual(manager.lastSavedDuration, "10:03")
+        XCTAssertEqual(manager.lastSavedSpeakerCount, 3)
+    }
+
+    func testDeferPendingSpeakerNamingReviewCompletesWithReviewLater() {
+        let manager = makeManager()
+        var completedUpdates: [SpeakerNameUpdate]?
+        manager.speakerNamingRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: tempDirectory.appendingPathComponent("call.md"),
+            transcriptId: UUID(),
+            systemAudioURL: tempDirectory.appendingPathComponent("system.wav"),
+            micAudioURL: nil,
+            onComplete: { updates in
+                completedUpdates = updates
+                manager.speakerNamingRequest = nil
+            }
+        )
+
+        XCTAssertTrue(manager.deferPendingSpeakerNamingReview(reason: "queued_transcription"))
+        XCTAssertEqual(completedUpdates?.count, 0)
+        XCTAssertNil(manager.speakerNamingRequest)
+        XCTAssertFalse(manager.deferPendingSpeakerNamingReview(reason: "queued_transcription"))
+    }
+
     func testTranscriptionTaskCarriesCalendarMeetingTitle() {
         let task = TranscriptionTask(
             micURL: tempDirectory.appendingPathComponent("mic.wav"),

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -78,6 +78,7 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         let transcriptURL = tempDirectory.appendingPathComponent("Customer_Call.md")
         try """
         ---
+        transcript_id: "00000000-0000-0000-0000-000000000321"
         title: "Customer Call"
         duration: "10:03"
         mic_speakers: 1
@@ -99,6 +100,7 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         manager.publishTranscriptSaved(from: transcriptURL)
 
         XCTAssertEqual(manager.displayStatus, .transcriptSaved)
+        XCTAssertEqual(manager.lastSavedTranscriptId, UUID(uuidString: "00000000-0000-0000-0000-000000000321"))
         XCTAssertEqual(manager.lastSavedTitle, "Customer Call")
         XCTAssertEqual(manager.lastSavedDuration, "10:03")
         XCTAssertEqual(manager.lastSavedSpeakerCount, 3)
@@ -115,7 +117,6 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             micAudioURL: nil,
             onComplete: { updates in
                 completedUpdates = updates
-                manager.speakerNamingRequest = nil
             }
         )
 
@@ -123,6 +124,67 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertEqual(completedUpdates?.count, 0)
         XCTAssertNil(manager.speakerNamingRequest)
         XCTAssertFalse(manager.deferPendingSpeakerNamingReview(reason: "queued_transcription"))
+    }
+
+    func testQueuedSpeakerNamingRequestDoesNotReplaceActiveReview() {
+        let manager = makeManager()
+        let firstId = UUID()
+        let secondId = UUID()
+
+        manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: tempDirectory.appendingPathComponent("first.md"),
+            transcriptId: firstId,
+            systemAudioURL: tempDirectory.appendingPathComponent("first-system.wav"),
+            micAudioURL: nil,
+            onComplete: { _ in }
+        ))
+        manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: tempDirectory.appendingPathComponent("second.md"),
+            transcriptId: secondId,
+            systemAudioURL: tempDirectory.appendingPathComponent("second-system.wav"),
+            micAudioURL: nil,
+            onComplete: { _ in }
+        ))
+
+        XCTAssertEqual(manager.speakerNamingRequest?.transcriptId, firstId)
+        XCTAssertEqual(manager.pendingSpeakerNamingRequests.map(\.transcriptId), [secondId])
+    }
+
+    func testStatusResetClearsSavedVisualWhileSpeakerReviewPendingButKeepsMetadata() async throws {
+        let manager = makeManager()
+        let transcriptURL = tempDirectory.appendingPathComponent("Customer_Call.md")
+        try """
+        ---
+        transcript_id: "00000000-0000-0000-0000-000000000654"
+        title: "Customer Call"
+        duration: "12:34"
+        mic_speakers: 1
+        system_speakers: 1
+        ---
+
+        # Meeting Recording
+        """.write(to: transcriptURL, atomically: true, encoding: .utf8)
+        manager.speakerNamingRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: UUID(),
+            systemAudioURL: tempDirectory.appendingPathComponent("system.wav"),
+            micAudioURL: nil,
+            onComplete: { _ in }
+        )
+
+        manager.publishTranscriptSaved(from: transcriptURL)
+        manager.scheduleStatusReset(delay: 0)
+
+        try await waitUntil {
+            if case .idle = manager.displayStatus { return true }
+            return false
+        }
+        XCTAssertEqual(manager.lastSavedTranscriptId, UUID(uuidString: "00000000-0000-0000-0000-000000000654"))
+        XCTAssertEqual(manager.lastSavedTitle, "Customer Call")
+        XCTAssertNotNil(manager.speakerNamingRequest)
     }
 
     func testTranscriptionTaskCarriesCalendarMeetingTitle() {
@@ -246,6 +308,59 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertTrue(failed.systemAudioURL?.path.hasPrefix(retainedAudioDirectory.path + "/") ?? false)
         XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path), "scratch mic audio should be removed after archive")
         XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path), "scratch system audio should be removed after archive")
+    }
+
+    func testSystemOnlyFailedQueueCreatesPlaceholderAndRetainsSystemAudio() throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(retainedAudioDirectory: retainedAudioDirectory)
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        try FileManager.default.createDirectory(at: scratchDirectory, withIntermediateDirectories: true)
+        let systemURL = scratchDirectory.appendingPathComponent("system.wav")
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        let didQueue = manager.addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: nil,
+            systemAudioURL: systemURL,
+            errorMessage: "Recording stopped without microphone audio."
+        )
+
+        XCTAssertTrue(didQueue)
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertTrue(failed.micAudioURL.lastPathComponent.contains("microphone_placeholder"))
+        XCTAssertTrue(failed.micAudioURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(failed.systemAudioURL?.path.hasPrefix(retainedAudioDirectory.path + "/") ?? false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failed.micAudioURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failed.systemAudioURL?.path ?? ""))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path), "scratch system audio should be removed after archive")
+    }
+
+    func testUnreadableAudioIsPreservedForRetryInsteadOfDeletedAsTooShort() async throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(retainedAudioDirectory: retainedAudioDirectory)
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("system.wav")
+        try Data("not-a-wav".utf8).write(to: micURL)
+        try Data("also-not-a-wav".utf8).write(to: systemURL)
+
+        manager.startTranscription(
+            micURL: micURL,
+            systemURL: systemURL,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts")
+        )
+
+        try await waitUntil {
+            manager.activeCount == 0 && manager.failedTranscriptionManager.failedTranscriptions.count == 1
+        }
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertNotEqual(failed.errorMessage, "Recording too short")
+        XCTAssertTrue(failed.audioFilesExist())
+        XCTAssertTrue(failed.micAudioURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(failed.systemAudioURL?.path.hasPrefix(retainedAudioDirectory.path + "/") ?? false)
     }
 
     func testStartImportedTranscriptionDoesNotDeleteOutOfSandboxFileWhenRejected() throws {
@@ -372,6 +487,20 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         }
 
         try file.write(from: buffer)
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 2.0,
+        condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        XCTFail("Timed out waiting for condition")
     }
 }
 


### PR DESCRIPTION
## Summary

- Hardens Parakeet audio startup against stalled CoreAudio graph work by timing out startup operations, retiring blocked graphs, and cleaning up late-start completions.
- Improves meeting/dictation failure classification so user-facing copy, retained-audio retries, Sentry tags, and analytics use stable failure buckets instead of brittle raw strings.
- Adds deeper failure diagnostics for meeting transcription failures while keeping off-device telemetry privacy-safe.
- Clears stale failure diagnostics when later non-failure transcription states are published.

## Why

Recent health findings pointed at two trust problems: recording startup could get wedged around audio route changes, and meeting failures were too vague to tell whether the problem was short audio, save failure, model readiness, pipeline contention, or an actual unexpected crash path.

## Impact

Users should see clearer recovery paths, fewer stuck recording starts, and safer retained-audio retry behavior. Support/debugging should get searchable coarse failure kinds without leaking transcript text, audio paths, emails, tokens, or raw meeting details.

## Validation

- `git diff --check`
- `bash run-tests.sh` — 1832/1832 passed
- `swift test` — 176/176 passed
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-integration-smoke.sh`

## Residual Risk

A truly stuck `AVAudioEngine.start()` call cannot be interrupted mid-call by Swift code, but the app now retires that graph and cleans it up if it returns late.