### PR TITLE
[codex] Simplify Transcripted Home meetings flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - `main` is the current Transcripted product, derived from the earlier Draft codebase.
 - The current app on `main` supports **dictation** and **meetings**.
 - Meeting capture includes local mic + system audio, imported-audio transcription, optional local-speaker review, and agent-readable Markdown output.
-- The older draft / ghostwriting flow is not active on `main`. `DictationSessionController` keeps compatibility stubs for removed draft-mode entry points.
+- The older draft / ghostwriting flow is not active on `main`. `DictationSessionController` only keeps `cancelSession()` as a compatibility hook for interrupt paths left from the removed draft-mode routing.
 - `Sources/TranscriptedCore/` is an in-repo library consumed through `Sources/Meeting/`. Keep it as a library boundary.
 - `Sources/Speech/` owns the app-owned local STT path. Meetings reuse that path through `Sources/Meeting/MeetingSTTAdapter.swift`.
 - `Sources/Reliability/` owns wake / sleep recovery for hotkeys and active capture flows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ The old standalone Transcripted app is preserved on:
 - branch `legacy/transcripted-standalone`
 - tag `pre-draft-takeover-2026-04-06`
 
-The older drafting / ghostwriting flow does not live on `main` anymore. `DictationSessionController` still exposes compatibility stubs for removed draft-mode entry points.
+The older drafting / ghostwriting flow does not live on `main` anymore. `DictationSessionController` only keeps `cancelSession()` as a compatibility hook for interrupt paths left from the removed draft-mode routing.
 
 ## First reads
 

--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -25,7 +25,7 @@ Important entry points:
 - `Support/ActivationPolicyController.swift` — main-actor policy for combining the Dock toggle with recording-state safety so active capture stays force-quit-visible
 - `Support/TranscriptedConstants.swift` — shared timing and behavior constants used across the app target
 - `Capture/ContextCaptureEngine.swift` — configurable physical-key dictation handling, meeting hotkey routing, and hotkey error surfacing
-- `UI/Overlay/DictationSessionController.swift` — dictation session orchestration; removed draft-mode methods are stubs
+- `UI/Overlay/DictationSessionController.swift` — dictation session orchestration; only `cancelSession()` remains as the removed draft-mode compatibility hook
 - `Meeting/MeetingPromptDetector.swift` — Calendar and runtime-app meeting detection used to offer one-tap meeting capture prompts
 - `Meeting/MeetingSessionController.swift` — app-side bridge into `TranscriptedCore`, including live capture, imported-audio handoff, queued meeting transcription, and local-speaker-split settings
 - `Speech/ParakeetEngine.swift` + `Speech/STTRouter.swift` — local STT path used by dictation and by the meeting adapter

--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -44,7 +44,7 @@
 12. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the recent-meetings UI state.
 13. After a transcript is saved, `MeetingAudioStorageManager` compresses retained WAV audio to M4A and applies the user's retention setting. Launch and Settings changes also run a backfill pass over existing Transcripted meeting transcripts.
 14. If the speaker review sheet shows multiple local speakers, the user can either name them individually or collapse them back to a single "You" track via the UI's "Keep as You" path.
-15. Failed meetings can be retried, deleted, or dismissed from the Settings meetings page, with `MeetingFailureKind` providing stable failure categories, `MeetingFailureExplanation` preserving retry/artifact state, and `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
+15. Failed meetings can be retried, deleted, or dismissed from the top of Settings Home, with `MeetingFailureKind` providing stable failure categories, `MeetingFailureExplanation` preserving retry/artifact state, and `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
 
 ## Key invariants
 
@@ -122,4 +122,4 @@ Relevant direct coverage:
 ## Agent notes
 
 - `MeetingSessionController` is the right place for app-level meeting behavior. If a change belongs to the reusable library, move down into `Sources/TranscriptedCore/`.
-- The menubar links to the Settings meetings page instead of rendering inline recent meetings. Meeting changes often require checking `Sources/UI/MenuBar/MenuBarPrimaryActionsView.swift`, `Sources/UI/Settings/TranscriptedSettingsView.swift`, and `Sources/UI/Overlay/MeetingOverlayController.swift`.
+- The menubar links recent meetings into Settings Home instead of rendering inline recent meetings. Meeting changes often require checking `Sources/UI/MenuBar/MenuBarPrimaryActionsView.swift`, `Sources/UI/Settings/TranscriptedSettingsView.swift`, and `Sources/UI/Overlay/MeetingOverlayController.swift`.

--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ## Files
 
-- `FailedMeetingPresentation.swift` — maps `FailedTranscription` into `FailedMeetingItem` view-models with human-readable titles and retry metadata
+- `FailedMeetingPresentation.swift` — maps `FailedTranscription` into `FailedMeetingItem` view-models with human-readable titles, retained-audio URLs, and retry metadata
 - `MeetingAudioStorageManager.swift` — compresses retained meeting WAVs to M4A, applies audio-retention cleanup, and backfills existing retained audio after launch or Settings changes
 - `MeetingAudioInactivityDetector.swift` — detects prolonged audio silence during meetings and emits warning/cleared events so the UI can prompt the user to confirm the recording is still needed
 - `MeetingCaptureBridge.swift` — `@MainActor` wrapper around core `Audio` that converts start/stop into async flows, waits for both live capture and system-audio-file readiness, and mirrors live levels for the UI
@@ -44,7 +44,7 @@
 12. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the recent-meetings UI state.
 13. After a transcript is saved, `MeetingAudioStorageManager` compresses retained WAV audio to M4A and applies the user's retention setting. Launch and Settings changes also run a backfill pass over existing Transcripted meeting transcripts.
 14. If the speaker review sheet shows multiple local speakers, the user can either name them individually or collapse them back to a single "You" track via the UI's "Keep as You" path.
-15. Failed meetings can be retried, deleted, or dismissed from the Settings meetings page, with `MeetingFailureKind` providing stable failure categories, `MeetingFailureExplanation` preserving retry/artifact state, and `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
+15. Failed meetings can be played, revealed, retried, deleted, or dismissed from Home and the Settings meetings page, with `MeetingFailureKind` providing stable failure categories, `MeetingFailureExplanation` preserving retry/artifact state, and `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
 
 ## Key invariants
 

