### PR TITLE
Release Transcripted 1.1.46

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.45"
-  sha256 "f7d255ab0452fd99fd50b1f85cbb6b5364a93f5611ea0e6c51e53c49f13f8cb8"
+  version "1.1.46"
+  sha256 "12f9d94caf9f43d93f5739da34bbcf60faba0c61d40e9aeebd94a783b1ba7999"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.45</string>
+	<string>1.1.46</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.45</string>
+	<string>1.1.46</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.46</title>
+      <pubDate>Tue, 02 Jun 2026 21:46:53 -0500</pubDate>
+      <sparkle:version>1.1.46</sparkle:version>
+      <sparkle:shortVersionString>1.1.46</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.46/Transcripted-1.1.46.dmg" length="535870030" type="application/octet-stream" sparkle:edSignature="NyGRNcncaJplgnaQH7xG3FUMBqAZoEtvoTgaQk4Zkx7J1QUX8bqQwaxmQjEuQ3nizmDR80EHwCyw5U0gwuKJDw==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.46</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.46</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.45</title>
       <pubDate>Mon, 01 Jun 2026 22:21:37 -0500</pubDate>
       <sparkle:version>1.1.45</sparkle:version>


### PR DESCRIPTION
Release metadata for Transcripted 1.1.46.\n\nIncluded:\n- Bump app bundle version to 1.1.46\n- Add Sparkle appcast entry for the notarized GitHub DMG\n- Update Homebrew cask sha256 for the 1.1.46 asset\n\nLocal verification:\n- bash build-deps.sh --force\n- NOTARY_PROFILE=Transcripted bash build-beta.sh "" Transcripted\n- dSYM UUID matches app binary: 0BC4858C-F1C6-337D-9976-072F6B1FCF95\n- bash scripts/release/verify-sparkle-release.sh 1.1.46\n- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh (3504 passed)\n\nKnown caveat:\n- Sentry release/dSYM upload is blocked by current local Sentry token being read-only/403.