### PR TITLE
[codex] Move audio import action to General settings

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -1808,7 +1808,6 @@ struct HomeActivityTabsCard: View {
     let copiedRowID: String?
     let canRetryFailedMeetings: Bool
     let failedMeetingRetryUnavailableReason: String?
-    let onImportAudio: () -> Void
     let onOpenDictation: (SavedDictationEntry) -> Void
     let onCopyDictation: (SavedDictationEntry) -> Void
     let onFlagDictation: (SavedDictationEntry) -> Void
@@ -1826,10 +1825,6 @@ struct HomeActivityTabsCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            if selectedTab == .meetings {
-                HomeMeetingImportActionRow(onImportAudio: onImportAudio)
-            }
-
             if isLoading {
                 HStack {
                     ProgressView()
@@ -1928,33 +1923,6 @@ struct HomeActivityTabsCard: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-    }
-}
-
-private struct HomeMeetingImportActionRow: View {
-    let onImportAudio: () -> Void
-
-    var body: some View {
-        HStack(alignment: .center, spacing: 12) {
-            VStack(alignment: .leading, spacing: 3) {
-                Text("Transcribe Audio File")
-                    .font(.subheadline.weight(.semibold))
-                Text("Turn a saved audio file into meeting notes.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-
-            Spacer(minLength: 8)
-
-            SettingsInlineActionButton(
-                title: "Choose File",
-                symbolName: "waveform",
-                tone: .accent,
-                action: onImportAudio
-            )
-            .help("Choose an audio file to transcribe")
-        }
-        .padding(.bottom, 6)
     }
 }
 

--- a/Sources/UI/Settings/TranscriptedSettingsPage.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsPage.swift
@@ -43,7 +43,7 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
         case .home:
             return "Start capture and check setup."
         case .general:
-            return "Startup, Dock, and corrections."
+            return "Startup, audio imports, and corrections."
         case .models:
             return "Local transcription model."
         case .shortcuts:

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -387,10 +387,6 @@ struct TranscriptedSettingsView: View {
                     copiedRowID: homeCopiedRowID,
                     canRetryFailedMeetings: canRetryFailedMeetings,
                     failedMeetingRetryUnavailableReason: failedMeetingRetryUnavailableReason,
-                    onImportAudio: {
-                        trackSettingsAction("import_recording", page: .home)
-                        actions.importAudioFile()
-                    },
                     onOpenDictation: { entry in
                         trackSettingsAction("open_recent_dictation", page: .home)
                         NSWorkspace.shared.open(entry.url)
@@ -1125,7 +1121,7 @@ struct TranscriptedSettingsView: View {
         VStack(alignment: .leading, spacing: 24) {
             SettingsPageIntro(
                 title: "General",
-                summary: "Startup and simple corrections for names, acronyms, and phrases."
+                summary: "Startup, audio imports, and simple corrections."
             )
 
             SettingsSection(
@@ -1182,6 +1178,34 @@ struct TranscriptedSettingsView: View {
                         }
                     )
                 )
+            }
+
+            SettingsSection(
+                title: "Audio Files",
+                detail: "Transcribe a recording you already have."
+            ) {
+                HStack(alignment: .center, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text("Transcribe Audio File")
+                            .font(.subheadline.weight(.semibold))
+                        Text("Choose a saved audio file and turn it into Transcripted Markdown.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Spacer(minLength: 8)
+
+                    SettingsInlineActionButton(
+                        title: "Choose File",
+                        symbolName: "waveform",
+                        tone: .accent
+                    ) {
+                        trackSettingsAction("import_recording", page: .general)
+                        actions.importAudioFile()
+                    }
+                    .help("Choose an audio file to transcribe")
+                }
             }
 
             SettingsSection(

--- a/Tests/HomeImportAudioActionTests.swift
+++ b/Tests/HomeImportAudioActionTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 func testHomeImportAudioAction() {
-    runSuite("Home meetings tab exposes imported-audio transcription") {
+    runSuite("General settings exposes imported-audio transcription") {
         let settingsSource = (try? String(
             contentsOf: repoFixtureURL("Sources/UI/Settings/TranscriptedSettingsView.swift"),
             encoding: .utf8
@@ -12,21 +12,22 @@ func testHomeImportAudioAction() {
         )) ?? ""
 
         assertTrue(
-            settingsSource.contains("onImportAudio: {"),
-            "settings home should pass an import-audio action into the meetings tab"
+            settingsSource.contains("SettingsSection(\n                title: \"Audio Files\""),
+            "general settings should include an audio-file section"
         )
         assertTrue(
             settingsSource.contains("actions.importAudioFile()"),
-            "settings home import action should call the existing audio import flow"
+            "general settings import action should call the existing audio import flow"
         )
         assertTrue(
-            homeSource.contains("Transcribe Audio File"),
-            "meetings tab should show a visible audio import affordance"
+            settingsSource.contains("Transcribe Audio File")
+                && settingsSource.contains("title: \"Choose File\""),
+            "general settings should expose a visible choose-file control"
         )
         assertTrue(
-            homeSource.contains("SettingsInlineActionButton(")
-                && homeSource.contains("title: \"Choose File\""),
-            "meetings tab should expose a clickable choose-file control"
+            !homeSource.contains("HomeMeetingImportActionRow")
+                && !homeSource.contains("onImportAudio"),
+            "meetings tab should not carry the imported-audio action"
         )
     }
 }


### PR DESCRIPTION
## What changed
- Moves the `Transcribe Audio File` affordance out of the Home Meetings tab.
- Adds it to General settings under a new `Audio Files` section.
- Keeps the action wired to the existing `actions.importAudioFile()` picker.
- Updates the regression test so the import action stays visible in General and does not drift back into the Meetings list.

## Why
The restored import row fixed issue #788, but its placement inside the Meetings history area looked bolted on. General is a quieter place for a standalone audio-file import action.

## Verification
- `bash build.sh --no-open`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh`
- `1924 passed, 0 failed`

## Runtime check
- Killed existing Transcripted/Draft app processes.
- Launched `/Users/redbars/.codex/worktrees/cc23/transcripted-latest/build/Transcripted.app`.
