### PR TITLE
Refresh Settings permissions after grants

### DIFF
--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -64,23 +64,31 @@ enum TranscriptedPermissionAccess {
 
     @MainActor
     static func openSettings(for kind: TranscriptedPermissionKind) {
+        Task { @MainActor in
+            _ = await requestAccessOrOpenSettings(for: kind)
+        }
+    }
+
+    @MainActor
+    @discardableResult
+    static func requestAccessOrOpenSettings(for kind: TranscriptedPermissionKind) async -> Bool {
         switch kind {
         case .microphone:
             switch microphoneAuthorizationStatus() {
             case .authorized:
-                break
+                return true
             case .notDetermined:
-                activateForPermissionPrompt()
-                AVCaptureDevice.requestAccess(for: .audio) { granted in
-                    guard !granted else { return }
-                    Task { @MainActor in
-                        openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
-                    }
+                let granted = await requestMicrophoneAccessIfNeeded()
+                if !granted {
+                    openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
                 }
+                return granted
             case .denied, .restricted:
                 openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
+                return false
             @unknown default:
                 openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")
+                return false
             }
         case .accessibility:
             if !AXIsProcessTrusted() {
@@ -88,24 +96,25 @@ enum TranscriptedPermissionAccess {
                 _ = AXIsProcessTrustedWithOptions(options)
             }
             openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+            return AXIsProcessTrusted()
         case .systemAudioRecording:
             if systemAudioRecordingStatus() == .granted {
                 openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_AudioCapture")
-                return
+                return true
             }
 
-            Task { @MainActor in
-                let granted = await requestSystemAudioRecordingAccessIfNeeded()
-                guard !granted else { return }
+            let granted = await requestSystemAudioRecordingAccessIfNeeded()
+            if !granted {
                 openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_AudioCapture")
             }
+            return granted
         case .calendar:
-            Task { @MainActor in
-                activateForPermissionPrompt()
-                let granted = await requestCalendarAccessIfNeeded()
-                guard !granted else { return }
+            activateForPermissionPrompt()
+            let granted = await requestCalendarAccessIfNeeded()
+            if !granted {
                 openSystemSettings("x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars")
             }
+            return granted
         }
     }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1708,8 +1708,10 @@ struct TranscriptedSettingsView: View {
                 ForEach(TranscriptedPermissionKind.allCases) { kind in
                     PermissionStatusRow(kind: kind, granted: permissionStates[kind] ?? false) {
                         trackPermissionCTA(kind)
-                        TranscriptedPermissionAccess.openSettings(for: kind)
-                        refreshPermissions()
+                        Task { @MainActor in
+                            await TranscriptedPermissionAccess.requestAccessOrOpenSettings(for: kind)
+                            refreshPermissions()
+                        }
                     }
                 }
             }

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -693,6 +693,29 @@ func testRepoCommandContract() {
             "onboarding telemetry should not send copied prompt text"
         )
     }
+
+    runSuite("Repo command contract - settings permissions refresh after async grants") {
+        let settingsContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
+        let permissionAccessContents = readRepoTextFile("Sources/Support/TranscriptedPermissionAccess.swift")
+
+        assertTrue(
+            permissionAccessContents.contains("static func requestAccessOrOpenSettings(for kind: TranscriptedPermissionKind) async -> Bool"),
+            "permission actions should expose an awaitable path so callers can refresh after macOS returns a grant"
+        )
+        assertTrue(
+            permissionAccessContents.contains("_ = await requestAccessOrOpenSettings(for: kind)"),
+            "legacy fire-and-forget permission actions should delegate to the awaitable implementation"
+        )
+        assertTrue(
+            settingsContents.contains("await TranscriptedPermissionAccess.requestAccessOrOpenSettings(for: kind)")
+                && settingsContents.contains("refreshPermissions()"),
+            "settings should refresh its permission snapshot after the permission request completes, not before"
+        )
+        assertFalse(
+            settingsContents.contains("TranscriptedPermissionAccess.openSettings(for: kind)\n                        refreshPermissions()"),
+            "settings should not immediately refresh after a fire-and-forget permission action"
+        )
+    }
 }
 
 private func repoRootURL() -> URL {


### PR DESCRIPTION
## Summary

- Add an awaitable permission action path so callers can refresh after macOS returns from a permission request.
- Update Settings > Privacy permission rows to refresh their snapshot after the request completes instead of immediately before the Calendar grant lands.
- Add a repo contract test for the stale Settings permission refresh path.

## Context

Follow-up to the latest customer comment on #803: 1.1.42 now prompts for Calendar access, but Settings can keep showing the Calendar warning until app restart because the UI refresh happens before the async EventKit request finishes.

## Validation

- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 2208 passed
- `bash build-deps.sh --force`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open`
- `git diff --check`
