### PR TITLE
[nightly-ux] Keep no-speech recovery hint readable

### DIFF
--- a/Sources/Support/TranscriptedConstants.swift
+++ b/Sources/Support/TranscriptedConstants.swift
@@ -193,7 +193,7 @@ enum TranscriptedConstants {
 
     /// Duration to show error messages in overlay before auto-dismiss (nanoseconds)
     static let errorDismissDelay: UInt64 = 2_500_000_000  // 2.5 seconds
-    static let noSpeechDismissDelay: UInt64 = 1_400_000_000  // 1.4 seconds — enough time to read the empty-recording hint
+    static let noSpeechDismissDelay: UInt64 = 2_200_000_000  // 2.2 seconds — enough time to read the physical-key recovery hint
 
     // MARK: - Feedback Sounds
 

--- a/Tests/TranscriptedConstantsTests.swift
+++ b/Tests/TranscriptedConstantsTests.swift
@@ -27,6 +27,17 @@ func testTranscriptedConstants() async {
         )
     }
 
+    runSuite("TranscriptedConstants keeps no-speech recovery copy readable") {
+        assertTrue(
+            TranscriptedConstants.noSpeechDismissDelay >= 2_000_000_000,
+            "no-speech overlay should stay visible long enough to read the physical-key recovery hint"
+        )
+        assertTrue(
+            TranscriptedConstants.noSpeechDismissDelay < TranscriptedConstants.errorDismissDelay,
+            "no-speech recovery should still dismiss faster than regular error states"
+        )
+    }
+
     runSuite("TranscriptedConstants gives meeting quit preservation enough time") {
         let meetingStopTimeoutSeconds = TimeInterval(TranscriptedConstants.meetingStopTimeout) / 1_000_000_000
         assertTrue(


### PR DESCRIPTION
## Summary
- extend the no-speech overlay read window from 1.4s to 2.2s
- keep it shorter than the normal error-dismiss path
- add a constants guardrail test

## Evidence
- PostHog 24h on 1.1.46: 14 `dictation_no_speech` events across 2 devices, all `lt_10s` physical-key attempts
- Current no-speech copy already gives the right recovery instruction, but the overlay dismissed after 1.4s
- Sentry has no `transcripted@1.1.46` production issue; top fresh Sentry meeting degradation is older `1.1.42`

## Verification
- `bash build.sh --no-open`
- `bash run-tests.sh` (3563 passed)

## Privacy
No telemetry payload changes. No transcript, audio, title, speaker, email, token, URL, app, device-name, or path data added.