### PR TITLE
[nightly-security] Redact spaced file paths in observability text

### DIFF
--- a/Sources/Observability/ObservabilityTextRedactor.swift
+++ b/Sources/Observability/ObservabilityTextRedactor.swift
@@ -123,7 +123,9 @@ enum ObservabilityTextRedactor {
                 break
             }
 
-            if isSoftPathDelimiter(character), pathPrefixLooksLikeFile(text[start..<index]) {
+            if isSoftPathDelimiter(character),
+               pathPrefixLooksLikeFile(text[start..<index]),
+               softDelimiterEndsPath(in: text, at: index) {
                 break
             }
 
@@ -157,6 +159,22 @@ enum ObservabilityTextRedactor {
             || character == ")"
             || character == "]"
             || character == "}"
+    }
+
+    private static func softDelimiterEndsPath(in text: String, at index: String.Index) -> Bool {
+        let nextIndex = text.index(after: index)
+        guard nextIndex < text.endIndex else { return true }
+
+        let nextCharacter = text[nextIndex]
+        if isHardPathDelimiter(nextCharacter) {
+            return true
+        }
+
+        if nextCharacter == " " {
+            return !nextTokenCouldContinuePath(nextPathToken(in: text, after: index))
+        }
+
+        return false
     }
 
     private static func pathPrefixLooksLikeFile(_ prefix: Substring) -> Bool {

--- a/Sources/Observability/ObservabilityTextRedactor.swift
+++ b/Sources/Observability/ObservabilityTextRedactor.swift
@@ -140,7 +140,6 @@ enum ObservabilityTextRedactor {
             }
 
             if isSoftPathDelimiter(character),
-               pathPrefixLooksLikeFile(text[start..<index]),
                softDelimiterEndsPath(in: text, at: index) {
                 break
             }
@@ -148,9 +147,13 @@ enum ObservabilityTextRedactor {
             if character == " " {
                 let prefix = text[start..<index]
                 let nextToken = nextPathToken(in: text, after: index)
-                if nextTokenLooksLikeMetadata(nextToken)
-                    || (pathPrefixLooksLikeFile(prefix)
-                        && !nextTokenCouldContinuePath(nextToken)) {
+                let pathContinuesLater = pathContinuationAppears(in: text, after: index)
+                if nextTokenLooksLikeMetadata(nextToken) && !pathContinuesLater {
+                    break
+                }
+                if pathPrefixLooksLikeFile(prefix)
+                    && !nextTokenCouldContinuePath(nextToken)
+                    && !pathContinuesLater {
                     break
                 }
             }
@@ -222,17 +225,61 @@ enum ObservabilityTextRedactor {
     }
 
     private static func nextTokenCouldContinuePath(_ token: String) -> Bool {
-        token.contains("/") || pathTokenLooksLikeFile(token)
+        let normalized = normalizedPathToken(token)
+        let lowercased = normalized.lowercased()
+        guard !normalized.contains("@"),
+              !lowercased.hasPrefix("http://"),
+              !lowercased.hasPrefix("https://"),
+              !lowercased.hasSuffix(".local") else {
+            return false
+        }
+        return normalized.contains("/") || pathTokenLooksLikeFile(normalized)
+    }
+
+    private static func pathContinuationAppears(in text: String, after spaceIndex: String.Index) -> Bool {
+        var index = text.index(after: spaceIndex)
+        var inspectedTokens = 0
+
+        while index < text.endIndex && inspectedTokens < 8 {
+            while index < text.endIndex, text[index] == " " {
+                index = text.index(after: index)
+            }
+            guard index < text.endIndex, !isHardPathDelimiter(text[index]) else {
+                return false
+            }
+
+            var token = ""
+            while index < text.endIndex {
+                let character = text[index]
+                if character == " " || isHardPathDelimiter(character) {
+                    break
+                }
+                token.append(character)
+                index = text.index(after: index)
+            }
+
+            if nextTokenCouldContinuePath(token) {
+                return true
+            }
+            inspectedTokens += 1
+        }
+
+        return false
     }
 
     private static func nextTokenLooksLikeMetadata(_ token: String) -> Bool {
-        guard !token.contains("/"),
-              !pathTokenLooksLikeFile(token),
-              let separator = token.firstIndex(of: "=") else {
+        let normalized = normalizedPathToken(token)
+        guard !normalized.contains("/"),
+              !pathTokenLooksLikeFile(normalized),
+              let separator = normalized.firstIndex(of: "=") else {
             return false
         }
-        let key = String(token[..<separator]).lowercased()
+        let key = String(normalized[..<separator]).lowercased()
         return pathDiagnosticMetadataKeys.contains(key)
+    }
+
+    private static func normalizedPathToken(_ token: String) -> String {
+        token.trimmingCharacters(in: CharacterSet(charactersIn: ",;:)]}"))
     }
 
     private static func pathTokenLooksLikeFile(_ token: String) -> Bool {

--- a/Sources/Observability/ObservabilityTextRedactor.swift
+++ b/Sources/Observability/ObservabilityTextRedactor.swift
@@ -55,6 +55,22 @@ enum ObservabilityTextRedactor {
     )
     private static let emailRegex = makeRegex(#"[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}"#, options: [.caseInsensitive])
     private static let localHostnameRegex = makeRegex(#"\b[a-zA-Z0-9._-]+\.local\b"#)
+    private static let pathDiagnosticMetadataKeys: Set<String> = [
+        "attempt",
+        "attempts",
+        "code",
+        "duration_ms",
+        "error",
+        "event",
+        "failure_kind",
+        "operation",
+        "outcome",
+        "reason",
+        "stage",
+        "status",
+        "trigger",
+        "wait_ms",
+    ]
 
     static func redact(_ text: String) -> String {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -132,9 +148,9 @@ enum ObservabilityTextRedactor {
             if character == " " {
                 let prefix = text[start..<index]
                 let nextToken = nextPathToken(in: text, after: index)
-                if pathPrefixLooksLikeFile(prefix)
-                    && (nextTokenLooksLikeMetadata(nextToken)
-                        || !nextTokenCouldContinuePath(nextToken)) {
+                if nextTokenLooksLikeMetadata(nextToken)
+                    || (pathPrefixLooksLikeFile(prefix)
+                        && !nextTokenCouldContinuePath(nextToken)) {
                     break
                 }
             }
@@ -210,9 +226,13 @@ enum ObservabilityTextRedactor {
     }
 
     private static func nextTokenLooksLikeMetadata(_ token: String) -> Bool {
-        token.contains("=")
-            && !token.contains("/")
-            && !pathTokenLooksLikeFile(token)
+        guard !token.contains("/"),
+              !pathTokenLooksLikeFile(token),
+              let separator = token.firstIndex(of: "=") else {
+            return false
+        }
+        let key = String(token[..<separator]).lowercased()
+        return pathDiagnosticMetadataKeys.contains(key)
     }
 
     private static func pathTokenLooksLikeFile(_ token: String) -> Bool {

--- a/Sources/Observability/ObservabilityTextRedactor.swift
+++ b/Sources/Observability/ObservabilityTextRedactor.swift
@@ -15,7 +15,7 @@ enum ObservabilityTextRedactor {
     }
 
     private static let pathStartRegex = makeRegex(
-        #"(?<!https:)(?<!http:)(?<![A-Za-z0-9._%+\-])/(?:System/Volumes/Data/)?(?:Users|Volumes|private/var|var|tmp|Applications|Library|opt)(?=/|$)"#
+        #"(?<!https:)(?<!http:)(?<![A-Za-z0-9._%+\-])/(?:System/Volumes/Data/)?(?:Users|Volumes|private/tmp|private/var|var|tmp|Applications|Library|opt)(?=/|$)"#
     )
     private static let userPathRegex = makeRegex(#"/Users/[^/\s]+/"#)
     private static let absolutePathRegex = makeRegex(

--- a/Sources/Observability/ObservabilityTextRedactor.swift
+++ b/Sources/Observability/ObservabilityTextRedactor.swift
@@ -123,11 +123,16 @@ enum ObservabilityTextRedactor {
                 break
             }
 
+            if isSoftPathDelimiter(character), pathPrefixLooksLikeFile(text[start..<index]) {
+                break
+            }
+
             if character == " " {
+                let prefix = text[start..<index]
                 let nextToken = nextPathToken(in: text, after: index)
-                if nextTokenLooksLikeMetadata(nextToken)
-                    || (pathPrefixLooksLikeFile(text[start..<index])
-                        && !nextTokenCouldContinuePath(nextToken)) {
+                if pathPrefixLooksLikeFile(prefix)
+                    && (nextTokenLooksLikeMetadata(nextToken)
+                        || !nextTokenCouldContinuePath(nextToken)) {
                     break
                 }
             }
@@ -143,6 +148,15 @@ enum ObservabilityTextRedactor {
             || character == "\r"
             || character == "\t"
             || character == "\""
+    }
+
+    private static func isSoftPathDelimiter(_ character: Character) -> Bool {
+        character == ","
+            || character == ";"
+            || character == ":"
+            || character == ")"
+            || character == "]"
+            || character == "}"
     }
 
     private static func pathPrefixLooksLikeFile(_ prefix: Substring) -> Bool {

--- a/Sources/Observability/ObservabilityTextRedactor.swift
+++ b/Sources/Observability/ObservabilityTextRedactor.swift
@@ -14,7 +14,9 @@ enum ObservabilityTextRedactor {
         return try! NSRegularExpression(pattern: "(?!)")
     }
 
-    private static let appSupportPathRegex = makeRegex(#"/Users/[^/\s]+/Library/Application Support/(?:Transcripted|Draft)(?:/[^\s"]*)?"#)
+    private static let pathStartRegex = makeRegex(
+        #"(?<!https:)(?<!http:)(?<![A-Za-z0-9._%+\-])/(?:System/Volumes/Data/)?(?:Users|Volumes|private/var|var|tmp|Applications|Library|opt)(?=/|$)"#
+    )
     private static let userPathRegex = makeRegex(#"/Users/[^/\s]+/"#)
     private static let absolutePathRegex = makeRegex(
         #"(?<!https:)(?<!http:)/(?:System/Volumes/Data/)?(?:Users|private|var|tmp|Volumes|Applications|Library|opt)[^\s"]*"#
@@ -60,7 +62,7 @@ enum ObservabilityTextRedactor {
 
         var result = trimmed
         var range = NSRange(result.startIndex..., in: result)
-        result = appSupportPathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-path]")
+        result = redactFilePaths(in: result)
         range = NSRange(result.startIndex..., in: result)
         result = userPathRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "/Users/****/")
         range = NSRange(result.startIndex..., in: result)
@@ -93,5 +95,98 @@ enum ObservabilityTextRedactor {
         result = localHostnameRegex.stringByReplacingMatches(in: result, range: range, withTemplate: "[redacted-host]")
 
         return result
+    }
+
+    private static func redactFilePaths(in text: String) -> String {
+        var result = text
+        let matches = pathStartRegex.matches(
+            in: result,
+            range: NSRange(result.startIndex..., in: result)
+        )
+
+        for match in matches.reversed() {
+            guard let start = Range(match.range, in: result)?.lowerBound else { continue }
+            let end = pathEnd(in: result, from: start)
+            guard start < end else { continue }
+            result.replaceSubrange(start..<end, with: "[redacted-path]")
+        }
+
+        return result
+    }
+
+    private static func pathEnd(in text: String, from start: String.Index) -> String.Index {
+        var index = start
+
+        while index < text.endIndex {
+            let character = text[index]
+            if isHardPathDelimiter(character) {
+                break
+            }
+
+            if character == " " {
+                let nextToken = nextPathToken(in: text, after: index)
+                if nextTokenLooksLikeMetadata(nextToken)
+                    || (pathPrefixLooksLikeFile(text[start..<index])
+                        && !nextTokenCouldContinuePath(nextToken)) {
+                    break
+                }
+            }
+
+            index = text.index(after: index)
+        }
+
+        return index
+    }
+
+    private static func isHardPathDelimiter(_ character: Character) -> Bool {
+        character == "\n"
+            || character == "\r"
+            || character == "\t"
+            || character == "\""
+    }
+
+    private static func pathPrefixLooksLikeFile(_ prefix: Substring) -> Bool {
+        guard let slash = prefix.lastIndex(of: "/") else { return false }
+        let filename = prefix[prefix.index(after: slash)...]
+        guard let dot = filename.lastIndex(of: ".") else { return false }
+        let ext = filename[filename.index(after: dot)...]
+        guard (1...8).contains(ext.count) else { return false }
+        return ext.allSatisfy { $0.isLetter || $0.isNumber }
+    }
+
+    private static func nextPathToken(in text: String, after spaceIndex: String.Index) -> String {
+        var index = text.index(after: spaceIndex)
+        while index < text.endIndex, text[index] == " " {
+            index = text.index(after: index)
+        }
+
+        var token = ""
+        while index < text.endIndex {
+            let character = text[index]
+            if character == " " || isHardPathDelimiter(character) {
+                break
+            }
+            token.append(character)
+            index = text.index(after: index)
+        }
+
+        return token
+    }
+
+    private static func nextTokenCouldContinuePath(_ token: String) -> Bool {
+        token.contains("/") || pathTokenLooksLikeFile(token)
+    }
+
+    private static func nextTokenLooksLikeMetadata(_ token: String) -> Bool {
+        token.contains("=")
+            && !token.contains("/")
+            && !pathTokenLooksLikeFile(token)
+    }
+
+    private static func pathTokenLooksLikeFile(_ token: String) -> Bool {
+        guard let dot = token.lastIndex(of: ".") else { return false }
+        let ext = token[token.index(after: dot)...]
+        guard (1...8).contains(ext.count) else { return false }
+        return ext.allSatisfy { $0.isLetter || $0.isNumber }
     }
 }

--- a/Tests/ObservabilityTextRedactorTests.swift
+++ b/Tests/ObservabilityTextRedactorTests.swift
@@ -99,6 +99,26 @@ func testObservabilityTextRedactor() {
         assertTrue(redacted.contains("trigger=hotkey"), "safe metadata after the path should remain")
     }
 
+    runSuite("ObservabilityTextRedactor keeps scanning dotted path components before spaced filenames") {
+        let input = "failed /Users/jane/Documents/Acme.com Client Call.wav status=retry"
+        let redacted = ObservabilityTextRedactor.redact(input)
+
+        assertFalse(redacted.contains("Acme.com"), "dotted folder names must not survive")
+        assertFalse(redacted.contains("Client Call.wav"), "spaced filename tail must not survive")
+        assertEqual(redacted, "failed [redacted-path] status=retry",
+                    "safe metadata after the path should remain")
+    }
+
+    runSuite("ObservabilityTextRedactor keeps metadata-like folders inside path tails") {
+        let input = "failed /Users/jane/Documents/Project status=retry Notes/source audio.wav status=done trigger=hotkey"
+        let redacted = ObservabilityTextRedactor.redact(input)
+
+        assertFalse(redacted.contains("status=retry Notes"), "metadata-like folder names must not survive")
+        assertFalse(redacted.contains("source audio.wav"), "filename tail after metadata-like folder must not survive")
+        assertEqual(redacted, "failed [redacted-path] status=done trigger=hotkey",
+                    "safe metadata after the path should remain")
+    }
+
     runSuite("ObservabilityTextRedactor preserves diagnostics after punctuated filenames") {
         let input = "failed /Users/jane/Documents/Report.pdf, permission denied code=1"
         let redacted = ObservabilityTextRedactor.redact(input)
@@ -106,6 +126,14 @@ func testObservabilityTextRedactor() {
         assertFalse(redacted.contains("Report.pdf"), "filename before punctuation must not survive")
         assertTrue(redacted.contains("[redacted-path], permission denied code=1"),
                    "diagnostic prose after path punctuation should remain")
+    }
+
+    runSuite("ObservabilityTextRedactor preserves diagnostics after punctuated extensionless paths") {
+        let input = "failed /tmp/imports, permission denied code=1"
+        let redacted = ObservabilityTextRedactor.redact(input)
+
+        assertEqual(redacted, "failed [redacted-path], permission denied code=1",
+                    "diagnostic prose after an extensionless path delimiter should remain")
     }
 
     runSuite("ObservabilityTextRedactor preserves metadata after extensionless paths") {

--- a/Tests/ObservabilityTextRedactorTests.swift
+++ b/Tests/ObservabilityTextRedactorTests.swift
@@ -108,6 +108,14 @@ func testObservabilityTextRedactor() {
                    "diagnostic prose after path punctuation should remain")
     }
 
+    runSuite("ObservabilityTextRedactor preserves metadata after extensionless paths") {
+        let input = "failed /tmp/imports status=retry trigger=hotkey"
+        let redacted = ObservabilityTextRedactor.redact(input)
+
+        assertEqual(redacted, "failed [redacted-path] status=retry trigger=hotkey",
+                    "safe key-value diagnostics after extensionless paths should remain")
+    }
+
     runSuite("ObservabilityTextRedactor keeps key-like tokens inside path tails") {
         let input = "failed /Users/jane/Documents/Project A=1 Notes/source audio.wav status=retry"
         let redacted = ObservabilityTextRedactor.redact(input)

--- a/Tests/ObservabilityTextRedactorTests.swift
+++ b/Tests/ObservabilityTextRedactorTests.swift
@@ -87,11 +87,13 @@ func testObservabilityTextRedactor() {
     }
 
     runSuite("ObservabilityTextRedactor does not stop early inside legal path names") {
-        let input = "failed /Users/jane/Documents/Acme.com Calls/source audio.wav and /Users/jane/Documents/Client [Acme]/source status=retry.wav trigger=hotkey"
+        let input = "failed /Users/jane/Documents/Acme.com Calls/source audio.wav, /Users/jane/Documents/Acme.com, Inc/source.wav, /Users/jane/Documents/v1.0,backup/source.wav, and /Users/jane/Documents/Client [Acme.com]/source status=retry.wav trigger=hotkey"
         let redacted = ObservabilityTextRedactor.redact(input)
 
         assertFalse(redacted.contains("Acme.com Calls"), "dotted path components before spaces must not leak")
-        assertFalse(redacted.contains("Client [Acme]"), "bracketed path components must not leak")
+        assertFalse(redacted.contains("Acme.com, Inc"), "punctuated dotted path components must not leak")
+        assertFalse(redacted.contains("v1.0,backup"), "punctuation after dotted path components must not leak")
+        assertFalse(redacted.contains("Client [Acme.com]"), "bracketed path components must not leak")
         assertFalse(redacted.contains("source audio.wav"), "file names after dotted components must not leak")
         assertFalse(redacted.contains("source status=retry.wav"), "file names with key-like tokens must not leak")
         assertTrue(redacted.contains("trigger=hotkey"), "safe metadata after the path should remain")

--- a/Tests/ObservabilityTextRedactorTests.swift
+++ b/Tests/ObservabilityTextRedactorTests.swift
@@ -60,12 +60,13 @@ func testObservabilityTextRedactor() {
     }
 
     runSuite("ObservabilityTextRedactor scrubs local paths that contain spaces") {
-        let input = "failed to read /Users/jane/Documents/Client Calls/ACME Roadmap.md and /tmp/Meeting Imports/source audio.wav from /Users/jane/Library/Application Support/Transcripted/John's Call (équipe).wav status=retry trigger=hotkey"
+        let input = "failed to read /Users/jane/Documents/Client Calls/ACME Roadmap.md, /tmp/Meeting Imports/source audio.wav, and /private/tmp/Private Temp Imports/source audio.wav from /Users/jane/Library/Application Support/Transcripted/John's Call (équipe).wav status=retry trigger=hotkey"
         let redacted = ObservabilityTextRedactor.redact(input)
 
         assertFalse(redacted.contains("Client Calls"), "user folder paths with spaces must not survive")
         assertFalse(redacted.contains("ACME Roadmap.md"), "full user path tail must be scrubbed")
         assertFalse(redacted.contains("Meeting Imports"), "temporary paths with spaces must not survive")
+        assertFalse(redacted.contains("Private Temp Imports"), "private temporary paths with spaces must not survive")
         assertFalse(redacted.contains("John's Call"), "apostrophes in app-support filenames must not leak")
         assertFalse(redacted.contains("équipe"), "non-ASCII app-support filename tails must not leak")
         assertTrue(redacted.contains("[redacted-path]"), "path marker should remain")

--- a/Tests/ObservabilityTextRedactorTests.swift
+++ b/Tests/ObservabilityTextRedactorTests.swift
@@ -97,6 +97,24 @@ func testObservabilityTextRedactor() {
         assertTrue(redacted.contains("trigger=hotkey"), "safe metadata after the path should remain")
     }
 
+    runSuite("ObservabilityTextRedactor preserves diagnostics after punctuated filenames") {
+        let input = "failed /Users/jane/Documents/Report.pdf, permission denied code=1"
+        let redacted = ObservabilityTextRedactor.redact(input)
+
+        assertFalse(redacted.contains("Report.pdf"), "filename before punctuation must not survive")
+        assertTrue(redacted.contains("[redacted-path], permission denied code=1"),
+                   "diagnostic prose after path punctuation should remain")
+    }
+
+    runSuite("ObservabilityTextRedactor keeps key-like tokens inside path tails") {
+        let input = "failed /Users/jane/Documents/Project A=1 Notes/source audio.wav status=retry"
+        let redacted = ObservabilityTextRedactor.redact(input)
+
+        assertFalse(redacted.contains("A=1 Notes"), "key-like path folder names must not leak")
+        assertFalse(redacted.contains("source audio.wav"), "path tails after key-like folders must not leak")
+        assertTrue(redacted.contains("status=retry"), "safe metadata after the path should remain")
+    }
+
     runSuite("ObservabilityTextRedactor scrubs inline key=value sensitive assignments") {
         let input = "ctx meeting_title=Private Roadmap speaker_name=Jane Doe trigger=hotkey"
         let redacted = ObservabilityTextRedactor.redact(input)

--- a/Tests/ObservabilityTextRedactorTests.swift
+++ b/Tests/ObservabilityTextRedactorTests.swift
@@ -59,6 +59,43 @@ func testObservabilityTextRedactor() {
                    "sensitive device/file assignments should be redacted")
     }
 
+    runSuite("ObservabilityTextRedactor scrubs local paths that contain spaces") {
+        let input = "failed to read /Users/jane/Documents/Client Calls/ACME Roadmap.md and /tmp/Meeting Imports/source audio.wav from /Users/jane/Library/Application Support/Transcripted/John's Call (équipe).wav status=retry trigger=hotkey"
+        let redacted = ObservabilityTextRedactor.redact(input)
+
+        assertFalse(redacted.contains("Client Calls"), "user folder paths with spaces must not survive")
+        assertFalse(redacted.contains("ACME Roadmap.md"), "full user path tail must be scrubbed")
+        assertFalse(redacted.contains("Meeting Imports"), "temporary paths with spaces must not survive")
+        assertFalse(redacted.contains("John's Call"), "apostrophes in app-support filenames must not leak")
+        assertFalse(redacted.contains("équipe"), "non-ASCII app-support filename tails must not leak")
+        assertTrue(redacted.contains("[redacted-path]"), "path marker should remain")
+        assertTrue(redacted.contains("status=retry"), "safe metadata after a path should remain")
+        assertTrue(redacted.contains("trigger=hotkey"), "safe metadata after a path should remain")
+    }
+
+    runSuite("ObservabilityTextRedactor scrubs user-selected paths with spaces") {
+        let input = "imported /Users/jane/Projects/Client Calls/ACME Roadmap.md and /Volumes/External Disk/Meeting Imports/source audio.wav by /Users/jane/Documents/person@example.com/Private Folder/followup.md"
+        let redacted = ObservabilityTextRedactor.redact(input)
+
+        assertFalse(redacted.contains("Client Calls"), "custom user folder paths with spaces must not survive")
+        assertFalse(redacted.contains("External Disk"), "volume paths with spaces must not survive")
+        assertFalse(redacted.contains("source audio.wav"), "volume path tails must not survive")
+        assertFalse(redacted.contains("person@example.com"), "emails embedded in paths must not survive")
+        assertFalse(redacted.contains("Private Folder"), "path tails after email-like segments must not survive")
+        assertTrue(redacted.contains("[redacted-path]"), "path marker should remain")
+    }
+
+    runSuite("ObservabilityTextRedactor does not stop early inside legal path names") {
+        let input = "failed /Users/jane/Documents/Acme.com Calls/source audio.wav and /Users/jane/Documents/Client [Acme]/source status=retry.wav trigger=hotkey"
+        let redacted = ObservabilityTextRedactor.redact(input)
+
+        assertFalse(redacted.contains("Acme.com Calls"), "dotted path components before spaces must not leak")
+        assertFalse(redacted.contains("Client [Acme]"), "bracketed path components must not leak")
+        assertFalse(redacted.contains("source audio.wav"), "file names after dotted components must not leak")
+        assertFalse(redacted.contains("source status=retry.wav"), "file names with key-like tokens must not leak")
+        assertTrue(redacted.contains("trigger=hotkey"), "safe metadata after the path should remain")
+    }
+
     runSuite("ObservabilityTextRedactor scrubs inline key=value sensitive assignments") {
         let input = "ctx meeting_title=Private Roadmap speaker_name=Jane Doe trigger=hotkey"
         let redacted = ObservabilityTextRedactor.redact(input)


### PR DESCRIPTION
## Summary
- redact full absolute path spans that contain spaces before Sentry/PostHog/support sanitization
- add regression coverage for spaced user paths, volume paths, and app-support paths

## Verification
- python3 scripts/ops/nightly-security-check.py --write-report build/nightly-security-report.json
- bash build-deps.sh --force
- bash build.sh --no-open
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh
- python3 scripts/ops/nightly-security-check.py --app-bundle build/Transcripted.app --write-report build/nightly-security-report.json
- bash scripts/release/verify-sparkle-release.sh 1.1.43