### PR TITLE
[codex] Fix speaker name finalization after restyle

### DIFF
--- a/Sources/Meeting/MeetingFailureCopy.swift
+++ b/Sources/Meeting/MeetingFailureCopy.swift
@@ -37,6 +37,11 @@ struct MeetingFailureCopy: Equatable {
                 title: "Couldn't save the transcript",
                 detail: shortErrorMessage
             )
+        case .speakerNameFinalizationFailed:
+            return MeetingFailureCopy(
+                title: "Couldn't save speaker names",
+                detail: "The transcript saved, but the speaker names did not. Try again to rebuild the meeting and save the names."
+            )
         case .stopTimeout:
             return MeetingFailureCopy(
                 title: "Recording didn't close cleanly",

--- a/Sources/Meeting/MeetingFailureExplanation.swift
+++ b/Sources/Meeting/MeetingFailureExplanation.swift
@@ -104,7 +104,7 @@ struct MeetingFailureExplanation: Equatable {
             audioCaptured: hasAudioFiles,
             transcriptionFailed: failureKind == .transcriptionInferenceFailed,
             diarizationFailed: failureKind == .diarizationFailed,
-            saveFailed: failureKind == .saveFailed,
+            saveFailed: failureKind == .saveFailed || failureKind == .speakerNameFinalizationFailed,
             recoverableArtifact: recoverableArtifact,
             retryAvailable: recoverableArtifact && (retryability == .retryable || retryability == .retryableAfterUserAction)
         )
@@ -161,7 +161,8 @@ struct MeetingFailureExplanation: Equatable {
             return .transcription
         case .diarizationFailed:
             return .diarization
-        case .saveFailed:
+        case .saveFailed,
+             .speakerNameFinalizationFailed:
             return .save
         case .unexpectedError:
             return .activeCapture
@@ -212,7 +213,8 @@ struct MeetingFailureExplanation: Equatable {
              .microphonePermission,
              .microphoneMissing,
              .audioDeviceUnavailable,
-             .saveFailed:
+             .saveFailed,
+             .speakerNameFinalizationFailed:
             return .retryableAfterUserAction
         default:
             return .permanent
@@ -252,7 +254,8 @@ struct MeetingFailureExplanation: Equatable {
         }
 
         switch failureKind {
-        case .saveFailed:
+        case .saveFailed,
+             .speakerNameFinalizationFailed:
             return .recoverableFailure
         default:
             return .permanentFailure

--- a/Sources/Meeting/MeetingFailureKind.swift
+++ b/Sources/Meeting/MeetingFailureKind.swift
@@ -9,6 +9,7 @@ enum MeetingFailureKind: String {
     case emptyAudio = "empty_audio"
     case invalidAudioFormat = "invalid_audio_format"
     case saveFailed = "save_failed"
+    case speakerNameFinalizationFailed = "speaker_name_finalization_failed"
     case modelDownloadFailed = "model_download_failed"
     case modelNotLoaded = "model_not_loaded"
     case transcriptionInferenceFailed = "transcription_inference_failed"
@@ -87,6 +88,14 @@ enum MeetingFailureKind: String {
             "empty audio",
         ]) {
             return .emptyAudio
+        }
+
+        if normalized.contains(anyOf: [
+            "speaker names could not be saved",
+            "failed to finalize speaker names",
+            "speaker-name finalization failed",
+        ]) {
+            return .speakerNameFinalizationFailed
         }
 
         if normalized.contains(anyOf: [

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1033,7 +1033,7 @@ final class MeetingSessionController: ObservableObject {
     }
 
     func retryFailedMeeting(id: UUID) {
-        guard !isRecording, !hasBackgroundTranscriptionWork else { return }
+        guard !isRecording, !hasBackgroundTranscriptionWork, !isSpeakerReviewPending else { return }
         guard !retryingFailedMeetingIDs.contains(id) else { return }
 
         retryingFailedMeetingIDs.insert(id)

--- a/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
+++ b/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
@@ -254,6 +254,7 @@ public struct SpeakerNamingRequest {
     public let systemAudioURL: URL
     public let micAudioURL: URL?
     public let shouldRemoveTemporaryAudioOnCleanup: Bool
+    public let sourceFailedTranscriptionId: UUID?
     public let onComplete: ([SpeakerNameUpdate]) -> Void
 
     public init(
@@ -264,6 +265,7 @@ public struct SpeakerNamingRequest {
         systemAudioURL: URL,
         micAudioURL: URL?,
         shouldRemoveTemporaryAudioOnCleanup: Bool = true,
+        sourceFailedTranscriptionId: UUID? = nil,
         onComplete: @escaping ([SpeakerNameUpdate]) -> Void
     ) {
         self.speakers = speakers
@@ -273,6 +275,7 @@ public struct SpeakerNamingRequest {
         self.systemAudioURL = systemAudioURL
         self.micAudioURL = micAudioURL
         self.shouldRemoveTemporaryAudioOnCleanup = shouldRemoveTemporaryAudioOnCleanup
+        self.sourceFailedTranscriptionId = sourceFailedTranscriptionId
         self.onComplete = onComplete
     }
 

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -390,7 +390,7 @@ extension TranscriptionTaskManager {
                     transcriptId: transcriptId,
                     systemAudioURL: systemURL,
                     micAudioURL: micURL,
-                    shouldRemoveTemporaryAudioOnCleanup: shouldRemoveScratchAudio,
+                    shouldRemoveTemporaryAudioOnCleanup: shouldRemoveScratchAudio && sourceFailedTranscriptionId == nil,
                     sourceFailedTranscriptionId: sourceFailedTranscriptionId,
                     onComplete: { [weak self] updates in
                         self?.handleNamingComplete(

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -15,7 +15,8 @@ extension TranscriptionTaskManager {
         taskId: UUID,
         healthInfo: RecordingHealthInfo?,
         splitLocalSpeakers: Bool = false,
-        meetingTitle: String? = nil
+        meetingTitle: String? = nil,
+        sourceFailedTranscriptionId: UUID? = nil
     ) async throws -> URL {
 
         // Require system audio for multichannel transcription
@@ -30,7 +31,8 @@ extension TranscriptionTaskManager {
             taskId: taskId,
             healthInfo: healthInfo,
             splitLocalSpeakers: splitLocalSpeakers,
-            meetingTitle: meetingTitle
+            meetingTitle: meetingTitle,
+            sourceFailedTranscriptionId: sourceFailedTranscriptionId
         )
     }
 
@@ -63,7 +65,8 @@ extension TranscriptionTaskManager {
         taskId: UUID,
         healthInfo: RecordingHealthInfo?,
         splitLocalSpeakers: Bool = false,
-        meetingTitle: String? = nil
+        meetingTitle: String? = nil,
+        sourceFailedTranscriptionId: UUID? = nil
     ) async throws -> URL {
 
         let transcription = await MainActor.run { self.transcription }
@@ -388,6 +391,7 @@ extension TranscriptionTaskManager {
                     systemAudioURL: systemURL,
                     micAudioURL: micURL,
                     shouldRemoveTemporaryAudioOnCleanup: shouldRemoveScratchAudio,
+                    sourceFailedTranscriptionId: sourceFailedTranscriptionId,
                     onComplete: { [weak self] updates in
                         self?.handleNamingComplete(
                             updates: updates,
@@ -397,6 +401,7 @@ extension TranscriptionTaskManager {
                             micURL: micURL,
                             systemURL: systemURL,
                             shouldRemoveTemporaryAudio: shouldRemoveScratchAudio,
+                            sourceFailedTranscriptionId: sourceFailedTranscriptionId,
                             clips: capturedEntries
                         )
                     }

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -618,13 +618,21 @@ public class TranscriptionTaskManager: ObservableObject {
                 outputFolder: outputFolder,
                 taskId: failedId,
                 healthInfo: nil,
-                splitLocalSpeakers: false
+                splitLocalSpeakers: false,
+                sourceFailedTranscriptionId: failedId
             )
 
             AppLogger.pipeline.info("Retry successful", ["file": transcriptURL.lastPathComponent])
 
             await MainActor.run {
-                failedTranscriptionManager.removeFailedTranscription(id: failedId)
+                let waitingForSpeakerNames = self.hasPendingSpeakerNamingRequest(sourceFailedTranscriptionId: failedId)
+                if waitingForSpeakerNames {
+                    AppLogger.pipeline.info("Retry transcript saved; keeping failed meeting until speaker names finalize", [
+                        "failedId": failedId.uuidString
+                    ])
+                } else {
+                    failedTranscriptionManager.removeFailedTranscription(id: failedId)
+                }
                 self.activeTasks.removeValue(forKey: failedId)
                 self.activeCount = max(0, self.activeCount - 1)
                 self.backgroundTaskCount = max(0, self.backgroundTaskCount - 1)
@@ -647,6 +655,13 @@ public class TranscriptionTaskManager: ObservableObject {
             }
             return false
         }
+    }
+
+    private func hasPendingSpeakerNamingRequest(sourceFailedTranscriptionId: UUID) -> Bool {
+        speakerNamingRequest?.sourceFailedTranscriptionId == sourceFailedTranscriptionId
+            || pendingSpeakerNamingRequests.contains {
+                $0.sourceFailedTranscriptionId == sourceFailedTranscriptionId
+            }
     }
 
     // MARK: - Task Completion & Cleanup

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -157,6 +157,31 @@ public class FailedTranscriptionManager: ObservableObject {
         AppLogger.pipeline.info("Removed failed transcription", ["id": "\(id)"])
     }
 
+    @discardableResult
+    public func updateFailedTranscriptionError(id: UUID, errorMessage: String) -> Bool {
+        guard let index = failedTranscriptions.firstIndex(where: { $0.id == id }) else {
+            return false
+        }
+
+        let existing = failedTranscriptions[index]
+        failedTranscriptions[index] = FailedTranscription(
+            id: existing.id,
+            timestamp: existing.timestamp,
+            micAudioURL: existing.micAudioURL,
+            systemAudioURL: existing.systemAudioURL,
+            errorMessage: errorMessage,
+            retryCount: existing.retryCount,
+            lastRetryDate: existing.lastRetryDate
+        )
+
+        let didPersist = saveFailedTranscriptions()
+        AppLogger.pipeline.info("Updated failed transcription error", [
+            "id": "\(id)",
+            "persisted": "\(didPersist)"
+        ])
+        return didPersist
+    }
+
     /// Removes a failed transcription and deletes its audio files
     public func deleteFailedTranscription(id: UUID) {
         guard let failed = failedTranscriptions.first(where: { $0.id == id }) else {

--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -918,6 +918,7 @@ extension TranscriptSaver {
         updatesByChannelKey: [String: (oldName: String, newName: String)]
     ) -> Bool {
         guard !result.systemUtterances.isEmpty else { return true }
+        guard content.contains("#### Remote Speaker Breakdown\n\n") else { return true }
 
         return rewriteSpeakerBreakdown(
             in: &content,

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -39,6 +39,7 @@ extension TranscriptionTaskManager {
         micURL: URL?,
         systemURL: URL,
         shouldRemoveTemporaryAudio: Bool = true,
+        sourceFailedTranscriptionId: UUID? = nil,
         clips: [SpeakerNamingEntry]
     ) {
         let speakerDB = transcription.speakerDB
@@ -68,7 +69,7 @@ extension TranscriptionTaskManager {
                     clips: clips,
                     micURL: micURL,
                     systemURL: systemURL,
-                    shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio
+                    shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio && sourceFailedTranscriptionId == nil
                 )
 
                 Task { @MainActor in
@@ -76,7 +77,8 @@ extension TranscriptionTaskManager {
                         didFinalizeTranscript: false,
                         updatesCount: updates.count,
                         transcriptId: transcriptId,
-                        resolvedURL: transcriptURL
+                        resolvedURL: transcriptURL,
+                        sourceFailedTranscriptionId: sourceFailedTranscriptionId
                     )
                 }
                 return
@@ -91,7 +93,7 @@ extension TranscriptionTaskManager {
                     clips: clips,
                     micURL: micURL,
                     systemURL: systemURL,
-                    shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio
+                    shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio && sourceFailedTranscriptionId == nil
                 )
 
                 Task { @MainActor in
@@ -99,7 +101,8 @@ extension TranscriptionTaskManager {
                         didFinalizeTranscript: false,
                         updatesCount: updates.count,
                         transcriptId: transcriptId,
-                        resolvedURL: resolvedURL
+                        resolvedURL: resolvedURL,
+                        sourceFailedTranscriptionId: sourceFailedTranscriptionId
                     )
                 }
                 return
@@ -174,11 +177,12 @@ extension TranscriptionTaskManager {
                 )
             }
 
+            let shouldKeepAudioForFailedRetry = !didFinalizeTranscript && sourceFailedTranscriptionId != nil
             self?.cleanupNamingArtifacts(
                 clips: clips,
                 micURL: micURL,
                 systemURL: systemURL,
-                shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio
+                shouldRemoveTemporaryAudio: shouldRemoveTemporaryAudio && !shouldKeepAudioForFailedRetry
             )
 
             Task { @MainActor in
@@ -186,7 +190,8 @@ extension TranscriptionTaskManager {
                     didFinalizeTranscript: didFinalizeTranscript,
                     updatesCount: updates.count,
                     transcriptId: transcriptId,
-                    resolvedURL: resolvedURL
+                    resolvedURL: resolvedURL,
+                    sourceFailedTranscriptionId: sourceFailedTranscriptionId
                 )
             }
         }
@@ -582,13 +587,17 @@ extension TranscriptionTaskManager {
         didFinalizeTranscript: Bool,
         updatesCount: Int,
         transcriptId: UUID,
-        resolvedURL: URL
+        resolvedURL: URL,
+        sourceFailedTranscriptionId: UUID? = nil
     ) {
         if didFinalizeTranscript {
             AppLogger.pipeline.info("Speaker naming complete", [
                 "named": "\(updatesCount)",
                 "transcript": resolvedURL.lastPathComponent
             ])
+            if let sourceFailedTranscriptionId {
+                failedTranscriptionManager.removeFailedTranscription(id: sourceFailedTranscriptionId)
+            }
             let didAlreadyPublishSavedTranscript = lastSavedTranscriptId == transcriptId
                 || lastSavedTranscriptURL == resolvedURL
             populateSavedMetadata(from: resolvedURL)
@@ -601,6 +610,12 @@ extension TranscriptionTaskManager {
                 "transcriptId": transcriptId.uuidString,
                 "transcript": resolvedURL.lastPathComponent
             ])
+            if let sourceFailedTranscriptionId {
+                failedTranscriptionManager.updateFailedTranscriptionError(
+                    id: sourceFailedTranscriptionId,
+                    errorMessage: "Speaker names could not be saved. The transcript saved, but speaker-name finalization failed."
+                )
+            }
             displayStatus = .failed(message: "Failed to finalize speaker names")
             scheduleStatusReset(delay: 8)
         }

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -191,7 +191,8 @@ extension TranscriptionTaskManager {
                     updatesCount: updates.count,
                     transcriptId: transcriptId,
                     resolvedURL: resolvedURL,
-                    sourceFailedTranscriptionId: sourceFailedTranscriptionId
+                    sourceFailedTranscriptionId: sourceFailedTranscriptionId,
+                    shouldDeleteSourceFailedAudio: shouldRemoveTemporaryAudio
                 )
             }
         }
@@ -588,7 +589,8 @@ extension TranscriptionTaskManager {
         updatesCount: Int,
         transcriptId: UUID,
         resolvedURL: URL,
-        sourceFailedTranscriptionId: UUID? = nil
+        sourceFailedTranscriptionId: UUID? = nil,
+        shouldDeleteSourceFailedAudio: Bool = true
     ) {
         if didFinalizeTranscript {
             AppLogger.pipeline.info("Speaker naming complete", [
@@ -596,7 +598,11 @@ extension TranscriptionTaskManager {
                 "transcript": resolvedURL.lastPathComponent
             ])
             if let sourceFailedTranscriptionId {
-                failedTranscriptionManager.removeFailedTranscription(id: sourceFailedTranscriptionId)
+                if shouldDeleteSourceFailedAudio {
+                    failedTranscriptionManager.deleteFailedTranscription(id: sourceFailedTranscriptionId)
+                } else {
+                    failedTranscriptionManager.removeFailedTranscription(id: sourceFailedTranscriptionId)
+                }
             }
             let didAlreadyPublishSavedTranscript = lastSavedTranscriptId == transcriptId
                 || lastSavedTranscriptURL == resolvedURL

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -824,6 +824,9 @@ struct TranscriptedSettingsView: View {
         if meetingSession.hasRuntimeDiagnosticsWork {
             return "Wait for the current meeting to finish saving or transcribing before retrying."
         }
+        if meetingSession.isSpeakerReviewPending {
+            return "Finish the speaker review window before retrying a failed meeting."
+        }
         return nil
     }
 

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -67,4 +67,15 @@ func testFailedMeetingPresentation() {
         assertEqual(copy.title, "Couldn't save the transcript", "save failures should keep the save-specific title")
         assertEqual(copy.detail, "Could not write transcript to meetings", "save failures should preserve the short write error")
     }
+
+    runSuite("FailedMeetingPresentation speaker-name failures stay speaker-specific") {
+        let copy = MeetingFailureCopy.make(
+            forMessage: "Speaker names could not be saved. The transcript saved, but speaker-name finalization failed.",
+            shortErrorMessage: "Speaker names could not be saved.",
+            isRetryable: true
+        )
+
+        assertEqual(copy.title, "Couldn't save speaker names", "speaker finalization failures should not look like full transcript failures")
+        assertTrue(copy.detail.contains("transcript saved"), "copy should say the transcript itself was saved")
+    }
 }

--- a/Tests/MeetingFailureExplanationTests.swift
+++ b/Tests/MeetingFailureExplanationTests.swift
@@ -72,6 +72,25 @@ func testMeetingFailureExplanation() async {
         assertEqual(explanation.reportFields["retry_available"], "yes", "save failures with retained audio should expose retry after repair")
     }
 
+    runSuite("MeetingFailureExplanation keeps speaker-name finalization failures retryable") {
+        let explanation = MeetingFailureExplanation.make(
+            failureKind: .speakerNameFinalizationFailed,
+            hasAudioFiles: true,
+            isRetryable: true,
+            stage: .save,
+            transcriptSaved: true,
+            failedQueueEntryRetained: true
+        )
+
+        assertEqual(explanation.outcomeKind, .recoverableFailure, "speaker-name save failures should keep a retry path")
+        assertEqual(explanation.retryability, .retryable, "retained audio should make speaker-name finalization retryable")
+        assertEqual(explanation.artifactRetention, .retainedPartialTranscript, "the saved transcript should stay visible as a partial artifact")
+        assertEqual(explanation.userVisibleState, .retryAvailable, "Home should offer retry without claiming the transcript was lost")
+        assertEqual(explanation.reportFields["failure_kind"], "speaker_name_finalization_failed", "support reports should keep the speaker-name failure explicit")
+        assertEqual(explanation.reportFields["save_failed"], "yes", "speaker-name finalization is a save-stage failure")
+        assertEqual(explanation.reportFields["retry_available"], "yes", "retry should stay available while the failed row is retained")
+    }
+
     runSuite("MeetingFailureExplanation blocks pre-recording permission failures cleanly") {
         let explanation = MeetingFailureExplanation.make(
             failureKind: .microphonePermission,

--- a/Tests/MeetingFailureKindTests.swift
+++ b/Tests/MeetingFailureKindTests.swift
@@ -49,6 +49,14 @@ func testMeetingFailureKind() {
         assertEqual(kind, .saveFailed, "save failures should keep their own analytics bucket")
     }
 
+    runSuite("MeetingFailureKind classifies speaker-name finalization failures") {
+        let kind = MeetingFailureKind.classify(
+            message: "Speaker names could not be saved. The transcript saved, but speaker-name finalization failed."
+        )
+
+        assertEqual(kind, .speakerNameFinalizationFailed, "speaker-name save failures should stay out of generic transcript save failures")
+    }
+
     runSuite("MeetingFailureKind classifies pipeline-busy errors") {
         let kind = MeetingFailureKind.classify(
             message: "Transcription already in progress"

--- a/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
@@ -1848,6 +1848,127 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testHandleNamingCompleteSucceedsAfterMeetingStylerRemovedRemoteBreakdown() async throws {
+        let harness = try makeHarness()
+        let transcriptId = UUID()
+        let persistentSpeakerId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.36, count: 256),
+            existingId: nil
+        ).id
+        let transcriptURL = harness.paths.transcripts.appendingPathComponent("Styled_Meeting.md")
+        let clipURL = tempDirectory.appendingPathComponent("speaker-styled.wav")
+        let micURL = tempDirectory.appendingPathComponent("mic-styled.wav")
+        let systemURL = tempDirectory.appendingPathComponent("system-styled.wav")
+        let speakers = [
+            MarkdownSpeaker(
+                id: "1",
+                persistentSpeakerId: persistentSpeakerId,
+                name: "Speaker 1",
+                confidence: "unknown",
+                source: "db_pending"
+            )
+        ]
+        let utterances = [
+            MarkdownUtterance(
+                timestamp: "00:01",
+                source: "System",
+                label: "Speaker 1",
+                text: "Thanks for joining."
+            )
+        ]
+        let styledTranscript = """
+        ---
+        transcript_id: "\(transcriptId.uuidString)"
+        title: "Styled Meeting"
+        date: 2026-04-10
+        time: 15:01:23
+        duration: "1:30"
+        processing_time: "3.0s"
+        transcription_engine: parakeet_local
+        diarization_engine: pyannote_offline
+        sources: [mic, system_audio]
+        mic_utterances: 0
+        system_utterances: 1
+        mic_speakers: 0
+        system_speakers: 1
+        total_word_count: 5
+        speakers:
+          - id: "1"
+            channel: system
+            db_id: "\(persistentSpeakerId.uuidString)"
+            name: "Speaker 1"
+            confidence: unknown
+            source: db_pending
+        ---
+
+        # Styled Meeting
+
+        Recorded Apr 10, 2026 at 3:01 PM  •  1:30  •  5 words  •  1 turn
+
+        ## Transcript
+
+        **00:01**  [System/Speaker 1]
+        Thanks for joining.
+        """
+
+        try styledTranscript.write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let transcriptionResult = sampleTranscriptionResult(speakers: speakers, utterances: utterances)
+        try Data().write(to: clipURL)
+        try Data().write(to: micURL)
+        try Data().write(to: systemURL)
+
+        harness.manager.speakerNamingRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: micURL,
+            onComplete: { _ in }
+        )
+
+        harness.manager.handleNamingComplete(
+            updates: [
+                SpeakerNameUpdate(
+                    persistentSpeakerId: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    newName: "Sarah Graham",
+                    previousName: "Speaker 1",
+                    action: .named
+                )
+            ],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            transcriptionResult: transcriptionResult,
+            micURL: micURL,
+            systemURL: systemURL,
+            clips: [
+                SpeakerNamingEntry(
+                    id: persistentSpeakerId,
+                    diarizerSpeakerId: "1",
+                    clipURL: clipURL,
+                    sampleText: "Thanks for joining.",
+                    currentName: nil,
+                    matchSimilarity: nil,
+                    needsNaming: true,
+                    needsConfirmation: false,
+                    sessionEmbedding: [Float](repeating: 0.36, count: 256)
+                )
+            ]
+        )
+
+        try await waitUntil {
+            harness.manager.speakerNamingRequest == nil
+                && harness.manager.displayStatus == .transcriptSaved
+        }
+
+        let savedTranscript = try String(contentsOf: transcriptURL, encoding: .utf8)
+        XCTAssertTrue(savedTranscript.contains(#"name: "Sarah Graham""#), savedTranscript)
+        XCTAssertTrue(savedTranscript.contains("**00:01**  [System/Sarah Graham]"), savedTranscript)
+        XCTAssertFalse(savedTranscript.contains("#### Remote Speaker Breakdown"), savedTranscript)
+        XCTAssertEqual(harness.speakerDB.getSpeaker(id: persistentSpeakerId)?.displayName, "Sarah Graham")
+    }
+
+    @MainActor
     func testHandleNamingCompleteCorrectionWithoutSessionEmbeddingFailsClosed() async throws {
         let harness = try makeHarness()
         let transcriptId = UUID()

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -421,6 +421,80 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         )
     }
 
+    func testRetryKeepsFailedMeetingWhenSpeakerNameFinalizationFails() async throws {
+        let speech = MetadataStubSpeechToTextEngine(transcript: "Thanks for joining.")
+        let diarization = MetadataStubDiarizationEngine(segments: [
+            SpeakerSegment(
+                speakerId: 1,
+                startTime: 0,
+                endTime: 2,
+                embedding: [Float](repeating: 0.42, count: 256),
+                qualityScore: 0.95
+            )
+        ])
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(
+            speechToText: speech,
+            diarization: diarization,
+            retainedAudioDirectory: retainedAudioDirectory
+        )
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("retry-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("retry-system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        XCTAssertTrue(manager.failedTranscriptionManager.addFailedTranscription(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: "Parakeet inference failed"
+        ))
+        let failedId = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first?.id)
+
+        let didRetry = await manager.retryFailedTranscription(
+            failedId: failedId,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts")
+        )
+
+        XCTAssertTrue(didRetry)
+        let request = try XCTUnwrap(manager.speakerNamingRequest)
+        XCTAssertEqual(request.sourceFailedTranscriptionId, failedId)
+        XCTAssertEqual(
+            manager.failedTranscriptionManager.failedTranscriptions.map(\.id),
+            [failedId],
+            "retry should stay visible until speaker-name finalization succeeds"
+        )
+        XCTAssertTrue(manager.failedTranscriptionManager.failedTranscriptions[0].audioFilesExist())
+
+        try FileManager.default.removeItem(at: request.transcriptURL)
+        let speaker = try XCTUnwrap(request.speakers.first)
+        request.onComplete([
+            SpeakerNameUpdate(
+                persistentSpeakerId: speaker.id,
+                diarizerSpeakerId: speaker.diarizerSpeakerId,
+                channel: speaker.channel,
+                newName: "Sarah Graham",
+                previousName: speaker.currentName,
+                action: .named
+            )
+        ])
+
+        try await waitUntil {
+            if case .failed(message: "Failed to finalize speaker names") = manager.displayStatus,
+               manager.speakerNamingRequest == nil {
+                return true
+            }
+            return false
+        }
+
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertEqual(failed.id, failedId)
+        XCTAssertTrue(failed.errorMessage.contains("Speaker names could not be saved"))
+        XCTAssertTrue(failed.audioFilesExist(), "failed retry audio should remain available for another pass")
+    }
+
     private func makeManager(
         speechToText: (any SpeechToTextEngine)? = nil,
         diarization: (any DiarizationEngine)? = nil,
@@ -439,6 +513,7 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
 
         try? FileManager.default.createDirectory(at: paths.transcripts, withIntermediateDirectories: true)
         try? FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(at: paths.speakerClips, withIntermediateDirectories: true)
         try? FileManager.default.createDirectory(at: paths.logs, withIntermediateDirectories: true)
 
         let resolvedSpeechToText = speechToText ?? MetadataStubSpeechToTextEngine()
@@ -449,6 +524,7 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             speechToText: resolvedSpeechToText,
             diarization: resolvedDiarization,
             speakerStore: SpeakerDatabase(path: paths.speakerDB.path),
+            speakerClipsDirectory: paths.speakerClips,
             cleanupDirectories: [paths.audioCaptures, paths.speakerClips],
             retainedAudioDirectory: retainedAudioDirectory,
             retainedAudioDirectoryProvider: retainedAudioDirectoryProvider
@@ -510,16 +586,18 @@ private final class MetadataStubSpeechToTextEngine: SpeechToTextEngine {
     nonisolated let objectWillChange = ObservableObjectPublisher()
     var isReady: Bool
     var initializeCallCount = 0
+    private let transcript: String
 
-    init(isReady: Bool = true) {
+    init(isReady: Bool = true, transcript: String = "") {
         self.isReady = isReady
+        self.transcript = transcript
     }
 
     func initialize() async {
         initializeCallCount += 1
         isReady = true
     }
-    func transcribeSegment(samples: [Float], source: AudioSource) async throws -> String { "" }
+    func transcribeSegment(samples: [Float], source: AudioSource) async throws -> String { transcript }
     func cleanup() {
         isReady = false
     }
@@ -531,17 +609,19 @@ private final class MetadataStubDiarizationEngine: DiarizationEngine {
     nonisolated let objectWillChange = ObservableObjectPublisher()
     var isReady: Bool
     var initializeCallCount = 0
+    private let segments: [SpeakerSegment]
 
-    init(isReady: Bool = true) {
+    init(isReady: Bool = true, segments: [SpeakerSegment] = []) {
         self.isReady = isReady
+        self.segments = segments
     }
 
     func initialize() async {
         initializeCallCount += 1
         isReady = true
     }
-    func diarizeOffline(samples: [Float], sampleRate: Int) async throws -> [SpeakerSegment] { [] }
-    func diarizeOffline(audioURL: URL) async throws -> [SpeakerSegment] { [] }
+    func diarizeOffline(samples: [Float], sampleRate: Int) async throws -> [SpeakerSegment] { segments }
+    func diarizeOffline(audioURL: URL) async throws -> [SpeakerSegment] { segments }
     func cleanup() {
         isReady = false
     }

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -421,6 +421,132 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         )
     }
 
+    func testRetryDeletesRetainedFailedAudioWhenSpeakerNameFinalizationSucceeds() async throws {
+        let speech = MetadataStubSpeechToTextEngine(transcript: "Thanks for joining.")
+        let diarization = MetadataStubDiarizationEngine(segments: [
+            SpeakerSegment(
+                speakerId: 1,
+                startTime: 0,
+                endTime: 2,
+                embedding: [Float](repeating: 0.42, count: 256),
+                qualityScore: 0.95
+            )
+        ])
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(
+            speechToText: speech,
+            diarization: diarization,
+            retainedAudioDirectory: retainedAudioDirectory
+        )
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("retry-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("retry-system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        XCTAssertTrue(manager.addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: "Parakeet inference failed"
+        ))
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        let failedId = failed.id
+        let retainedMicURL = failed.micAudioURL
+        let retainedSystemURL = try XCTUnwrap(failed.systemAudioURL)
+        let retainedDirectory = retainedMicURL.deletingLastPathComponent()
+        XCTAssertTrue(retainedMicURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(retainedSystemURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path), "scratch mic audio should move into the retained failed-audio archive")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path), "scratch system audio should move into the retained failed-audio archive")
+
+        let didRetry = await manager.retryFailedTranscription(
+            failedId: failedId,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts")
+        )
+
+        XCTAssertTrue(didRetry)
+        let request = try XCTUnwrap(manager.speakerNamingRequest)
+        let speaker = try XCTUnwrap(request.speakers.first)
+        request.onComplete([
+            SpeakerNameUpdate(
+                persistentSpeakerId: speaker.id,
+                diarizerSpeakerId: speaker.diarizerSpeakerId,
+                channel: speaker.channel,
+                newName: "Sarah Graham",
+                previousName: speaker.currentName,
+                action: .named
+            )
+        ])
+
+        try await waitUntil {
+            manager.failedTranscriptionManager.failedTranscriptions.isEmpty
+                && manager.speakerNamingRequest == nil
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: retainedMicURL.path), "successful failed-meeting retry should delete retained mic audio")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: retainedSystemURL.path), "successful failed-meeting retry should delete retained system audio")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: retainedDirectory.path), "successful failed-meeting retry should remove the now-empty retained audio directory")
+    }
+
+    func testRetryKeepsFailedAudioWhenSpeakerNameFinalizationSucceedsAfterArchiveFailure() async throws {
+        let speech = MetadataStubSpeechToTextEngine(transcript: "Thanks for joining.")
+        let diarization = MetadataStubDiarizationEngine(segments: [
+            SpeakerSegment(
+                speakerId: 1,
+                startTime: 0,
+                endTime: 2,
+                embedding: [Float](repeating: 0.42, count: 256),
+                qualityScore: 0.95
+            )
+        ])
+        let archiveBlockerURL = tempDirectory.appendingPathComponent("audio-archive-blocker")
+        try Data("not a directory".utf8).write(to: archiveBlockerURL)
+        let manager = makeManager(
+            speechToText: speech,
+            diarization: diarization,
+            retainedAudioDirectoryProvider: { archiveBlockerURL }
+        )
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("retry-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("retry-system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        XCTAssertTrue(manager.failedTranscriptionManager.addFailedTranscription(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: "Parakeet inference failed"
+        ))
+        let failedId = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first?.id)
+
+        let didRetry = await manager.retryFailedTranscription(
+            failedId: failedId,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts")
+        )
+
+        XCTAssertTrue(didRetry)
+        let request = try XCTUnwrap(manager.speakerNamingRequest)
+        let speaker = try XCTUnwrap(request.speakers.first)
+        request.onComplete([
+            SpeakerNameUpdate(
+                persistentSpeakerId: speaker.id,
+                diarizerSpeakerId: speaker.diarizerSpeakerId,
+                channel: speaker.channel,
+                newName: "Sarah Graham",
+                previousName: speaker.currentName,
+                action: .named
+            )
+        ])
+
+        try await waitUntil {
+            manager.failedTranscriptionManager.failedTranscriptions.isEmpty
+                && manager.speakerNamingRequest == nil
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path), "archive failure should leave the failed mic audio on disk")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path), "archive failure should leave the failed system audio on disk")
+    }
+
     func testRetryKeepsFailedMeetingWhenSpeakerNameFinalizationFails() async throws {
         let speech = MetadataStubSpeechToTextEngine(transcript: "Thanks for joining.")
         let diarization = MetadataStubDiarizationEngine(segments: [

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -461,6 +461,10 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertTrue(didRetry)
         let request = try XCTUnwrap(manager.speakerNamingRequest)
         XCTAssertEqual(request.sourceFailedTranscriptionId, failedId)
+        XCTAssertFalse(
+            request.shouldRemoveTemporaryAudioOnCleanup,
+            "failed-retry speaker review must not own cleanup for audio that keeps the failed row retryable"
+        )
         XCTAssertEqual(
             manager.failedTranscriptionManager.failedTranscriptions.map(\.id),
             [failedId],


### PR DESCRIPTION
## Summary
- Fix speaker-name finalization after the meeting preview styler rewrites saved Markdown.
- Keep failed-meeting retry rows until speaker-name finalization actually succeeds.
- Add speaker-name-specific Home copy, failure classification, and regression coverage.

## Root Cause
A meeting could save successfully, then the preview/finalize path restyled the transcript and removed the old `Remote Speaker Breakdown` section. The later speaker-name rewrite treated that missing optional section as fatal, so the user saw a save failure even though the transcript existed. This matches support reference `59a9141d9bfd046`.

PostHog showed no matching `meeting_transcript_failed` event for app version 1.1.36 around the report, and Sentry had no speaker-finalization issue, so this was a local finalize-path bug rather than a full transcription failure.

## Verification
- `bash build.sh`
- `bash run-tests.sh` — 1852 passed
- `bash run-integration-smoke.sh`
- `swift test` — 186 passed