### PR TITLE
[nightly-review] Clear import diagnostics on model failure

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -881,6 +881,7 @@ final class MeetingSessionController: ObservableObject {
         case .ready, .transcribing:
             break
         default:
+            Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "models_unavailable")
             return false
         }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -733,6 +733,30 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - imported audio clears runtime diagnostics when models are unavailable") {
+        let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let importBlock = sourceSlice(
+            controllerContents,
+            from: "func importAudioFile(from sourceURL: URL) async -> Bool {",
+            to: "private func importPreparationFailureKind"
+        )
+        let readinessBlock = sourceSlice(
+            importBlock,
+            from: "switch state {",
+            to: "let preparedAudio: PreparedImportedMeetingAudio"
+        )
+
+        assertTrue(
+            importBlock.contains("Self.runtimeDiagnosticsRecorder?.recordSession(kind: \"meeting\", stage: \"file_import_requested\")"),
+            "imported audio should mark runtime diagnostics while it prepares models and scratch audio"
+        )
+        assertTrue(
+            readinessBlock.contains("case .ready, .transcribing:")
+                && readinessBlock.contains("Self.runtimeDiagnosticsRecorder?.clearSession(kind: \"meeting\", outcome: \"models_unavailable\")"),
+            "failed imported-audio model prep should clear runtime diagnostics instead of leaving a false active session"
+        )
+    }
+
     runSuite("Repo command contract - bridge uses scaled meeting stop timeout") {
         let bridgeContents = readRepoTextFile("Sources/Meeting/MeetingCaptureBridge.swift")
         let stopBlock = sourceSlice(


### PR DESCRIPTION
## Nightly review

Reviewed last-24h landed work on origin/main: release 1.1.43 feed/cask updates, imported-audio source dates, queued meeting diagnostics, speaker finalization, and onboarding telemetry. Also checked open issues #500, #825, and #850.

Live Sentry/PostHog health was blocked because this environment has no Sentry or PostHog token configured.

## Top risks ranked

1. Imported-audio model prep could leave runtime diagnostics marked active after a normal model-unavailable return, creating a false unclean-shutdown report on next launch. Fixed here.
2. Long-meeting finalization remains the main open customer risk from #825, but the current release already has scaled stop/quit waits and retry visibility. I did not change that tonight.
3. Quiet-mic/system-output interaction from #500 is still open; recent diagnostics help, but no safe narrow audio-pipeline change was available from this pass.

## Change

- Clear the meeting runtime diagnostics session when imported audio cannot proceed because models are unavailable.
- Add a fast repo contract test so the import path keeps that clear call near the readiness gate.

## Verification

- bash build-deps.sh --force
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh
- bash scripts/release/verify-sparkle-release.sh 1.1.43
