### PR TITLE
[operator] Clarify launch install requirements

### DIFF
--- a/docs/launch-assets/README.md
+++ b/docs/launch-assets/README.md
@@ -44,6 +44,9 @@ Keep the spoken/written pitch short:
 > saves clean local Markdown, so Claude, Codex, Obsidian, and other agents can
 > use the spoken context that normally disappears.
 
+Before posting, include the install requirements anywhere the channel allows:
+Apple Silicon Mac, macOS 26 or later.
+
 ## Safety Notes
 
 The captured media uses synthetic demo meetings and dictations. Do not replace


### PR DESCRIPTION
## Summary
- Adds a short launch-pack reminder to include install requirements where the channel allows.
- Keeps the launch copy aligned with the README: Apple Silicon Mac, macOS 26 or later.

## Why
Wrong-platform installs are bad activation. This makes the launch/community handoff less likely to send Intel or older-macOS users into a dead end.

## Verification
- `bash scripts/dev/agent-preflight.sh`
- `rg -n "Apple Silicon|macOS 26" docs/launch-assets README.md`
- `git diff --check -- docs/launch-assets/README.md`

## Operator lane
Chosen lane: Execute. Docs-only activation fix, no privacy/audio/release risk.
