### PR TITLE
[codex] Generate meeting playback mix

### DIFF
--- a/Sources/Meeting/MeetingAudioStorageManager.swift
+++ b/Sources/Meeting/MeetingAudioStorageManager.swift
@@ -12,6 +12,15 @@ protocol MeetingAudioFileValidating {
     func isUsableAudioFile(at url: URL, fileManager: FileManager) -> Bool
 }
 
+protocol MeetingAudioPlaybackMixing {
+    func createPlaybackWAV(
+        microphoneURL: URL,
+        systemURL: URL,
+        destinationURL: URL,
+        fileManager: FileManager
+    ) async throws
+}
+
 struct AVFoundationMeetingAudioConverter: MeetingAudioFileConverting {
     func convertWAVToM4A(sourceURL: URL, destinationURL: URL) async throws {
         let asset = AVURLAsset(url: sourceURL)
@@ -22,6 +31,376 @@ struct AVFoundationMeetingAudioConverter: MeetingAudioFileConverting {
         session.shouldOptimizeForNetworkUse = false
 
         try await session.export(to: destinationURL, as: .m4a)
+    }
+}
+
+struct AVFoundationMeetingAudioPlaybackMixer: MeetingAudioPlaybackMixing {
+    private static let chunkFrames: AVAudioFrameCount = 4096
+    private static let gateWindowFrames = 1024
+    private static let micActiveThreshold: Float = 0.012
+    private static let systemActiveThreshold: Float = 0.012
+    private static let systemGain: Float = 0.95
+    private static let micGainQuietSystem: Float = 0.90
+    private static let micGainLikelySpeech: Float = 0.75
+    private static let micGainAmbiguous: Float = 0.12
+
+    func createPlaybackWAV(
+        microphoneURL: URL,
+        systemURL: URL,
+        destinationURL: URL,
+        fileManager: FileManager
+    ) async throws {
+        try mix(
+            microphoneURL: microphoneURL,
+            systemURL: systemURL,
+            destinationURL: destinationURL,
+            fileManager: fileManager
+        )
+    }
+
+    private func mix(
+        microphoneURL: URL,
+        systemURL: URL,
+        destinationURL: URL,
+        fileManager: FileManager
+    ) throws {
+        let microphoneFile = try AVAudioFile(forReading: microphoneURL)
+        let systemFile = try AVAudioFile(forReading: systemURL)
+        let microphoneFormat = microphoneFile.processingFormat
+        let systemFormat = systemFile.processingFormat
+
+        let outputChannelCount = max(
+            1,
+            Int(max(microphoneFormat.channelCount, systemFormat.channelCount))
+        )
+        guard let outputFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: systemFormat.sampleRate,
+            channels: AVAudioChannelCount(outputChannelCount),
+            interleaved: false
+        ) else {
+            throw MeetingAudioStorageError.mixBufferAllocationFailed
+        }
+
+        try? fileManager.removeItem(at: destinationURL)
+        do {
+            let outputFile = try AVAudioFile(
+                forWriting: destinationURL,
+                settings: outputFormat.settings,
+                commonFormat: outputFormat.commonFormat,
+                interleaved: outputFormat.isInterleaved
+            )
+
+            var microphoneDone = false
+            var systemDone = false
+            let microphoneReader = try MixInputReader(file: microphoneFile, outputFormat: outputFormat)
+            let systemReader = try MixInputReader(file: systemFile, outputFormat: outputFormat)
+
+            while !microphoneDone || !systemDone {
+                let microphoneBuffer = try microphoneReader.read(maximumFrames: Self.chunkFrames)
+                let systemBuffer = try systemReader.read(maximumFrames: Self.chunkFrames)
+
+                microphoneDone = microphoneBuffer == nil
+                systemDone = systemBuffer == nil
+
+                let frameCount = max(
+                    Int(microphoneBuffer?.frameLength ?? 0),
+                    Int(systemBuffer?.frameLength ?? 0)
+                )
+                guard frameCount > 0 else { continue }
+
+                guard let outputBuffer = AVAudioPCMBuffer(
+                    pcmFormat: outputFormat,
+                    frameCapacity: AVAudioFrameCount(frameCount)
+                ) else {
+                    throw MeetingAudioStorageError.mixBufferAllocationFailed
+                }
+                outputBuffer.frameLength = AVAudioFrameCount(frameCount)
+
+                mix(
+                    microphoneBuffer: microphoneBuffer,
+                    systemBuffer: systemBuffer,
+                    outputBuffer: outputBuffer,
+                    frameCount: frameCount,
+                    outputChannelCount: outputChannelCount
+                )
+                try outputFile.write(from: outputBuffer)
+            }
+
+            fileManager.restrictFileToOwnerOnly(at: destinationURL)
+        } catch {
+            try? fileManager.removeItem(at: destinationURL)
+            throw error
+        }
+    }
+
+    private func mix(
+        microphoneBuffer: AVAudioPCMBuffer?,
+        systemBuffer: AVAudioPCMBuffer?,
+        outputBuffer: AVAudioPCMBuffer,
+        frameCount: Int,
+        outputChannelCount: Int
+    ) {
+        var startFrame = 0
+        while startFrame < frameCount {
+            let blockFrameCount = min(Self.gateWindowFrames, frameCount - startFrame)
+            let microphoneRMS = rms(
+                in: microphoneBuffer,
+                startFrame: startFrame,
+                frameCount: blockFrameCount
+            )
+            let systemRMS = rms(
+                in: systemBuffer,
+                startFrame: startFrame,
+                frameCount: blockFrameCount
+            )
+            let microphoneGain = gainForMicrophone(
+                microphoneRMS: microphoneRMS,
+                systemRMS: systemRMS
+            )
+
+            for frame in startFrame..<(startFrame + blockFrameCount) {
+                for channel in 0..<outputChannelCount {
+                    let systemSample = sample(
+                        from: systemBuffer,
+                        channel: channel,
+                        frame: frame
+                    )
+                    let microphoneSample = sample(
+                        from: microphoneBuffer,
+                        channel: channel,
+                        frame: frame
+                    )
+                    let mixedSample = (systemSample * Self.systemGain)
+                        + (microphoneSample * microphoneGain)
+                    write(
+                        limited(mixedSample),
+                        to: outputBuffer,
+                        channel: channel,
+                        frame: frame
+                    )
+                }
+            }
+
+            startFrame += blockFrameCount
+        }
+    }
+
+    private func gainForMicrophone(microphoneRMS: Float, systemRMS: Float) -> Float {
+        guard microphoneRMS >= Self.micActiveThreshold else { return 0 }
+        guard systemRMS >= Self.systemActiveThreshold else { return Self.micGainQuietSystem }
+
+        if microphoneRMS >= systemRMS * 1.25 {
+            return Self.micGainLikelySpeech
+        }
+
+        if microphoneRMS >= systemRMS * 0.75 {
+            return Self.micGainAmbiguous
+        }
+
+        return 0
+    }
+
+    private func rms(
+        in buffer: AVAudioPCMBuffer?,
+        startFrame: Int,
+        frameCount: Int
+    ) -> Float {
+        guard let buffer else { return 0 }
+        let endFrame = min(startFrame + frameCount, Int(buffer.frameLength))
+        guard startFrame < endFrame else { return 0 }
+
+        let channels = max(1, Int(buffer.format.channelCount))
+        var sum: Float = 0
+        var sampleCount = 0
+
+        for frame in startFrame..<endFrame {
+            for channel in 0..<channels {
+                let value = sample(from: buffer, channel: channel, frame: frame)
+                sum += value * value
+                sampleCount += 1
+            }
+        }
+
+        guard sampleCount > 0 else { return 0 }
+        return sqrt(sum / Float(sampleCount))
+    }
+
+    private func sample(
+        from buffer: AVAudioPCMBuffer?,
+        channel: Int,
+        frame: Int
+    ) -> Float {
+        guard let buffer,
+              frame >= 0,
+              frame < Int(buffer.frameLength),
+              let channelData = buffer.floatChannelData else {
+            return 0
+        }
+
+        let channelCount = max(1, Int(buffer.format.channelCount))
+        let sourceChannel = channelCount == 1 ? 0 : min(channel, channelCount - 1)
+        if buffer.format.isInterleaved {
+            return channelData[0][frame * channelCount + sourceChannel]
+        }
+
+        return channelData[sourceChannel][frame]
+    }
+
+    private func write(
+        _ sample: Float,
+        to buffer: AVAudioPCMBuffer,
+        channel: Int,
+        frame: Int
+    ) {
+        guard let channelData = buffer.floatChannelData,
+              frame >= 0,
+              frame < Int(buffer.frameLength) else {
+            return
+        }
+
+        let channelCount = max(1, Int(buffer.format.channelCount))
+        let destinationChannel = min(channel, channelCount - 1)
+        if buffer.format.isInterleaved {
+            channelData[0][frame * channelCount + destinationChannel] = sample
+        } else {
+            channelData[destinationChannel][frame] = sample
+        }
+    }
+
+    private func limited(_ sample: Float) -> Float {
+        min(0.98, max(-0.98, sample))
+    }
+
+    private final class MixInputReader {
+        private let file: AVAudioFile
+        private let outputFormat: AVAudioFormat
+        private let converter: AVAudioConverter?
+        private var didReachInputEnd = false
+        private var didReachOutputEnd = false
+
+        init(file: AVAudioFile, outputFormat: AVAudioFormat) throws {
+            self.file = file
+            self.outputFormat = outputFormat
+            if Self.formatsMatch(file.processingFormat, outputFormat) {
+                self.converter = nil
+            } else {
+                guard let converter = AVAudioConverter(from: file.processingFormat, to: outputFormat) else {
+                    throw MeetingAudioStorageError.unsupportedPlaybackMixFormat
+                }
+                self.converter = converter
+            }
+        }
+
+        func read(maximumFrames: AVAudioFrameCount) throws -> AVAudioPCMBuffer? {
+            guard !didReachOutputEnd else { return nil }
+            guard let converter else {
+                return try readDirect(maximumFrames: maximumFrames)
+            }
+            return try readConverted(maximumFrames: maximumFrames, converter: converter)
+        }
+
+        private func readDirect(maximumFrames: AVAudioFrameCount) throws -> AVAudioPCMBuffer? {
+            let remainingFrames = file.length - file.framePosition
+            guard remainingFrames > 0 else {
+                didReachOutputEnd = true
+                return nil
+            }
+
+            let framesToRead = min(AVAudioFramePosition(maximumFrames), remainingFrames)
+            guard framesToRead > 0,
+                  let buffer = AVAudioPCMBuffer(
+                    pcmFormat: outputFormat,
+                    frameCapacity: AVAudioFrameCount(framesToRead)
+                  ) else {
+                return nil
+            }
+
+            try file.read(into: buffer, frameCount: AVAudioFrameCount(framesToRead))
+            if buffer.frameLength == 0 {
+                didReachOutputEnd = true
+                return nil
+            }
+            return buffer
+        }
+
+        private func readConverted(
+            maximumFrames: AVAudioFrameCount,
+            converter: AVAudioConverter
+        ) throws -> AVAudioPCMBuffer? {
+            guard let outputBuffer = AVAudioPCMBuffer(
+                pcmFormat: outputFormat,
+                frameCapacity: maximumFrames
+            ) else {
+                throw MeetingAudioStorageError.mixBufferAllocationFailed
+            }
+
+            var conversionError: NSError?
+            let status = converter.convert(to: outputBuffer, error: &conversionError) { packetCount, outStatus in
+                if self.didReachInputEnd {
+                    outStatus.pointee = .endOfStream
+                    return nil
+                }
+
+                do {
+                    let sourceBuffer = try self.readSourceBuffer(maximumFrames: packetCount)
+                    guard let sourceBuffer else {
+                        self.didReachInputEnd = true
+                        outStatus.pointee = .endOfStream
+                        return nil
+                    }
+                    outStatus.pointee = .haveData
+                    return sourceBuffer
+                } catch {
+                    conversionError = error as NSError
+                    outStatus.pointee = .noDataNow
+                    return nil
+                }
+            }
+
+            if let conversionError {
+                throw conversionError
+            }
+
+            switch status {
+            case .haveData, .inputRanDry:
+                if outputBuffer.frameLength > 0 {
+                    return outputBuffer
+                }
+                return try read(maximumFrames: maximumFrames)
+            case .endOfStream:
+                didReachOutputEnd = true
+                return outputBuffer.frameLength > 0 ? outputBuffer : nil
+            case .error:
+                throw MeetingAudioStorageError.unsupportedPlaybackMixFormat
+            @unknown default:
+                throw MeetingAudioStorageError.unsupportedPlaybackMixFormat
+            }
+        }
+
+        private func readSourceBuffer(maximumFrames: AVAudioFrameCount) throws -> AVAudioPCMBuffer? {
+            let remainingFrames = file.length - file.framePosition
+            guard remainingFrames > 0 else { return nil }
+
+            let framesToRead = min(AVAudioFramePosition(maximumFrames), remainingFrames)
+            guard framesToRead > 0,
+                  let buffer = AVAudioPCMBuffer(
+                    pcmFormat: file.processingFormat,
+                    frameCapacity: AVAudioFrameCount(framesToRead)
+                  ) else {
+                return nil
+            }
+
+            try file.read(into: buffer, frameCount: AVAudioFrameCount(framesToRead))
+            return buffer.frameLength > 0 ? buffer : nil
+        }
+
+        private static func formatsMatch(_ lhs: AVAudioFormat, _ rhs: AVAudioFormat) -> Bool {
+            lhs.commonFormat == rhs.commonFormat
+                && lhs.sampleRate == rhs.sampleRate
+                && lhs.channelCount == rhs.channelCount
+                && lhs.isInterleaved == rhs.isInterleaved
+        }
     }
 }
 
