### PR TITLE
[codex] Fix no-dialog speaker name save

### DIFF
--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -398,7 +398,8 @@ extension TranscriptSaver {
                 guard applyScopedBreakdownNameReplacements(
                     in: &content,
                     updatesByChannelKey: updatesByChannelKey,
-                    channels: [.system]
+                    channels: [.system],
+                    result: transcriptionResult
                 ) else {
                     AppLogger.pipeline.error("Scoped remote speaker breakdown fallback was ambiguous", [
                         "path": transcriptURL.lastPathComponent
@@ -418,7 +419,8 @@ extension TranscriptSaver {
                 guard applyScopedBreakdownNameReplacements(
                     in: &content,
                     updatesByChannelKey: updatesByChannelKey,
-                    channels: [.mic]
+                    channels: [.mic],
+                    result: transcriptionResult
                 ) else {
                     AppLogger.pipeline.error("Scoped local speaker breakdown fallback was ambiguous", [
                         "path": transcriptURL.lastPathComponent
@@ -926,13 +928,21 @@ extension TranscriptSaver {
             guard update.oldName != update.newName else { continue }
             guard let target = channelAndDiarizerID(forSpeakerKey: key) else { return false }
             let prefix = target.channel == .mic ? "Mic" : "System"
-            let expectedCount = expectedUtteranceCount(
+            let expectedCount = expectedVisibleUtteranceCount(
                 in: result,
                 channel: target.channel,
                 diarizerSpeakerId: target.diarizerSpeakerId
             )
-            guard expectedCount > 0,
-                  countTranscriptSpeakerLabels(in: content, prefix: prefix, oldName: update.oldName) == expectedCount else {
+            let labelCount = countTranscriptSpeakerLabels(
+                in: content,
+                prefix: prefix,
+                oldName: update.oldName
+            )
+            if expectedCount == 0 {
+                guard labelCount == 0 else { return false }
+                continue
+            }
+            guard labelCount == expectedCount else {
                 return false
             }
             replacementPlans.append((prefix: prefix, oldName: update.oldName, newName: update.newName))
@@ -973,7 +983,8 @@ extension TranscriptSaver {
     private static func applyScopedBreakdownNameReplacements(
         in content: inout String,
         updatesByChannelKey: [String: (oldName: String, newName: String)],
-        channels: Set<UtteranceChannel>
+        channels: Set<UtteranceChannel>,
+        result: TranscriptionResult
     ) -> Bool {
         var replacementPlans: [(prefix: String, oldName: String, newName: String, channel: UtteranceChannel)] = []
         for key in updatesByChannelKey.keys.sorted() {
@@ -984,6 +995,21 @@ extension TranscriptSaver {
             }
             let prefix = target.channel == .mic ? "Mic" : "System"
             guard update.oldName != update.newName else { continue }
+            let expectedCount = expectedVisibleUtteranceCount(
+                in: result,
+                channel: target.channel,
+                diarizerSpeakerId: target.diarizerSpeakerId
+            )
+            if expectedCount == 0 {
+                guard countSpeakerBreakdownRows(
+                    in: content,
+                    oldName: update.oldName,
+                    channel: target.channel
+                ) == 0 else {
+                    return false
+                }
+                continue
+            }
             replacementPlans.append((prefix: prefix, oldName: update.oldName, newName: update.newName, channel: target.channel))
         }
 
@@ -1025,13 +1051,16 @@ extension TranscriptSaver {
         return nil
     }
 
-    private static func expectedUtteranceCount(
+    private static func expectedVisibleUtteranceCount(
         in result: TranscriptionResult,
         channel: UtteranceChannel,
         diarizerSpeakerId: Int
     ) -> Int {
         let utterances = channel == .mic ? result.micUtterances : result.systemUtterances
-        return utterances.filter { $0.speakerId == diarizerSpeakerId }.count
+        return utterances.filter {
+            $0.speakerId == diarizerSpeakerId
+                && !$0.transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }.count
     }
 
     /// Parse a YAML double-quoted string value after a known key prefix.
@@ -1524,7 +1553,9 @@ extension TranscriptSaver {
         let chunks = String(content[range])
             .components(separatedBy: "\n\n")
             .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-        let utterances = result.allUtterances
+        let utterances = result.allUtterances.filter {
+            !$0.transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
         guard chunks.count == utterances.count else { return false }
 
         var rewrittenChunks: [String] = []

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -58,6 +58,17 @@ extension TranscriptionTaskManager {
             else if case .discardedFromDatabase = update.action { discardedUpdates.append(update) }
             else { regularUpdates.append(update) }
         }
+        let skippedNoDialogUpdates = regularUpdates.filter {
+            Self.visibleTranscriptUtteranceCount(for: $0, in: transcriptionResult) == 0
+        }
+        if !skippedNoDialogUpdates.isEmpty {
+            AppLogger.speakers.warning("Skipping speaker-name updates with no transcript dialog", [
+                "count": "\(skippedNoDialogUpdates.count)"
+            ])
+        }
+        regularUpdates = regularUpdates.filter {
+            Self.visibleTranscriptUtteranceCount(for: $0, in: transcriptionResult) > 0
+        }
         let newlyCreatedMicProfileIds = transcriptionResult.newlyCreatedMicProfileIds
 
         DispatchQueue.global(qos: .utility).async { [weak self] in
@@ -649,6 +660,20 @@ extension TranscriptionTaskManager {
         (name ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
+    }
+
+    nonisolated private static func visibleTranscriptUtteranceCount(
+        for update: SpeakerNameUpdate,
+        in result: TranscriptionResult
+    ) -> Int {
+        guard let diarizerSpeakerId = Int(update.diarizerSpeakerId) else { return 0 }
+        let utterances = update.channel == .mic
+            ? result.micUtterances
+            : result.systemUtterances
+        return utterances.filter {
+            $0.speakerId == diarizerSpeakerId
+                && !$0.transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }.count
     }
 
     @MainActor private func finishNamingFlow(

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -58,16 +58,20 @@ extension TranscriptionTaskManager {
             else if case .discardedFromDatabase = update.action { discardedUpdates.append(update) }
             else { regularUpdates.append(update) }
         }
-        let skippedNoDialogUpdates = regularUpdates.filter {
+        let visibleRegularUpdates = regularUpdates.filter {
+            Self.visibleTranscriptUtteranceCount(for: $0, in: transcriptionResult) > 0
+        }
+        let noDialogUpdates = regularUpdates.filter {
             Self.visibleTranscriptUtteranceCount(for: $0, in: transcriptionResult) == 0
         }
-        if !skippedNoDialogUpdates.isEmpty {
-            AppLogger.speakers.warning("Skipping speaker-name updates with no transcript dialog", [
-                "count": "\(skippedNoDialogUpdates.count)"
+        if !noDialogUpdates.isEmpty {
+            AppLogger.speakers.warning("Skipping transcript rewrites for speaker updates with no dialog", [
+                "count": "\(noDialogUpdates.count)"
             ])
         }
         regularUpdates = regularUpdates.filter {
             Self.visibleTranscriptUtteranceCount(for: $0, in: transcriptionResult) > 0
+                || Self.shouldApplyNoDialogDatabaseMutation($0.action)
         }
         let newlyCreatedMicProfileIds = transcriptionResult.newlyCreatedMicProfileIds
 
@@ -123,9 +127,12 @@ extension TranscriptionTaskManager {
                 ? Self.planDeferredReview(clips)
                 : nil
 
-            var didFinalizeTranscript = regularUpdates.isEmpty || TranscriptSaver.updateSpeakerNames(
+            let transcriptUpdates = plannedChanges.resolvedUpdates.filter {
+                Self.visibleTranscriptUtteranceCount(for: $0, in: transcriptionResult) > 0
+            }
+            var didFinalizeTranscript = visibleRegularUpdates.isEmpty || TranscriptSaver.updateSpeakerNames(
                 transcriptURL: resolvedURL,
-                updates: plannedChanges.resolvedUpdates,
+                updates: transcriptUpdates,
                 transcriptionResult: transcriptionResult,
                 speakerStore: speakerDB
             )
@@ -367,6 +374,15 @@ extension TranscriptionTaskManager {
         case .named, .corrected:
             return true
         case .confirmed, .merged, .collapsedToMe, .discardedFromDatabase:
+            return false
+        }
+    }
+
+    nonisolated private static func shouldApplyNoDialogDatabaseMutation(_ action: SpeakerNameUpdate.NamingAction) -> Bool {
+        switch action {
+        case .confirmed, .corrected, .merged:
+            return true
+        case .named, .collapsedToMe, .discardedFromDatabase:
             return false
         }
     }

--- a/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
@@ -300,6 +300,142 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testHandleNamingCompleteCoalescesSplitRowsAndSkipsNoDialogSpeaker() async throws {
+        let harness = try makeHarness()
+        let transcriptId = UUID()
+        let firstSpeakerId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.41, count: 256),
+            existingId: nil
+        ).id
+        let secondSpeakerId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.42, count: 256),
+            existingId: nil
+        ).id
+        let emptySpeakerId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.43, count: 256),
+            existingId: nil
+        ).id
+        let transcriptURL = harness.paths.transcripts.appendingPathComponent("Split_With_No_Dialog.md")
+        let micURL = harness.paths.audioCaptures.appendingPathComponent("split-empty-mic.wav")
+        let systemURL = harness.paths.audioCaptures.appendingPathComponent("split-empty-system.wav")
+        let clipURLs = [
+            harness.paths.speakerClips.appendingPathComponent("split-empty-1.wav"),
+            harness.paths.speakerClips.appendingPathComponent("split-empty-2.wav"),
+            harness.paths.speakerClips.appendingPathComponent("split-empty-3.wav"),
+        ]
+        let speakers = [
+            MarkdownSpeaker(id: "1", persistentSpeakerId: firstSpeakerId, name: "Speaker 1", confidence: "unknown", source: "db_pending"),
+            MarkdownSpeaker(id: "2", persistentSpeakerId: secondSpeakerId, name: "Speaker 2", confidence: "unknown", source: "db_pending"),
+            MarkdownSpeaker(id: "3", persistentSpeakerId: emptySpeakerId, name: "Speaker 3", confidence: "unknown", source: "db_pending"),
+        ]
+        let utterances = [
+            MarkdownUtterance(timestamp: "00:01", source: "System", label: "Speaker 1", text: "First fragment.", diarizerSpeakerId: 1),
+            MarkdownUtterance(timestamp: "00:05", source: "System", label: "Speaker 2", text: "Second fragment.", diarizerSpeakerId: 2),
+            MarkdownUtterance(timestamp: "00:09", source: "System", label: "Speaker 3", text: "", diarizerSpeakerId: 3),
+        ]
+        let styledTranscript = """
+        ---
+        transcript_id: "\(transcriptId.uuidString)"
+        title: "Styled Meeting"
+        date: 2026-04-10
+        time: 15:01:23
+        duration: "1:30"
+        processing_time: "3.0s"
+        transcription_engine: parakeet_local
+        diarization_engine: pyannote_offline
+        sources: [mic, system_audio]
+        mic_utterances: 0
+        system_utterances: 3
+        mic_speakers: 0
+        system_speakers: 3
+        total_word_count: 4
+        speakers:
+          - id: "1"
+            channel: system
+            db_id: "\(firstSpeakerId.uuidString)"
+            name: "Speaker 1"
+            confidence: unknown
+            source: db_pending
+          - id: "2"
+            channel: system
+            db_id: "\(secondSpeakerId.uuidString)"
+            name: "Speaker 2"
+            confidence: unknown
+            source: db_pending
+          - id: "3"
+            channel: system
+            db_id: "\(emptySpeakerId.uuidString)"
+            name: "Speaker 3"
+            confidence: unknown
+            source: db_pending
+        ---
+
+        # Styled Meeting
+
+        Recorded Apr 10, 2026 at 3:01 PM  •  1:30  •  4 words  •  3 turns
+
+        ## Transcript
+
+        **00:01**  [System/Speaker 1]
+        First fragment.
+
+        **00:05**  [System/Speaker 2]
+        Second fragment.
+        """
+
+        try styledTranscript.write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let transcriptionResult = sampleTranscriptionResult(speakers: speakers, utterances: utterances)
+        try Data().write(to: micURL)
+        try Data().write(to: systemURL)
+        for clipURL in clipURLs {
+            try Data().write(to: clipURL)
+        }
+
+        harness.manager.speakerNamingRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: micURL,
+            onComplete: { _ in }
+        )
+
+        harness.manager.handleNamingComplete(
+            updates: [
+                SpeakerNameUpdate(persistentSpeakerId: firstSpeakerId, diarizerSpeakerId: "1", newName: "Grigory", action: .named),
+                SpeakerNameUpdate(persistentSpeakerId: secondSpeakerId, diarizerSpeakerId: "2", newName: "grigory", action: .named),
+                SpeakerNameUpdate(persistentSpeakerId: emptySpeakerId, diarizerSpeakerId: "3", newName: "Phantom Speaker", action: .named),
+            ],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            transcriptionResult: transcriptionResult,
+            micURL: micURL,
+            systemURL: systemURL,
+            clips: [
+                SpeakerNamingEntry(id: firstSpeakerId, diarizerSpeakerId: "1", clipURL: clipURLs[0], sampleText: "First fragment.", currentName: nil, matchSimilarity: nil, needsNaming: true, needsConfirmation: false, sessionEmbedding: [Float](repeating: 0.41, count: 256)),
+                SpeakerNamingEntry(id: secondSpeakerId, diarizerSpeakerId: "2", clipURL: clipURLs[1], sampleText: "Second fragment.", currentName: nil, matchSimilarity: nil, needsNaming: true, needsConfirmation: false, sessionEmbedding: [Float](repeating: 0.42, count: 256)),
+                SpeakerNamingEntry(id: emptySpeakerId, diarizerSpeakerId: "3", clipURL: clipURLs[2], sampleText: "", currentName: nil, matchSimilarity: nil, needsNaming: true, needsConfirmation: false, sessionEmbedding: [Float](repeating: 0.43, count: 256)),
+            ]
+        )
+
+        try await waitUntil {
+            harness.manager.speakerNamingRequest == nil
+                && harness.manager.displayStatus == .transcriptSaved
+        }
+
+        let savedTranscript = try String(contentsOf: transcriptURL, encoding: .utf8)
+        XCTAssertTrue(savedTranscript.contains("**00:01**  [System/Grigory]"), savedTranscript)
+        XCTAssertTrue(savedTranscript.contains("**00:05**  [System/Grigory]"), savedTranscript)
+        XCTAssertFalse(savedTranscript.contains("[System/Phantom Speaker]"), savedTranscript)
+        XCTAssertFalse(savedTranscript.contains(#"name: "Phantom Speaker""#), savedTranscript)
+
+        let namedProfiles = harness.speakerDB.allSpeakers().filter { $0.displayName == "Grigory" }
+        XCTAssertEqual(namedProfiles.count, 1)
+        XCTAssertNil(harness.speakerDB.getSpeaker(id: secondSpeakerId))
+        XCTAssertNil(harness.speakerDB.getSpeaker(id: emptySpeakerId)?.displayName)
+    }
+
+    @MainActor
     func testHandleNamingCompleteCoalescesCorrectedAndNamedRowsWithSameName() async throws {
         let harness = try makeHarness()
         let transcriptId = UUID()

--- a/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
@@ -315,6 +315,12 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             embedding: [Float](repeating: 0.43, count: 256),
             existingId: nil
         ).id
+        let emptySpeakerTargetId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.44, count: 256),
+            existingId: nil
+        ).id
+        harness.speakerDB.setDisplayName(id: emptySpeakerTargetId, name: "Known Phantom")
+        let emptySpeakerTargetBefore = harness.speakerDB.getSpeaker(id: emptySpeakerTargetId)
         let transcriptURL = harness.paths.transcripts.appendingPathComponent("Split_With_No_Dialog.md")
         let micURL = harness.paths.audioCaptures.appendingPathComponent("split-empty-mic.wav")
         let systemURL = harness.paths.audioCaptures.appendingPathComponent("split-empty-system.wav")
@@ -404,7 +410,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             updates: [
                 SpeakerNameUpdate(persistentSpeakerId: firstSpeakerId, diarizerSpeakerId: "1", newName: "Grigory", action: .named),
                 SpeakerNameUpdate(persistentSpeakerId: secondSpeakerId, diarizerSpeakerId: "2", newName: "grigory", action: .named),
-                SpeakerNameUpdate(persistentSpeakerId: emptySpeakerId, diarizerSpeakerId: "3", newName: "Phantom Speaker", action: .named),
+                SpeakerNameUpdate(persistentSpeakerId: emptySpeakerId, diarizerSpeakerId: "3", newName: "Known Phantom", action: .merged(targetProfileId: emptySpeakerTargetId)),
             ],
             transcriptURL: transcriptURL,
             transcriptId: transcriptId,
@@ -426,13 +432,16 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
         let savedTranscript = try String(contentsOf: transcriptURL, encoding: .utf8)
         XCTAssertTrue(savedTranscript.contains("**00:01**  [System/Grigory]"), savedTranscript)
         XCTAssertTrue(savedTranscript.contains("**00:05**  [System/Grigory]"), savedTranscript)
-        XCTAssertFalse(savedTranscript.contains("[System/Phantom Speaker]"), savedTranscript)
-        XCTAssertFalse(savedTranscript.contains(#"name: "Phantom Speaker""#), savedTranscript)
+        XCTAssertFalse(savedTranscript.contains("[System/Known Phantom]"), savedTranscript)
+        XCTAssertFalse(savedTranscript.contains(#"name: "Known Phantom""#), savedTranscript)
 
         let namedProfiles = harness.speakerDB.allSpeakers().filter { $0.displayName == "Grigory" }
         XCTAssertEqual(namedProfiles.count, 1)
         XCTAssertNil(harness.speakerDB.getSpeaker(id: secondSpeakerId))
-        XCTAssertNil(harness.speakerDB.getSpeaker(id: emptySpeakerId)?.displayName)
+        XCTAssertNil(harness.speakerDB.getSpeaker(id: emptySpeakerId))
+        let emptySpeakerTarget = harness.speakerDB.getSpeaker(id: emptySpeakerTargetId)
+        XCTAssertEqual(emptySpeakerTarget?.displayName, "Known Phantom")
+        XCTAssertGreaterThan(emptySpeakerTarget?.callCount ?? 0, emptySpeakerTargetBefore?.callCount ?? 0)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- skip no-dialog speaker updates during speaker-name finalization
- rewrite styled transcripts against visible utterances only
- add a SpeakerNamingCoordinator regression for Grigory’s 1.1.43 save failure shape

## Root Cause
The styled meeting transcript omits empty/no-dialog transcript chunks, but the speaker-name save path still compared against every detected utterance. When a real speaker was split and a separate detected speaker had no dialog, the visible transcript count no longer matched the original result, so saving speaker names failed.

## Verification
- bash build.sh
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
