### PR TITLE
[codex] Fix meeting audio playback echo

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -2237,6 +2237,7 @@ private struct HomeMeetingPodcastPlayer: View {
     let audio: MeetingAudioAttachment
 
     @ObservedObject private var playback = MeetingAudioPlayback.shared
+    @State private var selectedPlaybackChoiceID: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 11) {
@@ -2255,6 +2256,15 @@ private struct HomeMeetingPodcastPlayer: View {
                     }
 
                     Spacer()
+
+                    MeetingAudioSourceMenu(
+                        attachment: audio,
+                        selectedChoiceID: selectedPlaybackChoiceBinding
+                    ) { choice in
+                        if playback.isActive(audio) {
+                            playback.switchSource(audio, choice: choice)
+                        }
+                    }
                 }
 
                 HStack(spacing: 14) {
@@ -2269,13 +2279,13 @@ private struct HomeMeetingPodcastPlayer: View {
                     }
 
                     HomePodcastPlayerButton(
-                        symbolName: playback.symbolName(for: audio),
+                        symbolName: playback.symbolName(for: audio, choice: selectedPlaybackChoice),
                         size: 46,
-                        isPrimary: playback.isActive(audio),
+                        isPrimary: playback.isActive(audio, choice: selectedPlaybackChoice),
                         isDisabled: false,
-                        help: "\(playback.buttonTitle(for: audio)) meeting audio"
+                        help: "\(playback.buttonTitle(for: audio, choice: selectedPlaybackChoice)) meeting audio"
                     ) {
-                        playback.toggle(audio)
+                        playback.toggle(audio, choice: selectedPlaybackChoice)
                     }
 
                     HomePodcastPlayerButton(
@@ -2310,6 +2320,17 @@ private struct HomeMeetingPodcastPlayer: View {
 
     private var canSeek: Bool {
         playback.isActive(audio) && playback.duration > 0
+    }
+
+    private var selectedPlaybackChoice: MeetingAudioPlaybackChoice? {
+        playback.activeChoice(for: audio) ?? audio.playbackChoice(id: selectedPlaybackChoiceID)
+    }
+
+    private var selectedPlaybackChoiceBinding: Binding<String?> {
+        Binding(
+            get: { selectedPlaybackChoice?.id },
+            set: { selectedPlaybackChoiceID = $0 }
+        )
     }
 }
 
@@ -2638,6 +2659,7 @@ private struct HomeFailedMeetingRow: View {
     let onClear: () -> Void
 
     @ObservedObject private var playback = MeetingAudioPlayback.shared
+    @State private var selectedPlaybackChoiceID: String?
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
@@ -2662,18 +2684,28 @@ private struct HomeFailedMeetingRow: View {
 
                 HStack(spacing: 8) {
                     if let audio {
+                        let selectedChoice = selectedPlaybackChoice(for: audio)
                         HomeMeetingAudioControl(
-                            title: playback.buttonTitle(for: audio),
-                            symbolName: playback.symbolName(for: audio),
-                            isActive: playback.isActive(audio),
-                            isPlaying: playback.isPlaying && playback.isActive(audio),
+                            title: playback.buttonTitle(for: audio, choice: selectedChoice),
+                            symbolName: playback.symbolName(for: audio, choice: selectedChoice),
+                            isActive: playback.isActive(audio, choice: selectedChoice),
+                            isPlaying: playback.isPlaying && playback.isActive(audio, choice: selectedChoice),
                             scrubber: playback.isActive(audio)
                                 ? AnyView(MeetingAudioScrubber(attachment: audio, width: 190))
                                 : nil
                         ) {
-                            playback.toggle(audio)
+                            playback.toggle(audio, choice: selectedChoice)
                         }
-                        .help("\(playback.buttonTitle(for: audio)) retained meeting audio")
+                        .help("\(playback.buttonTitle(for: audio, choice: selectedChoice)) retained meeting audio")
+
+                        MeetingAudioSourceMenu(
+                            attachment: audio,
+                            selectedChoiceID: selectedPlaybackChoiceBinding(for: audio)
+                        ) { choice in
+                            if playback.isActive(audio) {
+                                playback.switchSource(audio, choice: choice)
+                            }
+                        }
 
                         SettingsInlineActionButton(title: "Show Audio", symbolName: "folder") {
                             onRevealAudio()
@@ -2737,5 +2769,16 @@ private struct HomeFailedMeetingRow: View {
 
     private var hasRetainedAudioFiles: Bool {
         !item.audioURLs.isEmpty
+    }
+
+    private func selectedPlaybackChoice(for audio: MeetingAudioAttachment) -> MeetingAudioPlaybackChoice? {
+        playback.activeChoice(for: audio) ?? audio.playbackChoice(id: selectedPlaybackChoiceID)
+    }
+
+    private func selectedPlaybackChoiceBinding(for audio: MeetingAudioAttachment) -> Binding<String?> {
+        Binding(
+            get: { selectedPlaybackChoice(for: audio)?.id },
+            set: { selectedPlaybackChoiceID = $0 }
+        )
     }
 }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1059,11 +1059,7 @@ struct TranscriptedSettingsView: View {
     private func failedMeetingAudioAttachment(
         for item: MeetingSessionController.FailedMeetingItem
     ) -> MeetingAudioAttachment? {
-        guard let firstAudioURL = item.audioURLs.first else { return nil }
-        return MeetingAudioAttachment(
-            directoryURL: firstAudioURL.deletingLastPathComponent(),
-            urls: item.audioURLs
-        )
+        MeetingAudioAttachment.retainedAudio(urls: item.audioURLs)
     }
 
     private func revealFailedMeetingAudio(_ item: MeetingSessionController.FailedMeetingItem) {
@@ -3864,6 +3860,7 @@ private struct SettingsFailedMeetingRow: View {
     let revealAudioAction: () -> Void
     let secondaryAction: () -> Void
     @ObservedObject private var playback = MeetingAudioPlayback.shared
+    @State private var selectedPlaybackChoiceID: String?
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
@@ -3896,18 +3893,28 @@ private struct SettingsFailedMeetingRow: View {
             Spacer(minLength: 12)
 
             if let audio {
+                let selectedChoice = selectedPlaybackChoice(for: audio)
                 SettingsRecentMeetingAudioControl(
-                    title: playback.buttonTitle(for: audio),
-                    symbolName: playback.symbolName(for: audio),
-                    isActive: playback.isActive(audio),
-                    isPlaying: playback.isPlaying && playback.isActive(audio),
+                    title: playback.buttonTitle(for: audio, choice: selectedChoice),
+                    symbolName: playback.symbolName(for: audio, choice: selectedChoice),
+                    isActive: playback.isActive(audio, choice: selectedChoice),
+                    isPlaying: playback.isPlaying && playback.isActive(audio, choice: selectedChoice),
                     scrubber: playback.isActive(audio)
                         ? AnyView(MeetingAudioScrubber(attachment: audio, width: 190))
                         : nil
                 ) {
-                    playback.toggle(audio)
+                    playback.toggle(audio, choice: selectedChoice)
                 }
-                .help("\(playback.buttonTitle(for: audio)) retained meeting audio")
+                .help("\(playback.buttonTitle(for: audio, choice: selectedChoice)) retained meeting audio")
+
+                MeetingAudioSourceMenu(
+                    attachment: audio,
+                    selectedChoiceID: selectedPlaybackChoiceBinding(for: audio)
+                ) { choice in
+                    if playback.isActive(audio) {
+                        playback.switchSource(audio, choice: choice)
+                    }
+                }
 
                 Button {
                     revealAudioAction()
@@ -3985,6 +3992,17 @@ private struct SettingsFailedMeetingRow: View {
 
     private var hasRetainedAudioFiles: Bool {
         !item.audioURLs.isEmpty
+    }
+
+    private func selectedPlaybackChoice(for audio: MeetingAudioAttachment) -> MeetingAudioPlaybackChoice? {
+        playback.activeChoice(for: audio) ?? audio.playbackChoice(id: selectedPlaybackChoiceID)
+    }
+
+    private func selectedPlaybackChoiceBinding(for audio: MeetingAudioAttachment) -> Binding<String?> {
+        Binding(
+            get: { selectedPlaybackChoice(for: audio)?.id },
+            set: { selectedPlaybackChoiceID = $0 }
+        )
     }
 }
 

--- a/Sources/UI/Shared/MeetingAudioArchiveResolver.swift
+++ b/Sources/UI/Shared/MeetingAudioArchiveResolver.swift
@@ -8,8 +8,34 @@ struct MeetingAudioAttachment: Equatable, Sendable {
         urls.map { $0.standardizedFileURL.path }.joined(separator: "|")
     }
 
+    var playbackURLs: [URL] {
+        if urls.count <= 1 { return urls }
+        if let playbackURL = firstAudioFile(named: "playback", in: urls) {
+            return [playbackURL]
+        }
+        if let importedURL = firstAudioFile(named: "recording", in: urls) {
+            return [importedURL]
+        }
+        if let systemURL = firstAudioFile(named: "system_audio", in: urls) {
+            return [systemURL]
+        }
+        if let microphoneURL = firstAudioFile(named: "microphone", in: urls) {
+            return [microphoneURL]
+        }
+        return [urls[0]]
+    }
+
     var isCompositePlayback: Bool {
-        urls.count > 1
+        playbackURLs.count > 1
+    }
+
+    private func firstAudioFile(named stem: String, in urls: [URL]) -> URL? {
+        urls
+            .filter { $0.deletingPathExtension().lastPathComponent == stem }
+            .sorted { lhs, rhs in
+                lhs.pathExtension.localizedCaseInsensitiveCompare(rhs.pathExtension) == .orderedAscending
+            }
+            .first
     }
 }
 

--- a/Sources/UI/Shared/MeetingAudioArchiveResolver.swift
+++ b/Sources/UI/Shared/MeetingAudioArchiveResolver.swift
@@ -1,32 +1,94 @@
 import Foundation
 
+struct MeetingAudioPlaybackChoice: Equatable, Identifiable, Sendable {
+    let id: String
+    let title: String
+    let symbolName: String
+    let urls: [URL]
+}
+
 struct MeetingAudioAttachment: Equatable, Sendable {
     let directoryURL: URL
     let urls: [URL]
+
+    static func retainedAudio(urls: [URL]) -> MeetingAudioAttachment? {
+        guard let firstURL = urls.first else { return nil }
+        return MeetingAudioAttachment(
+            directoryURL: firstURL.deletingLastPathComponent(),
+            urls: urls
+        )
+    }
 
     var id: String {
         urls.map { $0.standardizedFileURL.path }.joined(separator: "|")
     }
 
     var playbackURLs: [URL] {
-        if urls.count <= 1 { return urls }
-        if let playbackURL = firstAudioFile(named: "playback", in: urls) {
-            return [playbackURL]
+        defaultPlaybackChoice?.urls ?? []
+    }
+
+    var playbackURLCandidates: [[URL]] {
+        playbackChoices.map(\.urls)
+    }
+
+    var playbackChoices: [MeetingAudioPlaybackChoice] {
+        if urls.count <= 1 {
+            return urls.map { playbackChoice(for: $0) }
         }
-        if let importedURL = firstAudioFile(named: "recording", in: urls) {
-            return [importedURL]
+
+        let preferredURLs = preferredAudioFiles(in: urls)
+        if !preferredURLs.isEmpty {
+            return preferredURLs.map { playbackChoice(for: $0) }
         }
-        if let systemURL = firstAudioFile(named: "system_audio", in: urls) {
-            return [systemURL]
-        }
-        if let microphoneURL = firstAudioFile(named: "microphone", in: urls) {
-            return [microphoneURL]
-        }
-        return [urls[0]]
+
+        return urls.map { playbackChoice(for: $0) }
+    }
+
+    var defaultPlaybackChoice: MeetingAudioPlaybackChoice? {
+        playbackChoices.first
+    }
+
+    func playbackChoice(id: String?) -> MeetingAudioPlaybackChoice? {
+        guard let id else { return defaultPlaybackChoice }
+        return playbackChoices.first { $0.id == id } ?? defaultPlaybackChoice
     }
 
     var isCompositePlayback: Bool {
         playbackURLs.count > 1
+    }
+
+    private func preferredAudioFiles(in urls: [URL]) -> [URL] {
+        let preferredStems = ["playback", "recording", "system_audio", "microphone"]
+        let preferredURLs = preferredStems.compactMap { firstAudioFile(named: $0, in: urls) }
+        let preferredPaths = Set(preferredURLs.map { $0.standardizedFileURL.path })
+        let remainingURLs = urls.filter { !preferredPaths.contains($0.standardizedFileURL.path) }
+        return preferredURLs + remainingURLs
+    }
+
+    private func playbackChoice(for url: URL) -> MeetingAudioPlaybackChoice {
+        let stem = url.deletingPathExtension().lastPathComponent
+        let metadata = playbackChoiceMetadata(for: stem)
+        return MeetingAudioPlaybackChoice(
+            id: "\(stem):\(url.standardizedFileURL.path)",
+            title: metadata.title,
+            symbolName: metadata.symbolName,
+            urls: [url]
+        )
+    }
+
+    private func playbackChoiceMetadata(for stem: String) -> (title: String, symbolName: String) {
+        switch stem {
+        case "playback":
+            return ("Mix", "waveform")
+        case "recording":
+            return ("Recording", "waveform")
+        case "system_audio":
+            return ("System", "speaker.wave.2.fill")
+        case "microphone":
+            return ("Mic", "mic.fill")
+        default:
+            return ("Audio", "waveform")
+        }
     }
 
     private func firstAudioFile(named stem: String, in urls: [URL]) -> URL? {

--- a/Sources/UI/Shared/MeetingAudioPlayback.swift
+++ b/Sources/UI/Shared/MeetingAudioPlayback.swift
@@ -10,56 +10,88 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
     @Published private(set) var activeAttachmentID: String?
     @Published private(set) var isPlaying = false
     @Published private(set) var isPaused = false
-    @Published private(set) var unavailableAttachmentID: String?
+    @Published private(set) var unavailablePlaybackID: String?
     @Published private(set) var currentTime: TimeInterval = 0
     @Published private(set) var duration: TimeInterval = 0
+    @Published private(set) var activeChoiceID: String?
 
     private var sounds: [NSSound] = []
     private var progressTimer: Timer?
 
-    func toggle(_ attachment: MeetingAudioAttachment) {
-        if activeAttachmentID == attachment.id {
+    func toggle(_ attachment: MeetingAudioAttachment, choice: MeetingAudioPlaybackChoice? = nil) {
+        let choiceID = (choice ?? attachment.defaultPlaybackChoice)?.id
+        if activeAttachmentID == attachment.id && activeChoiceID == choiceID {
             if isPlaying {
                 pause()
             } else if isPaused {
                 resume()
             } else {
-                play(attachment)
+                play(attachment, choice: choice)
             }
             return
         }
 
-        play(attachment)
+        play(attachment, choice: choice)
     }
 
-    func play(_ attachment: MeetingAudioAttachment) {
-        stop()
+    func play(_ attachment: MeetingAudioAttachment, choice: MeetingAudioPlaybackChoice? = nil) {
+        play(attachment, choice: choice, startTime: 0, startPaused: false)
+    }
 
-        let loadedSounds = attachment.playbackURLs.compactMap { url in
-            NSSound(contentsOf: url, byReference: true)
+    func switchSource(_ attachment: MeetingAudioAttachment, choice: MeetingAudioPlaybackChoice) {
+        guard isActive(attachment) else {
+            play(attachment, choice: choice)
+            return
         }
 
-        guard !loadedSounds.isEmpty else {
-            unavailableAttachmentID = attachment.id
+        play(
+            attachment,
+            choice: choice,
+            startTime: currentTime,
+            startPaused: isPaused
+        )
+    }
+
+    private func play(
+        _ attachment: MeetingAudioAttachment,
+        choice: MeetingAudioPlaybackChoice?,
+        startTime: TimeInterval,
+        startPaused: Bool
+    ) {
+        stop()
+
+        let requestedChoice = choice ?? attachment.defaultPlaybackChoice
+        guard let loadedPlayback = loadPlaybackSounds(for: attachment, preferredChoice: requestedChoice) else {
+            unavailablePlaybackID = playbackID(for: attachment, choice: requestedChoice)
             NSSound.beep()
             return
         }
 
-        unavailableAttachmentID = nil
+        let loadedSounds = loadedPlayback.sounds
+
+        unavailablePlaybackID = nil
         activeAttachmentID = attachment.id
+        activeChoiceID = loadedPlayback.choice.id
         sounds = loadedSounds
         duration = loadedSounds.map(\.duration).max() ?? 0
-        currentTime = 0
-        isPlaying = true
-        isPaused = false
+        currentTime = min(max(startTime, 0), duration)
+        isPlaying = !startPaused
+        isPaused = startPaused
 
         for sound in sounds {
             sound.delegate = self
-            sound.currentTime = 0
+            sound.currentTime = min(currentTime, max(sound.duration, 0))
             sound.play()
+            if startPaused {
+                sound.pause()
+            }
         }
 
-        startProgressTimer()
+        if startPaused {
+            stopProgressTimer()
+        } else {
+            startProgressTimer()
+        }
     }
 
     func pause() {
@@ -93,15 +125,27 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         }
         sounds.removeAll()
         activeAttachmentID = nil
+        activeChoiceID = nil
         isPlaying = false
         isPaused = false
-        unavailableAttachmentID = nil
+        unavailablePlaybackID = nil
         currentTime = 0
         duration = 0
     }
 
     func isActive(_ attachment: MeetingAudioAttachment) -> Bool {
         activeAttachmentID == attachment.id
+    }
+
+    func isActive(_ attachment: MeetingAudioAttachment, choice: MeetingAudioPlaybackChoice?) -> Bool {
+        guard activeAttachmentID == attachment.id else { return false }
+        guard let choice else { return true }
+        return activeChoiceID == choice.id
+    }
+
+    func activeChoice(for attachment: MeetingAudioAttachment) -> MeetingAudioPlaybackChoice? {
+        guard activeAttachmentID == attachment.id else { return nil }
+        return attachment.playbackChoice(id: activeChoiceID)
     }
 
     func seek(_ attachment: MeetingAudioAttachment, progress: Double) {
@@ -142,19 +186,23 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         return "\(Self.formatTime(currentTime)) / \(Self.formatTime(duration))"
     }
 
-    func buttonTitle(for attachment: MeetingAudioAttachment) -> String {
-        if unavailableAttachmentID == attachment.id { return "Unavailable" }
-        guard isActive(attachment) else { return "Play" }
+    func buttonTitle(for attachment: MeetingAudioAttachment, choice: MeetingAudioPlaybackChoice? = nil) -> String {
+        if isUnavailable(attachment, choice: choice) { return "Unavailable" }
+        guard isActive(attachment, choice: choice) else { return "Play" }
         if isPlaying { return "Pause" }
         if isPaused { return "Resume" }
         return "Play"
     }
 
-    func symbolName(for attachment: MeetingAudioAttachment) -> String {
-        if unavailableAttachmentID == attachment.id { return "exclamationmark.triangle.fill" }
-        guard isActive(attachment) else { return "play.fill" }
+    func symbolName(for attachment: MeetingAudioAttachment, choice: MeetingAudioPlaybackChoice? = nil) -> String {
+        if isUnavailable(attachment, choice: choice) { return "exclamationmark.triangle.fill" }
+        guard isActive(attachment, choice: choice) else { return "play.fill" }
         if isPlaying { return "pause.fill" }
         return "play.fill"
+    }
+
+    func isUnavailable(_ attachment: MeetingAudioAttachment, choice: MeetingAudioPlaybackChoice? = nil) -> Bool {
+        unavailablePlaybackID == playbackID(for: attachment, choice: choice ?? attachment.defaultPlaybackChoice)
     }
 
     nonisolated func sound(_ sound: NSSound, didFinishPlaying finishedPlaying: Bool) {
@@ -167,6 +215,22 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         guard !isPaused else { return }
         guard !sounds.contains(where: { $0.isPlaying }) else { return }
         stop()
+    }
+
+    private func loadPlaybackSounds(
+        for attachment: MeetingAudioAttachment,
+        preferredChoice: MeetingAudioPlaybackChoice?
+    ) -> (choice: MeetingAudioPlaybackChoice, sounds: [NSSound])? {
+        for choice in MeetingAudioPlaybackLoadingPolicy.choices(for: attachment, preferredChoice: preferredChoice) {
+            let loadedSounds = choice.urls.compactMap { url in
+                NSSound(contentsOf: url, byReference: true)
+            }
+            if loadedSounds.count == choice.urls.count, !loadedSounds.isEmpty {
+                return (choice, loadedSounds)
+            }
+        }
+
+        return nil
     }
 
     private func startProgressTimer() {
@@ -196,6 +260,10 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         currentTime = min(max(latestTime, 0), duration)
     }
 
+    private func playbackID(for attachment: MeetingAudioAttachment, choice: MeetingAudioPlaybackChoice?) -> String {
+        "\(attachment.id)#\(choice?.id ?? "default")"
+    }
+
     private static func formatTime(_ time: TimeInterval) -> String {
         let totalSeconds = max(0, Int(time.rounded(.down)))
         let hours = totalSeconds / 3600
@@ -207,6 +275,72 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
         }
 
         return String(format: "%d:%02d", minutes, seconds)
+    }
+}
+
+enum MeetingAudioPlaybackLoadingPolicy {
+    static func choices(
+        for attachment: MeetingAudioAttachment,
+        preferredChoice: MeetingAudioPlaybackChoice?
+    ) -> [MeetingAudioPlaybackChoice] {
+        let choices = attachment.playbackChoices
+        guard let preferredChoice else {
+            return choices.first.map { [$0] } ?? []
+        }
+        guard choices.contains(where: { $0.id == preferredChoice.id }) else {
+            return choices.first.map { [$0] } ?? []
+        }
+
+        // Source-aware controls should not silently switch from System to Mic.
+        // If the selected source cannot load, the user can choose another retained source.
+        return [preferredChoice]
+    }
+}
+
+struct MeetingAudioSourceMenu: View {
+    let attachment: MeetingAudioAttachment
+    @Binding var selectedChoiceID: String?
+    var onSelect: (MeetingAudioPlaybackChoice) -> Void = { _ in }
+
+    private var choices: [MeetingAudioPlaybackChoice] {
+        attachment.playbackChoices
+    }
+
+    private var selectedChoice: MeetingAudioPlaybackChoice? {
+        attachment.playbackChoice(id: selectedChoiceID)
+    }
+
+    var body: some View {
+        if choices.count > 1, let selectedChoice {
+            Menu {
+                ForEach(choices) { choice in
+                    Button {
+                        selectedChoiceID = choice.id
+                        onSelect(choice)
+                    } label: {
+                        Label(choice.title, systemImage: choice.id == selectedChoice.id ? "checkmark" : choice.symbolName)
+                    }
+                }
+            } label: {
+                HStack(spacing: 5) {
+                    Image(systemName: selectedChoice.symbolName)
+                        .font(.system(size: 10, weight: .semibold))
+                    Text(selectedChoice.title)
+                        .font(.caption.weight(.semibold))
+                        .lineLimit(1)
+                }
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(Color.secondary.opacity(0.08))
+                )
+            }
+            .buttonStyle(.plain)
+            .fixedSize()
+            .help("Choose retained meeting audio source")
+        }
     }
 }
 

--- a/Sources/UI/Shared/MeetingAudioPlayback.swift
+++ b/Sources/UI/Shared/MeetingAudioPlayback.swift
@@ -35,7 +35,7 @@ final class MeetingAudioPlayback: NSObject, ObservableObject, NSSoundDelegate {
     func play(_ attachment: MeetingAudioAttachment) {
         stop()
 
-        let loadedSounds = attachment.urls.compactMap { url in
+        let loadedSounds = attachment.playbackURLs.compactMap { url in
             NSSound(contentsOf: url, byReference: true)
         }
 

--- a/Tests/MeetingAudioArchiveResolverTests.swift
+++ b/Tests/MeetingAudioArchiveResolverTests.swift
@@ -2,14 +2,16 @@ import Foundation
 
 func testMeetingAudioArchiveResolver() {
     runSuite("MeetingAudioArchiveResolverTests") {
-        testResolverFindsLiveMeetingAudioPair()
+        testResolverKeepsLiveMeetingAudioPairButPrefersSystemPlayback()
+        testResolverFallsBackToMicrophonePlayback()
+        testAttachmentPlaybackPrefersSystemForFailedMeetingAudio()
         testResolverPrefersImportedRecording()
         testResolverPrefersPlaybackMix()
         testResolverReturnsNilWhenAudioIsMissing()
     }
 }
 
-private func testResolverFindsLiveMeetingAudioPair() {
+private func testResolverKeepsLiveMeetingAudioPairButPrefersSystemPlayback() {
     let directory = makeMeetingAudioResolverTestDirectory()
     defer { try? FileManager.default.removeItem(at: directory) }
 
@@ -31,9 +33,65 @@ private func testResolverFindsLiveMeetingAudioPair() {
     assertEqual(
         attachment?.urls.map(\.lastPathComponent),
         ["system_audio.wav", "microphone.wav"],
-        "Live playback should include system audio and microphone together"
+        "Live meetings should keep both retained source files available"
     )
-    assertTrue(attachment?.isCompositePlayback == true, "Two retained streams should be treated as composite playback")
+    assertEqual(
+        attachment?.playbackURLs.map(\.lastPathComponent),
+        ["system_audio.wav"],
+        "Live meeting playback should prefer the clean system track over mic+system echo"
+    )
+    assertTrue(attachment?.isCompositePlayback == false, "Live playback should not layer mic and system audio by default")
+}
+
+private func testResolverFallsBackToMicrophonePlayback() {
+    let directory = makeMeetingAudioResolverTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("In Room Meeting.md")
+    let audioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: transcriptURL)
+    try? FileManager.default.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+    FileManager.default.createFile(
+        atPath: audioDirectory.appendingPathComponent("microphone.wav").path,
+        contents: Data("mic".utf8)
+    )
+
+    let attachment = MeetingAudioArchiveResolver.attachment(forTranscript: transcriptURL)
+
+    assertEqual(
+        attachment?.urls.map(\.lastPathComponent),
+        ["microphone.wav"],
+        "Mic-only retained audio should still resolve"
+    )
+    assertEqual(
+        attachment?.playbackURLs.map(\.lastPathComponent),
+        ["microphone.wav"],
+        "Mic-only retained audio should remain playable when system audio is missing"
+    )
+    assertTrue(attachment?.isCompositePlayback == false, "A mic fallback should stay single-file playback")
+}
+
+private func testAttachmentPlaybackPrefersSystemForFailedMeetingAudio() {
+    let directory = makeMeetingAudioResolverTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let systemURL = directory.appendingPathComponent("system_audio.wav")
+    let micURL = directory.appendingPathComponent("microphone.wav")
+    let attachment = MeetingAudioAttachment(
+        directoryURL: directory,
+        urls: [micURL, systemURL]
+    )
+
+    assertEqual(
+        attachment.urls.map(\.lastPathComponent),
+        ["microphone.wav", "system_audio.wav"],
+        "Failed-meeting attachments should preserve all retained source URLs"
+    )
+    assertEqual(
+        attachment.playbackURLs.map(\.lastPathComponent),
+        ["system_audio.wav"],
+        "Failed-meeting playback should also avoid layering mic and system audio"
+    )
+    assertTrue(attachment.isCompositePlayback == false, "Failed-meeting playback should default to one source")
 }
 
 private func testResolverPrefersImportedRecording() {
@@ -58,6 +116,11 @@ private func testResolverPrefersImportedRecording() {
         attachment?.urls.map(\.lastPathComponent),
         ["recording.m4a"],
         "Imported recordings should play the original retained recording"
+    )
+    assertEqual(
+        attachment?.playbackURLs.map(\.lastPathComponent),
+        ["recording.m4a"],
+        "Imported recordings should keep the same single playback source"
     )
     assertTrue(attachment?.isCompositePlayback == false, "A single imported recording is not composite playback")
 }
@@ -92,6 +155,11 @@ private func testResolverPrefersPlaybackMix() {
         attachment?.urls.map(\.lastPathComponent),
         ["playback.m4a"],
         "Playback mixes should win over imported and split-stream audio"
+    )
+    assertEqual(
+        attachment?.playbackURLs.map(\.lastPathComponent),
+        ["playback.m4a"],
+        "Playback mixes should remain the default listening source"
     )
     assertTrue(attachment?.isCompositePlayback == false, "A single playback mix is not composite playback")
 }

--- a/Tests/MeetingAudioArchiveResolverTests.swift
+++ b/Tests/MeetingAudioArchiveResolverTests.swift
@@ -5,6 +5,9 @@ func testMeetingAudioArchiveResolver() {
         testResolverKeepsLiveMeetingAudioPairButPrefersSystemPlayback()
         testResolverFallsBackToMicrophonePlayback()
         testAttachmentPlaybackPrefersSystemForFailedMeetingAudio()
+        testRetainedAudioFactoryPreservesFailedMeetingSources()
+        testPlaybackLoadingPolicyUsesDefaultSourceOnly()
+        testPlaybackLoadingPolicyUsesSelectedSourceOnly()
         testResolverPrefersImportedRecording()
         testResolverPrefersPlaybackMix()
         testResolverReturnsNilWhenAudioIsMissing()
@@ -39,6 +42,16 @@ private func testResolverKeepsLiveMeetingAudioPairButPrefersSystemPlayback() {
         attachment?.playbackURLs.map(\.lastPathComponent),
         ["system_audio.wav"],
         "Live meeting playback should prefer the clean system track over mic+system echo"
+    )
+    assertEqual(
+        attachment?.playbackURLCandidates.map { $0.map(\.lastPathComponent).joined(separator: "+") },
+        ["system_audio.wav", "microphone.wav"],
+        "Live meeting playback should offer each retained source without layering them"
+    )
+    assertEqual(
+        attachment?.playbackChoices.map(\.title),
+        ["System", "Mic"],
+        "Live meeting playback should make the mic track selectable when system is the default"
     )
     assertTrue(attachment?.isCompositePlayback == false, "Live playback should not layer mic and system audio by default")
 }
@@ -91,7 +104,103 @@ private func testAttachmentPlaybackPrefersSystemForFailedMeetingAudio() {
         ["system_audio.wav"],
         "Failed-meeting playback should also avoid layering mic and system audio"
     )
+    assertEqual(
+        attachment.playbackURLCandidates.map { $0.map(\.lastPathComponent).joined(separator: "+") },
+        ["system_audio.wav", "microphone.wav"],
+        "Failed-meeting playback should offer each retained source without layering them"
+    )
+    assertEqual(
+        attachment.playbackChoices.map(\.title),
+        ["System", "Mic"],
+        "Failed-meeting playback should make the mic track selectable when system is the default"
+    )
     assertTrue(attachment.isCompositePlayback == false, "Failed-meeting playback should default to one source")
+}
+
+private func testRetainedAudioFactoryPreservesFailedMeetingSources() {
+    let directory = makeMeetingAudioResolverTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let micURL = directory.appendingPathComponent("microphone.wav")
+    let systemURL = directory.appendingPathComponent("system_audio.wav")
+
+    let attachment = MeetingAudioAttachment.retainedAudio(urls: [micURL, systemURL])
+
+    assertNotNil(attachment, "Failed-meeting retained audio should build a playback attachment")
+    assertEqual(
+        attachment?.directoryURL,
+        directory,
+        "Failed-meeting retained audio should use the retained audio directory"
+    )
+    assertEqual(
+        attachment?.urls.map(\.lastPathComponent),
+        ["microphone.wav", "system_audio.wav"],
+        "Failed-meeting retained audio should keep every source for retry/debug access"
+    )
+    assertEqual(
+        attachment?.playbackURLs.map(\.lastPathComponent),
+        ["system_audio.wav"],
+        "Failed-meeting retained audio should still default to one clean source"
+    )
+}
+
+private func testPlaybackLoadingPolicyUsesDefaultSourceOnly() {
+    let directory = makeMeetingAudioResolverTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let attachment = MeetingAudioAttachment(
+        directoryURL: directory,
+        urls: [
+            directory.appendingPathComponent("microphone.wav"),
+            directory.appendingPathComponent("system_audio.wav")
+        ]
+    )
+
+    let choices = MeetingAudioPlaybackLoadingPolicy.choices(
+        for: attachment,
+        preferredChoice: nil
+    )
+
+    assertEqual(
+        choices.map(\.title),
+        ["System"],
+        "The player should load only the default source instead of compositing mic plus system"
+    )
+    assertEqual(
+        choices.flatMap(\.urls).map(\.lastPathComponent),
+        ["system_audio.wav"],
+        "Default playback should not hand both retained files to NSSound"
+    )
+}
+
+private func testPlaybackLoadingPolicyUsesSelectedSourceOnly() {
+    let directory = makeMeetingAudioResolverTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let attachment = MeetingAudioAttachment(
+        directoryURL: directory,
+        urls: [
+            directory.appendingPathComponent("microphone.wav"),
+            directory.appendingPathComponent("system_audio.wav")
+        ]
+    )
+    let micChoice = attachment.playbackChoices.first { $0.title == "Mic" }
+
+    let choices = MeetingAudioPlaybackLoadingPolicy.choices(
+        for: attachment,
+        preferredChoice: micChoice
+    )
+
+    assertEqual(
+        choices.map(\.title),
+        ["Mic"],
+        "When the user chooses Mic, the player should load Mic without also adding System"
+    )
+    assertEqual(
+        choices.flatMap(\.urls).map(\.lastPathComponent),
+        ["microphone.wav"],
+        "Selected mic playback should stay single-source"
+    )
 }
 
 private func testResolverPrefersImportedRecording() {


### PR DESCRIPTION
## Summary

Fixes #827.

Recorded live meetings retain both `system_audio` and `microphone`. The echo was in review playback: Transcripted was loading every retained URL and playing them together, so laptop speaker bleed in the mic could be heard twice.

This keeps mic/system files available for transcription, retry, and debug, but makes review playback single-source by default:

- `playback.*` when present
- `recording.*` for imported audio
- `system_audio.*` for live meetings
- `microphone.*` when system audio is missing or when the user selects Mic

The UI now has a small source picker for retained System/Mic audio, and source switching preserves playback time/pause state. No capture, transcription, RealtimeAGC, or voice-processing behavior changed.

## Validation

- `bash build.sh`
- `bash run-tests.sh` — 2288 passed
- `bash run-integration-smoke.sh`
- `~/.codex/skills/codex-review/scripts/codex-review --mode branch --base origin/main` — clean

`swift test` was not required because this patch did not touch `Sources/TranscriptedCore` or `Package.swift`.