### PR TITLE
[docs] Update Claude helper docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The MCP server gives supported agents tools for recent context, search, recaps,
 meeting reads, dictation reads, and speaker lookup.
 
 For Claude Desktop, open Transcripted Settings, go to `Agent`, then click
-`Install for Claude Desktop`. Transcripted installs the local server, writes the
+`Install in Claude`. Transcripted installs the local server, writes the
 Claude Desktop config, checks your local library, and tells you when to restart
 Claude Desktop.
 

--- a/Tools/TranscriptedMCP/README.md
+++ b/Tools/TranscriptedMCP/README.md
@@ -7,7 +7,7 @@ For Claude Desktop users, the best setup is inside the app:
 1. Open Transcripted.
 2. Open Settings.
 3. Go to `Agent`.
-4. Click `Install for Claude Desktop`.
+4. Click `Install in Claude`.
 5. Restart Claude Desktop.
 
 That path installs the bundled helper, updates Claude Desktop's config, and

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -15,7 +15,7 @@ Claude Desktop is the best full-library experience.
 1. Open Transcripted.
 2. Open Settings.
 3. Go to `Agent`.
-4. Click `Install for Claude Desktop`.
+4. Click `Install in Claude`.
 5. Restart Claude Desktop.
 
 Transcripted copies the bundled `transcripted-mcp` helper into:
@@ -35,15 +35,15 @@ Transcripted backs it up before writing a clean config.
 
 If the installed helper's `--self-test` prints many `[transcripted-mcp] Indexed`
 lines before the JSON payload, the helper copied into Application Support is
-stale. Click `Install for Claude Desktop` again from Transcripted Settings to
-replace it with the current bundled helper. The current helper should print only
-the JSON self-test payload.
+stale. Click `Update Claude Helper` from Transcripted Settings to replace it
+with the current bundled helper. The current helper should print only the JSON
+self-test payload.
 
 A stale helper can also pass `--self-test` but still behave like an older build,
 for example if `transcripted-mcp --help` starts the MCP server instead of
 printing usage. If Transcripted Settings says the direct tools need repair, or
-the installed helper differs from the app-bundled helper, click `Install for
-Claude Desktop` again.
+the installed helper differs from the app-bundled helper, click the repair or
+update button shown in Settings.
 
 Current `transcripted-mcp` capabilities:
 


### PR DESCRIPTION
## Summary\n- update Claude Desktop setup docs to match the current Settings button label\n- clarify stale helper repair wording for the new update/repair states\n\n## Verification\n- bash scripts/dev/agent-preflight.sh\n- swift test --package-path Tools/TranscriptedMCP\n- git diff --check