### PR TITLE
[nightly-agent] Keep CLI retrieval builds independent

### DIFF
--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -72,7 +72,7 @@ swift run transcripted-cli context-recent
 swift run transcripted-cli context-search "roadmap"
 swift run transcripted-cli read-meeting "Product review"
 swift run transcripted-cli list-dictations --count 5
-swift run transcripted-cli diarize /path/to/audio.wav --json
+TRANSCRIPTEDCLI_ENABLE_DIARIZATION=1 swift run transcripted-cli diarize /path/to/audio.wav --json
 ```
 
 ## Common Retrieval Recipes
@@ -104,16 +104,17 @@ Binary path after build:
 .build/debug/transcripted-cli
 ```
 
-When the repo-level dependency bundle is missing, `swift build` still builds the
-local context commands so agent retrieval can work on a fresh checkout. The
-offline audio commands (`diarize` and `batch`) then exit with an explicit
-instruction to run `bash build-deps.sh` from the repo root before rebuilding.
+By default, `swift build` builds the local context commands without linking the
+offline diarization dependency bundle, so agent retrieval works on a fresh
+checkout. The offline audio commands (`diarize` and `batch`) then exit with an
+explicit instruction to run `bash build-deps.sh` from the repo root and rebuild
+with `TRANSCRIPTEDCLI_ENABLE_DIARIZATION=1` when diarization is needed.
 
 ## Gotchas
 
 - the context commands and the diarization commands serve different users, do not describe the whole package as diarization-only
 - direct dictation or meeting file reads should keep using `CLIPathSecurity` so filename inputs cannot escape the resolved Transcripted data roots
-- the diarization commands depend on repo-level artifacts, so run `bash build-deps.sh` first when those are missing
+- the diarization commands depend on repo-level artifacts, so run `bash build-deps.sh` and rebuild with `TRANSCRIPTEDCLI_ENABLE_DIARIZATION=1` when those are needed
 - retrieval-only commands should still build and run even when the diarization bundle is absent
 - `swift test` currently covers the agent-facing context path resolver and context-store loading behavior
 - the default context resolver prefers the app-selected capture library when Transcripted has one, then falls back to the current Transcripted capture folders, then Draft-era exports, then `~/Documents/Transcripted/`

--- a/Tools/TranscriptedCLI/Package.swift
+++ b/Tools/TranscriptedCLI/Package.swift
@@ -11,11 +11,13 @@ let fileManager = FileManager.default
 let depsModulesRoot = "\(repoRoot)/deps-modules"
 let depsFrameworksRoot = "\(repoRoot)/deps-frameworks"
 let depsLibsRoot = "\(repoRoot)/deps-libs"
+let enableDiarization = ProcessInfo.processInfo.environment["TRANSCRIPTEDCLI_ENABLE_DIARIZATION"] == "1"
 let fluidAudioModuleCandidates = [
     "\(depsModulesRoot)/FluidAudio.swiftmodule",
     "\(depsModulesRoot)/FluidAudio.swiftmodule/arm64-apple-macos.swiftmodule",
 ]
-let hasDiarizationDeps = fluidAudioModuleCandidates.contains(where: { fileManager.fileExists(atPath: $0) })
+let hasDiarizationDeps = enableDiarization
+    && fluidAudioModuleCandidates.contains(where: { fileManager.fileExists(atPath: $0) })
     && fileManager.fileExists(atPath: "\(depsLibsRoot)/libDraftDeps.a")
     && fileManager.fileExists(atPath: "\(depsFrameworksRoot)/ESpeakNG.framework")
 

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/BatchCommand.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/BatchCommand.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
 
-#if TRANSCRIPTEDCLI_WITH_DIARIZATION
+#if TRANSCRIPTEDCLI_WITH_DIARIZATION && canImport(FluidAudio)
 import FluidAudio
 
 struct Batch: AsyncParsableCommand {
@@ -133,7 +133,7 @@ struct Batch: AsyncParsableCommand {
     var ext: String = "m4a"
 
     func run() async throws {
-        throw ValidationError("Offline diarization dependencies are unavailable. Run `bash build-deps.sh` from the repo root, then rebuild `transcripted-cli`.")
+        throw ValidationError("Offline diarization dependencies are unavailable. Run `bash build-deps.sh` from the repo root, then rebuild with `TRANSCRIPTEDCLI_ENABLE_DIARIZATION=1`.")
     }
 }
 #endif

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ConfigLoader.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ConfigLoader.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if TRANSCRIPTEDCLI_WITH_DIARIZATION
+#if TRANSCRIPTEDCLI_WITH_DIARIZATION && canImport(FluidAudio)
 import FluidAudio
 
 /// JSON-decodable config for the supported OfflineDiarizerConfig parameters.

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/DiarizeCommand.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/DiarizeCommand.swift
@@ -1,7 +1,7 @@
 import ArgumentParser
 import Foundation
 
-#if TRANSCRIPTEDCLI_WITH_DIARIZATION
+#if TRANSCRIPTEDCLI_WITH_DIARIZATION && canImport(FluidAudio)
 import FluidAudio
 
 struct Diarize: AsyncParsableCommand {
@@ -147,7 +147,7 @@ struct Diarize: AsyncParsableCommand {
     var json: Bool = false
 
     func run() async throws {
-        throw ValidationError("Offline diarization dependencies are unavailable. Run `bash build-deps.sh` from the repo root, then rebuild `transcripted-cli`.")
+        throw ValidationError("Offline diarization dependencies are unavailable. Run `bash build-deps.sh` from the repo root, then rebuild with `TRANSCRIPTEDCLI_ENABLE_DIARIZATION=1`.")
     }
 }
 #endif

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/RTTMWriter.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/RTTMWriter.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if TRANSCRIPTEDCLI_WITH_DIARIZATION
+#if TRANSCRIPTEDCLI_WITH_DIARIZATION && canImport(FluidAudio)
 import FluidAudio
 
 enum RTTMWriter {


### PR DESCRIPTION
## Summary
- Keep TranscriptedCLI retrieval builds/tests from auto-linking offline diarization deps unless `TRANSCRIPTEDCLI_ENABLE_DIARIZATION=1` is set.
- Guard FluidAudio-only code with `canImport(FluidAudio)` and update CLI docs/error copy for the opt-in diarization build.

## Verification
- `swift test --package-path Tools/TranscriptedCLI`
- `swift test --package-path Tools/TranscriptedMCP`
- `cd Tools/TranscriptedMCP && swift build -c release`
- MCP self-tests: default, explicit dirs, and `TRANSCRIPTED_DATA_DIR` all returned valid JSON with 0 stderr bytes.
- CLI retrieval smoke: `context-recent`, meeting-only recent, `context-search`, speaker-filtered search, `read-meeting`, `list-dictations`, `read-dictation`, default manifest lookup, and `TRANSCRIPTED_DATA_DIR` all returned valid JSON.

## Nightly Note
- Local installed Claude Desktop helper still differs from the app-bundled helper and `--help` starts the old server path, though `--self-test` is clean. Smallest local setup step remains reinstalling from Transcripted Settings > Agent.
