### PR TITLE
[codex] Clarify dictation model loading overlay

### DIFF
--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -1164,29 +1164,29 @@ class DictationSessionController: ObservableObject {
         switch modelState {
         case .notLoaded:
             return .init(
-                title: "Starting dictation",
-                detail: "Transcripted is waking up the local voice model before it starts listening.",
+                title: "Starting voice model",
+                detail: "Recording starts automatically when it's ready.",
                 progress: 0.08,
                 status: "Preparing local model"
             )
         case .downloading(let progress):
             return .init(
-                title: "Downloading dictation model",
-                detail: "Transcripted is downloading the on-device voice model needed for local dictation.",
+                title: "Downloading voice model",
+                detail: "Keep Transcripted open. Dictation will start when it's ready.",
                 progress: max(0.12, min(0.84, 0.12 + progress * 0.72)),
                 status: "\(Int(progress * 100))% complete"
             )
         case .cached:
             return .init(
-                title: "Loading dictation",
-                detail: "Transcripted has the model files and is loading them into memory. Recording starts automatically when it finishes.",
+                title: "Loading voice model",
+                detail: "Recording starts automatically when it's ready.",
                 progress: 0.88,
                 status: "Loading cached model"
             )
         case .loading:
             return .init(
-                title: "Loading dictation",
-                detail: "Transcripted has the model files and is loading them into memory. Recording starts automatically when it finishes.",
+                title: "Loading voice model",
+                detail: "Recording starts automatically when it's ready.",
                 progress: 0.92,
                 status: "Almost ready"
             )

--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -14,8 +14,8 @@ class FloatingOverlayController {
         let status: String?
 
         static let initial = LoadingPresentation(
-            title: "Loading dictation",
-            detail: "Transcripted is getting the local voice model ready.",
+            title: "Loading voice model",
+            detail: "Recording starts automatically when it's ready.",
             progress: 0.08,
             status: "Starting up"
         )

--- a/Sources/UI/Overlay/OverlayHeaderView.swift
+++ b/Sources/UI/Overlay/OverlayHeaderView.swift
@@ -286,7 +286,7 @@ final class OverlayHeaderView: NSView {
             modeLabel.stringValue = "Pasted"
             modeLabel.textColor = OverlayTokens.textPrimary
         case .loading:
-            modeLabel.stringValue = loadingTitle ?? "Loading dictation"
+            modeLabel.stringValue = loadingTitle ?? "Dictation"
             modeLabel.textColor = OverlayTokens.textSecondary
         case .idle:
             modeLabel.stringValue = "Dictation"

--- a/Sources/UI/Overlay/OverlayRootView.swift
+++ b/Sources/UI/Overlay/OverlayRootView.swift
@@ -139,7 +139,7 @@ final class OverlayRootView: NSView {
         headerView.update(
             state: state,
             dictationShortcutHint: dictationShortcutHint,
-            loadingTitle: state == .loading ? loadingPresentation.title : nil,
+            loadingTitle: state == .loading ? "Dictation" : nil,
             isError: showError,
             isMiniCursorMode: isMiniCursorMode,
             meterPresentation: DictationMeterPolicy.presentation(
@@ -225,9 +225,9 @@ final class OverlayLoadingView: NSView {
         let pad: CGFloat = 14
         let contentWidth = max(0, bounds.width - pad * 2)
 
-        titleLabel.frame = NSRect(x: pad, y: 12, width: contentWidth, height: 16)
-        detailLabel.frame = NSRect(x: pad, y: 32, width: contentWidth, height: 16)
-        progressBar.frame = NSRect(x: pad, y: 54, width: contentWidth, height: 6)
+        titleLabel.frame = NSRect(x: pad, y: 9, width: contentWidth, height: 16)
+        detailLabel.frame = NSRect(x: pad, y: 29, width: contentWidth, height: 28)
+        progressBar.frame = NSRect(x: pad, y: 59, width: contentWidth, height: 6)
     }
 
     func update(


### PR DESCRIPTION
## Summary
- Simplifies the dictation model-loading overlay copy so users see one clear explanation.
- Keeps the header as `Dictation` and moves the actual state into the body: loading/downloading/starting the voice model.
- Gives the loading detail label enough height so short explanatory text does not clip.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (3504 passed)