### PR TITLE
[codex] Tighten agent operability docs

### DIFF
--- a/.agents/test-matrix.yml
+++ b/.agents/test-matrix.yml
@@ -78,6 +78,18 @@ rules:
       - "bash -n scripts/ops/daily-audio-reliability-check.sh"
 
   - paths:
+      - "scripts/ops/health-probe.sh"
+    checks:
+      - "scripts/dev/agent-preflight.sh"
+      - "bash -n scripts/ops/health-probe.sh"
+
+  - paths:
+      - "scripts/dev/onboarding.sh"
+    checks:
+      - "scripts/dev/agent-preflight.sh"
+      - "bash -n scripts/dev/onboarding.sh"
+
+  - paths:
       - "scripts/dev/benchmark-home-recent-captures.sh"
       - "Tests/Benchmarks/HomeRecentCaptureBenchmark.swift"
     checks:
@@ -93,10 +105,28 @@ rules:
       - "python3 scripts/ops/generate-nightly-digest.py --self-test"
 
   - paths:
-      - "scripts/dev/benchmark-home-recent-captures.sh"
+      - "scripts/ops/nightly-security-check.py"
     checks:
       - "scripts/dev/agent-preflight.sh"
-      - "bash -n scripts/dev/benchmark-home-recent-captures.sh"
+      - "python3 -m py_compile scripts/ops/nightly-security-check.py"
+
+  - paths:
+      - "scripts/ops/build-codex-memory-index.py"
+    checks:
+      - "scripts/dev/agent-preflight.sh"
+      - "python3 -m py_compile scripts/ops/build-codex-memory-index.py"
+
+  - paths:
+      - "scripts/ops/nightly-transcripted-archive-miner.sh"
+    checks:
+      - "scripts/dev/agent-preflight.sh"
+      - "bash -n scripts/ops/nightly-transcripted-archive-miner.sh"
+
+  - paths:
+      - "scripts/ops/performance-budget.rb"
+    checks:
+      - "scripts/dev/agent-preflight.sh"
+      - "ruby -c scripts/ops/performance-budget.rb"
 
   - paths:
       - "scripts/ops/transcripted-qa-bench.sh"
@@ -178,7 +208,7 @@ rules:
       - "bash build-deps.sh --force"
       - "bash build.sh --no-open"
       - "bash run-tests.sh"
-      - "SKIP_NOTARIZATION=1 bash build-beta.sh <token> <user-name>"
+      - "SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>"
 
   - paths:
       - "Tools/TranscriptedCLI/**"
@@ -207,7 +237,7 @@ rules:
       - "scripts/README.md"
       - "Sources/CLAUDE.md"
       - "Sources/**/CLAUDE.md"
-      - "Tools/CLAUDE.md"
+      - "Tools/README.md"
       - "Tools/**/CLAUDE.md"
       - ".agents/**"
       - ".github/**"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,7 @@
 ## How I checked it
 
 - [ ] `scripts/dev/agent-preflight.sh`
+- [ ] Selected checks from `.agents/test-matrix.yml` for the files changed
 - [ ] `bash build.sh --no-open`
 - [ ] `bash run-tests.sh`
 - [ ] Performance budget passed (`bash build.sh --no-open` runs the bundle gate; run `scripts/ops/performance-budget.rb --events "$HOME/Library/Application Support/Transcripted/logs/events.jsonl"` for runtime-sensitive changes)

--- a/.github/workflows/qa-gate-auto-close-bet88.yml
+++ b/.github/workflows/qa-gate-auto-close-bet88.yml
@@ -1,4 +1,5 @@
 name: BET-88 QA Gate Auto Close
+# Historical BET-88/#428 fixture. Keep label-gated unless this closed QA gate is retired.
 
 on:
   issue_comment:

--- a/.github/workflows/qa-gate-status-bet88.yml
+++ b/.github/workflows/qa-gate-status-bet88.yml
@@ -1,4 +1,5 @@
 name: BET-88 QA Gate Status
