### PR TITLE
[bug-hunter] Fix Calendar permission entitlement

### DIFF
--- a/Tests/NightlySecurityContractTests.swift
+++ b/Tests/NightlySecurityContractTests.swift
@@ -11,6 +11,35 @@ func testNightlySecurityContract() {
         assertNotNil(manifest["expected_info_plist"]?.dictionaryValue?["SUFeedURL"]?.stringValue, "manifest should pin the Sparkle feed URL")
     }
 
+    runSuite("Nightly security manifest preserves calendar access entitlement") {
+        let manifest = loadJSONFixture("config/security/nightly-security-manifest.json", as: [String: AnyDecodable].self)
+        let expectedEntitlements = manifest["expected_entitlements"]?.dictionaryValue ?? [:]
+        let calendarEntitlement = "com.apple.security.personal-information.calendars"
+        let localEntitlements = loadPlistDictionary("config/entitlements/local.plist")
+        let betaEntitlements = loadPlistDictionary("config/entitlements/beta.plist")
+
+        assertEqual(
+            expectedEntitlements["local"]?.dictionaryValue?[calendarEntitlement]?.boolValue,
+            true,
+            "local builds should be signed with the Calendar entitlement so EventKit can show the permission prompt"
+        )
+        assertEqual(
+            expectedEntitlements["beta"]?.dictionaryValue?[calendarEntitlement]?.boolValue,
+            true,
+            "beta builds should be signed with the Calendar entitlement so shipped apps appear in Calendar privacy settings"
+        )
+        assertEqual(
+            localEntitlements[calendarEntitlement] as? Bool,
+            true,
+            "local entitlement plist should keep Calendar personal-information access enabled"
+        )
+        assertEqual(
+            betaEntitlements[calendarEntitlement] as? Bool,
+            true,
+            "beta entitlement plist should keep Calendar personal-information access enabled"
+        )
+    }
+
     runSuite("Nightly security sanitizer corpus stays shared and non-empty") {
         let corpus = loadJSONFixture("Tests/Fixtures/ObservabilitySanitizerCorpus.json", as: ObservabilitySanitizerCorpus.self)
         let ids = corpus.cases.map(\.id)
@@ -27,6 +56,18 @@ func testNightlySecurityContract() {
         assertTrue(scriptsReadme.contains("nightly-security-check.py"), "scripts README should mention the nightly security checker")
         assertTrue(privacyDoc.contains("nightly-security-check.py"), "privacy observability doc should mention the nightly security checker")
     }
+}
+
+private func loadPlistDictionary(_ relativePath: String) -> [String: Any] {
+    let url = repoFixtureURL(relativePath)
+    guard let data = try? Data(contentsOf: url),
+          let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
+          let dictionary = plist as? [String: Any]
+    else {
+        return [:]
+    }
+
+    return dictionary
 }
 
 struct AnyDecodable: Decodable {

--- a/config/entitlements/beta.plist
+++ b/config/entitlements/beta.plist
@@ -10,6 +10,8 @@
     <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>

--- a/config/entitlements/local.plist
+++ b/config/entitlements/local.plist
@@ -8,5 +8,7 @@
     <true/>
     <key>com.apple.security.device.audio-capture</key>
     <true/>
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
 </dict>
 </plist>

--- a/config/security/nightly-security-manifest.json
+++ b/config/security/nightly-security-manifest.json
@@ -24,7 +24,8 @@
     "local": {
       "com.apple.security.app-sandbox": false,
       "com.apple.security.device.audio-capture": true,
-      "com.apple.security.device.audio-input": true
+      "com.apple.security.device.audio-input": true,
+      "com.apple.security.personal-information.calendars": true
     },
     "beta": {
       "com.apple.security.app-sandbox": false,
@@ -32,6 +33,7 @@
       "com.apple.security.cs.disable-library-validation": true,
       "com.apple.security.device.audio-capture": true,
       "com.apple.security.device.audio-input": true,
+      "com.apple.security.personal-information.calendars": true,
       "com.apple.security.network.client": true
     }
   },


### PR DESCRIPTION
## Summary

- Add the Calendar personal-information entitlement to both local and beta signing profiles.
- Pin the entitlement in the nightly security manifest.
- Add a regression test that checks both the manifest and the committed entitlement plist files.

## Root Cause

GitHub issue #803 reports that clicking Allow Calendar Access does not show the macOS permission prompt and Transcripted does not appear in Calendar privacy settings. The EventKit code already calls `requestFullAccessToEvents()` and `Info.plist` already has `NSCalendarsFullAccessUsageDescription`, but both signing entitlement files were missing `com.apple.security.personal-information.calendars`, so the signed app did not have the Calendar capability needed for the TCC prompt/listing path.

Fixes #803.

## Signal Checked

- Sentry MCP failed with `Transport closed`; local Sentry API fallback found no unresolved production `1.1.41` issues.
- PostHog last-24h/latest-release checks showed successful `1.1.41` dictation and meeting-save events, with no current-release failure rows.
- GitHub issue #803 was the freshest actionable user bug and was not covered by an existing matching draft PR.

## Validation

- `plutil -lint config/entitlements/local.plist`
- `plutil -lint config/entitlements/beta.plist`
- `python3 -m json.tool config/security/nightly-security-manifest.json >/dev/null`
- `bash build-deps.sh --force`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 2114 passed
- `python3 scripts/ops/nightly-security-check.py --write-report build/nightly-security-report.json` — 100/100, no deterministic findings
- `git diff --check`

## Notes

The successful local build printed the signed app entitlements and included `com.apple.security.personal-information.calendars = true`.
