### PR TITLE
Update release feeds for 1.1.43

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.42"
-  sha256 "eb9b349a28ee84f68419688f060d9320902d3e1e4ebf189817ecdde3d9cefd26"
+  version "1.1.43"
+  sha256 "2599531b300a8fc7c477ff14870d3908b5ed93b5de7d66aebc1d370090e8258d"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.43</title>
+      <pubDate>Fri, 22 May 2026 08:12:09 -0500</pubDate>
+      <sparkle:version>1.1.43</sparkle:version>
+      <sparkle:shortVersionString>1.1.43</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.43/Transcripted-1.1.43.dmg" length="535551588" type="application/octet-stream" sparkle:edSignature="L48gukYILzIw5FDcU16k6C8tkUopJjtD1MFagiJOILbo9j2uYD80mRjfSkmz8hWnVHNsrXo15QMPJpBinv+oAQ==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.43</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.43</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.42</title>
       <pubDate>Tue, 19 May 2026 12:04:39 -0500</pubDate>
       <sparkle:version>1.1.42</sparkle:version>


### PR DESCRIPTION
Updates Sparkle appcast and Homebrew cask for the published Transcripted 1.1.43 GitHub release.\n\nVerification:\n- bash scripts/release/verify-sparkle-release.sh 1.1.43\n- ruby -c Casks/transcripted.rb\n- git diff --check\n\nNote: Sentry release registration attempted after loading local env, but Sentry returned 403 permission denied. The dSYM remains at build/Transcripted.app.dSYM.