### PR TITLE
[codex] Add meeting audio recovery controls

### DIFF
--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ## Files
 
-- `FailedMeetingPresentation.swift` — maps `FailedTranscription` into `FailedMeetingItem` view-models with human-readable titles and retry metadata
+- `FailedMeetingPresentation.swift` — maps `FailedTranscription` into `FailedMeetingItem` view-models with human-readable titles, retained-audio URLs, and retry metadata
 - `MeetingAudioStorageManager.swift` — compresses retained meeting WAVs to M4A, applies audio-retention cleanup, and backfills existing retained audio after launch or Settings changes
 - `MeetingAudioInactivityDetector.swift` — detects prolonged audio silence during meetings and emits warning/cleared events so the UI can prompt the user to confirm the recording is still needed
 - `MeetingCaptureBridge.swift` — `@MainActor` wrapper around core `Audio` that converts start/stop into async flows, waits for both live capture and system-audio-file readiness, and mirrors live levels for the UI
@@ -44,7 +44,7 @@
 12. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the recent-meetings UI state.
 13. After a transcript is saved, `MeetingAudioStorageManager` compresses retained WAV audio to M4A and applies the user's retention setting. Launch and Settings changes also run a backfill pass over existing Transcripted meeting transcripts.
 14. If the speaker review sheet shows multiple local speakers, the user can either name them individually or collapse them back to a single "You" track via the UI's "Keep as You" path.
-15. Failed meetings can be retried, deleted, or dismissed from the Settings meetings page, with `MeetingFailureKind` providing stable failure categories, `MeetingFailureExplanation` preserving retry/artifact state, and `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
+15. Failed meetings can be played, revealed, retried, deleted, or dismissed from Home and the Settings meetings page, with `MeetingFailureKind` providing stable failure categories, `MeetingFailureExplanation` preserving retry/artifact state, and `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
 
 ## Key invariants
 

