### PR TITLE
[codex] Track first dictation activation save

### DIFF
--- a/Sources/Support/PermissionsOnboardingPreferences.swift
+++ b/Sources/Support/PermissionsOnboardingPreferences.swift
@@ -3,6 +3,7 @@ import Foundation
 enum PermissionsOnboardingPreferences {
     static let completionKey = "permissionsOnboardingCompleted"
     static let forceKey = "forcePermissionsOnboarding"
+    static let firstDictationSavedTrackedKey = "permissionsOnboardingFirstDictationSavedTracked"
 
     static func hasCompleted(userDefaults: UserDefaults = .standard) -> Bool {
         if userDefaults.bool(forKey: forceKey) {
@@ -14,5 +15,13 @@ enum PermissionsOnboardingPreferences {
     static func markCompleted(userDefaults: UserDefaults = .standard) {
         userDefaults.set(true, forKey: completionKey)
         userDefaults.removeObject(forKey: forceKey)
+    }
+
+    static func markFirstDictationSavedTrackedIfNeeded(userDefaults: UserDefaults = .standard) -> Bool {
+        guard !hasCompleted(userDefaults: userDefaults) else { return false }
+        guard !userDefaults.bool(forKey: firstDictationSavedTrackedKey) else { return false }
+
+        userDefaults.set(true, forKey: firstDictationSavedTrackedKey)
+        return true
     }
 }

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -1012,6 +1012,12 @@ class DictationSessionController: ObservableObject {
                     ]
                 )
             )
+            if saveFailureMessage == nil {
+                self.trackOnboardingFirstDictationSavedIfNeeded(
+                    delivery: pasteOutcome.delivery,
+                    wordCount: wordCount
+                )
+            }
             appState.runtimeDiagnostics.clearSession(kind: "dictation", outcome: "completed")
         }
     }
@@ -1498,6 +1504,22 @@ class DictationSessionController: ObservableObject {
                     "delivery": delivery.rawValue
                 ]
             )
+        )
+    }
+
+    private func trackOnboardingFirstDictationSavedIfNeeded(
+        delivery: DictationDelivery,
+        wordCount: Int
+    ) {
+        guard PermissionsOnboardingPreferences.markFirstDictationSavedTrackedIfNeeded() else { return }
+
+        AnalyticsReporter.track(
+            "onboarding_first_dictation_saved",
+            properties: [
+                "delivery": delivery.rawValue,
+                "step_id": "dictation_test",
+                "word_count_bucket": AnalyticsReporter.wordCountBucket(wordCount),
+            ]
         )
     }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -619,16 +619,22 @@ struct TranscriptedSettingsView: View {
 
     private func handleCopyMeetingPreview(_ preview: HomeMeetingPreview) {
         trackSettingsAction("copy_meeting_preview", page: .home)
+        let bundle = AgentConnectionGuide.portableMeetingBundle(
+            title: preview.title,
+            date: preview.date,
+            transcriptURL: preview.transcriptURL
+        )
         ActivationTelemetry.trackAgentPromptAction(
-            promptKind: .meetingMarkdown,
+            promptKind: bundle == nil ? .meetingMarkdown : .meetingBundle,
             actionKind: .copied,
             agentTarget: .localAgent,
             surface: .homePreview,
+            result: bundle == nil ? .fallbackCopied : .success,
             artifactKind: .meeting
         )
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-        pasteboard.setString(preview.markdown, forType: .string)
+        pasteboard.setString(bundle ?? preview.markdown, forType: .string)
     }
 
     private func handleRetranscribeMeeting(_ item: RecentMeetingItem) {

--- a/Tests/PermissionsOnboardingPreferencesTests.swift
+++ b/Tests/PermissionsOnboardingPreferencesTests.swift
@@ -40,4 +40,40 @@ func testPermissionsOnboardingPreferences() {
             "completion should win after clearing the stale force override"
         )
     }
+
+    runSuite("PermissionsOnboardingPreferences tracks first saved dictation once") {
+        let suiteName = "PermissionsOnboardingPreferencesTests.first-dictation.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        assertTrue(
+            PermissionsOnboardingPreferences.markFirstDictationSavedTrackedIfNeeded(userDefaults: defaults),
+            "first saved dictation should be tracked while onboarding is incomplete"
+        )
+        assertFalse(
+            PermissionsOnboardingPreferences.markFirstDictationSavedTrackedIfNeeded(userDefaults: defaults),
+            "first saved dictation should not be tracked more than once"
+        )
+        assertTrue(
+            defaults.bool(forKey: PermissionsOnboardingPreferences.firstDictationSavedTrackedKey),
+            "first saved dictation tracking should persist"
+        )
+    }
+
+    runSuite("PermissionsOnboardingPreferences skips first saved dictation after completion") {
+        let suiteName = "PermissionsOnboardingPreferencesTests.first-dictation-complete.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        PermissionsOnboardingPreferences.markCompleted(userDefaults: defaults)
+
+        assertFalse(
+            PermissionsOnboardingPreferences.markFirstDictationSavedTrackedIfNeeded(userDefaults: defaults),
+            "completed onboarding should not emit first saved dictation telemetry"
+        )
+        assertNil(
+            defaults.object(forKey: PermissionsOnboardingPreferences.firstDictationSavedTrackedKey),
+            "skipped tracking should not mark the first saved dictation key"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- emit `onboarding_first_dictation_saved` once after the first onboarding dictation Markdown save succeeds
- copy the portable meeting bundle from the Home preview `Copy for agent` action when possible, with Markdown fallback telemetry
- add tests for the one-shot onboarding preference guard

## Why
Live PostHog showed healthy artifact creation but weak post-artifact agent/return signal: 25 devices saved artifacts in 7d, while only 2 devices touched agent-action telemetry and 2 hit the return proxy. The first-dictation-saved event was allowlisted and expected by health scripts but not emitted by the app.

## Privacy
Telemetry stays enum/bucket-only: delivery, step id, word-count bucket, prompt kind, result, surface, and artifact kind. No transcript text, titles, file paths, URLs, speaker names, or prompts are sent.

## Checks
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (3586 passed)
