### PR TITLE
Release Transcripted 1.1.42

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.41"
-  sha256 "b83547ad9f80c03a12e11f25d3c2ff074ed9c45bcc442ad45913d4e16cf675cf"
+  version "1.1.42"
+  sha256 "eb9b349a28ee84f68419688f060d9320902d3e1e4ebf189817ecdde3d9cefd26"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.41</string>
+	<string>1.1.42</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.41</string>
+	<string>1.1.42</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.42</title>
+      <pubDate>Tue, 19 May 2026 12:04:39 -0500</pubDate>
+      <sparkle:version>1.1.42</sparkle:version>
+      <sparkle:shortVersionString>1.1.42</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.42/Transcripted-1.1.42.dmg" length="504118516" type="application/octet-stream" sparkle:edSignature="CY70CMA9pMVbn/bqZg9KAixkveHFQ+60IJWvdLjgbqmNTc0zHLIWm2RhNNrezp331qMLCFPajQsQ3IyrJR3FAQ==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.42</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.42</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.41</title>
       <pubDate>Mon, 18 May 2026 17:13:45 -0500</pubDate>
       <sparkle:version>1.1.41</sparkle:version>


### PR DESCRIPTION
## Summary
- bump Transcripted to 1.1.42
- add Sparkle appcast entry for the notarized 1.1.42 DMG
- update Homebrew cask sha for the published 1.1.42 GitHub release asset

## Verification
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-release-redbars redbars
- bash scripts/release/verify-sparkle-release.sh 1.1.42
- GitHub release v1.1.42 published with Transcripted-1.1.42.dmg

Note: Sentry release registration failed with a 403 using the current token.