### PR TITLE
[test-generator] Cover analytics telemetry guardrails

### DIFF
--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -191,6 +191,72 @@ func testAnalyticsEventPolicy() {
         assertEqual(sanitized["trigger"], "hotkey", "dictation start trigger should survive sanitization")
     }
 
+    runSuite("AnalyticsEventPolicy preserves zero-attempt start failure buckets") {
+        let dictationStartFailed = AnalyticsEventPolicy.policy(forEvent: "dictation_start_failed")
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "failure_kind": "microphone_permission_denied",
+                "start_attempt_bucket": "0",
+                "trigger": "menu",
+            ],
+            allowedKeys: dictationStartFailed?.allowedProperties ?? []
+        )
+
+        assertEqual(sanitized["failure_kind"], "microphone_permission_denied", "permission failures should keep their normalized failure kind")
+        assertEqual(sanitized["start_attempt_bucket"], "0", "immediate failures should preserve the zero-attempt bucket")
+        assertEqual(sanitized["trigger"], "menu", "non-hotkey triggers should remain attributable")
+    }
+
+    runSuite("AnalyticsEventPolicy drops raw dictation timeout counters") {
+        let dictationStartFailed = AnalyticsEventPolicy.policy(forEvent: "dictation_start_failed")
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "failure_kind": "microphone_start_timeout",
+                "forced_readiness_recoveries": "2",
+                "readiness_refreshes": "4",
+                "recovery_start_attempts": "3",
+                "start_attempt_bucket": "4_9",
+                "start_attempts": "7",
+                "trigger": "hotkey",
+                "wait_ms": "12000",
+            ],
+            allowedKeys: dictationStartFailed?.allowedProperties ?? []
+        )
+
+        assertEqual(sanitized["start_attempt_bucket"], "4_9", "only the coarse retry bucket should survive")
+        assertNil(sanitized["forced_readiness_recoveries"], "raw recovery counts should stay out of analytics")
+        assertNil(sanitized["readiness_refreshes"], "raw readiness refresh counts should stay out of analytics")
+        assertNil(sanitized["recovery_start_attempts"], "raw recovery start counts should stay out of analytics")
+        assertNil(sanitized["start_attempts"], "raw retry counts should stay out of analytics")
+        assertNil(sanitized["wait_ms"], "raw wait durations should stay out of analytics")
+    }
+
+    runSuite("AnalyticsEventPolicy drops raw dictation device labels") {
+        let dictationStartFailed = AnalyticsEventPolicy.policy(forEvent: "dictation_start_failed")
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "audio_device": "Desk microphone",
+                "default_input_name": "Desk microphone",
+                "failure_kind": "microphone_start_timeout",
+                "input_device_class": "built_in",
+                "output_device_name": "Desk speakers",
+                "route_shape": "built_in_input_to_built_in_output",
+                "start_attempt_bucket": "2_3",
+                "trigger": "hotkey",
+            ],
+            allowedKeys: dictationStartFailed?.allowedProperties ?? []
+        )
+
+        assertEqual(sanitized["input_device_class"], "built_in", "coarse input class should survive")
+        assertEqual(sanitized["route_shape"], "built_in_input_to_built_in_output", "coarse route shape should survive")
+        assertNil(sanitized["audio_device"], "raw audio device names should stay out of analytics")
+        assertNil(sanitized["default_input_name"], "raw input names should stay out of analytics")
+        assertNil(sanitized["output_device_name"], "raw output names should stay out of analytics")
+    }
+
     runSuite("AnalyticsEventPolicy allows dictation audio route lifecycle events") {
         let changed = AnalyticsEventPolicy.policy(forEvent: "dictation_audio_route_changed")
         let finished = AnalyticsEventPolicy.policy(forEvent: "dictation_audio_route_recovery_finished")

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -110,6 +110,89 @@ func testAnalyticsEventPolicy() {
         assertEqual(sanitized["surface"], "settings_about", "update surface should survive sanitization")
     }
 
+    runSuite("AnalyticsEventPolicy allows update download lifecycle attribution") {
+        let started = AnalyticsEventPolicy.policy(forEvent: "update_download_started")
+        let finished = AnalyticsEventPolicy.policy(forEvent: "update_download_finished")
+
+        assertEqual(started?.allowedProperties.contains("automatic_downloads_enabled"), true, "download starts should preserve automatic-download state")
+        assertEqual(started?.allowedProperties.contains("state"), true, "download starts should preserve update state")
+        assertEqual(started?.allowedProperties.contains("version"), true, "download starts should preserve the public app version")
+        assertEqual(finished?.allowedProperties.contains("failure_kind"), true, "download finishes should preserve normalized failure kind")
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "automatic_downloads_enabled": "true",
+                "state": "downloading",
+                "version": "1.2.3",
+            ],
+            allowedKeys: started?.allowedProperties ?? []
+        )
+        assertEqual(sanitized["automatic_downloads_enabled"], "true", "automatic-download state should survive sanitization")
+        assertEqual(sanitized["state"], "downloading", "download state should survive sanitization")
+        assertEqual(sanitized["version"], "1.2.3", "public update version should survive sanitization")
+    }
+
+    runSuite("AnalyticsEventPolicy preserves failed update download classification") {
+        let finished = AnalyticsEventPolicy.policy(forEvent: "update_download_finished")
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "automatic_downloads_enabled": "false",
+                "failure_kind": "download_failed",
+                "state": "available",
+                "version": "1.2.3",
+            ],
+            allowedKeys: finished?.allowedProperties ?? []
+        )
+
+        assertEqual(sanitized["automatic_downloads_enabled"], "false", "manual downloads should remain distinguishable from automatic downloads")
+        assertEqual(sanitized["failure_kind"], "download_failed", "normalized download failure kind should survive")
+        assertEqual(sanitized["state"], "available", "failed downloads should keep their post-failure state")
+        assertEqual(sanitized["version"], "1.2.3", "failed downloads should keep the public app version")
+    }
+
+    runSuite("AnalyticsEventPolicy preserves ready-to-install update state") {
+        let ready = AnalyticsEventPolicy.policy(forEvent: "update_ready_to_install")
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "automatic_downloads_enabled": "true",
+                "state": "ready_to_install",
+                "version": "1.2.3",
+            ],
+            allowedKeys: ready?.allowedProperties ?? []
+        )
+
+        assertEqual(sanitized["automatic_downloads_enabled"], "true", "ready-to-install telemetry should preserve automatic-download state")
+        assertEqual(sanitized["state"], "ready_to_install", "ready-to-install state should survive sanitization")
+        assertEqual(sanitized["version"], "1.2.3", "ready-to-install telemetry should preserve the public app version")
+    }
+
+    runSuite("AnalyticsEventPolicy keeps relaunch update telemetry narrow") {
+        let relaunching = AnalyticsEventPolicy.policy(forEvent: "update_relaunching")
+
+        assertEqual(relaunching?.allowedProperties.contains("version"), true, "relaunch telemetry should preserve the public app version")
+        assertEqual(relaunching?.allowedProperties.contains("state"), false, "relaunch telemetry should not add redundant update state")
+        assertEqual(relaunching?.allowedProperties.contains("automatic_downloads_enabled"), false, "relaunch telemetry should not add settings state")
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "automatic_downloads_enabled": "true",
+                "download_url": "redacted",
+                "error_message": "redacted",
+                "state": "ready_to_install",
+                "version": "1.2.3",
+            ],
+            allowedKeys: relaunching?.allowedProperties ?? []
+        )
+
+        assertEqual(sanitized["version"], "1.2.3", "relaunch telemetry should keep the public app version")
+        assertNil(sanitized["automatic_downloads_enabled"], "relaunch telemetry should stay narrow")
+        assertNil(sanitized["download_url"], "raw download locations should stay out of analytics")
+        assertNil(sanitized["error_message"], "raw update errors should stay out of analytics")
+        assertNil(sanitized["state"], "relaunch telemetry should not duplicate lifecycle state")
+    }
+
     runSuite("AnalyticsEventPolicy allows runtime diagnostic events") {
         let unclean = AnalyticsEventPolicy.policy(forEvent: "app_unclean_shutdown_detected")
         let stall = AnalyticsEventPolicy.policy(forEvent: "app_session_stall_detected")

--- a/Tests/AnalyticsReporterTests.swift
+++ b/Tests/AnalyticsReporterTests.swift
@@ -96,6 +96,47 @@ func testAnalyticsReporter() {
         assertEqual(properties["session_id"], "session-1", "default session id should remain")
     }
 
+    runSuite("AnalyticsReporter wordCountBucket keeps tiny captures coarse") {
+        assertEqual(
+            AnalyticsReporter.wordCountBucket(5),
+            "lt_10",
+            "tiny dictations and meetings should stay in the smallest coarse bucket"
+        )
+    }
+
+    runSuite("AnalyticsReporter wordCountBucket switches buckets at exact boundaries") {
+        assertEqual(AnalyticsReporter.wordCountBucket(10), "10_49", "ten words should enter the next bucket")
+        assertEqual(AnalyticsReporter.wordCountBucket(50), "50_149", "fifty words should enter the midrange bucket")
+        assertEqual(AnalyticsReporter.wordCountBucket(150), "150_299", "one hundred fifty words should enter the long-capture bucket")
+    }
+
+    runSuite("AnalyticsReporter wordCountBucket keeps upper edges in their current bucket") {
+        assertEqual(AnalyticsReporter.wordCountBucket(49), "10_49", "forty-nine words should stay below the midrange bucket")
+        assertEqual(AnalyticsReporter.wordCountBucket(149), "50_149", "one hundred forty-nine words should stay in the midrange bucket")
+        assertEqual(AnalyticsReporter.wordCountBucket(299), "150_299", "two hundred ninety-nine words should stay below the capped bucket")
+    }
+
+    runSuite("AnalyticsReporter wordCountBucket caps long transcripts") {
+        assertEqual(
+            AnalyticsReporter.wordCountBucket(300),
+            "300_plus",
+            "three hundred or more words should be bucketed instead of exposing raw length"
+        )
+        assertEqual(
+            AnalyticsReporter.wordCountBucket(5_000),
+            "300_plus",
+            "large transcripts should stay in the same coarse analytics bucket"
+        )
+    }
+
+    runSuite("AnalyticsReporter wordCountBucket treats invalid negative counts as tiny") {
+        assertEqual(
+            AnalyticsReporter.wordCountBucket(-4),
+            "lt_10",
+            "invalid negative word counts should fail closed to the smallest bucket"
+        )
+    }
+
     runSuite("AnalyticsReporter countBucket keeps zero start attempts explicit") {
         assertEqual(
             AnalyticsReporter.countBucket(0),

--- a/Tests/AnalyticsReporterTests.swift
+++ b/Tests/AnalyticsReporterTests.swift
@@ -131,4 +131,46 @@ func testAnalyticsReporter() {
             "large retry spikes should stay privacy-safe and dashboard-stable"
         )
     }
+
+    runSuite("AnalyticsReporter queueDepthBucket keeps empty meeting queues explicit") {
+        assertEqual(
+            AnalyticsReporter.queueDepthBucket(0),
+            "0",
+            "empty meeting queues should stay distinguishable from queued work"
+        )
+    }
+
+    runSuite("AnalyticsReporter queueDepthBucket preserves a single queued job") {
+        assertEqual(
+            AnalyticsReporter.queueDepthBucket(1),
+            "1",
+            "one queued meeting job should stay visible as a single-job backlog"
+        )
+    }
+
+    runSuite("AnalyticsReporter queueDepthBucket groups small meeting backlogs") {
+        assertEqual(AnalyticsReporter.queueDepthBucket(2), "2_3", "two queued meeting jobs should enter the small backlog bucket")
+        assertEqual(AnalyticsReporter.queueDepthBucket(3), "2_3", "three queued meeting jobs should stay in the small backlog bucket")
+    }
+
+    runSuite("AnalyticsReporter queueDepthBucket caps larger meeting backlogs") {
+        assertEqual(
+            AnalyticsReporter.queueDepthBucket(4),
+            "4_plus",
+            "four or more queued meeting jobs should be bucketed instead of exposing raw depth"
+        )
+        assertEqual(
+            AnalyticsReporter.queueDepthBucket(21),
+            "4_plus",
+            "large queued meeting backlogs should stay coarse for analytics"
+        )
+    }
+
+    runSuite("AnalyticsReporter queueDepthBucket treats invalid negative depths as empty") {
+        assertEqual(
+            AnalyticsReporter.queueDepthBucket(-3),
+            "0",
+            "invalid negative depths should fail closed to the empty queue bucket"
+        )
+    }
 }

--- a/Tests/AnalyticsReporterTests.swift
+++ b/Tests/AnalyticsReporterTests.swift
@@ -95,4 +95,40 @@ func testAnalyticsReporter() {
         assertEqual(properties["distinct_id"], "anonymous-device", "default distinct id should remain")
         assertEqual(properties["session_id"], "session-1", "default session id should remain")
     }
+
+    runSuite("AnalyticsReporter countBucket keeps zero start attempts explicit") {
+        assertEqual(
+            AnalyticsReporter.countBucket(0),
+            "0",
+            "start-failure telemetry should preserve that no recording attempt ran"
+        )
+    }
+
+    runSuite("AnalyticsReporter countBucket preserves a single start attempt") {
+        assertEqual(
+            AnalyticsReporter.countBucket(1),
+            "1",
+            "one failed recording attempt should stay distinguishable from retry loops"
+        )
+    }
+
+    runSuite("AnalyticsReporter countBucket groups midrange retry attempts") {
+        assertEqual(AnalyticsReporter.countBucket(2), "2_3", "two attempts should enter the first retry bucket")
+        assertEqual(AnalyticsReporter.countBucket(3), "2_3", "three attempts should stay in the first retry bucket")
+        assertEqual(AnalyticsReporter.countBucket(4), "4_9", "four attempts should enter the repeated retry bucket")
+        assertEqual(AnalyticsReporter.countBucket(9), "4_9", "nine attempts should remain below the high retry bucket")
+    }
+
+    runSuite("AnalyticsReporter countBucket caps unexpected retry spikes") {
+        assertEqual(
+            AnalyticsReporter.countBucket(10),
+            "10_plus",
+            "ten or more failed starts should be bucketed instead of exposing raw counts"
+        )
+        assertEqual(
+            AnalyticsReporter.countBucket(37),
+            "10_plus",
+            "large retry spikes should stay privacy-safe and dashboard-stable"
+        )
+    }
 }

