### PR TITLE
Bail cancelled queued-transcription tasks before touching shared state

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1579,12 +1579,15 @@ final class MeetingSessionController: ObservableObject {
 
     private func prepareAndStartQueuedTranscription(_ job: QueuedTranscriptionJob) async {
         let modelsReady = await ensureModelsReadyForQueuedTranscription(job)
+
+        // A cancelled task must not touch shared state: a newer
+        // startQueuedTranscription has already taken ownership of
+        // queuedTranscriptionStartTask / preparingQueuedTranscriptionJob.
+        guard !Task.isCancelled else { return }
         guard preparingQueuedTranscriptionJob?.id == job.id else { return }
 
         queuedTranscriptionStartTask = nil
         preparingQueuedTranscriptionJob = nil
-
-        guard !Task.isCancelled else { return }
 
         guard modelsReady else {
             failQueuedTranscriptionJobAfterModelRecovery(job)


### PR DESCRIPTION
## Summary

Second of three PRs from a multi-agent repo audit. Defensive fix to `MeetingSessionController.prepareAndStartQueuedTranscription` so a cancelled task can never wipe a newer task's shared state.

## Why

The audit flagged a potential race in queued-transcription cleanup. Tracing all `queuedTranscriptionStartTask?.cancel()` call sites shows the race isn't actually exploitable today — every cancel site also nils out `preparingQueuedTranscriptionJob`, so the existing `preparing.id == job.id` guard catches every stale resume. **But that's an invariant the function doesn't enforce itself.** Any future caller who cancels the task without also clearing `preparing` would let a stale resume slip past the guard, clear `queuedTranscriptionStartTask`, and silently strand a newer queued job.

## What changes

One file, two-line reorder:

```swift
private func prepareAndStartQueuedTranscription(_ job: QueuedTranscriptionJob) async {
    let modelsReady = await ensureModelsReadyForQueuedTranscription(job)

    // A cancelled task must not touch shared state...
    guard !Task.isCancelled else { return }       // moved up
    guard preparingQueuedTranscriptionJob?.id == job.id else { return }

    queuedTranscriptionStartTask = nil
    preparingQueuedTranscriptionJob = nil
    ...
}
```

Previously `Task.isCancelled` was checked *after* the state cleanup, which left a tiny window where a cancelled task could still wipe references. Now any cancelled task bails first; the no-cancellation path is unchanged.

## What I deliberately did NOT do

Skipped the in-PR regression test. `MeetingSessionController` has no unit-test harness (it depends on `STTRouter`, capture bridge, downloader, model warmup, runtime diagnostics — all live). Forging fakes for all of those just to exercise one cancellation ordering would be more code than the fix and would test the fake more than the controller. The existing `RepoCommandContractTests` source-string assertions on `prepareAndStartQueuedTranscription` still hold.

## Test plan

- [ ] `bash run-tests.sh` — `RepoCommandContractTests` still passes (function name + `preparing.id == job.id` string still present)
- [ ] `bash run-integration-smoke.sh`
- [ ] Manual: rapid stop → re-import flow (queue a meeting, immediately import another audio file) still transcribes both without dropping either

https://claude.ai/code/session_01NHSTyDvHkz7WXkqmC4ttGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHSTyDvHkz7WXkqmC4ttGJ)_