### PR TITLE
Improve meeting mic AGC recovery

### DIFF
--- a/Sources/TranscriptedCore/Audio/RealtimeAGC.swift
+++ b/Sources/TranscriptedCore/Audio/RealtimeAGC.swift
@@ -18,10 +18,12 @@ import Accelerate
 /// and slow release (raise gain gradually to avoid audible pumping during
 /// quiet stretches).
 ///
-/// The default tuning (`targetPeak = 0.45`, `maxGain = 12.0`,
-/// `minPeak = 0.0008`) mirrors `AudioSignalRecovery.normalizeForSpeech`
-/// so the saved WAV's loudness matches what the post-processing path would
-/// produce, and the in-memory STT copy stays consistent with the file.
+/// The default tuning (`targetPeak = 0.45`, `maxGain = 25.0`,
+/// `minPeak = 0.0008`) gives the live mic copy enough headroom for the
+/// more severe issue #500 voice-processing attenuation case while still
+/// refusing to chase near-silence. The post-processing path can normalize
+/// again before final transcription; this real-time pass protects the saved
+/// WAV, live preview, and diagnostics without touching system audio.
 ///
 /// Real-time safe: `process(buffer:)` performs zero allocations and no
 /// locking. Safe to invoke from an `AVAudioEngine` tap callback.
