### PR TITLE
Lock in metadata-date parser edge cases for imported audio (#850)

### DIFF
--- a/Tests/MeetingImportedAudioPreparerTests.swift
+++ b/Tests/MeetingImportedAudioPreparerTests.swift
@@ -123,6 +123,55 @@ func testMeetingImportedAudioPreparer() async {
         assertEqual(calendar.component(.month, from: parsed), 2, "string metadata should preserve the month")
         assertEqual(calendar.component(.day, from: parsed), 3, "string metadata should preserve the local day")
     }
+
+    runSuite("MeetingImportedAudioPreparer parses ISO8601 metadata with fractional seconds and Z suffix") {
+        let utc = TimeZone(secondsFromGMT: 0)!
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = utc
+
+        let parsed = MeetingImportedAudioPreparer.parseMetadataDate(
+            "2025-02-03T09:15:00.500Z",
+            defaultTimeZone: utc
+        )!
+
+        assertEqual(calendar.component(.year, from: parsed), 2025, "fractional ISO date should parse the year")
+        assertEqual(calendar.component(.month, from: parsed), 2, "fractional ISO date should parse the month")
+        assertEqual(calendar.component(.day, from: parsed), 3, "fractional ISO date should parse the day")
+        assertEqual(calendar.component(.hour, from: parsed), 9, "fractional ISO date should parse the UTC hour")
+        assertEqual(calendar.component(.minute, from: parsed), 15, "fractional ISO date should parse the minute")
+    }
+
+    runSuite("MeetingImportedAudioPreparer honors explicit ISO8601 timezone offsets") {
+        let utc = TimeZone(secondsFromGMT: 0)!
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = utc
+
+        // 2025-02-03 09:15:00 at -05:00 is 2025-02-03 14:15:00 UTC.
+        let parsed = MeetingImportedAudioPreparer.parseMetadataDate(
+            "2025-02-03T09:15:00-0500",
+            defaultTimeZone: utc
+        )!
+
+        assertEqual(calendar.component(.day, from: parsed), 3, "explicit-offset ISO date should keep the calendar day in UTC")
+        assertEqual(calendar.component(.hour, from: parsed), 14, "explicit-offset ISO date should resolve into UTC, not the default timezone")
+    }
+
+    runSuite("MeetingImportedAudioPreparer rejects empty and unparseable metadata strings") {
+        let utc = TimeZone(secondsFromGMT: 0)!
+
+        assertNil(
+            MeetingImportedAudioPreparer.parseMetadataDate("", defaultTimeZone: utc),
+            "empty metadata strings should not produce a date"
+        )
+        assertNil(
+            MeetingImportedAudioPreparer.parseMetadataDate("   \n\t  ", defaultTimeZone: utc),
+            "whitespace-only metadata should not produce a date"
+        )
+        assertNil(
+            MeetingImportedAudioPreparer.parseMetadataDate("banana", defaultTimeZone: utc),
+            "unrecognized tokens should not produce a date so the resolver falls back to the file system"
+        )
+    }
 }
 
 private func assertImportedAudioPreparationError(


### PR DESCRIPTION
## Summary

Adds three focused regression tests around `MeetingImportedAudioPreparer.parseMetadataDate` so the source-date guarantee from issue #850 stays locked in if the parser is refactored. **No production code changes** — the feature itself already landed on `main` in `d057ca8` and `470c6e2` (within hours of the issue being filed).

## Why these specific cases

The existing test suite (`Tests/MeetingImportedAudioPreparerTests.swift`) already covers:
- Source creation-date preferred over copy time (`Tests:44-85`)
- Timezone-less date strings stay on the local calendar day (`Tests:87-107`)
- String metadata beats AVFoundation's `dateValue` (`Tests:109-125`)
- Full pipeline writes source date to frontmatter / filename / stats (`Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift:577-633`)

The gaps these new cases close:

| Case | Protects |
|---|---|
| `"2025-02-03T09:15:00.500Z"` | The `ISO8601DateFormatter` `.withFractionalSeconds` branch at `MeetingImportedAudioPreparer.swift:229-232` |
| `"2025-02-03T09:15:00-0500"` | Explicit-offset parsing through either the `.withInternetDateTime` branch or the `yyyy-MM-dd'T'HH:mm:ssZ` DateFormatter fallback |
| `""`, `"   \n\t  "`, `"banana"` | The defensive `guard !trimmed.isEmpty` and the contract that unparseable metadata returns `nil` so the resolver falls through to the file-system creation date instead of inventing a date |

## Issue #850 acceptance — current state on `main`

| Requirement | Status |
|---|---|
| Imported audio Markdown uses source file creation date when available | ✅ `Sources/Meeting/MeetingImportedAudioPreparer.swift:129-150` |
| Falls back to transcription/import date when unreliable | ✅ `MeetingImportedAudioPreparer.swift:149` (`return Date()`) |
| Behavior covered by a focused test | ✅ Existing tests + this PR's parser hardening |
| App does not mutate the user's source audio metadata | ✅ Preparer copies the file and only restricts the *copy* to `0o600`; verified by `Tests:80-84` |

## Test plan

- [ ] `bash run-tests.sh` on macOS (this remote container has no Swift toolchain, so the new tests need to be exercised on the maintainer's box / macOS CI)
- [ ] Verify the three new `runSuite` blocks execute and pass
- [ ] Confirm no existing assertion regressed

https://claude.ai/code/session_01RXpnCZBnMDLaytSS3Snmdj

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXpnCZBnMDLaytSS3Snmdj)_