### PR TITLE
[operator] Skip non-meeting transcript restyles

### DIFF
--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -83,7 +83,24 @@ enum MeetingTranscriptStyler {
             return StyledMeetingTranscript(url: url, title: fallbackTitle(for: url))
         }
 
-        guard let document = parseDocument(raw, fallbackURL: url) else {
+        guard let frontmatter = TranscriptFrontmatter.document(in: raw) else {
+            return StyledMeetingTranscript(
+                url: url,
+                title: fallbackTitle(for: url)
+            )
+        }
+        guard isMeetingTranscript(frontmatter) else {
+            let explicitTitle = frontmatter.values["title"]?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let title = explicitTitle?.isEmpty == false
+                ? explicitTitle ?? fallbackTitle(for: url)
+                : fallbackTitle(for: url)
+            return StyledMeetingTranscript(
+                url: url,
+                title: title
+            )
+        }
+        guard let document = parseDocument(frontmatter, fallbackURL: url) else {
             return StyledMeetingTranscript(
                 url: url,
                 title: fallbackTitle(for: url)
@@ -95,9 +112,9 @@ enum MeetingTranscriptStyler {
             return StyledMeetingTranscript(url: url, title: title)
         }
 
-        let frontmatter = renderFrontmatter(lines: document.frontmatterLines, title: title)
+        let renderedFrontmatter = renderFrontmatter(lines: document.frontmatterLines, title: title)
         let body = renderBody(document: document, title: title)
-        let updated = frontmatter + "\n\n" + body + "\n"
+        let updated = renderedFrontmatter + "\n\n" + body + "\n"
         let finalURL = renameTranscriptArtifactsIfNeeded(at: url, title: title)
 
         if updated != raw {

--- a/Tests/MeetingTranscriptStylerTests.swift
+++ b/Tests/MeetingTranscriptStylerTests.swift
@@ -11,6 +11,7 @@ func testMeetingTranscriptStyler() {
         testMeetingTranscriptStylerPreviewReadsLegacyHeadingAtBodyStart()
         testMeetingTranscriptStylerPreviewReadsOversizedMeetingFrontmatter()
         testMeetingTranscriptStylerPreviewRejectsPlainMarkdown()
+        testMeetingTranscriptStylerSkipsNonMeetingFrontmatter()
         testMeetingTranscriptStylerRenamesRetainedAudioDirectory()
         testMeetingTranscriptStylerAvoidsAudioDirectoryCollisions()
         testMeetingTranscriptStylerPreservesObsidianSpeakerLinks()
@@ -193,6 +194,35 @@ private func testMeetingTranscriptStylerPreviewRejectsPlainMarkdown() {
     try? "# Notes\n\nNot a Transcripted meeting.".write(to: noteURL, atomically: true, encoding: .utf8)
 
     assertNil(MeetingTranscriptStyler.displayTranscriptPreview(at: noteURL), "Preview should skip non-meeting markdown files")
+}
+
+private func testMeetingTranscriptStylerSkipsNonMeetingFrontmatter() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let noteURL = directory.appendingPathComponent("notes.md")
+    let raw = """
+    ---
+    title: "Project Note"
+    date: "2026-04-07"
+    ---
+
+    # Project Note
+
+    This is not a Transcripted meeting.
+    """
+    try? raw.write(to: noteURL, atomically: true, encoding: .utf8)
+
+    let styled = MeetingTranscriptStyler.restyleTranscript(at: noteURL)
+    let updated = try? String(contentsOf: noteURL, encoding: .utf8)
+
+    assertEqual(styled.url, noteURL, "Styler should leave non-meeting notes at their original path")
+    assertEqual(styled.title, "Project Note", "Styler may display the explicit title without taking ownership")
+    assertEqual(updated, raw, "Styler should not rewrite Markdown that is not a Transcripted meeting")
+    assertFalse(
+        FileManager.default.fileExists(atPath: directory.appendingPathComponent("Project Note.md").path),
+        "Styler should not rename non-meeting notes"
+    )
 }
 
 private func testMeetingTranscriptStylerRenamesRetainedAudioDirectory() {


### PR DESCRIPTION
## Summary
- skip `MeetingTranscriptStyler.restyleTranscript` when frontmatter Markdown is not a Transcripted meeting
- add a regression test so non-meeting notes are not rewritten or renamed

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`

## Operator note
Chosen as a tiny trust-protecting regression from the nightly operator lanes. It avoids the open PostHog draft PR overlap and does not change audio capture behavior.