### PR TITLE
Fix repeated quit termination replies

### DIFF
--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -77,6 +77,8 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
     lazy var meetingPromptDetector = MeetingPromptDetector()
     private var workspaceObservers: [NSObjectProtocol] = []
     private var terminationCleanupStarted = false
+    private var terminationCleanupFinished = false
+    private var pendingTerminationReplyCount = 0
 
     /// Keeps NSApp in sync with the Dock visibility setting and promotes
     /// the app to `.regular` during active recording for force-quit
@@ -255,7 +257,13 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             return .terminateNow
         }
 
-        guard !terminationCleanupStarted else { return .terminateLater }
+        if terminationCleanupFinished {
+            return .terminateNow
+        }
+        guard !terminationCleanupStarted else {
+            pendingTerminationReplyCount += 1
+            return .terminateLater
+        }
         switch activeMeetingTerminationDecision() {
         case .keepRecording:
             return .terminateCancel
@@ -269,6 +277,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         }
 
         terminationCleanupStarted = true
+        pendingTerminationReplyCount = 1
 
         Task { @MainActor [weak self, sender] in
             guard let self else {
@@ -282,10 +291,20 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             }
             self.appState.shutdown()
             await EventReporter.shared.flushLocalEventsForShutdown()
-            sender.reply(toApplicationShouldTerminate: true)
+            self.terminationCleanupFinished = true
+            self.replyToPendingTerminationRequests(sender, shouldTerminate: true)
         }
 
         return .terminateLater
+    }
+
+    private func replyToPendingTerminationRequests(_ sender: NSApplication, shouldTerminate: Bool) {
+        let replyCount = max(pendingTerminationReplyCount, 1)
+        pendingTerminationReplyCount = 0
+
+        for _ in 0..<replyCount {
+            sender.reply(toApplicationShouldTerminate: shouldTerminate)
+        }
     }
 
     private func activeMeetingTerminationDecision() -> ActiveMeetingQuitDecision {

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -820,6 +820,31 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - repeated quit requests get AppKit replies") {
+        let appContents = readRepoTextFile("Sources/TranscriptedApp.swift")
+
+        assertTrue(
+            appContents.contains("private var pendingTerminationReplyCount = 0"),
+            "termination cleanup should track every deferred quit request"
+        )
+        assertTrue(
+            appContents.contains("pendingTerminationReplyCount += 1\n            return .terminateLater"),
+            "repeat quit requests during cleanup should be deferred with a later reply"
+        )
+        assertTrue(
+            appContents.contains("pendingTerminationReplyCount = 1"),
+            "the first deferred quit request should be counted before cleanup starts"
+        )
+        assertTrue(
+            appContents.contains("replyToPendingTerminationRequests(sender, shouldTerminate: true)"),
+            "termination cleanup should reply to every deferred quit request"
+        )
+        assertTrue(
+            appContents.contains("if terminationCleanupFinished {\n            return .terminateNow\n        }"),
+            "quit requests after cleanup should complete immediately"
+        )
+    }
+
     runSuite("Repo command contract - consolidated settings deep links expand their General section") {
         let windowControllerContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsWindowController.swift")
         let navigationContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsNavigationModel.swift")


### PR DESCRIPTION
## Summary
- reply to every deferred AppKit termination request during shutdown cleanup
- return terminateNow after cleanup has already finished
- add a repo contract test for repeated quit requests

## Verification
- bash build-deps.sh --force
- bash build.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh
- codex-review --mode branch --base origin/main --full-access --parallel-tests "TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh"