### PR TITLE
[codex] Harden Parakeet device rewarm recovery

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -35,17 +35,6 @@ private enum ParakeetAudioEngineWorkError: LocalizedError {
     }
 }
 
-private enum ParakeetDeviceRecoveryError: LocalizedError {
-    case routeNotSettled
-
-    var errorDescription: String? {
-        switch self {
-        case .routeNotSettled:
-            return "Audio route not settled after device change"
-        }
-    }
-}
-
 private enum CoreAudioInputDeviceLookup {
     static func preferredDictationInputSelection() throws -> DictationInputDeviceSelection {
         let defaultInputID = try defaultInputDeviceID()
@@ -1267,41 +1256,44 @@ class ParakeetEngine: ObservableObject {
             guard !Task.isCancelled, let self = self else { return }
             guard !self.recoveryState.isStale(generation: myGeneration) else { return }
             do {
-                // Two-step format validation. CoreAudio sometimes reports zero
-                // sample rate on first read after device change, even past the
-                // initial settle delay. One extra wait + re-read is enough.
-                var snapshot = try await self.audioInputSnapshot(
-                    operation: "device_recovery",
-                    recoveryGeneration: myGeneration
-                )
-                if self.audioFormatReadiness(outputFormat: snapshot.outputFormat, hwFormat: snapshot.hwFormat, selection: snapshot.selection) != .ready {
-                    try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
-                    guard !self.recoveryState.isStale(generation: myGeneration) else { return }
-                    snapshot = try await self.audioInputSnapshot(
-                        operation: "device_recovery_retry",
+                var recoveryAttempt = 0
+                var readySnapshot: ParakeetAudioInputSnapshot?
+                while readySnapshot == nil {
+                    recoveryAttempt += 1
+                    let snapshot = try await self.audioInputSnapshot(
+                        operation: recoveryAttempt == 1 ? "device_recovery" : "device_recovery_retry",
                         recoveryGeneration: myGeneration
                     )
-                }
-                let readiness = self.audioFormatReadiness(
-                    outputFormat: snapshot.outputFormat,
-                    hwFormat: snapshot.hwFormat,
-                    selection: snapshot.selection
-                )
-                guard readiness == .ready else {
-                    EventReporter.shared.capture(
-                        level: .warning,
-                        engine: "parakeet",
-                        event: "device_change_rewarm_deferred",
-                        message: "Audio route still settling after device change",
-                        context: self.audioFormatContext(
+                    let readiness = self.audioFormatReadiness(
+                        outputFormat: snapshot.outputFormat,
+                        hwFormat: snapshot.hwFormat,
+                        selection: snapshot.selection
+                    )
+                    switch ParakeetDeviceRecoveryReadinessPolicy.action(for: readiness) {
+                    case .finishRecovery:
+                        readySnapshot = snapshot
+                    case .keepWaiting:
+                        var context = self.audioFormatContext(
                             outputFormat: snapshot.outputFormat,
                             hwFormat: snapshot.hwFormat,
                             selection: snapshot.selection,
                             readiness: readiness
                         )
-                    )
-                    throw ParakeetDeviceRecoveryError.routeNotSettled
+                        context["recovery_attempt"] = "\(recoveryAttempt)"
+                        EventReporter.shared.capture(
+                            level: .warning,
+                            engine: "parakeet",
+                            event: "device_change_rewarm_deferred",
+                            message: "Audio route still settling after device change",
+                            context: context
+                        )
+                        try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
+                        guard !Task.isCancelled else { return }
+                        guard !self.recoveryState.isStale(generation: myGeneration) else { return }
+                        continue
+                    }
                 }
+                guard let snapshot = readySnapshot else { return }
                 self.updateNativeSampleRate(snapshot.outputFormat.sampleRate)
                 self.prewarmRetryCount = 0
                 print("🔄 PARAKEET | audio device changed → \(self.inputDeviceName) (\(self.safeNativeSampleRate())Hz), input ready")
@@ -1421,10 +1413,7 @@ class ParakeetEngine: ObservableObject {
                             ]
                         ))
                 }
-                let rebuildReason = error is ParakeetDeviceRecoveryError
-                    ? "device_change_route_not_settled"
-                    : "device_change_rewarm_failed"
-                await self.rebuildAudioEngine(reason: rebuildReason)
+                await self.rebuildAudioEngine(reason: "device_change_rewarm_failed")
                 if failureAction.schedulePrewarmRetry {
                     self.prewarmRetryCount = 0
                     self.schedulePrewarmRetry()

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -18,6 +18,11 @@ struct ParakeetDeviceRecoveryFailureAction: Equatable {
     let schedulePrewarmRetry: Bool
 }
 
+enum ParakeetDeviceRecoveryReadinessAction: Equatable {
+    case finishRecovery
+    case keepWaiting
+}
+
 enum ParakeetAudioEngineRebuildStrategy: Equatable {
     case queuedOnAudioEngineQueue
     case abandonBlockedAudioGraph
@@ -54,6 +59,17 @@ enum ParakeetDeviceRecoveryFailurePolicy {
             markRecordingInterrupted: wasRecording,
             schedulePrewarmRetry: true
         )
+    }
+}
+
+enum ParakeetDeviceRecoveryReadinessPolicy {
+    static func action(for readiness: ParakeetAudioFormatReadiness) -> ParakeetDeviceRecoveryReadinessAction {
+        switch readiness {
+        case .ready:
+            return .finishRecovery
+        case .invalid, .routeNotSettled:
+            return .keepWaiting
+        }
     }
 }
 

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -83,6 +83,30 @@ func testParakeetStartRecordingFailurePolicy() {
         assertTrue(action.schedulePrewarmRetry, "recording recovery should still schedule a follow-up prewarm")
     }
 
+    runSuite("ParakeetDeviceRecoveryReadinessPolicy waits on unsettled route formats") {
+        assertEqual(
+            ParakeetDeviceRecoveryReadinessPolicy.action(for: .routeNotSettled),
+            .keepWaiting,
+            "route churn should keep using the recovery budget instead of failing after the first stale format"
+        )
+    }
+
+    runSuite("ParakeetDeviceRecoveryReadinessPolicy waits on invalid transient formats") {
+        assertEqual(
+            ParakeetDeviceRecoveryReadinessPolicy.action(for: .invalid),
+            .keepWaiting,
+            "zero or invalid formats during device churn should wait for the recovery timeout"
+        )
+    }
+
+    runSuite("ParakeetDeviceRecoveryReadinessPolicy finishes only on ready formats") {
+        assertEqual(
+            ParakeetDeviceRecoveryReadinessPolicy.action(for: .ready),
+            .finishRecovery,
+            "ready formats should complete the device-change recovery"
+        )
+    }
+
     runSuite("ParakeetDeviceRecoveryTimeoutPolicy abandons blocked audio graph") {
         let idleAction = ParakeetDeviceRecoveryTimeoutPolicy.action(wasRecording: false)
         let recordingAction = ParakeetDeviceRecoveryTimeoutPolicy.action(wasRecording: true)


### PR DESCRIPTION
## Summary

- Keep Parakeet device-change recovery polling until the existing recovery timeout instead of failing after one stale route read.
- Add a small recovery-readiness policy so invalid or route-not-settled formats keep using the recovery budget.
- Cover the new policy behavior in the Parakeet start/recovery tests.

## Root Cause

APPLE-MACOS-17 is `parakeet.device_change_rewarm_failed`. The freshest pulled Sentry events were from `transcripted@1.1.28` on one `Mac16,10` app device. The fragile path was still in the current code: CoreAudio route churn could return a transient invalid or stale format after device change, and Transcripted would turn that into a rewarm failure before the full recovery window had elapsed.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` -> 2113 passed, 0 failed
- `bash /Users/redbars/.codex/skills/transcripted-repro-lab/scripts/run_daily_audio_reliability.sh --synthetic` -> PASS, 72 checks
- `git diff --check`

## Release Risk

Low code risk, but there is a small UX tradeoff: during device churn, Transcripted may wait up to the recovery timeout instead of surfacing an early interruption. That is intentional because Bluetooth/CoreAudio can need more than the first couple of reads to settle.

The current live signal appears concentrated on old `1.1.28` installs, not `1.1.41`, so shipping this fix will help future/current-updated users but will not quiet stale old installs until they update.