### PR TITLE
[bug-hunter] Tighten dictation start timeout recovery

### DIFF
--- a/Sources/Observability/SentryEventPolicy.swift
+++ b/Sources/Observability/SentryEventPolicy.swift
@@ -124,11 +124,6 @@ struct SentryEventPolicy: Equatable {
             event: "audio_format_failed",
             summary: "Transcripted could not create the expected audio format."
         ),
-        "parakeet.audio_format_read_timeout": .init(
-            engine: "parakeet",
-            event: "audio_format_read_timeout",
-            summary: "Speech audio format readiness timed out."
-        ),
         "parakeet.audio_engine_start_failed": .init(
             engine: "parakeet",
             event: "audio_engine_start_failed",

--- a/Sources/Speech/DictationReadinessWaitPolicy.swift
+++ b/Sources/Speech/DictationReadinessWaitPolicy.swift
@@ -41,14 +41,15 @@ struct DictationReadinessWaitPolicy {
             return .startRecording
         }
 
+        let refreshedEnoughForRecoveryStart = readinessRefreshes >= refreshesBeforeRecoveryStart
         let shouldTryRecoveryStart = readinessRefreshTimedOut
-            || readinessRefreshes >= refreshesBeforeRecoveryStart
+            || refreshedEnoughForRecoveryStart
         if shouldTryRecoveryStart,
            recoveryStartAttempts == 0 {
             return .startRecoveryRecording
         }
 
-        if shouldTryRecoveryStart,
+        if refreshedEnoughForRecoveryStart,
            forcedRecoveryAttempts > 0,
            forcedRecoveryAttempts < maxForcedRecoveryAttempts,
            recoveryStartAttempts < maxRecoveryStartAttempts {

--- a/Tests/DictationReadinessWaitPolicyTests.swift
+++ b/Tests/DictationReadinessWaitPolicyTests.swift
@@ -219,6 +219,19 @@ func testDictationReadinessWaitPolicy() {
         assertEqual(action, .startRecoveryRecording, "after a hard input recovery, one more guarded recovery start should be allowed")
     }
 
+    runSuite("DictationReadinessWaitPolicy — stale timeout does not rush post-recovery start") {
+        let action = DictationReadinessWaitPolicy.action(
+            isRecovering: false,
+            inputFormatReady: false,
+            readinessRefreshes: 0,
+            forcedRecoveryAttempts: 1,
+            recoveryStartAttempts: 1,
+            readinessRefreshTimedOut: true
+        )
+
+        assertEqual(action, .refreshInputReadiness, "after hard recovery, a stale timeout flag should wait for fresh readiness refreshes before another recovery start")
+    }
+
     runSuite("DictationReadinessWaitPolicy — recovery start is bounded before forced recovery") {
         let action = DictationReadinessWaitPolicy.action(
             isRecovering: false,

--- a/Tests/SentryEventPolicyTests.swift
+++ b/Tests/SentryEventPolicyTests.swift
@@ -22,7 +22,7 @@ func testSentryEventPolicy() {
             forEngine: "parakeet",
             event: "audio_engine_start_failed"
         )
-        let audioFormatReadTimeout = SentryEventPolicy.policy(
+        let recoverableAudioFormatReadTimeout = SentryEventPolicy.policy(
             forEngine: "parakeet",
             event: "audio_format_read_timeout"
         )
@@ -96,7 +96,7 @@ func testSentryEventPolicy() {
         assertEqual(sessionStall?.summary, "Transcripted detected a stalled runtime session.", "session stalls should be visible in Sentry")
         assertEqual(hotkeyFailure?.summary, "Transcripted could not register a keyboard shortcut.", "capture failure should stay allowlisted")
         assertEqual(audioStartFailure?.summary, "Speech audio engine failed to start.", "audio-start failures should stay allowlisted with a privacy-safe summary")
-        assertEqual(audioFormatReadTimeout?.summary, "Speech audio format readiness timed out.", "audio-format readiness timeouts should be visible in Sentry")
+        assertNil(recoverableAudioFormatReadTimeout, "recoverable format-read timeouts should stay local; final microphone timeouts carry richer Sentry context")
         assertEqual(audioEngineStartTimeout?.summary, "Speech audio engine start timed out.", "audio start timeouts should be visible in Sentry")
         assertEqual(zombieEngineRecoveryFailed?.summary, "Speech engine zombie-state recovery failed.", "zombie recovery failures should be visible in Sentry")
         assertEqual(microphoneStartTimeout?.summary, "Dictation microphone start timed out.", "microphone start timeouts should be visible in Sentry without raw device names")


### PR DESCRIPTION
## Summary

- keep recoverable `parakeet.audio_format_read_timeout` events local-only so Sentry alerts on the final richer `dictation.microphone_start_timeout` when startup actually fails
- prevent a stale readiness-refresh timeout flag from triggering a second post-recovery recording start before fresh readiness refreshes happen
- add focused policy coverage for the stale-timeout/post-recovery path

## Production signal

- Sentry `APPLE-MACOS-1S`, event `fc0e4d70b755483cb00317b1f7c93f81`
- current release `transcripted@1.1.44`
- single `audio_format_read_timeout` during `dictation_start_requested`
- related 7d cluster includes current-release `dictation.microphone_start_timeout` events, which already carry richer start-attempt/recovery context

## Notes

Draft PR #918 touches the broader dictation start recovery tuning path. This PR is intentionally smaller: alert de-noise plus one bounded policy guard.

## Verification

- `bash build.sh --no-open`
- `bash run-tests.sh`
