### PR TITLE
[operator] Track onboarding shown telemetry

### DIFF
--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -3,6 +3,7 @@
 
 import SwiftUI
 import AppKit
+import AVFoundation
 import Carbon
 import Combine
 import TranscriptedCore
@@ -53,7 +54,10 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         actions: settingsActions
     )
     private lazy var onboardingWindowController = TranscriptedOnboardingWindowController(
-        makeView: { [unowned self] in self.makeOnboardingView() }
+        makeView: { [unowned self] in self.makeOnboardingView() },
+        onPresent: { [weak self] entrypoint in
+            self?.trackOnboardingShown(entrypoint: entrypoint)
+        }
     )
     private lazy var menuPanelController = MenuBarPanelController(
         appState: appState,
@@ -223,7 +227,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
 
         if !PermissionsOnboardingPreferences.hasCompleted() {
             _ = resolvedSourceApp()
-            onboardingWindowController.present()
+            onboardingWindowController.present(entrypoint: "dock_icon")
             return false
         }
 
@@ -357,7 +361,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         closePopover()
 
         if !PermissionsOnboardingPreferences.hasCompleted() {
-            onboardingWindowController.present()
+            onboardingWindowController.present(entrypoint: "single_instance_reopen")
         } else {
             showSettingsWindow(page: .home, source: "single_instance_reopen")
         }
@@ -368,7 +372,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     @objc func togglePopover() {
         if !PermissionsOnboardingPreferences.hasCompleted() {
             _ = resolvedSourceApp()
-            onboardingWindowController.present()
+            onboardingWindowController.present(entrypoint: "status_item")
             return
         }
 
@@ -504,7 +508,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
             guard let self, !self.onboardingWindowController.isVisible, !PermissionsOnboardingPreferences.hasCompleted() else { return }
-            self.onboardingWindowController.present()
+            self.onboardingWindowController.present(entrypoint: "initial_launch")
         }
     }
 
@@ -536,21 +540,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     }
 
     private func trackMenuBarOpened(entrypoint: String) {
-        let modelState: String
-        switch appState.sttRouter.modelDownloadState {
-        case .notLoaded:
-            modelState = "not_loaded"
-        case .downloading:
-            modelState = "downloading"
-        case .cached:
-            modelState = "cached"
-        case .loading:
-            modelState = "loading"
-        case .ready:
-            modelState = "ready"
-        case .failed:
-            modelState = "failed"
-        }
+        let modelState = modelStateAnalyticsName(appState.sttRouter.modelDownloadState)
 
         let updateState: String
         switch appState.sparkleUpdater.updateStatus.state {
@@ -582,6 +572,54 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                 "update_state": updateState,
             ]
         )
