### PR TITLE
Harden AirPods dictation route settling

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -1347,17 +1347,10 @@ class ParakeetEngine: ObservableObject {
             "audio_input_selection_load_ms": Self.elapsedMilliseconds(since: selectionStartedAt)
         ]
         if let selection, selection.didOverrideDefault {
-            let deviceCheckStartedAt = CFAbsoluteTimeGetCurrent()
-            let shouldApplyOverride = try await runTimedAudioEngineWork(operation: "\(operation)_device_check") { engine in
-                engine.inputNode.auAudioUnit.deviceID != selection.selectedInput.id
-            }
-            stageTimings["audio_input_device_check_ms"] = Self.elapsedMilliseconds(since: deviceCheckStartedAt)
-            if let recoveryGeneration, recoveryState.isStale(generation: recoveryGeneration) {
-                throw CancellationError()
-            }
-            if shouldApplyOverride {
-                ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent() + 1.0
-            }
+            // Avoid touching the current default input before the override is applied.
+            // On AirPods routes, even a short read of the default input can briefly
+            // pull playback toward headset-mode audio.
+            ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent() + 1.0
         }
 
         if let recoveryGeneration, recoveryState.isStale(generation: recoveryGeneration) {
@@ -1482,7 +1475,9 @@ class ParakeetEngine: ObservableObject {
                 let frameLength = monoSamples.count
                 guard frameLength > 0 else { return }
                 let bufferFormat = Self.audioFormatSummary(buffer.format)
-                let effectiveSampleRate = ParakeetAudioFormatReadinessPolicy.captureSampleRateOrFallback(bufferFormat.sampleRate)
+                let effectiveSampleRate = ParakeetTapSampleRatePolicy.effectiveSampleRate(
+                    bufferSampleRate: bufferFormat.sampleRate
+                )
                 self.nativeSampleRate = effectiveSampleRate
 
                 if !self.didReceiveAudioSamples && frameLength > 0 {

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -148,7 +148,7 @@ enum ParakeetAudioFormatReadinessPolicy {
         selectedInputClass: String,
         outputDeviceClass: String,
         selectionOverrodeDefault: Bool,
-        selectionReason: DictationInputDeviceSelectionReason? = nil
+        selectionReason _: DictationInputDeviceSelectionReason? = nil
     ) -> ParakeetAudioFormatReadiness {
         guard isUsableCaptureSampleRate(outputSampleRate), outputChannelCount > 0,
               isUsableCaptureSampleRate(inputSampleRate), inputChannelCount > 0 else {
@@ -158,7 +158,6 @@ enum ParakeetAudioFormatReadinessPolicy {
         let lowRateOutputBus = likelyBluetoothSpeechRates.contains(Int(outputSampleRate.rounded()))
         let overriddenBluetoothOutputRoute = selectionOverrodeDefault
             && outputDeviceClass == "bluetooth"
-            && selectionReason != .preferredBuiltInForBluetoothHeadset
 
         if selectedInputClass != "bluetooth",
            inputSampleRate >= 44_100,
@@ -199,7 +198,19 @@ enum ParakeetAudioFormatReadinessPolicy {
 
 enum ParakeetInputOverrideSettlePolicy {
     static func delayNanoseconds(afterImmediateReadiness readiness: ParakeetAudioFormatReadiness) -> UInt64 {
-        readiness == .ready ? 0 : TranscriptedConstants.audioRecoveryDelay
+        switch readiness {
+        case .ready, .invalid, .routeNotSettled:
+            return TranscriptedConstants.audioRecoveryDelay
+        }
+    }
+}
+
+enum ParakeetTapSampleRatePolicy {
+    static func effectiveSampleRate(
+        bufferSampleRate: Double,
+        hardwareSampleRate _: Double? = nil
+    ) -> Double {
+        ParakeetAudioFormatReadinessPolicy.captureSampleRateOrFallback(bufferSampleRate)
     }
 }
 

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -201,7 +201,7 @@ func testParakeetStartRecordingFailurePolicy() {
         assertEqual(readiness.startFailureReason, .audioRouteNotSettled, "stale Bluetooth output routes should map to route-not-settled")
     }
 
-    runSuite("ParakeetAudioFormatReadinessPolicy accepts preferred built-in fallback with Bluetooth output") {
+    runSuite("ParakeetAudioFormatReadinessPolicy defers preferred built-in fallback with Bluetooth speech output") {
         let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
             outputSampleRate: 24_000,
             outputChannelCount: 1,
@@ -213,10 +213,10 @@ func testParakeetStartRecordingFailurePolicy() {
             selectionReason: .preferredBuiltInForBluetoothHeadset
         )
 
-        assertEqual(readiness, .ready, "built-in fallback for Bluetooth output should start instead of timing out")
+        assertEqual(readiness, .routeNotSettled, "forced built-in fallback should wait until Bluetooth output leaves speech mode")
     }
 
-    runSuite("ParakeetAudioFormatReadinessPolicy accepts preferred fallback across Bluetooth speech rates") {
+    runSuite("ParakeetAudioFormatReadinessPolicy defers preferred fallback across Bluetooth speech rates") {
         for outputRate in [8_000.0, 16_000.0] {
             let readiness = ParakeetAudioFormatReadinessPolicy.readiness(
                 outputSampleRate: outputRate,
@@ -229,7 +229,7 @@ func testParakeetStartRecordingFailurePolicy() {
                 selectionReason: .preferredBuiltInForBluetoothHeadset
             )
 
-            assertEqual(readiness, .ready, "preferred built-in fallback should not wait on Bluetooth speech output rate \(outputRate)")
+            assertEqual(readiness, .routeNotSettled, "preferred built-in fallback should wait on Bluetooth speech output rate \(outputRate)")
         }
     }
 
@@ -357,11 +357,11 @@ func testParakeetStartRecordingFailurePolicy() {
         assertEqual(readiness, .ready, "native 24k external capture should stay usable when input and output agree")
     }
 
-    runSuite("ParakeetInputOverrideSettlePolicy skips delay when immediate format is ready") {
+    runSuite("ParakeetInputOverrideSettlePolicy waits after a ready input override") {
         assertEqual(
             ParakeetInputOverrideSettlePolicy.delayNanoseconds(afterImmediateReadiness: .ready),
-            0,
-            "ready formats after an input override should not pay a fixed settle delay"
+            TranscriptedConstants.audioRecoveryDelay,
+            "ready formats still get a short settle after forcing AirPods input away from the headset mic"
         )
     }
 
@@ -375,6 +375,32 @@ func testParakeetStartRecordingFailurePolicy() {
             ParakeetInputOverrideSettlePolicy.delayNanoseconds(afterImmediateReadiness: .invalid),
             TranscriptedConstants.audioRecoveryDelay,
             "invalid formats should still get the full CoreAudio settle delay"
+        )
+    }
+
+    runSuite("ParakeetTapSampleRatePolicy trusts the tap buffer rate over AirPods hardware rate") {
+        let effectiveSampleRate = ParakeetTapSampleRatePolicy.effectiveSampleRate(
+            bufferSampleRate: 48_000,
+            hardwareSampleRate: 24_000
+        )
+
+        assertEqual(
+            effectiveSampleRate,
+            48_000,
+            "AirPods HFP can expose 24k hardware while the tap delivers 48k buffers; dictation must resample from the tap rate"
+        )
+    }
+
+    runSuite("ParakeetTapSampleRatePolicy falls back for invalid tap rates") {
+        let effectiveSampleRate = ParakeetTapSampleRatePolicy.effectiveSampleRate(
+            bufferSampleRate: 0,
+            hardwareSampleRate: 24_000
+        )
+
+        assertEqual(
+            effectiveSampleRate,
+            ParakeetAudioFormatReadinessPolicy.fallbackCaptureSampleRate,
+            "invalid tap rates should still use the central safe fallback"
         )
     }
 


### PR DESCRIPTION
## Summary
- avoid probing the current AirPods default input before applying the built-in mic override
- require Bluetooth output speech-rate routes to settle before forced built-in fallback is treated as ready
- keep dictation resampling pinned to the tap buffer rate so 48k AirPods tap buffers are not mislabeled as 24k hardware audio

## Verification
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh (3750 passed)
- bash run-daily-audio-reliability.sh --synthetic
- manual AirPods dictation on the patched build: completed/pasted cleanly with built-in mic + Bluetooth output

## Notes
This targets the annoying AirPods headset-mode dictation route without re-enabling VPIO or changing global/default audio devices.