### PR TITLE
[codex] Fix Bluetooth dictation microphone timeout

### DIFF
--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -161,14 +161,6 @@ enum ParakeetAudioFormatReadinessPolicy {
             return .routeNotSettled
         }
 
-        if selectionOverrodeDefault,
-           selectedInputClass != "bluetooth",
-           outputDeviceClass == "bluetooth",
-           inputSampleRate >= 44_100,
-           likelyBluetoothSpeechRates.contains(Int(outputSampleRate.rounded())) {
-            return .routeNotSettled
-        }
-
         return .ready
     }
 

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -186,7 +186,7 @@ func testParakeetStartRecordingFailurePolicy() {
         assertEqual(readiness, .ready, "AirPods HFP 24k hardware to 48k output should remain valid")
     }
 
-    runSuite("ParakeetAudioFormatReadinessPolicy defers built-in override with Bluetooth output speech bus") {
+    runSuite("ParakeetAudioFormatReadinessPolicy accepts built-in override with Bluetooth output speech bus") {
         let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
             outputSampleRate: 24_000,
             outputChannelCount: 1,
@@ -197,7 +197,7 @@ func testParakeetStartRecordingFailurePolicy() {
             selectionOverrodeDefault: true
         )
 
-        assertEqual(readiness, .routeNotSettled, "built-in override with a 24k Bluetooth output bus should wait for CoreAudio to settle")
+        assertEqual(readiness, .ready, "built-in fallback with Bluetooth output can start because the tap uses the delivered buffer format")
     }
 
     runSuite("ParakeetAudioFormatReadinessPolicy accepts intentional Bluetooth output speech bus") {


### PR DESCRIPTION
## Summary
- allow the built-in mic fallback to start while Bluetooth output remains on a speech-rate bus
- keep stale non-Bluetooth low-rate route protection intact
- update the focused readiness regression for the APPLE-MACOS-14 route shape

## Root Cause
Sentry APPLE-MACOS-14 showed `dictation.microphone_start_timeout` on `built_in_input_to_bluetooth_output` with `format_ready=false` and `sample_flow_started=false`. The readiness policy was treating this Bluetooth-output speech bus as unsettled after Transcripted intentionally selected the built-in mic, so the dictation wait loop never installed the tap.

## Verification
- `bash run-tests.sh` -> `2681 tests, 2681 passed, 0 failed`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
