### PR TITLE
Add issue 500 audio guardrail tests

### DIFF
--- a/Tests/TranscriptedCoreTests/AudioDiagnosticsSnapshotTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioDiagnosticsSnapshotTests.swift
@@ -44,6 +44,48 @@ final class AudioDiagnosticsSnapshotTests: XCTestCase {
         XCTAssertNotNil(snapshot.privacySafeContext["captured_input_volume_during"])
     }
 
+    func testHandleMicBufferAppliesAGCBeforeMicCallbackAndDiagnostics() throws {
+        let audio = makeAudio()
+        audio.prepareForNewRecordingStart()
+        audio.realtimeAGC = RealtimeAGC()
+        defer {
+            audio.onMicPCMBuffer = nil
+            audio.realtimeAGC = nil
+        }
+
+        var callbackPeaks: [Float] = []
+        audio.onMicPCMBuffer = { buffer in
+            callbackPeaks.append(audio.linearPeak(buffer: buffer))
+        }
+
+        let rawPeak: Float = 0.04
+        for _ in 0..<40 {
+            let buffer = try makeMonoSineBuffer(peak: rawPeak)
+            let originalPeak = audio.linearPeak(buffer: buffer)
+            audio.handleMicBuffer(buffer)
+
+            XCTAssertEqual(
+                audio.linearPeak(buffer: buffer),
+                originalPeak,
+                accuracy: 0.0001,
+                "handleMicBuffer must leave the CoreAudio-owned input buffer untouched"
+            )
+        }
+
+        let processedPeak = try XCTUnwrap(callbackPeaks.last)
+        XCTAssertGreaterThan(processedPeak, 0.40, "mic callback should receive the AGC-processed copy")
+        XCTAssertLessThan(processedPeak, 0.55, "mic callback should stay near the AGC target and avoid clipping")
+
+        let snapshot = audio.createPipelineDiagnosticsSnapshot()
+        XCTAssertEqual(snapshot.micRawPeak, "0.04000")
+        XCTAssertGreaterThan(
+            Double(snapshot.micProcessedPeak) ?? 0,
+            Double(snapshot.micRawPeak) ?? 1,
+            "diagnostics should prove the processed meeting mic path is louder than the raw input"
+        )
+        XCTAssertEqual(snapshot.privacySafeContext["realtime_agc"], "true")
+    }
+
     func testSnapshotResetsSignalDiagnosticsForNewRecording() {
         let audio = makeAudio()
         audio.recordMicSignalPeaks(raw: 0.03, processed: 0.36)
@@ -95,6 +137,32 @@ final class AudioDiagnosticsSnapshotTests: XCTestCase {
         let level = audio.normalizedRMSLevel(buffer: buffer)
 
         XCTAssertGreaterThan(level, 0.8)
+    }
+
+    private func makeMonoSineBuffer(peak: Float, frames: Int = 4096) throws -> AVAudioPCMBuffer {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        ))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(frames)
+        ))
+        buffer.frameLength = AVAudioFrameCount(frames)
+
+        guard let channelData = buffer.floatChannelData?[0] else {
+            XCTFail("Missing channel data")
+            return buffer
+        }
+
+        let twoPiF = 2.0 * Double.pi * 1_000.0
+        for index in 0..<frames {
+            let t = Double(index) / 48_000.0
+            channelData[index] = peak * Float(sin(twoPiF * t))
+        }
+        return buffer
     }
 
     private func makeStereoBuffer(left: Float, right: Float) throws -> AVAudioPCMBuffer {

--- a/Tests/TranscriptedCoreTests/MeetingInputDeviceSelectionPolicyTests.swift
+++ b/Tests/TranscriptedCoreTests/MeetingInputDeviceSelectionPolicyTests.swift
@@ -58,6 +58,21 @@ final class MeetingInputDeviceSelectionPolicyTests: XCTestCase {
         XCTAssertFalse(selection.didOverrideDefault)
     }
 
+    func testPrefersBuiltInInputWhenBluetoothOutputLookupIsUnavailable() {
+        let airPods = device(id: 10, name: "AirPods Pro", transport: .bluetooth, channels: 1)
+        let macBookMic = device(id: 20, name: "MacBook Pro Microphone", transport: .builtIn, channels: 1)
+
+        let selection = MeetingInputDeviceSelectionPolicy.selection(
+            defaultInput: airPods,
+            defaultOutput: nil,
+            availableInputs: [airPods, macBookMic]
+        )
+
+        XCTAssertEqual(selection.selectedInput, macBookMic)
+        XCTAssertEqual(selection.reason, .preferredBuiltInForBluetoothHeadset)
+        XCTAssertTrue(selection.didOverrideDefault)
+    }
+
     func testRanksMacBookMicrophoneAheadOfOtherBuiltInCandidates() {
         let airPods = device(id: 10, name: "AirPods Pro", transport: .bluetooth, channels: 1)
         let studioDisplayMic = device(

--- a/Tests/TranscriptedCoreTests/RealtimeAGCTests.swift
+++ b/Tests/TranscriptedCoreTests/RealtimeAGCTests.swift
@@ -23,6 +23,27 @@ final class RealtimeAGCTests: XCTestCase {
         return buffer
     }
 
+    /// Build a non-interleaved stereo Float32 buffer with different channel peaks.
+    private func makeStereoBuffer(leftPeak: Float, rightPeak: Float, frames: Int = 4096, sampleRate: Double = 48_000) -> AVAudioPCMBuffer {
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 2,
+            interleaved: false
+        )!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frames))!
+        buffer.frameLength = AVAudioFrameCount(frames)
+        let left = buffer.floatChannelData![0]
+        let right = buffer.floatChannelData![1]
+        let twoPiF = 2.0 * Double.pi * 1_000.0
+        for i in 0..<frames {
+            let t = Double(i) / sampleRate
+            left[i] = leftPeak * Float(sin(twoPiF * t))
+            right[i] = rightPeak * Float(sin(twoPiF * t))
+        }
+        return buffer
+    }
+
     /// Read samples back out of a mono buffer.
     private func samples(from buffer: AVAudioPCMBuffer) -> [Float] {
         let count = Int(buffer.frameLength)
@@ -33,6 +54,16 @@ final class RealtimeAGCTests: XCTestCase {
     /// Buffer peak (max |x|).
     private func peak(of samples: [Float]) -> Float {
         samples.reduce(0) { max($0, abs($1)) }
+    }
+
+    private func peak(of buffer: AVAudioPCMBuffer, channel: Int) -> Float {
+        let count = Int(buffer.frameLength)
+        guard let channelData = buffer.floatChannelData?[channel] else { return 0 }
+        var result: Float = 0
+        for index in 0..<count {
+            result = max(result, abs(channelData[index]))
+        }
+        return result
     }
 
     /// Generate a 1 kHz sine at the given peak amplitude. Defaults match
@@ -223,5 +254,28 @@ final class RealtimeAGCTests: XCTestCase {
         }
         XCTAssertEqual(maxLeft, maxRight, accuracy: 0.001, "Interleaved channels should receive identical gain")
         XCTAssertGreaterThan(maxLeft, 0.04, "Interleaved stereo should also be boosted")
+    }
+
+    func testNonInterleavedStereoUsesLoudestChannelForSharedGain() {
+        // Meeting mic buffers are commonly non-interleaved. A channel scan
+        // regression here can make one quiet channel drive huge gain and clip
+        // the louder channel, which looks like a channel/gain issue #500.
+        let agc = RealtimeAGC()
+        var finalBuffer: AVAudioPCMBuffer?
+        for _ in 0..<40 {
+            let buffer = makeStereoBuffer(leftPeak: 0.03, rightPeak: 0.30)
+            agc.process(buffer: buffer)
+            finalBuffer = buffer
+        }
+
+        let buffer = finalBuffer!
+        let leftPeak = peak(of: buffer, channel: 0)
+        let rightPeak = peak(of: buffer, channel: 1)
+
+        XCTAssertGreaterThan(rightPeak, 0.40, "Louder channel should land near the AGC target peak")
+        XCTAssertLessThan(rightPeak, 0.55, "Louder channel should not clip because a quieter sibling channel drove gain")
+        XCTAssertGreaterThan(leftPeak, 0.035, "Quiet sibling channel should receive the same shared gain")
+        XCTAssertLessThan(leftPeak, 0.07, "Quiet sibling channel should not get independent over-boost")
+        XCTAssertEqual(leftPeak / rightPeak, 0.10, accuracy: 0.02, "Shared gain should preserve the stereo channel ratio")
     }
 }


