### PR TITLE
[operator] Add Sentry health issue rollup

### DIFF
--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -47,6 +47,23 @@ func testRepoCommandContract() {
         assertFalse(contents.contains("\"r3d-bar\""), "Cloudflare probe should not check the old redbars Pages project name")
     }
 
+    runSuite("Repo command contract - Sentry health probe prints aggregate issue rollup") {
+        let contents = readRepoTextFile("scripts/ops/health-probe.sh")
+
+        assertTrue(
+            contents.contains("Sentry unresolved issue rollup (top 5):")
+                && contents.contains(".shortId")
+                && contents.contains("count=\\(.count")
+                && contents.contains("users=\\(.userCount")
+                && contents.contains("lastSeen=\\(.lastSeen"),
+            "Sentry probe should show aggregate issue counts and freshness for operator triage"
+        )
+        assertFalse(
+            contents.contains("/events/"),
+            "Sentry health probe should not fetch raw event payloads for the nightly rollup"
+        )
+    }
+
     runSuite("Repo command contract - PostHog health probe uses the query API") {
         let contents = readRepoTextFile("scripts/ops/health-probe.sh")
 

--- a/scripts/ops/health-probe.sh
+++ b/scripts/ops/health-probe.sh
@@ -107,9 +107,8 @@ probe_sentry() {
   echo "Sentry unresolved issues: $count"
 
   if [[ "$count" -gt 0 ]]; then
-    local top_issue
-    top_issue=$(echo "$response" | jq -r '.[0] | "[\(.id)] \(.title)"')
-    echo "Top issue: $top_issue"
+    echo "Sentry unresolved issue rollup (top 5):"
+    echo "$response" | jq -r '.[0:5][] | " - [\(.shortId // .id)] count=\(.count // 0) users=\(.userCount // 0) lastSeen=\(.lastSeen // "unknown") \(.title)"'
   fi
 }
 


### PR DESCRIPTION
## Summary
- print a top-five aggregate Sentry issue rollup from the health probe instead of only the first issue
- add a repo contract test that keeps the probe on issue summaries, not raw event payloads

## Why
The nightly operator saw 10 unresolved Sentry issues, but the probe only exposed one top issue. Counts and last-seen timestamps make the reliability lane easier to triage without expanding app telemetry or pulling sensitive event payloads.

## Verification
- `bash -n scripts/ops/health-probe.sh`
- `bash scripts/ops/health-probe.sh sentry`
- `bash build-deps.sh --force`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash build.sh --no-open`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` (3254 tests passed)
