### PR TITLE
[bug-hunter] Fix stale runtime shutdown diagnostics

### DIFF
--- a/Sources/Observability/RuntimeDiagnostics.swift
+++ b/Sources/Observability/RuntimeDiagnostics.swift
@@ -72,6 +72,7 @@ final class RuntimeDiagnostics {
             marker.sessionStage = stage
             marker.sessionActive = active
             marker.lastEvent = "\(kind)_\(stage)"
+            marker.retainedForActiveWork = nil
         }
     }
 
@@ -88,9 +89,11 @@ final class RuntimeDiagnostics {
             if shouldResetToIdle {
                 marker.sessionKind = "none"
                 marker.sessionStage = "idle"
+                marker.retainedForActiveWork = nil
             } else {
                 marker.sessionKind = kind
                 marker.sessionStage = outcome
+                marker.retainedForActiveWork = true
             }
         }
     }

--- a/Sources/Observability/RuntimeDiagnostics.swift
+++ b/Sources/Observability/RuntimeDiagnostics.swift
@@ -81,10 +81,11 @@ final class RuntimeDiagnostics {
             start()
         }
         guard marker != nil else { return }
+        let shouldResetToIdle = resetToIdle || !(activeWorkProvider?() ?? false)
         updateMarker { marker in
             marker.sessionActive = false
             marker.lastEvent = "\(kind)_\(outcome)"
-            if resetToIdle {
+            if shouldResetToIdle {
                 marker.sessionKind = "none"
                 marker.sessionStage = "idle"
             } else {

--- a/Sources/Observability/RuntimeDiagnosticsStore.swift
+++ b/Sources/Observability/RuntimeDiagnosticsStore.swift
@@ -12,6 +12,7 @@ struct RuntimeDiagnosticsMarker: Codable, Equatable {
     var sessionKind: String
     var sessionStage: String
     var sessionActive: Bool
+    var retainedForActiveWork: Bool? = nil
 }
 
 enum RuntimeDiagnosticsStore {
@@ -164,6 +165,7 @@ enum RuntimeDiagnosticsStore {
         }
 
         if marker.sessionKind == "dictation" {
+            guard marker.retainedForActiveWork != true else { return false }
             return terminalDictationStages.contains(marker.sessionStage)
         }
 
@@ -221,5 +223,6 @@ enum RuntimeDiagnosticsStore {
 
         marker.sessionKind = "none"
         marker.sessionStage = "idle"
+        marker.retainedForActiveWork = nil
     }
 }

--- a/Sources/Observability/RuntimeDiagnosticsStore.swift
+++ b/Sources/Observability/RuntimeDiagnosticsStore.swift
@@ -140,6 +140,10 @@ enum RuntimeDiagnosticsStore {
             return true
         }
 
+        if shouldSuppressInactiveSessionMarker(marker) {
+            return false
+        }
+
         if marker.sessionKind != "none" || marker.sessionStage != "idle" {
             return true
         }
@@ -151,6 +155,62 @@ enum RuntimeDiagnosticsStore {
 
         return heartbeatAgeBucket(previousUpdate: marker.updatedAt, now: now) != "lt_15s"
     }
+
+    private static func shouldSuppressInactiveSessionMarker(
+        _ marker: RuntimeDiagnosticsMarker
+    ) -> Bool {
+        if marker.sessionKind == "none" && marker.sessionStage == "idle" {
+            return terminalIdleEvents.contains(marker.lastEvent)
+        }
+
+        if marker.sessionKind == "dictation" {
+            return terminalDictationStages.contains(marker.sessionStage)
+        }
+
+        return false
+    }
+
+    private static let terminalIdleEvents: Set<String> = [
+        "app_launched",
+        "heartbeat",
+        "clean_shutdown",
+        "dictation_cancelled",
+        "dictation_completed",
+        "dictation_interrupted",
+        "dictation_microphone_route_not_ready",
+        "dictation_microphone_start_failed",
+        "dictation_microphone_start_timeout",
+        "dictation_model_failed",
+        "dictation_model_load_timeout",
+        "dictation_model_unavailable",
+        "dictation_no_speech",
+        "dictation_start_failed",
+        "meeting_cancelled",
+        "meeting_file_import_failed",
+        "meeting_models_unavailable",
+        "meeting_recording_too_short",
+        "meeting_speaker_finalization_failed",
+        "meeting_start_blocked_permission",
+        "meeting_start_failed",
+        "meeting_stop_timeout",
+        "meeting_transcript_failed",
+        "meeting_transcript_saved",
+        "meeting_transcription_cancelled",
+    ]
+
+    private static let terminalDictationStages: Set<String> = [
+        "cancelled",
+        "completed",
+        "interrupted",
+        "microphone_route_not_ready",
+        "microphone_start_failed",
+        "microphone_start_timeout",
+        "model_failed",
+        "model_load_timeout",
+        "model_unavailable",
+        "no_speech",
+        "start_failed",
+    ]
 
     static func clearInactiveSessionContextForHeartbeat(
         _ marker: inout RuntimeDiagnosticsMarker,

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -478,6 +478,7 @@ class DictationSessionController: ObservableObject {
                 if started {
                     overlayController.state = .listening
                     resizePanelToCompact()
+                    appState.runtimeDiagnostics.recordSession(kind: "dictation", stage: "recording_after_wait")
                     let waited = Int((ProcessInfo.processInfo.systemUptime - startedAt) * 1000)
                     appState.logger.log("DICTATION | started after forced recovery start and \(waited)ms wait (parakeet, \(appState.sttRouter.inputDeviceName))")
                     DiagnosticsTrail.record(

--- a/Tests/RuntimeDiagnosticsStoreTests.swift
+++ b/Tests/RuntimeDiagnosticsStoreTests.swift
@@ -210,6 +210,52 @@ func testRuntimeDiagnosticsStore() {
         assertEqual(shouldReport, true, "active meeting shutdowns should stay visible")
     }
 
+    runSuite("RuntimeDiagnosticsStore suppresses completed dictation before heartbeat cleanup") {
+        let marker = RuntimeDiagnosticsMarker(
+            launchID: "completed-dictation",
+            appVersion: "1.2.3",
+            buildVersion: "456",
+            osMajor: 26,
+            cleanShutdown: false,
+            startedAt: Date(timeIntervalSince1970: 1_000),
+            updatedAt: Date(timeIntervalSince1970: 1_100),
+            lastEvent: "dictation_completed",
+            sessionKind: "dictation",
+            sessionStage: "completed",
+            sessionActive: false
+        )
+
+        let shouldReport = RuntimeDiagnosticsStore.shouldReportUncleanShutdown(
+            previous: marker,
+            now: Date(timeIntervalSince1970: 1_260)
+        )
+
+        assertEqual(shouldReport, false, "completed dictation should not be reported as an unclean shutdown")
+    }
+
+    runSuite("RuntimeDiagnosticsStore suppresses idle terminal session events") {
+        let marker = RuntimeDiagnosticsMarker(
+            launchID: "idle-terminal",
+            appVersion: "1.2.3",
+            buildVersion: "456",
+            osMajor: 26,
+            cleanShutdown: false,
+            startedAt: Date(timeIntervalSince1970: 1_000),
+            updatedAt: Date(timeIntervalSince1970: 1_100),
+            lastEvent: "dictation_microphone_start_timeout",
+            sessionKind: "none",
+            sessionStage: "idle",
+            sessionActive: false
+        )
+
+        let shouldReport = RuntimeDiagnosticsStore.shouldReportUncleanShutdown(
+            previous: marker,
+            now: Date(timeIntervalSince1970: 1_260)
+        )
+
+        assertEqual(shouldReport, false, "terminal idle outcomes should not report after the heartbeat window")
+    }
+
     runSuite("RuntimeDiagnosticsStore clears inactive session context on heartbeat") {
         var marker = RuntimeDiagnosticsMarker(
             launchID: "completed-dictation",

--- a/Tests/RuntimeDiagnosticsStoreTests.swift
+++ b/Tests/RuntimeDiagnosticsStoreTests.swift
@@ -233,6 +233,30 @@ func testRuntimeDiagnosticsStore() {
         assertEqual(shouldReport, false, "completed dictation should not be reported as an unclean shutdown")
     }
 
+    runSuite("RuntimeDiagnosticsStore reports terminal dictation retained during active work") {
+        let marker = RuntimeDiagnosticsMarker(
+            launchID: "dictation-with-background-work",
+            appVersion: "1.2.3",
+            buildVersion: "456",
+            osMajor: 26,
+            cleanShutdown: false,
+            startedAt: Date(timeIntervalSince1970: 1_000),
+            updatedAt: Date(timeIntervalSince1970: 1_100),
+            lastEvent: "dictation_completed",
+            sessionKind: "dictation",
+            sessionStage: "completed",
+            sessionActive: false,
+            retainedForActiveWork: true
+        )
+
+        let shouldReport = RuntimeDiagnosticsStore.shouldReportUncleanShutdown(
+            previous: marker,
+            now: Date(timeIntervalSince1970: 1_260)
+        )
+
+        assertEqual(shouldReport, true, "terminal dictation should still report when retained because other work was active")
+    }
+
     runSuite("RuntimeDiagnosticsStore suppresses idle terminal session events") {
         let marker = RuntimeDiagnosticsMarker(
             launchID: "idle-terminal",


### PR DESCRIPTION
## Signal checked
- Sentry: latest shipped release is `transcripted@1.1.38`; no unresolved production issues on that release, and no production issues first/last seen in the last 24h.
- PostHog: last 24h on app version `1.1.38` showed `app_unclean_shutdown_detected` events after dictation lifecycle states, including completed dictation with `session_active=false`.
- GitHub: no open duplicate PRs; only open issue is #500, unrelated to this signal.

## Root cause
Inactive terminal dictation states could stay in the runtime diagnostics marker until the next heartbeat, so a normal completed dictation followed by app exit before heartbeat cleanup could be reported as an unclean shutdown.

## Fix
- Reset runtime diagnostics to idle immediately when `clearSession` sees no active runtime work.
- Suppress stale terminal dictation markers from older releases when deciding whether to report an unclean shutdown.
- Record `recording_after_wait` on the forced recovery recording start path so successful starts do not stay stuck at `start_requested`.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh`

## Privacy
Only coarse runtime fields were used. No transcript text, audio references, titles, speaker names, emails, file paths, device names, URLs, or tokens are included.