### PR TITLE
[nightly-regression] Cover PostHog DAU probe contract

### DIFF
--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -47,6 +47,29 @@ func testRepoCommandContract() {
         assertFalse(contents.contains("\"r3d-bar\""), "Cloudflare probe should not check the old redbars Pages project name")
     }
 
+    runSuite("Repo command contract - PostHog health probe keeps aggregate daily active-device trend") {
+        let contents = readRepoTextFile("scripts/ops/health-probe.sh")
+
+        assertTrue(
+            contents.contains("daily_query=")
+                && contents.contains("toDate(timestamp) as day")
+                && contents.contains("uniq(distinct_id) as active_devices")
+                && contents.contains("group by day order by day asc"),
+            "PostHog probe should keep the daily aggregate active-device trend query"
+        )
+        assertTrue(
+            contents.contains("daily_payload=")
+                && contents.contains("daily_response=")
+                && contents.contains("daily_devices=")
+                && contents.contains("PostHog daily active devices:"),
+            "PostHog probe should print the daily aggregate trend alongside 7-day totals"
+        )
+        assertFalse(
+            contents.contains("PostHog daily active device ids"),
+            "PostHog probe should not print user or device identifiers"
+        )
+    }
+
     runSuite("Repo command contract - build bundles only the runtime Parakeet model") {
         let contents = readRepoTextFile("scripts/entrypoints/build.sh")
         assertTrue(


### PR DESCRIPTION
## Nightly review

Reviewed current origin/main plus landed work since 2026-05-24T05:36:32Z: PRs #867, #868, #869, and #870. Checked open nightly PRs first; none were open.

Live evidence used:
- PostHog last 24h: 10 app launches, 63 dictation starts, 55 dictation completions, 1 dictation start failure, 1 meeting start, 1 meeting transcript save, 0 meeting transcript failures, 0 skipped meeting transcripts, 0 unclean shutdowns, 1 update download finished, and 1 ready-to-install event.
- Sentry MCP returned `Transport closed`, and this shell has no `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, or `SENTRY_PROJECT`, so Sentry issue detail was unavailable tonight.
- Open GitHub risks still watched: #500 quiet mic/system-output interaction, #825 long meetings visibility/recovery, and #850 imported-audio source date still open even though the current code path is covered by recent PR work.

## Top risks ranked

1. The new PostHog DAU trend probe had shell syntax/skip validation but no regression guard for the aggregate-only daily trend query or output line. Covered here.
2. Runtime audio reliability still has known product risk through #500, but last-24h PostHog showed only 1 dictation start failure and no meeting transcript failures or unclean shutdowns. No safe narrow app-code fix was higher-confidence tonight.
3. Long-meeting visibility remains tracked by #825, but current main already includes stop-timeout preservation, retry visibility, and failed-meeting recovery work; this pass did not find a fresh small patch there.

## Change

- Adds a fast repo-contract test that keeps `scripts/ops/health-probe.sh` reporting the PostHog daily active-device trend as aggregate day=count output.
- Guards against accidentally changing that probe into an ID-printing shape.

## Verification

- `bash scripts/dev/agent-preflight.sh`
- `bash scripts/ops/health-probe.sh posthog` (skipped cleanly because `POSTHOG_PERSONAL_API_KEY` is not set in this shell)
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build-deps.sh --force`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` (`2470 tests, 2470 passed`)
- `~/.codex/skills/codex-review/scripts/codex-review --mode local` (clean; nested `bash run-tests.sh` also passed with `2470 tests, 2470 passed`)

Tests-only root fast-test change, so `.agents/test-matrix.yml` did not require integration smoke.