### PR TITLE
Surface stale Claude helper repairs

### DIFF
--- a/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
+++ b/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
@@ -22,6 +22,30 @@ struct ClaudeDesktopIntegrationStatus: Equatable {
     var isInstalled: Bool {
         state == .installed
     }
+
+    var attentionMessage: String? {
+        if !bundledBinaryExists {
+            return "This app build does not include Transcripted direct tools yet."
+        }
+
+        if !configIsReadable {
+            return "Claude Desktop config is not readable JSON. Install will back it up and write a clean config."
+        }
+
+        guard state == .needsRepair else {
+            return nil
+        }
+
+        if !installedBinaryExists {
+            return "Claude Desktop direct tools are missing. Install will copy a fresh helper."
+        }
+
+        if !installedBinaryMatchesBundled {
+            return "Claude Desktop is using an older Transcripted helper. Update now to replace it."
+        }
+
+        return "Claude Desktop points at another Transcripted helper. Repair will update the config."
+    }
 }
 
 struct ClaudeDesktopIntegrationInstallResult: Equatable {

--- a/Sources/UI/Settings/AgentConnectionSettingsPage.swift
+++ b/Sources/UI/Settings/AgentConnectionSettingsPage.swift
@@ -151,6 +151,14 @@ struct AgentConnectionSettingsPage: View {
                 }
             }
 
+            if let attentionMessage = claudeDesktopStatus.attentionMessage {
+                Label(attentionMessage, systemImage: claudeDesktopStatusSymbol)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(claudeDesktopStatusTint)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 2)
+            }
+
             VStack(alignment: .leading, spacing: 8) {
                 SettingsInlineActionButton(
                     title: openedCodexInboxSetup ? "Opened Codex Setup" : "Set up Codex Inbox",
@@ -192,6 +200,10 @@ struct AgentConnectionSettingsPage: View {
         case .notInstalled:
             return "Install in Claude"
         case .needsRepair:
+            if claudeDesktopStatus.installedBinaryExists,
+               !claudeDesktopStatus.installedBinaryMatchesBundled {
+                return "Update Claude Helper"
+            }
             return "Repair Claude Setup"
         }
     }
@@ -227,6 +239,10 @@ struct AgentConnectionSettingsPage: View {
         case .notInstalled:
             return "Not installed"
         case .needsRepair:
+            if claudeDesktopStatus.installedBinaryExists,
+               !claudeDesktopStatus.installedBinaryMatchesBundled {
+                return "Helper stale"
+            }
             return "Repair"
         }
     }
@@ -540,6 +556,10 @@ private struct ClaudeDesktopStatusRow: View {
             return "Claude Desktop config is not readable JSON. Install will back it up and write a clean config."
         }
 
+        if let attentionMessage = status.attentionMessage {
+            return attentionMessage
+        }
+
         switch status.state {
         case .installed:
             return "Claude Desktop is configured. Restart Claude Desktop if you just installed it."
@@ -548,12 +568,6 @@ private struct ClaudeDesktopStatusRow: View {
                 ? "Click Install for Claude Desktop, then restart Claude Desktop."
                 : "Claude Desktop was not found. You can still install now, then install Claude Desktop."
         case .needsRepair:
-            if !status.installedBinaryExists {
-                return "The server file is missing. Install will copy a fresh one and update Claude Desktop."
-            }
-            if !status.installedBinaryMatchesBundled {
-                return "The installed server is from an older app build. Install will copy the current one."
-            }
             return "Claude Desktop points at another Transcripted server. Install will update it."
         }
     }

--- a/Tests/ClaudeDesktopIntegrationInstallerTests.swift
+++ b/Tests/ClaudeDesktopIntegrationInstallerTests.swift
@@ -132,6 +132,11 @@ func testClaudeDesktopIntegrationInstaller() {
 
         assertEqual(status.state, .needsRepair, "stale installed helper should be repaired even when config points at it")
         assertFalse(status.installedBinaryMatchesBundled, "status should expose stale helper mismatch")
+        assertEqual(
+            status.attentionMessage,
+            "Claude Desktop is using an older Transcripted helper. Update now to replace it.",
+            "stale helper should have a direct user-facing repair reason"
+        )
     }
 
     runSuite("ClaudeDesktopIntegrationInstaller.bundledMCPBinaryURL — uses Helpers bundle location only") {


### PR DESCRIPTION
## Summary
- show a direct warning when Claude Desktop is using an older Transcripted helper
- make the primary Agent settings action say Update Claude Helper for stale installs
- cover the stale-helper attention message in installer tests

## Verification
- bash build.sh --no-open
- bash run-tests.sh