### PR TITLE
Clarify offline speaker post-processing

### DIFF
--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -143,9 +143,9 @@ extension Transcription {
             AppLogger.transcription.info("Running offline diarization on system audio")
             let rawSegments = try await diarization.diarizeOffline(samples: systemSamples, sampleRate: 16000)
 
-            // Post-process diarization segments. Keep PyAnnote/VBx speaker IDs intact
-            // before review: over-segmentation is fixable by merging/name review, but
-            // pre-review pairwise merges can irreversibly collapse real participants.
+            // Post-process diarization segments, but skip the broad pairwise merge
+            // phase for PyAnnote/VBx output. Small-cluster absorption and DB-informed
+            // split still run for noise cleanup and known-speaker corrections.
             let existingProfiles = speakerDB.allSpeakers()
             let speakerSegments = EmbeddingClusterer.postProcess(
                 segments: rawSegments,

--- a/Sources/TranscriptedCore/Speaker/EmbeddingClusterer.swift
+++ b/Sources/TranscriptedCore/Speaker/EmbeddingClusterer.swift
@@ -23,9 +23,10 @@ public enum EmbeddingClusterer {
     /// multiple known DB voices.
     ///
     /// - Parameter pairwiseMergeThreshold: Cosine similarity threshold for merging
-    ///   fragmented speaker clusters. Pass `nil` to skip pairwise merge entirely.
-    ///   Sortformer default: 0.85 (conservative). PyAnnote: 0.78 (VBx already does
-    ///   initial clustering, but fragments dominant speakers on codec-compressed audio).
+    ///   fragmented speaker clusters. Pass `nil` to skip only the pairwise merge
+    ///   phase; small-cluster absorption and DB-informed split still run.
+    ///   Sortformer default: 0.85 (conservative). Offline PyAnnote callers pass
+    ///   `nil` because VBx already handles the base merge/fragmentation case.
     public static func postProcess(
         segments: [SpeakerSegment],
         existingProfiles: [SpeakerProfile],

--- a/Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift
+++ b/Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift
@@ -17,7 +17,7 @@ final class EmbeddingClustererTests: XCTestCase {
         XCTAssertEqual(Set(merged.map(\.speakerId)), [1])
     }
 
-    func testOfflinePostProcessCanSkipPairwiseMergeForMultiSpeakerCalls() {
+    func testOfflinePostProcessSkipsTransitivePairwiseCollapse() {
         let segments = [
             segment(speakerId: 1, startTime: 0, endTime: 3, embedding: unitVector(degrees: 0)),
             segment(speakerId: 2, startTime: 3, endTime: 6, embedding: unitVector(degrees: 30)),
@@ -33,13 +33,47 @@ final class EmbeddingClustererTests: XCTestCase {
             "Transitive pairwise merge reproduces the reported multi-speaker collapse risk"
         )
 
-        let preserved = EmbeddingClusterer.postProcess(
+        let withoutPairwise = EmbeddingClusterer.postProcess(
             segments: segments,
             existingProfiles: [],
             pairwiseMergeThreshold: nil
         )
 
-        XCTAssertEqual(Set(preserved.map(\.speakerId)).count, 6)
+        XCTAssertEqual(Set(withoutPairwise.map(\.speakerId)).count, 6)
+    }
+
+    func testPostProcessStillAbsorbsSmallClustersWhenPairwiseMergeIsSkipped() {
+        let processed = EmbeddingClusterer.postProcess(
+            segments: [
+                segment(speakerId: 1, startTime: 0, endTime: 40, embedding: [1.0, 0.0]),
+                segment(speakerId: 2, startTime: 40, endTime: 44, embedding: unitVector(cosineToXAxis: 0.95)),
+                segment(speakerId: 3, startTime: 44, endTime: 84, embedding: [0.0, 1.0]),
+            ],
+            existingProfiles: [],
+            pairwiseMergeThreshold: nil
+        )
+
+        XCTAssertEqual(Set(processed.map(\.speakerId)), [1, 3])
+    }
+
+    func testPostProcessStillRunsDbInformedSplitWhenPairwiseMergeIsSkipped() {
+        let profileA = speakerProfile(id: UUID(), embedding: [1.0, 0.0], name: "Alex")
+        let profileB = speakerProfile(id: UUID(), embedding: [0.0, 1.0], name: "Blair")
+        var segments: [SpeakerSegment] = []
+        for index in 0..<8 {
+            segments.append(segment(speakerId: 1, startTime: Double(index), endTime: Double(index + 1), embedding: [1.0, 0.0]))
+        }
+        for index in 8..<16 {
+            segments.append(segment(speakerId: 1, startTime: Double(index), endTime: Double(index + 1), embedding: [0.0, 1.0]))
+        }
+
+        let processed = EmbeddingClusterer.postProcess(
+            segments: segments,
+            existingProfiles: [profileA, profileB],
+            pairwiseMergeThreshold: nil
+        )
+
+        XCTAssertEqual(Set(processed.map { $0.speakerId }).count, 2)
     }
 
     func testAbsorbSmallClustersPreservesAtLeastTwoSpeakers() {


### PR DESCRIPTION
## Summary
- Cherry-picks the `8b5d448` follow-up from `codex/grigory-pairwise-overmerge-guard` onto current `origin/main`
- Keeps the patch scoped to offline speaker post-processing and EmbeddingClusterer speaker-test coverage

## Validation
- `git diff --check origin/main..HEAD` passed
- `swift test --filter EmbeddingClustererTests` attempted, but local SwiftPM build is blocked because the checkout is missing required binary dependency folders: `deps-libs`, `deps-frameworks`, and `deps-modules`; compiler error: `no such module 'FluidAudio'`
