### PR TITLE
Unify Sentry/Analytics sanitizers via shared PayloadSanitizationCore

### DIFF
--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -58,14 +58,7 @@ enum AnalyticsPayloadSanitizer {
     }
 
     static func sanitizeText(_ text: String) -> String {
-        let redacted = redact(text)
-        guard !redacted.isEmpty else { return "" }
-
-        if redacted.count > maxValueLength {
-            return String(redacted.prefix(maxValueLength)) + "..."
-        }
-
-        return redacted
+        PayloadSanitizationCore.redactAndCap(text, maxValueLength: maxValueLength)
     }
 
     /// Apply regex-based redaction without the analytics length cap.
@@ -77,7 +70,6 @@ enum AnalyticsPayloadSanitizer {
     }
 
     private static func shouldDrop(key: String) -> Bool {
-        let normalized = key.lowercased()
-        return sensitiveKeyFragments.contains(where: { normalized.contains($0) })
+        PayloadSanitizationCore.shouldDrop(key: key, sensitiveFragments: sensitiveKeyFragments)
     }
 }

--- a/Sources/Observability/CLAUDE.md
+++ b/Sources/Observability/CLAUDE.md
@@ -24,6 +24,7 @@ anonymous analytics, and Sparkle update plumbing.
 - `AnalyticsPayloadSanitizer.swift` — strips sensitive analytics properties before send
 - `SentryEventPolicy.swift` — explicit allowlist of non-fatal events permitted to reach Sentry
 - `SentryPayloadSanitizer.swift` — strips obvious sensitive values before Sentry sends
+- `PayloadSanitizationCore.swift` — shared `shouldDrop(key:)` + `redactAndCap(_:maxValueLength:)` helpers used by both sanitizers so redaction rules stay in one place while each destination keeps its own length cap and sensitive-key list
 - `SentryRuntimeConfiguration.swift` — resolves Sentry DSN, environment, release, and dist from `Info.plist` or process environment
 - `SparkleUpdaterController.swift` — live Sparkle update controller used by the menubar app, including update-state telemetry and ready-to-install restart flows
 - `UpdateFailureKind.swift` — canonical Sparkle/update failure taxonomy used to normalize network, appcast, download, signature, install, and busy-session errors for analytics

--- a/Sources/Observability/PayloadSanitizationCore.swift
+++ b/Sources/Observability/PayloadSanitizationCore.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Shared building blocks for `SentryPayloadSanitizer` and `AnalyticsPayloadSanitizer`.
+///
+/// Both sanitizers historically duplicated `shouldDrop` and the
+/// "redact then truncate to max length" pipeline. Centralizing those keeps
+/// the two destinations from drifting when redaction rules change — each
+/// sanitizer still owns its own sensitive-key list and length cap, but the
+/// mechanics live in one place.
+enum PayloadSanitizationCore {
+    /// Apply `ObservabilityTextRedactor.redact` and then cap the result at
+    /// `maxValueLength`, appending an ellipsis when truncated. Returns an
+    /// empty string when the input redacts to empty so callers can drop
+    /// the value cleanly.
+    static func redactAndCap(_ text: String, maxValueLength: Int) -> String {
+        let redacted = ObservabilityTextRedactor.redact(text)
+        guard !redacted.isEmpty else { return "" }
+
+        if redacted.count > maxValueLength {
+            return String(redacted.prefix(maxValueLength)) + "..."
+        }
+
+        return redacted
+    }
+
+    /// Drop the value if any sensitive-key fragment appears as a substring
+    /// of the lowercased key. Each sanitizer passes its own fragment list
+    /// because the Sentry and Analytics destinations have slightly different
+    /// risk profiles.
+    static func shouldDrop(key: String, sensitiveFragments: [String]) -> Bool {
+        let normalized = key.lowercased()
+        return sensitiveFragments.contains(where: { normalized.contains($0) })
+    }
+}

--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -78,14 +78,7 @@ enum SentryPayloadSanitizer {
     }
 
     static func sanitizeText(_ text: String) -> String {
-        let result = ObservabilityTextRedactor.redact(text)
-        guard !result.isEmpty else { return "" }
-
-        if result.count > maxValueLength {
-            return String(result.prefix(maxValueLength)) + "..."
-        }
-
-        return result
+        PayloadSanitizationCore.redactAndCap(text, maxValueLength: maxValueLength)
     }
 
     private static func sanitizeAnyValue(_ value: Any) -> Any? {
@@ -108,7 +101,6 @@ enum SentryPayloadSanitizer {
     }
 
     private static func shouldDrop(key: String) -> Bool {
-        let normalized = key.lowercased()
-        return sensitiveKeyFragments.contains(where: { normalized.contains($0) })
+        PayloadSanitizationCore.shouldDrop(key: key, sensitiveFragments: sensitiveKeyFragments)
     }
 }

