### PR TITLE
[bug-hunter] Scale long meeting stop timeout

### DIFF
--- a/Sources/Meeting/MeetingAudioStorageManager.swift
+++ b/Sources/Meeting/MeetingAudioStorageManager.swift
@@ -56,7 +56,7 @@ struct MeetingAudioStorageMaintenanceResult: Equatable {
 
 enum MeetingAudioStorageManager {
     private static let frontmatterPreviewByteLimit = 64 * 1024
-    private static let staleTemporaryM4AAge: TimeInterval = 10 * 60
+    private static let staleTemporaryM4AAge: TimeInterval = 6 * 60 * 60
     private static let managedAudioStems = ["microphone", "system_audio", "recording", "playback"]
 
     @discardableResult

--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -104,13 +104,16 @@ final class MeetingCaptureBridge: ObservableObject {
         guard audio.isRecording else {
             return currentStopResult()
         }
+        let stopTimeout = TranscriptedConstants.meetingStopTimeout(
+            forRecordingDuration: max(recordingDuration, audio.recordingDuration)
+        )
 
         return await withCheckedContinuation { continuation in
             let attemptID = completionAttempt.begin(continuation)
             audio.stop()
 
             completionAttempt.setTimeoutTask(Task { @MainActor [weak self] in
-                try? await Task.sleep(nanoseconds: TranscriptedConstants.meetingStopTimeout)
+                try? await Task.sleep(nanoseconds: stopTimeout)
                 guard let self,
                       let continuation = self.completionAttempt.resetIfCurrent(attemptID) else { return }
 
@@ -123,6 +126,7 @@ final class MeetingCaptureBridge: ObservableObject {
                         [
                             "mic_file_available": "\(self.audio.micAudioFileURL != nil)",
                             "system_file_available": "\(self.audio.systemAudioFileURL != nil)",
+                            "stop_timeout_seconds": "\(stopTimeout / 1_000_000_000)",
                         ],
                         uniquingKeysWith: { _, new in new }
                     )

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -53,15 +53,35 @@ enum TranscriptedConstants {
     /// neither the success nor error publisher has fired.
     static let meetingStartTimeout: UInt64 = 5_000_000_000  // 5 seconds
 
-    /// Timeout for waiting on meeting capture file-close callbacks after stop.
-    /// The bridge falls back to the best URLs it has instead of leaving the UI
-    /// stuck forever if CoreAudio cleanup never calls completion.
+    /// Base timeout for waiting on meeting capture file-close callbacks after
+    /// stop. Long recordings can need more time to flush and merge audio, so
+    /// call `meetingStopTimeout(forRecordingDuration:)` for live capture.
     static let meetingStopTimeout: UInt64 = 30_000_000_000  // 30 seconds
 
+    /// Maximum stop wait for long recordings. This keeps 2h+ meetings from
+    /// being failed while audio finalization is still making progress.
+    static let meetingMaximumStopTimeout: UInt64 = 120_000_000_000  // 120 seconds
+
+    /// Adds this much stop-wait budget for each recorded hour, capped by
+    /// `meetingMaximumStopTimeout`.
+    static let meetingStopTimeoutGrowthStep: UInt64 = 30_000_000_000  // 30 seconds
+
+    static func meetingStopTimeout(forRecordingDuration duration: TimeInterval) -> UInt64 {
+        guard duration.isFinite, duration > 0 else { return meetingStopTimeout }
+
+        let maxGrowthSteps = (meetingMaximumStopTimeout - meetingStopTimeout) / meetingStopTimeoutGrowthStep
+        let recordedHours = UInt64(min(duration / 3_600, Double(maxGrowthSteps)))
+        guard recordedHours > 0 else { return meetingStopTimeout }
+
+        let scaledTimeout = meetingStopTimeout + (recordedHours * meetingStopTimeoutGrowthStep)
+        return min(scaledTimeout, meetingMaximumStopTimeout)
+    }
+
     /// Max time app termination waits for an in-flight meeting stop to finish.
-    /// This must stay above `meetingStopTimeout` so quit preservation does not
-    /// give up before the bridge returns retained audio URLs.
-    static let meetingTerminationFinishWaitTimeout: TimeInterval = 35.0
+    /// This must stay above the maximum scaled stop timeout so quit
+    /// preservation does not give up before the bridge returns retained audio
+    /// URLs.
+    static let meetingTerminationFinishWaitTimeout: TimeInterval = 125.0
 
     /// Failed meeting audio is recoverable, but old unretried files should not grow forever.
     static let failedMeetingAudioRetentionDays = 30

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -67,10 +67,10 @@ enum TranscriptedConstants {
     static let meetingStopTimeoutGrowthStep: UInt64 = 30_000_000_000  // 30 seconds
 
     static func meetingStopTimeout(forRecordingDuration duration: TimeInterval) -> UInt64 {
-        guard duration.isFinite, duration > 0 else { return meetingStopTimeout }
+        guard duration.isFinite, duration >= 3_600 else { return meetingStopTimeout }
 
         let maxGrowthSteps = (meetingMaximumStopTimeout - meetingStopTimeout) / meetingStopTimeoutGrowthStep
-        let recordedHours = UInt64(min(duration / 3_600, Double(maxGrowthSteps)))
+        let recordedHours = UInt64(min(ceil(duration / 3_600), Double(maxGrowthSteps)))
         guard recordedHours > 0 else { return meetingStopTimeout }
 
         let scaledTimeout = meetingStopTimeout + (recordedHours * meetingStopTimeoutGrowthStep)

--- a/Sources/TranscriptedCore/Audio/MicRecordingFileMerger.swift
+++ b/Sources/TranscriptedCore/Audio/MicRecordingFileMerger.swift
@@ -4,6 +4,7 @@ import Foundation
 enum MicRecordingFileMerger {
     private static let outputSampleRate: Double = 16_000
     private static let chunkSize = 16_000 * 30
+    private static let chunkDurationSeconds: Double = 30
 
     static func merge(primaryURL: URL?, segments: [MicRecordingSegment]) throws -> URL? {
         guard let primaryURL else { return segments.last?.url }
@@ -18,7 +19,7 @@ enum MicRecordingFileMerger {
             commonFormat: .pcmFormatFloat32,
             sampleRate: outputSampleRate,
             channels: 1,
-            interleaved: true
+            interleaved: false
         ) else {
             throw NSError(domain: "MicRecordingFileMerger", code: 1, userInfo: [
                 NSLocalizedDescriptionKey: "Failed to create merged mic format"
@@ -44,11 +45,7 @@ enum MicRecordingFileMerger {
                     }
                 }
 
-                let samples = try AudioResampler.loadAndResample(
-                    url: segment.url,
-                    targetRate: outputSampleRate
-                )
-                try writeSamples(samples, to: mergedFile, format: outputFormat)
+                try appendSegment(segment.url, to: mergedFile, outputFormat: outputFormat)
             }
 
             FileManager.default.restrictToOwnerOnly(atPath: mergedURL.path)
@@ -62,38 +59,150 @@ enum MicRecordingFileMerger {
         }
     }
 
-    private static func writeSamples(
-        _ samples: [Float],
-        to file: AVAudioFile,
-        format: AVAudioFormat
+    private static func appendSegment(
+        _ url: URL,
+        to outputFile: AVAudioFile,
+        outputFormat: AVAudioFormat
     ) throws {
-        var offset = 0
+        let sourceFile = try AVAudioFile(forReading: url)
+        let sourceFormat = sourceFile.processingFormat
 
-        while offset < samples.count {
-            let count = min(chunkSize, samples.count - offset)
-            guard let buffer = AVAudioPCMBuffer(
-                pcmFormat: format,
-                frameCapacity: AVAudioFrameCount(count)
+        guard sourceFile.length > 0 else {
+            throw PipelineError.emptyAudioFile
+        }
+        guard sourceFile.length <= Int64(AVAudioFrameCount.max) else {
+            throw NSError(domain: "MicRecordingFileMerger", code: 4, userInfo: [
+                NSLocalizedDescriptionKey: "Audio segment is too large to merge safely"
+            ])
+        }
+        guard AudioRecordingFormatPolicy.isUsableSampleRate(sourceFormat.sampleRate),
+              AudioRecordingFormatPolicy.isUsableSampleRate(outputFormat.sampleRate),
+              sourceFormat.channelCount > 0 else {
+            throw NSError(domain: "MicRecordingFileMerger", code: 5, userInfo: [
+                NSLocalizedDescriptionKey: "Audio segment has an invalid sample rate or channel count"
+            ])
+        }
+        if formatsMatch(sourceFormat, outputFormat) {
+            try appendCompatibleSegment(sourceFile, to: outputFile, format: outputFormat)
+            return
+        }
+        guard let converter = AVAudioConverter(from: sourceFormat, to: outputFormat) else {
+            throw NSError(domain: "MicRecordingFileMerger", code: 6, userInfo: [
+                NSLocalizedDescriptionKey: "Failed to create segment converter"
+            ])
+        }
+
+        let outputCapacity = AVAudioFrameCount(outputFormat.sampleRate * chunkDurationSeconds)
+        let inputCapacity = AVAudioFrameCount(sourceFormat.sampleRate * chunkDurationSeconds)
+        var inputEnded = false
+        var inputBlockError: Error?
+        var noProgressIterations = 0
+
+        while true {
+            guard let outputBuffer = AVAudioPCMBuffer(
+                pcmFormat: outputFormat,
+                frameCapacity: outputCapacity
             ) else {
-                throw NSError(domain: "MicRecordingFileMerger", code: 2, userInfo: [
-                    NSLocalizedDescriptionKey: "Failed to allocate merged mic buffer"
+                throw NSError(domain: "MicRecordingFileMerger", code: 7, userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to allocate merged segment output buffer"
                 ])
             }
 
-            buffer.frameLength = AVAudioFrameCount(count)
-            if let channelData = buffer.floatChannelData?[0] {
-                samples.withUnsafeBufferPointer { pointer in
-                    // Security: guard against nil baseAddress — baseAddress is non-nil for
-                    // non-empty arrays, which is guaranteed by the loop condition (offset <
-                    // samples.count), but force-unwrapping here would crash the audio thread
-                    // if the invariant were ever violated.
-                    guard let base = pointer.baseAddress else { return }
-                    channelData.update(from: base + offset, count: count)
+            var conversionError: NSError?
+            let status = converter.convert(to: outputBuffer, error: &conversionError) { _, outStatus in
+                guard !inputEnded, sourceFile.framePosition < sourceFile.length else {
+                    inputEnded = true
+                    outStatus.pointee = .endOfStream
+                    return nil
+                }
+
+                let remainingFrames = sourceFile.length - sourceFile.framePosition
+                let framesToRead = min(inputCapacity, AVAudioFrameCount(remainingFrames))
+                guard framesToRead > 0,
+                      let inputBuffer = AVAudioPCMBuffer(
+                        pcmFormat: sourceFormat,
+                        frameCapacity: framesToRead
+                      ) else {
+                    inputBlockError = NSError(domain: "MicRecordingFileMerger", code: 8, userInfo: [
+                        NSLocalizedDescriptionKey: "Failed to allocate merged segment input buffer"
+                    ])
+                    inputEnded = true
+                    outStatus.pointee = .endOfStream
+                    return nil
+                }
+
+                do {
+                    try sourceFile.read(into: inputBuffer, frameCount: framesToRead)
+                    outStatus.pointee = .haveData
+                    return inputBuffer
+                } catch {
+                    inputBlockError = error
+                    inputEnded = true
+                    outStatus.pointee = .endOfStream
+                    return nil
                 }
             }
 
-            try file.write(from: buffer)
-            offset += count
+            if let conversionError { throw conversionError }
+            if let inputBlockError { throw inputBlockError }
+
+            if outputBuffer.frameLength > 0 {
+                try outputFile.write(from: outputBuffer)
+                noProgressIterations = 0
+            } else {
+                noProgressIterations += 1
+            }
+
+            switch status {
+            case .haveData, .inputRanDry:
+                guard noProgressIterations < 32 else {
+                    throw NSError(domain: "MicRecordingFileMerger", code: 9, userInfo: [
+                        NSLocalizedDescriptionKey: "Segment conversion made no progress"
+                    ])
+                }
+                continue
+            case .endOfStream:
+                return
+            case .error:
+                throw conversionError ?? NSError(domain: "MicRecordingFileMerger", code: 10, userInfo: [
+                    NSLocalizedDescriptionKey: "Segment conversion failed"
+                ])
+            @unknown default:
+                throw NSError(domain: "MicRecordingFileMerger", code: 12, userInfo: [
+                    NSLocalizedDescriptionKey: "Segment conversion returned an unknown status"
+                ])
+            }
+        }
+    }
+
+    private static func formatsMatch(_ lhs: AVAudioFormat, _ rhs: AVAudioFormat) -> Bool {
+        lhs.commonFormat == rhs.commonFormat
+            && lhs.sampleRate == rhs.sampleRate
+            && lhs.channelCount == rhs.channelCount
+            && lhs.isInterleaved == rhs.isInterleaved
+    }
+
+    private static func appendCompatibleSegment(
+        _ sourceFile: AVAudioFile,
+        to outputFile: AVAudioFile,
+        format: AVAudioFormat
+    ) throws {
+        while sourceFile.framePosition < sourceFile.length {
+            let remainingFrames = sourceFile.length - sourceFile.framePosition
+            let framesToRead = min(AVAudioFrameCount(chunkSize), AVAudioFrameCount(remainingFrames))
+            guard let buffer = AVAudioPCMBuffer(
+                pcmFormat: format,
+                frameCapacity: framesToRead
+            ) else {
+                throw NSError(domain: "MicRecordingFileMerger", code: 13, userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to allocate direct segment buffer"
+                ])
+            }
+
+            try sourceFile.read(into: buffer, frameCount: framesToRead)
+            if buffer.frameLength > 0 {
+                try outputFile.write(from: buffer)
+            }
         }
     }
 

--- a/Tests/MeetingAudioStorageManagerTests.swift
+++ b/Tests/MeetingAudioStorageManagerTests.swift
@@ -165,7 +165,7 @@ func testMeetingAudioStorageManager() async {
         )
     }
 
-    await runSuite("MeetingAudioStorageManager removes only stale Transcripted temp M4A files") {
+    await runSuite("MeetingAudioStorageManager removes only old Transcripted temp M4A files") {
         let directory = makeMeetingAudioStorageTestDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
 
@@ -173,23 +173,23 @@ func testMeetingAudioStorageManager() async {
         let transcriptURL = try! makeTranscript(named: "Temp Cleanup", in: directory, ageDays: 1)
         let audioDirectory = makeAudioDirectory(for: transcriptURL)
         let finalM4A = audioDirectory.appendingPathComponent("recording.m4a")
-        let staleTemp = audioDirectory.appendingPathComponent(".recording-092B8B54-B598-4796-9573-00E0D9FC9EE1.m4a")
-        let freshTemp = audioDirectory.appendingPathComponent(".recording-3F5531EE-C352-429F-A10F-EC978BBC2927.m4a")
+        let oldTemp = audioDirectory.appendingPathComponent(".recording-092B8B54-B598-4796-9573-00E0D9FC9EE1.m4a")
+        let longRunningTemp = audioDirectory.appendingPathComponent(".recording-3F5531EE-C352-429F-A10F-EC978BBC2927.m4a")
         let unrelatedHiddenFile = audioDirectory.appendingPathComponent(".user-note.m4a")
         try! Data("m4a".utf8).write(to: finalM4A)
-        try! Data("stale".utf8).write(to: staleTemp)
-        try! Data("fresh".utf8).write(to: freshTemp)
+        try! Data("old".utf8).write(to: oldTemp)
+        try! Data("active".utf8).write(to: longRunningTemp)
         try! Data("user".utf8).write(to: unrelatedHiddenFile)
         try! FileManager.default.setAttributes(
-            [.modificationDate: now.addingTimeInterval(-11 * 60)],
-            ofItemAtPath: staleTemp.path
+            [.modificationDate: now.addingTimeInterval(-7 * 60 * 60)],
+            ofItemAtPath: oldTemp.path
         )
         try! FileManager.default.setAttributes(
-            [.modificationDate: now.addingTimeInterval(-60)],
-            ofItemAtPath: freshTemp.path
+            [.modificationDate: now.addingTimeInterval(-2 * 60 * 60)],
+            ofItemAtPath: longRunningTemp.path
         )
         try! FileManager.default.setAttributes(
-            [.modificationDate: now.addingTimeInterval(-11 * 60)],
+            [.modificationDate: now.addingTimeInterval(-7 * 60 * 60)],
             ofItemAtPath: unrelatedHiddenFile.path
         )
 
@@ -201,8 +201,8 @@ func testMeetingAudioStorageManager() async {
         )
 
         assertEqual(converted, 0, "temp cleanup should not count as a WAV conversion")
-        assertFalse(FileManager.default.fileExists(atPath: staleTemp.path), "stale app-owned temp file should be removed")
-        assertTrue(FileManager.default.fileExists(atPath: freshTemp.path), "recent temp file should not be removed")
+        assertFalse(FileManager.default.fileExists(atPath: oldTemp.path), "old app-owned temp file should be removed")
+        assertTrue(FileManager.default.fileExists(atPath: longRunningTemp.path), "long-running conversion temp files should not be removed too early")
         assertTrue(FileManager.default.fileExists(atPath: unrelatedHiddenFile.path), "unrelated hidden M4A should not be removed")
         assertTrue(FileManager.default.fileExists(atPath: finalM4A.path), "final M4A should stay")
     }

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -683,6 +683,25 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - bridge uses scaled meeting stop timeout") {
+        let bridgeContents = readRepoTextFile("Sources/Meeting/MeetingCaptureBridge.swift")
+        let stopBlock = sourceSlice(
+            bridgeContents,
+            from: "func stopAndAwaitFiles() async -> CaptureStopResult {",
+            to: "func stopAndDiscardFiles() async -> CaptureStopResult {"
+        )
+
+        assertTrue(
+            stopBlock.contains("TranscriptedConstants.meetingStopTimeout(")
+                && stopBlock.contains("forRecordingDuration: max(recordingDuration, audio.recordingDuration)"),
+            "meeting stop should scale the timeout from the observed recording duration"
+        )
+        assertTrue(
+            stopBlock.contains("Task.sleep(nanoseconds: stopTimeout)"),
+            "meeting stop should sleep on the scaled timeout, not the fixed base timeout"
+        )
+    }
+
     runSuite("Repo command contract - old failed meeting audio is pruned by age") {
         let constantsContents = readRepoTextFile("Sources/Support/TranscriptedConstants.swift")
         let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
@@ -739,6 +758,19 @@ func testRepoCommandContract() {
             ),
             1,
             "direct failed-queue writes in MeetingSessionController should stay centralized in the refresh helper"
+        )
+    }
+
+    runSuite("Repo command contract - mic recovery merge streams long segments") {
+        let mergerContents = readRepoTextFile("Sources/TranscriptedCore/Audio/MicRecordingFileMerger.swift")
+
+        assertFalse(
+            mergerContents.contains("AudioResampler.loadAndResample"),
+            "mic segment merge should not load full long recordings into memory during stop"
+        )
+        assertTrue(
+            mergerContents.contains("converter.convert(to: outputBuffer"),
+            "mic segment merge should stream conversion into bounded output buffers"
         )
     }
 

--- a/Tests/TranscriptedConstantsTests.swift
+++ b/Tests/TranscriptedConstantsTests.swift
@@ -21,6 +21,29 @@ func testTranscriptedConstants() async {
             TranscriptedConstants.meetingTerminationFinishWaitTimeout > meetingStopTimeoutSeconds,
             "termination wait should outlast meeting stop timeout so retained audio can be queued before quit"
         )
+        let maximumStopTimeoutSeconds = TimeInterval(TranscriptedConstants.meetingMaximumStopTimeout) / 1_000_000_000
+        assertTrue(
+            TranscriptedConstants.meetingTerminationFinishWaitTimeout > maximumStopTimeoutSeconds,
+            "termination wait should outlast the longest scaled stop timeout"
+        )
+    }
+
+    runSuite("TranscriptedConstants scales meeting stop timeout for long recordings") {
+        assertEqual(
+            TranscriptedConstants.meetingStopTimeout(forRecordingDuration: 10 * 60),
+            TranscriptedConstants.meetingStopTimeout,
+            "short meetings should keep the fast base stop timeout"
+        )
+        assertTrue(
+            TranscriptedConstants.meetingStopTimeout(forRecordingDuration: 2 * 60 * 60)
+                > TranscriptedConstants.meetingStopTimeout,
+            "multi-hour meetings should get extra time to flush and merge audio"
+        )
+        assertEqual(
+            TranscriptedConstants.meetingStopTimeout(forRecordingDuration: 12 * 60 * 60),
+            TranscriptedConstants.meetingMaximumStopTimeout,
+            "very long meetings should cap the stop wait"
+        )
     }
 
     runSuite("TranscriptedConstants keeps failed meeting audio cleanup conservative") {

--- a/Tests/TranscriptedConstantsTests.swift
+++ b/Tests/TranscriptedConstantsTests.swift
@@ -34,10 +34,15 @@ func testTranscriptedConstants() async {
             TranscriptedConstants.meetingStopTimeout,
             "short meetings should keep the fast base stop timeout"
         )
-        assertTrue(
-            TranscriptedConstants.meetingStopTimeout(forRecordingDuration: 2 * 60 * 60)
-                > TranscriptedConstants.meetingStopTimeout,
-            "multi-hour meetings should get extra time to flush and merge audio"
+        assertEqual(
+            TranscriptedConstants.meetingStopTimeout(forRecordingDuration: 119 * 60),
+            TranscriptedConstants.meetingStopTimeout + (2 * TranscriptedConstants.meetingStopTimeoutGrowthStep),
+            "meetings close to two hours should get the two-hour stop budget"
+        )
+        assertEqual(
+            TranscriptedConstants.meetingStopTimeout(forRecordingDuration: 2 * 60 * 60),
+            TranscriptedConstants.meetingStopTimeout + (2 * TranscriptedConstants.meetingStopTimeoutGrowthStep),
+            "two-hour meetings should get extra time to flush and merge audio"
         )
         assertEqual(
             TranscriptedConstants.meetingStopTimeout(forRecordingDuration: 12 * 60 * 60),

--- a/Tests/TranscriptedCoreTests/MicRecordingFileMergerTests.swift
+++ b/Tests/TranscriptedCoreTests/MicRecordingFileMergerTests.swift
@@ -79,6 +79,76 @@ final class MicRecordingFileMergerTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: primaryURL.path))
     }
 
+    func testMergeStreamsAlreadyTargetFormatSegments() throws {
+        let primaryURL = temporaryDirectory.appendingPathComponent("primary-16k.wav")
+        let recoveryURL = temporaryDirectory.appendingPathComponent("recovery-16k.wav")
+
+        try writeMonoWAV(
+            to: primaryURL,
+            sampleRate: 16_000,
+            samples: Array(repeating: 0.3, count: 1_600)
+        )
+        try writeMonoWAV(
+            to: recoveryURL,
+            sampleRate: 16_000,
+            samples: Array(repeating: 0.6, count: 1_600)
+        )
+
+        let mergedURL = try XCTUnwrap(
+            MicRecordingFileMerger.merge(
+                primaryURL: primaryURL,
+                segments: [
+                    MicRecordingSegment(url: primaryURL),
+                    MicRecordingSegment(url: recoveryURL)
+                ]
+            )
+        )
+
+        let merged = try AudioResampler.loadWAV(url: mergedURL)
+        XCTAssertEqual(merged.sampleRate, 16_000, accuracy: 0.5)
+        XCTAssertEqual(merged.samples.count, 3_200)
+        XCTAssertEqual(average(of: merged.samples, range: 200..<1_000), 0.3, accuracy: 0.01)
+        XCTAssertEqual(average(of: merged.samples, range: 2_000..<2_800), 0.6, accuracy: 0.01)
+    }
+
+    func testMergeManyRecoverySegmentsKeepsEverySegmentInOrder() throws {
+        var segments: [MicRecordingSegment] = []
+        var urls: [URL] = []
+
+        for index in 0..<6 {
+            let url = temporaryDirectory.appendingPathComponent("segment-\(index).wav")
+            try writeMonoWAV(
+                to: url,
+                sampleRate: index.isMultiple(of: 2) ? 48_000 : 44_100,
+                samples: Array(repeating: Float(index + 1) / 10.0, count: index.isMultiple(of: 2) ? 4_800 : 4_410)
+            )
+            urls.append(url)
+            segments.append(MicRecordingSegment(
+                url: url,
+                gapBeforeDuration: index == 0 ? 0 : 0.05
+            ))
+        }
+
+        let mergedURL = try XCTUnwrap(
+            MicRecordingFileMerger.merge(
+                primaryURL: urls[0],
+                segments: segments
+            )
+        )
+
+        let merged = try AudioResampler.loadWAV(url: mergedURL)
+        XCTAssertEqual(merged.sampleRate, 16_000, accuracy: 0.5)
+        XCTAssertLessThanOrEqual(abs(merged.samples.count - 13_600), 384)
+        XCTAssertGreaterThan(average(of: merged.samples, range: 200..<900), 0.09)
+        XCTAssertLessThan(averageAbsolute(of: merged.samples, range: 1_700..<2_300), 0.001)
+        XCTAssertGreaterThan(average(of: merged.samples, range: 12_600..<13_200), 0.55)
+        XCTAssertLessThan(average(of: merged.samples, range: 12_600..<13_200), 0.65)
+
+        for url in urls {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+        }
+    }
+
     private func writeMonoWAV(to url: URL, sampleRate: Double, samples: [Float]) throws {
         guard let format = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,


### PR DESCRIPTION
## Signal

GitHub issue #825 has a fresh production-support follow-up describing long meetings hitting stop/finalization timeouts, then becoming failed or invisible while audio is still closing/merging.

Sentry/PostHog did not show a broader latest-release outage during this run. Latest shipped release is 1.1.42. The active latest-release telemetry is still the known dictation microphone timeout shape from 1 device, already fixed on `main` but not yet shipped.

## Root cause

`MeetingCaptureBridge.stopAndAwaitFiles()` used one fixed 30s wait for every meeting. Long recordings can need more time for async audio teardown, file close, and mic segment merge, so a 2h+ meeting can be marked as timed out while finalization is still making progress.

## Fix

- Keep the existing 30s stop timeout for short meetings.
- Scale the stop timeout by recorded duration, capped at 120s.
- Make quit preservation wait longer than the maximum scaled stop timeout.
- Cover the timeout scaling and quit-wait invariant in fast tests.

## Verification

- `bash build-deps.sh --force`
- `bash build.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 2342 passed
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh`
