### PR TITLE
Keep long meetings visible after stop failures

### DIFF
--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -41,6 +41,7 @@ final class MeetingCaptureBridge: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
     private let completionAttempt = MeetingCaptureAttempt<CaptureStopResult>()
     private let startAttempt = MeetingCaptureAttempt<Bool>()
+    private var timedOutStopCompletionHandler: ((CaptureStopResult) -> Void)?
 
     init(audio: Audio = Audio()) {
         self.audio = audio
@@ -100,7 +101,9 @@ final class MeetingCaptureBridge: ObservableObject {
     /// expiry (`didTimeOut == true`). On timeout the WAV header may not be
     /// fully patched, so the caller should treat the audio as failed-but-
     /// recoverable rather than enqueuing it for transcription directly.
-    func stopAndAwaitFiles() async -> CaptureStopResult {
+    func stopAndAwaitFiles(
+        onTimedOutCompletion: ((CaptureStopResult) -> Void)? = nil
+    ) async -> CaptureStopResult {
         guard audio.isRecording else {
             return currentStopResult()
         }
@@ -131,6 +134,7 @@ final class MeetingCaptureBridge: ObservableObject {
                         uniquingKeysWith: { _, new in new }
                     )
                 )
+                self.timedOutStopCompletionHandler = onTimedOutCompletion
                 continuation.resume(returning: self.currentStopResult(didTimeOut: true))
             })
         }
@@ -184,11 +188,20 @@ final class MeetingCaptureBridge: ObservableObject {
             // Hop to main and resume the continuation exactly once.
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                self.completionAttempt.reset()?.resume(returning: CaptureStopResult(
+                let result = CaptureStopResult(
                     micURL: micURL,
                     systemURL: systemURL,
                     didTimeOut: false
-                ))
+                )
+                if let continuation = self.completionAttempt.reset() {
+                    self.timedOutStopCompletionHandler = nil
+                    continuation.resume(returning: result)
+                    return
+                }
+
+                let handler = self.timedOutStopCompletionHandler
+                self.timedOutStopCompletionHandler = nil
+                handler?(result)
             }
         }
 

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -557,7 +557,13 @@ final class MeetingSessionController: ObservableObject {
             )
         )
 
