### PR TITLE
[docs] Update AirPods route docs

### DIFF
--- a/docs/autoeval-dictation-start-time-2026-05-31.md
+++ b/docs/autoeval-dictation-start-time-2026-05-31.md
@@ -1,5 +1,10 @@
 # Dictation Start Time Autoeval - 2026-05-31
 
+> Update 2026-06-05: The kept input-override change from this run is historical.
+> AirPods route hardening later restored the fixed settle wait even when the
+> immediate format is `.ready`, because a ready snapshot can still be mid-route.
+> Treat the "skip ready settle delay" rows below as superseded.
+
 ## Goal
 
 Improve the ready-engine dictation start path, measured by `dictation_recording_fast_start` `start_ms`.


### PR DESCRIPTION
## Summary
- mark the old dictation start-time input-override settle result as superseded by the AirPods route hardening change
- keep the historical autoeval results intact while preventing agents from treating the ready-settle skip as current behavior

## Verification
- bash scripts/dev/agent-preflight.sh
- git diff --check
- ruby -c scripts/ops/dictation-recovery-autoeval.rb
- ruby scripts/ops/dictation-recovery-autoeval.rb --details