### PR TITLE
[nightly-agent] Document stale MCP helper repair signal

### DIFF
--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -39,6 +39,12 @@ stale. Click `Install for Claude Desktop` again from Transcripted Settings to
 replace it with the current bundled helper. The current helper should print only
 the JSON self-test payload.
 
+A stale helper can also pass `--self-test` but still behave like an older build,
+for example if `transcripted-mcp --help` starts the MCP server instead of
+printing usage. If Transcripted Settings says the direct tools need repair, or
+the installed helper differs from the app-bundled helper, click `Install for
+Claude Desktop` again.
+
 Current `transcripted-mcp` capabilities:
 
 - `recent_context`


### PR DESCRIPTION
## Summary
- add troubleshooting copy for stale installed MCP helpers that still pass self-test
- call out the --help-starts-server symptom and Settings repair path

## Verification
- swift test --package-path Tools/TranscriptedCLI
- swift test --package-path Tools/TranscriptedMCP
- cd Tools/TranscriptedMCP && swift build -c release
- repo, app-bundled, and installed MCP --self-test checks
- CLI context-recent, context-search, list-dictations, read-meeting, read-dictation with explicit directory overrides
- bash scripts/dev/agent-preflight.sh