### PR TITLE
[docs] Update live preview server docs

### DIFF
--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -122,6 +122,7 @@ Relevant direct coverage:
 - `Tests/MeetingSessionUIPolicyTests.swift`
 - `Tests/MeetingAudioStorageManagerTests.swift`
 - `Tests/MeetingTranscriptStylerTests.swift`
+- `Tests/LiveMeetingPreviewServerTests.swift`
 - `Tests/SpeakerNamingPolicyTests.swift`
 - `Tests/Integration/AppCoreIntegrationSmoke.swift`
 


### PR DESCRIPTION
## Summary
- Add the new live meeting preview server fast test to the Meeting local coverage list.

## Verification
- bash scripts/dev/agent-preflight.sh
- git diff --check