### PR TITLE
[bug-hunter] Refresh settings permissions after prompts

### DIFF
--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -72,8 +72,9 @@ enum TranscriptedPermissionAccess {
             case .notDetermined:
                 activateForPermissionPrompt()
                 AVCaptureDevice.requestAccess(for: .audio) { granted in
-                    guard !granted else { return }
                     Task { @MainActor in
+                        notifyPermissionsDidChange(kind: .microphone)
+                        guard !granted else { return }
                         openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
                     }
                 }
@@ -88,6 +89,7 @@ enum TranscriptedPermissionAccess {
                 _ = AXIsProcessTrustedWithOptions(options)
             }
             openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+            notifyPermissionsDidChange(kind: .accessibility)
         case .systemAudioRecording:
             if systemAudioRecordingStatus() == .granted {
                 openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_AudioCapture")
@@ -96,6 +98,7 @@ enum TranscriptedPermissionAccess {
 
             Task { @MainActor in
                 let granted = await requestSystemAudioRecordingAccessIfNeeded()
+                notifyPermissionsDidChange(kind: .systemAudioRecording)
                 guard !granted else { return }
                 openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_AudioCapture")
             }
@@ -103,23 +106,29 @@ enum TranscriptedPermissionAccess {
             Task { @MainActor in
                 activateForPermissionPrompt()
                 let granted = await requestCalendarAccessIfNeeded()
+                notifyPermissionsDidChange(kind: .calendar)
                 guard !granted else { return }
                 openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars")
             }
         }
     }
 
-    static func requestCalendarAccessIfNeeded() async -> Bool {
-        let status = EKEventStore.authorizationStatus(for: .event)
+    static func requestCalendarAccessIfNeeded(
+        statusProvider: () -> EKAuthorizationStatus = { EKEventStore.authorizationStatus(for: .event) },
+        requester: () async throws -> Bool = {
+            let store = EKEventStore()
+            return try await store.requestFullAccessToEvents()
+        }
+    ) async -> Bool {
+        let status = statusProvider()
         switch status {
         case .fullAccess:
             return true
         case .authorized:
             return true
         case .notDetermined:
-            let store = EKEventStore()
             do {
-                return try await store.requestFullAccessToEvents()
+                return try await requester()
             } catch {
                 return false
             }
@@ -212,6 +221,15 @@ enum TranscriptedPermissionAccess {
         guard let url = URL(string: urlString) else { return }
         NSWorkspace.shared.open(url)
     }
+
+    @MainActor
+    private static func notifyPermissionsDidChange(kind: TranscriptedPermissionKind) {
+        NotificationCenter.default.post(name: .transcriptedPermissionsDidChange, object: kind)
+    }
+}
+
+extension Notification.Name {
+    static let transcriptedPermissionsDidChange = Notification.Name("transcriptedPermissionsDidChange")
 }
 
 @available(macOS 26.0, *)

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -202,6 +202,9 @@ struct TranscriptedSettingsView: View {
         .onReceive(NotificationCenter.default.publisher(for: .localSpeakerPrefsDidChange)) { _ in
             splitLocalSpeakersEnabled = LocalSpeakerPreferences.isEnabled()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .transcriptedPermissionsDidChange)) { _ in
+            refreshPermissions()
+        }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             refreshPermissions()
             refreshRecentCaptures()

--- a/Tests/TranscriptedPermissionAccessTests.swift
+++ b/Tests/TranscriptedPermissionAccessTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import EventKit
 
 @MainActor
 private final class PermissionRequestBox {
@@ -207,6 +208,48 @@ func testTranscriptedPermissionAccess() async {
 
         assertFalse(granted, "denied microphone access should stay blocked until Settings changes")
         assertEqual(requestBox.callCount, 0, "denied microphone access should not show a repeat system prompt")
+    }
+
+    await runSuite("TranscriptedPermissionAccess.requestCalendarAccessIfNeeded — skips requester when calendar is already authorized") {
+        let requestBox = PermissionRequestBox()
+        let granted = await TranscriptedPermissionAccess.requestCalendarAccessIfNeeded(
+            statusProvider: { .fullAccess },
+            requester: {
+                requestBox.callCount += 1
+                return false
+            }
+        )
+
+        assertTrue(granted, "full calendar access should return true")
+        assertEqual(requestBox.callCount, 0, "authorized calendar status should not trigger another prompt")
+    }
+
+    await runSuite("TranscriptedPermissionAccess.requestCalendarAccessIfNeeded — prompts when calendar is not determined") {
+        let requestBox = PermissionRequestBox()
+        let granted = await TranscriptedPermissionAccess.requestCalendarAccessIfNeeded(
+            statusProvider: { .notDetermined },
+            requester: {
+                requestBox.callCount += 1
+                return true
+            }
+        )
+
+        assertTrue(granted, "not-determined calendar access should return the requester result")
+        assertEqual(requestBox.callCount, 1, "not-determined calendar access should ask EventKit once")
+    }
+
+    await runSuite("TranscriptedPermissionAccess.requestCalendarAccessIfNeeded — does not prompt after denial") {
+        let requestBox = PermissionRequestBox()
+        let granted = await TranscriptedPermissionAccess.requestCalendarAccessIfNeeded(
+            statusProvider: { .denied },
+            requester: {
+                requestBox.callCount += 1
+                return true
+            }
+        )
+
+        assertFalse(granted, "denied calendar access should stay blocked until Settings changes")
+        assertEqual(requestBox.callCount, 0, "denied calendar access should not show a repeat system prompt")
     }
 
     runSuite("TranscriptedPermissionAccess.systemAudioRecordingStatus — separates unknown from denied state") {


### PR DESCRIPTION
## Summary
- Refresh Settings permission rows after macOS permission prompts finish.
- Add injectable calendar permission helper tests.

## Signal
- Anchored to Transcripted 1.1.42.
- Sentry: latest-release fatal APPLE-MACOS-S is real, but the stack has no concrete Transcripted source frame, so I did not patch it here.
- PostHog: one latest-release unclean shutdown correlates with active dictation; no checked start-failure or meeting-failure spike.
- GitHub: fresh #803 follow-up says Calendar access is granted in 1.1.42, but the Settings row stays stale until restart.

## Root Cause
Settings refreshed immediately when opening Calendar permission, before the EventKit prompt resolved, and did not listen for permission prompt completion.

## Verification
- bash build-deps.sh
- bash build.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh (2210 passed)

Privacy note: this PR does not include user transcript text, audio references, meeting titles, speaker names, emails, tokens, device names, or paths.