### PR TITLE
[nightly-ux] Clarify physical-key no-speech copy

### DIFF
--- a/Sources/UI/Overlay/DictationNoSpeechPresentationPolicy.swift
+++ b/Sources/UI/Overlay/DictationNoSpeechPresentationPolicy.swift
@@ -3,7 +3,7 @@ import Foundation
 enum DictationNoSpeechPresentationPolicy {
     static func message(trigger: String) -> String {
         if trigger == "physical_key" {
-            return "Transcripted didn't catch your voice. Hold the dictation key while you talk."
+            return "Transcripted didn't catch your voice. Keep holding the dictation key until you're done talking."
         }
         return "No speech heard. Try speaking a little longer."
     }

--- a/Tests/DictationNoSpeechPresentationPolicyTests.swift
+++ b/Tests/DictationNoSpeechPresentationPolicyTests.swift
@@ -6,8 +6,8 @@ func testDictationNoSpeechPresentationPolicy() {
 
         assertEqual(
             message,
-            "Transcripted didn't catch your voice. Hold the dictation key while you talk.",
-            "physical key no-speech copy should explain the press-and-talk behavior"
+            "Transcripted didn't catch your voice. Keep holding the dictation key until you're done talking.",
+            "physical key no-speech copy should explain the press-and-hold behavior"
         )
     }
 


### PR DESCRIPTION
## Summary
- Makes the physical-key no-speech overlay say to keep holding the dictation key until talking is done.
- Updates the focused copy policy test.

## Nightly sweep evidence
- PostHog last 7 days: 72 `dictation_no_speech` events.
- 67/72 were `trigger=physical_key`.
- 69/72 were `duration_bucket=lt_10s`, pointing to early release/stop behavior.
- Current-release adoption is still thin; the strongest repeated evidence is across active older builds, with 1.1.36 showing 2 events and 1.1.37 only one launch so far.

## Candidate scores
Winner: physical-key no-speech guidance, 78/100.
- User pain/workflow distortion: 24/30
- Debugging/confusion severity: 16/25
- Current-release relevance: 8/15
- Small-patch safety: 15/15
- Privacy/payload confidence: 15/15

Next candidates that lost:
- Runtime dirty-shutdown noise, 74/100: strong Sentry/PostHog signal, but it is concentrated on older versions and PR #763 is already open for the main current-code cleanup.
- Meeting transcript failures, 72/100: 19 failures in 7 days, mostly `unexpected_error` / `pipeline_failed`, but PR #761 just shipped deeper failure diagnostics and PostHog does not yet show 1.1.36/1.1.37 failure concentration.

## Verification
- `git diff --check`
- `bash build-deps.sh --force`
- `bash build.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 1838/1838 passed
- `scripts/dev/agent-preflight.sh`

## Privacy
No telemetry payload shape changed. This is copy-only UX polish.