### PR TITLE
[bug-hunter] Classify update check timeouts

### DIFF
--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -293,9 +293,7 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
         fallback: UpdateFailureKind = .unknown
     ) {
         cancelObservedUpdateCheckTimeout()
-        if error != nil {
-            didTrackCurrentUpdateCycleFailure = true
-        }
+        didTrackCurrentUpdateCycleFailure = true
 
         if updateStatus.availableUpdateVersion == nil {
             let state: UpdateStatus.State = updater.canCheckForUpdates ? .readyToCheck : .unknown

--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -287,7 +287,11 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
         markUpdateCheckFailed(from: updater, error: nil)
     }
 
-    private func markUpdateCheckFailed(from updater: SPUUpdater, error: (any Error)?) {
+    private func markUpdateCheckFailed(
+        from updater: SPUUpdater,
+        error: (any Error)?,
+        fallback: UpdateFailureKind = .unknown
+    ) {
         cancelObservedUpdateCheckTimeout()
         if error != nil {
             didTrackCurrentUpdateCycleFailure = true
@@ -302,7 +306,7 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
             result: "error",
             state: updateStatus.state,
             version: updateStatus.availableUpdateVersion,
-            failureKind: UpdateFailureKind.classify(error).rawValue
+            failureKind: UpdateFailureKind.classify(error, fallback: fallback).rawValue
         )
     }
 
@@ -326,7 +330,11 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
         observedUpdateCheckTimeoutTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: Self.observedUpdateCheckTimeoutNanoseconds)
             guard let self, !Task.isCancelled, self.updateStatus.state == .checking else { return }
-            self.markUpdateCheckFailed(from: self.updaterController.updater, error: nil)
+            self.markUpdateCheckFailed(
+                from: self.updaterController.updater,
+                error: nil,
+                fallback: .checkTimedOut
+            )
         }
     }
 

--- a/Sources/Observability/UpdateFailureKind.swift
+++ b/Sources/Observability/UpdateFailureKind.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum UpdateFailureKind: String {
     case badAppcast = "bad_appcast"
+    case checkTimedOut = "check_timed_out"
     case downloadFailed = "download_failed"
     case feedUnreachable = "feed_unreachable"
     case installFailed = "install_failed"

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -257,6 +257,24 @@ func testRepoCommandContract() {
         }
     }
 
+    runSuite("Repo command contract - update check timeout marks the cycle failed") {
+        let controller = readRepoTextFile("Sources/Observability/SparkleUpdaterController.swift")
+        let failureBlock = sourceSlice(
+            controller,
+            from: "private func markUpdateCheckFailed(",
+            to: "private func markUpdaterIdle("
+        )
+
+        assertTrue(
+            failureBlock.contains("didTrackCurrentUpdateCycleFailure = true"),
+            "tracked update-check failures should suppress duplicate finish-cycle error telemetry"
+        )
+        assertFalse(
+            failureBlock.contains("if error != nil {\n            didTrackCurrentUpdateCycleFailure = true\n        }"),
+            "timeout fallback failures have nil errors but still count as tracked failures"
+        )
+    }
+
     runSuite("Repo command contract - release docs keep Sparkle and Homebrew gates explicit") {
         let releaseDocs = readRepoTextFile("docs/release-packaging.md")
         let sparkleDocs = readRepoTextFile("docs/sparkle-updates.md")

--- a/Tests/UpdateFailureKindTests.swift
+++ b/Tests/UpdateFailureKindTests.swift
@@ -7,6 +7,11 @@ func testUpdateFailureKind() {
             .sparkleBusy,
             "callers with known context should be able to keep a non-unknown fallback"
         )
+        assertEqual(
+            UpdateFailureKind.classify(nil, fallback: .checkTimedOut),
+            .checkTimedOut,
+            "observed update-check timeouts should keep their concrete failure kind"
+        )
     }
 
     runSuite("UpdateFailureKind classifies offline and unreachable network errors") {


### PR DESCRIPTION
## Signal
- Latest shipped release is `1.1.42` across `Info.plist`, GitHub release `v1.1.42`, the appcast, and Sentry release `transcripted@1.1.42`.
- Sentry current-release unresolved rows were `APPLE-MACOS-14` dictation microphone start timeout and `APPLE-MACOS-S` `objc_release`. The microphone timeout shape is already fixed on `main` by PR #824 but is not in the shipped `v1.1.42` build.
- PostHog shows a fresh latest-release update-check telemetry spike: `update_check_finished` with `result=error` and `failure_kind=unknown` across the last 48h, including 55 events in the last 24h.

## Root cause
The observed Sparkle update-check timeout path called `markUpdateCheckFailed(error: nil)`, so the failure classifier had no error and emitted `unknown` even though the app knew the check had timed out.

## Fix
- Add `check_timed_out` to `UpdateFailureKind`.
- Pass that fallback from the observed update-check timeout task.
- Cover the fallback in the fast tests.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 2339 passed
