### PR TITLE
[codex] Autoeval dictation start latency (unstacked)

### DIFF
--- a/Sources/Speech/DictationReadinessWaitPolicy.swift
+++ b/Sources/Speech/DictationReadinessWaitPolicy.swift
@@ -14,7 +14,7 @@ enum DictationReadinessWaitAction: Equatable {
 
 struct DictationReadinessWaitPolicy {
     private static let refreshesBeforeRecoveryStart = 4
-    private static let startFailuresBeforeForcedRecovery = 3
+    private static let startFailuresBeforeForcedRecovery = 2
     private static let maxRecoveryStartAttempts = 2
 
     static func action(

--- a/Sources/Speech/ParakeetAudioEngineSupport.swift
+++ b/Sources/Speech/ParakeetAudioEngineSupport.swift
@@ -64,10 +64,12 @@ struct ParakeetAudioInputSnapshot {
     let selection: DictationInputDeviceSelection?
     let selectionApplication: ParakeetInputDeviceApplication?
     let engineWasRunning: Bool
+    let stageTimings: [String: Int]
 }
 
 struct ParakeetAudioStartSnapshot {
     let engineWasRunning: Bool
+    let stageTimings: [String: Int]
 }
 
 struct ParakeetInputDeviceApplication {

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -221,6 +221,16 @@ class ParakeetEngine: ObservableObject {
         }
     }
 
+    private static func elapsedMilliseconds(since start: CFAbsoluteTime) -> Int {
+        max(0, Int((CFAbsoluteTimeGetCurrent() - start) * 1000))
+    }
+
+    private static func timingContext(_ timings: [String: Int]) -> [String: String] {
+        timings.reduce(into: [:]) { context, entry in
+            context[entry.key] = "\(entry.value)"
+        }
+    }
+
     private static func cleanUpLateAudioStart(on audioEngine: AVAudioEngine) {
         audioEngine.inputNode.removeTap(onBus: 0)
         if audioEngine.isRunning {
@@ -1328,13 +1338,20 @@ class ParakeetEngine: ObservableObject {
         recoveryGeneration: UInt64? = nil,
         allowsBuiltInBluetoothFallback: Bool = true
     ) async throws -> ParakeetAudioInputSnapshot {
+        let snapshotStartedAt = CFAbsoluteTimeGetCurrent()
+        let selectionStartedAt = CFAbsoluteTimeGetCurrent()
         let selection = Self.loadDictationInputDeviceSelection(
             allowsBuiltInBluetoothFallback: allowsBuiltInBluetoothFallback
         )
+        var stageTimings = [
+            "audio_input_selection_load_ms": Self.elapsedMilliseconds(since: selectionStartedAt)
+        ]
         if let selection, selection.didOverrideDefault {
+            let deviceCheckStartedAt = CFAbsoluteTimeGetCurrent()
             let shouldApplyOverride = try await runTimedAudioEngineWork(operation: "\(operation)_device_check") { engine in
                 engine.inputNode.auAudioUnit.deviceID != selection.selectedInput.id
             }
+            stageTimings["audio_input_device_check_ms"] = Self.elapsedMilliseconds(since: deviceCheckStartedAt)
             if let recoveryGeneration, recoveryState.isStale(generation: recoveryGeneration) {
                 throw CancellationError()
             }
@@ -1347,17 +1364,27 @@ class ParakeetEngine: ObservableObject {
             throw CancellationError()
         }
         let snapshotGraphGeneration = audioGraphGeneration
-        let snapshot = try await runTimedAudioEngineWork(operation: "\(operation)_snapshot") { audioEngine in
+        let snapshotReadStartedAt = CFAbsoluteTimeGetCurrent()
+        let snapshotResult = try await runTimedAudioEngineWork(operation: "\(operation)_snapshot") { audioEngine in
             let inputNode = audioEngine.inputNode
             let selectionApplication = Self.applyPreferredDictationInputDevice(selection, to: inputNode)
-            return ParakeetAudioInputSnapshot(
+            return (
                 outputFormat: Self.audioFormatSummary(inputNode.outputFormat(forBus: 0)),
                 hwFormat: Self.audioFormatSummary(inputNode.inputFormat(forBus: 0)),
-                selection: selection,
                 selectionApplication: selectionApplication,
                 engineWasRunning: audioEngine.isRunning
             )
         }
+        stageTimings["audio_input_snapshot_read_ms"] = Self.elapsedMilliseconds(since: snapshotReadStartedAt)
+        stageTimings["audio_input_total_ms"] = Self.elapsedMilliseconds(since: snapshotStartedAt)
+        let snapshot = ParakeetAudioInputSnapshot(
+            outputFormat: snapshotResult.outputFormat,
+            hwFormat: snapshotResult.hwFormat,
+            selection: selection,
+            selectionApplication: snapshotResult.selectionApplication,
+            engineWasRunning: snapshotResult.engineWasRunning,
+            stageTimings: stageTimings
+        )
         if let recoveryGeneration, recoveryState.isStale(generation: recoveryGeneration) {
             throw CancellationError()
         }
@@ -1381,22 +1408,33 @@ class ParakeetEngine: ObservableObject {
             return snapshot
         }
 
+        let settleSleepStartedAt = CFAbsoluteTimeGetCurrent()
         try? await Task.sleep(nanoseconds: overrideSettleDelay)
+        stageTimings["audio_input_override_settle_sleep_ms"] = Self.elapsedMilliseconds(since: settleSleepStartedAt)
         if let recoveryGeneration, recoveryState.isStale(generation: recoveryGeneration) {
             throw CancellationError()
         }
 
         let settledGraphGeneration = audioGraphGeneration
-        let settledSnapshot = try await runTimedAudioEngineWork(operation: "\(operation)_settled_snapshot") { audioEngine in
+        let settledSnapshotStartedAt = CFAbsoluteTimeGetCurrent()
+        let settledSnapshotResult = try await runTimedAudioEngineWork(operation: "\(operation)_settled_snapshot") { audioEngine in
             let inputNode = audioEngine.inputNode
-            return ParakeetAudioInputSnapshot(
+            return (
                 outputFormat: Self.audioFormatSummary(inputNode.outputFormat(forBus: 0)),
                 hwFormat: Self.audioFormatSummary(inputNode.inputFormat(forBus: 0)),
-                selection: selection,
-                selectionApplication: snapshot.selectionApplication,
                 engineWasRunning: audioEngine.isRunning
             )
         }
+        stageTimings["audio_input_settled_snapshot_read_ms"] = Self.elapsedMilliseconds(since: settledSnapshotStartedAt)
+        stageTimings["audio_input_total_ms"] = Self.elapsedMilliseconds(since: snapshotStartedAt)
+        let settledSnapshot = ParakeetAudioInputSnapshot(
+            outputFormat: settledSnapshotResult.outputFormat,
+            hwFormat: settledSnapshotResult.hwFormat,
+            selection: selection,
+            selectionApplication: snapshot.selectionApplication,
+            engineWasRunning: settledSnapshotResult.engineWasRunning,
+            stageTimings: stageTimings
+        )
         if let recoveryGeneration, recoveryState.isStale(generation: recoveryGeneration) {
             throw CancellationError()
         }
@@ -1431,8 +1469,13 @@ class ParakeetEngine: ObservableObject {
             operation: "start_recording",
             cleanupAfterLateCompletion: Self.cleanUpLateAudioStart(on:)
         ) { audioEngine in
+            let workStartedAt = CFAbsoluteTimeGetCurrent()
+            var stageTimings: [String: Int] = [:]
             let inputNode = audioEngine.inputNode
+            let tapRemoveStartedAt = CFAbsoluteTimeGetCurrent()
             inputNode.removeTap(onBus: 0)
+            stageTimings["audio_tap_remove_ms"] = Self.elapsedMilliseconds(since: tapRemoveStartedAt)
+            let tapInstallStartedAt = CFAbsoluteTimeGetCurrent()
             inputNode.installTap(onBus: 0, bufferSize: TranscriptedConstants.audioTapBufferSize, format: nil) { [weak self] buffer, _ in
                 guard let self = self,
                       let monoSamples = self.extractMonoSamples(from: buffer) else { return }
@@ -1502,13 +1545,23 @@ class ParakeetEngine: ObservableObject {
                     self?.audioLevel = normalized
                 }
             }
+            stageTimings["audio_tap_install_ms"] = Self.elapsedMilliseconds(since: tapInstallStartedAt)
 
             let engineWasRunning = audioEngine.isRunning
             if !wasPrewarmed || !audioEngine.isRunning {
-                audioEngine.prepare()
+                stageTimings["audio_engine_prepare_ms"] = 0
+                let engineStartStartedAt = CFAbsoluteTimeGetCurrent()
                 try audioEngine.start()
+                stageTimings["audio_engine_start_ms"] = Self.elapsedMilliseconds(since: engineStartStartedAt)
+            } else {
+                stageTimings["audio_engine_prepare_ms"] = 0
+                stageTimings["audio_engine_start_ms"] = 0
             }
-            return ParakeetAudioStartSnapshot(engineWasRunning: engineWasRunning)
+            stageTimings["audio_start_work_ms"] = Self.elapsedMilliseconds(since: workStartedAt)
+            return ParakeetAudioStartSnapshot(
+                engineWasRunning: engineWasRunning,
+                stageTimings: stageTimings
+            )
         }
     }
 
@@ -2010,6 +2063,25 @@ class ParakeetEngine: ObservableObject {
                 }
                 inputTapInstalled = true
                 isEnginePrewarmed = true
+
+                var timingContext = dictationRouteAnalyticsContext(
+                    outputFormat: snapshot.outputFormat,
+                    hwFormat: snapshot.hwFormat,
+                    selection: snapshot.selection,
+                    extra: [
+                        "engine_running_before_start": "\(startSnapshot.engineWasRunning)",
+                        "start_mode": isRecoveryAttempt ? "recovery" : "normal",
+                    ]
+                )
+                timingContext.merge(Self.timingContext(snapshot.stageTimings)) { current, _ in current }
+                timingContext.merge(Self.timingContext(startSnapshot.stageTimings)) { current, _ in current }
+                EventReporter.shared.capture(
+                    level: .info,
+                    engine: "parakeet",
+                    event: "dictation_audio_start_timing",
+                    message: "Dictation audio start stage timing",
+                    context: timingContext
+                )
 
                 if !startSnapshot.engineWasRunning && isEnginePrewarmed {
                     EventReporter.shared.capture(level: .info, engine: "parakeet",

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -31,6 +31,7 @@ class ParakeetEngine: ObservableObject {
     private var recoveredRecordingTimeline = RecordedAudioTimeline()
     private var preservingRecordingAcrossRecovery = false
     private nonisolated(unsafe) var nativeSampleRate: Double = 48000
+    private nonisolated(unsafe) var audioStartReferenceTime: CFAbsoluteTime?
     private let pendingSamplesLock = NSLock()
     private var pendingSamples: [Float] = []
     private nonisolated(unsafe) var lastLevelUpdate: CFAbsoluteTime = 0
@@ -1443,14 +1444,21 @@ class ParakeetEngine: ObservableObject {
 
                 if !self.didReceiveAudioSamples && frameLength > 0 {
                     self.didReceiveAudioSamples = true
+                    let startToFirstSampleMs = self.audioStartReferenceTime.map {
+                        Int((CFAbsoluteTimeGetCurrent() - $0) * 1000)
+                    }
                     Task { @MainActor in
+                        var context = [
+                            "sample_rate": "\(effectiveSampleRate)",
+                            "channels": "\(bufferFormat.channelCount)",
+                            "frames": "\(frameLength)"
+                        ]
+                        if let startToFirstSampleMs {
+                            context["start_to_first_sample_ms"] = "\(startToFirstSampleMs)"
+                        }
                         EventReporter.shared.capture(level: .info, engine: "parakeet", event: "audio_samples_detected",
                             message: "Audio samples started flowing",
-                            context: [
-                                "sample_rate": "\(effectiveSampleRate)",
-                                "channels": "\(bufferFormat.channelCount)",
-                                "frames": "\(frameLength)"
-                            ])
+                            context: context)
                     }
                 }
 
@@ -1837,6 +1845,7 @@ class ParakeetEngine: ObservableObject {
             return false
         }
         audioStartInProgress = true
+        audioStartReferenceTime = CFAbsoluteTimeGetCurrent()
         audioGraphGeneration += 1
         var startGeneration = audioGraphGeneration
         defer {

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -1368,7 +1368,19 @@ class ParakeetEngine: ObservableObject {
             return snapshot
         }
 
-        try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
+        let immediateReadiness = audioFormatReadiness(
+            outputFormat: snapshot.outputFormat,
+            hwFormat: snapshot.hwFormat,
+            selection: snapshot.selection
+        )
+        let overrideSettleDelay = ParakeetInputOverrideSettlePolicy.delayNanoseconds(
+            afterImmediateReadiness: immediateReadiness
+        )
+        if overrideSettleDelay == 0 {
+            return snapshot
+        }
+
+        try? await Task.sleep(nanoseconds: overrideSettleDelay)
         if let recoveryGeneration, recoveryState.isStale(generation: recoveryGeneration) {
             throw CancellationError()
         }

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -197,6 +197,12 @@ enum ParakeetAudioFormatReadinessPolicy {
     }
 }
 
+enum ParakeetInputOverrideSettlePolicy {
+    static func delayNanoseconds(afterImmediateReadiness readiness: ParakeetAudioFormatReadiness) -> UInt64 {
+        readiness == .ready ? 0 : TranscriptedConstants.audioRecoveryDelay
+    }
+}
+
 struct ParakeetAudioFormatSummary: Equatable {
     let sampleRate: Double
     let channelCount: UInt32

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -108,7 +108,7 @@ enum TranscriptedConstants {
     static let dictationRecoveryBudget: TimeInterval = 6.0
 
     /// Poll interval while dictation waits on engine readiness (nanoseconds).
-    static let dictationReadinessPollInterval: UInt64 = 150_000_000  // 150ms
+    static let dictationReadinessPollInterval: UInt64 = 100_000_000  // 100ms
 
     /// Minimum interval between active readiness refreshes while dictation waits.
     /// This lets a failed recovery get unstuck without hammering CoreAudio.
@@ -120,7 +120,7 @@ enum TranscriptedConstants {
 
     /// Number of active readiness refreshes before a user-started dictation
     /// performs a hard idle audio graph rebuild.
-    static let dictationReadinessForcedRecoveryRefreshes: Int = 6
+    static let dictationReadinessForcedRecoveryRefreshes: Int = 5
 
     /// Max hard recovery attempts inside one user-started dictation wait.
     static let dictationReadinessForcedRecoveryAttempts: Int = 2

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -95,6 +95,7 @@ class DictationSessionController: ObservableObject {
         trigger: DictationTrigger = .unknown,
         anchorRect: NSRect? = nil
     ) {
+        let requestStartedAt = CFAbsoluteTimeGetCurrent()
         guard let (appState, overlayController) = readyState() else { return }
         guard !isDictating else { return }
         guard !appState.sttRouter.isTranscribing else {
@@ -106,7 +107,7 @@ class DictationSessionController: ObservableObject {
         sessionSourceApp = sourceApp
         sessionPasteTarget = DictationPasteTarget.capture(sourceApp: sourceApp)
         sessionAnchorRect = anchorRect
-        sessionStartTime = CFAbsoluteTimeGetCurrent()
+        sessionStartTime = requestStartedAt
         currentDictationTrigger = trigger
         lastCompletedText = nil
         appState.runtimeDiagnostics.recordSession(kind: "dictation", stage: "start_requested")
@@ -256,6 +257,7 @@ class DictationSessionController: ObservableObject {
                     return
                 }
                 if started {
+                    let requestToRecordingMs = Int((CFAbsoluteTimeGetCurrent() - self.sessionStartTime) * 1000)
                     self.recordingStartRetryTask = nil
                     overlayController.state = .listening
                     if !overlayController.isVisible {
@@ -271,6 +273,8 @@ class DictationSessionController: ObservableObject {
                         message: "Dictation recording started through the ready-engine fast path",
                         context: self.dictationContext(
                             extra: [
+                                "pre_recording_overhead_ms": "\(max(0, requestToRecordingMs - startMs))",
+                                "request_to_recording_ms": "\(requestToRecordingMs)",
                                 "start_ms": "\(startMs)",
                                 "audio_device": appState.sttRouter.inputDeviceName,
                                 "trigger": self.currentDictationTrigger.rawValue
@@ -280,6 +284,7 @@ class DictationSessionController: ObservableObject {
                     AppSoundPlayer.shared.play(.dictationStart)
                     self.installSessionTimeout()
                 } else {
+                    let requestToFallbackMs = Int((CFAbsoluteTimeGetCurrent() - self.sessionStartTime) * 1000)
                     DiagnosticsTrail.record(
                         logger: appState.logger,
                         level: .warning,
@@ -288,6 +293,8 @@ class DictationSessionController: ObservableObject {
                         message: "Ready-engine dictation fast start failed and fell back to recovery wait",
                         context: self.dictationContext(
                             extra: [
+                                "pre_recording_overhead_ms": "\(max(0, requestToFallbackMs - startMs))",
+                                "request_to_fallback_ms": "\(requestToFallbackMs)",
                                 "start_ms": "\(startMs)",
                                 "audio_device": appState.sttRouter.inputDeviceName,
                                 "trigger": self.currentDictationTrigger.rawValue,
@@ -456,6 +463,7 @@ class DictationSessionController: ObservableObject {
                     resizePanelToCompact()
                     appState.runtimeDiagnostics.recordSession(kind: "dictation", stage: "recording_after_wait")
                     let waited = Int((ProcessInfo.processInfo.systemUptime - startedAt) * 1000)
+                    let requestToRecordingMs = Int((CFAbsoluteTimeGetCurrent() - sessionStartTime) * 1000)
                     appState.logger.log("DICTATION | started after forced recovery start and \(waited)ms wait (parakeet, \(appState.sttRouter.inputDeviceName))")
                     DiagnosticsTrail.record(
                         logger: appState.logger,
@@ -464,6 +472,7 @@ class DictationSessionController: ObservableObject {
                         message: "Dictation started after forcing a recovery recording start",
                         context: dictationContext(
                             extra: [
+                                "request_to_recording_ms": "\(requestToRecordingMs)",
                                 "wait_ms": "\(waited)",
                                 "start_attempts": "\(startAttempts)",
                                 "readiness_refreshes": "\(readinessRefreshes)"
@@ -494,6 +503,7 @@ class DictationSessionController: ObservableObject {
                     resizePanelToCompact()
                     appState.runtimeDiagnostics.recordSession(kind: "dictation", stage: "recording_after_wait")
                     let waited = Int((ProcessInfo.processInfo.systemUptime - startedAt) * 1000)
+                    let requestToRecordingMs = Int((CFAbsoluteTimeGetCurrent() - sessionStartTime) * 1000)
                     appState.logger.log("DICTATION | started after \(waited)ms wait (parakeet, \(appState.sttRouter.inputDeviceName))")
                     DiagnosticsTrail.record(
                         logger: appState.logger,
@@ -502,6 +512,7 @@ class DictationSessionController: ObservableObject {
                         message: "Dictation started after waiting for engine readiness",
                         context: dictationContext(
                             extra: [
+                                "request_to_recording_ms": "\(requestToRecordingMs)",
                                 "wait_ms": "\(waited)",
                                 "audio_device": appState.sttRouter.inputDeviceName,
                                 "start_attempts": "\(startAttempts)",

--- a/Tests/DictationReadinessWaitPolicyTests.swift
+++ b/Tests/DictationReadinessWaitPolicyTests.swift
@@ -88,6 +88,24 @@ func testDictationReadinessWaitPolicy() {
         assertEqual(action, .waitForRecovery, "active device recovery should not be interrupted by the forced recovery threshold")
     }
 
+    runSuite("DictationReadinessWaitPolicy — default forced recovery threshold is bounded") {
+        let belowThreshold = DictationReadinessWaitPolicy.action(
+            isRecovering: false,
+            inputFormatReady: false,
+            readinessRefreshes: TranscriptedConstants.dictationReadinessForcedRecoveryRefreshes - 1,
+            recoveryStartAttempts: 1
+        )
+        assertEqual(belowThreshold, .refreshInputReadiness, "one refresh before the default threshold should keep the route refreshable")
+
+        let atThreshold = DictationReadinessWaitPolicy.action(
+            isRecovering: false,
+            inputFormatReady: false,
+            readinessRefreshes: TranscriptedConstants.dictationReadinessForcedRecoveryRefreshes,
+            recoveryStartAttempts: 1
+        )
+        assertEqual(atThreshold, .forceInputRecovery, "the default threshold should force one hard input recovery")
+    }
+
     runSuite("DictationReadinessWaitPolicy — starts recording when input is ready") {
         let action = DictationReadinessWaitPolicy.action(
             isRecovering: false,
@@ -101,18 +119,18 @@ func testDictationReadinessWaitPolicy() {
         let action = DictationReadinessWaitPolicy.action(
             isRecovering: false,
             inputFormatReady: true,
-            readyStartFailures: 2,
+            readyStartFailures: 1,
             forcedRecoveryAttempts: 0
         )
 
-        assertEqual(action, .startRecording, "a couple of failed starts should still use the normal start path")
+        assertEqual(action, .startRecording, "one failed start should still use the normal start path")
     }
 
     runSuite("DictationReadinessWaitPolicy — repeated ready start failures force recovery") {
         let action = DictationReadinessWaitPolicy.action(
             isRecovering: false,
             inputFormatReady: true,
-            readyStartFailures: 3,
+            readyStartFailures: 2,
             forcedRecoveryAttempts: 0
         )
 
@@ -123,7 +141,7 @@ func testDictationReadinessWaitPolicy() {
         let action = DictationReadinessWaitPolicy.action(
             isRecovering: false,
             inputFormatReady: true,
-            readyStartFailures: 3,
+            readyStartFailures: 2,
             forcedRecoveryAttempts: 1
         )
 
@@ -134,7 +152,7 @@ func testDictationReadinessWaitPolicy() {
         let action = DictationReadinessWaitPolicy.action(
             isRecovering: false,
             inputFormatReady: true,
-            readyStartFailures: 6,
+            readyStartFailures: 4,
             forcedRecoveryAttempts: 1
         )
 
@@ -145,7 +163,7 @@ func testDictationReadinessWaitPolicy() {
         let action = DictationReadinessWaitPolicy.action(
             isRecovering: false,
             inputFormatReady: true,
-            readyStartFailures: 6,
+            readyStartFailures: 4,
             forcedRecoveryAttempts: 2,
             maxForcedRecoveryAttempts: 2
         )

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -301,6 +301,27 @@ func testParakeetStartRecordingFailurePolicy() {
         assertEqual(readiness, .ready, "native 24k external capture should stay usable when input and output agree")
     }
 
+    runSuite("ParakeetInputOverrideSettlePolicy skips delay when immediate format is ready") {
+        assertEqual(
+            ParakeetInputOverrideSettlePolicy.delayNanoseconds(afterImmediateReadiness: .ready),
+            0,
+            "ready formats after an input override should not pay a fixed settle delay"
+        )
+    }
+
+    runSuite("ParakeetInputOverrideSettlePolicy keeps delay while route is settling") {
+        assertEqual(
+            ParakeetInputOverrideSettlePolicy.delayNanoseconds(afterImmediateReadiness: .routeNotSettled),
+            TranscriptedConstants.audioRecoveryDelay,
+            "stale route formats should still get the full CoreAudio settle delay"
+        )
+        assertEqual(
+            ParakeetInputOverrideSettlePolicy.delayNanoseconds(afterImmediateReadiness: .invalid),
+            TranscriptedConstants.audioRecoveryDelay,
+            "invalid formats should still get the full CoreAudio settle delay"
+        )
+    }
+
     runSuite("ParakeetAudioFormatReadinessPolicy rejects zero formats") {
         let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
             outputSampleRate: 0,

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -939,6 +939,14 @@ func testRepoCommandContract() {
             "performance budget should report per-stage stop latency and identify the slowest stop segment"
         )
         assertTrue(
+            contents.contains("dictation_request_to_recording_ms"),
+            "performance budget should surface true request-to-recording timing when logs include it"
+        )
+        assertTrue(
+            contents.contains("start_to_first_sample_ms"),
+            "performance budget should surface audio-flow timing when logs include it"
+        )
+        assertTrue(
             contents.contains("--stats PATH"),
             "performance budget should support optional meeting throughput stats"
         )
@@ -1053,6 +1061,14 @@ func testRepoCommandContract() {
             "fast dictation start should emit a measurable local proof event"
         )
         assertTrue(
+            fastPathBlock.contains("request_to_recording_ms"),
+            "fast dictation start should measure request-to-recording latency, not only CoreAudio start time"
+        )
+        assertTrue(
+            fastPathBlock.contains("pre_recording_overhead_ms"),
+            "fast dictation start should expose non-CoreAudio overhead for future autoeval runs"
+        )
+        assertTrue(
             fastPathBlock.contains("dictation_fast_start_fell_back_to_wait"),
             "fast dictation start fallback should emit a local proof event"
         )
@@ -1097,6 +1113,14 @@ func testRepoCommandContract() {
                 && contents.contains("\"stop_to_paste_bucket\"")
                 && contents.contains("\"stop_to_done_bucket\""),
             "dictation stop analytics should send coarse latency buckets instead of raw milliseconds"
+        )
+    }
+
+    runSuite("Repo command contract - audio sample flow start stays measurable") {
+        let contents = readRepoTextFile("Sources/Speech/ParakeetEngine.swift")
+        assertTrue(
+            contents.contains("start_to_first_sample_ms"),
+            "audio_samples_detected should include start-to-first-buffer latency for dictation start autoevals"
         )
     }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -888,6 +888,14 @@ func testRepoCommandContract() {
             "performance budget should cap ready-engine dictation start latency when samples are required"
         )
         assertTrue(
+            contents.contains("MAX_DICTATION_REQUEST_TO_RECORDING_P95_MS = 250.0"),
+            "performance budget should cap request-to-recording latency when strict start samples are required"
+        )
+        assertTrue(
+            contents.contains("MAX_DICTATION_START_TO_FIRST_SAMPLE_P95_MS = 350.0"),
+            "performance budget should cap start-to-first-sample latency when strict start samples are required"
+        )
+        assertTrue(
             contents.contains("MAX_DICTATION_STOP_TO_PASTE_P95_MS = 750.0"),
             "performance budget should cap stop-to-paste latency when samples are required"
         )
@@ -906,6 +914,11 @@ func testRepoCommandContract() {
         assertTrue(
             contents.contains("--require-dictation-fast-start-samples"),
             "performance budget should support strict fresh dictation start proof"
+        )
+        assertTrue(
+            contents.contains("--max-dictation-request-to-recording-p95-ms")
+                && contents.contains("--max-dictation-start-to-first-sample-p95-ms"),
+            "strict dictation start proof should expose budgets for the user-visible start and audio-flow metrics"
         )
         assertTrue(
             contents.contains("--require-dictation-stop-latency-samples"),
@@ -945,6 +958,14 @@ func testRepoCommandContract() {
         assertTrue(
             contents.contains("start_to_first_sample_ms"),
             "performance budget should surface audio-flow timing when logs include it"
+        )
+        assertTrue(
+            contents.contains("dictation_start_proof_events")
+                && contents.contains("dictation request-to-recording samples")
+                && contents.contains("Dictation request-to-recording p95 is")
+                && contents.contains("dictation start-to-first-sample samples")
+                && contents.contains("Dictation start-to-first-sample p95 is"),
+            "strict dictation start proof should enforce the collected request-to-recording and audio-flow samples"
         )
         assertTrue(
             contents.contains("--stats PATH"),
@@ -1035,6 +1056,33 @@ func testRepoCommandContract() {
                 && betaBuildScript.contains("-whole-module-optimization")
                 && betaBuildScript.contains("-num-threads \"$SWIFTC_NUM_THREADS\""),
             "beta release build should use threaded whole-module Swift compilation"
+        )
+    }
+
+    runSuite("Repo command contract - dictation recovery autoeval separates baseline from kept policy") {
+        let contents = readRepoTextFile("scripts/ops/dictation-recovery-autoeval.rb")
+        let baselineBlock = sourceSlice(contents, from: "BASELINE = Config.new(", to: ")\n\nKEPT_POLICY = Config.new(")
+        let keptBlock = sourceSlice(contents, from: "KEPT_POLICY = Config.new(", to: ")\n\nSCENARIOS = [")
+
+        assertTrue(
+            baselineBlock.contains("name: \"baseline\"")
+                && baselineBlock.contains("poll_ms: 150")
+                && baselineBlock.contains("forced_recovery_refreshes: 6")
+                && baselineBlock.contains("max_recording_start_attempts: 3"),
+            "recovery autoeval baseline should stay the pre-keeper policy, not the kept winner"
+        )
+        assertTrue(
+            keptBlock.contains("name: \"kept_current_policy\"")
+                && keptBlock.contains("poll_ms: 100")
+                && keptBlock.contains("forced_recovery_refreshes: 5")
+                && keptBlock.contains("max_recording_start_attempts: 2"),
+            "recovery autoeval should name the current kept policy separately from the baseline"
+        )
+        assertTrue(
+            contents.contains("all_results.fetch(BASELINE.name)")
+                && contents.contains("Baseline: pre-keeper policy")
+                && contents.contains("Kept current policy:"),
+            "recovery autoeval deltas and raw rows should be anchored to the real baseline"
         )
     }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1124,6 +1124,20 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - dictation audio start exposes stage timings") {
+        let contents = readRepoTextFile("Sources/Speech/ParakeetEngine.swift")
+        assertTrue(
+            contents.contains("dictation_audio_start_timing"),
+            "dictation start autoevals need a local stage-timing event"
+        )
+        assertTrue(
+            contents.contains("audio_input_snapshot_read_ms")
+                && contents.contains("audio_tap_install_ms")
+                && contents.contains("audio_engine_start_ms"),
+            "stage timing should cover audio snapshot read, tap install, and engine start"
+        )
+    }
+
     runSuite("Repo command contract - mini cursor stays compact from startup through paste") {
         let overlayContents = readRepoTextFile("Sources/UI/Overlay/FloatingOverlayController.swift")
         let sizeBlock = sourceSlice(

--- a/docs/autoeval-dictation-recovery-time-2026-05-31.md
+++ b/docs/autoeval-dictation-recovery-time-2026-05-31.md
@@ -1,0 +1,198 @@
+# Autoeval: Dictation Recovery Time
+
+## Verdict
+
+Winner: keep the input-override settle change already on this branch.
+
+When Transcripted applies a preferred dictation input override and the immediate
+CoreAudio snapshot is already ready, the app now skips the old fixed 300 ms
+settle delay. It still waits when the route is stale or invalid, so it does not
+pretend to be listening before recording can actually start.
+
+## Metric
+
+- Primary: time from dictation start request to listening when dictation does
+  not cleanly hit the ready fast path, measured by `dictation_started_after_wait`
+  `wait_ms`.
+- Secondary: counts of `dictation_recording_retry`,
+  `dictation_fast_start_fell_back_to_wait` / `audio_start_deferred`,
+  `microphone_start_timeout`, guarded recovery starts, forced input recoveries,
+  and readiness refresh timeouts.
+- Guardrails: no fake listening before real recording, no infinite retries, no
+  extra `microphone_start_timeout`, privacy-safe route diagnostics only, and
+  green build/tests.
+
+## Event Sources
+
+- Runtime events: `~/Library/Application Support/Transcripted/logs/events.jsonl`
+- Build performance gate: `scripts/ops/performance-budget.rb`
+- Synthetic guardrail: `bash run-daily-audio-reliability.sh --synthetic`
+- Manual recovery checklist reference:
+  `docs/qa-parakeet-start-failure-smoke.md`
+
+Relevant event names found in code:
+
+- `dictation_recording_fast_start`
+- `dictation_fast_start_fell_back_to_wait`
+- `dictation_started_after_wait`
+- `dictation_recording_retry`
+- `dictation_recording_recovery_start`
+- `dictation_readiness_refresh_timeout`
+- `input_readiness_recovery_forced`
+- `audio_start_deferred`
+- `audio_format_unavailable`
+- `audio_engine_start_failed`
+- `device_change_rewarm_deferred`
+- `device_change_recovery_deferred`
+- `microphone_start_timeout`
+
+## Baseline Raw Results
+
+Source file:
+
+```text
+~/Library/Application Support/Transcripted/logs/events.jsonl
+```
+
+Raw slice:
+
+```text
+events_total=14270
+first=2026-05-09T11:01:58Z
+last=2026-05-31T19:06:41Z
+```
+
+Baseline metrics:
+
+| Metric | Raw result |
+| --- | ---: |
+| `dictation_started_after_wait` samples | 64 |
+| wait min | 349 ms |
+| wait p50 | 386 ms |
+| wait p90 | 402 ms |
+| wait p95 | 455 ms |
+| wait max | 6547 ms |
+| `dictation_recording_retry` | 61 |
+| fallback-to-wait-like events | 65 |
+| `dictation_recording_recovery_start` | 5 |
+| `input_readiness_recovery_forced` | 4 |
+| `dictation_readiness_refresh_timeout` | 1 |
+| `microphone_start_timeout` | 2 |
+| audio start / format failures | 8 |
+| `dictation_input_device_override_settled` | 403 |
+
+By route:
+
+| Route | Samples | p50 | p90 | p95 | Max |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| built-in input to built-in output | 61 | 386 ms | 399 ms | 402 ms | 455 ms |
+| built-in input to Bluetooth output | 3 | 717 ms | 6547 ms | 6547 ms | 6547 ms |
+
+Last 24h recovery counts were all zero for `dictation_started_after_wait`,
+`dictation_recording_retry`, fallback-to-wait, guarded recovery starts, forced
+input recovery, and `microphone_start_timeout`, so the recovery baseline is
+historical rather than a fresh live repro.
+
+## Recovery Scenarios Checked
+
+| Scenario | Evidence |
+| --- | --- |
+| App just launched | 703 `app_launched` events; current last-24h logs had no recovery waits/timeouts. |
+| Wake from sleep | 4 `wake_recovery` and 2 `wake_hotkey_recovery_failed` events in the log set. |
+| Bluetooth reconnect/switch | 262 `default_input_device_changed`, 703 `device_change_rewarm_deferred`, and 253 `prewarm_invalid_format` events. |
+| Selected route stale | 6 `audio_format_unavailable` and 2 `audio_route_not_settled` events. |
+| First start fails, retry succeeds | 62 after-wait starts had more than one start attempt. |
+| Format ready but start fails | 61 ready-format start-deferred/retry events. |
+| Recovery waits too long before refresh | 1 `dictation_readiness_refresh_timeout` and 4 `input_readiness_recovery_forced` events. |
+
+## Knobs Tested
+
+| # | Knob | Change | Raw result | Decision |
+| ---: | --- | --- | --- | --- |
+| 1 | Skip fixed input-override settle delay when immediate format is ready | 300 ms -> 0 ms only for `.ready`; keep 300 ms for `.routeNotSettled` / `.invalid` | Recovery projection: 3 eligible Bluetooth-output after-wait samples. All waits p95 455 -> 417 ms. Bluetooth waits p50 717 -> 417 ms. Max 6547 -> 6247 ms. | Keep |
+| 2 | Readiness polling interval | Considered 150 ms -> lower | Logs show common built-in waits are dominated by one recovery delay plus actual start, not by polling alone. Would add more UI/CoreAudio polling with weak evidence. | Reject |
+| 3 | Readiness refresh interval | Considered 0.3 s -> lower | Timeout path already has a 0.9 s stale-refresh guard; route-settling failures were mostly stale Bluetooth output, not slow refresh cadence. | Reject |
+| 4 | Forced recovery threshold | Considered forcing earlier than 6 refreshes | Historical hard cases still had `.routeNotSettled`; earlier hard rebuilds risk more rebuild churn without proof of fewer timeouts. | Reject |
+| 5 | Device recovery timeout budget | Considered reducing 4 s | Could reduce the 6547 ms outlier, but there are 78 idle recovery-deferred events and no local success-duration event proving 3 s is safe. | Reject |
+| 6 | Max start attempts before hard recovery | Already bounded by policy | Existing policy caps normal ready-input starts and recovery starts; changing it would risk more retries rather than fewer. | No change |
+| 7 | Trust stale ready state | Keep current distrust | Code already requires not recovering plus ready format before normal start; recovery attempts are explicitly marked. | No change |
+| 8 | Move failure cleanup/reporting off critical path | Not applicable | Timeout cleanup is after the 6 s budget and does not improve start-to-listening. | Reject |
+
+Projection command for the kept knob:
+
+```bash
+ruby -rjson -rtime - "$HOME/Library/Application Support/Transcripted/logs/events.jsonl"
+```
+
+Projection output:
+
+```text
+eligible_recovery_wait_samples=3
+all_waits count=64 p50=386.0->386.0 p90=402.0->400.0 p95=455.0->417.0 max=6547.0->6247.0
+bluetooth_waits count=3 p50=717.0->417.0 p90=6547.0->6247.0 p95=6547.0->6247.0 max=6547.0->6247.0
+eligible_rows:
+2026-05-19T11:13:18Z built_in_input_to_bluetooth_output 681.0->381.0
+2026-05-20T17:30:35Z built_in_input_to_bluetooth_output 717.0->417.0
+2026-05-27T01:08:08Z built_in_input_to_bluetooth_output 6547.0->6247.0
+```
+
+## Kept Changes
+
+- `Sources/Speech/ParakeetEngine.swift`
+  - Checks immediate audio format readiness after applying a preferred input
+    override.
+  - Returns immediately when the format is `.ready`.
+  - Keeps the old settle wait when the route is stale or invalid.
+- `Sources/Speech/ParakeetStartRecordingFailurePolicy.swift`
+  - Adds `ParakeetInputOverrideSettlePolicy`.
+- `Tests/ParakeetStartRecordingFailurePolicyTests.swift`
+  - Covers ready, route-not-settled, and invalid settle decisions.
+
+## Rejected Attempts
+
+- Did not lower polling/refresh intervals. The measured recovery waits do not
+  prove those are the dominant delay, and lower intervals would increase churn.
+- Did not reduce the 4 s device recovery timeout. It might help one outlier but
+  could prematurely abandon slower real device recovery.
+- Did not raise retry counts. The goal is fewer retries and clearer failure, not
+  more attempts.
+- Did not change timeout cleanup. It happens after the recovery budget is
+  exhausted, so it does not reduce start-to-listening.
+
+## Tests Run
+
+```bash
+bash build.sh --no-open
+bash run-tests.sh
+bash run-daily-audio-reliability.sh --synthetic
+ruby -c scripts/ops/performance-budget.rb
+ruby scripts/ops/performance-budget.rb --allow-missing-parakeet-model --events "$HOME/Library/Application Support/Transcripted/logs/events.jsonl" --stats "$HOME/Library/Application Support/Transcripted/state/stats.sqlite"
+```
+
+Results:
+
+- `bash build.sh --no-open`: passed. The build's built-in performance budget
+  passed.
+- `bash run-tests.sh`: passed, 2929 passed / 0 failed.
+- `bash run-daily-audio-reliability.sh --synthetic`: passed, 72 passed / 0
+  failed / 0 skipped.
+- `ruby -c scripts/ops/performance-budget.rb`: passed.
+- Full historical `performance-budget.rb --events --stats`: failed on existing
+  transcription and meeting throughput budgets, not on dictation recovery
+  metrics. It does not currently score `dictation_started_after_wait`.
+
+## Remaining Risks
+
+- This is a historical projection plus unit/build verification, not a fresh live
+  Bluetooth recovery capture from this exact build.
+- The biggest 6547 ms case is mostly route-settling/device-recovery timeout, so
+  the kept change only shaves the final ready override settle delay from it.
+- There is no local event for successful device-recovery duration, which makes
+  lowering `audioDeviceRecoveryTimeout` too speculative.
+
+## Next Run
+
+Capture 10-20 fresh starts on a Bluetooth-output route from this branch and
+compare `dictation_started_after_wait`, `dictation_recording_retry`,
+`dictation_recording_recovery_start`, and `microphone_start_timeout` against the
+baseline above.

--- a/docs/autoeval-dictation-recovery-time-2026-05-31.md
+++ b/docs/autoeval-dictation-recovery-time-2026-05-31.md
@@ -2,35 +2,45 @@
 
 ## Verdict
 
-Winner: keep the input-override settle change already on this branch.
+Winner: keep the bounded recovery-loop combo.
 
-When Transcripted applies a preferred dictation input override and the immediate
-CoreAudio snapshot is already ready, the app now skips the old fixed 300 ms
-settle delay. It still waits when the route is stale or invalid, so it does not
-pretend to be listening before recording can actually start.
+Changes kept:
+
+- Poll the dictation readiness wait loop every 100 ms instead of 150 ms.
+- Force hard input-readiness recovery after 5 stale refreshes instead of 6.
+- Cap ready-flag microphone start failures at 2 attempts instead of 3.
+
+Controlled recovery harness result:
+
+- Baseline slow-path p95/max: 2440 ms / 2440 ms.
+- Winning combo p95/max: 1990 ms / 1990 ms.
+- Change: -450 ms p95 and max, -1 start attempt, no new unexpected success
+  failures, no new `microphone_start_timeout`.
+
+This is the fastest safe combo from the expanded pass. More aggressive knobs
+looked tempting, but they either started recovery too early for late Bluetooth
+settling or increased refresh/rebuild churn.
 
 ## Metric
 
-- Primary: time from dictation start request to listening when dictation does
-  not cleanly hit the ready fast path, measured by `dictation_started_after_wait`
-  `wait_ms`.
-- Secondary: counts of `dictation_recording_retry`,
-  `dictation_fast_start_fell_back_to_wait` / `audio_start_deferred`,
-  `microphone_start_timeout`, guarded recovery starts, forced input recoveries,
-  and readiness refresh timeouts.
-- Guardrails: no fake listening before real recording, no infinite retries, no
-  extra `microphone_start_timeout`, privacy-safe route diagnostics only, and
-  green build/tests.
+- Primary: request-to-listening time for dictation starts that miss the clean
+  ready fast path.
+- Secondary: start attempts, guarded recovery starts, forced recoveries,
+  refresh timeouts, and `microphone_start_timeout`.
+- Guardrails: no fake listening before real recording, no infinite retry loops,
+  no worse ready-fast-path behavior, bounded hard recovery, privacy-safe
+  diagnostics only, and green build/tests.
 
-## Event Sources
+## Event And Test Sources
 
-- Runtime events: `~/Library/Application Support/Transcripted/logs/events.jsonl`
-- Build performance gate: `scripts/ops/performance-budget.rb`
-- Synthetic guardrail: `bash run-daily-audio-reliability.sh --synthetic`
-- Manual recovery checklist reference:
-  `docs/qa-parakeet-start-failure-smoke.md`
+- Live event log: `~/Library/Application Support/Transcripted/logs/events.jsonl`
+- Controlled policy harness:
+  `ruby scripts/ops/dictation-recovery-autoeval.rb --details`
+- Build budget: `scripts/ops/performance-budget.rb`
+- Synthetic reliability check: `bash run-daily-audio-reliability.sh --synthetic`
+- Manual checklist reference: `docs/qa-parakeet-start-failure-smoke.md`
 
-Relevant event names found in code:
+Existing relevant events found in code/logs:
 
 - `dictation_recording_fast_start`
 - `dictation_fast_start_fell_back_to_wait`
@@ -42,128 +52,153 @@ Relevant event names found in code:
 - `audio_start_deferred`
 - `audio_format_unavailable`
 - `audio_engine_start_failed`
-- `device_change_rewarm_deferred`
-- `device_change_recovery_deferred`
 - `microphone_start_timeout`
+- `audio_samples_detected`
 
-## Baseline Raw Results
+## Historical Baseline
 
-Source file:
-
-```text
-~/Library/Application Support/Transcripted/logs/events.jsonl
-```
+Command source: live local events log, refreshed on 2026-05-31.
 
 Raw slice:
 
 ```text
-events_total=14270
-first=2026-05-09T11:01:58Z
-last=2026-05-31T19:06:41Z
+events_total=15053
+first=2026-05-09T11:01:58.936Z
+last=2026-05-31T19:56:36.271Z
 ```
-
-Baseline metrics:
 
 | Metric | Raw result |
 | --- | ---: |
-| `dictation_started_after_wait` samples | 64 |
+| `dictation_started_after_wait` samples | 65 |
 | wait min | 349 ms |
 | wait p50 | 386 ms |
-| wait p90 | 402 ms |
-| wait p95 | 455 ms |
+| wait p90 | 407 ms |
+| wait p95 | 681 ms |
 | wait max | 6547 ms |
 | `dictation_recording_retry` | 61 |
-| fallback-to-wait-like events | 65 |
-| `dictation_recording_recovery_start` | 5 |
+| `dictation_fast_start_fell_back_to_wait` | 5 |
+| `dictation_recording_recovery_start` | 6 |
 | `input_readiness_recovery_forced` | 4 |
-| `dictation_readiness_refresh_timeout` | 1 |
+| `dictation_readiness_refresh_timeout` | 2 |
 | `microphone_start_timeout` | 2 |
-| audio start / format failures | 8 |
-| `dictation_input_device_override_settled` | 403 |
+| `audio_format_unavailable` | 6 |
+| `audio_engine_start_failed` | 0 |
+| `audio_samples_detected` start-to-first-sample p95 | 232 ms |
 
-By route:
+Last 24h recovery counts:
 
-| Route | Samples | p50 | p90 | p95 | Max |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| built-in input to built-in output | 61 | 386 ms | 399 ms | 402 ms | 455 ms |
-| built-in input to Bluetooth output | 3 | 717 ms | 6547 ms | 6547 ms | 6547 ms |
+```text
+dictation_started_after_wait=1
+dictation_fast_start_fell_back_to_wait=1
+dictation_recording_retry=0
+dictation_recording_recovery_start=1
+dictation_readiness_refresh_timeout=1
+input_readiness_recovery_forced=0
+microphone_start_timeout=0
+```
 
-Last 24h recovery counts were all zero for `dictation_started_after_wait`,
-`dictation_recording_retry`, fallback-to-wait, guarded recovery starts, forced
-input recovery, and `microphone_start_timeout`, so the recovery baseline is
-historical rather than a fresh live repro.
+The live log is useful for failure shape, but it is not enough to compare knobs:
+the hard cases are sparse and depend on physical route timing. The harness below
+is the repeatable scoring command for knob testing.
 
-## Recovery Scenarios Checked
+## Controlled Baseline
 
-| Scenario | Evidence |
-| --- | --- |
-| App just launched | 703 `app_launched` events; current last-24h logs had no recovery waits/timeouts. |
-| Wake from sleep | 4 `wake_recovery` and 2 `wake_hotkey_recovery_failed` events in the log set. |
-| Bluetooth reconnect/switch | 262 `default_input_device_changed`, 703 `device_change_rewarm_deferred`, and 253 `prewarm_invalid_format` events. |
-| Selected route stale | 6 `audio_format_unavailable` and 2 `audio_route_not_settled` events. |
-| First start fails, retry succeeds | 62 after-wait starts had more than one start attempt. |
-| Format ready but start fails | 61 ready-format start-deferred/retry events. |
-| Recovery waits too long before refresh | 1 `dictation_readiness_refresh_timeout` and 4 `input_readiness_recovery_forced` events. |
+Command:
+
+```bash
+ruby scripts/ops/dictation-recovery-autoeval.rb --details
+```
+
+Baseline raw results:
+
+| Scenario | Outcome | Time | Normal | Recovery | Refreshes | Forced | Timeouts | Reason |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| fast_ready_no_recovery | success | 85 ms | 1 | 0 | 0 | 0 | 0 | ready_start |
+| cold_launch_unready_then_ready | success | 840 ms | 1 | 0 | 3 | 0 | 0 | ready_start |
+| wake_recovery_finishes | success | 1290 ms | 1 | 0 | 0 | 0 | 0 | ready_start |
+| bluetooth_reconnect_stale_flag | success | 1170 ms | 0 | 1 | 4 | 0 | 0 | recovery_start |
+| bluetooth_late_ready_stale_flag | success | 1170 ms | 0 | 1 | 4 | 0 | 0 | recovery_start |
+| slow_refresh_would_recover | success | 2440 ms | 1 | 1 | 0 | 1 | 0 | ready_start |
+| selected_input_stale_until_force | success | 2440 ms | 1 | 1 | 0 | 1 | 0 | ready_start |
+| first_start_fails_retry_succeeds | success | 330 ms | 2 | 0 | 1 | 0 | 0 | ready_start |
+| ready_flag_start_keeps_failing | success | 1600 ms | 4 | 0 | 0 | 1 | 0 | ready_start |
+| refresh_times_out_then_recovery_start | success | 1000 ms | 0 | 1 | 1 | 0 | 1 | recovery_start |
+| unrecoverable_route_times_out | timeout | 6000 ms | 0 | 2 | 5 | 2 | 0 | microphone_start_timeout |
 
 ## Knobs Tested
 
-| # | Knob | Change | Raw result | Decision |
+| # | Knob | Status | Raw result | Decision |
 | ---: | --- | --- | --- | --- |
-| 1 | Skip fixed input-override settle delay when immediate format is ready | 300 ms -> 0 ms only for `.ready`; keep 300 ms for `.routeNotSettled` / `.invalid` | Recovery projection: 3 eligible Bluetooth-output after-wait samples. All waits p95 455 -> 417 ms. Bluetooth waits p50 717 -> 417 ms. Max 6547 -> 6247 ms. | Keep |
-| 2 | Readiness polling interval | Considered 150 ms -> lower | Logs show common built-in waits are dominated by one recovery delay plus actual start, not by polling alone. Would add more UI/CoreAudio polling with weak evidence. | Reject |
-| 3 | Readiness refresh interval | Considered 0.3 s -> lower | Timeout path already has a 0.9 s stale-refresh guard; route-settling failures were mostly stale Bluetooth output, not slow refresh cadence. | Reject |
-| 4 | Forced recovery threshold | Considered forcing earlier than 6 refreshes | Historical hard cases still had `.routeNotSettled`; earlier hard rebuilds risk more rebuild churn without proof of fewer timeouts. | Reject |
-| 5 | Device recovery timeout budget | Considered reducing 4 s | Could reduce the 6547 ms outlier, but there are 78 idle recovery-deferred events and no local success-duration event proving 3 s is safe. | Reject |
-| 6 | Max start attempts before hard recovery | Already bounded by policy | Existing policy caps normal ready-input starts and recovery starts; changing it would risk more retries rather than fewer. | No change |
-| 7 | Trust stale ready state | Keep current distrust | Code already requires not recovering plus ready format before normal start; recovery attempts are explicitly marked. | No change |
-| 8 | Move failure cleanup/reporting off critical path | Not applicable | Timeout cleanup is after the 6 s budget and does not improve start-to-listening. | Reject |
+| 1 | Poll interval 150 -> 100 ms | kept | p95 2440 -> 2290 ms, starts unchanged, refreshes +1 | Safe responsiveness win |
+| 2 | Poll interval 150 -> 75 ms | rejected | p95 unchanged, refreshes +4 | More churn for no p95 win |
+| 3 | Refresh interval 300 -> 200 ms | rejected | p95 unchanged | No standalone win |
+| 4 | Refresh interval 300 -> 150 ms | rejected | p95 -570 ms but starts +2, refreshes +5, forced +2, Bluetooth +700 ms | Too much churn and Bluetooth regression |
+| 5 | Recovery start after 3 refreshes | rejected | Bluetooth early case -300 ms, late Bluetooth +1300 ms, p95 +30 ms | Burns guarded attempt too early |
+| 6 | Recovery start after 2 refreshes | rejected | cold launch -290 ms, Bluetooth +1300 ms, starts +2, forced +2 | Too aggressive |
+| 7 | Ready-start cap 3 -> 2 | kept | ready-flag-start-failing 1600 -> 1350 ms, starts -1 | Fewer retries without hurting first-fail retry-success |
+| 8 | Ready-start cap 3 -> 1 | rejected | first-fail retry-success +600 ms, ready-flag-start-failing +500 ms, forced +2 | Removes useful single retry |
+| 9 | Forced recovery threshold 6 -> 5 | kept | p95 2440 -> 2140 ms, starts unchanged, forced unchanged, refreshes +2 | Earlier hard recovery after one guarded start |
+| 10 | Forced recovery threshold 6 -> 4 | rejected | p95 -540 ms but Bluetooth +730 ms, recovery starts -5, forced +2 | Rebuilds too early |
+| 11 | Combo: poll100 + force5 | tested | p95 1990 ms, starts unchanged, refreshes +3 | Good, but keep attempt cap too |
+| 12 | Combo: poll100 + ready cap 2 | tested | p95 2290 ms, starts -1 | Safe but smaller win |
+| 13 | Combo: poll100 + force5 + ready cap 2 | kept | p95 2440 -> 1990 ms, starts 18 -> 17, forced unchanged, no new timeouts | Best safe overall |
+| 14 | Combo: poll100 + refresh200 + ready cap 2 | rejected | p95 1920 ms, but late Bluetooth +750 ms, refreshes +4, forced +1 | Faster aggregate, worse route-switch guardrail |
+| 15 | Device recovery timeout 4 s -> lower | ruled out | Historical logs have no successful device-recovery duration event | Too likely to abandon slow real hardware |
+| 16 | Recovery budget 6 s -> lower | ruled out | Would only make failure faster, not recovery more reliable | Risks false timeouts |
+| 17 | Audio tap buffer size | not run | An unrelated worktree change appeared, but this pass did not test it | Kept out of this commit |
 
-Projection command for the kept knob:
+Winning combo raw scenario deltas:
 
-```bash
-ruby -rjson -rtime - "$HOME/Library/Application Support/Transcripted/logs/events.jsonl"
-```
-
-Projection output:
-
-```text
-eligible_recovery_wait_samples=3
-all_waits count=64 p50=386.0->386.0 p90=402.0->400.0 p95=455.0->417.0 max=6547.0->6247.0
-bluetooth_waits count=3 p50=717.0->417.0 p90=6547.0->6247.0 p95=6547.0->6247.0 max=6547.0->6247.0
-eligible_rows:
-2026-05-19T11:13:18Z built_in_input_to_bluetooth_output 681.0->381.0
-2026-05-20T17:30:35Z built_in_input_to_bluetooth_output 717.0->417.0
-2026-05-27T01:08:08Z built_in_input_to_bluetooth_output 6547.0->6247.0
-```
+| Scenario | Baseline | Winner | Delta |
+| --- | ---: | ---: | ---: |
+| fast_ready_no_recovery | 85 ms | 85 ms | 0 |
+| cold_launch_unready_then_ready | 840 ms | 790 ms | -50 |
+| wake_recovery_finishes | 1290 ms | 1290 ms | 0 |
+| bluetooth_reconnect_stale_flag | 1170 ms | 1120 ms | -50 |
+| bluetooth_late_ready_stale_flag | 1170 ms | 1120 ms | -50 |
+| slow_refresh_would_recover | 2440 ms | 1990 ms | -450 |
+| selected_input_stale_until_force | 2440 ms | 1990 ms | -450 |
+| first_start_fails_retry_succeeds | 330 ms | 280 ms | -50 |
+| ready_flag_start_keeps_failing | 1600 ms | 1200 ms | -400 |
+| refresh_times_out_then_recovery_start | 1000 ms | 1000 ms | 0 |
+| unrecoverable_route_times_out | 6000 ms | 6000 ms | 0 |
 
 ## Kept Changes
 
-- `Sources/Speech/ParakeetEngine.swift`
-  - Checks immediate audio format readiness after applying a preferred input
-    override.
-  - Returns immediately when the format is `.ready`.
-  - Keeps the old settle wait when the route is stale or invalid.
-- `Sources/Speech/ParakeetStartRecordingFailurePolicy.swift`
-  - Adds `ParakeetInputOverrideSettlePolicy`.
-- `Tests/ParakeetStartRecordingFailurePolicyTests.swift`
-  - Covers ready, route-not-settled, and invalid settle decisions.
+- `Sources/Support/TranscriptedConstants.swift`
+  - `dictationReadinessPollInterval`: 150 ms -> 100 ms.
+  - `dictationReadinessForcedRecoveryRefreshes`: 6 -> 5.
+- `Sources/Speech/DictationReadinessWaitPolicy.swift`
+  - Ready-format start failure cap: 3 -> 2.
+- `Tests/DictationReadinessWaitPolicyTests.swift`
+  - Updated retry-cap assertions and added default forced-threshold coverage.
+- `scripts/ops/dictation-recovery-autoeval.rb`
+  - Added repeatable controlled recovery harness for this class of changes.
 
 ## Rejected Attempts
 
-- Did not lower polling/refresh intervals. The measured recovery waits do not
-  prove those are the dominant delay, and lower intervals would increase churn.
-- Did not reduce the 4 s device recovery timeout. It might help one outlier but
-  could prematurely abandon slower real device recovery.
-- Did not raise retry counts. The goal is fewer retries and clearer failure, not
-  more attempts.
-- Did not change timeout cleanup. It happens after the recovery budget is
-  exhausted, so it does not reduce start-to-listening.
+- Did not lower refresh interval. The best-looking refresh interval run created
+  more starts, refreshes, and forced recoveries, and regressed late Bluetooth.
+- Did not lower guarded recovery start threshold. It helps if Bluetooth is ready
+  early, but late Bluetooth burns the one guarded attempt and gets slower.
+- Did not force after 4 refreshes. It rebuilds before the guarded recovery start
+  can prove whether audio is already recordable.
+- Did not cap ready starts at 1. One retry is still useful and tested.
+- Did not reduce device recovery timeout or total recovery budget. Those would
+  make failure faster without proving recovery is safer.
+- Did not include the unrelated `audioTapBufferSize` 1024 -> 256 worktree
+  change. It was not tested in this autoeval.
 
 ## Tests Run
 
 ```bash
+ruby -c scripts/ops/dictation-recovery-autoeval.rb
+ruby scripts/ops/dictation-recovery-autoeval.rb --details
 bash build.sh --no-open
 bash run-tests.sh
+bash run-integration-smoke.sh
+swift test
+bash run-e2e-smoke.sh
 bash run-daily-audio-reliability.sh --synthetic
 ruby -c scripts/ops/performance-budget.rb
 ruby scripts/ops/performance-budget.rb --allow-missing-parakeet-model --events "$HOME/Library/Application Support/Transcripted/logs/events.jsonl" --stats "$HOME/Library/Application Support/Transcripted/state/stats.sqlite"
@@ -171,28 +206,39 @@ ruby scripts/ops/performance-budget.rb --allow-missing-parakeet-model --events "
 
 Results:
 
-- `bash build.sh --no-open`: passed. The build's built-in performance budget
-  passed.
-- `bash run-tests.sh`: passed, 2929 passed / 0 failed.
+- Harness: passed; winning combo p95/max 1990 ms.
+- `bash build.sh --no-open`: passed, including built-in performance budget.
+- `bash run-tests.sh`: passed, 2936 passed / 0 failed.
+- `bash run-integration-smoke.sh`: passed.
+- `swift test`: passed, 339 passed / 0 failed / 1 skipped live capture test.
+- `bash run-e2e-smoke.sh`: passed.
 - `bash run-daily-audio-reliability.sh --synthetic`: passed, 72 passed / 0
   failed / 0 skipped.
 - `ruby -c scripts/ops/performance-budget.rb`: passed.
-- Full historical `performance-budget.rb --events --stats`: failed on existing
-  transcription and meeting throughput budgets, not on dictation recovery
-  metrics. It does not currently score `dictation_started_after_wait`.
+- Full historical `performance-budget.rb --events --stats`: failed existing
+  non-recovery budgets: dictation transcription p95 RTF 0.053 > 0.050 and
+  meeting processing p95 RTF 0.065 > 0.050.
 
 ## Remaining Risks
 
-- This is a historical projection plus unit/build verification, not a fresh live
-  Bluetooth recovery capture from this exact build.
-- The biggest 6547 ms case is mostly route-settling/device-recovery timeout, so
-  the kept change only shaves the final ready override settle delay from it.
-- There is no local event for successful device-recovery duration, which makes
-  lowering `audioDeviceRecoveryTimeout` too speculative.
+- Live Bluetooth reconnect/sleep testing was not run because it needs physical
+  route manipulation and microphone capture. The deterministic harness covers
+  those timing shapes, but it is still not a hardware trace.
+- The historical 6547 ms outlier is still a device/route settling long tail.
+  This patch should shorten the recovery loop before hard rebuild, but it does
+  not prove every physical device will settle under 2 seconds.
+- The new harness is intentionally conservative and synthetic. It should be
+  rerun with fresh hardware logs as soon as a route-switch capture is available.
 
 ## Next Run
 
-Capture 10-20 fresh starts on a Bluetooth-output route from this branch and
-compare `dictation_started_after_wait`, `dictation_recording_retry`,
-`dictation_recording_recovery_start`, and `microphone_start_timeout` against the
-baseline above.
+Run 10-20 fresh dictation starts each for built-in input, Bluetooth reconnect,
+and wake-from-sleep on this branch. Compare:
+
+- `dictation_started_after_wait.wait_ms`
+- `dictation_started_after_wait.request_to_recording_ms`
+- `dictation_recording_retry`
+- `dictation_recording_recovery_start`
+- `input_readiness_recovery_forced`
+- `dictation_readiness_refresh_timeout`
+- `microphone_start_timeout`

--- a/docs/autoeval-dictation-start-time-2026-05-31.md
+++ b/docs/autoeval-dictation-start-time-2026-05-31.md
@@ -384,3 +384,139 @@ Verification:
 
 - `bash run-tests.sh` - 2938 passed, 0 failed.
 - `bash build.sh --no-open` - build, signing, launch smoke, and performance budget passed.
+
+## Continued Loop - Slow-Path Recovery Knobs
+
+This lane scores the fallback wait path separately from normal built-in starts. It should not be mixed into the normal p95 score because the recovery path only runs after the ready-engine fast start cannot start recording.
+
+### Current Audio Route Availability
+
+Command:
+
+```bash
+system_profiler SPAudioDataType -json | ruby -rjson -e 'data=JSON.parse(STDIN.read); devices=(data["SPAudioDataType"]||[]).flat_map{|x| x["_items"]||[]}; puts devices.map{|d| [d["_name"], d["coreaudio_default_audio_input_device"], d["coreaudio_default_audio_output_device"]].compact.join(" | ")}; bluetooth=devices.select{|d| d.to_s.downcase.include?("bluetooth") || d.to_s.downcase.include?("airpods")}; warn "bluetooth_count=#{bluetooth.length}"'
+```
+
+Result:
+
+```text
+bluetooth_count=0
+MacBook Pro Microphone | spaudio_yes
+MacBook Pro Speakers | spaudio_yes
+```
+
+No Bluetooth route is currently available for fresh route-recovery samples.
+
+### Historical Recovery Signal
+
+Command:
+
+```bash
+ruby -rjson -e 'path=File.expand_path("~/Library/Application Support/Transcripted/logs/events.jsonl"); counts=Hash.new(0); waits=[]; recovery_starts=[]; File.foreach(path){|line| begin; e=JSON.parse(line); rescue JSON::ParserError; next; end; event=e["event"]||e["name"]; ctx=e["context"]||e["properties"]||{}; next unless event; if %w[dictation_recording_recovery_start dictation_readiness_refresh_timeout microphone_start_timeout dictation_started_after_wait].include?(event); route=ctx["route_shape"]||"unknown"; counts[[event,route]]+=1; waits << ctx["wait_ms"].to_i if event=="dictation_started_after_wait" && ctx["wait_ms"]; recovery_starts << ctx["readiness_refreshes"].to_i if event=="dictation_recording_recovery_start" && ctx["readiness_refreshes"]; end}; counts.sort.each{|(event,route),count| puts "#{event},#{route},#{count}"}; if waits.any?; s=waits.sort; p95=s[((s.length-1)*0.95).ceil]; puts "started_after_wait_wait_ms:n=#{s.length},p50=#{s[s.length/2]},p95=#{p95},max=#{s[-1]}"; end; if recovery_starts.any?; hist=Hash.new(0); recovery_starts.each{|v| hist[v]+=1}; puts "recovery_start_readiness_refreshes=#{hist.sort.to_h}"; end'
+```
+
+Result:
+
+| Event | Route | Count |
+| --- | --- | ---: |
+| `dictation_readiness_refresh_timeout` | `built_in_input_to_bluetooth_output` | 1 |
+| `dictation_readiness_refresh_timeout` | `built_in_input_to_built_in_output` | 1 |
+| `dictation_recording_recovery_start` | `built_in_input_to_bluetooth_output` | 5 |
+| `dictation_recording_recovery_start` | `built_in_input_to_built_in_output` | 1 |
+| `dictation_started_after_wait` | `built_in_input_to_bluetooth_output` | 3 |
+| `dictation_started_after_wait` | `built_in_input_to_built_in_output` | 62 |
+| `microphone_start_timeout` | `built_in_input_to_bluetooth_output` | 2 |
+
+Historical `dictation_started_after_wait` values: `n=65`, `p50=386 ms`, `p95=681 ms`, `max=6547 ms`.
+
+Recovery-start refresh counts seen historically: `{0=>1, 1=>1, 4=>4}`.
+
+This is useful context, but it is not a clean fresh branch corpus. The Bluetooth-output recovery path cannot be proven better or worse until Bluetooth output is connected again.
+
+### Deterministic Policy Score
+
+Command:
+
+```bash
+ruby -c scripts/ops/dictation-recovery-autoeval.rb
+ruby scripts/ops/dictation-recovery-autoeval.rb
+ruby scripts/ops/dictation-recovery-autoeval.rb --details
+```
+
+Result:
+
+The existing `scripts/ops/dictation-recovery-autoeval.rb` scorer had drifted from the live policy constants. This pass updated its baseline to match current code:
+
+- poll interval: `100 ms`
+- refresh interval: `300 ms`
+- refresh timeout: `900 ms`
+- forced recovery threshold: `5` refreshes
+- ready-start attempt cap: `2`
+
+Knob summary after fixing the scorer:
+
+| Knob | p95 ms | p95 delta | Max ms | Max delta | Unexpected failures | Starts | Start delta | Refreshes | Refresh delta | Recovery starts | Forced | Refresh timeouts | Mic timeouts |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| baseline | 1990 | 0 | 1990 | 0 | 0 | 17 | 0 | 21 | 0 | 7 | 5 | 1 | 1 |
+| poll_75ms | 2140 | +150 | 2140 | +150 | 0 | 17 | 0 | 19 | -2 | 7 | 5 | 1 | 1 |
+| poll_50ms | 2040 | +50 | 2040 | +50 | 0 | 17 | 0 | 20 | -1 | 7 | 5 | 1 | 1 |
+| refresh_interval_200ms | 1720 | -270 | 1720 | -270 | 0 | 18 | +1 | 24 | +3 | 7 | 6 | 1 | 1 |
+| refresh_interval_150ms | 1720 | -270 | 1720 | -270 | 0 | 18 | +1 | 24 | +3 | 7 | 6 | 1 | 1 |
+| refresh_timeout_600ms | 3800 | +1810 | 3800 | +1810 | 2 | 21 | +4 | 42 | +21 | 10 | 8 | 13 | 3 |
+| recovery_start_after_3_refreshes | 2020 | +30 | 2020 | +30 | 0 | 18 | +1 | 16 | -5 | 7 | 6 | 1 | 1 |
+| recovery_start_after_2_refreshes | 2020 | +30 | 2020 | +30 | 0 | 20 | +3 | 13 | -8 | 8 | 7 | 1 | 1 |
+| max_ready_start_attempts_1 | 1990 | 0 | 1990 | 0 | 0 | 17 | 0 | 20 | -1 | 7 | 7 | 1 | 1 |
+| force_after_4_refreshes | 1800 | -190 | 1800 | -190 | 0 | 14 | -3 | 14 | -7 | 2 | 7 | 1 | 1 |
+| combo_poll100_refresh200_attempts2 | 1720 | -270 | 1720 | -270 | 0 | 18 | +1 | 24 | +3 | 7 | 6 | 1 | 1 |
+
+Important per-scenario regressions from `--details`:
+
+| Knob | Regressed scenario | Delta | Why it was rejected |
+| --- | --- | ---: | --- |
+| `refresh_interval_200ms` | `bluetooth_late_ready_stale_flag` | +600 ms | Starts recovery earlier, wastes the guarded attempt, then waits for forced recovery. |
+| `refresh_interval_150ms` | `bluetooth_late_ready_stale_flag` | +600 ms | Same regression as 200 ms with no extra p95 gain. |
+| `refresh_timeout_600ms` | `selected_input_stale_until_force` | timeout | Adds false stale-refresh failures. |
+| `refresh_timeout_600ms` | `ready_flag_start_keeps_failing` | timeout | Turns an expected success into `microphone_start_timeout`. |
+| `recovery_start_after_3_refreshes` | `bluetooth_late_ready_stale_flag` | +900 ms | Starts too early and loses the useful guarded attempt. |
+| `recovery_start_after_2_refreshes` | `bluetooth_reconnect_stale_flag` | +900 ms | Too aggressive for Bluetooth route settle. |
+| `max_ready_start_attempts_1` | `first_start_fails_retry_succeeds` | +600 ms | Forces hard recovery instead of allowing the cheap retry. |
+| `force_after_4_refreshes` | `bluetooth_reconnect_stale_flag` | +680 ms | Skips the faster guarded recovery start and forces a slower rebuild. |
+
+Decision:
+
+- `dictationReadinessPollInterval`: rejected. 75 ms and 50 ms worsened aggregate p95 in the deterministic suite.
+- `dictationReadinessRefreshInterval`: rejected. 200 ms/150 ms improved aggregate p95 by 270 ms, but increased starts/refreshes/forced recoveries and regressed the late Bluetooth settle scenario by 600 ms.
+- `dictationReadinessRefreshTimeout`: rejected. 600 ms created 2 unexpected failures and 3 simulated microphone timeouts.
+- recovery-start threshold: rejected. Starting after 3 or 2 refreshes regressed late Bluetooth scenarios by 900 ms.
+- ready-start attempt cap: rejected. One attempt regressed cheap retry success by 600 ms and repeated ready-start failure recovery by 700 ms.
+- forced recovery threshold: rejected. Forcing after 4 refreshes improved aggregate p95 by 190 ms, but regressed Bluetooth reconnect by 680 ms.
+- `dictationRecoveryBudget` 6 s: ruled out for latency. Lowering it only fails faster; raising it worsens start latency. Keep the current budget unless the metric changes to recovery success rate.
+- forced recovery attempt budget: ruled out for this latency goal. The scorer already keeps attempts bounded; more attempts would increase worst-case latency and fewer attempts would reduce recovery chance.
+
+### Final Knob Ledger
+
+| Knob | Status | Decision |
+| --- | --- | --- |
+| Stage timing inside `audioInputSnapshot` / tap / engine start | Kept | Added `dictation_audio_start_timing`; proved CoreAudio start work dominates built-in p95. |
+| Cache route/device lookup until route changes | Ruled out for built-in | Selection load p95 was 1 ms; no built-in override check ran. |
+| Preferred-input override delay tuning | Kept then blocked | The safe ready-route skip is kept; deeper Bluetooth tuning is blocked without Bluetooth output. |
+| First audio buffer cadence via tap buffer | Rejected | 1024 -> 256 did not reduce 4800-frame first buffers or improve p95. |
+| Overlay/UI pre-start work | Ruled out | `pre_recording_overhead_ms` p95 was 11-18 ms, too small for the requested win. |
+| Diagnostics/logging hot path | Ruled out | Stage timing shows post-start diagnostics are not the request-to-recording bottleneck. |
+| Skip explicit `audioEngine.prepare()` | Kept | Built-in p95 request-to-recording improved 106 -> 98 ms with no guardrail events. |
+| Keep engine running between starts | Ruled out | Would keep mic hardware active after stop and weaken privacy/battery expectations. |
+| Recovery poll interval | Rejected | 75 ms and 50 ms worsened deterministic p95. |
+| Recovery refresh interval | Rejected | 200 ms/150 ms improved aggregate p95 but regressed late Bluetooth settle by 600 ms and increased starts/refreshes/forced recoveries. |
+| Recovery refresh timeout | Rejected | 600 ms created 2 unexpected failures and 3 simulated microphone timeouts. |
+| Recovery start threshold | Rejected | Earlier recovery starts regressed Bluetooth settle scenarios by 900 ms. |
+| Recovery budget | Ruled out | Lower budget fails faster rather than starting faster; higher budget worsens latency. |
+
+## Final Verdict
+
+Built-in route: no 20-30% win found. The kept measured win is small: p95 request-to-recording improved 106 -> 98 ms, and p95 start improved 97 -> 88 ms in the instrumented run.
+
+Bluetooth-output route: blocked by missing hardware in the current environment. The prior safe improvement for ready Bluetooth routes is kept, but deeper route-settle tuning cannot be scored right now.
+
+Slow recovery route: no safe code change kept. After updating the deterministic scorer to current constants, every recovery knob either worsened p95, created failure regressions, or improved aggregate p95 while hurting a Bluetooth-settle scenario enough to reject it.
+
+Conclusion: this autoeval found a small built-in-route keeper and then hit a clear no-win/blocker boundary for the remaining knobs.

--- a/docs/autoeval-dictation-start-time-2026-05-31.md
+++ b/docs/autoeval-dictation-start-time-2026-05-31.md
@@ -1,0 +1,115 @@
+# Dictation Start Time Autoeval - 2026-05-31
+
+## Goal
+
+Improve the ready-engine dictation start path, measured by `dictation_recording_fast_start` `start_ms`.
+
+## Event Source
+
+`~/Library/Application Support/Transcripted/logs/events.jsonl`
+
+## Baseline Raw Results
+
+Command:
+
+```bash
+ruby -rjson -rtime -e 'path = ARGV.fetch(0); cutoff = Time.now - 24 * 60 * 60; sets = { "all" => [], "last_24h" => [] }; fallbacks = []; waits = []; timeouts = []; File.foreach(path) do |line| e = JSON.parse(line) rescue next; t = (Time.parse(e["timestamp"]) rescue nil); c = e["context"] || {}; case e["event"]; when "dictation_recording_fast_start"; ms = c["start_ms"].to_f; row = { t: t, ms: ms, trigger: c["trigger"], route: c["route_shape"], version: e["appVersion"] }; sets["all"] << row; sets["last_24h"] << row if t && t >= cutoff; when "dictation_fast_start_fell_back_to_wait", "dictation_recording_retry", "audio_start_deferred"; fallbacks << { t: t, event: e["event"], ms: c["start_ms"] || c["wait_ms"], trigger: c["trigger"], route: c["route_shape"], version: e["appVersion"] }; when "dictation_started_after_wait"; waits << { t: t, ms: c["wait_ms"].to_f, trigger: c["trigger"], route: c["route_shape"], version: e["appVersion"] }; when "microphone_start_timeout"; timeouts << { t: t, ms: c["wait_ms"], trigger: c["trigger"], route: c["route_shape"], version: e["appVersion"] }; end; end; def pct(values, q); return nil if values.empty?; sorted = values.sort; sorted[[((sorted.length * q).ceil - 1), 0].max]; end; sets.each do |name, rows| values = rows.map { |r| r[:ms] }; puts "#{name}: fast_start_samples=#{values.length} min=#{values.min&.round(1)} p50=#{pct(values,0.50)&.round(1)} p90=#{pct(values,0.90)&.round(1)} p95=#{pct(values,0.95)&.round(1)} max=#{values.max&.round(1)}"; end; puts "fallback_like_count=#{fallbacks.length} after_wait_count=#{waits.length} timeout_count=#{timeouts.length}"' "$HOME/Library/Application Support/Transcripted/logs/events.jsonl"
+```
+
+Route breakdown command:
+
+```bash
+ruby -rjson -rtime -e 'path = ARGV.fetch(0); rows=[]; File.foreach(path) do |line| e = JSON.parse(line) rescue next; next unless e["event"] == "dictation_recording_fast_start"; c = e["context"] || {}; rows << { t: (Time.parse(e["timestamp"]) rescue nil), ms: c["start_ms"].to_f, trigger: c["trigger"], route: c["route_shape"] || "unknown", version: e["appVersion"] }; end; def pct(values, q); return nil if values.empty?; sorted = values.sort; sorted[[((sorted.length * q).ceil - 1), 0].max]; end; rows.group_by { |r| r[:route] }.sort_by { |_route, rs| -rs.length }.each do |route, rs| v = rs.map { |r| r[:ms] }; puts "route=#{route} samples=#{v.length} min=#{v.min.round(1)} p50=#{pct(v,0.50).round(1)} p90=#{pct(v,0.90).round(1)} p95=#{pct(v,0.95).round(1)} max=#{v.max.round(1)} versions=#{rs.map { |r| r[:version] }.compact.uniq.join(",")}"; end' "$HOME/Library/Application Support/Transcripted/logs/events.jsonl"
+```
+
+Results:
+
+| Slice | Samples | p50 | p90 | p95 | Max |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| All routes, all logs | 573 | 86 ms | 134 ms | 432 ms | 1178 ms |
+| Last 24h | 38 | 91 ms | 106 ms | 116 ms | 124 ms |
+| Built-in input to built-in output | 401 | 87 ms | 120 ms | 134 ms | 402 ms |
+| Built-in input to Bluetooth output | 172 | 86 ms | 478 ms | 556 ms | 1178 ms |
+
+Fallback/recovery baseline:
+
+| Event group | Count |
+| --- | ---: |
+| `dictation_fast_start_fell_back_to_wait` / `dictation_recording_retry` / `audio_start_deferred` | 126 |
+| `dictation_started_after_wait` | 64 |
+| `microphone_start_timeout` | 2 |
+
+The current built-in route is already fast. The bad p95 comes mostly from historical Bluetooth-output sessions.
+
+## Knobs Considered
+
+| Knob | Decision | Why |
+| --- | --- | --- |
+| Move overlay work after recording start | Not tested | Current `start_ms` begins after the pre-start overlay call, so this would not improve the primary metric. |
+| Move logging/sound after start | Not tested | These already happen after `startRecording()` succeeds, so they do not affect `start_ms`. |
+| Change readiness polling interval | Not first | This affects the slow recovery path, not the ready-engine fast path. |
+| Reduce fixed input-override settle delay | Tested | Slow Bluetooth-output starts consistently showed `dictation_input_device_override_settled` before fast start. |
+| Cache/skip device lookup | Deferred | Plausible, but riskier and less directly tied to the observed p95 spike. |
+
+## Experiment
+
+Changed the input-override settle rule:
+
+- Before: after applying a preferred input-device override, always wait `audioRecoveryDelay` (300 ms).
+- After: if the immediate CoreAudio snapshot is already `.ready`, skip the fixed wait.
+- Still wait 300 ms for `.routeNotSettled` or `.invalid`.
+
+Files changed:
+
+- `Sources/Speech/ParakeetEngine.swift`
+- `Sources/Speech/ParakeetStartRecordingFailurePolicy.swift`
+- `Tests/ParakeetStartRecordingFailurePolicyTests.swift`
+
+## Results Table
+
+Historical projection command:
+
+```bash
+ruby -rjson -e 'path=ARGV[0]; rows=[]; File.foreach(path) do |line| e=JSON.parse(line) rescue next; next unless e["event"] == "dictation_recording_fast_start"; c=e["context"] || {}; ms=c["start_ms"].to_f; eligible = c["route_shape"] == "built_in_input_to_bluetooth_output" && c["selection_overrode_default"] == "true" && ms >= 300; rows << { ms: ms, projected: eligible ? ms - 300 : ms, route: c["route_shape"], eligible: eligible }; end; def pct(values, q); s=values.sort; s[((s.length - 1) * q).round]; end; all_before=rows.map { |r| r[:ms] }; all_after=rows.map { |r| r[:projected] }; bt=rows.select { |r| r[:route] == "built_in_input_to_bluetooth_output" }; bt_before=bt.map { |r| r[:ms] }; bt_after=bt.map { |r| r[:projected] }; puts "eligible_projected_samples=#{rows.count { |r| r[:eligible] }}"; puts "all p50=#{pct(all_before,0.50).round(1)}->#{pct(all_after,0.50).round(1)} p90=#{pct(all_before,0.90).round(1)}->#{pct(all_after,0.90).round(1)} p95=#{pct(all_before,0.95).round(1)}->#{pct(all_after,0.95).round(1)} max=#{all_before.max.round(1)}->#{all_after.max.round(1)}"; puts "bluetooth_output p50=#{pct(bt_before,0.50).round(1)}->#{pct(bt_after,0.50).round(1)} p90=#{pct(bt_before,0.90).round(1)}->#{pct(bt_after,0.90).round(1)} p95=#{pct(bt_before,0.95).round(1)}->#{pct(bt_after,0.95).round(1)} max=#{bt_before.max.round(1)}->#{bt_after.max.round(1)}"' "$HOME/Library/Application Support/Transcripted/logs/events.jsonl"
+```
+
+Projection rule: subtract the old 300 ms fixed wait from fast-start samples that matched the observed slow path: `built_in_input_to_bluetooth_output`, `selection_overrode_default=true`, and `start_ms >= 300`.
+
+| Slice | Eligible samples | p50 before | p50 projected | p90 before | p90 projected | p95 before | p95 projected | Max before | Max projected |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| All routes | 30 | 87 ms | 87 ms | 134 ms | 132 ms | 402 ms | 168 ms | 1178 ms | 878 ms |
+| Bluetooth output | 30 | 86 ms | 86 ms | 478 ms | 191 ms | 555 ms | 255 ms | 1178 ms | 878 ms |
+
+This is a projected historical win, not a live post-change measurement.
+
+## Winner
+
+Winner for this pass: skip the fixed 300 ms input-override settle delay when the immediate audio format is already ready.
+
+Why it wins:
+
+- It targets the observed p95 spike.
+- It keeps the safety wait for stale or invalid routes.
+- It is small and covered by policy tests.
+
+## Verification
+
+Commands run:
+
+```bash
+bash build-deps.sh --force
+bash build.sh --no-open
+bash run-tests.sh
+```
+
+Results:
+
+- `bash build-deps.sh --force`: passed.
+- `bash build.sh --no-open`: passed after one rerun. First run failed because an unrelated edit touched `Sources/UI/Overlay/DictationSessionController.swift` during compilation.
+- `bash run-tests.sh`: passed, 2929 passed / 0 failed.
+
+## Remaining Risks
+
+- No live post-change Bluetooth-output sample was captured from this worktree build because the installed `/Applications/Transcripted.app` was already running. I did not interrupt it.
+- The next autoeval loop should collect 10-20 live starts on the Bluetooth-output route and confirm no increase in fallback events or `microphone_start_timeout`.
+- Full-log historical p95 still contains old samples; use fresh samples or a bounded time window for future scoring.

--- a/docs/autoeval-dictation-start-time-2026-05-31.md
+++ b/docs/autoeval-dictation-start-time-2026-05-31.md
@@ -445,51 +445,55 @@ ruby scripts/ops/dictation-recovery-autoeval.rb --details
 
 Result:
 
-The existing `scripts/ops/dictation-recovery-autoeval.rb` scorer had drifted from the live policy constants. This pass updated its baseline to match current code:
+The existing `scripts/ops/dictation-recovery-autoeval.rb` scorer had drifted into a misleading shape where the `baseline` row was also the kept/current policy. This pass now separates the pre-keeper baseline from the kept policy:
 
-- poll interval: `100 ms`
+- baseline poll interval: `150 ms`
 - refresh interval: `300 ms`
 - refresh timeout: `900 ms`
-- forced recovery threshold: `5` refreshes
-- ready-start attempt cap: `2`
+- baseline forced recovery threshold: `6` refreshes
+- baseline ready-start attempt cap: `3`
+- kept current policy: `100 ms` poll, force after `5` refreshes, ready-start cap `2`
 
-Knob summary after fixing the scorer:
+Knob summary after fixing the scorer anchor:
 
 | Knob | p95 ms | p95 delta | Max ms | Max delta | Unexpected failures | Starts | Start delta | Refreshes | Refresh delta | Recovery starts | Forced | Refresh timeouts | Mic timeouts |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| baseline | 1990 | 0 | 1990 | 0 | 0 | 17 | 0 | 21 | 0 | 7 | 5 | 1 | 1 |
-| poll_75ms | 2140 | +150 | 2140 | +150 | 0 | 17 | 0 | 19 | -2 | 7 | 5 | 1 | 1 |
-| poll_50ms | 2040 | +50 | 2040 | +50 | 0 | 17 | 0 | 20 | -1 | 7 | 5 | 1 | 1 |
-| refresh_interval_200ms | 1720 | -270 | 1720 | -270 | 0 | 18 | +1 | 24 | +3 | 7 | 6 | 1 | 1 |
-| refresh_interval_150ms | 1720 | -270 | 1720 | -270 | 0 | 18 | +1 | 24 | +3 | 7 | 6 | 1 | 1 |
-| refresh_timeout_600ms | 3800 | +1810 | 3800 | +1810 | 2 | 21 | +4 | 42 | +21 | 10 | 8 | 13 | 3 |
-| recovery_start_after_3_refreshes | 2020 | +30 | 2020 | +30 | 0 | 18 | +1 | 16 | -5 | 7 | 6 | 1 | 1 |
-| recovery_start_after_2_refreshes | 2020 | +30 | 2020 | +30 | 0 | 20 | +3 | 13 | -8 | 8 | 7 | 1 | 1 |
-| max_ready_start_attempts_1 | 1990 | 0 | 1990 | 0 | 0 | 17 | 0 | 20 | -1 | 7 | 7 | 1 | 1 |
-| force_after_4_refreshes | 1800 | -190 | 1800 | -190 | 0 | 14 | -3 | 14 | -7 | 2 | 7 | 1 | 1 |
-| combo_poll100_refresh200_attempts2 | 1720 | -270 | 1720 | -270 | 0 | 18 | +1 | 24 | +3 | 7 | 6 | 1 | 1 |
+| baseline | 2440 | 0 | 2440 | 0 | 0 | 18 | 0 | 18 | 0 | 7 | 5 | 1 | 1 |
+| poll_100ms | 2290 | -150 | 2290 | -150 | 0 | 18 | 0 | 19 | +1 | 7 | 5 | 1 | 1 |
+| poll_75ms | 2440 | 0 | 2440 | 0 | 0 | 18 | 0 | 22 | +4 | 7 | 4 | 1 | 1 |
+| poll_50ms | 2340 | -100 | 2340 | -100 | 0 | 18 | 0 | 23 | +5 | 7 | 4 | 1 | 1 |
+| refresh_interval_200ms | 2440 | 0 | 2440 | 0 | 0 | 18 | 0 | 18 | 0 | 7 | 5 | 1 | 1 |
+| refresh_interval_150ms | 1870 | -570 | 1870 | -570 | 0 | 20 | +2 | 23 | +5 | 7 | 7 | 1 | 1 |
+| refresh_timeout_600ms | 4400 | +1960 | 4400 | +1960 | 2 | 24 | +6 | 33 | +15 | 9 | 8 | 14 | 3 |
+| recovery_start_after_3_refreshes | 2470 | +30 | 2470 | +30 | 0 | 19 | +1 | 13 | -5 | 7 | 6 | 1 | 1 |
+| recovery_start_after_2_refreshes | 2470 | +30 | 2470 | +30 | 0 | 20 | +2 | 9 | -9 | 8 | 7 | 1 | 1 |
+| max_ready_start_attempts_2 | 2440 | 0 | 2440 | 0 | 0 | 17 | -1 | 18 | 0 | 7 | 5 | 1 | 1 |
+| max_ready_start_attempts_1 | 2440 | 0 | 2440 | 0 | 0 | 17 | -1 | 17 | -1 | 7 | 7 | 1 | 1 |
+| force_after_5_refreshes | 2140 | -300 | 2140 | -300 | 0 | 18 | 0 | 20 | +2 | 7 | 5 | 1 | 1 |
+| force_after_4_refreshes | 1900 | -540 | 1900 | -540 | 0 | 15 | -3 | 14 | -4 | 2 | 7 | 1 | 1 |
+| kept_current_policy | 1990 | -450 | 1990 | -450 | 0 | 17 | -1 | 21 | +3 | 7 | 5 | 1 | 1 |
+| combo_poll100_refresh200_attempts2 | 1920 | -520 | 1920 | -520 | 0 | 18 | 0 | 22 | +4 | 7 | 6 | 1 | 1 |
 
 Important per-scenario regressions from `--details`:
 
 | Knob | Regressed scenario | Delta | Why it was rejected |
 | --- | --- | ---: | --- |
-| `refresh_interval_200ms` | `bluetooth_late_ready_stale_flag` | +600 ms | Starts recovery earlier, wastes the guarded attempt, then waits for forced recovery. |
-| `refresh_interval_150ms` | `bluetooth_late_ready_stale_flag` | +600 ms | Same regression as 200 ms with no extra p95 gain. |
+| `refresh_interval_150ms` | `bluetooth_late_ready_stale_flag` | +700 ms | Improves aggregate p95 but starts recovery too early for Bluetooth settle. |
 | `refresh_timeout_600ms` | `selected_input_stale_until_force` | timeout | Adds false stale-refresh failures. |
 | `refresh_timeout_600ms` | `ready_flag_start_keeps_failing` | timeout | Turns an expected success into `microphone_start_timeout`. |
-| `recovery_start_after_3_refreshes` | `bluetooth_late_ready_stale_flag` | +900 ms | Starts too early and loses the useful guarded attempt. |
-| `recovery_start_after_2_refreshes` | `bluetooth_reconnect_stale_flag` | +900 ms | Too aggressive for Bluetooth route settle. |
+| `recovery_start_after_3_refreshes` | aggregate | +30 ms p95 | Starts too early without a reliable p95 win. |
+| `recovery_start_after_2_refreshes` | aggregate | +30 ms p95 | Too aggressive for Bluetooth route settle. |
 | `max_ready_start_attempts_1` | `first_start_fails_retry_succeeds` | +600 ms | Forces hard recovery instead of allowing the cheap retry. |
-| `force_after_4_refreshes` | `bluetooth_reconnect_stale_flag` | +680 ms | Skips the faster guarded recovery start and forces a slower rebuild. |
+| `force_after_4_refreshes` | `bluetooth_reconnect_stale_flag` | +730 ms | Skips the faster guarded recovery start and forces a slower rebuild. |
 
 Decision:
 
-- `dictationReadinessPollInterval`: rejected. 75 ms and 50 ms worsened aggregate p95 in the deterministic suite.
-- `dictationReadinessRefreshInterval`: rejected. 200 ms/150 ms improved aggregate p95 by 270 ms, but increased starts/refreshes/forced recoveries and regressed the late Bluetooth settle scenario by 600 ms.
+- `dictationReadinessPollInterval`: keep 100 ms as part of the current policy. 75 ms and 50 ms added refresh churn without beating the kept combo.
+- `dictationReadinessRefreshInterval`: rejected. 150 ms improved aggregate p95 by 570 ms, but increased starts/refreshes/forced recoveries and regressed Bluetooth settle by 700 ms.
 - `dictationReadinessRefreshTimeout`: rejected. 600 ms created 2 unexpected failures and 3 simulated microphone timeouts.
-- recovery-start threshold: rejected. Starting after 3 or 2 refreshes regressed late Bluetooth scenarios by 900 ms.
-- ready-start attempt cap: rejected. One attempt regressed cheap retry success by 600 ms and repeated ready-start failure recovery by 700 ms.
-- forced recovery threshold: rejected. Forcing after 4 refreshes improved aggregate p95 by 190 ms, but regressed Bluetooth reconnect by 680 ms.
+- recovery-start threshold: rejected. Starting after 3 or 2 refreshes worsened aggregate p95.
+- ready-start attempt cap: keep 2 as part of the current policy. One attempt still regresses cheap retry success.
+- forced recovery threshold: keep 5 as part of the current policy. Forcing after 4 refreshes improved aggregate p95 more, but regressed Bluetooth reconnect by 730 ms.
 - `dictationRecoveryBudget` 6 s: ruled out for latency. Lowering it only fails faster; raising it worsens start latency. Keep the current budget unless the metric changes to recovery success rate.
 - forced recovery attempt budget: ruled out for this latency goal. The scorer already keeps attempts bounded; more attempts would increase worst-case latency and fewer attempts would reduce recovery chance.
 
@@ -505,10 +509,10 @@ Decision:
 | Diagnostics/logging hot path | Ruled out | Stage timing shows post-start diagnostics are not the request-to-recording bottleneck. |
 | Skip explicit `audioEngine.prepare()` | Kept | Built-in p95 request-to-recording improved 106 -> 98 ms with no guardrail events. |
 | Keep engine running between starts | Ruled out | Would keep mic hardware active after stop and weaken privacy/battery expectations. |
-| Recovery poll interval | Rejected | 75 ms and 50 ms worsened deterministic p95. |
-| Recovery refresh interval | Rejected | 200 ms/150 ms improved aggregate p95 but regressed late Bluetooth settle by 600 ms and increased starts/refreshes/forced recoveries. |
+| Recovery poll interval | Partly kept | 100 ms is in the kept current policy; 75 ms and 50 ms added churn without beating the kept combo. |
+| Recovery refresh interval | Rejected | 150 ms improved aggregate p95 but regressed Bluetooth settle by 700 ms and increased starts/refreshes/forced recoveries. |
 | Recovery refresh timeout | Rejected | 600 ms created 2 unexpected failures and 3 simulated microphone timeouts. |
-| Recovery start threshold | Rejected | Earlier recovery starts regressed Bluetooth settle scenarios by 900 ms. |
+| Recovery start threshold | Rejected | Earlier recovery starts worsened aggregate p95 by 30 ms and regressed Bluetooth settle scenarios by 1300 ms. |
 | Recovery budget | Ruled out | Lower budget fails faster rather than starting faster; higher budget worsens latency. |
 
 ## Final Verdict
@@ -517,6 +521,6 @@ Built-in route: no 20-30% win found. The kept measured win is small: p95 request
 
 Bluetooth-output route: blocked by missing hardware in the current environment. The prior safe improvement for ready Bluetooth routes is kept, but deeper route-settle tuning cannot be scored right now.
 
-Slow recovery route: no safe code change kept. After updating the deterministic scorer to current constants, every recovery knob either worsened p95, created failure regressions, or improved aggregate p95 while hurting a Bluetooth-settle scenario enough to reject it.
+Slow recovery route: no further safe code change kept. After fixing the deterministic scorer to compare against the real pre-keeper baseline, the current policy remains the safe kept combo; more aggressive knobs either create failure regressions or improve aggregate p95 while hurting a Bluetooth-settle scenario enough to reject them.
 
 Conclusion: this autoeval found a small built-in-route keeper and then hit a clear no-win/blocker boundary for the remaining knobs.

--- a/docs/autoeval-dictation-start-time-2026-05-31.md
+++ b/docs/autoeval-dictation-start-time-2026-05-31.md
@@ -113,3 +113,63 @@ Results:
 - No live post-change Bluetooth-output sample was captured from this worktree build because the installed `/Applications/Transcripted.app` was already running. I did not interrupt it.
 - The next autoeval loop should collect 10-20 live starts on the Bluetooth-output route and confirm no increase in fallback events or `microphone_start_timeout`.
 - Full-log historical p95 still contains old samples; use fresh samples or a bounded time window for future scoring.
+
+## Continued Loop Notes
+
+This is not a final "done forever" verdict. Experiment 1 found a real bottleneck, but the normal built-in fast path still needed more scrutiny.
+
+Normal built-in path from current logs:
+
+| Metric | Samples | p50 | p90 | p95 | Max |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `start_ms` (`sttRouter.startRecording()`) | 410 | 87 ms | 120 ms | 134 ms | 402 ms |
+| `audio_engine_started` -> fast-start event | 408 | 3 ms | 4 ms | 5 ms | 11 ms |
+| fast-start event -> `audio_samples_detected` | 410 | 102 ms | 104 ms | 104 ms | 124 ms |
+
+Interpretation:
+
+- Normal built-in dictation is fast, but it is not fully proven end-to-end.
+- Existing logs say post-start event/log/UI work is tiny, around 3-5 ms p95.
+- First audio-buffer arrival is consistently about 100 ms after fast-start, with 4800-frame buffers.
+- The old metric missed true request-to-recording time, so the next code change adds that instrumentation.
+
+### Experiment 2 - Add Missing End-to-End Timing
+
+Added fields for future samples:
+
+- `request_to_recording_ms` on `dictation_recording_fast_start` and `dictation_started_after_wait`
+- `pre_recording_overhead_ms` on fast-start success/fallback
+- `start_to_first_sample_ms` on `audio_samples_detected`
+
+Also updated `scripts/ops/performance-budget.rb` so it prints request-to-recording and start-to-first-sample p95 when logs include those fields.
+
+Decision: keep as measurement infrastructure. This is not a claimed speed win.
+
+### Rejected Experiment - Eager Sample-Buffer Reserve
+
+`ParakeetEngine.startRecording()` reserves capacity for a 30-minute Float buffer. That looked suspicious, so I microbenchmarked the exact reserve size:
+
+```bash
+swift -e 'import Foundation
+let count = 86_400_000
+var times: [Double] = []
+for _ in 0..<10 {
+  var values: [Float] = []
+  let start = CFAbsoluteTimeGetCurrent()
+  values.reserveCapacity(count)
+  times.append((CFAbsoluteTimeGetCurrent() - start) * 1000)
+  values.removeAll(keepingCapacity: false)
+}
+print(times)'
+```
+
+Result: p50 `0.000 ms`, max `0.013 ms`.
+
+Decision: reject as a start-latency knob. It may still be worth a memory-footprint pass, but it is not the current dictation-start p95 problem.
+
+Still-open knobs:
+
+- stage timing inside `audioInputSnapshot`
+- whether route lookup can be cached safely
+- whether first-sample cadence can move below about 100 ms without weakening AirPods/HFP compatibility
+- live 10-20 sample proof on both built-in and Bluetooth-output routes

--- a/docs/autoeval-dictation-start-time-2026-05-31.md
+++ b/docs/autoeval-dictation-start-time-2026-05-31.md
@@ -173,3 +173,78 @@ Still-open knobs:
 - whether route lookup can be cached safely
 - whether first-sample cadence can move below about 100 ms without weakening AirPods/HFP compatibility
 - live 10-20 sample proof on both built-in and Bluetooth-output routes
+
+## Continued Loop - Fresh Branch Samples
+
+Branch build tested:
+
+- Branch: `codex/dictation-start-autoeval`
+- App path: `/Users/redbars/transcripted-latest/build/Transcripted.app`
+- Trigger: synthetic Right Option physical-key event
+- Route: `built_in_input_to_built_in_output`
+- Sample method: warm model once, then 20 start/stop cycles with TextEdit as the paste target
+
+Fresh built-in baseline from branch build:
+
+| Cutoff | Samples | Metric | p50 | p90 | p95 | Max | Guardrails |
+| --- | ---: | --- | ---: | ---: | ---: | ---: | --- |
+| `2026-05-31T19:48:16Z` | 20 intended starts | `request_to_recording_ms` | 88 ms | 93 ms | 98 ms | 100 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T19:48:16Z` | 20 intended starts | `pre_recording_overhead_ms` | 10 ms | 12 ms | 13 ms | 14 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T19:48:16Z` | 20 intended starts | `start_ms` | 78 ms | 88 ms | 91 ms | 91 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T19:48:16Z` | 20 intended starts | `start_to_first_sample_ms` | 183 ms | 192 ms | 196 ms | 196 ms | 4800-frame first buffers |
+
+Same-cadence 1024-buffer rerun:
+
+| Cutoff | Samples | Metric | p50 | p90 | p95 | Max | Guardrails |
+| --- | ---: | --- | ---: | ---: | ---: | ---: | --- |
+| `2026-05-31T20:01:08Z` | 20 | `request_to_recording_ms` | 94 ms | 100 ms | 100 ms | 100 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T20:01:08Z` | 20 | `pre_recording_overhead_ms` | 10 ms | 11 ms | 11 ms | 11 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T20:01:08Z` | 20 | `start_ms` | 84 ms | 89 ms | 90 ms | 90 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T20:01:08Z` | 20 | `start_to_first_sample_ms` | 189 ms | 194 ms | 194 ms | 194 ms | 4800-frame first buffers |
+
+### Tested Knob - Tap Buffer Size
+
+Changed `TranscriptedConstants.audioTapBufferSize` from `1024` to `256`, rebuilt, warmed the model, then ran the same 20-cycle sampler.
+
+Result:
+
+| Cutoff | Samples | Metric | p50 | p90 | p95 | Max | Guardrails |
+| --- | ---: | --- | ---: | ---: | ---: | ---: | --- |
+| `2026-05-31T19:55:59Z` | 20 | `request_to_recording_ms` | 89 ms | 100 ms | 102 ms | 102 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T19:55:59Z` | 20 | `pre_recording_overhead_ms` | 9 ms | 12 ms | 13 ms | 13 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T19:55:59Z` | 20 | `start_ms` | 80 ms | 87 ms | 93 ms | 93 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T19:55:59Z` | 20 | `start_to_first_sample_ms` | 185 ms | 192 ms | 198 ms | 198 ms | 4800-frame first buffers |
+
+Decision: reject and revert.
+
+Why:
+
+- It did not reduce the actual first buffer size. The first buffer stayed at 4800 frames.
+- It did not improve request-to-recording p95.
+- It did not improve start-to-first-sample p95.
+
+An earlier aggressive sampler run started again while the overlay was still in the short no-speech cleanup state and caused one `audio_format_read_timeout`. That was treated as a harness error, not as the knob score. The clean rerun above had no fallback, retry, or timeout events.
+
+### Current Knob Ledger
+
+| Knob | Status | Evidence |
+| --- | --- | --- |
+| Skip ready input-override settle delay | Kept | Historical Bluetooth-output projection improved p95 from 555 ms to 255 ms while keeping the wait for unready routes. |
+| Add end-to-end timing fields | Kept | Enabled live scoring for `request_to_recording_ms`, `pre_recording_overhead_ms`, and `start_to_first_sample_ms`. |
+| Eager sample-buffer reserve | Rejected | Microbench max was 0.013 ms. Not a start-latency problem. |
+| Tap buffer size 1024 -> 256 | Rejected | Same 4800-frame first buffers; p95 `start_to_first_sample_ms` was 198 ms vs 194 ms on same-cadence 1024 rerun. |
+| Overlay/UI pre-start work | Ruled out for now | `pre_recording_overhead_ms` p95 is 11-13 ms, so even deleting it all cannot hit a 20-30% win. |
+| Diagnostics/logging hot path | Ruled out for primary metric | The primary request-to-recording fields are captured before the expensive post-start delivery/transcription path. |
+| Cache route/device lookup on normal built-in route | Ruled out for current route | Built-in route uses `selection_reason=defaultIsSafe` with no input override; no live evidence of lookup cost in the 20-sample runs. |
+| Preferred-input override delay beyond kept fix | Blocked | Needs live Bluetooth-output samples. Current branch samples were built-in input to built-in output only. |
+| Slow-path recovery knobs | Separate lane | Relevant to fallback recovery, not normal ready-engine p95. Do not mix into the normal fast-start score. |
+
+### Next Experiments
+
+The normal built-in path is now probably close to the floor for this route: p95 request-to-recording is about 100 ms and p95 first sample is about 194 ms.
+
+The remaining high-value tests are:
+
+1. Collect 20 live Bluetooth-output starts on this branch.
+2. If Bluetooth still has p95 spikes, test only override/route-settle knobs there.
+3. If built-in needs more speed anyway, add stage timing inside `audioInputSnapshot` and `installTapAndStartEngine`; do not guess at cache changes without that split.

--- a/docs/autoeval-dictation-start-time-2026-05-31.md
+++ b/docs/autoeval-dictation-start-time-2026-05-31.md
@@ -248,3 +248,139 @@ The remaining high-value tests are:
 1. Collect 20 live Bluetooth-output starts on this branch.
 2. If Bluetooth still has p95 spikes, test only override/route-settle knobs there.
 3. If built-in needs more speed anyway, add stage timing inside `audioInputSnapshot` and `installTapAndStartEngine`; do not guess at cache changes without that split.
+
+## Continued Loop - Stage Timing And Prepare Knob
+
+### Bluetooth-Output Case
+
+Status: blocked for this run.
+
+Commands:
+
+```bash
+which SwitchAudioSource || true
+system_profiler SPAudioDataType -json
+```
+
+Result:
+
+- `SwitchAudioSource` was not installed.
+- CoreAudio only reported `MacBook Pro Microphone` and `MacBook Pro Speakers`.
+- No Bluetooth output route was available to switch to, so 20 Bluetooth-output samples could not be collected.
+
+### Measurement Patch - Audio Start Stage Timing
+
+Added a local `dictation_audio_start_timing` event with:
+
+- `audio_input_selection_load_ms`
+- `audio_input_device_check_ms`
+- `audio_input_snapshot_read_ms`
+- `audio_input_override_settle_sleep_ms`
+- `audio_input_settled_snapshot_read_ms`
+- `audio_input_total_ms`
+- `audio_tap_remove_ms`
+- `audio_tap_install_ms`
+- `audio_engine_prepare_ms`
+- `audio_engine_start_ms`
+- `audio_start_work_ms`
+
+Command:
+
+```bash
+bash build.sh --no-open
+# launch /Users/redbars/transcripted-latest/build/Transcripted.app
+# warm once, then run 20 Right Option start/stop cycles
+```
+
+Instrumented built-in route result:
+
+| Cutoff | Samples | Metric | p50 | p90 | p95 | Max | Guardrails |
+| --- | ---: | --- | ---: | ---: | ---: | ---: | --- |
+| `2026-05-31T20:09:41Z` | 20 | `request_to_recording_ms` | 95 ms | 106 ms | 106 ms | 106 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T20:09:41Z` | 20 | `pre_recording_overhead_ms` | 10 ms | 15 ms | 18 ms | 18 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T20:09:41Z` | 20 | `start_ms` | 85 ms | 91 ms | 97 ms | 97 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T20:09:41Z` | 20 | `start_to_first_sample_ms` | 189 ms | 195 ms | 200 ms | 200 ms | 4800-frame first buffers |
+
+Stage timing summary:
+
+| Stage | Samples | p50 | p90 | p95 | Max |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `audio_input_selection_load_ms` | 20 | 0 ms | 0 ms | 1 ms | 1 ms |
+| `audio_input_snapshot_read_ms` | 20 | 16 ms | 18 ms | 19 ms | 19 ms |
+| `audio_input_total_ms` | 20 | 17 ms | 19 ms | 19 ms | 19 ms |
+| `audio_tap_remove_ms` | 20 | 0 ms | 0 ms | 0 ms | 0 ms |
+| `audio_tap_install_ms` | 20 | 0 ms | 0 ms | 0 ms | 0 ms |
+| `audio_engine_prepare_ms` | 20 | 21 ms | 25 ms | 28 ms | 28 ms |
+| `audio_engine_start_ms` | 20 | 45 ms | 47 ms | 49 ms | 49 ms |
+| `audio_start_work_ms` | 20 | 66 ms | 72 ms | 78 ms | 78 ms |
+
+Decision:
+
+- Keep the measurement event for now. It proved route lookup is not the built-in p95 problem.
+- Cache route/device lookup is ruled out for the built-in route because selection load was 0-1 ms and no device override check ran.
+- The actual built-in hot chunk is CoreAudio prepare/start, not app route lookup.
+
+### Tested Knob - Skip Explicit `audioEngine.prepare()`
+
+Changed the start path to call `audioEngine.start()` without a separate `audioEngine.prepare()` call. `AVAudioEngine.start()` can prepare implicitly, so this tests whether the explicit prepare is only duplicating work.
+
+Command:
+
+```bash
+bash build.sh --no-open
+# launch /Users/redbars/transcripted-latest/build/Transcripted.app
+# warm once, then run 20 Right Option start/stop cycles
+```
+
+Result:
+
+| Cutoff | Samples | Metric | p50 | p90 | p95 | Max | Guardrails |
+| --- | ---: | --- | ---: | ---: | ---: | ---: | --- |
+| `2026-05-31T20:15:13Z` | 20 | `request_to_recording_ms` | 93 ms | 97 ms | 98 ms | 98 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T20:15:13Z` | 20 | `pre_recording_overhead_ms` | 9 ms | 11 ms | 11 ms | 11 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T20:15:13Z` | 20 | `start_ms` | 85 ms | 87 ms | 88 ms | 88 ms | 0 fallback / 0 retry / 0 timeout |
+| `2026-05-31T20:15:13Z` | 20 | `start_to_first_sample_ms` | 189 ms | 192 ms | 193 ms | 193 ms | 4800-frame first buffers |
+
+Stage comparison:
+
+| Stage | With explicit prepare p95 | Skip explicit prepare p95 | Decision |
+| --- | ---: | ---: | --- |
+| `audio_engine_prepare_ms` | 28 ms | 0 ms | removed |
+| `audio_engine_start_ms` | 49 ms | 69 ms | start absorbs some work |
+| `audio_start_work_ms` | 78 ms | 69 ms | 9 ms p95 win |
+| `request_to_recording_ms` | 106 ms | 98 ms | 8 ms p95 win |
+| `start_ms` | 97 ms | 88 ms | 9 ms p95 win |
+
+Decision: keep as a small win.
+
+This is not the requested 20-30% win, but it is measured, isolated, and had no fallback/retry/timeout regression in 20 samples.
+
+### Updated Knob Ledger
+
+| Knob | Status | Evidence |
+| --- | --- | --- |
+| Stage timing inside `audioInputSnapshot` / tap / engine start | Kept | Added `dictation_audio_start_timing`; 20/20 starts emitted timing events. |
+| Cache route/device lookup on built-in route | Ruled out | Selection load p95 was 1 ms; no override device check ran on built-in route. |
+| Further preferred-input override delay tuning | Blocked | Needs Bluetooth-output route; current machine only exposed built-in input/output. |
+| First audio buffer cadence via tap buffer | Rejected | 1024 -> 256 kept 4800-frame first buffers and did not improve p95. |
+| Overlay/UI pre-start work | Ruled out for now | `pre_recording_overhead_ms` p95 was 11-18 ms, below the requested 20-30% win by itself. |
+| Diagnostics/logging hot path | Ruled out for primary start win | Stage data shows CoreAudio start work dominates; post-start delivery/transcription logging is outside request-to-recording. |
+| Skip explicit `audioEngine.prepare()` | Kept | p95 request-to-recording 106 -> 98 ms in the instrumented run, with no guardrail events. |
+| Keep engine running between starts | Ruled out | Would likely keep mic hardware active after stop, weakening privacy/battery expectations. |
+
+### Current Verdict
+
+Built-in route: small measured win, no 20-30% win.
+
+Bluetooth-output route: blocked until a Bluetooth output device is connected.
+
+Best next run:
+
+1. Connect Bluetooth output and rerun the 20-sample branch sampler.
+2. If Bluetooth still spikes, tune only the route/override path.
+3. If no Bluetooth route is available, treat this as a built-in-route no-win except for the kept 8-9 ms p95 prepare/start cleanup.
+
+Verification:
+
+- `bash run-tests.sh` - 2938 passed, 0 failed.
+- `bash build.sh --no-open` - build, signing, launch smoke, and performance budget passed.

--- a/scripts/ops/dictation-recovery-autoeval.rb
+++ b/scripts/ops/dictation-recovery-autoeval.rb
@@ -65,6 +65,19 @@ end
 
 BASELINE = Config.new(
   name: "baseline",
+  poll_ms: 150,
+  refresh_interval_ms: 300,
+  refresh_timeout_ms: 900,
+  budget_ms: 6000,
+  refreshes_before_recovery_start: 4,
+  forced_recovery_refreshes: 6,
+  max_forced_recoveries: 2,
+  max_recovery_start_attempts: 2,
+  max_recording_start_attempts: 3
+)
+
+KEPT_POLICY = Config.new(
+  name: "kept_current_policy",
   poll_ms: 100,
   refresh_interval_ms: 300,
   refresh_timeout_ms: 900,
@@ -291,6 +304,7 @@ SCENARIOS = [
 def config_variants
   [
     BASELINE,
+    BASELINE.dup.tap { |config| config.name = "poll_100ms"; config.poll_ms = 100 },
     BASELINE.dup.tap { |config| config.name = "poll_75ms"; config.poll_ms = 75 },
     BASELINE.dup.tap { |config| config.name = "poll_50ms"; config.poll_ms = 50 },
     BASELINE.dup.tap { |config| config.name = "refresh_interval_200ms"; config.refresh_interval_ms = 200 },
@@ -298,8 +312,11 @@ def config_variants
     BASELINE.dup.tap { |config| config.name = "refresh_timeout_600ms"; config.refresh_timeout_ms = 600 },
     BASELINE.dup.tap { |config| config.name = "recovery_start_after_3_refreshes"; config.refreshes_before_recovery_start = 3 },
     BASELINE.dup.tap { |config| config.name = "recovery_start_after_2_refreshes"; config.refreshes_before_recovery_start = 2 },
+    BASELINE.dup.tap { |config| config.name = "max_ready_start_attempts_2"; config.max_recording_start_attempts = 2 },
     BASELINE.dup.tap { |config| config.name = "max_ready_start_attempts_1"; config.max_recording_start_attempts = 1 },
+    BASELINE.dup.tap { |config| config.name = "force_after_5_refreshes"; config.forced_recovery_refreshes = 5 },
     BASELINE.dup.tap { |config| config.name = "force_after_4_refreshes"; config.forced_recovery_refreshes = 4 },
+    KEPT_POLICY,
     BASELINE.dup.tap do |config|
       config.name = "combo_poll100_refresh200_attempts2"
       config.poll_ms = 100
@@ -604,12 +621,14 @@ variants = config_variants
 all_results = variants.to_h do |config|
   [config.name, SCENARIOS.map { |scenario| simulate(scenario, config) }]
 end
-baseline_summary = summarize(all_results.fetch("baseline"))
+baseline_summary = summarize(all_results.fetch(BASELINE.name))
 
 puts "# Dictation Recovery Autoeval"
 puts
 puts "Primary metric: request-to-listening time for slow dictation recovery scenarios."
 puts "Guardrails: expected success cases must still succeed; unrecoverable route must time out clearly; attempts and hard recoveries stay bounded."
+puts "Baseline: pre-keeper policy, 150ms poll, force after 6 stale refreshes, ready-start cap 3."
+puts "Kept current policy: 100ms poll, force after 5 stale refreshes, ready-start cap 2."
 puts
 
 puts "## Scenarios"
@@ -661,7 +680,7 @@ print_table(
 puts
 
 puts "## Baseline Raw Results"
-baseline_rows = all_results.fetch("baseline").map do |result|
+baseline_rows = all_results.fetch(BASELINE.name).map do |result|
   [
     result.scenario,
     result.success ? "success" : "timeout",
@@ -682,11 +701,11 @@ print_table(
 if options[:details]
   puts
   puts "## Per-Knob Raw Results"
-  variants.reject { |config| config.name == "baseline" }.each do |config|
+  variants.reject { |config| config.name == BASELINE.name }.each do |config|
     puts
     puts "### #{config.name}"
     rows = all_results.fetch(config.name).map do |result|
-      baseline = all_results.fetch("baseline").find { |base| base.scenario == result.scenario }
+      baseline = all_results.fetch(BASELINE.name).find { |base| base.scenario == result.scenario }
       [
         result.scenario,
         result.success ? "success" : "timeout",

--- a/scripts/ops/dictation-recovery-autoeval.rb
+++ b/scripts/ops/dictation-recovery-autoeval.rb
@@ -65,15 +65,15 @@ end
 
 BASELINE = Config.new(
   name: "baseline",
-  poll_ms: 150,
+  poll_ms: 100,
   refresh_interval_ms: 300,
   refresh_timeout_ms: 900,
   budget_ms: 6000,
   refreshes_before_recovery_start: 4,
-  forced_recovery_refreshes: 6,
+  forced_recovery_refreshes: 5,
   max_forced_recoveries: 2,
   max_recovery_start_attempts: 2,
-  max_recording_start_attempts: 3
+  max_recording_start_attempts: 2
 )
 
 SCENARIOS = [
@@ -291,32 +291,15 @@ SCENARIOS = [
 def config_variants
   [
     BASELINE,
-    BASELINE.dup.tap { |config| config.name = "poll_100ms"; config.poll_ms = 100 },
     BASELINE.dup.tap { |config| config.name = "poll_75ms"; config.poll_ms = 75 },
+    BASELINE.dup.tap { |config| config.name = "poll_50ms"; config.poll_ms = 50 },
     BASELINE.dup.tap { |config| config.name = "refresh_interval_200ms"; config.refresh_interval_ms = 200 },
     BASELINE.dup.tap { |config| config.name = "refresh_interval_150ms"; config.refresh_interval_ms = 150 },
+    BASELINE.dup.tap { |config| config.name = "refresh_timeout_600ms"; config.refresh_timeout_ms = 600 },
     BASELINE.dup.tap { |config| config.name = "recovery_start_after_3_refreshes"; config.refreshes_before_recovery_start = 3 },
     BASELINE.dup.tap { |config| config.name = "recovery_start_after_2_refreshes"; config.refreshes_before_recovery_start = 2 },
-    BASELINE.dup.tap { |config| config.name = "max_ready_start_attempts_2"; config.max_recording_start_attempts = 2 },
     BASELINE.dup.tap { |config| config.name = "max_ready_start_attempts_1"; config.max_recording_start_attempts = 1 },
-    BASELINE.dup.tap { |config| config.name = "force_after_5_refreshes"; config.forced_recovery_refreshes = 5 },
     BASELINE.dup.tap { |config| config.name = "force_after_4_refreshes"; config.forced_recovery_refreshes = 4 },
-    BASELINE.dup.tap do |config|
-      config.name = "combo_poll100_force5"
-      config.poll_ms = 100
-      config.forced_recovery_refreshes = 5
-    end,
-    BASELINE.dup.tap do |config|
-      config.name = "combo_poll100_ready_attempts2"
-      config.poll_ms = 100
-      config.max_recording_start_attempts = 2
-    end,
-    BASELINE.dup.tap do |config|
-      config.name = "combo_poll100_force5_attempts2"
-      config.poll_ms = 100
-      config.forced_recovery_refreshes = 5
-      config.max_recording_start_attempts = 2
-    end,
     BASELINE.dup.tap do |config|
       config.name = "combo_poll100_refresh200_attempts2"
       config.poll_ms = 100

--- a/scripts/ops/dictation-recovery-autoeval.rb
+++ b/scripts/ops/dictation-recovery-autoeval.rb
@@ -1,0 +1,725 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Deterministic policy lab for the dictation start wait loop.
+#
+# This does not pretend to replace live CoreAudio testing. It gives us a stable
+# way to score recovery knobs against the scenarios that are hard to reproduce
+# on demand: wake, Bluetooth route churn, stale input flags, failed starts, and
+# unrecoverable routes.
+
+require "optparse"
+
+Config = Struct.new(
+  :name,
+  :poll_ms,
+  :refresh_interval_ms,
+  :refresh_timeout_ms,
+  :budget_ms,
+  :refreshes_before_recovery_start,
+  :forced_recovery_refreshes,
+  :max_forced_recoveries,
+  :max_recovery_start_attempts,
+  :max_recording_start_attempts,
+  keyword_init: true
+)
+
+Scenario = Struct.new(
+  :name,
+  :description,
+  :recovering_until_ms,
+  :flag_ready_at_ms,
+  :actual_ready_at_ms,
+  :passive_flag_updates,
+  :refresh_updates_flag,
+  :refresh_duration_ms,
+  :refresh_never_finishes,
+  :normal_start_ms,
+  :recovery_start_ms,
+  :force_recovery_ms,
+  :force_makes_flag_ready,
+  :force_makes_actual_ready,
+  :normal_start_outcomes,
+  :recovery_start_outcomes,
+  :expect_success,
+  keyword_init: true
+)
+
+Result = Struct.new(
+  :config,
+  :scenario,
+  :success,
+  :time_ms,
+  :normal_starts,
+  :recovery_starts,
+  :refreshes,
+  :forced_recoveries,
+  :refresh_timeouts,
+  :reason,
+  keyword_init: true
+) do
+  def start_attempts
+    normal_starts + recovery_starts
+  end
+end
+
+BASELINE = Config.new(
+  name: "baseline",
+  poll_ms: 150,
+  refresh_interval_ms: 300,
+  refresh_timeout_ms: 900,
+  budget_ms: 6000,
+  refreshes_before_recovery_start: 4,
+  forced_recovery_refreshes: 6,
+  max_forced_recoveries: 2,
+  max_recovery_start_attempts: 2,
+  max_recording_start_attempts: 3
+)
+
+SCENARIOS = [
+  Scenario.new(
+    name: "fast_ready_no_recovery",
+    description: "Normal ready route should not get slower or trigger recovery work.",
+    recovering_until_ms: 0,
+    flag_ready_at_ms: 0,
+    actual_ready_at_ms: 0,
+    passive_flag_updates: true,
+    refresh_updates_flag: true,
+    refresh_duration_ms: 70,
+    refresh_never_finishes: false,
+    normal_start_ms: 85,
+    recovery_start_ms: 100,
+    force_recovery_ms: 550,
+    force_makes_flag_ready: true,
+    force_makes_actual_ready: true,
+    normal_start_outcomes: [:success],
+    recovery_start_outcomes: [:when_actual_ready],
+    expect_success: true
+  ),
+  Scenario.new(
+    name: "cold_launch_unready_then_ready",
+    description: "App starts dictation before the route flag has caught up.",
+    recovering_until_ms: 0,
+    flag_ready_at_ms: 520,
+    actual_ready_at_ms: 520,
+    passive_flag_updates: false,
+    refresh_updates_flag: true,
+    refresh_duration_ms: 80,
+    refresh_never_finishes: false,
+    normal_start_ms: 90,
+    recovery_start_ms: 100,
+    force_recovery_ms: 550,
+    force_makes_flag_ready: true,
+    force_makes_actual_ready: true,
+    normal_start_outcomes: [:when_actual_ready],
+    recovery_start_outcomes: [:when_actual_ready],
+    expect_success: true
+  ),
+  Scenario.new(
+    name: "wake_recovery_finishes",
+    description: "Mac wakes and the audio device recovery flag clears later.",
+    recovering_until_ms: 1200,
+    flag_ready_at_ms: 1200,
+    actual_ready_at_ms: 1200,
+    passive_flag_updates: true,
+    refresh_updates_flag: true,
+    refresh_duration_ms: 80,
+    refresh_never_finishes: false,
+    normal_start_ms: 90,
+    recovery_start_ms: 100,
+    force_recovery_ms: 650,
+    force_makes_flag_ready: true,
+    force_makes_actual_ready: true,
+    normal_start_outcomes: [:when_actual_ready],
+    recovery_start_outcomes: [:when_actual_ready],
+    expect_success: true
+  ),
+  Scenario.new(
+    name: "bluetooth_reconnect_stale_flag",
+    description: "Bluetooth route becomes recordable before the readiness flag updates.",
+    recovering_until_ms: 0,
+    flag_ready_at_ms: 1300,
+    actual_ready_at_ms: 760,
+    passive_flag_updates: false,
+    refresh_updates_flag: true,
+    refresh_duration_ms: 100,
+    refresh_never_finishes: false,
+    normal_start_ms: 100,
+    recovery_start_ms: 120,
+    force_recovery_ms: 700,
+    force_makes_flag_ready: true,
+    force_makes_actual_ready: true,
+    normal_start_outcomes: [:when_actual_ready],
+    recovery_start_outcomes: [:when_actual_ready],
+    expect_success: true
+  ),
+  Scenario.new(
+    name: "bluetooth_late_ready_stale_flag",
+    description: "Bluetooth route settles later; early recovery starts can waste the one guarded attempt.",
+    recovering_until_ms: 0,
+    flag_ready_at_ms: 1600,
+    actual_ready_at_ms: 1050,
+    passive_flag_updates: false,
+    refresh_updates_flag: true,
+    refresh_duration_ms: 100,
+    refresh_never_finishes: false,
+    normal_start_ms: 100,
+    recovery_start_ms: 120,
+    force_recovery_ms: 700,
+    force_makes_flag_ready: true,
+    force_makes_actual_ready: true,
+    normal_start_outcomes: [:when_actual_ready],
+    recovery_start_outcomes: [:when_actual_ready],
+    expect_success: true
+  ),
+  Scenario.new(
+    name: "slow_refresh_would_recover",
+    description: "A slow route would become ready via refresh without hard recovery.",
+    recovering_until_ms: 0,
+    flag_ready_at_ms: 1260,
+    actual_ready_at_ms: 1260,
+    passive_flag_updates: false,
+    refresh_updates_flag: true,
+    refresh_duration_ms: 90,
+    refresh_never_finishes: false,
+    normal_start_ms: 90,
+    recovery_start_ms: 100,
+    force_recovery_ms: 650,
+    force_makes_flag_ready: true,
+    force_makes_actual_ready: true,
+    normal_start_outcomes: [:when_actual_ready],
+    recovery_start_outcomes: [:when_actual_ready],
+    expect_success: true
+  ),
+  Scenario.new(
+    name: "selected_input_stale_until_force",
+    description: "Selected route is stale and refreshes cannot repair it.",
+    recovering_until_ms: 0,
+    flag_ready_at_ms: nil,
+    actual_ready_at_ms: nil,
+    passive_flag_updates: false,
+    refresh_updates_flag: false,
+    refresh_duration_ms: 90,
+    refresh_never_finishes: false,
+    normal_start_ms: 90,
+    recovery_start_ms: 100,
+    force_recovery_ms: 650,
+    force_makes_flag_ready: true,
+    force_makes_actual_ready: true,
+    normal_start_outcomes: [:when_actual_ready],
+    recovery_start_outcomes: [:when_actual_ready],
+    expect_success: true
+  ),
+  Scenario.new(
+    name: "first_start_fails_retry_succeeds",
+    description: "Input says ready, the first CoreAudio start fails, retry succeeds.",
+    recovering_until_ms: 0,
+    flag_ready_at_ms: 0,
+    actual_ready_at_ms: 0,
+    passive_flag_updates: true,
+    refresh_updates_flag: true,
+    refresh_duration_ms: 70,
+    refresh_never_finishes: false,
+    normal_start_ms: 90,
+    recovery_start_ms: 100,
+    force_recovery_ms: 600,
+    force_makes_flag_ready: true,
+    force_makes_actual_ready: true,
+    normal_start_outcomes: [:fail, :success],
+    recovery_start_outcomes: [:when_actual_ready],
+    expect_success: true
+  ),
+  Scenario.new(
+    name: "ready_flag_start_keeps_failing",
+    description: "Input format says ready, but every normal start fails until rebuild.",
+    recovering_until_ms: 0,
+    flag_ready_at_ms: 0,
+    actual_ready_at_ms: nil,
+    passive_flag_updates: true,
+    refresh_updates_flag: true,
+    refresh_duration_ms: 80,
+    refresh_never_finishes: false,
+    normal_start_ms: 100,
+    recovery_start_ms: 110,
+    force_recovery_ms: 650,
+    force_makes_flag_ready: true,
+    force_makes_actual_ready: true,
+    normal_start_outcomes: [:fail, :fail, :when_actual_ready],
+    recovery_start_outcomes: [:when_actual_ready],
+    expect_success: true
+  ),
+  Scenario.new(
+    name: "refresh_times_out_then_recovery_start",
+    description: "A readiness refresh wedges and the guarded recovery start must unblock it.",
+    recovering_until_ms: 0,
+    flag_ready_at_ms: nil,
+    actual_ready_at_ms: 950,
+    passive_flag_updates: false,
+    refresh_updates_flag: false,
+    refresh_duration_ms: 5000,
+    refresh_never_finishes: true,
+    normal_start_ms: 90,
+    recovery_start_ms: 100,
+    force_recovery_ms: 650,
+    force_makes_flag_ready: true,
+    force_makes_actual_ready: true,
+    normal_start_outcomes: [:when_actual_ready],
+    recovery_start_outcomes: [:when_actual_ready],
+    expect_success: true
+  ),
+  Scenario.new(
+    name: "unrecoverable_route_times_out",
+    description: "Mic route never becomes recordable; failure must stay clear and bounded.",
+    recovering_until_ms: 0,
+    flag_ready_at_ms: nil,
+    actual_ready_at_ms: nil,
+    passive_flag_updates: false,
+    refresh_updates_flag: false,
+    refresh_duration_ms: 100,
+    refresh_never_finishes: false,
+    normal_start_ms: 90,
+    recovery_start_ms: 100,
+    force_recovery_ms: 700,
+    force_makes_flag_ready: false,
+    force_makes_actual_ready: false,
+    normal_start_outcomes: [:fail],
+    recovery_start_outcomes: [:fail],
+    expect_success: false
+  )
+].freeze
+
+def config_variants
+  [
+    BASELINE,
+    BASELINE.dup.tap { |config| config.name = "poll_100ms"; config.poll_ms = 100 },
+    BASELINE.dup.tap { |config| config.name = "poll_75ms"; config.poll_ms = 75 },
+    BASELINE.dup.tap { |config| config.name = "refresh_interval_200ms"; config.refresh_interval_ms = 200 },
+    BASELINE.dup.tap { |config| config.name = "refresh_interval_150ms"; config.refresh_interval_ms = 150 },
+    BASELINE.dup.tap { |config| config.name = "recovery_start_after_3_refreshes"; config.refreshes_before_recovery_start = 3 },
+    BASELINE.dup.tap { |config| config.name = "recovery_start_after_2_refreshes"; config.refreshes_before_recovery_start = 2 },
+    BASELINE.dup.tap { |config| config.name = "max_ready_start_attempts_2"; config.max_recording_start_attempts = 2 },
+    BASELINE.dup.tap { |config| config.name = "max_ready_start_attempts_1"; config.max_recording_start_attempts = 1 },
+    BASELINE.dup.tap { |config| config.name = "force_after_5_refreshes"; config.forced_recovery_refreshes = 5 },
+    BASELINE.dup.tap { |config| config.name = "force_after_4_refreshes"; config.forced_recovery_refreshes = 4 },
+    BASELINE.dup.tap do |config|
+      config.name = "combo_poll100_force5"
+      config.poll_ms = 100
+      config.forced_recovery_refreshes = 5
+    end,
+    BASELINE.dup.tap do |config|
+      config.name = "combo_poll100_ready_attempts2"
+      config.poll_ms = 100
+      config.max_recording_start_attempts = 2
+    end,
+    BASELINE.dup.tap do |config|
+      config.name = "combo_poll100_force5_attempts2"
+      config.poll_ms = 100
+      config.forced_recovery_refreshes = 5
+      config.max_recording_start_attempts = 2
+    end,
+    BASELINE.dup.tap do |config|
+      config.name = "combo_poll100_refresh200_attempts2"
+      config.poll_ms = 100
+      config.refresh_interval_ms = 200
+      config.max_recording_start_attempts = 2
+    end
+  ]
+end
+
+def percentile(values, ratio)
+  return nil if values.empty?
+
+  sorted = values.sort
+  sorted[[((sorted.length - 1) * ratio).ceil, sorted.length - 1].min]
+end
+
+def recording_start_attempts_exhausted?(input_format_ready, attempts, config)
+  input_format_ready && config.max_recording_start_attempts.positive? &&
+    attempts >= config.max_recording_start_attempts
+end
+
+def wait_action(state, config)
+  return :wait_for_recovery if state[:is_recovering]
+
+  exhausted = recording_start_attempts_exhausted?(
+    state[:input_format_ready],
+    state[:recording_start_attempts_since_recovery],
+    config
+  )
+  should_force = state[:readiness_refreshes] >= config.forced_recovery_refreshes || exhausted
+  return :force_input_recovery if should_force && state[:forced_recoveries] < config.max_forced_recoveries
+
+  if state[:input_format_ready]
+    return :refresh_input_readiness if exhausted
+
+    return :start_recording
+  end
+
+  should_try_recovery_start = state[:readiness_refresh_timed_out] ||
+    state[:readiness_refreshes] >= config.refreshes_before_recovery_start
+  return :start_recovery_recording if should_try_recovery_start && state[:recovery_starts].zero?
+
+  if should_try_recovery_start &&
+     state[:forced_recoveries].positive? &&
+     state[:forced_recoveries] < config.max_forced_recoveries &&
+     state[:recovery_starts] < config.max_recovery_start_attempts
+    return :start_recovery_recording
+  end
+
+  :refresh_input_readiness
+end
+
+def ready_at_time?(time_ms, ready_at_ms)
+  ready_at_ms && time_ms >= ready_at_ms
+end
+
+def outcome_success?(outcomes, attempt_index, actual_ready)
+  outcome = outcomes[[attempt_index, outcomes.length - 1].min] || :fail
+  case outcome
+  when :success
+    true
+  when :fail
+    false
+  when :when_actual_ready
+    actual_ready
+  else
+    raise "unknown start outcome: #{outcome.inspect}"
+  end
+end
+
+def start_refresh!(state, now_ms, scenario, forced: false)
+  return false if state[:active_refresh]
+
+  finish_ms = scenario.refresh_never_finishes ? now_ms + 1_000_000 : now_ms + scenario.refresh_duration_ms
+  if forced
+    finish_ms = now_ms + scenario.force_recovery_ms
+    state[:forced_recoveries] += 1
+    state[:readiness_refreshes] = 0
+    state[:recording_start_attempts_since_recovery] = 0
+    state[:active_refresh] = {
+      kind: :force,
+      started_at_ms: now_ms,
+      finish_at_ms: finish_ms
+    }
+  else
+    state[:readiness_refreshes] += 1
+    state[:active_refresh] = {
+      kind: :refresh,
+      started_at_ms: now_ms,
+      finish_at_ms: finish_ms
+    }
+  end
+  true
+end
+
+def complete_refresh_if_ready!(state, now_ms, scenario)
+  active = state[:active_refresh]
+  return unless active && active[:finish_at_ms] <= now_ms
+
+  case active[:kind]
+  when :refresh
+    if scenario.refresh_updates_flag &&
+       ready_at_time?(active[:finish_at_ms], scenario.flag_ready_at_ms)
+      state[:input_format_ready] = true
+    end
+  when :force
+    state[:actual_recording_ready] = true if scenario.force_makes_actual_ready
+    state[:input_format_ready] = true if scenario.force_makes_flag_ready
+  end
+
+  state[:active_refresh] = nil
+end
+
+def cancel_refresh_if_timed_out!(state, now_ms, config)
+  active = state[:active_refresh]
+  return unless active
+  return if now_ms - active[:started_at_ms] < config.refresh_timeout_ms
+
+  state[:active_refresh] = nil
+  state[:readiness_refresh_timed_out] = true
+  state[:refresh_timeouts] += 1
+end
+
+def update_passive_state!(state, now_ms, scenario)
+  if scenario.passive_flag_updates && ready_at_time?(now_ms, scenario.flag_ready_at_ms)
+    state[:input_format_ready] = true
+  end
+
+  if ready_at_time?(now_ms, scenario.actual_ready_at_ms)
+    state[:actual_recording_ready] = true
+  end
+end
+
+def simulate(scenario, config)
+  now_ms = 0
+  state = {
+    active_refresh: nil,
+    actual_recording_ready: ready_at_time?(0, scenario.actual_ready_at_ms),
+    input_format_ready: ready_at_time?(0, scenario.flag_ready_at_ms),
+    readiness_refreshes: 0,
+    forced_recoveries: 0,
+    recovery_starts: 0,
+    normal_starts: 0,
+    refresh_timeouts: 0,
+    readiness_refresh_timed_out: false,
+    recording_start_attempts_since_recovery: 0,
+    is_recovering: scenario.recovering_until_ms.positive?
+  }
+  next_refresh_at_ms = 0
+
+  unless state[:is_recovering] || state[:input_format_ready]
+    start_refresh!(state, now_ms, scenario, forced: false)
+    next_refresh_at_ms = now_ms + config.refresh_interval_ms
+  end
+
+  while now_ms < config.budget_ms
+    complete_refresh_if_ready!(state, now_ms, scenario)
+    cancel_refresh_if_timed_out!(state, now_ms, config)
+    update_passive_state!(state, now_ms, scenario)
+
+    state[:is_recovering] = now_ms < scenario.recovering_until_ms ||
+      (state[:active_refresh]&.fetch(:kind) == :force)
+
+    action = wait_action(state, config)
+    case action
+    when :wait_for_recovery
+      # keep waiting
+    when :refresh_input_readiness
+      if now_ms >= next_refresh_at_ms &&
+         start_refresh!(state, now_ms, scenario, forced: false)
+        next_refresh_at_ms = now_ms + config.refresh_interval_ms
+      end
+    when :force_input_recovery
+      if start_refresh!(state, now_ms, scenario, forced: true)
+        next_refresh_at_ms = now_ms + config.refresh_interval_ms
+      end
+    when :start_recovery_recording
+      state[:recovery_starts] += 1
+      state[:readiness_refresh_timed_out] = false
+      attempt_index = state[:recovery_starts] - 1
+      now_ms += scenario.recovery_start_ms
+      update_passive_state!(state, now_ms, scenario)
+      if outcome_success?(scenario.recovery_start_outcomes, attempt_index, state[:actual_recording_ready])
+        return Result.new(
+          config: config.name,
+          scenario: scenario.name,
+          success: true,
+          time_ms: now_ms,
+          normal_starts: state[:normal_starts],
+          recovery_starts: state[:recovery_starts],
+          refreshes: state[:readiness_refreshes],
+          forced_recoveries: state[:forced_recoveries],
+          refresh_timeouts: state[:refresh_timeouts],
+          reason: "recovery_start"
+        )
+      end
+      if start_refresh!(state, now_ms, scenario, forced: false)
+        next_refresh_at_ms = now_ms + config.refresh_interval_ms
+      end
+    when :start_recording
+      state[:normal_starts] += 1
+      state[:recording_start_attempts_since_recovery] += 1
+      attempt_index = state[:normal_starts] - 1
+      now_ms += scenario.normal_start_ms
+      update_passive_state!(state, now_ms, scenario)
+      if outcome_success?(scenario.normal_start_outcomes, attempt_index, state[:actual_recording_ready])
+        return Result.new(
+          config: config.name,
+          scenario: scenario.name,
+          success: true,
+          time_ms: now_ms,
+          normal_starts: state[:normal_starts],
+          recovery_starts: state[:recovery_starts],
+          refreshes: state[:readiness_refreshes],
+          forced_recoveries: state[:forced_recoveries],
+          refresh_timeouts: state[:refresh_timeouts],
+          reason: "ready_start"
+        )
+      end
+      if start_refresh!(state, now_ms, scenario, forced: false)
+        next_refresh_at_ms = now_ms + config.refresh_interval_ms
+      end
+    else
+      raise "unknown action: #{action.inspect}"
+    end
+
+    now_ms += config.poll_ms
+  end
+
+  Result.new(
+    config: config.name,
+    scenario: scenario.name,
+    success: false,
+    time_ms: config.budget_ms,
+    normal_starts: state[:normal_starts],
+    recovery_starts: state[:recovery_starts],
+    refreshes: state[:readiness_refreshes],
+    forced_recoveries: state[:forced_recoveries],
+    refresh_timeouts: state[:refresh_timeouts],
+    reason: "microphone_start_timeout"
+  )
+end
+
+def summarize(results)
+  successes = results.select(&:success)
+  expected_successes = results.select { |result| scenario_by_name(result.scenario).expect_success }
+  success_times = expected_successes.select(&:success).map(&:time_ms)
+  {
+    successes: successes.length,
+    failures: results.length - successes.length,
+    unexpected_failures: expected_successes.count { |result| !result.success },
+    p50_ms: percentile(success_times, 0.50),
+    p90_ms: percentile(success_times, 0.90),
+    p95_ms: percentile(success_times, 0.95),
+    max_ms: success_times.max,
+    start_attempts: results.sum(&:start_attempts),
+    recovery_starts: results.sum(&:recovery_starts),
+    refreshes: results.sum(&:refreshes),
+    forced_recoveries: results.sum(&:forced_recoveries),
+    refresh_timeouts: results.sum(&:refresh_timeouts),
+    microphone_start_timeouts: results.count { |result| !result.success }
+  }
+end
+
+def scenario_by_name(name)
+  SCENARIOS.find { |scenario| scenario.name == name } || raise("missing scenario #{name}")
+end
+
+def delta(current, baseline)
+  return "" if current.nil? || baseline.nil?
+
+  value = current - baseline
+  value.zero? ? "0" : format("%+d", value)
+end
+
+def print_table(headers, rows)
+  widths = headers.map(&:length)
+  rows.each do |row|
+    row.each_with_index do |cell, index|
+      widths[index] = [widths[index], cell.to_s.length].max
+    end
+  end
+  puts "| #{headers.each_with_index.map { |header, i| header.ljust(widths[i]) }.join(" | ")} |"
+  puts "| #{widths.map { |width| "-" * width }.join(" | ")} |"
+  rows.each do |row|
+    puts "| #{row.each_with_index.map { |cell, i| cell.to_s.ljust(widths[i]) }.join(" | ")} |"
+  end
+end
+
+options = {
+  details: false
+}
+
+OptionParser.new do |parser|
+  parser.banner = "Usage: ruby scripts/ops/dictation-recovery-autoeval.rb [--details]"
+  parser.on("--details", "Print per-scenario rows for every tested knob") do
+    options[:details] = true
+  end
+end.parse!
+
+variants = config_variants
+all_results = variants.to_h do |config|
+  [config.name, SCENARIOS.map { |scenario| simulate(scenario, config) }]
+end
+baseline_summary = summarize(all_results.fetch("baseline"))
+
+puts "# Dictation Recovery Autoeval"
+puts
+puts "Primary metric: request-to-listening time for slow dictation recovery scenarios."
+puts "Guardrails: expected success cases must still succeed; unrecoverable route must time out clearly; attempts and hard recoveries stay bounded."
+puts
+
+puts "## Scenarios"
+print_table(
+  ["scenario", "expect_success", "purpose"],
+  SCENARIOS.map { |scenario| [scenario.name, scenario.expect_success ? "yes" : "no", scenario.description] }
+)
+puts
+
+puts "## Knob Summary"
+summary_rows = variants.map do |config|
+  summary = summarize(all_results.fetch(config.name))
+  [
+    config.name,
+    summary[:p95_ms],
+    delta(summary[:p95_ms], baseline_summary[:p95_ms]),
+    summary[:max_ms],
+    delta(summary[:max_ms], baseline_summary[:max_ms]),
+    summary[:unexpected_failures],
+    summary[:start_attempts],
+    delta(summary[:start_attempts], baseline_summary[:start_attempts]),
+    summary[:refreshes],
+    delta(summary[:refreshes], baseline_summary[:refreshes]),
+    summary[:recovery_starts],
+    summary[:forced_recoveries],
+    summary[:refresh_timeouts],
+    summary[:microphone_start_timeouts]
+  ]
+end
+print_table(
+  [
+    "knob",
+    "p95_ms",
+    "p95_delta",
+    "max_ms",
+    "max_delta",
+    "unexpected_failures",
+    "starts",
+    "start_delta",
+    "refreshes",
+    "refresh_delta",
+    "recovery_starts",
+    "forced",
+    "refresh_timeouts",
+    "mic_timeouts"
+  ],
+  summary_rows
+)
+puts
+
+puts "## Baseline Raw Results"
+baseline_rows = all_results.fetch("baseline").map do |result|
+  [
+    result.scenario,
+    result.success ? "success" : "timeout",
+    result.time_ms,
+    result.normal_starts,
+    result.recovery_starts,
+    result.refreshes,
+    result.forced_recoveries,
+    result.refresh_timeouts,
+    result.reason
+  ]
+end
+print_table(
+  ["scenario", "outcome", "time_ms", "normal", "recovery", "refreshes", "forced", "timeouts", "reason"],
+  baseline_rows
+)
+
+if options[:details]
+  puts
+  puts "## Per-Knob Raw Results"
+  variants.reject { |config| config.name == "baseline" }.each do |config|
+    puts
+    puts "### #{config.name}"
+    rows = all_results.fetch(config.name).map do |result|
+      baseline = all_results.fetch("baseline").find { |base| base.scenario == result.scenario }
+      [
+        result.scenario,
+        result.success ? "success" : "timeout",
+        result.time_ms,
+        delta(result.time_ms, baseline.time_ms),
+        result.normal_starts,
+        result.recovery_starts,
+        result.refreshes,
+        result.forced_recoveries,
+        result.refresh_timeouts,
+        result.reason
+      ]
+    end
+    print_table(
+      ["scenario", "outcome", "time_ms", "delta", "normal", "recovery", "refreshes", "forced", "timeouts", "reason"],
+      rows
+    )
+  end
+end

--- a/scripts/ops/generate-nightly-digest.py
+++ b/scripts/ops/generate-nightly-digest.py
@@ -572,6 +572,13 @@ def classify_lane(automation: Automation, content: str, now: datetime, fresh_hou
             status = "needs_review"
             signal = "Support found user-facing pain that needs a reply or investigation."
             action = "Review support draft"
+        elif contains_any(lower, ("no new external", "no new user", "no new public")) and contains_any(
+            lower,
+            ("no new pr recommended", "no new pr from", "no new pr was opened"),
+        ):
+            status = "watch"
+            signal = "Support found no new external support thread; existing audio and web-route risks stay on watch."
+            action = "Review support watch list"
         elif "support inbox: watch" in lower or "issue #500" in lower:
             status = "watch"
             signal = "Support watch is centered on issue #500 and meeting-audio confidence."
@@ -626,7 +633,13 @@ def classify_lane(automation: Automation, content: str, now: datetime, fresh_hou
     elif automation.id == "transcripted-nightly-reviewer":
         if contains_any(lower, ("needs changes", "blocker")) and "blockers: none" not in lower:
             status = "blocked"
-            if "issue #500" in lower or "#500" in lower:
+            if contains_any(lower, ("live sidecar preview", "live preview", "live sidecar files")) and contains_any(
+                lower,
+                ("no token", "access-control-allow-origin: *", "tokenized preview", "fixed `http://127.0.0.1:47834`"),
+            ):
+                signal = "Reviewer found a live sidecar preview privacy/docs blocker."
+                action = "Hold PR #924 until preview privacy and docs match"
+            elif "issue #500" in lower or "#500" in lower:
                 signal = "Reviewer kept issue #500 as the real user-trust blocker."
                 action = "Run the issue #500 audio matrix"
             else:
@@ -846,6 +859,8 @@ def human_next_steps(
         lane = blocked_lanes[0]
         if lane.human_action == "Run the issue #500 audio matrix":
             steps.append("Run the issue #500 audio matrix before broad meeting-audio or launch claims.")
+        elif lane.human_action.startswith("Hold PR #"):
+            steps.append(f"{lane.human_action}.")
         else:
             steps.append(f"Clear blocker: {lane.name} says {lane.human_action.lower()}.")
 
@@ -1281,6 +1296,8 @@ def build_recommendations(
         lane = blocked_lanes[0]
         if lane.human_action == "Run the issue #500 audio matrix":
             recommendations.append("Run the issue #500 audio matrix before broad meeting-audio or launch claims.")
+        elif lane.human_action.startswith("Hold PR #"):
+            recommendations.append(f"{lane.human_action}.")
         else:
             recommendations.append(f"Clear blocker: {lane.name} says {lane.human_action.lower()}.")
     if open_prs:

--- a/scripts/ops/performance-budget.rb
+++ b/scripts/ops/performance-budget.rb
@@ -17,6 +17,8 @@ MAX_TRANSCRIPTION_P95_SECONDS = 0.5
 MAX_TRANSCRIPTION_P95_RTF = 0.05
 MAX_MODEL_READY_P90_SECONDS = 30.0
 MAX_DICTATION_FAST_START_P95_MS = 250.0
+MAX_DICTATION_REQUEST_TO_RECORDING_P95_MS = 250.0
+MAX_DICTATION_START_TO_FIRST_SAMPLE_P95_MS = 350.0
 MAX_DICTATION_STOP_TO_PASTE_P95_MS = 750.0
 MAX_DICTATION_STOP_TO_DONE_P95_MS = 1_000.0
 MAX_MEETING_P95_RTF = 0.05
@@ -45,6 +47,8 @@ options = {
   max_transcription_p95_rtf: MAX_TRANSCRIPTION_P95_RTF,
   max_model_ready_p90_seconds: MAX_MODEL_READY_P90_SECONDS,
   max_dictation_fast_start_p95_ms: MAX_DICTATION_FAST_START_P95_MS,
+  max_dictation_request_to_recording_p95_ms: MAX_DICTATION_REQUEST_TO_RECORDING_P95_MS,
+  max_dictation_start_to_first_sample_p95_ms: MAX_DICTATION_START_TO_FIRST_SAMPLE_P95_MS,
   max_dictation_stop_to_paste_p95_ms: MAX_DICTATION_STOP_TO_PASTE_P95_MS,
   max_dictation_stop_to_done_p95_ms: MAX_DICTATION_STOP_TO_DONE_P95_MS,
   max_meeting_p95_rtf: MAX_MEETING_P95_RTF,
@@ -70,6 +74,8 @@ OptionParser.new do |parser|
   parser.on("--max-transcription-p95-rtf VALUE", Float, "Dictation transcription p95 RTF budget") { |rtf| options[:max_transcription_p95_rtf] = rtf }
   parser.on("--max-model-ready-p90-s SECONDS", Float, "Launch to model-ready p90 budget") { |seconds| options[:max_model_ready_p90_seconds] = seconds }
   parser.on("--max-dictation-fast-start-p95-ms MS", Float, "Ready-engine dictation fast-start p95 budget") { |ms| options[:max_dictation_fast_start_p95_ms] = ms }
+  parser.on("--max-dictation-request-to-recording-p95-ms MS", Float, "Dictation request-to-recording p95 budget for strict fresh start proof") { |ms| options[:max_dictation_request_to_recording_p95_ms] = ms }
+  parser.on("--max-dictation-start-to-first-sample-p95-ms MS", Float, "Dictation start-to-first-audio-sample p95 budget for strict fresh start proof") { |ms| options[:max_dictation_start_to_first_sample_p95_ms] = ms }
   parser.on("--max-dictation-stop-to-paste-p95-ms MS", Float, "Dictation stop-to-paste p95 budget") { |ms| options[:max_dictation_stop_to_paste_p95_ms] = ms }
   parser.on("--max-dictation-stop-to-done-p95-ms MS", Float, "Dictation stop pipeline p95 budget") { |ms| options[:max_dictation_stop_to_done_p95_ms] = ms }
   parser.on("--max-meeting-p95-rtf VALUE", Float, "Meeting processing p95 real-time-factor budget") { |rtf| options[:max_meeting_p95_rtf] = rtf }
@@ -275,15 +281,20 @@ if options[:events_path]
       .map { |event| [event["_time"], float_or_nil(event.fetch("context", {})["start_ms"])] }
       .select { |time, value| time && value }
     dictation_fast_start_ms = dictation_fast_starts.map { |_, value| value }
-    dictation_request_to_recording_ms = events
+    first_fast_start_time = dictation_fast_starts.map(&:first).min
+    dictation_start_proof_events = if first_fast_start_time
+      events.select { |event| event["_time"] && event["_time"] >= first_fast_start_time }
+    else
+      events
+    end
+    dictation_request_to_recording_ms = dictation_start_proof_events
       .select { |event| ["dictation_recording_fast_start", "dictation_started_after_wait"].include?(event["event"]) }
       .map { |event| float_or_nil(event.fetch("context", {})["request_to_recording_ms"]) }
       .compact
-    dictation_start_to_first_sample_ms = events
+    dictation_start_to_first_sample_ms = dictation_start_proof_events
       .select { |event| event["event"] == "audio_samples_detected" }
       .map { |event| float_or_nil(event.fetch("context", {})["start_to_first_sample_ms"]) }
       .compact
-    first_fast_start_time = dictation_fast_starts.map(&:first).min
     fast_start_fallback_events = if first_fast_start_time
       events.select do |event|
         [
@@ -327,11 +338,24 @@ if options[:events_path]
       end
     end
 
-    if options[:require_dictation_fast_start_samples].positive?
-      if dictation_fast_start_ms.length < options[:require_dictation_fast_start_samples]
-        errors << "Only #{dictation_fast_start_ms.length} dictation fast-start samples, need at least #{options[:require_dictation_fast_start_samples]}"
+    required_fast_start_samples = options[:require_dictation_fast_start_samples]
+    if required_fast_start_samples.positive?
+      if dictation_fast_start_ms.length < required_fast_start_samples
+        errors << "Only #{dictation_fast_start_ms.length} dictation fast-start samples, need at least #{required_fast_start_samples}"
       elsif percentile(dictation_fast_start_ms, 0.95) > options[:max_dictation_fast_start_p95_ms]
         errors << "Dictation fast-start p95 is #{format("%.1fms", percentile(dictation_fast_start_ms, 0.95))}, above #{format("%.1fms", options[:max_dictation_fast_start_p95_ms])}"
+      end
+
+      if dictation_request_to_recording_ms.length < required_fast_start_samples
+        errors << "Only #{dictation_request_to_recording_ms.length} dictation request-to-recording samples, need at least #{required_fast_start_samples}"
+      elsif percentile(dictation_request_to_recording_ms, 0.95) > options[:max_dictation_request_to_recording_p95_ms]
+        errors << "Dictation request-to-recording p95 is #{format("%.1fms", percentile(dictation_request_to_recording_ms, 0.95))}, above #{format("%.1fms", options[:max_dictation_request_to_recording_p95_ms])}"
+      end
+
+      if dictation_start_to_first_sample_ms.length < required_fast_start_samples
+        errors << "Only #{dictation_start_to_first_sample_ms.length} dictation start-to-first-sample samples, need at least #{required_fast_start_samples}"
+      elsif percentile(dictation_start_to_first_sample_ms, 0.95) > options[:max_dictation_start_to_first_sample_p95_ms]
+        errors << "Dictation start-to-first-sample p95 is #{format("%.1fms", percentile(dictation_start_to_first_sample_ms, 0.95))}, above #{format("%.1fms", options[:max_dictation_start_to_first_sample_p95_ms])}"
       end
 
       unless fast_start_fallback_events.empty?

--- a/scripts/ops/performance-budget.rb
+++ b/scripts/ops/performance-budget.rb
@@ -275,6 +275,14 @@ if options[:events_path]
       .map { |event| [event["_time"], float_or_nil(event.fetch("context", {})["start_ms"])] }
       .select { |time, value| time && value }
     dictation_fast_start_ms = dictation_fast_starts.map { |_, value| value }
+    dictation_request_to_recording_ms = events
+      .select { |event| ["dictation_recording_fast_start", "dictation_started_after_wait"].include?(event["event"]) }
+      .map { |event| float_or_nil(event.fetch("context", {})["request_to_recording_ms"]) }
+      .compact
+    dictation_start_to_first_sample_ms = events
+      .select { |event| event["event"] == "audio_samples_detected" }
+      .map { |event| float_or_nil(event.fetch("context", {})["start_to_first_sample_ms"]) }
+      .compact
     first_fast_start_time = dictation_fast_starts.map(&:first).min
     fast_start_fallback_events = if first_fast_start_time
       events.select do |event|
@@ -353,6 +361,10 @@ if options[:events_path]
       startup_p90: percentile(startup_durations, 0.90),
       dictation_fast_start_samples: dictation_fast_start_ms.length,
       dictation_fast_start_p95: percentile(dictation_fast_start_ms, 0.95),
+      dictation_request_to_recording_samples: dictation_request_to_recording_ms.length,
+      dictation_request_to_recording_p95: percentile(dictation_request_to_recording_ms, 0.95),
+      dictation_start_to_first_sample_samples: dictation_start_to_first_sample_ms.length,
+      dictation_start_to_first_sample_p95: percentile(dictation_start_to_first_sample_ms, 0.95),
       dictation_fast_start_fallback_events: fast_start_fallback_events.length,
       dictation_stop_latency_samples: dictation_stop_latency_events.length,
       dictation_stop_to_paste_p95: percentile(dictation_stop_to_paste_ms, 0.95),
@@ -427,6 +439,14 @@ if runtime_summary
   puts "Dictation fast-start samples: #{runtime_summary[:dictation_fast_start_samples]}"
   if runtime_summary[:dictation_fast_start_p95]
     puts "Dictation fast-start p95: #{format("%.1fms", runtime_summary[:dictation_fast_start_p95])}"
+  end
+  puts "Dictation request-to-recording samples: #{runtime_summary[:dictation_request_to_recording_samples]}"
+  if runtime_summary[:dictation_request_to_recording_p95]
+    puts "Dictation request-to-recording p95: #{format("%.1fms", runtime_summary[:dictation_request_to_recording_p95])}"
+  end
+  puts "Dictation start-to-first-sample samples: #{runtime_summary[:dictation_start_to_first_sample_samples]}"
+  if runtime_summary[:dictation_start_to_first_sample_p95]
+    puts "Dictation start-to-first-sample p95: #{format("%.1fms", runtime_summary[:dictation_start_to_first_sample_p95])}"
   end
   puts "Dictation fast-start fallback/retry events: #{runtime_summary[:dictation_fast_start_fallback_events]}"
   puts "Dictation stop latency samples: #{runtime_summary[:dictation_stop_latency_samples]}"


### PR DESCRIPTION
Draft replacement for #918.\n\nThis replays only the commits unique to #918 onto current origin/main, excluding the lower-stack codex/dictation-stop-autoeval work at 5093edd4. The original #918 should be superseded by this PR or force-pushed later only with coordinator approval.\n\nValidation run locally in /Users/redbars/coord-worktrees/pr918-unstack-main:\n- git diff --check\n- ruby -c scripts/ops/dictation-recovery-autoeval.rb\n- ruby -c scripts/ops/performance-budget.rb\n- ruby scripts/ops/dictation-recovery-autoeval.rb\n- ruby scripts/ops/dictation-recovery-autoeval.rb --details\n- scripts/dev/agent-preflight.sh\n- bash build-deps.sh --force\n- bash build.sh --no-open\n- bash run-tests.sh (3504 passed, 0 failed)