### PR TITLE
[codex] Force speaker ID for saved meeting retranscription

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1189,7 +1189,7 @@ final class MeetingSessionController: ObservableObject {
             systemURL: systemAudioURL,
             outputFolder: MeetingStoragePaths.transcriptsFolder,
             meetingTitle: title,
-            splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()
+            splitLocalSpeakers: true
         )
         return true
     }

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -852,6 +852,23 @@ func testRepoCommandContract() {
             controllerContents.contains("guard !(sttRouter.isRecording || sttRouter.isTranscribing)"),
             "saved meeting re-transcription should enforce the dictation-active guard at the controller entry point"
         )
+        guard
+            let functionStart = controllerContents.range(of: "func retranscribeSavedMeeting("),
+            let functionEnd = controllerContents.range(of: "func dismissFailedMeeting", range: functionStart.upperBound..<controllerContents.endIndex)
+        else {
+            assertionFailure("MeetingSessionController should keep a saved-meeting re-transcription entry point")
+            return
+        }
+
+        let functionBody = String(controllerContents[functionStart.lowerBound..<functionEnd.lowerBound])
+        assertTrue(
+            functionBody.contains("splitLocalSpeakers: true"),
+            "saved meeting re-transcription should force the speaker-ID pass instead of depending on the global local-speaker preference"
+        )
+        assertFalse(
+            functionBody.contains("splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()"),
+            "the saved-meeting Identify speakers action should not silently do a single-speaker mic retry when the preference is off"
+        )
     }
 
     runSuite("Repo command contract - Paste Last Dictation uses the paste target guard") {


### PR DESCRIPTION
## Summary
- Force the saved-meeting re-transcribe action to run the local speaker-ID pass.
- Keep the retained-audio flow intact so users do not have to import files manually.
- Add a contract test to lock the app-side behavior.

## Validation
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh — 2403 passed
- bash run-integration-smoke.sh

## Reply for Daniel
Hey Daniel, I added the saved-meeting re-transcribe flow. If a meeting has retained audio, Transcripted can now rerun it with speaker identification on directly from Home, without manually importing the audio again through Settings. It keeps the original audio in place and waits if another recording/transcription/review is active.