### PR TITLE
Fix delayed dictation pasteback clipboard race

### DIFF
--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -138,6 +138,12 @@ final class ClipboardRestoringTextPaster {
         temporaryPasteboardDataProvider = nil
     }
 
+    func waitForPendingClipboardRestore() async {
+        while let clipboardRestoreTask {
+            await clipboardRestoreTask.value
+        }
+    }
+
     func paste(
         _ text: String,
         target: DictationPasteTarget? = nil,

--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -1,6 +1,6 @@
 // ClipboardRestoringTextPaster.swift
 // Pastes text into the current target app by borrowing the clipboard briefly
-// and restoring the prior clipboard contents after Cmd+V completes.
+// and restoring the prior clipboard contents after the target reads the text.
 
 import AppKit
 import ApplicationServices
@@ -47,6 +47,45 @@ enum TextPasteOutcome: Equatable {
     }
 }
 
+@MainActor
+protocol ClipboardPasteboard: AnyObject {
+    var changeCount: Int { get }
+    var pasteboardItems: [NSPasteboardItem]? { get }
+
+    @discardableResult
+    func clearContents() -> Int
+
+    @discardableResult
+    func setString(_ string: String, forType dataType: NSPasteboard.PasteboardType) -> Bool
+
+    func string(forType dataType: NSPasteboard.PasteboardType) -> String?
+
+    @discardableResult
+    func writePasteboardItems(_ items: [NSPasteboardItem]) -> Bool
+}
+
+extension NSPasteboard: ClipboardPasteboard {
+    @discardableResult
+    func writePasteboardItems(_ items: [NSPasteboardItem]) -> Bool {
+        writeObjects(items)
+    }
+}
+
+private func postClipboardPasteShortcut() -> Bool {
+    guard let vDown = CGEvent(keyboardEventSource: nil, virtualKey: 0x09, keyDown: true),
+          let vUp = CGEvent(keyboardEventSource: nil, virtualKey: 0x09, keyDown: false) else {
+        return false
+    }
+
+    vDown.flags = .maskCommand
+    vDown.post(tap: .cghidEventTap)
+
+    vUp.flags = .maskCommand
+    vUp.post(tap: .cghidEventTap)
+
+    return true
+}
+
 struct DictationPasteTarget: Equatable {
     let processIdentifier: pid_t?
     let bundleIdentifier: String?
@@ -85,20 +124,33 @@ final class ClipboardRestoringTextPaster {
     typealias PasteboardSnapshot = [[NSPasteboard.PasteboardType: Data]]
 
     private var clipboardRestoreTask: Task<Void, Never>?
+    private var temporaryPasteboardDataProvider: TemporaryPasteboardStringProvider?
+    private var pasteGeneration = 0
 
     deinit {
         clipboardRestoreTask?.cancel()
     }
 
     func cancelPendingClipboardRestore() {
+        pasteGeneration += 1
         clipboardRestoreTask?.cancel()
         clipboardRestoreTask = nil
+        temporaryPasteboardDataProvider = nil
     }
 
     func paste(
         _ text: String,
         target: DictationPasteTarget? = nil,
-        activationWait: TimeInterval = TranscriptedConstants.clipboardTargetActivationWait
+        activationWait: TimeInterval = TranscriptedConstants.clipboardTargetActivationWait,
+        pasteboard: any ClipboardPasteboard = NSPasteboard.general,
+        accessibilityTrusted: () -> Bool = { AXIsProcessTrusted() },
+        requestAccessibilityTrust: () -> Void = {
+            let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+            _ = AXIsProcessTrustedWithOptions(options)
+        },
+        pasteDispatcher: @MainActor () -> Bool = postClipboardPasteShortcut,
+        restoreDelay: UInt64 = TranscriptedConstants.clipboardRestoreDelay,
+        fallbackRestoreDelay: UInt64 = TranscriptedConstants.clipboardRestoreFallbackDelay
     ) -> TextPasteOutcome {
         cancelPendingClipboardRestore()
 
@@ -112,49 +164,93 @@ final class ClipboardRestoringTextPaster {
             )
         }
 
-        guard AXIsProcessTrusted() else {
-            let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
-            _ = AXIsProcessTrustedWithOptions(options)
-            copyTextToClipboard(text)
+        guard accessibilityTrusted() else {
+            requestAccessibilityTrust()
+            copyTextToClipboard(text, to: pasteboard)
             return .copied(
                 "Couldn't paste automatically. Accessibility is off, so the text was copied.",
                 reason: .accessibilityMissing
             )
         }
 
-        let pasteboard = NSPasteboard.general
         let savedItems = snapshotPasteboardItems(from: pasteboard)
+        pasteGeneration += 1
+        let generation = pasteGeneration
+        var temporaryChangeCount = 0
 
         pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
+        let wroteTemporaryString = writeTemporaryString(text, to: pasteboard) { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.scheduleClipboardRestore(
+                    savedItems,
+                    temporaryString: text,
+                    temporaryChangeCount: temporaryChangeCount,
+                    to: pasteboard,
+                    generation: generation,
+                    delay: restoreDelay
+                )
+            }
+        }
 
-        guard let vDown = CGEvent(keyboardEventSource: nil, virtualKey: 0x09, keyDown: true),
-              let vUp = CGEvent(keyboardEventSource: nil, virtualKey: 0x09, keyDown: false) else {
+        if !wroteTemporaryString {
+            pasteboard.clearContents()
+            guard pasteboard.setString(text, forType: .string),
+                  pasteboard.string(forType: .string) == text else {
+                return .failed("Couldn't prepare the clipboard for automatic paste. The dictation was saved, but paste-back did not run.")
+            }
+        }
+        temporaryChangeCount = pasteboard.changeCount
+
+        scheduleClipboardRestore(
+            savedItems,
+            temporaryString: text,
+            temporaryChangeCount: temporaryChangeCount,
+            to: pasteboard,
+            generation: generation,
+            delay: fallbackRestoreDelay
+        )
+
+        guard pasteDispatcher() else {
+            cancelPendingClipboardRestore()
+            guard copyTextToClipboard(text, to: pasteboard) else {
+                return .failed("Couldn't prepare the clipboard for automatic paste. The dictation was saved, but paste-back did not run.")
+            }
             return .copied(
                 "Couldn't paste automatically. The text was copied instead.",
                 reason: .pasteEventCreationFailed
             )
         }
 
-        vDown.flags = .maskCommand
-        vDown.post(tap: .cghidEventTap)
+        return .pasted
+    }
 
-        vUp.flags = .maskCommand
-        vUp.post(tap: .cghidEventTap)
-
-        let changeCountAfterSet = pasteboard.changeCount
+    private func scheduleClipboardRestore(
+        _ savedItems: PasteboardSnapshot,
+        temporaryString: String,
+        temporaryChangeCount: Int,
+        to pasteboard: any ClipboardPasteboard,
+        generation: Int,
+        delay: UInt64
+    ) {
+        guard generation == pasteGeneration else { return }
+        clipboardRestoreTask?.cancel()
         clipboardRestoreTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(nanoseconds: TranscriptedConstants.clipboardRestoreDelay)
-            guard !Task.isCancelled else { return }
-            self?.restorePasteboardItems(
+            try? await Task.sleep(nanoseconds: delay)
+            guard let self,
+                  !Task.isCancelled,
+                  self.pasteGeneration == generation else { return }
+            self.restorePasteboardItems(
                 savedItems,
-                temporaryString: text,
-                temporaryChangeCount: changeCountAfterSet,
+                temporaryString: temporaryString,
+                temporaryChangeCount: temporaryChangeCount,
                 to: pasteboard
             )
+            self.temporaryPasteboardDataProvider = nil
+            self.clipboardRestoreTask = nil
+            if self.pasteGeneration == generation {
+                self.pasteGeneration += 1
+            }
         }
-
-        return .pasted
     }
 
     private func waitForTargetActivation(_ target: DictationPasteTarget, timeout: TimeInterval) -> Bool {
@@ -170,13 +266,40 @@ final class ClipboardRestoringTextPaster {
         return target.matchesCurrentFrontmostApp()
     }
 
-    func copyTextToClipboard(_ text: String) {
-        let pasteboard = NSPasteboard.general
+    @discardableResult
+    func copyTextToClipboard(_ text: String, to pasteboard: any ClipboardPasteboard = NSPasteboard.general) -> Bool {
         pasteboard.clearContents()
-        pasteboard.setString(text, forType: .string)
+        return pasteboard.setString(text, forType: .string)
+            && pasteboard.string(forType: .string) == text
     }
 
-    func snapshotPasteboardItems(from pasteboard: NSPasteboard) -> PasteboardSnapshot {
+    @discardableResult
+    func writeTemporaryString(
+        _ text: String,
+        to pasteboard: any ClipboardPasteboard,
+        onTemporaryStringRead: @escaping () -> Void
+    ) -> Bool {
+        guard pasteboard is NSPasteboard else { return false }
+
+        let provider = TemporaryPasteboardStringProvider(
+            text: text,
+            onTemporaryStringRead: onTemporaryStringRead
+        )
+        let item = NSPasteboardItem()
+        guard item.setDataProvider(provider, forTypes: [.string]) else {
+            return false
+        }
+
+        guard pasteboard.writePasteboardItems([item]) else {
+            temporaryPasteboardDataProvider = nil
+            return false
+        }
+
+        temporaryPasteboardDataProvider = provider
+        return true
+    }
+
+    func snapshotPasteboardItems(from pasteboard: any ClipboardPasteboard) -> PasteboardSnapshot {
         pasteboard.pasteboardItems?.map { item in
             var typeData: [NSPasteboard.PasteboardType: Data] = [:]
             for type in item.types {
@@ -192,7 +315,7 @@ final class ClipboardRestoringTextPaster {
         _ savedItems: PasteboardSnapshot,
         temporaryString: String,
         temporaryChangeCount: Int,
-        to pasteboard: NSPasteboard
+        to pasteboard: any ClipboardPasteboard
     ) {
         guard pasteboard.changeCount == temporaryChangeCount,
               pasteboard.string(forType: .string) == temporaryString else {
@@ -208,7 +331,40 @@ final class ClipboardRestoringTextPaster {
             return item
         }
         if !items.isEmpty {
-            pasteboard.writeObjects(items)
+            pasteboard.writePasteboardItems(items)
+        }
+    }
+}
+
+private final class TemporaryPasteboardStringProvider: NSObject, NSPasteboardItemDataProvider {
+    private let text: String
+    private let onTemporaryStringRead: () -> Void
+    private let lock = NSLock()
+    private var didNotifyRead = false
+
+    init(text: String, onTemporaryStringRead: @escaping () -> Void) {
+        self.text = text
+        self.onTemporaryStringRead = onTemporaryStringRead
+    }
+
+    func pasteboard(
+        _ pasteboard: NSPasteboard?,
+        item: NSPasteboardItem,
+        provideDataForType type: NSPasteboard.PasteboardType
+    ) {
+        guard type == .string else { return }
+        item.setString(text, forType: .string)
+        notifyReadOnce()
+    }
+
+    private func notifyReadOnce() {
+        lock.lock()
+        let shouldNotify = !didNotifyRead
+        didNotifyRead = true
+        lock.unlock()
+
+        if shouldNotify {
+            onTemporaryStringRead()
         }
     }
 }

--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -157,8 +157,14 @@ enum TranscriptedConstants {
 
     // MARK: - Clipboard
 
-    /// Delay after posting Cmd+V before restoring the user's clipboard.
+    /// Delay after the target app reads the borrowed dictation text before
+    /// restoring the user's clipboard.
     static let clipboardRestoreDelay: UInt64 = 120_000_000  // 120ms
+
+    /// Maximum time to keep borrowed dictation text available if the target app
+    /// has not requested it yet. This protects slower paste consumers without
+    /// leaving the user's clipboard borrowed indefinitely.
+    static let clipboardRestoreFallbackDelay: UInt64 = 900_000_000  // 900ms
 
     /// Max time to wait for a just-activated target app before paste-back falls
     /// back to copying. This covers menu/settings flows where activation is async.

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -1428,6 +1428,10 @@ class DictationSessionController: ObservableObject {
 
         try? await Task.sleep(nanoseconds: TranscriptedConstants.dictationAutoEnterDelay)
         guard !Task.isCancelled else { return .disabled }
+        if delivery == .pasted {
+            await textPaster.waitForPendingClipboardRestore()
+        }
+        guard !Task.isCancelled else { return .disabled }
         return autoSender.send(DictationAutoSendPreferences.sendKey())
     }
 

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -190,6 +190,11 @@ func testClipboardRestoringTextPaster() async {
         }
 
         assertEqual(outcome, .pasted, "valid pasteback should report automatic paste")
+        let waitTask = Task { @MainActor in
+            await paster.waitForPendingClipboardRestore()
+            let pasteboard = NSPasteboard(name: pasteboardName)
+            return pasteboard.string(forType: .string)
+        }
         try? await Task.sleep(nanoseconds: 30_000_000)
 
         let delayedRead = await MainActor.run {
@@ -202,15 +207,11 @@ func testClipboardRestoringTextPaster() async {
             "a target that reads after the eager restore delay should still get the dictation text"
         )
 
-        try? await Task.sleep(nanoseconds: 20_000_000)
-        let restoredClipboard = await MainActor.run {
-            let pasteboard = NSPasteboard(name: pasteboardName)
-            return pasteboard.string(forType: .string)
-        }
+        let restoredClipboard = await waitTask.value
         assertEqual(
             restoredClipboard,
             existingClipboard,
-            "after the target reads the temporary text, the user's original clipboard should be restored"
+            "waiting for pending restore should include the delayed read-triggered restore before auto-enter"
         )
     }
 }

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -65,6 +65,72 @@ func testClipboardRestoringTextPaster() async {
             )
         }
 
+        runSuite("ClipboardRestoringTextPaster.paste — dispatches after dictation text is on the pasteboard") {
+            let pasteboard = FakeClipboardPasteboard(initialString: "synthetic existing clipboard")
+            let paster = ClipboardRestoringTextPaster()
+            let dictationText = "synthetic just-finished dictation"
+            var observedTextAtPost: String?
+            var postCount = 0
+
+            let outcome = paster.paste(
+                dictationText,
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: {
+                    postCount += 1
+                    observedTextAtPost = pasteboard.string(forType: .string)
+                    return true
+                }
+            )
+
+            assertEqual(outcome, .pasted, "valid pasteboard write should allow automatic paste")
+            assertEqual(postCount, 1, "automatic paste should dispatch exactly once")
+            assertEqual(
+                observedTextAtPost,
+                dictationText,
+                "paste shortcut should only fire after the borrowed clipboard contains dictation text"
+            )
+        }
+
+        runSuite("ClipboardRestoringTextPaster.paste — blocks Cmd+V when the dictation clipboard write fails") {
+            let existingClipboard = "synthetic existing clipboard"
+            let pasteboard = FakeClipboardPasteboard(
+                initialString: existingClipboard,
+                clearContentsClears: false,
+                setStringSucceeds: false,
+                writePasteboardItemsSucceeds: false
+            )
+            let paster = ClipboardRestoringTextPaster()
+            var observedTextAtPost: String?
+            var postCount = 0
+
+            let outcome = paster.paste(
+                "synthetic just-finished dictation",
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: {
+                    postCount += 1
+                    observedTextAtPost = pasteboard.string(forType: .string)
+                    return true
+                }
+            )
+
+            assertEqual(
+                outcome,
+                .failed("Couldn't prepare the clipboard for automatic paste. The dictation was saved, but paste-back did not run."),
+                "failed clipboard writes should be reported as paste-back failures"
+            )
+            assertEqual(postCount, 0, "Cmd+V should not fire when the dictation text is not on the pasteboard")
+            assertNil(observedTextAtPost, "failed pasteboard prep should not reach the paste dispatcher")
+            assertEqual(
+                pasteboard.string(forType: .string),
+                existingClipboard,
+                "failed pasteback should not paste the pre-existing clipboard contents"
+            )
+        }
+
         runSuite("DictationPasteTarget — accepts only the captured foreground app") {
             let target = DictationPasteTarget(
                 processIdentifier: 42,
@@ -99,10 +165,129 @@ func testClipboardRestoringTextPaster() async {
             )
         }
     }
+
+    await runSuite("ClipboardRestoringTextPaster.paste — keeps dictation available for delayed paste consumers") {
+        let existingClipboard = "synthetic existing clipboard"
+        let dictationText = "synthetic delayed dictation"
+        let pasteboardName = NSPasteboard.Name("TranscriptedDelayedPasteTest-\(UUID().uuidString)")
+        let paster = await MainActor.run {
+            ClipboardRestoringTextPaster()
+        }
+
+        let outcome = await MainActor.run {
+            let pasteboard = NSPasteboard(name: pasteboardName)
+            pasteboard.clearContents()
+            pasteboard.setString(existingClipboard, forType: .string)
+            return paster.paste(
+                dictationText,
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: { true },
+                restoreDelay: 5_000_000,
+                fallbackRestoreDelay: 80_000_000
+            )
+        }
+
+        assertEqual(outcome, .pasted, "valid pasteback should report automatic paste")
+        try? await Task.sleep(nanoseconds: 30_000_000)
+
+        let delayedRead = await MainActor.run {
+            let pasteboard = NSPasteboard(name: pasteboardName)
+            return pasteboard.string(forType: .string)
+        }
+        assertEqual(
+            delayedRead,
+            dictationText,
+            "a target that reads after the eager restore delay should still get the dictation text"
+        )
+
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        let restoredClipboard = await MainActor.run {
+            let pasteboard = NSPasteboard(name: pasteboardName)
+            return pasteboard.string(forType: .string)
+        }
+        assertEqual(
+            restoredClipboard,
+            existingClipboard,
+            "after the target reads the temporary text, the user's original clipboard should be restored"
+        )
+    }
 }
 
 private func readClipboardPasterSource() -> String {
     let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
         .appendingPathComponent("Sources/Support/ClipboardRestoringTextPaster.swift")
     return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+}
+
+@MainActor
+private final class FakeClipboardPasteboard: ClipboardPasteboard {
+    var changeCount = 0
+    var clearContentsClears: Bool
+    var setStringSucceeds: Bool
+    var writePasteboardItemsSucceeds: Bool
+    private var storedString: String?
+    private var storedItems: [NSPasteboardItem]?
+
+    init(
+        initialString: String?,
+        clearContentsClears: Bool = true,
+        setStringSucceeds: Bool = true,
+        writePasteboardItemsSucceeds: Bool = true
+    ) {
+        self.storedString = initialString
+        self.clearContentsClears = clearContentsClears
+        self.setStringSucceeds = setStringSucceeds
+        self.writePasteboardItemsSucceeds = writePasteboardItemsSucceeds
+    }
+
+    var pasteboardItems: [NSPasteboardItem]? {
+        if let storedString,
+           let data = storedString.data(using: .utf8) {
+            let item = NSPasteboardItem()
+            item.setData(data, forType: .string)
+            return [item]
+        }
+        return storedItems
+    }
+
+    @discardableResult
+    func clearContents() -> Int {
+        changeCount += 1
+        if clearContentsClears {
+            storedString = nil
+            storedItems = nil
+        }
+        return changeCount
+    }
+
+    @discardableResult
+    func setString(_ string: String, forType dataType: NSPasteboard.PasteboardType) -> Bool {
+        guard setStringSucceeds, dataType == .string else { return false }
+        storedString = string
+        storedItems = nil
+        changeCount += 1
+        return true
+    }
+
+    func string(forType dataType: NSPasteboard.PasteboardType) -> String? {
+        guard dataType == .string else { return nil }
+        if let storedString {
+            return storedString
+        }
+        return storedItems?.compactMap { item in
+            item.data(forType: .string)
+                .flatMap { String(data: $0, encoding: .utf8) }
+        }.first
+    }
+
+    @discardableResult
+    func writePasteboardItems(_ items: [NSPasteboardItem]) -> Bool {
+        guard writePasteboardItemsSucceeds else { return false }
+        changeCount += 1
+        storedString = nil
+        storedItems = items
+        return true
+    }
 }

--- a/Tests/TranscriptedConstantsTests.swift
+++ b/Tests/TranscriptedConstantsTests.swift
@@ -8,10 +8,18 @@ func testTranscriptedConstants() async {
         assertTrue(TranscriptedConstants.hasMinimumParakeetAudioSamples(20_000), "longer audio should still be accepted")
     }
 
-    runSuite("TranscriptedConstants restores borrowed clipboard before auto-enter") {
+    runSuite("TranscriptedConstants restores consumed borrowed clipboard before auto-enter") {
         assertTrue(
             TranscriptedConstants.clipboardRestoreDelay < TranscriptedConstants.dictationAutoEnterDelay,
             "clipboard restore should happen before follow-up keypresses and before users can easily paste stale dictation text"
+        )
+        assertTrue(
+            TranscriptedConstants.clipboardRestoreFallbackDelay > TranscriptedConstants.clipboardRestoreDelay,
+            "fallback restore should give slow paste consumers longer to read the borrowed dictation text"
+        )
+        assertTrue(
+            TranscriptedConstants.clipboardRestoreFallbackDelay <= 1_000_000_000,
+            "fallback restore should still return the user's clipboard promptly when no paste consumer reads it"
         )
         assertTrue(
             TranscriptedConstants.dictationAutoEnterDelay <= 150_000_000,


### PR DESCRIPTION
## Summary
- keep borrowed dictation text available via a lazy NSPasteboard data provider until the target app reads it
- add a bounded fallback restore so the user clipboard is not borrowed indefinitely
- block Cmd+V if Transcripted cannot prepare the pasteboard, plus synthetic delayed-consumer coverage

## Root cause
Transcripted restored the user's previous clipboard on a fixed 120ms timer after posting Cmd+V. If the destination app consumed paste late, it could read the restored old clipboard instead of the just-finished dictation text.

## Verification
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh (3516 passed)
