### PR TITLE
[nightly-maintenance] Clarify beta agent doc pointer

### DIFF
--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -113,7 +113,7 @@ Rule of thumb:
 - `Sources/Accessibility/CLAUDE.md`
   Focused-editor AX metadata, overlay placement, and paste-back context.
 - `Sources/Beta/CLAUDE.md`
-  Beta-build configuration and archived beta-worker boundaries.
+  Current `BETA_BUILD` shell, removed proxy-token path, and archived beta-worker handoff.
 - `Sources/Dictation/CLAUDE.md`
   Dictation persistence, daily Markdown files, and timeout helpers.
 - `Sources/Meeting/CLAUDE.md`


### PR DESCRIPTION
## Summary
- Clarifies the `Sources/Beta/CLAUDE.md` pointer in `docs/agent-onboarding.md` so agents see the current empty `BETA_BUILD` shell first.
- Keeps the archived beta worker framed as handoff context, not active app behavior.

## Verification
- `bash scripts/dev/agent-preflight.sh`
- `git diff --check`