### PR TITLE
[nightly-telemetry] Fix PostHog health probe

### DIFF
--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -70,6 +70,10 @@ func testRepoCommandContract() {
             contents.contains("https://us.i.posthog.com/api/projects"),
             "PostHog probe should not send API queries to the ingest host"
         )
+        assertTrue(
+            contents.contains("validate_posthog_api_host") && contents.contains("POSTHOG_ALLOW_UNTRUSTED_HOST"),
+            "PostHog probe should validate hosts before sending the personal API key"
+        )
     }
 
     runSuite("Repo command contract - build bundles only the runtime Parakeet model") {

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -47,6 +47,31 @@ func testRepoCommandContract() {
         assertFalse(contents.contains("\"r3d-bar\""), "Cloudflare probe should not check the old redbars Pages project name")
     }
 
+    runSuite("Repo command contract - PostHog health probe uses the query API") {
+        let contents = readRepoTextFile("scripts/ops/health-probe.sh")
+
+        assertTrue(
+            contents.contains("posthog_api_host()"),
+            "PostHog probe should normalize app/ingest hosts before querying"
+        )
+        assertTrue(
+            contents.contains("https://us.i.posthog.com)") && contents.contains("https://us.posthog.com"),
+            "PostHog probe should translate the US ingest host to the API host"
+        )
+        assertTrue(
+            contents.contains("kind: \"HogQLQuery\"") && contents.contains("refresh: \"blocking\""),
+            "PostHog probe should use the current HogQL query API payload"
+        )
+        assertTrue(
+            contents.contains("(.data // .results)"),
+            "PostHog probe should parse both old and current query response shapes"
+        )
+        assertFalse(
+            contents.contains("https://us.i.posthog.com/api/projects"),
+            "PostHog probe should not send API queries to the ingest host"
+        )
+    }
+
     runSuite("Repo command contract - build bundles only the runtime Parakeet model") {
         let contents = readRepoTextFile("scripts/entrypoints/build.sh")
         assertTrue(

--- a/docs/ops-credentials.md
+++ b/docs/ops-credentials.md
@@ -39,7 +39,7 @@ Only report aggregate counts, status codes, deployment IDs, and issue titles. Fo
 
 The PostHog probe reports aggregate 7-day counts for active devices, workflow events, onboarding events, and first-value events. It also prints a 7-day daily active-device trend so operators can see whether DAU is rising, flat, or missing without inspecting user-level data. First-value events are limited to `onboarding_first_dictation_saved`, `meeting_transcript_saved`, and `onboarding_agent_cta_clicked`, so the health lane can see whether users reached a saved Markdown artifact or agent payoff without exposing transcript text, file paths, titles, or user identifiers.
 
-If `POSTHOG_HOST` points at the app ingest host, such as `https://us.i.posthog.com`, the probe normalizes it to the matching PostHog API host before running HogQL.
+If `POSTHOG_HOST` points at the app ingest host, such as `https://us.i.posthog.com`, the probe normalizes it to the matching PostHog API host before running HogQL. The probe only sends `POSTHOG_PERSONAL_API_KEY` to HTTPS PostHog API hosts by default. Set `POSTHOG_ALLOW_UNTRUSTED_HOST=1` only when using a trusted self-hosted PostHog endpoint.
 
 ## Quick Start
 

--- a/docs/ops-credentials.md
+++ b/docs/ops-credentials.md
@@ -39,6 +39,8 @@ Only report aggregate counts, status codes, deployment IDs, and issue titles. Fo
 
 The PostHog probe reports aggregate 7-day counts for active devices, workflow events, onboarding events, and first-value events. It also prints a 7-day daily active-device trend so operators can see whether DAU is rising, flat, or missing without inspecting user-level data. First-value events are limited to `onboarding_first_dictation_saved`, `meeting_transcript_saved`, and `onboarding_agent_cta_clicked`, so the health lane can see whether users reached a saved Markdown artifact or agent payoff without exposing transcript text, file paths, titles, or user identifiers.
 
+If `POSTHOG_HOST` points at the app ingest host, such as `https://us.i.posthog.com`, the probe normalizes it to the matching PostHog API host before running HogQL.
+
 ## Quick Start
 
 1. Set your credentials as environment variables (or in your shell profile):

--- a/scripts/ops/health-probe.sh
+++ b/scripts/ops/health-probe.sh
@@ -36,6 +36,29 @@ posthog_api_host() {
   echo "$host"
 }
 
+validate_posthog_api_host() {
+  local host="$1"
+
+  if [[ "$host" != https://* ]]; then
+    echo "PostHog: refusing to send API key because host must use HTTPS: $host"
+    return 1
+  fi
+
+  if [[ "${POSTHOG_ALLOW_UNTRUSTED_HOST:-0}" == "1" ]]; then
+    return 0
+  fi
+
+  case "$host" in
+    https://app.posthog.com|https://eu.posthog.com|https://posthog.com|https://us.posthog.com)
+      return 0
+      ;;
+  esac
+
+  echo "PostHog: refusing to send API key to untrusted host: $host"
+  echo "PostHog: set POSTHOG_ALLOW_UNTRUSTED_HOST=1 only for a trusted self-hosted endpoint"
+  return 1
+}
+
 probe_github() {
   if ! command -v gh &> /dev/null; then
     echo "SKIP github: gh CLI not found"
@@ -112,6 +135,10 @@ probe_posthog() {
 
   local posthog_host response daily_response
   posthog_host="$(posthog_api_host)"
+  if ! validate_posthog_api_host "$posthog_host"; then
+    return 1
+  fi
+
   if ! response=$(curl -s -f -X POST \
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
     -H "Content-Type: application/json" \

--- a/scripts/ops/health-probe.sh
+++ b/scripts/ops/health-probe.sh
@@ -20,6 +20,22 @@ skip_lane() {
   return 0
 }
 
+posthog_api_host() {
+  local host="${POSTHOG_APP_HOST:-${POSTHOG_HOST:-https://us.posthog.com}}"
+  host="${host%/}"
+
+  case "$host" in
+    https://us.i.posthog.com)
+      host="https://us.posthog.com"
+      ;;
+    https://eu.i.posthog.com)
+      host="https://eu.posthog.com"
+      ;;
+  esac
+
+  echo "$host"
+}
+
 probe_github() {
   if ! command -v gh &> /dev/null; then
     echo "SKIP github: gh CLI not found"
@@ -91,20 +107,27 @@ probe_posthog() {
   first_value_events="'onboarding_first_dictation_saved','meeting_transcript_saved','onboarding_agent_cta_clicked'"
   query="select uniq(distinct_id) as devices_7d, sum(case when event in ($workflow_events) then 1 else 0 end) as workflow_events_7d, sum(case when event in ($onboarding_events) then 1 else 0 end) as onboarding_events_7d, sum(case when event in ($first_value_events) then 1 else 0 end) as first_value_events_7d from events where timestamp >= now() - interval 7 day"
   daily_query="select toDate(timestamp) as day, uniq(distinct_id) as active_devices from events where timestamp >= now() - interval 7 day and event in ($workflow_events) group by day order by day asc"
-  payload=$(jq -cn --arg query "$query" '{query: $query}')
-  daily_payload=$(jq -cn --arg query "$daily_query" '{query: $query}')
+  payload=$(jq -cn --arg query "$query" '{query: {kind: "HogQLQuery", query: $query}, refresh: "blocking"}')
+  daily_payload=$(jq -cn --arg query "$daily_query" '{query: {kind: "HogQLQuery", query: $query}, refresh: "blocking"}')
 
-  local response daily_response
-  response=$(curl -s -f -X POST \
+  local posthog_host response daily_response
+  posthog_host="$(posthog_api_host)"
+  if ! response=$(curl -s -f -X POST \
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
     -H "Content-Type: application/json" \
-    "https://us.i.posthog.com/api/projects/$POSTHOG_PROJECT_ID/query/" \
-    -d "$payload")
-  daily_response=$(curl -s -f -X POST \
+    "$posthog_host/api/projects/$POSTHOG_PROJECT_ID/query/" \
+    -d "$payload"); then
+    echo "PostHog: query failed"
+    return 1
+  fi
+  if ! daily_response=$(curl -s -f -X POST \
     -H "Authorization: Bearer $POSTHOG_PERSONAL_API_KEY" \
     -H "Content-Type: application/json" \
-    "https://us.i.posthog.com/api/projects/$POSTHOG_PROJECT_ID/query/" \
-    -d "$daily_payload")
+    "$posthog_host/api/projects/$POSTHOG_PROJECT_ID/query/" \
+    -d "$daily_payload"); then
+    echo "PostHog: daily query failed"
+    return 1
+  fi
 
   if [[ -z "$response" ]] || [[ -z "$daily_response" ]]; then
     echo "PostHog: query failed"
@@ -112,10 +135,10 @@ probe_posthog() {
   fi
 
   local devices events onboarding first_value daily_devices
-  devices=$(echo "$response" | jq -r '.data[0][0]')
-  events=$(echo "$response" | jq -r '.data[0][1]')
-  onboarding=$(echo "$response" | jq -r '.data[0][2] // 0')
-  first_value=$(echo "$response" | jq -r '.data[0][3] // 0')
+  devices=$(echo "$response" | jq -r '(.data // .results)[0][0]')
+  events=$(echo "$response" | jq -r '(.data // .results)[0][1]')
+  onboarding=$(echo "$response" | jq -r '(.data // .results)[0][2] // 0')
+  first_value=$(echo "$response" | jq -r '(.data // .results)[0][3] // 0')
   daily_devices=$(echo "$daily_response" | jq -r '((.data // .results // []) | map("\(.[0])=\(.[1])") | join(", "))')
   if [[ -z "$daily_devices" ]]; then
     daily_devices="none"


### PR DESCRIPTION
## Summary
- Normalize PostHog ingest hosts like https://us.i.posthog.com to the API host before running ops queries.
- Send the current HogQL query payload shape and parse the current results response.
- Pin the contract in RepoCommandContractTests and document the host normalization.

## Nightly sweep
Winner: broken PostHog ops health probe, score 89/100.

Why it won:
- Live PostHog snapshot worked, but bash scripts/ops/health-probe.sh posthog failed with present credentials after printing only PostHog health check...
- Recent PR #869 made this probe more important by adding the daily DAU trend.
- Patch is tiny, privacy-safe, aggregate-only, and directly verifiable.

Next candidates that lost:
- Long-meeting trust issue #825 remains higher user pain, but the next useful work is a long-recording regression pass, not a tiny localized patch.
- Meeting save trigger=unknown is still noisy on older releases, but 1.1.43 saves are attributed, so it stays watchlist.

## Verification
- set -a; . /Users/redbars/.hermes/.env; set +a; bash scripts/ops/health-probe.sh posthog
- bash build-deps.sh --force
- bash build.sh
- bash run-tests.sh
