### PR TITLE
[docs] Update core logging docs

### DIFF
--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -4,10 +4,10 @@
 
 `Sources/TranscriptedCore/` is the reusable meeting transcription library embedded in this repo. It is consumed by the app through `Sources/Meeting/`, and it can also be tested as a standalone Swift package through the root `Package.swift`.
 
-## Subsystems (66 Swift files)
+## Subsystems (67 Swift files)
 
 - `Audio/` (18 files) — mic + system audio capture, imported-audio prep helpers, capture start-state gating, device recovery, Bluetooth-input avoidance for meetings, signal analysis and normalization helpers, real-time AGC, resampling, level metering, process tap, ScreenCaptureKit-backed system-audio capture, backend selection, buffer writing, merge helpers, and privacy-safe pipeline diagnostics snapshots
-- `Logging/` (2 files) — shared app logger and JSONL file logger
+- `Logging/` (3 files) — shared app logger, JSONL file logger, and log privacy sanitizer
 - `Models/` (5 files) — public data types: `TranscriptionResult`, `DisplayStatus`, `FailedTranscription`, `SpeakerMapping`, and recording-health metadata builders
 - `Pipeline/` (4 files) — transcription orchestration, pipeline runner, and task queue
 - `Protocols/` (7 files) — host-injected seams: `SpeechToTextEngine`, `DiarizationEngine`, `SpeakerStore`, `TranscriptNotifier`, `AudioCaptureEngine`, `StatsStore`, `TranscriptStorage`


### PR DESCRIPTION
## Summary
- update TranscriptedCore CLAUDE.md file counts after LogPrivacySanitizer landed
- name the core logging privacy sanitizer in the subsystem list

## Verification
- bash scripts/dev/agent-preflight.sh
- git diff --check