### PR TITLE
[nightly-review] Force recovery after ready dictation start failures

### DIFF
--- a/Sources/Speech/DictationReadinessWaitPolicy.swift
+++ b/Sources/Speech/DictationReadinessWaitPolicy.swift
@@ -14,11 +14,13 @@ enum DictationReadinessWaitAction: Equatable {
 
 struct DictationReadinessWaitPolicy {
     private static let refreshesBeforeRecoveryStart = 4
+    private static let startFailuresBeforeForcedRecovery = 3
     private static let maxRecoveryStartAttempts = 2
 
     static func action(
         isRecovering: Bool,
         inputFormatReady: Bool,
+        readyStartFailures: Int = 0,
         readinessRefreshes: Int = 0,
         forcedRecoveryAttempts: Int = 0,
         forcedRecoveryRefreshThreshold: Int = TranscriptedConstants.dictationReadinessForcedRecoveryRefreshes,
@@ -31,6 +33,11 @@ struct DictationReadinessWaitPolicy {
         }
 
         if inputFormatReady {
+            let nextForcedRecoveryThreshold = startFailuresBeforeForcedRecovery * (forcedRecoveryAttempts + 1)
+            if readyStartFailures >= nextForcedRecoveryThreshold,
+               forcedRecoveryAttempts < maxForcedRecoveryAttempts {
+                return .forceInputRecovery
+            }
             return .startRecording
         }
 

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -334,6 +334,7 @@ class DictationSessionController: ObservableObject {
         let startedAt = ProcessInfo.processInfo.systemUptime
         let deadline = startedAt + TranscriptedConstants.dictationRecoveryBudget
         var startAttempts = 0
+        var readyStartFailures = 0
         var recoveryStartAttempts = 0
         var readinessRefreshes = 0
         var forcedReadinessRecoveries = 0
@@ -393,6 +394,7 @@ class DictationSessionController: ObservableObject {
             switch DictationReadinessWaitPolicy.action(
                 isRecovering: isRecovering,
                 inputFormatReady: inputFormatReady,
+                readyStartFailures: readyStartFailures,
                 readinessRefreshes: readinessRefreshes,
                 forcedRecoveryAttempts: forcedReadinessRecoveries,
                 recoveryStartAttempts: recoveryStartAttempts,
@@ -508,6 +510,7 @@ class DictationSessionController: ObservableObject {
                     return
                 }
 
+                readyStartFailures += 1
                 DiagnosticsTrail.record(
                     logger: appState.logger,
                     level: .warning,

--- a/Tests/DictationReadinessWaitPolicyTests.swift
+++ b/Tests/DictationReadinessWaitPolicyTests.swift
@@ -97,6 +97,74 @@ func testDictationReadinessWaitPolicy() {
         assertEqual(action, .startRecording, "ready input should start recording")
     }
 
+    runSuite("DictationReadinessWaitPolicy — ready input retries before hard recovery threshold") {
+        let action = DictationReadinessWaitPolicy.action(
+            isRecovering: false,
+            inputFormatReady: true,
+            readyStartFailures: 2,
+            forcedRecoveryAttempts: 0
+        )
+
+        assertEqual(action, .startRecording, "a couple of failed starts should still use the normal start path")
+    }
+
+    runSuite("DictationReadinessWaitPolicy — repeated ready start failures force recovery") {
+        let action = DictationReadinessWaitPolicy.action(
+            isRecovering: false,
+            inputFormatReady: true,
+            readyStartFailures: 3,
+            forcedRecoveryAttempts: 0
+        )
+
+        assertEqual(action, .forceInputRecovery, "repeated ready-state start failures should stop looping normal starts")
+    }
+
+    runSuite("DictationReadinessWaitPolicy — first hard recovery unlocks another normal start") {
+        let action = DictationReadinessWaitPolicy.action(
+            isRecovering: false,
+            inputFormatReady: true,
+            readyStartFailures: 3,
+            forcedRecoveryAttempts: 1
+        )
+
+        assertEqual(action, .startRecording, "after one hard recovery the loop should try recording again before forcing another rebuild")
+    }
+
+    runSuite("DictationReadinessWaitPolicy — second ready failure threshold can force another recovery") {
+        let action = DictationReadinessWaitPolicy.action(
+            isRecovering: false,
+            inputFormatReady: true,
+            readyStartFailures: 6,
+            forcedRecoveryAttempts: 1
+        )
+
+        assertEqual(action, .forceInputRecovery, "continued ready-state failures can spend the second hard recovery budget")
+    }
+
+    runSuite("DictationReadinessWaitPolicy — ready failure hard recovery stays bounded") {
+        let action = DictationReadinessWaitPolicy.action(
+            isRecovering: false,
+            inputFormatReady: true,
+            readyStartFailures: 6,
+            forcedRecoveryAttempts: 2,
+            maxForcedRecoveryAttempts: 2
+        )
+
+        assertEqual(action, .startRecording, "after the hard recovery budget is spent the policy should stay bounded")
+    }
+
+    runSuite("DictationReadinessWaitPolicy — recovery starts do not count as ready failures") {
+        let action = DictationReadinessWaitPolicy.action(
+            isRecovering: false,
+            inputFormatReady: true,
+            readyStartFailures: 1,
+            forcedRecoveryAttempts: 0,
+            recoveryStartAttempts: 2
+        )
+
+        assertEqual(action, .startRecording, "recovery-start attempts should not spend the ready-failure hard recovery threshold")
+    }
+
     runSuite("DictationReadinessWaitPolicy — stuck recovery timeout becomes refreshable") {
         var recovery = ParakeetRecoveryState()
         let generation = recovery.beginConfigChange()


### PR DESCRIPTION
## Summary
- Chose the bug-fix path for the 2026-05-29 missed nightly code review run.
- Fixes the ready-input retry loop behind fresh `dictation.microphone_start_timeout` signals on 1.1.44.
- After three normal start failures while input still reports ready, the wait policy now spends the existing bounded hard-recovery path instead of looping normal starts until timeout.

## Nightly Signals Reviewed
- No open `[nightly-review]` or `[nightly-regression]` PRs were found before starting.
- `origin/main` was still at `a5b752b6` from the 1.1.44 release merge, with no new merged code since the prior 2026-05-28 nightly run.
- Sentry `APPLE-MACOS-14`: 2 unresolved 1.1.44 `dictation.microphone_start_timeout` events, both on `built_in_input_to_bluetooth_output`, with `start_attempts=11`, `readiness_refreshes=12`, and `forced_readiness_recoveries=0`.
- PostHog last 24h: 2 `dictation_start_failed` events on 1.1.44 and 5 `dictation_audio_route_recovery_timeout` events on 1.1.43, all in the same Bluetooth fallback route family.

## Top Risks
1. Ready-input dictation start loop on Bluetooth fallback routes. Fixed here.
2. Meeting capture degraded signal remains active, but PR #901 already owns the diagnostics path, so I avoided overlap.
3. Imported-audio date issue #850 has PR #899 open, so I avoided overlap there too.

## Verification
- `bash scripts/dev/agent-preflight.sh`
- `git diff --check`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` -> 2832 passed
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build-deps.sh --force`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open`
- `/Users/redbars/.codex/skills/codex-review/scripts/codex-review --mode branch` -> clean, no accepted/actionable findings

Note: the first build attempt before `build-deps.sh --force` stopped on stale generated deps. The refreshed dependency build and final app build both passed.