### PR TITLE
[bug-hunter] Fix Agent setup details toggle

### DIFF
--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -4026,7 +4026,7 @@ private struct AgentConnectionSettingsPage: View {
                 title: "Details",
                 detail: "Advanced setup."
             ) {
-                DisclosureGroup("Show setup details", isExpanded: $showAdvancedAgentSetup) {
+                AgentSetupDetailsDisclosure(isExpanded: $showAdvancedAgentSetup) {
                     VStack(alignment: .leading, spacing: 14) {
                         ClaudeDesktopStatusRow(status: claudeDesktopStatus)
 
@@ -4099,7 +4099,6 @@ private struct AgentConnectionSettingsPage: View {
                             }
                         }
                     }
-                    .padding(.top, 10)
                 }
             }
         }
@@ -4332,6 +4331,71 @@ private struct AgentConnectActionButton: View {
             hoverStroke: tint.opacity(0.56)
         ))
         .disabled(!isEnabled)
+    }
+}
+
+private struct AgentSetupDetailsDisclosure<Content: View>: View {
+    @Binding var isExpanded: Bool
+    let content: Content
+
+    init(
+        isExpanded: Binding<Bool>,
+        @ViewBuilder content: () -> Content
+    ) {
+        self._isExpanded = isExpanded
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation(.snappy(duration: 0.18)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(.secondary)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .frame(width: 16, height: 16)
+
+                    Text("Show setup details")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.primary)
+
+                    Spacer(minLength: 12)
+
+                    Text(isExpanded ? "Hide" : "Show")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+            .buttonStyle(SettingsHoverButtonStyle(
+                tone: .neutral,
+                cornerRadius: 8,
+                normalFill: Color.primary.opacity(0.018),
+                normalStroke: Color.primary.opacity(0.07),
+                hoverFill: Color.primary.opacity(0.04),
+                pressedFill: Color.primary.opacity(0.06),
+                hoverStroke: Color.primary.opacity(0.12)
+            ))
+            .accessibilityLabel(Text("Show setup details"))
+            .accessibilityValue(Text(isExpanded ? "Expanded" : "Collapsed"))
+            .accessibilityHint(Text(isExpanded ? "Hide advanced agent setup details" : "Show advanced agent setup details"))
+
+            if isExpanded {
+                VStack(alignment: .leading, spacing: 14) {
+                    content
+                }
+                .padding(.top, 14)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
     }
 }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -818,6 +818,27 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - Agent setup details has an explicit toggle") {
+        let contents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
+
+        assertTrue(
+            contents.contains("AgentSetupDetailsDisclosure(isExpanded: $showAdvancedAgentSetup)"),
+            "Agent settings should use the explicit setup-details toggle row"
+        )
+        assertTrue(
+            contents.contains("private struct AgentSetupDetailsDisclosure<Content: View>"),
+            "Agent setup-details disclosure should stay owned by a dedicated view"
+        )
+        assertTrue(
+            contents.contains("withAnimation(.snappy(duration: 0.18)) {\n                    isExpanded.toggle()"),
+            "Agent setup-details disclosure should toggle its expansion state directly"
+        )
+        assertFalse(
+            contents.contains("DisclosureGroup(\"Show setup details\", isExpanded: $showAdvancedAgentSetup)"),
+            "Agent setup details should not rely on the macOS DisclosureGroup click path"
+        )
+    }
+
     runSuite("Repo command contract - settings permissions refresh after async grants") {
         let settingsContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let permissionAccessContents = readRepoTextFile("Sources/Support/TranscriptedPermissionAccess.swift")


### PR DESCRIPTION
## Summary
- replace the Agent page's stock setup-details disclosure with an explicit full-row toggle
- keep the existing Claude config, folder, and fallback setup content behind that toggle
- add a source-contract regression check so the Agent page does not drift back to the flaky disclosure path

## Signal
- Fresh GitHub bug issue #825 reports that "Show setup details" in Settings > Agent does nothing when clicked.
- Sentry/PostHog latest-release checks also showed repeated `dictation.microphone_start_timeout` on `transcripted@1.1.42`, but merged PR #824 already fixed that path on `origin/main`.
- Sentry `APPLE-MACOS-S` on `transcripted@1.1.42` matches the CoreML lifetime crash shape already fixed by merged PR #814.

## Root Cause
The Agent page used SwiftUI's stock `DisclosureGroup` for setup details, leaving the click behavior on macOS to the small disclosure hit target instead of a reliable full-row Settings action.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` (2271 passed)

Refs #825
