### PR TITLE
[nightly-telemetry] Filter Sentry test events from health probe

### DIFF
--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -58,6 +58,11 @@ func testRepoCommandContract() {
                 && contents.contains("lastSeen=\\(.lastSeen"),
             "Sentry probe should show aggregate issue counts and freshness for operator triage"
         )
+        assertTrue(
+            contents.contains("sentry_test_event")
+                && contents.contains("select(((.title // \"\") | contains(\"sentry_test_event\")) | not)"),
+            "Sentry probe should filter manual verification events out of health rollups"
+        )
         assertFalse(
             contents.contains("/events/"),
             "Sentry health probe should not fetch raw event payloads for the nightly rollup"

--- a/scripts/ops/health-probe.sh
+++ b/scripts/ops/health-probe.sh
@@ -96,6 +96,7 @@ probe_sentry() {
   response=$(curl -s -f -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
     "https://sentry.io/api/0/projects/r3dbars/apple-macos/issues/?query=is:unresolved&limit=10" \
     --header "Content-Type: application/json")
+  response=$(echo "$response" | jq '[.[] | select(((.title // "") | contains("sentry_test_event")) | not)]')
 
   if [[ -z "$response" ]]; then
     echo "Sentry: no unresolved issues"


### PR DESCRIPTION
## Summary
- filter `sentry_test_event` out of the Sentry health-probe unresolved rollup
- add a repo contract assertion so manual verification events stay out of operator health counts

## Evidence
- Sentry release query for `transcripted@1.1.46` only returned `sentry_test_event` in production
- The live health probe previously counted it before real unresolved issues, despite docs treating manual Sentry tests as dashboard-verification noise
- PostHog current-release workflow telemetry is healthy: 96 launches, 151 dictation completions, 43 meeting saves, and 58 clean update checks in 7d

## Verification
- `bash -n scripts/ops/health-probe.sh`
- `bash scripts/ops/health-probe.sh sentry`
- `bash run-tests.sh` (3749 passed)

## Privacy
No off-device payload changes. This only filters an existing manual verification event from local health-probe output.