### PR TITLE
[docs] Update live meeting coverage docs

### DIFF
--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -122,7 +122,9 @@ Relevant direct coverage:
 - `Tests/MeetingSessionUIPolicyTests.swift`
 - `Tests/MeetingAudioStorageManagerTests.swift`
 - `Tests/MeetingTranscriptStylerTests.swift`
+- `Tests/LiveMeetingCodexSessionTests.swift`
 - `Tests/LiveMeetingPreviewServerTests.swift`
+- `Tests/LiveMeetingStreamingUpdatePolicyTests.swift`
 - `Tests/SpeakerNamingPolicyTests.swift`
 - `Tests/Integration/AppCoreIntegrationSmoke.swift`
 


### PR DESCRIPTION
## Summary
- add existing live meeting sidecar and streaming update tests to the Meeting CLAUDE.md direct coverage list

## Verification
- bash scripts/dev/agent-preflight.sh
- git diff --check