### PR TITLE
[codex] Refresh speaker queue after saved meetings

### DIFF
--- a/Sources/UI/Settings/SettingsRecentCaptureRefreshPolicy.swift
+++ b/Sources/UI/Settings/SettingsRecentCaptureRefreshPolicy.swift
@@ -16,6 +16,12 @@ enum SettingsRecentCaptureRefreshPolicy {
     }
 }
 
+enum SettingsSpeakerQueueRefreshPolicy {
+    static func shouldRefreshAfterMeetingTranscriptSave(_ url: URL?) -> Bool {
+        url != nil
+    }
+}
+
 enum SettingsDashboardRefreshPolicy {
     static let passiveRefreshMinimumInterval: TimeInterval = 1.5
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -180,8 +180,11 @@ struct TranscriptedSettingsView: View {
             }
             trackSettingsPageViewed(page, source: "navigation")
         }
-        .onChange(of: meetingSession.lastSavedTranscriptURL) { _, _ in
+        .onChange(of: meetingSession.lastSavedTranscriptURL) { _, newURL in
             refreshRecentCaptures(force: true)
+            if SettingsSpeakerQueueRefreshPolicy.shouldRefreshAfterMeetingTranscriptSave(newURL) {
+                speakerPeopleModel.refresh()
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: .dictationTranscriptDidSave)) { _ in
             refreshRecentCaptures(force: true)

--- a/Tests/SettingsRecentCaptureRefreshPolicyTests.swift
+++ b/Tests/SettingsRecentCaptureRefreshPolicyTests.swift
@@ -78,4 +78,18 @@ func testSettingsRecentCaptureRefreshPolicy() {
             "new/deleted captures should refresh even when passive refreshes would be skipped"
         )
     }
+
+    runSuite("SettingsSpeakerQueueRefreshPolicy.shouldRefreshAfterMeetingTranscriptSave — refreshes on concrete saves") {
+        assertTrue(
+            SettingsSpeakerQueueRefreshPolicy.shouldRefreshAfterMeetingTranscriptSave(
+                URL(fileURLWithPath: "/tmp/Transcripted/captures/meetings/example.md")
+            ),
+            "a newly saved meeting can add speaker review work, so the speaker queue should refresh"
+        )
+
+        assertFalse(
+            SettingsSpeakerQueueRefreshPolicy.shouldRefreshAfterMeetingTranscriptSave(nil),
+            "nil reset events should not trigger extra speaker queue work"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Refresh the Speakers queue when a saved meeting transcript lands so deferred speaker review badges update immediately.
- Add a focused policy test for concrete save URLs vs nil reset events.

## Verification
- bash build.sh --no-open
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh
- codex-review branch rerun: build, fast tests, integration smoke, swift test all passed