@@ -61,8 +63,9 @@ public final class RealtimeAGC {
 
     /// - Parameters:
     ///   - targetPeak: Desired peak after gain. 0.45 leaves headroom under 1.0.
-    ///   - maxGain: Upper bound on applied gain. 12.0 matches the
-    ///     post-processing recovery cap.
+    ///   - maxGain: Upper bound on applied gain. 25.0 lets a very quiet
+    ///     but real shared-device mic stream reach the usable diagnostic bar
+    ///     without opting into Apple's system-wide voice-processing ducking.
     ///   - minPeak: Silence threshold for hold behavior. 0.0008 matches
     ///     AudioSignalRecovery's lower bound for WebRTC-attenuated input.
     ///   - windowSize: Buffers of peak history.
@@ -75,7 +78,7 @@ public final class RealtimeAGC {
     ///     coefficients. 4096 frames at 48 kHz ≈ 85ms.
     public init(
         targetPeak: Float = 0.45,
-        maxGain: Float = 12.0,
+        maxGain: Float = 25.0,
         minPeak: Float = 0.0008,
         windowSize: Int = 16,
         attackTimeMs: Float = 20,
@@ -174,7 +177,7 @@ public final class RealtimeAGC {
         }
 
         // 6. Hard-clip to [-1, 1]. With targetPeak = 0.45 and a maxGain of
-        // 12.0 we shouldn't exceed unity often; this is a safety net for
+        // 25.0 we shouldn't exceed unity often; this is a safety net for
         // transients above the windowed peak.
         var lo: Float = -1.0
         var hi: Float = 1.0

--- a/Tests/TranscriptedCoreTests/RealtimeAGCTests.swift
+++ b/Tests/TranscriptedCoreTests/RealtimeAGCTests.swift
@@ -81,6 +81,25 @@ final class RealtimeAGCTests: XCTestCase {
         XCTAssertLessThanOrEqual(agc.appliedGain, 12.0 + 0.001, "appliedGain should not exceed maxGain")
     }
 
+    func testIssue500VeryQuietMicReachesUsableProcessedPeak() {
+        // Issue #500 voice-processing attenuation can be quieter than the
+        // original scalar-drop case. At the old 12x default cap, a 0.005 peak
+        // stayed below the 0.12 processed-peak diagnostics bar and still looked
+        // unrecovered. The default realtime path should now cross that bar
+        // without opting into Apple VPIO.
+        let agc = RealtimeAGC()
+        var lastPeak: Float = 0
+        for _ in 0..<32 {
+            let buffer = makeMonoBuffer(samples: sineSamples(peak: 0.005))
+            agc.process(buffer: buffer)
+            lastPeak = peak(of: samples(from: buffer))
+        }
+
+        XCTAssertGreaterThanOrEqual(lastPeak, 0.12, "Severely attenuated issue #500 mic input should become diagnostically usable")
+        XCTAssertLessThanOrEqual(lastPeak, 0.14, "Default cap should avoid a large overshoot for very quiet input")
+        XCTAssertLessThanOrEqual(agc.appliedGain, 25.0 + 0.001, "default appliedGain should respect the raised cap")
+    }
+
     func testNormalLevelInputPassesThrough() {
         // Speech already at the target peak should not be amplified or
         // attenuated meaningfully — gain stays near 1.0.

--- a/Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift
@@ -274,6 +274,27 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
         XCTAssertGreaterThan(normalized.samples.map(abs).max() ?? 0, analysis.peak)
     }
 
+    func testQuietWebRTCMicSegmentIsPreparedForTranscription() {
+        var samples = [Float](repeating: 0.0, count: 64_000)
+        let quietSpeech = alternatingSamples(amplitude: 0.006, count: 24_000)
+        samples.replaceSubrange(20_000..<44_000, with: quietSpeech)
+
+        let segments = Transcription.detectSpeechSegments(samples: samples, sampleRate: 16_000)
+        let prepared = Transcription.prepareMicSegmentForTranscription(
+            samples: samples,
+            sampleRate: 16_000
+        )
+
+        XCTAssertFalse(segments.isEmpty, "Quiet issue #500-style mic speech should still be segmented")
+        XCTAssertNotNil(prepared, "Quiet issue #500-style mic speech should still reach Parakeet")
+        XCTAssertGreaterThan(prepared?.gain ?? 1, 1, "Prepared mic speech should be normalized before STT")
+        XCTAssertGreaterThan(
+            prepared?.samples.map(abs).max() ?? 0,
+            samples.map(abs).max() ?? 0,
+            "Prepared mic speech should be louder than the captured quiet segment"
+        )
+    }
+
     func testPrepareMicSegmentPadsShortQuietSpeechForParakeet() {
         let samples = alternatingSamples(amplitude: 0.006, count: 8_000)
 


### PR DESCRIPTION
## Summary
- Raises the default software RealtimeAGC cap from 12x to 25x for meeting mic capture, so severe issue #500-style WebRTC attenuation can cross the existing usable processed-peak diagnostics bar without enabling Apple VPIO.
- Keeps the fix inside the default software AGC path, avoiding system output ducking and avoiding any system/default input-volume writes.
- Adds focused coverage for very quiet issue #500-style mic input and the downstream mic segment preparation path.

## Root cause model
Issue #500 has two historical shapes: input scalar drop and WebRTC voice-processing attenuation. The current default software AGC handled moderate attenuation, but the 12x cap left a real-but-very-quiet raw mic peak around 0.005 at roughly 0.06 processed peak, below the existing 0.12 `quiet_mic_recovered` diagnostic bar. The saved mic WAV/live preview could still appear too quiet even though later transcription has another normalization pass.

## Verification
- `swift test --filter RealtimeAGCTests`
- `swift test --filter TranscriptionPipelineHelpersTests`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `swift test`
- `bash /Users/redbars/.codex/skills/transcripted-repro-lab/scripts/run_daily_audio_reliability.sh --synthetic`
- `/Users/redbars/.codex/skills/codex-review/scripts/codex-review --parallel-tests "swift test --filter RealtimeAGCTests"`

## Manual QA gate
Still needs hardware/browser meeting QA before calling #500 fully fixed: Chrome/Safari/Firefox or Zoom/Meet with another app holding the mic, confirm local mic remains audible, system audio does not duck, and diagnostics report recovered processed mic rather than unrecovered quiet mic.

## Release note
Candidate for 1.1.47 if manual QA passes. Do not cut release from this PR alone.

Refs #500