### PR TITLE
[nightly-agent] Document stale MCP helper refresh

### DIFF
--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -33,6 +33,12 @@ Then it safely merges this entry into Claude Desktop's config:
 Existing MCP servers are preserved. If the config is invalid JSON,
 Transcripted backs it up before writing a clean config.
 
+If the installed helper's `--self-test` prints many `[transcripted-mcp] Indexed`
+lines before the JSON payload, the helper copied into Application Support is
+stale. Click `Install for Claude Desktop` again from Transcripted Settings to
+replace it with the current bundled helper. The current helper should print only
+the JSON self-test payload.
+
 Current `transcripted-mcp` capabilities:
 
 - `recent_context`


### PR DESCRIPTION
## Summary
- Adds a Claude Desktop troubleshooting note for stale installed `transcripted-mcp` helpers.
- Explains that noisy `--self-test` indexing lines mean the Application Support helper should be refreshed from Transcripted Settings.

## Why
The current repo-built and app-bundled helpers print clean JSON for `--self-test`, but the already-installed Claude Desktop helper on this machine is older and writes many index diagnostics to stderr before the JSON payload.

## Verification
- `swift test --package-path Tools/TranscriptedCLI`
- `swift test --package-path Tools/TranscriptedMCP`
- `swift build -c release` in `Tools/TranscriptedMCP`
- `Tools/TranscriptedMCP/.build/release/transcripted-mcp --self-test`
- `/Applications/Transcripted.app/Contents/Helpers/transcripted-mcp --self-test`
- CLI retrieval checks for `context-recent`, `context-search`, `list-dictations`, `read-meeting`, and `read-dictation` with explicit capture-directory overrides