### PR TITLE
[codex] Fix CoreML inference lifetime crash

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -450,6 +450,9 @@ class ParakeetEngine: ObservableObject {
     private var modelFilePrefetchTask: Task<URL, Error>?
     private var prefetchedModelPath: URL?
     private var audioWatchdogTask: Task<Void, Never>?
+    private var asrInferenceActivity = ParakeetASRInferenceActivityState()
+    private var asrInferenceWaiters: [CheckedContinuation<Void, Never>] = []
+    private var pureSampleTranscriptionActivityCount = 0
     private var asrManagerReady = false
     private nonisolated(unsafe) var didReceiveAudioSamples = false
     private var cachedInputDeviceName = "Unknown"
@@ -2776,9 +2779,77 @@ class ParakeetEngine: ObservableObject {
     }
 
     private func finishTranscription() {
-        isTranscribing = false
+        if !hasActiveASRWork {
+            isTranscribing = false
+        }
         sampleBuffer.removeAll(keepingCapacity: true)
         clearRecoveredRecordingTimeline(keepingCapacity: true)
+    }
+
+    private var hasActiveASRWork: Bool {
+        asrInferenceActivity.isActive
+            || !asrInferenceWaiters.isEmpty
+            || pureSampleTranscriptionActivityCount > 0
+    }
+
+    private func beginPureSampleTranscriptionActivity() {
+        pureSampleTranscriptionActivityCount += 1
+        isTranscribing = true
+    }
+
+    private func finishPureSampleTranscriptionActivity() {
+        pureSampleTranscriptionActivityCount = max(0, pureSampleTranscriptionActivityCount - 1)
+        if !hasActiveASRWork {
+            isTranscribing = false
+        }
+    }
+
+    private func beginASRInference() async {
+        if !asrInferenceActivity.isActive {
+            asrInferenceActivity.begin()
+            isTranscribing = true
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            asrInferenceWaiters.append(continuation)
+        }
+        asrInferenceActivity.begin()
+        isTranscribing = true
+    }
+
+    private func finishASRInference() {
+        asrInferenceActivity.finish()
+        if let next = asrInferenceWaiters.first {
+            asrInferenceWaiters.removeFirst()
+            isTranscribing = true
+            next.resume()
+            return
+        }
+
+        if !hasActiveASRWork {
+            isTranscribing = false
+        }
+    }
+
+    private func runASRInference(
+        manager: AsrManager,
+        samples: [Float],
+        source: AudioSource
+    ) async throws -> String {
+        await beginASRInference()
+        do {
+            try Task.checkCancellation()
+            let result = try await manager.transcribe(samples, source: source)
+            let text = withExtendedLifetime(result) {
+                String(result.text)
+            }
+            finishASRInference()
+            return text
+        } catch {
+            finishASRInference()
+            throw error
+        }
     }
 
     func transcribe() async -> String? {
@@ -2830,9 +2901,13 @@ class ParakeetEngine: ObservableObject {
         }
 
         do {
-            let result = try await manager.transcribe(resampled, source: .microphone)
+            let resultText = try await runASRInference(
+                manager: manager,
+                samples: resampled,
+                source: .microphone
+            )
             let elapsed = CFAbsoluteTimeGetCurrent() - startTime
-            let trimmed = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmed = resultText.trimmingCharacters(in: .whitespacesAndNewlines)
             let corrected = CustomDictionaryTextProcessor.apply(to: trimmed)
 
             let audioDuration = Double(resampled.count) / TranscriptedConstants.parakeetSampleRate
@@ -2865,9 +2940,13 @@ class ParakeetEngine: ObservableObject {
                     )
 
                     do {
-                        let retryResult = try await manager.transcribe(retrySamples, source: .microphone)
+                        let retryResultText = try await runASRInference(
+                            manager: manager,
+                            samples: retrySamples,
+                            source: .microphone
+                        )
                         let retryElapsed = CFAbsoluteTimeGetCurrent() - retryStarted
-                        let retryTrimmed = retryResult.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                        let retryTrimmed = retryResultText.trimmingCharacters(in: .whitespacesAndNewlines)
                         let retryCorrected = CustomDictionaryTextProcessor.apply(to: retryTrimmed)
                         if !retryTrimmed.isEmpty {
                             let totalElapsed = CFAbsoluteTimeGetCurrent() - startTime
@@ -2969,6 +3048,9 @@ class ParakeetEngine: ObservableObject {
     /// - Returns: Transcribed text, trimmed. Empty string if Parakeet returned nothing.
     /// - Throws: Re-throws `AsrManager.transcribe` errors (including model-not-ready).
     func transcribeSamples(_ samples: [Float], source: AudioSource) async throws -> String {
+        beginPureSampleTranscriptionActivity()
+        defer { finishPureSampleTranscriptionActivity() }
+
         guard let manager = asrManager, asrManagerReady else {
             EventReporter.shared.capture(level: .error, engine: "parakeet", event: "asr_manager_unavailable",
                 message: "ASR manager not available for transcribeSamples")
@@ -2996,8 +3078,11 @@ class ParakeetEngine: ObservableObject {
         let sourceDescription = source == .microphone ? "microphone" : "system"
         let resultText: String
         do {
-            let result = try await manager.transcribe(samples, source: source)
-            resultText = result.text
+            resultText = try await runASRInference(
+                manager: manager,
+                samples: samples,
+                source: source
+            )
         } catch {
             if let fallbackDecision = ParakeetShortAudioGate.meetingSegmentFallback(
                 sampleCount: samples.count,
@@ -3188,7 +3273,9 @@ class ParakeetEngine: ObservableObject {
             wakeObserver = nil
         }
         removeInputDeviceChangeListener()
-        let cleanupDecision = ParakeetASRManagerCleanupPolicy.decision(isTranscribing: isTranscribing)
+        let cleanupDecision = ParakeetASRManagerCleanupPolicy.decision(
+            isTranscribing: isTranscribing || hasActiveASRWork
+        )
         let mgr = asrManager
         if cleanupDecision == .cleanupNow {
             asrManager = nil

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -99,6 +99,22 @@ enum ParakeetASRManagerCleanupPolicy {
     }
 }
 
+struct ParakeetASRInferenceActivityState: Equatable {
+    private(set) var activeCount = 0
+
+    var isActive: Bool {
+        activeCount > 0
+    }
+
+    mutating func begin() {
+        activeCount += 1
+    }
+
+    mutating func finish() {
+        activeCount = max(0, activeCount - 1)
+    }
+}
+
 enum ParakeetAudioFormatReadiness: String, Equatable {
     case ready
     case invalid

--- a/Sources/TranscriptedCore/Services/DiarizationService.swift
+++ b/Sources/TranscriptedCore/Services/DiarizationService.swift
@@ -13,10 +13,10 @@
 // so the entire speaker identification stack works unchanged.
 
 import Foundation
-import FluidAudio
+@preconcurrency import FluidAudio
 
 /// A speaker segment from diarization with optional voice fingerprint
-public struct SpeakerSegment {
+public struct SpeakerSegment: Sendable {
     public let speakerId: Int          // Unlimited speakers (PyAnnote offline) or 0-3 (Sortformer streaming)
     public let startTime: Double       // seconds
     public let endTime: Double         // seconds
@@ -177,15 +177,19 @@ public class DiarizationService: ObservableObject {
 
         let result = try await manager.process(audio: samples)
 
-        // Convert FluidAudio segments to our SpeakerSegment type
-        let segments = result.segments.map { segment in
-            SpeakerSegment(
-                speakerId: speakerIdFromString(segment.speakerId),
-                startTime: Double(segment.startTimeSeconds),
-                endTime: Double(segment.endTimeSeconds),
-                embedding: segment.embedding.isEmpty ? nil : segment.embedding,
-                qualityScore: segment.qualityScore
-            )
+        // Copy FluidAudio/CoreML-backed outputs into plain Swift values before
+        // result cleanup can recycle CoreML feature buffers on another queue.
+        let segments = withExtendedLifetime(result) {
+            result.segments.map { segment in
+                let embedding = segment.embedding
+                return SpeakerSegment(
+                    speakerId: speakerIdFromString(segment.speakerId),
+                    startTime: Double(segment.startTimeSeconds),
+                    endTime: Double(segment.endTimeSeconds),
+                    embedding: embedding.isEmpty ? nil : embedding.map { $0 },
+                    qualityScore: segment.qualityScore
+                )
+            }
         }
 
         let speakerIds = Set(segments.map { $0.speakerId })
@@ -217,14 +221,17 @@ public class DiarizationService: ObservableObject {
 
         let result = try manager.performCompleteDiarization(samples, sampleRate: sampleRate)
 
-        let segments = result.segments.map { segment in
-            SpeakerSegment(
-                speakerId: speakerIdFromString(segment.speakerId),
-                startTime: Double(segment.startTimeSeconds),
-                endTime: Double(segment.endTimeSeconds),
-                embedding: segment.embedding.isEmpty ? nil : segment.embedding,
-                qualityScore: segment.qualityScore
-            )
+        let segments = withExtendedLifetime(result) {
+            result.segments.map { segment in
+                let embedding = segment.embedding
+                return SpeakerSegment(
+                    speakerId: speakerIdFromString(segment.speakerId),
+                    startTime: Double(segment.startTimeSeconds),
+                    endTime: Double(segment.endTimeSeconds),
+                    embedding: embedding.isEmpty ? nil : embedding.map { $0 },
+                    qualityScore: segment.qualityScore
+                )
+            }
         }
 
         let speakerIds = Set(segments.map { $0.speakerId })

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -138,6 +138,26 @@ func testParakeetStartRecordingFailurePolicy() {
         )
     }
 
+    runSuite("ParakeetASRInferenceActivityState stays active until all inference exits") {
+        var state = ParakeetASRInferenceActivityState()
+
+        state.begin()
+        state.begin()
+        assertTrue(state.isActive, "any active CoreML inference should block manager cleanup")
+        assertEqual(state.activeCount, 2, "nested activity should keep an exact count")
+
+        state.finish()
+        assertTrue(state.isActive, "one completed inference should not clear cleanup protection while another remains")
+        assertEqual(state.activeCount, 1, "finish should decrement one active inference")
+
+        state.finish()
+        assertFalse(state.isActive, "cleanup protection can clear once every inference is done")
+        assertEqual(state.activeCount, 0, "activity count should return to zero")
+
+        state.finish()
+        assertEqual(state.activeCount, 0, "extra finish calls should not underflow")
+    }
+
     runSuite("ParakeetAudioFormatReadinessPolicy accepts normal built-in formats") {
         let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
             outputSampleRate: 48_000,

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -666,6 +666,23 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - CoreML inference outputs stay locally owned") {
+        let engineContents = readRepoTextFile("Sources/Speech/ParakeetEngine.swift")
+        let diarizationContents = readRepoTextFile("Sources/TranscriptedCore/Services/DiarizationService.swift")
+
+        assertTrue(
+            engineContents.contains("runASRInference(")
+                && engineContents.contains("beginASRInference()")
+                && engineContents.contains("finishASRInference()"),
+            "meeting segment ASR should mark CoreML inference active so cleanup cannot release the manager mid-prediction"
+        )
+        assertTrue(
+            diarizationContents.contains("withExtendedLifetime(result)")
+                && diarizationContents.contains("embedding.map { $0 }"),
+            "diarization should copy CoreML-backed embeddings into plain Swift arrays before returning segments"
+        )
+    }
+
     runSuite("Repo command contract - agent todo runner cleans unauthorized queued issues") {
         let contents = readRepoTextFile("scripts/ops/agent-todo-runner.rb")
         assertTrue(


### PR DESCRIPTION
## Summary

Fixes the `transcripted@1.1.42` force-crash shape seen in Sentry issue `APPLE-MACOS-S` and the local Apple crash report.

## Root cause

Meeting-segment Parakeet inference was not counted as active `isTranscribing` work. That meant shutdown/cancel cleanup could release the CoreML-backed ASR manager while a meeting inference task was still unwinding. The crash report showed `objc_release` during Swift task autorelease-pool drain with adjacent CoreML/Espresso output work active.

## Changes

- Route all Parakeet ASR predictions through an explicit inference activity gate.
- Keep meeting pure-sample transcription marked active for cleanup/shutdown policy.
- Copy FluidAudio/CoreML diarization embeddings into plain Swift arrays while the result is still alive.
- Add policy/contract tests covering inference activity and CoreML output ownership.

## Validation

- `bash build-deps.sh`
- `bash build.sh --no-open`
- `bash run-tests.sh` (`2213/2213` passed)
- `bash run-integration-smoke.sh`
- `swift test` (`197` tests, `1` skipped, `0` failures)
