### PR TITLE
Fix Parakeet zombie recovery reset

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -2293,12 +2293,14 @@ class ParakeetEngine: ObservableObject {
             self.pendingSamplesLock.withLock {
                 self.pendingSamples.removeAll(keepingCapacity: true)
             }
+            self.isRecording = false
+            self.audioLevel = 0
+            self.configChangeWasRecording = false
+            self.ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent() + 1.0
             await self.eouManager?.reset()
             await self.removeRecordingTap()
             await self.stopAudioEngine()
             self.isEnginePrewarmed = false
-            self.isRecording = false
-            self.audioLevel = 0
 
             try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
             guard !Task.isCancelled else { return }

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -568,4 +568,40 @@ func testParakeetStartRecordingFailurePolicy() {
             "non-route CoreAudio errors should stay generic engine-start failures"
         )
     }
+
+    runSuite("ParakeetEngine zombie watchdog marks recording idle before graph reset") {
+        let source = readParakeetEngineSource()
+        guard let watchdogStart = source.range(of: "private func startAudioWatchdog()"),
+              let watchdogEnd = source.range(of: "func stopRecording()", range: watchdogStart.upperBound..<source.endIndex) else {
+            assertTrue(false, "test should find the zombie watchdog body")
+            return
+        }
+        let watchdog = String(source[watchdogStart.lowerBound..<watchdogEnd.lowerBound])
+        guard let markIdle = watchdog.range(of: "self.isRecording = false"),
+              let clearRestartFlag = watchdog.range(of: "self.configChangeWasRecording = false"),
+              let suppressConfigChanges = watchdog.range(of: "self.ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent() + 1.0"),
+              let removeTap = watchdog.range(of: "await self.removeRecordingTap()"),
+              let stopEngine = watchdog.range(of: "await self.stopAudioEngine()") else {
+            assertTrue(false, "zombie watchdog should mark internal reset state before touching CoreAudio")
+            return
+        }
+
+        assertTrue(markIdle.lowerBound < removeTap.lowerBound, "zombie reset should stop being treated as active recording before tap removal can post config changes")
+        assertTrue(markIdle.lowerBound < stopEngine.lowerBound, "zombie reset should stop being treated as active recording before engine stop can post config changes")
+        assertTrue(clearRestartFlag.lowerBound < removeTap.lowerBound, "zombie reset should not leave the device-change restart flag armed")
+        assertTrue(suppressConfigChanges.lowerBound < removeTap.lowerBound, "zombie reset should suppress self-induced config changes before graph teardown")
+    }
+}
+
+private func readParakeetEngineSource(file: String = #file, line: Int = #line) -> String {
+    let url = repoFixtureURL("Sources/Speech/ParakeetEngine.swift")
+    do {
+        return try String(contentsOf: url, encoding: .utf8)
+    } catch {
+        totalTests += 1
+        failedTests += 1
+        let loc = "\(URL(fileURLWithPath: file).lastPathComponent):\(line)"
+        print("  FAIL [\(loc)] could not read ParakeetEngine.swift: \(error)")
+        return ""
+    }
 }


### PR DESCRIPTION
## Summary
- fix the Parakeet zombie watchdog reset so it marks recording idle before touching the CoreAudio graph
- clear the device-change restart flag and briefly suppress self-induced config notifications during zombie reset
- add focused fast coverage guarding the zombie reset ordering

## Sentry
- APPLE-MACOS-1T: parakeet.zombie_engine_recovery_failed
- APPLE-MACOS-1V: parakeet.recording_interrupted with reason=recording_restart_budget_exhausted
- route shape: built_in_input_to_bluetooth_output, sample_flow_started=false

## Verification
- bash run-tests.sh -> 3754 passed
- bash build-deps.sh --force
- bash build.sh --no-open

## Patch verdict
Fast-patch-worthy for current 1.1.46 users. Ship through a Sparkle-visible patch build rather than waiting for broader launch work.