### PR TITLE
[nightly-review] Cancel zombie recovery restart on stop

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -77,6 +77,7 @@ class ParakeetEngine: ObservableObject {
     private var modelFilePrefetchTask: Task<URL, Error>?
     private var prefetchedModelPath: URL?
     private var audioWatchdogTask: Task<Void, Never>?
+    private var zombieRecoveryRestartPending = false
     private var asrInferenceActivity = ParakeetASRInferenceActivityState()
     private var asrInferenceHandoffCount = 0
     private var asrInferenceWaiters: [CheckedContinuation<Void, Never>] = []
@@ -2293,6 +2294,7 @@ class ParakeetEngine: ObservableObject {
             self.pendingSamplesLock.withLock {
                 self.pendingSamples.removeAll(keepingCapacity: true)
             }
+            self.zombieRecoveryRestartPending = true
             self.isRecording = false
             self.audioLevel = 0
             self.configChangeWasRecording = false
@@ -2303,7 +2305,11 @@ class ParakeetEngine: ObservableObject {
             self.isEnginePrewarmed = false
 
             try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, self.zombieRecoveryRestartPending else {
+                self.zombieRecoveryRestartPending = false
+                return
+            }
+            self.zombieRecoveryRestartPending = false
 
             // Retry once — isRecoveryAttempt prevents another watchdog
             if await self.startRecording(isRecoveryAttempt: true) {
@@ -2322,6 +2328,12 @@ class ParakeetEngine: ObservableObject {
 
     func stopRecording() async {
         guard isRecording else {
+            if zombieRecoveryRestartPending {
+                audioGraphGeneration += 1
+                cancelAudioWatchdog()
+                clearRecoveredRecordingTimeline(keepingCapacity: true)
+                return
+            }
             if audioStartInProgress {
                 audioGraphGeneration += 1
             } else {
@@ -2976,6 +2988,7 @@ class ParakeetEngine: ObservableObject {
     private func cancelAudioWatchdog() {
         audioWatchdogTask?.cancel()
         audioWatchdogTask = nil
+        zombieRecoveryRestartPending = false
     }
 
     func cleanup() {

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -577,19 +577,54 @@ func testParakeetStartRecordingFailurePolicy() {
             return
         }
         let watchdog = String(source[watchdogStart.lowerBound..<watchdogEnd.lowerBound])
-        guard let markIdle = watchdog.range(of: "self.isRecording = false"),
+        guard let markRestartPending = watchdog.range(of: "self.zombieRecoveryRestartPending = true"),
+              let markIdle = watchdog.range(of: "self.isRecording = false"),
               let clearRestartFlag = watchdog.range(of: "self.configChangeWasRecording = false"),
               let suppressConfigChanges = watchdog.range(of: "self.ignoreInputSelectionConfigChangesUntil = CFAbsoluteTimeGetCurrent() + 1.0"),
+              let pendingRestartGuard = watchdog.range(of: "self.zombieRecoveryRestartPending else"),
+              let clearPendingBeforeRetry = watchdog.range(of: "self.zombieRecoveryRestartPending = false", range: pendingRestartGuard.upperBound..<watchdog.endIndex),
+              let retryStart = watchdog.range(of: "await self.startRecording(isRecoveryAttempt: true)"),
               let removeTap = watchdog.range(of: "await self.removeRecordingTap()"),
               let stopEngine = watchdog.range(of: "await self.stopAudioEngine()") else {
             assertTrue(false, "zombie watchdog should mark internal reset state before touching CoreAudio")
             return
         }
 
+        assertTrue(markRestartPending.lowerBound < markIdle.lowerBound, "zombie reset should mark the recovery restart window before publishing idle state")
         assertTrue(markIdle.lowerBound < removeTap.lowerBound, "zombie reset should stop being treated as active recording before tap removal can post config changes")
         assertTrue(markIdle.lowerBound < stopEngine.lowerBound, "zombie reset should stop being treated as active recording before engine stop can post config changes")
         assertTrue(clearRestartFlag.lowerBound < removeTap.lowerBound, "zombie reset should not leave the device-change restart flag armed")
         assertTrue(suppressConfigChanges.lowerBound < removeTap.lowerBound, "zombie reset should suppress self-induced config changes before graph teardown")
+        assertTrue(pendingRestartGuard.lowerBound < retryStart.lowerBound, "zombie retry should be gated by the pending restart flag so user stop can cancel it")
+        assertTrue(clearPendingBeforeRetry.lowerBound < retryStart.lowerBound, "zombie retry should clear pending restart state before attempting the recovery start")
+    }
+
+    runSuite("ParakeetEngine stopRecording cancels pending zombie restart while idle") {
+        let source = readParakeetEngineSource()
+        guard let stopStart = source.range(of: "func stopRecording()"),
+              let stopEnd = source.range(of: "// MARK: - EOU Streaming", range: stopStart.upperBound..<source.endIndex),
+              let cancelStart = source.range(of: "private func cancelAudioWatchdog()") else {
+            assertTrue(false, "test should find stopRecording and watchdog cancellation bodies")
+            return
+        }
+        let stopBody = String(source[stopStart.lowerBound..<stopEnd.lowerBound])
+        let cancelBody = String(source[cancelStart.lowerBound..<source.endIndex])
+        guard let pendingBranch = stopBody.range(of: "if zombieRecoveryRestartPending"),
+              let graphBump = stopBody.range(of: "audioGraphGeneration += 1", range: pendingBranch.upperBound..<stopBody.endIndex),
+              let cancelWatchdog = stopBody.range(of: "cancelAudioWatchdog()", range: pendingBranch.upperBound..<stopBody.endIndex),
+              let clearTimeline = stopBody.range(of: "clearRecoveredRecordingTimeline(keepingCapacity: true)", range: pendingBranch.upperBound..<stopBody.endIndex),
+              let returnFromBranch = stopBody.range(of: "return", range: pendingBranch.upperBound..<stopBody.endIndex) else {
+            assertTrue(false, "inactive stopRecording should cancel pending zombie recovery restart")
+            return
+        }
+
+        assertTrue(graphBump.lowerBound < cancelWatchdog.lowerBound, "canceling a pending zombie restart should invalidate in-flight audio starts")
+        assertTrue(cancelWatchdog.lowerBound < returnFromBranch.lowerBound, "stopRecording should cancel the watchdog before returning from pending zombie restart")
+        assertTrue(clearTimeline.lowerBound < returnFromBranch.lowerBound, "stopRecording should clear recovered timeline before returning from pending zombie restart")
+        assertTrue(
+            cancelBody.contains("zombieRecoveryRestartPending = false"),
+            "shared watchdog cancellation should clear pending zombie restart state"
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- fixes a stop/restart race introduced around Parakeet zombie recovery reset
- tracks the pending zombie recovery restart window explicitly
- cancels that pending restart when `stopRecording()` is called after the watchdog has already marked recording idle
- extends the registered fast guard in `ParakeetStartRecordingFailurePolicyTests`

## Nightly evidence
- Live Sentry after loading local ops env still showed fresh Parakeet recovery failures: `APPLE-MACOS-1T` (`parakeet.zombie_engine_recovery_failed`) and `APPLE-MACOS-1V` (`parakeet.recording_interrupted`).
- The last-24h merged patch #984 moved `isRecording = false` before async graph teardown so self-induced config changes do not re-arm restart recovery.
- That made `stopRecording()` take its idle branch during the watchdog teardown/retry delay, leaving the watchdog task alive and able to restart recording after the user asked to stop.
- Open issue signal remains #500 meeting quietness and #825 long meetings; this patch is scoped to the higher-confidence current Speech regression.

## Ranked risks reviewed
1. Parakeet zombie recovery can restart dictation after a user stop during the recovery window.
2. Meeting capture degradation is still visible in Sentry (`APPLE-MACOS-1B`) and tied to open issue #500/manual QA rather than a one-line safe fix tonight.
3. Long-meeting visibility (#825) remains open but was not touched by the last-day diff.

## Verification
- `git diff --check`
- `scripts/dev/agent-preflight.sh`
- `bash run-tests.sh` (`3780 passed`)
- `bash build.sh --no-open`

## Notes
- The automation's configured worktree `/Users/redbars/.codex/worktrees/9b7e/transcripted-latest` is still missing. This run used `/Users/redbars/.codex/worktrees/nightly-build-20260606-0300/transcripted-latest`, moved to current `origin/main` before review.
- Sentry/PostHog probes only worked after sourcing `/Users/redbars/.hermes/.env`; without it, both lanes skipped for missing credentials.