--- a/Sources/Meeting/FailedMeetingPresentation.swift
+++ b/Sources/Meeting/FailedMeetingPresentation.swift
@@ -7,6 +7,7 @@ enum FailedMeetingPresentation {
         isRetrying: Bool
     ) -> MeetingSessionController.FailedMeetingItem {
         let failureKind = MeetingFailureKind.classify(message: failed.errorMessage)
+        let availableAudioURLs = audioURLs(for: failed)
         let copy = MeetingFailureCopy.make(
             forMessage: failed.errorMessage,
             shortErrorMessage: failed.shortErrorMessage,
@@ -18,18 +19,26 @@ enum FailedMeetingPresentation {
             timestamp: failed.timestamp,
             title: copy.title,
             detail: copy.detail,
-            meta: meta(for: failed, isRetrying: isRetrying),
+            meta: meta(for: failed, hasAudioFiles: !availableAudioURLs.isEmpty, isRetrying: isRetrying),
             failureKind: failureKind,
             isRetryable: failed.isRetryable,
             isRetrying: isRetrying,
-            hasAudioFiles: failed.audioFilesExist()
+            hasAudioFiles: !availableAudioURLs.isEmpty,
+            audioURLs: availableAudioURLs
         )
     }
 
-    private static func meta(for failed: FailedTranscription, isRetrying: Bool) -> String {
+    private static func audioURLs(for failed: FailedTranscription) -> [URL] {
+        let fileManager = FileManager.default
+        return [failed.systemAudioURL, failed.micAudioURL]
+            .compactMap { $0 }
+            .filter { fileManager.fileExists(atPath: $0.path) }
+    }
+
+    private static func meta(for failed: FailedTranscription, hasAudioFiles: Bool, isRetrying: Bool) -> String {
         var parts = [failed.formattedTimestamp]
 
-        if failed.audioFilesExist() {
+        if hasAudioFiles {
             let sizeText = failed.formattedFileSize
             if sizeText == "Unknown" {
                 parts.append("Audio kept")

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -69,6 +69,7 @@ final class MeetingSessionController: ObservableObject {
         let isRetryable: Bool
         let isRetrying: Bool
         let hasAudioFiles: Bool
+        let audioURLs: [URL]
     }
 
     private struct QueuedTranscriptionJob {

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -74,7 +74,7 @@ The current agent-connect surfaces should keep one simple mental model:
 
 - `Settings/HomeMeetingPreviewFormatter.swift` — formats recent meeting preview metadata for the Settings home dashboard
 - `Settings/HomeTranscriptionActivityPresentation.swift` — presentation model derived from `MeetingSessionController` state for the home page's live transcription activity card (tone, progress, transcript URL)
-- `Settings/HomeView.swift` — redesigned Settings home dashboard with fast recent activity loading, grouped recent dictations/meetings, summary stats, and lightweight copy/feedback/delete affordances
+- `Settings/HomeView.swift` — redesigned Settings home dashboard with fast recent activity loading, grouped recent dictations/meetings, meeting-audio playback, failed-meeting recovery, summary stats, and lightweight copy/feedback/delete affordances
 - `Settings/HotkeyRecorderAppKitView.swift` — AppKit view for recording custom hotkey bindings
 - `Settings/PermissionsOnboardingView.swift` — first-launch permissions walkthrough
 - `Settings/SettingsRecentCaptureRefreshPolicy.swift` — central policy for whether Settings should refresh the home dashboard, the recent meetings/dictations lists, or neither when navigation changes
@@ -143,7 +143,8 @@ Manual checks:
 - menubar popover renders shortcuts, primary actions, settings actions, and the agent-connect page cleanly
 - speaker settings can preview clips, surface duplicates, toggle local-speaker splitting, and rename / merge people cleanly
 - completed meeting review cleanly separates "People in the room" from remote participants, can resolve retained meeting audio playback, and "Keep as You" restores the single-speaker local path when needed
-- recent meetings in Settings can play retained audio attachments without losing sync between transcript rows and playback state
+- recent meetings on Home and in Settings can play retained audio attachments without losing sync between transcript rows and playback state
+- failed meetings surface retained audio on Home and Settings so users can play it, reveal it in Finder, or retry transcription from the preserved files
 - the Settings home dashboard opens quickly, shows grouped recent dictations and meetings, and its load-more actions keep working on large libraries
 - permissions onboarding and first-run onboarding window still open correctly
 - first-run CTA copy updates correctly as permissions and local-model state change

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -960,7 +960,7 @@ struct HomeMeetingRow: View {
                     .foregroundStyle(.secondary)
                     .padding(.top, 2)
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: 4) {
                     Text(item.title)
                         .font(.system(size: 12.5, weight: .medium))
                         .foregroundStyle(Color.primary)
@@ -970,6 +970,10 @@ struct HomeMeetingRow: View {
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+
+                    if let audio = item.audio, playback.isActive(audio) {
+                        MeetingAudioScrubber(attachment: audio, width: 170, showsTime: false)
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -1027,40 +1031,63 @@ private struct HomeMeetingAudioControl: View {
     let symbolName: String
     let isActive: Bool
     let isPlaying: Bool
+    let scrubber: AnyView?
     let action: () -> Void
 
+    init(
+        title: String,
+        symbolName: String,
+        isActive: Bool,
+        isPlaying: Bool,
+        scrubber: AnyView? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.symbolName = symbolName
+        self.isActive = isActive
+        self.isPlaying = isPlaying
+        self.scrubber = scrubber
+        self.action = action
+    }
+
     var body: some View {
-        Button(action: action) {
-            HStack(spacing: 8) {
-                Image(systemName: symbolName)
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(isActive ? Color.white : Color.secondary)
-                    .frame(width: 22, height: 22)
-                    .background(Circle().fill(isActive ? Color.accentColor : Color.primary.opacity(0.10)))
+        VStack(alignment: .leading, spacing: 6) {
+            Button(action: action) {
+                HStack(spacing: 8) {
+                    Image(systemName: symbolName)
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(isActive ? Color.white : Color.secondary)
+                        .frame(width: 22, height: 22)
+                        .background(Circle().fill(isActive ? Color.accentColor : Color.primary.opacity(0.10)))
 
-                Text(title)
-                    .font(.caption.weight(.semibold))
-                    .lineLimit(1)
+                    Text(title)
+                        .font(.caption.weight(.semibold))
+                        .lineLimit(1)
 
-                if isPlaying {
-                    Circle()
-                        .fill(Color.accentColor)
-                        .frame(width: 5, height: 5)
+                    if isPlaying {
+                        Circle()
+                            .fill(Color.accentColor)
+                            .frame(width: 5, height: 5)
+                    }
                 }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(isActive ? Color.accentColor.opacity(0.14) : Color.secondary.opacity(0.08))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(isActive ? Color.accentColor.opacity(0.28) : Color.primary.opacity(0.10), lineWidth: 1)
+                )
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(isActive ? Color.accentColor.opacity(0.14) : Color.secondary.opacity(0.08))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(isActive ? Color.accentColor.opacity(0.28) : Color.primary.opacity(0.10), lineWidth: 1)
-            )
+            .buttonStyle(.plain)
+            .accessibilityLabel(title)
+
+            if let scrubber {
+                scrubber
+            }
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel(title)
     }
 }
 
@@ -1419,7 +1446,10 @@ struct HomeMeetingPreviewSheet: View {
                         title: playback.buttonTitle(for: audio),
                         symbolName: playback.symbolName(for: audio),
                         isActive: playback.isActive(audio),
-                        isPlaying: playback.isPlaying && playback.isActive(audio)
+                        isPlaying: playback.isPlaying && playback.isActive(audio),
+                        scrubber: playback.isActive(audio)
+                            ? AnyView(MeetingAudioScrubber(attachment: audio, width: 230))
+                            : nil
                     ) {
                         playback.toggle(audio)
                     }
@@ -1633,6 +1663,7 @@ struct HomeNeedsAttentionCard: View {
 struct HomeFailedMeetingsCard: View {
     let items: [MeetingSessionController.FailedMeetingItem]
     let canRetry: Bool
+    let retryUnavailableReason: String?
     let audioAttachment: (MeetingSessionController.FailedMeetingItem) -> MeetingAudioAttachment?
     let onRetry: (MeetingSessionController.FailedMeetingItem) -> Void
     let onRevealAudio: (MeetingSessionController.FailedMeetingItem) -> Void
@@ -1658,6 +1689,7 @@ struct HomeFailedMeetingsCard: View {
                     HomeFailedMeetingRow(
                         item: item,
                         canRetry: canRetry,
+                        retryUnavailableReason: retryUnavailableReason,
                         audio: audioAttachment(item),
                         onRetry: { onRetry(item) },
                         onRevealAudio: { onRevealAudio(item) },
@@ -1690,6 +1722,7 @@ struct HomeFailedMeetingsCard: View {
 private struct HomeFailedMeetingRow: View {
     let item: MeetingSessionController.FailedMeetingItem
     let canRetry: Bool
+    let retryUnavailableReason: String?
     let audio: MeetingAudioAttachment?
     let onRetry: () -> Void
     let onRevealAudio: () -> Void
@@ -1724,7 +1757,10 @@ private struct HomeFailedMeetingRow: View {
                             title: playback.buttonTitle(for: audio),
                             symbolName: playback.symbolName(for: audio),
                             isActive: playback.isActive(audio),
-                            isPlaying: playback.isPlaying && playback.isActive(audio)
+                            isPlaying: playback.isPlaying && playback.isActive(audio),
+                            scrubber: playback.isActive(audio)
+                                ? AnyView(MeetingAudioScrubber(attachment: audio, width: 190))
+                                : nil
                         ) {
                             playback.toggle(audio)
                         }
@@ -1753,7 +1789,8 @@ private struct HomeFailedMeetingRow: View {
                         }
                         .buttonStyle(.borderedProminent)
                         .controlSize(.small)
-                        .disabled(!canRetry || !item.isRetryable || item.isRetrying)
+                        .disabled(retryDisabled)
+                        .help(retryHelp)
                     }
 
                     Button(role: item.hasAudioFiles ? .destructive : nil) {
@@ -1768,5 +1805,25 @@ private struct HomeFailedMeetingRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.vertical, 10)
+    }
+
+    private var retryDisabled: Bool {
+        !canRetry || !item.isRetryable || item.isRetrying
+    }
+
+    private var retryHelp: String {
+        if item.isRetrying {
+            return "Retry is already running."
+        }
+        if !item.isRetryable {
+            return "This meeting does not have enough saved audio to retry."
+        }
+        if let retryUnavailableReason {
+            return retryUnavailableReason
+        }
+        if !canRetry {
+            return "Wait for the current meeting work to finish before retrying."
+        }
+        return "Transcribe this saved audio again."
     }
 }

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -287,6 +287,7 @@ struct HomeMeetingPreview: Identifiable {
     let title: String
     let date: Date
     let transcriptURL: URL
+    let audio: MeetingAudioAttachment?
     let markdown: String
     let readError: String?
     let feedbackTarget: HomeFeedbackTarget
@@ -296,6 +297,7 @@ struct HomeMeetingPreview: Identifiable {
         title = item.title
         date = item.date
         transcriptURL = item.transcriptURL
+        audio = item.audio
         self.markdown = markdown
         self.readError = readError
         feedbackTarget = HomeFeedbackTarget.meeting(item)
@@ -731,9 +733,14 @@ struct HomeRowActionButtons: View {
     let onCopy: () -> Void
     let onFlag: () -> Void
     let menuItems: [HomeRowMenuItem]
+    var leadingAccessory: AnyView? = nil
 
     var body: some View {
         HStack(spacing: 4) {
+            if let leadingAccessory {
+                leadingAccessory
+            }
+
             iconButton(
                 systemName: isCopied ? "checkmark" : "square.on.square",
                 help: isCopied ? "Copied" : "Copy",
@@ -850,6 +857,7 @@ private struct HomeActivityRowShell<Content: View>: View {
     let onCopy: () -> Void
     let onFlag: () -> Void
     let menuItems: [HomeRowMenuItem]
+    var leadingAccessory: AnyView? = nil
     var compact: Bool = false
     @ViewBuilder let content: () -> Content
 
@@ -876,7 +884,8 @@ private struct HomeActivityRowShell<Content: View>: View {
                 isCopied: isCopied,
                 onCopy: onCopy,
                 onFlag: onFlag,
-                menuItems: menuItems
+                menuItems: menuItems,
+                leadingAccessory: leadingAccessory
             )
             .opacity(isHovering ? 1 : 0.55)
             .animation(.easeOut(duration: 0.12), value: isHovering)
@@ -932,6 +941,7 @@ struct HomeMeetingRow: View {
     let onCopy: () -> Void
     let onFlag: () -> Void
     let menuItems: [HomeRowMenuItem]
+    @ObservedObject private var playback = MeetingAudioPlayback.shared
 
     var body: some View {
         HomeActivityRowShell(
@@ -941,6 +951,7 @@ struct HomeMeetingRow: View {
             onCopy: onCopy,
             onFlag: onFlag,
             menuItems: menuItems,
+            leadingAccessory: audioAccessory,
             compact: true
         ) {
             HStack(alignment: .top, spacing: 10) {
@@ -949,13 +960,107 @@ struct HomeMeetingRow: View {
                     .foregroundStyle(.secondary)
                     .padding(.top, 2)
 
-                Text(item.title)
-                    .font(.system(size: 12.5, weight: .medium))
-                    .foregroundStyle(Color.primary)
-                    .lineLimit(1)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(item.title)
+                        .font(.system(size: 12.5, weight: .medium))
+                        .foregroundStyle(Color.primary)
+                        .lineLimit(1)
+
+                    Text(audioStatusText)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
+    }
+
+    private var audioAccessory: AnyView? {
+        guard let audio = item.audio else { return nil }
+        return AnyView(
+            HomeAudioIconButton(
+                title: playback.buttonTitle(for: audio),
+                symbolName: playback.symbolName(for: audio),
+                isActive: playback.isActive(audio),
+                isPlaying: playback.isPlaying && playback.isActive(audio)
+            ) {
+                playback.toggle(audio)
+            }
+            .help("\(playback.buttonTitle(for: audio)) meeting audio")
+        )
+    }
+
+    private var audioStatusText: String {
+        guard let audio = item.audio else { return "Transcript only" }
+        return audio.isCompositePlayback ? "Mic + system audio kept" : "Audio kept"
+    }
+}
+
+private struct HomeAudioIconButton: View {
+    let title: String
+    let symbolName: String
+    let isActive: Bool
+    let isPlaying: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: symbolName)
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(isActive ? Color.white : Color.secondary)
+                .frame(width: 26, height: 26)
+                .background(Circle().fill(isActive ? Color.accentColor : Color.primary.opacity(0.08)))
+                .overlay(
+                    Circle()
+                        .stroke(isPlaying ? Color.accentColor.opacity(0.5) : Color.primary.opacity(0.06), lineWidth: 1)
+                )
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+    }
+}
+
+private struct HomeMeetingAudioControl: View {
+    let title: String
+    let symbolName: String
+    let isActive: Bool
+    let isPlaying: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: symbolName)
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(isActive ? Color.white : Color.secondary)
+                    .frame(width: 22, height: 22)
+                    .background(Circle().fill(isActive ? Color.accentColor : Color.primary.opacity(0.10)))
+
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+
+                if isPlaying {
+                    Circle()
+                        .fill(Color.accentColor)
+                        .frame(width: 5, height: 5)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(isActive ? Color.accentColor.opacity(0.14) : Color.secondary.opacity(0.08))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(isActive ? Color.accentColor.opacity(0.28) : Color.primary.opacity(0.10), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
     }
 }
 
@@ -1103,6 +1208,14 @@ struct HomeActivityTabsCard: View {
                 headerSpacing: 1,
                 row: row
             )
+
+            if canLoadMore || isLoadingMore {
+                HomeLoadMoreButton(
+                    title: loadMoreTitle,
+                    isLoading: isLoadingMore,
+                    action: loadMoreAction
+                )
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -1265,6 +1378,7 @@ struct HomeMeetingPreviewSheet: View {
     let onReportIssue: () -> Void
     let onDone: () -> Void
     private let readableContent: HomeMeetingPreviewContent
+    @ObservedObject private var playback = MeetingAudioPlayback.shared
 
     init(
         preview: HomeMeetingPreview,
@@ -1297,6 +1411,32 @@ struct HomeMeetingPreviewSheet: View {
 
                 Button("Done", action: onDone)
                     .keyboardShortcut(.defaultAction)
+            }
+
+            HStack(spacing: 10) {
+                if let audio = preview.audio {
+                    HomeMeetingAudioControl(
+                        title: playback.buttonTitle(for: audio),
+                        symbolName: playback.symbolName(for: audio),
+                        isActive: playback.isActive(audio),
+                        isPlaying: playback.isPlaying && playback.isActive(audio)
+                    ) {
+                        playback.toggle(audio)
+                    }
+                    .help("\(playback.buttonTitle(for: audio)) meeting audio")
+                } else {
+                    Label("No retained audio", systemImage: "speaker.slash")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .fill(Color.secondary.opacity(0.08))
+                        )
+                }
+
+                Spacer()
             }
 
             Group {
@@ -1487,5 +1627,146 @@ struct HomeNeedsAttentionCard: View {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .stroke(Color.orange.opacity(0.32), lineWidth: 1)
         )
+    }
+}
+
+struct HomeFailedMeetingsCard: View {
+    let items: [MeetingSessionController.FailedMeetingItem]
+    let canRetry: Bool
+    let audioAttachment: (MeetingSessionController.FailedMeetingItem) -> MeetingAudioAttachment?
+    let onRetry: (MeetingSessionController.FailedMeetingItem) -> Void
+    let onRevealAudio: (MeetingSessionController.FailedMeetingItem) -> Void
+    let onClear: (MeetingSessionController.FailedMeetingItem) -> Void
+    let onOpenMeetings: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Image(systemName: "waveform")
+                    .foregroundStyle(.orange)
+                    .font(.system(size: 14, weight: .semibold))
+                Text(title)
+                    .font(.headline)
+                Spacer()
+                Button("Review all", action: onOpenMeetings)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            }
+
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                    HomeFailedMeetingRow(
+                        item: item,
+                        canRetry: canRetry,
+                        audio: audioAttachment(item),
+                        onRetry: { onRetry(item) },
+                        onRevealAudio: { onRevealAudio(item) },
+                        onClear: { onClear(item) }
+                    )
+
+                    if index < items.count - 1 {
+                        Divider()
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.orange.opacity(0.07))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.orange.opacity(0.32), lineWidth: 1)
+        )
+    }
+
+    private var title: String {
+        items.count == 1 ? "Recover this meeting" : "Recover unfinished meetings"
+    }
+}
+
+private struct HomeFailedMeetingRow: View {
+    let item: MeetingSessionController.FailedMeetingItem
+    let canRetry: Bool
+    let audio: MeetingAudioAttachment?
+    let onRetry: () -> Void
+    let onRevealAudio: () -> Void
+    let onClear: () -> Void
+
+    @ObservedObject private var playback = MeetingAudioPlayback.shared
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: item.failureKind == .recordingTooShort ? "timer" : "exclamationmark.triangle.fill")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(item.failureKind == .recordingTooShort ? Color.secondary : Color.orange)
+                .frame(width: 24)
+                .padding(.top, 3)
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(item.title)
+                    .font(.subheadline.weight(.semibold))
+
+                Text(item.detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(item.meta)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+
+                HStack(spacing: 8) {
+                    if let audio {
+                        HomeMeetingAudioControl(
+                            title: playback.buttonTitle(for: audio),
+                            symbolName: playback.symbolName(for: audio),
+                            isActive: playback.isActive(audio),
+                            isPlaying: playback.isPlaying && playback.isActive(audio)
+                        ) {
+                            playback.toggle(audio)
+                        }
+                        .help("\(playback.buttonTitle(for: audio)) retained meeting audio")
+
+                        Button {
+                            onRevealAudio()
+                        } label: {
+                            Label("Show Audio", systemImage: "folder")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    } else {
+                        Label("No audio kept", systemImage: "speaker.slash")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer(minLength: 8)
+
+                    if item.isRetryable || item.isRetrying {
+                        Button {
+                            onRetry()
+                        } label: {
+                            Label(item.isRetrying ? "Retrying..." : "Try Again", systemImage: "arrow.clockwise")
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(!canRetry || !item.isRetryable || item.isRetrying)
+                    }
+
+                    Button(role: item.hasAudioFiles ? .destructive : nil) {
+                        onClear()
+                    } label: {
+                        Label(item.hasAudioFiles ? "Delete" : "Dismiss", systemImage: item.hasAudioFiles ? "trash" : "xmark")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.vertical, 10)
     }
 }

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -858,37 +858,45 @@ private struct HomeActivityRowShell<Content: View>: View {
     let onFlag: () -> Void
     let menuItems: [HomeRowMenuItem]
     var leadingAccessory: AnyView? = nil
+    var bottomAccessory: AnyView? = nil
     var compact: Bool = false
     @ViewBuilder let content: () -> Content
 
     @State private var isHovering = false
 
     var body: some View {
-        HStack(alignment: .top, spacing: 14) {
-            Button(action: onOpen) {
-                HStack(alignment: .top, spacing: 14) {
-                    Text(timeString)
-                        .font(.system(size: 12, weight: .medium, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                        .frame(width: 64, alignment: .leading)
-                        .padding(.top, 2)
+        VStack(alignment: .leading, spacing: compact ? 4 : 7) {
+            HStack(alignment: .top, spacing: 14) {
+                Button(action: onOpen) {
+                    HStack(alignment: .top, spacing: 14) {
+                        Text(timeString)
+                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 64, alignment: .leading)
+                            .padding(.top, 2)
 
-                    content()
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        content()
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .contentShape(Rectangle())
                 }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
+                .buttonStyle(.plain)
 
-            HomeRowActionButtons(
-                isCopied: isCopied,
-                onCopy: onCopy,
-                onFlag: onFlag,
-                menuItems: menuItems,
-                leadingAccessory: leadingAccessory
-            )
-            .opacity(isHovering ? 1 : 0.55)
-            .animation(.easeOut(duration: 0.12), value: isHovering)
+                HomeRowActionButtons(
+                    isCopied: isCopied,
+                    onCopy: onCopy,
+                    onFlag: onFlag,
+                    menuItems: menuItems,
+                    leadingAccessory: leadingAccessory
+                )
+                .opacity(isHovering ? 1 : 0.55)
+                .animation(.easeOut(duration: 0.12), value: isHovering)
+            }
+
+            if let bottomAccessory {
+                bottomAccessory
+                    .padding(.leading, 78)
+            }
         }
         .padding(.horizontal, 8)
         .padding(.vertical, compact ? 5 : 9)
@@ -952,6 +960,7 @@ struct HomeMeetingRow: View {
             onFlag: onFlag,
             menuItems: menuItems,
             leadingAccessory: audioAccessory,
+            bottomAccessory: audioScrubber,
             compact: true
         ) {
             HStack(alignment: .top, spacing: 10) {
@@ -970,10 +979,6 @@ struct HomeMeetingRow: View {
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
-
-                    if let audio = item.audio, playback.isActive(audio) {
-                        MeetingAudioScrubber(attachment: audio, width: 170, showsTime: false)
-                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -993,6 +998,11 @@ struct HomeMeetingRow: View {
             }
             .help("\(playback.buttonTitle(for: audio)) meeting audio")
         )
+    }
+
+    private var audioScrubber: AnyView? {
+        guard let audio = item.audio, playback.isActive(audio) else { return nil }
+        return AnyView(MeetingAudioScrubber(attachment: audio, width: 170, showsTime: false))
     }
 
     private var audioStatusText: String {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -281,6 +281,7 @@ struct TranscriptedSettingsView: View {
     private var homePage: some View {
         let stats = homeStatItems
         let needsAttention = homeNeedsAttentionIssues
+        let failedMeetings = Array(meetingSession.failedMeetings.prefix(3))
 
         return VStack(alignment: .leading, spacing: 14) {
             HStack(alignment: .top, spacing: 20) {
@@ -339,6 +340,30 @@ struct TranscriptedSettingsView: View {
                     onLoadMoreMeetings: {
                         trackSettingsAction("load_more_meetings", page: .home)
                         homeViewModel.loadMoreMeetings()
+                    }
+                )
+            }
+
+            if !failedMeetings.isEmpty {
+                HomeFailedMeetingsCard(
+                    items: failedMeetings,
+                    canRetry: canRetryFailedMeetings,
+                    audioAttachment: { failedMeetingAudioAttachment(for: $0) },
+                    onRetry: { item in
+                        trackSettingsAction("home_retry_failed_meeting", page: .home)
+                        meetingSession.retryFailedMeeting(id: item.id)
+                    },
+                    onRevealAudio: { item in
+                        trackSettingsAction("home_reveal_failed_meeting_audio", page: .home)
+                        revealFailedMeetingAudio(item)
+                    },
+                    onClear: { item in
+                        trackSettingsAction(item.hasAudioFiles ? "home_delete_failed_meeting" : "home_dismiss_failed_meeting", page: .home)
+                        clearFailedMeeting(item)
+                    },
+                    onOpenMeetings: {
+                        trackSettingsAction("home_open_failed_meetings", page: .home)
+                        navigation.selectedPage = .meetings
                     }
                 )
             }
@@ -631,6 +656,9 @@ struct TranscriptedSettingsView: View {
 
     private func deleteMeeting(_ item: RecentMeetingItem) {
         do {
+            if let audio = item.audio, MeetingAudioPlayback.shared.isActive(audio) {
+                MeetingAudioPlayback.shared.stop()
+            }
             try removeItemIfPresent(at: item.transcriptURL)
             if let audio = item.audio {
                 try removeItemIfPresent(at: audio.directoryURL)
@@ -641,6 +669,37 @@ struct TranscriptedSettingsView: View {
                 title: "Could not delete meeting",
                 error: error
             )
+        }
+    }
+
+    private func failedMeetingAudioAttachment(
+        for item: MeetingSessionController.FailedMeetingItem
+    ) -> MeetingAudioAttachment? {
+        guard let firstAudioURL = item.audioURLs.first else { return nil }
+        return MeetingAudioAttachment(
+            directoryURL: firstAudioURL.deletingLastPathComponent(),
+            urls: item.audioURLs
+        )
+    }
+
+    private func revealFailedMeetingAudio(_ item: MeetingSessionController.FailedMeetingItem) {
+        guard let firstAudioURL = item.audioURLs.first else {
+            NSSound.beep()
+            return
+        }
+        NSWorkspace.shared.activateFileViewerSelecting([firstAudioURL])
+    }
+
+    private func clearFailedMeeting(_ item: MeetingSessionController.FailedMeetingItem) {
+        if let audio = failedMeetingAudioAttachment(for: item),
+           MeetingAudioPlayback.shared.isActive(audio) {
+            MeetingAudioPlayback.shared.stop()
+        }
+
+        if item.hasAudioFiles {
+            meetingSession.deleteFailedMeeting(id: item.id)
+        } else {
+            meetingSession.dismissFailedMeeting(id: item.id)
         }
     }
 
@@ -759,6 +818,10 @@ struct TranscriptedSettingsView: View {
         }
 
         return issues
+    }
+
+    private var canRetryFailedMeetings: Bool {
+        !meetingSession.hasRuntimeDiagnosticsWork
     }
 
     private var shortcutsPage: some View {
@@ -1230,17 +1293,19 @@ struct TranscriptedSettingsView: View {
                     ForEach(meetingSession.failedMeetings) { item in
                         SettingsFailedMeetingRow(
                             item: item,
+                            canRetry: canRetryFailedMeetings,
+                            audio: failedMeetingAudioAttachment(for: item),
                             retryAction: {
                                 trackSettingsAction("retry_failed_meeting", page: .meetings)
                                 meetingSession.retryFailedMeeting(id: item.id)
                             },
+                            revealAudioAction: {
+                                trackSettingsAction("reveal_failed_meeting_audio", page: .meetings)
+                                revealFailedMeetingAudio(item)
+                            },
                             secondaryAction: {
                                 trackSettingsAction(item.hasAudioFiles ? "delete_failed_meeting" : "dismiss_failed_meeting", page: .meetings)
-                                if item.hasAudioFiles {
-                                    meetingSession.deleteFailedMeeting(id: item.id)
-                                } else {
-                                    meetingSession.dismissFailedMeeting(id: item.id)
-                                }
+                                clearFailedMeeting(item)
                             }
                         )
                     }
@@ -3030,8 +3095,12 @@ private struct SettingsRecentMeetingAudioControl: View {
 
 private struct SettingsFailedMeetingRow: View {
     let item: MeetingSessionController.FailedMeetingItem
+    let canRetry: Bool
+    let audio: MeetingAudioAttachment?
     let retryAction: () -> Void
+    let revealAudioAction: () -> Void
     let secondaryAction: () -> Void
+    @ObservedObject private var playback = MeetingAudioPlayback.shared
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
@@ -3063,15 +3132,35 @@ private struct SettingsFailedMeetingRow: View {
 
             Spacer(minLength: 12)
 
+            if let audio {
+                SettingsRecentMeetingAudioControl(
+                    title: playback.buttonTitle(for: audio),
+                    symbolName: playback.symbolName(for: audio),
+                    isActive: playback.isActive(audio),
+                    isPlaying: playback.isPlaying && playback.isActive(audio)
+                ) {
+                    playback.toggle(audio)
+                }
+                .help("\(playback.buttonTitle(for: audio)) retained meeting audio")
+
+                Button {
+                    revealAudioAction()
+                } label: {
+                    Label("Show Audio", systemImage: "folder")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
             if item.isRetryable || item.isRetrying {
                 Button {
                     retryAction()
                 } label: {
-                    Label(item.isRetrying ? "Retrying..." : "Retry", systemImage: "arrow.clockwise")
+                    Label(item.isRetrying ? "Retrying..." : "Try Again", systemImage: "arrow.clockwise")
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
-                .disabled(!item.isRetryable || item.isRetrying)
+                .disabled(!canRetry || !item.isRetryable || item.isRetrying)
             }
 
             Button(role: item.hasAudioFiles ? .destructive : nil) {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -348,6 +348,7 @@ struct TranscriptedSettingsView: View {
                 HomeFailedMeetingsCard(
                     items: failedMeetings,
                     canRetry: canRetryFailedMeetings,
+                    retryUnavailableReason: failedMeetingRetryUnavailableReason,
                     audioAttachment: { failedMeetingAudioAttachment(for: $0) },
                     onRetry: { item in
                         trackSettingsAction("home_retry_failed_meeting", page: .home)
@@ -821,7 +822,17 @@ struct TranscriptedSettingsView: View {
     }
 
     private var canRetryFailedMeetings: Bool {
-        !meetingSession.hasRuntimeDiagnosticsWork
+        failedMeetingRetryUnavailableReason == nil
+    }
+
+    private var failedMeetingRetryUnavailableReason: String? {
+        if meetingSession.isRecording {
+            return "Stop the current recording before retrying a failed meeting."
+        }
+        if meetingSession.hasRuntimeDiagnosticsWork {
+            return "Wait for the current meeting to finish saving or transcribing before retrying."
+        }
+        return nil
     }
 
     private var shortcutsPage: some View {
@@ -1294,6 +1305,7 @@ struct TranscriptedSettingsView: View {
                         SettingsFailedMeetingRow(
                             item: item,
                             canRetry: canRetryFailedMeetings,
+                            retryUnavailableReason: failedMeetingRetryUnavailableReason,
                             audio: failedMeetingAudioAttachment(for: item),
                             retryAction: {
                                 trackSettingsAction("retry_failed_meeting", page: .meetings)
@@ -3003,7 +3015,10 @@ private struct SettingsRecentMeetingRow: View {
                         title: playback.buttonTitle(for: audio),
                         symbolName: playback.symbolName(for: audio),
                         isActive: playback.isActive(audio),
-                        isPlaying: playback.isPlaying && playback.isActive(audio)
+                        isPlaying: playback.isPlaying && playback.isActive(audio),
+                        scrubber: playback.isActive(audio)
+                            ? AnyView(MeetingAudioScrubber(attachment: audio, width: 210))
+                            : nil
                     ) {
                         playback.toggle(audio)
                     }
@@ -3027,49 +3042,72 @@ private struct SettingsRecentMeetingAudioControl: View {
     let symbolName: String
     let isActive: Bool
     let isPlaying: Bool
+    let scrubber: AnyView?
     let action: () -> Void
 
+    init(
+        title: String,
+        symbolName: String,
+        isActive: Bool,
+        isPlaying: Bool,
+        scrubber: AnyView? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.symbolName = symbolName
+        self.isActive = isActive
+        self.isPlaying = isPlaying
+        self.scrubber = scrubber
+        self.action = action
+    }
+
     var body: some View {
-        Button(action: action) {
-            HStack(spacing: 8) {
-                Image(systemName: symbolName)
-                    .font(.system(size: 9, weight: .bold))
-                    .foregroundStyle(iconForeground)
-                    .frame(width: 20, height: 20)
-                    .background(Circle().fill(iconBackground))
+        VStack(alignment: .leading, spacing: 6) {
+            Button(action: action) {
+                HStack(spacing: 8) {
+                    Image(systemName: symbolName)
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(iconForeground)
+                        .frame(width: 20, height: 20)
+                        .background(Circle().fill(iconBackground))
 
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill(Color.secondary.opacity(0.22))
-                        .frame(width: 44, height: 4)
+                    ZStack(alignment: .leading) {
+                        Capsule()
+                            .fill(Color.secondary.opacity(0.22))
+                            .frame(width: 44, height: 4)
 
-                    Capsule()
-                        .fill(playheadColor)
-                        .frame(width: isPlaying ? 28 : 8, height: 4)
+                        Capsule()
+                            .fill(playheadColor)
+                            .frame(width: isPlaying ? 28 : 8, height: 4)
 
-                    Circle()
-                        .fill(playheadColor)
-                        .frame(width: 8, height: 8)
-                        .offset(x: isPlaying ? 24 : 4)
+                        Circle()
+                            .fill(playheadColor)
+                            .frame(width: 8, height: 8)
+                            .offset(x: isPlaying ? 24 : 4)
+                    }
+                    .frame(width: 44, height: 12)
+
+                    Text(title)
+                        .font(.caption.weight(.semibold))
+                        .lineLimit(1)
                 }
-                .frame(width: 44, height: 12)
-
-                Text(title)
-                    .font(.caption.weight(.semibold))
-                    .lineLimit(1)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(background)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(stroke, lineWidth: 1)
+                )
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(background)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(stroke, lineWidth: 1)
-            )
+            .buttonStyle(.plain)
+
+            if let scrubber {
+                scrubber
+            }
         }
-        .buttonStyle(.plain)
     }
 
     private var background: Color {
@@ -3096,6 +3134,7 @@ private struct SettingsRecentMeetingAudioControl: View {
 private struct SettingsFailedMeetingRow: View {
     let item: MeetingSessionController.FailedMeetingItem
     let canRetry: Bool
+    let retryUnavailableReason: String?
     let audio: MeetingAudioAttachment?
     let retryAction: () -> Void
     let revealAudioAction: () -> Void
@@ -3137,7 +3176,10 @@ private struct SettingsFailedMeetingRow: View {
                     title: playback.buttonTitle(for: audio),
                     symbolName: playback.symbolName(for: audio),
                     isActive: playback.isActive(audio),
-                    isPlaying: playback.isPlaying && playback.isActive(audio)
+                    isPlaying: playback.isPlaying && playback.isActive(audio),
+                    scrubber: playback.isActive(audio)
+                        ? AnyView(MeetingAudioScrubber(attachment: audio, width: 190))
+                        : nil
                 ) {
                     playback.toggle(audio)
                 }
@@ -3160,7 +3202,8 @@ private struct SettingsFailedMeetingRow: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
-                .disabled(!canRetry || !item.isRetryable || item.isRetrying)
+                .disabled(retryDisabled)
+                .help(retryHelp)
             }
 
             Button(role: item.hasAudioFiles ? .destructive : nil) {
@@ -3171,6 +3214,26 @@ private struct SettingsFailedMeetingRow: View {
             .buttonStyle(.bordered)
             .controlSize(.small)
         }
+    }
+
+    private var retryDisabled: Bool {
+        !canRetry || !item.isRetryable || item.isRetrying
+    }
+
+    private var retryHelp: String {
+        if item.isRetrying {
+            return "Retry is already running."
+        }
+        if !item.isRetryable {
+            return "This meeting does not have enough saved audio to retry."
+        }
+        if let retryUnavailableReason {
+            return retryUnavailableReason
+        }
+        if !canRetry {
+            return "Wait for the current meeting work to finish before retrying."
+        }
+        return "Transcribe this saved audio again."
     }
 }
 

--- a/Sources/UI/Shared/MeetingAudioPlayback.swift
+++ b/Sources/UI/Shared/MeetingAudioPlayback.swift
@@ -9,6 +9,7 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
     @Published private(set) var activeAttachmentID: String?
     @Published private(set) var isPlaying = false
     @Published private(set) var isPaused = false
+    @Published private(set) var unavailableAttachmentID: String?
 
     private var sounds: [NSSound] = []
 
@@ -34,8 +35,13 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
             NSSound(contentsOf: url, byReference: true)
         }
 
-        guard !loadedSounds.isEmpty else { return }
+        guard !loadedSounds.isEmpty else {
+            unavailableAttachmentID = attachment.id
+            NSSound.beep()
+            return
+        }
 
+        unavailableAttachmentID = nil
         activeAttachmentID = attachment.id
         sounds = loadedSounds
         isPlaying = true
@@ -75,6 +81,7 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         activeAttachmentID = nil
         isPlaying = false
         isPaused = false
+        unavailableAttachmentID = nil
     }
 
     func isActive(_ attachment: MeetingAudioAttachment) -> Bool {
@@ -82,6 +89,7 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
     }
 
     func buttonTitle(for attachment: MeetingAudioAttachment) -> String {
+        if unavailableAttachmentID == attachment.id { return "Unavailable" }
         guard isActive(attachment) else { return "Play" }
         if isPlaying { return "Pause" }
         if isPaused { return "Resume" }
@@ -89,6 +97,7 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
     }
 
     func symbolName(for attachment: MeetingAudioAttachment) -> String {
+        if unavailableAttachmentID == attachment.id { return "exclamationmark.triangle.fill" }
         guard isActive(attachment) else { return "play.fill" }
         if isPlaying { return "pause.fill" }
         return "play.fill"

--- a/Sources/UI/Shared/MeetingAudioPlayback.swift
+++ b/Sources/UI/Shared/MeetingAudioPlayback.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Combine
 import Foundation
+import SwiftUI
 
 @MainActor
 final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
@@ -10,8 +11,11 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
     @Published private(set) var isPlaying = false
     @Published private(set) var isPaused = false
     @Published private(set) var unavailableAttachmentID: String?
+    @Published private(set) var currentTime: TimeInterval = 0
+    @Published private(set) var duration: TimeInterval = 0
 
     private var sounds: [NSSound] = []
+    private var progressTimer: Timer?
 
     func toggle(_ attachment: MeetingAudioAttachment) {
         if activeAttachmentID == attachment.id {
@@ -44,13 +48,18 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         unavailableAttachmentID = nil
         activeAttachmentID = attachment.id
         sounds = loadedSounds
+        duration = loadedSounds.map(\.duration).max() ?? 0
+        currentTime = 0
         isPlaying = true
         isPaused = false
 
         for sound in sounds {
             sound.delegate = self
+            sound.currentTime = 0
             sound.play()
         }
+
+        startProgressTimer()
     }
 
     func pause() {
@@ -58,6 +67,7 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         for sound in sounds {
             sound.pause()
         }
+        stopProgressTimer()
         isPlaying = false
         isPaused = true
     }
@@ -70,9 +80,13 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         }
         isPlaying = resumedAnySound
         isPaused = !resumedAnySound
+        if resumedAnySound {
+            startProgressTimer()
+        }
     }
 
     func stop() {
+        stopProgressTimer()
         for sound in sounds {
             sound.stop()
             sound.delegate = nil
@@ -82,10 +96,35 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         isPlaying = false
         isPaused = false
         unavailableAttachmentID = nil
+        currentTime = 0
+        duration = 0
     }
 
     func isActive(_ attachment: MeetingAudioAttachment) -> Bool {
         activeAttachmentID == attachment.id
+    }
+
+    func seek(_ attachment: MeetingAudioAttachment, progress: Double) {
+        guard isActive(attachment), duration > 0 else { return }
+        let clampedProgress = min(max(progress, 0), 1)
+        let targetTime = duration * clampedProgress
+
+        for sound in sounds {
+            let soundDuration = max(sound.duration, 0)
+            sound.currentTime = min(targetTime, soundDuration)
+        }
+
+        currentTime = targetTime
+    }
+
+    func progress(for attachment: MeetingAudioAttachment) -> Double {
+        guard isActive(attachment), duration > 0 else { return 0 }
+        return min(max(currentTime / duration, 0), 1)
+    }
+
+    func timeLabel(for attachment: MeetingAudioAttachment) -> String {
+        guard isActive(attachment), duration > 0 else { return "0:00" }
+        return "\(Self.formatTime(currentTime)) / \(Self.formatTime(duration))"
     }
 
     func buttonTitle(for attachment: MeetingAudioAttachment) -> String {
@@ -113,5 +152,81 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         guard !isPaused else { return }
         guard !sounds.contains(where: { $0.isPlaying }) else { return }
         stop()
+    }
+
+    private func startProgressTimer() {
+        stopProgressTimer()
+        let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.updatePlaybackTime()
+            }
+        }
+        progressTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+        updatePlaybackTime()
+    }
+
+    private func stopProgressTimer() {
+        progressTimer?.invalidate()
+        progressTimer = nil
+    }
+
+    private func updatePlaybackTime() {
+        guard !sounds.isEmpty, duration > 0 else {
+            currentTime = 0
+            return
+        }
+
+        let latestTime = sounds.map(\.currentTime).max() ?? 0
+        currentTime = min(max(latestTime, 0), duration)
+    }
+
+    private static func formatTime(_ time: TimeInterval) -> String {
+        let totalSeconds = max(0, Int(time.rounded(.down)))
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
+
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}
+
+struct MeetingAudioScrubber: View {
+    let attachment: MeetingAudioAttachment
+    var width: CGFloat?
+    var showsTime = true
+
+    @ObservedObject private var playback = MeetingAudioPlayback.shared
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Slider(
+                value: Binding(
+                    get: { playback.progress(for: attachment) },
+                    set: { playback.seek(attachment, progress: $0) }
+                ),
+                in: 0...1
+            )
+            .controlSize(.small)
+            .disabled(!canScrub)
+
+            if showsTime {
+                Text(playback.timeLabel(for: attachment))
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .frame(width: 78, alignment: .trailing)
+            }
+        }
+        .frame(width: width, alignment: .leading)
+        .help(canScrub ? "Drag to scrub meeting audio" : "Start playback before scrubbing")
+    }
+
+    private var canScrub: Bool {
+        playback.isActive(attachment) && playback.duration > 0
     }
 }

--- a/Sources/UI/Shared/MeetingAudioPlayback.swift
+++ b/Sources/UI/Shared/MeetingAudioPlayback.swift
@@ -111,7 +111,11 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
 
         for sound in sounds {
             let soundDuration = max(sound.duration, 0)
-            sound.currentTime = min(targetTime, soundDuration)
+            let seekTime = min(targetTime, soundDuration)
+            sound.currentTime = seekTime
+            if isPlaying, !sound.isPlaying, seekTime < soundDuration {
+                sound.play()
+            }
         }
 
         currentTime = targetTime

--- a/Tests/MeetingAudioArchiveResolverTests.swift
+++ b/Tests/MeetingAudioArchiveResolverTests.swift
@@ -4,6 +4,7 @@ func testMeetingAudioArchiveResolver() {
     runSuite("MeetingAudioArchiveResolverTests") {
         testResolverFindsLiveMeetingAudioPair()
         testResolverPrefersImportedRecording()
+        testResolverPrefersPlaybackMix()
         testResolverReturnsNilWhenAudioIsMissing()
     }
 }
@@ -59,6 +60,40 @@ private func testResolverPrefersImportedRecording() {
         "Imported recordings should play the original retained recording"
     )
     assertTrue(attachment?.isCompositePlayback == false, "A single imported recording is not composite playback")
+}
+
+private func testResolverPrefersPlaybackMix() {
+    let directory = makeMeetingAudioResolverTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Weekly Review.md")
+    let audioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: transcriptURL)
+    try? FileManager.default.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+    FileManager.default.createFile(
+        atPath: audioDirectory.appendingPathComponent("playback.m4a").path,
+        contents: Data("mix".utf8)
+    )
+    FileManager.default.createFile(
+        atPath: audioDirectory.appendingPathComponent("recording.m4a").path,
+        contents: Data("imported".utf8)
+    )
+    FileManager.default.createFile(
+        atPath: audioDirectory.appendingPathComponent("system_audio.m4a").path,
+        contents: Data("system".utf8)
+    )
+    FileManager.default.createFile(
+        atPath: audioDirectory.appendingPathComponent("microphone.m4a").path,
+        contents: Data("mic".utf8)
+    )
+
+    let attachment = MeetingAudioArchiveResolver.attachment(forTranscript: transcriptURL)
+
+    assertEqual(
+        attachment?.urls.map(\.lastPathComponent),
+        ["playback.m4a"],
+        "Playback mixes should win over imported and split-stream audio"
+    )
+    assertTrue(attachment?.isCompositePlayback == false, "A single playback mix is not composite playback")
 }
 
 private func testResolverReturnsNilWhenAudioIsMissing() {


### PR DESCRIPTION
## Summary
- adds retained meeting-audio playback controls to Home and Settings meeting surfaces
- surfaces failed-meeting retained audio so users can play, reveal, retry, or clear it
- fixes composite audio scrubbing so finished streams restart when seeking back

## Why
Retained meeting audio was harder to inspect after capture failures, and composite mic/system playback could lose one stream after seeking. This keeps recovery paths visible and makes scrubbing reliable.

## Validation
- `bash build.sh`
- `bash run-tests.sh` — 1840 tests passed
- `bash run-integration-smoke.sh`
- `~/.codex/skills/codex-review/scripts/codex-review --mode branch --base origin/main` — clean, no accepted/actionable findings
