### PR TITLE
Release Transcripted 1.1.41

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.40"
-  sha256 "e62ebbc6a8ca761810794ba1f6a4144f1b6fa8271a444fef51135b5dd1488dc1"
+  version "1.1.41"
+  sha256 "b83547ad9f80c03a12e11f25d3c2ff074ed9c45bcc442ad45913d4e16cf675cf"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.40</string>
+	<string>1.1.41</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.40</string>
+	<string>1.1.41</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.41</title>
+      <pubDate>Mon, 18 May 2026 17:13:45 -0500</pubDate>
+      <sparkle:version>1.1.41</sparkle:version>
+      <sparkle:shortVersionString>1.1.41</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.41/Transcripted-1.1.41.dmg" length="504124288" type="application/octet-stream" sparkle:edSignature="cW+YHvzaLm2WPA/yxYnBuvzFQWalS4Jj2Zc0qVSu59FczhvbnuQSqetZxKJhVo7NDizfceQZ7HRSQDzUPt+cCQ==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.41</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.41</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.40</title>
       <pubDate>Mon, 18 May 2026 14:54:53 -0500</pubDate>
       <sparkle:version>1.1.40</sparkle:version>


### PR DESCRIPTION
## Summary
- bump Transcripted to 1.1.41
- publish Sparkle appcast entry for 1.1.41
- update Homebrew cask hash for the 1.1.41 DMG

## Verification
- bash build-deps.sh --force
- bash build.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift test
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-e2e-smoke.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-live-capture-smoke.sh --skip-build
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-public-1.1.41 Transcripted
- bash scripts/release/verify-sparkle-release.sh 1.1.41
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh