### PR TITLE
[codex] Fix failed meeting recovery actions

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1163,9 +1163,14 @@ final class MeetingSessionController: ObservableObject {
         return preservedCount
     }
 
-    func retryFailedMeeting(id: UUID) {
-        guard !isRecording, !hasBackgroundTranscriptionWork, !isSpeakerReviewPending else { return }
-        guard !retryingFailedMeetingIDs.contains(id) else { return }
+    @discardableResult
+    func retryFailedMeeting(id: UUID) -> Bool {
+        guard !isRecording, !hasBackgroundTranscriptionWork, !isSpeakerReviewPending else { return false }
+        guard !retryingFailedMeetingIDs.contains(id) else { return false }
+        guard failedManager.failedTranscriptions.contains(where: { $0.id == id }) else {
+            refreshFailedMeetings()
+            return false
+        }
 
         retryingFailedMeetingIDs.insert(id)
         activeTranscriptionTrigger = .unknown
@@ -1194,6 +1199,7 @@ final class MeetingSessionController: ObservableObject {
             self.retryingFailedMeetingIDs.remove(id)
             self.refreshFailedMeetings()
         }
+        return true
     }
 
     @discardableResult
@@ -1266,16 +1272,20 @@ final class MeetingSessionController: ObservableObject {
         return true
     }
 
-    func dismissFailedMeeting(id: UUID) {
+    @discardableResult
+    func dismissFailedMeeting(id: UUID) -> Bool {
         retryingFailedMeetingIDs.remove(id)
-        failedManager.removeFailedTranscription(id: id)
+        let didDismiss = failedManager.removeFailedTranscription(id: id)
         refreshFailedMeetings()
+        return didDismiss || !failedManager.failedTranscriptions.contains(where: { $0.id == id })
     }
 
-    func deleteFailedMeeting(id: UUID) {
+    @discardableResult
+    func deleteFailedMeeting(id: UUID) -> Bool {
         retryingFailedMeetingIDs.remove(id)
-        failedManager.deleteFailedTranscription(id: id)
+        let didDelete = failedManager.deleteFailedTranscription(id: id)
         refreshFailedMeetings()
+        return didDelete || !failedManager.failedTranscriptions.contains(where: { $0.id == id })
     }
 
     // MARK: - Subscriptions

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -717,7 +717,12 @@ public class TranscriptionTaskManager: ObservableObject {
             errorMessage: errorMessage,
             meetingTitle: meetingTitle
         )
-        guard didPersist else { return false }
+        guard didPersist else {
+            if let retainedAudio {
+                removeRetainedFailedAudio(retainedAudio)
+            }
+            return false
+        }
         guard removeOriginalsAfterArchive else { return true }
 
         if retainedAudio?.micURL != nil {
@@ -729,6 +734,21 @@ public class TranscriptionTaskManager: ObservableObject {
             removeManagedCleanupFile(originalSystemURL, label: "archived failed system scratch")
         }
         return true
+    }
+
+    private func removeRetainedFailedAudio(_ retainedAudio: RetainedRecordingAudio) {
+        let fileManager = FileManager.default
+        for url in [retainedAudio.micURL, retainedAudio.systemURL].compactMap({ $0 }) {
+            try? fileManager.removeItem(at: url)
+        }
+
+        let remaining = (try? fileManager.contentsOfDirectory(
+            at: retainedAudio.directory,
+            includingPropertiesForKeys: nil
+        )) ?? []
+        if remaining.isEmpty {
+            try? fileManager.removeItem(at: retainedAudio.directory)
+        }
     }
 
     private func makeSilentMicPlaceholderIfNeeded(
@@ -809,7 +829,7 @@ public class TranscriptionTaskManager: ObservableObject {
         guard failed.audioFilesExist() else {
             AppLogger.pipeline.error("Audio files no longer exist for failed transcription", ["failedId": "\(failedId)"])
             await MainActor.run {
-                failedTranscriptionManager.removeFailedTranscription(id: failedId)
+                _ = failedTranscriptionManager.removeFailedTranscription(id: failedId)
             }
             return false
         }

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -187,16 +187,24 @@ public class FailedTranscriptionManager: ObservableObject {
         return didPersist
     }
 
-    /// Removes a failed transcription from the queue
-    public func removeFailedTranscription(id: UUID) {
+    /// Removes a failed transcription from the queue.
+    @discardableResult
+    public func removeFailedTranscription(id: UUID) -> Bool {
         guard let index = failedTranscriptions.firstIndex(where: { $0.id == id }) else {
-            return
+            return false
         }
 
-        failedTranscriptions.remove(at: index)
-        saveFailedTranscriptions()
+        let removed = failedTranscriptions.remove(at: index)
+        let didPersist = saveFailedTranscriptions()
+        if !didPersist {
+            failedTranscriptions.insert(removed, at: index)
+        }
 
-        AppLogger.pipeline.info("Removed failed transcription", ["id": "\(id)"])
+        AppLogger.pipeline.info("Removed failed transcription", [
+            "id": "\(id)",
+            "persisted": "\(didPersist)"
+        ])
+        return didPersist
     }
 
     @discardableResult
@@ -225,10 +233,15 @@ public class FailedTranscriptionManager: ObservableObject {
         return didPersist
     }
 
-    /// Removes a failed transcription and deletes its audio files
-    public func deleteFailedTranscription(id: UUID) {
+    /// Removes a failed transcription and deletes its audio files.
+    @discardableResult
+    public func deleteFailedTranscription(id: UUID) -> Bool {
         guard let failed = failedTranscriptions.first(where: { $0.id == id }) else {
-            return
+            return false
+        }
+
+        guard removeFailedTranscription(id: id) else {
+            return false
         }
 
         // Delete audio files independently so one failure does not hide the other.
@@ -242,8 +255,7 @@ public class FailedTranscriptionManager: ObservableObject {
             removeEmptyAudioArchiveDirectoryIfNeeded(containing: systemURL)
         }
 
-        // Remove from queue
-        removeFailedTranscription(id: id)
+        return true
     }
 
     /// Increments retry count for a failed transcription

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -306,7 +306,7 @@ struct TranscriptedSettingsView: View {
                     audioAttachment: { failedMeetingAudioAttachment(for: $0) },
                     onRetry: { item in
                         trackSettingsAction("home_retry_failed_meeting", page: .home)
-                        meetingSession.retryFailedMeeting(id: item.id)
+                        retryFailedMeeting(item)
                     },
                     onRevealAudio: { item in
                         trackSettingsAction("home_reveal_failed_meeting_audio", page: .home)
@@ -420,7 +420,7 @@ struct TranscriptedSettingsView: View {
                     },
                     onRetryFailedMeeting: { item in
                         trackSettingsAction("home_retry_failed_meeting", page: .home)
-                        meetingSession.retryFailedMeeting(id: item.id)
+                        retryFailedMeeting(item)
                     },
                     onRevealFailedMeetingAudio: { item in
                         trackSettingsAction("home_reveal_failed_meeting_audio", page: .home)
@@ -841,10 +841,21 @@ struct TranscriptedSettingsView: View {
             MeetingAudioPlayback.shared.stop()
         }
 
+        let didClear: Bool
+        let failureTitle: String
         if !item.audioURLs.isEmpty {
-            meetingSession.deleteFailedMeeting(id: item.id)
+            didClear = meetingSession.deleteFailedMeeting(id: item.id)
+            failureTitle = "Could not delete failed meeting"
         } else {
-            meetingSession.dismissFailedMeeting(id: item.id)
+            didClear = meetingSession.dismissFailedMeeting(id: item.id)
+            failureTitle = "Could not dismiss failed meeting"
+        }
+
+        if !didClear {
+            presentHomeActionFailure(
+                title: failureTitle,
+                message: "Transcripted could not update the failed-meeting queue. Check the capture folder, then try again."
+            )
         }
     }
 
@@ -854,11 +865,26 @@ struct TranscriptedSettingsView: View {
     }
 
     private func presentHomeDeleteFailure(title: String, error: Error) {
+        presentHomeActionFailure(title: title, message: error.localizedDescription)
+    }
+
+    private func presentHomeActionFailure(title: String, message: String) {
         NSSound.beep()
         homeDeleteFailure = HomeDeleteFailure(
             title: title,
-            message: error.localizedDescription
+            message: message
         )
+    }
+
+    private func retryFailedMeeting(_ item: MeetingSessionController.FailedMeetingItem) {
+        let didStart = meetingSession.retryFailedMeeting(id: item.id)
+        if !didStart {
+            presentHomeActionFailure(
+                title: "Could not retry meeting",
+                message: failedMeetingRetryUnavailableReason
+                    ?? "Transcripted could not start that retry. The saved audio may already be cleared."
+            )
+        }
     }
 
     private var homeWelcomeSummary: String {

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1816,6 +1816,40 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - Home failed meeting actions surface failures") {
+        let settingsContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
+        let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let managerContents = readRepoTextFile("Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift")
+
+        assertTrue(
+            controllerContents.contains("func retryFailedMeeting(id: UUID) -> Bool"),
+            "failed-meeting retry should report whether the retry started"
+        )
+        assertTrue(
+            controllerContents.contains("func dismissFailedMeeting(id: UUID) -> Bool")
+                && controllerContents.contains("func deleteFailedMeeting(id: UUID) -> Bool"),
+            "failed-meeting clear actions should report whether the queue changed"
+        )
+        assertTrue(
+            managerContents.contains("public func removeFailedTranscription(id: UUID) -> Bool")
+                && managerContents.contains("public func deleteFailedTranscription(id: UUID) -> Bool"),
+            "failed-queue manager deletes should return persistence results instead of fire-and-forget"
+        )
+        assertTrue(
+            settingsContents.contains("retryFailedMeeting(item)")
+                && settingsContents.contains("let didStart = meetingSession.retryFailedMeeting(id: item.id)")
+                && settingsContents.contains("title: \"Could not retry meeting\""),
+            "Home retry clicks should surface immediate retry blockers"
+        )
+        assertTrue(
+            settingsContents.contains("let didClear: Bool")
+                && settingsContents.contains("didClear = meetingSession.deleteFailedMeeting(id: item.id)")
+                && settingsContents.contains("didClear = meetingSession.dismissFailedMeeting(id: item.id)")
+                && settingsContents.contains("if !didClear"),
+            "Home delete/dismiss clicks should surface failed queue updates"
+        )
+    }
+
     runSuite("Repo command contract - Paste Last Dictation uses the paste target guard") {
         let menuContents = readRepoTextFile("Sources/UI/MenuBar/MenuBarPanelController.swift")
         let appContents = readRepoTextFile("Sources/TranscriptedApp.swift")

--- a/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
@@ -160,6 +160,64 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertEqual(manager.failedTranscriptions.count, 1)
     }
 
+    func testDeleteFailedTranscriptionRemovesTinyRetainedAudioAndQueueEntry() throws {
+        let paths = makePaths(root: testRoot)
+        let archiveRoot = paths.transcripts.appendingPathComponent("audio", isDirectory: true)
+        let archivedDirectory = archiveRoot.appendingPathComponent("Tiny_Recoverable_Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: archivedDirectory, withIntermediateDirectories: true)
+
+        let archivedMicURL = archivedDirectory.appendingPathComponent("microphone.wav")
+        let archivedSystemURL = archivedDirectory.appendingPathComponent("system_audio.wav")
+        FileManager.default.createFile(atPath: archivedMicURL.path, contents: Data([0x01]))
+        FileManager.default.createFile(atPath: archivedSystemURL.path, contents: Data([0x02]))
+
+        let manager = FailedTranscriptionManager(paths: paths)
+        let failedId = UUID()
+        XCTAssertTrue(manager.addFailedTranscription(
+            id: failedId,
+            micAudioURL: archivedMicURL,
+            systemAudioURL: archivedSystemURL,
+            errorMessage: "Meeting saved before quit. Audio is safe; finish the transcript from Home after reopening."
+        ))
+
+        XCTAssertTrue(manager.deleteFailedTranscription(id: failedId))
+        XCTAssertTrue(manager.failedTranscriptions.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: archivedMicURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: archivedSystemURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: archivedDirectory.path))
+
+        let persisted = try JSONDecoder.iso8601.decode(
+            [FailedTranscription].self,
+            from: Data(contentsOf: paths.failedQueue)
+        )
+        XCTAssertTrue(persisted.isEmpty)
+    }
+
+    func testDeleteFailedTranscriptionRollsBackWhenPersistenceFails() throws {
+        let paths = makePaths(root: testRoot)
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+
+        let micURL = paths.audioCaptures.appendingPathComponent("safe-mic.wav")
+        FileManager.default.createFile(atPath: micURL.path, contents: Data("mic".utf8))
+
+        let manager = FailedTranscriptionManager(paths: paths)
+        let failedId = UUID()
+        XCTAssertTrue(manager.addFailedTranscription(
+            id: failedId,
+            micAudioURL: micURL,
+            systemAudioURL: nil,
+            errorMessage: "Temporary transcription failure"
+        ))
+        let failure = try XCTUnwrap(manager.failedTranscriptions.first)
+
+        try FileManager.default.removeItem(at: paths.failedQueue)
+        try FileManager.default.createDirectory(at: paths.failedQueue, withIntermediateDirectories: true)
+
+        XCTAssertFalse(manager.deleteFailedTranscription(id: failedId))
+        XCTAssertEqual(manager.failedTranscriptions, [failure])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
+    }
+
     func testAddFailedTranscriptionPersistsMeetingTitle() throws {
         let paths = makePaths(root: testRoot)
         try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -520,6 +520,39 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path), "scratch system audio should be removed after archive")
     }
 
+    func testManualFailedQueueRemovesRetainedAudioWhenQueuePersistenceFails() throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(retainedAudioDirectory: retainedAudioDirectory)
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        try FileManager.default.createDirectory(at: scratchDirectory, withIntermediateDirectories: true)
+        let micURL = scratchDirectory.appendingPathComponent("mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+        try FileManager.default.createDirectory(
+            at: tempDirectory.appendingPathComponent("failed_transcriptions.json"),
+            withIntermediateDirectories: true
+        )
+
+        let didQueue = manager.addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: "Temporary transcription failure"
+        )
+
+        XCTAssertFalse(didQueue)
+        XCTAssertTrue(manager.failedTranscriptionManager.failedTranscriptions.isEmpty)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path), "scratch mic audio should stay when queue persistence fails")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path), "scratch system audio should stay when queue persistence fails")
+        let retainedChildren = (try? FileManager.default.contentsOfDirectory(
+            at: retainedAudioDirectory,
+            includingPropertiesForKeys: nil
+        )) ?? []
+        XCTAssertTrue(retainedChildren.isEmpty, "failed queue persistence should not leave orphan retained audio")
+    }
+
     func testSystemOnlyFailedQueueCreatesPlaceholderAndRetainsSystemAudio() throws {
         let retainedAudioDirectory = tempDirectory
             .appendingPathComponent("transcripts", isDirectory: true)


### PR DESCRIPTION
## Summary
- make failed meeting delete/dismiss report whether the queue actually changed
- surface retry/delete failures in Home instead of silently leaving the recovery card unchanged
- clean up copied retained audio if queue persistence fails
- add regression coverage for tiny retained audio deletion, queue rollback, orphan cleanup, and Home wiring

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` -> 3406 passed
- `bash run-integration-smoke.sh`
- `swift test` -> 349 passed, 1 skipped
