### PR TITLE
[bug-hunter] Harden meeting mic tap teardown

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -101,13 +101,16 @@ enum AudioRecordingFormatPolicy {
 
 enum AudioInputTapTeardownStep: Equatable {
     case stopEngine
+    case waitForStoppedInputCallbacks
     case removeInputTap
 }
 
 enum AudioInputTapTeardownPolicy {
+    static let inputCallbackDrainDelay: TimeInterval = 0.05
+
     static func steps(engineIsRunning: Bool) -> [AudioInputTapTeardownStep] {
         engineIsRunning
-            ? [.stopEngine, .removeInputTap]
+            ? [.stopEngine, .waitForStoppedInputCallbacks, .removeInputTap]
             : [.removeInputTap]
     }
 }
@@ -341,6 +344,8 @@ public class Audio: ObservableObject, @unchecked Sendable {
                     "operation": operation
                 ])
                 engine.stop()
+            case .waitForStoppedInputCallbacks:
+                Thread.sleep(forTimeInterval: AudioInputTapTeardownPolicy.inputCallbackDrainDelay)
             case .removeInputTap:
                 inputNode.removeTap(onBus: 0)
             }

--- a/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
@@ -85,13 +85,13 @@ final class AudioInitializationTests: XCTestCase {
     func testInputTapTeardownStopsRunningEngineBeforeRemovingTap() {
         XCTAssertEqual(
             AudioInputTapTeardownPolicy.steps(engineIsRunning: true),
-            [.stopEngine, .removeInputTap],
-            "Running AVAudioEngine graphs must be stopped before the input tap is removed so CoreAudio never receives input with tap == nil"
+            [.stopEngine, .waitForStoppedInputCallbacks, .removeInputTap],
+            "Running AVAudioEngine graphs must stop and drain input callbacks before removing the tap so CoreAudio never receives input with tap == nil"
         )
         XCTAssertEqual(
             AudioInputTapTeardownPolicy.steps(engineIsRunning: false),
             [.removeInputTap],
-            "Stopped engines can remove the tap directly"
+            "Stopped engines can remove the tap directly without the drain delay"
         )
     }
 


### PR DESCRIPTION
## Signal
- Latest shipped release is `1.1.42` across `Info.plist`, GitHub release `v1.1.42`, appcast, and Homebrew cask.
- Sentry issue `APPLE-MACOS-1P` is unresolved on the latest release: fatal AVFAudio assertion `isSink || tap != nullptr`, first seen on `1.1.35`, last seen on `1.1.42` at 2026-05-21T16:29Z.
- Event runtime context was an active meeting recording with an `8h_plus` duration bucket and an unclean previous shutdown marker.
- Sentry event entries place the crash on the CoreAudio input callback path: `HALC_IOThread -> AUHALOutputUnit_InputAvailableCallback -> AVAudioEngineGraph::InputAvailable`.
- Related current-release meeting capture degradation is already covered by draft PR #845. Long-meeting timeout/visibility is already covered by draft PR #841.

## Root cause
The meeting mic graph can remove the AVAudioEngine input tap immediately after `engine.stop()` while CoreAudio still has a stopped-input callback in flight, leaving the input callback path with no tap and triggering AVFAudio's `isSink || tap != nullptr` assertion.

## Fix
- Add an explicit stopped-input callback drain step between `engine.stop()` and `inputNode.removeTap(onBus:)` for running engine graphs.
- Keep stopped engines on the direct remove-tap path.
- Update the tap-teardown policy regression test so this ordering stays locked.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 2338 passed
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh`
- `swift test` — 205 passed, 1 skipped

Note: initial `build.sh` / `swift test` attempts failed before dependency rebuild because dependency artifacts were missing/stale, including `FluidAudio`; reruns after `build-deps.sh --force` passed.