--- a/scripts/entrypoints/run-e2e-smoke.sh
+++ b/scripts/entrypoints/run-e2e-smoke.sh
@@ -51,6 +51,7 @@ SWIFT_SOURCES=(
     "Sources/UI/Shared/RecentCaptureScanners.swift"
     "Sources/UI/Settings/HomeMeetingPreviewFormatter.swift"
     "Sources/Observability/ObservabilityTextRedactor.swift"
+    "Sources/Observability/PayloadSanitizationCore.swift"
     "Sources/Observability/AnalyticsPayloadSanitizer.swift"
     "Sources/UI/Shared/SupportDiagnosticsBundle.swift"
     "Tools/TranscriptedMCP/Sources/TranscriptedMCP/DataDirectories.swift"

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -202,6 +202,7 @@ APP_SOURCES=(
     "Sources/Observability/LockedFileAppender.swift"
     "Sources/Observability/AnalyticsEventPolicy.swift"
     "Sources/Observability/ObservabilityTextRedactor.swift"
+    "Sources/Observability/PayloadSanitizationCore.swift"
     "Sources/Observability/AnalyticsPayloadSanitizer.swift"
     "Sources/Observability/AnalyticsPreferences.swift"
     "Sources/Observability/CrashReportingPreferences.swift"


### PR DESCRIPTION
## Summary

Third of three PRs from a multi-agent repo audit. Removes drift risk between `SentryPayloadSanitizer` and `AnalyticsPayloadSanitizer` by extracting their two shared building blocks into `PayloadSanitizationCore`. Behavior-preserving by construction.

## Why

Both sanitizers had duplicated:
- `shouldDrop(key:)` — lowercase the key, substring-match against a sensitive-fragment list
- `sanitizeText` — `ObservabilityTextRedactor.redact(...)` then truncate to a per-destination max length with `...` ellipsis

The nightly security check (`scripts/ops/nightly-security-check.py:704+`) explicitly verifies that both sanitizers continue to load the shared corpus fixture, because the *intent* is for them to stay in sync. The implementation made that easy to forget.

## What changes

**New file: `Sources/Observability/PayloadSanitizationCore.swift`** (~35 lines) with two helpers:
- `redactAndCap(_ text: String, maxValueLength: Int) -> String`
- `shouldDrop(key: String, sensitiveFragments: [String]) -> Bool`

**`SentryPayloadSanitizer`** keeps its 22-fragment list and 240-char cap; `sanitizeText` and `shouldDrop` now delegate to the shared core. Public API unchanged: `sanitizeTags`, `sanitizeContext`, `sanitizeAnyDictionary`, `sanitizeEventContexts`, `sanitizeText`.

**`AnalyticsPayloadSanitizer`** keeps its 21-fragment list and 80-char cap; same delegation. Public API unchanged: `sanitizeProperties`, `sanitizeDiagnosticContextForDisplay`, `sanitizeText`, `redact`.

Net: −20 lines, +1 new file, drift footgun closed without changing any output.

## What I deliberately did NOT do

- Did **not** unify the two fragment lists. Sentry has `"context"` in its list because Sentry contexts arrive as free-form strings; Analytics filters by `allowedKeys` first, so the same fragment would be redundant noise. Keeping them separate matches each destination's actual risk profile.
- Did **not** change the cap values (240 vs 80). Sentry needs longer values for diagnostic context; analytics events are intentionally short.
- Did **not** touch `ObservabilityTextRedactor` — the actual redaction regex pipeline. That's the higher-value but higher-risk consolidation; PII regex changes need their own PR with the corpus extended.

## Test plan

- [ ] `bash run-tests.sh` — `SentryPayloadSanitizerTests` and `AnalyticsPayloadSanitizerTests` both pass against `Tests/Fixtures/ObservabilitySanitizerCorpus.json` (the regression fixture is unchanged)
- [ ] `python3 scripts/ops/nightly-security-check.py --write-report build/nightly-security-report.json` — the sanitizer-corpus checks still pass
- [ ] Both `SupportDiagnosticsBundle` and `FeedbackIssueBuilder` callers of `AnalyticsPayloadSanitizer.redact` / `.sanitizeDiagnosticContextForDisplay` keep working (public API preserved)

https://claude.ai/code/session_01NHSTyDvHkz7WXkqmC4ttGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHSTyDvHkz7WXkqmC4ttGJ)_