### PR TITLE
[nightly-ux] Clarify Bluetooth dictation timeout copy

### DIFF
--- a/Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift
+++ b/Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift
@@ -62,6 +62,35 @@ struct DictationRecordingStartFailurePolicy {
     }
 }
 
+struct DictationMicrophoneTimeoutPresentationPolicy {
+    static func message(
+        deviceName: String,
+        startAttempts: Int,
+        inputFormatReady: Bool,
+        routeContext: [String: String] = [:]
+    ) -> String {
+        if isBluetoothFallbackRoute(routeContext) {
+            return "Couldn't start the built-in microphone while Bluetooth audio was active. Try again, or choose a different input in System Settings."
+        }
+
+        if startAttempts > 0, inputFormatReady {
+            return "Couldn't start the microphone. Try again, or choose a different input in System Settings."
+        }
+
+        return "Couldn't reach \(deviceName). Try selecting a different input in System Settings."
+    }
+
+    private static func isBluetoothFallbackRoute(_ context: [String: String]) -> Bool {
+        let selectedInputClass = context["selected_input_class"] ?? context["input_device_class"]
+
+        return context["selection_overrode_default"] == "true"
+            && context["selection_reason"] == "preferredBuiltInForBluetoothHeadset"
+            && context["default_input_class"] == "bluetooth"
+            && context["default_output_class"] == "bluetooth"
+            && selectedInputClass == "built_in"
+    }
+}
+
 struct DictationActiveTaskCancellationPlan: Equatable {
     let cancelStreamingTask: Bool
     let cancelSpeechEngine: Bool

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -590,7 +590,8 @@ class DictationSessionController: ObservableObject {
             microphoneTimeoutMessage(
                 deviceName: appState.sttRouter.inputDeviceName,
                 startAttempts: startAttempts,
-                inputFormatReady: appState.sttRouter.inputFormatReady
+                inputFormatReady: appState.sttRouter.inputFormatReady,
+                routeContext: appState.sttRouter.dictationAudioRouteAnalyticsContext
             ),
             actionTitle: "Try Again",
             action: { [weak self] in
@@ -775,7 +776,8 @@ class DictationSessionController: ObservableObject {
                 microphoneTimeoutMessage(
                     deviceName: appState.sttRouter.inputDeviceName,
                     startAttempts: 0,
-                    inputFormatReady: appState.sttRouter.inputFormatReady
+                    inputFormatReady: appState.sttRouter.inputFormatReady,
+                    routeContext: appState.sttRouter.dictationAudioRouteAnalyticsContext
                 ),
                 actionTitle: "Try Again",
                 action: { [weak self] in
@@ -1161,12 +1163,15 @@ class DictationSessionController: ObservableObject {
     private func microphoneTimeoutMessage(
         deviceName: String,
         startAttempts: Int,
-        inputFormatReady: Bool
+        inputFormatReady: Bool,
+        routeContext: [String: String]
     ) -> String {
-        if startAttempts > 0, inputFormatReady {
-            return "Couldn't start the microphone. Try again, or choose a different input in System Settings."
-        }
-        return "Couldn't reach \(deviceName). Try selecting a different input in System Settings."
+        DictationMicrophoneTimeoutPresentationPolicy.message(
+            deviceName: deviceName,
+            startAttempts: startAttempts,
+            inputFormatReady: inputFormatReady,
+            routeContext: routeContext
+        )
     }
 
     /// Shrink the panel to compact (header-only) height without animation.

--- a/Tests/DictationRecordingStartOverlayPolicyTests.swift
+++ b/Tests/DictationRecordingStartOverlayPolicyTests.swift
@@ -122,6 +122,41 @@ func testDictationRecordingStartOverlayPolicy() {
         assertFalse(plan.reportRuntimeStall, "handled startup failures should not become stall telemetry")
     }
 
+    runSuite("DictationMicrophoneTimeoutPresentationPolicy names Bluetooth fallback failures") {
+        let message = DictationMicrophoneTimeoutPresentationPolicy.message(
+            deviceName: "MacBook Pro Microphone",
+            startAttempts: 1,
+            inputFormatReady: false,
+            routeContext: [
+                "default_input_class": "bluetooth",
+                "default_output_class": "bluetooth",
+                "selected_input_class": "built_in",
+                "selection_overrode_default": "true",
+                "selection_reason": "preferredBuiltInForBluetoothHeadset",
+            ]
+        )
+
+        assertEqual(
+            message,
+            "Couldn't start the built-in microphone while Bluetooth audio was active. Try again, or choose a different input in System Settings.",
+            "Bluetooth fallback timeouts should tell users what changed instead of blaming only the selected mic"
+        )
+    }
+
+    runSuite("DictationMicrophoneTimeoutPresentationPolicy keeps generic fallback copy") {
+        let message = DictationMicrophoneTimeoutPresentationPolicy.message(
+            deviceName: "Studio Display Microphone",
+            startAttempts: 0,
+            inputFormatReady: false
+        )
+
+        assertEqual(
+            message,
+            "Couldn't reach Studio Display Microphone. Try selecting a different input in System Settings.",
+            "non-Bluetooth route failures should keep the existing device-specific guidance"
+        )
+    }
+
     runSuite("DictationActiveTaskCancellationPolicy leaves active inference alone") {
         let plan = DictationActiveTaskCancellationPolicy.plan(
             cancelRecording: true,


### PR DESCRIPTION
## Summary
- make dictation mic-start timeout copy specific when Transcripted switched away from a Bluetooth headset mic to the built-in mic
- keep the existing generic copy for non-Bluetooth timeout paths
- add focused policy coverage for both cases

## Evidence
- Sentry `APPLE-MACOS-14` is current on `transcripted@1.1.43`, last seen 2026-05-26, with Bluetooth input/output active and a built-in fallback selection before timeout.
- Existing overlay copy only said the selected microphone could not be reached, which hides the route change that likely explains the failure.

## Score
UX candidate score: 91/100.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh`
- `bash run-tests.sh` (2647/2647)