### PR TITLE
[nightly-telemetry] Add dictation start attempt bucket

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -387,6 +387,7 @@ struct AnalyticsEventPolicy: Equatable {
             name: "dictation_start_failed",
             allowedProperties: dictationRouteDiagnosticProperties.union(Set([
                 "failure_kind",
+                "start_attempt_bucket",
                 "trigger",
             ]))
         ),

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -181,14 +181,18 @@ class DictationSessionController: ObservableObject {
         )
     }
 
-    private func trackDictationStartFailed(_ failureKind: String) {
+    private func trackDictationStartFailed(
+        _ failureKind: String,
+        extra: [String: String] = [:]
+    ) {
+        var properties = extra
+        properties["failure_kind"] = failureKind
+        properties["trigger"] = currentDictationTrigger.rawValue
+
         AnalyticsReporter.track(
             "dictation_start_failed",
             properties: dictationAnalyticsProperties(
-                extra: [
-                    "failure_kind": failureKind,
-                    "trigger": currentDictationTrigger.rawValue,
-                ]
+                extra: properties
             )
         )
     }
@@ -565,7 +569,12 @@ class DictationSessionController: ObservableObject {
                 ]
             )
         )
-        trackDictationStartFailed(cleanupPlan.outcome)
+        trackDictationStartFailed(
+            cleanupPlan.outcome,
+            extra: [
+                "start_attempt_bucket": AnalyticsReporter.countBucket(startAttempts)
+            ]
+        )
         if cleanupPlan.reportRuntimeStall {
             appState.runtimeDiagnostics.recordStall(
                 kind: "dictation",

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -155,6 +155,7 @@ func testAnalyticsEventPolicy() {
         assertEqual(dictationStartFailed?.allowedProperties.contains("trigger"), true, "dictation start failures should preserve trigger attribution")
         assertEqual(dictationStartFailed?.allowedProperties.contains("route_shape"), true, "dictation start failures should preserve safe route shape")
         assertEqual(dictationStartFailed?.allowedProperties.contains("selection_reason"), true, "dictation start failures should preserve coarse device-selection reason")
+        assertEqual(dictationStartFailed?.allowedProperties.contains("start_attempt_bucket"), true, "dictation start failures should bucket retry-loop attempts")
 
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
             [
@@ -173,6 +174,8 @@ func testAnalyticsEventPolicy() {
                 "route_shape": "bluetooth_input_to_bluetooth_output",
                 "sample_flow_started": "false",
                 "selection_reason": "noBuiltInFallbackAvailable",
+                "start_attempt_bucket": "10_plus",
+                "start_attempts": "12",
                 "trigger": "hotkey",
             ],
             allowedKeys: dictationStartFailed?.allowedProperties ?? []
@@ -183,6 +186,8 @@ func testAnalyticsEventPolicy() {
         assertEqual(sanitized["route_shape"], "bluetooth_input_to_bluetooth_output", "safe route shape should survive sanitization")
         assertEqual(sanitized["hfp_suspected"], "true", "Bluetooth HFP suspicion should survive as a boolean")
         assertEqual(sanitized["sample_flow_started"], "false", "sample flow state should survive as a boolean")
+        assertEqual(sanitized["start_attempt_bucket"], "10_plus", "retry count bucket should survive sanitization")
+        assertNil(sanitized["start_attempts"], "raw retry count should stay out of analytics")
         assertEqual(sanitized["trigger"], "hotkey", "dictation start trigger should survive sanitization")
     }
 

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -141,6 +141,7 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - booleans as `"true"` / `"false"`
 - coarse buckets like `10_29s`, `50_149`, `4_plus`
 - stable trigger enums like `hotkey`, `menu`, `detected_prompt`
+- retry attempt buckets like `start_attempt_bucket`, not raw retry counts
 - normalized failure kinds like `system_audio`, `recording_too_short`, `other`
 - normalized failure-code buckets like `url_-1009`, `sparkle_2003`, `other_42`
 


### PR DESCRIPTION
## Summary
- add `start_attempt_bucket` to `dictation_start_failed` analytics for microphone-start timeouts
- keep raw `start_attempts` out of PostHog while preserving a coarse retry-loop bucket
- document the allowed property style for retry attempt buckets

## Evidence
- Sentry has 2 production `microphone_start_timeout` events on `transcripted@1.1.44`, both showing 11 start attempts on the same route shape
- PostHog has matching 1.1.44 `dictation_start_failed` events but lacked the retry-attempt dimension
- Candidate score: 91/100; meeting capture degradation lost because recent PR #901 already improved diagnostics and likely needs QA, not another tiny telemetry patch

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `bash scripts/dev/agent-preflight.sh`