### PR TITLE
Fix release gate blockers

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1050,7 +1050,7 @@ final class MeetingSessionController: ObservableObject {
     }
 
     private func waitForRecordingFinishBeforeTermination() async {
-        let deadline = Date().addingTimeInterval(20)
+        let deadline = Date().addingTimeInterval(TranscriptedConstants.meetingTerminationFinishWaitTimeout)
         while isFinishingRecording && Date() < deadline {
             try? await Task.sleep(nanoseconds: 100_000_000)
         }

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -451,6 +451,7 @@ class ParakeetEngine: ObservableObject {
     private var prefetchedModelPath: URL?
     private var audioWatchdogTask: Task<Void, Never>?
     private var asrInferenceActivity = ParakeetASRInferenceActivityState()
+    private var asrInferenceHandoffCount = 0
     private var asrInferenceWaiters: [CheckedContinuation<Void, Never>] = []
     private var pureSampleTranscriptionActivityCount = 0
     private var asrManagerReady = false
@@ -2779,56 +2780,46 @@ class ParakeetEngine: ObservableObject {
     }
 
     private func finishTranscription() {
-        if !hasActiveASRWork {
-            isTranscribing = false
-        }
+        isTranscribing = false
         sampleBuffer.removeAll(keepingCapacity: true)
         clearRecoveredRecordingTimeline(keepingCapacity: true)
     }
 
     private var hasActiveASRWork: Bool {
         asrInferenceActivity.isActive
+            || asrInferenceHandoffCount > 0
             || !asrInferenceWaiters.isEmpty
             || pureSampleTranscriptionActivityCount > 0
     }
 
     private func beginPureSampleTranscriptionActivity() {
         pureSampleTranscriptionActivityCount += 1
-        isTranscribing = true
     }
 
     private func finishPureSampleTranscriptionActivity() {
         pureSampleTranscriptionActivityCount = max(0, pureSampleTranscriptionActivityCount - 1)
-        if !hasActiveASRWork {
-            isTranscribing = false
-        }
     }
 
     private func beginASRInference() async {
         if !asrInferenceActivity.isActive {
             asrInferenceActivity.begin()
-            isTranscribing = true
             return
         }
 
         await withCheckedContinuation { continuation in
             asrInferenceWaiters.append(continuation)
         }
+        asrInferenceHandoffCount = max(0, asrInferenceHandoffCount - 1)
         asrInferenceActivity.begin()
-        isTranscribing = true
     }
 
     private func finishASRInference() {
         asrInferenceActivity.finish()
         if let next = asrInferenceWaiters.first {
             asrInferenceWaiters.removeFirst()
-            isTranscribing = true
+            asrInferenceHandoffCount += 1
             next.resume()
             return
-        }
-
-        if !hasActiveASRWork {
-            isTranscribing = false
         }
     }
 
@@ -2912,7 +2903,7 @@ class ParakeetEngine: ObservableObject {
 
             let audioDuration = Double(resampled.count) / TranscriptedConstants.parakeetSampleRate
             let rtf = audioDuration > 0 ? elapsed / audioDuration : 0
-            print("✅ PARAKEET | transcribed in \(String(format: "%.2f", elapsed))s: \"\(corrected.prefix(80))...\"")
+            print("✅ PARAKEET | transcribed in \(String(format: "%.2f", elapsed))s, chars=\(corrected.count)")
 
             if trimmed.isEmpty {
                 let analysis = DictationAudioRecovery.analyze(

--- a/Sources/Speech/WhisperEngine.swift
+++ b/Sources/Speech/WhisperEngine.swift
@@ -122,7 +122,7 @@ final class WhisperEngine: ObservableObject {
             let audioDuration = Double(samples.count) / TranscriptedConstants.parakeetSampleRate
             let rtf = audioDuration > 0 ? elapsed / audioDuration : 0
 
-            print("✅ WHISPER | \(model.title) transcribed \(sourceDescription) in \(String(format: "%.2f", elapsed))s: \"\(trimmed.prefix(80))...\"")
+            print("✅ WHISPER | \(model.title) transcribed \(sourceDescription) in \(String(format: "%.2f", elapsed))s, chars=\(trimmed.count)")
             EventReporter.shared.capture(
                 level: .info,
                 engine: model.engineName,

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -58,6 +58,11 @@ enum TranscriptedConstants {
     /// stuck forever if CoreAudio cleanup never calls completion.
     static let meetingStopTimeout: UInt64 = 30_000_000_000  // 30 seconds
 
+    /// Max time app termination waits for an in-flight meeting stop to finish.
+    /// This must stay above `meetingStopTimeout` so quit preservation does not
+    /// give up before the bridge returns retained audio URLs.
+    static let meetingTerminationFinishWaitTimeout: TimeInterval = 35.0
+
     /// Max time wake recovery should wait for background model warmup.
     /// Hotkey recovery must finish even if a model load stalls after sleep.
     static let wakeRuntimeReadinessTimeout: TimeInterval = 30.0

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -676,8 +676,9 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         }
 
         let sourceApp = resolvedSourceApp()
+        let pasteTarget = DictationPasteTarget.capture(sourceApp: sourceApp)
         sourceApp?.activate(options: [])
-        _ = settingsTextPaster.paste(latestText)
+        _ = settingsTextPaster.paste(latestText, target: pasteTarget)
     }
 
     @available(macOS 14.0, *)

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -35,9 +35,9 @@ public class FailedTranscriptionManager: ObservableObject {
         encoder.dateEncodingStrategy = .iso8601
         decoder.dateDecodingStrategy = .iso8601
 
-        // Load existing failed transcriptions and auto-clean permanent failures
+        // Load existing failed transcriptions. User-visible failed meetings stay
+        // queued until the user retries, deletes, or the age-based cleanup runs.
         loadFailedTranscriptions()
-        cleanupPermanentFailures()
     }
 
     /// Loads failed transcriptions from disk
@@ -222,37 +222,6 @@ public class FailedTranscriptionManager: ObservableObject {
     /// Gets the total number of failed transcriptions
     public var count: Int {
         return failedTranscriptions.count
-    }
-
-    /// Auto-clean permanent failures (unrecoverable errors or exhausted retries).
-    /// Deletes audio files and removes from queue on launch.
-    private func cleanupPermanentFailures() {
-        let toRemove = failedTranscriptions.filter { failed in
-            // Permanent error that will never succeed
-            !failed.isRetryable ||
-            // Exhausted retries (3+ attempts, still failing)
-            failed.retryCount >= 3
-        }
-
-        guard !toRemove.isEmpty else { return }
-
-        for failure in toRemove {
-            // Delete audio files to reclaim disk space
-            removeAudioFile(failure.micAudioURL, label: "cleanup mic audio")
-            if let systemURL = failure.systemAudioURL {
-                removeAudioFile(systemURL, label: "cleanup system audio")
-            }
-            removeEmptyAudioArchiveDirectoryIfNeeded(containing: failure.micAudioURL)
-            if let systemURL = failure.systemAudioURL {
-                removeEmptyAudioArchiveDirectoryIfNeeded(containing: systemURL)
-            }
-        }
-
-        let removedIds = Set(toRemove.map { $0.id })
-        failedTranscriptions.removeAll { removedIds.contains($0.id) }
-        saveFailedTranscriptions()
-
-        AppLogger.pipeline.info("Auto-cleaned permanent failures", ["count": "\(toRemove.count)"])
     }
 
     /// Cleans up failed transcriptions older than the specified number of days

--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -276,9 +276,10 @@ final class MenuBarPanelController: NSViewController {
         }
 
         let sourceApp = resolvedSourceApp()
+        let pasteTarget = DictationPasteTarget.capture(sourceApp: sourceApp)
         dismissPopover()
         sourceApp?.activate(options: [])
-        _ = textPaster.paste(latestText)
+        _ = textPaster.paste(latestText, target: pasteTarget)
     }
 
     private func openSettingsFromMenu(_ page: TranscriptedSettingsPage, actionID: String? = nil) {

--- a/Sources/UI/Settings/TranscriptedSettingsNavigationModel.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsNavigationModel.swift
@@ -5,9 +5,11 @@ import Observation
 @MainActor
 final class TranscriptedSettingsNavigationModel {
     var selectedPage: TranscriptedSettingsPage
+    var presentedPage: TranscriptedSettingsPage
     var presentationID = UUID()
 
     init(selectedPage: TranscriptedSettingsPage = .home) {
         self.selectedPage = selectedPage
+        self.presentedPage = selectedPage
     }
 }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -448,6 +448,7 @@ struct TranscriptedSettingsView: View {
         .background(Color(nsColor: .windowBackgroundColor))
         .task(id: navigation.presentationID) {
             refreshState()
+            expandGeneralDisclosureForPresentedPage()
             trackSettingsPageViewed(navigation.selectedPage, source: "presentation")
         }
         .onChange(of: navigation.selectedPage) { _, page in
@@ -2988,6 +2989,19 @@ struct TranscriptedSettingsView: View {
         anonymousAnalyticsEnabled = AnalyticsPreferences.isEnabled()
         if case .unknown = sparkleUpdater.updateStatus.state {
             sparkleUpdater.refreshUpdateStatus()
+        }
+    }
+
+    private func expandGeneralDisclosureForPresentedPage() {
+        switch navigation.presentedPage {
+        case .models:
+            showGeneralModelSettings = true
+        case .shortcuts:
+            showGeneralShortcutSettings = true
+        case .privacy:
+            showGeneralPrivacySettings = true
+        default:
+            break
         }
     }
 

--- a/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
@@ -50,6 +50,7 @@ final class TranscriptedSettingsWindowController: NSWindowController, NSWindowDe
         guard let window else { return }
         let presentedPage = page.consolidatedDestination
         speakerPeopleModel.refresh()
+        navigationModel.presentedPage = page
         navigationModel.selectedPage = presentedPage
         navigationModel.presentationID = UUID()
         AnalyticsReporter.track(

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -274,7 +274,7 @@ func testRepoCommandContract() {
             "release packaging docs should warn when the cask is stale"
         )
         assertTrue(
-            releaseDocs.contains("SKIP_NOTARIZATION=1 REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 bash build-beta.sh <beta-token> <user-name>"),
+            releaseDocs.contains("SKIP_NOTARIZATION=1 REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 REQUIRE_BUNDLED_DIARIZER_MODELS=0 BUNDLE_DIARIZER_MODELS=0 bash build-beta.sh <beta-token> <user-name>"),
             "release packaging docs should include a local thin packaging smoke command"
         )
         assertTrue(
@@ -540,6 +540,16 @@ func testRepoCommandContract() {
             "beta release build should not allow thin distribution unless the model requirement is explicitly disabled"
         )
         assertTrue(
+            betaBuildScript.contains("BUNDLE_DIARIZER_MODELS=\"${BUNDLE_DIARIZER_MODELS:-1}\"")
+                && betaBuildScript.contains("offline-diarizer-models")
+                && betaBuildScript.contains("speaker-diarization-coreml"),
+            "beta release build should bundle the offline diarizer models used by meeting capture"
+        )
+        assertTrue(
+            betaBuildScript.contains("BUNDLE_DIARIZER_MODELS=0 requires REQUIRE_BUNDLED_DIARIZER_MODELS=0"),
+            "beta release build should not allow missing diarizer models unless the requirement is explicitly disabled"
+        )
+        assertTrue(
             betaBuildScript.contains("SWIFTC_NUM_THREADS")
                 && betaBuildScript.contains("-whole-module-optimization")
                 && betaBuildScript.contains("-num-threads \"$SWIFTC_NUM_THREADS\""),
@@ -668,6 +678,7 @@ func testRepoCommandContract() {
 
     runSuite("Repo command contract - CoreML inference outputs stay locally owned") {
         let engineContents = readRepoTextFile("Sources/Speech/ParakeetEngine.swift")
+        let whisperContents = readRepoTextFile("Sources/Speech/WhisperEngine.swift")
         let diarizationContents = readRepoTextFile("Sources/TranscriptedCore/Services/DiarizationService.swift")
 
         assertTrue(
@@ -680,6 +691,66 @@ func testRepoCommandContract() {
             diarizationContents.contains("withExtendedLifetime(result)")
                 && diarizationContents.contains("embedding.map { $0 }"),
             "diarization should copy CoreML-backed embeddings into plain Swift arrays before returning segments"
+        )
+        assertFalse(
+            engineContents.contains("corrected.prefix(80)") || whisperContents.contains("trimmed.prefix(80)"),
+            "local STT success logs should report counts and timing, not transcript snippets"
+        )
+    }
+
+    runSuite("Repo command contract - meeting ASR does not block dictation state") {
+        let engineContents = readRepoTextFile("Sources/Speech/ParakeetEngine.swift")
+        guard
+            let pureStart = engineContents.range(of: "private func beginPureSampleTranscriptionActivity()"),
+            let inferenceStart = engineContents.range(of: "private func beginASRInference()", range: pureStart.upperBound..<engineContents.endIndex),
+            let runStart = engineContents.range(of: "private func runASRInference(", range: inferenceStart.upperBound..<engineContents.endIndex)
+        else {
+            assertionFailure("ParakeetEngine should keep pure-sample and ASR inference helpers")
+            return
+        }
+
+        let pureAndInferenceHelpers = String(engineContents[pureStart.lowerBound..<runStart.lowerBound])
+        assertFalse(
+            pureAndInferenceHelpers.contains("isTranscribing = true") || pureAndInferenceHelpers.contains("isTranscribing = false"),
+            "meeting/import pure-sample ASR should not flip the published dictation transcribing flag"
+        )
+    }
+
+    runSuite("Repo command contract - Paste Last Dictation uses the paste target guard") {
+        let menuContents = readRepoTextFile("Sources/UI/MenuBar/MenuBarPanelController.swift")
+        let appContents = readRepoTextFile("Sources/TranscriptedApp.swift")
+
+        assertTrue(
+            menuContents.contains("let pasteTarget = DictationPasteTarget.capture(sourceApp: sourceApp)")
+                && menuContents.contains("textPaster.paste(latestText, target: pasteTarget)"),
+            "menu Paste Last Dictation should copy instead of pasting if focus moves away from the source app"
+        )
+        assertTrue(
+            appContents.contains("let pasteTarget = DictationPasteTarget.capture(sourceApp: sourceApp)")
+                && appContents.contains("settingsTextPaster.paste(latestText, target: pasteTarget)"),
+            "settings Paste Last Dictation should use the same focus guard as normal dictation paste"
+        )
+    }
+
+    runSuite("Repo command contract - consolidated settings deep links expand their General section") {
+        let windowControllerContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsWindowController.swift")
+        let navigationContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsNavigationModel.swift")
+        let viewContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
+
+        assertTrue(
+            navigationContents.contains("var presentedPage: TranscriptedSettingsPage")
+                && windowControllerContents.contains("navigationModel.presentedPage = page"),
+            "settings presentation should retain the originally requested page before consolidating to General"
+        )
+        assertTrue(
+            viewContents.contains("expandGeneralDisclosureForPresentedPage()")
+                && viewContents.contains("case .models:")
+                && viewContents.contains("showGeneralModelSettings = true")
+                && viewContents.contains("case .shortcuts:")
+                && viewContents.contains("showGeneralShortcutSettings = true")
+                && viewContents.contains("case .privacy:")
+                && viewContents.contains("showGeneralPrivacySettings = true"),
+            "legacy settings deep links should reveal their matching consolidated General controls"
         )
     }
 

--- a/Tests/TranscriptedConstantsTests.swift
+++ b/Tests/TranscriptedConstantsTests.swift
@@ -15,6 +15,14 @@ func testTranscriptedConstants() async {
         )
     }
 
+    runSuite("TranscriptedConstants gives meeting quit preservation enough time") {
+        let meetingStopTimeoutSeconds = TimeInterval(TranscriptedConstants.meetingStopTimeout) / 1_000_000_000
+        assertTrue(
+            TranscriptedConstants.meetingTerminationFinishWaitTimeout > meetingStopTimeoutSeconds,
+            "termination wait should outlast meeting stop timeout so retained audio can be queued before quit"
+        )
+    }
+
     await runSuite("TranscriptedConstants.withTimeout — returns completed work before deadline") {
         let result = try? await TranscriptedConstants.withTimeout(seconds: 1) {
             "ok"

--- a/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
@@ -233,6 +233,58 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
     }
 
+    func testInitKeepsNonRetryableFailuresUntilUserDeletesThem() throws {
+        let paths = makePaths(root: testRoot)
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: paths.failedQueue.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let micURL = paths.audioCaptures.appendingPathComponent("missing-system-audio-mic.wav")
+        FileManager.default.createFile(atPath: micURL.path, contents: Data("mic".utf8))
+
+        let failure = FailedTranscription(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 10),
+            micAudioURL: micURL,
+            systemAudioURL: nil,
+            errorMessage: "System audio is required to transcribe this meeting."
+        )
+        XCTAssertFalse(failure.isRetryable)
+        try JSONEncoder.iso8601.encode([failure]).write(to: paths.failedQueue, options: .atomic)
+
+        let manager = FailedTranscriptionManager(paths: paths)
+
+        XCTAssertEqual(manager.failedTranscriptions, [failure])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
+    }
+
+    func testInitKeepsExhaustedRetryFailuresUntilUserDeletesThem() throws {
+        let paths = makePaths(root: testRoot)
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: paths.failedQueue.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let micURL = paths.audioCaptures.appendingPathComponent("exhausted-retry-mic.wav")
+        FileManager.default.createFile(atPath: micURL.path, contents: Data("mic".utf8))
+
+        let failure = FailedTranscription(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 11),
+            micAudioURL: micURL,
+            systemAudioURL: nil,
+            errorMessage: "Temporary transcription failure",
+            retryCount: 3
+        )
+        try JSONEncoder.iso8601.encode([failure]).write(to: paths.failedQueue, options: .atomic)
+
+        let manager = FailedTranscriptionManager(paths: paths)
+
+        XCTAssertEqual(manager.failedTranscriptions, [failure])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
+    }
+
     func testFailedTranscriptionRetryabilityDoesNotOvermatchGenericMinimumLanguage() {
         let failure = FailedTranscription(
             micAudioURL: testRoot.appendingPathComponent("mic.wav"),

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -77,19 +77,20 @@ SIGN_IDENTITY=<sha-or-name-fragment> bash build.sh
 SIGNING_IDENTITY=<sha-or-name-fragment> bash build-beta.sh <beta-token> <user-name>
 ```
 
-`build-beta.sh` bundles Parakeet by default for distribution builds. That keeps
-the first dictation/meeting path local after install.
+`build-beta.sh` bundles Parakeet and offline diarizer models by default for
+distribution builds. That keeps the first dictation/meeting path local after
+install.
 
 If you deliberately want a thin local test artifact, make both opt-outs explicit:
 
 ```bash
-REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 bash build-beta.sh <beta-token> <user-name>
+REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 REQUIRE_BUNDLED_DIARIZER_MODELS=0 BUNDLE_DIARIZER_MODELS=0 bash build-beta.sh <beta-token> <user-name>
 ```
 
 For a thin packaging smoke that also skips notarization, keep every opt-out visible:
 
 ```bash
-SKIP_NOTARIZATION=1 REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 bash build-beta.sh <beta-token> <user-name>
+SKIP_NOTARIZATION=1 REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 REQUIRE_BUNDLED_DIARIZER_MODELS=0 BUNDLE_DIARIZER_MODELS=0 bash build-beta.sh <beta-token> <user-name>
 ```
 
 ## Release Flow

--- a/scripts/entrypoints/build-beta.sh
+++ b/scripts/entrypoints/build-beta.sh
@@ -25,6 +25,8 @@ USER_NAME="${2:-beta}"
 SKIP_NOTARIZATION="${SKIP_NOTARIZATION:-0}"
 REQUIRE_BUNDLED_PARAKEET_MODELS="${REQUIRE_BUNDLED_PARAKEET_MODELS:-1}"
 BUNDLE_PARAKEET_MODELS="${BUNDLE_PARAKEET_MODELS:-1}"
+REQUIRE_BUNDLED_DIARIZER_MODELS="${REQUIRE_BUNDLED_DIARIZER_MODELS:-1}"
+BUNDLE_DIARIZER_MODELS="${BUNDLE_DIARIZER_MODELS:-1}"
 REGISTER_SENTRY_RELEASE="${REGISTER_SENTRY_RELEASE:-0}"
 SWIFTC_NUM_THREADS="${SWIFTC_NUM_THREADS:-$(sysctl -n hw.ncpu 2>/dev/null || printf '8')}"
 SENTRY_METADATA="$(python3 scripts/release/sentry-release-metadata.py --format shell Info.plist)"
@@ -45,6 +47,15 @@ if [ "$BUNDLE_PARAKEET_MODELS" = "0" ] && [ "$REQUIRE_BUNDLED_PARAKEET_MODELS" !
     echo "   depend on a runtime model download."
     echo "   If you intentionally want a thin local test build, rerun with:"
     echo "   REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 bash build-beta.sh <beta-token> <user-name>"
+    exit 1
+fi
+
+if [ "$BUNDLE_DIARIZER_MODELS" = "0" ] && [ "$REQUIRE_BUNDLED_DIARIZER_MODELS" != "0" ]; then
+    echo "❌ BUNDLE_DIARIZER_MODELS=0 requires REQUIRE_BUNDLED_DIARIZER_MODELS=0"
+    echo "   Distribution builds bundle offline diarizer models by default so meetings"
+    echo "   do not depend on a runtime model download."
+    echo "   If you intentionally want a thin local test build, rerun with:"
+    echo "   REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 REQUIRE_BUNDLED_DIARIZER_MODELS=0 BUNDLE_DIARIZER_MODELS=0 bash build-beta.sh <beta-token> <user-name>"
     exit 1
 fi
 
@@ -385,6 +396,30 @@ else
         echo "   distribution builds do not fall back to a runtime download on first launch."
         echo "   If you intentionally want a thin local test build, rerun with:"
         echo "   REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 bash build-beta.sh <beta-token> <user-name>"
+        exit 1
+    fi
+fi
+
+# Bundle offline diarizer CoreML models used by DiarizationService.
+DIARIZER_SRC="$HOME/Library/Application Support/FluidAudio/Models/speaker-diarization-coreml"
+DIARIZER_DEST="$APP_BUNDLE/Contents/Resources/offline-diarizer-models"
+if [ "$BUNDLE_DIARIZER_MODELS" = "0" ]; then
+    echo "⚠️  Skipping bundled offline diarizer models because BUNDLE_DIARIZER_MODELS=0"
+    echo "   Runtime model download may occur on first meeting."
+elif [ -d "$DIARIZER_SRC/speaker-diarization-offline" ] && [ -d "$DIARIZER_SRC/wespeaker_v2.mlmodelc" ]; then
+    echo "Bundling offline diarizer models..."
+    mkdir -p "$DIARIZER_DEST"
+    cp -R "$DIARIZER_SRC"/. "$DIARIZER_DEST/"
+else
+    if [ "$REQUIRE_BUNDLED_DIARIZER_MODELS" = "0" ]; then
+        echo "⚠️  Offline diarizer models not found — proceeding because REQUIRE_BUNDLED_DIARIZER_MODELS=0"
+        echo "   Runtime model download may still occur on first meeting."
+    else
+        echo "❌ Missing local offline diarizer models: $DIARIZER_SRC"
+        echo "   build-beta.sh now requires bundled diarizer models by default so"
+        echo "   distribution builds do not fall back to a runtime download on first meeting."
+        echo "   If you intentionally want a thin local test build, rerun with:"
+        echo "   REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 REQUIRE_BUNDLED_DIARIZER_MODELS=0 BUNDLE_DIARIZER_MODELS=0 bash build-beta.sh <beta-token> <user-name>"
         exit 1
     fi
 fi


### PR DESCRIPTION
## Summary
- preserve failed meeting audio until user retry/delete or age cleanup
- bundle offline diarizer models in beta/release packaging by default
- keep meeting ASR from blocking dictation UI state
- guard Paste Last Dictation paste targets and reveal consolidated settings deep links
- extend quit preservation wait beyond meeting stop timeout

## Verification
- bash build-deps.sh --force
- swift test --filter FailedTranscriptionManagerTests
- git diff --check && bash -n scripts/entrypoints/build-beta.sh
- bash build.sh --no-open
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- SKIP_NOTARIZATION=1 bash build-beta.sh smoke Justin