### PR TITLE
Remove duplicate home stats sheet

### DIFF
--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -779,15 +779,6 @@ struct TranscriptedSettingsView: View {
                 }
             )
         }
-        .sheet(isPresented: $homeShowsStatsDetails) {
-            HomeStatsDetailSheet(
-                stats: homeStatItems,
-                streak: homeStreak,
-                onDone: {
-                    homeShowsStatsDetails = false
-                }
-            )
-        }
         .onChange(of: homeActivityTab) { _, newValue in
             trackSettingsAction("home_tab_\(newValue.rawValue)", page: .home)
             if newValue == .meetings {


### PR DESCRIPTION
Fixes the post-merge duplicate Home stats sheet presenter found by codex-review.\n\nVerification:\n- bash build.sh --no-open\n- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh