### PR TITLE
[release] Transcripted 1.1.39

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.38"
-  sha256 "1d212cf3450567a0e586091346bcbb0f6f0002ce030037b218fa9b160b02f6cf"
+  version "1.1.39"
+  sha256 "4c06be076d2dd3ab13872c4d7d7433bf2c14e4bf7b524ed1134a33ae8659457d"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.38</string>
+	<string>1.1.39</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.38</string>
+	<string>1.1.39</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.39</title>
+      <pubDate>Mon, 18 May 2026 06:57:22 -0500</pubDate>
+      <sparkle:version>1.1.39</sparkle:version>
+      <sparkle:shortVersionString>1.1.39</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.39/Transcripted-1.1.39.dmg" length="504172338" type="application/octet-stream" sparkle:edSignature="zZdVx8tNGh9TKrb4ZgHw3LHRHcra0aXpvD7uifOIucAxf2ySvrcwFUCuW1zAYU+yCcofGu83DSSspFYRUrJ3DA==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.39</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.39</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.38</title>
       <pubDate>Sat, 16 May 2026 15:46:51 -0500</pubDate>
       <sparkle:version>1.1.38</sparkle:version>


### PR DESCRIPTION
## Summary
- bump Transcripted to 1.1.39
- add the 1.1.39 Sparkle appcast item for the published GitHub DMG
- update the Homebrew cask sha256 for the 1.1.39 asset

## Verification
- bash build-deps.sh --force
- bash build.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh (1940 passed)
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh
- swift test (195 passed)
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-public-1.1.39 Transcripted
- xcrun stapler validate build/Transcripted-1.1.39.dmg
- spctl -a -t exec -vv build/Transcripted.app
- bash scripts/release/verify-sparkle-release.sh 1.1.39

GitHub release: https://github.com/r3dbars/transcripted/releases/tag/v1.1.39