### PR TITLE
[nightly-regression] Cover saved meeting retranscription gates

### DIFF
--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -188,6 +188,53 @@ func testRecentCaptureScanners() {
         )
     }
 
+    runSuite("SavedMeetingRetranscriptionAvailabilityPolicy blocks during live work") {
+        assertEqual(
+            SavedMeetingRetranscriptionAvailabilityPolicy.unavailableReason(
+                isDictationActive: true,
+                isMeetingRecording: false,
+                isPreparingModels: false,
+                hasMeetingWork: false,
+                isSpeakerReviewPending: false
+            ),
+            "Wait for the current dictation to finish before re-transcribing saved audio.",
+            "saved-meeting re-transcription should not race an active dictation"
+        )
+        assertEqual(
+            SavedMeetingRetranscriptionAvailabilityPolicy.unavailableReason(
+                isDictationActive: false,
+                isMeetingRecording: true,
+                isPreparingModels: false,
+                hasMeetingWork: false,
+                isSpeakerReviewPending: false
+            ),
+            "Stop the current recording before re-transcribing saved audio.",
+            "saved-meeting re-transcription should not start while a meeting is recording"
+        )
+        assertEqual(
+            SavedMeetingRetranscriptionAvailabilityPolicy.unavailableReason(
+                isDictationActive: false,
+                isMeetingRecording: false,
+                isPreparingModels: false,
+                hasMeetingWork: true,
+                isSpeakerReviewPending: false
+            ),
+            "Wait for the current meeting to finish saving or transcribing before re-transcribing saved audio.",
+            "saved-meeting re-transcription should stay single-flight with background meeting work"
+        )
+        assertEqual(
+            SavedMeetingRetranscriptionAvailabilityPolicy.unavailableReason(
+                isDictationActive: false,
+                isMeetingRecording: false,
+                isPreparingModels: false,
+                hasMeetingWork: false,
+                isSpeakerReviewPending: true
+            ),
+            "Finish the speaker review window before re-transcribing saved audio.",
+            "saved-meeting re-transcription should wait until speaker review is resolved"
+        )
+    }
+
     runSuite("SavedMeetingRetranscriptionAvailabilityPolicy allows idle saved meetings") {
         assertNil(
             SavedMeetingRetranscriptionAvailabilityPolicy.unavailableReason(


### PR DESCRIPTION
## Summary
- add fast-test coverage for saved-meeting re-transcription being blocked during active dictation, active meeting recording, background meeting work, and pending speaker review
- keep the new saved-audio speaker-ID path guarded against obvious concurrency races

## Nightly review notes
- Top risk: saved meeting re-transcription is new and touches live meeting/dictation state, so the safest action was tests-only coverage for its gate policy.
- Sentry: latest 24h production errors are still audio-device/dictation-start shaped; the current 1.1.42 dictation timeouts happened before the Bluetooth readiness fix merged.
- PostHog: last 24h showed meeting_transcript_saved activity and zero meeting_transcript_failed events.

## Verification
- bash run-tests.sh
- bash build-deps.sh --force
- bash build.sh
