### PR TITLE
[codex] Fix stale home speaker review badges

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -1436,6 +1436,7 @@ struct HomeMeetingRow: View {
     let onOpen: () -> Void
     let onCopy: () -> Void
     let onFlag: () -> Void
+    let hasSpeakerReviewWork: Bool
     let onReviewSpeakers: () -> Void
     let menuItems: [HomeRowMenuItem]
 
@@ -1459,7 +1460,10 @@ struct HomeMeetingRow: View {
     }
 
     private var reviewSpeakersAccessory: AnyView? {
-        guard item.speakerStatus.needsReview else { return nil }
+        guard RecentMeetingSpeakerReviewActionPolicy.shouldShowReviewAction(
+            speakerStatus: item.speakerStatus,
+            hasSpeakerReviewWork: hasSpeakerReviewWork
+        ) else { return nil }
         return AnyView(
             HomeAttentionActionButton(
                 title: "Review speakers",
@@ -1872,6 +1876,7 @@ struct HomeActivityTabsCard: View {
                                 onOpen: { onOpenMeeting(meeting) },
                                 onCopy: { onCopyMeeting(meeting) },
                                 onFlag: { onFlagMeeting(meeting) },
+                                hasSpeakerReviewWork: hasSpeakerReviewWork,
                                 onReviewSpeakers: { onReviewMeetingSpeakers(meeting) },
                                 menuItems: meetingMenuItems(meeting)
                             )
@@ -1892,6 +1897,10 @@ struct HomeActivityTabsCard: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var hasSpeakerReviewWork: Bool {
+        !speakerPeopleModel.hasLoadedProfiles || speakerPeopleModel.needsReviewCount > 0
     }
 
     @ViewBuilder

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -76,6 +76,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
     @Published var profiles: [SpeakerProfile] = []
     @Published var searchText: String = ""
     @Published var profileFilter: SpeakerPeopleProfileFilter = .all
+    @Published private(set) var hasLoadedProfiles = false
 
     private let speakerDatabase: SpeakerDatabase
     private let preferredClipsDirectory: URL
@@ -285,6 +286,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         duplicateCountsByProfileID = snapshot.duplicateCountsByProfileID
         mergeTargetsByProfileID = snapshot.mergeTargetsByProfileID
         clipURLsByProfileID = snapshot.clipURLsByProfileID
+        hasLoadedProfiles = true
         profiles = snapshot.profiles
     }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -476,6 +476,11 @@ struct TranscriptedSettingsView: View {
         }
         .onChange(of: homeActivityTab) { _, newValue in
             trackSettingsAction("home_tab_\(newValue.rawValue)", page: .home)
+            if newValue == .meetings {
+                refreshRecentCaptures(force: true)
+            } else if newValue == .speakers {
+                speakerPeopleModel.refresh()
+            }
         }
         .alert(item: $homeDeleteConfirmation) { confirmation in
             Alert(

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -117,6 +117,15 @@ enum RecentMeetingSpeakerStatus: Equatable, Sendable {
     }
 }
 
+enum RecentMeetingSpeakerReviewActionPolicy {
+    static func shouldShowReviewAction(
+        speakerStatus: RecentMeetingSpeakerStatus,
+        hasSpeakerReviewWork: Bool
+    ) -> Bool {
+        speakerStatus.needsReview && hasSpeakerReviewWork
+    }
+}
+
 struct RecentCaptureSnapshot: Sendable {
     let meetings: [RecentMeetingItem]
     let dictations: [SavedDictationEntry]

--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -78,4 +78,31 @@ func testRecentCaptureScanners() {
             "Legacy inline transcript labels should still surface review work"
         )
     }
+
+    runSuite("RecentMeetingSpeakerReviewActionPolicy hides stale meeting review buttons when people queue is clean") {
+        assertFalse(
+            RecentMeetingSpeakerReviewActionPolicy.shouldShowReviewAction(
+                speakerStatus: .needsReview(1),
+                hasSpeakerReviewWork: false
+            ),
+            "A generic old transcript should not keep showing a review button after the Speakers queue is clean"
+        )
+    }
+
+    runSuite("RecentMeetingSpeakerReviewActionPolicy shows actionable meeting review buttons") {
+        assertTrue(
+            RecentMeetingSpeakerReviewActionPolicy.shouldShowReviewAction(
+                speakerStatus: .needsReview(1),
+                hasSpeakerReviewWork: true
+            ),
+            "Generic speaker labels should still show a review button while Speakers has review work"
+        )
+        assertFalse(
+            RecentMeetingSpeakerReviewActionPolicy.shouldShowReviewAction(
+                speakerStatus: .ready,
+                hasSpeakerReviewWork: true
+            ),
+            "Ready meetings should not show a speaker review button"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Hide per-meeting `Review speakers` actions when the Speakers cleanup queue is already loaded and clean.
- Force the Home Meetings tab to rescan recent captures when switching back from Speakers.
- Add policy coverage for the stale-button case.

## Root cause
The Home meeting rows were using an older transcript scan to decide whether a meeting needed speaker review, but the button sends users to the global Speakers cleanup queue. After users cleaned that queue, the cached meeting row could still show review work.

## Validation
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (1943 passed)
- `git diff --check`