### PR TITLE
[nightly-maintenance] Update tool onboarding docs

### DIFF
--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -121,6 +121,10 @@ Rule of thumb:
   Global trigger and hotkey routing behavior.
 - `Tools/TranscriptedCLI/CLAUDE.md`
   Standalone local-context and offline diarization CLI.
+- `Tools/TranscriptedMCP/CLAUDE.md`
+  Read-only MCP server for saved meetings and dictations.
+- `Tools/TranscriptedQA/CLAUDE.md`
+  Standalone artifact validation and QA CLI.
 
 ## Historical Zones
 


### PR DESCRIPTION
## Summary

- Added the missing `Tools/TranscriptedMCP/CLAUDE.md` and `Tools/TranscriptedQA/CLAUDE.md` entries to the highest-value local docs list.
- Keeps the agent onboarding doc aligned with the current `Tools/` package surface.

## Verification

- `bash scripts/dev/agent-preflight.sh`
- `git diff --check`