+# Historical BET-88/#428 fixture. Use workflow_dispatch only unless this closed QA gate is retired.
 
 on:
   workflow_dispatch:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,11 +76,12 @@ bash run-integration-smoke.sh
 swift test
 ```
 
-Rules:
+Rules. Use `.agents/test-matrix.yml` for the full path-to-verification map;
+these are the common minimums:
 
 1. After changing Swift source, run `bash build.sh --no-open` and `bash run-tests.sh`.
-2. If you touch `Sources/Meeting/` or `Sources/TranscriptedCore/`, also run `bash run-integration-smoke.sh`.
-3. If you touch `Package.swift`, `Sources/TranscriptedCore/`, or the public core seam, also run `swift test`.
+2. If you touch `Sources/Meeting/` or `Sources/TranscriptedCore/`, also run `bash build-deps.sh --force` and `bash run-integration-smoke.sh`.
+3. If you touch `Package.swift`, `Sources/TranscriptedCore/`, or the public core seam, also run `bash build-deps.sh --force`, `bash run-integration-smoke.sh`, and `swift test`.
 4. `build.sh` must not compile `Sources/TranscriptedCore/` directly into the app target.
 
 ## Releases, Sparkle, and Homebrew
@@ -112,7 +113,7 @@ Rules:
    - `bash build-deps.sh --force` when dependency tooling changes
    - `bash build.sh --no-open`
    - `bash run-tests.sh`
-   - `SKIP_NOTARIZATION=1 bash build-beta.sh <token> <user-name>` for packaging smoke, or the full notarized path when cutting a real release
+   - `SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>` for packaging smoke, or the full notarized path when cutting a real release
 
 ## Observability, Sentry, and Analytics
 

--- a/AGENT_START.md
+++ b/AGENT_START.md
@@ -67,14 +67,14 @@ checks for the files changed.
 Default rules:
 
 - Swift app change: `bash build.sh --no-open` and `bash run-tests.sh`
-- `Sources/Meeting/` or `Sources/TranscriptedCore/`: also `bash run-integration-smoke.sh`
-- `Package.swift` or public core seam: also `swift test`
+- `Sources/Meeting/` or `Sources/TranscriptedCore/`: also `bash build-deps.sh --force` and `bash run-integration-smoke.sh`
+- `Package.swift` or public core seam: also `bash build-deps.sh --force`, `bash run-integration-smoke.sh`, and `swift test`
 - release/update path: read `docs/release-packaging.md` and `docs/sparkle-updates.md`
 
 ## Handoff
 
-For worker-lane closeout, use the `AGENTS.md` coordinator closeout shape:
-`Status`, `Changed`, `Verified`, `Risk`, `Next`.
+For worker-lane closeout, use the exact `AGENTS.md` coordinator closeout line:
+`COORD_DONE: GREEN/BRIEF/RED | PR URL if any | changes made | GitHub cleanup recommendations | decisions needed | tests/checks run | smallest next action`.
 
 ## Safety
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ bash run-integration-smoke.sh      # app/core linkage + wake recovery + MicRecor
 bash run-e2e-smoke.sh              # deterministic release-critical artifact smoke (no mic/TCC)
 bash run-live-capture-smoke.sh     # local hardware/TCC smoke (needs mic + System Audio Recording perms)
 swift test                         # Swift Package tests for TranscriptedCore seam only
-bash build-beta.sh <token> <user>  # signed beta/distribution build; SKIP_NOTARIZATION=1 for packaging smoke
+bash build-beta.sh '' <user>       # signed beta/distribution build; first arg is compatibility-only
 bash scripts/dev/agent-preflight.sh  # prints suggested verification map for the current branch diff
 ```
 
@@ -55,7 +55,7 @@ Verification rules (mirror `.agents/test-matrix.yml`; if a change matches multip
 - Touched live-capture smoke paths (`Tests/TranscriptedCoreTests/LiveCaptureSmokeTests.swift`, `run-live-capture-smoke.sh`, `scripts/entrypoints/run-live-capture-smoke.sh`) → `bash run-live-capture-smoke.sh --skip-build`
 - Touched `Package.swift`, `Sources/TranscriptedCore/**`, or `Tests/TranscriptedCoreTests/**` → `bash build-deps.sh --force` + `bash build.sh --no-open` + `bash run-tests.sh` + `bash run-integration-smoke.sh` + `swift test`
 - Touched `Sources/Observability/**`, `Info.plist`, `docs/sparkle-updates.md`, or `docs/appcast.xml` → `bash build.sh --no-open` + `bash run-tests.sh`
-- Touched release path (`build-beta.sh`, `scripts/entrypoints/build-beta.sh`, `scripts/release/**`, `docs/release-packaging.md`, `docs/sparkle-updates.md`, `Casks/**`, `docs/appcast.xml`) → `bash build.sh --no-open` + `bash run-tests.sh` + `SKIP_NOTARIZATION=1 bash build-beta.sh <token> <user-name>`
+- Touched release path (`build-beta.sh`, `scripts/entrypoints/build-beta.sh`, `scripts/release/**`, `docs/release-packaging.md`, `docs/sparkle-updates.md`, `Casks/**`, `docs/appcast.xml`) → `bash build.sh --no-open` + `bash run-tests.sh` + `SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>`
 - Touched `Tools/TranscriptedCLI/**` → `swift test --package-path Tools/TranscriptedCLI`
 - Touched `Tools/TranscriptedMCP/**` → `swift test --package-path Tools/TranscriptedMCP`
 - Touched `Tools/TranscriptedQA/**` → `swift test --package-path Tools/TranscriptedQA`

--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -55,9 +55,9 @@ app target entirely. If a historical doc still mentions `Sources/Text/` or
 ## Read before editing
 
 - touching dictation persistence: `Sources/Dictation/CLAUDE.md`
-- touching meeting flow or imported-audio transcription: `Sources/Meeting/CLAUDE.md`
+- touching meeting flow, imported-audio transcription, or meeting UI: `Sources/Meeting/CLAUDE.md`
 - touching core library or meeting pipeline internals: `Sources/TranscriptedCore/CLAUDE.md`
-- touching STT / recording lifecycle: `Sources/Speech/CLAUDE.md`
+- touching STT, recording lifecycle, audio recovery, or device handling: `Sources/Speech/CLAUDE.md`
 - touching app-wide support utilities: `Sources/Support/CLAUDE.md`
 - touching overlay, menubar, onboarding, settings, or agent-connect UI: `Sources/UI/CLAUDE.md`
 - touching hotkeys or physical dictation trigger routing: `Sources/Capture/CLAUDE.md`

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -233,9 +233,15 @@ func testRepoCommandContract() {
             "bash -n scripts/entrypoints/run-tests.sh",
             "bash -n scripts/entrypoints/run-integration-smoke.sh",
             "bash -n scripts/ops/daily-audio-reliability-check.sh",
+            "bash -n scripts/ops/health-probe.sh",
+            "bash -n scripts/dev/onboarding.sh",
             "bash -n scripts/dev/benchmark-home-recent-captures.sh",
             "python3 -m py_compile scripts/ops/generate-nightly-digest.py",
             "python3 scripts/ops/generate-nightly-digest.py --self-test",
+            "python3 -m py_compile scripts/ops/nightly-security-check.py",
+            "python3 -m py_compile scripts/ops/build-codex-memory-index.py",
+            "bash -n scripts/ops/nightly-transcripted-archive-miner.sh",
+            "ruby -c scripts/ops/performance-budget.rb",
             "ruby -c scripts/ops/dictation-recovery-autoeval.rb"
         ]
 
@@ -773,13 +779,13 @@ func testRepoCommandContract() {
         assertTrue(
             releaseMatrixBlock.contains("bash build-deps.sh --force")
                 && releaseMatrixBlock.contains("bash build.sh --no-open")
-                && releaseMatrixBlock.contains("SKIP_NOTARIZATION=1 bash build-beta.sh <token> <user-name>"),
+                && releaseMatrixBlock.contains("SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>"),
             "release-path matrix checks should rebuild deps before app and packaging smoke"
         )
         assertTrue(
             releasePreflightBlock.contains("add_command \"bash build-deps.sh --force\"")
                 && releasePreflightBlock.contains("add_command \"bash build.sh --no-open\"")
-                && releasePreflightBlock.contains("add_command \"SKIP_NOTARIZATION=1 bash build-beta.sh <token> <user-name>\""),
+                && releasePreflightBlock.contains("add_command \"SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>\""),
             "agent preflight should suggest dependency rebuilds for release-path edits"
         )
     }
@@ -2162,10 +2168,14 @@ func testRepoCommandContract() {
         let prTemplate = readRepoTextFile(".github/PULL_REQUEST_TEMPLATE.md")
         let repoHygieneWorkflow = readRepoTextFile(".github/workflows/repo-hygiene.yml")
         let qaGateAutoClose = readRepoTextFile(".github/workflows/qa-gate-auto-close-bet88.yml")
+        let qaGateStatus = readRepoTextFile(".github/workflows/qa-gate-status-bet88.yml")
+        let workflow = readRepoTextFile("WORKFLOW.md")
+        let orchestration = readRepoTextFile("docs/agent-issue-orchestration.md")
 
         assertTrue(
             matrix.contains("\".github/**\"")
                 && matrix.contains("\"WORKFLOW.md\"")
+                && matrix.contains("\"Tools/README.md\"")
                 && matrix.contains("\"scripts/dev/agent-preflight.sh\"")
                 && matrix.contains("ruby -c scripts/ops/agent-todo-runner.rb")
                 && matrix.contains("bash -n scripts/ops/qa-gate-check.sh"),
@@ -2174,6 +2184,7 @@ func testRepoCommandContract() {
         assertTrue(
             preflight.contains("\".github/*\"")
                 && preflight.contains("\"WORKFLOW.md\"")
+                && preflight.contains("\"Tools/README.md\"")
                 && preflight.contains("\"scripts/dev/agent-preflight.sh\"")
                 && preflight.contains("ruby -c scripts/ops/agent-todo-runner.rb")
                 && preflight.contains("bash -n scripts/ops/qa-gate-check.sh"),
@@ -2197,6 +2208,7 @@ func testRepoCommandContract() {
         )
         assertTrue(
             prTemplate.contains("`scripts/dev/agent-preflight.sh`")
+                && prTemplate.contains("Selected checks from `.agents/test-matrix.yml`")
                 && prTemplate.contains("`swift test` if I touched `Package.swift`, `Sources/TranscriptedCore/`, or the public core seam")
                 && prTemplate.contains("Lane: `activation` / `dictation reliability` / `meeting reliability` / `release ops` / `agent workflow`")
                 && prTemplate.contains("COORD_DONE: GREEN/BRIEF/RED")
@@ -2213,8 +2225,15 @@ func testRepoCommandContract() {
         )
         assertTrue(
             qaGateAutoClose.contains("contains(github.event.issue.labels.*.name, 'qa-gate-auto-close')")
+                && qaGateAutoClose.contains("Historical BET-88/#428 fixture")
+                && qaGateStatus.contains("Historical BET-88/#428 fixture")
                 && !qaGateAutoClose.contains("child_issue_number"),
             "old BET-88 auto-close workflow should be label-gated and should not mutate a hard-coded child issue"
+        )
+        assertTrue(
+            workflow.contains("symphony-workspaces` folder name is historical")
+                && orchestration.contains("symphony-workspaces` name is historical"),
+            "agent issue workflow docs should explain the historical local workspace folder name"
         )
     }
 
@@ -2245,8 +2264,14 @@ func testRepoCommandContract() {
             repoLayout.contains("docs/activation-lane.md")
                 && repoLayout.contains("docs/agent-closeout.md")
                 && repoLayout.contains("docs/agent-connect.md")
-                && repoLayout.contains("Casks/"),
-            "repo layout should list activation, handoff, agent-connect, and Homebrew release surfaces"
+                && repoLayout.contains("Casks/")
+                && repoLayout.contains("Dated audit and autoeval docs in `docs/` are point-in-time evidence"),
+            "repo layout should list activation, handoff, agent-connect, Homebrew, and point-in-time audit surfaces"
+        )
+        assertTrue(
+            onboarding.contains("Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift")
+                && onboarding.contains("Sources/TranscriptedCore/Audio/Audio.swift"),
+            "agent onboarding should flag the large Core coordination files alongside the app mega-files"
         )
         assertTrue(
             activation.contains("saved Markdown -> agent use -> return")

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -38,6 +38,9 @@ Workspace:
 
 {{ workspace.path }}
 
+The `symphony-workspaces` folder name is historical. Treat it as the current
+local runner workspace root unless the frontmatter above changes.
+
 ## Job
 
 Take this GitHub issue from `agent todo` or `agent in progress` to a reviewable pull request.

--- a/docs/agent-closeout.md
+++ b/docs/agent-closeout.md
@@ -18,7 +18,7 @@ Status meanings:
   clear next move
 - `RED` - blocked, unsafe, failing verification, or needs a human decision
 
-## Before Closeout
+## Before Patch Closeout
 
 - Run `git status --short` and make sure only your task files are changed.
 - Run `bash scripts/dev/agent-preflight.sh`.
@@ -28,7 +28,12 @@ Status meanings:
   release metadata, dSYM upload, and public download surfaces were updated.
 - If you touched observability, say which sanitizer/policy tests or privacy
   checks covered the payload shape.
-- If you did not make a patch, say why.
+
+## Before Read-Only Closeout
+
+- Run `git status --short`.
+- Say why no patch was needed.
+- List any follow-up checks you skipped because there were no edits.
 
 ## GitHub Cleanup Boundaries
 

--- a/docs/agent-issue-orchestration.md
+++ b/docs/agent-issue-orchestration.md
@@ -80,6 +80,8 @@ bash scripts/ops/agent-todo-launchagent.sh restart
 - Reads `WORKFLOW.md`.
 - Finds open issues labeled `agent todo` or `agent in progress`.
 - Creates or reuses `/Users/redbars/code/symphony-workspaces/GH-<issue-number>`.
+  The `symphony-workspaces` name is historical; it is still the current local
+  runner workspace root until `WORKFLOW.md` changes.
 - Creates a single `## Codex Workpad` issue comment if one does not exist.
 - Moves new work from `agent todo` to `agent in progress`.
 - Launches Codex in that issue workspace.

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -214,6 +214,8 @@ Current high-ingestion files to treat carefully, ranked by agent pain:
 8. `Sources/UI/Overlay/MeetingOverlayController.swift` - meeting prompt/recording panel, views, and tokens
 9. `Sources/UI/Settings/SpeakerPeopleSettingsSection.swift` - people settings view model and row composition
 10. `Sources/Meeting/LiveMeetingCodexSession.swift` - live sidecar state, file writes, handoff text, and preview HTML
+11. `Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift` - Core queueing, retries, task lifecycle, and metadata handoff
+12. `Sources/TranscriptedCore/Audio/Audio.swift` - Core mic/system-audio start-stop state, recovery, and capture lifecycle
 
 Safe decomposition usually looks like extracting a pure presentation policy,
 formatter, or row helper with focused tests. Risky decomposition looks like

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -25,6 +25,7 @@ Use these as the active command surface:
 bash scripts/dev/agent-preflight.sh
 bash build-deps.sh
 bash build.sh --no-open
+bash build-beta.sh '' <user>
 bash run-tests.sh
 bash run-integration-smoke.sh
 bash run-e2e-smoke.sh
@@ -80,6 +81,10 @@ For helper and legacy scripts, see `scripts/README.md`.
 - `Casks/` — committed Homebrew cask release surface
 - `Resources/` — bundled app assets
 - `scripts/entrypoints/` — implementations behind the thin root command wrappers
+
+Dated audit and autoeval docs in `docs/` are point-in-time evidence. Use the
+current command map, local `CLAUDE.md`, and `.agents/test-matrix.yml` for live
+instructions unless a dated doc is explicitly the target of the task.
 
 ## Docs Map
 

--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -135,6 +135,16 @@ if [ -n "$changed_paths" ]; then
             add_command "bash -n scripts/ops/daily-audio-reliability-check.sh"
         fi
 
+        if matches_any "$path" "scripts/ops/health-probe.sh"; then
+            add_command "scripts/dev/agent-preflight.sh"
+            add_command "bash -n scripts/ops/health-probe.sh"
+        fi
+
+        if matches_any "$path" "scripts/dev/onboarding.sh"; then
+            add_command "scripts/dev/agent-preflight.sh"
+            add_command "bash -n scripts/dev/onboarding.sh"
+        fi
+
         if matches_any "$path" "scripts/dev/benchmark-home-recent-captures.sh" "Tests/Benchmarks/HomeRecentCaptureBenchmark.swift"; then
             add_command "scripts/dev/agent-preflight.sh"
             add_command "bash -n scripts/dev/benchmark-home-recent-captures.sh"
@@ -147,9 +157,24 @@ if [ -n "$changed_paths" ]; then
             add_command "python3 scripts/ops/generate-nightly-digest.py --self-test"
         fi
 
-        if matches_any "$path" "scripts/dev/benchmark-home-recent-captures.sh"; then
+        if matches_any "$path" "scripts/ops/nightly-security-check.py"; then
             add_command "scripts/dev/agent-preflight.sh"
-            add_command "bash -n scripts/dev/benchmark-home-recent-captures.sh"
+            add_command "python3 -m py_compile scripts/ops/nightly-security-check.py"
+        fi
+
+        if matches_any "$path" "scripts/ops/build-codex-memory-index.py"; then
+            add_command "scripts/dev/agent-preflight.sh"
+            add_command "python3 -m py_compile scripts/ops/build-codex-memory-index.py"
+        fi
+
+        if matches_any "$path" "scripts/ops/nightly-transcripted-archive-miner.sh"; then
+            add_command "scripts/dev/agent-preflight.sh"
+            add_command "bash -n scripts/ops/nightly-transcripted-archive-miner.sh"
+        fi
+
+        if matches_any "$path" "scripts/ops/performance-budget.rb"; then
+            add_command "scripts/dev/agent-preflight.sh"
+            add_command "ruby -c scripts/ops/performance-budget.rb"
         fi
 
         if matches_any "$path" "scripts/ops/transcripted-qa-bench.sh" "scripts/ops/validate-meeting-corpus.py" "scripts/ops/compare-meeting-corpus.py" "docs/qa-test-bench.md"; then
@@ -206,10 +231,10 @@ if [ -n "$changed_paths" ]; then
             add_command "bash build-deps.sh --force"
             add_command "bash build.sh --no-open"
             add_command "bash run-tests.sh"
-            add_command "SKIP_NOTARIZATION=1 bash build-beta.sh <token> <user-name>"
+            add_command "SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>"
         fi
 
-        if matches_any "$path" "README.md" "AGENT_START.md" "AGENTS.md" "CLAUDE.md" "CONTRIBUTING.md" "WORKFLOW.md" "docs/*" "Tests/README.md" "scripts/README.md" "Sources/CLAUDE.md" "Sources/*/CLAUDE.md" "Sources/*/*/CLAUDE.md" "Tools/CLAUDE.md" "Tools/*/CLAUDE.md" "Tools/*/*/CLAUDE.md" ".agents/*" ".github/*" "scripts/dev/agent-preflight.sh"; then
+        if matches_any "$path" "README.md" "AGENT_START.md" "AGENTS.md" "CLAUDE.md" "CONTRIBUTING.md" "WORKFLOW.md" "docs/*" "Tests/README.md" "scripts/README.md" "Sources/CLAUDE.md" "Sources/*/CLAUDE.md" "Sources/*/*/CLAUDE.md" "Tools/README.md" "Tools/*/CLAUDE.md" "Tools/*/*/CLAUDE.md" ".agents/*" ".github/*" "scripts/dev/agent-preflight.sh"; then
             add_command "scripts/dev/agent-preflight.sh"
         fi
     done <<< "$changed_paths"


### PR DESCRIPTION
## What changed

- Aligned first-read agent docs around `COORD_DONE`, stricter Meeting/Core verification, beta compatibility args, and `Tools/README.md` routing.
- Expanded `.agents/test-matrix.yml` and `scripts/dev/agent-preflight.sh` coverage for active ops scripts, while removing the duplicate benchmark-only rule.
- Clarified PR checklist matrix checks, BET-88 workflow fixture status, local runner workspace naming, dated audit doc status, and large Core coordination files.

## Checks

- `scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `git diff --check`
- YAML load for `.agents/test-matrix.yml`

## Notes

Docs/tooling only. No product behavior changes.