### PR TITLE
[codex] Extend meeting prompt timeout

### DIFF
--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -1077,6 +1077,7 @@ enum MeetingOverlayTokens {
     static let tooltipOffset: CGFloat = 8
     static let tooltipScreenInset: CGFloat = 6
     static let tooltipDelayNanoseconds: UInt64 = 80_000_000
+    static let defaultDetectedMeetingPromptTimeoutSeconds = 30
 }
 
 // MARK: - Controller
@@ -1212,7 +1213,10 @@ final class MeetingOverlayController {
     }
 
     @discardableResult
-    func presentDetectedMeetingPrompt(_ candidate: MeetingPromptDetector.Candidate, timeout seconds: Int = 10) -> Bool {
+    func presentDetectedMeetingPrompt(
+        _ candidate: MeetingPromptDetector.Candidate,
+        timeout seconds: Int = MeetingOverlayTokens.defaultDetectedMeetingPromptTimeoutSeconds
+    ) -> Bool {
         guard let session = meetingSession else { return false }
 
         switch session.state {


### PR DESCRIPTION
## Summary

- Extend the detected meeting prompt countdown from 10 seconds to 30 seconds.
- Move the default into a named overlay token so explicit test/debug timeouts can still override it.

## Why

The meeting reminder popup was disappearing too quickly. This gives users a longer window to notice it and choose Record, Remind me soon, or Not now.

## Impact

Only the detected meeting prompt default changed. Audio-inactivity prompts keep their existing countdown behavior.

## Verification

- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` - 3504 passed