--- a/Tests/AnalyticsReporterTests.swift
+++ b/Tests/AnalyticsReporterTests.swift
@@ -96,6 +96,55 @@ func testAnalyticsReporter() {
         assertEqual(properties["session_id"], "session-1", "default session id should remain")
     }
 
+    runSuite("AnalyticsReporter default properties fall back when build metadata is unavailable") {
+        let properties = AnalyticsReporter.defaultProperties(
+            distinctID: "anonymous-device",
+            sessionID: "session-1",
+            infoDictionary: [:],
+            operatingSystemVersion: OperatingSystemVersion(majorVersion: 15, minorVersion: 4, patchVersion: 0)
+        )
+
+        assertEqual(properties["app_version"], "unknown", "missing app version should not remove default metadata")
+        assertEqual(properties["build_version"], "unknown", "missing build version should not remove default metadata")
+        assertEqual(properties["os_major"], "15", "OS major version should still be present")
+    }
+
+    runSuite("AnalyticsReporter default properties trim session identifiers") {
+        let properties = AnalyticsReporter.defaultProperties(
+            distinctID: "anonymous-device",
+            sessionID: "  session-1  ",
+            infoDictionary: [:],
+            operatingSystemVersion: OperatingSystemVersion(majorVersion: 15, minorVersion: 4, patchVersion: 0)
+        )
+
+        assertEqual(properties["session_id"], "session-1", "session identifiers should be trimmed before analytics capture")
+    }
+
+    runSuite("AnalyticsReporter default properties omit blank session identifiers") {
+        let properties = AnalyticsReporter.defaultProperties(
+            distinctID: "anonymous-device",
+            sessionID: "   ",
+            infoDictionary: [:],
+            operatingSystemVersion: OperatingSystemVersion(majorVersion: 15, minorVersion: 4, patchVersion: 0)
+        )
+
+        assertNil(properties["session_id"], "blank session identifiers should not be sent as analytics metadata")
+    }
+
+    runSuite("AnalyticsReporter default properties cap long session identifiers") {
+        let longSessionID = String(repeating: "session-fragment-", count: 8)
+        let properties = AnalyticsReporter.defaultProperties(
+            distinctID: "anonymous-device",
+            sessionID: longSessionID,
+            infoDictionary: [:],
+            operatingSystemVersion: OperatingSystemVersion(majorVersion: 15, minorVersion: 4, patchVersion: 0)
+        )
+
+        let sessionID = properties["session_id"] ?? ""
+        assertTrue(sessionID.count <= 83, "session identifiers should honor the analytics value cap")
+        assertTrue(sessionID.hasSuffix("..."), "capped session identifiers should keep the truncation marker")
+    }
+
     runSuite("AnalyticsReporter wordCountBucket keeps tiny captures coarse") {
         assertEqual(
             AnalyticsReporter.wordCountBucket(5),

--- a/Tests/AnalyticsReporterTests.swift
+++ b/Tests/AnalyticsReporterTests.swift
@@ -173,4 +173,45 @@ func testAnalyticsReporter() {
             "invalid negative depths should fail closed to the empty queue bucket"
         )
     }
+
+    runSuite("AnalyticsReporter durationBucket keeps short captures coarse") {
+        assertEqual(
+            AnalyticsReporter.durationBucket(seconds: 5),
+            "lt_10s",
+            "short dictation and meeting durations should stay in the shortest coarse bucket"
+        )
+    }
+
+    runSuite("AnalyticsReporter durationBucket switches buckets at second boundaries") {
+        assertEqual(AnalyticsReporter.durationBucket(seconds: 10), "10_29s", "ten seconds should enter the next bucket")
+        assertEqual(AnalyticsReporter.durationBucket(seconds: 30), "30_119s", "thirty seconds should enter the next bucket")
+        assertEqual(AnalyticsReporter.durationBucket(seconds: 120), "2_9m", "two minutes should enter the minutes bucket")
+    }
+
+    runSuite("AnalyticsReporter durationBucket keeps upper edges in their current bucket") {
+        assertEqual(AnalyticsReporter.durationBucket(seconds: 29.9), "10_29s", "values below thirty seconds should stay in the second bucket")
+        assertEqual(AnalyticsReporter.durationBucket(seconds: 119.9), "30_119s", "values below two minutes should stay in the midrange bucket")
+        assertEqual(AnalyticsReporter.durationBucket(seconds: 599.9), "2_9m", "values below ten minutes should stay in the short meeting bucket")
+    }
+
+    runSuite("AnalyticsReporter durationBucket caps long sessions") {
+        assertEqual(
+            AnalyticsReporter.durationBucket(seconds: 1800),
+            "30m_plus",
+            "thirty minutes or more should stay bucketed instead of exposing raw duration"
+        )
+        assertEqual(
+            AnalyticsReporter.durationBucket(seconds: 7200),
+            "30m_plus",
+            "multi-hour sessions should stay in the same coarse analytics bucket"
+        )
+    }
+
+    runSuite("AnalyticsReporter durationBucket treats invalid negative durations as short") {
+        assertEqual(
+            AnalyticsReporter.durationBucket(seconds: -1),
+            "lt_10s",
+            "invalid negative durations should fail closed to the shortest duration bucket"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Add focused fast coverage for `AnalyticsReporter.countBucket`, `queueDepthBucket`, `durationBucket`, and `wordCountBucket`, which back bucketed dictation, meeting, onboarding, runtime, and reliability telemetry.
- Add `AnalyticsReporter.defaultProperties` guardrails for missing build metadata and sanitized session IDs.
- Add `dictation_start_failed` analytics policy guardrails so the retry-attempt bucket survives while raw timeout counters and device labels stay out of PostHog.
- Add Sparkle update lifecycle analytics guardrails for download start, download failure, ready-to-install, and relaunch telemetry.

## Missing coverage
Recent analytics and update-flow work expanded allowlisted telemetry around dictation start failures and Sparkle lifecycle events. The branch now proves the safe bucketed fields survive sanitization while raw counts, device labels, download locations, and raw error details remain filtered.

## Tests added
- `AnalyticsEventPolicy preserves zero-attempt start failure buckets`
- `AnalyticsEventPolicy drops raw dictation timeout counters`
- `AnalyticsEventPolicy drops raw dictation device labels`
- `AnalyticsEventPolicy allows update download lifecycle attribution`
- `AnalyticsEventPolicy preserves failed update download classification`
- `AnalyticsEventPolicy preserves ready-to-install update state`
- `AnalyticsEventPolicy keeps relaunch update telemetry narrow`
- Existing branch coverage also includes direct boundary and guardrail tests for `countBucket`, `queueDepthBucket`, `durationBucket`, `wordCountBucket`, and reporter default metadata.

## Verification
- `bash scripts/dev/agent-preflight.sh`
- `bash build.sh --no-open`
- `bash run-tests.sh` (3108 passed)
- Prior branch verification also ran `bash build-deps.sh --force` before the original build when stale deps were detected.
