### PR TITLE
[operator] Count meeting saves as first value

### DIFF
--- a/docs/ops-credentials.md
+++ b/docs/ops-credentials.md
@@ -36,7 +36,7 @@ Only report aggregate counts, status codes, deployment IDs, and issue titles. Fo
 
 ### PostHog Probe Shape
 
-The PostHog probe reports aggregate 7-day counts for active devices, workflow events, onboarding events, and first-value events. First-value events are limited to `onboarding_first_dictation_saved` and `onboarding_agent_cta_clicked`, so the health lane can see whether users reached a saved Markdown artifact or agent payoff without exposing transcript text, file paths, titles, or user identifiers.
+The PostHog probe reports aggregate 7-day counts for active devices, workflow events, onboarding events, and first-value events. First-value events are limited to `onboarding_first_dictation_saved`, `meeting_transcript_saved`, and `onboarding_agent_cta_clicked`, so the health lane can see whether users reached a saved Markdown artifact or agent payoff without exposing transcript text, file paths, titles, or user identifiers.
 
 ## Quick Start
 

--- a/scripts/ops/health-probe.sh
+++ b/scripts/ops/health-probe.sh
@@ -88,7 +88,7 @@ probe_posthog() {
   local workflow_events onboarding_events first_value_events query payload
   workflow_events="'app_launched','app_unclean_shutdown_detected','app_session_stall_detected','onboarding_completed','dictation_started','dictation_start_failed','dictation_completed','dictation_cancelled','dictation_no_speech','dictation_audio_route_recovery_timeout','meeting_recording_started','meeting_recording_start_failed','meeting_recording_stopped','meeting_recording_cancelled','meeting_transcript_saved','meeting_transcript_failed','meeting_transcript_skipped'"
   onboarding_events="'onboarding_shown','onboarding_step_viewed','onboarding_permission_cta_clicked','onboarding_permission_status_changed','onboarding_model_state_changed','onboarding_primary_cta_clicked','onboarding_first_dictation_started','onboarding_first_dictation_saved','onboarding_first_dictation_stop_clicked','onboarding_first_dictation_empty','onboarding_meeting_dry_run_clicked','onboarding_agent_cta_clicked','onboarding_reporting_toggle_changed','onboarding_completed','onboarding_dismissed'"
-  first_value_events="'onboarding_first_dictation_saved','onboarding_agent_cta_clicked'"
+  first_value_events="'onboarding_first_dictation_saved','meeting_transcript_saved','onboarding_agent_cta_clicked'"
   query="select uniq(distinct_id) as devices_7d, sum(case when event in ($workflow_events) then 1 else 0 end) as workflow_events_7d, sum(case when event in ($onboarding_events) then 1 else 0 end) as onboarding_events_7d, sum(case when event in ($first_value_events) then 1 else 0 end) as first_value_events_7d from events where timestamp >= now() - interval 7 day"
   payload=$(jq -cn --arg query "$query" '{query: $query}')
 


### PR DESCRIPTION
## Summary
- Count `meeting_transcript_saved` as a first-value event in the PostHog health probe.
- Update the ops credentials doc so the documented aggregate first-value shape matches the query.

## Why
Transcripted is meetings-first now. A saved meeting Markdown file is first value, so the nightly 1,000 DAU visibility loop should not only count first dictation or agent setup.

## Privacy
This reuses an existing allowlisted aggregate event. It does not add app telemetry or send transcript text, titles, speaker names, audio references, paths, or identifiers.

## Verification
- `bash -n scripts/ops/health-probe.sh`
- `bash scripts/ops/health-probe.sh posthog` (clean skip: missing `POSTHOG_PERSONAL_API_KEY`)
- `scripts/dev/agent-preflight.sh`
- `git diff --check -- docs/ops-credentials.md scripts/ops/health-probe.sh`