### PR TITLE
[operator] Fix Cloudflare health probe projects

### DIFF
--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -38,6 +38,15 @@ func testRepoCommandContract() {
         assertEqual(disallowedMatches, [], "live docs/scripts should reference bash build.sh, not the historical Xcode project")
     }
 
+    runSuite("Repo command contract - health probe checks live Cloudflare Pages projects") {
+        let contents = readRepoTextFile("scripts/ops/health-probe.sh")
+
+        assertTrue(contents.contains("\"transcripted-web\""), "Cloudflare probe should check the live Transcripted Pages project")
+        assertTrue(contents.contains("\"redbars\""), "Cloudflare probe should check the live r3d.bar Pages project")
+        assertFalse(contents.contains("\"transcripted-app\""), "Cloudflare probe should not check the old Transcripted Pages project name")
+        assertFalse(contents.contains("\"r3d-bar\""), "Cloudflare probe should not check the old redbars Pages project name")
+    }
+
     runSuite("Repo command contract - build bundles only the runtime Parakeet model") {
         let contents = readRepoTextFile("scripts/entrypoints/build.sh")
         assertTrue(

--- a/scripts/ops/health-probe.sh
+++ b/scripts/ops/health-probe.sh
@@ -136,7 +136,7 @@ probe_cloudflare() {
     return 1
   fi
 
-  local project_names=("transcripted-app" "r3d-bar")
+  local project_names=("transcripted-web" "redbars")
   for proj in "${project_names[@]}"; do
     local project_data
     project_data=$(echo "$projects" | jq -r --arg name "$proj" '.result[] | select(.name == $name)')


### PR DESCRIPTION
## Summary
- update the ops health probe to check the live Cloudflare Pages projects: `transcripted-web` and `redbars`
- add a repo command contract test so the project names do not drift back

## Verification
- `bash -n scripts/ops/health-probe.sh`
- `bash scripts/ops/health-probe.sh cloudflare` (skips cleanly without `CLOUDFLARE_API_TOKEN`)
- `bash build.sh`
- `bash run-tests.sh`

## Notes
- Avoids overlap with open automation PRs #818, #819, and #820.
- Does not touch release metadata, audio cleanup, privacy payloads, or product positioning.