### PR TITLE
[nightly-telemetry] Track update failure codes

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -292,6 +292,7 @@ struct AnalyticsEventPolicy: Equatable {
             name: "update_check_finished",
             allowedProperties: [
                 "automatic_downloads_enabled",
+                "failure_code",
                 "failure_kind",
                 "result",
                 "state",

--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -305,7 +305,8 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
             result: "error",
             state: updateStatus.state,
             version: updateStatus.availableUpdateVersion,
-            failureKind: UpdateFailureKind.classify(error, fallback: fallback).rawValue
+            failureKind: UpdateFailureKind.classify(error, fallback: fallback).rawValue,
+            failureCode: UpdateFailureKind.diagnosticCode(error)
         )
     }
 
@@ -401,12 +402,16 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
         result: String,
         state: UpdateStatus.State,
         version: String?,
-        failureKind: String? = nil
+        failureKind: String? = nil,
+        failureCode: String? = nil
     ) {
         var properties = baseUpdateTelemetryProperties(state: state, version: version)
         properties["result"] = result
         if let failureKind {
             properties["failure_kind"] = failureKind
+        }
+        if let failureCode {
+            properties["failure_code"] = failureCode
         }
         AnalyticsReporter.track("update_check_finished", properties: properties)
     }

--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -517,6 +517,7 @@ extension SparkleUpdaterController: SPUUpdaterDelegate {
         let version = versionString(for: item)
         let state = UpdateStatus.State.updateAvailable(version: version)
         let failureKind = UpdateFailureKind.classify(error, fallback: .downloadFailed).rawValue
+        let failureCode = UpdateFailureKind.diagnosticCode(error)
         setUpdateStatus(state, canCheckForUpdates: updater.canCheckForUpdates)
         trackUpdateLifecycleEvent(
             "update_download_finished",
@@ -528,7 +529,8 @@ extension SparkleUpdaterController: SPUUpdaterDelegate {
             result: "download_failed",
             state: state,
             version: version,
-            failureKind: failureKind
+            failureKind: failureKind,
+            failureCode: failureCode
         )
     }
 

--- a/Sources/Observability/UpdateFailureKind.swift
+++ b/Sources/Observability/UpdateFailureKind.swift
@@ -11,6 +11,27 @@ enum UpdateFailureKind: String {
     case sparkleBusy = "sparkle_busy"
     case unknown = "unknown"
 
+    static func diagnosticCode(_ error: Error?) -> String? {
+        guard let error else { return nil }
+
+        let nsError = error as NSError
+        let domain = nsError.domain.lowercased()
+        let codePrefix: String
+
+        switch nsError.domain {
+        case NSURLErrorDomain:
+            codePrefix = "url"
+        case NSCocoaErrorDomain:
+            codePrefix = "cocoa"
+        case NSPOSIXErrorDomain:
+            codePrefix = "posix"
+        default:
+            codePrefix = domain.contains("sparkle") ? "sparkle" : "other"
+        }
+
+        return "\(codePrefix)_\(nsError.code)"
+    }
+
     static func classify(_ error: Error?, fallback: UpdateFailureKind = .unknown) -> UpdateFailureKind {
         guard let error else { return fallback }
 

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -83,11 +83,13 @@ func testAnalyticsEventPolicy() {
         assertEqual(updateSetting?.allowedProperties.contains("setting_id"), true, "update settings should preserve the changed toggle")
         assertEqual(updateCheckFinished?.allowedProperties.contains("result"), true, "update checks should preserve the coarse outcome")
         assertEqual(updateCheckFinished?.allowedProperties.contains("failure_kind"), true, "update failures should preserve the normalized failure kind")
+        assertEqual(updateCheckFinished?.allowedProperties.contains("failure_code"), true, "update failures should preserve coarse error-code buckets")
 
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
             [
                 "action_id": "start_dictation",
                 "automatic_downloads_enabled": "true",
+                "failure_code": "sparkle_2003",
                 "failure_kind": "feed_unreachable",
                 "page_id": "home",
                 "setting_id": "menu_bar_start_dictation",
@@ -95,10 +97,11 @@ func testAnalyticsEventPolicy() {
                 "state": "ready_to_install",
                 "surface": "settings_about",
             ],
-            allowedKeys: ["action_id", "automatic_downloads_enabled", "failure_kind", "page_id", "setting_id", "source", "state", "surface"]
+            allowedKeys: ["action_id", "automatic_downloads_enabled", "failure_code", "failure_kind", "page_id", "setting_id", "source", "state", "surface"]
         )
         assertEqual(sanitized["action_id"], "start_dictation", "action ids should survive sanitization")
         assertEqual(sanitized["automatic_downloads_enabled"], "true", "automatic update download state should survive sanitization")
+        assertEqual(sanitized["failure_code"], "sparkle_2003", "coarse update failure codes should survive sanitization")
         assertEqual(sanitized["failure_kind"], "feed_unreachable", "update failure kind should survive sanitization")
         assertEqual(sanitized["page_id"], "home", "page ids should survive sanitization")
         assertEqual(sanitized["setting_id"], "menu_bar_start_dictation", "setting ids should survive sanitization")

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -392,6 +392,25 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - Sparkle download failures include diagnostic codes") {
+        let controller = readRepoTextFile("Sources/Observability/SparkleUpdaterController.swift")
+        let downloadFailureBlock = sourceSlice(
+            controller,
+            from: "func updater(_ updater: SPUUpdater, failedToDownloadUpdate item: SUAppcastItem, error: any Error)",
+            to: "func updater(\n        _ updater: SPUUpdater,\n        willInstallUpdateOnQuit"
+        )
+
+        assertTrue(
+            downloadFailureBlock.contains("failureCode: UpdateFailureKind.diagnosticCode(error)")
+                || downloadFailureBlock.contains("failureCode = UpdateFailureKind.diagnosticCode(error)"),
+            "Sparkle download failures should attach a coarse diagnostic code to finished telemetry"
+        )
+        assertTrue(
+            downloadFailureBlock.contains("failureCode: failureCode"),
+            "download_failed update_check_finished telemetry should include the diagnostic code"
+        )
+    }
+
     runSuite("Repo command contract - downloaded Sparkle state emits ready telemetry") {
         let controller = readRepoTextFile("Sources/Observability/SparkleUpdaterController.swift")
         let readyHelper = sourceSlice(

--- a/Tests/UpdateFailureKindTests.swift
+++ b/Tests/UpdateFailureKindTests.swift
@@ -69,4 +69,17 @@ func testUpdateFailureKind() {
         assertEqual(UpdateFailureKind.classify(busy), .sparkleBusy, "session-in-progress errors should normalize to sparkle_busy")
         assertEqual(UpdateFailureKind.classify(unknown, fallback: .feedUnreachable), .feedUnreachable, "unrecognized text should keep the caller fallback")
     }
+
+    runSuite("UpdateFailureKind emits coarse diagnostic codes") {
+        let offline = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+        let sparkle = NSError(domain: "SUSparkleErrorDomain", code: 2003)
+        let cocoa = NSError(domain: NSCocoaErrorDomain, code: 260)
+        let custom = NSError(domain: "SensitiveVendor.PrivateDomain", code: 42)
+
+        assertEqual(UpdateFailureKind.diagnosticCode(nil), nil, "missing errors should not invent failure codes")
+        assertEqual(UpdateFailureKind.diagnosticCode(offline), "url_-1009", "URL errors should keep only the coarse domain bucket and code")
+        assertEqual(UpdateFailureKind.diagnosticCode(sparkle), "sparkle_2003", "Sparkle errors should be grouped without raw localized text")
+        assertEqual(UpdateFailureKind.diagnosticCode(cocoa), "cocoa_260", "Cocoa errors should use a stable public domain bucket")
+        assertEqual(UpdateFailureKind.diagnosticCode(custom), "other_42", "custom domains should not be sent off-device")
+    }
 }

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -142,6 +142,7 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - coarse buckets like `10_29s`, `50_149`, `4_plus`
 - stable trigger enums like `hotkey`, `menu`, `detected_prompt`
 - normalized failure kinds like `system_audio`, `recording_too_short`, `other`
+- normalized failure-code buckets like `url_-1009`, `sparkle_2003`, `other_42`
 
 Meeting workflow analytics should keep that same stable `trigger` enum on later
 stop/save/fail events so product and reliability reviews can attribute outcomes


### PR DESCRIPTION
## Summary
- add coarse `failure_code` buckets to failed Sparkle update-check telemetry
- allowlist the new PostHog property and document the privacy-safe shape
- cover URL, Sparkle, Cocoa, and custom-domain bucketing in fast tests

## Evidence
- PostHog 7d: `update_check_finished` had 84 current-release `1.1.43` errors across 13 devices with `failure_kind=unknown` and `state=unknown`.
- The patch keeps raw error text/domains off-device and sends only buckets like `url_-1009`, `sparkle_2003`, or `other_42`.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `bash scripts/dev/agent-preflight.sh`