@@ -46,6 +425,8 @@ enum MeetingAudioStorageError: Error {
     case exportSessionUnavailable
     case conversionFailed
     case emptyConvertedFile
+    case unsupportedPlaybackMixFormat
+    case mixBufferAllocationFailed
 }
 
 struct MeetingAudioStorageMaintenanceResult: Equatable {
@@ -56,7 +437,7 @@ struct MeetingAudioStorageMaintenanceResult: Equatable {
 
 enum MeetingAudioStorageManager {
     private static let frontmatterPreviewByteLimit = 64 * 1024
-    private static let staleTemporaryM4AAge: TimeInterval = 10 * 60
+    private static let staleTemporaryAudioAge: TimeInterval = 10 * 60
     private static let managedAudioStems = ["microphone", "system_audio", "recording", "playback"]
 
     @discardableResult
@@ -66,7 +447,8 @@ enum MeetingAudioStorageManager {
         now: Date = Date(),
         fileManager: FileManager = .default,
         converter: MeetingAudioFileConverting = AVFoundationMeetingAudioConverter(),
-        validator: MeetingAudioFileValidating = AVFoundationMeetingAudioValidator()
+        validator: MeetingAudioFileValidating = AVFoundationMeetingAudioValidator(),
+        playbackMixer: MeetingAudioPlaybackMixing = AVFoundationMeetingAudioPlaybackMixer()
     ) async -> MeetingAudioStorageMaintenanceResult {
         let prunedDirectories = pruneRetainedAudio(
             in: meetingsFolder,
@@ -82,6 +464,13 @@ enum MeetingAudioStorageManager {
 
         var convertedFiles = 0
         for directory in directories {
+            await createPlaybackMixIfNeeded(
+                in: directory,
+                now: now,
+                fileManager: fileManager,
+                validator: validator,
+                playbackMixer: playbackMixer
+            )
             convertedFiles += await compressWAVAudio(
                 in: directory,
                 now: now,
@@ -104,9 +493,17 @@ enum MeetingAudioStorageManager {
         now: Date = Date(),
         fileManager: FileManager = .default,
         converter: MeetingAudioFileConverting = AVFoundationMeetingAudioConverter(),
-        validator: MeetingAudioFileValidating = AVFoundationMeetingAudioValidator()
+        validator: MeetingAudioFileValidating = AVFoundationMeetingAudioValidator(),
+        playbackMixer: MeetingAudioPlaybackMixing = AVFoundationMeetingAudioPlaybackMixer()
     ) async {
         let audioDirectory = audioDirectoryURL(forTranscript: transcriptURL)
+        await createPlaybackMixIfNeeded(
+            in: audioDirectory,
+            now: now,
+            fileManager: fileManager,
+            validator: validator,
+            playbackMixer: playbackMixer
+        )
         await compressWAVAudio(
             in: audioDirectory,
             now: now,
@@ -173,7 +570,7 @@ enum MeetingAudioStorageManager {
 
         var removedAny = false
         for file in files where isManagedRetainedAudioFile(file, fileManager: fileManager)
-            || isTranscriptedTemporaryM4AFileName(file) {
+            || isTranscriptedTemporaryAudioFileName(file) {
             do {
                 try fileManager.removeItem(at: file)
                 removedAny = true
@@ -197,6 +594,62 @@ enum MeetingAudioStorageManager {
     }
 
     @discardableResult
+    static func createPlaybackMixIfNeeded(
+        in audioDirectory: URL,
+        now: Date = Date(),
+        fileManager: FileManager = .default,
+        validator: MeetingAudioFileValidating = AVFoundationMeetingAudioValidator(),
+        playbackMixer: MeetingAudioPlaybackMixing = AVFoundationMeetingAudioPlaybackMixer()
+    ) async -> Bool {
+        guard isSafeNonSymlinkDirectory(audioDirectory, fileManager: fileManager) else { return false }
+        removeStaleTemporaryAudioFiles(in: audioDirectory, now: now, fileManager: fileManager)
+
+        let playbackWAVURL = audioDirectory.appendingPathComponent("playback.wav")
+        let playbackM4AURL = audioDirectory.appendingPathComponent("playback.m4a")
+        if validator.isUsableAudioFile(at: playbackM4AURL, fileManager: fileManager)
+            || validator.isUsableAudioFile(at: playbackWAVURL, fileManager: fileManager) {
+            return false
+        }
+
+        guard let microphoneURL = firstRetainedAudioFile(
+            named: "microphone",
+            in: audioDirectory,
+            fileManager: fileManager
+        ), let systemURL = firstRetainedAudioFile(
+            named: "system_audio",
+            in: audioDirectory,
+            fileManager: fileManager
+        ) else {
+            return false
+        }
+
+        let tempURL = audioDirectory
+            .appendingPathComponent(".playback-\(UUID().uuidString)")
+            .appendingPathExtension("wav")
+
+        do {
+            try await playbackMixer.createPlaybackWAV(
+                microphoneURL: microphoneURL,
+                systemURL: systemURL,
+                destinationURL: tempURL,
+                fileManager: fileManager
+            )
+            guard validator.isUsableAudioFile(at: tempURL, fileManager: fileManager) else {
+                throw MeetingAudioStorageError.emptyConvertedFile
+            }
+            if fileManager.fileExists(atPath: playbackWAVURL.path) {
+                try fileManager.removeItem(at: playbackWAVURL)
+            }
+            try fileManager.moveItem(at: tempURL, to: playbackWAVURL)
+            fileManager.restrictFileToOwnerOnly(at: playbackWAVURL)
+            return true
+        } catch {
+            try? fileManager.removeItem(at: tempURL)
+            return false
+        }
+    }
+
+    @discardableResult
     static func compressWAVAudio(
         in audioDirectory: URL,
         now: Date = Date(),
@@ -205,7 +658,7 @@ enum MeetingAudioStorageManager {
         validator: MeetingAudioFileValidating = AVFoundationMeetingAudioValidator()
     ) async -> Int {
         guard isSafeNonSymlinkDirectory(audioDirectory, fileManager: fileManager) else { return 0 }
-        removeStaleTemporaryM4AFiles(in: audioDirectory, now: now, fileManager: fileManager)
+        removeStaleTemporaryAudioFiles(in: audioDirectory, now: now, fileManager: fileManager)
 
         guard let files = try? fileManager.contentsOfDirectory(
             at: audioDirectory,
@@ -257,7 +710,22 @@ enum MeetingAudioStorageManager {
     static func removeStaleTemporaryM4AFiles(
         in audioDirectory: URL,
         now: Date = Date(),
-        minimumAge: TimeInterval = staleTemporaryM4AAge,
+        minimumAge: TimeInterval = staleTemporaryAudioAge,
+        fileManager: FileManager = .default
+    ) -> Int {
+        removeStaleTemporaryAudioFiles(
+            in: audioDirectory,
+            now: now,
+            minimumAge: minimumAge,
+            fileManager: fileManager
+        )
+    }
+
+    @discardableResult
+    static func removeStaleTemporaryAudioFiles(
+        in audioDirectory: URL,
+        now: Date = Date(),
+        minimumAge: TimeInterval = staleTemporaryAudioAge,
         fileManager: FileManager = .default
     ) -> Int {
         guard isSafeNonSymlinkDirectory(audioDirectory, fileManager: fileManager) else { return 0 }
@@ -270,7 +738,7 @@ enum MeetingAudioStorageManager {
         }
 
         var removedCount = 0
-        for file in files where isStaleTemporaryM4AFile(
+        for file in files where isStaleTemporaryAudioFile(
             file,
             now: now,
             minimumAge: minimumAge,
@@ -396,6 +864,43 @@ enum MeetingAudioStorageManager {
         }
     }
 
+    private static func firstRetainedAudioFile(
+        named stem: String,
+        in audioDirectory: URL,
+        fileManager: FileManager
+    ) -> URL? {
+        guard let files = try? fileManager.contentsOfDirectory(
+            at: audioDirectory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+
+        return files
+            .filter { url in
+                url.deletingPathExtension().lastPathComponent == stem
+                    && isManagedRetainedAudioFile(url, fileManager: fileManager)
+            }
+            .sorted { lhs, rhs in
+                retainedAudioFileSortKey(lhs) < retainedAudioFileSortKey(rhs)
+            }
+            .first
+    }
+
+    private static func retainedAudioFileSortKey(_ url: URL) -> String {
+        let extensionRank: String
+        switch url.pathExtension.lowercased() {
+        case "wav":
+            extensionRank = "0"
+        case "m4a":
+            extensionRank = "1"
+        default:
+            extensionRank = "2"
+        }
+        return "\(extensionRank)-\(url.lastPathComponent)"
+    }
+
     private static func restrictRetainedM4AFiles(_ files: [URL], fileManager: FileManager) {
         for file in files where file.pathExtension.localizedCaseInsensitiveCompare("m4a") == .orderedSame
             && isManagedRetainedAudioFile(file, fileManager: fileManager) {
@@ -409,7 +914,21 @@ enum MeetingAudioStorageManager {
         minimumAge: TimeInterval,
         fileManager: FileManager
     ) -> Bool {
-        guard isTranscriptedTemporaryM4AFileName(url) else { return false }
+        isStaleTemporaryAudioFile(
+            url,
+            now: now,
+            minimumAge: minimumAge,
+            fileManager: fileManager
+        )
+    }
+
+    private static func isStaleTemporaryAudioFile(
+        _ url: URL,
+        now: Date,
+        minimumAge: TimeInterval,
+        fileManager: FileManager
+    ) -> Bool {
+        guard isTranscriptedTemporaryAudioFileName(url) else { return false }
         guard !isSymbolicLink(url, fileManager: fileManager) else { return false }
         let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .contentModificationDateKey])
         guard values?.isRegularFile == true, let modified = values?.contentModificationDate else {
@@ -419,7 +938,13 @@ enum MeetingAudioStorageManager {
     }
 
     private static func isTranscriptedTemporaryM4AFileName(_ url: URL) -> Bool {
-        guard url.pathExtension.localizedCaseInsensitiveCompare("m4a") == .orderedSame else { return false }
+        isTranscriptedTemporaryAudioFileName(url)
+    }
+
+    private static func isTranscriptedTemporaryAudioFileName(_ url: URL) -> Bool {
+        guard ["m4a", "wav"].contains(where: { url.pathExtension.localizedCaseInsensitiveCompare($0) == .orderedSame }) else {
+            return false
+        }
         let hiddenStem = url.deletingPathExtension().lastPathComponent
         guard hiddenStem.hasPrefix(".") else { return false }
         let stem = String(hiddenStem.dropFirst())

--- a/Sources/UI/Shared/MeetingAudioArchiveResolver.swift
+++ b/Sources/UI/Shared/MeetingAudioArchiveResolver.swift
@@ -43,6 +43,10 @@ struct MeetingAudioAttachment: Equatable, Sendable {
             return urls.map { playbackChoice(for: $0) }
         }
 
+        if let splitChoices = splitStreamPlaybackChoices(in: urls) {
+            return splitChoices
+        }
+
         let preferredURLs = preferredAudioFiles(in: urls)
         if !preferredURLs.isEmpty {
             return preferredURLs.map { playbackChoice(for: $0) }
@@ -70,6 +74,34 @@ struct MeetingAudioAttachment: Equatable, Sendable {
         let preferredPaths = Set(preferredURLs.map { $0.standardizedFileURL.path })
         let remainingURLs = urls.filter { !preferredPaths.contains($0.standardizedFileURL.path) }
         return preferredURLs + remainingURLs
+    }
+
+    private func splitStreamPlaybackChoices(in urls: [URL]) -> [MeetingAudioPlaybackChoice]? {
+        guard let systemURL = firstAudioFile(named: "system_audio", in: urls),
+              let microphoneURL = firstAudioFile(named: "microphone", in: urls) else {
+            return nil
+        }
+
+        let sourcePaths = Set([systemURL, microphoneURL].map { $0.standardizedFileURL.path })
+        let remainingURLs = urls.filter { !sourcePaths.contains($0.standardizedFileURL.path) }
+
+        return [
+            playbackChoice(for: systemURL),
+            compositePlaybackChoice(systemURL: systemURL, microphoneURL: microphoneURL),
+            playbackChoice(for: microphoneURL)
+        ] + remainingURLs.map { playbackChoice(for: $0) }
+    }
+
+    private func compositePlaybackChoice(
+        systemURL: URL,
+        microphoneURL: URL
+    ) -> MeetingAudioPlaybackChoice {
+        MeetingAudioPlaybackChoice(
+            id: "full:\(systemURL.standardizedFileURL.path)|\(microphoneURL.standardizedFileURL.path)",
+            title: "Full",
+            symbolName: "person.2.wave.2.fill",
+            urls: [systemURL, microphoneURL]
+        )
     }
 
     private func playbackChoice(for url: URL) -> MeetingAudioPlaybackChoice {

--- a/Sources/UI/Shared/MeetingAudioArchiveResolver.swift
+++ b/Sources/UI/Shared/MeetingAudioArchiveResolver.swift
@@ -43,8 +43,8 @@ struct MeetingAudioAttachment: Equatable, Sendable {
             return urls.map { playbackChoice(for: $0) }
         }
 
-        if let splitChoices = splitStreamPlaybackChoices(in: urls) {
-            return splitChoices
+        if let splitChoice = splitStreamPlaybackChoice(in: urls) {
+            return [splitChoice]
         }
 
         let preferredURLs = preferredAudioFiles(in: urls)
@@ -76,32 +76,13 @@ struct MeetingAudioAttachment: Equatable, Sendable {
         return preferredURLs + remainingURLs
     }
 
-    private func splitStreamPlaybackChoices(in urls: [URL]) -> [MeetingAudioPlaybackChoice]? {
+    private func splitStreamPlaybackChoice(in urls: [URL]) -> MeetingAudioPlaybackChoice? {
         guard let systemURL = firstAudioFile(named: "system_audio", in: urls),
-              let microphoneURL = firstAudioFile(named: "microphone", in: urls) else {
+              firstAudioFile(named: "microphone", in: urls) != nil else {
             return nil
         }
 
-        let sourcePaths = Set([systemURL, microphoneURL].map { $0.standardizedFileURL.path })
-        let remainingURLs = urls.filter { !sourcePaths.contains($0.standardizedFileURL.path) }
-
-        return [
-            playbackChoice(for: systemURL),
-            compositePlaybackChoice(systemURL: systemURL, microphoneURL: microphoneURL),
-            playbackChoice(for: microphoneURL)
-        ] + remainingURLs.map { playbackChoice(for: $0) }
-    }
-
-    private func compositePlaybackChoice(
-        systemURL: URL,
-        microphoneURL: URL
-    ) -> MeetingAudioPlaybackChoice {
-        MeetingAudioPlaybackChoice(
-            id: "full:\(systemURL.standardizedFileURL.path)|\(microphoneURL.standardizedFileURL.path)",
-            title: "Full",
-            symbolName: "person.2.wave.2.fill",
-            urls: [systemURL, microphoneURL]
-        )
+        return playbackChoice(for: systemURL)
     }
 
     private func playbackChoice(for url: URL) -> MeetingAudioPlaybackChoice {

--- a/Tests/MeetingAudioArchiveResolverTests.swift
+++ b/Tests/MeetingAudioArchiveResolverTests.swift
@@ -8,6 +8,7 @@ func testMeetingAudioArchiveResolver() {
         testRetainedAudioFactoryPreservesFailedMeetingSources()
         testPlaybackLoadingPolicyUsesDefaultSourceOnly()
         testPlaybackLoadingPolicyUsesSelectedSourceOnly()
+        testPlaybackLoadingPolicyAllowsExplicitFullMix()
         testResolverPrefersImportedRecording()
         testResolverUsesPlaybackMixForPlaybackOnlyArchive()
         testResolverPrefersPlaybackMix()
@@ -49,13 +50,13 @@ private func testResolverKeepsLiveMeetingAudioPairButPrefersSystemPlayback() {
     )
     assertEqual(
         attachment?.playbackURLCandidates.map { $0.map(\.lastPathComponent).joined(separator: "+") },
-        ["system_audio.wav", "microphone.wav"],
-        "Live meeting playback should offer each retained source without layering them"
+        ["system_audio.wav", "system_audio.wav+microphone.wav", "microphone.wav"],
+        "Live meeting playback should default to one source while keeping full playback available"
     )
     assertEqual(
         attachment?.playbackChoices.map(\.title),
-        ["System", "Mic"],
-        "Live meeting playback should make the mic track selectable when system is the default"
+        ["System", "Full", "Mic"],
+        "Live meeting playback should make full and mic playback selectable when system is the default"
     )
     assertTrue(attachment?.isCompositePlayback == false, "Live playback should not layer mic and system audio by default")
 }
@@ -110,13 +111,13 @@ private func testAttachmentPlaybackPrefersSystemForFailedMeetingAudio() {
     )
     assertEqual(
         attachment.playbackURLCandidates.map { $0.map(\.lastPathComponent).joined(separator: "+") },
-        ["system_audio.wav", "microphone.wav"],
-        "Failed-meeting playback should offer each retained source without layering them"
+        ["system_audio.wav", "system_audio.wav+microphone.wav", "microphone.wav"],
+        "Failed-meeting playback should default to one source while keeping full playback available"
     )
     assertEqual(
         attachment.playbackChoices.map(\.title),
-        ["System", "Mic"],
-        "Failed-meeting playback should make the mic track selectable when system is the default"
+        ["System", "Full", "Mic"],
+        "Failed-meeting playback should make full and mic playback selectable when system is the default"
     )
     assertTrue(attachment.isCompositePlayback == false, "Failed-meeting playback should default to one source")
 }
@@ -204,6 +205,36 @@ private func testPlaybackLoadingPolicyUsesSelectedSourceOnly() {
         choices.flatMap(\.urls).map(\.lastPathComponent),
         ["microphone.wav"],
         "Selected mic playback should stay single-source"
+    )
+}
+
+private func testPlaybackLoadingPolicyAllowsExplicitFullMix() {
+    let directory = makeMeetingAudioResolverTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let attachment = MeetingAudioAttachment(
+        directoryURL: directory,
+        urls: [
+            directory.appendingPathComponent("microphone.wav"),
+            directory.appendingPathComponent("system_audio.wav")
+        ]
+    )
+    let fullChoice = attachment.playbackChoices.first { $0.title == "Full" }
+
+    let choices = MeetingAudioPlaybackLoadingPolicy.choices(
+        for: attachment,
+        preferredChoice: fullChoice
+    )
+
+    assertEqual(
+        choices.map(\.title),
+        ["Full"],
+        "Headphone or clean-room playback should still allow the complete system plus mic mix"
+    )
+    assertEqual(
+        choices.flatMap(\.urls).map(\.lastPathComponent),
+        ["system_audio.wav", "microphone.wav"],
+        "Full playback should deliberately load both retained streams only when selected"
     )
 }
 

--- a/Tests/MeetingAudioArchiveResolverTests.swift
+++ b/Tests/MeetingAudioArchiveResolverTests.swift
@@ -2,13 +2,11 @@ import Foundation
 
 func testMeetingAudioArchiveResolver() {
     runSuite("MeetingAudioArchiveResolverTests") {
-        testResolverKeepsLiveMeetingAudioPairButPrefersSystemPlayback()
+        testResolverKeepsLiveMeetingAudioPairButUsesSinglePlaybackSource()
         testResolverFallsBackToMicrophonePlayback()
         testAttachmentPlaybackPrefersSystemForFailedMeetingAudio()
         testRetainedAudioFactoryPreservesFailedMeetingSources()
         testPlaybackLoadingPolicyUsesDefaultSourceOnly()
-        testPlaybackLoadingPolicyUsesSelectedSourceOnly()
-        testPlaybackLoadingPolicyAllowsExplicitFullMix()
         testResolverPrefersImportedRecording()
         testResolverUsesPlaybackMixForPlaybackOnlyArchive()
         testResolverPrefersPlaybackMix()
@@ -19,7 +17,7 @@ func testMeetingAudioArchiveResolver() {
     }
 }
 
-private func testResolverKeepsLiveMeetingAudioPairButPrefersSystemPlayback() {
+private func testResolverKeepsLiveMeetingAudioPairButUsesSinglePlaybackSource() {
     let directory = makeMeetingAudioResolverTestDirectory()
     defer { try? FileManager.default.removeItem(at: directory) }
 
@@ -50,13 +48,13 @@ private func testResolverKeepsLiveMeetingAudioPairButPrefersSystemPlayback() {
     )
     assertEqual(
         attachment?.playbackURLCandidates.map { $0.map(\.lastPathComponent).joined(separator: "+") },
-        ["system_audio.wav", "system_audio.wav+microphone.wav", "microphone.wav"],
-        "Live meeting playback should default to one source while keeping full playback available"
+        ["system_audio.wav"],
+        "Live meeting fallback playback should not expose a raw mic+system composite"
     )
     assertEqual(
         attachment?.playbackChoices.map(\.title),
-        ["System", "Full", "Mic"],
-        "Live meeting playback should make full and mic playback selectable when system is the default"
+        ["System"],
+        "Live meeting fallback playback should keep the normal UI to one source"
     )
     assertTrue(attachment?.isCompositePlayback == false, "Live playback should not layer mic and system audio by default")
 }
@@ -111,13 +109,13 @@ private func testAttachmentPlaybackPrefersSystemForFailedMeetingAudio() {
     )
     assertEqual(
         attachment.playbackURLCandidates.map { $0.map(\.lastPathComponent).joined(separator: "+") },
-        ["system_audio.wav", "system_audio.wav+microphone.wav", "microphone.wav"],
-        "Failed-meeting playback should default to one source while keeping full playback available"
+        ["system_audio.wav"],
+        "Failed-meeting playback should not expose a raw mic+system composite"
     )
     assertEqual(
         attachment.playbackChoices.map(\.title),
-        ["System", "Full", "Mic"],
-        "Failed-meeting playback should make full and mic playback selectable when system is the default"
+        ["System"],
+        "Failed-meeting playback should keep the normal UI to one source"
     )
     assertTrue(attachment.isCompositePlayback == false, "Failed-meeting playback should default to one source")
 }
@@ -175,66 +173,6 @@ private func testPlaybackLoadingPolicyUsesDefaultSourceOnly() {
         choices.flatMap(\.urls).map(\.lastPathComponent),
         ["system_audio.wav"],
         "Default playback should not hand both retained files to NSSound"
-    )
-}
-
-private func testPlaybackLoadingPolicyUsesSelectedSourceOnly() {
-    let directory = makeMeetingAudioResolverTestDirectory()
-    defer { try? FileManager.default.removeItem(at: directory) }
-
-    let attachment = MeetingAudioAttachment(
-        directoryURL: directory,
-        urls: [
-            directory.appendingPathComponent("microphone.wav"),
-            directory.appendingPathComponent("system_audio.wav")
-        ]
-    )
-    let micChoice = attachment.playbackChoices.first { $0.title == "Mic" }
-
-    let choices = MeetingAudioPlaybackLoadingPolicy.choices(
-        for: attachment,
-        preferredChoice: micChoice
-    )
-
-    assertEqual(
-        choices.map(\.title),
-        ["Mic"],
-        "When the user chooses Mic, the player should load Mic without also adding System"
-    )
-    assertEqual(
-        choices.flatMap(\.urls).map(\.lastPathComponent),
-        ["microphone.wav"],
-        "Selected mic playback should stay single-source"
-    )
-}
-
-private func testPlaybackLoadingPolicyAllowsExplicitFullMix() {
-    let directory = makeMeetingAudioResolverTestDirectory()
-    defer { try? FileManager.default.removeItem(at: directory) }
-
-    let attachment = MeetingAudioAttachment(
-        directoryURL: directory,
-        urls: [
-            directory.appendingPathComponent("microphone.wav"),
-            directory.appendingPathComponent("system_audio.wav")
-        ]
-    )
-    let fullChoice = attachment.playbackChoices.first { $0.title == "Full" }
-
-    let choices = MeetingAudioPlaybackLoadingPolicy.choices(
-        for: attachment,
-        preferredChoice: fullChoice
-    )
-
-    assertEqual(
-        choices.map(\.title),
-        ["Full"],
-        "Headphone or clean-room playback should still allow the complete system plus mic mix"
-    )
-    assertEqual(
-        choices.flatMap(\.urls).map(\.lastPathComponent),
-        ["system_audio.wav", "microphone.wav"],
-        "Full playback should deliberately load both retained streams only when selected"
     )
 }
 

--- a/Tests/MeetingAudioStorageManagerTests.swift
+++ b/Tests/MeetingAudioStorageManagerTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 
 func testMeetingAudioStorageManager() async {
@@ -142,6 +143,156 @@ func testMeetingAudioStorageManager() async {
         assertEqual(posixPermissions(at: m4aURL), 0o600, "existing retained M4A should be owner-only")
     }
 
+    await runSuite("MeetingAudioStorageManager creates playback mix before compressing live split audio") {
+        let directory = makeMeetingAudioStorageTestDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let transcriptURL = try! makeTranscript(named: "Live Split Call", in: directory, ageDays: 1)
+        let audioDirectory = makeAudioDirectory(for: transcriptURL)
+        let micWAV = audioDirectory.appendingPathComponent("microphone.wav")
+        let systemWAV = audioDirectory.appendingPathComponent("system_audio.wav")
+        try! Data("mic".utf8).write(to: micWAV)
+        try! Data("system".utf8).write(to: systemWAV)
+
+        await MeetingAudioStorageManager.processSavedTranscript(
+            at: transcriptURL,
+            retentionWindow: .never,
+            converter: FakeMeetingAudioConverter(),
+            validator: FakeMeetingAudioValidator(),
+            playbackMixer: FakeMeetingAudioPlaybackMixer()
+        )
+
+        assertTrue(
+            FileManager.default.fileExists(atPath: audioDirectory.appendingPathComponent("playback.m4a").path),
+            "saved live meetings should get one derived playback file"
+        )
+        assertTrue(
+            FileManager.default.fileExists(atPath: audioDirectory.appendingPathComponent("microphone.m4a").path),
+            "raw microphone audio should remain available after playback mix generation"
+        )
+        assertTrue(
+            FileManager.default.fileExists(atPath: audioDirectory.appendingPathComponent("system_audio.m4a").path),
+            "raw system audio should remain available after playback mix generation"
+        )
+        assertFalse(FileManager.default.fileExists(atPath: micWAV.path), "raw mic WAV should still follow normal compression")
+        assertFalse(FileManager.default.fileExists(atPath: systemWAV.path), "raw system WAV should still follow normal compression")
+    }
+
+    await runSuite("MeetingAudioStorageManager keeps raw split audio when playback mix generation fails") {
+        let directory = makeMeetingAudioStorageTestDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let transcriptURL = try! makeTranscript(named: "Mixer Failed Call", in: directory, ageDays: 1)
+        let audioDirectory = makeAudioDirectory(for: transcriptURL)
+        try! Data("mic".utf8).write(to: audioDirectory.appendingPathComponent("microphone.wav"))
+        try! Data("system".utf8).write(to: audioDirectory.appendingPathComponent("system_audio.wav"))
+
+        await MeetingAudioStorageManager.processSavedTranscript(
+            at: transcriptURL,
+            retentionWindow: .never,
+            converter: FakeMeetingAudioConverter(),
+            validator: FakeMeetingAudioValidator(),
+            playbackMixer: FakeMeetingAudioPlaybackMixer(shouldFail: true)
+        )
+
+        assertFalse(
+            FileManager.default.fileExists(atPath: audioDirectory.appendingPathComponent("playback.m4a").path),
+            "a failed playback mix should not leave a fake final playback file"
+        )
+        assertTrue(
+            FileManager.default.fileExists(atPath: audioDirectory.appendingPathComponent("microphone.m4a").path),
+            "mic audio should survive playback mix failure"
+        )
+        assertTrue(
+            FileManager.default.fileExists(atPath: audioDirectory.appendingPathComponent("system_audio.m4a").path),
+            "system audio should survive playback mix failure"
+        )
+    }
+
+    await runSuite("MeetingAudioStorageManager does not overwrite an existing playback mix") {
+        let directory = makeMeetingAudioStorageTestDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let transcriptURL = try! makeTranscript(named: "Existing Mix Call", in: directory, ageDays: 1)
+        let audioDirectory = makeAudioDirectory(for: transcriptURL)
+        let playbackM4A = audioDirectory.appendingPathComponent("playback.m4a")
+        try! Data("m4a".utf8).write(to: playbackM4A)
+        try! Data("mic".utf8).write(to: audioDirectory.appendingPathComponent("microphone.wav"))
+        try! Data("system".utf8).write(to: audioDirectory.appendingPathComponent("system_audio.wav"))
+
+        await MeetingAudioStorageManager.processSavedTranscript(
+            at: transcriptURL,
+            retentionWindow: .never,
+            converter: FakeMeetingAudioConverter(),
+            validator: FakeMeetingAudioValidator(),
+            playbackMixer: FakeMeetingAudioPlaybackMixer(shouldFail: true)
+        )
+
+        assertEqual(
+            try? Data(contentsOf: playbackM4A),
+            Data("m4a".utf8),
+            "existing usable playback audio should not be regenerated"
+        )
+        assertTrue(
+            FileManager.default.fileExists(atPath: audioDirectory.appendingPathComponent("microphone.m4a").path),
+            "raw microphone audio should still be compressed normally"
+        )
+        assertTrue(
+            FileManager.default.fileExists(atPath: audioDirectory.appendingPathComponent("system_audio.m4a").path),
+            "raw system audio should still be compressed normally"
+        )
+    }
+
+    await runSuite("MeetingAudioPlaybackMixer suppresses likely speaker bleed without clipping") {
+        let directory = makeMeetingAudioStorageTestDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let systemURL = directory.appendingPathComponent("system_audio.wav")
+        let micURL = directory.appendingPathComponent("microphone.wav")
+        let playbackURL = directory.appendingPathComponent("playback.wav")
+        try! writeFloatWAV(samples: Array(repeating: 0.40, count: 4096), to: systemURL)
+        try! writeFloatWAV(samples: Array(repeating: 0.08, count: 4096), to: micURL)
+
+        try! await AVFoundationMeetingAudioPlaybackMixer().createPlaybackWAV(
+            microphoneURL: micURL,
+            systemURL: systemURL,
+            destinationURL: playbackURL,
+            fileManager: .default
+        )
+
+        let samples = try! readFloatWAVSamples(from: playbackURL)
+        let maximum = samples.map { abs($0) }.max() ?? 0
+        let average = samples.reduce(Float(0), +) / Float(max(samples.count, 1))
+        assertTrue(maximum <= 0.98, "generated playback audio should be limited")
+        assertTrue(
+            average < 0.43,
+            "likely speaker bleed from the mic should not be mixed at full volume"
+        )
+    }
+
+    await runSuite("MeetingAudioPlaybackMixer resamples split streams with different sample rates") {
+        let directory = makeMeetingAudioStorageTestDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let systemURL = directory.appendingPathComponent("system_audio.wav")
+        let micURL = directory.appendingPathComponent("microphone.wav")
+        let playbackURL = directory.appendingPathComponent("playback.wav")
+        try! writeFloatWAV(samples: Array(repeating: 0.25, count: 4096), to: systemURL, sampleRate: 48_000)
+        try! writeFloatWAV(samples: Array(repeating: 0.18, count: 2048), to: micURL, sampleRate: 16_000)
+
+        try! await AVFoundationMeetingAudioPlaybackMixer().createPlaybackWAV(
+            microphoneURL: micURL,
+            systemURL: systemURL,
+            destinationURL: playbackURL,
+            fileManager: .default
+        )
+
+        let samples = try! readFloatWAVSamples(from: playbackURL)
+        let maximum = samples.map { abs($0) }.max() ?? 0
+        assertTrue(samples.count >= 4096, "generated playback should contain the system stream after resampling")
+        assertTrue(maximum <= 0.98, "resampled playback audio should be limited")
+    }
+
     await runSuite("MeetingAudioStorageManager ignores unrelated WAV files") {
         let directory = makeMeetingAudioStorageTestDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -165,7 +316,7 @@ func testMeetingAudioStorageManager() async {
         )
     }
 
-    await runSuite("MeetingAudioStorageManager removes only stale Transcripted temp M4A files") {
+    await runSuite("MeetingAudioStorageManager removes only stale Transcripted temp audio files") {
         let directory = makeMeetingAudioStorageTestDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
 
@@ -175,11 +326,17 @@ func testMeetingAudioStorageManager() async {
         let finalM4A = audioDirectory.appendingPathComponent("recording.m4a")
         let staleTemp = audioDirectory.appendingPathComponent(".recording-092B8B54-B598-4796-9573-00E0D9FC9EE1.m4a")
         let freshTemp = audioDirectory.appendingPathComponent(".recording-3F5531EE-C352-429F-A10F-EC978BBC2927.m4a")
+        let stalePlaybackTemp = audioDirectory.appendingPathComponent(".playback-86CE71C0-7B0D-43BC-8A3F-68C36195C8C6.wav")
+        let freshPlaybackTemp = audioDirectory.appendingPathComponent(".playback-196F0C64-898B-41E1-8062-7B2F3A2ED03E.wav")
         let unrelatedHiddenFile = audioDirectory.appendingPathComponent(".user-note.m4a")
+        let unrelatedHiddenWAV = audioDirectory.appendingPathComponent(".user-note.wav")
         try! Data("m4a".utf8).write(to: finalM4A)
         try! Data("stale".utf8).write(to: staleTemp)
         try! Data("fresh".utf8).write(to: freshTemp)
+        try! Data("stale playback".utf8).write(to: stalePlaybackTemp)
+        try! Data("fresh playback".utf8).write(to: freshPlaybackTemp)
         try! Data("user".utf8).write(to: unrelatedHiddenFile)
+        try! Data("user wav".utf8).write(to: unrelatedHiddenWAV)
         try! FileManager.default.setAttributes(
             [.modificationDate: now.addingTimeInterval(-11 * 60)],
             ofItemAtPath: staleTemp.path
@@ -190,7 +347,19 @@ func testMeetingAudioStorageManager() async {
         )
         try! FileManager.default.setAttributes(
             [.modificationDate: now.addingTimeInterval(-11 * 60)],
+            ofItemAtPath: stalePlaybackTemp.path
+        )
+        try! FileManager.default.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-60)],
+            ofItemAtPath: freshPlaybackTemp.path
+        )
+        try! FileManager.default.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-11 * 60)],
             ofItemAtPath: unrelatedHiddenFile.path
+        )
+        try! FileManager.default.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-11 * 60)],
+            ofItemAtPath: unrelatedHiddenWAV.path
         )
 
         let converted = await MeetingAudioStorageManager.compressWAVAudio(
@@ -202,8 +371,17 @@ func testMeetingAudioStorageManager() async {
 
         assertEqual(converted, 0, "temp cleanup should not count as a WAV conversion")
         assertFalse(FileManager.default.fileExists(atPath: staleTemp.path), "stale app-owned temp file should be removed")
+        assertFalse(
+            FileManager.default.fileExists(atPath: stalePlaybackTemp.path),
+            "stale playback temp WAV should be removed"
+        )
         assertTrue(FileManager.default.fileExists(atPath: freshTemp.path), "recent temp file should not be removed")
+        assertTrue(
+            FileManager.default.fileExists(atPath: freshPlaybackTemp.path),
+            "recent playback temp WAV should not be removed"
+        )
         assertTrue(FileManager.default.fileExists(atPath: unrelatedHiddenFile.path), "unrelated hidden M4A should not be removed")
+        assertTrue(FileManager.default.fileExists(atPath: unrelatedHiddenWAV.path), "unrelated hidden WAV should not be removed")
         assertTrue(FileManager.default.fileExists(atPath: finalM4A.path), "final M4A should stay")
     }
 
@@ -483,6 +661,22 @@ private struct FakeMeetingAudioConverter: MeetingAudioFileConverting {
     }
 }
 
+private struct FakeMeetingAudioPlaybackMixer: MeetingAudioPlaybackMixing {
+    var shouldFail = false
+
+    func createPlaybackWAV(
+        microphoneURL: URL,
+        systemURL: URL,
+        destinationURL: URL,
+        fileManager: FileManager
+    ) async throws {
+        if shouldFail {
+            throw MeetingAudioStorageError.conversionFailed
+        }
+        try Data("m4a".utf8).write(to: destinationURL)
+    }
+}
+
 private struct FakeMeetingAudioValidator: MeetingAudioFileValidating {
     func isUsableAudioFile(at url: URL, fileManager: FileManager) -> Bool {
         guard fileManager.fileExists(atPath: url.path) else { return false }
@@ -550,4 +744,48 @@ private func makeAudioDirectory(for transcriptURL: URL) -> URL {
         .appendingPathComponent("\(transcriptURL.deletingPathExtension().lastPathComponent)_audio", isDirectory: true)
     try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     return directory
+}
+
+private func writeFloatWAV(samples: [Float], to url: URL, sampleRate: Double = 48_000) throws {
+    guard let format = AVAudioFormat(
+        commonFormat: .pcmFormatFloat32,
+        sampleRate: sampleRate,
+        channels: 1,
+        interleaved: false
+    ), let buffer = AVAudioPCMBuffer(
+        pcmFormat: format,
+        frameCapacity: AVAudioFrameCount(samples.count)
+    ) else {
+        throw MeetingAudioStorageError.mixBufferAllocationFailed
+    }
+
+    buffer.frameLength = AVAudioFrameCount(samples.count)
+    samples.withUnsafeBufferPointer { pointer in
+        guard let base = pointer.baseAddress,
+              let destination = buffer.floatChannelData?[0] else {
+            return
+        }
+        destination.update(from: base, count: samples.count)
+    }
+
+    let file = try AVAudioFile(
+        forWriting: url,
+        settings: format.settings,
+        commonFormat: format.commonFormat,
+        interleaved: format.isInterleaved
+    )
+    try file.write(from: buffer)
+}
+
+private func readFloatWAVSamples(from url: URL) throws -> [Float] {
+    let file = try AVAudioFile(forReading: url)
+    guard let buffer = AVAudioPCMBuffer(
+        pcmFormat: file.processingFormat,
+        frameCapacity: AVAudioFrameCount(file.length)
+    ) else {
+        throw MeetingAudioStorageError.mixBufferAllocationFailed
+    }
+    try file.read(into: buffer)
+    guard let data = buffer.floatChannelData?[0] else { return [] }
+    return Array(UnsafeBufferPointer(start: data, count: Int(buffer.frameLength)))
 }


### PR DESCRIPTION
## Summary
- generate one derived playback mix for retained live meeting audio before WAV compression
- keep raw microphone and system audio retained for retranscription, retry, and debug flows
- remove the raw Full/System/Mic playback choice path so normal playback does not layer mic bleed over system audio
- preserve issue #500 guardrails by leaving capture, RealtimeAGC, and voice-processing defaults unchanged

## Verification
- bash run-tests.sh
- bash build.sh
- bash run-integration-smoke.sh
- swift test
- codex-review --full-access: clean
