### PR TITLE
[codex] Fix long meeting failed-state refresh

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -629,7 +629,7 @@ final class MeetingSessionController: ObservableObject {
         )
 
         guard let micURL = files.micURL else {
-            let preserved = taskManager.addFailedTranscriptionRetainingAvailableAudio(
+            let preserved = preserveFailedMeetingForRetry(
                 micAudioURL: nil,
                 systemAudioURL: files.systemURL,
                 errorMessage: "Recording stopped without microphone audio.",
@@ -648,9 +648,6 @@ final class MeetingSessionController: ObservableObject {
                     ]
                 )
             )
-            if preserved {
-                refreshFailedMeetings()
-            }
             Self.runtimeDiagnosticsRecorder?.clearSession(
                 kind: "meeting",
                 outcome: files.systemURL == nil ? "no_audio_captured" : "missing_mic_audio"
@@ -676,7 +673,7 @@ final class MeetingSessionController: ObservableObject {
                     "reason": reason.rawValue
                 ]
             )
-            taskManager.addFailedTranscriptionRetainingAudio(
+            let preserved = preserveFailedMeetingForRetry(
                 micAudioURL: micURL,
                 systemAudioURL: files.systemURL,
                 errorMessage: "Recording stop timed out before audio files were finalized.",
@@ -687,7 +684,12 @@ final class MeetingSessionController: ObservableObject {
                 engine: "meeting",
                 event: "meeting_recording_stop_timeout_failed",
                 message: "Meeting routed to failed queue due to stop timeout",
-                context: baseDiagnosticsContext(extra: ["reason": reason.rawValue])
+                context: baseDiagnosticsContext(
+                    extra: [
+                        "reason": reason.rawValue,
+                        "preserved_for_retry": boolString(preserved)
+                    ]
+                )
             )
             state = .error("Recording didn't close cleanly. Open Transcripted Home to retry.")
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "stop_timeout")
@@ -967,7 +969,7 @@ final class MeetingSessionController: ObservableObject {
         for job in queuedJobs + [preparingJob].compactMap({ $0 }) {
             switch job.kind {
             case .recorded(let micURL, let systemURL, _, let meetingTitle):
-                taskManager.addFailedTranscriptionRetainingAudio(
+                preserveFailedMeetingForRetry(
                     micAudioURL: micURL,
                     systemAudioURL: systemURL,
                     errorMessage: "Transcription cancelled",
@@ -1013,7 +1015,7 @@ final class MeetingSessionController: ObservableObject {
             activeRecordingSuggestedTitle = nil
 
             if files.micURL != nil || files.systemURL != nil {
-                didPreserveRecording = taskManager.addFailedTranscriptionRetainingAvailableAudio(
+                didPreserveRecording = preserveFailedMeetingForRetry(
                     micAudioURL: files.micURL,
                     systemAudioURL: files.systemURL,
                     errorMessage: "Meeting saved before quit. Audio is safe; finish the transcript from Home after reopening.",
@@ -1073,7 +1075,7 @@ final class MeetingSessionController: ObservableObject {
         for job in jobs {
             switch job.kind {
             case .recorded(let micURL, let systemURL, _, let meetingTitle):
-                if taskManager.addFailedTranscriptionRetainingAvailableAudio(
+                if preserveFailedMeetingForRetry(
                     micAudioURL: micURL,
                     systemAudioURL: systemURL,
                     errorMessage: errorMessage,
@@ -1247,8 +1249,8 @@ final class MeetingSessionController: ObservableObject {
             .store(in: &cancellables)
 
         failedManager.$failedTranscriptions
-            .sink { [weak self] _ in
-                self?.refreshFailedMeetings()
+            .sink { [weak self] failedTranscriptions in
+                self?.refreshFailedMeetings(failedTranscriptions)
             }
             .store(in: &cancellables)
 
@@ -1595,7 +1597,7 @@ final class MeetingSessionController: ObservableObject {
 
         switch job.kind {
         case .recorded(let micURL, let systemURL, _, let meetingTitle):
-            taskManager.addFailedTranscriptionRetainingAudio(
+            preserveFailedMeetingForRetry(
                 micAudioURL: micURL,
                 systemAudioURL: systemURL,
                 errorMessage: message,
@@ -2045,8 +2047,27 @@ final class MeetingSessionController: ObservableObject {
         value ? "true" : "false"
     }
 
-    private func refreshFailedMeetings() {
-        let failedTranscriptions = failedManager.failedTranscriptions
+    @discardableResult
+    private func preserveFailedMeetingForRetry(
+        micAudioURL: URL?,
+        systemAudioURL: URL?,
+        errorMessage: String,
+        meetingTitle: String?
+    ) -> Bool {
+        let preserved = taskManager.addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: micAudioURL,
+            systemAudioURL: systemAudioURL,
+            errorMessage: errorMessage,
+            meetingTitle: meetingTitle
+        )
+        if preserved {
+            refreshFailedMeetings()
+        }
+        return preserved
+    }
+
+    private func refreshFailedMeetings(_ updatedFailedTranscriptions: [FailedTranscription]? = nil) {
+        let failedTranscriptions = updatedFailedTranscriptions ?? failedManager.failedTranscriptions
         retryingFailedMeetingIDs.formIntersection(Set(failedTranscriptions.map(\.id)))
 
         failedMeetings = failedTranscriptions

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -698,6 +698,50 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - stop-timeout failed meetings refresh Home immediately") {
+        let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let timeoutBlock = sourceSlice(
+            controllerContents,
+            from: "if stopResult.didTimeOut {",
+            to: "let outcome = enqueueTranscriptionJob("
+        )
+        let helperBlock = sourceSlice(
+            controllerContents,
+            from: "private func preserveFailedMeetingForRetry(",
+            to: "private func refreshFailedMeetings("
+        )
+
+        assertTrue(
+            timeoutBlock.contains("let preserved = preserveFailedMeetingForRetry("),
+            "stop timeouts should route retained audio through the refresh helper before returning"
+        )
+        assertTrue(
+            timeoutBlock.contains("\"preserved_for_retry\": boolString(preserved)"),
+            "stop-timeout diagnostics should state whether the retained audio reached the retry queue"
+        )
+        assertTrue(
+            helperBlock.contains("taskManager.addFailedTranscriptionRetainingAvailableAudio(")
+                && helperBlock.contains("if preserved {\n            refreshFailedMeetings()"),
+            "retained failed-meeting audio should refresh MeetingSessionController.failedMeetings immediately"
+        )
+        assertTrue(
+            controllerContents.contains(".sink { [weak self] failedTranscriptions in\n                self?.refreshFailedMeetings(failedTranscriptions)"),
+            "the failed-manager subscription should render the emitted queue instead of re-reading stale @Published state"
+        )
+        assertFalse(
+            controllerContents.contains("taskManager.addFailedTranscriptionRetainingAudio("),
+            "MeetingSessionController should not bypass the failed-meeting refresh helper"
+        )
+        assertEqual(
+            countOccurrences(
+                of: "taskManager.addFailedTranscriptionRetainingAvailableAudio(",
+                in: controllerContents
+            ),
+            1,
+            "direct failed-queue writes in MeetingSessionController should stay centralized in the refresh helper"
+        )
+    }
+
     runSuite("Repo command contract - dictation joins existing model downloads") {
         let overlayContents = readRepoTextFile("Sources/UI/Overlay/DictationSessionController.swift")
         let engineContents = readRepoTextFile("Sources/Speech/ParakeetEngine.swift")
@@ -1024,6 +1068,29 @@ private func shouldScanForLiveCommandContract(_ relativePath: String) -> Bool {
         || relativePath.hasPrefix("docs/")
         || relativePath.hasPrefix("scripts/")
         || relativePath.hasSuffix(".sh")
+}
+
+private func sourceSlice(_ contents: String, from start: String, to end: String) -> String {
+    guard
+        let startRange = contents.range(of: start),
+        let endRange = contents.range(of: end, range: startRange.upperBound..<contents.endIndex)
+    else {
+        return ""
+    }
+
+    return String(contents[startRange.lowerBound..<endRange.lowerBound])
+}
+
+private func countOccurrences(of needle: String, in haystack: String) -> Int {
+    guard !needle.isEmpty else { return 0 }
+
+    var count = 0
+    var searchRange = haystack.startIndex..<haystack.endIndex
+    while let range = haystack.range(of: needle, range: searchRange) {
+        count += 1
+        searchRange = range.upperBound..<haystack.endIndex
+    }
+    return count
 }
 
 private func isTextPath(_ relativePath: String) -> Bool {


### PR DESCRIPTION
## Summary
- Route stop-timeout retained meeting audio through the failed-meeting refresh path so Home shows the retryable item immediately.
- Render the failed-manager emitted queue directly instead of re-reading potentially stale @Published state.
- Add a repo contract test covering the timeout refresh path.

## Root Cause
Long meetings can hit the recording stop timeout. The app preserved the audio in the failed/retry queue, but that timeout branch returned without refreshing `MeetingSessionController.failedMeetings`, which made Home look like the meeting disappeared.

## Validation
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` — 2286 passed
- `bash run-integration-smoke.sh`

## Notes
- Addresses the long-meeting disappearance part of #825.
- The Agent tab setup-details click issue and Ready text overlap appear unrelated, so they are left as separate follow-ups.
