### PR TITLE
[nightly-regression] Cover imported audio scratch permissions

### DIFF
--- a/Tests/MeetingImportedAudioPreparerTests.swift
+++ b/Tests/MeetingImportedAudioPreparerTests.swift
@@ -51,7 +51,8 @@ func testMeetingImportedAudioPreparer() async {
         try! FileManager.default.setAttributes(
             [
                 .creationDate: sourceRecordingDate,
-                .modificationDate: sourceRecordingDate.addingTimeInterval(86_400)
+                .modificationDate: sourceRecordingDate.addingTimeInterval(86_400),
+                .posixPermissions: 0o644
             ],
             ofItemAtPath: sourceURL.path
         )
@@ -70,6 +71,16 @@ func testMeetingImportedAudioPreparer() async {
         assertTrue(
             abs(prepared.recordingDate.timeIntervalSince(sourceRecordingDate)) < 1,
             "import metadata should use the source file creation date instead of the scratch-copy date"
+        )
+        assertEqual(
+            importedAudioFilePermissions(of: prepared.copiedAudioURL),
+            NSNumber(value: 0o600),
+            "scratch copy should be restricted to the owner"
+        )
+        assertEqual(
+            importedAudioFilePermissions(of: sourceURL),
+            NSNumber(value: 0o644),
+            "preparing imported audio should not mutate the user's source file permissions"
         )
     }
 
@@ -143,4 +154,9 @@ private func temporaryImportAudioPreparerRoot() -> URL {
         "MeetingImportedAudioPreparerTests-\(UUID().uuidString)",
         isDirectory: true
     )
+}
+
+private func importedAudioFilePermissions(of url: URL) -> NSNumber? {
+    let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+    return attributes?[.posixPermissions] as? NSNumber
 }


### PR DESCRIPTION
## Nightly review

Reviewed current origin/main plus last-run landed work since 2026-05-23T05:36:27Z: PRs #863, #864, #865, and #866. Checked open nightly PRs first; none were open.

Live evidence used:
- Sentry last 24h production unresolved: APPLE-MACOS-9 app hang, APPLE-MACOS-1D unclean shutdown, APPLE-MACOS-1H meeting transcript failed.
- PostHog last 24h verified event counts: 13 app launches, 12 dictation starts, 9 dictation completes, 3 meeting starts, 7 meeting transcript saves, 1 meeting transcript failure, 5 update downloads finished, 3 ready-to-install events, 1 unclean shutdown.
- Open GitHub issues still watched: #500 quiet mic/system-output interaction, #825 long meetings visibility/recovery, #850 imported audio source date.

## Top risks ranked

1. Imported audio privacy regression coverage was too thin: the code copies user-selected audio into app scratch and tightens it to owner-only, but the behavior test only checked that a copy existed.
2. Runtime reliability is still noisy: Sentry still shows app hangs, unclean shutdowns, and one meeting transcript failure in the last 24h. No narrow current-code fix was higher confidence tonight.
3. Meeting audio trust remains the larger open product risk through #500 and #825, but the recent stop-timeout, retained-audio, diagnostics, and temp-cleanup changes looked internally consistent in this pass.

## Change

- Extended `MeetingImportedAudioPreparerTests` so imported audio preparation proves the scratch copy is `0600`.
- Also proves the user's source file permissions are not mutated during import preparation.

## Verification

- `bash scripts/dev/agent-preflight.sh`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build-deps.sh --force`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` (`2467 tests, 2467 passed`)
- `~/.codex/skills/codex-review/scripts/codex-review --mode local` (clean; reran `bash run-tests.sh` with `2467 tests, 2467 passed`)

Tests-only root fast-test change, so `.agents/test-matrix.yml` did not require integration smoke.
