### PR TITLE
[operator] Track onboarding completion

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -226,7 +226,7 @@ struct AnalyticsEventPolicy: Equatable {
             allowedProperties: [
                 "anonymous_usage_enabled",
                 "calendar_status",
-                "completion_path",
+                "completion_flow",
                 "crash_reporting_enabled",
                 "first_dictation_saved",
                 "flow_elapsed_bucket",

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -46,6 +46,8 @@ struct PermissionsOnboardingView: View {
     @State private var copiedAgentItem: AgentCopyItem?
     @State private var copiedResetTask: Task<Void, Never>?
     @State private var pollTask: Task<Void, Never>?
+    @State private var flowStartedAt: CFAbsoluteTime?
+    @State private var didTrackCompletion = false
     @FocusState private var demoEditorFocused: Bool
 
     init(onComplete: @escaping () -> Void) {
@@ -101,6 +103,9 @@ struct PermissionsOnboardingView: View {
         .frame(width: Self.preferredSize.width, height: Self.preferredSize.height)
         .background(OnboardingTheme.canvas)
         .onAppear {
+            if flowStartedAt == nil {
+                flowStartedAt = CFAbsoluteTimeGetCurrent()
+            }
             checkAllPermissions()
             startPolling()
         }
@@ -517,7 +522,26 @@ struct PermissionsOnboardingView: View {
     private func completeOnboarding() {
         guard hasRequiredPermissions else { return }
         stopPolling()
+        trackCompletionIfNeeded()
         onComplete()
+    }
+
+    private func trackCompletionIfNeeded() {
+        guard !didTrackCompletion else { return }
+        didTrackCompletion = true
+
+        AnalyticsReporter.track(
+            "onboarding_completed",
+            properties: FirstRunExperience.onboardingCompletionAnalyticsProperties(
+                completionPath: selectedUseCase.completionPath,
+                systemAudioGranted: screenRecordingGranted,
+                calendarGranted: calendarGranted,
+                meetingPromptsEnabled: meetingPromptsEnabled,
+                anonymousUsageEnabled: AnalyticsPreferences.isEnabled(),
+                crashReportingEnabled: CrashReportingPreferences.isEnabled(),
+                elapsedSeconds: flowStartedAt.map { CFAbsoluteTimeGetCurrent() - $0 }
+            )
+        )
     }
 
     static var hasCompleted: Bool {
@@ -594,6 +618,15 @@ private enum OnboardingUseCase: Hashable {
     case dictation
 
     var shortcutPolicyUseCase: OnboardingDictationShortcutPolicy.UseCase {
+        switch self {
+        case .meetings:
+            return .meetings
+        case .dictation:
+            return .dictation
+        }
+    }
+
+    var completionPath: FirstRunCompletionPath {
         switch self {
         case .meetings:
             return .meetings

--- a/Sources/UI/Shared/FirstRunExperience.swift
+++ b/Sources/UI/Shared/FirstRunExperience.swift
@@ -253,7 +253,7 @@ enum FirstRunExperience {
                 calendarGranted: calendarGranted,
                 meetingPromptsEnabled: meetingPromptsEnabled
             ),
-            "completion_path": completionPath.rawValue,
+            "completion_flow": completionPath.rawValue,
             "crash_reporting_enabled": booleanString(crashReportingEnabled),
             "meeting_recording_ready": booleanString(systemAudioGranted),
             "step_id": "done",

--- a/Sources/UI/Shared/FirstRunExperience.swift
+++ b/Sources/UI/Shared/FirstRunExperience.swift
@@ -111,6 +111,11 @@ struct FirstRunOnboardingActionState: Equatable {
     let isPrimaryEnabled: Bool
 }
 
+enum FirstRunCompletionPath: String, Equatable {
+    case meetings
+    case dictation
+}
+
 struct FirstRunOnboardingCopy {
     static let heroDetail = "Dictations and meetings become private Markdown files on this Mac, ready for search, notes, and agent context."
     static let valueFooter = "Your spoken context is saved as clean local Markdown."
@@ -233,6 +238,34 @@ enum FirstRunExperience {
         [.systemAudioRecording, .calendar]
     }
 
+    static func onboardingCompletionAnalyticsProperties(
+        completionPath: FirstRunCompletionPath,
+        systemAudioGranted: Bool,
+        calendarGranted: Bool,
+        meetingPromptsEnabled: Bool,
+        anonymousUsageEnabled: Bool,
+        crashReportingEnabled: Bool,
+        elapsedSeconds: Double?
+    ) -> [String: String] {
+        var properties: [String: String] = [
+            "anonymous_usage_enabled": booleanString(anonymousUsageEnabled),
+            "calendar_status": calendarStatus(
+                calendarGranted: calendarGranted,
+                meetingPromptsEnabled: meetingPromptsEnabled
+            ),
+            "completion_path": completionPath.rawValue,
+            "crash_reporting_enabled": booleanString(crashReportingEnabled),
+            "meeting_recording_ready": booleanString(systemAudioGranted),
+            "step_id": "done",
+        ]
+
+        if let elapsedSeconds {
+            properties["flow_elapsed_bucket"] = AnalyticsReporter.durationBucket(seconds: elapsedSeconds)
+        }
+
+        return properties
+    }
+
     static func primaryAction(
         hasRequiredPermissions: Bool,
         hasPasteTarget: Bool,
@@ -284,6 +317,18 @@ enum FirstRunExperience {
             isEnabled: true,
             shouldStartDictation: false
         )
+    }
+
+    private static func booleanString(_ value: Bool) -> String {
+        value ? "true" : "false"
+    }
+
+    private static func calendarStatus(
+        calendarGranted: Bool,
+        meetingPromptsEnabled: Bool
+    ) -> String {
+        guard meetingPromptsEnabled else { return "disabled" }
+        return calendarGranted ? "granted" : "not_granted"
     }
 
     static func modelCard(

--- a/Tests/FirstRunExperienceTests.swift
+++ b/Tests/FirstRunExperienceTests.swift
@@ -98,7 +98,7 @@ func testFirstRunExperience() {
             elapsedSeconds: 75
         )
 
-        assertEqual(properties["completion_path"], "meetings", "completion path should stay a coarse enum")
+        assertEqual(properties["completion_flow"], "meetings", "completion flow should stay a coarse enum")
         assertEqual(properties["meeting_recording_ready"], "true", "completion should preserve meeting readiness")
         assertEqual(properties["calendar_status"], "not_granted", "calendar status should avoid raw event details")
         assertEqual(properties["anonymous_usage_enabled"], "true", "completion should preserve analytics preference state")
@@ -108,6 +108,12 @@ func testFirstRunExperience() {
         assertNil(properties["transcript"], "completion analytics should not include spoken content")
         assertNil(properties["audio_path"], "completion analytics should not include local paths")
         assertNil(properties["meeting_title"], "completion analytics should not include titles")
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            properties,
+            allowedKeys: AnalyticsEventPolicy.policy(forEvent: "onboarding_completed")?.allowedProperties ?? []
+        )
+        assertEqual(sanitized["completion_flow"], "meetings", "completion flow should survive analytics sanitization")
     }
 
     runSuite("FirstRunExperience.meetingAction — switches menu copy while recording") {

--- a/Tests/FirstRunExperienceTests.swift
+++ b/Tests/FirstRunExperienceTests.swift
@@ -87,6 +87,29 @@ func testFirstRunExperience() {
         )
     }
 
+    runSuite("FirstRunExperience.onboardingCompletionAnalyticsProperties — keeps completion payload coarse") {
+        let properties = FirstRunExperience.onboardingCompletionAnalyticsProperties(
+            completionPath: .meetings,
+            systemAudioGranted: true,
+            calendarGranted: false,
+            meetingPromptsEnabled: true,
+            anonymousUsageEnabled: true,
+            crashReportingEnabled: false,
+            elapsedSeconds: 75
+        )
+
+        assertEqual(properties["completion_path"], "meetings", "completion path should stay a coarse enum")
+        assertEqual(properties["meeting_recording_ready"], "true", "completion should preserve meeting readiness")
+        assertEqual(properties["calendar_status"], "not_granted", "calendar status should avoid raw event details")
+        assertEqual(properties["anonymous_usage_enabled"], "true", "completion should preserve analytics preference state")
+        assertEqual(properties["crash_reporting_enabled"], "false", "completion should preserve crash preference state")
+        assertEqual(properties["flow_elapsed_bucket"], "30_119s", "completion should bucket elapsed time")
+        assertEqual(properties["step_id"], "done", "completion should anchor to the final onboarding step")
+        assertNil(properties["transcript"], "completion analytics should not include spoken content")
+        assertNil(properties["audio_path"], "completion analytics should not include local paths")
+        assertNil(properties["meeting_title"], "completion analytics should not include titles")
+    }
+
     runSuite("FirstRunExperience.meetingAction — switches menu copy while recording") {
         let idle = FirstRunExperience.meetingAction(
             dictationReady: true,


### PR DESCRIPTION
## Summary
- emit the existing allowlisted onboarding_completed event from the real first-run completion path
- keep the payload coarse: completion path, preference booleans, calendar status, meeting readiness, elapsed bucket, final step id
- add a focused regression for the completion analytics payload shape

## Verification
- bash build-deps.sh --force (needed because local dependency bundle was missing/stale)
- bash build.sh
- bash run-tests.sh