### PR TITLE
[codex] Tighten speaker-name regression coverage

### DIFF
--- a/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
@@ -300,7 +300,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
     }
 
     @MainActor
-    func testHandleNamingCompleteCoalescesSplitRowsAndSkipsNoDialogSpeaker() async throws {
+    func testHandleNamingCompleteRegression1143CoalescesSplitRowsAndSkipsNoDialogSpeaker() async throws {
         let harness = try makeHarness()
         let transcriptId = UUID()
         let firstSpeakerId = harness.speakerDB.addOrUpdateSpeaker(
@@ -337,7 +337,6 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
         let utterances = [
             MarkdownUtterance(timestamp: "00:01", source: "System", label: "Speaker 1", text: "First fragment.", diarizerSpeakerId: 1),
             MarkdownUtterance(timestamp: "00:05", source: "System", label: "Speaker 2", text: "Second fragment.", diarizerSpeakerId: 2),
-            MarkdownUtterance(timestamp: "00:09", source: "System", label: "Speaker 3", text: "", diarizerSpeakerId: 3),
         ]
         let styledTranscript = """
         ---
@@ -351,7 +350,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
         diarization_engine: pyannote_offline
         sources: [mic, system_audio]
         mic_utterances: 0
-        system_utterances: 3
+        system_utterances: 2
         mic_speakers: 0
         system_speakers: 3
         total_word_count: 4


### PR DESCRIPTION
## Summary

- Tightens the speaker-name save regression for the 1.1.43 failure shape.
- Models the silent detected speaker as having no transcript utterance at all.
- Keeps the split real speaker save path covered while skipping transcript rewrites for the silent speaker.

## Why

The production failure happened after the transcript saved, while speaker-name finalization handled a split real speaker plus another detected speaker with no dialog. This makes that exact shape explicit so the save path stays protected.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (2681 passed)
- `bash run-integration-smoke.sh`
- `swift test` (332 passed, 1 live-capture test skipped)
