### PR TITLE
[bug-hunter] Refresh queued meeting runtime diagnostics

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -182,6 +182,7 @@ final class MeetingSessionController: ObservableObject {
     private var queuedTranscriptionJobs: [QueuedTranscriptionJob] = []
     private var preparingQueuedTranscriptionJob: QueuedTranscriptionJob?
     private var queuedTranscriptionStartTask: Task<Void, Never>?
+    private var queuedRuntimeDiagnosticsJobIDs: Set<UUID> = []
     private var lastTerminalTranscriptionOutcome: TerminalTranscriptionOutcome?
     private var activeRecordingTrigger: StartTrigger = .unknown
     private var activeRecordingSuggestedTitle: String?
@@ -1553,7 +1554,7 @@ final class MeetingSessionController: ObservableObject {
         if !isCaptureSessionActive {
             state = .transcribing
         }
-        Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "transcribing")
+        recordQueuedTranscriptionRuntimeDiagnosticsIfSafe(for: job)
 
         displayStatus = .gettingReady
         queuedTranscriptionStartTask?.cancel()
@@ -1641,6 +1642,7 @@ final class MeetingSessionController: ObservableObject {
 
     private func runPreparedQueuedTranscription(_ job: QueuedTranscriptionJob) {
         sttAdapter.selectPreparedModel(job.sttModel)
+        queuedRuntimeDiagnosticsJobIDs.remove(job.id)
 
         switch job.kind {
         case .recorded(let micURL, let systemURL, let healthInfo, let meetingTitle):
@@ -1678,6 +1680,24 @@ final class MeetingSessionController: ObservableObject {
         case .imported(let audioURL, _):
             try? FileManager.default.removeItem(at: audioURL)
         }
+        clearQueuedTranscriptionRuntimeDiagnosticsIfOwned(for: job, outcome: "model_recovery_failed")
+    }
+
+    private func recordQueuedTranscriptionRuntimeDiagnosticsIfSafe(for job: QueuedTranscriptionJob) {
+        guard !isCaptureSessionActive else { return }
+        guard !(sttRouter.isRecording || sttRouter.isTranscribing) else { return }
+        queuedRuntimeDiagnosticsJobIDs.insert(job.id)
+        Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "transcribing")
+    }
+
+    private func clearQueuedTranscriptionRuntimeDiagnosticsIfOwned(
+        for job: QueuedTranscriptionJob,
+        outcome: String
+    ) {
+        guard queuedRuntimeDiagnosticsJobIDs.remove(job.id) != nil else { return }
+        guard !isCaptureSessionActive else { return }
+        guard !(sttRouter.isRecording || sttRouter.isTranscribing) else { return }
+        Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: outcome)
     }
 
     private func canStartQueuedTranscriptionImmediately(

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1553,6 +1553,7 @@ final class MeetingSessionController: ObservableObject {
         if !isCaptureSessionActive {
             state = .transcribing
         }
+        Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "transcribing")
 
         displayStatus = .gettingReady
         queuedTranscriptionStartTask?.cancel()

--- a/Sources/Observability/RuntimeDiagnosticsStore.swift
+++ b/Sources/Observability/RuntimeDiagnosticsStore.swift
@@ -189,6 +189,7 @@ enum RuntimeDiagnosticsStore {
         "dictation_start_failed",
         "meeting_cancelled",
         "meeting_file_import_failed",
+        "meeting_model_recovery_failed",
         "meeting_models_unavailable",
         "meeting_recording_too_short",
         "meeting_speaker_finalization_failed",

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -700,8 +700,31 @@ func testRepoCommandContract() {
             to: "private func prepareAndStartQueuedTranscription(_ job: QueuedTranscriptionJob) async {"
         )
         assertTrue(
-            startQueuedBlock.contains("recordSession(kind: \"meeting\", stage: \"transcribing\")"),
+            startQueuedBlock.contains("recordQueuedTranscriptionRuntimeDiagnosticsIfSafe(for: job)")
+                && controllerContents.contains("recordSession(kind: \"meeting\", stage: \"transcribing\")"),
             "each queued meeting start should refresh runtime diagnostics away from the previous terminal outcome"
+        )
+        assertTrue(
+            controllerContents.contains("queuedRuntimeDiagnosticsJobIDs")
+                && controllerContents.contains("recordQueuedTranscriptionRuntimeDiagnosticsIfSafe(for: job)")
+                && controllerContents.contains("guard !isCaptureSessionActive else { return }"),
+            "queued meeting diagnostics should not clobber foreground recording diagnostics"
+        )
+        assertTrue(
+            controllerContents.contains("guard !(sttRouter.isRecording || sttRouter.isTranscribing) else { return }"),
+            "queued meeting diagnostics should not clobber foreground dictation diagnostics"
+        )
+        let queuedRecoveryFailureBlock = sourceSlice(
+            controllerContents,
+            from: "private func failQueuedTranscriptionJobAfterModelRecovery(_ job: QueuedTranscriptionJob) {",
+            to: "private func canStartQueuedTranscriptionImmediately("
+        )
+        assertTrue(
+            queuedRecoveryFailureBlock.contains("clearQueuedTranscriptionRuntimeDiagnosticsIfOwned(for: job, outcome: \"model_recovery_failed\")")
+                && controllerContents.contains("queuedRuntimeDiagnosticsJobIDs.remove(job.id)")
+                && queuedRecoveryFailureBlock.contains("guard !isCaptureSessionActive else { return }")
+                && queuedRecoveryFailureBlock.contains("guard !(sttRouter.isRecording || sttRouter.isTranscribing) else { return }"),
+            "queued model recovery failures should clear only the runtime diagnostics session started before recovery"
         )
         assertTrue(
             downloaderContents.contains("func ensureModelsReady(sttModel: TranscriptionModelChoice) async throws")

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -694,6 +694,15 @@ func testRepoCommandContract() {
                 && controllerContents.contains("preparingQueuedTranscriptionJob?.id == job.id"),
             "model recovery should count as active background work and stale prep tasks must not clear newer queued work"
         )
+        let startQueuedBlock = sourceSlice(
+            controllerContents,
+            from: "private func startQueuedTranscription(_ job: QueuedTranscriptionJob) {",
+            to: "private func prepareAndStartQueuedTranscription(_ job: QueuedTranscriptionJob) async {"
+        )
+        assertTrue(
+            startQueuedBlock.contains("recordSession(kind: \"meeting\", stage: \"transcribing\")"),
+            "each queued meeting start should refresh runtime diagnostics away from the previous terminal outcome"
+        )
         assertTrue(
             downloaderContents.contains("func ensureModelsReady(sttModel: TranscriptionModelChoice) async throws")
                 && downloaderContents.contains("stt.prepare(model: sttModel)"),

--- a/Tests/RuntimeDiagnosticsStoreTests.swift
+++ b/Tests/RuntimeDiagnosticsStoreTests.swift
@@ -280,6 +280,29 @@ func testRuntimeDiagnosticsStore() {
         assertEqual(shouldReport, false, "terminal idle outcomes should not report after the heartbeat window")
     }
 
+    runSuite("RuntimeDiagnosticsStore suppresses queued model recovery terminal event") {
+        let marker = RuntimeDiagnosticsMarker(
+            launchID: "queued-model-recovery-failed",
+            appVersion: "1.2.3",
+            buildVersion: "456",
+            osMajor: 26,
+            cleanShutdown: false,
+            startedAt: Date(timeIntervalSince1970: 1_000),
+            updatedAt: Date(timeIntervalSince1970: 1_100),
+            lastEvent: "meeting_model_recovery_failed",
+            sessionKind: "none",
+            sessionStage: "idle",
+            sessionActive: false
+        )
+
+        let shouldReport = RuntimeDiagnosticsStore.shouldReportUncleanShutdown(
+            previous: marker,
+            now: Date(timeIntervalSince1970: 1_260)
+        )
+
+        assertEqual(shouldReport, false, "queued model recovery failures are terminal once the session is cleared")
+    }
+
     runSuite("RuntimeDiagnosticsStore clears inactive session context on heartbeat") {
         var marker = RuntimeDiagnosticsMarker(
             launchID: "completed-dictation",


### PR DESCRIPTION
## Signal
- Latest shipped release is `1.1.42` across `Info.plist`, GitHub release `v1.1.42`, appcast, Homebrew cask, and the live `/download` page.
- Sentry current-release issue `APPLE-MACOS-1H` is still active: `meeting.meeting_transcript_failed`, 44 total events, last seen 2026-05-21T19:43Z.
- Latest event tags show `failure_kind=no_speech_detected`, `trigger=menu`, and `stt_model=parakeet-tdt-v3`.
- The suspicious part was the event runtime context: `last_event=meeting_transcript_saved`, `session_stage=transcript_saved`, while the same event context had `display_status=failed` and `session_state=transcribing`.

## Root cause
A queued meeting transcription starts without refreshing `RuntimeDiagnostics`, so if the previous queued job saved successfully, a later queued failure can inherit stale `transcript_saved` runtime context in Sentry.

## Fix
- Refresh meeting runtime diagnostics to `stage=transcribing` when `startQueuedTranscription(_:)` starts any queued meeting job.
- Add a repo contract assertion so queued starts keep updating runtime diagnostics instead of reusing the previous terminal outcome.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 2362 passed
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh`

## Notes
- This does not change the transcription/no-speech pipeline. One latest event had `no_speech_detected`, and the code path only throws that after both mic and system utterance arrays are empty.
- This PR fixes the stale evidence that made the Sentry event look contradictory, so future failures should be easier to triage without exposing private audio or transcript content.
- Existing open draft PR #845 already covers `APPLE-MACOS-1B` system-audio status attribution.
- Merged PR #846 already covers the fatal AVFAudio tap-teardown crash seen as `APPLE-MACOS-1P` on `1.1.42`.
