### PR TITLE
[nightly-maintenance] Clarify scripts wrapper map

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,9 +16,9 @@ stable and the docs can keep pointing at the same commands:
 - `run-live-capture-smoke.sh` — local hardware/TCC smoke for app launch plus mic and system-audio capture
 - `run-daily-audio-reliability.sh` — interactive or synthetic daily audio reliability check
 
-## Entrypoint implementations
+## Wrapper implementations
 
-The actual script bodies live under `scripts/entrypoints/` so the repo root does
+Most root wrapper bodies live under `scripts/entrypoints/` so the repo root does
 not have to carry the full operational logic:
 
 - `scripts/entrypoints/build-deps.sh`
@@ -28,6 +28,9 @@ not have to carry the full operational logic:
 - `scripts/entrypoints/run-tests.sh`
 - `scripts/entrypoints/run-integration-smoke.sh`
 - `scripts/entrypoints/run-live-capture-smoke.sh`
+
+`run-daily-audio-reliability.sh` is the exception: it keeps its implementation
+with the operational health probes at `scripts/ops/daily-audio-reliability-check.sh`.
 
 ## Active helper scripts
 


### PR DESCRIPTION
## Summary

Clarifies `scripts/README.md` so the wrapper implementation section does not imply every root wrapper delegates into `scripts/entrypoints/`.

`run-daily-audio-reliability.sh` is now called out as the exception that delegates to `scripts/ops/daily-audio-reliability-check.sh`, matching the current tree.

## Validation

- `scripts/dev/agent-preflight.sh`
- `git diff --check`

## Notes

Normal git push over SSH failed because no SSH key was available, and HTTPS git push reached GitHub but was rejected with a remote 500. I created the same branch/file commit through the GitHub API so the draft PR is still available for review.