### PR TITLE
Release Transcripted 1.1.44

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.43"
-  sha256 "2599531b300a8fc7c477ff14870d3908b5ed93b5de7d66aebc1d370090e8258d"
+  version "1.1.44"
+  sha256 "3e16f98852d5d4fafa00f647580264134e202025f2091a3d8ecb8ca83d005d36"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.43</string>
+	<string>1.1.44</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.43</string>
+	<string>1.1.44</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.44</title>
+      <pubDate>Wed, 27 May 2026 10:49:24 -0500</pubDate>
+      <sparkle:version>1.1.44</sparkle:version>
+      <sparkle:shortVersionString>1.1.44</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.44/Transcripted-1.1.44.dmg" length="535558767" type="application/octet-stream" sparkle:edSignature="A3UyIEyv4g7JEM2dyXahj+DOSsCVXbD5xlG+0QxTkD4GHA+IQ/fmtkSClc9kzkNYeSaW0Oeuot0o0BYurasVBg==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.44</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.44</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.43</title>
       <pubDate>Fri, 22 May 2026 08:12:09 -0500</pubDate>
       <sparkle:version>1.1.43</sparkle:version>


### PR DESCRIPTION
## Summary
- bump Transcripted to 1.1.44
- publish Sparkle appcast entry for v1.1.44
- update Homebrew cask to the published DMG hash

## Verification
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift test
- NOTARY_PROFILE=Transcripted bash build-beta.sh transcripted-beta-justin Justin
- xcrun stapler validate build/Transcripted-1.1.44.dmg
- bash scripts/release/verify-sparkle-release.sh 1.1.44

GitHub release: https://github.com/r3dbars/transcripted/releases/tag/v1.1.44
DMG SHA-256: 3e16f98852d5d4fafa00f647580264134e202025f2091a3d8ecb8ca83d005d36

Note: Sentry release registration attempted but Sentry returned 403 for the current credentials.