### PR TITLE
Release Transcripted 1.1.37

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.36"
-  sha256 "90f98a36295b8352e037f5b7dc1ea4df632cc268e5331f1ac7348ede7f8bc6e2"
+  version "1.1.37"
+  sha256 "02122f881ab4c914e381cdf0f4834ca287e2b99a44c167fec07d73b31b2432a8"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.36</string>
+	<string>1.1.37</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.36</string>
+	<string>1.1.37</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.37</title>
+      <pubDate>Thu, 14 May 2026 19:54:36 -0500</pubDate>
+      <sparkle:version>1.1.37</sparkle:version>
+      <sparkle:shortVersionString>1.1.37</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.37/Transcripted-1.1.37.dmg" length="504003196" type="application/octet-stream" sparkle:edSignature="wkOIadT+OMUB+f910YOkb8ZAz3xMpirNhN2bGzkmuIDcdxdELH0CMSYxovqvr0oKOnjW60ncUlxU+KaNa8PSDw==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.37</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.37</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.36</title>
       <pubDate>Thu, 14 May 2026 06:58:36 -0500</pubDate>
       <sparkle:version>1.1.36</sparkle:version>


### PR DESCRIPTION
## Summary\n- Bump Transcripted to 1.1.37 after the audio startup reliability fix in #761.\n- Publish Sparkle appcast metadata for v1.1.37.\n- Update the Homebrew cask to the v1.1.37 DMG and sha256.\n\n## Validation\n- bash build-deps.sh --force\n- bash build.sh\n- bash run-tests.sh — 1838/1838 passed\n- swift test — 184/184 passed\n- bash run-integration-smoke.sh\n- NOTARY_PROFILE=Transcripted bash build-beta.sh release Justin\n- bash scripts/release/verify-sparkle-release.sh 1.1.37\n\nGitHub release: https://github.com/r3dbars/transcripted/releases/tag/v1.1.37