### PR TITLE
Fix meeting mic downmix attenuation

### DIFF
--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -462,7 +462,9 @@ extension Audio {
 
     // MARK: - Buffer Utilities
 
-    /// Manually downmix multi-channel audio to mono by averaging all channels
+    /// Manually downmix multi-channel mic audio to mono by taking the dominant
+    /// channel for this buffer. Averaging can halve a real mic when the second
+    /// channel is silent, and opposite-polarity channel pairs can cancel speech.
     func manualDownmix(buffer: AVAudioPCMBuffer, to monoFormat: AVAudioFormat) -> AVAudioPCMBuffer? {
         let frameCount = buffer.frameLength
         let channelCount = Int(buffer.format.channelCount)
@@ -476,32 +478,64 @@ extension Audio {
 
         guard let monoData = monoBuffer.floatChannelData?[0] else { return nil }
 
+        let dominantChannel = dominantChannelIndex(buffer: buffer, frameCount: Int(frameCount))
+
         // Check if buffer is interleaved or non-interleaved
         if buffer.format.isInterleaved {
             // Interleaved: samples are [L0, R0, C0, S0, L1, R1, C1, S1, ...]
             guard let interleavedData = buffer.floatChannelData?[0] else { return nil }
 
             for frame in 0..<Int(frameCount) {
-                var sum: Float = 0
-                for channel in 0..<channelCount {
-                    sum += interleavedData[frame * channelCount + channel]
-                }
-                monoData[frame] = sum / Float(channelCount)
+                monoData[frame] = interleavedData[frame * channelCount + dominantChannel]
             }
         } else {
             // Non-interleaved: each channel is a separate array
             guard let channelData = buffer.floatChannelData else { return nil }
 
             for frame in 0..<Int(frameCount) {
-                var sum: Float = 0
-                for channel in 0..<channelCount {
-                    sum += channelData[channel][frame]
-                }
-                monoData[frame] = sum / Float(channelCount)
+                monoData[frame] = channelData[dominantChannel][frame]
             }
         }
 
         return monoBuffer
+    }
+
+    private func dominantChannelIndex(buffer: AVAudioPCMBuffer, frameCount: Int) -> Int {
+        let channelCount = Int(buffer.format.channelCount)
+        guard channelCount > 1, frameCount > 0 else { return 0 }
+
+        var bestChannel = 0
+        var bestEnergy: Float = -1
+
+        if buffer.format.isInterleaved {
+            guard let interleavedData = buffer.floatChannelData?[0] else { return 0 }
+            for channel in 0..<channelCount {
+                var energy: Float = 0
+                for frame in 0..<frameCount {
+                    let sample = interleavedData[frame * channelCount + channel]
+                    energy += sample * sample
+                }
+                if energy > bestEnergy {
+                    bestEnergy = energy
+                    bestChannel = channel
+                }
+            }
+        } else {
+            guard let channelData = buffer.floatChannelData else { return 0 }
+            for channel in 0..<channelCount {
+                var energy: Float = 0
+                for frame in 0..<frameCount {
+                    let sample = channelData[channel][frame]
+                    energy += sample * sample
+                }
+                if energy > bestEnergy {
+                    bestEnergy = energy
+                    bestChannel = channel
+                }
+            }
+        }
+
+        return bestChannel
     }
 
     /// Deep copy an AVAudioPCMBuffer to ensure data safety across async dispatch

--- a/Tests/TranscriptedCoreTests/AudioFileManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioFileManagerTests.swift
@@ -107,12 +107,14 @@ final class AudioFileManagerTests: XCTestCase {
 
     // MARK: - manualDownmix (AudioFileManager.swift:465)
 
-    func testManualDownmixAveragesNonInterleavedStereoChannels() throws {
+    func testManualDownmixUsesDominantNonInterleavedChannelWithoutPhaseCancellation() throws {
         let root = makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let audio = makeAudio(root: root)
 
-        // Left = 1.0, Right = -1.0 -> mono average = 0.0 across every frame.
+        // Left = 1.0, Right = -1.0 used to average to silence. For mic capture,
+        // choose the dominant channel instead so opposite-polarity inputs do not
+        // erase local speech.
         let stereo = try makeNonInterleavedBuffer(
             channels: 2,
             sampleRate: 48_000,
@@ -131,18 +133,18 @@ final class AudioFileManagerTests: XCTestCase {
         XCTAssertEqual(mono.format.channelCount, 1)
         let monoData = try XCTUnwrap(mono.floatChannelData?[0])
         for frame in 0..<256 {
-            XCTAssertEqual(monoData[frame], 0.0, accuracy: 1e-6)
+            XCTAssertEqual(monoData[frame], 1.0, accuracy: 1e-6)
         }
     }
 
-    func testManualDownmixAveragesInterleavedStereoChannels() throws {
+    func testManualDownmixUsesDominantInterleavedStereoChannel() throws {
         let root = makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         let audio = makeAudio(root: root)
 
         // Interleaved branch in manualDownmix (AudioFileManager.swift:479) reads
-        // [L0,R0,L1,R1,...] and must produce the same per-frame average as the
-        // non-interleaved path.
+        // [L0,R0,L1,R1,...] and must preserve the dominant channel just like
+        // the non-interleaved path.
         let stereo = try makeInterleavedBuffer(
             channels: 2,
             sampleRate: 44_100,
@@ -160,7 +162,34 @@ final class AudioFileManagerTests: XCTestCase {
         XCTAssertEqual(mono.frameLength, 128)
         let monoData = try XCTUnwrap(mono.floatChannelData?[0])
         for frame in 0..<128 {
-            XCTAssertEqual(monoData[frame], 0.6, accuracy: 1e-6)
+            XCTAssertEqual(monoData[frame], 0.8, accuracy: 1e-6)
+        }
+    }
+
+    func testManualDownmixDoesNotHalveSpeechWhenSecondChannelIsSilent() throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let audio = makeAudio(root: root)
+
+        let stereo = try makeNonInterleavedBuffer(
+            channels: 2,
+            sampleRate: 48_000,
+            frameCount: 128
+        ) { ch, frame in
+            ch == 0 ? Float(frame) / 128.0 : 0.0
+        }
+
+        let monoFormat = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        ))
+
+        let mono = try XCTUnwrap(audio.manualDownmix(buffer: stereo, to: monoFormat))
+        let monoData = try XCTUnwrap(mono.floatChannelData?[0])
+        for frame in 0..<128 {
+            XCTAssertEqual(monoData[frame], Float(frame) / 128.0, accuracy: 1e-6)
         }
     }
 


### PR DESCRIPTION
## Summary
- Preserve the dominant active channel when downmixing multi-channel meeting mic buffers to mono.
- Add regressions for silent secondary channels and opposite-polarity stereo input so speech is not halved or cancelled before transcription.

## Audit notes
- Five independent passes focused on Meeting/Speech/Capture/WebRTC contention converged on the live mic downmix as the smallest high-confidence fix.
- Follow-up worth tracking separately: playback.m4a intentionally suppresses mic under loud system audio, so listen-back can still make the mic sound quieter than the split mic track. Device-selection diagnostics could also expose the Bluetooth built-in fallback reason more clearly.

## Verification
- bash build-deps.sh --force
- swift test --filter AudioFileManagerTests
- bash build.sh --no-open
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- bash scripts/dev/agent-preflight.sh

## Release risk
- I would not block 1.1.47 on this after review plus the issue #500 manual WebRTC/Zoom QA pass. If manual QA still reports quiet mic, the likely next suspect is playback mix suppression rather than live transcription input.