### PR TITLE
Use the source audio's recording date for imported notes (#850)

### DIFF
--- a/Sources/Meeting/MeetingImportedAudioPreparer.swift
+++ b/Sources/Meeting/MeetingImportedAudioPreparer.swift
@@ -50,6 +50,16 @@ enum MeetingImportedAudioPreparationError: LocalizedError, Equatable {
 }
 
 enum MeetingImportedAudioPreparer {
+    /// A source timestamp within this window of the import is treated as the copy
+    /// or download act rather than the original recording time (issue #850).
+    static let copyDetectionWindow: TimeInterval = 120
+
+    /// Embedded dates before this are treated as malformed/sentinel values — e.g.
+    /// the 1904 QuickTime epoch or the 1970 Unix epoch written by buggy encoders —
+    /// rather than real recording times (issue #850). 1990-01-01 UTC predates any
+    /// consumer digital recorder that embeds creation metadata.
+    static let earliestPlausibleRecordingDate = Date(timeIntervalSince1970: 631_152_000)
+
     static func prepareImportedAudio(
         from sourceURL: URL,
         scratchDirectory: URL = MeetingStoragePaths.recordingsScratch
@@ -128,25 +138,66 @@ enum MeetingImportedAudioPreparer {
 
     private static func recordingDate(
         from sourceURL: URL,
-        sourceAttributes: [FileAttributeKey: Any]
+        sourceAttributes: [FileAttributeKey: Any],
+        now: Date = Date()
     ) async -> Date {
-        if let embeddedDate = await embeddedRecordingDate(from: sourceURL) {
+        // Prefer a date the recorder embedded in the file: it describes when the
+        // audio was actually captured, which is what an imported note should show.
+        // Ignore implausible dates (future, or sentinel/zero values) so a bogus tag
+        // never becomes the note date — fall through to the file system instead.
+        if let embeddedDate = await embeddedRecordingDate(from: sourceURL),
+           isPlausibleEmbeddedDate(embeddedDate, now: now) {
             return embeddedDate
         }
 
+        // Otherwise fall back to the source file's own timestamps, but only when
+        // they look like the original recording rather than a copy or download.
+        if let filesystemDate = reliableFilesystemDate(
+            from: sourceURL,
+            sourceAttributes: sourceAttributes,
+            now: now
+        ) {
+            return filesystemDate
+        }
+
+        // Last resort (issue #850): creation date unavailable or unreliable, so
+        // use the import time.
+        return now
+    }
+
+    /// Whether an embedded recording date looks like a real capture time. Rejects
+    /// sentinel/zero dates written by buggy encoders and anything in the future, so
+    /// the resolver falls through to the file system rather than stamping the note
+    /// with a bogus date (issue #850).
+    static func isPlausibleEmbeddedDate(_ date: Date, now: Date) -> Bool {
+        date >= earliestPlausibleRecordingDate
+            && date.timeIntervalSince(now) <= copyDetectionWindow
+    }
+
+    /// Best file-system estimate of when the source audio was recorded. Copies,
+    /// downloads, and AirDrops only ever push a file's timestamps forward, so the
+    /// earliest timestamp is the closest lower bound on the original recording.
+    /// Any timestamp inside the import window is the copy act itself and is
+    /// discarded as unreliable (issue #850).
+    static func reliableFilesystemDate(
+        from sourceURL: URL,
+        sourceAttributes: [FileAttributeKey: Any],
+        now: Date
+    ) -> Date? {
+        var candidates: [Date] = []
         if let creationDate = sourceAttributes[.creationDate] as? Date {
-            return creationDate
+            candidates.append(creationDate)
+        } else if let resourceDate = try? sourceURL
+            .resourceValues(forKeys: [.creationDateKey]).creationDate {
+            candidates.append(resourceDate)
         }
-
-        if let resourceDate = try? sourceURL.resourceValues(forKeys: [.creationDateKey]).creationDate {
-            return resourceDate
-        }
-
         if let modificationDate = sourceAttributes[.modificationDate] as? Date {
-            return modificationDate
+            candidates.append(modificationDate)
         }
 
-        return Date()
+        return candidates
+            .filter { now.timeIntervalSince($0) >= copyDetectionWindow }
+            .min()
     }
 
     private static func embeddedRecordingDate(from sourceURL: URL) async -> Date? {
@@ -161,32 +212,83 @@ enum MeetingImportedAudioPreparer {
         }
 
         let metadata = (try? await asset.load(.metadata)) ?? []
-        var dates: [Date] = []
-        for item in metadata where isRecordingDateMetadata(item) {
-            if let date = await metadataDate(item) {
-                dates.append(date)
+        var best: (priority: Int, date: Date)?
+        for item in metadata {
+            let keyString = metadataKeyString(for: item)
+            guard isRecordingDateMetadata(keyString: keyString),
+                  let date = await metadataDate(item) else { continue }
+            let priority = recordingDatePriority(forKeyString: keyString)
+            // Prefer the most explicit creation/recording tag. Earlier code took
+            // the globally earliest matched date, which let a stray tag win.
+            if let current = best {
+                if priority < current.priority
+                    || (priority == current.priority && date < current.date) {
+                    best = (priority, date)
+                }
+            } else {
+                best = (priority, date)
             }
         }
-        return dates.sorted().first
+        return best?.date
     }
 
-    private static func isRecordingDateMetadata(_ item: AVMetadataItem) -> Bool {
-        let fields = [
+    /// Lowercased identifier/key text used to classify a metadata item.
+    static func metadataKeyString(for item: AVMetadataItem) -> String {
+        [
             item.identifier?.rawValue,
             item.commonKey?.rawValue,
             item.keySpace?.rawValue,
             item.key.map { String(describing: $0) }
         ]
-        let joined = fields
-            .compactMap { $0 }
-            .joined(separator: " ")
-            .lowercased()
+        .compactMap { $0 }
+        .joined(separator: " ")
+        .lowercased()
+    }
 
-        return joined.contains("creation")
-            || joined.contains("created")
-            || joined.contains("recorded")
-            || joined.contains("recordingdate")
-            || joined.contains("date")
+    static func isRecordingDateMetadata(_ item: AVMetadataItem) -> Bool {
+        isRecordingDateMetadata(keyString: metadataKeyString(for: item))
+    }
+
+    /// True only for metadata that records when the audio was captured. Dates that
+    /// describe something else — store purchase, encode/tagging time, release or
+    /// album date — are rejected so they can never become the note date (#850).
+    static func isRecordingDateMetadata(keyString: String) -> Bool {
+        let nonRecordingMarkers = [
+            "purchase",   // iTunes purchaseDate
+            "encod",      // encodedBy / encodingTime / TENC / TSSE
+            "tagging",    // TDTG tagging time
+            "release",    // TDRL / TDOR / originalReleaseTime / albumReleaseDate
+            "publish",
+            "album",
+            "modif"       // modification date
+        ]
+        if nonRecordingMarkers.contains(where: keyString.contains) {
+            return false
+        }
+
+        let recordingMarkers = [
+            "creationdate",
+            "creation",
+            "created",
+            "recordingdate",
+            "recordingtime",
+            "recorded",
+            "tdrc"        // ID3v2.4 recording time
+        ]
+        return recordingMarkers.contains(where: keyString.contains)
+    }
+
+    /// Ranks recording-date metadata so an explicit creation tag wins over a looser
+    /// recording tag, and both win over anything generic. Lower is better.
+    static func recordingDatePriority(forKeyString keyString: String) -> Int {
+        if keyString.contains("creation") || keyString.contains("created") {
+            return 0
+        }
+        if keyString.contains("recording") || keyString.contains("recorded")
+            || keyString.contains("tdrc") {
+            return 1
+        }
+        return 2
     }
 
     static func metadataDate(

--- a/Tests/MeetingImportedAudioPreparerTests.swift
+++ b/Tests/MeetingImportedAudioPreparerTests.swift
@@ -172,6 +172,173 @@ func testMeetingImportedAudioPreparer() async {
             "unrecognized tokens should not produce a date so the resolver falls back to the file system"
         )
     }
+
+    runSuite("MeetingImportedAudioPreparer treats only genuine recording tags as recording dates") {
+        assertTrue(
+            MeetingImportedAudioPreparer.isRecordingDateMetadata(keyString: "comn/creationdate"),
+            "the common creation-date tag is a recording date"
+        )
+        assertTrue(
+            MeetingImportedAudioPreparer.isRecordingDateMetadata(keyString: "id3/tdrc recordingtime"),
+            "the ID3 recording-time frame is a recording date"
+        )
+        assertTrue(
+            MeetingImportedAudioPreparer.isRecordingDateMetadata(keyString: "quicktimemetadatacreationdate"),
+            "the QuickTime creation-date tag is a recording date"
+        )
+        assertFalse(
+            MeetingImportedAudioPreparer.isRecordingDateMetadata(keyString: "itsk/purchasedate"),
+            "an iTunes purchase date must never be treated as the recording date"
+        )
+        assertFalse(
+            MeetingImportedAudioPreparer.isRecordingDateMetadata(keyString: "id3/tenc encodingtime"),
+            "an encode time must never be treated as the recording date"
+        )
+        assertFalse(
+            MeetingImportedAudioPreparer.isRecordingDateMetadata(keyString: "id3/tdtg taggingtime"),
+            "a tagging time must never be treated as the recording date"
+        )
+        assertFalse(
+            MeetingImportedAudioPreparer.isRecordingDateMetadata(keyString: "id3/tdrl releasetime"),
+            "a release date must never be treated as the recording date"
+        )
+        assertFalse(
+            MeetingImportedAudioPreparer.isRecordingDateMetadata(keyString: "albumreleasedate"),
+            "an album release date must never be treated as the recording date"
+        )
+        assertFalse(
+            MeetingImportedAudioPreparer.isRecordingDateMetadata(keyString: "modificationdate"),
+            "a modification date is not a recording date for matching purposes"
+        )
+        assertFalse(
+            MeetingImportedAudioPreparer.isRecordingDateMetadata(keyString: "title"),
+            "non-date metadata is not a recording date"
+        )
+    }
+
+    runSuite("MeetingImportedAudioPreparer ranks explicit creation tags above looser recording tags") {
+        assertEqual(
+            MeetingImportedAudioPreparer.recordingDatePriority(forKeyString: "comn/creationdate"),
+            0,
+            "explicit creation tags rank highest"
+        )
+        assertEqual(
+            MeetingImportedAudioPreparer.recordingDatePriority(forKeyString: "id3/tdrc recordingtime"),
+            1,
+            "recording-time tags rank below explicit creation tags"
+        )
+        assertEqual(
+            MeetingImportedAudioPreparer.recordingDatePriority(forKeyString: "somethingelse"),
+            2,
+            "anything else ranks last"
+        )
+    }
+
+    runSuite("MeetingImportedAudioPreparer uses the earliest reliable file-system timestamp") {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let recordedDay = now.addingTimeInterval(-90 * 86_400)
+        let laterEdit = recordedDay.addingTimeInterval(3_600)
+        let dummy = URL(fileURLWithPath: "/dev/null")
+
+        let resolved = MeetingImportedAudioPreparer.reliableFilesystemDate(
+            from: dummy,
+            sourceAttributes: [.creationDate: recordedDay, .modificationDate: laterEdit],
+            now: now
+        )
+        assertNotNil(resolved, "an old creation date is reliable")
+        assertTrue(
+            abs(resolved!.timeIntervalSince(recordedDay)) < 1,
+            "the earliest reliable timestamp should win"
+        )
+    }
+
+    runSuite("MeetingImportedAudioPreparer ignores a copy-time creation date but keeps a preserved mtime") {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let copyTime = now.addingTimeInterval(-5)
+        let originalRecording = now.addingTimeInterval(-30 * 86_400)
+        let dummy = URL(fileURLWithPath: "/dev/null")
+
+        let resolved = MeetingImportedAudioPreparer.reliableFilesystemDate(
+            from: dummy,
+            sourceAttributes: [.creationDate: copyTime, .modificationDate: originalRecording],
+            now: now
+        )
+        assertNotNil(resolved, "a preserved modification date is still usable")
+        assertTrue(
+            abs(resolved!.timeIntervalSince(originalRecording)) < 1,
+            "a copy-time creation date must not win over the preserved recording time"
+        )
+    }
+
+    runSuite("MeetingImportedAudioPreparer reports no reliable date when every timestamp is the import act") {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let dummy = URL(fileURLWithPath: "/dev/null")
+
+        let resolved = MeetingImportedAudioPreparer.reliableFilesystemDate(
+            from: dummy,
+            sourceAttributes: [
+                .creationDate: now.addingTimeInterval(-3),
+                .modificationDate: now.addingTimeInterval(-1)
+            ],
+            now: now
+        )
+        assertNil(
+            resolved,
+            "a freshly downloaded file has no reliable source date, so the caller falls back to the import date"
+        )
+    }
+
+    runSuite("MeetingImportedAudioPreparer rejects implausible embedded dates") {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+
+        assertTrue(
+            MeetingImportedAudioPreparer.isPlausibleEmbeddedDate(now.addingTimeInterval(-30 * 86_400), now: now),
+            "a recent embedded recording date is plausible"
+        )
+        assertTrue(
+            MeetingImportedAudioPreparer.isPlausibleEmbeddedDate(now.addingTimeInterval(30), now: now),
+            "minor forward clock skew should still be accepted"
+        )
+        assertFalse(
+            MeetingImportedAudioPreparer.isPlausibleEmbeddedDate(Date(timeIntervalSince1970: 0), now: now),
+            "the 1970 Unix epoch is a sentinel, not a recording date"
+        )
+        assertFalse(
+            MeetingImportedAudioPreparer.isPlausibleEmbeddedDate(Date(timeIntervalSince1970: -2_082_844_800), now: now),
+            "the 1904 QuickTime epoch is a sentinel, not a recording date"
+        )
+        assertFalse(
+            MeetingImportedAudioPreparer.isPlausibleEmbeddedDate(now.addingTimeInterval(3_600), now: now),
+            "a date an hour in the future is never a real recording time"
+        )
+    }
+
+    await runSuite("MeetingImportedAudioPreparer prefers a preserved recording time over the copy date end-to-end") {
+        let root = temporaryImportAudioPreparerRoot()
+        let sourceURL = root.appendingPathComponent("Downloaded_Call.wav")
+        let scratchURL = root.appendingPathComponent("scratch", isDirectory: true)
+        let originalRecording = Date().addingTimeInterval(-45 * 86_400)
+        try! FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: sourceURL.path, contents: Data([0, 1, 2, 3]))
+        try! FileManager.default.setAttributes(
+            [
+                .creationDate: Date(),
+                .modificationDate: originalRecording,
+                .posixPermissions: 0o644
+            ],
+            ofItemAtPath: sourceURL.path
+        )
+
+        let prepared = try! await MeetingImportedAudioPreparer.prepareImportedAudio(
+            from: sourceURL,
+            scratchDirectory: scratchURL
+        )
+
+        assertTrue(
+            abs(prepared.recordingDate.timeIntervalSince(originalRecording)) < 2,
+            "imported audio should use the preserved recording time, not the copy/download date"
+        )
+    }
 }
 
 private func assertImportedAudioPreparationError(

--- a/Tests/MeetingTranscriptStylerTests.swift
+++ b/Tests/MeetingTranscriptStylerTests.swift
@@ -16,6 +16,7 @@ func testMeetingTranscriptStyler() {
         testMeetingTranscriptStylerAvoidsAudioDirectoryCollisions()
         testMeetingTranscriptStylerPreservesObsidianSpeakerLinks()
         testMeetingTranscriptStylerRestrictsRewrittenTranscript()
+        testMeetingTranscriptStylerPreservesImportedRecordingDate()
     }
 }
 
@@ -81,6 +82,34 @@ private func testMeetingTranscriptStylerPreservesExplicitTitle() {
     assertEqual(styled.title, "Customer Interview April", "Styler should respect an explicit imported transcript title")
     assertEqual(styled.url.lastPathComponent, "Customer Interview April.md", "Explicit titles should drive the final transcript filename")
     assertTrue(updatedMarkdown?.contains("# Customer Interview April") == true, "Explicit titles should be written back into the rendered markdown")
+}
+
+private func testMeetingTranscriptStylerPreservesImportedRecordingDate() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    // The styler renames an imported note off its Call_<date> stem to a title
+    // stem. It must not drop or rewrite the recording date carried in the front
+    // matter — preserving that source date end-to-end is the point of issue #850.
+    let transcriptURL = directory.appendingPathComponent("Call_2026-04-07_09-14-00.md")
+    try? sampleImportedTranscript().write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+    let styled = MeetingTranscriptStyler.restyleTranscript(at: transcriptURL)
+    let updatedMarkdown = (try? String(contentsOf: styled.url, encoding: .utf8)) ?? ""
+
+    assertEqual(
+        styled.url.lastPathComponent,
+        "Customer Interview April.md",
+        "Imported notes should still be renamed to their explicit title"
+    )
+    assertTrue(
+        updatedMarkdown.contains("date: \"2026-04-07\""),
+        "Restyling must preserve the imported recording date in the front matter"
+    )
+    assertTrue(
+        updatedMarkdown.contains("time: \"09:14:00\""),
+        "Restyling must preserve the imported recording time in the front matter"
+    )
 }
 
 private func testMeetingTranscriptStylerDisplaysExplicitTitleWithoutFullBodyRead() {


### PR DESCRIPTION
## What & why

Imported-audio notes (Settings → Audio Files → **Transcribe Audio File**) should be dated by **when the recording happened**, not when it was transcribed (issue #850).

Diagnosis surprise: the date *chain* was already wired end to end (`MeetingImportedAudioPreparer.recordingDate` → pipeline → `TranscriptSaver` → Markdown `date:`/`time:` + filename). #875 was a tests-only no-op that referenced `(#850)` without a closing keyword, so the issue never auto-closed. The real defects were in how the preparer *selected* the date — files with stray date tags or copied/downloaded files still got the wrong date.

## Fixes (`MeetingImportedAudioPreparer.swift`)

- **Over-broad matcher** — `isRecordingDateMetadata` matched any key containing the substring `"date"`, so `purchaseDate` / `encodingTime` / release tags qualified. Now an allowlist of genuine creation/recording markers with an explicit denylist (purchase, encode, tagging, release, album, modification).
- **Earliest-wins** — `embeddedRecordingDate` returned `dates.sorted().first`. Now ranks an explicit creation tag above a looser recording tag, ties broken on the earliest date.
- **No "unreliable creation date" handling** — a copied/downloaded/AirDropped file's filesystem `creationDate` is the *copy time*, not the recording time. New `reliableFilesystemDate` drops any timestamp within 120s of import and takes the earliest reliable one (copies only ever push timestamps forward, so the earliest reliable stamp is the best lower bound on the real recording time).
- **Sentinel/future embedded dates** — embedded dates are now bounded both ways: the 1904 QuickTime epoch, the 1970 Unix epoch, and future dates fall through to the file system instead of becoming the note date.

Source audio metadata is still never mutated (unchanged: only the scratch copy is touched).

## Tests (regression prevention)

New focused coverage so this can't silently regress:
- matcher rejects purchase/encode/tagging/release/album/modification dates, accepts creation/recording tags
- creation tags outrank looser recording tags
- filesystem reliability: earliest reliable wins; a copy-time creation date loses to a preserved mtime; all-recent timestamps → no reliable date (fall back to import)
- plausibility guard rejects 1904/1970/future
- end-to-end: a "downloaded" file (copy-time creation, preserved old mtime) uses the preserved recording time
- styler test proving restyle/rename preserves the `date:`/`time:` front matter

## Verification

- `bash build.sh --no-open` ✅
- `bash run-tests.sh` ✅ 2853/2853
- `bash run-integration-smoke.sh` ✅
- existing `swift test --filter testStartImportedTranscriptionUsesSourceRecordingDateForSavedMetadata` ✅ (date → saved Markdown)

## Known follow-ups (out of scope)

Re-transcribing existing saved audio (`startSavedAudioRetranscription`) resets the note date to now; the legacy `TranscriptSaver.save(text:)` path hardcodes the current date but has no live callers. Neither affects imported audio.

Closes #850

🤖 Generated with [Claude Code](https://claude.com/claude-code)