### PR TITLE
[codex] Polish first artifact handoff

### DIFF
--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -773,7 +773,7 @@ final class MeetingOverlayRootView: NSView {
             updateStatusDot(color: MeetingOverlayTokens.dotPrep)
             detailLabel.stringValue = ""
         case .saved:
-            titleLabel.stringValue = "Saved transcript"
+            titleLabel.stringValue = "Saved to Markdown"
             updateStatusDot(color: MeetingOverlayTokens.dotSaved)
             detailLabel.stringValue = ""
         case .error(let message):

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -619,16 +619,36 @@ struct TranscriptedSettingsView: View {
 
     private func handleCopyMeetingPreview(_ preview: HomeMeetingPreview) {
         trackSettingsAction("copy_meeting_preview", page: .home)
+        let bundle = AgentConnectionGuide.portableMeetingBundle(
+            title: preview.title,
+            date: preview.date,
+            transcriptURL: preview.transcriptURL
+        )
+        let fallbackMarkdown = preview.markdown.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let text = bundle ?? (fallbackMarkdown.isEmpty ? nil : preview.markdown) else {
+            ActivationTelemetry.trackAgentPromptAction(
+                promptKind: .meetingBundle,
+                actionKind: .copied,
+                agentTarget: .localAgent,
+                surface: .homePreview,
+                result: .failed,
+                artifactKind: .meeting
+            )
+            NSSound.beep()
+            return
+        }
+
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
         ActivationTelemetry.trackAgentPromptAction(
-            promptKind: .meetingMarkdown,
+            promptKind: .meetingBundle,
             actionKind: .copied,
             agentTarget: .localAgent,
             surface: .homePreview,
+            result: bundle == nil ? .fallbackCopied : .success,
             artifactKind: .meeting
         )
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(preview.markdown, forType: .string)
     }
 
     private func handleRetranscribeMeeting(_ item: RecentMeetingItem) {

--- a/Tests/HomeFirstArtifactVisibilityTests.swift
+++ b/Tests/HomeFirstArtifactVisibilityTests.swift
@@ -10,6 +10,10 @@ func testHomeFirstArtifactVisibility() {
             contentsOf: repoFixtureURL("Sources/UI/Settings/TranscriptedSettingsView.swift"),
             encoding: .utf8
         )) ?? ""
+        let meetingOverlaySource = (try? String(
+            contentsOf: repoFixtureURL("Sources/UI/Overlay/MeetingOverlayController.swift"),
+            encoding: .utf8
+        )) ?? ""
 
         assertTrue(
             homeSource.contains(#"return HomeArtifactStatus(text: "Saved to Markdown", tone: .ready)"#),
@@ -32,10 +36,21 @@ func testHomeFirstArtifactVisibility() {
             settingsSource.contains(#"actionTitle: activity.transcriptURL == nil ? nil : "Open Markdown""#),
             "the just-saved meeting activity card should name the Markdown artifact"
         )
+        assertTrue(
+            meetingOverlaySource.contains(#"titleLabel.stringValue = "Saved to Markdown""#),
+            "the meeting saved overlay should name the Markdown artifact at the moment of first value"
+        )
+        assertTrue(
+            settingsSource.contains("AgentConnectionGuide.portableMeetingBundle(")
+                && settingsSource.contains(#"promptKind: .meetingBundle"#)
+                && settingsSource.contains(#"result: bundle == nil ? .fallbackCopied : .success"#),
+            "meeting preview Copy for agent should prefer the portable meeting bundle over raw Markdown"
+        )
         assertFalse(
             homeSource.contains(#"HomeArtifactStatus(text: "Saved only""#)
                 || settingsSource.contains(#"HomeRowMenuItem(title: "Open saved file""#)
-                || settingsSource.contains(#"actionTitle: activity.transcriptURL == nil ? nil : "Open Transcript""#),
+                || settingsSource.contains(#"actionTitle: activity.transcriptURL == nil ? nil : "Open Transcript""#)
+                || meetingOverlaySource.contains(#"titleLabel.stringValue = "Saved transcript""#),
             "old vague saved-file copy should not return"
         )
     }


### PR DESCRIPTION
## Summary
- Rename the meeting saved overlay from `Saved transcript` to `Saved to Markdown` so the first saved meeting artifact is explicit.
- Make Home meeting preview `Copy for agent` prefer the portable meeting bundle instead of raw Markdown, with raw Markdown only as a fallback.
- Add a first-artifact visibility guard for the meeting overlay copy and preview agent-bundle path.

## Why
Live PostHog still shows strong capture usage but very small agent/activation CTA usage, so the low-risk product move is to make saved Markdown and the next agent handoff more obvious without changing persistence or broad telemetry.

## Checks
- `bash scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (`3583 passed`)
- `git diff --check`

## Manual test
- Save a meeting and confirm the transient meeting overlay says `Saved to Markdown`.
- Open Home, preview a recent meeting, click `Copy for agent`, and paste into a local agent/chat to confirm it includes the portable Transcripted meeting bundle.