### PR TITLE
Release Transcripted 1.1.45 metadata

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.44"
-  sha256 "3e16f98852d5d4fafa00f647580264134e202025f2091a3d8ecb8ca83d005d36"
+  version "1.1.45"
+  sha256 "f7d255ab0452fd99fd50b1f85cbb6b5364a93f5611ea0e6c51e53c49f13f8cb8"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.44</string>
+	<string>1.1.45</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.44</string>
+	<string>1.1.45</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.45</title>
+      <pubDate>Mon, 01 Jun 2026 22:21:37 -0500</pubDate>
+      <sparkle:version>1.1.45</sparkle:version>
+      <sparkle:shortVersionString>1.1.45</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.45/Transcripted-1.1.45.dmg" length="535809718" type="application/octet-stream" sparkle:edSignature="6NkU8GwQdcGH45Z1fvvLA57lVhgW1+/p/hA8qOpGRX+qv/iai6WdPTkTjXD/Pi+aypI9RPRlPWTA87hpkEQzAg==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.45</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.45</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.44</title>
       <pubDate>Wed, 27 May 2026 10:49:24 -0500</pubDate>
       <sparkle:version>1.1.44</sparkle:version>


### PR DESCRIPTION
Updates Transcripted release metadata for 1.1.45.\n\nIncludes:\n- Info.plist version bump to 1.1.45\n- Sparkle appcast entry for the notarized 1.1.45 DMG\n- Homebrew cask version and sha256 update\n\nVerified:\n- bash build-deps.sh --force\n- bash build.sh --no-open\n- NOTARY_PROFILE=Transcripted bash build-beta.sh "" Justin\n- bash scripts/release/verify-sparkle-release.sh 1.1.45\n- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh\n\nResidual blocker:\n- Sentry release registration and dSYM upload are not complete because current sentry-cli auth is read-only and returns 403. Needs a write-capable Sentry token with release/debug-file permissions.