### PR TITLE
[bug-hunter] Fix Bluetooth output dictation readiness

### DIFF
--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -161,6 +161,14 @@ enum ParakeetAudioFormatReadinessPolicy {
             return .routeNotSettled
         }
 
+        if selectionOverrodeDefault,
+           selectedInputClass != "bluetooth",
+           outputDeviceClass == "bluetooth",
+           inputSampleRate >= 44_100,
+           likelyBluetoothSpeechRates.contains(Int(outputSampleRate.rounded())) {
+            return .routeNotSettled
+        }
+
         return .ready
     }
 

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -186,7 +186,7 @@ func testParakeetStartRecordingFailurePolicy() {
         assertEqual(readiness, .ready, "AirPods HFP 24k hardware to 48k output should remain valid")
     }
 
-    runSuite("ParakeetAudioFormatReadinessPolicy accepts built-in mic with Bluetooth output speech bus") {
+    runSuite("ParakeetAudioFormatReadinessPolicy defers built-in override with Bluetooth output speech bus") {
         let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
             outputSampleRate: 24_000,
             outputChannelCount: 1,
@@ -197,7 +197,21 @@ func testParakeetStartRecordingFailurePolicy() {
             selectionOverrodeDefault: true
         )
 
-        assertEqual(readiness, .ready, "built-in mic with Bluetooth output can capture at the 24k bus and resample")
+        assertEqual(readiness, .routeNotSettled, "built-in override with a 24k Bluetooth output bus should wait for CoreAudio to settle")
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy accepts intentional Bluetooth output speech bus") {
+        let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: 24_000,
+            outputChannelCount: 1,
+            inputSampleRate: 48_000,
+            inputChannelCount: 1,
+            selectedInputClass: "built_in",
+            outputDeviceClass: "bluetooth",
+            selectionOverrodeDefault: false
+        )
+
+        assertEqual(readiness, .ready, "native built-in capture with Bluetooth output can still use the speech bus when Transcripted did not force an input override")
     }
 
     runSuite("ParakeetAudioFormatReadinessPolicy defers stale AirPods-to-built-in switch formats") {


### PR DESCRIPTION
## Summary
- treats forced built-in-mic dictation over a Bluetooth speech output bus as route-not-settled instead of ready
- keeps intentional Bluetooth-output speech-bus capture allowed when Transcripted did not override the input
- updates the route-readiness regression coverage

## Signal
Sentry issue `APPLE-MACOS-14` is unresolved and repeated on the latest shipped release `transcripted@1.1.42`: two last-24h `dictation.microphone_start_timeout` events. PostHog also shows two `dictation_start_failed` events on `1.1.42`, both `microphone_start_timeout` on `built_in_input_to_bluetooth_output`.

## Root Cause
When Transcripted overrides a Bluetooth headset mic to the built-in mic, the readiness policy still accepted a low-rate Bluetooth output bus as ready, so dictation could repeatedly attempt startup before CoreAudio finished settling.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh`
