### PR TITLE
Release Transcripted 1.1.38

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.37"
-  sha256 "02122f881ab4c914e381cdf0f4834ca287e2b99a44c167fec07d73b31b2432a8"
+  version "1.1.38"
+  sha256 "1d212cf3450567a0e586091346bcbb0f6f0002ce030037b218fa9b160b02f6cf"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.37</string>
+	<string>1.1.38</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.37</string>
+	<string>1.1.38</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/Package.swift
+++ b/Package.swift
@@ -2,14 +2,14 @@
 import PackageDescription
 import Foundation
 
-// TranscriptedCore — shared library target co-hosted with Draft.
+// TranscriptedCore — shared library target used by Transcripted's meeting pipeline.
 //
 // Consumed by:
-//   1. Draft's meeting integration via build-deps.sh
+//   1. Transcripted's app build through build-deps.sh
 //   2. `swift test` for the TranscriptedCore smoke tests in this repo
 //
 // Binary dependency layout:
-//   deps-libs/libDraftDeps.a          — prebuilt mega-library (FluidAudio 0.7.9 + MLX + deps + TranscriptedCore)
+//   deps-libs/libDraftDeps.a          — legacy-named prebuilt library (FluidAudio 0.7.9 + MLX + deps + TranscriptedCore)
 //   deps-libs/libExternalDeps.a       — external-only archive for SPM tests (no TranscriptedCore objects)
 //   deps-frameworks/ESpeakNG.framework — FluidAudio binary dependency for package recompiles
 //   deps-modules/*.swiftmodule        — Swift interface files for FluidAudio et al.

--- a/Sources/Dictation/DictationTranscriptStore.swift
+++ b/Sources/Dictation/DictationTranscriptStore.swift
@@ -176,6 +176,7 @@ enum DictationTranscriptStore {
             let header = headerPreface(in: content)
             let rebuilt = (header + kept.joined(separator: "\n\n")).trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
             try rebuilt.write(to: url, atomically: true, encoding: .utf8)
+            FileManager.default.restrictFileToOwnerOnly(at: url)
         }
 
         NotificationCenter.default.post(name: .dictationTranscriptDidSave, object: url)

--- a/Sources/Meeting/FailedMeetingPresentation.swift
+++ b/Sources/Meeting/FailedMeetingPresentation.swift
@@ -8,6 +8,7 @@ enum FailedMeetingPresentation {
     ) -> MeetingSessionController.FailedMeetingItem {
         let failureKind = MeetingFailureKind.classify(message: failed.errorMessage)
         let availableAudioURLs = audioURLs(for: failed)
+        let hasRetryableAudioFiles = failed.audioFilesExist()
         let copy = MeetingFailureCopy.make(
             forMessage: failed.errorMessage,
             shortErrorMessage: failed.shortErrorMessage,
@@ -23,7 +24,7 @@ enum FailedMeetingPresentation {
             failureKind: failureKind,
             isRetryable: failed.isRetryable,
             isRetrying: isRetrying,
-            hasAudioFiles: !availableAudioURLs.isEmpty,
+            hasAudioFiles: hasRetryableAudioFiles,
             audioURLs: availableAudioURLs
         )
     }

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -649,14 +649,14 @@ final class MeetingSessionController: ObservableObject {
             )
             state = files.systemURL == nil
                 ? .error("No meeting audio was captured.")
-                : .error("Microphone audio was missing. Open Settings → Meetings to retry the system audio.")
+                : .error("Microphone audio was missing. Open Transcripted Home to retry the system audio.")
             return
         }
 
         // Stop timeout means Audio.onRecordingComplete never fired. The WAV
         // header may not be fully patched, so route the audio to the failed
         // queue rather than enqueuing for transcription. The user can retry
-        // from Settings → Meetings, where the pipeline will either succeed
+        // from Transcripted Home, where the pipeline will either succeed
         // on a now-finalized file or fail cleanly.
         if stopResult.didTimeOut {
             Self.runtimeDiagnosticsRecorder?.recordStall(
@@ -681,7 +681,7 @@ final class MeetingSessionController: ObservableObject {
                 message: "Meeting routed to failed queue due to stop timeout",
                 context: baseDiagnosticsContext(extra: ["reason": reason.rawValue])
             )
-            state = .error("Recording didn't close cleanly. Open Settings → Meetings to retry.")
+            state = .error("Recording didn't close cleanly. Open Transcripted Home to retry.")
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "stop_timeout")
             return
         }

