### PR TITLE
[bug-hunter] Fix saved-before-quit recovery classification

### DIFF
--- a/Sources/Meeting/MeetingFailureExplanation.swift
+++ b/Sources/Meeting/MeetingFailureExplanation.swift
@@ -230,7 +230,8 @@ struct MeetingFailureExplanation: Equatable {
              .audioDeviceUnavailable,
              .saveFailed,
              .speakerNameFinalizationFailed,
-             .speakerFinalizationFailed:
+             .speakerFinalizationFailed,
+             .savedBeforeQuit:
             return .retryableAfterUserAction
         default:
             return .permanent
@@ -272,7 +273,8 @@ struct MeetingFailureExplanation: Equatable {
         switch failureKind {
         case .saveFailed,
              .speakerNameFinalizationFailed,
-             .speakerFinalizationFailed:
+             .speakerFinalizationFailed,
+             .savedBeforeQuit:
             return .recoverableFailure
         default:
             return .permanentFailure

--- a/Tests/MeetingFailureExplanationTests.swift
+++ b/Tests/MeetingFailureExplanationTests.swift
@@ -107,6 +107,24 @@ func testMeetingFailureExplanation() async {
         assertEqual(explanation.reportFields["retry_available"], "yes", "retained audio should preserve a retry path")
     }
 
+    runSuite("MeetingFailureExplanation keeps saved-before-quit recordings recoverable") {
+        let explanation = MeetingFailureExplanation.make(
+            failureKind: .savedBeforeQuit,
+            hasAudioFiles: true,
+            isRetryable: false,
+            failedQueueEntryRetained: true
+        )
+
+        assertEqual(explanation.stage, .save, "saved-before-quit entries should stay on the save stage")
+        assertEqual(explanation.outcomeKind, .recoverableFailure, "saved-before-quit audio should not become permanent loss")
+        assertEqual(explanation.retryability, .retryableAfterUserAction, "saved-before-quit audio should be finishable from Home")
+        assertEqual(explanation.artifactRetention, .retainedFailedQueueEntry, "saved-before-quit audio should keep the failed row")
+        assertEqual(explanation.userVisibleState, .needsUserAction, "Home should ask the user to finish the transcript")
+        assertEqual(explanation.reportFields["failure_kind"], "saved_before_quit", "support reports should keep the dedicated failure kind")
+        assertEqual(explanation.reportFields["save_failed"], "yes", "saved-before-quit is a save-stage recovery state")
+        assertEqual(explanation.reportFields["retry_available"], "yes", "retained audio should preserve the finish-later path")
+    }
+
     runSuite("MeetingFailureExplanation blocks pre-recording permission failures cleanly") {
         let explanation = MeetingFailureExplanation.make(
             failureKind: .microphonePermission,


### PR DESCRIPTION
## Summary
- fixes `.savedBeforeQuit` meeting failures so retained audio is classified as recoverable instead of permanent when the failed row is not marked directly retryable
- adds a regression test for the finish-later path from Home

## Signal
Recent PR #815 added active-meeting quit safety and a `savedBeforeQuit` failure kind. Review feedback on that PR flagged that `MeetingFailureExplanation` added the kind to save-stage reporting, but not to the sibling retryability/outcome switches.

## Root Cause
`MeetingFailureExplanation` listed save-stage recovery kinds in multiple switches, and `.savedBeforeQuit` was missing from `resolvedRetryability` and `resolvedOutcomeKind`.

## Verification
- `bash build-deps.sh --force` (needed because local deps were stale)
- `bash build.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh`
- `bash run-integration-smoke.sh`