### PR DESCRIPTION
## Summary

Adds test-only guardrails for issue #500 meeting mic quietness paths:

- proves `Audio.handleMicBuffer(_:)` deep-copies the raw CoreAudio buffer, applies software AGC to the mic callback copy, and records raw/processed peaks in diagnostics
- covers non-interleaved stereo AGC so a quiet sibling channel cannot overdrive/clamp a louder channel
- covers meeting input fallback when Bluetooth input is default and output lookup is unavailable

## Local Repro / Test Matrix

Automated and semi-automated local checks:

```bash
bash /Users/redbars/.codex/skills/transcripted-repro-lab/scripts/run_daily_audio_reliability.sh --synthetic
bash build-deps.sh --force
TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift test --filter RealtimeAGCTests
TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift test --filter MeetingInputDeviceSelectionPolicyTests
TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift test --filter AudioDiagnosticsSnapshotTests/testHandleMicBufferAppliesAGCBeforeMicCallbackAndDiagnostics
bash build.sh --no-open
bash run-tests.sh
bash run-integration-smoke.sh
TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift test
```

WebRTC mic contention semi-automated route, still requiring local browser/mic permission:

```bash
python3 /Users/redbars/.codex/skills/transcripted-repro-lab/scripts/start_mic_locker.py
open http://127.0.0.1:8765
```

Then hold the mic in Chrome/Safari/Firefox, record the privacy-safe phrase in Transcripted, and review local event fields: `mic_raw_peak`, `mic_processed_peak`, `system_peak`, volume before/during/after, `quiet_mic_recovered`, `quiet_mic_unrecovered`, and `output_ducking_detected`.

## Test Proof

- synthetic repro: PASS, report at `/tmp/transcripted-repro-lab/audio-daily-20260603-125049/daily-audio-reliability-report.md`
- `bash build-deps.sh --force` PASS
- focused `RealtimeAGCTests` PASS, 10 tests
- focused `MeetingInputDeviceSelectionPolicyTests` PASS, 5 tests
- focused `AudioDiagnosticsSnapshotTests/testHandleMicBufferAppliesAGCBeforeMicCallbackAndDiagnostics` PASS
- `bash build.sh --no-open` PASS
- `bash run-tests.sh` PASS, 3553 tests
- `bash run-integration-smoke.sh` PASS
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift test` PASS, 360 tests, 1 skipped

## Manual QA Still Needed

Automated tests do not prove real browser/meeting app behavior. Before calling issue #500 green, run the manual matrix in `docs/qa-issue-500-meeting-audio.md`:

- Chrome Meet, Safari Meet, Firefox Meet, WhatsApp Mac, Zoom, and no meeting app
- built-in mic/speakers, AirPods/Bluetooth, and USB mic if available
- Safari/Firefox with Apple voice processing off and on
- stop immediately if meeting audio gets quieter
- keep all audio/transcripts local; do not upload artifacts
