### PR TITLE
[nightly-telemetry] Bucket degraded meeting Sentry counts

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -2414,6 +2414,8 @@ final class MeetingSessionController: ObservableObject {
         guard shouldReport else { return }
 
         var context = captureDiagnostics
+        context.removeValue(forKey: "gap_count")
+        context.removeValue(forKey: "route_change_count")
         context["capture_quality"] = healthInfo.captureQuality.rawValue
         context["duration_bucket"] = AnalyticsReporter.durationBucket(seconds: durationSeconds)
         context["gap_count_bucket"] = AnalyticsReporter.countBucket(healthInfo.audioGaps)

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -2416,10 +2416,10 @@ final class MeetingSessionController: ObservableObject {
         var context = captureDiagnostics
         context["capture_quality"] = healthInfo.captureQuality.rawValue
         context["duration_bucket"] = AnalyticsReporter.durationBucket(seconds: durationSeconds)
-        context["gap_count"] = "\(healthInfo.audioGaps)"
+        context["gap_count_bucket"] = AnalyticsReporter.countBucket(healthInfo.audioGaps)
         context["mic_file_available"] = boolString(files.micURL != nil)
         context["reason"] = reason.rawValue
-        context["route_change_count"] = "\(healthInfo.deviceSwitches)"
+        context["route_change_count_bucket"] = AnalyticsReporter.countBucket(healthInfo.deviceSwitches)
         context["stop_timed_out"] = boolString(stopTimedOut)
         context["system_stream_present"] = boolString(files.systemURL != nil)
         context["trigger"] = trigger.rawValue

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1564,6 +1564,14 @@ func testRepoCommandContract() {
             reportBlock.contains("context[\"route_change_count_bucket\"] = AnalyticsReporter.countBucket(healthInfo.deviceSwitches)"),
             "degraded meeting Sentry events should preserve coarse route-change counts"
         )
+        assertTrue(
+            reportBlock.contains("context.removeValue(forKey: \"gap_count\")"),
+            "raw gap counts inherited from capture diagnostics should be stripped before Sentry context"
+        )
+        assertTrue(
+            reportBlock.contains("context.removeValue(forKey: \"route_change_count\")"),
+            "raw route-change counts inherited from capture diagnostics should be stripped before Sentry context"
+        )
         assertFalse(
             reportBlock.contains("context[\"gap_count\"] ="),
             "raw gap counts should stay out of degraded meeting Sentry context"

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1548,6 +1548,32 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - degraded meeting Sentry context stays bucketed") {
+        let contents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let reportBlock = sourceSlice(
+            contents,
+            from: "private func reportCaptureHealthIfNeeded(",
+            to: "private func savedTranscriptAnalyticsProperties()"
+        )
+
+        assertTrue(
+            reportBlock.contains("context[\"gap_count_bucket\"] = AnalyticsReporter.countBucket(healthInfo.audioGaps)"),
+            "degraded meeting Sentry events should preserve coarse gap counts"
+        )
+        assertTrue(
+            reportBlock.contains("context[\"route_change_count_bucket\"] = AnalyticsReporter.countBucket(healthInfo.deviceSwitches)"),
+            "degraded meeting Sentry events should preserve coarse route-change counts"
+        )
+        assertFalse(
+            reportBlock.contains("context[\"gap_count\"] ="),
+            "raw gap counts should stay out of degraded meeting Sentry context"
+        )
+        assertFalse(
+            reportBlock.contains("context[\"route_change_count\"] ="),
+            "raw route-change counts should stay out of degraded meeting Sentry context"
+        )
+    }
+
     runSuite("Repo command contract - queued meetings recover unloaded models before transcription") {
         let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
         let downloaderContents = readRepoTextFile("Sources/Meeting/MeetingModelDownloader.swift")


### PR DESCRIPTION
## Summary
- send `gap_count_bucket` and `route_change_count_bucket` on degraded meeting Sentry events
- keep raw meeting gap and route-change counts out of the off-device Sentry context
- add a repo contract test for the degraded-capture reporter wiring

## Evidence
- Sentry current release `transcripted@1.1.46` has repeated `meeting.recording_capture_degraded` events on two devices in the last 24h.
- PostHog `meeting_capture_health_snapshot` already carries the matching bucketed context, but the Sentry reporter was using raw `gap_count` and `route_change_count`, which the Sentry tag policy does not allow.

## Verification
- `./run-tests.sh` — 3905 passed, 0 failed
