### PR TITLE
[codex] Fix Bluetooth mic start timeout

### DIFF
--- a/Sources/Speech/DictationInputDeviceSelectionPolicy.swift
+++ b/Sources/Speech/DictationInputDeviceSelectionPolicy.swift
@@ -23,6 +23,7 @@ struct DictationAudioDevice: Equatable {
 enum DictationInputDeviceSelectionReason: String {
     case defaultIsSafe
     case preferredBuiltInForBluetoothHeadset
+    case builtInFallbackSuppressedForRecoveryAttempt
     case noBuiltInFallbackAvailable
 }
 
@@ -41,7 +42,8 @@ enum DictationInputDeviceSelectionPolicy {
     static func selection(
         defaultInput: DictationAudioDevice,
         defaultOutput: DictationAudioDevice?,
-        availableInputs: [DictationAudioDevice]
+        availableInputs: [DictationAudioDevice],
+        allowsBuiltInBluetoothFallback: Bool = true
     ) -> DictationInputDeviceSelection {
         guard shouldAvoidBluetoothHeadsetInput(defaultInput, defaultOutput: defaultOutput) else {
             return DictationInputDeviceSelection(
@@ -49,6 +51,15 @@ enum DictationInputDeviceSelectionPolicy {
                 selectedInput: defaultInput,
                 defaultOutput: defaultOutput,
                 reason: .defaultIsSafe
+            )
+        }
+
+        guard allowsBuiltInBluetoothFallback else {
+            return DictationInputDeviceSelection(
+                defaultInput: defaultInput,
+                selectedInput: defaultInput,
+                defaultOutput: defaultOutput,
+                reason: .builtInFallbackSuppressedForRecoveryAttempt
             )
         }
 

--- a/Sources/Speech/ParakeetAudioDeviceLookup.swift
+++ b/Sources/Speech/ParakeetAudioDeviceLookup.swift
@@ -26,7 +26,9 @@ enum ParakeetAudioEngineWorkError: LocalizedError {
 }
 
 enum CoreAudioInputDeviceLookup {
-    static func preferredDictationInputSelection() throws -> DictationInputDeviceSelection {
+    static func preferredDictationInputSelection(
+        allowsBuiltInBluetoothFallback: Bool = true
+    ) throws -> DictationInputDeviceSelection {
         let defaultInputID = try defaultInputDeviceID()
         var availableInputs = try allInputDevices()
 
@@ -43,7 +45,8 @@ enum CoreAudioInputDeviceLookup {
         return DictationInputDeviceSelectionPolicy.selection(
             defaultInput: defaultInput,
             defaultOutput: defaultOutput,
-            availableInputs: availableInputs
+            availableInputs: availableInputs,
+            allowsBuiltInBluetoothFallback: allowsBuiltInBluetoothFallback
         )
     }
 

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -103,9 +103,13 @@ class ParakeetEngine: ObservableObject {
         DispatchQueue(label: "com.transcripted.parakeet.audio-engine", qos: .userInitiated)
     }
 
-    nonisolated private static func loadDictationInputDeviceSelection() -> DictationInputDeviceSelection? {
+    nonisolated private static func loadDictationInputDeviceSelection(
+        allowsBuiltInBluetoothFallback: Bool = true
+    ) -> DictationInputDeviceSelection? {
         do {
-            return try CoreAudioInputDeviceLookup.preferredDictationInputSelection()
+            return try CoreAudioInputDeviceLookup.preferredDictationInputSelection(
+                allowsBuiltInBluetoothFallback: allowsBuiltInBluetoothFallback
+            )
         } catch {
             return nil
         }
@@ -1319,9 +1323,12 @@ class ParakeetEngine: ObservableObject {
 
     private func audioInputSnapshot(
         operation: String,
-        recoveryGeneration: UInt64? = nil
+        recoveryGeneration: UInt64? = nil,
+        allowsBuiltInBluetoothFallback: Bool = true
     ) async throws -> ParakeetAudioInputSnapshot {
-        let selection = Self.loadDictationInputDeviceSelection()
+        let selection = Self.loadDictationInputDeviceSelection(
+            allowsBuiltInBluetoothFallback: allowsBuiltInBluetoothFallback
+        )
         if let selection, selection.didOverrideDefault {
             let shouldApplyOverride = try await runTimedAudioEngineWork(operation: "\(operation)_device_check") { engine in
                 engine.inputNode.auAudioUnit.deviceID != selection.selectedInput.id
@@ -1877,7 +1884,10 @@ class ParakeetEngine: ObservableObject {
 
             let snapshot: ParakeetAudioInputSnapshot
             do {
-                snapshot = try await audioInputSnapshot(operation: "start_recording")
+                snapshot = try await audioInputSnapshot(
+                    operation: "start_recording",
+                    allowsBuiltInBluetoothFallback: !isRecoveryAttempt
+                )
             } catch {
                 let operationTimedOut = error is ParakeetAudioEngineWorkError
                 EventReporter.shared.capture(

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -154,10 +154,14 @@ enum ParakeetAudioFormatReadinessPolicy {
             return .invalid
         }
 
+        let lowRateOutputBus = likelyBluetoothSpeechRates.contains(Int(outputSampleRate.rounded()))
+        let overriddenBluetoothOutputRoute = selectionOverrodeDefault
+            && outputDeviceClass == "bluetooth"
+
         if selectedInputClass != "bluetooth",
-           outputDeviceClass != "bluetooth",
            inputSampleRate >= 44_100,
-           likelyBluetoothSpeechRates.contains(Int(outputSampleRate.rounded())) {
+           lowRateOutputBus,
+           (outputDeviceClass != "bluetooth" || overriddenBluetoothOutputRoute) {
             return .routeNotSettled
         }
 

--- a/Tests/DictationInputDeviceSelectionPolicyTests.swift
+++ b/Tests/DictationInputDeviceSelectionPolicyTests.swift
@@ -32,6 +32,23 @@ func testDictationInputDeviceSelectionPolicy() {
         assertEqual(selection.selectedInput, macBookMic, "MacBook mic should be the first built-in fallback")
     }
 
+    runSuite("DictationInputDeviceSelectionPolicy can suppress built-in fallback for recovery starts") {
+        let airPodsInput = device(1, "Justin's AirPods Pro", .bluetooth)
+        let airPodsOutput = device(2, "Justin's AirPods Pro", .bluetooth, inputChannels: 0)
+        let macBookMic = device(3, "MacBook Pro Microphone", .builtIn)
+
+        let selection = DictationInputDeviceSelectionPolicy.selection(
+            defaultInput: airPodsInput,
+            defaultOutput: airPodsOutput,
+            availableInputs: [airPodsInput, macBookMic],
+            allowsBuiltInBluetoothFallback: false
+        )
+
+        assertEqual(selection.selectedInput, airPodsInput, "recovery starts should get one chance to use the matched Bluetooth route")
+        assertFalse(selection.didOverrideDefault, "suppressed fallback should not force the hybrid built-in/Bluetooth route")
+        assertEqual(selection.reason, .builtInFallbackSuppressedForRecoveryAttempt, "selection reason should make the recovery fallback queryable")
+    }
+
     runSuite("DictationInputDeviceSelectionPolicy keeps Bluetooth input when output is not Bluetooth") {
         let airPodsInput = device(1, "Justin's AirPods Pro", .bluetooth)
         let speakers = device(2, "MacBook Pro Speakers", .builtIn, inputChannels: 0)

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -186,7 +186,7 @@ func testParakeetStartRecordingFailurePolicy() {
         assertEqual(readiness, .ready, "AirPods HFP 24k hardware to 48k output should remain valid")
     }
 
-    runSuite("ParakeetAudioFormatReadinessPolicy accepts built-in override with Bluetooth output speech bus") {
+    runSuite("ParakeetAudioFormatReadinessPolicy defers built-in override with Bluetooth output speech bus") {
         let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
             outputSampleRate: 24_000,
             outputChannelCount: 1,
@@ -197,7 +197,8 @@ func testParakeetStartRecordingFailurePolicy() {
             selectionOverrodeDefault: true
         )
 
-        assertEqual(readiness, .ready, "built-in fallback with Bluetooth output can start because the tap uses the delivered buffer format")
+        assertEqual(readiness, .routeNotSettled, "built-in fallback should wait until the Bluetooth output bus leaves speech mode")
+        assertEqual(readiness.startFailureReason, .audioRouteNotSettled, "stale Bluetooth output routes should map to route-not-settled")
     }
 
     runSuite("ParakeetAudioFormatReadinessPolicy accepts intentional Bluetooth output speech bus") {
@@ -212,6 +213,20 @@ func testParakeetStartRecordingFailurePolicy() {
         )
 
         assertEqual(readiness, .ready, "native built-in capture with Bluetooth output can still use the speech bus when Transcripted did not force an input override")
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy accepts settled built-in override with Bluetooth output") {
+        let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: 48_000,
+            outputChannelCount: 1,
+            inputSampleRate: 48_000,
+            inputChannelCount: 1,
+            selectedInputClass: "built_in",
+            outputDeviceClass: "bluetooth",
+            selectionOverrodeDefault: true
+        )
+
+        assertEqual(readiness, .ready, "built-in fallback can start once the Bluetooth output bus settles back to a normal capture rate")
     }
 
     runSuite("ParakeetAudioFormatReadinessPolicy defers stale AirPods-to-built-in switch formats") {

--- a/Tests/ReliabilityPacketRecorderTests.swift
+++ b/Tests/ReliabilityPacketRecorderTests.swift
@@ -73,6 +73,50 @@ func testReliabilityPacketRecorder() {
         assertNil(ReliabilityPacketRecorder.packet(from: event), "boring app launch should not create a packet")
     }
 
+    runSuite("ReliabilityPacketRecorder maps dictation microphone timeout route shape safely") {
+        let event = ObservabilityEvent(
+            timestamp: "2026-06-02T14:18:42.771Z",
+            level: "error",
+            engine: "dictation",
+            event: "microphone_start_timeout",
+            message: "Dictation recording failed to start within recovery budget",
+            context: [
+                "audio_device": "Private AirPods",
+                "default_input_class": "bluetooth",
+                "default_output_class": "bluetooth",
+                "error": "private raw error",
+                "failure_kind": "microphone_start_timeout",
+                "format_ready": "false",
+                "input_device_class": "built_in",
+                "output_device_class": "bluetooth",
+                "route_shape": "built_in_input_to_bluetooth_output",
+                "sample_flow_started": "false",
+                "selected_input_class": "built_in",
+                "selection_overrode_default": "true",
+                "selection_reason": "preferredBuiltInForBluetoothHeadset",
+                "source_app_name": "Private App",
+                "stt_model": "parakeet-tdt-v3",
+                "transcript_text": "private words",
+            ],
+            appVersion: "1.1.45",
+            osVersion: "Version 26.5.0"
+        )
+
+        let packet = ReliabilityPacketRecorder.packet(from: event)
+
+        assertNotNil(packet, "dictation mic start timeout should produce a reliability packet")
+        assertEqual(packet?.feature, "dictation", "packet feature should classify dictation")
+        assertEqual(packet?.stage, "start", "packet stage should classify startup")
+        assertEqual(packet?.outcome, "failed_retryable", "mic start timeout should be retryable")
+        assertEqual(packet?.context["route_shape"], "built_in_input_to_bluetooth_output", "coarse route shape should survive")
+        assertEqual(packet?.context["sample_flow_started"], "false", "sample-flow proof should stay queryable")
+        assertEqual(packet?.context["selection_reason"], "preferredBuiltInForBluetoothHeadset", "selection reason should stay coarse")
+        assertNil(packet?.context["audio_device"], "raw device names should not be copied into reliability packets")
+        assertNil(packet?.context["error"], "raw error text should not be copied into reliability packets")
+        assertNil(packet?.context["source_app_name"], "source app names should not be copied into reliability packets")
+        assertNil(packet?.context["transcript_text"], "transcript text should not be copied into reliability packets")
+    }
+
     runSuite("ReliabilityPacketRecorder preserves coarse runtime shutdown duration") {
         let event = ObservabilityEvent(
             timestamp: "2026-05-03T01:15:11.605Z",

--- a/Tests/SentryEventPolicyTests.swift
+++ b/Tests/SentryEventPolicyTests.swift
@@ -127,12 +127,12 @@ func testSentryEventPolicy() {
                 "forced_readiness_recoveries": "2",
                 "format_ready": "false",
                 "hfp_suspected": "false",
-                "input_device_class": "bluetooth",
+                "input_device_class": "built_in",
                 "output_device_class": "bluetooth",
                 "readiness_refreshes": "8",
                 "recovering": "false",
                 "recovery_start_attempts": "2",
-                "route_shape": "bluetooth_input_to_built_in_output",
+                "route_shape": "built_in_input_to_bluetooth_output",
                 "sample_flow_started": "false",
                 "selected_input_class": "built_in",
                 "selection_overrode_default": "true",
@@ -151,9 +151,9 @@ func testSentryEventPolicy() {
         assertEqual(tags["format_ready"], "false", "format readiness should be queryable")
         assertEqual(tags["hfp_suspected"], "false", "HFP suspicion should be queryable")
         assertEqual(tags["recovering"], "false", "recovery state should be queryable")
-        assertEqual(tags["input_device_class"], "bluetooth", "coarse device class should be queryable")
+        assertEqual(tags["input_device_class"], "built_in", "coarse device class should be queryable")
         assertEqual(tags["output_device_class"], "bluetooth", "coarse output class should be queryable")
-        assertEqual(tags["route_shape"], "bluetooth_input_to_built_in_output", "coarse route shape should be queryable")
+        assertEqual(tags["route_shape"], "built_in_input_to_bluetooth_output", "coarse route shape should be queryable")
         assertEqual(tags["sample_flow_started"], "false", "sample-flow state should be queryable")
         assertEqual(tags["selected_input_class"], "built_in", "selected input class should be queryable")
         assertEqual(tags["selection_overrode_default"], "true", "input override state should be queryable")


### PR DESCRIPTION
## Summary

Fixes the Bluetooth-route dictation start timeout cluster (`APPLE-MACOS-14`) where Transcripted forced built-in input while Bluetooth output stayed active, then repeatedly retried the same hybrid route without audio samples flowing.

## Root Cause

The dictation input policy correctly preferred the built-in mic to avoid Bluetooth headset mode, but readiness still treated a forced built-in input plus low-rate Bluetooth output bus as ready. In live Sentry, that showed up as `route_shape=built_in_input_to_bluetooth_output`, `selection_reason=preferredBuiltInForBluetoothHeadset`, `format_ready=false`, and `sample_flow_started=false`.

## What Changed

- Treat forced built-in input with Bluetooth output still in speech-rate mode as `routeNotSettled`.
- Allow bounded recovery starts to suppress the built-in fallback and try the matched default Bluetooth route once, instead of looping the same hybrid route.
- Added focused tests for the route-selection fallback, readiness policy, Sentry tags, and reliability packet privacy.

## Verification

- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (3423 passed)
- `bash run-daily-audio-reliability.sh --skip-build --no-launch --synthetic` (PASS, 72 checks passed)

## Privacy

No raw device names, transcript text, speaker names, paths, tokens, or source app identifiers were added to telemetry. The new coverage keeps only coarse route classes and normalized selection reasons.