### PR TITLE
[nightly-review] Fix failed meeting review expansion

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -1673,13 +1673,14 @@ struct HomeNeedsAttentionCard: View {
 
 struct HomeFailedMeetingsCard: View {
     let items: [MeetingSessionController.FailedMeetingItem]
+    let hiddenCount: Int
     let canRetry: Bool
     let retryUnavailableReason: String?
     let audioAttachment: (MeetingSessionController.FailedMeetingItem) -> MeetingAudioAttachment?
     let onRetry: (MeetingSessionController.FailedMeetingItem) -> Void
     let onRevealAudio: (MeetingSessionController.FailedMeetingItem) -> Void
     let onClear: (MeetingSessionController.FailedMeetingItem) -> Void
-    let onOpenMeetings: () -> Void
+    let onShowAll: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -1690,9 +1691,11 @@ struct HomeFailedMeetingsCard: View {
                 Text(title)
                     .font(.headline)
                 Spacer()
-                Button("Review all", action: onOpenMeetings)
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
+                if hiddenCount > 0 {
+                    Button(showAllTitle, action: onShowAll)
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                }
             }
 
             VStack(alignment: .leading, spacing: 0) {
@@ -1727,6 +1730,10 @@ struct HomeFailedMeetingsCard: View {
 
     private var title: String {
         items.count == 1 ? "Recover this meeting" : "Recover unfinished meetings"
+    }
+
+    private var showAllTitle: String {
+        hiddenCount == 1 ? "Show 1 more" : "Show \(hiddenCount) more"
     }
 }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -78,6 +78,7 @@ struct TranscriptedSettingsView: View {
     @State private var homeDeleteConfirmation: HomeDeleteConfirmation?
     @State private var homeDeleteFailure: HomeDeleteFailure?
     @State private var homeFeedbackTarget: HomeFeedbackTarget?
+    @State private var homeShowsAllFailedMeetings = false
     @State private var homeMeetingPreview: HomeMeetingPreview?
     @State private var homeMeetingPreviewLoadTask: Task<Void, Never>?
     @State private var settingsColumnVisibility: NavigationSplitViewVisibility = .all
@@ -273,12 +274,17 @@ struct TranscriptedSettingsView: View {
     private var homePage: some View {
         let stats = homeStatItems
         let needsAttention = homeNeedsAttentionIssues
-        let failedMeetings = Array(meetingSession.failedMeetings.prefix(3))
+        let allFailedMeetings = meetingSession.failedMeetings
+        let failedMeetings = homeShowsAllFailedMeetings
+            ? allFailedMeetings
+            : Array(allFailedMeetings.prefix(3))
+        let hiddenFailedMeetingCount = max(0, allFailedMeetings.count - failedMeetings.count)
 
         return VStack(alignment: .leading, spacing: 14) {
             if !failedMeetings.isEmpty {
                 HomeFailedMeetingsCard(
                     items: failedMeetings,
+                    hiddenCount: hiddenFailedMeetingCount,
                     canRetry: canRetryFailedMeetings,
                     retryUnavailableReason: failedMeetingRetryUnavailableReason,
                     audioAttachment: { failedMeetingAudioAttachment(for: $0) },
@@ -294,9 +300,9 @@ struct TranscriptedSettingsView: View {
                         trackSettingsAction(item.hasAudioFiles ? "home_delete_failed_meeting" : "home_dismiss_failed_meeting", page: .home)
                         clearFailedMeeting(item)
                     },
-                    onOpenMeetings: {
-                        trackSettingsAction("home_open_failed_meetings", page: .home)
-                        homeActivityTab = .meetings
+                    onShowAll: {
+                        trackSettingsAction("home_show_all_failed_meetings", page: .home)
+                        homeShowsAllFailedMeetings = true
                     }
                 )
             }


### PR DESCRIPTION
## Summary
- Fixes the new Home failed-meeting recovery card so hidden queue entries can actually be revealed.
- Replaces the misleading Review all jump with a Show N more action that expands the failed-meeting list in place.

## Nightly review evidence
- Recent code reviewed: PRs #763-#768 and current origin/main.
- Live Sentry last 24h: APPLE-MACOS-1H, 3 meeting_transcript_failed events on transcripted@1.1.37.
- Live PostHog last 24h: 26 meeting starts/stops, 42 meeting saves, 3 meeting failures, 3 unclean shutdown detections.

## Top risks ranked
1. Failed meetings beyond the first three were stranded after the Meetings settings page was folded into Home.
2. 1.1.37 still has live meeting_transcript_failed events, so recovery UX needs to stay complete.
3. 1.1.37 is behind main by several reliability/UI PRs, so production proof for the latest fixes is still thin.

## Verification
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh