### PR TITLE
[support] Preserve system recording support diagnostics

### DIFF
--- a/Sources/UI/Shared/SupportDiagnosticsBundle.swift
+++ b/Sources/UI/Shared/SupportDiagnosticsBundle.swift
@@ -107,7 +107,7 @@ enum SupportDiagnosticsBundle {
             "pasteback_granted": bool(snapshot.pastebackGranted),
             "queued_meeting_count": "\(snapshot.queuedMeetingCount)",
             "reliability_packet_count": "\(min(snapshot.reliabilityPackets.count, maxReliabilityPackets))",
-            "system_audio_recording_granted": bool(snapshot.systemAudioRecordingGranted),
+            "system_recording_granted": bool(snapshot.systemAudioRecordingGranted),
         ]
         if let latest = snapshot.reliabilityPackets.last {
             context["latest_reliability_packet"] = latest

--- a/Tests/SupportDiagnosticsBundleTests.swift
+++ b/Tests/SupportDiagnosticsBundleTests.swift
@@ -115,6 +115,8 @@ func testSupportDiagnosticsBundle() {
         assertEqual(sanitized["queued_meeting_count"], "2", "queued meeting count should survive Sentry key sanitization")
         assertEqual(sanitized["meeting_shortcut"], "⌥M", "meeting shortcut should survive Sentry key sanitization")
         assertEqual(sanitized["reliability_packet_count"], "1", "support diagnostics should include packet count")
+        assertEqual(sanitized["system_recording_granted"], "true", "system recording permission should survive Sentry key sanitization")
+        assertNil(sanitized["system_audio_recording_granted"], "support diagnostics should avoid audio-prefixed permission keys")
         assertNil(sanitized["audio_input_device_class"], "support diagnostics should not use audio-prefixed Sentry keys")
     }
 }


### PR DESCRIPTION
## Summary
- Rename the Sentry support diagnostic permission key from system_audio_recording_granted to system_recording_granted so it survives the privacy sanitizer.
- Add regression coverage that the sanitized support context keeps the system recording permission state and avoids the old audio-prefixed key.

## Verification
- bash build-deps.sh --force
- bash build.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh