### PR TITLE
[nightly-agent] Align Claude setup copy

### DIFF
--- a/Sources/UI/AgentConnect/AgentConnectionWindowView.swift
+++ b/Sources/UI/AgentConnect/AgentConnectionWindowView.swift
@@ -165,7 +165,7 @@ struct AgentConnectionWindowView: View {
             title: "Claude Desktop",
             subtitle: "Best path: install Transcripted direct tools, then restart Claude Desktop."
         ) {
-            AgentConnectionBodyText("Use Transcripted Settings > Agent > Install for Claude Desktop. The app writes the Claude config and checks your local library.")
+            AgentConnectionBodyText("Use Transcripted Settings > Agent > Install in Claude. The app writes the Claude config and checks your local library.")
 
             HStack(spacing: 10) {
                 Button(viewModel.copyLabel(for: .mcp, default: "Copy Steps")) {

--- a/Sources/UI/Settings/AgentConnectionSettingsPage.swift
+++ b/Sources/UI/Settings/AgentConnectionSettingsPage.swift
@@ -750,7 +750,7 @@ private struct ClaudeDesktopStatusRow: View {
             return "Claude Desktop is configured. Restart Claude Desktop if you just installed it."
         case .notInstalled:
             return status.claudeDesktopLikelyInstalled
-                ? "Click Install for Claude Desktop, then restart Claude Desktop."
+                ? "Click Install in Claude, then restart Claude Desktop."
                 : "Claude Desktop was not found. You can still install now, then install Claude Desktop."
         case .needsRepair:
             return "Claude Desktop points at another Transcripted server. Install will update it."

--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -469,7 +469,7 @@ enum AgentConnectionGuide {
             "Transcripted direct tools setup:",
             "- Server name: transcripted",
             "- Transport: local stdio",
-            "- Claude Desktop app flow: open Transcripted Settings > Agent, click Install for Claude Desktop, then restart Claude Desktop.",
+            "- Claude Desktop app flow: open Transcripted Settings > Agent, click Install in Claude, then restart Claude Desktop.",
             "- Installed command path after setup: \(ClaudeDesktopIntegrationInstaller.installedMCPBinaryURL.path)",
             "- Claude Desktop config path: \(ClaudeDesktopIntegrationInstaller.claudeDesktopConfigURL.path)",
         ]
@@ -515,7 +515,7 @@ enum AgentConnectionGuide {
             "Claude Desktop setup:",
             "1. Open Transcripted Settings.",
             "2. Go to Agent.",
-            "3. Click Install for Claude Desktop.",
+            "3. Click Install in Claude.",
             "4. Restart Claude Desktop.",
             "",
             "Installed command path after setup:",

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -195,8 +195,8 @@ func testAgentConnectionGuide() {
             "Claude Desktop setup should start inside the app"
         )
         assertTrue(
-            setupText.contains("Click Install for Claude Desktop."),
-            "Claude Desktop setup should use the in-app installer"
+            setupText.contains("Click Install in Claude."),
+            "Claude Desktop setup should use the exact in-app installer label"
         )
         assertTrue(
             setupText.contains(ClaudeDesktopIntegrationInstaller.installedMCPBinaryURL.path),


### PR DESCRIPTION
## Summary
- Align Claude Desktop setup copy with the actual Agent page button label: `Install in Claude`.
- Update the standalone agent-connect window, Settings status detail, shared copied setup text, and the existing guide test.

## Why
The nightly agent-surface pass found generated setup instructions saying `Install for Claude Desktop`, while the current button and docs say `Install in Claude`. That can slow down outside-agent setup even though the tool paths are otherwise healthy.

## Verification
- `swift test --package-path Tools/TranscriptedCLI`
- `swift test --package-path Tools/TranscriptedMCP`
- `cd Tools/TranscriptedMCP && swift build -c release`
- repo/app/installed `transcripted-mcp --self-test` returned valid JSON with zero stderr
- CLI `context-recent`, `context-search`, `list-dictations`, `read-meeting --json`, and `read-dictation --json` against local captures
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`