--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -99,6 +99,7 @@ enum MeetingTranscriptStyler {
         if updated != raw {
             do {
                 try updated.write(to: finalURL, atomically: true, encoding: .utf8)
+                FileManager.default.restrictFileToOwnerOnly(at: finalURL)
             } catch {
                 logFailure(
                     event: "meeting_transcript_write_failed",

--- a/Sources/Observability/EventReporter.swift
+++ b/Sources/Observability/EventReporter.swift
@@ -113,9 +113,9 @@ private actor EventFileWriter {
 
         if !FileManager.default.fileExists(atPath: fileURL.path) {
             FileManager.default.createFile(atPath: fileURL.path, contents: nil)
-            FileManager.default.restrictFileToOwnerOnly(at: fileURL)
             print("📊 EVENT | created events.jsonl at \(fileURL.path)")
         }
+        FileManager.default.restrictFileToOwnerOnly(at: fileURL)
 
         do {
             handle = try FileHandle(forWritingTo: fileURL)

--- a/Sources/Observability/ReliabilityPacketRecorder.swift
+++ b/Sources/Observability/ReliabilityPacketRecorder.swift
@@ -61,8 +61,8 @@ private actor ReliabilityPacketFileWriter {
 
         if !FileManager.default.fileExists(atPath: fileURL.path) {
             FileManager.default.createFile(atPath: fileURL.path, contents: nil)
-            FileManager.default.restrictFileToOwnerOnly(at: fileURL)
         }
+        FileManager.default.restrictFileToOwnerOnly(at: fileURL)
 
         do {
             handle = try FileHandle(forWritingTo: fileURL)

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -413,6 +413,8 @@ class ParakeetEngine: ObservableObject {
     private var audioStartInProgress = false
     private var inputTapInstalled = false
     private var sampleBuffer: [Float] = []
+    private var recoveredRecordingTimeline = RecordedAudioTimeline()
+    private var preservingRecordingAcrossRecovery = false
     private nonisolated(unsafe) var nativeSampleRate: Double = 48000
     private let pendingSamplesLock = NSLock()
     private var pendingSamples: [Float] = []
@@ -1225,9 +1227,7 @@ class ParakeetEngine: ObservableObject {
         prewarmRetryTask = nil
 
         if isRecording {
-            pendingSamplesLock.withLock {
-                pendingSamples.removeAll(keepingCapacity: true)
-            }
+            preserveCurrentRecordingBuffersForRecovery()
             streamingSamplesLock.withLock { streamingSampleBuffer.removeAll(keepingCapacity: true) }
             Task { await eouManager?.reset() }
             await removeRecordingTap()
@@ -2235,6 +2235,9 @@ class ParakeetEngine: ObservableObject {
         recordingInterrupted = false
         didReceiveAudioSamples = false
         cancelAudioWatchdog()
+        if !isRecoveryAttempt && !preservingRecordingAcrossRecovery {
+            recoveredRecordingTimeline.removeAll(keepingCapacity: true)
+        }
         pendingSamplesLock.withLock {
             pendingSamples.removeAll(keepingCapacity: true)
         }
@@ -2602,6 +2605,8 @@ class ParakeetEngine: ObservableObject {
         guard isRecording else {
             if audioStartInProgress {
                 audioGraphGeneration += 1
+            } else {
+                clearRecoveredRecordingTimeline(keepingCapacity: true)
             }
             return
         }
@@ -2648,6 +2653,61 @@ class ParakeetEngine: ObservableObject {
         }
     }
 
+    private func preserveCurrentRecordingBuffersForRecovery() {
+        drainPendingSamplesIntoSampleBuffer()
+        if !sampleBuffer.isEmpty {
+            recoveredRecordingTimeline.append(sampleBuffer, sampleRate: safeNativeSampleRate())
+            sampleBuffer.removeAll(keepingCapacity: true)
+        }
+        preservingRecordingAcrossRecovery = !recoveredRecordingTimeline.isEmpty
+    }
+
+    private func clearRecoveredRecordingTimeline(keepingCapacity: Bool = true) {
+        recoveredRecordingTimeline.removeAll(keepingCapacity: keepingCapacity)
+        preservingRecordingAcrossRecovery = false
+    }
+
+    private func drainRecordedSamplesForInference() async -> (nativeSampleCount: Int, samples16k: [Float])? {
+        drainPendingSamplesIntoSampleBuffer()
+
+        if !recoveredRecordingTimeline.isEmpty {
+            recoveredRecordingTimeline.append(sampleBuffer, sampleRate: safeNativeSampleRate())
+            sampleBuffer.removeAll(keepingCapacity: true)
+            let segments = recoveredRecordingTimeline.drain()
+            preservingRecordingAcrossRecovery = false
+            let nativeSampleCount = segments.reduce(0) { $0 + $1.samples.count }
+            guard nativeSampleCount > 0 else { return nil }
+            let resampled = await Task.detached(priority: .userInitiated) {
+                var combined: [Float] = []
+                for segment in segments {
+                    combined.append(contentsOf: AudioResampler.resample(
+                        segment.samples,
+                        from: segment.sampleRate,
+                        to: TranscriptedConstants.parakeetSampleRate
+                    ))
+                }
+                return combined
+            }.value
+            return (nativeSampleCount, resampled)
+        }
+
+        guard !sampleBuffer.isEmpty else { return nil }
+        var samples: [Float] = []
+        swap(&samples, &sampleBuffer)
+        let inputRate = safeNativeSampleRate()
+        let nativeSampleCount = samples.count
+        let samplesForResampling = samples
+        samples.removeAll(keepingCapacity: false)
+        let resampled = await Task.detached(priority: .userInitiated) {
+            AudioResampler.resample(
+                samplesForResampling,
+                from: inputRate,
+                to: TranscriptedConstants.parakeetSampleRate
+            )
+        }.value
+        return (nativeSampleCount, resampled)
+    }
+
     /// Convert [Float] samples to AVAudioPCMBuffer for StreamingEouAsrManager.
     private func makePCMBuffer(from samples: [Float]) -> AVAudioPCMBuffer? {
         guard let format = eouPCMFormat,
@@ -2677,7 +2737,7 @@ class ParakeetEngine: ObservableObject {
 
         drainPendingSamplesIntoSampleBuffer()
 
-        guard !sampleBuffer.isEmpty else {
+        guard !sampleBuffer.isEmpty || !recoveredRecordingTimeline.isEmpty else {
             EventReporter.shared.capture(
                 level: .warning,
                 engine: engineName,
@@ -2688,15 +2748,12 @@ class ParakeetEngine: ObservableObject {
         }
 
         isTranscribing = true
-        var samples: [Float] = []
-        swap(&samples, &sampleBuffer)
-        let inputRate = safeNativeSampleRate()
-        let nativeCount = samples.count
-        let samplesForResampling = samples
-        samples.removeAll(keepingCapacity: false)
-        let resampled = await Task.detached(priority: .userInitiated) {
-            AudioResampler.resample(samplesForResampling, from: inputRate, to: 16000)
-        }.value
+        guard let recorded = await drainRecordedSamplesForInference() else {
+            finishExternalTranscription()
+            return nil
+        }
+        let nativeCount = recorded.nativeSampleCount
+        let resampled = recorded.samples16k
         print("🔄 \(engineName.uppercased()) | resampled \(nativeCount) → \(resampled.count) samples")
 
         let shortAudioDecision = ParakeetShortAudioGate.dictation(
@@ -2727,6 +2784,7 @@ class ParakeetEngine: ObservableObject {
     private func finishTranscription() {
         isTranscribing = false
         sampleBuffer.removeAll(keepingCapacity: true)
+        clearRecoveredRecordingTimeline(keepingCapacity: true)
     }
 
     func transcribe() async -> String? {
@@ -2736,7 +2794,7 @@ class ParakeetEngine: ObservableObject {
             return nil
         }
         drainPendingSamplesIntoSampleBuffer()
-        guard !sampleBuffer.isEmpty else {
+        guard !sampleBuffer.isEmpty || !recoveredRecordingTimeline.isEmpty else {
             EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "no_audio_samples",
                 message: "No audio samples in buffer when transcribe() called")
             return nil
@@ -2749,22 +2807,14 @@ class ParakeetEngine: ObservableObject {
         }
 
         isTranscribing = true
-        // Swap instead of copy — moves data out of sampleBuffer without allocating a duplicate.
-        // sampleBuffer is cleared immediately, freeing capacity before resampling.
-        var samples: [Float] = []
-        swap(&samples, &sampleBuffer)
-        let inputRate = safeNativeSampleRate()
-
         let startTime = CFAbsoluteTimeGetCurrent()
 
-        // Resample to 16kHz for Parakeet inference, then free the native-rate buffer
-        // before inference — avoids holding both the raw and resampled arrays simultaneously.
-        let nativeCount = samples.count
-        let samplesForResampling = samples
-        samples.removeAll(keepingCapacity: false)
-        let resampled = await Task.detached(priority: .userInitiated) {
-            AudioResampler.resample(samplesForResampling, from: inputRate, to: 16000)
-        }.value
+        guard let recorded = await drainRecordedSamplesForInference() else {
+            finishTranscription()
+            return nil
+        }
+        let nativeCount = recorded.nativeSampleCount
+        let resampled = recorded.samples16k
         print("🔄 PARAKEET | resampled \(nativeCount) → \(resampled.count) samples")
 
         let shortAudioDecision = ParakeetShortAudioGate.dictation(
@@ -3016,6 +3066,7 @@ class ParakeetEngine: ObservableObject {
         audioLevel = 0
         didReceiveAudioSamples = false
         sampleBuffer.removeAll(keepingCapacity: true)
+        clearRecoveredRecordingTimeline(keepingCapacity: true)
         liveTranscript = ""
         committedStreamText = ""
         audioGraphGeneration += 1
@@ -3049,6 +3100,7 @@ class ParakeetEngine: ObservableObject {
         audioLevel = 0
         didReceiveAudioSamples = false
         sampleBuffer.removeAll(keepingCapacity: true)
+        clearRecoveredRecordingTimeline(keepingCapacity: true)
         liveTranscript = ""
         committedStreamText = ""
         abandonBlockedAudioEngine(reason: reason)
@@ -3085,6 +3137,7 @@ class ParakeetEngine: ObservableObject {
             await self?.releaseIdleAudioHardware(removeTap: true, expectedGeneration: cleanupGeneration)
         }
         sampleBuffer.removeAll()
+        clearRecoveredRecordingTimeline(keepingCapacity: false)
         isTranscribing = false
         liveTranscript = ""
         committedStreamText = ""

--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -9,6 +9,7 @@ import Foundation
 enum TextPasteCopyReason: Equatable {
     case accessibilityMissing
     case pasteEventCreationFailed
+    case focusChanged
 }
 
 enum TextPasteOutcome: Equatable {
@@ -46,6 +47,39 @@ enum TextPasteOutcome: Equatable {
     }
 }
 
+struct DictationPasteTarget: Equatable {
+    let processIdentifier: pid_t?
+    let bundleIdentifier: String?
+
+    static func capture(sourceApp: NSRunningApplication?) -> DictationPasteTarget? {
+        guard let sourceApp else { return nil }
+        return DictationPasteTarget(
+            processIdentifier: sourceApp.processIdentifier,
+            bundleIdentifier: sourceApp.bundleIdentifier
+        )
+    }
+
+    func matchesCurrentFrontmostApp() -> Bool {
+        guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
+            return false
+        }
+        return matches(
+            processIdentifier: frontmostApp.processIdentifier,
+            bundleIdentifier: frontmostApp.bundleIdentifier
+        )
+    }
+
+    func matches(processIdentifier currentProcessIdentifier: pid_t?, bundleIdentifier currentBundleIdentifier: String?) -> Bool {
+        if let processIdentifier, let currentProcessIdentifier {
+            return processIdentifier == currentProcessIdentifier
+        }
+        if let bundleIdentifier, let currentBundleIdentifier {
+            return bundleIdentifier == currentBundleIdentifier
+        }
+        return false
+    }
+}
+
 @MainActor
 final class ClipboardRestoringTextPaster {
     typealias PasteboardSnapshot = [[NSPasteboard.PasteboardType: Data]]
@@ -61,8 +95,16 @@ final class ClipboardRestoringTextPaster {
         clipboardRestoreTask = nil
     }
 
-    func paste(_ text: String) -> TextPasteOutcome {
+    func paste(_ text: String, target: DictationPasteTarget? = nil) -> TextPasteOutcome {
         cancelPendingClipboardRestore()
+
+        if let target, !target.matchesCurrentFrontmostApp() {
+            copyTextToClipboard(text)
+            return .copied(
+                "Focus changed before Transcripted could paste, so the text was copied.",
+                reason: .focusChanged
+            )
+        }
 
         guard AXIsProcessTrusted() else {
             let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -417,11 +417,11 @@ extension TranscriptionTaskManager {
         }
 
         // No naming needed — clean up scratch audio once retained copies exist.
-        if shouldRemoveScratchAudio, let micURL {
-            try? FileManager.default.removeItem(at: micURL)
-        }
-        if shouldRemoveScratchAudio {
-            try? FileManager.default.removeItem(at: systemURL)
+        // Failed-queue source audio is deleted by retry completion, since it may
+        // live outside the normal scratch cleanup roots.
+        if shouldRemoveScratchAudio, sourceFailedTranscriptionId == nil {
+            removeManagedCleanupFile(micURL, label: "completed mic scratch")
+            removeManagedCleanupFile(systemURL, label: "completed system scratch")
         }
 
         return savedURL

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -641,7 +641,7 @@ public class TranscriptionTaskManager: ObservableObject {
                         "failedId": failedId.uuidString
                     ])
                 } else {
-                    failedTranscriptionManager.removeFailedTranscription(id: failedId)
+                    failedTranscriptionManager.deleteFailedTranscription(id: failedId)
                 }
                 self.activeTasks.removeValue(forKey: failedId)
                 self.activeCount = max(0, self.activeCount - 1)
@@ -653,13 +653,18 @@ public class TranscriptionTaskManager: ObservableObject {
 
         } catch {
             AppLogger.pipeline.error("Retry failed", ["error": "\(error.localizedDescription)"])
+            let diagnosticMessage = "Retry failed: \(Self.safeFailureDiagnosticMessage(for: error))"
             await MainActor.run {
                 self.activeTasks.removeValue(forKey: failedId)
                 self.activeCount = max(0, self.activeCount - 1)
                 self.backgroundTaskCount = max(0, self.backgroundTaskCount - 1)
+                failedTranscriptionManager.updateFailedTranscriptionError(
+                    id: failedId,
+                    errorMessage: diagnosticMessage
+                )
                 self.publishFailure(
                     displayMessage: "Retry failed",
-                    diagnosticMessage: "Retry failed: \(Self.safeFailureDiagnosticMessage(for: error))"
+                    diagnosticMessage: diagnosticMessage
                 )
                 self.scheduleStatusReset(delay: 8)
             }

--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -88,6 +88,7 @@ extension TranscriptSaver {
             // Write back atomically
             do {
                 try content.write(to: fileURL, atomically: true, encoding: .utf8)
+                restrictTranscriptToOwnerOnly(fileURL)
                 updatedCount += 1
             } catch {
                 AppLogger.pipeline.warning("Failed to update transcript retroactively", ["file": fileURL.lastPathComponent, "error": error.localizedDescription])
@@ -138,6 +139,7 @@ extension TranscriptSaver {
 
             do {
                 try content.write(to: fileURL, atomically: true, encoding: .utf8)
+                restrictTranscriptToOwnerOnly(fileURL)
                 updatedCount += 1
             } catch {
                 AppLogger.pipeline.warning("Failed to update merged speaker transcript", [
@@ -190,6 +192,7 @@ extension TranscriptSaver {
 
             do {
                 try content.write(to: transcriptURL, atomically: true, encoding: .utf8)
+                restrictTranscriptToOwnerOnly(transcriptURL)
             } catch {
                 AppLogger.pipeline.error("Failed to write deferred speaker review metadata", ["error": error.localizedDescription])
                 return false
@@ -234,6 +237,7 @@ extension TranscriptSaver {
 
             do {
                 try content.write(to: transcriptURL, atomically: true, encoding: .utf8)
+                restrictTranscriptToOwnerOnly(transcriptURL)
             } catch {
                 AppLogger.pipeline.error("Failed to write updated transcript (generic)", ["error": error.localizedDescription])
                 return false
@@ -333,6 +337,7 @@ extension TranscriptSaver {
             // Atomic write back
             do {
                 try content.write(to: transcriptURL, atomically: true, encoding: .utf8)
+                restrictTranscriptToOwnerOnly(transcriptURL)
             } catch {
                 AppLogger.pipeline.error("Failed to write updated transcript", ["error": error.localizedDescription])
                 return false
@@ -417,6 +422,7 @@ extension TranscriptSaver {
 
             do {
                 try content.write(to: transcriptURL, atomically: true, encoding: .utf8)
+                restrictTranscriptToOwnerOnly(transcriptURL)
             } catch {
                 AppLogger.pipeline.error("Failed to write collapsed transcript", ["error": error.localizedDescription])
                 return false
@@ -452,6 +458,7 @@ extension TranscriptSaver {
 
             do {
                 try content.write(to: transcriptURL, atomically: true, encoding: .utf8)
+                restrictTranscriptToOwnerOnly(transcriptURL)
             } catch {
                 AppLogger.pipeline.error("Failed to write discarded speaker metadata", ["error": error.localizedDescription])
                 return false
@@ -463,6 +470,10 @@ extension TranscriptSaver {
             ])
             return true
         }
+    }
+
+    private static func restrictTranscriptToOwnerOnly(_ transcriptURL: URL) {
+        FileManager.default.restrictToOwnerOnly(atPath: transcriptURL.path)
     }
 
     /// Remove speaker YAML entries whose `channel:` line matches `channel`.

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -59,6 +59,7 @@ class DictationSessionController: ObservableObject {
     }
 
     private var sessionSourceApp: NSRunningApplication?
+    private var sessionPasteTarget: DictationPasteTarget?
     private var sessionAnchorRect: NSRect?
     private var startupTask: Task<Void, Never>?
     private var streamingTask: Task<Void, Never>?
@@ -130,6 +131,7 @@ class DictationSessionController: ObservableObject {
         isDictating = true
         currentDictationSessionID = UUID()
         sessionSourceApp = sourceApp
+        sessionPasteTarget = DictationPasteTarget.capture(sourceApp: sourceApp)
         sessionAnchorRect = anchorRect
         sessionStartTime = CFAbsoluteTimeGetCurrent()
         currentDictationTrigger = trigger
@@ -774,6 +776,7 @@ class DictationSessionController: ObservableObject {
         guard appState.sttRouter.isRecording else {
             recordingStartRetryTask?.cancel()
             recordingStartRetryTask = nil
+            appState.sttRouter.cancel()
             let failureKind = appState.sttRouter.inputFormatReady
                 ? "microphone_start_failed"
                 : "microphone_route_not_ready"
@@ -1327,7 +1330,7 @@ class DictationSessionController: ObservableObject {
     }
 
     private func pasteWithClipboardRestore(_ text: String) -> DictationPasteOutcome {
-        let outcome = textPaster.paste(text)
+        let outcome = textPaster.paste(text, target: sessionPasteTarget)
 
         switch outcome.copyReason {
         case .accessibilityMissing:
@@ -1336,6 +1339,10 @@ class DictationSessionController: ObservableObject {
             EventReporter.shared.capture(level: .error, engine: "overlay", event: "cgevent_create_failed",
                 message: "CGEvent creation returned nil — paste will not work")
             appState?.logger.log("DICTATION | CGEvent paste failed, keeping text on clipboard")
+        case .focusChanged:
+            EventReporter.shared.capture(level: .warning, engine: "overlay", event: "dictation_paste_target_changed",
+                message: "Focus changed before dictation paste")
+            appState?.logger.log("DICTATION | focus changed, copying text instead")
         case nil:
             break
         }

--- a/Sources/UI/Settings/HomeDeleteConfirmationPolicy.swift
+++ b/Sources/UI/Settings/HomeDeleteConfirmationPolicy.swift
@@ -12,4 +12,10 @@ enum HomeDeleteConfirmationPolicy {
         message: "Do you want to delete all of the audio and the transcript that has to do with this meeting? This cannot be undone.",
         confirmTitle: "Delete Meeting"
     )
+
+    static let failedMeeting = HomeDeleteConfirmationPresentation(
+        title: "Delete this failed meeting?",
+        message: "Do you want to delete the saved retry audio for this failed meeting? This cannot be undone.",
+        confirmTitle: "Delete Failed Meeting"
+    )
 }

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -1494,7 +1494,7 @@ struct HomeFailedMeetingInlineRow: View {
 
     private var actions: some View {
         HStack(spacing: 6) {
-            if item.hasAudioFiles {
+            if hasRetainedAudioFiles {
                 Button {
                     onRevealAudio()
                 } label: {
@@ -1516,9 +1516,9 @@ struct HomeFailedMeetingInlineRow: View {
 
             HomeRowMoreMenuButton(items: [
                 HomeRowMenuItem(
-                    title: item.hasAudioFiles ? "Delete failed meeting" : "Dismiss",
-                    symbolName: item.hasAudioFiles ? "trash" : "xmark",
-                    isDestructive: item.hasAudioFiles,
+                    title: hasRetainedAudioFiles ? "Delete failed meeting" : "Dismiss",
+                    symbolName: hasRetainedAudioFiles ? "trash" : "xmark",
+                    isDestructive: hasRetainedAudioFiles,
                     action: onClear
                 )
             ])
@@ -1571,6 +1571,9 @@ struct HomeFailedMeetingInlineRow: View {
         if item.isRetrying {
             return "Retry is already running."
         }
+        if !item.hasAudioFiles {
+            return "This meeting does not have enough saved audio to retry."
+        }
         if !item.isRetryable {
             return "This meeting does not have enough saved audio to retry."
         }
@@ -1581,6 +1584,10 @@ struct HomeFailedMeetingInlineRow: View {
             return "Wait for the current meeting work to finish before retrying."
         }
         return "Transcribe this saved audio again."
+    }
+
+    private var hasRetainedAudioFiles: Bool {
+        !item.audioURLs.isEmpty
     }
 }
 
@@ -2678,9 +2685,9 @@ private struct HomeFailedMeetingRow: View {
                     }
 
                     SettingsInlineActionButton(
-                        title: item.hasAudioFiles ? "Delete" : "Dismiss",
-                        symbolName: item.hasAudioFiles ? "trash" : "xmark",
-                        tone: item.hasAudioFiles ? .destructive : .neutral
+                        title: hasRetainedAudioFiles ? "Delete" : "Dismiss",
+                        symbolName: hasRetainedAudioFiles ? "trash" : "xmark",
+                        tone: hasRetainedAudioFiles ? .destructive : .neutral
                     ) {
                         onClear()
                     }
@@ -2692,12 +2699,15 @@ private struct HomeFailedMeetingRow: View {
     }
 
     private var retryDisabled: Bool {
-        !canRetry || !item.isRetryable || item.isRetrying
+        !canRetry || !item.isRetryable || !item.hasAudioFiles || item.isRetrying
     }
 
     private var retryHelp: String {
         if item.isRetrying {
             return "Retry is already running."
+        }
+        if !item.hasAudioFiles {
+            return "This meeting does not have enough saved audio to retry."
         }
         if !item.isRetryable {
             return "This meeting does not have enough saved audio to retry."
@@ -2709,5 +2719,9 @@ private struct HomeFailedMeetingRow: View {
             return "Wait for the current meeting work to finish before retrying."
         }
         return "Transcribe this saved audio again."
+    }
+
+    private var hasRetainedAudioFiles: Bool {
+        !item.audioURLs.isEmpty
     }
 }

--- a/Sources/UI/Settings/TranscriptedSettingsComponents.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsComponents.swift
@@ -687,12 +687,11 @@ struct SettingsToggleRow: View {
                 .controlSize(.regular)
                 .tint(.accentColor)
                 .help(help ?? title)
+                .accessibilityLabel(Text(title))
+                .accessibilityValue(Text(isOn ? "On" : "Off"))
+                .accessibilityHint(Text(detail))
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(Text(title))
-        .accessibilityValue(Text(isOn ? "On" : "Off"))
-        .accessibilityHint(Text(detail))
     }
 }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -293,8 +293,7 @@ struct TranscriptedSettingsView: View {
                         revealFailedMeetingAudio(item)
                     },
                     onClear: { item in
-                        trackSettingsAction(item.hasAudioFiles ? "home_delete_failed_meeting" : "home_dismiss_failed_meeting", page: .home)
-                        clearFailedMeeting(item)
+                        requestClearFailedMeeting(item)
                     },
                     onShowAll: {
                         trackSettingsAction("home_show_all_failed_meetings", page: .home)
@@ -397,8 +396,7 @@ struct TranscriptedSettingsView: View {
                         revealFailedMeetingAudio(item)
                     },
                     onClearFailedMeeting: { item in
-                        trackSettingsAction(item.hasAudioFiles ? "home_delete_failed_meeting" : "home_dismiss_failed_meeting", page: .home)
-                        clearFailedMeeting(item)
+                        requestClearFailedMeeting(item)
                     },
                     onLoadMoreDictations: {
                         trackSettingsAction("load_more_dictations", page: .home)
@@ -436,7 +434,10 @@ struct TranscriptedSettingsView: View {
                 },
                 onReportIssue: {
                     homeMeetingPreview = nil
-                    homeFeedbackTarget = preview.feedbackTarget
+                    Task { @MainActor in
+                        await Task.yield()
+                        homeFeedbackTarget = preview.feedbackTarget
+                    }
                 },
                 onDone: {
                     homeMeetingPreview = nil
@@ -752,13 +753,32 @@ struct TranscriptedSettingsView: View {
         NSWorkspace.shared.activateFileViewerSelecting([firstAudioURL])
     }
 
+    private func requestClearFailedMeeting(_ item: MeetingSessionController.FailedMeetingItem) {
+        if !item.audioURLs.isEmpty {
+            trackSettingsAction("home_delete_failed_meeting_request", page: .home)
+            let presentation = HomeDeleteConfirmationPolicy.failedMeeting
+            homeDeleteConfirmation = HomeDeleteConfirmation(
+                title: presentation.title,
+                message: presentation.message,
+                confirmTitle: presentation.confirmTitle
+            ) {
+                trackSettingsAction("home_delete_failed_meeting_confirm", page: .home)
+                clearFailedMeeting(item)
+            }
+            return
+        }
+
+        trackSettingsAction("home_dismiss_failed_meeting", page: .home)
+        clearFailedMeeting(item)
+    }
+
     private func clearFailedMeeting(_ item: MeetingSessionController.FailedMeetingItem) {
         if let audio = failedMeetingAudioAttachment(for: item),
            MeetingAudioPlayback.shared.isActive(audio) {
             MeetingAudioPlayback.shared.stop()
         }
 
-        if item.hasAudioFiles {
+        if !item.audioURLs.isEmpty {
             meetingSession.deleteFailedMeeting(id: item.id)
         } else {
             meetingSession.dismissFailedMeeting(id: item.id)
@@ -3124,30 +3144,33 @@ private struct SettingsFailedMeetingRow: View {
                 .help(retryHelp)
             }
 
-            Button(role: item.hasAudioFiles ? .destructive : nil) {
+            Button(role: hasRetainedAudioFiles ? .destructive : nil) {
                 secondaryAction()
             } label: {
-                Label(item.hasAudioFiles ? "Delete" : "Dismiss", systemImage: item.hasAudioFiles ? "trash" : "xmark")
+                Label(hasRetainedAudioFiles ? "Delete" : "Dismiss", systemImage: hasRetainedAudioFiles ? "trash" : "xmark")
                     .font(.caption.weight(.semibold))
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
             }
             .buttonStyle(SettingsHoverButtonStyle(
-                tone: item.hasAudioFiles ? .destructive : .neutral,
+                tone: hasRetainedAudioFiles ? .destructive : .neutral,
                 cornerRadius: 8,
-                normalFill: item.hasAudioFiles ? Color.red.opacity(0.06) : Color.primary.opacity(0.025),
-                normalStroke: item.hasAudioFiles ? Color.red.opacity(0.14) : Color.primary.opacity(0.06)
+                normalFill: hasRetainedAudioFiles ? Color.red.opacity(0.06) : Color.primary.opacity(0.025),
+                normalStroke: hasRetainedAudioFiles ? Color.red.opacity(0.14) : Color.primary.opacity(0.06)
             ))
         }
     }
 
     private var retryDisabled: Bool {
-        !canRetry || !item.isRetryable || item.isRetrying
+        !canRetry || !item.isRetryable || !item.hasAudioFiles || item.isRetrying
     }
 
     private var retryHelp: String {
         if item.isRetrying {
             return "Retry is already running."
+        }
+        if !item.hasAudioFiles {
+            return "This meeting does not have enough saved audio to retry."
         }
         if !item.isRetryable {
             return "This meeting does not have enough saved audio to retry."
@@ -3159,6 +3182,10 @@ private struct SettingsFailedMeetingRow: View {
             return "Wait for the current meeting work to finish before retrying."
         }
         return "Transcribe this saved audio again."
+    }
+
+    private var hasRetainedAudioFiles: Bool {
+        !item.audioURLs.isEmpty
     }
 }
 

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -64,5 +64,25 @@ func testClipboardRestoringTextPaster() async {
                 "unchanged temporary pasteboard content should be restored to the previous snapshot"
             )
         }
+
+        runSuite("DictationPasteTarget — accepts only the captured foreground app") {
+            let target = DictationPasteTarget(
+                processIdentifier: 42,
+                bundleIdentifier: "com.example.Target"
+            )
+
+            assertTrue(
+                target.matches(processIdentifier: 42, bundleIdentifier: "com.example.Other"),
+                "matching process id should keep paste directed at the original app"
+            )
+            assertTrue(
+                target.matches(processIdentifier: nil, bundleIdentifier: "com.example.Target"),
+                "bundle id should be a fallback when a process id is unavailable"
+            )
+            assertFalse(
+                target.matches(processIdentifier: 7, bundleIdentifier: "com.example.Target"),
+                "a different frontmost process should block automatic paste even if bundle ids match"
+            )
+        }
     }
 }

--- a/Tests/DictationAudioRecoveryTests.swift
+++ b/Tests/DictationAudioRecoveryTests.swift
@@ -79,4 +79,40 @@ func testDictationAudioRecovery() {
             )
         }
     }
+
+    runSuite("ParakeetEngine — preserves dictation audio across route recovery") {
+        let engineSource = (try? String(
+            contentsOf: repoFixtureURL("Sources/Speech/ParakeetEngine.swift"),
+            encoding: .utf8
+        )) ?? ""
+        let sessionSource = (try? String(
+            contentsOf: repoFixtureURL("Sources/UI/Overlay/DictationSessionController.swift"),
+            encoding: .utf8
+        )) ?? ""
+
+        assertTrue(
+            engineSource.contains("private var recoveredRecordingTimeline = RecordedAudioTimeline()"),
+            "engine should keep a multi-segment audio timeline for route-change recovery"
+        )
+        assertTrue(
+            engineSource.contains("preserveCurrentRecordingBuffersForRecovery()"),
+            "config changes during recording should preserve buffered audio before tearing down the tap"
+        )
+        assertTrue(
+            engineSource.contains("recoveredRecordingTimeline.append(sampleBuffer, sampleRate: safeNativeSampleRate())"),
+            "current-device audio should be retained with its native sample rate"
+        )
+        assertTrue(
+            engineSource.contains("private func clearRecoveredRecordingTimeline(keepingCapacity: Bool = true)"),
+            "recovery preservation should have a single cleanup path"
+        )
+        assertTrue(
+            sessionSource.contains("appState.sttRouter.cancel()\n            let failureKind"),
+            "abandoned capture-not-started sessions should cancel the speech engine and clear preserved recovery audio"
+        )
+        assertTrue(
+            engineSource.contains("drainRecordedSamplesForInference()"),
+            "transcription should drain preserved segments instead of resampling all audio as one rate"
+        )
+    }
 }

--- a/Tests/DictationTranscriptStoreTests.swift
+++ b/Tests/DictationTranscriptStoreTests.swift
@@ -212,6 +212,7 @@ func testDictationTranscriptStore() {
         second text
         """
         try? markdown.write(to: dayFile, atomically: true, encoding: .utf8)
+        try? fm.setAttributes([.posixPermissions: 0o644], ofItemAtPath: dayFile.path)
 
         let entries = DictationTranscriptStore.recentSavedDictations(limit: 2, directory: outputDir)
         guard let second = entries.first(where: { $0.entryID == "dictation-second" }) else {
@@ -230,6 +231,11 @@ func testDictationTranscriptStore() {
         assertTrue(remainingContent.contains("first text"), "first entry body remains")
         assertFalse(remainingContent.contains("dictation-second"), "second entry ID removed")
         assertFalse(remainingContent.contains("second text"), "second entry body removed")
+        assertEqual(
+            dictationStoreFilePermissions(of: dayFile),
+            NSNumber(value: 0o600),
+            "deleteEntry rewrites should restore owner-only permissions"
+        )
     }
 
     runSuite("DictationTranscriptStore.deleteEntry — same-timestamp saved entries keep distinct IDs") {
@@ -282,6 +288,11 @@ private func temporaryDictationStoreTestRoot(fileManager: FileManager) -> URL {
         "TranscriptedDictationStoreTests-\(UUID().uuidString)",
         isDirectory: true
     )
+}
+
+private func dictationStoreFilePermissions(of url: URL) -> NSNumber? {
+    let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+    return attributes?[.posixPermissions] as? NSNumber
 }
 
 private func isoDate(_ string: String) -> Date {

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -125,4 +125,24 @@ func testFailedMeetingPresentation() {
         assertEqual(copy.title, "Couldn't save speaker names", "speaker finalization failures should not look like full transcript failures")
         assertTrue(copy.detail.contains("transcript saved"), "copy should say the transcript itself was saved")
     }
+
+    runSuite("FailedMeetingPresentation separates retained audio from retry-ready audio") {
+        let source = (try? String(
+            contentsOf: repoFixtureURL("Sources/Meeting/FailedMeetingPresentation.swift"),
+            encoding: .utf8
+        )) ?? ""
+
+        assertTrue(
+            source.contains("let availableAudioURLs = audioURLs(for: failed)"),
+            "available retained audio should stay separate from retry readiness"
+        )
+        assertTrue(
+            source.contains("let hasRetryableAudioFiles = failed.audioFilesExist()"),
+            "retry readiness should require all failed-transcription audio files"
+        )
+        assertTrue(
+            source.contains("hasAudioFiles: hasRetryableAudioFiles"),
+            "partial retained audio should not enable the retry action"
+        )
+    }
 }

--- a/Tests/HomeDeleteConfirmationPolicyTests.swift
+++ b/Tests/HomeDeleteConfirmationPolicyTests.swift
@@ -20,4 +20,23 @@ func testHomeDeleteConfirmationPolicy() {
             "destructive button should be specific"
         )
     }
+
+    runSuite("HomeDeleteConfirmationPolicy failed meeting delete copy is explicit") {
+        let presentation = HomeDeleteConfirmationPolicy.failedMeeting
+
+        assertEqual(
+            presentation.title,
+            "Delete this failed meeting?",
+            "failed meeting delete alert should name the destructive action"
+        )
+        assertTrue(
+            presentation.message.contains("saved retry audio"),
+            "failed meeting delete alert should explain it deletes retry audio"
+        )
+        assertEqual(
+            presentation.confirmTitle,
+            "Delete Failed Meeting",
+            "destructive button should be specific"
+        )
+    }
 }

--- a/Tests/MeetingTranscriptStylerTests.swift
+++ b/Tests/MeetingTranscriptStylerTests.swift
@@ -12,6 +12,7 @@ func testMeetingTranscriptStyler() {
         testMeetingTranscriptStylerRenamesRetainedAudioDirectory()
         testMeetingTranscriptStylerAvoidsAudioDirectoryCollisions()
         testMeetingTranscriptStylerPreservesObsidianSpeakerLinks()
+        testMeetingTranscriptStylerRestrictsRewrittenTranscript()
     }
 }
 
@@ -196,6 +197,23 @@ private func testMeetingTranscriptStylerPreservesObsidianSpeakerLinks() {
     assertTrue(updatedMarkdown?.contains("Linked speaker text should stay intact.") == true, "Styler should keep the transcript text attached to the right speaker")
 }
 
+private func testMeetingTranscriptStylerRestrictsRewrittenTranscript() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Call_2026-04-07_09-14-00.md")
+    try? sampleMeetingTranscript().write(to: transcriptURL, atomically: true, encoding: .utf8)
+    try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: transcriptURL.path)
+
+    let styled = MeetingTranscriptStyler.restyleTranscript(at: transcriptURL)
+
+    assertEqual(
+        meetingTranscriptStylerFilePermissions(of: styled.url),
+        NSNumber(value: 0o600),
+        "rewriting a transcript should restore owner-only permissions"
+    )
+}
+
 private func sampleMeetingTranscript() -> String {
     """
     ---
@@ -261,4 +279,9 @@ private func makeTemporaryTestDirectory() -> URL {
     let directory = FileManager.default.temporaryDirectory.appendingPathComponent("MeetingTranscriptStylerTests-\(UUID().uuidString)")
     try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     return directory
+}
+
+private func meetingTranscriptStylerFilePermissions(of url: URL) -> NSNumber? {
+    let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+    return attributes?[.posixPermissions] as? NSNumber
 }

--- a/Tests/ObservabilityLogWriterTests.swift
+++ b/Tests/ObservabilityLogWriterTests.swift
@@ -45,6 +45,20 @@ func testObservabilityLogWriter() {
         )
     }
 
+    runSuite("Observability file writers tighten pre-existing logs before appending") {
+        let eventReporter = readObservabilityTestRepoTextFile("Sources/Observability/EventReporter.swift")
+        let reliabilityRecorder = readObservabilityTestRepoTextFile("Sources/Observability/ReliabilityPacketRecorder.swift")
+
+        assertTrue(
+            eventReporter.contains("FileManager.default.restrictFileToOwnerOnly(at: fileURL)\n\n        do {"),
+            "events.jsonl should be chmodded even when it already exists"
+        )
+        assertTrue(
+            reliabilityRecorder.contains("FileManager.default.restrictFileToOwnerOnly(at: fileURL)\n\n        do {"),
+            "reliability packets should be chmodded even when the JSONL already exists"
+        )
+    }
+
     runSuite("LockedFileAppender keeps concurrent log records line-delimited") {
         let fm = FileManager.default
         let root = fm.temporaryDirectory.appendingPathComponent("ObservabilityLogWriterTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -4,6 +4,7 @@ func testRepoCommandContract() {
     runSuite("Repo command contract - root build and test wrappers stay script-based") {
         let wrappers = [
             "build-deps.sh": "scripts/entrypoints/build-deps.sh",
+            "build-beta.sh": "scripts/entrypoints/build-beta.sh",
             "build.sh": "scripts/entrypoints/build.sh",
             "run-tests.sh": "scripts/entrypoints/run-tests.sh",
             "run-integration-smoke.sh": "scripts/entrypoints/run-integration-smoke.sh"
@@ -44,6 +45,30 @@ func testRepoCommandContract() {
         assertFalse(
             contents.contains("\"parakeet-tdt-0.6b-v3\""),
             "build.sh should not bundle the legacy Parakeet directory as a second 461 MB copy"
+        )
+    }
+
+    runSuite("Repo command contract - build-deps readiness matches the app build") {
+        let buildDepsScript = readRepoTextFile("scripts/entrypoints/build-deps.sh")
+        assertTrue(
+            buildDepsScript.contains("TRANSCRIPTED_CORE_MODULE=\"$DEPS_MODULES/TranscriptedCore.swiftmodule/arm64-apple-macos.swiftmodule\""),
+            "build-deps.sh should not skip when the app-required TranscriptedCore module is missing"
+        )
+        assertTrue(
+            buildDepsScript.contains("newest_dependency_input") && buildDepsScript.contains("deps_are_ready"),
+            "build-deps.sh should rebuild stale TranscriptedCore artifacts instead of printing a false ready message"
+        )
+    }
+
+    runSuite("Repo command contract - fast test runner generation is per-process") {
+        let contents = readRepoTextFile("scripts/entrypoints/run-tests.sh")
+        assertTrue(
+            contents.contains("GENERATED_RUNNER=\"$BUILD_DIR/FastTestRunner.$$.swift\""),
+            "parallel run-tests.sh invocations should not overwrite the same generated Swift source"
+        )
+        assertTrue(
+            contents.contains("trap cleanup_generated_runner EXIT"),
+            "temporary generated test runners should be removed on exit"
         )
     }
 

--- a/Tests/TranscriptedCoreTests/RetroactiveSpeakerUpdaterTests.swift
+++ b/Tests/TranscriptedCoreTests/RetroactiveSpeakerUpdaterTests.swift
@@ -50,6 +50,26 @@ final class RetroactiveSpeakerUpdaterTests: XCTestCase {
         XCTAssertFalse(updated.contains(#"[System/Dana "D" Smith]"#))
     }
 
+    func testRetroactivelyUpdateSpeakerRestrictsRewrittenTranscript() throws {
+        let speakerId = UUID()
+        let transcriptURL = temporaryDirectory.appendingPathComponent("permissions.md")
+
+        try markdown(
+            speakerId: speakerId,
+            speakerName: "Speaker 1"
+        ).write(to: transcriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: transcriptURL.path)
+
+        TranscriptSaver.retroactivelyUpdateSpeaker(
+            dbId: speakerId,
+            newName: "Jamie",
+            in: temporaryDirectory
+        )
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: transcriptURL.path)
+        XCTAssertEqual(attributes[.posixPermissions] as? NSNumber, NSNumber(value: 0o600))
+    }
+
     func testRetroactivelyUpdateSpeakerRenamesEscapedBackslashes() throws {
         let speakerId = UUID()
         let transcriptURL = temporaryDirectory.appendingPathComponent("backslash.md")

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -397,6 +397,46 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertTrue(markdown.contains("Recovered meeting artifact."))
     }
 
+    func testRetrySuccessWithoutSpeakerNamingDeletesRetainedFailedAudio() async throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "Recovered meeting artifact."),
+            retainedAudioDirectory: retainedAudioDirectory
+        )
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("retry-retained-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("retry-retained-system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        XCTAssertTrue(manager.addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: "Parakeet inference failed",
+            meetingTitle: "Recovered Customer Call"
+        ))
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        let retainedMicURL = failed.micAudioURL
+        let retainedSystemURL = try XCTUnwrap(failed.systemAudioURL)
+        let retainedDirectory = retainedMicURL.deletingLastPathComponent()
+        XCTAssertTrue(retainedMicURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(retainedSystemURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+
+        let didRetry = await manager.retryFailedTranscription(
+            failedId: failed.id,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts", isDirectory: true)
+        )
+
+        XCTAssertTrue(didRetry)
+        XCTAssertTrue(manager.failedTranscriptionManager.failedTranscriptions.isEmpty)
+        XCTAssertNil(manager.speakerNamingRequest)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: retainedMicURL.path), "successful retry should delete retained failed mic audio")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: retainedSystemURL.path), "successful retry should delete retained failed system audio")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: retainedDirectory.path), "successful retry should remove the now-empty retained audio directory")
+    }
+
     func testStartImportedTranscriptionDoesNotDeleteOutOfSandboxFileWhenRejected() throws {
         let manager = makeManager()
         let externalURL = tempDirectory.appendingPathComponent("outside.wav")
@@ -407,6 +447,26 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             audioURL: externalURL,
             outputFolder: tempDirectory.appendingPathComponent("transcripts")
         )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: externalURL.path))
+    }
+
+    func testStartImportedTranscriptionDoesNotDeleteOutOfSandboxFileAfterSuccess() async throws {
+        let manager = makeManager(
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "Imported meeting artifact.")
+        )
+        let externalURL = tempDirectory.appendingPathComponent("outside-success.wav")
+        try writeMonoWAV(to: externalURL, duration: 2.5)
+
+        manager.startImportedTranscription(
+            audioURL: externalURL,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts"),
+            meetingTitle: "Imported customer call"
+        )
+
+        try await waitUntil {
+            manager.lastSavedTranscriptURL != nil && manager.activeTasks.isEmpty
+        }
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: externalURL.path))
     }
@@ -659,6 +719,37 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertTrue(failed.audioFilesExist(), "failed retry audio should remain available for another pass")
     }
 
+    func testRetryFailureUpdatesPersistedFailedMeetingError() async throws {
+        let speech = MetadataStubSpeechToTextEngine(
+            transcribeError: PipelineError.modelInferenceFailed(model: "Parakeet", underlying: "boom")
+        )
+        let manager = makeManager(speechToText: speech)
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("retry-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("retry-system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        XCTAssertTrue(manager.failedTranscriptionManager.addFailedTranscription(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: "Original failure",
+            meetingTitle: "Customer call"
+        ))
+        let failedId = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first?.id)
+
+        let didRetry = await manager.retryFailedTranscription(
+            failedId: failedId,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts")
+        )
+
+        XCTAssertFalse(didRetry)
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertEqual(failed.id, failedId)
+        XCTAssertEqual(failed.meetingTitle, "Customer call")
+        XCTAssertEqual(failed.errorMessage, "Retry failed: Parakeet inference failed")
+    }
+
     private func makeManager(
         speechToText: (any SpeechToTextEngine)? = nil,
         diarization: (any DiarizationEngine)? = nil,
@@ -751,10 +842,12 @@ private final class MetadataStubSpeechToTextEngine: SpeechToTextEngine {
     var isReady: Bool
     var initializeCallCount = 0
     private let transcript: String
+    private let transcribeError: Error?
 
-    init(isReady: Bool = true, transcript: String = "") {
+    init(isReady: Bool = true, transcript: String = "", transcribeError: Error? = nil) {
         self.isReady = isReady
         self.transcript = transcript
+        self.transcribeError = transcribeError
     }
 
     func initialize() async {
@@ -762,7 +855,10 @@ private final class MetadataStubSpeechToTextEngine: SpeechToTextEngine {
         isReady = true
     }
     func transcribeSegment(samples: [Float], source: AudioSource) async throws -> String {
-        transcript
+        if let transcribeError {
+            throw transcribeError
+        }
+        return transcript
     }
     func cleanup() {
         isReady = false

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -1091,8 +1091,16 @@ enum CLIContextStore {
     }
 
     private static func parseDurationSeconds(_ rawDuration: String?) -> Int {
-        let components = (rawDuration ?? "").split(separator: ":").compactMap { Int($0) }
+        guard let rawDuration else { return 0 }
+        let rawComponents = rawDuration.split(separator: ":", omittingEmptySubsequences: false)
+        let components = rawComponents.compactMap { Int($0) }
+        guard components.count == rawComponents.count,
+              !components.contains(where: { $0 < 0 }) else {
+            return 0
+        }
         switch components.count {
+        case 1:
+            return components[0]
         case 2:
             return components[0] * 60 + components[1]
         case 3:

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -133,6 +133,59 @@ final class ContextStoreTests: XCTestCase {
         XCTAssertEqual(items.first?.preview, "Still works.")
     }
 
+    func testMalformedDurationFallsBackToZero() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let meetingsDir = root.appendingPathComponent("meetings", isDirectory: true)
+        let dictationsDir = root.appendingPathComponent("dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: meetingsDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dictationsDir, withIntermediateDirectories: true)
+
+        for (filename, duration) in [
+            ("Bad text duration.md", "1:bad"),
+            ("Negative duration.md", "-1:02"),
+        ] {
+            let meeting = """
+            ---
+            capture_type: meeting
+            title: Parser fixture
+            date: 2026-04-18
+            time: 09:15:00
+            duration: "\(duration)"
+            ---
+
+            # Parser fixture
+
+            ## Full Transcript
+
+            [00:03] [Mic/You] Still works.
+            """
+            try meeting.write(
+                to: meetingsDir.appendingPathComponent(filename),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        let items = CLIContextStore.recent(
+            in: CLIContextDirectories(meetingsDir: meetingsDir, dictationsDir: dictationsDir),
+            kind: .meeting,
+            count: 5,
+            dateFrom: nil,
+            dateTo: nil
+        )
+
+        XCTAssertEqual(items.count, 2)
+
+        let contextStoreSourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("Sources/TranscriptedCLI/ContextStore.swift")
+        let source = try String(contentsOf: contextStoreSourceURL, encoding: .utf8)
+        XCTAssertTrue(source.contains("split(separator: \":\", omittingEmptySubsequences: false)"))
+        XCTAssertTrue(source.contains("components.count == rawComponents.count"))
+        XCTAssertTrue(source.contains("!components.contains(where: { $0 < 0 })"))
+    }
+
     func testSearchSpeakerFilterUsesMatchingSpeakerUtterance() throws {
         let root = makeTempDir()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
@@ -515,8 +515,16 @@ enum TranscriptLoader {
     }
 
     private static func parseDurationSeconds(_ rawDuration: String?) -> Int {
-        let components = (rawDuration ?? "").split(separator: ":").compactMap { Int($0) }
+        guard let rawDuration else { return 0 }
+        let rawComponents = rawDuration.split(separator: ":", omittingEmptySubsequences: false)
+        let components = rawComponents.compactMap { Int($0) }
+        guard components.count == rawComponents.count,
+              !components.contains(where: { $0 < 0 }) else {
+            return 0
+        }
         switch components.count {
+        case 1:
+            return components[0]
         case 2:
             return components[0] * 60 + components[1]
         case 3:

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptLoaderTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptLoaderTests.swift
@@ -78,6 +78,33 @@ final class TranscriptLoaderTests: XCTestCase {
         XCTAssertEqual(transcript?.utterances.first?.text, "Still works.")
     }
 
+    func testMalformedDurationFallsBackToZero() throws {
+        for (filename, duration) in [
+            ("Call_bad_text_duration", "1:bad"),
+            ("Call_negative_duration", "-1:02"),
+        ] {
+            let markdown = """
+            ---
+            capture_type: meeting
+            date: 2026-04-18
+            time: 09:15:00
+            duration: "\(duration)"
+            ---
+
+            # Parser fixture
+
+            ## Full Transcript
+
+            [00:03] [Mic/You] Still works.
+            """
+            try markdown.write(to: tempDir.appendingPathComponent("\(filename).md"), atomically: true, encoding: .utf8)
+
+            let transcript = TranscriptLoader.load(tempDir.appendingPathComponent("\(filename).md"))
+
+            XCTAssertEqual(transcript?.recording.durationSeconds, 0)
+        }
+    }
+
     func testLoadMissingFileReturnsNil() {
         let transcript = TranscriptLoader.load(tempDir.appendingPathComponent("Call_missing.md"))
         XCTAssertNil(transcript)

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.38</title>
+      <pubDate>Sat, 16 May 2026 15:46:51 -0500</pubDate>
+      <sparkle:version>1.1.38</sparkle:version>
+      <sparkle:shortVersionString>1.1.38</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.38/Transcripted-1.1.38.dmg" length="504112212" type="application/octet-stream" sparkle:edSignature="Z3pgJRIOW9h+aFADK0vhe6Zy4Kd/Oqb6JQ+1sUnM1x+9m/kKKau7ToqJUcejQZtMublaoHCpiqbKxP0HElOJAg==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.38</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.38</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.37</title>
       <pubDate>Thu, 14 May 2026 19:54:36 -0500</pubDate>
       <sparkle:version>1.1.37</sparkle:version>

--- a/scripts/entrypoints/build-deps.sh
+++ b/scripts/entrypoints/build-deps.sh
@@ -21,6 +21,9 @@ DEPS_BUILD_STAMP="$DEPS_LIBS/.build-deps-stamp"
 DEPS_MODULES="$DRAFT_DIR/deps-modules"
 DEPS_FRAMEWORKS="$DRAFT_DIR/deps-frameworks"
 DEPS_TOOLS="$DRAFT_DIR/deps-tools"
+TRANSCRIPTED_CORE_MODULE="$DEPS_MODULES/TranscriptedCore.swiftmodule/arm64-apple-macos.swiftmodule"
+ARGMAX_CORE_MODULE="$DEPS_MODULES/ArgmaxCore.swiftmodule/arm64-apple-macos.swiftmodule"
+WHISPERKIT_MODULE="$DEPS_MODULES/WhisperKit.swiftmodule/arm64-apple-macos.swiftmodule"
 FLUID_AUDIO_VERSION="${FLUID_AUDIO_VERSION:-0.7.9}"
 MLX_SWIFT_LM_REVISION="${MLX_SWIFT_LM_REVISION:-25b00d4}"
 SWIFT_TRANSFORMERS_VERSION="${SWIFT_TRANSFORMERS_VERSION:-1.2.1}"
@@ -30,6 +33,67 @@ SPARKLE_VERSION="${SPARKLE_VERSION:-2.9.1}"
 SENTRY_COCOA_VERSION="${SENTRY_COCOA_VERSION:-9.10.0}"
 SPARKLE_SHA256="${SPARKLE_SHA256:-9fec2b888e6e2940b1bfbd5d3d010b9f67076b52170923549095cbb74132403b}"
 SENTRY_COCOA_SHA256="${SENTRY_COCOA_SHA256:-1dd70512f3b5af6c74f1b8f11279531900173fb638d7d541320a7cbc00ed06bc}"
+
+dependency_input_listing() {
+    {
+        printf '%s\n' "Package.swift"
+        printf '%s\n' "scripts/entrypoints/build-deps.sh"
+        find "Sources/TranscriptedCore" -type f ! -name "CLAUDE.md"
+    } | while IFS= read -r path; do
+        [ -e "$path" ] || continue
+        printf '%s\t%s\n' "$(stat -f '%m' "$path")" "$path"
+    done
+}
+
+newest_dependency_input() {
+    dependency_input_listing | awk 'NR == 1 || $1 > max { max = $1; line = $0 } END { if (line != "") print line }'
+}
+
+deps_build_stamp_info() {
+    if [ -f "$DEPS_BUILD_STAMP" ]; then
+        printf '%s\t%s\n' "$(stat -f '%m' "$DEPS_BUILD_STAMP")" "$DEPS_BUILD_STAMP"
+    fi
+}
+
+deps_are_ready() {
+    local newest_input
+    local build_stamp
+    local newest_input_mtime
+    local newest_input_path
+    local build_stamp_mtime
+    local build_stamp_path
+
+    if [ ! -f "$DEPS_LIBS/libDraftDeps.a" ] \
+        || [ ! -f "$DEPS_LIBS/libExternalDeps.a" ] \
+        || [ ! -f "$DEPS_BUILD_STAMP" ] \
+        || [ ! -d "$DEPS_MODULES" ] \
+        || [ ! -f "$TRANSCRIPTED_CORE_MODULE" ] \
+        || [ ! -f "$ARGMAX_CORE_MODULE" ] \
+        || [ ! -f "$WHISPERKIT_MODULE" ] \
+        || [ ! -d "$DEPS_FRAMEWORKS/ESpeakNG.framework" ] \
+        || [ ! -d "$DEPS_FRAMEWORKS/Sentry.framework" ] \
+        || [ ! -d "$DEPS_FRAMEWORKS/Sparkle.framework" ] \
+        || [ ! -x "$DEPS_TOOLS/sparkle/bin/generate_appcast" ]; then
+        return 1
+    fi
+
+    newest_input="$(newest_dependency_input)"
+    build_stamp="$(deps_build_stamp_info)"
+
+    IFS=$'\t' read -r newest_input_mtime newest_input_path <<< "$newest_input"
+    IFS=$'\t' read -r build_stamp_mtime build_stamp_path <<< "$build_stamp"
+
+    if [ -n "$newest_input_mtime" ] && [ -n "$build_stamp_mtime" ] && [ "$newest_input_mtime" -gt "$build_stamp_mtime" ]; then
+        echo "[build-deps] Dependencies are stale for TranscriptedCore."
+        echo "[build-deps] Newest input:"
+        echo "[build-deps]   $newest_input_path"
+        echo "[build-deps] Built deps stamp:"
+        echo "[build-deps]   $build_stamp_path"
+        return 1
+    fi
+
+    return 0
+}
 
 verify_download_sha256() {
     local downloaded_file="$1"
@@ -188,15 +252,17 @@ resolve_transcripted_core_root() {
 resolve_transcripted_core_root
 echo "[build-deps] Using TranscriptedCore from: $TRANSCRIPTED_ROOT"
 
-# Skip if already built (use --force to rebuild).
-# libExternalDeps.a was added later for SPM-based `swift test`, so require it too;
-# otherwise legacy worktrees would keep skipping while missing the archive.
-if [ -f "$DEPS_LIBS/libDraftDeps.a" ] && [ -f "$DEPS_LIBS/libExternalDeps.a" ] && [ -f "$DEPS_BUILD_STAMP" ] && [ -d "$DEPS_MODULES" ] && [ -f "$DEPS_MODULES/ArgmaxCore.swiftmodule/arm64-apple-macos.swiftmodule" ] && [ -f "$DEPS_MODULES/WhisperKit.swiftmodule/arm64-apple-macos.swiftmodule" ] && [ -d "$DEPS_FRAMEWORKS/ESpeakNG.framework" ] && [ -d "$DEPS_FRAMEWORKS/Sentry.framework" ] && [ -d "$DEPS_FRAMEWORKS/Sparkle.framework" ] && [ -x "$DEPS_TOOLS/sparkle/bin/generate_appcast" ] && [ "${1:-}" != "--force" ]; then
+# Skip if already built (use --force to rebuild). Keep this in lockstep with
+# build.sh's required artifacts so a "ready" deps pass always means the app can build.
+if [ "${1:-}" != "--force" ] && deps_are_ready; then
     echo "Dependencies already built. Use --force to rebuild."
     echo "  libs:    $DEPS_LIBS/libDraftDeps.a"
     echo "           $DEPS_LIBS/libExternalDeps.a"
     echo "  stamp:   $DEPS_BUILD_STAMP"
     echo "  modules: $DEPS_MODULES/"
+    echo "           $TRANSCRIPTED_CORE_MODULE"
+    echo "           $ARGMAX_CORE_MODULE"
+    echo "           $WHISPERKIT_MODULE"
     echo "  frameworks: $DEPS_FRAMEWORKS/ESpeakNG.framework"
     echo "              $DEPS_FRAMEWORKS/Sentry.framework"
     echo "              $DEPS_FRAMEWORKS/Sparkle.framework"

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -10,7 +10,12 @@ cd "$REPO_ROOT"
 
 MANIFEST="Tests/FastTests.manifest"
 BUILD_DIR="build"
-GENERATED_RUNNER="$BUILD_DIR/FastTestRunner.swift"
+GENERATED_RUNNER="$BUILD_DIR/FastTestRunner.$$.swift"
+
+cleanup_generated_runner() {
+    rm -f "$GENERATED_RUNNER"
+}
+trap cleanup_generated_runner EXIT
 
 if [ ! -f "$MANIFEST" ]; then
     echo "Fast test manifest not found: $MANIFEST"


### PR DESCRIPTION
Deep review follow-up and Transcripted 1.1.38 release metadata.

Changes:
- Hardens failed meeting retry cleanup and retained-audio handling.
- Preserves dictation audio across route recovery without leaking abandoned buffers into later sessions.

- Guards paste-back when focus changes, tightens file permissions/log files, and rejects malformed duration metadata.
- Refreshes build/test freshness checks and per-process fast test runners.
- Bumps app version to 1.1.38, updates Sparkle appcast, and updates the Homebrew cask.

Validation:
- build-deps.sh --force
- build.sh --no-open
- run-tests.sh
- swift test
- Tools/TranscriptedMCP swift test- Tools/TranscriptedCLI swift test

- run-integration-smoke.sh
- notarized/stapled build/Transcripted-1.1.38.dmg