### PR TITLE
[nightly-maintenance] Document smoke command wrappers

### DIFF
--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -27,6 +27,8 @@ bash build-deps.sh
 bash build.sh
 bash run-tests.sh
 bash run-integration-smoke.sh
+bash run-e2e-smoke.sh
+bash run-live-capture-smoke.sh
 bash run-daily-audio-reliability.sh
 bash scripts/ops/transcripted-qa-bench.sh --mode quick
 bash scripts/ops/transcripted-qa-bench.sh --mode corpus
@@ -42,6 +44,8 @@ Command ownership:
 - `build-beta.sh` — thin root wrapper for signed beta/distribution builds
 - `run-tests.sh` — thin root wrapper for curated fast tests
 - `run-integration-smoke.sh` — thin root wrapper for app/core smoke verification
+- `run-e2e-smoke.sh` — thin root wrapper for deterministic release-critical artifact smoke
+- `run-live-capture-smoke.sh` — thin root wrapper for local hardware/TCC capture smoke
 - `run-daily-audio-reliability.sh` — thin root wrapper for the interactive and synthetic daily audio reliability check
 - `scripts/ops/transcripted-qa-bench.sh` — orchestrated QA tester pass with local report output
 - `scripts/ops/validate-meeting-corpus.py` — local-only meeting corpus validator for Downloads fixtures

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,8 @@ stable and the docs can keep pointing at the same commands:
 - `build-beta.sh` — signed beta/distribution build
 - `run-tests.sh` — curated fast test runner
 - `run-integration-smoke.sh` — app/core smoke verification
+- `run-e2e-smoke.sh` — deterministic release-critical artifact smoke without microphone/TCC
+- `run-live-capture-smoke.sh` — local hardware/TCC smoke for app launch plus mic and system-audio capture
 - `run-daily-audio-reliability.sh` — interactive or synthetic daily audio reliability check
 
 ## Entrypoint implementations
@@ -22,8 +24,10 @@ not have to carry the full operational logic:
 - `scripts/entrypoints/build-deps.sh`
 - `scripts/entrypoints/build.sh`
 - `scripts/entrypoints/build-beta.sh`
+- `scripts/entrypoints/run-e2e-smoke.sh`
 - `scripts/entrypoints/run-tests.sh`
 - `scripts/entrypoints/run-integration-smoke.sh`
+- `scripts/entrypoints/run-live-capture-smoke.sh`
 
 ## Active helper scripts
 


### PR DESCRIPTION
## Summary
- list the existing root E2E and live-capture smoke wrappers in the command surface docs
- mirror those wrapper implementation paths in scripts/README.md

## Validation
- scripts/dev/agent-preflight.sh
- git diff --check
