### PR TITLE
Avoid recursive prefetch content scan

### DIFF
--- a/Sources/Support/ExistingInstallModelPrefetchPolicy.swift
+++ b/Sources/Support/ExistingInstallModelPrefetchPolicy.swift
@@ -61,27 +61,30 @@ enum ExistingInstallModelPrefetchPolicy {
     ) -> Bool {
         ["dictations", "meetings"].contains { subdirectory in
             let directory = captureLibraryURL.appendingPathComponent(subdirectory, isDirectory: true)
-            return directoryContainsRegularFile(directory, fileManager: fileManager)
+            return directoryContainsDirectRegularFile(directory, fileManager: fileManager)
         }
     }
 
-    private static func directoryContainsRegularFile(
+    private static func directoryContainsDirectRegularFile(
         _ directory: URL,
         fileManager: FileManager
     ) -> Bool {
         var isDirectory: ObjCBool = false
         guard fileManager.fileExists(atPath: directory.path, isDirectory: &isDirectory),
-              isDirectory.boolValue,
-              let enumerator = fileManager.enumerator(
-                at: directory,
-                includingPropertiesForKeys: [.isRegularFileKey],
-                options: [.skipsHiddenFiles]
-              )
+              isDirectory.boolValue
         else {
             return false
         }
 
-        for case let fileURL as URL in enumerator {
+        guard let fileURLs = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return false
+        }
+
+        for fileURL in fileURLs {
             let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey])
             if values?.isRegularFile == true {
                 return true

--- a/Tests/ExistingInstallModelPrefetchPolicyTests.swift
+++ b/Tests/ExistingInstallModelPrefetchPolicyTests.swift
@@ -159,6 +159,34 @@ func testExistingInstallModelPrefetchPolicy() {
             "saved dictation or meeting notes should count as existing content"
         )
     }
+
+    runSuite("ExistingInstallModelPrefetchPolicy.captureLibraryHasContent — ignores nested archive files") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ExistingInstallModelPrefetchPolicyTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        writeExistingInstallTestFile(
+            root.appendingPathComponent("meetings", isDirectory: true)
+                .appendingPathComponent("audio", isDirectory: true)
+                .appendingPathComponent("Synthetic_audio", isDirectory: true)
+                .appendingPathComponent("recording.m4a", isDirectory: false)
+        )
+
+        assertFalse(
+            ExistingInstallModelPrefetchPolicy.captureLibraryHasContent(at: root),
+            "startup prefetch detection should avoid recursively walking nested audio archives"
+        )
+
+        writeExistingInstallTestFile(
+            root.appendingPathComponent("meetings", isDirectory: true)
+                .appendingPathComponent("Meeting.md", isDirectory: false)
+        )
+
+        assertTrue(
+            ExistingInstallModelPrefetchPolicy.captureLibraryHasContent(at: root),
+            "direct saved meeting files should still count as existing content"
+        )
+    }
 }
 
 private func writeExistingInstallTestFile(_ url: URL) {


### PR DESCRIPTION
## Summary
- avoid recursively walking nested capture archives when checking existing-install model prefetch signals
- keep direct saved meeting/dictation files counting as existing content
- add regression coverage for nested retained-audio archive files

## Verification
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh
- bash run-integration-smoke.sh
- REPETITIONS=5 scripts/dev/benchmark-home-recent-captures.sh
- ruby scripts/ops/dictation-recovery-autoeval.rb --details
- bash run-daily-audio-reliability.sh --synthetic --skip-build --no-launch

## Perf notes
- Home/recent-captures synthetic 10k load: avg 212.3 ms, best 195.9 ms, cancel 0.0 ms
- Dictation recovery autoeval: kept current policy p95 1990 ms vs 2440 ms baseline, 0 unexpected failures
- Synthetic audio reliability: PASS, 72 checks passed, 0 failed
