### PR TITLE
[codex] Preserve finalized long meeting retry audio

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1061,6 +1061,7 @@ final class MeetingSessionController: ObservableObject {
         var didPreserveRecording = false
         var recordingTrigger = activeRecordingTrigger
         var stoppedFiles: (micURL: URL?, systemURL: URL?) = (nil, nil)
+        var stopTimedOut = false
 
         if isFinishingRecording {
             await waitForRecordingFinishBeforeTermination()
@@ -1073,8 +1074,15 @@ final class MeetingSessionController: ObservableObject {
             _ = audioInactivityDetector.stopRecording()
             audioInactivityWarning = nil
 
-            let files = await capture.stopAndAwaitFiles()
+            let shutdownFailedTaskId = UUID()
+            let files = await capture.stopAndAwaitFiles { [weak self] lateResult in
+                self?.refreshTimedOutFailedMeetingAudio(
+                    id: shutdownFailedTaskId,
+                    result: lateResult
+                )
+            }
             stoppedFiles = (micURL: files.micURL, systemURL: files.systemURL)
+            stopTimedOut = files.didTimeOut
             finishLiveCodexSessionForActiveRecording(status: .failed, shouldAwaitFinalTranscript: false)
             let meetingTitle = activeRecordingSuggestedTitle
             activeRecordingTrigger = .unknown
@@ -1082,10 +1090,12 @@ final class MeetingSessionController: ObservableObject {
 
             if files.micURL != nil || files.systemURL != nil {
                 didPreserveRecording = preserveFailedMeetingForRetry(
+                    taskId: shutdownFailedTaskId,
                     micAudioURL: files.micURL,
                     systemAudioURL: files.systemURL,
                     errorMessage: "Meeting saved before quit. Audio is safe; finish the transcript from Home after reopening.",
-                    meetingTitle: meetingTitle
+                    meetingTitle: meetingTitle,
+                    archiveAudio: !files.didTimeOut
                 )
             }
         } else {
@@ -1120,6 +1130,7 @@ final class MeetingSessionController: ObservableObject {
                     "trigger": recordingTrigger.rawValue,
                     "mic_file_present": boolString(stoppedFiles.micURL != nil),
                     "system_file_present": boolString(stoppedFiles.systemURL != nil),
+                    "stop_timed_out": boolString(stopTimedOut),
                     "active_preserved": "\(activePreserved)",
                     "queued_preserved": "\(queuedPreserved)"
                 ]
@@ -2533,7 +2544,7 @@ final class MeetingSessionController: ObservableObject {
             .systemAudioURL
         let systemURL = result.systemURL ?? existingSystemURL
 
-        let updated = failedManager.updateFailedTranscriptionAudio(
+        let updated = taskManager.promoteFinalizedFailedTranscriptionAudio(
             id: id,
             micAudioURL: micURL,
             systemAudioURL: systemURL

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -2538,10 +2538,11 @@ final class MeetingSessionController: ObservableObject {
     }
 
     private func refreshTimedOutFailedMeetingAudio(id: UUID, result: CaptureStopResult) {
-        guard let micURL = result.micURL else { return }
-        let existingSystemURL = failedManager.failedTranscriptions
-            .first(where: { $0.id == id })?
-            .systemAudioURL
+        let existingFailure = failedManager.failedTranscriptions
+            .first(where: { $0.id == id })
+        let existingMicURL = existingFailure?.micAudioURL
+        let existingSystemURL = existingFailure?.systemAudioURL
+        guard let micURL = result.micURL ?? existingMicURL else { return }
         let systemURL = result.systemURL ?? existingSystemURL
 
         let updated = taskManager.promoteFinalizedFailedTranscriptionAudio(

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -656,6 +656,48 @@ public class TranscriptionTaskManager: ObservableObject {
     }
 
     @discardableResult
+    public func promoteFinalizedFailedTranscriptionAudio(
+        id: UUID,
+        micAudioURL: URL,
+        systemAudioURL: URL?
+    ) -> Bool {
+        guard failedTranscriptionManager.failedTranscriptions.contains(where: { $0.id == id }) else {
+            AppLogger.pipeline.warning("Failed transcription audio promotion skipped because entry was missing", [
+                "id": id.uuidString
+            ])
+            return false
+        }
+
+        let retainedAudio = archiveFailedRecordingAudioIfConfigured(
+            micURL: micAudioURL,
+            systemURL: systemAudioURL,
+            taskId: id
+        )
+        let promotedMicURL = retainedAudio?.micURL ?? micAudioURL
+        let promotedSystemURL = retainedAudio?.systemURL ?? systemAudioURL
+        let didPersist = failedTranscriptionManager.updateFailedTranscriptionAudio(
+            id: id,
+            micAudioURL: promotedMicURL,
+            systemAudioURL: promotedSystemURL
+        )
+
+        guard didPersist else {
+            if let retainedAudio {
+                removeRetainedFailedAudio(retainedAudio)
+            }
+            return false
+        }
+
+        if retainedAudio?.micURL != nil {
+            removeManagedCleanupFile(micAudioURL, label: "finalized failed mic scratch")
+        }
+        if retainedAudio?.systemURL != nil {
+            removeManagedCleanupFile(systemAudioURL, label: "finalized failed system scratch")
+        }
+        return true
+    }
+
+    @discardableResult
     public func addFailedTranscriptionRetainingAvailableAudio(
         micAudioURL: URL?,
         systemAudioURL: URL?,

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -673,6 +673,7 @@ public class TranscriptionTaskManager: ObservableObject {
             systemURL: systemAudioURL,
             taskId: id
         )
+        let retryIsUsingOriginalAudio = activeTasks[id] != nil
         let promotedMicURL = retainedAudio?.micURL ?? micAudioURL
         let promotedSystemURL = retainedAudio?.systemURL ?? systemAudioURL
         let didPersist = failedTranscriptionManager.updateFailedTranscriptionAudio(
@@ -688,10 +689,15 @@ public class TranscriptionTaskManager: ObservableObject {
             return false
         }
 
-        if retainedAudio?.micURL != nil {
+        if retryIsUsingOriginalAudio, retainedAudio != nil {
+            AppLogger.pipeline.info("Deferred finalized failed audio scratch cleanup until active retry finishes", [
+                "id": id.uuidString
+            ])
+        }
+        if retainedAudio?.micURL != nil, !retryIsUsingOriginalAudio {
             removeManagedCleanupFile(micAudioURL, label: "finalized failed mic scratch")
         }
-        if retainedAudio?.systemURL != nil {
+        if retainedAudio?.systemURL != nil, !retryIsUsingOriginalAudio {
             removeManagedCleanupFile(systemAudioURL, label: "finalized failed system scratch")
         }
         return true
@@ -911,6 +917,11 @@ public class TranscriptionTaskManager: ObservableObject {
                 guard !self.finishCancelledTaskIfNeeded(taskId: failedId) else { return false }
 
                 let waitingForSpeakerNames = self.hasPendingSpeakerNamingRequest(sourceFailedTranscriptionId: failedId)
+                self.removeSupersededRetrySourceAudioIfNeeded(
+                    failedId: failedId,
+                    micURL: failed.micAudioURL,
+                    systemURL: failed.systemAudioURL
+                )
                 if waitingForSpeakerNames {
                     AppLogger.pipeline.info("Retry transcript saved; keeping failed meeting until speaker names finalize", [
                         "failedId": failedId.uuidString
@@ -940,6 +951,11 @@ public class TranscriptionTaskManager: ObservableObject {
                     id: failedId,
                     errorMessage: diagnosticMessage
                 )
+                self.removeSupersededRetrySourceAudioIfNeeded(
+                    failedId: failedId,
+                    micURL: failed.micAudioURL,
+                    systemURL: failed.systemAudioURL
+                )
                 self.publishFailure(
                     displayMessage: "Retry failed",
                     diagnosticMessage: diagnosticMessage
@@ -955,6 +971,23 @@ public class TranscriptionTaskManager: ObservableObject {
             || pendingSpeakerNamingRequests.contains {
                 $0.sourceFailedTranscriptionId == sourceFailedTranscriptionId
             }
+    }
+
+    private func removeSupersededRetrySourceAudioIfNeeded(
+        failedId: UUID,
+        micURL: URL,
+        systemURL: URL?
+    ) {
+        guard let current = failedTranscriptionManager.failedTranscriptions.first(where: { $0.id == failedId }) else {
+            return
+        }
+
+        if current.micAudioURL != micURL {
+            removeManagedCleanupFile(micURL, label: "superseded retry mic scratch")
+        }
+        if let systemURL, current.systemAudioURL != systemURL {
+            removeManagedCleanupFile(systemURL, label: "superseded retry system scratch")
+        }
     }
 
     // MARK: - Task Completion & Cleanup

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -180,6 +180,9 @@ public class FailedTranscriptionManager: ObservableObject {
         )
 
         let didPersist = saveFailedTranscriptions()
+        if !didPersist {
+            failedTranscriptions[index] = existing
+        }
         AppLogger.pipeline.info("Updated failed transcription audio", [
             "id": "\(id)",
             "persisted": "\(didPersist)"

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1618,8 +1618,8 @@ func testRepoCommandContract() {
         )
         assertTrue(
             controllerContents.contains("refreshTimedOutFailedMeetingAudio(")
-                && controllerContents.contains("updateFailedTranscriptionAudio("),
-            "late WAV finalization should refresh the failed queue so retries do not point at deleted mic recovery segments"
+                && controllerContents.contains("promoteFinalizedFailedTranscriptionAudio("),
+            "late WAV finalization should promote finalized failed audio before refreshing the failed queue"
         )
         assertTrue(
             timeoutBlock.contains("\"preserved_for_retry\": boolString(preserved)"),
@@ -1723,6 +1723,17 @@ func testRepoCommandContract() {
         assertTrue(
             terminationBlock.contains("activeQueuedTranscriptionJobID = nil"),
             "shutdown preservation should clear the active queued job owner used for live sidecar final attachment"
+        )
+        assertTrue(
+            terminationBlock.contains("let shutdownFailedTaskId = UUID()")
+                && terminationBlock.contains("capture.stopAndAwaitFiles {")
+                && terminationBlock.contains("refreshTimedOutFailedMeetingAudio("),
+            "shutdown stop timeouts should keep the same late-finalization repair path as normal meeting stops"
+        )
+        assertTrue(
+            terminationBlock.contains("taskId: shutdownFailedTaskId")
+                && terminationBlock.contains("archiveAudio: !files.didTimeOut"),
+            "shutdown stop timeouts should keep unfinished scratch audio in place until late finalization can promote it"
         )
     }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1621,6 +1621,17 @@ func testRepoCommandContract() {
                 && controllerContents.contains("promoteFinalizedFailedTranscriptionAudio("),
             "late WAV finalization should promote finalized failed audio before refreshing the failed queue"
         )
+        let refreshTimedOutAudioBlock = sourceSlice(
+            controllerContents,
+            from: "private func refreshTimedOutFailedMeetingAudio(",
+            to: "private func refreshFailedMeetings("
+        )
+        assertTrue(
+            refreshTimedOutAudioBlock.contains("let existingFailure = failedManager.failedTranscriptions")
+                && refreshTimedOutAudioBlock.contains("let existingMicURL = existingFailure?.micAudioURL")
+                && refreshTimedOutAudioBlock.contains("guard let micURL = result.micURL ?? existingMicURL"),
+            "late finalization should still promote system-only failed audio by reusing the failed queue mic placeholder"
+        )
         assertTrue(
             timeoutBlock.contains("\"preserved_for_retry\": boolString(preserved)"),
             "stop-timeout diagnostics should state whether the retained audio reached the retry queue"

--- a/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
@@ -317,6 +317,38 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         XCTAssertEqual(persisted.first?.systemAudioURL, systemURL)
     }
 
+    func testUpdateFailedTranscriptionAudioRollsBackMemoryWhenPersistenceFails() throws {
+        let paths = makePaths(root: testRoot)
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+
+        let firstMicURL = paths.audioCaptures.appendingPathComponent("timeout-segment.wav")
+        let finalMicURL = paths.audioCaptures.appendingPathComponent("timeout-merged.wav")
+        FileManager.default.createFile(atPath: firstMicURL.path, contents: Data("mic".utf8))
+        FileManager.default.createFile(atPath: finalMicURL.path, contents: Data("merged".utf8))
+
+        let manager = FailedTranscriptionManager(paths: paths)
+        let failedId = UUID()
+        XCTAssertTrue(manager.addFailedTranscription(
+            id: failedId,
+            micAudioURL: firstMicURL,
+            systemAudioURL: nil,
+            errorMessage: "Recording stop timed out before audio files were finalized."
+        ))
+        try FileManager.default.removeItem(at: paths.failedQueue)
+        try FileManager.default.createDirectory(at: paths.failedQueue, withIntermediateDirectories: true)
+
+        XCTAssertFalse(manager.updateFailedTranscriptionAudio(
+            id: failedId,
+            micAudioURL: finalMicURL,
+            systemAudioURL: nil
+        ))
+
+        let failed = try XCTUnwrap(manager.failedTranscriptions.first)
+        XCTAssertEqual(failed.id, failedId)
+        XCTAssertEqual(failed.micAudioURL, firstMicURL)
+        XCTAssertNil(failed.systemAudioURL)
+    }
+
     func testAddFailedTranscriptionRollsBackMemoryWhenPersistenceFails() throws {
         let paths = makePaths(root: testRoot)
         try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -816,6 +816,102 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertEqual(persisted.first?.retryCount, 1)
     }
 
+    func testLateStopTimeoutFinalizationKeepsScratchAudioDuringActiveRetry() throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(retainedAudioDirectory: retainedAudioDirectory)
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("timeout-active-retry-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("timeout-active-retry-system.wav")
+        let failedId = UUID()
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        XCTAssertTrue(manager.addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: "Recording stop timed out before audio files were finalized.",
+            taskId: failedId,
+            meetingTitle: "Active Retry Call",
+            archiveAudio: false
+        ))
+
+        let sentinel = Task {}
+        manager.activeTasks[failedId] = sentinel
+        defer {
+            sentinel.cancel()
+            manager.activeTasks.removeValue(forKey: failedId)
+        }
+
+        XCTAssertTrue(manager.promoteFinalizedFailedTranscriptionAudio(
+            id: failedId,
+            micAudioURL: micURL,
+            systemAudioURL: systemURL
+        ))
+
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        let retainedSystemURL = try XCTUnwrap(failed.systemAudioURL)
+        XCTAssertTrue(failed.micAudioURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(retainedSystemURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failed.micAudioURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: retainedSystemURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path), "active retry may still be reading the original mic scratch")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path), "active retry may still be reading the original system scratch")
+    }
+
+    func testRetryCompletionRemovesSupersededScratchAudioAfterLatePromotion() async throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let speech = BlockingMetadataStubSpeechToTextEngine(transcript: "Recovered after late finalization.")
+        let manager = makeManager(
+            speechToText: speech,
+            retainedAudioDirectory: retainedAudioDirectory
+        )
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("timeout-retry-finish-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("timeout-retry-finish-system.wav")
+        let failedId = UUID()
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        XCTAssertTrue(manager.addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: "Recording stop timed out before audio files were finalized.",
+            taskId: failedId,
+            meetingTitle: "Retry Finish Call",
+            archiveAudio: false
+        ))
+
+        let retry = Task {
+            await manager.retryFailedTranscription(
+                failedId: failedId,
+                outputFolder: tempDirectory.appendingPathComponent("transcripts")
+            )
+        }
+        try await waitUntil(timeout: 3.0) {
+            speech.didStart
+        }
+
+        XCTAssertTrue(manager.promoteFinalizedFailedTranscriptionAudio(
+            id: failedId,
+            micAudioURL: micURL,
+            systemAudioURL: systemURL
+        ))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))
+
+        speech.release()
+        let didRetry = await retry.value
+
+        XCTAssertTrue(didRetry)
+        XCTAssertTrue(manager.failedTranscriptionManager.failedTranscriptions.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path), "finished retry should clean up superseded mic scratch")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path), "finished retry should clean up superseded system scratch")
+    }
+
     func testLateStopTimeoutFinalizationPromotesSystemOnlyFailedAudioToRetainedArchive() throws {
         let retainedAudioDirectory = tempDirectory
             .appendingPathComponent("transcripts", isDirectory: true)

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -816,6 +816,47 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertEqual(persisted.first?.retryCount, 1)
     }
 
+    func testLateStopTimeoutFinalizationPromotesSystemOnlyFailedAudioToRetainedArchive() throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(retainedAudioDirectory: retainedAudioDirectory)
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let systemURL = scratchDirectory.appendingPathComponent("timeout-final-system.wav")
+        let failedId = UUID()
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        XCTAssertTrue(manager.addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: nil,
+            systemAudioURL: systemURL,
+            errorMessage: "Recording stop timed out before audio files were finalized.",
+            taskId: failedId,
+            meetingTitle: "System Only Call",
+            archiveAudio: false
+        ))
+
+        let placeholderMicURL = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first?.micAudioURL)
+        XCTAssertTrue(placeholderMicURL.lastPathComponent.contains("microphone_placeholder"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: placeholderMicURL.path))
+
+        XCTAssertTrue(manager.promoteFinalizedFailedTranscriptionAudio(
+            id: failedId,
+            micAudioURL: placeholderMicURL,
+            systemAudioURL: systemURL
+        ))
+
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        let retainedSystemURL = try XCTUnwrap(failed.systemAudioURL)
+        XCTAssertEqual(failed.id, failedId)
+        XCTAssertEqual(failed.meetingTitle, "System Only Call")
+        XCTAssertTrue(failed.micAudioURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(retainedSystemURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failed.micAudioURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: retainedSystemURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: placeholderMicURL.path), "finalized timeout mic placeholder scratch should be removed after archive")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path), "finalized timeout system scratch should be removed after archive")
+    }
+
     func testRetryFailedTranscriptionSuccessCreatesMarkdownAndClearsFailedQueue() async throws {
         let manager = makeManager(
             speechToText: MetadataStubSpeechToTextEngine(transcript: "Recovered meeting artifact.")

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -765,6 +765,57 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: retainedAudioDirectory.path), "stop-timeout preservation should not copy possibly unfinished WAVs into the retained archive")
     }
 
+    func testLateStopTimeoutFinalizationPromotesFailedQueueAudioToRetainedArchive() throws {
+        let retainedAudioDirectory = tempDirectory
+            .appendingPathComponent("transcripts", isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(retainedAudioDirectory: retainedAudioDirectory)
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("timeout-final-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("timeout-final-system.wav")
+        let failedId = UUID()
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        XCTAssertTrue(manager.addFailedTranscriptionRetainingAvailableAudio(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: "Recording stop timed out before audio files were finalized.",
+            taskId: failedId,
+            meetingTitle: "Long Customer Call",
+            archiveAudio: false
+        ))
+        manager.failedTranscriptionManager.incrementRetryCount(id: failedId)
+
+        XCTAssertTrue(manager.promoteFinalizedFailedTranscriptionAudio(
+            id: failedId,
+            micAudioURL: micURL,
+            systemAudioURL: systemURL
+        ))
+
+        let failed = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        let retainedSystemURL = try XCTUnwrap(failed.systemAudioURL)
+        XCTAssertEqual(failed.id, failedId)
+        XCTAssertEqual(failed.meetingTitle, "Long Customer Call")
+        XCTAssertEqual(failed.retryCount, 1)
+        XCTAssertTrue(failed.micAudioURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(retainedSystemURL.path.hasPrefix(retainedAudioDirectory.path + "/"))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failed.micAudioURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: retainedSystemURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path), "finalized timeout mic scratch should be removed after archive")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path), "finalized timeout system scratch should be removed after archive")
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let persisted = try decoder.decode(
+            [FailedTranscription].self,
+            from: Data(contentsOf: tempDirectory.appendingPathComponent("failed_transcriptions.json"))
+        )
+        XCTAssertEqual(persisted.first?.micAudioURL, failed.micAudioURL)
+        XCTAssertEqual(persisted.first?.systemAudioURL, failed.systemAudioURL)
+        XCTAssertEqual(persisted.first?.retryCount, 1)
+    }
+
     func testRetryFailedTranscriptionSuccessCreatesMarkdownAndClearsFailedQueue() async throws {
         let manager = makeManager(
             speechToText: MetadataStubSpeechToTextEngine(transcript: "Recovered meeting artifact.")


### PR DESCRIPTION
## Summary
- Promote late-finalized stop-timeout meeting audio into the retained meeting-audio archive before refreshing Home.
- Make quit-time recording preservation use the same timeout + late-finalization repair path as normal stop.
- Roll back failed-queue audio updates in memory if `failed_transcriptions.json` cannot persist the change.

## Issue
Addresses a high-confidence slice of #825: long recordings that hit stop/finalization timeout can become visible as failed/retry-ready, but late-finalized audio could stay tied to scratch paths instead of retained-audio semantics. Quit-time stop timeouts also skipped the late-finalization repair callback.

This does not implement full save-as-recorded/chunked processing.

## Repro / Evidence
Safe synthetic evidence saved locally:
`/tmp/transcripted-repro-lab/825-long-meeting-20260603-111551/evidence.md`

Focused repro covered:
- timeout failed queue initially keeps scratch WAVs with `archiveAudio: false`
- late finalization promotes the same audio to retained archive
- failed queue persists the retained URLs and preserves retry metadata
- scratch originals are removed only after persistence succeeds

## Verification
- `bash build-deps.sh --force`
- `swift test --filter 'TranscriptionTaskManagerMetadataTests/testLateStopTimeoutFinalizationPromotesFailedQueueAudioToRetainedArchive|FailedTranscriptionManagerTests/testUpdateFailedTranscriptionAudioRollsBackMemoryWhenPersistenceFails'`
- `bash build.sh --no-open`
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh` — 3536 passed
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh`
- `swift test` — 354 tests, 1 skipped, 0 failed

## Remaining #825 Work
- Larger save-as-recorded / chunked processing for very long meetings remains open.
- No orphan-audio scanner was added; that could resurface audio users intentionally deleted or dismissed.