### PR TITLE
[nightly-ux] Clarify failed meeting retry state

### DIFF
--- a/Sources/UI/Settings/HomeFailedMeetingInlinePresentation.swift
+++ b/Sources/UI/Settings/HomeFailedMeetingInlinePresentation.swift
@@ -21,8 +21,8 @@ struct HomeFailedMeetingInlinePresentation: Equatable {
 
         if isRetryable, hasAudioFiles {
             return HomeFailedMeetingInlinePresentation(
-                statusText: "Needs retry",
-                inlineDetail: nil,
+                statusText: "Retry ready",
+                inlineDetail: "Saved audio is still here. Try again will transcribe it.",
                 canShowRetryAction: true
             )
         }

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -85,7 +85,7 @@ func testFailedMeetingPresentation() {
         assertFalse(presentation.canShowRetryAction, "non-retryable failures should not show Try again")
     }
 
-    runSuite("HomeFailedMeetingInlinePresentation keeps retryable rows minimal") {
+    runSuite("HomeFailedMeetingInlinePresentation explains retryable saved audio") {
         let presentation = HomeFailedMeetingInlinePresentation.make(
             isRetryable: true,
             isRetrying: false,
@@ -93,8 +93,12 @@ func testFailedMeetingPresentation() {
             detail: "Model was not ready."
         )
 
-        assertEqual(presentation.statusText, "Needs retry", "retryable rows should keep the simple retry label")
-        assertNil(presentation.inlineDetail, "retryable rows do not need extra inline copy")
+        assertEqual(presentation.statusText, "Retry ready", "retryable rows should show that recovery is available")
+        assertEqual(
+            presentation.inlineDetail,
+            "Saved audio is still here. Try again will transcribe it.",
+            "retryable rows should make saved audio preservation visible"
+        )
         assertTrue(presentation.canShowRetryAction, "retryable failures with audio should show Try again")
     }
 


### PR DESCRIPTION
## Summary
- Show retryable failed meetings as Retry ready instead of Needs retry.
- Add inline copy that saved audio is still there and Try again will transcribe it.
- Update the existing failed-meeting presentation test.

## Evidence
- Issue #825 was updated on 2026-05-21 asking for clearer visibility into whether long-meeting failures preserved audio and had a rescue path.
- This is a localized UI trust fix, not a telemetry payload change.

## Verification
- bash build-deps.sh --force
- bash build.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh (2338/2338)