### PR TITLE
[nightly-telemetry] Preserve meeting failure trigger telemetry

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1615,7 +1615,11 @@ final class MeetingSessionController: ObservableObject {
     ) {
         guard !hasVisibleBackgroundTranscriptionWork(snapshot: snapshot) else { return }
         guard !isCaptureSessionActive else { return }
-        activeTranscriptionTrigger = .unknown
+        if MeetingSessionUIPolicy.shouldClearTranscriptionTriggerAfterBackgroundWork(
+            hasTerminalOutcome: lastTerminalTranscriptionOutcome != nil
+        ) {
+            activeTranscriptionTrigger = .unknown
+        }
 
         switch lastTerminalTranscriptionOutcome {
         case .failed(let message):

--- a/Sources/Meeting/MeetingSessionUIPolicy.swift
+++ b/Sources/Meeting/MeetingSessionUIPolicy.swift
@@ -15,6 +15,12 @@ enum MeetingSessionUIPolicy {
         activeTranscriptions == 0
             && !isPreparingQueuedTranscriptionStart
     }
+
+    static func shouldClearTranscriptionTriggerAfterBackgroundWork(
+        hasTerminalOutcome: Bool
+    ) -> Bool {
+        hasTerminalOutcome
+    }
 }
 
 enum MeetingRecordingTitlePolicy {

--- a/Tests/MeetingSessionUIPolicyTests.swift
+++ b/Tests/MeetingSessionUIPolicyTests.swift
@@ -68,6 +68,21 @@ func testMeetingSessionUIPolicy() {
         )
     }
 
+    runSuite("MeetingSessionUIPolicy.shouldClearTranscriptionTriggerAfterBackgroundWork — waits for terminal status") {
+        assertFalse(
+            MeetingSessionUIPolicy.shouldClearTranscriptionTriggerAfterBackgroundWork(
+                hasTerminalOutcome: false
+            ),
+            "the trigger should survive if active work clears before the saved/failed status arrives"
+        )
+        assertTrue(
+            MeetingSessionUIPolicy.shouldClearTranscriptionTriggerAfterBackgroundWork(
+                hasTerminalOutcome: true
+            ),
+            "the trigger can clear once terminal telemetry has a status to report"
+        )
+    }
+
     runSuite("MeetingRecordingTitlePolicy — explicit prompt title wins over calendar fallback") {
         assertEqual(
             MeetingRecordingTitlePolicy.resolve(


### PR DESCRIPTION
## Summary
- preserves the active meeting transcription trigger until the terminal saved/failed status records telemetry
- adds a policy test for the active-count-before-status ordering

## Nightly evidence
- Sentry: `meeting.meeting_transcript_failed` is still current, 42 unresolved production events, last seen about 20 hours ago
- PostHog: 21 `meeting_transcript_failed` events in the last 7 days, all with `trigger = unknown` despite `trigger` being allowlisted
- This keeps the existing privacy-safe enum (`menu`, `hotkey`, `detected_prompt`, etc.) instead of adding any new payload field

## Candidate score
- Winner: meeting transcript failures lose workflow trigger attribution, 89/100
- Lost: `meeting_transcript_failed` still has 13 `unexpected_error` failures, but Sentry detail was unavailable after the connector dropped, so the smallest safe classifier patch was not clear
- Lost: issue #500 meeting audio volume trust remains user-facing, but current code already has targeted diagnostics and a small safe UX/telemetry patch was less obvious

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`