### PR TITLE
Add ghost speaker merge floor

### DIFF
--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -266,29 +266,33 @@ extension Transcription {
                 // speaker is a ghost we still need a persistent UUID for later transcript
                 // metadata updates, so fall back to creating a best-effort profile.
                 if isGhost {
-                    var bestNonGhostId: Int?
-                    var bestSimilarity: Double = -1
-                    for (otherId, otherMean) in nonGhostMeans {
-                        let sim = Self.cosineSimilarityStatic(meanEmbedding, otherMean)
-                        if sim > bestSimilarity {
-                            bestSimilarity = sim
-                            bestNonGhostId = otherId
-                        }
-                    }
-                    if let targetId = bestNonGhostId {
-                        speakerIdRemap[speakerId] = targetId
+                    let mergeCandidate = Self.bestGhostSpeakerMergeCandidate(
+                        for: meanEmbedding,
+                        nonGhostMeans: nonGhostMeans
+                    )
+                    if let candidate = mergeCandidate, candidate.similarity >= Self.ghostSpeakerMergeSimilarityFloor {
+                        speakerIdRemap[speakerId] = candidate.speakerId
                         AppLogger.transcription.info("Ghost speaker force-merged", [
                             "ghostSpk": "\(speakerId)",
-                            "into": "\(targetId)",
-                            "similarity": String(format: "%.3f", bestSimilarity)
+                            "into": "\(candidate.speakerId)",
+                            "similarity": String(format: "%.3f", candidate.similarity),
+                            "threshold": String(format: "%.2f", Self.ghostSpeakerMergeSimilarityFloor)
                         ])
                     } else {
                         let newProfile = speakerDB.addOrUpdateSpeaker(embedding: meanEmbedding, existingId: nil)
                         speakerNewProfiles[speakerId] = newProfile.id
-                        AppLogger.transcription.warning("Ghost speaker kept as standalone best-effort profile", [
+                        var context = [
                             "speakerId": "\(speakerId)",
-                            "reason": "no-non-ghost-speaker-to-merge-into"
-                        ])
+                            "threshold": String(format: "%.2f", Self.ghostSpeakerMergeSimilarityFloor)
+                        ]
+                        if let candidate = mergeCandidate {
+                            context["bestNonGhostSpk"] = "\(candidate.speakerId)"
+                            context["similarity"] = String(format: "%.3f", candidate.similarity)
+                            context["reason"] = "below-minimum-similarity"
+                        } else {
+                            context["reason"] = "no-non-ghost-speaker-to-merge-into"
+                        }
+                        AppLogger.transcription.warning("Ghost speaker kept as standalone best-effort profile", context)
                     }
                     continue
                 }
@@ -596,6 +600,29 @@ extension Transcription {
         let newlyCreatedProfileIds: Set<UUID>
     }
 
+    struct GhostSpeakerMergeCandidate: Equatable {
+        let speakerId: Int
+        let similarity: Double
+    }
+
+    /// Ghost speakers only have a best-effort embedding from segments that were
+    /// too short, low-quality, or contaminated for normal profile matching. Keep
+    /// the auto-merge floor high enough that uncertain voices survive to review.
+    nonisolated static let ghostSpeakerMergeSimilarityFloor: Double = 0.72
+
+    nonisolated static func bestGhostSpeakerMergeCandidate(
+        for meanEmbedding: [Float],
+        nonGhostMeans: [Int: [Float]]
+    ) -> GhostSpeakerMergeCandidate? {
+        var bestCandidate: GhostSpeakerMergeCandidate?
+        for (otherId, otherMean) in nonGhostMeans {
+            let similarity = cosineSimilarityStatic(meanEmbedding, otherMean)
+            guard bestCandidate == nil || similarity > bestCandidate!.similarity else { continue }
+            bestCandidate = GhostSpeakerMergeCandidate(speakerId: otherId, similarity: similarity)
+        }
+        return bestCandidate
+    }
+
     /// Diarize + transcribe the mic channel when local-speaker split is on.
     /// Mirrors the system-audio classification path but skips the cross-channel
     /// contamination gate (there's nothing to gate against inside mic processing itself).
@@ -680,14 +707,12 @@ extension Transcription {
             let isGhost = ghostSpeakerIdSet.contains(speakerId)
 
             if isGhost {
-                var bestNonGhostId: Int?
-                var bestSimilarity: Double = -1
-                for (otherId, otherMean) in nonGhostMeans {
-                    let sim = Self.cosineSimilarityStatic(meanEmbedding, otherMean)
-                    if sim > bestSimilarity { bestSimilarity = sim; bestNonGhostId = otherId }
-                }
-                if let targetId = bestNonGhostId {
-                    speakerIdRemap[speakerId] = targetId
+                let mergeCandidate = Self.bestGhostSpeakerMergeCandidate(
+                    for: meanEmbedding,
+                    nonGhostMeans: nonGhostMeans
+                )
+                if let candidate = mergeCandidate, candidate.similarity >= Self.ghostSpeakerMergeSimilarityFloor {
+                    speakerIdRemap[speakerId] = candidate.speakerId
                 } else {
                     let newProfile = speakerDB.addOrUpdateSpeaker(embedding: meanEmbedding, existingId: nil)
                     speakerNewProfiles[speakerId] = newProfile.id

--- a/Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift
@@ -1,4 +1,6 @@
 import XCTest
+import Combine
+import FluidAudio
 @testable import TranscriptedCore
 
 @available(macOS 14.0, *)
@@ -68,6 +70,78 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         )
 
         XCTAssertEqual(merged.count, 2)
+    }
+
+    @MainActor
+    func testMicDiarizationKeepsWeakGhostSpeakerStandalone() async throws {
+        let speakerDB = try temporarySpeakerDatabase()
+        var droppedSegments = 0
+
+        let result = try await Transcription.processMicChannelWithDiarization(
+            samples: alternatingSamples(amplitude: 0.02, count: 47 * 16_000),
+            diarization: PipelineStubDiarizationEngine(segments: [
+                speakerSegment(speakerId: 7, start: 0.0, end: 35.0, embedding: [1.0, 0.0], qualityScore: 0.95),
+                speakerSegment(speakerId: 6, start: 35.0, end: 47.0, embedding: unitVector(cosineToXAxis: 0.42), qualityScore: 0.20),
+            ]),
+            parakeet: PipelineStubSpeechToTextEngine(transcript: "spoken words"),
+            speakerDB: speakerDB,
+            existingProfiles: [],
+            droppedSegments: &droppedSegments,
+            onProgress: nil
+        )
+
+        XCTAssertEqual(droppedSegments, 0)
+        XCTAssertEqual(Set(result.utterances.map(\.speakerId)), [6, 7])
+        XCTAssertEqual(result.speakerContexts.count, 2)
+        XCTAssertEqual(speakerDB.allSpeakers().count, 2)
+    }
+
+    @MainActor
+    func testMicDiarizationStillMergesStrongGhostSpeakerMatch() async throws {
+        let speakerDB = try temporarySpeakerDatabase()
+        var droppedSegments = 0
+
+        let result = try await Transcription.processMicChannelWithDiarization(
+            samples: alternatingSamples(amplitude: 0.02, count: 47 * 16_000),
+            diarization: PipelineStubDiarizationEngine(segments: [
+                speakerSegment(speakerId: 7, start: 0.0, end: 35.0, embedding: [1.0, 0.0], qualityScore: 0.95),
+                speakerSegment(speakerId: 6, start: 35.0, end: 47.0, embedding: unitVector(cosineToXAxis: 0.78), qualityScore: 0.20),
+            ]),
+            parakeet: PipelineStubSpeechToTextEngine(transcript: "spoken words"),
+            speakerDB: speakerDB,
+            existingProfiles: [],
+            droppedSegments: &droppedSegments,
+            onProgress: nil
+        )
+
+        XCTAssertEqual(droppedSegments, 0)
+        XCTAssertEqual(Set(result.utterances.map(\.speakerId)), [7])
+        XCTAssertEqual(result.speakerContexts.count, 1)
+        XCTAssertEqual(speakerDB.allSpeakers().count, 1)
+    }
+
+    @MainActor
+    func testMicDiarizationKeepsGhostSpeakerStandaloneWhenNoNonGhostTargetExists() async throws {
+        let speakerDB = try temporarySpeakerDatabase()
+        var droppedSegments = 0
+
+        let result = try await Transcription.processMicChannelWithDiarization(
+            samples: alternatingSamples(amplitude: 0.02, count: 24 * 16_000),
+            diarization: PipelineStubDiarizationEngine(segments: [
+                speakerSegment(speakerId: 6, start: 0.0, end: 12.0, embedding: [1.0, 0.0], qualityScore: 0.20),
+                speakerSegment(speakerId: 7, start: 12.0, end: 24.0, embedding: [0.0, 1.0], qualityScore: 0.20),
+            ]),
+            parakeet: PipelineStubSpeechToTextEngine(transcript: "spoken words"),
+            speakerDB: speakerDB,
+            existingProfiles: [],
+            droppedSegments: &droppedSegments,
+            onProgress: nil
+        )
+
+        XCTAssertEqual(droppedSegments, 0)
+        XCTAssertEqual(Set(result.utterances.map(\.speakerId)), [6, 7])
+        XCTAssertEqual(result.speakerContexts.count, 2)
+        XCTAssertEqual(speakerDB.allSpeakers().count, 2)
     }
 
     func testDetectSpeechSegmentsSplitsOnLongSilence() {
@@ -264,6 +338,37 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         (0..<count).map { $0.isMultiple(of: 2) ? amplitude : -amplitude }
     }
 
+    private func unitVector(cosineToXAxis: Float) -> [Float] {
+        let y = sqrt(max(0, 1 - (cosineToXAxis * cosineToXAxis)))
+        return [cosineToXAxis, y]
+    }
+
+    private func speakerSegment(
+        speakerId: Int,
+        start: Double,
+        end: Double,
+        embedding: [Float],
+        qualityScore: Float
+    ) -> SpeakerSegment {
+        SpeakerSegment(
+            speakerId: speakerId,
+            startTime: start,
+            endTime: end,
+            embedding: embedding,
+            qualityScore: qualityScore
+        )
+    }
+
+    private func temporarySpeakerDatabase() throws -> SpeakerDatabase {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionPipelineHelpersTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+        }
+        return SpeakerDatabase(path: root.appendingPathComponent("speakers.sqlite").path)
+    }
+
     private func utterance(
         start: Double,
         end: Double,
@@ -282,5 +387,57 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
             matchSimilarity: matchSimilarity,
             transcript: transcript
         )
+    }
+}
+
+@available(macOS 14.0, *)
+@MainActor
+private final class PipelineStubSpeechToTextEngine: SpeechToTextEngine {
+    nonisolated let objectWillChange = ObservableObjectPublisher()
+    var isReady = true
+    private let transcript: String
+
+    init(transcript: String) {
+        self.transcript = transcript
+    }
+
+    func initialize() async {
+        isReady = true
+    }
+
+    func transcribeSegment(samples: [Float], source: AudioSource) async throws -> String {
+        transcript
+    }
+
+    func cleanup() {
+        isReady = false
+    }
+}
+
+@available(macOS 14.0, *)
+@MainActor
+private final class PipelineStubDiarizationEngine: DiarizationEngine {
+    nonisolated let objectWillChange = ObservableObjectPublisher()
+    var isReady = true
+    private let segments: [SpeakerSegment]
+
+    init(segments: [SpeakerSegment]) {
+        self.segments = segments
+    }
+
+    func initialize() async {
+        isReady = true
+    }
+
+    func diarizeOffline(samples: [Float], sampleRate: Int) async throws -> [SpeakerSegment] {
+        segments
+    }
+
+    func diarizeOffline(audioURL: URL) async throws -> [SpeakerSegment] {
+        segments
+    }
+
+    func cleanup() {
+        isReady = false
     }
 }


### PR DESCRIPTION
## Summary
- add a 0.72 minimum similarity floor before ghost speakers can be auto-merged
- apply the floor in both system-audio and mic diarization paths
- add synthetic regression coverage for weak, strong, and no-target ghost speaker cases

## Source truth
Grigory's June 1 support thread reported Transcripted 1.1.44 collapsing a six-person meeting to three speakers because ghost speakers were force-merged at weak cosine similarities.

## Findings
The "Save Names" symptom appears downstream of the merge: the naming sheet only receives already-processed speaker rows. Existing Grigory-style speaker naming regressions still pass, so I did not patch naming finalization separately.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (3252/3252)
- `bash run-integration-smoke.sh`
- `swift test` (346 passed, 1 skipped)
- `swift test --filter TranscriptionPipelineHelpersTests` (20/20)
- `swift test --filter SpeakerNamingCoordinatorTests` (21/21)
- deterministic E2E smoke
- Transcripted QA bench deep: 11/12 green; only warning was pre-existing local saved-library/index drift
- Codex review: clean
