### PR TITLE
[codex] Add activation telemetry events

### DIFF
--- a/Sources/Observability/ActivationTelemetry.swift
+++ b/Sources/Observability/ActivationTelemetry.swift
@@ -1,0 +1,198 @@
+import Foundation
+
+enum ActivationTelemetry {
+    enum ArtifactKind: String {
+        case dictation
+        case meeting
+    }
+
+    enum ArtifactActionKind: String {
+        case openMarkdown = "open_markdown"
+        case revealFolder = "reveal_folder"
+        case preview
+    }
+
+    enum Surface: String {
+        case onboarding
+        case home
+        case homeRow = "home_row"
+        case homeMenu = "home_menu"
+        case homePreview = "home_preview"
+        case homeCurrentActivity = "home_current_activity"
+        case agentSettings = "agent_settings"
+        case menubarAgent = "menubar_agent"
+    }
+
+    enum AgentPromptKind: String {
+        case localAgentPrompt = "local_agent_prompt"
+        case claudeDesktopSetup = "claude_desktop_setup"
+        case folderAccess = "folder_access"
+        case folderPaths = "folder_paths"
+        case codexInboxSetup = "codex_inbox_setup"
+        case liveMeetingCodexSetup = "live_meeting_codex_setup"
+        case liveMeetingCoworkSetup = "live_meeting_cowork_setup"
+        case liveMeetingPreview = "live_meeting_preview"
+        case meetingBundle = "meeting_bundle"
+        case meetingMarkdown = "meeting_markdown"
+    }
+
+    enum AgentTarget: String {
+        case claudeDesktop = "claude_desktop"
+        case codex
+        case cowork
+        case fallbackFolder = "fallback_folder"
+        case localAgent = "local_agent"
+    }
+
+    enum AgentPromptActionKind: String {
+        case copied
+        case opened
+    }
+
+    enum AgentPromptResult: String {
+        case success
+        case fallbackCopied = "fallback_copied"
+        case failed
+    }
+
+    enum AgentSetupKind: String {
+        case claudeDesktop = "claude_desktop"
+        case codexInbox = "codex_inbox"
+        case folderAccess = "folder_access"
+        case livePreview = "live_preview"
+        case liveSidecar = "live_sidecar"
+        case localPrompt = "local_prompt"
+    }
+
+    enum AgentSetupPriorStatus: String {
+        case installed
+        case needsRepair = "needs_repair"
+        case notInstalled = "not_installed"
+        case partial
+        case ready
+        case unknown
+    }
+
+    enum AgentSetupResult: String {
+        case fallbackCopied = "fallback_copied"
+        case failed
+        case success
+    }
+
+    static func trackArtifactAction(
+        artifactKind: ArtifactKind,
+        actionKind: ArtifactActionKind,
+        surface: Surface,
+        artifactDate: Date? = nil,
+        now: Date = Date()
+    ) {
+        AnalyticsReporter.track(
+            "activation_artifact_action_clicked",
+            properties: [
+                "action_kind": actionKind.rawValue,
+                "artifact_age_bucket": artifactAgeBucket(since: artifactDate, now: now),
+                "artifact_kind": artifactKind.rawValue,
+                "surface": surface.rawValue,
+            ]
+        )
+    }
+
+    static func trackAgentPromptAction(
+        promptKind: AgentPromptKind,
+        actionKind: AgentPromptActionKind,
+        agentTarget: AgentTarget,
+        surface: Surface,
+        result: AgentPromptResult = .success,
+        artifactKind: ArtifactKind? = nil
+    ) {
+        var properties = [
+            "action_kind": actionKind.rawValue,
+            "agent_target": agentTarget.rawValue,
+            "prompt_kind": promptKind.rawValue,
+            "result": result.rawValue,
+            "surface": surface.rawValue,
+        ]
+        if let artifactKind {
+            properties["artifact_kind"] = artifactKind.rawValue
+        }
+
+        AnalyticsReporter.track("activation_agent_prompt_action_clicked", properties: properties)
+    }
+
+    static func trackAgentSetupCTA(
+        setupKind: AgentSetupKind,
+        agentTarget: AgentTarget,
+        surface: Surface,
+        priorStatus: AgentSetupPriorStatus = .unknown,
+        result: AgentSetupResult = .success
+    ) {
+        AnalyticsReporter.track(
+            "activation_agent_setup_cta_clicked",
+            properties: [
+                "agent_target": agentTarget.rawValue,
+                "prior_status": priorStatus.rawValue,
+                "result": result.rawValue,
+                "setup_kind": setupKind.rawValue,
+                "surface": surface.rawValue,
+            ]
+        )
+    }
+
+    @discardableResult
+    static func trackReturnProxyIfEligible(
+        priorArtifactKind: ArtifactKind,
+        priorArtifactDate: Date,
+        surface: Surface,
+        now: Date = Date()
+    ) -> Bool {
+        guard let returnWindowBucket = returnWindowBucket(since: priorArtifactDate, now: now) else {
+            return false
+        }
+
+        AnalyticsReporter.track(
+            "activation_return_proxy_observed",
+            properties: [
+                "prior_artifact_kind": priorArtifactKind.rawValue,
+                "proxy_kind": "home_recent_artifact",
+                "return_window_bucket": returnWindowBucket,
+                "surface": surface.rawValue,
+            ]
+        )
+        return true
+    }
+
+    static func artifactAgeBucket(since date: Date?, now: Date = Date()) -> String {
+        guard let date else { return "unknown" }
+        let hours = max(0, now.timeIntervalSince(date)) / 3_600
+
+        switch hours {
+        case ..<12:
+            return "lt_12h"
+        case ..<24:
+            return "12_24h"
+        case ..<48:
+            return "24_48h"
+        case ..<168:
+            return "2_7d"
+        default:
+            return "older"
+        }
+    }
+
+    static func returnWindowBucket(since date: Date, now: Date = Date()) -> String? {
+        let hours = max(0, now.timeIntervalSince(date)) / 3_600
+
+        switch hours {
+        case ..<18:
+            return nil
+        case ..<36:
+            return "18_36h"
+        case ..<72:
+            return "36_72h"
+        case ..<168:
+            return "3_7d"
+        default:
+            return "older"
+        }
+    }
+}

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -100,6 +100,37 @@ struct AnalyticsEventPolicy: Equatable {
         "trigger",
     ]
 
