### PR TITLE
[codex] Clarify agent first-answer prompts

### DIFF
--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -173,6 +173,10 @@ enum AgentConnectionGuide {
 
         Use these files as the source of truth.
 
+        Good first asks:
+        - Summarize my latest meeting. Tell me which Transcripted source you used, including the filename/date, then list decisions and action items.
+        - Review yesterday. Use recent context or a recap to tell me what I promised, what changed, and what I should follow up on today.
+
         Rules:
         - Prefer Transcripted direct tools when available; otherwise search meetings and dictations together from files.
         - Cite filenames, dates, speakers, and timestamps when useful.

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -68,6 +68,14 @@ func testAgentConnectionGuide() {
             "prompt should support direct-tool retrieval and folder fallback"
         )
         assertTrue(
+            prompt.contains("Summarize my latest meeting. Tell me which Transcripted source you used, including the filename/date, then list decisions and action items."),
+            "prompt should give agents a concrete first-answer ask"
+        )
+        assertTrue(
+            prompt.contains("Review yesterday. Use recent context or a recap to tell me what I promised, what changed, and what I should follow up on today."),
+            "prompt should make the next-day return ask obvious"
+        )
+        assertTrue(
             prompt.contains("For relative dates like today or yesterday, state the exact dates searched."),
             "prompt should force exact dates for relative-date work"
         )

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -18,6 +18,22 @@ Claude Desktop is the best full-library experience.
 4. Click `Install in Claude`.
 5. Restart Claude Desktop.
 
+After restart, ask Claude:
+
+```text
+Use Transcripted to summarize my latest meeting. Tell me which Transcripted source you used, including the filename/date, then list decisions and action items.
+```
+
+Tomorrow, ask:
+
+```text
+Review yesterday. Use recent context or a recap to tell me what I promised, what changed, and what I should follow up on today.
+```
+
+Claude answers from Transcripted's read-only direct tools. If those tools are
+unavailable, use the local-agent prompt below so an agent can fall back to the
+saved Markdown folders.
+
 Transcripted copies the bundled `transcripted-mcp` helper into:
 
 ```text
@@ -56,6 +72,9 @@ Current `transcripted-mcp` capabilities:
 - `search`
 - `who_is`
 - `recap`
+
+These tools are read-only, but they are not redacted. `read_meeting` and
+`read_dictation` can return local transcript text to the agent you connected.
 
 ## Good Path: Local Coding Agents
 


### PR DESCRIPTION
## What changed

- Adds concrete first-answer and next-day review asks to the shared Transcripted local-agent starter prompt.
- Covers those asks in `AgentConnectionGuideTests` so the activation copy stays test-protected.
- Updates `docs/agent-connect.md` so Claude Desktop users know what to ask immediately after restart and what to ask tomorrow.
- Clarifies that Transcripted MCP tools are read-only but can return local transcript text to the connected agent.

## Why

The first agent-answer bridge was one click short: setup explained connection, but did not make the immediate useful question or next-day return loop explicit.

## Verification

- `scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force` after the first app build reported stale/missing deps
- `bash build.sh --no-open`
- `bash run-tests.sh` (3409 passed, 0 failed)
