### PR TITLE
[nightly-maintenance] Clarify removed draft-mode docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - `main` is the current Transcripted product, derived from the earlier Draft codebase.
 - The current app on `main` supports **dictation** and **meetings**.
 - Meeting capture includes local mic + system audio, imported-audio transcription, optional local-speaker review, and agent-readable Markdown output.
-- The older draft / ghostwriting flow is not active on `main`. `DictationSessionController` keeps compatibility stubs for removed draft-mode entry points.
+- The older draft / ghostwriting flow is not active on `main`. `DictationSessionController` only keeps `cancelSession()` as a compatibility hook for interrupt paths left from the removed draft-mode routing.
 - `Sources/TranscriptedCore/` is an in-repo library consumed through `Sources/Meeting/`. Keep it as a library boundary.
 - `Sources/Speech/` owns the app-owned local STT path. Meetings reuse that path through `Sources/Meeting/MeetingSTTAdapter.swift`.
 - `Sources/Reliability/` owns wake / sleep recovery for hotkeys and active capture flows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The old standalone Transcripted app is preserved on:
 - branch `legacy/transcripted-standalone`
 - tag `pre-draft-takeover-2026-04-06`
 
-The older drafting / ghostwriting flow does not live on `main` anymore. `DictationSessionController` still exposes compatibility stubs for removed draft-mode entry points.
+The older drafting / ghostwriting flow does not live on `main` anymore. `DictationSessionController` only keeps `cancelSession()` as a compatibility hook for interrupt paths left from the removed draft-mode routing.
 
 ## First reads
 

--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -25,7 +25,7 @@ Important entry points:
 - `Support/ActivationPolicyController.swift` — main-actor policy for combining the Dock toggle with recording-state safety so active capture stays force-quit-visible
 - `Support/TranscriptedConstants.swift` — shared timing and behavior constants used across the app target
 - `Capture/ContextCaptureEngine.swift` — configurable physical-key dictation handling, meeting hotkey routing, and hotkey error surfacing
-- `UI/Overlay/DictationSessionController.swift` — dictation session orchestration; removed draft-mode methods are stubs
+- `UI/Overlay/DictationSessionController.swift` — dictation session orchestration; only `cancelSession()` remains as the removed draft-mode compatibility hook
 - `Meeting/MeetingPromptDetector.swift` — Calendar and runtime-app meeting detection used to offer one-tap meeting capture prompts
 - `Meeting/MeetingSessionController.swift` — app-side bridge into `TranscriptedCore`, including live capture, imported-audio handoff, queued meeting transcription, and local-speaker-split settings
 - `Speech/ParakeetEngine.swift` + `Speech/STTRouter.swift` — local STT path used by dictation and by the meeting adapter

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -21,7 +21,7 @@ Draft-mode UI is not an active product path in this worktree.
 - `Overlay/DictationMicrophoneLoadingPresentationPolicy.swift` — copy and timing policy for the microphone-starting / device-switching overlay state
 - `Overlay/DictationNoSpeechPresentationPolicy.swift` — user-facing no-speech copy for hotkey and non-hotkey dictation attempts
 - `Overlay/DictationRecordingStartOverlayPolicy.swift` — decides whether recording can skip the loading UI or should wait for microphone recovery
-- `Overlay/DictationSessionController.swift` — dictation session orchestration; removed draft-mode methods are stubs
+- `Overlay/DictationSessionController.swift` — dictation session orchestration; only `cancelSession()` remains as the removed draft-mode compatibility hook
 - `Overlay/FloatingOverlayController.swift` — owns the dictation overlay panel lifecycle and Combine subscriptions
 - `Overlay/FloatingOverlayPanel.swift` — non-activating NSPanel for the dictation overlay
 - `Overlay/OverlayDraftingView.swift` — drafting/processing state view

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -1,6 +1,6 @@
 // DictationSessionController.swift
-// Session orchestration for dictation mode plus compatibility stubs for the
-// removed draft mode.
+// Session orchestration for dictation mode plus the remaining cancelSession()
+// compatibility hook from the removed draft-mode routing.
 
 import AppKit
 import AVFoundation


### PR DESCRIPTION
## Summary
- Clarifies the removed Draft-mode compatibility wording in the repo agent docs.
- Updates the DictationSessionController header to match the current source truth: only cancelSession() remains as the interrupt-path hook.

## Verification
- bash scripts/dev/agent-preflight.sh
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh