### PR TITLE
[codex] Skip offline pairwise speaker merges

### DIFF
--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -143,17 +143,14 @@ extension Transcription {
             AppLogger.transcription.info("Running offline diarization on system audio")
             let rawSegments = try await diarization.diarizeOffline(samples: systemSamples, sampleRate: 16000)
 
-            // Post-process diarization segments:
-            // PyAnnote's VBx does initial clustering but fragments dominant speakers
-            // on codec-compressed audio (e.g., one person split into 3 IDs during a
-            // long monologue). Pairwise merge at 0.78 catches same-person fragments
-            // (typically 0.75-0.85 similarity) without merging different speakers
-            // (typically 0.50-0.65 on Zoom audio).
+            // Post-process diarization segments. Keep PyAnnote/VBx speaker IDs intact
+            // before review: over-segmentation is fixable by merging/name review, but
+            // pre-review pairwise merges can irreversibly collapse real participants.
             let existingProfiles = speakerDB.allSpeakers()
             let speakerSegments = EmbeddingClusterer.postProcess(
                 segments: rawSegments,
                 existingProfiles: existingProfiles,
-                pairwiseMergeThreshold: 0.78
+                pairwiseMergeThreshold: nil
             )
 
             let rawSpeakerCount = Set(rawSegments.map { $0.speakerId }).count
@@ -644,7 +641,7 @@ extension Transcription {
         let speakerSegments = EmbeddingClusterer.postProcess(
             segments: rawSegments,
             existingProfiles: existingProfiles,
-            pairwiseMergeThreshold: 0.78
+            pairwiseMergeThreshold: nil
         )
 
         let rawSpeakerCount = Set(rawSegments.map { $0.speakerId }).count

--- a/Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift
+++ b/Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift
@@ -17,6 +17,31 @@ final class EmbeddingClustererTests: XCTestCase {
         XCTAssertEqual(Set(merged.map(\.speakerId)), [1])
     }
 
+    func testOfflinePostProcessCanSkipPairwiseMergeForMultiSpeakerCalls() {
+        let segments = [
+            segment(speakerId: 1, startTime: 0, endTime: 3, embedding: unitVector(degrees: 0)),
+            segment(speakerId: 2, startTime: 3, endTime: 6, embedding: unitVector(degrees: 30)),
+            segment(speakerId: 3, startTime: 6, endTime: 9, embedding: unitVector(degrees: 60)),
+            segment(speakerId: 4, startTime: 9, endTime: 12, embedding: unitVector(degrees: 90)),
+            segment(speakerId: 5, startTime: 12, endTime: 15, embedding: unitVector(degrees: 120)),
+            segment(speakerId: 6, startTime: 15, endTime: 18, embedding: unitVector(degrees: 150)),
+        ]
+
+        XCTAssertEqual(
+            Set(EmbeddingClusterer.pairwiseMerge(segments: segments, threshold: 0.78).map(\.speakerId)).count,
+            1,
+            "Transitive pairwise merge reproduces the reported multi-speaker collapse risk"
+        )
+
+        let preserved = EmbeddingClusterer.postProcess(
+            segments: segments,
+            existingProfiles: [],
+            pairwiseMergeThreshold: nil
+        )
+
+        XCTAssertEqual(Set(preserved.map(\.speakerId)).count, 6)
+    }
+
     func testAbsorbSmallClustersPreservesAtLeastTwoSpeakers() {
         let protected = EmbeddingClusterer.absorbSmallClusters(
             segments: [
@@ -87,5 +112,10 @@ final class EmbeddingClustererTests: XCTestCase {
     private func unitVector(cosineToXAxis: Float) -> [Float] {
         let y = sqrt(max(0, 1 - (cosineToXAxis * cosineToXAxis)))
         return [cosineToXAxis, y]
+    }
+
+    private func unitVector(degrees: Float) -> [Float] {
+        let radians = degrees * .pi / 180
+        return [cos(radians), sin(radians)]
     }
 }


### PR DESCRIPTION
## Summary
- disables pre-review pairwise speaker merging for offline diarization paths
- preserves raw PyAnnote/VBx speaker IDs so review can merge/name speakers without irreversible over-collapse
- adds a TranscriptedCore regression test showing the transitive pairwise merge collapse risk

## Why
This branch was pushed but had no PR. It appears intended to guard against multi-speaker calls being collapsed before speaker review.

## Verification
- Not rerun during coordinator cleanup; opened as draft so it can go through normal review/test gate.