### PR TITLE
[operator] Track onboarding agent copy

### DIFF
--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -454,20 +454,30 @@ struct PermissionsOnboardingView: View {
 
     private func copyAgentItem(_ item: AgentCopyItem) {
         let value: String
+        let agentCTA: String
         switch item {
         case .claudeDesktopSetup:
+            agentCTA = "claude_desktop_setup"
             value = """
             \(AgentConnectionGuide.mcpSetupText)
 
             \(AgentConnectionGuide.mcpConfigExample)
             """
         case .localAgentPrompt:
+            agentCTA = "local_agent_prompt"
             value = AgentConnectionGuide.starterPrompt(filename: nil)
         }
 
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(value, forType: .string)
+        AnalyticsReporter.track(
+            "onboarding_agent_cta_clicked",
+            properties: [
+                "agent_cta": agentCTA,
+                "step_id": "connect_agent",
+            ]
+        )
 
         copiedAgentItem = item
         copiedResetTask?.cancel()

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -380,6 +380,22 @@ func testRepoCommandContract() {
             "runner should keep unauthorized active issue detection explicit"
         )
     }
+
+    runSuite("Repo command contract - onboarding agent copy remains measurable") {
+        let contents = readRepoTextFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
+        assertTrue(
+            contents.contains("AnalyticsReporter.track(\n            \"onboarding_agent_cta_clicked\""),
+            "copying onboarding agent setup should emit the existing first-value activation event"
+        )
+        assertTrue(
+            contents.contains("\"agent_cta\": agentCTA") && contents.contains("\"step_id\": \"connect_agent\""),
+            "onboarding agent setup telemetry should stay limited to coarse CTA and step ids"
+        )
+        assertFalse(
+            contents.contains("AgentConnectionGuide.starterPrompt(filename: nil)\n        AnalyticsReporter.track"),
+            "onboarding telemetry should not send copied prompt text"
+        )
+    }
 }
 
 private func repoRootURL() -> URL {


### PR DESCRIPTION
## Summary
- Emit the existing `onboarding_agent_cta_clicked` analytics event when a user copies onboarding agent setup steps.
- Keep the payload limited to coarse `agent_cta` and `step_id` values.
- Add a source contract so the first-value measurement does not drift.

## Why
The nightly signal keeps pointing at first useful local Markdown and first agent payoff as the activation gap. The event was already privacy-reviewed and allowlisted, but the onboarding copy buttons were not emitting it.

## Verification
- `bash run-tests.sh`
- `bash build-deps.sh --force`
- `bash build.sh`
- `git diff --check -- Sources/UI/Settings/PermissionsOnboardingView.swift Tests/RepoCommandContractTests.swift`

## Operator note
Checked open automation PRs first and avoided duplicate work in #763, #764, and #756.
