### PR TITLE
[codex] Speed up Home recent capture loading

### DIFF
--- a/.agent-review/autoeval-home-recent-captures.md
+++ b/.agent-review/autoeval-home-recent-captures.md
@@ -1,0 +1,54 @@
+# Autoeval: Settings Home Recent Captures
+
+## Verdict
+winner
+
+The kept change cuts the 10k fake-library full snapshot from `474.4 ms` average to `235.6 ms` average, with cancellation returning immediately in the benchmark.
+
+## Metric
+- Primary: wall-clock time for `RecentCaptureLoader.load(dictationLimit: 11, meetingLimit: 11, includeDictationCounts: true)`.
+- Fixtures: generated temp capture libraries only, split evenly between meeting Markdown files and dictation day files.
+- Guardrails: newest-first rows, requested dictation counts, requested word totals, and canceled loads returning no stale rows.
+
+## Baseline
+- Command: `bash scripts/dev/benchmark-home-recent-captures.sh`
+- Raw result:
+
+| captures | meetings | dictations | reps | raw load ms | avg load ms | best load ms | cancel ms |
+|---:|---:|---:|---:|---|---:|---:|---:|
+| 1000 | 500 | 500 | 3 | 58.0, 52.3, 50.7 | 53.7 | 50.7 | 50.7 |
+| 10000 | 5000 | 5000 | 3 | 484.9, 483.8, 454.5 | 474.4 | 454.5 | 451.7 |
+
+## Knobs Tested
+| # | Knob | Status | Change | Command | Raw result | Decision |
+|---|------|--------|--------|---------|------------|----------|
+| 1 | Concurrent loader phases | kept | Run meeting scan, recent dictation scan, and optional dictation counts as child tasks. | `bash scripts/dev/benchmark-home-recent-captures.sh` | 1k avg `36.6 ms`; 10k avg `246.3 ms`; cancel `230.7 ms` at 10k | Kept. Big 10k win with same snapshot shape. |
+| 2 | One meeting metadata read | kept | Reuse the resource-value read for file type and date instead of reading file metadata twice. | `bash scripts/dev/benchmark-home-recent-captures.sh` | 1k avg `27.4 ms`; 10k avg `237.1 ms`; cancel `222.3 ms` at 10k | Kept. Small additional win, no behavior change intended. |
+| 3 | Cancellation bridge and scan checks | kept | Make cancellation sticky in `LoadTaskBox`; check cancellation inside large meeting/dictation loops. | `bash scripts/dev/benchmark-home-recent-captures.sh` | 1k avg `27.8 ms`; 10k avg `233.1 ms`; cancel `0.0 ms` at 10k | Kept. Fixes stale-row cancellation path. |
+| 4 | Stream dictation count lines | rejected | Use `String.enumerateLines` in dictation count parsing. | `bash scripts/dev/benchmark-home-recent-captures.sh` | 1k avg `27.6 ms`; 10k avg `317.1 ms`; cancel `0.1 ms` at 10k | Rejected and reverted. Slower on 10k. |
+| 5 | Final kept state | kept | Re-run after reverting losing line-stream parser. | `bash scripts/dev/benchmark-home-recent-captures.sh` | 1k raw `34.6, 26.9, 26.0`, avg `29.2 ms`; 10k raw `253.2, 227.4, 226.3`, avg `235.6 ms`; cancel `0.0 ms` at 10k | Final winner. |
+
+## Kept Changes
+- `Sources/UI/Shared/RecentCaptureScanners.swift`: parallelizes independent scan phases, removes duplicate meeting metadata reads, and makes cancellation reliable.
+- `Sources/Dictation/DictationTranscriptStore.swift`: checks `Task.isCancelled` inside large dictation scans.
+- `Tests/RecentCaptureScannersTests.swift`: adds temp-library loader tests for sorting, counts, and cancellation.
+- `Tests/Benchmarks/HomeRecentCaptureBenchmark.swift` and `scripts/dev/benchmark-home-recent-captures.sh`: deterministic local benchmark using generated fixtures only.
+
+## Rejected Changes
+- Streaming dictation count parsing with `enumerateLines`; it raised 10k average load time from the kept `~233 ms` range to `317.1 ms`.
+
+## Untested Or Ruled-Out Knobs
+- Defer Home stats counts behind visible rows: ruled out for this pass because the full snapshot already improved by about 50% without changing Home's stats timing.
+- Top-N meeting partial sort: ruled out for this pass because non-meeting Markdown can be skipped after preview, so a naive top-N candidate cap can return fewer valid meetings than the current exact newest-first scan.
+
+## Risks
+- The benchmark uses many small synthetic files. Real libraries with very large Markdown transcripts may still be dominated by reading the visible meeting files for speaker status.
+- The loader now does more work concurrently, so very slow disks could see more simultaneous I/O. The measured wall-clock result still improved on the target fixture sizes.
+
+## Verification
+- `bash build-deps.sh --force` passed after the fresh worktree was missing dependency artifacts.
+- `bash build.sh --no-open` passed.
+- `bash run-tests.sh` passed: `3037 tests, 3037 passed, 0 failed`.
+
+## Next Run
+- Add a fixture variant with large visible meeting transcripts and test a bounded speaker-status scan that avoids reading full Markdown when only labels are needed.

