### PR TITLE
[test-generator] Cover shallow prefetch scan guardrails

### DIFF
--- a/Tests/ExistingInstallModelPrefetchPolicyTests.swift
+++ b/Tests/ExistingInstallModelPrefetchPolicyTests.swift
@@ -187,6 +187,77 @@ func testExistingInstallModelPrefetchPolicy() {
             "direct saved meeting files should still count as existing content"
         )
     }
+
+    runSuite("ExistingInstallModelPrefetchPolicy.captureLibraryHasContent — ignores files outside capture buckets") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ExistingInstallModelPrefetchPolicyTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        writeExistingInstallTestFile(
+            root.appendingPathComponent("loose-note.md", isDirectory: false)
+        )
+
+        assertFalse(
+            ExistingInstallModelPrefetchPolicy.captureLibraryHasContent(at: root),
+            "files outside dictations or meetings should not count as capture history"
+        )
+    }
+
+    runSuite("ExistingInstallModelPrefetchPolicy.captureLibraryHasContent — ignores hidden direct files") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ExistingInstallModelPrefetchPolicyTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        writeExistingInstallTestFile(
+            root.appendingPathComponent("dictations", isDirectory: true)
+                .appendingPathComponent(".hidden.md", isDirectory: false)
+        )
+
+        assertFalse(
+            ExistingInstallModelPrefetchPolicy.captureLibraryHasContent(at: root),
+            "hidden files should not make a fresh install look like it has saved captures"
+        )
+    }
+
+    runSuite("ExistingInstallModelPrefetchPolicy.captureLibraryHasContent — ignores direct child directories") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ExistingInstallModelPrefetchPolicyTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try? FileManager.default.createDirectory(
+            at: root.appendingPathComponent("meetings", isDirectory: true)
+                .appendingPathComponent("audio", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        assertFalse(
+            ExistingInstallModelPrefetchPolicy.captureLibraryHasContent(at: root),
+            "top-level capture subdirectories should not count without a direct saved file"
+        )
+    }
+
+    runSuite("ExistingInstallModelPrefetchPolicy.captureLibraryHasContent — visible direct files win with ignored siblings") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ExistingInstallModelPrefetchPolicyTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let dictations = root.appendingPathComponent("dictations", isDirectory: true)
+
+        try? FileManager.default.createDirectory(
+            at: dictations.appendingPathComponent("drafts", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        writeExistingInstallTestFile(
+            dictations.appendingPathComponent(".hidden.md", isDirectory: false)
+        )
+        writeExistingInstallTestFile(
+            dictations.appendingPathComponent("saved.md", isDirectory: false)
+        )
+
+        assertTrue(
+            ExistingInstallModelPrefetchPolicy.captureLibraryHasContent(at: root),
+            "a visible direct saved file should still count when ignored siblings are present"
+        )
+    }
 }
 
 private func writeExistingInstallTestFile(_ url: URL) {


### PR DESCRIPTION
## Missing coverage

Recent existing-install prefetch work changed capture-library detection to a shallow direct-file scan so nested retained-audio archives do not trigger background model work. The existing tests covered nested archives, but not other directory shapes that could accidentally mark a fresh install as existing.

## Tests added

- Root-level files outside `dictations/` and `meetings/` are ignored.
- Hidden direct files are ignored.
- Direct child directories are ignored.
- A visible direct saved file still counts when ignored hidden or directory siblings are present.

## Checks run

- `bash scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force` — refreshed stale dependency artifacts before the required build
- `bash build.sh --no-open`
- `bash run-tests.sh` — 3752 tests passed
