### PR TITLE
[operator] Add PostHog daily DAU trend probe

### DIFF
--- a/docs/ops-credentials.md
+++ b/docs/ops-credentials.md
@@ -37,7 +37,7 @@ Only report aggregate counts, status codes, deployment IDs, and issue titles. Fo
 
 ### PostHog Probe Shape
 
-The PostHog probe reports aggregate 7-day counts for active devices, workflow events, onboarding events, and first-value events. First-value events are limited to `onboarding_first_dictation_saved`, `meeting_transcript_saved`, and `onboarding_agent_cta_clicked`, so the health lane can see whether users reached a saved Markdown artifact or agent payoff without exposing transcript text, file paths, titles, or user identifiers.
+The PostHog probe reports aggregate 7-day counts for active devices, workflow events, onboarding events, and first-value events. It also prints a 7-day daily active-device trend so operators can see whether DAU is rising, flat, or missing without inspecting user-level data. First-value events are limited to `onboarding_first_dictation_saved`, `meeting_transcript_saved`, and `onboarding_agent_cta_clicked`, so the health lane can see whether users reached a saved Markdown artifact or agent payoff without exposing transcript text, file paths, titles, or user identifiers.
 
 ## Quick Start
 

--- a/scripts/ops/health-probe.sh
+++ b/scripts/ops/health-probe.sh
@@ -85,31 +85,43 @@ probe_posthog() {
   fi
 
   echo "PostHog health check..."
-  local workflow_events onboarding_events first_value_events query payload
+  local workflow_events onboarding_events first_value_events query daily_query payload daily_payload
   workflow_events="'app_launched','app_unclean_shutdown_detected','app_session_stall_detected','onboarding_completed','dictation_started','dictation_start_failed','dictation_completed','dictation_cancelled','dictation_no_speech','dictation_audio_route_recovery_timeout','meeting_recording_started','meeting_recording_start_failed','meeting_recording_stopped','meeting_recording_cancelled','meeting_transcript_saved','meeting_transcript_failed','meeting_transcript_skipped'"
   onboarding_events="'onboarding_shown','onboarding_step_viewed','onboarding_permission_cta_clicked','onboarding_permission_status_changed','onboarding_model_state_changed','onboarding_primary_cta_clicked','onboarding_first_dictation_started','onboarding_first_dictation_saved','onboarding_first_dictation_stop_clicked','onboarding_first_dictation_empty','onboarding_meeting_dry_run_clicked','onboarding_agent_cta_clicked','onboarding_reporting_toggle_changed','onboarding_completed','onboarding_dismissed'"
   first_value_events="'onboarding_first_dictation_saved','meeting_transcript_saved','onboarding_agent_cta_clicked'"
   query="select uniq(distinct_id) as devices_7d, sum(case when event in ($workflow_events) then 1 else 0 end) as workflow_events_7d, sum(case when event in ($onboarding_events) then 1 else 0 end) as onboarding_events_7d, sum(case when event in ($first_value_events) then 1 else 0 end) as first_value_events_7d from events where timestamp >= now() - interval 7 day"
+  daily_query="select toDate(timestamp) as day, uniq(distinct_id) as active_devices from events where timestamp >= now() - interval 7 day and event in ($workflow_events) group by day order by day asc"
   payload=$(jq -cn --arg query "$query" '{query: $query}')
+  daily_payload=$(jq -cn --arg query "$daily_query" '{query: $query}')
 
-  local response
+  local response daily_response
   response=$(curl -s -f -X POST \
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
     -H "Content-Type: application/json" \
     "https://us.i.posthog.com/api/projects/$POSTHOG_PROJECT_ID/query/" \
     -d "$payload")
+  daily_response=$(curl -s -f -X POST \
+    -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
+    -H "Content-Type: application/json" \
+    "https://us.i.posthog.com/api/projects/$POSTHOG_PROJECT_ID/query/" \
+    -d "$daily_payload")
 
-  if [[ -z "$response" ]]; then
+  if [[ -z "$response" ]] || [[ -z "$daily_response" ]]; then
     echo "PostHog: query failed"
     return 1
   fi
 
-  local devices events onboarding first_value
+  local devices events onboarding first_value daily_devices
   devices=$(echo "$response" | jq -r '.data[0][0]')
   events=$(echo "$response" | jq -r '.data[0][1]')
   onboarding=$(echo "$response" | jq -r '.data[0][2] // 0')
   first_value=$(echo "$response" | jq -r '.data[0][3] // 0')
+  daily_devices=$(echo "$daily_response" | jq -r '((.data // .results // []) | map("\(.[0])=\(.[1])") | join(", "))')
+  if [[ -z "$daily_devices" ]]; then
+    daily_devices="none"
+  fi
   echo "PostHog (last 7d): devices=$devices, workflow_events=$events, onboarding_events=$onboarding, first_value_events=$first_value"
+  echo "PostHog daily active devices: $daily_devices"
 }
 
 probe_cloudflare() {


### PR DESCRIPTION
## Summary
- Adds a daily active-device trend query to the PostHog health probe.
- Keeps the output aggregate-only: day plus active-device count, no user IDs or event payloads.
- Updates the ops credential doc to describe the DAU trend output.

## Why
The nightly operator needs to see whether usage is rising, flat, or missing on the path to 1,000 DAU. The existing probe only printed a 7-day aggregate, which hid day-to-day movement.

## Verification
- `bash -n scripts/ops/health-probe.sh`
- `bash scripts/ops/health-probe.sh posthog` (skips cleanly because `POSTHOG_PERSONAL_API_KEY` is not set in this shell)
- `git diff --check -- scripts/ops/health-probe.sh docs/ops-credentials.md`