### PR TITLE
[test-generator] Cover source app bundle redaction guardrails

### DIFF
--- a/Tests/ObservabilityTextRedactorTests.swift
+++ b/Tests/ObservabilityTextRedactorTests.swift
@@ -165,6 +165,48 @@ func testObservabilityTextRedactor() {
         assertTrue(redacted.contains("trigger=hotkey"), "non-sensitive trigger should remain")
     }
 
+    runSuite("ObservabilityTextRedactor scrubs inline source_app_bundle assignments") {
+        let input = "ctx source_app_bundle=com.example.privateapp result=ok"
+        let redacted = ObservabilityTextRedactor.redact(input)
+
+        assertFalse(redacted.contains("com.example.privateapp"), "inline source_app_bundle value must not survive")
+        assertEqual(redacted,
+                    "ctx source_app_bundle=[redacted-sensitive-value] result=ok",
+                    "inline source_app_bundle should redact only the sensitive assignment")
+    }
+
+    runSuite("ObservabilityTextRedactor scrubs case-insensitive inline source_app_bundle assignments") {
+        let input = "ctx SOURCE_APP_BUNDLE=com.example.PrivateApp stage=ready"
+        let redacted = ObservabilityTextRedactor.redact(input)
+
+        assertFalse(redacted.contains("com.example.PrivateApp"), "case-varied source_app_bundle value must not survive")
+        assertEqual(redacted,
+                    "ctx SOURCE_APP_BUNDLE=[redacted-sensitive-value] stage=ready",
+                    "case-insensitive inline keys should preserve safe metadata after redaction")
+    }
+
+    runSuite("ObservabilityTextRedactor scrubs trailing inline source_app_bundle assignments") {
+        let input = "ctx source_app_bundle=com.example.privateapp"
+        let redacted = ObservabilityTextRedactor.redact(input)
+
+        assertFalse(redacted.contains("com.example.privateapp"), "trailing source_app_bundle value must not survive")
+        assertEqual(redacted,
+                    "ctx source_app_bundle=[redacted-sensitive-value]",
+                    "source_app_bundle at end of line should still collapse to the redaction marker")
+    }
+
+    runSuite("ObservabilityTextRedactor leaves source_app_bundle lookalike keys alone") {
+        let input = "ctx safe_source_app_bundle=com.example.coarse source_app_bundle=com.example.privateapp result=ok"
+        let redacted = ObservabilityTextRedactor.redact(input)
+
+        assertTrue(redacted.contains("safe_source_app_bundle=com.example.coarse"),
+                   "non-sensitive lookalike key should remain")
+        assertFalse(redacted.contains("com.example.privateapp"), "real source_app_bundle value must not survive")
+        assertTrue(redacted.contains("source_app_bundle=[redacted-sensitive-value]"),
+                   "real source_app_bundle key should still redact")
+        assertTrue(redacted.contains("result=ok"), "safe metadata should remain")
+    }
+
     runSuite("ObservabilityTextRedactor scrubs (parakeet, device) and (whisper, device) tuples") {
         // The engineDeviceLogRegex protects logs like `STT route changed (parakeet, Jane's Mic)`
         // where the engine name is fine but the device name leaks.


### PR DESCRIPTION
## Missing coverage

Recent observability sanitizer work added `source_app_bundle` redaction coverage for JSON/context payloads, but the root fast redactor tests did not directly pin inline `source_app_bundle=...` log messages.

## Tests added

- Inline `source_app_bundle=...` redacts the value while preserving safe metadata.
- Case-insensitive inline keys redact and keep following metadata.
- Trailing inline `source_app_bundle=...` at end of line redacts.
- A lookalike non-sensitive key is not overmatched while the real key still redacts.

## Checks run

- `bash scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force` (local dependency stamp recovery)
- `bash build.sh --no-open`
- `bash run-tests.sh` (3769 passed)