### PR TITLE
[nightly-agent] Detect stale Claude MCP helper

### DIFF
--- a/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
+++ b/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
@@ -14,6 +14,7 @@ struct ClaudeDesktopIntegrationStatus: Equatable {
     let configuredCommandPath: String?
     let installedBinaryExists: Bool
     let bundledBinaryExists: Bool
+    let installedBinaryMatchesBundled: Bool
     let configExists: Bool
     let configIsReadable: Bool
     let claudeDesktopLikelyInstalled: Bool
@@ -121,9 +122,16 @@ enum ClaudeDesktopIntegrationInstaller {
         let configuredCommandPath = configRead.config.flatMap(transcriptedCommandPath(in:))
         let configIsReadable = !configExists || configRead.config != nil
         let isConfiguredForInstalledBinary = configuredCommandPath == installedBinaryURL.path
+        let installedBinaryMatchesBundled = installedBinaryMatchesBundled(
+            installedBinaryURL: installedBinaryURL,
+            bundledBinaryURL: bundledBinaryURL,
+            installedBinaryExists: installedBinaryExists,
+            bundledBinaryExists: bundledBinaryExists,
+            fileManager: fileManager
+        )
 
         let state: ClaudeDesktopIntegrationStatus.State
-        if installedBinaryExists && isConfiguredForInstalledBinary {
+        if installedBinaryExists && isConfiguredForInstalledBinary && installedBinaryMatchesBundled {
             state = .installed
         } else if !configExists && !installedBinaryExists {
             state = .notInstalled
@@ -139,6 +147,7 @@ enum ClaudeDesktopIntegrationInstaller {
             configuredCommandPath: configuredCommandPath,
             installedBinaryExists: installedBinaryExists,
             bundledBinaryExists: bundledBinaryExists,
+            installedBinaryMatchesBundled: installedBinaryMatchesBundled,
             configExists: configExists,
             configIsReadable: configIsReadable,
             claudeDesktopLikelyInstalled: claudeDesktopLikelyInstalled(fileManager: fileManager)
@@ -312,6 +321,26 @@ enum ClaudeDesktopIntegrationInstaller {
         }
 
         return transcripted["command"] as? String
+    }
+
+    private static func installedBinaryMatchesBundled(
+        installedBinaryURL: URL,
+        bundledBinaryURL: URL?,
+        installedBinaryExists: Bool,
+        bundledBinaryExists: Bool,
+        fileManager: FileManager
+    ) -> Bool {
+        guard installedBinaryExists,
+              bundledBinaryExists,
+              let bundledBinaryURL else {
+            return true
+        }
+
+        if installedBinaryURL.standardizedFileURL.path == bundledBinaryURL.standardizedFileURL.path {
+            return true
+        }
+
+        return fileManager.contentsEqual(atPath: installedBinaryURL.path, andPath: bundledBinaryURL.path)
     }
 
     private static func backupConfig(at configURL: URL, fileManager: FileManager) throws -> URL? {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -4568,6 +4568,9 @@ private struct ClaudeDesktopStatusRow: View {
             if !status.installedBinaryExists {
                 return "The server file is missing. Install will copy a fresh one and update Claude Desktop."
             }
+            if !status.installedBinaryMatchesBundled {
+                return "The installed server is from an older app build. Install will copy the current one."
+            }
             return "Claude Desktop points at another Transcripted server. Install will update it."
         }
     }

--- a/Tests/ClaudeDesktopIntegrationInstallerTests.swift
+++ b/Tests/ClaudeDesktopIntegrationInstallerTests.swift
@@ -98,7 +98,40 @@ func testClaudeDesktopIntegrationInstaller() {
 
         assertEqual(status.state, .installed, "matching executable and config should be installed")
         assertTrue(status.isInstalled, "installed convenience flag should be true")
+        assertTrue(status.installedBinaryMatchesBundled, "installed helper should match bundled helper")
         assertEqual(status.configuredCommandPath, binaryURL.path, "status should expose configured command")
+    }
+
+    runSuite("ClaudeDesktopIntegrationInstaller.currentStatus — detects stale installed helper") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeStaleHelperTests-\(UUID().uuidString)", isDirectory: true)
+        let configURL = tempRoot
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("claude_desktop_config.json", isDirectory: false)
+        let installedBinaryURL = tempRoot
+            .appendingPathComponent("mcp", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        let bundledBinaryURL = tempRoot
+            .appendingPathComponent("bundle", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try? FileManager.default.createDirectory(at: installedBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(at: bundledBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? "#!/bin/sh\nexit 0\n".write(to: installedBinaryURL, atomically: true, encoding: .utf8)
+        try? "#!/bin/sh\necho current\n".write(to: bundledBinaryURL, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: installedBinaryURL.path)
+        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: bundledBinaryURL.path)
+        _ = try? ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig(commandPath: installedBinaryURL.path, configURL: configURL)
+
+        let status = ClaudeDesktopIntegrationInstaller.currentStatus(
+            configURL: configURL,
+            installedBinaryURL: installedBinaryURL,
+            bundledBinaryURL: bundledBinaryURL
+        )
+
+        assertEqual(status.state, .needsRepair, "stale installed helper should be repaired even when config points at it")
+        assertFalse(status.installedBinaryMatchesBundled, "status should expose stale helper mismatch")
     }
 
     runSuite("ClaudeDesktopIntegrationInstaller.bundledMCPBinaryURL — uses Helpers bundle location only") {


### PR DESCRIPTION
## Summary
- detect when the installed Claude Desktop MCP helper differs from the bundled helper
- mark stale helpers as repair-needed instead of installed
- add settings copy and fast-test coverage for the stale helper path

## Verification
- swift test --package-path Tools/TranscriptedCLI
- swift test --package-path Tools/TranscriptedMCP
- cd Tools/TranscriptedMCP && swift build -c release
- Tools/TranscriptedMCP/.build/release/transcripted-mcp --help
- Tools/TranscriptedMCP/.build/release/transcripted-mcp --self-test
- explicit TRANSCRIPTED_DATA_DIR MCP self-test
- CLI context-recent/context-search/list-dictations/read-meeting/read-dictation with explicit --data-dir
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh