### PR TITLE
[bug-hunter] Fix meeting system-audio status

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -887,6 +887,17 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
         isRecording = true
         isStarting = false
+        restoreSystemAudioHealthyStatusAfterSuccessfulStart()
+    }
+
+    func restoreSystemAudioHealthyStatusAfterSuccessfulStart() {
+        guard systemAudioFileURL != nil,
+              !systemAudioFailed,
+              systemAudioStatus == .unknown else {
+            return
+        }
+
+        systemAudioStatus = .healthy
     }
 
     // MARK: - Stop Recording

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -900,6 +900,13 @@ public class Audio: ObservableObject, @unchecked Sendable {
         systemAudioStatus = .healthy
     }
 
+    func assignSystemAudioFileURLIfCurrent(_ fileURL: URL, sessionGeneration: UInt64) {
+        guard recordingSessionGeneration == sessionGeneration else { return }
+
+        systemAudioFileURL = fileURL
+        restoreSystemAudioHealthyStatusAfterSuccessfulStart()
+    }
+
     // MARK: - Stop Recording
 
     public func stop() {

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -222,7 +222,7 @@ extension Audio {
 
                     DispatchQueue.main.async {
                         guard sessionGeneration == strongSelf.recordingSessionGeneration else { return }
-                        strongSelf.systemAudioFileURL = fileURL
+                        strongSelf.assignSystemAudioFileURLIfCurrent(fileURL, sessionGeneration: sessionGeneration)
                     }
                     AppLogger.audioSystem.info("System audio capture started")
 

--- a/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
@@ -340,4 +340,41 @@ final class AudioInitializationTests: XCTestCase {
             "a clean system-audio file should not stay unknown after the meeting start succeeds"
         )
     }
+
+    func testSystemAudioFileAssignmentRestoresStatusWhenSuccessfulStartFinishedFirst() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioInitializationTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let paths = CoreStoragePaths(
+            transcripts: root.appendingPathComponent("captures/meetings", isDirectory: true),
+            speakerDB: root.appendingPathComponent("state/speakers.sqlite"),
+            statsDB: root.appendingPathComponent("state/stats.sqlite"),
+            failedQueue: root.appendingPathComponent("state/failed_transcriptions.json"),
+            speakerClips: root.appendingPathComponent("tmp/recordings/speaker_clips", isDirectory: true),
+            audioCaptures: root.appendingPathComponent("tmp/recordings", isDirectory: true),
+            logs: root.appendingPathComponent("logs", isDirectory: true)
+        )
+
+        let audio = Audio(paths: paths)
+        audio.prepareForNewRecordingStart()
+        let startGeneration = audio.recordingSessionGeneration
+
+        audio.updateSystemAudioStatus(fromError: nil)
+        XCTAssertEqual(audio.systemAudioStatus, .unknown)
+
+        audio.isRecording = true
+        audio.restoreSystemAudioHealthyStatusAfterSuccessfulStart()
+        XCTAssertEqual(audio.systemAudioStatus, .unknown)
+
+        let systemURL = root.appendingPathComponent("system.wav")
+        audio.assignSystemAudioFileURLIfCurrent(systemURL, sessionGeneration: startGeneration)
+
+        XCTAssertEqual(audio.systemAudioFileURL, systemURL)
+        XCTAssertEqual(
+            audio.systemAudioStatus,
+            .healthy,
+            "when the async file URL arrives after the start finish callback, it should complete the status repair"
+        )
+    }
 }

--- a/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
@@ -309,4 +309,35 @@ final class AudioInitializationTests: XCTestCase {
         XCTAssertFalse(audio.systemAudioFailed)
         XCTAssertTrue(audio.micSegments.isEmpty)
     }
+
+    func testSuccessfulStartRestoresHealthySystemAudioStatusAfterEarlyNilUpdate() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioInitializationTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let paths = CoreStoragePaths(
+            transcripts: root.appendingPathComponent("captures/meetings", isDirectory: true),
+            speakerDB: root.appendingPathComponent("state/speakers.sqlite"),
+            statsDB: root.appendingPathComponent("state/stats.sqlite"),
+            failedQueue: root.appendingPathComponent("state/failed_transcriptions.json"),
+            speakerClips: root.appendingPathComponent("tmp/recordings/speaker_clips", isDirectory: true),
+            audioCaptures: root.appendingPathComponent("tmp/recordings", isDirectory: true),
+            logs: root.appendingPathComponent("logs", isDirectory: true)
+        )
+
+        let audio = Audio(paths: paths)
+        audio.prepareForNewRecordingStart()
+        audio.systemAudioFileURL = root.appendingPathComponent("system.wav")
+
+        audio.updateSystemAudioStatus(fromError: nil)
+        XCTAssertEqual(audio.systemAudioStatus, .unknown)
+
+        audio.restoreSystemAudioHealthyStatusAfterSuccessfulStart()
+
+        XCTAssertEqual(
+            audio.systemAudioStatus,
+            .healthy,
+            "a clean system-audio file should not stay unknown after the meeting start succeeds"
+        )
+    }
 }


### PR DESCRIPTION
## Signal
- Latest shipped release is `1.1.42` across `Info.plist`, GitHub release `v1.1.42`, the live appcast, and Sentry release `transcripted@1.1.42`.
- Sentry issue `APPLE-MACOS-1B` is unresolved on the latest release: `meeting.recording_capture_degraded`, 18 events, last seen 2026-05-21T13:50Z.
- The latest event context showed `system_stream_present=true` shape through the system-audio file path, but `system_status=unknown`.
- PostHog had 1 latest-release degraded `meeting_capture_health_snapshot` in the last 24h and 0 `meeting_transcript_failed` events, so this is a narrow telemetry/status fix rather than a broad capture rewrite.

## Root cause
A nil system-audio error update can arrive before `Audio.finishSuccessfulStartIfCurrent` flips `isRecording` true, so `updateSystemAudioStatus(fromError: nil)` resets the status to `unknown` and a successful meeting start never restores it to `healthy`.

## Fix
- Restore `systemAudioStatus` to `healthy` after a successful start when a system-audio file exists and no system-audio failure was recorded.
- Add a package regression test for the early nil-update race.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 2338 passed
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh`
- `swift test` — 206 passed, 1 skipped
