### PR TITLE
[nightly-review] Clear meeting diagnostics after missing mic stop

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -641,6 +641,10 @@ final class MeetingSessionController: ObservableObject {
             if preserved {
                 refreshFailedMeetings()
             }
+            Self.runtimeDiagnosticsRecorder?.clearSession(
+                kind: "meeting",
+                outcome: files.systemURL == nil ? "no_audio_captured" : "missing_mic_audio"
+            )
             state = files.systemURL == nil
                 ? .error("No meeting audio was captured.")
                 : .error("Microphone audio was missing. Open Settings → Meetings to retry the system audio.")


### PR DESCRIPTION
## Summary
- Clears the meeting runtime diagnostics session when stop finishes with missing microphone audio.
- Keeps the new failed-audio retry preservation path intact, but prevents the marker from staying active as `meeting/transcribing` after the handled failure.

## Nightly review evidence
- Latest release is `v1.1.37` and appcast/Homebrew metadata are aligned with the published DMG hash.
- Live Sentry still shows `app.unclean_shutdown_detected` as the top unresolved production issue, with recent events.
- PostHog last 24h shows active usage on older versions: 126 dictation starts, 98 completions, 30 meeting starts/stops, 25 meeting saves, and 3 meeting failures; `1.1.37` only has one launch so far.

## Top risks ranked
1. Handled meeting stop failures can leave runtime diagnostics marked as active work, polluting later unclean-shutdown signal. Fixed here.
2. 1.1.37 has very thin adoption so far, so the deep audio reliability fixes are not proven in production yet.
3. Open issue #500 remains the main user-facing audio-quality watch item for quiet mic recording.

## Verification
- `bash build-deps.sh`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `scripts/dev/agent-preflight.sh`
