### PR TITLE
[nightly-regression] Cover Bluetooth dictation start failure copy

### DIFF
--- a/Tests/DictationRecordingStartOverlayPolicyTests.swift
+++ b/Tests/DictationRecordingStartOverlayPolicyTests.swift
@@ -143,6 +143,27 @@ func testDictationRecordingStartOverlayPolicy() {
         )
     }
 
+    runSuite("DictationMicrophoneTimeoutPresentationPolicy names immediate Bluetooth fallback start failures") {
+        let message = DictationMicrophoneTimeoutPresentationPolicy.message(
+            deviceName: "MacBook Pro Microphone",
+            startAttempts: 0,
+            inputFormatReady: true,
+            routeContext: [
+                "default_input_class": "bluetooth",
+                "default_output_class": "bluetooth",
+                "selected_input_class": "built_in",
+                "selection_overrode_default": "true",
+                "selection_reason": "preferredBuiltInForBluetoothHeadset",
+            ]
+        )
+
+        assertEqual(
+            message,
+            "Couldn't start the built-in microphone while Bluetooth audio was active. Try again, or choose a different input in System Settings.",
+            "Bluetooth fallback start failures should not fall through to generic microphone copy"
+        )
+    }
+
     runSuite("DictationMicrophoneTimeoutPresentationPolicy keeps generic fallback copy") {
         let message = DictationMicrophoneTimeoutPresentationPolicy.message(
             deviceName: "Studio Display Microphone",


### PR DESCRIPTION
## Nightly review

Reviewed current `origin/main` plus landed work since `2026-05-26T11:22:57Z`: #883 repo/Core cleanup, #884 mic-timeout Sentry tag coverage, and #885 Bluetooth dictation timeout copy. Checked open PRs first; no open `[nightly-review]` or `[nightly-regression]` draft PR was present.

Live evidence used:
- Sentry last 24h: unresolved `APPLE-MACOS-14` on `transcripted@1.1.43`, with Bluetooth input/output active, built-in input selected, and sample flow not started.
- Sentry last 24h also showed `APPLE-MACOS-4`, but it is on older `transcripted@1.1.20` and not a safe current-main patch target tonight.
- PostHog last 24h: `dictation_started=146`, `dictation_completed=128`, `dictation_audio_route_recovery_timeout=5`, `dictation_start_failed=3`, `meeting_transcript_saved=23`, and no returned `meeting_transcript_failed` count.
- PostHog breakdown for the dictation failures: Bluetooth default input/output, built-in selected by `preferredBuiltInForBluetoothHeadset`, `sample_flow_started=false`; one of the failures used `failure_kind=microphone_start_failed` rather than timeout.

## Top risks ranked

1. Bluetooth fallback dictation failures are still current in live telemetry. #885 fixed the copy path, but coverage only locked the timeout-shaped path, not the immediate `microphone_start_failed` shape seen in PostHog.
2. `APPLE-MACOS-14` remains the current production reliability issue. #884 already locked the Sentry tag contract and #885 improved user-facing copy, so no safe second behavior patch was warranted tonight.
3. `APPLE-MACOS-4` launch hang is real but stale-release (`1.1.20`) and broad around launch-time file metadata, so it needs triage before code changes.

## Change

- Adds focused fast-test coverage proving Bluetooth fallback copy wins even when startup fails immediately with `startAttempts=0` and `inputFormatReady=true`.
- Product behavior is unchanged; this protects the already-correct branch ordering in `DictationMicrophoneTimeoutPresentationPolicy`.

## Verification

- `bash scripts/dev/agent-preflight.sh`
- `git diff --check`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` (`2682 tests, 2682 passed`)
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build-deps.sh --force`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open`
- `~/.codex/skills/codex-review/scripts/codex-review --mode local` clean; no accepted/actionable findings

Note: first `build.sh --no-open` stopped before compile because deps were stale and requested `bash build-deps.sh --force`; after refreshing deps, the build passed.