### PR TITLE
[codex] Clarify meeting speaker save failures

### DIFF
--- a/Sources/Meeting/MeetingFailureKind.swift
+++ b/Sources/Meeting/MeetingFailureKind.swift
@@ -137,10 +137,21 @@ enum MeetingFailureKind: String {
             return .noSpeechDetected
         }
 
+        let mentionsSpeakerNames = normalized.contains("speaker name")
+            || normalized.contains("speaker names")
+        let mentionsSpeakerNameSaveFailure = mentionsSpeakerNames
+            && normalized.contains(anyOf: [
+                "couldn't save",
+                "couldnt save",
+                "could not save",
+                "failed to save",
+                "save failed",
+                "need another pass",
+            ])
         if normalized.contains(anyOf: [
             "speaker names could not be saved",
             "speaker-name finalization failed",
-        ]) {
+        ]) || mentionsSpeakerNameSaveFailure {
             return .speakerNameFinalizationFailed
         }
 

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1750,6 +1750,7 @@ final class MeetingSessionController: ObservableObject {
                     context: baseDiagnosticsContext(
                         extra: [
                             "failure_kind": failureKind.rawValue,
+                            "session_stage": CaptureFailureStage.save.rawValue,
                             "queue_depth": "\(queuedTranscriptionJobs.count)",
                             "queue_depth_bucket": queueDepthBucket,
                             "trigger": transcriptionTrigger.rawValue
@@ -1759,6 +1760,7 @@ final class MeetingSessionController: ObservableObject {
                 AnalyticsReporter.track(
                     "meeting_speaker_finalization_failed",
                     properties: [
+                        "session_stage": CaptureFailureStage.save.rawValue,
                         "failure_kind": failureKind.rawValue,
                         "queue_depth_bucket": queueDepthBucket,
                         "trigger": transcriptionTrigger.rawValue,

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -518,6 +518,7 @@ struct AnalyticsEventPolicy: Equatable {
             allowedProperties: [
                 "failure_kind",
                 "queue_depth_bucket",
+                "session_stage",
                 "trigger",
             ]
         ),

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -362,6 +362,7 @@ func testAnalyticsEventPolicy() {
         assertEqual(failed?.allowedProperties.contains("trigger"), true, "meeting failures should preserve trigger attribution")
         assertEqual(speakerFinalizationFailed?.allowedProperties.contains("trigger"), true, "speaker finalization failures should preserve trigger attribution")
         assertEqual(speakerFinalizationFailed?.allowedProperties.contains("queue_depth_bucket"), true, "speaker finalization failures should preserve bucketed queue depth")
+        assertEqual(speakerFinalizationFailed?.allowedProperties.contains("session_stage"), true, "speaker finalization failures should keep save-stage attribution")
         assertEqual(skipped?.allowedProperties.contains("trigger"), true, "skipped meeting transcripts should preserve trigger attribution")
     }
 

--- a/Tests/MeetingFailureKindTests.swift
+++ b/Tests/MeetingFailureKindTests.swift
@@ -73,6 +73,14 @@ func testMeetingFailureKind() {
         assertEqual(kind, .speakerNameFinalizationFailed, "speaker-name save failures should stay out of generic transcript save failures")
     }
 
+    runSuite("MeetingFailureKind classifies support-thread speaker-name save wording") {
+        let kind = MeetingFailureKind.classify(
+            message: "Couldnt save speaker names. Saved them all in preview window, then got failed to save need another pass."
+        )
+
+        assertEqual(kind, .speakerNameFinalizationFailed, "Grigory-style save-stage speaker-name failures should not become generic transcript save failures")
+    }
+
     runSuite("MeetingFailureKind classifies pipeline-busy errors") {
         let kind = MeetingFailureKind.classify(
             message: "Transcription already in progress"

--- a/Tests/SentryEventPolicyTests.swift
+++ b/Tests/SentryEventPolicyTests.swift
@@ -158,6 +158,7 @@ func testSentryEventPolicy() {
             context: [
                 "failure_kind": "speaker_finalization_failed",
                 "queue_depth_bucket": "zero",
+                "session_stage": "save",
                 "speaker_name": "Private Person",
                 "trigger": "unknown",
             ]
@@ -165,6 +166,7 @@ func testSentryEventPolicy() {
 
         assertEqual(tags["failure_kind"], "speaker_finalization_failed", "speaker finalization should keep its stable failure kind")
         assertEqual(tags["queue_depth_bucket"], "zero", "queue depth should stay bucketed")
+        assertEqual(tags["session_stage"], "save", "save-stage failures should be queryable separately from transcription failures")
         assertEqual(tags["trigger"], "unknown", "trigger should stay queryable")
         assertNil(tags["speaker_name"], "speaker names must stay out of Sentry tags")
     }


### PR DESCRIPTION
## Summary

- Classify support-thread speaker-name save wording as `speaker_name_finalization_failed`
- Add `session_stage=save` to speaker finalization diagnostics, Sentry tags, and analytics
- Cover the classifier and observability allowlists with fast tests

## Why

The Grigory support thread and old Sentry issue `APPLE-MACOS-1H` showed saved-meeting speaker-name failures looking too much like full transcript failures. The core bug was already fixed in newer releases, but this keeps any future save-stage speaker-name issue out of the generic transcript-failure bucket.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` — 2113 passed
- `bash run-integration-smoke.sh`

## Notes

Sentry API fallback showed the matching `APPLE-MACOS-1H` events were old `transcripted@1.1.37` events, and no matching `1.1.40` / `1.1.41` events were found.
