### PR TITLE
[nightly-maintenance] Trim beta proxy history comment

### DIFF
--- a/Sources/Beta/BetaConfig.swift
+++ b/Sources/Beta/BetaConfig.swift
@@ -3,8 +3,7 @@
 //
 // History: this file used to ship a per-user bearer token baked in at build time
 // via sed/perl substitution in build-beta.sh. That token authenticated the app
-// against the archived proxy worker at draft-proxy.tz427gsydr.workers.dev, which
-// also re-exposed Anthropic's /v1/messages endpoint.
+// against an archived proxy worker that is no longer part of the live product.
 //
 // The proxy client is no longer part of the app target (BetaTelemetry and the
 // /config update-check flow are gone — Sparkle handles updates, Sentry handles


### PR DESCRIPTION
## Summary
- removed obsolete archived proxy domain/endpoint detail from the live BetaConfig source comment
- kept the security rationale and future keychain guidance intact

## Verification
- bash scripts/dev/agent-preflight.sh
- git diff --check
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh

Note: the first build attempt hit the expected missing-deps guard, then passed after refreshing deps.