### PR TITLE
[nightly-regression] Cover mic timeout Sentry tags

### DIFF
--- a/Tests/SentryEventPolicyTests.swift
+++ b/Tests/SentryEventPolicyTests.swift
@@ -106,27 +106,45 @@ func testSentryEventPolicy() {
             event: "microphone_start_timeout",
             context: [
                 "audio_device": "Justin's AirPods",
+                "default_input_class": "bluetooth",
+                "default_output_class": "bluetooth",
                 "failure_kind": "microphone_start_timeout",
                 "forced_readiness_recoveries": "2",
                 "format_ready": "false",
+                "hfp_suspected": "false",
                 "input_device_class": "bluetooth",
+                "output_device_class": "bluetooth",
                 "readiness_refreshes": "8",
                 "recovering": "false",
                 "recovery_start_attempts": "2",
                 "route_shape": "bluetooth_input_to_built_in_output",
+                "sample_flow_started": "false",
+                "selected_input_class": "built_in",
+                "selection_overrode_default": "true",
+                "selection_reason": "preferredBuiltInForBluetoothHeadset",
                 "start_attempts": "4",
+                "stt_model": "parakeet-tdt-v3",
                 "transcript_text": "private words",
                 "trigger": "physical_key",
                 "wait_ms": "6000",
             ]
         )
 
+        assertEqual(tags["default_input_class"], "bluetooth", "default input class should be queryable")
+        assertEqual(tags["default_output_class"], "bluetooth", "default output class should be queryable")
         assertEqual(tags["failure_kind"], "microphone_start_timeout", "failure kind should be queryable")
         assertEqual(tags["format_ready"], "false", "format readiness should be queryable")
+        assertEqual(tags["hfp_suspected"], "false", "HFP suspicion should be queryable")
         assertEqual(tags["recovering"], "false", "recovery state should be queryable")
         assertEqual(tags["input_device_class"], "bluetooth", "coarse device class should be queryable")
+        assertEqual(tags["output_device_class"], "bluetooth", "coarse output class should be queryable")
         assertEqual(tags["route_shape"], "bluetooth_input_to_built_in_output", "coarse route shape should be queryable")
+        assertEqual(tags["sample_flow_started"], "false", "sample-flow state should be queryable")
+        assertEqual(tags["selected_input_class"], "built_in", "selected input class should be queryable")
+        assertEqual(tags["selection_overrode_default"], "true", "input override state should be queryable")
+        assertEqual(tags["selection_reason"], "preferredBuiltInForBluetoothHeadset", "selection reason should be queryable")
         assertEqual(tags["start_attempts"], "4", "bounded retry count should be queryable")
+        assertEqual(tags["stt_model"], "parakeet-tdt-v3", "selected STT model should be queryable")
         assertEqual(tags["readiness_refreshes"], "8", "readiness refresh count should be queryable")
         assertEqual(tags["recovery_start_attempts"], "2", "recovery start count should be queryable")
         assertEqual(tags["forced_readiness_recoveries"], "2", "forced recovery count should be queryable")


### PR DESCRIPTION
## Nightly review

Reviewed current `origin/main` plus landed work since `2026-05-25T05:36:14Z`: nightly regression #871, PostHog probe #872, non-meeting styler guard #873, maintenance/docs PRs #874/#876/#877, imported-audio parser coverage #875, broad audio/pipeline/observability coverage #878, cleanup/audio-lock fixes #879, queued transcription cancellation guard #880, sanitizer extraction #881, and no-dialog speaker-name save fix #882. Checked open nightly PRs first; none were open. Existing open non-nightly draft: #883.

Live evidence used:
- Sentry last 24h: unresolved `APPLE-MACOS-14` on `transcripted@1.1.43`, `dictation.microphone_start_timeout`, last seen during this run.
- PostHog repo health probe: last 7d `devices=38`, `workflow_events=2265`, `onboarding_events=69`, `first_value_events=211`; daily active devices: `2026-05-19=15`, `2026-05-20=26`, `2026-05-21=16`, `2026-05-22=15`, `2026-05-23=8`, `2026-05-24=5`, `2026-05-25=10`, `2026-05-26=5`.
- Open GitHub risks still watched: #500 quiet mic/system-output interaction, #825 long meetings visibility/recovery, #850 imported-audio source date still open even though current code is covered.

## Top risks ranked

1. Current production mic-start timeouts still need the full route-selection tag shape in Sentry. Recent sanitizer/allowlist work makes this worth locking down, even though this PR does not change app behavior.
2. The no-dialog speaker-name save fix from #882 is important for meeting trust and has focused coverage; no higher-confidence extra patch was found tonight.
3. #500 quiet mic/system-output remains the larger audio reliability risk, but tonight's live signal did not narrow it into a safe small code fix.

## Change

- Extends `SentryEventPolicyTests` so `dictation.microphone_start_timeout` keeps the live triage tags searchable: default/selected input classes, output class, selection override/reason, sample-flow state, HFP flag, STT model, and existing retry/readiness counters.
- Keeps raw device names and transcript text out of Sentry tags.

## Verification

- `bash scripts/dev/agent-preflight.sh`
- `git diff --check`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` (`2654 tests, 2654 passed`)
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build-deps.sh --force`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open`

Note: the first build attempt stopped before compile because deps were stale and requested `bash build-deps.sh --force`; deps were refreshed and the build then passed.