### PR TITLE
[nightly-regression] Cover Sparkle no-update delegate paths

### DIFF
--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -485,16 +485,33 @@ func testRepoCommandContract() {
 
     runSuite("Repo command contract - Sparkle no-update finish cycles stay successful") {
         let controller = readRepoTextFile("Sources/Observability/SparkleUpdaterController.swift")
+        let didNotFindBlock = sourceSlice(
+            controller,
+            from: "func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: any Error)",
+            to: "func updaterDidNotFindUpdate(_ updater: SPUUpdater)"
+        )
         let finishCycleBlock = sourceSlice(
             controller,
             from: "func updater(_ updater: SPUUpdater, didFinishUpdateCycleFor updateCheck: SPUUpdateCheck, error: (any Error)?)",
             to: "func updaterWillRelaunchApplication"
         )
 
+        let didNotFindNoUpdateCheck = didNotFindBlock.range(of: "UpdateFailureKind.isNoUpdate(error)")
+        let didNotFindNoUpdateHandler = didNotFindBlock.range(of: "markNoUpdateAvailable(from: updater)")
+        let didNotFindFailureHandler = didNotFindBlock.range(of: "markUpdateCheckFailed(from: updater, error: error)")
         let noUpdateCheck = finishCycleBlock.range(of: "UpdateFailureKind.isNoUpdate(error)")
         let noUpdateHandler = finishCycleBlock.range(of: "markNoUpdateAvailable(from: updater)")
         let failureHandler = finishCycleBlock.range(of: "markUpdateCheckFailed(from: updater, error: error)")
 
+        assertNotNil(didNotFindNoUpdateCheck, "Sparkle 1001 did-not-find callbacks should be detected as no-update outcomes")
+        assertNotNil(didNotFindNoUpdateHandler, "Sparkle no-update did-not-find callbacks should use the success path")
+        assertNotNil(didNotFindFailureHandler, "real did-not-find errors should still use the failure path")
+        if let didNotFindNoUpdateCheck, let didNotFindFailureHandler {
+            assertTrue(
+                didNotFindNoUpdateCheck.lowerBound < didNotFindFailureHandler.lowerBound,
+                "no-update did-not-find callbacks should be handled before the generic failure path"
+            )
+        }
         assertNotNil(noUpdateCheck, "Sparkle 1001 finish-cycle errors should be detected as no-update outcomes")
         assertNotNil(noUpdateHandler, "Sparkle no-update finish cycles should use the success path")
         assertNotNil(failureHandler, "real finish-cycle errors should still use the failure path")


### PR DESCRIPTION
## Summary
- Adds regression coverage for Sparkle `updaterDidNotFindUpdate(_:error:)` so code `1001` stays on the no-update success path.
- Keeps the existing finish-cycle no-update guard in the same contract test.

## Nightly evidence
- Live PostHog last 24h: `update_check_finished=41`; `failure_code=sparkle_1001` accounted for 40 `failure_kind=unknown` events.
- Current `main` already contains the code fix; this PR tightens the test guard for the second delegate path.
- Live Sentry unresolved 24h query returned no issues.
- Open product issues still worth watching: #500 quiet mic / meeting audio, #825 long-meeting visibility.

## Verification
- `git diff --check`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (3034 passed)
- `codex review --uncommitted` (no actionable findings; reran full fast tests after rejecting an unsupported filter flag)
