### PR TITLE
Stop prompts for ended meeting events

### DIFF
--- a/Sources/Meeting/MeetingPromptDetector.swift
+++ b/Sources/Meeting/MeetingPromptDetector.swift
@@ -331,7 +331,11 @@ final class MeetingPromptDetector {
         guard let meetingURL = extractMeetingURL(from: event), let provider = provider(for: meetingURL) else { return nil }
 
         let startsIn = event.startDate.timeIntervalSince(now)
-        let genericWindow = MeetingPromptWindowPolicy.shouldOfferCalendarPrompt(startsIn: startsIn)
+        let endsIn = event.endDate.timeIntervalSince(now)
+        let genericWindow = MeetingPromptWindowPolicy.shouldOfferCalendarPrompt(
+            startsIn: startsIn,
+            endsIn: endsIn
+        )
         let runtimeReason = activeRuntimeReason(
             for: provider,
             runningBundleIDs: runningBundleIDs,

--- a/Sources/Meeting/MeetingPromptHeuristics.swift
+++ b/Sources/Meeting/MeetingPromptHeuristics.swift
@@ -100,8 +100,9 @@ struct MeetingPromptBackoffDecision: Equatable {
 }
 
 enum MeetingPromptWindowPolicy {
-    static func shouldOfferCalendarPrompt(startsIn: TimeInterval) -> Bool {
-        (-MeetingPromptHeuristics.calendarReminderPostStartGrace ... MeetingPromptHeuristics.calendarReminderLeadTime)
+    static func shouldOfferCalendarPrompt(startsIn: TimeInterval, endsIn: TimeInterval) -> Bool {
+        guard endsIn > 0 else { return false }
+        return (-MeetingPromptHeuristics.calendarReminderPostStartGrace ... MeetingPromptHeuristics.calendarReminderLeadTime)
             .contains(startsIn)
     }
 }

--- a/Tests/MeetingPromptHeuristicsTests.swift
+++ b/Tests/MeetingPromptHeuristicsTests.swift
@@ -243,13 +243,15 @@ func testMeetingPromptHeuristics() {
     runSuite("MeetingPromptWindowPolicy.shouldOfferCalendarPrompt — only prompts in the one-minute lead window") {
         assertFalse(
             MeetingPromptWindowPolicy.shouldOfferCalendarPrompt(
-                startsIn: MeetingPromptHeuristics.calendarReminderLeadTime + 1
+                startsIn: MeetingPromptHeuristics.calendarReminderLeadTime + 1,
+                endsIn: 30 * 60
             ),
             "calendar prompts should not fire earlier than one minute before the meeting"
         )
         assertTrue(
             MeetingPromptWindowPolicy.shouldOfferCalendarPrompt(
-                startsIn: MeetingPromptHeuristics.calendarReminderLeadTime
+                startsIn: MeetingPromptHeuristics.calendarReminderLeadTime,
+                endsIn: 30 * 60
             ),
             "calendar prompts should fire at one minute before the meeting"
         )
@@ -258,15 +260,41 @@ func testMeetingPromptHeuristics() {
     runSuite("MeetingPromptWindowPolicy.shouldOfferCalendarPrompt — keeps a short grace period after start") {
         assertTrue(
             MeetingPromptWindowPolicy.shouldOfferCalendarPrompt(
-                startsIn: -MeetingPromptHeuristics.calendarReminderPostStartGrace
+                startsIn: -MeetingPromptHeuristics.calendarReminderPostStartGrace,
+                endsIn: 25 * 60
             ),
             "calendar prompts should still be eligible during the short after-start grace period"
         )
         assertFalse(
             MeetingPromptWindowPolicy.shouldOfferCalendarPrompt(
-                startsIn: -(MeetingPromptHeuristics.calendarReminderPostStartGrace + 1)
+                startsIn: -(MeetingPromptHeuristics.calendarReminderPostStartGrace + 1),
+                endsIn: 25 * 60
             ),
             "calendar prompts should expire after the post-start grace period"
+        )
+    }
+
+    runSuite("MeetingPromptWindowPolicy.shouldOfferCalendarPrompt — rejects ended calendar events") {
+        assertFalse(
+            MeetingPromptWindowPolicy.shouldOfferCalendarPrompt(
+                startsIn: -3 * 60,
+                endsIn: -30
+            ),
+            "calendar prompts should not fire after a Zoom calendar event has already ended"
+        )
+        assertFalse(
+            MeetingPromptWindowPolicy.shouldOfferCalendarPrompt(
+                startsIn: -3 * 60,
+                endsIn: 0
+            ),
+            "calendar prompts should stop at the event end boundary"
+        )
+        assertTrue(
+            MeetingPromptWindowPolicy.shouldOfferCalendarPrompt(
+                startsIn: -3 * 60,
+                endsIn: 20 * 60
+            ),
+            "in-progress calendar-backed meetings should still be eligible during the post-start grace period"
         )
     }
 }


### PR DESCRIPTION
## Summary
- Prevent calendar-backed meeting prompts after the calendar event has already ended.
- Pass event end timing into `MeetingPromptWindowPolicy`.
- Add regression coverage for ended Zoom calendar-event prompts while preserving in-progress prompt behavior.

## Root Cause Confidence
Medium-high for the remaining current-main false-positive path: Zoom app-only prompts were already fixed on `main`, and current Zoom prompts require calendar evidence. The missing guard was that calendar prompt eligibility checked start timing but not event end timing.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`

## Notes
Local logs did not contain a recent `meeting_prompt_shown` or `meeting_audio_inactivity_*` event, so this was not live-reproduced against a real Zoom call. Zoom is installed locally (`us.zoom.xos`), but the safe app-open transition should not produce a Zoom runtime prompt on current `main`.