--- a/Sources/Dictation/DictationTranscriptStore.swift
+++ b/Sources/Dictation/DictationTranscriptStore.swift
@@ -93,6 +93,7 @@ enum DictationTranscriptStore {
         var totalWords = 0
 
         for file in files where isDictationDayFile(file) {
+            if Task.isCancelled { break }
             let stats = fileStats(in: file)
             total += stats.entries
             totalWords += stats.words
@@ -125,6 +126,7 @@ enum DictationTranscriptStore {
 
         var collectedEntries: [SavedDictationEntry] = []
         for file in dayFiles {
+            if Task.isCancelled { break }
             let remaining = limit - collectedEntries.count
             collectedEntries.append(contentsOf: entries(in: file, limit: remaining))
             if collectedEntries.count >= limit {
@@ -232,6 +234,7 @@ enum DictationTranscriptStore {
         var sawMetadataLine = false
 
         for line in content.components(separatedBy: "\n") {
+            if Task.isCancelled { break }
             if isEntryHeading(line) {
                 entries += 1
                 scanningMetadata = true

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -187,35 +187,28 @@ enum RecentCaptureLoader {
                     return emptySnapshot()
                 }
 
-                let meetings = RecentMeetingsScanner.loadRecent(limit: meetingLimit)
-                guard !Task.isCancelled else {
-                    return emptySnapshot()
-                }
-
-                let dictations = DictationTranscriptStore.recentSavedDictations(limit: dictationLimit)
-                guard !Task.isCancelled else {
-                    return emptySnapshot()
-                }
-
-                let dictationCounts = includeDictationCounts
+                async let meetings = RecentMeetingsScanner.loadRecent(limit: meetingLimit)
+                async let dictations = DictationTranscriptStore.recentSavedDictations(limit: dictationLimit)
+                async let dictationCounts = includeDictationCounts
                     ? DictationTranscriptStore.savedDictationCounts()
                     : DictationTranscriptCounts(total: 0, today: 0, totalWords: 0)
 
-                guard !Task.isCancelled else {
-                    return emptySnapshot()
-                }
-
-                return RecentCaptureSnapshot(
+                let snapshot = await RecentCaptureSnapshot(
                     meetings: meetings,
                     dictations: dictations,
                     dictationCounts: dictationCounts
                 )
+                guard !Task.isCancelled else {
+                    return emptySnapshot()
+                }
+
+                return snapshot
             }
 
             taskBox.task = task
             return await task.value
         } onCancel: {
-            taskBox.task?.cancel()
+            taskBox.cancel()
         }
     }
 
@@ -231,13 +224,26 @@ enum RecentCaptureLoader {
 private final class LoadTaskBox: @unchecked Sendable {
     private let lock = NSLock()
     private var storedTask: Task<RecentCaptureSnapshot, Never>?
+    private var isCancelled = false
 
     var task: Task<RecentCaptureSnapshot, Never>? {
         get {
             lock.withLock { storedTask }
         }
         set {
-            lock.withLock { storedTask = newValue }
+            lock.withLock {
+                storedTask = newValue
+                if isCancelled {
+                    newValue?.cancel()
+                }
+            }
+        }
+    }
+
+    func cancel() {
+        lock.withLock {
+            isCancelled = true
+            storedTask?.cancel()
         }
     }
 }
@@ -253,21 +259,28 @@ enum RecentMeetingsScanner {
         guard fm.fileExists(atPath: dir.path) else { return [] }
 
         let keys: [URLResourceKey] = [.creationDateKey, .contentModificationDateKey, .isRegularFileKey]
+        let requestedKeys = Set(keys)
         guard let urls = try? fm.contentsOfDirectory(
             at: dir,
             includingPropertiesForKeys: keys,
             options: [.skipsHiddenFiles]
         ) else { return [] }
 
-        let candidates: [(url: URL, date: Date)] = urls.compactMap { url in
-            guard isMarkdownCandidate(url, fileManager: fm) else { return nil }
-            let values = try? url.resourceValues(forKeys: Set(keys))
+        var candidates: [(url: URL, date: Date)] = []
+        for url in urls {
+            if Task.isCancelled { return [] }
+            guard isMarkdownCandidate(url) else { continue }
+            let values = try? url.resourceValues(forKeys: requestedKeys)
+            if values?.isRegularFile == false {
+                continue
+            }
             let date = values?.creationDate ?? values?.contentModificationDate ?? .distantPast
-            return (url, date)
+            candidates.append((url, date))
         }
 
         var recentItems: [RecentMeetingItem] = []
         for entry in candidates.sorted(by: { $0.date > $1.date }) {
+            if Task.isCancelled { return [] }
             guard let styled = MeetingTranscriptStyler.displayTranscriptPreview(at: entry.url) else {
                 continue
             }
@@ -289,16 +302,7 @@ enum RecentMeetingsScanner {
         return recentItems
     }
 
-    private static func isMarkdownCandidate(_ url: URL, fileManager: FileManager) -> Bool {
-        guard url.pathExtension == "md", !excludedMarkdownFilenames.contains(url.lastPathComponent) else {
-            return false
-        }
-
-        if let values = try? url.resourceValues(forKeys: [.isRegularFileKey]),
-           values.isRegularFile == false {
-            return false
-        }
-
-        return true
+    private static func isMarkdownCandidate(_ url: URL) -> Bool {
+        url.pathExtension == "md" && !excludedMarkdownFilenames.contains(url.lastPathComponent)
     }
 }

--- a/Tests/Benchmarks/HomeRecentCaptureBenchmark.swift
+++ b/Tests/Benchmarks/HomeRecentCaptureBenchmark.swift
@@ -1,0 +1,289 @@
+import Foundation
+
+@main
+struct HomeRecentCaptureBenchmark {
+    static func main() async throws {
+        let configuration = try BenchmarkConfiguration(arguments: CommandLine.arguments)
+        let fileManager = FileManager.default
+        let runRoot = URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent("build/home-recent-capture-benchmark", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let captureRoot = runRoot.appendingPathComponent("captures", isDirectory: true)
+        let meetingsRoot = captureRoot.appendingPathComponent("meetings", isDirectory: true)
+        let dictationsRoot = captureRoot.appendingPathComponent("dictations", isDirectory: true)
+        let previousCaptureLocation = UserDefaults.standard.object(
+            forKey: TranscriptedStoragePreferences.captureLibraryLocationKey
+        )
+
+        try fileManager.createDirectory(at: meetingsRoot, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: dictationsRoot, withIntermediateDirectories: true)
+        defer {
+            if let previousCaptureLocation {
+                UserDefaults.standard.set(previousCaptureLocation, forKey: TranscriptedStoragePreferences.captureLibraryLocationKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: TranscriptedStoragePreferences.captureLibraryLocationKey)
+            }
+            try? fileManager.removeItem(at: runRoot)
+        }
+
+        UserDefaults.standard.set(captureRoot.path, forKey: TranscriptedStoragePreferences.captureLibraryLocationKey)
+
+        let fixture = try FixtureBuilder(
+            captures: configuration.captures,
+            meetingsRoot: meetingsRoot,
+            dictationsRoot: dictationsRoot
+        ).build()
+
+        var loadDurations: [Double] = []
+        for _ in 0..<configuration.repetitions {
+            let start = DispatchTime.now()
+            let snapshot = await RecentCaptureLoader.load(
+                dictationLimit: configuration.visibleLimit + 1,
+                meetingLimit: configuration.visibleLimit + 1,
+                includeDictationCounts: true
+            )
+            let elapsed = milliseconds(since: start)
+            try validate(snapshot: snapshot, fixture: fixture, visibleLimit: configuration.visibleLimit + 1)
+            loadDurations.append(elapsed)
+        }
+
+        let cancellationStart = DispatchTime.now()
+        let task = Task {
+            await RecentCaptureLoader.load(
+                dictationLimit: configuration.visibleLimit + 1,
+                meetingLimit: configuration.visibleLimit + 1,
+                includeDictationCounts: true
+            )
+        }
+        task.cancel()
+        _ = await task.value
+        let cancellationDuration = milliseconds(since: cancellationStart)
+
+        print(
+            BenchmarkResult(
+                captures: configuration.captures,
+                meetings: fixture.meetingCount,
+                dictations: fixture.dictationCount,
+                repetitions: configuration.repetitions,
+                loadDurations: loadDurations,
+                cancellationDuration: cancellationDuration
+            ).markdownRow
+        )
+    }
+
+    private static func validate(
+        snapshot: RecentCaptureSnapshot,
+        fixture: FixtureSummary,
+        visibleLimit: Int
+    ) throws {
+        guard snapshot.meetings.count == min(visibleLimit, fixture.meetingCount) else {
+            throw BenchmarkError.validation("expected \(min(visibleLimit, fixture.meetingCount)) meetings, got \(snapshot.meetings.count)")
+        }
+        guard snapshot.dictations.count == min(visibleLimit, fixture.dictationCount) else {
+            throw BenchmarkError.validation("expected \(min(visibleLimit, fixture.dictationCount)) dictations, got \(snapshot.dictations.count)")
+        }
+        guard snapshot.dictationCounts.total == fixture.dictationCount else {
+            throw BenchmarkError.validation("expected \(fixture.dictationCount) counted dictations, got \(snapshot.dictationCounts.total)")
+        }
+        guard snapshot.dictationCounts.totalWords == fixture.totalDictationWords else {
+            throw BenchmarkError.validation("expected \(fixture.totalDictationWords) counted words, got \(snapshot.dictationCounts.totalWords)")
+        }
+        guard isNewestFirst(snapshot.meetings.map(\.date)) else {
+            throw BenchmarkError.validation("meetings were not sorted newest-first")
+        }
+        guard isNewestFirst(snapshot.dictations.map(\.createdAt)) else {
+            throw BenchmarkError.validation("dictations were not sorted newest-first")
+        }
+    }
+
+    private static func isNewestFirst(_ dates: [Date]) -> Bool {
+        zip(dates, dates.dropFirst()).allSatisfy { $0 >= $1 }
+    }
+
+    private static func milliseconds(since start: DispatchTime) -> Double {
+        let elapsed = DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds
+        return Double(elapsed) / 1_000_000
+    }
+}
+
+private struct BenchmarkConfiguration {
+    let captures: Int
+    let repetitions: Int
+    let visibleLimit: Int
+
+    init(arguments: [String]) throws {
+        captures = try Self.intValue(for: "--captures", in: arguments) ?? 1_000
+        repetitions = try Self.intValue(for: "--repetitions", in: arguments) ?? 3
+        visibleLimit = try Self.intValue(for: "--visible-limit", in: arguments) ?? 10
+        guard captures > 0, repetitions > 0, visibleLimit > 0 else {
+            throw BenchmarkError.configuration("captures, repetitions, and visible-limit must be positive")
+        }
+    }
+
+    private static func intValue(for flag: String, in arguments: [String]) throws -> Int? {
+        guard let index = arguments.firstIndex(of: flag) else { return nil }
+        let valueIndex = arguments.index(after: index)
+        guard arguments.indices.contains(valueIndex), let value = Int(arguments[valueIndex]) else {
+            throw BenchmarkError.configuration("missing integer value for \(flag)")
+        }
+        return value
+    }
+}
+
+private struct FixtureBuilder {
+    let captures: Int
+    let meetingsRoot: URL
+    let dictationsRoot: URL
+
+    private var meetingCount: Int { captures / 2 }
+    private var dictationCount: Int { captures - meetingCount }
+    private let calendar = Calendar(identifier: .gregorian)
+    private let baseDate = Date(timeIntervalSince1970: 1_779_470_400) // 2026-05-18T14:00:00Z
+
+    func build() throws -> FixtureSummary {
+        var totalWords = 0
+        for index in 0..<meetingCount {
+            try writeMeeting(index: index)
+        }
+        for index in 0..<dictationCount {
+            totalWords += try writeDictation(index: index)
+        }
+        return FixtureSummary(
+            meetingCount: meetingCount,
+            dictationCount: dictationCount,
+            totalDictationWords: totalWords
+        )
+    }
+
+    private func writeMeeting(index: Int) throws {
+        let date = date(offsetMinutes: -index)
+        let filename = String(format: "Meeting_%05d.md", index)
+        let url = meetingsRoot.appendingPathComponent(filename, isDirectory: false)
+        let markdown = """
+        ---
+        title: "Synthetic Meeting \(index)"
+        capture_type: meeting
+        date: "\(dayString(from: date))"
+        time: "\(timeString(from: date))"
+        duration: "10:00"
+        total_word_count: 8
+        mic_utterances: 1
+        system_utterances: 1
+        ---
+
+        # Synthetic Meeting \(index)
+
+        ## Transcript
+
+        **00:01** [Mic/You]
+        Synthetic meeting line \(index).
+
+        **00:04** [System/Alex]
+        Another synthetic line \(index).
+        """
+        try markdown.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.creationDate: date, .modificationDate: date],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private func writeDictation(index: Int) throws -> Int {
+        let date = date(offsetDays: -index)
+        let filename = "Dictations_\(dayString(from: date)).md"
+        let url = dictationsRoot.appendingPathComponent(filename, isDirectory: false)
+        let wordCount = 6
+        let markdown = """
+        ---
+        title: "Dictations for \(dayString(from: date))"
+        date: \(dayString(from: date))
+        capture_type: dictation_day
+        ---
+
+        # Dictations for \(dayString(from: date))
+
+        ## \(sectionTimeString(from: date)) - Synthetic dictation \(index)
+
+        Entry ID: `dictation-\(index)`
+        Captured: \(isoString(from: date))
+        Source app: Benchmark
+        Delivery: copied
+        Words: \(wordCount)
+        Characters: 42
+
+        synthetic dictation body number \(index)
+        """
+        try markdown.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.creationDate: date, .modificationDate: date],
+            ofItemAtPath: url.path
+        )
+        return wordCount
+    }
+
+    private func date(offsetMinutes: Int) -> Date {
+        calendar.date(byAdding: .minute, value: offsetMinutes, to: baseDate) ?? baseDate
+    }
+
+    private func date(offsetDays: Int) -> Date {
+        calendar.date(byAdding: .day, value: offsetDays, to: baseDate) ?? baseDate
+    }
+
+    private func dayString(from date: Date) -> String {
+        format(date, pattern: "yyyy-MM-dd")
+    }
+
+    private func timeString(from date: Date) -> String {
+        format(date, pattern: "HH:mm:ss")
+    }
+
+    private func sectionTimeString(from date: Date) -> String {
+        format(date, pattern: "h:mm a")
+    }
+
+    private func isoString(from date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+
+    private func format(_ date: Date, pattern: String) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = pattern
+        return formatter.string(from: date)
+    }
+}
+
+private struct FixtureSummary {
+    let meetingCount: Int
+    let dictationCount: Int
+    let totalDictationWords: Int
+}
+
+private struct BenchmarkResult {
+    let captures: Int
+    let meetings: Int
+    let dictations: Int
+    let repetitions: Int
+    let loadDurations: [Double]
+    let cancellationDuration: Double
+
+    var markdownRow: String {
+        let raw = loadDurations.map { String(format: "%.1f", $0) }.joined(separator: ", ")
+        let average = loadDurations.reduce(0, +) / Double(loadDurations.count)
+        let best = loadDurations.min() ?? 0
+        return "| \(captures) | \(meetings) | \(dictations) | \(repetitions) | \(raw) | \(String(format: "%.1f", average)) | \(String(format: "%.1f", best)) | \(String(format: "%.1f", cancellationDuration)) |"
+    }
+}
+
+private enum BenchmarkError: Error, CustomStringConvertible {
+    case configuration(String)
+    case validation(String)
+
+    var description: String {
+        switch self {
+        case .configuration(let message), .validation(let message):
+            return message
+        }
+    }
+}

--- a/Tests/Benchmarks/HomeRecentCaptureBenchmark.swift
+++ b/Tests/Benchmarks/HomeRecentCaptureBenchmark.swift
@@ -23,6 +23,7 @@ struct HomeRecentCaptureBenchmark {
             } else {
                 UserDefaults.standard.removeObject(forKey: TranscriptedStoragePreferences.captureLibraryLocationKey)
             }
+            _ = fileManager.transcriptedCaptureLibraryDir
             try? fileManager.removeItem(at: runRoot)
         }
 

--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-func testRecentCaptureScanners() {
+func testRecentCaptureScanners() async {
     runSuite("RecentMeetingSpeakerStatus.detect flags generic speaker labels") {
         let markdown = """
         # Design review
@@ -247,4 +247,159 @@ func testRecentCaptureScanners() {
             "idle saved meetings with retained audio should stay re-transcribable"
         )
     }
+
+    await testRecentCaptureLoader()
+}
+
+func testRecentCaptureLoader() async {
+    await runSuite("RecentCaptureLoader returns newest rows and requested dictation counts from a temp library") {
+        await withTemporaryRecentCaptureLibrary { captureRoot in
+            let meetingsRoot = captureRoot.appendingPathComponent("meetings", isDirectory: true)
+            let dictationsRoot = captureRoot.appendingPathComponent("dictations", isDirectory: true)
+
+            try? writeRecentLoaderMeeting(
+                title: "Older Sync",
+                date: recentLoaderDate("2026-05-17T14:00:00Z"),
+                to: meetingsRoot.appendingPathComponent("older.md", isDirectory: false)
+            )
+            try? writeRecentLoaderMeeting(
+                title: "Newer Sync",
+                date: recentLoaderDate("2026-05-18T14:00:00Z"),
+                to: meetingsRoot.appendingPathComponent("newer.md", isDirectory: false)
+            )
+            _ = try? DictationTranscriptStore.save(
+                text: "older dictation words",
+                sourceApp: nil,
+                delivery: .copied,
+                createdAt: recentLoaderDate("2026-05-17T13:00:00Z"),
+                directory: dictationsRoot
+            )
+            _ = try? DictationTranscriptStore.save(
+                text: "newer dictation words now",
+                sourceApp: nil,
+                delivery: .pasted,
+                createdAt: recentLoaderDate("2026-05-18T13:00:00Z"),
+                directory: dictationsRoot
+            )
+
+            let snapshot = await RecentCaptureLoader.load(
+                dictationLimit: 2,
+                meetingLimit: 2,
+                includeDictationCounts: true
+            )
+
+            assertEqual(snapshot.meetings.map(\.title), ["Newer Sync", "Older Sync"], "meetings should be newest-first")
+            assertEqual(snapshot.dictations.map(\.text), ["newer dictation words now", "older dictation words"], "dictations should be newest-first")
+            assertEqual(snapshot.dictationCounts.total, 2, "requested dictation counts should include all entries")
+            assertEqual(snapshot.dictationCounts.totalWords, 7, "requested dictation counts should include word totals")
+        }
+    }
+
+    await runSuite("RecentCaptureLoader cancellation returns no stale rows") {
+        await withTemporaryRecentCaptureLibrary { captureRoot in
+            let meetingsRoot = captureRoot.appendingPathComponent("meetings", isDirectory: true)
+            let dictationsRoot = captureRoot.appendingPathComponent("dictations", isDirectory: true)
+            for index in 0..<200 {
+                let date = Date(timeIntervalSince1970: 1_779_470_400 - Double(index * 60))
+                try? writeRecentLoaderMeeting(
+                    title: "Canceled Sync \(index)",
+                    date: date,
+                    to: meetingsRoot.appendingPathComponent("meeting-\(index).md", isDirectory: false)
+                )
+                _ = try? DictationTranscriptStore.save(
+                    text: "canceled dictation \(index)",
+                    sourceApp: nil,
+                    delivery: .copied,
+                    createdAt: date,
+                    directory: dictationsRoot
+                )
+            }
+
+            let task = Task {
+                await RecentCaptureLoader.load(
+                    dictationLimit: 10,
+                    meetingLimit: 10,
+                    includeDictationCounts: true
+                )
+            }
+            task.cancel()
+            let snapshot = await task.value
+
+            assertEqual(snapshot.meetings.count, 0, "canceled loads should not publish meeting rows")
+            assertEqual(snapshot.dictations.count, 0, "canceled loads should not publish dictation rows")
+            assertEqual(snapshot.dictationCounts.total, 0, "canceled loads should not publish stale counts")
+        }
+    }
+}
+
+private func withTemporaryRecentCaptureLibrary(
+    _ body: (URL) async -> Void
+) async {
+    let fm = FileManager.default
+    let root = URL(fileURLWithPath: fm.currentDirectoryPath, isDirectory: true)
+        .appendingPathComponent("build/recent-capture-loader-tests", isDirectory: true)
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let captureRoot = root.appendingPathComponent("captures", isDirectory: true)
+    let previous = UserDefaults.standard.object(forKey: TranscriptedStoragePreferences.captureLibraryLocationKey)
+
+    try? fm.createDirectory(
+        at: captureRoot.appendingPathComponent("meetings", isDirectory: true),
+        withIntermediateDirectories: true
+    )
+    try? fm.createDirectory(
+        at: captureRoot.appendingPathComponent("dictations", isDirectory: true),
+        withIntermediateDirectories: true
+    )
+    UserDefaults.standard.set(captureRoot.path, forKey: TranscriptedStoragePreferences.captureLibraryLocationKey)
+
+    await body(captureRoot)
+
+    if let previous {
+        UserDefaults.standard.set(previous, forKey: TranscriptedStoragePreferences.captureLibraryLocationKey)
+    } else {
+        UserDefaults.standard.removeObject(forKey: TranscriptedStoragePreferences.captureLibraryLocationKey)
+    }
+    try? fm.removeItem(at: root)
+}
+
+private func writeRecentLoaderMeeting(title: String, date: Date, to url: URL) throws {
+    let markdown = """
+    ---
+    title: "\(title)"
+    capture_type: meeting
+    date: "\(recentLoaderFormat(date, "yyyy-MM-dd"))"
+    time: "\(recentLoaderFormat(date, "HH:mm:ss"))"
+    duration: "10:00"
+    total_word_count: 5
+    mic_utterances: 1
+    system_utterances: 1
+    ---
+
+    # \(title)
+
+    ## Transcript
+
+    **00:01** [Mic/You]
+    Synthetic test meeting.
+
+    **00:04** [System/Alex]
+    Synthetic response.
+    """
+    try markdown.write(to: url, atomically: true, encoding: .utf8)
+    try FileManager.default.setAttributes(
+        [.creationDate: date, .modificationDate: date],
+        ofItemAtPath: url.path
+    )
+}
+
+private func recentLoaderDate(_ string: String) -> Date {
+    ISO8601DateFormatter().date(from: string) ?? Date(timeIntervalSince1970: 0)
+}
+
+private func recentLoaderFormat(_ date: Date, _ pattern: String) -> String {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = pattern
+    return formatter.string(from: date)
 }

--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -359,6 +359,7 @@ private func withTemporaryRecentCaptureLibrary(
     } else {
         UserDefaults.standard.removeObject(forKey: TranscriptedStoragePreferences.captureLibraryLocationKey)
     }
+    _ = fm.transcriptedCaptureLibraryDir
     try? fm.removeItem(at: root)
 }
 

--- a/scripts/dev/benchmark-home-recent-captures.sh
+++ b/scripts/dev/benchmark-home-recent-captures.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUILD_DIR="$ROOT_DIR/build/benchmarks"
+BINARY="$BUILD_DIR/home-recent-captures-benchmark"
+
+mkdir -p "$BUILD_DIR"
+
+swiftc \
+  "$ROOT_DIR/Tests/Benchmarks/HomeRecentCaptureBenchmark.swift" \
+  "$ROOT_DIR/Sources/Support/TranscriptedStoragePaths.swift" \
+  "$ROOT_DIR/Sources/Dictation/DictationStoragePaths.swift" \
+  "$ROOT_DIR/Sources/Dictation/DictationTranscriptWriter.swift" \
+  "$ROOT_DIR/Sources/Dictation/DictationTranscriptStore.swift" \
+  "$ROOT_DIR/Sources/Meeting/MeetingStoragePaths.swift" \
+  "$ROOT_DIR/Sources/Meeting/MeetingTranscriptStyler.swift" \
+  "$ROOT_DIR/Sources/TranscriptedCore/Speaker/SpeakerProfile.swift" \
+  "$ROOT_DIR/Sources/TranscriptedCore/Models/TranscriptionTypes.swift" \
+  "$ROOT_DIR/Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift" \
+  "$ROOT_DIR/Sources/UI/Shared/MeetingAudioArchiveResolver.swift" \
+  "$ROOT_DIR/Sources/UI/Shared/RecentCaptureScanners.swift" \
+  -framework AppKit \
+  -parse-as-library \
+  -O \
+  -o "$BINARY"
+
+echo "| captures | meetings | dictations | reps | raw load ms | avg load ms | best load ms | cancel ms |"
+echo "|---:|---:|---:|---:|---|---:|---:|---:|"
+"$BINARY" --captures 1000 --repetitions "${REPETITIONS:-3}"
+"$BINARY" --captures 10000 --repetitions "${REPETITIONS:-3}"


### PR DESCRIPTION
# Autoeval: Settings Home Recent Captures

## Verdict
winner

The kept change cuts the 10k fake-library full snapshot from `474.4 ms` average to `235.6 ms` average, with cancellation returning immediately in the benchmark.

## Metric
- Primary: wall-clock time for `RecentCaptureLoader.load(dictationLimit: 11, meetingLimit: 11, includeDictationCounts: true)`.
- Fixtures: generated temp capture libraries only, split evenly between meeting Markdown files and dictation day files.
- Guardrails: newest-first rows, requested dictation counts, requested word totals, and canceled loads returning no stale rows.

## Baseline
- Command: `bash scripts/dev/benchmark-home-recent-captures.sh`
- Raw result:

| captures | meetings | dictations | reps | raw load ms | avg load ms | best load ms | cancel ms |
|---:|---:|---:|---:|---|---:|---:|---:|
| 1000 | 500 | 500 | 3 | 58.0, 52.3, 50.7 | 53.7 | 50.7 | 50.7 |
| 10000 | 5000 | 5000 | 3 | 484.9, 483.8, 454.5 | 474.4 | 454.5 | 451.7 |

## Knobs Tested
| # | Knob | Status | Change | Command | Raw result | Decision |
|---|------|--------|--------|---------|------------|----------|
| 1 | Concurrent loader phases | kept | Run meeting scan, recent dictation scan, and optional dictation counts as child tasks. | `bash scripts/dev/benchmark-home-recent-captures.sh` | 1k avg `36.6 ms`; 10k avg `246.3 ms`; cancel `230.7 ms` at 10k | Kept. Big 10k win with same snapshot shape. |
| 2 | One meeting metadata read | kept | Reuse the resource-value read for file type and date instead of reading file metadata twice. | `bash scripts/dev/benchmark-home-recent-captures.sh` | 1k avg `27.4 ms`; 10k avg `237.1 ms`; cancel `222.3 ms` at 10k | Kept. Small additional win, no behavior change intended. |
| 3 | Cancellation bridge and scan checks | kept | Make cancellation sticky in `LoadTaskBox`; check cancellation inside large meeting/dictation loops. | `bash scripts/dev/benchmark-home-recent-captures.sh` | 1k avg `27.8 ms`; 10k avg `233.1 ms`; cancel `0.0 ms` at 10k | Kept. Fixes stale-row cancellation path. |
| 4 | Stream dictation count lines | rejected | Use `String.enumerateLines` in dictation count parsing. | `bash scripts/dev/benchmark-home-recent-captures.sh` | 1k avg `27.6 ms`; 10k avg `317.1 ms`; cancel `0.1 ms` at 10k | Rejected and reverted. Slower on 10k. |
| 5 | Final kept state | kept | Re-run after reverting losing line-stream parser. | `bash scripts/dev/benchmark-home-recent-captures.sh` | 1k raw `34.6, 26.9, 26.0`, avg `29.2 ms`; 10k raw `253.2, 227.4, 226.3`, avg `235.6 ms`; cancel `0.0 ms` at 10k | Final winner. |

## Kept Changes
- `Sources/UI/Shared/RecentCaptureScanners.swift`: parallelizes independent scan phases, removes duplicate meeting metadata reads, and makes cancellation reliable.
- `Sources/Dictation/DictationTranscriptStore.swift`: checks `Task.isCancelled` inside large dictation scans.
- `Tests/RecentCaptureScannersTests.swift`: adds temp-library loader tests for sorting, counts, and cancellation.
- `Tests/Benchmarks/HomeRecentCaptureBenchmark.swift` and `scripts/dev/benchmark-home-recent-captures.sh`: deterministic local benchmark using generated fixtures only.

## Rejected Changes
- Streaming dictation count parsing with `enumerateLines`; it raised 10k average load time from the kept `~233 ms` range to `317.1 ms`.

## Untested Or Ruled-Out Knobs
- Defer Home stats counts behind visible rows: ruled out for this pass because the full snapshot already improved by about 50% without changing Home's stats timing.
- Top-N meeting partial sort: ruled out for this pass because non-meeting Markdown can be skipped after preview, so a naive top-N candidate cap can return fewer valid meetings than the current exact newest-first scan.

## Risks
- The benchmark uses many small synthetic files. Real libraries with very large Markdown transcripts may still be dominated by reading the visible meeting files for speaker status.
- The loader now does more work concurrently, so very slow disks could see more simultaneous I/O. The measured wall-clock result still improved on the target fixture sizes.

## Verification
- `bash build-deps.sh --force` passed after the fresh worktree was missing dependency artifacts.
- `bash build.sh --no-open` passed.
- `bash run-tests.sh` passed: `3037 tests, 3037 passed, 0 failed`.

## Next Run
- Add a fixture variant with large visible meeting transcripts and test a bounded speaker-status scan that avoids reading full Markdown when only labels are needed.
