### PR TITLE
[nightly-review] Fail live sidecar handoff on cancel

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1042,6 +1042,10 @@ final class MeetingSessionController: ObservableObject {
         }
 
         taskManager.cancelAll()
+        if liveCodexSessionAwaitingFinalTranscript {
+            finishLiveCodexSession(status: .failed, shouldAwaitFinalTranscript: false)
+            activeQueuedTranscriptionJobID = nil
+        }
         state = .ready
         DiagnosticsTrail.record(
             level: .warning,

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1485,6 +1485,25 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - transcription cancellation clears live sidecar waits") {
+        let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let cancelBlock = sourceSlice(
+            controllerContents,
+            from: "func cancelActiveTranscription(reason: TranscriptionCancelReason = .unknown) {",
+            to: "func prepareForTermination() async {"
+        )
+
+        assertTrue(
+            cancelBlock.contains("if liveCodexSessionAwaitingFinalTranscript")
+                && cancelBlock.contains("finishLiveCodexSession(status: .failed, shouldAwaitFinalTranscript: false)"),
+            "cancelling the owning transcription should fail the pending live sidecar handoff instead of leaving agents waiting forever"
+        )
+        assertTrue(
+            cancelBlock.contains("activeQueuedTranscriptionJobID = nil"),
+            "transcription cancellation should clear the queued job owner used for live sidecar final attachment"
+        )
+    }
+
     runSuite("Repo command contract - live sidecar attaches only its queued meeting") {
         let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
         let taskManagerContents = readRepoTextFile("Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift")


### PR DESCRIPTION
## Nightly review

Checked current `origin/main`, last-24h PRs, open issues, open nightly PRs, Sentry, and PostHog.

Top risks ranked:

1. Live meeting sidecar final handoff could stay stuck after transcription cancellation. Fixed here.
2. Bluetooth dictation start timeouts still appear in Sentry (`APPLE-MACOS-14`), but open PR #922 is already aimed at stale readiness refreshes, so I did not duplicate that lane.
3. `update_check_finished` still shows `failure_kind=unknown` / `sparkle_1001` on released build `1.1.44`; current `main` already has the no-update classification guard from the prior nightly PR, so this stays watch-only until a newer build emits data.

## Change

- When `cancelActiveTranscription` runs while a live sidecar is waiting for the final Transcripted Markdown, mark that sidecar handoff as failed instead of leaving agents waiting forever.
- Added a `RepoCommandContractTests` guard so this cancel path keeps clearing the pending live sidecar wait.

## Verification

- `git diff --check`
- `scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (`3254 passed`)
- `bash run-integration-smoke.sh`
