### PR TITLE
[test-generator] Cover Bluetooth readiness reason guardrails

### DIFF
--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -216,6 +216,62 @@ func testParakeetStartRecordingFailurePolicy() {
         assertEqual(readiness, .ready, "built-in fallback for Bluetooth output should start instead of timing out")
     }
 
+    runSuite("ParakeetAudioFormatReadinessPolicy accepts preferred fallback across Bluetooth speech rates") {
+        for outputRate in [8_000.0, 16_000.0] {
+            let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+                outputSampleRate: outputRate,
+                outputChannelCount: 1,
+                inputSampleRate: 48_000,
+                inputChannelCount: 1,
+                selectedInputClass: "built_in",
+                outputDeviceClass: "bluetooth",
+                selectionOverrodeDefault: true,
+                selectionReason: .preferredBuiltInForBluetoothHeadset
+            )
+
+            assertEqual(readiness, .ready, "preferred built-in fallback should not wait on Bluetooth speech output rate \(outputRate)")
+        }
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy defers non-preferred override reasons on Bluetooth output") {
+        let nonPreferredReasons: [DictationInputDeviceSelectionReason] = [
+            .defaultIsSafe,
+            .builtInFallbackSuppressedForRecoveryAttempt,
+            .noBuiltInFallbackAvailable
+        ]
+
+        for reason in nonPreferredReasons {
+            let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+                outputSampleRate: 24_000,
+                outputChannelCount: 1,
+                inputSampleRate: 48_000,
+                inputChannelCount: 1,
+                selectedInputClass: "built_in",
+                outputDeviceClass: "bluetooth",
+                selectionOverrodeDefault: true,
+                selectionReason: reason
+            )
+
+            assertEqual(readiness, .routeNotSettled, "\(reason.rawValue) should not bypass route settling")
+            assertEqual(readiness.startFailureReason, .audioRouteNotSettled, "\(reason.rawValue) should keep the start failure recoverable")
+        }
+    }
+
+    runSuite("ParakeetAudioFormatReadinessPolicy scopes preferred fallback exception to Bluetooth output") {
+        let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
+            outputSampleRate: 24_000,
+            outputChannelCount: 1,
+            inputSampleRate: 48_000,
+            inputChannelCount: 1,
+            selectedInputClass: "built_in",
+            outputDeviceClass: "built_in",
+            selectionOverrodeDefault: true,
+            selectionReason: .preferredBuiltInForBluetoothHeadset
+        )
+
+        assertEqual(readiness, .routeNotSettled, "preferred fallback should still wait on stale non-Bluetooth output formats")
+    }
+
     runSuite("ParakeetAudioFormatReadinessPolicy accepts intentional Bluetooth output speech bus") {
         let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
             outputSampleRate: 24_000,


### PR DESCRIPTION
## Missing coverage

Recent Speech changes allow the built-in mic fallback to skip Bluetooth output route settling only when the input selection reason is `preferredBuiltInForBluetoothHeadset`. Existing tests covered the primary happy path, but not the reason guardrails or the non-Bluetooth stale-output shape.

## Tests added

- Preferred built-in fallback stays ready across additional Bluetooth speech output rates.
- Non-preferred selection reasons still defer as `routeNotSettled` on Bluetooth speech output.
- The preferred-fallback exception stays scoped to Bluetooth output and does not bypass stale non-Bluetooth output formats.

## Checks run

- `bash scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (3513 passed, 0 failed)