+    private static let activationArtifactActionProperties: Set<String> = [
+        "action_kind",
+        "artifact_age_bucket",
+        "artifact_kind",
+        "surface",
+    ]
+
+    private static let activationAgentPromptActionProperties: Set<String> = [
+        "action_kind",
+        "agent_target",
+        "artifact_kind",
+        "prompt_kind",
+        "result",
+        "surface",
+    ]
+
+    private static let activationAgentSetupProperties: Set<String> = [
+        "agent_target",
+        "prior_status",
+        "result",
+        "setup_kind",
+        "surface",
+    ]
+
+    private static let activationReturnProxyProperties: Set<String> = [
+        "prior_artifact_kind",
+        "proxy_kind",
+        "return_window_bucket",
+        "surface",
+    ]
+
     private static let allowedPolicies: [String: AnalyticsEventPolicy] = [
         "app_launched": .init(
             name: "app_launched",
@@ -255,6 +286,22 @@ struct AnalyticsEventPolicy: Equatable {
                 "step_id",
                 "step_index",
             ]
+        ),
+        "activation_artifact_action_clicked": .init(
+            name: "activation_artifact_action_clicked",
+            allowedProperties: activationArtifactActionProperties
+        ),
+        "activation_agent_prompt_action_clicked": .init(
+            name: "activation_agent_prompt_action_clicked",
+            allowedProperties: activationAgentPromptActionProperties
+        ),
+        "activation_agent_setup_cta_clicked": .init(
+            name: "activation_agent_setup_cta_clicked",
+            allowedProperties: activationAgentSetupProperties
+        ),
+        "activation_return_proxy_observed": .init(
+            name: "activation_return_proxy_observed",
+            allowedProperties: activationReturnProxyProperties
         ),
         "menu_bar_opened": .init(
             name: "menu_bar_opened",

--- a/Sources/UI/MenuBar/MenuAgentConnectPageView.swift
+++ b/Sources/UI/MenuBar/MenuAgentConnectPageView.swift
@@ -189,6 +189,17 @@ final class MenuAgentConnectPageView: NSView {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(AgentConnectionGuide.starterPrompt(filename: nil), forType: .string)
+        ActivationTelemetry.trackAgentSetupCTA(
+            setupKind: .localPrompt,
+            agentTarget: .localAgent,
+            surface: .menubarAgent
+        )
+        ActivationTelemetry.trackAgentPromptAction(
+            promptKind: .localAgentPrompt,
+            actionKind: .copied,
+            agentTarget: .localAgent,
+            surface: .menubarAgent
+        )
 
         resetTask?.cancel()
         copyPromptButton.title = "Copied"
@@ -208,6 +219,17 @@ final class MenuAgentConnectPageView: NSView {
             "\(AgentConnectionGuide.mcpSetupText)\n\n\(AgentConnectionGuide.mcpConfigExample)",
             forType: .string
         )
+        ActivationTelemetry.trackAgentSetupCTA(
+            setupKind: .claudeDesktop,
+            agentTarget: .claudeDesktop,
+            surface: .menubarAgent
+        )
+        ActivationTelemetry.trackAgentPromptAction(
+            promptKind: .claudeDesktopSetup,
+            actionKind: .copied,
+            agentTarget: .claudeDesktop,
+            surface: .menubarAgent
+        )
 
         resetTask?.cancel()
         copyMCPButton.title = "Copied"
@@ -224,6 +246,12 @@ final class MenuAgentConnectPageView: NSView {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(AgentConnectionGuide.folderPathsText, forType: .string)
+        ActivationTelemetry.trackAgentPromptAction(
+            promptKind: .folderPaths,
+            actionKind: .copied,
+            agentTarget: .fallbackFolder,
+            surface: .menubarAgent
+        )
 
         resetTask?.cancel()
         copyFoldersButton.title = "Copied"

--- a/Sources/UI/Settings/AgentConnectionSettingsPage.swift
+++ b/Sources/UI/Settings/AgentConnectionSettingsPage.swift
@@ -60,6 +60,12 @@ struct AgentConnectionSettingsPage: View {
                                 title: copiedClaudeDesktopConfig ? "Copied" : "Copy Claude Config",
                                 symbolName: "doc.on.doc"
                             ) {
+                                ActivationTelemetry.trackAgentPromptAction(
+                                    promptKind: .claudeDesktopSetup,
+                                    actionKind: .copied,
+                                    agentTarget: .claudeDesktop,
+                                    surface: .agentSettings
+                                )
                                 copyText(
                                     ClaudeDesktopIntegrationInstaller.configSnippet(),
                                     showingCopiedFeedback: $copiedClaudeDesktopConfig
@@ -106,6 +112,12 @@ struct AgentConnectionSettingsPage: View {
                                     title: copiedFolderPrompt ? "Copied" : "Copy Folder Prompt",
                                     symbolName: "doc.on.doc"
                                 ) {
+                                    ActivationTelemetry.trackAgentPromptAction(
+                                        promptKind: .folderAccess,
+                                        actionKind: .copied,
+                                        agentTarget: .fallbackFolder,
+                                        surface: .agentSettings
+                                    )
                                     copyText(
                                         AgentConnectionGuide.folderAccessPrompt,
                                         showingCopiedFeedback: $copiedFolderPrompt
@@ -116,6 +128,12 @@ struct AgentConnectionSettingsPage: View {
                                     title: copiedFolderPaths ? "Copied" : "Copy Paths",
                                     symbolName: "folder"
                                 ) {
+                                    ActivationTelemetry.trackAgentPromptAction(
+                                        promptKind: .folderPaths,
+                                        actionKind: .copied,
+                                        agentTarget: .fallbackFolder,
+                                        surface: .agentSettings
+                                    )
                                     copyText(
                                         AgentConnectionGuide.folderPathsText,
                                         showingCopiedFeedback: $copiedFolderPaths
@@ -154,6 +172,17 @@ struct AgentConnectionSettingsPage: View {
                     tint: Color(nsColor: .systemBlue),
                     isEnabled: true
                 ) {
+                    ActivationTelemetry.trackAgentSetupCTA(
+                        setupKind: .localPrompt,
+                        agentTarget: .localAgent,
+                        surface: .agentSettings
+                    )
+                    ActivationTelemetry.trackAgentPromptAction(
+                        promptKind: .localAgentPrompt,
+                        actionKind: .copied,
+                        agentTarget: .localAgent,
+                        surface: .agentSettings
+                    )
                     copyText(
                         AgentConnectionGuide.starterPrompt(filename: nil),
                         showingCopiedFeedback: $copiedLocalAgentPrompt
@@ -339,6 +368,7 @@ struct AgentConnectionSettingsPage: View {
 
     private func installClaudeDesktop() {
         guard !isInstallingClaudeDesktop else { return }
+        let priorStatus = claudeDesktopActivationPriorStatus
         isInstallingClaudeDesktop = true
         claudeDesktopInstallResult = nil
         claudeDesktopInstallError = nil
@@ -351,9 +381,23 @@ struct AgentConnectionSettingsPage: View {
 
                 claudeDesktopInstallResult = result
                 refreshClaudeDesktopStatus()
+                ActivationTelemetry.trackAgentSetupCTA(
+                    setupKind: .claudeDesktop,
+                    agentTarget: .claudeDesktop,
+                    surface: .agentSettings,
+                    priorStatus: priorStatus,
+                    result: .success
+                )
             } catch {
                 claudeDesktopInstallError = error.localizedDescription
                 refreshClaudeDesktopStatus()
+                ActivationTelemetry.trackAgentSetupCTA(
+                    setupKind: .claudeDesktop,
+                    agentTarget: .claudeDesktop,
+                    surface: .agentSettings,
+                    priorStatus: priorStatus,
+                    result: .failed
+                )
             }
 
             isInstallingClaudeDesktop = false
@@ -366,14 +410,37 @@ struct AgentConnectionSettingsPage: View {
         do {
             let inboxURL = try AgentConnectionGuide.ensureCodexInboxFolder()
             copyText(AgentConnectionGuide.codexInboxSetupPrompt(inboxURL: inboxURL))
+            ActivationTelemetry.trackAgentPromptAction(
+                promptKind: .codexInboxSetup,
+                actionKind: .copied,
+                agentTarget: .codex,
+                surface: .agentSettings
+            )
 
             guard let setupURL = AgentConnectionGuide.codexInboxSetupURL(inboxURL: inboxURL) else {
                 NSWorkspace.shared.activateFileViewerSelecting([inboxURL])
                 codexInboxSetupError = "The setup prompt was copied. Open Codex and paste it."
+                ActivationTelemetry.trackAgentSetupCTA(
+                    setupKind: .codexInbox,
+                    agentTarget: .codex,
+                    surface: .agentSettings,
+                    result: .fallbackCopied
+                )
                 return
             }
 
             if NSWorkspace.shared.open(setupURL) {
+                ActivationTelemetry.trackAgentSetupCTA(
+                    setupKind: .codexInbox,
+                    agentTarget: .codex,
+                    surface: .agentSettings
+                )
+                ActivationTelemetry.trackAgentPromptAction(
+                    promptKind: .codexInboxSetup,
+                    actionKind: .opened,
+                    agentTarget: .codex,
+                    surface: .agentSettings
+                )
                 openedCodexInboxSetup = true
                 Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 1_500_000_000)
@@ -382,9 +449,21 @@ struct AgentConnectionSettingsPage: View {
             } else {
                 NSWorkspace.shared.activateFileViewerSelecting([inboxURL])
                 codexInboxSetupError = "Codex was not found. The setup prompt was copied and the inbox folder is open."
+                ActivationTelemetry.trackAgentSetupCTA(
+                    setupKind: .codexInbox,
+                    agentTarget: .codex,
+                    surface: .agentSettings,
+                    result: .fallbackCopied
+                )
             }
         } catch {
             codexInboxSetupError = "Could not set up Codex Inbox: \(error.localizedDescription)"
+            ActivationTelemetry.trackAgentSetupCTA(
+                setupKind: .codexInbox,
+                agentTarget: .codex,
+                surface: .agentSettings,
+                result: .failed
+            )
         }
     }
 
@@ -396,14 +475,37 @@ struct AgentConnectionSettingsPage: View {
             LiveMeetingCodexPreferences.setEnabled(true)
             let workspaceURL = try prepareLiveMeetingSidecarWorkspaceForUse()
             copyText(AgentConnectionGuide.liveMeetingCodexSetupPrompt(workspaceURL: workspaceURL))
+            ActivationTelemetry.trackAgentPromptAction(
+                promptKind: .liveMeetingCodexSetup,
+                actionKind: .copied,
+                agentTarget: .codex,
+                surface: .agentSettings
+            )
 
             guard let setupURL = AgentConnectionGuide.liveMeetingCodexSetupURL(workspaceURL: workspaceURL) else {
                 NSWorkspace.shared.activateFileViewerSelecting([workspaceURL])
                 liveMeetingCodexSetupError = "The setup prompt was copied. Open Codex and paste it."
+                ActivationTelemetry.trackAgentSetupCTA(
+                    setupKind: .liveSidecar,
+                    agentTarget: .codex,
+                    surface: .agentSettings,
+                    result: .fallbackCopied
+                )
                 return
             }
 
             if NSWorkspace.shared.open(setupURL) {
+                ActivationTelemetry.trackAgentSetupCTA(
+                    setupKind: .liveSidecar,
+                    agentTarget: .codex,
+                    surface: .agentSettings
+                )
+                ActivationTelemetry.trackAgentPromptAction(
+                    promptKind: .liveMeetingCodexSetup,
+                    actionKind: .opened,
+                    agentTarget: .codex,
+                    surface: .agentSettings
+                )
                 openedLiveMeetingCodexSetup = true
                 Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 1_500_000_000)
@@ -412,6 +514,12 @@ struct AgentConnectionSettingsPage: View {
             } else {
                 NSWorkspace.shared.activateFileViewerSelecting([workspaceURL])
                 liveMeetingCodexSetupError = "Codex was not found. The setup prompt was copied and the live folder is open."
+                ActivationTelemetry.trackAgentSetupCTA(
+                    setupKind: .liveSidecar,
+                    agentTarget: .codex,
+                    surface: .agentSettings,
+                    result: .fallbackCopied
+                )
             }
         } catch {
             liveMeetingCodexEnabled = false
@@ -419,6 +527,12 @@ struct AgentConnectionSettingsPage: View {
             meetingSession?.stopLiveCodexSessionFromSettings()
             stopLiveMeetingSidecarPreview()
             liveMeetingCodexSetupError = "Could not set up Live Sidecar: \(error.localizedDescription)"
+            ActivationTelemetry.trackAgentSetupCTA(
+                setupKind: .liveSidecar,
+                agentTarget: .codex,
+                surface: .agentSettings,
+                result: .failed
+            )
         }
     }
 
@@ -444,6 +558,17 @@ struct AgentConnectionSettingsPage: View {
             LiveMeetingCodexPreferences.setEnabled(true)
             let workspaceURL = try prepareLiveMeetingSidecarWorkspaceForUse()
             copyText(AgentConnectionGuide.liveMeetingCoworkSetupPrompt(workspaceURL: workspaceURL))
+            ActivationTelemetry.trackAgentSetupCTA(
+                setupKind: .liveSidecar,
+                agentTarget: .cowork,
+                surface: .agentSettings
+            )
+            ActivationTelemetry.trackAgentPromptAction(
+                promptKind: .liveMeetingCoworkSetup,
+                actionKind: .copied,
+                agentTarget: .cowork,
+                surface: .agentSettings
+            )
             copiedLiveMeetingCoworkSetup = true
             NSWorkspace.shared.activateFileViewerSelecting([workspaceURL])
             Task { @MainActor in
@@ -456,6 +581,12 @@ struct AgentConnectionSettingsPage: View {
             meetingSession?.stopLiveCodexSessionFromSettings()
             stopLiveMeetingSidecarPreview()
             liveMeetingCodexSetupError = "Could not set up Live Sidecar: \(error.localizedDescription)"
+            ActivationTelemetry.trackAgentSetupCTA(
+                setupKind: .liveSidecar,
+                agentTarget: .cowork,
+                surface: .agentSettings,
+                result: .failed
+            )
         }
     }
 
@@ -477,6 +608,17 @@ struct AgentConnectionSettingsPage: View {
             }
 
             if NSWorkspace.shared.open(previewURL) {
+                ActivationTelemetry.trackAgentSetupCTA(
+                    setupKind: .livePreview,
+                    agentTarget: .localAgent,
+                    surface: .agentSettings
+                )
+                ActivationTelemetry.trackAgentPromptAction(
+                    promptKind: .liveMeetingPreview,
+                    actionKind: .opened,
+                    agentTarget: .localAgent,
+                    surface: .agentSettings
+                )
                 openedLiveMeetingPreview = true
                 Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 1_500_000_000)
@@ -485,6 +627,12 @@ struct AgentConnectionSettingsPage: View {
             } else {
                 NSWorkspace.shared.activateFileViewerSelecting([previewURL])
                 liveMeetingCodexSetupError = "The live preview is ready at \(previewURL.absoluteString)."
+                ActivationTelemetry.trackAgentSetupCTA(
+                    setupKind: .livePreview,
+                    agentTarget: .localAgent,
+                    surface: .agentSettings,
+                    result: .fallbackCopied
+                )
             }
         } catch {
             liveMeetingCodexEnabled = false
@@ -492,6 +640,12 @@ struct AgentConnectionSettingsPage: View {
             meetingSession?.stopLiveCodexSessionFromSettings()
             stopLiveMeetingSidecarPreview()
             liveMeetingCodexSetupError = "Could not open Live Preview: \(error.localizedDescription)"
+            ActivationTelemetry.trackAgentSetupCTA(
+                setupKind: .livePreview,
+                agentTarget: .localAgent,
+                surface: .agentSettings,
+                result: .failed
+            )
         }
     }
 
@@ -528,7 +682,24 @@ struct AgentConnectionSettingsPage: View {
 
     private func openClaudeDesktopDownload() {
         guard let url = URL(string: "https://claude.ai/download") else { return }
+        ActivationTelemetry.trackAgentSetupCTA(
+            setupKind: .claudeDesktop,
+            agentTarget: .claudeDesktop,
+            surface: .agentSettings,
+            priorStatus: claudeDesktopActivationPriorStatus
+        )
         NSWorkspace.shared.open(url)
+    }
+
+    private var claudeDesktopActivationPriorStatus: ActivationTelemetry.AgentSetupPriorStatus {
+        switch claudeDesktopStatus.state {
+        case .installed:
+            return .installed
+        case .notInstalled:
+            return .notInstalled
+        case .needsRepair:
+            return .needsRepair
+        }
     }
 }
 

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -23,6 +23,7 @@ final class HomeViewModel: ObservableObject {
     private var refreshGeneration = 0
     private var dictationLimit = 10
     private var meetingLimit = 10
+    private var didTrackActivationReturnProxy = false
 
     // Settings Home must open instantly, even for users with thousands of dictations.
     // Keep the dashboard to a small recent slice and leave deep history to the dedicated pages/files.
@@ -85,6 +86,10 @@ final class HomeViewModel: ObservableObject {
             self.meetingDaySections = Self.groupByDay(visibleMeetings, dateForItem: \.date)
             self.canLoadMoreDictations = snapshot.dictations.count > requestedDictationLimit
             self.canLoadMoreMeetings = snapshot.meetings.count > requestedMeetingLimit
+            self.trackActivationReturnProxyIfNeeded(
+                dictations: visibleDictations,
+                meetings: visibleMeetings
+            )
             self.isLoading = false
             self.isLoadingMore = false
         }
@@ -129,6 +134,29 @@ final class HomeViewModel: ObservableObject {
         if calendar.isDateInYesterday(day) { return "Yesterday" }
         let formatter = Self.daySectionFormatter
         return formatter.string(from: day)
+    }
+
+    private func trackActivationReturnProxyIfNeeded(
+        dictations: [SavedDictationEntry],
+        meetings: [RecentMeetingItem]
+    ) {
+        guard !didTrackActivationReturnProxy else { return }
+
+        let dictationCandidates = dictations.map { entry in
+            (kind: ActivationTelemetry.ArtifactKind.dictation, date: entry.createdAt)
+        }
+        let meetingCandidates = meetings.map { item in
+            (kind: ActivationTelemetry.ArtifactKind.meeting, date: item.date)
+        }
+        guard let latest = (dictationCandidates + meetingCandidates).max(by: { $0.date < $1.date }) else {
+            return
+        }
+
+        didTrackActivationReturnProxy = ActivationTelemetry.trackReturnProxyIfEligible(
+            priorArtifactKind: latest.kind,
+            priorArtifactDate: latest.date,
+            surface: .home
+        )
     }
 
     private static let daySectionFormatter: DateFormatter = {

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -462,9 +462,15 @@ struct PermissionsOnboardingView: View {
     private func copyAgentItem(_ item: AgentCopyItem) {
         let value: String
         let agentCTA: String
+        let promptKind: ActivationTelemetry.AgentPromptKind
+        let setupKind: ActivationTelemetry.AgentSetupKind
+        let agentTarget: ActivationTelemetry.AgentTarget
         switch item {
         case .claudeDesktopSetup:
             agentCTA = "claude_desktop_setup"
+            promptKind = .claudeDesktopSetup
+            setupKind = .claudeDesktop
+            agentTarget = .claudeDesktop
             value = """
             \(AgentConnectionGuide.mcpSetupText)
 
@@ -472,12 +478,26 @@ struct PermissionsOnboardingView: View {
             """
         case .localAgentPrompt:
             agentCTA = "local_agent_prompt"
+            promptKind = .localAgentPrompt
+            setupKind = .localPrompt
+            agentTarget = .localAgent
             value = AgentConnectionGuide.starterPrompt(filename: nil)
         }
 
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(value, forType: .string)
+        ActivationTelemetry.trackAgentSetupCTA(
+            setupKind: setupKind,
+            agentTarget: agentTarget,
+            surface: .onboarding
+        )
+        ActivationTelemetry.trackAgentPromptAction(
+            promptKind: promptKind,
+            actionKind: .copied,
+            agentTarget: agentTarget,
+            surface: .onboarding
+        )
         AnalyticsReporter.track(
             "onboarding_agent_cta_clicked",
             properties: [

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -361,6 +361,11 @@ struct TranscriptedSettingsView: View {
                     action: activity.transcriptURL.map { transcriptURL in
                         {
                             trackSettingsAction("open_current_activity", page: .home)
+                            ActivationTelemetry.trackArtifactAction(
+                                artifactKind: .meeting,
+                                actionKind: .openMarkdown,
+                                surface: .homeCurrentActivity
+                            )
                             NSWorkspace.shared.open(transcriptURL)
                         }
                     }
@@ -387,6 +392,12 @@ struct TranscriptedSettingsView: View {
                     savedMeetingRetranscriptionUnavailableReason: savedMeetingRetranscriptionUnavailableReason,
                     onOpenDictation: { entry in
                         trackSettingsAction("open_recent_dictation", page: .home)
+                        ActivationTelemetry.trackArtifactAction(
+                            artifactKind: .dictation,
+                            actionKind: .openMarkdown,
+                            surface: .homeRow,
+                            artifactDate: entry.createdAt
+                        )
                         NSWorkspace.shared.open(entry.url)
                     },
                     onCopyDictation: { entry in
@@ -458,6 +469,12 @@ struct TranscriptedSettingsView: View {
                 preview: preview,
                 onOpenMarkdown: {
                     trackSettingsAction("open_recent_meeting_markdown", page: .home)
+                    ActivationTelemetry.trackArtifactAction(
+                        artifactKind: .meeting,
+                        actionKind: .openMarkdown,
+                        surface: .homePreview,
+                        artifactDate: preview.date
+                    )
                     NSWorkspace.shared.open(preview.transcriptURL)
                 },
                 onCopyForAgent: {
@@ -576,6 +593,13 @@ struct TranscriptedSettingsView: View {
 
     private func handleCopyMeeting(_ item: RecentMeetingItem) {
         trackSettingsAction("copy_meeting", page: .home)
+        ActivationTelemetry.trackAgentPromptAction(
+            promptKind: .meetingBundle,
+            actionKind: .copied,
+            agentTarget: .localAgent,
+            surface: .homeRow,
+            artifactKind: .meeting
+        )
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         if let bundle = AgentConnectionGuide.portableMeetingBundle(
@@ -595,6 +619,13 @@ struct TranscriptedSettingsView: View {
 
     private func handleCopyMeetingPreview(_ preview: HomeMeetingPreview) {
         trackSettingsAction("copy_meeting_preview", page: .home)
+        ActivationTelemetry.trackAgentPromptAction(
+            promptKind: .meetingMarkdown,
+            actionKind: .copied,
+            agentTarget: .localAgent,
+            surface: .homePreview,
+            artifactKind: .meeting
+        )
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(preview.markdown, forType: .string)
@@ -621,6 +652,12 @@ struct TranscriptedSettingsView: View {
 
     private func presentHomeMeetingPreview(_ item: RecentMeetingItem) {
         trackSettingsAction("preview_recent_meeting", page: .home)
+        ActivationTelemetry.trackArtifactAction(
+            artifactKind: .meeting,
+            actionKind: .preview,
+            surface: .homeRow,
+            artifactDate: item.date
+        )
         homeMeetingPreviewLoadTask?.cancel()
         homeMeetingPreviewLoadTask = Task { @MainActor in
             let readResult = await Self.readMeetingMarkdown(at: item.transcriptURL)
@@ -700,6 +737,12 @@ struct TranscriptedSettingsView: View {
         [
             HomeRowMenuItem(title: "Open saved file", symbolName: "doc.text") {
                 trackSettingsAction("open_recent_dictation_file", page: .home)
+                ActivationTelemetry.trackArtifactAction(
+                    artifactKind: .dictation,
+                    actionKind: .openMarkdown,
+                    surface: .homeMenu,
+                    artifactDate: entry.createdAt
+                )
                 NSWorkspace.shared.open(entry.url)
             },
             HomeRowMenuItem(title: "Report issue", symbolName: "flag") {
@@ -708,6 +751,12 @@ struct TranscriptedSettingsView: View {
             },
             HomeRowMenuItem(title: "Reveal in Finder", symbolName: "folder") {
                 trackSettingsAction("reveal_dictation_in_finder", page: .home)
+                ActivationTelemetry.trackArtifactAction(
+                    artifactKind: .dictation,
+                    actionKind: .revealFolder,
+                    surface: .homeMenu,
+                    artifactDate: entry.createdAt
+                )
                 NSWorkspace.shared.activateFileViewerSelecting([entry.url])
             },
             HomeRowMenuItem(title: "Delete dictation", symbolName: "trash", isDestructive: true) {
@@ -741,6 +790,12 @@ struct TranscriptedSettingsView: View {
             },
             HomeRowMenuItem(title: "Show transcript in Finder", symbolName: "doc.text") {
                 trackSettingsAction("reveal_meeting_in_finder", page: .home)
+                ActivationTelemetry.trackArtifactAction(
+                    artifactKind: .meeting,
+                    actionKind: .revealFolder,
+                    surface: .homeMenu,
+                    artifactDate: item.date
+                )
                 NSWorkspace.shared.activateFileViewerSelecting([item.transcriptURL])
             }
         ])

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -57,6 +57,107 @@ func testAnalyticsEventPolicy() {
         assertEqual(sanitized["step_id"], "meeting_setup", "step id should survive sanitization")
     }
 
+    runSuite("AnalyticsEventPolicy pins active onboarding activation events") {
+        let expected: [(String, Set<String>)] = [
+            ("onboarding_model_state_changed", ["from_status", "step_id", "to_status"]),
+            ("onboarding_primary_cta_clicked", ["cta", "cta_type", "flow_elapsed_bucket", "model_state", "step_elapsed_bucket", "step_id"]),
+            ("onboarding_first_dictation_started", ["model_state", "step_id"]),
+            ("onboarding_first_dictation_saved", ["delivery", "step_id", "word_count_bucket"]),
+            ("onboarding_first_dictation_stop_clicked", ["step_id"]),
+            ("onboarding_first_dictation_empty", ["step_id"]),
+            ("onboarding_agent_cta_clicked", ["agent_cta", "step_id"]),
+            ("onboarding_reporting_toggle_changed", ["available", "enabled", "reporting_kind", "step_id"]),
+        ]
+
+        for (event, properties) in expected {
+            assertEqual(
+                AnalyticsEventPolicy.policy(forEvent: event)?.allowedProperties ?? Set<String>(),
+                properties,
+                "\(event) should keep a narrow activation payload"
+            )
+        }
+    }
+
+    runSuite("AnalyticsEventPolicy allows post-artifact activation events") {
+        let artifact = AnalyticsEventPolicy.policy(forEvent: "activation_artifact_action_clicked")
+        let prompt = AnalyticsEventPolicy.policy(forEvent: "activation_agent_prompt_action_clicked")
+        let setup = AnalyticsEventPolicy.policy(forEvent: "activation_agent_setup_cta_clicked")
+        let returnProxy = AnalyticsEventPolicy.policy(forEvent: "activation_return_proxy_observed")
+
+        assertEqual(artifact?.allowedProperties ?? Set<String>(), ["action_kind", "artifact_age_bucket", "artifact_kind", "surface"], "artifact actions should stay bucketed")
+        assertEqual(prompt?.allowedProperties ?? Set<String>(), ["action_kind", "agent_target", "artifact_kind", "prompt_kind", "result", "surface"], "agent prompt actions should stay enum-only")
+        assertEqual(setup?.allowedProperties ?? Set<String>(), ["agent_target", "prior_status", "result", "setup_kind", "surface"], "setup CTAs should stay enum-only")
+        assertEqual(returnProxy?.allowedProperties ?? Set<String>(), ["prior_artifact_kind", "proxy_kind", "return_window_bucket", "surface"], "return proxy should not include paths or titles")
+
+        let activationAllowedProperties = (prompt?.allowedProperties ?? Set<String>())
+            .union(artifact?.allowedProperties ?? Set<String>())
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "action_kind": "open_markdown",
+                "agent_target": "codex",
+                "artifact_age_bucket": "24_48h",
+                "artifact_kind": "meeting",
+                "prompt_kind": "meeting_bundle",
+                "result": "success",
+                "surface": "home_preview",
+                "transcript": "private words",
+                "meeting_title": "Customer call",
+                "speaker_name": "Alice",
+                "audio_path": "/Users/redbars/private.wav",
+                "file_path": "/Users/redbars/private.md",
+                "meeting_url": "https://example.com/private",
+                "prompt_text": "Read my transcript",
+                "word_count": "4217",
+            ],
+            allowedKeys: activationAllowedProperties
+        )
+
+        assertEqual(sanitized["action_kind"], "open_markdown", "action kind should survive")
+        assertEqual(sanitized["agent_target"], "codex", "agent target should survive")
+        assertEqual(sanitized["artifact_age_bucket"], "24_48h", "artifact age bucket should survive")
+        assertEqual(sanitized["artifact_kind"], "meeting", "artifact kind should survive")
+        assertEqual(sanitized["prompt_kind"], "meeting_bundle", "prompt kind should survive")
+        assertEqual(sanitized["result"], "success", "coarse action result should survive")
+        assertEqual(sanitized["surface"], "home_preview", "surface should survive")
+        assertNil(sanitized["transcript"], "raw transcript text must not be sent")
+        assertNil(sanitized["meeting_title"], "meeting titles must not be sent")
+        assertNil(sanitized["speaker_name"], "speaker names must not be sent")
+        assertNil(sanitized["audio_path"], "audio paths must not be sent")
+        assertNil(sanitized["file_path"], "file paths must not be sent")
+        assertNil(sanitized["meeting_url"], "meeting URLs must not be sent")
+        assertNil(sanitized["prompt_text"], "raw prompt text must not be sent")
+        assertNil(sanitized["word_count"], "raw counts should stay out of activation analytics")
+    }
+
+    runSuite("ActivationTelemetry buckets artifact age and next-day return proxy") {
+        let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
+
+        assertEqual(
+            ActivationTelemetry.artifactAgeBucket(since: now.addingTimeInterval(-3 * 3_600), now: now),
+            "lt_12h",
+            "same-session artifacts should stay in the shortest age bucket"
+        )
+        assertEqual(
+            ActivationTelemetry.artifactAgeBucket(since: now.addingTimeInterval(-30 * 3_600), now: now),
+            "24_48h",
+            "next-day artifacts should use a stable age bucket"
+        )
+        assertNil(
+            ActivationTelemetry.returnWindowBucket(since: now.addingTimeInterval(-2 * 3_600), now: now),
+            "return proxy should not fire for immediate same-session refreshes"
+        )
+        assertEqual(
+            ActivationTelemetry.returnWindowBucket(since: now.addingTimeInterval(-24 * 3_600), now: now),
+            "18_36h",
+            "next-day return proxy should capture the 18-36h window"
+        )
+        assertEqual(
+            ActivationTelemetry.returnWindowBucket(since: now.addingTimeInterval(-96 * 3_600), now: now),
+            "3_7d",
+            "late return proxy should stay bucketed"
+        )
+    }
+
     runSuite("AnalyticsEventPolicy allows menu and settings behavior events") {
         let menuOpened = AnalyticsEventPolicy.policy(forEvent: "menu_bar_opened")
         let menuAction = AnalyticsEventPolicy.policy(forEvent: "menu_bar_action_clicked")

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -97,6 +97,10 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `onboarding_reporting_toggle_changed`
 - `onboarding_completed`
 - `onboarding_dismissed`
+- `activation_artifact_action_clicked`
+- `activation_agent_prompt_action_clicked`
+- `activation_agent_setup_cta_clicked`
+- `activation_return_proxy_observed`
 - `menu_bar_opened`
 - `menu_bar_action_clicked`
 - `update_action_clicked`

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -208,6 +208,7 @@ APP_SOURCES=(
     "Sources/Meeting/LiveMeetingStreamingUpdatePolicy.swift"
     "Sources/UI/MenuBar/MenuBarHeaderLayoutPolicy.swift"
     "Sources/Observability/AnalyticsReporter.swift"
+    "Sources/Observability/ActivationTelemetry.swift"
     "Sources/Observability/LockedFileAppender.swift"
     "Sources/Observability/JSONLWriter.swift"
     "Sources/Observability/AnalyticsEventPolicy.swift"


### PR DESCRIPTION
## What changed

- Added `ActivationTelemetry` as the app-side helper for privacy-safe activation events.
- Added allowlisted PostHog events for artifact actions, agent prompt actions, agent setup CTAs, and a next-day return proxy.
- Wired Home, onboarding, menubar agent, and Settings Agent actions to emit enum/bucket-only activation telemetry.
- Updated analytics policy/docs/tests and the fast-test source list.

## Privacy

Payloads are limited to controlled values such as `artifact_kind`, `action_kind`, `surface`, `prompt_kind`, `agent_target`, `result`, and coarse age/return buckets. No transcript text, prompt text, titles, speaker names, audio refs, paths, URLs, device names, or raw counts are sent.

## Validation

- `scripts/dev/agent-preflight.sh`
- `bash -n run-tests.sh`
- `bash -n scripts/entrypoints/run-tests.sh`
- `git diff --check`
- `bash build-deps.sh --force` (needed because deps were stale before build)
- `bash build.sh --no-open`
- `bash run-tests.sh` (3439 passed, 0 failed)

## Notes

Artifact save still uses existing events: `dictation_completed` and `meeting_transcript_saved`. This PR fills the missing post-artifact bridge and return-loop instrumentation; it still does not prove an external agent answered successfully.