### PR TITLE
[nightly-review] Clear preserved dictation audio on interruption

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -1350,7 +1350,7 @@ class ParakeetEngine: ObservableObject {
                         try? await Task.sleep(nanoseconds: TranscriptedConstants.recordingRestartRetryDelay)
                     }
                     if !restarted {
-                        self.recordingInterrupted = true
+                        self.interruptRecordingAndClearRecoveredTimeline()
                         EventReporter.shared.capture(level: .error, engine: "parakeet",
                             event: "recording_interrupted",
                             message: "Recording could not restart after device change within retry budget",
@@ -1384,7 +1384,7 @@ class ParakeetEngine: ObservableObject {
                     )
                 )
                 if failureAction.markRecordingInterrupted {
-                    self.recordingInterrupted = true
+                    self.interruptRecordingAndClearRecoveredTimeline()
                     EventReporter.shared.capture(level: .error, engine: "parakeet",
                         event: "recording_interrupted",
                         message: "Recording interrupted — engine rewarm failed after device change",
@@ -1479,7 +1479,7 @@ class ParakeetEngine: ObservableObject {
                 )
             )
             if failureAction.markRecordingInterrupted {
-                self.recordingInterrupted = true
+                self.interruptRecordingAndClearRecoveredTimeline()
                 EventReporter.shared.capture(
                     level: .error,
                     engine: "parakeet",
@@ -1994,7 +1994,7 @@ class ParakeetEngine: ObservableObject {
         isEnginePrewarmed = false
 
         if wasRecording {
-            recordingInterrupted = true
+            interruptRecordingAndClearRecoveredTimeline()
             EventReporter.shared.capture(level: .warning, engine: "parakeet", event: "recording_interrupted",
                 message: "Recording interrupted by system sleep/wake")
         }
@@ -2596,7 +2596,7 @@ class ParakeetEngine: ObservableObject {
                 EventReporter.shared.capture(level: .error, engine: "parakeet", event: "zombie_engine_recovery_failed",
                     message: "Audio engine could not recover after reset",
                     context: ["audio_device": self.inputDeviceName])
-                self.recordingInterrupted = true
+                self.interruptRecordingAndClearRecoveredTimeline()
             }
         }
     }
@@ -2665,6 +2665,11 @@ class ParakeetEngine: ObservableObject {
     private func clearRecoveredRecordingTimeline(keepingCapacity: Bool = true) {
         recoveredRecordingTimeline.removeAll(keepingCapacity: keepingCapacity)
         preservingRecordingAcrossRecovery = false
+    }
+
+    private func interruptRecordingAndClearRecoveredTimeline() {
+        clearRecoveredRecordingTimeline(keepingCapacity: true)
+        recordingInterrupted = true
     }
 
     private func drainRecordedSamplesForInference() async -> (nativeSampleCount: Int, samples16k: [Float])? {

--- a/Tests/DictationAudioRecoveryTests.swift
+++ b/Tests/DictationAudioRecoveryTests.swift
@@ -107,6 +107,16 @@ func testDictationAudioRecovery() {
             "recovery preservation should have a single cleanup path"
         )
         assertTrue(
+            engineSource.contains("private func interruptRecordingAndClearRecoveredTimeline()"),
+            "interrupted recovery should clear preserved audio before publishing interruption"
+        )
+        let directInterruptAssignments = engineSource.components(separatedBy: "recordingInterrupted = true").count - 1
+        assertEqual(
+            directInterruptAssignments,
+            1,
+            "all recording interruption paths should go through the cleanup helper"
+        )
+        assertTrue(
             sessionSource.contains("appState.sttRouter.cancel()\n            let failureKind"),
             "abandoned capture-not-started sessions should cancel the speech engine and clear preserved recovery audio"
         )


### PR DESCRIPTION
## Summary
- Clear preserved dictation recovery audio before publishing recording interruptions.
- Add a fast regression guard so interruption paths go through the cleanup helper.

## Nightly review evidence
- Top risk fixed: failed route-change/zombie recovery could leave old dictation audio in memory for the next dictation.
- Follow-up risk: failed-meeting retry audio deletion after archive failure remains worth a separate review pass.
- Production signal: last-24h Sentry events predated 1.1.38; PostHog has sparse 1.1.38 workflow proof so far.

## Verification
- bash build-deps.sh
- bash build.sh --no-open
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- codex review --uncommitted