### PR TITLE
[release] Transcripted 1.1.40

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.39"
-  sha256 "4c06be076d2dd3ab13872c4d7d7433bf2c14e4bf7b524ed1134a33ae8659457d"
+  version "1.1.40"
+  sha256 "e62ebbc6a8ca761810794ba1f6a4144f1b6fa8271a444fef51135b5dd1488dc1"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.39</string>
+	<string>1.1.40</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.39</string>
+	<string>1.1.40</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.40</title>
+      <pubDate>Mon, 18 May 2026 14:54:53 -0500</pubDate>
+      <sparkle:version>1.1.40</sparkle:version>
+      <sparkle:shortVersionString>1.1.40</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.40/Transcripted-1.1.40.dmg" length="504172830" type="application/octet-stream" sparkle:edSignature="67jO5ahgufEu6tBBu70RZ7VmwR8XI/zV7U3sRcsOa82DczUpocYSmk7jpEnkiXyo70s2u3vRUDb4DgcxbIkADw==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.40</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.40</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.39</title>
       <pubDate>Mon, 18 May 2026 06:57:22 -0500</pubDate>
       <sparkle:version>1.1.39</sparkle:version>


### PR DESCRIPTION
## Summary
- Bump Transcripted to 1.1.40.
- Publish Sparkle appcast entry for v1.1.40.
- Update Homebrew cask to the v1.1.40 DMG hash.

## Release
- GitHub release: https://github.com/r3dbars/transcripted/releases/tag/v1.1.40
- DMG sha256: e62ebbc6a8ca761810794ba1f6a4144f1b6fa8271a444fef51135b5dd1488dc1

## Verification
- bash build-deps.sh --force
- bash build.sh --no-open
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-public-1.1.40 Transcripted
- bash scripts/release/verify-sparkle-release.sh 1.1.40
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh
- swift test
- https://transcripted.app/download redirects to the v1.1.40 DMG