### PR TITLE
[nightly-telemetry] Track ready update state

### DIFF
--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -70,6 +70,7 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
     private var hasPerformedStartupCheck = false
     private var pendingImmediateInstallHandler: (() -> Void)?
     private var pendingImmediateInstallVersion: String?
+    private var lastTrackedReadyToInstallVersion: String?
     private var didTrackCurrentUpdateCycleFailure = false
     private var observedUpdateCheckTimeoutTask: Task<Void, Never>?
     private static let observedUpdateCheckTimeoutNanoseconds: UInt64 = 30_000_000_000
@@ -423,6 +424,15 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
         AnalyticsReporter.track(event, properties: properties)
     }
 
+    private func markUpdateReadyToInstall(from updater: SPUUpdater, version: String) {
+        let state = UpdateStatus.State.readyToInstall(version: version)
+        setUpdateStatus(state, canCheckForUpdates: updater.canCheckForUpdates)
+
+        guard lastTrackedReadyToInstallVersion != version else { return }
+        lastTrackedReadyToInstallVersion = version
+        trackUpdateLifecycleEvent("update_ready_to_install", state: state, version: version)
+    }
+
     private func baseUpdateTelemetryProperties(state: UpdateStatus.State, version: String?) -> [String: String] {
         var properties = [
             "automatic_downloads_enabled": automaticUpdateSettings.automaticDownloadsEnabled ? "true" : "false",
@@ -523,11 +533,9 @@ extension SparkleUpdaterController: SPUUpdaterDelegate {
         immediateInstallationBlock immediateInstallHandler: @escaping () -> Void
     ) -> Bool {
         let version = versionString(for: item)
-        let state = UpdateStatus.State.readyToInstall(version: version)
         pendingImmediateInstallHandler = immediateInstallHandler
         pendingImmediateInstallVersion = version
-        setUpdateStatus(state, canCheckForUpdates: updater.canCheckForUpdates)
-        trackUpdateLifecycleEvent("update_ready_to_install", state: state, version: version)
+        markUpdateReadyToInstall(from: updater, version: version)
         return true
     }
 
@@ -590,10 +598,15 @@ extension SparkleUpdaterController: SPUStandardUserDriverDelegate {
         }
         Task { @MainActor [weak self] in
             guard let self else { return }
-            self.setUpdateStatus(
-                updateState,
-                canCheckForUpdates: self.updaterController.updater.canCheckForUpdates
-            )
+            switch updateState {
+            case .readyToInstall(let version):
+                self.markUpdateReadyToInstall(from: self.updaterController.updater, version: version)
+            case .unknown, .readyToCheck, .checking, .noUpdateAvailable, .updateAvailable, .downloading:
+                self.setUpdateStatus(
+                    updateState,
+                    canCheckForUpdates: self.updaterController.updater.canCheckForUpdates
+                )
+            }
         }
     }
 }

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -275,6 +275,33 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - downloaded Sparkle state emits ready telemetry") {
+        let controller = readRepoTextFile("Sources/Observability/SparkleUpdaterController.swift")
+        let readyHelper = sourceSlice(
+            controller,
+            from: "private func markUpdateReadyToInstall(",
+            to: "private func baseUpdateTelemetryProperties("
+        )
+        let userDriverBlock = sourceSlice(
+            controller,
+            from: "nonisolated func standardUserDriverWillHandleShowingUpdate(",
+            to: "\n    }\n}"
+        )
+
+        assertTrue(
+            readyHelper.contains("lastTrackedReadyToInstallVersion != version"),
+            "ready-to-install telemetry should stay one event per version"
+        )
+        assertTrue(
+            readyHelper.contains("update_ready_to_install"),
+            "ready-to-install helper should emit the update funnel event"
+        )
+        assertTrue(
+            userDriverBlock.contains("markUpdateReadyToInstall"),
+            "Sparkle downloaded-state UI should not skip ready-to-install telemetry"
+        )
+    }
+
     runSuite("Repo command contract - release docs keep Sparkle and Homebrew gates explicit") {
         let releaseDocs = readRepoTextFile("docs/release-packaging.md")
         let sparkleDocs = readRepoTextFile("docs/sparkle-updates.md")


### PR DESCRIPTION
## Summary
- Track `update_ready_to_install` when Sparkle reports the downloaded update UI state, not only when the quit-time install delegate fires.
- Dedupe ready-to-install telemetry per version so the update funnel does not double-count.
- Add a repo contract test covering the downloaded-state telemetry path.

## Why
Nightly telemetry showed `1.1.42 -> 1.1.43` update downloads in PostHog, but no `update_ready_to_install` or `update_relaunching` events. That made it hard to tell whether users actually reached the trusted restart/install step after the download finished.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (`2461 tests, 2461 passed, 0 failed`)