### PR TITLE
[codex] Allow built-in mic fallback with Bluetooth output

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -1193,7 +1193,8 @@ class ParakeetEngine: ObservableObject {
             inputChannelCount: hwFormat.channelCount,
             selectedInputClass: selectedInputClass(for: selection),
             outputDeviceClass: defaultOutputClass(for: selection),
-            selectionOverrodeDefault: selection?.didOverrideDefault ?? false
+            selectionOverrodeDefault: selection?.didOverrideDefault ?? false,
+            selectionReason: selection?.reason
         )
     }
 

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -147,7 +147,8 @@ enum ParakeetAudioFormatReadinessPolicy {
         inputChannelCount: UInt32,
         selectedInputClass: String,
         outputDeviceClass: String,
-        selectionOverrodeDefault: Bool
+        selectionOverrodeDefault: Bool,
+        selectionReason: DictationInputDeviceSelectionReason? = nil
     ) -> ParakeetAudioFormatReadiness {
         guard isUsableCaptureSampleRate(outputSampleRate), outputChannelCount > 0,
               isUsableCaptureSampleRate(inputSampleRate), inputChannelCount > 0 else {
@@ -157,6 +158,7 @@ enum ParakeetAudioFormatReadinessPolicy {
         let lowRateOutputBus = likelyBluetoothSpeechRates.contains(Int(outputSampleRate.rounded()))
         let overriddenBluetoothOutputRoute = selectionOverrodeDefault
             && outputDeviceClass == "bluetooth"
+            && selectionReason != .preferredBuiltInForBluetoothHeadset
 
         if selectedInputClass != "bluetooth",
            inputSampleRate >= 44_100,

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -201,6 +201,21 @@ func testParakeetStartRecordingFailurePolicy() {
         assertEqual(readiness.startFailureReason, .audioRouteNotSettled, "stale Bluetooth output routes should map to route-not-settled")
     }
 
+    runSuite("ParakeetAudioFormatReadinessPolicy accepts preferred built-in fallback with Bluetooth output") {
+        let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: 24_000,
+            outputChannelCount: 1,
+            inputSampleRate: 48_000,
+            inputChannelCount: 1,
+            selectedInputClass: "built_in",
+            outputDeviceClass: "bluetooth",
+            selectionOverrodeDefault: true,
+            selectionReason: .preferredBuiltInForBluetoothHeadset
+        )
+
+        assertEqual(readiness, .ready, "built-in fallback for Bluetooth output should start instead of timing out")
+    }
+
     runSuite("ParakeetAudioFormatReadinessPolicy accepts intentional Bluetooth output speech bus") {
         let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
             outputSampleRate: 24_000,


### PR DESCRIPTION
## What changed

- Let the audio format readiness policy treat the preferred built-in mic fallback as ready when Bluetooth output is active.
- Keep the existing stale-route protection for unknown built-in overrides.
- Add a focused regression test for the Sentry route shape: `built_in_input_to_bluetooth_output` with `preferredBuiltInForBluetoothHeadset`.

## Why

Sentry issue `APPLE-MACOS-14` had a fresh `1.1.45` timeout where dictation selected the built-in mic to avoid Bluetooth headset input, but readiness stayed false while Bluetooth output was active.

## Validation

- `bash run-tests.sh` passed: 3485/3485
- `bash build.sh --no-open` passed