### PR TITLE
[codex] Harden Sentry dSYM release registration

### DIFF
--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -481,6 +481,47 @@ func testRepoCommandContract() {
         assertTrue(cask.contains("depends_on macos: \">= :tahoe\""), "Homebrew cask should stay aligned with the macOS 26+ release floor")
     }
 
+    runSuite("Repo command contract - Sentry release registration requires matching dSYM") {
+        let buildBeta = readRepoTextFile("scripts/entrypoints/build-beta.sh")
+        let registerSentry = readRepoTextFile("scripts/release/register-sentry-release.sh")
+        let releaseDocs = readRepoTextFile("docs/release-packaging.md")
+
+        assertTrue(
+            buildBeta.contains("GENERATE_DSYM=\"${GENERATE_DSYM:-1}\"")
+                && buildBeta.contains("dsymutil \"$APP_BINARY\" -o \"$APP_DSYM\""),
+            "release builds should generate the app dSYM by default"
+        )
+        assertTrue(
+            buildBeta.contains("SENTRY_REQUIRE_DEBUG_FILES=\"${SENTRY_REQUIRE_DEBUG_FILES:-1}\"")
+                && buildBeta.contains("SENTRY_APP_BINARY_PATH=\"${SENTRY_APP_BINARY_PATH:-$APP_BINARY}\"")
+                && buildBeta.contains("SENTRY_DEBUG_FILES_PATH=\"${SENTRY_DEBUG_FILES_PATH:-$APP_DSYM}\""),
+            "build-beta.sh should register Sentry with the exact app/dSYM pair from the release build"
+        )
+        assertTrue(
+            registerSentry.contains("SENTRY_REQUIRE_DEBUG_FILES=\"${SENTRY_REQUIRE_DEBUG_FILES:-1}\"")
+                && registerSentry.contains("SENTRY_DEBUG_FILES_PATH=\"${SENTRY_DEBUG_FILES_PATH:-build/Transcripted.app.dSYM}\"")
+                && registerSentry.contains("SENTRY_APP_BINARY_PATH=\"${SENTRY_APP_BINARY_PATH:-build/Transcripted.app/Contents/MacOS/Transcripted}\""),
+            "standalone Sentry registration should require the release dSYM and know the matching app binary path by default"
+        )
+        assertTrue(
+            registerSentry.contains("dwarfdump --uuid \"$path\"")
+                && registerSentry.contains("verify_debug_file_match \"$SENTRY_APP_BINARY_PATH\" \"$SENTRY_DEBUG_FILES_PATH\"")
+                && registerSentry.contains("Sentry debug files do not match the app binary."),
+            "Sentry registration should fail before upload when the dSYM UUID does not match the app binary"
+        )
+        assertTrue(
+            registerSentry.contains("Release is yellow unless matching dSYM was uploaded separately"),
+            "explicit debug-file skips should call the release yellow"
+        )
+        assertTrue(
+            releaseDocs.contains("verifies the dSYM UUID matches the built app binary")
+                && releaseDocs.contains("SENTRY_DEBUG_FILES_PATH=/path/to/Transcripted.app.dSYM")
+                && releaseDocs.contains("SENTRY_APP_BINARY_PATH=/path/to/Transcripted.app/Contents/MacOS/Transcripted")
+                && releaseDocs.contains("call the release yellow"),
+            "release docs should tell future workers how to register a reused artifact without stale symbols"
+        )
+    }
+
     runSuite("Repo command contract - Sparkle app settings point at the committed appcast") {
         let infoPlist = readRepoTextFile("Info.plist")
         let appcast = readRepoTextFile("docs/appcast.xml")

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -128,19 +128,30 @@ Sparkle steps in `docs/sparkle-updates.md`.
 
 After the release is published on GitHub, register the matching Sentry release
 so Sentry sees a real finalized release before production events arrive. This
-also uploads `build/Transcripted.app.dSYM` when it is present:
+also requires and uploads `build/Transcripted.app.dSYM` by default:
 
 ```bash
-bash scripts/release/register-sentry-release.sh <version>
+SENTRY_REQUIRE_DEBUG_FILES=1 bash scripts/release/register-sentry-release.sh <version>
 ```
 
 The script creates/finalizes `transcripted@<version>` for the `r3dbars/apple-macos`
 Sentry project, associates commits when Sentry can resolve the repo, and uploads
-debug symbol files through `sentry-cli debug-files upload --no-sources`. If the
-dSYM was moved, set `SENTRY_DEBUG_FILES_PATH=/path/to/Transcripted.app.dSYM`. If
-symbols are intentionally unavailable for a one-off local registration, set
-`SENTRY_UPLOAD_DEBUG_FILES=0`; shipped releases should not skip this because
-crash reports may lose app frames.
+debug symbol files through `sentry-cli debug-files upload --no-sources`. Before
+upload, it verifies the dSYM UUID matches the built app binary at
+`build/Transcripted.app/Contents/MacOS/Transcripted`.
+
+If you are registering a reused artifact, set both paths so they point at the
+matching pair from that exact release build:
+
+```bash
+SENTRY_DEBUG_FILES_PATH=/path/to/Transcripted.app.dSYM \
+SENTRY_APP_BINARY_PATH=/path/to/Transcripted.app/Contents/MacOS/Transcripted \
+bash scripts/release/register-sentry-release.sh <version>
+```
+
+If symbols are intentionally unavailable for a one-off local registration, set
+`SENTRY_UPLOAD_DEBUG_FILES=0` and call the release yellow; shipped releases
+should not skip this because crash reports may lose app frames.
 
 If you expect `brew install` or `brew upgrade` to pick up the new version, do
 not stop after the GitHub release is published. You must also refresh and push

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,7 +40,7 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
 - `scripts/release/verify-sparkle-release.sh` — verify a GitHub release DMG, Sparkle appcast entry, and app updater settings line up
 - `scripts/release/update-cask.sh` — bump `Casks/transcripted.rb` to point at a newly published GitHub release
 - `scripts/release/sentry-release-metadata.py` — print the Sentry release/dist that the app will report from `Info.plist`
-- `scripts/release/register-sentry-release.sh` — create/finalize the matching Sentry release and upload release dSYMs after a GitHub release is published
+- `scripts/release/register-sentry-release.sh` — create/finalize the matching Sentry release, verify the release dSYM matches the app binary, and upload it after a GitHub release is published
 - `scripts/dev/onboarding.sh` — inspect, reset, or force the first-run onboarding state while iterating on copy and layout
 
 ## Operational health probes

--- a/scripts/entrypoints/build-beta.sh
+++ b/scripts/entrypoints/build-beta.sh
@@ -641,6 +641,7 @@ fi
 if [ "$REGISTER_SENTRY_RELEASE" = "1" ]; then
     echo "Registering Sentry release..."
     SENTRY_REQUIRE_DEBUG_FILES="${SENTRY_REQUIRE_DEBUG_FILES:-1}" \
+        SENTRY_APP_BINARY_PATH="${SENTRY_APP_BINARY_PATH:-$APP_BINARY}" \
         SENTRY_DEBUG_FILES_PATH="${SENTRY_DEBUG_FILES_PATH:-$APP_DSYM}" \
         bash scripts/release/register-sentry-release.sh "$APP_VERSION"
 fi

--- a/scripts/release/register-sentry-release.sh
+++ b/scripts/release/register-sentry-release.sh
@@ -6,6 +6,7 @@ usage() {
     echo "Usage: bash scripts/release/register-sentry-release.sh [version]"
     echo ""
     echo "Creates and finalizes the Sentry release matching Info.plist."
+    echo "Requires and uploads the matching release dSYM by default."
     echo "Defaults: SENTRY_ORG=r3dbars, SENTRY_PROJECT=apple-macos"
 }
 
@@ -25,8 +26,9 @@ SENTRY_PROJECT="${SENTRY_PROJECT:-apple-macos}"
 SENTRY_REPOSITORY="${SENTRY_REPOSITORY:-r3dbars/transcripted}"
 SENTRY_SET_COMMITS="${SENTRY_SET_COMMITS:-1}"
 SENTRY_UPLOAD_DEBUG_FILES="${SENTRY_UPLOAD_DEBUG_FILES:-1}"
-SENTRY_REQUIRE_DEBUG_FILES="${SENTRY_REQUIRE_DEBUG_FILES:-0}"
+SENTRY_REQUIRE_DEBUG_FILES="${SENTRY_REQUIRE_DEBUG_FILES:-1}"
 SENTRY_DEBUG_FILES_PATH="${SENTRY_DEBUG_FILES_PATH:-build/Transcripted.app.dSYM}"
+SENTRY_APP_BINARY_PATH="${SENTRY_APP_BINARY_PATH:-build/Transcripted.app/Contents/MacOS/Transcripted}"
 
 if ! command -v sentry-cli >/dev/null 2>&1; then
     echo "Missing sentry-cli."
@@ -82,6 +84,76 @@ sentry_commit_spec() {
     fi
 }
 
+uuid_set_for_path() {
+    local path="$1"
+    dwarfdump --uuid "$path" 2>/dev/null | awk '/^UUID:/ { print $2 }' | sort -u
+}
+
+print_uuid_set() {
+    local value="$1"
+
+    if [ -n "$value" ]; then
+        printf '%s\n' "$value" | sed 's/^/    /' >&2
+    else
+        echo "    [none]" >&2
+    fi
+}
+
+verify_debug_file_match() {
+    local binary_path="$1"
+    local debug_files_path="$2"
+    local binary_uuids
+    local debug_file_uuids
+
+    if ! command -v dwarfdump >/dev/null 2>&1; then
+        echo "Missing dwarfdump; cannot verify that Sentry debug files match the app binary." >&2
+        echo "Install Xcode command line tools before registering a shipped release." >&2
+        return 1
+    fi
+
+    if [ ! -e "$binary_path" ]; then
+        echo "Missing app binary for Sentry debug-file match verification: $binary_path" >&2
+        echo "Keep the release app bundle next to the dSYM, or set SENTRY_APP_BINARY_PATH to the matching app binary." >&2
+        return 1
+    fi
+
+    if ! binary_uuids="$(uuid_set_for_path "$binary_path")"; then
+        echo "Could not read UUIDs from app binary: $binary_path" >&2
+        return 1
+    fi
+
+    if ! debug_file_uuids="$(uuid_set_for_path "$debug_files_path")"; then
+        echo "Could not read UUIDs from Sentry debug files: $debug_files_path" >&2
+        return 1
+    fi
+
+    if [ -z "$binary_uuids" ] || [ -z "$debug_file_uuids" ]; then
+        echo "Sentry debug-file UUID verification failed." >&2
+        echo "  app binary: $binary_path" >&2
+        echo "  app UUID(s):" >&2
+        print_uuid_set "$binary_uuids"
+        echo "  debug files: $debug_files_path" >&2
+        echo "  debug UUID(s):" >&2
+        print_uuid_set "$debug_file_uuids"
+        return 1
+    fi
+
+    if [ "$binary_uuids" != "$debug_file_uuids" ]; then
+        echo "Sentry debug files do not match the app binary." >&2
+        echo "  app binary: $binary_path" >&2
+        echo "  app UUID(s):" >&2
+        print_uuid_set "$binary_uuids"
+        echo "  debug files: $debug_files_path" >&2
+        echo "  debug UUID(s):" >&2
+        print_uuid_set "$debug_file_uuids"
+        echo "Rebuild with build-beta.sh, or point SENTRY_DEBUG_FILES_PATH and SENTRY_APP_BINARY_PATH at the matching artifact pair." >&2
+        return 1
+    fi
+
+    echo "Verified Sentry debug files match the app binary UUID(s):"
+    printf '%s\n' "$binary_uuids" | sed 's/^/  /'
+}
+
 echo "Sentry release: $SENTRY_RELEASE"
 echo "Sentry dist: $SENTRY_DIST"
 echo "Sentry project: $SENTRY_ORG/$SENTRY_PROJECT"
@@ -112,6 +184,7 @@ fi
 
 if [ "$SENTRY_UPLOAD_DEBUG_FILES" = "1" ]; then
     if [ -e "$SENTRY_DEBUG_FILES_PATH" ]; then
+        verify_debug_file_match "$SENTRY_APP_BINARY_PATH" "$SENTRY_DEBUG_FILES_PATH"
         echo "Uploading Sentry debug files: $SENTRY_DEBUG_FILES_PATH"
         sentry-cli debug-files upload \
             --org "$SENTRY_ORG" \
@@ -125,10 +198,11 @@ if [ "$SENTRY_UPLOAD_DEBUG_FILES" = "1" ]; then
         exit 1
     else
         echo "Sentry debug files not found: $SENTRY_DEBUG_FILES_PATH"
-        echo "Skipping debug-file upload. Crash reports may be missing app frames."
+        echo "Skipping debug-file upload. Release is yellow unless matching dSYM was uploaded separately; crash reports may be missing app frames."
     fi
 else
     echo "Skipping Sentry debug-file upload because SENTRY_UPLOAD_DEBUG_FILES=$SENTRY_UPLOAD_DEBUG_FILES."
+    echo "Release is yellow unless matching dSYM was uploaded separately."
 fi
 
 echo "Sentry release registration complete."


### PR DESCRIPTION
## What changed

- Require Sentry release registration to require debug files by default and verify the dSYM UUID matches the app binary before upload.
- Pass the exact beta-build app binary path into Sentry registration when `REGISTER_SENTRY_RELEASE=1`.
- Document the reused-artifact path and add a repo command-contract guard for future release workers.

## Why

The 1.1.45 release was yellow because no matching dSYM was found/uploaded. This makes future release registration fail before upload on missing or non-matching symbols, or call the release yellow when debug-file upload is explicitly skipped.

## Verification

- `git diff --check`
- `bash -n scripts/release/register-sentry-release.sh`
- `bash -n scripts/entrypoints/build-beta.sh`
- `bash -n build-beta.sh`
- `scripts/dev/agent-preflight.sh`
- `python3 -m py_compile scripts/ops/generate-nightly-digest.py`
- `python3 scripts/ops/generate-nightly-digest.py --self-test`
- `bash run-tests.sh`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `SKIP_NOTARIZATION=1 REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 REQUIRE_BUNDLED_DIARIZER_MODELS=0 BUNDLE_DIARIZER_MODELS=0 REGISTER_SENTRY_RELEASE=0 bash build-beta.sh codex-smoke Codex`
- `dwarfdump --uuid build/Transcripted.app/Contents/MacOS/Transcripted`
- `dwarfdump --uuid build/Transcripted.app.dSYM`

The beta smoke generated matching UUID `930B4460-91F6-3BB5-B49E-1ED2694F9CF2` for the app binary and dSYM.