### PR TITLE
[nightly-review] Prune old failed meeting audio

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -244,6 +244,9 @@ final class MeetingSessionController: ObservableObject {
         // wired through `retryFailedMeeting`, `dismissFailedMeeting`, and
         // `deleteFailedMeeting`.
         self.failedManager = FailedTranscriptionManager(paths: storagePaths)
+        self.failedManager.cleanupOldFailedTranscriptions(
+            olderThanDays: TranscriptedConstants.failedMeetingAudioRetentionDays
+        )
 
         // DI container — the protocol-typed "what Core sees" surface.
         self.services = AppServices(

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -63,6 +63,9 @@ enum TranscriptedConstants {
     /// give up before the bridge returns retained audio URLs.
     static let meetingTerminationFinishWaitTimeout: TimeInterval = 35.0
 
+    /// Failed meeting audio is recoverable, but old unretried files should not grow forever.
+    static let failedMeetingAudioRetentionDays = 30
+
     /// Max time wake recovery should wait for background model warmup.
     /// Hotkey recovery must finish even if a model load stalls after sleep.
     static let wakeRuntimeReadinessTimeout: TimeInterval = 30.0

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -662,6 +662,21 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - old failed meeting audio is pruned by age") {
+        let constantsContents = readRepoTextFile("Sources/Support/TranscriptedConstants.swift")
+        let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+
+        assertTrue(
+            constantsContents.contains("failedMeetingAudioRetentionDays"),
+            "failed meeting audio cleanup should use a named retention constant"
+        )
+        assertTrue(
+            controllerContents.contains("cleanupOldFailedTranscriptions(")
+                && controllerContents.contains("TranscriptedConstants.failedMeetingAudioRetentionDays"),
+            "MeetingSessionController should prune old failed meeting audio during startup"
+        )
+    }
+
     runSuite("Repo command contract - dictation joins existing model downloads") {
         let overlayContents = readRepoTextFile("Sources/UI/Overlay/DictationSessionController.swift")
         let engineContents = readRepoTextFile("Sources/Speech/ParakeetEngine.swift")

--- a/Tests/TranscriptedConstantsTests.swift
+++ b/Tests/TranscriptedConstantsTests.swift
@@ -23,6 +23,13 @@ func testTranscriptedConstants() async {
         )
     }
 
+    runSuite("TranscriptedConstants keeps failed meeting audio cleanup conservative") {
+        assertTrue(
+            TranscriptedConstants.failedMeetingAudioRetentionDays >= 30,
+            "failed meeting audio should stay recoverable long enough for users to retry or delete it intentionally"
+        )
+    }
+
     await runSuite("TranscriptedConstants.withTimeout — returns completed work before deadline") {
         let result = try? await TranscriptedConstants.withTimeout(seconds: 1) {
             "ok"


### PR DESCRIPTION
## Summary
- Wires the existing FailedTranscriptionManager age cleanup into MeetingSessionController startup.
- Adds a named 30-day failed-meeting audio retention constant.
- Adds fast regression coverage so the cleanup hook does not disappear again.

## Nightly evidence
- Reviewed PRs #800-#817 and current origin/main.
- Live Sentry still shows one 1.1.42 CoreML/objc_release fatal before the main-branch lifetime fix landed; next release should carry that fix.
- PR #817 intentionally preserved failed recordings, but the old cleanup method had zero call sites, so stale failed audio could accumulate indefinitely.

## Verification
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh
- bash run-integration-smoke.sh