-        let stopResult = await capture.stopAndAwaitFiles()
+        let stopTimeoutFailedTaskId = UUID()
+        let stopResult = await capture.stopAndAwaitFiles { [weak self] lateResult in
+            self?.refreshTimedOutFailedMeetingAudio(
+                id: stopTimeoutFailedTaskId,
+                result: lateResult
+            )
+        }
         let files = (micURL: stopResult.micURL, systemURL: stopResult.systemURL)
         let afterStopVolumeContext = capture.routeVolumeDiagnosticsContext(currentPhase: "after")
         let stopCaptureDiagnostics = MeetingCaptureVolumeDiagnostics.annotatedStopContext(
@@ -675,10 +681,12 @@ final class MeetingSessionController: ObservableObject {
                 ]
             )
             let preserved = preserveFailedMeetingForRetry(
+                taskId: stopTimeoutFailedTaskId,
                 micAudioURL: micURL,
                 systemAudioURL: files.systemURL,
                 errorMessage: "Recording stop timed out before audio files were finalized.",
-                meetingTitle: recordingSnapshot.suggestedTitle
+                meetingTitle: recordingSnapshot.suggestedTitle,
+                archiveAudio: false
             )
             DiagnosticsTrail.record(
                 level: .warning,
@@ -2121,21 +2129,57 @@ final class MeetingSessionController: ObservableObject {
 
     @discardableResult
     private func preserveFailedMeetingForRetry(
+        taskId: UUID = UUID(),
         micAudioURL: URL?,
         systemAudioURL: URL?,
         errorMessage: String,
-        meetingTitle: String?
+        meetingTitle: String?,
+        archiveAudio: Bool = true
     ) -> Bool {
         let preserved = taskManager.addFailedTranscriptionRetainingAvailableAudio(
             micAudioURL: micAudioURL,
             systemAudioURL: systemAudioURL,
             errorMessage: errorMessage,
-            meetingTitle: meetingTitle
+            taskId: taskId,
+            meetingTitle: meetingTitle,
+            archiveAudio: archiveAudio
         )
         if preserved {
             refreshFailedMeetings()
         }
         return preserved
+    }
+
+    private func refreshTimedOutFailedMeetingAudio(id: UUID, result: CaptureStopResult) {
+        guard let micURL = result.micURL else { return }
+        let existingSystemURL = failedManager.failedTranscriptions
+            .first(where: { $0.id == id })?
+            .systemAudioURL
+        let systemURL = result.systemURL ?? existingSystemURL
+
+        let updated = failedManager.updateFailedTranscriptionAudio(
+            id: id,
+            micAudioURL: micURL,
+            systemAudioURL: systemURL
+        )
+        DiagnosticsTrail.record(
+            level: updated ? .info : .warning,
+            engine: "meeting",
+            event: "meeting_recording_stop_timeout_audio_finalized",
+            message: updated
+                ? "Timed-out meeting audio finalized and failed queue was refreshed"
+                : "Timed-out meeting audio finalized but failed queue entry was not found",
+            context: baseDiagnosticsContext(
+                extra: [
+                    "failed_id": id.uuidString,
+                    "mic_file_present": boolString(FileManager.default.fileExists(atPath: micURL.path)),
+                    "system_file_present": boolString(systemURL.map { FileManager.default.fileExists(atPath: $0.path) } ?? false)
+                ]
+            )
+        )
+        if updated {
+            refreshFailedMeetings()
+        }
     }
 
     private func refreshFailedMeetings(_ updatedFailedTranscriptions: [FailedTranscription]? = nil) {

--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -36,9 +36,12 @@ enum MeetingTranscriptStyler {
     }
 
     static func displayTranscriptPreview(at url: URL) -> StyledMeetingTranscript? {
-        let raw: String
+        let frontmatter: TranscriptFrontmatterDocument?
         do {
-            raw = try previewString(at: url)
+            frontmatter = try TranscriptFrontmatter.readDocument(
+                from: url,
+                byteLimit: frontmatterPreviewByteLimit
+            )
         } catch {
             logFailure(
                 event: "meeting_transcript_preview_read_failed",
@@ -51,8 +54,9 @@ enum MeetingTranscriptStyler {
             return nil
         }
 
-        guard isMeetingTranscript(raw) else { return nil }
-        guard let document = parseDocument(raw, fallbackURL: url) else {
+        guard let frontmatter,
+              isMeetingTranscript(frontmatter) else { return nil }
+        guard let document = parseDocument(frontmatter, fallbackURL: url) else {
             return StyledMeetingTranscript(url: url, title: fallbackTitle(for: url))
         }
 
@@ -134,22 +138,26 @@ enum MeetingTranscriptStyler {
             ?? raw.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private static func previewString(at url: URL, byteLimit: Int = 64 * 1024) throws -> String {
-        let handle = try FileHandle(forReadingFrom: url)
-        defer { try? handle.close() }
-        let data = try handle.read(upToCount: byteLimit) ?? Data()
-        return String(decoding: data, as: UTF8.self)
-    }
-
-    private static func isMeetingTranscript(_ raw: String) -> Bool {
-        raw.hasPrefix("---\n") && (raw.contains("\n## Full Transcript") || raw.contains("\n## Transcript"))
+    private static func isMeetingTranscript(_ document: TranscriptFrontmatterDocument) -> Bool {
+        let body = document.body.trimmingCharacters(in: .whitespacesAndNewlines)
+        return document.values["capture_type"] == "meeting"
+            || body.hasPrefix("## Full Transcript")
+            || body.hasPrefix("## Transcript")
+            || body.contains("\n## Full Transcript")
+            || body.contains("\n## Transcript")
     }
 
     private static func parseDocument(_ raw: String, fallbackURL: URL) -> ParsedDocument? {
         guard let frontmatter = TranscriptFrontmatter.document(in: raw) else {
             return nil
         }
+        return parseDocument(frontmatter, fallbackURL: fallbackURL)
+    }
 
+    private static func parseDocument(
+        _ frontmatter: TranscriptFrontmatterDocument,
+        fallbackURL: URL
+    ) -> ParsedDocument? {
         let values = frontmatter.values
 
         let recordedAt = parseRecordedAt(values: values, fallbackURL: fallbackURL)

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -44,9 +44,7 @@ extension Transcription {
         let processingStartTime = Date()
 
         do {
-            let durationFileURL = micURL ?? systemURL
-            let durationFile = try AVAudioFile(forReading: durationFileURL)
-            let duration = Double(durationFile.length) / durationFile.processingFormat.sampleRate
+            let duration = try Self.longestAudioDuration(micURL: micURL, systemURL: systemURL)
 
             onProgress?(0.0)
 
@@ -571,6 +569,19 @@ extension Transcription {
             }
             throw error
         }
+    }
+
+    nonisolated private static func longestAudioDuration(micURL: URL?, systemURL: URL) throws -> TimeInterval {
+        var durations = [try audioDuration(at: systemURL)]
+        if let micURL {
+            durations.append(try audioDuration(at: micURL))
+        }
+        return durations.max() ?? 0
+    }
+
+    nonisolated private static func audioDuration(at url: URL) throws -> TimeInterval {
+        let file = try AVAudioFile(forReading: url)
+        return Double(file.length) / file.processingFormat.sampleRate
     }
 
     // MARK: - Mic Channel Diarization

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -621,14 +621,16 @@ public class TranscriptionTaskManager: ObservableObject {
         systemAudioURL: URL?,
         errorMessage: String,
         taskId: UUID = UUID(),
-        meetingTitle: String? = nil
+        meetingTitle: String? = nil,
+        archiveAudio: Bool = true
     ) {
         _ = addFailedTranscriptionRetainingAvailableAudio(
             micAudioURL: micAudioURL,
             systemAudioURL: systemAudioURL,
             errorMessage: errorMessage,
             taskId: taskId,
-            meetingTitle: meetingTitle
+            meetingTitle: meetingTitle,
+            archiveAudio: archiveAudio
         )
     }
 
@@ -638,7 +640,8 @@ public class TranscriptionTaskManager: ObservableObject {
         systemAudioURL: URL?,
         errorMessage: String,
         taskId: UUID = UUID(),
-        meetingTitle: String? = nil
+        meetingTitle: String? = nil,
+        archiveAudio: Bool = true
     ) -> Bool {
         guard micAudioURL != nil || systemAudioURL != nil else {
             AppLogger.pipeline.error("No audio files available to retain for failed transcription", [
@@ -647,27 +650,33 @@ public class TranscriptionTaskManager: ObservableObject {
             return false
         }
 
-        let retainedAudio = archiveFailedRecordingAudioIfConfigured(
-            micURL: micAudioURL,
-            systemURL: systemAudioURL,
-            taskId: taskId
-        )
+        let retainedAudio = archiveAudio
+            ? archiveFailedRecordingAudioIfConfigured(
+                micURL: micAudioURL,
+                systemURL: systemAudioURL,
+                taskId: taskId
+            )
+            : nil
         return enqueueFailedTranscriptionAfterRetainingAudio(
+            taskId: taskId,
             retainedAudio: retainedAudio,
             originalMicURL: micAudioURL,
             originalSystemURL: systemAudioURL,
             errorMessage: errorMessage,
-            meetingTitle: meetingTitle
+            meetingTitle: meetingTitle,
+            removeOriginalsAfterArchive: archiveAudio
         )
     }
 
     @discardableResult
     private func enqueueFailedTranscriptionAfterRetainingAudio(
+        taskId: UUID,
         retainedAudio: RetainedRecordingAudio?,
         originalMicURL: URL?,
         originalSystemURL: URL?,
         errorMessage: String,
-        meetingTitle: String?
+        meetingTitle: String?,
+        removeOriginalsAfterArchive: Bool
     ) -> Bool {
         let failedSystemURL = retainedAudio?.systemURL ?? originalSystemURL
         let placeholderMicURL = makeSilentMicPlaceholderIfNeeded(
@@ -681,12 +690,14 @@ public class TranscriptionTaskManager: ObservableObject {
         }
 
         let didPersist = failedTranscriptionManager.addFailedTranscription(
+            id: taskId,
             micAudioURL: failedMicURL,
             systemAudioURL: failedSystemURL,
             errorMessage: errorMessage,
             meetingTitle: meetingTitle
         )
         guard didPersist else { return false }
+        guard removeOriginalsAfterArchive else { return true }
 
         if retainedAudio?.micURL != nil {
             removeManagedCleanupFile(originalMicURL, label: "archived failed mic scratch")

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -110,6 +110,7 @@ public class FailedTranscriptionManager: ObservableObject {
     /// Adds a new failed transcription to the queue
     @discardableResult
     public func addFailedTranscription(
+        id: UUID = UUID(),
         micAudioURL: URL,
         systemAudioURL: URL?,
         errorMessage: String,
@@ -128,6 +129,7 @@ public class FailedTranscriptionManager: ObservableObject {
         }
 
         let failed = FailedTranscription(
+            id: id,
             micAudioURL: micAudioURL,
             systemAudioURL: systemAudioURL,
             errorMessage: errorMessage,
@@ -142,6 +144,44 @@ public class FailedTranscriptionManager: ObservableObject {
 
         AppLogger.pipeline.info("Added failed transcription", [
             "id": "\(failed.id)",
+            "persisted": "\(didPersist)"
+        ])
+        return didPersist
+    }
+
+    @discardableResult
+    public func updateFailedTranscriptionAudio(
+        id: UUID,
+        micAudioURL: URL,
+        systemAudioURL: URL?
+    ) -> Bool {
+        guard isSafeAudioURL(micAudioURL), systemAudioURL.map(isSafeAudioURL) ?? true else {
+            AppLogger.pipeline.error("Rejected failed transcription audio update with out-of-sandbox path", [
+                "id": id.uuidString,
+                "micURL": micAudioURL.path,
+                "systemURL": systemAudioURL?.path ?? "none"
+            ])
+            return false
+        }
+        guard let index = failedTranscriptions.firstIndex(where: { $0.id == id }) else {
+            return false
+        }
+
+        let existing = failedTranscriptions[index]
+        failedTranscriptions[index] = FailedTranscription(
+            id: existing.id,
+            timestamp: existing.timestamp,
+            micAudioURL: micAudioURL,
+            systemAudioURL: systemAudioURL,
+            errorMessage: existing.errorMessage,
+            meetingTitle: existing.meetingTitle,
+            retryCount: existing.retryCount,
+            lastRetryDate: existing.lastRetryDate
+        )
+
+        let didPersist = saveFailedTranscriptions()
+        AppLogger.pipeline.info("Updated failed transcription audio", [
+            "id": "\(id)",
             "persisted": "\(didPersist)"
         ])
         return didPersist

--- a/Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift
@@ -19,6 +19,7 @@ public struct TranscriptFrontmatterDocument: Sendable {
 
 public enum TranscriptFrontmatter {
     public static let previewByteLimit = 64 * 1024
+    public static let maximumFrontmatterByteLimit = 512 * 1024
 
     private static let recordedAtFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -88,9 +89,26 @@ public enum TranscriptFrontmatter {
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
 
-        let data = try handle.read(upToCount: byteLimit) ?? Data()
-        let raw = String(decoding: data, as: UTF8.self)
-        return document(in: raw)
+        let readLimit = max(byteLimit, maximumFrontmatterByteLimit)
+        let chunkSize = max(1, min(byteLimit, previewByteLimit))
+        var data = Data()
+
+        while data.count < readLimit {
+            let remaining = readLimit - data.count
+            guard let chunk = try handle.read(upToCount: min(chunkSize, remaining)),
+                  !chunk.isEmpty else {
+                break
+            }
+            data.append(chunk)
+
+            let raw = String(decoding: data, as: UTF8.self)
+            guard raw.hasPrefix("---\n") else { return nil }
+            if let document = document(in: raw) {
+                return document
+            }
+        }
+
+        return nil
     }
 
     public static func readValues(

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1256,6 +1256,22 @@ struct TranscriptedSettingsView: View {
             )
         }
 
+        if !meetingSession.failedMeetings.isEmpty {
+            let count = meetingSession.failedMeetings.count
+            issues.append(
+                HomeNeedsAttentionCard.Issue(
+                    id: "failed-meetings",
+                    symbolName: "waveform.badge.exclamationmark",
+                    title: count == 1 ? "Meeting needs attention" : "Meetings need attention",
+                    detail: count == 1
+                        ? "Saved audio is waiting for review or retry."
+                        : "\(count) saved recordings are waiting for review or retry.",
+                    destination: .failedMeetings,
+                    actionTitle: "Review"
+                )
+            )
+        }
+
         let modelCard = FirstRunExperience.modelCard(
             for: FirstRunLocalModelState(sttRouter.modelDownloadState),
             model: effectiveTranscriptionModel

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -102,6 +102,39 @@ func testFailedMeetingPresentation() {
         assertTrue(presentation.canShowRetryAction, "retryable failures with audio should show Try again")
     }
 
+    runSuite("HomeFailedMeetingInlinePresentation stop-timeout retained audio appears retry-ready in Home") {
+        let directory = makeFailedMeetingPresentationTestDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let micURL = directory.appendingPathComponent("microphone.wav")
+        let systemURL = directory.appendingPathComponent("system_audio.wav")
+        FileManager.default.createFile(atPath: micURL.path, contents: Data("mic".utf8))
+        FileManager.default.createFile(atPath: systemURL.path, contents: Data("system".utf8))
+
+        let hasAudioFiles = FileManager.default.fileExists(atPath: micURL.path)
+            && FileManager.default.fileExists(atPath: systemURL.path)
+        let presentation = HomeFailedMeetingInlinePresentation.make(
+            isRetryable: true,
+            isRetrying: false,
+            hasAudioFiles: hasAudioFiles,
+            detail: "Recording stop timed out before audio files were finalized."
+        )
+
+        assertEqual(
+            MeetingFailureKind.classify(message: "Recording stop timed out before audio files were finalized."),
+            .stopTimeout,
+            "stop-timeout failures should keep their recovery category"
+        )
+        assertTrue(hasAudioFiles, "retained timeout audio should make the Home row retry-ready")
+        assertEqual(presentation.statusText, "Retry ready", "Home should show that saved audio can be retried")
+        assertEqual(
+            presentation.inlineDetail,
+            "Saved audio is still here. Try again will transcribe it.",
+            "Home should make the recovery path visible"
+        )
+        assertTrue(presentation.canShowRetryAction, "retained stop-timeout audio should show Try again")
+    }
+
     runSuite("HomeFailedMeetingInlinePresentation blocks retries when audio is gone") {
         let presentation = HomeFailedMeetingInlinePresentation.make(
             isRetryable: true,
@@ -149,4 +182,11 @@ func testFailedMeetingPresentation() {
             "partial retained audio should not enable the retry action"
         )
     }
+}
+
+private func makeFailedMeetingPresentationTestDirectory() -> URL {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent("FailedMeetingPresentationTests-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    return directory
 }

--- a/Tests/MeetingTranscriptStylerTests.swift
+++ b/Tests/MeetingTranscriptStylerTests.swift
@@ -8,6 +8,8 @@ func testMeetingTranscriptStyler() {
         testMeetingTranscriptStylerPreservesExplicitTitle()
         testMeetingTranscriptStylerDisplaysExplicitTitleWithoutFullBodyRead()
         testMeetingTranscriptStylerPreviewReadsBoundedMeetingMetadata()
+        testMeetingTranscriptStylerPreviewReadsLegacyHeadingAtBodyStart()
+        testMeetingTranscriptStylerPreviewReadsOversizedMeetingFrontmatter()
         testMeetingTranscriptStylerPreviewRejectsPlainMarkdown()
         testMeetingTranscriptStylerRenamesRetainedAudioDirectory()
         testMeetingTranscriptStylerAvoidsAudioDirectoryCollisions()
@@ -120,6 +122,67 @@ private func testMeetingTranscriptStylerPreviewReadsBoundedMeetingMetadata() {
 
     assertEqual(preview?.title, "Customer Interview April", "Preview should derive the same title without requiring a full restyle pass")
     assertEqual(preview?.url, transcriptURL, "Preview should not rename or rewrite the transcript")
+}
+
+private func testMeetingTranscriptStylerPreviewReadsLegacyHeadingAtBodyStart() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Legacy_Call.md")
+    let raw = """
+    ---
+    title: "Legacy Meeting"
+    date: "2026-04-07"
+    time: "09:14:00"
+    duration: "12:30"
+    total_word_count: "42"
+    mic_utterances: "0"
+    system_utterances: "1"
+    ---
+    ## Transcript
+
+    [00:00] [System/Speaker 1] Hello.
+    """
+    try? raw.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+    let preview = MeetingTranscriptStyler.displayTranscriptPreview(at: transcriptURL)
+
+    assertEqual(preview?.title, "Legacy Meeting", "Preview should include legacy meeting transcripts when the body starts with the transcript heading")
+    assertEqual(preview?.url, transcriptURL, "Preview should not rename or rewrite legacy meeting transcripts")
+}
+
+private func testMeetingTranscriptStylerPreviewReadsOversizedMeetingFrontmatter() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Long_Call_2026-04-07_09-14-00.md")
+    let gapEvents = (0..<3_000)
+        .map { "  - \"gap \($0) \(String(repeating: "x", count: 24))\"" }
+        .joined(separator: "\n")
+    let raw = """
+    ---
+    capture_type: meeting
+    title: "Long Customer Call"
+    date: 2026-04-07
+    time: 09:14:00
+    duration: "120:00"
+    mic_utterances: 1
+    system_utterances: 24
+    total_word_count: 5000
+    gap_events:
+    \(gapEvents)
+    ---
+
+    ## Full Transcript
+
+    [00:00] [System/Speaker 1] Hello.
+    """
+    try? raw.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+    let preview = MeetingTranscriptStyler.displayTranscriptPreview(at: transcriptURL)
+
+    assertEqual(preview?.title, "Long Customer Call", "Preview should include long meetings even when frontmatter exceeds the first preview chunk")
+    assertEqual(preview?.url, transcriptURL, "Preview should not rename or rewrite oversized meeting transcripts")
 }
 
 private func testMeetingTranscriptStylerPreviewRejectsPlainMarkdown() {

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -705,7 +705,7 @@ func testRepoCommandContract() {
         let bridgeContents = readRepoTextFile("Sources/Meeting/MeetingCaptureBridge.swift")
         let stopBlock = sourceSlice(
             bridgeContents,
-            from: "func stopAndAwaitFiles() async -> CaptureStopResult {",
+            from: "func stopAndAwaitFiles(",
             to: "func stopAndDiscardFiles() async -> CaptureStopResult {"
         )
 
@@ -717,6 +717,11 @@ func testRepoCommandContract() {
         assertTrue(
             stopBlock.contains("Task.sleep(nanoseconds: stopTimeout)"),
             "meeting stop should sleep on the scaled timeout, not the fixed base timeout"
+        )
+        assertTrue(
+            stopBlock.contains("onTimedOutCompletion")
+                && stopBlock.contains("timedOutStopCompletionHandler"),
+            "late audio finalization after a stop timeout should be surfaced to repair retry paths"
         )
     }
 
@@ -753,6 +758,15 @@ func testRepoCommandContract() {
             "stop timeouts should route retained audio through the refresh helper before returning"
         )
         assertTrue(
+            timeoutBlock.contains("archiveAudio: false"),
+            "stop timeouts should keep scratch audio in place because WAV finalization may still be running"
+        )
+        assertTrue(
+            controllerContents.contains("refreshTimedOutFailedMeetingAudio(")
+                && controllerContents.contains("updateFailedTranscriptionAudio("),
+            "late WAV finalization should refresh the failed queue so retries do not point at deleted mic recovery segments"
+        )
+        assertTrue(
             timeoutBlock.contains("\"preserved_for_retry\": boolString(preserved)"),
             "stop-timeout diagnostics should state whether the retained audio reached the retry queue"
         )
@@ -776,6 +790,24 @@ func testRepoCommandContract() {
             ),
             1,
             "direct failed-queue writes in MeetingSessionController should stay centralized in the refresh helper"
+        )
+    }
+
+    runSuite("Repo command contract - Home attention summary includes failed meetings") {
+        let settingsContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
+        let needsAttentionBlock = sourceSlice(
+            settingsContents,
+            from: "private var homeNeedsAttentionIssues: [HomeNeedsAttentionCard.Issue] {",
+            to: "private var homeMeetingDaySections:"
+        )
+
+        assertTrue(
+            needsAttentionBlock.contains("!meetingSession.failedMeetings.isEmpty"),
+            "failed meetings should contribute to the Home Needs Attention summary"
+        )
+        assertTrue(
+            needsAttentionBlock.contains("destination: .failedMeetings"),
+            "the Home Needs Attention failed-meeting issue should jump to the failed meetings section"
         )
     }
 

--- a/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
@@ -214,6 +214,51 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertEqual(persisted.first?.meetingTitle, "Design review")
     }
 
+    func testUpdateFailedTranscriptionAudioPreservesRetryMetadata() throws {
+        let paths = makePaths(root: testRoot)
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+
+        let firstMicURL = paths.audioCaptures.appendingPathComponent("timeout-segment.wav")
+        let finalMicURL = paths.audioCaptures.appendingPathComponent("timeout-merged.wav")
+        let systemURL = paths.audioCaptures.appendingPathComponent("timeout-system.wav")
+        FileManager.default.createFile(atPath: firstMicURL.path, contents: Data("mic".utf8))
+        FileManager.default.createFile(atPath: finalMicURL.path, contents: Data("merged".utf8))
+        FileManager.default.createFile(atPath: systemURL.path, contents: Data("system".utf8))
+
+        let manager = FailedTranscriptionManager(paths: paths)
+        let failedId = UUID()
+        XCTAssertTrue(manager.addFailedTranscription(
+            id: failedId,
+            micAudioURL: firstMicURL,
+            systemAudioURL: nil,
+            errorMessage: "Recording stop timed out before audio files were finalized.",
+            meetingTitle: "Design review"
+        ))
+        manager.incrementRetryCount(id: failedId)
+
+        XCTAssertTrue(manager.updateFailedTranscriptionAudio(
+            id: failedId,
+            micAudioURL: finalMicURL,
+            systemAudioURL: systemURL
+        ))
+
+        let failed = try XCTUnwrap(manager.failedTranscriptions.first)
+        XCTAssertEqual(failed.id, failedId)
+        XCTAssertEqual(failed.micAudioURL, finalMicURL)
+        XCTAssertEqual(failed.systemAudioURL, systemURL)
+        XCTAssertEqual(failed.errorMessage, "Recording stop timed out before audio files were finalized.")
+        XCTAssertEqual(failed.meetingTitle, "Design review")
+        XCTAssertEqual(failed.retryCount, 1)
+        XCTAssertNotNil(failed.lastRetryDate)
+
+        let persisted = try JSONDecoder.iso8601.decode(
+            [FailedTranscription].self,
+            from: Data(contentsOf: paths.failedQueue)
+        )
+        XCTAssertEqual(persisted.first?.micAudioURL, finalMicURL)
+        XCTAssertEqual(persisted.first?.systemAudioURL, systemURL)
+    }
+
     func testAddFailedTranscriptionRollsBackMemoryWhenPersistenceFails() throws {
         let paths = makePaths(root: testRoot)
         try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)

--- a/Tests/TranscriptedCoreTests/TranscriptFrontmatterTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptFrontmatterTests.swift
@@ -83,4 +83,36 @@ final class TranscriptFrontmatterTests: XCTestCase {
         XCTAssertEqual(values["title"], "Large Meeting")
         XCTAssertEqual(values["duration"], "42:17")
     }
+
+    func testReadValuesContinuesUntilLargeFrontmatterCloses() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptFrontmatterTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let url = directory.appendingPathComponent("long-meeting.md")
+        let gapEvents = (0..<3_000)
+            .map { "  - \"gap \($0) \(String(repeating: "x", count: 24))\"" }
+            .joined(separator: "\n")
+        let raw = """
+        ---
+        capture_type: meeting
+        title: "Long Meeting"
+        duration: "120:00"
+        gap_events:
+        \(gapEvents)
+        ---
+
+        ## Full Transcript
+
+        Hello.
+        """
+        try raw.write(to: url, atomically: true, encoding: .utf8)
+
+        let values = try XCTUnwrap(try TranscriptFrontmatter.readValues(from: url))
+
+        XCTAssertEqual(values["capture_type"], "meeting")
+        XCTAssertEqual(values["title"], "Long Meeting")
+        XCTAssertEqual(values["duration"], "120:00")
+    }
 }

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -363,6 +363,72 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertTrue(failed.systemAudioURL?.path.hasPrefix(retainedAudioDirectory.path + "/") ?? false)
     }
 
+    func testLiveMeetingDurationUsesLongestReadableTrack() async throws {
+        let speech = MetadataStubSpeechToTextEngine(transcript: "Thanks for joining.")
+        let diarization = MetadataStubDiarizationEngine(segments: [
+            SpeakerSegment(
+                speakerId: 1,
+                startTime: 0,
+                endTime: 3.5,
+                embedding: [Float](repeating: 0.42, count: 256),
+                qualityScore: 0.95
+            )
+        ])
+        let manager = makeManager(
+            speechToText: speech,
+            diarization: diarization,
+            retainedAudioDirectory: tempDirectory
+                .appendingPathComponent("transcripts", isDirectory: true)
+                .appendingPathComponent("audio", isDirectory: true)
+        )
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("short-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("long-system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 4.0)
+
+        manager.startTranscription(
+            micURL: micURL,
+            systemURL: systemURL,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts"),
+            meetingTitle: "Long system call"
+        )
+
+        try await waitUntil {
+            manager.lastSavedTranscriptURL != nil && manager.activeTasks.isEmpty
+        }
+        let transcriptURL = try XCTUnwrap(manager.lastSavedTranscriptURL)
+        let values = try XCTUnwrap(try TranscriptFrontmatter.readValues(from: transcriptURL))
+
+        XCTAssertEqual(values["duration"], "0:04", "meeting metadata should use the longest readable track, not a short mic placeholder")
+    }
+
+    func testStopTimeoutFailedQueueCanKeepScratchAudioUntilItFinalizes() throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(retainedAudioDirectory: retainedAudioDirectory)
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("timeout-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("timeout-system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        XCTAssertTrue(manager.addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: "Recording stop timed out before audio files were finalized.",
+            archiveAudio: false
+        ))
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+
+        XCTAssertEqual(failed.micAudioURL, micURL)
+        XCTAssertEqual(failed.systemAudioURL, systemURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path), "timeout scratch mic audio should stay in place so late WAV finalization can complete")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path), "timeout scratch system audio should stay in place so late WAV finalization can complete")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: retainedAudioDirectory.path), "stop-timeout preservation should not copy possibly unfinished WAVs into the retained archive")
+    }
+
     func testRetryFailedTranscriptionSuccessCreatesMarkdownAndClearsFailedQueue() async throws {
         let manager = makeManager(
             speechToText: MetadataStubSpeechToTextEngine(transcript: "Recovered meeting artifact.")
@@ -392,7 +458,7 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
 
         let transcriptURL = try XCTUnwrap(manager.lastSavedTranscriptURL)
         XCTAssertTrue(FileManager.default.fileExists(atPath: transcriptURL.path))
-        let markdown = try String(contentsOf: transcriptURL)
+        let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
         XCTAssertTrue(markdown.contains("Recovered Customer Call"))
         XCTAssertTrue(markdown.contains("Recovered meeting artifact."))
     }


### PR DESCRIPTION
## Summary
- preserve stop-timeout failed meetings for retry without archiving unfinished scratch audio
- refresh failed-meeting queue entries when late audio finalization completes
- read oversized transcript frontmatter and classify legacy meeting transcripts in previews
- use the longest available meeting audio track for duration metadata

## Verification
- git diff --check
- bash build-deps.sh --force
- bash build.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh
- swift test
- bash run-integration-smoke.sh