### PR TITLE
Extend dictation pasteback fallback for slow consumers

### DIFF
--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -164,7 +164,7 @@ enum TranscriptedConstants {
     /// Maximum time to keep borrowed dictation text available if the target app
     /// has not requested it yet. This protects slower paste consumers without
     /// leaving the user's clipboard borrowed indefinitely.
-    static let clipboardRestoreFallbackDelay: UInt64 = 900_000_000  // 900ms
+    static let clipboardRestoreFallbackDelay: UInt64 = 2_500_000_000  // 2.5s
 
     /// Max time to wait for a just-activated target app before paste-back falls
     /// back to copying. This covers menu/settings flows where activation is async.

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -215,6 +215,55 @@ func testClipboardRestoringTextPaster() async {
         )
     }
 
+    await runSuite("ClipboardRestoringTextPaster.paste — covers slower consumers beyond the old fallback window") {
+        let existingClipboard = "synthetic existing clipboard"
+        let dictationText = "synthetic slow consumer dictation"
+        let pasteboardName = NSPasteboard.Name("TranscriptedSlowPasteConsumerTest-\(UUID().uuidString)")
+        let paster = await MainActor.run {
+            ClipboardRestoringTextPaster()
+        }
+
+        let outcome = await MainActor.run {
+            let pasteboard = NSPasteboard(name: pasteboardName)
+            pasteboard.clearContents()
+            pasteboard.setString(existingClipboard, forType: .string)
+            return paster.paste(
+                dictationText,
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: { true },
+                restoreDelay: 5_000_000,
+                fallbackRestoreDelay: TranscriptedConstants.clipboardRestoreFallbackDelay
+            )
+        }
+
+        assertEqual(outcome, .pasted, "valid pasteback should report automatic paste")
+        let waitTask = Task { @MainActor in
+            await paster.waitForPendingClipboardRestore()
+            let pasteboard = NSPasteboard(name: pasteboardName)
+            return pasteboard.string(forType: .string)
+        }
+        try? await Task.sleep(nanoseconds: 950_000_000)
+
+        let delayedRead = await MainActor.run {
+            let pasteboard = NSPasteboard(name: pasteboardName)
+            return pasteboard.string(forType: .string)
+        }
+        assertEqual(
+            delayedRead,
+            dictationText,
+            "a target that reads after the old 900ms fallback should still get the dictation text"
+        )
+
+        let restoredClipboard = await waitTask.value
+        assertEqual(
+            restoredClipboard,
+            existingClipboard,
+            "slow-consumer pasteback should still restore the previous clipboard afterward"
+        )
+    }
+
     await runSuite("ClipboardRestoringTextPaster.waitForPendingClipboardRestore — waits for fallback restore") {
         let existingClipboard = "synthetic existing clipboard"
         let pasteText = "synthetic paste text"

--- a/Tests/TranscriptedConstantsTests.swift
+++ b/Tests/TranscriptedConstantsTests.swift
@@ -18,7 +18,11 @@ func testTranscriptedConstants() async {
             "fallback restore should give slow paste consumers longer to read the borrowed dictation text"
         )
         assertTrue(
-            TranscriptedConstants.clipboardRestoreFallbackDelay <= 1_000_000_000,
+            TranscriptedConstants.clipboardRestoreFallbackDelay >= 2_000_000_000,
+            "fallback restore should cover slower apps that consume Cmd+V after the old sub-second window"
+        )
+        assertTrue(
+            TranscriptedConstants.clipboardRestoreFallbackDelay <= 3_000_000_000,
             "fallback restore should still return the user's clipboard promptly when no paste consumer reads it"
         )
         assertTrue(


### PR DESCRIPTION
## Summary
- extend the dictation pasteback clipboard fallback from 900ms to 2.5s
- add a slow-consumer regression test for reads after the old 900ms window
- update constant guardrails so the fallback cannot drift back below the repro boundary

## Evidence
- shipped 1.1.46 restored the previous clipboard after a fixed 120ms, which can paste stale clipboard contents if the target app reads late
- current main fixed that with read-triggered restore plus a 900ms fallback, but synthetic slow-consumer repro still failed around 910ms+
- this patch keeps dictation text available through the slow-consumer window while still restoring the previous clipboard afterward

## Verification
- `bash build-deps.sh --force` to recover fresh worktree deps
- `bash build.sh --no-open`
- `bash run-tests.sh` -> 3565 passed, 0 failed

Draft because this should still get manual QA in slow target apps before a release.