### PR TITLE
[docs] Update dictation and live sidecar docs

### DIFF
--- a/.agents/test-matrix.yml
+++ b/.agents/test-matrix.yml
@@ -96,6 +96,13 @@ rules:
       - "python3 -m py_compile scripts/ops/compare-meeting-corpus.py"
 
   - paths:
+      - "scripts/ops/dictation-stop-autoeval.sh"
+      - "docs/autoeval-dictation-stop-speed-*.md"
+    checks:
+      - "scripts/dev/agent-preflight.sh"
+      - "bash -n scripts/ops/dictation-stop-autoeval.sh"
+
+  - paths:
       - "scripts/ops/agent-todo-runner.rb"
       - "scripts/ops/agent-todo-launchagent.sh"
       - "scripts/ops/qa-gate-check.sh"

--- a/Sources/Dictation/CLAUDE.md
+++ b/Sources/Dictation/CLAUDE.md
@@ -8,15 +8,18 @@
 
 - `DictationSessionTimeout.swift` — uptime-based timeout helper so sleep does not consume a session's remaining record window
 - `DictationStoragePaths.swift` — capture-library-backed storage root for dictation artifacts
-- `DictationTranscriptWriter.swift` — groups completed dictations into one markdown file per day
+- `DictationTranscriptWriter.swift` — groups completed dictations into one markdown file per day; serializes day-file writes through `DictationTranscriptMutationLock`
 - `DictationTranscriptStore.swift` — shared seam for saving dictation markdown and reading the newest saved dictation back out
+- `DictationStopFinalizationPolicy.swift` — chooses whether the Markdown save runs before or after the optional Auto Enter keystroke; the default is `saveBeforeAutoEnter`
+- `DictationStopBenchmarkRunner.swift` — env-gated in-app benchmark for stop-to-text, stop-to-saved, and stop-to-delivery timing on synthetic audio fixtures; it does not touch the real clipboard or focused app
 
 ## Flow
 
 1. `Sources/UI/Overlay/DictationSessionController.swift` transcribes audio with `STTRouter`.
 2. The session tries to paste the text back into the target app.
 3. The session records whether delivery was `pasted`, `copied`, or `failed`.
-4. `DictationTranscriptStore.save(...)` appends a new section to that day's markdown file.
+4. `DictationStopFinalizationPolicy.order` decides whether the session saves before or after the optional Auto Enter keystroke. The current default starts the save before Auto Enter, then awaits the save result.
+5. `DictationTranscriptStore.save(...)` appends a new section to that day's markdown file, with mutations serialized through `DictationTranscriptMutationLock`.
 
 ## Storage
 

--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -17,6 +17,7 @@
 - `MeetingFailureKind.swift` — canonical failure taxonomy that classifies raw meeting errors into stable machine-readable kinds
 - `MeetingImportedAudioPreparer.swift` — copies imported recordings into app-managed scratch paths, derives titles, and prepares single-file meeting transcription jobs
 - `LiveMeetingCodexSession.swift` — app-owned sidecar writer for the opt-in live-meeting workspace used by Codex and Claude Cowork; it must not replace or mutate the normal saved meeting transcript pipeline
+- `LiveMeetingPreviewServer.swift` — loopback HTTP server that serves the live sidecar preview on a tokenized URL so the page updates in place without full-page refreshes while Transcripted is running
 - `LiveMeetingStreamingUpdatePolicy.swift` — tiny throttling/deduplication policy for provisional live ASR updates before they are appended to the sidecar
 - `LiveMeetingTranscriber.swift` — opt-in streaming ASR bridge that feeds mic/system live PCM copies into FluidAudio's local streaming Parakeet manager and appends provisional sidecar text
 - `MeetingModelDownloader.swift` — loads the selected STT and diarization models together

--- a/docs/autoeval-dictation-stop-speed-2026-05-31.md
+++ b/docs/autoeval-dictation-stop-speed-2026-05-31.md
@@ -15,7 +15,7 @@ The benchmark uses synthetic local audio fixtures and injects samples into the a
 
 ## Commands and sources
 
-- Repo/path: `/Users/redbars/.codex/worktrees/dictation-stop-full-autoeval`
+- Repo: Transcripted checkout on the `codex/dictation-stop-full-autoeval` branch
 - Stop path read: `Sources/UI/Overlay/DictationSessionController.swift`, `Sources/Speech/STTRouter.swift`, `Sources/Speech/ParakeetEngine.swift`, `Sources/Dictation/`
 - Existing timing read: `transcription_complete`, `dictation_export_saved`, `dictation_delivery_completed`, `dictation_no_speech`, `scripts/ops/performance-budget.rb`
 - Build: `bash build-deps.sh --force`, `bash build.sh --no-open --full`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -60,6 +60,9 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
   - Thin-build usage: `scripts/ops/performance-budget.rb --allow-missing-parakeet-model --max-app-mb 220 --max-resources-mb 80`
   - Optional runtime log verification: `scripts/ops/performance-budget.rb --events "$HOME/Library/Application Support/Transcripted/logs/events.jsonl"`
   - Optional meeting throughput verification: `scripts/ops/performance-budget.rb --stats "$HOME/Library/Application Support/Transcripted/state/stats.sqlite"` (defaults to recordings 30s or longer)
+- `scripts/ops/dictation-stop-autoeval.sh` — synthetic local-audio benchmark for dictation stop-to-text, stop-to-saved, and stop-to-delivery timing
+  - Usage: `bash scripts/ops/dictation-stop-autoeval.sh --label baseline --variant native`
+  - Writes ignored scratch output under `.autoeval/dictation-stop/`
 - `scripts/ops/agent-todo-runner.rb` — local GitHub Issues queue runner for Codex agent tasks
   - Usage: `ruby scripts/ops/agent-todo-runner.rb --labels-only`
   - Usage: `ruby scripts/ops/agent-todo-runner.rb --once`

--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -147,6 +147,11 @@ if [ -n "$changed_paths" ]; then
             add_command "python3 -m py_compile scripts/ops/compare-meeting-corpus.py"
         fi
 
+        if matches_any "$path" "scripts/ops/dictation-stop-autoeval.sh" "docs/autoeval-dictation-stop-speed-*.md"; then
+            add_command "scripts/dev/agent-preflight.sh"
+            add_command "bash -n scripts/ops/dictation-stop-autoeval.sh"
+        fi
+
         if matches_any "$path" "scripts/ops/agent-todo-runner.rb" "scripts/ops/agent-todo-launchagent.sh" "scripts/ops/qa-gate-check.sh" "scripts/ops/qa-gate-closeout.sh"; then
             add_command "scripts/dev/agent-preflight.sh"
             add_command "ruby -c scripts/ops/agent-todo-runner.rb"


### PR DESCRIPTION
## Summary
- Document dictation stop finalization policy, benchmark runner, and mutation lock ownership in Sources/Dictation/CLAUDE.md
- Add LiveMeetingPreviewServer to the meeting subsystem file map

## Verification
- bash scripts/dev/agent-preflight.sh