### PR TITLE
[codex] Use source dates for imported audio transcripts

### DIFF
--- a/Sources/Meeting/MeetingImportedAudioPreparer.swift
+++ b/Sources/Meeting/MeetingImportedAudioPreparer.swift
@@ -151,6 +151,15 @@ enum MeetingImportedAudioPreparer {
 
     private static func embeddedRecordingDate(from sourceURL: URL) async -> Date? {
         let asset = AVURLAsset(url: sourceURL)
+        return await embeddedRecordingDate(from: asset)
+    }
+
+    static func embeddedRecordingDate(from asset: AVURLAsset) async -> Date? {
+        if let creationDate = try? await asset.load(.creationDate),
+           let date = await metadataDate(creationDate) {
+            return date
+        }
+
         let metadata = (try? await asset.load(.metadata)) ?? []
         var dates: [Date] = []
         for item in metadata where isRecordingDateMetadata(item) {
@@ -180,8 +189,12 @@ enum MeetingImportedAudioPreparer {
             || joined.contains("date")
     }
 
-    private static func metadataDate(_ item: AVMetadataItem) async -> Date? {
-        if let date = try? await item.load(.dateValue) {
+    static func metadataDate(
+        _ item: AVMetadataItem,
+        defaultTimeZone: TimeZone = .current
+    ) async -> Date? {
+        if let string = try? await item.load(.stringValue),
+           let date = parseMetadataDate(string, defaultTimeZone: defaultTimeZone) {
             return date
         }
 
@@ -190,19 +203,26 @@ enum MeetingImportedAudioPreparer {
                 return date
             }
             if let string = value as? String,
-               let date = parseMetadataDate(string) {
+               let date = parseMetadataDate(string, defaultTimeZone: defaultTimeZone) {
+                return date
+            }
+            if let string = value as? NSString,
+               let date = parseMetadataDate(String(string), defaultTimeZone: defaultTimeZone) {
                 return date
             }
         }
 
-        if let string = try? await item.load(.stringValue) {
-            return parseMetadataDate(string)
+        if let date = try? await item.load(.dateValue) {
+            return date
         }
 
         return nil
     }
 
-    private static func parseMetadataDate(_ value: String) -> Date? {
+    static func parseMetadataDate(
+        _ value: String,
+        defaultTimeZone: TimeZone = .current
+    ) -> Date? {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
 
@@ -222,8 +242,17 @@ enum MeetingImportedAudioPreparer {
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         for format in [
             "yyyy-MM-dd'T'HH:mm:ssZ",
-            "yyyy-MM-dd'T'HH:mm:ss",
             "yyyy-MM-dd HH:mm:ssZ",
+        ] {
+            formatter.dateFormat = format
+            if let date = formatter.date(from: trimmed) {
+                return date
+            }
+        }
+
+        formatter.timeZone = defaultTimeZone
+        for format in [
+            "yyyy-MM-dd'T'HH:mm:ss",
             "yyyy-MM-dd HH:mm:ss",
             "yyyy-MM-dd"
         ] {

--- a/Sources/Meeting/MeetingImportedAudioPreparer.swift
+++ b/Sources/Meeting/MeetingImportedAudioPreparer.swift
@@ -1,9 +1,11 @@
 import Foundation
+import AVFoundation
 import UniformTypeIdentifiers
 
 struct PreparedImportedMeetingAudio: Sendable {
     let copiedAudioURL: URL
     let suggestedTitle: String
+    let recordingDate: Date
 }
 
 enum MeetingImportedAudioPreparationError: LocalizedError, Equatable {
@@ -51,7 +53,7 @@ enum MeetingImportedAudioPreparer {
     static func prepareImportedAudio(
         from sourceURL: URL,
         scratchDirectory: URL = MeetingStoragePaths.recordingsScratch
-    ) throws -> PreparedImportedMeetingAudio {
+    ) async throws -> PreparedImportedMeetingAudio {
         let fileManager = FileManager.default
         fileManager.ensurePrivateDirectory(
             at: scratchDirectory,
@@ -116,8 +118,122 @@ enum MeetingImportedAudioPreparer {
 
         return PreparedImportedMeetingAudio(
             copiedAudioURL: destinationURL,
-            suggestedTitle: suggestedTitle(from: resolvedSourceURL)
+            suggestedTitle: suggestedTitle(from: resolvedSourceURL),
+            recordingDate: await recordingDate(
+                from: resolvedSourceURL,
+                sourceAttributes: sourceAttributes
+            )
         )
+    }
+
+    private static func recordingDate(
+        from sourceURL: URL,
+        sourceAttributes: [FileAttributeKey: Any]
+    ) async -> Date {
+        if let embeddedDate = await embeddedRecordingDate(from: sourceURL) {
+            return embeddedDate
+        }
+
+        if let creationDate = sourceAttributes[.creationDate] as? Date {
+            return creationDate
+        }
+
+        if let resourceDate = try? sourceURL.resourceValues(forKeys: [.creationDateKey]).creationDate {
+            return resourceDate
+        }
+
+        if let modificationDate = sourceAttributes[.modificationDate] as? Date {
+            return modificationDate
+        }
+
+        return Date()
+    }
+
+    private static func embeddedRecordingDate(from sourceURL: URL) async -> Date? {
+        let asset = AVURLAsset(url: sourceURL)
+        let metadata = (try? await asset.load(.metadata)) ?? []
+        var dates: [Date] = []
+        for item in metadata where isRecordingDateMetadata(item) {
+            if let date = await metadataDate(item) {
+                dates.append(date)
+            }
+        }
+        return dates.sorted().first
+    }
+
+    private static func isRecordingDateMetadata(_ item: AVMetadataItem) -> Bool {
+        let fields = [
+            item.identifier?.rawValue,
+            item.commonKey?.rawValue,
+            item.keySpace?.rawValue,
+            item.key.map { String(describing: $0) }
+        ]
+        let joined = fields
+            .compactMap { $0 }
+            .joined(separator: " ")
+            .lowercased()
+
+        return joined.contains("creation")
+            || joined.contains("created")
+            || joined.contains("recorded")
+            || joined.contains("recordingdate")
+            || joined.contains("date")
+    }
+
+    private static func metadataDate(_ item: AVMetadataItem) async -> Date? {
+        if let date = try? await item.load(.dateValue) {
+            return date
+        }
+
+        if let value = try? await item.load(.value) {
+            if let date = value as? Date {
+                return date
+            }
+            if let string = value as? String,
+               let date = parseMetadataDate(string) {
+                return date
+            }
+        }
+
+        if let string = try? await item.load(.stringValue) {
+            return parseMetadataDate(string)
+        }
+
+        return nil
+    }
+
+    private static func parseMetadataDate(_ value: String) -> Date? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = isoFormatter.date(from: trimmed) {
+            return date
+        }
+
+        isoFormatter.formatOptions = [.withInternetDateTime]
+        if let date = isoFormatter.date(from: trimmed) {
+            return date
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        for format in [
+            "yyyy-MM-dd'T'HH:mm:ssZ",
+            "yyyy-MM-dd'T'HH:mm:ss",
+            "yyyy-MM-dd HH:mm:ssZ",
+            "yyyy-MM-dd HH:mm:ss",
+            "yyyy-MM-dd"
+        ] {
+            formatter.dateFormat = format
+            if let date = formatter.date(from: trimmed) {
+                return date
+            }
+        }
+
+        return nil
     }
 
     private static func uniqueScratchURL(

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -84,7 +84,8 @@ final class MeetingSessionController: ObservableObject {
             )
             case imported(
                 audioURL: URL,
-                suggestedTitle: String
+                suggestedTitle: String,
+                recordingDate: Date
             )
         }
 
@@ -877,7 +878,7 @@ final class MeetingSessionController: ObservableObject {
         let preparedAudio: PreparedImportedMeetingAudio
         do {
             preparedAudio = try await Task.detached(priority: .utility) {
-                try MeetingImportedAudioPreparer.prepareImportedAudio(from: sourceURL)
+                try await MeetingImportedAudioPreparer.prepareImportedAudio(from: sourceURL)
             }.value
         } catch {
             let failureKind = importPreparationFailureKind(for: error)
@@ -910,6 +911,7 @@ final class MeetingSessionController: ObservableObject {
         let outcome = enqueueImportedAudioJob(
             audioURL: preparedAudio.copiedAudioURL,
             suggestedTitle: preparedAudio.suggestedTitle,
+            recordingDate: preparedAudio.recordingDate,
             startTrigger: .fileImport
         )
 
@@ -976,7 +978,7 @@ final class MeetingSessionController: ObservableObject {
                     errorMessage: "Transcription cancelled",
                     meetingTitle: meetingTitle
                 )
-            case .imported(let audioURL, _):
+            case .imported(let audioURL, _, _):
                 try? FileManager.default.removeItem(at: audioURL)
             }
         }
@@ -1084,7 +1086,7 @@ final class MeetingSessionController: ObservableObject {
                 ) {
                     preservedCount += 1
                 }
-            case .imported(let audioURL, _):
+            case .imported(let audioURL, _, _):
                 try? FileManager.default.removeItem(at: audioURL)
             }
         }
@@ -1520,12 +1522,14 @@ final class MeetingSessionController: ObservableObject {
     private func enqueueImportedAudioJob(
         audioURL: URL,
         suggestedTitle: String,
+        recordingDate: Date,
         startTrigger: StartTrigger
     ) -> QueueInsertionOutcome {
         let job = QueuedTranscriptionJob(
             kind: .imported(
                 audioURL: audioURL,
-                suggestedTitle: suggestedTitle
+                suggestedTitle: suggestedTitle,
+                recordingDate: recordingDate
             ),
             startTrigger: startTrigger,
             sttModel: sttRouter.selectedModel
@@ -1651,11 +1655,12 @@ final class MeetingSessionController: ObservableObject {
                 meetingTitle: meetingTitle,
                 splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()
             )
-        case .imported(let audioURL, let suggestedTitle):
+        case .imported(let audioURL, let suggestedTitle, let recordingDate):
             taskManager.startImportedTranscription(
                 audioURL: audioURL,
                 outputFolder: MeetingStoragePaths.transcriptsFolder,
-                meetingTitle: suggestedTitle
+                meetingTitle: suggestedTitle,
+                recordingDate: recordingDate
             )
         }
     }
@@ -1674,7 +1679,7 @@ final class MeetingSessionController: ObservableObject {
                 errorMessage: message,
                 meetingTitle: meetingTitle
             )
-        case .imported(let audioURL, _):
+        case .imported(let audioURL, _, _):
             try? FileManager.default.removeItem(at: audioURL)
         }
     }

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -43,7 +43,8 @@ extension TranscriptionTaskManager {
         audioURL: URL,
         outputFolder: URL,
         taskId: UUID,
-        meetingTitle: String? = nil
+        meetingTitle: String? = nil,
+        recordingDate: Date? = nil
     ) async throws -> URL {
         try await transcribeMultichannelPipeline(
             micURL: nil,
@@ -52,7 +53,8 @@ extension TranscriptionTaskManager {
             taskId: taskId,
             healthInfo: nil,
             splitLocalSpeakers: false,
-            meetingTitle: meetingTitle
+            meetingTitle: meetingTitle,
+            recordingDate: recordingDate
         )
     }
 
@@ -68,6 +70,7 @@ extension TranscriptionTaskManager {
         healthInfo: RecordingHealthInfo?,
         splitLocalSpeakers: Bool = false,
         meetingTitle: String? = nil,
+        recordingDate: Date? = nil,
         sourceFailedTranscriptionId: UUID? = nil,
         removeSourceAudioAfterArchive: Bool = true
     ) async throws -> URL {
@@ -285,6 +288,7 @@ extension TranscriptionTaskManager {
             notifier: notifier,
             speakerStore: speakerDB,
             statsStore: statsStore,
+            recordingDate: recordingDate,
             transcriptionEngine: speechEngine
         ) else {
             throw PipelineError.saveFailed(detail: "Could not write transcript to \(outputFolder.lastPathComponent)")

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -234,7 +234,8 @@ public class TranscriptionTaskManager: ObservableObject {
     public func startImportedTranscription(
         audioURL: URL,
         outputFolder: URL,
-        meetingTitle: String? = nil
+        meetingTitle: String? = nil,
+        recordingDate: Date? = nil
     ) {
         if !activeTasks.isEmpty {
             AppLogger.pipeline.warning("Rejecting imported transcription — another pipeline is already active", ["activeCount": "\(activeTasks.count)"])
@@ -279,7 +280,8 @@ public class TranscriptionTaskManager: ObservableObject {
                     audioURL: audioURL,
                     outputFolder: outputFolder,
                     taskId: taskId,
-                    meetingTitle: meetingTitle
+                    meetingTitle: meetingTitle,
+                    recordingDate: recordingDate
                 )
 
                 await MainActor.run {

--- a/Sources/TranscriptedCore/Stats/StatsService.swift
+++ b/Sources/TranscriptedCore/Stats/StatsService.swift
@@ -289,14 +289,15 @@ extension StatsService {
         from result: TranscriptionResult,
         captureId: UUID,
         transcriptPath: String?,
-        title: String?
+        title: String?,
+        date: Date = Date()
     ) -> RecordingMetadata {
         let totalWordCount = result.micWordCount + result.systemWordCount
         let totalSpeakers = result.micSpeakerCount + result.systemSpeakerCount
 
         return RecordingMetadata(
             id: captureId.uuidString,
-            date: Date(),
+            date: date,
             durationSeconds: Int(result.duration),
             wordCount: totalWordCount,
             speakerCount: totalSpeakers,

--- a/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
@@ -158,6 +158,7 @@ public class TranscriptSaver {
         notifier: TranscriptNotifier? = nil,
         speakerStore: (any SpeakerStore)? = nil,
         statsStore: (any StatsStore)? = nil,
+        recordingDate: Date? = nil,
         transcriptionEngine: SpeechTranscriptionEngineDescriptor
     ) -> URL? {
         let saveDir = directory ?? defaultSaveDirectory
@@ -177,7 +178,8 @@ public class TranscriptSaver {
             return nil
         }
 
-        let timestamp = DateFormattingHelper.formatFilename(Date())
+        let transcriptDate = recordingDate ?? Date()
+        let timestamp = DateFormattingHelper.formatFilename(transcriptDate)
         var fileURL = saveDir.appendingPathComponent("Call_\(timestamp).md")
         var counter = 1
         while FileManager.default.fileExists(atPath: fileURL.path) {
@@ -191,7 +193,7 @@ public class TranscriptSaver {
             speakerMappings: speakerMappings,
             speakerSources: speakerSources,
             speakerDbIds: speakerDbIds,
-            date: Date(),
+            date: transcriptDate,
             meetingTitle: meetingTitle,
             healthInfo: healthInfo,
             transcriptionEngine: transcriptionEngine
@@ -224,7 +226,8 @@ public class TranscriptSaver {
                 from: result,
                 captureId: transcriptId,
                 transcriptPath: savedURL.path,
-                title: meetingTitle
+                title: meetingTitle,
+                date: transcriptDate
             )
             (statsStore ?? StatsDatabase.shared).recordSession(metadata)
         }

--- a/Tests/MeetingImportedAudioPreparerTests.swift
+++ b/Tests/MeetingImportedAudioPreparerTests.swift
@@ -1,53 +1,61 @@
 import Foundation
 
-func testMeetingImportedAudioPreparer() {
-    runSuite("MeetingImportedAudioPreparer gives a stable missing-file error") {
+func testMeetingImportedAudioPreparer() async {
+    await runSuite("MeetingImportedAudioPreparer gives a stable missing-file error") {
         let root = temporaryImportAudioPreparerRoot()
         let sourceURL = root.appendingPathComponent("missing.m4a")
         let scratchURL = root.appendingPathComponent("scratch", isDirectory: true)
 
-        assertImportedAudioPreparationError(
+        await assertImportedAudioPreparationError(
             .fileMissing,
             sourceURL: sourceURL,
             scratchURL: scratchURL
         )
     }
 
-    runSuite("MeetingImportedAudioPreparer rejects folders with import-specific copy") {
+    await runSuite("MeetingImportedAudioPreparer rejects folders with import-specific copy") {
         let root = temporaryImportAudioPreparerRoot()
         let sourceURL = root.appendingPathComponent("folder.wav", isDirectory: true)
         let scratchURL = root.appendingPathComponent("scratch", isDirectory: true)
         try! FileManager.default.createDirectory(at: sourceURL, withIntermediateDirectories: true)
 
-        assertImportedAudioPreparationError(
+        await assertImportedAudioPreparationError(
             .notRegularFile,
             sourceURL: sourceURL,
             scratchURL: scratchURL
         )
     }
 
-    runSuite("MeetingImportedAudioPreparer rejects non-audio files before copying") {
+    await runSuite("MeetingImportedAudioPreparer rejects non-audio files before copying") {
         let root = temporaryImportAudioPreparerRoot()
         let sourceURL = root.appendingPathComponent("notes.txt")
         let scratchURL = root.appendingPathComponent("scratch", isDirectory: true)
         try! FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         try! "not audio".write(to: sourceURL, atomically: true, encoding: .utf8)
 
-        assertImportedAudioPreparationError(
+        await assertImportedAudioPreparationError(
             .unsupportedAudioType,
             sourceURL: sourceURL,
             scratchURL: scratchURL
         )
     }
 
-    runSuite("MeetingImportedAudioPreparer copies audio-looking files into scratch") {
+    await runSuite("MeetingImportedAudioPreparer copies audio-looking files into scratch") {
         let root = temporaryImportAudioPreparerRoot()
         let sourceURL = root.appendingPathComponent("Customer_Call-1.wav")
         let scratchURL = root.appendingPathComponent("scratch", isDirectory: true)
+        let sourceRecordingDate = Date(timeIntervalSince1970: 1_704_067_200)
         try! FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         FileManager.default.createFile(atPath: sourceURL.path, contents: Data([0, 1, 2, 3]))
+        try! FileManager.default.setAttributes(
+            [
+                .creationDate: sourceRecordingDate,
+                .modificationDate: sourceRecordingDate.addingTimeInterval(86_400)
+            ],
+            ofItemAtPath: sourceURL.path
+        )
 
-        let prepared = try! MeetingImportedAudioPreparer.prepareImportedAudio(
+        let prepared = try! await MeetingImportedAudioPreparer.prepareImportedAudio(
             from: sourceURL,
             scratchDirectory: scratchURL
         )
@@ -58,6 +66,10 @@ func testMeetingImportedAudioPreparer() {
         )
         assertEqual(prepared.copiedAudioURL.deletingPathExtension().lastPathComponent.hasPrefix("imported-"), true, "scratch filenames should be app-owned")
         assertEqual(prepared.suggestedTitle, "Customer Call 1", "import title should come from the selected filename")
+        assertTrue(
+            abs(prepared.recordingDate.timeIntervalSince(sourceRecordingDate)) < 1,
+            "import metadata should use the source file creation date instead of the scratch-copy date"
+        )
     }
 }
 
@@ -65,9 +77,9 @@ private func assertImportedAudioPreparationError(
     _ expected: MeetingImportedAudioPreparationError,
     sourceURL: URL,
     scratchURL: URL
-) {
+) async {
     do {
-        _ = try MeetingImportedAudioPreparer.prepareImportedAudio(
+        _ = try await MeetingImportedAudioPreparer.prepareImportedAudio(
             from: sourceURL,
             scratchDirectory: scratchURL
         )

--- a/Tests/MeetingImportedAudioPreparerTests.swift
+++ b/Tests/MeetingImportedAudioPreparerTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 
 func testMeetingImportedAudioPreparer() async {
@@ -70,6 +71,46 @@ func testMeetingImportedAudioPreparer() async {
             abs(prepared.recordingDate.timeIntervalSince(sourceRecordingDate)) < 1,
             "import metadata should use the source file creation date instead of the scratch-copy date"
         )
+    }
+
+    runSuite("MeetingImportedAudioPreparer keeps timezone-less metadata on the local calendar day") {
+        let localTimeZone = TimeZone(secondsFromGMT: -6 * 60 * 60)!
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = localTimeZone
+
+        let dateOnly = MeetingImportedAudioPreparer.parseMetadataDate(
+            "2025-02-03",
+            defaultTimeZone: localTimeZone
+        )!
+        assertEqual(calendar.component(.year, from: dateOnly), 2025, "date-only metadata should keep the local year")
+        assertEqual(calendar.component(.month, from: dateOnly), 2, "date-only metadata should keep the local month")
+        assertEqual(calendar.component(.day, from: dateOnly), 3, "date-only metadata should not shift to the previous local day")
+
+        let localDateTime = MeetingImportedAudioPreparer.parseMetadataDate(
+            "2025-02-03 09:15:00",
+            defaultTimeZone: localTimeZone
+        )!
+        assertEqual(calendar.component(.day, from: localDateTime), 3, "timezone-less datetime should keep the local day")
+        assertEqual(calendar.component(.hour, from: localDateTime), 9, "timezone-less datetime should keep the local hour")
+        assertEqual(calendar.component(.minute, from: localDateTime), 15, "timezone-less datetime should keep the local minute")
+    }
+
+    await runSuite("MeetingImportedAudioPreparer prefers string metadata before AVFoundation dateValue") {
+        let localTimeZone = TimeZone(secondsFromGMT: -6 * 60 * 60)!
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = localTimeZone
+        let item = AVMutableMetadataItem()
+        item.identifier = .commonIdentifierCreationDate
+        item.value = "2025-02-03" as NSString
+
+        let parsed = await MeetingImportedAudioPreparer.metadataDate(
+            item,
+            defaultTimeZone: localTimeZone
+        )!
+
+        assertEqual(calendar.component(.year, from: parsed), 2025, "string metadata should not use AVFoundation's bogus dateValue")
+        assertEqual(calendar.component(.month, from: parsed), 2, "string metadata should preserve the month")
+        assertEqual(calendar.component(.day, from: parsed), 3, "string metadata should preserve the local day")
     }
 }
 

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -392,7 +392,7 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
 
         let transcriptURL = try XCTUnwrap(manager.lastSavedTranscriptURL)
         XCTAssertTrue(FileManager.default.fileExists(atPath: transcriptURL.path))
-        let markdown = try String(contentsOf: transcriptURL)
+        let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
         XCTAssertTrue(markdown.contains("Recovered Customer Call"))
         XCTAssertTrue(markdown.contains("Recovered meeting artifact."))
     }
@@ -506,6 +506,65 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         }
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: externalURL.path))
+    }
+
+    func testStartImportedTranscriptionUsesSourceRecordingDateForSavedMetadata() async throws {
+        let sourceRecordingDate = localDate(
+            year: 2025,
+            month: 2,
+            day: 3,
+            hour: 4,
+            minute: 5,
+            second: 6
+        )
+        let statsStore = MetadataCapturingStatsStore()
+        let manager = makeManager(
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "Imported meeting artifact."),
+            diarization: MetadataStubDiarizationEngine(segments: [
+                SpeakerSegment(
+                    speakerId: 1,
+                    startTime: 0,
+                    endTime: 2,
+                    embedding: [Float](repeating: 0.42, count: 256),
+                    qualityScore: 0.95
+                )
+            ]),
+            statsStore: statsStore
+        )
+        let externalURL = tempDirectory.appendingPathComponent("source-recorded-date.wav")
+        try writeMonoWAV(to: externalURL, duration: 2.5)
+
+        manager.startImportedTranscription(
+            audioURL: externalURL,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts"),
+            meetingTitle: "Imported customer call",
+            recordingDate: sourceRecordingDate
+        )
+
+        try await waitUntil {
+            manager.lastSavedTranscriptURL != nil && manager.activeTasks.isEmpty
+        }
+
+        let transcriptURL = try XCTUnwrap(manager.lastSavedTranscriptURL)
+        let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
+        XCTAssertTrue(
+            transcriptURL.lastPathComponent.hasPrefix("Call_\(DateFormattingHelper.formatFilename(sourceRecordingDate))"),
+            "imported-audio filenames should use the source recording date"
+        )
+        XCTAssertTrue(
+            markdown.contains("\ndate: \(frontmatterDateString(sourceRecordingDate))\n"),
+            "frontmatter date should use the source recording date"
+        )
+        XCTAssertTrue(
+            markdown.contains("\ntime: \(frontmatterTimeString(sourceRecordingDate))\n"),
+            "frontmatter time should use the source recording time"
+        )
+        let metadata = try XCTUnwrap(statsStore.recordedSessions.first)
+        XCTAssertLessThan(
+            abs(metadata.date.timeIntervalSince(sourceRecordingDate)),
+            0.001,
+            "recording metadata should use the source recording date"
+        )
     }
 
     func testStartImportedTranscriptionSurfacesNoSpeechWhenNoUtterances() async throws {
@@ -1015,7 +1074,8 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         speechToText: (any SpeechToTextEngine)? = nil,
         diarization: (any DiarizationEngine)? = nil,
         retainedAudioDirectory: URL? = nil,
-        retainedAudioDirectoryProvider: (() -> URL?)? = nil
+        retainedAudioDirectoryProvider: (() -> URL?)? = nil,
+        statsStore: (any StatsStore)? = nil
     ) -> TranscriptionTaskManager {
         let paths = CoreStoragePaths(
             transcripts: tempDirectory.appendingPathComponent("transcripts"),
@@ -1043,7 +1103,8 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             speakerClipsDirectory: paths.speakerClips,
             cleanupDirectories: [paths.audioCaptures, paths.speakerClips],
             retainedAudioDirectory: retainedAudioDirectory,
-            retainedAudioDirectoryProvider: retainedAudioDirectoryProvider
+            retainedAudioDirectoryProvider: retainedAudioDirectoryProvider,
+            statsStore: statsStore
         )
     }
 
@@ -1093,6 +1154,71 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             try await Task.sleep(nanoseconds: 50_000_000)
         }
         XCTFail("Timed out waiting for condition")
+    }
+
+    private func localDate(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        minute: Int,
+        second: Int
+    ) -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .current
+        return calendar.date(from: DateComponents(
+            timeZone: .current,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute,
+            second: second
+        ))!
+    }
+
+    private func frontmatterDateString(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+
+    private func frontmatterTimeString(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter.string(from: date)
+    }
+}
+
+@available(macOS 14.0, *)
+private final class MetadataCapturingStatsStore: StatsStore {
+    private let lock = NSLock()
+    private var sessions: [RecordingMetadata] = []
+
+    var recordedSessions: [RecordingMetadata] {
+        lock.lock()
+        defer { lock.unlock() }
+        return sessions
+    }
+
+    func recordSession(_ metadata: RecordingMetadata) {
+        lock.lock()
+        sessions.append(metadata)
+        lock.unlock()
+    }
+
+    func getTotalRecordingsCount() -> Int {
+        recordedSessions.count
+    }
+
+    func getRecordings(from startDate: Date, to endDate: Date) -> [RecordingMetadata] {
+        recordedSessions.filter { $0.date >= startDate && $0.date <= endDate }
+    }
+
+    func recordingExists(transcriptPath: String) -> Bool {
+        recordedSessions.contains { $0.transcriptPath == transcriptPath }
     }
 }
 


### PR DESCRIPTION
## Summary

- Read an imported audio file's embedded recording date when present, then fall back to source creation/modification dates before copying into scratch.
- Carry that date through the imported-audio queue into TranscriptedCore saves.
- Use the source date for the saved Markdown filename, frontmatter `date`/`time`, and recording stats metadata.
- Add importer and core metadata coverage for the source-date path.

## Why

`Transcribe Audio File` was saving imported recordings with the transcription time, because the core saver always used `Date()` and the app copied the source file into scratch before transcription. That made old recordings look like they happened today.

## Validation

- `bash run-tests.sh`
- `bash build.sh`
- `bash run-integration-smoke.sh`
- `swift test`