### PR TITLE
[nightly-telemetry] Treat Sparkle no-update as up to date

### DIFF
--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -492,6 +492,11 @@ extension SparkleUpdaterController: SPUUpdaterDelegate {
     }
 
     func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: any Error) {
+        if UpdateFailureKind.isNoUpdate(error) {
+            markNoUpdateAvailable(from: updater)
+            return
+        }
+
         markUpdateCheckFailed(from: updater, error: error)
     }
 

--- a/Sources/Observability/UpdateFailureKind.swift
+++ b/Sources/Observability/UpdateFailureKind.swift
@@ -11,6 +11,14 @@ enum UpdateFailureKind: String {
     case sparkleBusy = "sparkle_busy"
     case unknown = "unknown"
 
+    static func isNoUpdate(_ error: Error?) -> Bool {
+        guard let error else { return false }
+
+        let nsError = error as NSError
+        return nsError.domain.lowercased().contains("sparkle")
+            && nsError.code == 1001
+    }
+
     static func diagnosticCode(_ error: Error?) -> String? {
         guard let error else { return nil }
 

--- a/Tests/UpdateFailureKindTests.swift
+++ b/Tests/UpdateFailureKindTests.swift
@@ -1,6 +1,16 @@
 import Foundation
 
 func testUpdateFailureKind() {
+    runSuite("UpdateFailureKind recognizes Sparkle no-update callbacks") {
+        let noUpdate = NSError(domain: "SUSparkleErrorDomain", code: 1001)
+        let appcastParse = NSError(domain: "SUSparkleErrorDomain", code: 1000)
+        let unrelated = NSError(domain: NSCocoaErrorDomain, code: 1001)
+
+        assertEqual(UpdateFailureKind.isNoUpdate(noUpdate), true, "Sparkle no-update code should not be treated as an update failure")
+        assertEqual(UpdateFailureKind.isNoUpdate(appcastParse), false, "other Sparkle appcast errors should stay failure candidates")
+        assertEqual(UpdateFailureKind.isNoUpdate(unrelated), false, "code 1001 outside Sparkle should not be reclassified")
+    }
+
     runSuite("UpdateFailureKind preserves explicit fallback when no error exists") {
         assertEqual(
             UpdateFailureKind.classify(nil, fallback: .sparkleBusy),


### PR DESCRIPTION
## Summary
- Reclassifies Sparkle no-update callback code 1001 as up-to-date instead of an update-check failure.
- Keeps real Sparkle errors on the existing failure path.
- Adds fast coverage for the no-update helper.

## Evidence
- PostHog 7d: 1.1.44 had 8 `update_check_finished` rows across 4 devices with `result=error`, `failure_kind=unknown`, `failure_code=sparkle_1001`.
- Sparkle API names error code 1001 as the no-update condition, so this was inflating current-release update failure telemetry.
- No unresolved Sentry production issues matched `release:transcripted@1.1.44`.

## Candidate scoring
- Winner: false Sparkle no-update failures, 91/100.
- Lost: long-meeting trust #825 remains real, but needs a larger long-recording regression/chunked processing pass.
- Lost: quiet mic/system audio #500 still matters, but current telemetry is mixed and an audio fix is not tiny.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `bash scripts/dev/agent-preflight.sh`