--- a/Sources/Meeting/FailedMeetingPresentation.swift
+++ b/Sources/Meeting/FailedMeetingPresentation.swift
@@ -7,6 +7,7 @@ enum FailedMeetingPresentation {
         isRetrying: Bool
     ) -> MeetingSessionController.FailedMeetingItem {
         let failureKind = MeetingFailureKind.classify(message: failed.errorMessage)
+        let availableAudioURLs = audioURLs(for: failed)
         let copy = MeetingFailureCopy.make(
             forMessage: failed.errorMessage,
             shortErrorMessage: failed.shortErrorMessage,
@@ -18,18 +19,26 @@ enum FailedMeetingPresentation {
             timestamp: failed.timestamp,
             title: copy.title,
             detail: copy.detail,
-            meta: meta(for: failed, isRetrying: isRetrying),
+            meta: meta(for: failed, hasAudioFiles: !availableAudioURLs.isEmpty, isRetrying: isRetrying),
             failureKind: failureKind,
             isRetryable: failed.isRetryable,
             isRetrying: isRetrying,
-            hasAudioFiles: failed.audioFilesExist()
+            hasAudioFiles: !availableAudioURLs.isEmpty,
+            audioURLs: availableAudioURLs
         )
     }
 
-    private static func meta(for failed: FailedTranscription, isRetrying: Bool) -> String {
+    private static func audioURLs(for failed: FailedTranscription) -> [URL] {
+        let fileManager = FileManager.default
+        return [failed.systemAudioURL, failed.micAudioURL]
+            .compactMap { $0 }
+            .filter { fileManager.fileExists(atPath: $0.path) }
+    }
+
+    private static func meta(for failed: FailedTranscription, hasAudioFiles: Bool, isRetrying: Bool) -> String {
         var parts = [failed.formattedTimestamp]
 
-        if failed.audioFilesExist() {
+        if hasAudioFiles {
             let sizeText = failed.formattedFileSize
             if sizeText == "Unknown" {
                 parts.append("Audio kept")

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -69,6 +69,7 @@ final class MeetingSessionController: ObservableObject {
         let isRetryable: Bool
         let isRetrying: Bool
         let hasAudioFiles: Bool
+        let audioURLs: [URL]
     }
 
     private struct QueuedTranscriptionJob {

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -641,6 +641,10 @@ final class MeetingSessionController: ObservableObject {
             if preserved {
                 refreshFailedMeetings()
             }
+            Self.runtimeDiagnosticsRecorder?.clearSession(
+                kind: "meeting",
+                outcome: files.systemURL == nil ? "no_audio_captured" : "missing_mic_audio"
+            )
             state = files.systemURL == nil
                 ? .error("No meeting audio was captured.")
                 : .error("Microphone audio was missing. Open Settings → Meetings to retry the system audio.")

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -84,7 +84,7 @@ The current agent-connect surfaces should keep one simple mental model:
 - `Settings/TranscriptedSettingsActions.swift` — struct of callbacks (start dictation, start meeting, import audio, paste, connect agent, check updates, send feedback, copy/send diagnostics) injected into the settings view
 - `Settings/TranscriptedSettingsComponents.swift` — shared SwiftUI building blocks (`SettingsPageIntro`, `SettingsSection`) used across settings pages
 - `Settings/TranscriptedSettingsNavigationModel.swift` — observable navigation state for the current `TranscriptedSettingsPage` selection
-- `Settings/TranscriptedSettingsPage.swift` — enum of settings pages (home, general, models, shortcuts, meetings, dictations, people, storage, connectAgent, privacy, support, about) with titles, summaries, and SF Symbol names
+- `Settings/TranscriptedSettingsPage.swift` — enum of settings pages (home, general, models, shortcuts, dictations, people, storage, connectAgent, privacy, support, about) with titles, summaries, and SF Symbol names
 - `Settings/TranscriptedSettingsView.swift` — main settings view
 - `Settings/TranscriptedSettingsWindowController.swift` — NSWindowController for settings
 
@@ -96,7 +96,7 @@ The current agent-connect surfaces should keep one simple mental model:
 - `Shared/FirstRunExperience.swift` — shared first-run menu and onboarding state helpers for permission, local-model, dictation, and meeting CTA copy
 - `Shared/MeetingAudioArchiveResolver.swift` — resolves retained meeting-audio attachments that belong to a saved transcript for review playback
 - `Shared/MeetingAudioPlayback.swift` — shared play/pause/resume `NSSound`-backed controller for recent-meeting audio previews in Settings
-- `Shared/RecentCaptureScanners.swift` — `RecentMeetingsScanner` that loads recent meeting transcripts plus retained audio attachments for the Settings meetings page
+- `Shared/RecentCaptureScanners.swift` — `RecentMeetingsScanner` that loads recent meeting transcripts plus retained audio attachments for the Settings home page
 - `Shared/SpeakerClipPlayback.swift` — reusable audio-preview helper for persisted speaker sample clips
 - `Shared/SupportDiagnosticsBundle.swift` — privacy-safe support summary used for copied diagnostics and manual diagnostic events, including recent coarse reliability packet summaries
 - `Shared/TranscriptedSupportActions.swift` — support flows for feedback, copied diagnostics, and manually queued diagnostic events

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -74,7 +74,7 @@ The current agent-connect surfaces should keep one simple mental model:
 
 - `Settings/HomeMeetingPreviewFormatter.swift` — formats recent meeting preview metadata for the Settings home dashboard
 - `Settings/HomeTranscriptionActivityPresentation.swift` — presentation model derived from `MeetingSessionController` state for the home page's live transcription activity card (tone, progress, transcript URL)
-- `Settings/HomeView.swift` — redesigned Settings home dashboard with fast recent activity loading, grouped recent dictations/meetings, summary stats, and lightweight copy/feedback/delete affordances
+- `Settings/HomeView.swift` — redesigned Settings home dashboard with fast recent activity loading, grouped recent dictations/meetings, meeting-audio playback, failed-meeting recovery, summary stats, and lightweight copy/feedback/delete affordances
 - `Settings/HotkeyRecorderAppKitView.swift` — AppKit view for recording custom hotkey bindings
 - `Settings/PermissionsOnboardingView.swift` — first-launch permissions walkthrough
 - `Settings/SettingsRecentCaptureRefreshPolicy.swift` — central policy for whether Settings should refresh the home dashboard, the recent meetings/dictations lists, or neither when navigation changes
@@ -143,7 +143,8 @@ Manual checks:
 - menubar popover renders shortcuts, primary actions, settings actions, and the agent-connect page cleanly
 - speaker settings can preview clips, surface duplicates, toggle local-speaker splitting, and rename / merge people cleanly
 - completed meeting review cleanly separates "People in the room" from remote participants, can resolve retained meeting audio playback, and "Keep as You" restores the single-speaker local path when needed
-- recent meetings in Settings can play retained audio attachments without losing sync between transcript rows and playback state
+- recent meetings on Home and in Settings can play retained audio attachments without losing sync between transcript rows and playback state
+- failed meetings surface retained audio on Home and Settings so users can play it, reveal it in Finder, or retry transcription from the preserved files
 - the Settings home dashboard opens quickly, shows grouped recent dictations and meetings, and its load-more actions keep working on large libraries
 - permissions onboarding and first-run onboarding window still open correctly
 - first-run CTA copy updates correctly as permissions and local-model state change

--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -21,7 +21,7 @@ Draft-mode UI is not an active product path in this worktree.
 - `Overlay/DictationMicrophoneLoadingPresentationPolicy.swift` — copy and timing policy for the microphone-starting / device-switching overlay state
 - `Overlay/DictationNoSpeechPresentationPolicy.swift` — user-facing no-speech copy for hotkey and non-hotkey dictation attempts
 - `Overlay/DictationRecordingStartOverlayPolicy.swift` — decides whether recording can skip the loading UI or should wait for microphone recovery
-- `Overlay/DictationSessionController.swift` — dictation session orchestration; removed draft-mode methods are stubs
+- `Overlay/DictationSessionController.swift` — dictation session orchestration; only `cancelSession()` remains as the removed draft-mode compatibility hook
 - `Overlay/FloatingOverlayController.swift` — owns the dictation overlay panel lifecycle and Combine subscriptions
 - `Overlay/FloatingOverlayPanel.swift` — non-activating NSPanel for the dictation overlay
 - `Overlay/OverlayDraftingView.swift` — drafting/processing state view

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -47,7 +47,7 @@ final class MenuBarPanelController: NSViewController {
         content.primaryActionsView.onStartDictation = { [weak self] in self?.startDictationFromMenu() }
         content.primaryActionsView.onStartMeeting = { [weak self] in self?.startMeetingFromMenu() }
         content.primaryActionsView.onPasteLastDictation = { [weak self] in self?.pasteLastDictationFromMenu() }
-        content.primaryActionsView.onOpenRecentMeetings = { [weak self] in self?.openSettingsFromMenu(.meetings) }
+        content.primaryActionsView.onOpenRecentMeetings = { [weak self] in self?.openSettingsFromMenu(.home, actionID: "recent_meetings") }
         content.utilityActionsView.onOpenSettings = { [weak self] in self?.openSettingsFromMenu(.home) }
         content.utilityActionsView.onCheckForUpdates = { [weak self] in self?.performUpdateActionFromMenu() }
         content.utilityActionsView.onOpenConnectAgent = { [weak self] in self?.openSettingsFromMenu(.connectAgent) }
@@ -245,8 +245,8 @@ final class MenuBarPanelController: NSViewController {
         _ = textPaster.paste(latestText)
     }
 
-    private func openSettingsFromMenu(_ page: TranscriptedSettingsPage) {
-        trackMenuAction(page == .home ? "home" : "open_\(page.analyticsValue)")
+    private func openSettingsFromMenu(_ page: TranscriptedSettingsPage, actionID: String? = nil) {
+        trackMenuAction(actionID ?? (page == .home ? "home" : "open_\(page.analyticsValue)"))
         dismissPopover()
         openSettingsWindow(page)
     }

--- a/Sources/UI/Overlay/DictationNoSpeechPresentationPolicy.swift
+++ b/Sources/UI/Overlay/DictationNoSpeechPresentationPolicy.swift
@@ -3,7 +3,7 @@ import Foundation
 enum DictationNoSpeechPresentationPolicy {
     static func message(trigger: String) -> String {
         if trigger == "physical_key" {
-            return "Transcripted didn't catch your voice. Hold the dictation key while you talk."
+            return "Transcripted didn't catch your voice. Keep holding the dictation key until you're done talking."
         }
         return "No speech heard. Try speaking a little longer."
     }

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -1,6 +1,6 @@
 // DictationSessionController.swift
-// Session orchestration for dictation mode plus compatibility stubs for the
-// removed draft mode.
+// Session orchestration for dictation mode plus the remaining cancelSession()
+// compatibility hook from the removed draft-mode routing.
 
 import AppKit
 import AVFoundation

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -960,7 +960,7 @@ struct HomeMeetingRow: View {
                     .foregroundStyle(.secondary)
                     .padding(.top, 2)
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: 4) {
                     Text(item.title)
                         .font(.system(size: 12.5, weight: .medium))
                         .foregroundStyle(Color.primary)
@@ -970,6 +970,10 @@ struct HomeMeetingRow: View {
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+
+                    if let audio = item.audio, playback.isActive(audio) {
+                        MeetingAudioScrubber(attachment: audio, width: 170, showsTime: false)
+                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -1027,40 +1031,63 @@ private struct HomeMeetingAudioControl: View {
     let symbolName: String
     let isActive: Bool
     let isPlaying: Bool
+    let scrubber: AnyView?
     let action: () -> Void
 
+    init(
+        title: String,
+        symbolName: String,
+        isActive: Bool,
+        isPlaying: Bool,
+        scrubber: AnyView? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.symbolName = symbolName
+        self.isActive = isActive
+        self.isPlaying = isPlaying
+        self.scrubber = scrubber
+        self.action = action
+    }
+
     var body: some View {
-        Button(action: action) {
-            HStack(spacing: 8) {
-                Image(systemName: symbolName)
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(isActive ? Color.white : Color.secondary)
-                    .frame(width: 22, height: 22)
-                    .background(Circle().fill(isActive ? Color.accentColor : Color.primary.opacity(0.10)))
+        VStack(alignment: .leading, spacing: 6) {
+            Button(action: action) {
+                HStack(spacing: 8) {
+                    Image(systemName: symbolName)
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(isActive ? Color.white : Color.secondary)
+                        .frame(width: 22, height: 22)
+                        .background(Circle().fill(isActive ? Color.accentColor : Color.primary.opacity(0.10)))
 
-                Text(title)
-                    .font(.caption.weight(.semibold))
-                    .lineLimit(1)
+                    Text(title)
+                        .font(.caption.weight(.semibold))
+                        .lineLimit(1)
 
-                if isPlaying {
-                    Circle()
-                        .fill(Color.accentColor)
-                        .frame(width: 5, height: 5)
+                    if isPlaying {
+                        Circle()
+                            .fill(Color.accentColor)
+                            .frame(width: 5, height: 5)
+                    }
                 }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(isActive ? Color.accentColor.opacity(0.14) : Color.secondary.opacity(0.08))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(isActive ? Color.accentColor.opacity(0.28) : Color.primary.opacity(0.10), lineWidth: 1)
+                )
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(isActive ? Color.accentColor.opacity(0.14) : Color.secondary.opacity(0.08))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(isActive ? Color.accentColor.opacity(0.28) : Color.primary.opacity(0.10), lineWidth: 1)
-            )
+            .buttonStyle(.plain)
+            .accessibilityLabel(title)
+
+            if let scrubber {
+                scrubber
+            }
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel(title)
     }
 }
 
@@ -1419,7 +1446,10 @@ struct HomeMeetingPreviewSheet: View {
                         title: playback.buttonTitle(for: audio),
                         symbolName: playback.symbolName(for: audio),
                         isActive: playback.isActive(audio),
-                        isPlaying: playback.isPlaying && playback.isActive(audio)
+                        isPlaying: playback.isPlaying && playback.isActive(audio),
+                        scrubber: playback.isActive(audio)
+                            ? AnyView(MeetingAudioScrubber(attachment: audio, width: 230))
+                            : nil
                     ) {
                         playback.toggle(audio)
                     }
@@ -1633,6 +1663,7 @@ struct HomeNeedsAttentionCard: View {
 struct HomeFailedMeetingsCard: View {
     let items: [MeetingSessionController.FailedMeetingItem]
     let canRetry: Bool
+    let retryUnavailableReason: String?
     let audioAttachment: (MeetingSessionController.FailedMeetingItem) -> MeetingAudioAttachment?
     let onRetry: (MeetingSessionController.FailedMeetingItem) -> Void
     let onRevealAudio: (MeetingSessionController.FailedMeetingItem) -> Void
@@ -1658,6 +1689,7 @@ struct HomeFailedMeetingsCard: View {
                     HomeFailedMeetingRow(
                         item: item,
                         canRetry: canRetry,
+                        retryUnavailableReason: retryUnavailableReason,
                         audio: audioAttachment(item),
                         onRetry: { onRetry(item) },
                         onRevealAudio: { onRevealAudio(item) },
@@ -1690,6 +1722,7 @@ struct HomeFailedMeetingsCard: View {
 private struct HomeFailedMeetingRow: View {
     let item: MeetingSessionController.FailedMeetingItem
     let canRetry: Bool
+    let retryUnavailableReason: String?
     let audio: MeetingAudioAttachment?
     let onRetry: () -> Void
     let onRevealAudio: () -> Void
@@ -1724,7 +1757,10 @@ private struct HomeFailedMeetingRow: View {
                             title: playback.buttonTitle(for: audio),
                             symbolName: playback.symbolName(for: audio),
                             isActive: playback.isActive(audio),
-                            isPlaying: playback.isPlaying && playback.isActive(audio)
+                            isPlaying: playback.isPlaying && playback.isActive(audio),
+                            scrubber: playback.isActive(audio)
+                                ? AnyView(MeetingAudioScrubber(attachment: audio, width: 190))
+                                : nil
                         ) {
                             playback.toggle(audio)
                         }
@@ -1753,7 +1789,8 @@ private struct HomeFailedMeetingRow: View {
                         }
                         .buttonStyle(.borderedProminent)
                         .controlSize(.small)
-                        .disabled(!canRetry || !item.isRetryable || item.isRetrying)
+                        .disabled(retryDisabled)
+                        .help(retryHelp)
                     }
 
                     Button(role: item.hasAudioFiles ? .destructive : nil) {
@@ -1768,5 +1805,25 @@ private struct HomeFailedMeetingRow: View {
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(.vertical, 10)
+    }
+
+    private var retryDisabled: Bool {
+        !canRetry || !item.isRetryable || item.isRetrying
+    }
+
+    private var retryHelp: String {
+        if item.isRetrying {
+            return "Retry is already running."
+        }
+        if !item.isRetryable {
+            return "This meeting does not have enough saved audio to retry."
+        }
+        if let retryUnavailableReason {
+            return retryUnavailableReason
+        }
+        if !canRetry {
+            return "Wait for the current meeting work to finish before retrying."
+        }
+        return "Transcribe this saved audio again."
     }
 }

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -287,6 +287,7 @@ struct HomeMeetingPreview: Identifiable {
     let title: String
     let date: Date
     let transcriptURL: URL
+    let audio: MeetingAudioAttachment?
     let markdown: String
     let readError: String?
     let feedbackTarget: HomeFeedbackTarget
@@ -296,6 +297,7 @@ struct HomeMeetingPreview: Identifiable {
         title = item.title
         date = item.date
         transcriptURL = item.transcriptURL
+        audio = item.audio
         self.markdown = markdown
         self.readError = readError
         feedbackTarget = HomeFeedbackTarget.meeting(item)
@@ -731,9 +733,14 @@ struct HomeRowActionButtons: View {
     let onCopy: () -> Void
     let onFlag: () -> Void
     let menuItems: [HomeRowMenuItem]
+    var leadingAccessory: AnyView? = nil
 
     var body: some View {
         HStack(spacing: 4) {
+            if let leadingAccessory {
+                leadingAccessory
+            }
+
             iconButton(
                 systemName: isCopied ? "checkmark" : "square.on.square",
                 help: isCopied ? "Copied" : "Copy",
@@ -850,6 +857,7 @@ private struct HomeActivityRowShell<Content: View>: View {
     let onCopy: () -> Void
     let onFlag: () -> Void
     let menuItems: [HomeRowMenuItem]
+    var leadingAccessory: AnyView? = nil
     var compact: Bool = false
     @ViewBuilder let content: () -> Content
 
@@ -876,7 +884,8 @@ private struct HomeActivityRowShell<Content: View>: View {
                 isCopied: isCopied,
                 onCopy: onCopy,
                 onFlag: onFlag,
-                menuItems: menuItems
+                menuItems: menuItems,
+                leadingAccessory: leadingAccessory
             )
             .opacity(isHovering ? 1 : 0.55)
             .animation(.easeOut(duration: 0.12), value: isHovering)
@@ -932,6 +941,7 @@ struct HomeMeetingRow: View {
     let onCopy: () -> Void
     let onFlag: () -> Void
     let menuItems: [HomeRowMenuItem]
+    @ObservedObject private var playback = MeetingAudioPlayback.shared
 
     var body: some View {
         HomeActivityRowShell(
@@ -941,6 +951,7 @@ struct HomeMeetingRow: View {
             onCopy: onCopy,
             onFlag: onFlag,
             menuItems: menuItems,
+            leadingAccessory: audioAccessory,
             compact: true
         ) {
             HStack(alignment: .top, spacing: 10) {
@@ -949,13 +960,107 @@ struct HomeMeetingRow: View {
                     .foregroundStyle(.secondary)
                     .padding(.top, 2)
 
-                Text(item.title)
-                    .font(.system(size: 12.5, weight: .medium))
-                    .foregroundStyle(Color.primary)
-                    .lineLimit(1)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(item.title)
+                        .font(.system(size: 12.5, weight: .medium))
+                        .foregroundStyle(Color.primary)
+                        .lineLimit(1)
+
+                    Text(audioStatusText)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
+    }
+
+    private var audioAccessory: AnyView? {
+        guard let audio = item.audio else { return nil }
+        return AnyView(
+            HomeAudioIconButton(
+                title: playback.buttonTitle(for: audio),
+                symbolName: playback.symbolName(for: audio),
+                isActive: playback.isActive(audio),
+                isPlaying: playback.isPlaying && playback.isActive(audio)
+            ) {
+                playback.toggle(audio)
+            }
+            .help("\(playback.buttonTitle(for: audio)) meeting audio")
+        )
+    }
+
+    private var audioStatusText: String {
+        guard let audio = item.audio else { return "Transcript only" }
+        return audio.isCompositePlayback ? "Mic + system audio kept" : "Audio kept"
+    }
+}
+
+private struct HomeAudioIconButton: View {
+    let title: String
+    let symbolName: String
+    let isActive: Bool
+    let isPlaying: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: symbolName)
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(isActive ? Color.white : Color.secondary)
+                .frame(width: 26, height: 26)
+                .background(Circle().fill(isActive ? Color.accentColor : Color.primary.opacity(0.08)))
+                .overlay(
+                    Circle()
+                        .stroke(isPlaying ? Color.accentColor.opacity(0.5) : Color.primary.opacity(0.06), lineWidth: 1)
+                )
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+    }
+}
+
+private struct HomeMeetingAudioControl: View {
+    let title: String
+    let symbolName: String
+    let isActive: Bool
+    let isPlaying: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Image(systemName: symbolName)
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundStyle(isActive ? Color.white : Color.secondary)
+                    .frame(width: 22, height: 22)
+                    .background(Circle().fill(isActive ? Color.accentColor : Color.primary.opacity(0.10)))
+
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+
+                if isPlaying {
+                    Circle()
+                        .fill(Color.accentColor)
+                        .frame(width: 5, height: 5)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(isActive ? Color.accentColor.opacity(0.14) : Color.secondary.opacity(0.08))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(isActive ? Color.accentColor.opacity(0.28) : Color.primary.opacity(0.10), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
     }
 }
 
@@ -1103,6 +1208,14 @@ struct HomeActivityTabsCard: View {
                 headerSpacing: 1,
                 row: row
             )
+
+            if canLoadMore || isLoadingMore {
+                HomeLoadMoreButton(
+                    title: loadMoreTitle,
+                    isLoading: isLoadingMore,
+                    action: loadMoreAction
+                )
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -1265,6 +1378,7 @@ struct HomeMeetingPreviewSheet: View {
     let onReportIssue: () -> Void
     let onDone: () -> Void
     private let readableContent: HomeMeetingPreviewContent
+    @ObservedObject private var playback = MeetingAudioPlayback.shared
 
     init(
         preview: HomeMeetingPreview,
@@ -1297,6 +1411,32 @@ struct HomeMeetingPreviewSheet: View {
 
                 Button("Done", action: onDone)
                     .keyboardShortcut(.defaultAction)
+            }
+
+            HStack(spacing: 10) {
+                if let audio = preview.audio {
+                    HomeMeetingAudioControl(
+                        title: playback.buttonTitle(for: audio),
+                        symbolName: playback.symbolName(for: audio),
+                        isActive: playback.isActive(audio),
+                        isPlaying: playback.isPlaying && playback.isActive(audio)
+                    ) {
+                        playback.toggle(audio)
+                    }
+                    .help("\(playback.buttonTitle(for: audio)) meeting audio")
+                } else {
+                    Label("No retained audio", systemImage: "speaker.slash")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .fill(Color.secondary.opacity(0.08))
+                        )
+                }
+
+                Spacer()
             }
 
             Group {
@@ -1487,5 +1627,146 @@ struct HomeNeedsAttentionCard: View {
             RoundedRectangle(cornerRadius: 16, style: .continuous)
                 .stroke(Color.orange.opacity(0.32), lineWidth: 1)
         )
+    }
+}
+
+struct HomeFailedMeetingsCard: View {
+    let items: [MeetingSessionController.FailedMeetingItem]
+    let canRetry: Bool
+    let audioAttachment: (MeetingSessionController.FailedMeetingItem) -> MeetingAudioAttachment?
+    let onRetry: (MeetingSessionController.FailedMeetingItem) -> Void
+    let onRevealAudio: (MeetingSessionController.FailedMeetingItem) -> Void
+    let onClear: (MeetingSessionController.FailedMeetingItem) -> Void
+    let onOpenMeetings: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+                Image(systemName: "waveform")
+                    .foregroundStyle(.orange)
+                    .font(.system(size: 14, weight: .semibold))
+                Text(title)
+                    .font(.headline)
+                Spacer()
+                Button("Review all", action: onOpenMeetings)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+            }
+
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                    HomeFailedMeetingRow(
+                        item: item,
+                        canRetry: canRetry,
+                        audio: audioAttachment(item),
+                        onRetry: { onRetry(item) },
+                        onRevealAudio: { onRevealAudio(item) },
+                        onClear: { onClear(item) }
+                    )
+
+                    if index < items.count - 1 {
+                        Divider()
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.orange.opacity(0.07))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(Color.orange.opacity(0.32), lineWidth: 1)
+        )
+    }
+
+    private var title: String {
+        items.count == 1 ? "Recover this meeting" : "Recover unfinished meetings"
+    }
+}
+
+private struct HomeFailedMeetingRow: View {
+    let item: MeetingSessionController.FailedMeetingItem
+    let canRetry: Bool
+    let audio: MeetingAudioAttachment?
+    let onRetry: () -> Void
+    let onRevealAudio: () -> Void
+    let onClear: () -> Void
+
+    @ObservedObject private var playback = MeetingAudioPlayback.shared
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: item.failureKind == .recordingTooShort ? "timer" : "exclamationmark.triangle.fill")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(item.failureKind == .recordingTooShort ? Color.secondary : Color.orange)
+                .frame(width: 24)
+                .padding(.top, 3)
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(item.title)
+                    .font(.subheadline.weight(.semibold))
+
+                Text(item.detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(item.meta)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+
+                HStack(spacing: 8) {
+                    if let audio {
+                        HomeMeetingAudioControl(
+                            title: playback.buttonTitle(for: audio),
+                            symbolName: playback.symbolName(for: audio),
+                            isActive: playback.isActive(audio),
+                            isPlaying: playback.isPlaying && playback.isActive(audio)
+                        ) {
+                            playback.toggle(audio)
+                        }
+                        .help("\(playback.buttonTitle(for: audio)) retained meeting audio")
+
+                        Button {
+                            onRevealAudio()
+                        } label: {
+                            Label("Show Audio", systemImage: "folder")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    } else {
+                        Label("No audio kept", systemImage: "speaker.slash")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Spacer(minLength: 8)
+
+                    if item.isRetryable || item.isRetrying {
+                        Button {
+                            onRetry()
+                        } label: {
+                            Label(item.isRetrying ? "Retrying..." : "Try Again", systemImage: "arrow.clockwise")
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(!canRetry || !item.isRetryable || item.isRetrying)
+                    }
+
+                    Button(role: item.hasAudioFiles ? .destructive : nil) {
+                        onClear()
+                    } label: {
+                        Label(item.hasAudioFiles ? "Delete" : "Dismiss", systemImage: item.hasAudioFiles ? "trash" : "xmark")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.vertical, 10)
     }
 }

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -858,37 +858,45 @@ private struct HomeActivityRowShell<Content: View>: View {
     let onFlag: () -> Void
     let menuItems: [HomeRowMenuItem]
     var leadingAccessory: AnyView? = nil
+    var bottomAccessory: AnyView? = nil
     var compact: Bool = false
     @ViewBuilder let content: () -> Content
 
     @State private var isHovering = false
 
     var body: some View {
-        HStack(alignment: .top, spacing: 14) {
-            Button(action: onOpen) {
-                HStack(alignment: .top, spacing: 14) {
-                    Text(timeString)
-                        .font(.system(size: 12, weight: .medium, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                        .frame(width: 64, alignment: .leading)
-                        .padding(.top, 2)
+        VStack(alignment: .leading, spacing: compact ? 4 : 7) {
+            HStack(alignment: .top, spacing: 14) {
+                Button(action: onOpen) {
+                    HStack(alignment: .top, spacing: 14) {
+                        Text(timeString)
+                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 64, alignment: .leading)
+                            .padding(.top, 2)
 
-                    content()
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        content()
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .contentShape(Rectangle())
                 }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
+                .buttonStyle(.plain)
 
-            HomeRowActionButtons(
-                isCopied: isCopied,
-                onCopy: onCopy,
-                onFlag: onFlag,
-                menuItems: menuItems,
-                leadingAccessory: leadingAccessory
-            )
-            .opacity(isHovering ? 1 : 0.55)
-            .animation(.easeOut(duration: 0.12), value: isHovering)
+                HomeRowActionButtons(
+                    isCopied: isCopied,
+                    onCopy: onCopy,
+                    onFlag: onFlag,
+                    menuItems: menuItems,
+                    leadingAccessory: leadingAccessory
+                )
+                .opacity(isHovering ? 1 : 0.55)
+                .animation(.easeOut(duration: 0.12), value: isHovering)
+            }
+
+            if let bottomAccessory {
+                bottomAccessory
+                    .padding(.leading, 78)
+            }
         }
         .padding(.horizontal, 8)
         .padding(.vertical, compact ? 5 : 9)
@@ -952,6 +960,7 @@ struct HomeMeetingRow: View {
             onFlag: onFlag,
             menuItems: menuItems,
             leadingAccessory: audioAccessory,
+            bottomAccessory: audioScrubber,
             compact: true
         ) {
             HStack(alignment: .top, spacing: 10) {
@@ -970,10 +979,6 @@ struct HomeMeetingRow: View {
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
-
-                    if let audio = item.audio, playback.isActive(audio) {
-                        MeetingAudioScrubber(attachment: audio, width: 170, showsTime: false)
-                    }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -993,6 +998,11 @@ struct HomeMeetingRow: View {
             }
             .help("\(playback.buttonTitle(for: audio)) meeting audio")
         )
+    }
+
+    private var audioScrubber: AnyView? {
+        guard let audio = item.audio, playback.isActive(audio) else { return nil }
+        return AnyView(MeetingAudioScrubber(attachment: audio, width: 170, showsTime: false))
     }
 
     private var audioStatusText: String {

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -850,6 +850,7 @@ private struct HomeActivityRowShell<Content: View>: View {
     let onCopy: () -> Void
     let onFlag: () -> Void
     let menuItems: [HomeRowMenuItem]
+    let accessory: AnyView?
     var compact: Bool = false
     @ViewBuilder let content: () -> Content
 
@@ -871,6 +872,12 @@ private struct HomeActivityRowShell<Content: View>: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+
+            if let accessory {
+                accessory
+                    .opacity(isHovering ? 1 : 0.78)
+                    .animation(.easeOut(duration: 0.12), value: isHovering)
+            }
 
             HomeRowActionButtons(
                 isCopied: isCopied,
@@ -906,7 +913,8 @@ struct HomeDictationRow: View {
             onOpen: onOpen,
             onCopy: onCopy,
             onFlag: onFlag,
-            menuItems: menuItems
+            menuItems: menuItems,
+            accessory: nil
         ) {
             VStack(alignment: .leading, spacing: 4) {
                 Text(preview)
@@ -932,6 +940,7 @@ struct HomeMeetingRow: View {
     let onCopy: () -> Void
     let onFlag: () -> Void
     let menuItems: [HomeRowMenuItem]
+    @ObservedObject private var playback = MeetingAudioPlayback.shared
 
     var body: some View {
         HomeActivityRowShell(
@@ -941,6 +950,7 @@ struct HomeMeetingRow: View {
             onCopy: onCopy,
             onFlag: onFlag,
             menuItems: menuItems,
+            accessory: audioAccessory,
             compact: true
         ) {
             HStack(alignment: .top, spacing: 10) {
@@ -956,6 +966,92 @@ struct HomeMeetingRow: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
+    }
+
+    private var audioAccessory: AnyView? {
+        guard let audio = item.audio else { return nil }
+        return AnyView(
+            HomeMeetingInlineAudioControl(
+                title: playback.buttonTitle(for: audio),
+                symbolName: playback.symbolName(for: audio),
+                isActive: playback.isActive(audio),
+                isPlaying: playback.isPlaying && playback.isActive(audio)
+            ) {
+                playback.toggle(audio)
+            }
+            .help("\(playback.buttonTitle(for: audio)) meeting audio")
+        )
+    }
+}
+
+private struct HomeMeetingInlineAudioControl: View {
+    let title: String
+    let symbolName: String
+    let isActive: Bool
+    let isPlaying: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 7) {
+                Image(systemName: symbolName)
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(iconForeground)
+                    .frame(width: 18, height: 18)
+                    .background(Circle().fill(iconBackground))
+
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Color.secondary.opacity(0.20))
+                        .frame(width: 42, height: 4)
+
+                    Capsule()
+                        .fill(playheadColor)
+                        .frame(width: isPlaying ? 28 : 8, height: 4)
+
+                    Circle()
+                        .fill(playheadColor)
+                        .frame(width: 8, height: 8)
+                        .offset(x: isPlaying ? 24 : 4)
+                }
+                .frame(width: 42, height: 12)
+
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(background)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(stroke, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var background: Color {
+        isActive ? Color.accentColor.opacity(0.14) : Color.secondary.opacity(0.08)
+    }
+
+    private var stroke: Color {
+        isActive ? Color.accentColor.opacity(0.28) : Color.primary.opacity(0.10)
+    }
+
+    private var iconBackground: Color {
+        isActive ? Color.accentColor : Color.primary.opacity(0.12)
+    }
+
+    private var iconForeground: Color {
+        isActive ? .white : .secondary
+    }
+
+    private var playheadColor: Color {
+        isActive ? .accentColor : .secondary.opacity(0.65)
     }
 }
 

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -454,20 +454,30 @@ struct PermissionsOnboardingView: View {
 
     private func copyAgentItem(_ item: AgentCopyItem) {
         let value: String
+        let agentCTA: String
         switch item {
         case .claudeDesktopSetup:
+            agentCTA = "claude_desktop_setup"
             value = """
             \(AgentConnectionGuide.mcpSetupText)
 
             \(AgentConnectionGuide.mcpConfigExample)
             """
         case .localAgentPrompt:
+            agentCTA = "local_agent_prompt"
             value = AgentConnectionGuide.starterPrompt(filename: nil)
         }
 
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(value, forType: .string)
+        AnalyticsReporter.track(
+            "onboarding_agent_cta_clicked",
+            properties: [
+                "agent_cta": agentCTA,
+                "step_id": "connect_agent",
+            ]
+        )
 
         copiedAgentItem = item
         copiedResetTask?.cancel()

--- a/Sources/UI/Settings/SettingsRecentCaptureRefreshPolicy.swift
+++ b/Sources/UI/Settings/SettingsRecentCaptureRefreshPolicy.swift
@@ -11,7 +11,7 @@ enum SettingsRecentCaptureRefreshPolicy {
         switch page {
         case .home:
             return .homeDashboard
-        case .meetings, .dictations:
+        case .dictations:
             return .recentLists
         case .general, .models, .shortcuts, .people, .storage, .connectAgent, .privacy, .support, .about:
             return .none

--- a/Sources/UI/Settings/TranscriptedSettingsPage.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsPage.swift
@@ -5,7 +5,6 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
     case general
     case models
     case shortcuts
-    case meetings
     case dictations
     case people
     case storage
@@ -31,7 +30,6 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
         case .general: return "General"
         case .models: return "Models"
         case .shortcuts: return "Shortcuts"
-        case .meetings: return "Meetings"
         case .dictations: return "Dictation"
         case .people: return "People"
         case .storage: return "Storage"
@@ -52,8 +50,6 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
             return "Local transcription model."
         case .shortcuts:
             return "Keys and send-after-paste rules."
-        case .meetings:
-            return "Recording, imports, and recent calls."
         case .dictations:
             return "Paste-back and sound cues."
         case .people:
@@ -77,7 +73,6 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
         case .general: return "gearshape.fill"
         case .models: return "cpu.fill"
         case .shortcuts: return "keyboard"
-        case .meetings: return "person.2.wave.2.fill"
         case .dictations: return "quote.bubble.fill"
         case .people: return "person.2.fill"
         case .storage: return "externaldrive.fill"

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -281,6 +281,7 @@ struct TranscriptedSettingsView: View {
     private var homePage: some View {
         let stats = homeStatItems
         let needsAttention = homeNeedsAttentionIssues
+        let failedMeetings = Array(meetingSession.failedMeetings.prefix(3))
 
         return VStack(alignment: .leading, spacing: 14) {
             HStack(alignment: .top, spacing: 20) {
@@ -339,6 +340,30 @@ struct TranscriptedSettingsView: View {
                     onLoadMoreMeetings: {
                         trackSettingsAction("load_more_meetings", page: .home)
                         homeViewModel.loadMoreMeetings()
+                    }
+                )
+            }
+
+            if !failedMeetings.isEmpty {
+                HomeFailedMeetingsCard(
+                    items: failedMeetings,
+                    canRetry: canRetryFailedMeetings,
+                    audioAttachment: { failedMeetingAudioAttachment(for: $0) },
+                    onRetry: { item in
+                        trackSettingsAction("home_retry_failed_meeting", page: .home)
+                        meetingSession.retryFailedMeeting(id: item.id)
+                    },
+                    onRevealAudio: { item in
+                        trackSettingsAction("home_reveal_failed_meeting_audio", page: .home)
+                        revealFailedMeetingAudio(item)
+                    },
+                    onClear: { item in
+                        trackSettingsAction(item.hasAudioFiles ? "home_delete_failed_meeting" : "home_dismiss_failed_meeting", page: .home)
+                        clearFailedMeeting(item)
+                    },
+                    onOpenMeetings: {
+                        trackSettingsAction("home_open_failed_meetings", page: .home)
+                        navigation.selectedPage = .meetings
                     }
                 )
             }
@@ -631,6 +656,9 @@ struct TranscriptedSettingsView: View {
 
     private func deleteMeeting(_ item: RecentMeetingItem) {
         do {
+            if let audio = item.audio, MeetingAudioPlayback.shared.isActive(audio) {
+                MeetingAudioPlayback.shared.stop()
+            }
             try removeItemIfPresent(at: item.transcriptURL)
             if let audio = item.audio {
                 try removeItemIfPresent(at: audio.directoryURL)
@@ -641,6 +669,37 @@ struct TranscriptedSettingsView: View {
                 title: "Could not delete meeting",
                 error: error
             )
+        }
+    }
+
+    private func failedMeetingAudioAttachment(
+        for item: MeetingSessionController.FailedMeetingItem
+    ) -> MeetingAudioAttachment? {
+        guard let firstAudioURL = item.audioURLs.first else { return nil }
+        return MeetingAudioAttachment(
+            directoryURL: firstAudioURL.deletingLastPathComponent(),
+            urls: item.audioURLs
+        )
+    }
+
+    private func revealFailedMeetingAudio(_ item: MeetingSessionController.FailedMeetingItem) {
+        guard let firstAudioURL = item.audioURLs.first else {
+            NSSound.beep()
+            return
+        }
+        NSWorkspace.shared.activateFileViewerSelecting([firstAudioURL])
+    }
+
+    private func clearFailedMeeting(_ item: MeetingSessionController.FailedMeetingItem) {
+        if let audio = failedMeetingAudioAttachment(for: item),
+           MeetingAudioPlayback.shared.isActive(audio) {
+            MeetingAudioPlayback.shared.stop()
+        }
+
+        if item.hasAudioFiles {
+            meetingSession.deleteFailedMeeting(id: item.id)
+        } else {
+            meetingSession.dismissFailedMeeting(id: item.id)
         }
     }
 
@@ -759,6 +818,10 @@ struct TranscriptedSettingsView: View {
         }
 
         return issues
+    }
+
+    private var canRetryFailedMeetings: Bool {
+        !meetingSession.hasRuntimeDiagnosticsWork
     }
 
     private var shortcutsPage: some View {
@@ -1230,17 +1293,19 @@ struct TranscriptedSettingsView: View {
                     ForEach(meetingSession.failedMeetings) { item in
                         SettingsFailedMeetingRow(
                             item: item,
+                            canRetry: canRetryFailedMeetings,
+                            audio: failedMeetingAudioAttachment(for: item),
                             retryAction: {
                                 trackSettingsAction("retry_failed_meeting", page: .meetings)
                                 meetingSession.retryFailedMeeting(id: item.id)
                             },
+                            revealAudioAction: {
+                                trackSettingsAction("reveal_failed_meeting_audio", page: .meetings)
+                                revealFailedMeetingAudio(item)
+                            },
                             secondaryAction: {
                                 trackSettingsAction(item.hasAudioFiles ? "delete_failed_meeting" : "dismiss_failed_meeting", page: .meetings)
-                                if item.hasAudioFiles {
-                                    meetingSession.deleteFailedMeeting(id: item.id)
-                                } else {
-                                    meetingSession.dismissFailedMeeting(id: item.id)
-                                }
+                                clearFailedMeeting(item)
                             }
                         )
                     }
@@ -3030,8 +3095,12 @@ private struct SettingsRecentMeetingAudioControl: View {
 
 private struct SettingsFailedMeetingRow: View {
     let item: MeetingSessionController.FailedMeetingItem
+    let canRetry: Bool
+    let audio: MeetingAudioAttachment?
     let retryAction: () -> Void
+    let revealAudioAction: () -> Void
     let secondaryAction: () -> Void
+    @ObservedObject private var playback = MeetingAudioPlayback.shared
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
@@ -3063,15 +3132,35 @@ private struct SettingsFailedMeetingRow: View {
 
             Spacer(minLength: 12)
 
+            if let audio {
+                SettingsRecentMeetingAudioControl(
+                    title: playback.buttonTitle(for: audio),
+                    symbolName: playback.symbolName(for: audio),
+                    isActive: playback.isActive(audio),
+                    isPlaying: playback.isPlaying && playback.isActive(audio)
+                ) {
+                    playback.toggle(audio)
+                }
+                .help("\(playback.buttonTitle(for: audio)) retained meeting audio")
+
+                Button {
+                    revealAudioAction()
+                } label: {
+                    Label("Show Audio", systemImage: "folder")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
             if item.isRetryable || item.isRetrying {
                 Button {
                     retryAction()
                 } label: {
-                    Label(item.isRetrying ? "Retrying..." : "Retry", systemImage: "arrow.clockwise")
+                    Label(item.isRetrying ? "Retrying..." : "Try Again", systemImage: "arrow.clockwise")
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
-                .disabled(!item.isRetryable || item.isRetrying)
+                .disabled(!canRetry || !item.isRetryable || item.isRetrying)
             }
 
             Button(role: item.hasAudioFiles ? .destructive : nil) {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -11,7 +11,7 @@ private struct SettingsSidebarSection: Identifiable {
 
     static let defaultSections = [
         SettingsSidebarSection(id: "home", title: nil, pages: [.home]),
-        SettingsSidebarSection(id: "recording", title: "Recording", pages: [.meetings, .dictations, .people, .shortcuts]),
+        SettingsSidebarSection(id: "recording", title: "Recording", pages: [.dictations, .people, .shortcuts]),
         SettingsSidebarSection(id: "setup", title: "Setup", pages: [.general, .models, .storage, .connectAgent]),
         SettingsSidebarSection(id: "trust", title: "Trust", pages: [.privacy, .support, .about])
     ]
@@ -53,7 +53,6 @@ struct TranscriptedSettingsView: View {
     @State private var diagnosticsActionStatus: String?
     @State private var permissionStates = PermissionSnapshot.current()
     @State private var captureLibraryURL = FileManager.default.transcriptedCaptureLibraryDir
-    @State private var recentMeetings: [RecentMeetingItem] = []
     @State private var recentDictations: [SavedDictationEntry] = []
     @State private var recentCapturesLoading = false
     @State private var recentCaptureRefreshTask: Task<Void, Never>?
@@ -70,7 +69,6 @@ struct TranscriptedSettingsView: View {
     @State private var showModelCacheCleanupConfirmation = false
     @State private var showWhisperCacheCleanupConfirmation = false
     @State private var showReclaimableCacheCleanupConfirmation = false
-    @State private var copiedAgentMeetingID: String?
     @State private var meetingVoiceProcessingEnabled = MicrophoneProcessingPreferences.isVoiceProcessingEnabled()
     @State private var audioRetentionWindow = AudioStoragePreferences.deleteAudioAfter()
     @State private var pendingAudioRetentionWindow: AudioRetentionWindow?
@@ -259,8 +257,6 @@ struct TranscriptedSettingsView: View {
             modelsPage
         case .shortcuts:
             shortcutsPage
-        case .meetings:
-            meetingsPage
         case .dictations:
             dictationsPage
         case .people:
@@ -283,6 +279,10 @@ struct TranscriptedSettingsView: View {
         let needsAttention = homeNeedsAttentionIssues
 
         return VStack(alignment: .leading, spacing: 14) {
+            if !meetingSession.failedMeetings.isEmpty {
+                homeFailedMeetingsCard
+            }
+
             HStack(alignment: .top, spacing: 20) {
                 HomeWelcomeHeader(
                     name: homeViewModel.welcomeName,
@@ -292,6 +292,8 @@ struct TranscriptedSettingsView: View {
 
                 HomeStatsTopCard(stats: stats, streak: homeStreak)
             }
+
+            homeQuickActions
 
             HomeHeroCard(
                 selectedMode: homeHeroModeSelection
@@ -432,6 +434,112 @@ struct TranscriptedSettingsView: View {
                 },
                 secondaryButton: .cancel()
             )
+        }
+    }
+
+    private var homeFailedMeetingsCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(.orange)
+                    .padding(.top, 2)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Unfinished meetings")
+                        .font(.headline)
+                    Text("Retry the transcript or delete the saved audio before this gets buried.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer()
+            }
+
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(meetingSession.failedMeetings) { item in
+                    SettingsFailedMeetingRow(
+                        item: item,
+                        retryAction: {
+                            trackSettingsAction("retry_failed_meeting", page: .home)
+                            meetingSession.retryFailedMeeting(id: item.id)
+                        },
+                        secondaryAction: {
+                            trackSettingsAction(item.hasAudioFiles ? "delete_failed_meeting" : "dismiss_failed_meeting", page: .home)
+                            if item.hasAudioFiles {
+                                meetingSession.deleteFailedMeeting(id: item.id)
+                            } else {
+                                meetingSession.dismissFailedMeeting(id: item.id)
+                            }
+                        }
+                    )
+                }
+            }
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(Color.orange.opacity(0.10))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.orange.opacity(0.42), lineWidth: 1)
+        )
+    }
+
+    private var homeQuickActions: some View {
+        let columns = [
+            GridItem(.flexible(minimum: 240), spacing: 12),
+            GridItem(.flexible(minimum: 240), spacing: 12)
+        ]
+
+        return LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
+            SettingsActionTile(
+                symbolName: "record.circle.fill",
+                title: "Start Meeting",
+                detail: "Capture your mic and computer audio.",
+                tone: .accent,
+                menuBarVisibility: menuBarVisibilityBinding(for: .startMeeting),
+                actionHelp: "Start a meeting recording.",
+                menuBarVisibilityHelp: "Show or hide Start Meeting in the menu bar popover."
+            ) {
+                trackSettingsAction("start_meeting", page: .home)
+                actions.startMeeting()
+            }
+
+            SettingsActionTile(
+                symbolName: "waveform",
+                title: "Transcribe Audio File",
+                detail: "Turn an audio file into meeting notes.",
+                actionHelp: "Choose an audio file to transcribe."
+            ) {
+                trackSettingsAction("import_recording", page: .home)
+                actions.importAudioFile()
+            }
+
+            SettingsActionTile(
+                symbolName: "mic.fill",
+                title: "Start Dictation",
+                detail: "Say something and paste it back.",
+                menuBarVisibility: menuBarVisibilityBinding(for: .startDictation),
+                actionHelp: "Start dictation.",
+                menuBarVisibilityHelp: "Show or hide Start Dictation in the menu bar popover."
+            ) {
+                trackSettingsAction("start_dictation", page: .home)
+                actions.startDictation()
+            }
+
+            SettingsActionTile(
+                symbolName: "sparkles",
+                title: "Connect Agent",
+                detail: "Copy a prompt or install direct local tools.",
+                actionHelp: "Open agent setup."
+            ) {
+                trackSettingsAction("open_agent", page: .home)
+                navigation.selectedPage = .connectAgent
+            }
         }
     }
 
@@ -1157,123 +1265,6 @@ struct TranscriptedSettingsView: View {
         }
     }
 
-    private var meetingsPage: some View {
-        VStack(alignment: .leading, spacing: 24) {
-            SettingsPageIntro(
-                title: "Meetings",
-                summary: "Record meetings, import audio, and open recent transcripts."
-            )
-
-            SettingsSection(
-                title: "Start or Import",
-                detail: "Record now, or transcribe a file."
-            ) {
-                SettingsQuickLinkRow(
-                    symbolName: "record.circle.fill",
-                    title: "Start Meeting",
-                    detail: "Capture your mic and computer audio."
-                ) {
-                    trackSettingsAction("start_meeting", page: .meetings)
-                    actions.startMeeting()
-                }
-
-                SettingsQuickLinkRow(
-                    symbolName: "waveform",
-                    title: "Transcribe Audio File",
-                    detail: "Turn an audio file into meeting notes."
-                ) {
-                    trackSettingsAction("import_recording", page: .meetings)
-                    actions.importAudioFile()
-                }
-
-                Text("Blocked? Open Privacy and check microphone or system audio.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            SettingsSection(
-                title: "Recent Meetings",
-                detail: "The last five saved meeting transcripts."
-            ) {
-                if recentCapturesLoading && recentMeetings.isEmpty {
-                    Text("Loading recent meetings...")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                } else if recentMeetings.isEmpty {
-                    Text("Record or import a meeting and it will appear here.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(recentMeetings) { item in
-                        SettingsRecentMeetingRow(
-                            item: item,
-                            detail: formattedRecentDate(item.date),
-                            isCopied: copiedAgentMeetingID == item.id,
-                            openAction: {
-                                trackSettingsAction("open_recent_meeting", page: .meetings)
-                                NSWorkspace.shared.open(item.transcriptURL)
-                            },
-                            copyForAgentAction: {
-                                trackSettingsAction("copy_recent_meeting_for_agent", page: .meetings)
-                                copyMeetingForAgent(item)
-                            }
-                        )
-                    }
-                }
-            }
-
-            if !meetingSession.failedMeetings.isEmpty {
-                SettingsSection(
-                    title: "Needs Attention",
-                    detail: "Retry or clear unfinished meetings."
-                ) {
-                    ForEach(meetingSession.failedMeetings) { item in
-                        SettingsFailedMeetingRow(
-                            item: item,
-                            retryAction: {
-                                trackSettingsAction("retry_failed_meeting", page: .meetings)
-                                meetingSession.retryFailedMeeting(id: item.id)
-                            },
-                            secondaryAction: {
-                                trackSettingsAction(item.hasAudioFiles ? "delete_failed_meeting" : "dismiss_failed_meeting", page: .meetings)
-                                if item.hasAudioFiles {
-                                    meetingSession.deleteFailedMeeting(id: item.id)
-                                } else {
-                                    meetingSession.dismissFailedMeeting(id: item.id)
-                                }
-                            }
-                        )
-                    }
-                }
-            }
-
-            SettingsSection(
-                title: "Microphone Processing",
-                detail: "How Transcripted cleans up your mic for meetings."
-            ) {
-                Toggle("Use Apple voice processing for Safari/Firefox mic attenuation", isOn: Binding(
-                    get: { meetingVoiceProcessingEnabled },
-                    set: { newValue in
-                        meetingVoiceProcessingEnabled = newValue
-                        trackSettingsToggle("meeting_voice_processing", enabled: newValue, page: .meetings)
-                        MicrophoneProcessingPreferences.setVoiceProcessingEnabled(newValue)
-                    }
-                ))
-
-                Text(meetingVoiceProcessingEnabled
-                    ? "May lower other app audio in Zoom/Meet."
-                    : "Off — Transcripted boosts the saved mic and live STT copy in software without changing system audio."
-                )
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-                Text("Takes effect on the next recording.")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-            }
-        }
-    }
-
     private var peoplePage: some View {
         VStack(alignment: .leading, spacing: 24) {
             SettingsPageIntro(
@@ -1599,6 +1590,31 @@ struct TranscriptedSettingsView: View {
                         refreshPermissions()
                     }
                 }
+            }
+
+            SettingsSection(
+                title: "Meeting Audio",
+                detail: "How Transcripted handles your microphone during meetings."
+            ) {
+                Toggle("Use Apple voice processing for Safari/Firefox mic attenuation", isOn: Binding(
+                    get: { meetingVoiceProcessingEnabled },
+                    set: { newValue in
+                        meetingVoiceProcessingEnabled = newValue
+                        trackSettingsToggle("meeting_voice_processing", enabled: newValue, page: .privacy)
+                        MicrophoneProcessingPreferences.setVoiceProcessingEnabled(newValue)
+                    }
+                ))
+
+                Text(meetingVoiceProcessingEnabled
+                    ? "May lower other app audio in Zoom/Meet."
+                    : "Off. Transcripted boosts the saved mic and live transcript in software without changing system audio."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+                Text("Takes effect on the next recording.")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
             }
 
             SettingsSection(
@@ -2290,7 +2306,6 @@ struct TranscriptedSettingsView: View {
             recentCaptureRefreshTask = Task { @MainActor in
                 let snapshot = await RecentCaptureLoader.load(limit: 5)
                 guard !Task.isCancelled else { return }
-                recentMeetings = snapshot.meetings
                 recentDictations = snapshot.dictations
                 recentCapturesLoading = false
             }
@@ -2690,29 +2705,6 @@ struct TranscriptedSettingsView: View {
         Self.recentCaptureDateFormatter.string(from: date)
     }
 
-    private func copyMeetingForAgent(_ item: RecentMeetingItem) {
-        guard let bundle = AgentConnectionGuide.portableMeetingBundle(
-            title: item.title,
-            date: item.date,
-            transcriptURL: item.transcriptURL
-        ) else {
-            NSSound.beep()
-            return
-        }
-
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(bundle, forType: .string)
-        copiedAgentMeetingID = item.id
-
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 1_200_000_000)
-            if copiedAgentMeetingID == item.id {
-                copiedAgentMeetingID = nil
-            }
-        }
-    }
-
     private static let recentCaptureDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = .current
@@ -2891,140 +2883,6 @@ private struct AutoEnterAllowedAppRow: View {
 
             Button("Remove", action: remove)
         }
-    }
-}
-
-private struct SettingsRecentMeetingRow: View {
-    let item: RecentMeetingItem
-    let detail: String
-    let isCopied: Bool
-    let openAction: () -> Void
-    let copyForAgentAction: () -> Void
-    @ObservedObject private var playback = MeetingAudioPlayback.shared
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Button(action: openAction) {
-                HStack(alignment: .top, spacing: 12) {
-                    Image(systemName: "doc.text")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundStyle(.secondary)
-                        .frame(width: 24)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(item.title)
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(Color.primary)
-
-                        Text(detail)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-
-                    Spacer(minLength: 12)
-
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 10, weight: .semibold))
-                        .foregroundStyle(.tertiary)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .buttonStyle(.plain)
-
-            HStack(spacing: 10) {
-                if let audio = item.audio {
-                    SettingsRecentMeetingAudioControl(
-                        title: playback.buttonTitle(for: audio),
-                        symbolName: playback.symbolName(for: audio),
-                        isActive: playback.isActive(audio),
-                        isPlaying: playback.isPlaying && playback.isActive(audio)
-                    ) {
-                        playback.toggle(audio)
-                    }
-                    .help("\(playback.buttonTitle(for: audio)) meeting audio")
-                }
-
-                Button {
-                    copyForAgentAction()
-                } label: {
-                    Label(isCopied ? "Copied" : "Copy for Agent", systemImage: isCopied ? "checkmark" : "sparkles")
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-            }
-        }
-    }
-}
-
-private struct SettingsRecentMeetingAudioControl: View {
-    let title: String
-    let symbolName: String
-    let isActive: Bool
-    let isPlaying: Bool
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 8) {
-                Image(systemName: symbolName)
-                    .font(.system(size: 9, weight: .bold))
-                    .foregroundStyle(iconForeground)
-                    .frame(width: 20, height: 20)
-                    .background(Circle().fill(iconBackground))
-
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill(Color.secondary.opacity(0.22))
-                        .frame(width: 44, height: 4)
-
-                    Capsule()
-                        .fill(playheadColor)
-                        .frame(width: isPlaying ? 28 : 8, height: 4)
-
-                    Circle()
-                        .fill(playheadColor)
-                        .frame(width: 8, height: 8)
-                        .offset(x: isPlaying ? 24 : 4)
-                }
-                .frame(width: 44, height: 12)
-
-                Text(title)
-                    .font(.caption.weight(.semibold))
-                    .lineLimit(1)
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(background)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(stroke, lineWidth: 1)
-            )
-        }
-        .buttonStyle(.plain)
-    }
-
-    private var background: Color {
-        isActive ? Color.accentColor.opacity(0.14) : Color.secondary.opacity(0.08)
-    }
-
-    private var stroke: Color {
-        isActive ? Color.accentColor.opacity(0.28) : Color.primary.opacity(0.10)
-    }
-
-    private var iconBackground: Color {
-        isActive ? Color.accentColor : Color.primary.opacity(0.12)
-    }
-
-    private var iconForeground: Color {
-        isActive ? .white : .secondary
-    }
-
-    private var playheadColor: Color {
-        isActive ? .accentColor : .secondary.opacity(0.65)
     }
 }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -348,6 +348,7 @@ struct TranscriptedSettingsView: View {
                 HomeFailedMeetingsCard(
                     items: failedMeetings,
                     canRetry: canRetryFailedMeetings,
+                    retryUnavailableReason: failedMeetingRetryUnavailableReason,
                     audioAttachment: { failedMeetingAudioAttachment(for: $0) },
                     onRetry: { item in
                         trackSettingsAction("home_retry_failed_meeting", page: .home)
@@ -821,7 +822,17 @@ struct TranscriptedSettingsView: View {
     }
 
     private var canRetryFailedMeetings: Bool {
-        !meetingSession.hasRuntimeDiagnosticsWork
+        failedMeetingRetryUnavailableReason == nil
+    }
+
+    private var failedMeetingRetryUnavailableReason: String? {
+        if meetingSession.isRecording {
+            return "Stop the current recording before retrying a failed meeting."
+        }
+        if meetingSession.hasRuntimeDiagnosticsWork {
+            return "Wait for the current meeting to finish saving or transcribing before retrying."
+        }
+        return nil
     }
 
     private var shortcutsPage: some View {
@@ -1294,6 +1305,7 @@ struct TranscriptedSettingsView: View {
                         SettingsFailedMeetingRow(
                             item: item,
                             canRetry: canRetryFailedMeetings,
+                            retryUnavailableReason: failedMeetingRetryUnavailableReason,
                             audio: failedMeetingAudioAttachment(for: item),
                             retryAction: {
                                 trackSettingsAction("retry_failed_meeting", page: .meetings)
@@ -3003,7 +3015,10 @@ private struct SettingsRecentMeetingRow: View {
                         title: playback.buttonTitle(for: audio),
                         symbolName: playback.symbolName(for: audio),
                         isActive: playback.isActive(audio),
-                        isPlaying: playback.isPlaying && playback.isActive(audio)
+                        isPlaying: playback.isPlaying && playback.isActive(audio),
+                        scrubber: playback.isActive(audio)
+                            ? AnyView(MeetingAudioScrubber(attachment: audio, width: 210))
+                            : nil
                     ) {
                         playback.toggle(audio)
                     }
@@ -3027,49 +3042,72 @@ private struct SettingsRecentMeetingAudioControl: View {
     let symbolName: String
     let isActive: Bool
     let isPlaying: Bool
+    let scrubber: AnyView?
     let action: () -> Void
 
+    init(
+        title: String,
+        symbolName: String,
+        isActive: Bool,
+        isPlaying: Bool,
+        scrubber: AnyView? = nil,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.symbolName = symbolName
+        self.isActive = isActive
+        self.isPlaying = isPlaying
+        self.scrubber = scrubber
+        self.action = action
+    }
+
     var body: some View {
-        Button(action: action) {
-            HStack(spacing: 8) {
-                Image(systemName: symbolName)
-                    .font(.system(size: 9, weight: .bold))
-                    .foregroundStyle(iconForeground)
-                    .frame(width: 20, height: 20)
-                    .background(Circle().fill(iconBackground))
+        VStack(alignment: .leading, spacing: 6) {
+            Button(action: action) {
+                HStack(spacing: 8) {
+                    Image(systemName: symbolName)
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(iconForeground)
+                        .frame(width: 20, height: 20)
+                        .background(Circle().fill(iconBackground))
 
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill(Color.secondary.opacity(0.22))
-                        .frame(width: 44, height: 4)
+                    ZStack(alignment: .leading) {
+                        Capsule()
+                            .fill(Color.secondary.opacity(0.22))
+                            .frame(width: 44, height: 4)
 
-                    Capsule()
-                        .fill(playheadColor)
-                        .frame(width: isPlaying ? 28 : 8, height: 4)
+                        Capsule()
+                            .fill(playheadColor)
+                            .frame(width: isPlaying ? 28 : 8, height: 4)
 
-                    Circle()
-                        .fill(playheadColor)
-                        .frame(width: 8, height: 8)
-                        .offset(x: isPlaying ? 24 : 4)
+                        Circle()
+                            .fill(playheadColor)
+                            .frame(width: 8, height: 8)
+                            .offset(x: isPlaying ? 24 : 4)
+                    }
+                    .frame(width: 44, height: 12)
+
+                    Text(title)
+                        .font(.caption.weight(.semibold))
+                        .lineLimit(1)
                 }
-                .frame(width: 44, height: 12)
-
-                Text(title)
-                    .font(.caption.weight(.semibold))
-                    .lineLimit(1)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(background)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(stroke, lineWidth: 1)
+                )
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(background)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(stroke, lineWidth: 1)
-            )
+            .buttonStyle(.plain)
+
+            if let scrubber {
+                scrubber
+            }
         }
-        .buttonStyle(.plain)
     }
 
     private var background: Color {
@@ -3096,6 +3134,7 @@ private struct SettingsRecentMeetingAudioControl: View {
 private struct SettingsFailedMeetingRow: View {
     let item: MeetingSessionController.FailedMeetingItem
     let canRetry: Bool
+    let retryUnavailableReason: String?
     let audio: MeetingAudioAttachment?
     let retryAction: () -> Void
     let revealAudioAction: () -> Void
@@ -3137,7 +3176,10 @@ private struct SettingsFailedMeetingRow: View {
                     title: playback.buttonTitle(for: audio),
                     symbolName: playback.symbolName(for: audio),
                     isActive: playback.isActive(audio),
-                    isPlaying: playback.isPlaying && playback.isActive(audio)
+                    isPlaying: playback.isPlaying && playback.isActive(audio),
+                    scrubber: playback.isActive(audio)
+                        ? AnyView(MeetingAudioScrubber(attachment: audio, width: 190))
+                        : nil
                 ) {
                     playback.toggle(audio)
                 }
@@ -3160,7 +3202,8 @@ private struct SettingsFailedMeetingRow: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
-                .disabled(!canRetry || !item.isRetryable || item.isRetrying)
+                .disabled(retryDisabled)
+                .help(retryHelp)
             }
 
             Button(role: item.hasAudioFiles ? .destructive : nil) {
@@ -3171,6 +3214,26 @@ private struct SettingsFailedMeetingRow: View {
             .buttonStyle(.bordered)
             .controlSize(.small)
         }
+    }
+
+    private var retryDisabled: Bool {
+        !canRetry || !item.isRetryable || item.isRetrying
+    }
+
+    private var retryHelp: String {
+        if item.isRetrying {
+            return "Retry is already running."
+        }
+        if !item.isRetryable {
+            return "This meeting does not have enough saved audio to retry."
+        }
+        if let retryUnavailableReason {
+            return retryUnavailableReason
+        }
+        if !canRetry {
+            return "Wait for the current meeting work to finish before retrying."
+        }
+        return "Transcribe this saved audio again."
     }
 }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -60,7 +60,6 @@ struct TranscriptedSettingsView: View {
     @State private var homeDashboardRefreshInFlight = false
     @State private var homeDashboardRefreshGeneration = 0
     @State private var lastHomeDashboardRefreshStartedAt: Date?
-    @State private var menuBarItemVisibility = MenuBarVisibilityPreferences.snapshot()
     @State private var showSupportFolders = false
     @State private var modelCacheSnapshot: ModelCacheSnapshot?
     @State private var modelCacheLoading = false
@@ -168,9 +167,6 @@ struct TranscriptedSettingsView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .transcriptionModelPreferenceDidChange)) { _ in
             preferredTranscriptionModel = TranscriptionModelPreferences.preferredModel()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .menuBarVisibilityPreferencesDidChange)) { _ in
-            refreshMenuBarVisibility()
         }
         .onReceive(NotificationCenter.default.publisher(for: .dockVisibilityPreferencesDidChange)) { _ in
             refreshDockVisibility()
@@ -292,8 +288,6 @@ struct TranscriptedSettingsView: View {
 
                 HomeStatsTopCard(stats: stats, streak: homeStreak)
             }
-
-            homeQuickActions
 
             HomeHeroCard(
                 selectedMode: homeHeroModeSelection
@@ -487,60 +481,6 @@ struct TranscriptedSettingsView: View {
             RoundedRectangle(cornerRadius: 18, style: .continuous)
                 .stroke(Color.orange.opacity(0.42), lineWidth: 1)
         )
-    }
-
-    private var homeQuickActions: some View {
-        let columns = [
-            GridItem(.flexible(minimum: 240), spacing: 12),
-            GridItem(.flexible(minimum: 240), spacing: 12)
-        ]
-
-        return LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
-            SettingsActionTile(
-                symbolName: "record.circle.fill",
-                title: "Start Meeting",
-                detail: "Capture your mic and computer audio.",
-                tone: .accent,
-                menuBarVisibility: menuBarVisibilityBinding(for: .startMeeting),
-                actionHelp: "Start a meeting recording.",
-                menuBarVisibilityHelp: "Show or hide Start Meeting in the menu bar popover."
-            ) {
-                trackSettingsAction("start_meeting", page: .home)
-                actions.startMeeting()
-            }
-
-            SettingsActionTile(
-                symbolName: "waveform",
-                title: "Transcribe Audio File",
-                detail: "Turn an audio file into meeting notes.",
-                actionHelp: "Choose an audio file to transcribe."
-            ) {
-                trackSettingsAction("import_recording", page: .home)
-                actions.importAudioFile()
-            }
-
-            SettingsActionTile(
-                symbolName: "mic.fill",
-                title: "Start Dictation",
-                detail: "Say something and paste it back.",
-                menuBarVisibility: menuBarVisibilityBinding(for: .startDictation),
-                actionHelp: "Start dictation.",
-                menuBarVisibilityHelp: "Show or hide Start Dictation in the menu bar popover."
-            ) {
-                trackSettingsAction("start_dictation", page: .home)
-                actions.startDictation()
-            }
-
-            SettingsActionTile(
-                symbolName: "sparkles",
-                title: "Connect Agent",
-                detail: "Copy a prompt or install direct local tools.",
-                actionHelp: "Open agent setup."
-            ) {
-                trackSettingsAction("open_agent", page: .home)
-                navigation.selectedPage = .connectAgent
-            }
-        }
     }
 
     private var settingsContentTopPadding: CGFloat {
@@ -2106,7 +2046,6 @@ struct TranscriptedSettingsView: View {
         refreshStoragePaths()
         refreshRecentCaptures(force: true)
         refreshShortcutState()
-        refreshMenuBarVisibility()
         refreshDockVisibility()
         refreshLaunchAtLoginState()
         customDictionaryText = CustomDictionaryPreferences.rawText()
@@ -2347,10 +2286,6 @@ struct TranscriptedSettingsView: View {
         )
     }
 
-    private func refreshMenuBarVisibility() {
-        menuBarItemVisibility = MenuBarVisibilityPreferences.snapshot()
-    }
-
     private func refreshDockVisibility() {
         showTranscriptedInDock = DockVisibilityPreferences.isVisible()
     }
@@ -2458,17 +2393,6 @@ struct TranscriptedSettingsView: View {
         Task { @MainActor in
             await sttRouter.initializeSelectedModel()
         }
-    }
-
-    private func menuBarVisibilityBinding(for item: MenuBarOptionalItem) -> Binding<Bool> {
-        Binding(
-            get: { menuBarItemVisibility[item] ?? true },
-            set: { newValue in
-                menuBarItemVisibility[item] = newValue
-                trackSettingsToggle("menu_bar_\(item.analyticsValue)", enabled: newValue, page: .home)
-                MenuBarVisibilityPreferences.setVisible(item, newValue)
-            }
-        )
     }
 
     private func sendTestSentryEvent() {

--- a/Sources/UI/Shared/MeetingAudioPlayback.swift
+++ b/Sources/UI/Shared/MeetingAudioPlayback.swift
@@ -9,6 +9,7 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
     @Published private(set) var activeAttachmentID: String?
     @Published private(set) var isPlaying = false
     @Published private(set) var isPaused = false
+    @Published private(set) var unavailableAttachmentID: String?
 
     private var sounds: [NSSound] = []
 
@@ -34,8 +35,13 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
             NSSound(contentsOf: url, byReference: true)
         }
 
-        guard !loadedSounds.isEmpty else { return }
+        guard !loadedSounds.isEmpty else {
+            unavailableAttachmentID = attachment.id
+            NSSound.beep()
+            return
+        }
 
+        unavailableAttachmentID = nil
         activeAttachmentID = attachment.id
         sounds = loadedSounds
         isPlaying = true
@@ -75,6 +81,7 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         activeAttachmentID = nil
         isPlaying = false
         isPaused = false
+        unavailableAttachmentID = nil
     }
 
     func isActive(_ attachment: MeetingAudioAttachment) -> Bool {
@@ -82,6 +89,7 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
     }
 
     func buttonTitle(for attachment: MeetingAudioAttachment) -> String {
+        if unavailableAttachmentID == attachment.id { return "Unavailable" }
         guard isActive(attachment) else { return "Play" }
         if isPlaying { return "Pause" }
         if isPaused { return "Resume" }
@@ -89,6 +97,7 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
     }
 
     func symbolName(for attachment: MeetingAudioAttachment) -> String {
+        if unavailableAttachmentID == attachment.id { return "exclamationmark.triangle.fill" }
         guard isActive(attachment) else { return "play.fill" }
         if isPlaying { return "pause.fill" }
         return "play.fill"

--- a/Sources/UI/Shared/MeetingAudioPlayback.swift
+++ b/Sources/UI/Shared/MeetingAudioPlayback.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Combine
 import Foundation
+import SwiftUI
 
 @MainActor
 final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
@@ -10,8 +11,11 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
     @Published private(set) var isPlaying = false
     @Published private(set) var isPaused = false
     @Published private(set) var unavailableAttachmentID: String?
+    @Published private(set) var currentTime: TimeInterval = 0
+    @Published private(set) var duration: TimeInterval = 0
 
     private var sounds: [NSSound] = []
+    private var progressTimer: Timer?
 
     func toggle(_ attachment: MeetingAudioAttachment) {
         if activeAttachmentID == attachment.id {
@@ -44,13 +48,18 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         unavailableAttachmentID = nil
         activeAttachmentID = attachment.id
         sounds = loadedSounds
+        duration = loadedSounds.map(\.duration).max() ?? 0
+        currentTime = 0
         isPlaying = true
         isPaused = false
 
         for sound in sounds {
             sound.delegate = self
+            sound.currentTime = 0
             sound.play()
         }
+
+        startProgressTimer()
     }
 
     func pause() {
@@ -58,6 +67,7 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         for sound in sounds {
             sound.pause()
         }
+        stopProgressTimer()
         isPlaying = false
         isPaused = true
     }
@@ -70,9 +80,13 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         }
         isPlaying = resumedAnySound
         isPaused = !resumedAnySound
+        if resumedAnySound {
+            startProgressTimer()
+        }
     }
 
     func stop() {
+        stopProgressTimer()
         for sound in sounds {
             sound.stop()
             sound.delegate = nil
@@ -82,10 +96,35 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         isPlaying = false
         isPaused = false
         unavailableAttachmentID = nil
+        currentTime = 0
+        duration = 0
     }
 
     func isActive(_ attachment: MeetingAudioAttachment) -> Bool {
         activeAttachmentID == attachment.id
+    }
+
+    func seek(_ attachment: MeetingAudioAttachment, progress: Double) {
+        guard isActive(attachment), duration > 0 else { return }
+        let clampedProgress = min(max(progress, 0), 1)
+        let targetTime = duration * clampedProgress
+
+        for sound in sounds {
+            let soundDuration = max(sound.duration, 0)
+            sound.currentTime = min(targetTime, soundDuration)
+        }
+
+        currentTime = targetTime
+    }
+
+    func progress(for attachment: MeetingAudioAttachment) -> Double {
+        guard isActive(attachment), duration > 0 else { return 0 }
+        return min(max(currentTime / duration, 0), 1)
+    }
+
+    func timeLabel(for attachment: MeetingAudioAttachment) -> String {
+        guard isActive(attachment), duration > 0 else { return "0:00" }
+        return "\(Self.formatTime(currentTime)) / \(Self.formatTime(duration))"
     }
 
     func buttonTitle(for attachment: MeetingAudioAttachment) -> String {
@@ -113,5 +152,81 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         guard !isPaused else { return }
         guard !sounds.contains(where: { $0.isPlaying }) else { return }
         stop()
+    }
+
+    private func startProgressTimer() {
+        stopProgressTimer()
+        let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.updatePlaybackTime()
+            }
+        }
+        progressTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+        updatePlaybackTime()
+    }
+
+    private func stopProgressTimer() {
+        progressTimer?.invalidate()
+        progressTimer = nil
+    }
+
+    private func updatePlaybackTime() {
+        guard !sounds.isEmpty, duration > 0 else {
+            currentTime = 0
+            return
+        }
+
+        let latestTime = sounds.map(\.currentTime).max() ?? 0
+        currentTime = min(max(latestTime, 0), duration)
+    }
+
+    private static func formatTime(_ time: TimeInterval) -> String {
+        let totalSeconds = max(0, Int(time.rounded(.down)))
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
+
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}
+
+struct MeetingAudioScrubber: View {
+    let attachment: MeetingAudioAttachment
+    var width: CGFloat?
+    var showsTime = true
+
+    @ObservedObject private var playback = MeetingAudioPlayback.shared
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Slider(
+                value: Binding(
+                    get: { playback.progress(for: attachment) },
+                    set: { playback.seek(attachment, progress: $0) }
+                ),
+                in: 0...1
+            )
+            .controlSize(.small)
+            .disabled(!canScrub)
+
+            if showsTime {
+                Text(playback.timeLabel(for: attachment))
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .frame(width: 78, alignment: .trailing)
+            }
+        }
+        .frame(width: width, alignment: .leading)
+        .help(canScrub ? "Drag to scrub meeting audio" : "Start playback before scrubbing")
+    }
+
+    private var canScrub: Bool {
+        playback.isActive(attachment) && playback.duration > 0
     }
 }

--- a/Sources/UI/Shared/MeetingAudioPlayback.swift
+++ b/Sources/UI/Shared/MeetingAudioPlayback.swift
@@ -111,7 +111,11 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
 
         for sound in sounds {
             let soundDuration = max(sound.duration, 0)
-            sound.currentTime = min(targetTime, soundDuration)
+            let seekTime = min(targetTime, soundDuration)
+            sound.currentTime = seekTime
+            if isPlaying, !sound.isPlaying, seekTime < soundDuration {
+                sound.play()
+            }
         }
 
         currentTime = targetTime

--- a/Tests/DictationNoSpeechPresentationPolicyTests.swift
+++ b/Tests/DictationNoSpeechPresentationPolicyTests.swift
@@ -6,8 +6,8 @@ func testDictationNoSpeechPresentationPolicy() {
 
         assertEqual(
             message,
-            "Transcripted didn't catch your voice. Hold the dictation key while you talk.",
-            "physical key no-speech copy should explain the press-and-talk behavior"
+            "Transcripted didn't catch your voice. Keep holding the dictation key until you're done talking.",
+            "physical key no-speech copy should explain the press-and-hold behavior"
         )
     }
 

--- a/Tests/MeetingAudioArchiveResolverTests.swift
+++ b/Tests/MeetingAudioArchiveResolverTests.swift
@@ -4,6 +4,7 @@ func testMeetingAudioArchiveResolver() {
     runSuite("MeetingAudioArchiveResolverTests") {
         testResolverFindsLiveMeetingAudioPair()
         testResolverPrefersImportedRecording()
+        testResolverPrefersPlaybackMix()
         testResolverReturnsNilWhenAudioIsMissing()
     }
 }
@@ -59,6 +60,40 @@ private func testResolverPrefersImportedRecording() {
         "Imported recordings should play the original retained recording"
     )
     assertTrue(attachment?.isCompositePlayback == false, "A single imported recording is not composite playback")
+}
+
+private func testResolverPrefersPlaybackMix() {
+    let directory = makeMeetingAudioResolverTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Weekly Review.md")
+    let audioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: transcriptURL)
+    try? FileManager.default.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+    FileManager.default.createFile(
+        atPath: audioDirectory.appendingPathComponent("playback.m4a").path,
+        contents: Data("mix".utf8)
+    )
+    FileManager.default.createFile(
+        atPath: audioDirectory.appendingPathComponent("recording.m4a").path,
+        contents: Data("imported".utf8)
+    )
+    FileManager.default.createFile(
+        atPath: audioDirectory.appendingPathComponent("system_audio.m4a").path,
+        contents: Data("system".utf8)
+    )
+    FileManager.default.createFile(
+        atPath: audioDirectory.appendingPathComponent("microphone.m4a").path,
+        contents: Data("mic".utf8)
+    )
+
+    let attachment = MeetingAudioArchiveResolver.attachment(forTranscript: transcriptURL)
+
+    assertEqual(
+        attachment?.urls.map(\.lastPathComponent),
+        ["playback.m4a"],
+        "Playback mixes should win over imported and split-stream audio"
+    )
+    assertTrue(attachment?.isCompositePlayback == false, "A single playback mix is not composite playback")
 }
 
 private func testResolverReturnsNilWhenAudioIsMissing() {

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -380,6 +380,22 @@ func testRepoCommandContract() {
             "runner should keep unauthorized active issue detection explicit"
         )
     }
+
+    runSuite("Repo command contract - onboarding agent copy remains measurable") {
+        let contents = readRepoTextFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
+        assertTrue(
+            contents.contains("AnalyticsReporter.track(\n            \"onboarding_agent_cta_clicked\""),
+            "copying onboarding agent setup should emit the existing first-value activation event"
+        )
+        assertTrue(
+            contents.contains("\"agent_cta\": agentCTA") && contents.contains("\"step_id\": \"connect_agent\""),
+            "onboarding agent setup telemetry should stay limited to coarse CTA and step ids"
+        )
+        assertFalse(
+            contents.contains("AgentConnectionGuide.starterPrompt(filename: nil)\n        AnalyticsReporter.track"),
+            "onboarding telemetry should not send copied prompt text"
+        )
+    }
 }
 
 private func repoRootURL() -> URL {

--- a/Tests/SettingsRecentCaptureRefreshPolicyTests.swift
+++ b/Tests/SettingsRecentCaptureRefreshPolicyTests.swift
@@ -9,12 +9,7 @@ func testSettingsRecentCaptureRefreshPolicy() {
         )
     }
 
-    runSuite("SettingsRecentCaptureRefreshPolicy.mode — only loads recent lists for list pages") {
-        assertEqual(
-            SettingsRecentCaptureRefreshPolicy.mode(for: .meetings),
-            .recentLists,
-            "meetings should load the small recent list"
-        )
+    runSuite("SettingsRecentCaptureRefreshPolicy.mode — only loads recent lists for the dictation page") {
         assertEqual(
             SettingsRecentCaptureRefreshPolicy.mode(for: .dictations),
             .recentLists,

--- a/docs/ui-settings-menubar-spec.md
+++ b/docs/ui-settings-menubar-spec.md
@@ -110,16 +110,6 @@ When an update is found, the row also shows the available version as supporting 
 
 - `Version 1.1.10 ready`
 
-Primary action rows can be hidden from switches on the matching Settings
-`Home` action tiles where the control is surfaced:
-
-- `Start Dictation`
-- `Start Meeting`
-
-These switches default on. Hovering a switch explains that it shows or hides the
-matching row in the menu bar popover. The action arrow on each tile should read
-as an explicit icon button and expose a short hover description for the action.
-
 Utility rows such as `Connect Agent`, `Submit Feedback`, updates, `Settings`,
 and `Quit` remain visible in this version.
 
@@ -133,19 +123,11 @@ Show the simplest ways to use Transcripted and surface high-value status.
 Contents:
 
 - top-of-page unfinished meeting warnings, when a meeting needs retry/delete
-- large action buttons for:
-  - `Start Dictation`
-  - `Start Meeting`
-  - `Transcribe Audio File…`
-  - `Connect Agent`
+- overall dictation and meeting stats
 - recent activity for:
   - meetings, including retained-audio playback when available
   - dictations
-- setup/status cards for:
-  - local model readiness
-  - permissions health
-  - capture library location
-- quick links into the most important pages
+- compact setup issues only when something needs attention
 
 ### Shortcuts
 

--- a/docs/ui-settings-menubar-spec.md
+++ b/docs/ui-settings-menubar-spec.md
@@ -36,8 +36,8 @@ It uses a native macOS sidebar with these pages:
 
 - `Home`
 - `Recording`
-  - `Meetings`
   - `Dictation`
+  - `People`
   - `Shortcuts`
 - `Setup`
   - `General`
@@ -111,12 +111,10 @@ When an update is found, the row also shows the available version as supporting 
 - `Version 1.1.10 ready`
 
 Primary action rows can be hidden from switches on the matching Settings
-`Home` action tiles:
+`Home` action tiles where the control is surfaced:
 
 - `Start Dictation`
 - `Start Meeting`
-- `Paste Last Dictation`
-- `Recent Meetings`
 
 These switches default on. Hovering a switch explains that it shows or hides the
 matching row in the menu bar popover. The action arrow on each tile should read
@@ -134,11 +132,15 @@ Show the simplest ways to use Transcripted and surface high-value status.
 
 Contents:
 
+- top-of-page unfinished meeting warnings, when a meeting needs retry/delete
 - large action buttons for:
   - `Start Dictation`
   - `Start Meeting`
   - `Transcribe Audio File…`
   - `Connect Agent`
+- recent activity for:
+  - meetings, including retained-audio playback when available
+  - dictations
 - setup/status cards for:
   - local model readiness
   - permissions health
@@ -180,19 +182,19 @@ Contents:
 - model file status
 - optional model picker
 
-### Meetings
+### People
 
 Purpose:
-Own meeting-specific capture and meeting-speaker behavior.
+Own meeting speaker cleanup.
 
 Contents:
 
-- `Start Meeting`
-- `Transcribe Audio File…`
+- deferred speaker names
+- speaker sample playback
+- duplicate cleanup
 - local speaker split toggle
-- speaker people management
 
-Imported audio transcription lives here because it uses the meeting transcription pipeline.
+Meeting start, audio import, recent meeting transcripts, and unfinished meeting repair live on `Home`.
 
 ### Dictation
 
@@ -251,6 +253,7 @@ Contents:
   - accessibility
   - system audio recording
   - calendar
+- meeting microphone processing toggle
 - `Send crash and error reports`
 - `Send anonymous usage statistics`
 - `Send Test Sentry Event`
@@ -281,7 +284,6 @@ Optional supporting text can explain local-first behavior in one short paragraph
 ### Transcribe Audio File
 
 - appears on `Home`
-- appears on `Meetings`
 - does not appear in the menubar popover in this version
 
 ### Update Status


### PR DESCRIPTION
## Summary

- Removes the standalone Meetings settings page and routes recent-meeting entry points back to Home.
- Surfaces unfinished meetings and meeting playback inside Home, with meeting audio processing moved under Privacy.
- Removes the four Home action tiles so the Home section stays focused on status and recent activity.

## Validation

- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- bash build.sh --no-open