+    }
+
+    private func trackOnboardingShown(entrypoint: String) {
+        AnalyticsReporter.track(
+            "onboarding_shown",
+            properties: [
+                "analytics_available": AnalyticsReporter.isAvailable ? "true" : "false",
+                "crash_reporting_available": CrashReporter.isAvailable ? "true" : "false",
+                "entrypoint": entrypoint,
+                "has_target": lastExternalApplication == nil ? "false" : "true",
+                "meeting_recording_ready": TranscriptedPermissionAccess.isGranted(.systemAudioRecording) ? "true" : "false",
+                "mic_status": microphoneStatusAnalyticsName(TranscriptedPermissionAccess.microphoneAuthorizationStatus()),
+                "model_state": modelStateAnalyticsName(appState.sttRouter.modelDownloadState),
+                "pasteback_status": TranscriptedPermissionAccess.isGranted(.accessibility) ? "granted" : "not_granted",
+            ]
+        )
+    }
+
+    private func modelStateAnalyticsName(_ state: ParakeetModelState) -> String {
+        switch state {
+        case .notLoaded:
+            return "not_loaded"
+        case .downloading:
+            return "downloading"
+        case .cached:
+            return "cached"
+        case .loading:
+            return "loading"
+        case .ready:
+            return "ready"
+        case .failed:
+            return "failed"
+        }
+    }
+
+    private func microphoneStatusAnalyticsName(_ status: AVAuthorizationStatus) -> String {
+        switch status {
+        case .notDetermined:
+            return "not_determined"
+        case .restricted:
+            return "restricted"
+        case .denied:
+            return "denied"
+        case .authorized:
+            return "authorized"
+        @unknown default:
+            return "unknown"
+        }
     }
 
     private func resolvedSourceApp() -> NSRunningApplication? {

--- a/Sources/UI/Settings/TranscriptedOnboardingWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedOnboardingWindowController.swift
@@ -4,10 +4,15 @@ import AppKit
 @MainActor
 final class TranscriptedOnboardingWindowController: NSWindowController {
     private let makeView: () -> PermissionsOnboardingView
+    private let onPresent: (String) -> Void
     private let hostingController: NSHostingController<PermissionsOnboardingView>
 
-    init(makeView: @escaping () -> PermissionsOnboardingView) {
+    init(
+        makeView: @escaping () -> PermissionsOnboardingView,
+        onPresent: @escaping (String) -> Void = { _ in }
+    ) {
         self.makeView = makeView
+        self.onPresent = onPresent
         self.hostingController = NSHostingController(
             rootView: makeView()
         )
@@ -43,12 +48,16 @@ final class TranscriptedOnboardingWindowController: NSWindowController {
         window?.isVisible == true
     }
 
-    func present() {
+    func present(entrypoint: String = "unknown") {
         guard let window else { return }
+        let wasVisible = window.isVisible
         hostingController.rootView = makeView()
         window.center()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+        if !wasVisible {
+            onPresent(entrypoint)
+        }
     }
 
     func dismiss() {

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -870,6 +870,34 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - onboarding shown telemetry stays coarse") {
+        let appContents = readRepoTextFile("Sources/TranscriptedApp.swift")
+        let windowContents = readRepoTextFile("Sources/UI/Settings/TranscriptedOnboardingWindowController.swift")
+
+        assertTrue(
+            appContents.contains("AnalyticsReporter.track(\n            \"onboarding_shown\""),
+            "showing first-run onboarding should emit the existing activation funnel denominator"
+        )
+        assertTrue(
+            appContents.contains("\"entrypoint\": entrypoint")
+                && appContents.contains("\"has_target\": lastExternalApplication == nil ? \"false\" : \"true\"")
+                && appContents.contains("\"model_state\": modelStateAnalyticsName(appState.sttRouter.modelDownloadState)")
+                && appContents.contains("\"pasteback_status\": TranscriptedPermissionAccess.isGranted(.accessibility) ? \"granted\" : \"not_granted\""),
+            "onboarding_shown should stay limited to coarse setup state"
+        )
+        assertTrue(
+            windowContents.contains("let wasVisible = window.isVisible")
+                && windowContents.contains("if !wasVisible {")
+                && windowContents.contains("onPresent(entrypoint)"),
+            "onboarding_shown should not fire repeatedly while the onboarding window is already visible"
+        )
+        assertFalse(
+            appContents.contains("\"source_app_name\"")
+                || appContents.contains("\"source_app_bundle_id\""),
+            "onboarding_shown telemetry should not include source app names or bundle ids"
+        )
+    }
+
     runSuite("Repo command contract - home stats action uses parent presenter") {
         let homeContents = readRepoTextFile("Sources/UI/Settings/HomeView.swift")
         let settingsContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsView.swift")


### PR DESCRIPTION
## What changed
- Emit the existing allowlisted `onboarding_shown` analytics event when first-run onboarding is actually presented.
- Include only coarse setup state: entrypoint, analytics/crash availability, target presence, permission readiness, and model state.
- Guard the event so repeated `present()` calls do not fire again while the onboarding window is already visible.
- Add a repo contract test to keep the event coarse and non-repeating.

## Why
Nightly activation checks showed the onboarding funnel had event names in policy/schema but no reliable denominator for users who saw onboarding. This gives Transcripted a privacy-safe first-run visibility point without adding new payload categories.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (2342 passed)