### PR TITLE
Fix speaker review duplicate meeting rows

### DIFF
--- a/Sources/Meeting/LocalMeetingSummarizer.swift
+++ b/Sources/Meeting/LocalMeetingSummarizer.swift
@@ -195,6 +195,22 @@ enum LocalMeetingSummaryStore {
     static func summaryExists(for transcriptURL: URL, fileManager: FileManager = .default) -> Bool {
         fileManager.fileExists(atPath: summaryURL(for: transcriptURL).path)
     }
+
+    @discardableResult
+    static func removeGeneratedSummary(
+        for transcriptURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> Bool {
+        let url = summaryURL(for: transcriptURL)
+        guard fileManager.fileExists(atPath: url.path),
+              let values = try TranscriptFrontmatter.readValues(from: url),
+              values["capture_type"] == "meeting_summary",
+              values["source_transcript"] == transcriptURL.lastPathComponent else {
+            return false
+        }
+        try fileManager.removeItem(at: url)
+        return true
+    }
 }
 
 enum LocalMeetingTranscriptExtractor {

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1217,7 +1217,9 @@ final class MeetingSessionController: ObservableObject {
     func retranscribeSavedMeeting(
         micAudioURL: URL?,
         systemAudioURL: URL,
-        title: String?
+        title: String?,
+        transcriptURL: URL? = nil,
+        recordingDate: Date? = nil
     ) async -> Bool {
         guard !(sttRouter.isRecording || sttRouter.isTranscribing) else {
             state = .error("Wait for the current dictation to finish before re-transcribing saved audio.")
@@ -1278,7 +1280,9 @@ final class MeetingSessionController: ObservableObject {
             systemURL: systemAudioURL,
             outputFolder: MeetingStoragePaths.transcriptsFolder,
             meetingTitle: title,
-            splitLocalSpeakers: true
+            splitLocalSpeakers: true,
+            replacementTranscriptURL: transcriptURL,
+            recordingDate: recordingDate
         )
         return true
     }

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1282,9 +1282,36 @@ final class MeetingSessionController: ObservableObject {
             meetingTitle: title,
             splitLocalSpeakers: true,
             replacementTranscriptURL: transcriptURL,
-            recordingDate: recordingDate
+            recordingDate: recordingDate,
+            onReplacementTranscriptCommitted: { [weak self] committedTranscriptURL in
+                self?.clearGeneratedSummaryAfterReplacementRetranscription(for: committedTranscriptURL)
+            }
         )
         return true
+    }
+
+    private func clearGeneratedSummaryAfterReplacementRetranscription(for transcriptURL: URL) {
+        do {
+            guard try LocalMeetingSummaryStore.removeGeneratedSummary(for: transcriptURL) else {
+                return
+            }
+            DiagnosticsTrail.record(
+                engine: "meeting",
+                event: "meeting_retranscription_summary_invalidated",
+                message: "Removed stale local summary after saved meeting retranscription",
+                context: baseDiagnosticsContext()
+            )
+        } catch {
+            DiagnosticsTrail.record(
+                level: .warning,
+                engine: "meeting",
+                event: "meeting_retranscription_summary_invalidation_failed",
+                message: "Failed to remove stale local summary after saved meeting retranscription",
+                context: baseDiagnosticsContext(extra: [
+                    "error_type": "\(type(of: error))"
+                ])
+            )
+        }
     }
 
     @discardableResult

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -152,6 +152,7 @@ final class MeetingSessionController: ObservableObject {
     @Published private(set) var displayStatus: DisplayStatus = .idle
     @Published private(set) var lastSavedTranscriptURL: URL? = nil
     @Published private(set) var lastSavedTitle: String? = nil
+    @Published private(set) var savedMeetingReplacementCommitCount: Int = 0
     @Published private(set) var audioInactivityWarning: MeetingAudioInactivityWarning?
 
     @Published private(set) var failedMeetings: [FailedMeetingItem] = []
@@ -1284,10 +1285,15 @@ final class MeetingSessionController: ObservableObject {
             replacementTranscriptURL: transcriptURL,
             recordingDate: recordingDate,
             onReplacementTranscriptCommitted: { [weak self] committedTranscriptURL in
-                self?.clearGeneratedSummaryAfterReplacementRetranscription(for: committedTranscriptURL)
+                self?.handleReplacementTranscriptCommitted(for: committedTranscriptURL)
             }
         )
         return true
+    }
+
+    private func handleReplacementTranscriptCommitted(for transcriptURL: URL) {
+        clearGeneratedSummaryAfterReplacementRetranscription(for: transcriptURL)
+        savedMeetingReplacementCommitCount &+= 1
     }
 
     private func clearGeneratedSummaryAfterReplacementRetranscription(for transcriptURL: URL) {

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -370,7 +370,8 @@ extension TranscriptionTaskManager {
                 retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
                 retainedAudioURLs: archiveOutcome.retainedAudioURLs,
                 speakerClipURLs: namingEntries.map(\.clipURL),
-                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
+                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
+                replacementTranscriptRollback: replacementTranscriptRollback
             )
         }
 
@@ -413,7 +414,8 @@ extension TranscriptionTaskManager {
                 retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
                 retainedAudioURLs: archiveOutcome.retainedAudioURLs,
                 speakerClipURLs: namingEntries.map(\.clipURL),
-                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
+                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
+                replacementTranscriptRollback: replacementTranscriptRollback
             )
         }
 

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -269,7 +269,8 @@ extension TranscriptionTaskManager {
             }
         }
 
-        let transcriptId = UUID()
+        let replacementTranscriptRollback = try ReplacementTranscriptRollback.capture(for: targetTranscriptURL)
+        let transcriptId = replacementTranscriptRollback?.transcriptId ?? UUID()
         try Task.checkCancellation()
         // Phase 2: Save transcript with speaker names
         let notifier: TranscriptNotifier? = await MainActor.run {
@@ -300,10 +301,11 @@ extension TranscriptionTaskManager {
         ) else {
             throw PipelineError.saveFailed(detail: "Could not write transcript to \(outputFolder.lastPathComponent)")
         }
-        let deleteSavedTranscriptOnCancellation = targetTranscriptURL == nil
+        let deleteSavedTranscriptOnCancellation = replacementTranscriptRollback == nil
         try await checkCancellationAfterTranscriptSideEffects(
             savedURL: savedURL,
-            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
+            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
+            replacementTranscriptRollback: replacementTranscriptRollback
         )
 
         AppLogger.pipeline.info("Phase 2 complete: Transcript saved", ["file": savedURL.lastPathComponent])
@@ -323,7 +325,8 @@ extension TranscriptionTaskManager {
             savedURL: savedURL,
             retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
             retainedAudioURLs: archiveOutcome.retainedAudioURLs,
-            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
+            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
+            replacementTranscriptRollback: replacementTranscriptRollback
         )
         let shouldRemoveScratchAudio = archiveOutcome.didArchiveRecordingAudio && removeSourceAudioAfterArchive
 
@@ -433,7 +436,8 @@ extension TranscriptionTaskManager {
                 retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
                 retainedAudioURLs: archiveOutcome.retainedAudioURLs,
                 speakerClipURLs: capturedEntries.map(\.clipURL),
-                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
+                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
+                replacementTranscriptRollback: replacementTranscriptRollback
             )
             await MainActor.run {
                 self.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
@@ -466,7 +470,8 @@ extension TranscriptionTaskManager {
                 retainedAudioURLs: archiveOutcome.retainedAudioURLs,
                 speakerClipURLs: capturedEntries.map(\.clipURL),
                 queuedSpeakerRequestTranscriptId: transcriptId,
-                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
+                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
+                replacementTranscriptRollback: replacementTranscriptRollback
             )
             try await commitSavedTranscriptSideEffectsUnlessCancelled(
                 taskId: taskId,
@@ -480,7 +485,8 @@ extension TranscriptionTaskManager {
                 retainedAudioURLs: archiveOutcome.retainedAudioURLs,
                 speakerClipURLs: capturedEntries.map(\.clipURL),
                 queuedSpeakerRequestTranscriptId: transcriptId,
-                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
+                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
+                replacementTranscriptRollback: replacementTranscriptRollback
             )
 
             AppLogger.pipeline.info("Speaker naming requested", [
@@ -501,7 +507,8 @@ extension TranscriptionTaskManager {
             notifier: notifier,
             retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
             retainedAudioURLs: archiveOutcome.retainedAudioURLs,
-            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
+            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
+            replacementTranscriptRollback: replacementTranscriptRollback
         )
 
         // No naming needed — clean up scratch audio after the saved outcome has
@@ -519,6 +526,54 @@ extension TranscriptionTaskManager {
         let didArchiveRecordingAudio: Bool
         let retainedAudioDirectory: URL?
         let retainedAudioURLs: [URL]
+    }
+
+    private struct ReplacementTranscriptRollback: Sendable {
+        let url: URL
+        let originalData: Data
+        let transcriptId: UUID?
+
+        static func capture(for targetURL: URL?) throws -> ReplacementTranscriptRollback? {
+            guard let targetURL else { return nil }
+
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: targetURL.path, isDirectory: &isDirectory),
+                  !isDirectory.boolValue else {
+                return nil
+            }
+
+            let originalData = try Data(contentsOf: targetURL)
+            let values = try? TranscriptFrontmatter.readValues(from: targetURL)
+            let transcriptId = replacementTranscriptId(from: values)
+            return ReplacementTranscriptRollback(
+                url: targetURL,
+                originalData: originalData,
+                transcriptId: transcriptId
+            )
+        }
+
+        func restore() {
+            do {
+                try originalData.write(to: url, options: .atomic)
+                FileManager.default.restrictToOwnerOnly(atPath: url.path)
+            } catch {
+                AppLogger.pipeline.error("Failed to restore cancelled replacement transcript", [
+                    "error": error.localizedDescription
+                ])
+            }
+        }
+
+        private static func replacementTranscriptId(from values: [String: String]?) -> UUID? {
+            if let transcriptId = values?["transcript_id"],
+               let uuid = UUID(uuidString: transcriptId) {
+                return uuid
+            }
+            if let captureId = values?["capture_id"],
+               let uuid = UUID(uuidString: captureId) {
+                return uuid
+            }
+            return nil
+        }
     }
 
     nonisolated private func archiveRecordingAudioIfConfigured(
@@ -601,7 +656,8 @@ extension TranscriptionTaskManager {
         retainedAudioURLs: [URL] = [],
         speakerClipURLs: [URL] = [],
         queuedSpeakerRequestTranscriptId: UUID? = nil,
-        deleteSavedTranscriptOnCancellation: Bool = true
+        deleteSavedTranscriptOnCancellation: Bool = true,
+        replacementTranscriptRollback: ReplacementTranscriptRollback? = nil
     ) async throws {
         try await checkCancellationAfterTranscriptSideEffects(
             savedURL: savedURL,
@@ -609,7 +665,8 @@ extension TranscriptionTaskManager {
             retainedAudioURLs: retainedAudioURLs,
             speakerClipURLs: speakerClipURLs,
             queuedSpeakerRequestTranscriptId: queuedSpeakerRequestTranscriptId,
-            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
+            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,
+            replacementTranscriptRollback: replacementTranscriptRollback
         )
 
         let didCommit = await MainActor.run {
@@ -638,7 +695,8 @@ extension TranscriptionTaskManager {
                 retainedAudioDirectory: retainedAudioDirectory,
                 retainedAudioURLs: retainedAudioURLs,
                 speakerClipURLs: speakerClipURLs,
-                deleteSavedTranscript: deleteSavedTranscriptOnCancellation
+                deleteSavedTranscript: deleteSavedTranscriptOnCancellation,
+                replacementTranscriptRollback: replacementTranscriptRollback
             )
             throw CancellationError()
         }
@@ -650,7 +708,8 @@ extension TranscriptionTaskManager {
         retainedAudioURLs: [URL] = [],
         speakerClipURLs: [URL] = [],
         queuedSpeakerRequestTranscriptId: UUID? = nil,
-        deleteSavedTranscriptOnCancellation: Bool = true
+        deleteSavedTranscriptOnCancellation: Bool = true,
+        replacementTranscriptRollback: ReplacementTranscriptRollback? = nil
     ) async throws {
         do {
             try Task.checkCancellation()
@@ -665,7 +724,8 @@ extension TranscriptionTaskManager {
                 retainedAudioDirectory: retainedAudioDirectory,
                 retainedAudioURLs: retainedAudioURLs,
                 speakerClipURLs: speakerClipURLs,
-                deleteSavedTranscript: deleteSavedTranscriptOnCancellation
+                deleteSavedTranscript: deleteSavedTranscriptOnCancellation,
+                replacementTranscriptRollback: replacementTranscriptRollback
             )
             throw error
         }
@@ -676,9 +736,12 @@ extension TranscriptionTaskManager {
         retainedAudioDirectory: URL?,
         retainedAudioURLs: [URL],
         speakerClipURLs: [URL],
-        deleteSavedTranscript: Bool
+        deleteSavedTranscript: Bool,
+        replacementTranscriptRollback: ReplacementTranscriptRollback?
     ) {
-        if deleteSavedTranscript {
+        if let replacementTranscriptRollback {
+            replacementTranscriptRollback.restore()
+        } else if deleteSavedTranscript {
             try? FileManager.default.removeItem(at: savedURL)
         }
         for retainedAudioURL in retainedAudioURLs {

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -533,6 +533,7 @@ extension TranscriptionTaskManager {
     private struct ReplacementTranscriptRollback: Sendable {
         let url: URL
         let originalData: Data
+        private let originalFileDates: OriginalFileDates?
         let transcriptId: UUID?
 
         static func capture(for targetURL: URL?) throws -> ReplacementTranscriptRollback? {
@@ -545,11 +546,13 @@ extension TranscriptionTaskManager {
             }
 
             let originalData = try Data(contentsOf: targetURL)
+            let originalFileDates = OriginalFileDates.capture(for: targetURL)
             let values = try? TranscriptFrontmatter.readValues(from: targetURL)
             let transcriptId = replacementTranscriptId(from: values)
             return ReplacementTranscriptRollback(
                 url: targetURL,
                 originalData: originalData,
+                originalFileDates: originalFileDates,
                 transcriptId: transcriptId
             )
         }
@@ -558,10 +561,46 @@ extension TranscriptionTaskManager {
             do {
                 try originalData.write(to: url, options: .atomic)
                 FileManager.default.restrictToOwnerOnly(atPath: url.path)
+                originalFileDates?.restore(to: url)
             } catch {
                 AppLogger.pipeline.error("Failed to restore cancelled replacement transcript", [
                     "error": error.localizedDescription
                 ])
+            }
+        }
+
+        private struct OriginalFileDates: Sendable {
+            let creationDate: Date?
+            let modificationDate: Date?
+
+            static func capture(for url: URL) -> OriginalFileDates? {
+                guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path) else {
+                    return nil
+                }
+
+                return OriginalFileDates(
+                    creationDate: attributes[.creationDate] as? Date,
+                    modificationDate: attributes[.modificationDate] as? Date
+                )
+            }
+
+            func restore(to url: URL) {
+                var attributes: [FileAttributeKey: Any] = [:]
+                if let creationDate {
+                    attributes[.creationDate] = creationDate
+                }
+                if let modificationDate {
+                    attributes[.modificationDate] = modificationDate
+                }
+                guard !attributes.isEmpty else { return }
+
+                do {
+                    try FileManager.default.setAttributes(attributes, ofItemAtPath: url.path)
+                } catch {
+                    AppLogger.pipeline.warning("Failed to restore replacement rollback file dates", [
+                        "error_type": String(describing: type(of: error))
+                    ])
+                }
             }
         }
 

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -72,7 +72,9 @@ extension TranscriptionTaskManager {
         meetingTitle: String? = nil,
         recordingDate: Date? = nil,
         sourceFailedTranscriptionId: UUID? = nil,
-        removeSourceAudioAfterArchive: Bool = true
+        removeSourceAudioAfterArchive: Bool = true,
+        targetTranscriptURL: URL? = nil,
+        archiveRecordingAudio: Bool = true
     ) async throws -> URL {
 
         let transcription = await MainActor.run { self.transcription }
@@ -292,6 +294,7 @@ extension TranscriptionTaskManager {
             speakerStore: speakerDB,
             statsStore: DeferredTranscriptStatsStore(),
             recordingDate: transcriptDate,
+            targetURL: targetTranscriptURL,
             transcriptionEngine: speechEngine,
             formatOptions: formatOptions
         ) else {
@@ -301,11 +304,17 @@ extension TranscriptionTaskManager {
 
         AppLogger.pipeline.info("Phase 2 complete: Transcript saved", ["file": savedURL.lastPathComponent])
 
-        let archiveOutcome = await archiveRecordingAudioIfConfigured(
-            micURL: micURL,
-            systemURL: systemURL,
-            savedURL: savedURL
-        )
+        let archiveOutcome = archiveRecordingAudio
+            ? await archiveRecordingAudioIfConfigured(
+                micURL: micURL,
+                systemURL: systemURL,
+                savedURL: savedURL
+            )
+            : RecordingAudioArchiveOutcome(
+                didArchiveRecordingAudio: false,
+                retainedAudioDirectory: nil,
+                retainedAudioURLs: []
+            )
         try await checkCancellationAfterTranscriptSideEffects(
             savedURL: savedURL,
             retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -300,7 +300,11 @@ extension TranscriptionTaskManager {
         ) else {
             throw PipelineError.saveFailed(detail: "Could not write transcript to \(outputFolder.lastPathComponent)")
         }
-        try await checkCancellationAfterTranscriptSideEffects(savedURL: savedURL)
+        let deleteSavedTranscriptOnCancellation = targetTranscriptURL == nil
+        try await checkCancellationAfterTranscriptSideEffects(
+            savedURL: savedURL,
+            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
+        )
 
         AppLogger.pipeline.info("Phase 2 complete: Transcript saved", ["file": savedURL.lastPathComponent])
 
@@ -318,7 +322,8 @@ extension TranscriptionTaskManager {
         try await checkCancellationAfterTranscriptSideEffects(
             savedURL: savedURL,
             retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
-            retainedAudioURLs: archiveOutcome.retainedAudioURLs
+            retainedAudioURLs: archiveOutcome.retainedAudioURLs,
+            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
         )
         let shouldRemoveScratchAudio = archiveOutcome.didArchiveRecordingAudio && removeSourceAudioAfterArchive
 
@@ -361,7 +366,8 @@ extension TranscriptionTaskManager {
                 savedURL: savedURL,
                 retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
                 retainedAudioURLs: archiveOutcome.retainedAudioURLs,
-                speakerClipURLs: namingEntries.map(\.clipURL)
+                speakerClipURLs: namingEntries.map(\.clipURL),
+                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
             )
         }
 
@@ -403,7 +409,8 @@ extension TranscriptionTaskManager {
                 savedURL: savedURL,
                 retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
                 retainedAudioURLs: archiveOutcome.retainedAudioURLs,
-                speakerClipURLs: namingEntries.map(\.clipURL)
+                speakerClipURLs: namingEntries.map(\.clipURL),
+                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
             )
         }
 
@@ -425,7 +432,8 @@ extension TranscriptionTaskManager {
                 savedURL: savedURL,
                 retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
                 retainedAudioURLs: archiveOutcome.retainedAudioURLs,
-                speakerClipURLs: capturedEntries.map(\.clipURL)
+                speakerClipURLs: capturedEntries.map(\.clipURL),
+                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
             )
             await MainActor.run {
                 self.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
@@ -457,7 +465,8 @@ extension TranscriptionTaskManager {
                 retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
                 retainedAudioURLs: archiveOutcome.retainedAudioURLs,
                 speakerClipURLs: capturedEntries.map(\.clipURL),
-                queuedSpeakerRequestTranscriptId: transcriptId
+                queuedSpeakerRequestTranscriptId: transcriptId,
+                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
             )
             try await commitSavedTranscriptSideEffectsUnlessCancelled(
                 taskId: taskId,
@@ -470,7 +479,8 @@ extension TranscriptionTaskManager {
                 retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
                 retainedAudioURLs: archiveOutcome.retainedAudioURLs,
                 speakerClipURLs: capturedEntries.map(\.clipURL),
-                queuedSpeakerRequestTranscriptId: transcriptId
+                queuedSpeakerRequestTranscriptId: transcriptId,
+                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
             )
 
             AppLogger.pipeline.info("Speaker naming requested", [
@@ -490,7 +500,8 @@ extension TranscriptionTaskManager {
             transcriptDate: transcriptDate,
             notifier: notifier,
             retainedAudioDirectory: archiveOutcome.retainedAudioDirectory,
-            retainedAudioURLs: archiveOutcome.retainedAudioURLs
+            retainedAudioURLs: archiveOutcome.retainedAudioURLs,
+            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
         )
 
         // No naming needed — clean up scratch audio after the saved outcome has
@@ -589,14 +600,16 @@ extension TranscriptionTaskManager {
         retainedAudioDirectory: URL? = nil,
         retainedAudioURLs: [URL] = [],
         speakerClipURLs: [URL] = [],
-        queuedSpeakerRequestTranscriptId: UUID? = nil
+        queuedSpeakerRequestTranscriptId: UUID? = nil,
+        deleteSavedTranscriptOnCancellation: Bool = true
     ) async throws {
         try await checkCancellationAfterTranscriptSideEffects(
             savedURL: savedURL,
             retainedAudioDirectory: retainedAudioDirectory,
             retainedAudioURLs: retainedAudioURLs,
             speakerClipURLs: speakerClipURLs,
-            queuedSpeakerRequestTranscriptId: queuedSpeakerRequestTranscriptId
+            queuedSpeakerRequestTranscriptId: queuedSpeakerRequestTranscriptId,
+            deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation
         )
 
         let didCommit = await MainActor.run {
@@ -624,7 +637,8 @@ extension TranscriptionTaskManager {
                 savedURL: savedURL,
                 retainedAudioDirectory: retainedAudioDirectory,
                 retainedAudioURLs: retainedAudioURLs,
-                speakerClipURLs: speakerClipURLs
+                speakerClipURLs: speakerClipURLs,
+                deleteSavedTranscript: deleteSavedTranscriptOnCancellation
             )
             throw CancellationError()
         }
@@ -635,7 +649,8 @@ extension TranscriptionTaskManager {
         retainedAudioDirectory: URL? = nil,
         retainedAudioURLs: [URL] = [],
         speakerClipURLs: [URL] = [],
-        queuedSpeakerRequestTranscriptId: UUID? = nil
+        queuedSpeakerRequestTranscriptId: UUID? = nil,
+        deleteSavedTranscriptOnCancellation: Bool = true
     ) async throws {
         do {
             try Task.checkCancellation()
@@ -649,7 +664,8 @@ extension TranscriptionTaskManager {
                 savedURL: savedURL,
                 retainedAudioDirectory: retainedAudioDirectory,
                 retainedAudioURLs: retainedAudioURLs,
-                speakerClipURLs: speakerClipURLs
+                speakerClipURLs: speakerClipURLs,
+                deleteSavedTranscript: deleteSavedTranscriptOnCancellation
             )
             throw error
         }
@@ -659,9 +675,12 @@ extension TranscriptionTaskManager {
         savedURL: URL,
         retainedAudioDirectory: URL?,
         retainedAudioURLs: [URL],
-        speakerClipURLs: [URL]
+        speakerClipURLs: [URL],
+        deleteSavedTranscript: Bool
     ) {
-        try? FileManager.default.removeItem(at: savedURL)
+        if deleteSavedTranscript {
+            try? FileManager.default.removeItem(at: savedURL)
+        }
         for retainedAudioURL in retainedAudioURLs {
             try? FileManager.default.removeItem(at: retainedAudioURL)
         }
@@ -679,6 +698,7 @@ extension TranscriptionTaskManager {
         }
         AppLogger.pipeline.info("Cleaned cancelled transcription side effects", [
             "transcript": savedURL.lastPathComponent,
+            "transcriptRemoved": "\(deleteSavedTranscript)",
             "clips": "\(speakerClipURLs.count)",
             "retainedAudioFiles": "\(retainedAudioURLs.count)",
             "retainedAudio": retainedAudioDirectory == nil ? "false" : "true"

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -336,7 +336,9 @@ public class TranscriptionTaskManager: ObservableObject {
         systemURL: URL,
         outputFolder: URL,
         meetingTitle: String? = nil,
-        splitLocalSpeakers: Bool = false
+        splitLocalSpeakers: Bool = false,
+        replacementTranscriptURL: URL? = nil,
+        recordingDate: Date? = nil
     ) {
         if !activeTasks.isEmpty {
             AppLogger.pipeline.warning("Rejecting saved-audio retranscription — another pipeline is already active", ["activeCount": "\(activeTasks.count)"])
@@ -394,7 +396,10 @@ public class TranscriptionTaskManager: ObservableObject {
                     healthInfo: nil,
                     splitLocalSpeakers: splitLocalSpeakers,
                     meetingTitle: meetingTitle,
-                    removeSourceAudioAfterArchive: false
+                    recordingDate: recordingDate,
+                    removeSourceAudioAfterArchive: false,
+                    targetTranscriptURL: replacementTranscriptURL,
+                    archiveRecordingAudio: replacementTranscriptURL == nil
                 )
 
                 await MainActor.run {

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -338,7 +338,8 @@ public class TranscriptionTaskManager: ObservableObject {
         meetingTitle: String? = nil,
         splitLocalSpeakers: Bool = false,
         replacementTranscriptURL: URL? = nil,
-        recordingDate: Date? = nil
+        recordingDate: Date? = nil,
+        onReplacementTranscriptCommitted: (@MainActor @Sendable (URL) -> Void)? = nil
     ) {
         if !activeTasks.isEmpty {
             AppLogger.pipeline.warning("Rejecting saved-audio retranscription — another pipeline is already active", ["activeCount": "\(activeTasks.count)"])
@@ -404,6 +405,9 @@ public class TranscriptionTaskManager: ObservableObject {
 
                 await MainActor.run {
                     guard !self.finishCancelledTaskIfNeeded(taskId: taskId) else { return }
+                    if replacementTranscriptURL != nil {
+                        onReplacementTranscriptCommitted?(transcriptURL)
+                    }
                     self.publishTranscriptSaved(from: transcriptURL, taskId: taskId)
                     self.handleTaskCompletion(taskId: taskId)
                 }

--- a/Sources/TranscriptedCore/Stats/StatsDatabase.swift
+++ b/Sources/TranscriptedCore/Stats/StatsDatabase.swift
@@ -228,6 +228,7 @@ public final class StatsDatabase {
 
         // Wrap INSERT + daily activity update in a transaction so both succeed or neither does
         transaction {
+            let existing = recordingMetadataImpl(id: metadata.id)
             let sql = """
             INSERT OR REPLACE INTO recordings (id, date, time, duration_seconds, word_count, speaker_count, processing_time_ms, transcript_path, title, created_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
@@ -270,8 +271,29 @@ public final class StatsDatabase {
             sqlite3_finalize(statement)
 
             // Update daily activity (inside same transaction)
-            updateDailyActivityImpl(for: metadata.date, durationDelta: metadata.durationSeconds)
+            updateDailyActivityForSessionChange(from: existing, to: metadata)
         }
+    }
+
+    private func recordingMetadataImpl(id: String) -> RecordingMetadata? {
+        let sql = """
+        SELECT id, date, time, duration_seconds, word_count, speaker_count, processing_time_ms, transcript_path, title
+        FROM recordings
+        WHERE id = ?
+        LIMIT 1;
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            AppLogger.stats.error("Failed to prepare recording lookup", ["sqlite_error": dbErrorMessage()])
+            return nil
+        }
+        defer { sqlite3_finalize(statement) }
+
+        sqlite3_bind_text(statement, 1, (id as NSString).utf8String, -1, SQLITE_TRANSIENT)
+        guard sqlite3_step(statement) == SQLITE_ROW else {
+            return nil
+        }
+        return recordingMetadataFromRow(statement)
     }
 
     /// Get all recordings (thread-safe, sync)
@@ -367,7 +389,42 @@ public final class StatsDatabase {
 
     // MARK: - Daily Activity Update
 
-    func updateDailyActivityImpl(for date: Date, durationDelta: Int) {
+    private func updateDailyActivityForSessionChange(
+        from existing: RecordingMetadata?,
+        to metadata: RecordingMetadata
+    ) {
+        guard let existing else {
+            updateDailyActivityImpl(
+                for: metadata.date,
+                recordingCountDelta: 1,
+                durationDelta: metadata.durationSeconds
+            )
+            return
+        }
+
+        if dailyActivityDateString(for: existing.date) == dailyActivityDateString(for: metadata.date) {
+            updateDailyActivityImpl(
+                for: metadata.date,
+                recordingCountDelta: 0,
+                durationDelta: metadata.durationSeconds - existing.durationSeconds
+            )
+        } else {
+            updateDailyActivityImpl(
+                for: existing.date,
+                recordingCountDelta: -1,
+                durationDelta: -existing.durationSeconds
+            )
+            updateDailyActivityImpl(
+                for: metadata.date,
+                recordingCountDelta: 1,
+                durationDelta: metadata.durationSeconds
+            )
+        }
+    }
+
+    func updateDailyActivityImpl(for date: Date, recordingCountDelta: Int, durationDelta: Int) {
+        guard recordingCountDelta != 0 || durationDelta != 0 else { return }
+
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
         let dateStr = dateFormatter.string(from: date)
@@ -375,10 +432,10 @@ public final class StatsDatabase {
         // Upsert: insert new or increment existing daily activity
         let updateSQL = """
         INSERT INTO daily_activity (date, recording_count, total_duration_seconds, action_items_count, updated_at)
-        VALUES (?, 1, ?, 0, datetime('now'))
+        VALUES (?, MAX(?, 0), MAX(?, 0), 0, datetime('now'))
         ON CONFLICT(date) DO UPDATE SET
-            recording_count = recording_count + 1,
-            total_duration_seconds = total_duration_seconds + ?,
+            recording_count = MAX(recording_count + ?, 0),
+            total_duration_seconds = MAX(total_duration_seconds + ?, 0),
             updated_at = datetime('now');
         """
 
@@ -386,8 +443,10 @@ public final class StatsDatabase {
 
         if sqlite3_prepare_v2(db, updateSQL, -1, &statement, nil) == SQLITE_OK {
             sqlite3_bind_text(statement, 1, (dateStr as NSString).utf8String, -1, SQLITE_TRANSIENT)
-            sqlite3_bind_int(statement, 2, Int32(durationDelta))
+            sqlite3_bind_int(statement, 2, Int32(recordingCountDelta))
             sqlite3_bind_int(statement, 3, Int32(durationDelta))
+            sqlite3_bind_int(statement, 4, Int32(recordingCountDelta))
+            sqlite3_bind_int(statement, 5, Int32(durationDelta))
 
             if sqlite3_step(statement) != SQLITE_DONE {
                 AppLogger.stats.error("Failed to update daily activity", ["sqlite_error": dbErrorMessage()])
@@ -397,6 +456,12 @@ public final class StatsDatabase {
         }
 
         sqlite3_finalize(statement)
+    }
+
+    private func dailyActivityDateString(for date: Date) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        return dateFormatter.string(from: date)
     }
 }
 

--- a/Sources/TranscriptedCore/Stats/StatsDatabase.swift
+++ b/Sources/TranscriptedCore/Stats/StatsDatabase.swift
@@ -229,6 +229,17 @@ public final class StatsDatabase {
         // Wrap INSERT + daily activity update in a transaction so both succeed or neither does
         transaction {
             let existing = recordingMetadataImpl(id: metadata.id)
+                ?? recordingMetadataImpl(transcriptPath: metadata.transcriptPath)
+            let storedMetadata = RecordingMetadata(
+                id: existing?.id ?? metadata.id,
+                date: metadata.date,
+                durationSeconds: metadata.durationSeconds,
+                wordCount: metadata.wordCount,
+                speakerCount: metadata.speakerCount,
+                processingTimeMs: metadata.processingTimeMs,
+                transcriptPath: metadata.transcriptPath,
+                title: metadata.title
+            )
             let sql = """
             INSERT OR REPLACE INTO recordings (id, date, time, duration_seconds, word_count, speaker_count, processing_time_ms, transcript_path, title, created_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
@@ -240,25 +251,25 @@ public final class StatsDatabase {
                 let dateFormatter = DateFormatter()
                 dateFormatter.locale = Locale(identifier: "en_US_POSIX")
                 dateFormatter.dateFormat = "yyyy-MM-dd"
-                let dateString = dateFormatter.string(from: metadata.date)
+                let dateString = dateFormatter.string(from: storedMetadata.date)
 
                 let timeFormatter = DateFormatter()
                 timeFormatter.locale = Locale(identifier: "en_US_POSIX")
                 timeFormatter.dateFormat = "HH:mm:ss"
-                let timeString = timeFormatter.string(from: metadata.date)
+                let timeString = timeFormatter.string(from: storedMetadata.date)
 
                 let isoFormatter = ISO8601DateFormatter()
-                let createdAt = isoFormatter.string(from: metadata.date)
+                let createdAt = isoFormatter.string(from: storedMetadata.date)
 
-                sqlite3_bind_text(statement, 1, (metadata.id as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                sqlite3_bind_text(statement, 1, (storedMetadata.id as NSString).utf8String, -1, SQLITE_TRANSIENT)
                 sqlite3_bind_text(statement, 2, (dateString as NSString).utf8String, -1, SQLITE_TRANSIENT)
                 sqlite3_bind_text(statement, 3, (timeString as NSString).utf8String, -1, SQLITE_TRANSIENT)
-                sqlite3_bind_int(statement, 4, Int32(metadata.durationSeconds))
-                sqlite3_bind_int(statement, 5, Int32(metadata.wordCount))
-                sqlite3_bind_int(statement, 6, Int32(metadata.speakerCount))
-                sqlite3_bind_int(statement, 7, Int32(metadata.processingTimeMs))
-                sqlite3_bind_text(statement, 8, ((metadata.transcriptPath ?? "") as NSString).utf8String, -1, SQLITE_TRANSIENT)
-                sqlite3_bind_text(statement, 9, ((metadata.title ?? "") as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                sqlite3_bind_int(statement, 4, Int32(storedMetadata.durationSeconds))
+                sqlite3_bind_int(statement, 5, Int32(storedMetadata.wordCount))
+                sqlite3_bind_int(statement, 6, Int32(storedMetadata.speakerCount))
+                sqlite3_bind_int(statement, 7, Int32(storedMetadata.processingTimeMs))
+                sqlite3_bind_text(statement, 8, ((storedMetadata.transcriptPath ?? "") as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                sqlite3_bind_text(statement, 9, ((storedMetadata.title ?? "") as NSString).utf8String, -1, SQLITE_TRANSIENT)
                 sqlite3_bind_text(statement, 10, (createdAt as NSString).utf8String, -1, SQLITE_TRANSIENT)
 
                 if sqlite3_step(statement) != SQLITE_DONE {
@@ -271,7 +282,7 @@ public final class StatsDatabase {
             sqlite3_finalize(statement)
 
             // Update daily activity (inside same transaction)
-            updateDailyActivityForSessionChange(from: existing, to: metadata)
+            updateDailyActivityForSessionChange(from: existing, to: storedMetadata)
         }
     }
 
@@ -290,6 +301,31 @@ public final class StatsDatabase {
         defer { sqlite3_finalize(statement) }
 
         sqlite3_bind_text(statement, 1, (id as NSString).utf8String, -1, SQLITE_TRANSIENT)
+        guard sqlite3_step(statement) == SQLITE_ROW else {
+            return nil
+        }
+        return recordingMetadataFromRow(statement)
+    }
+
+    private func recordingMetadataImpl(transcriptPath: String?) -> RecordingMetadata? {
+        guard let transcriptPath, !transcriptPath.isEmpty else {
+            return nil
+        }
+
+        let sql = """
+        SELECT id, date, time, duration_seconds, word_count, speaker_count, processing_time_ms, transcript_path, title
+        FROM recordings
+        WHERE transcript_path = ?
+        LIMIT 1;
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else {
+            AppLogger.stats.error("Failed to prepare recording path lookup", ["sqlite_error": dbErrorMessage()])
+            return nil
+        }
+        defer { sqlite3_finalize(statement) }
+
+        sqlite3_bind_text(statement, 1, (transcriptPath as NSString).utf8String, -1, SQLITE_TRANSIENT)
         guard sqlite3_step(statement) == SQLITE_ROW else {
             return nil
         }

--- a/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
@@ -192,10 +192,12 @@ public class TranscriptSaver {
         speakerStore: (any SpeakerStore)? = nil,
         statsStore: (any StatsStore)? = nil,
         recordingDate: Date? = nil,
+        targetURL: URL? = nil,
         transcriptionEngine: SpeechTranscriptionEngineDescriptor,
         formatOptions: TranscriptFormatOptions = .default
     ) -> URL? {
-        let saveDir = directory ?? defaultSaveDirectory
+        let explicitFileURL = targetURL
+        let saveDir = explicitFileURL?.deletingLastPathComponent() ?? directory ?? defaultSaveDirectory
 
         do {
             try FileManager.default.createDirectory(at: saveDir, withIntermediateDirectories: true)
@@ -213,12 +215,18 @@ public class TranscriptSaver {
         }
 
         let transcriptDate = recordingDate ?? Date()
-        let timestamp = DateFormattingHelper.formatFilename(transcriptDate)
-        var fileURL = saveDir.appendingPathComponent("Call_\(timestamp).md")
-        var counter = 1
-        while FileManager.default.fileExists(atPath: fileURL.path) {
-            fileURL = saveDir.appendingPathComponent("Call_\(timestamp)_\(counter).md")
-            counter += 1
+        let fileURL: URL
+        if let explicitFileURL {
+            fileURL = explicitFileURL
+        } else {
+            let timestamp = DateFormattingHelper.formatFilename(transcriptDate)
+            var candidateURL = saveDir.appendingPathComponent("Call_\(timestamp).md")
+            var counter = 1
+            while FileManager.default.fileExists(atPath: candidateURL.path) {
+                candidateURL = saveDir.appendingPathComponent("Call_\(timestamp)_\(counter).md")
+                counter += 1
+            }
+            fileURL = candidateURL
         }
 
         let markdown = formatTranscriptMarkdown(

--- a/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptSaver.swift
@@ -216,6 +216,7 @@ public class TranscriptSaver {
 
         let transcriptDate = recordingDate ?? Date()
         let fileURL: URL
+        let replacementFileDates = ExistingFileDates.capture(for: explicitFileURL)
         if let explicitFileURL {
             fileURL = explicitFileURL
         } else {
@@ -247,6 +248,7 @@ public class TranscriptSaver {
             do {
                 try markdown.write(to: fileURL, atomically: true, encoding: .utf8)
                 FileManager.default.restrictToOwnerOnly(atPath: fileURL.path)
+                replacementFileDates?.restore(to: fileURL)
 
                 AppLogger.pipeline.info("Transcript saved", ["path": fileURL.path])
 
@@ -276,6 +278,43 @@ public class TranscriptSaver {
         }
 
         return savedURL
+    }
+
+    private struct ExistingFileDates {
+        let creationDate: Date?
+        let modificationDate: Date?
+
+        static func capture(for url: URL?) -> ExistingFileDates? {
+            guard let url,
+                  FileManager.default.fileExists(atPath: url.path),
+                  let attributes = try? FileManager.default.attributesOfItem(atPath: url.path) else {
+                return nil
+            }
+
+            return ExistingFileDates(
+                creationDate: attributes[.creationDate] as? Date,
+                modificationDate: attributes[.modificationDate] as? Date
+            )
+        }
+
+        func restore(to url: URL) {
+            var attributes: [FileAttributeKey: Any] = [:]
+            if let creationDate {
+                attributes[.creationDate] = creationDate
+            }
+            if let modificationDate {
+                attributes[.modificationDate] = modificationDate
+            }
+            guard !attributes.isEmpty else { return }
+
+            do {
+                try FileManager.default.setAttributes(attributes, ofItemAtPath: url.path)
+            } catch {
+                AppLogger.pipeline.warning("Failed to restore replacement transcript file dates", [
+                    "error_type": String(describing: type(of: error))
+                ])
+            }
+        }
     }
 }
 

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -2168,7 +2168,7 @@ struct HomeActivityTabsCard: View {
                                 onOpen: { onOpenMeeting(meeting) },
                                 onCopy: { onCopyMeeting(meeting) },
                                 onFlag: { onFlagMeeting(meeting) },
-                                hasSpeakerReviewWork: hasSpeakerReviewWork,
+                                hasSpeakerReviewWork: hasSpeakerReviewWork(for: meeting),
                                 canRetranscribe: canRetranscribeSavedMeetings,
                                 retranscriptionUnavailableReason: savedMeetingRetranscriptionUnavailableReason,
                                 onReviewSpeakers: { onReviewMeetingSpeakers(meeting) },
@@ -2194,8 +2194,11 @@ struct HomeActivityTabsCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var hasSpeakerReviewWork: Bool {
-        !speakerPeopleModel.hasLoadedProfiles || speakerPeopleModel.needsReviewCount > 0
+    private func hasSpeakerReviewWork(for meeting: RecentMeetingItem) -> Bool {
+        guard speakerPeopleModel.hasLoadedProfiles else {
+            return meeting.speakerStatus.needsReview
+        }
+        return speakerPeopleModel.hasPendingReview(forTranscript: meeting.transcriptURL)
     }
 
     @ViewBuilder

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -194,6 +194,13 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         NSWorkspace.shared.open(item.transcriptURL)
     }
 
+    func hasPendingReview(forTranscript transcriptURL: URL) -> Bool {
+        let targetPath = transcriptURL.standardizedFileURL.path
+        return reviewQueueItems.contains {
+            $0.transcriptURL.standardizedFileURL.path == targetPath
+        }
+    }
+
     func namePendingReviewItem(_ item: SpeakerPendingReviewItem, to newName: String) {
         let trimmed = newName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -674,7 +674,9 @@ struct TranscriptedSettingsView: View {
             let didStart = await meetingSession.retranscribeSavedMeeting(
                 micAudioURL: input.micURL,
                 systemAudioURL: input.systemURL,
-                title: item.title
+                title: item.title,
+                transcriptURL: item.transcriptURL,
+                recordingDate: item.startDate ?? item.date
             )
             if !didStart {
                 NSSound.beep()

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -178,6 +178,10 @@ struct TranscriptedSettingsView: View {
                 speakerPeopleModel.refresh()
             }
         }
+        .onChange(of: meetingSession.savedMeetingReplacementCommitCount) { _, _ in
+            refreshRecentCaptures(force: true)
+            speakerPeopleModel.refresh()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .dictationTranscriptDidSave)) { _ in
             refreshRecentCaptures(force: true)
         }

--- a/Tests/LocalMeetingSummarizerTests.swift
+++ b/Tests/LocalMeetingSummarizerTests.swift
@@ -160,6 +160,50 @@ func testLocalMeetingSummarizer() async {
         )
     }
 
+    runSuite("LocalMeetingSummaryStore removes only generated summaries for the matching transcript") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LocalMeetingSummaryRemovalTests-\(UUID().uuidString)", isDirectory: true)
+        let transcriptURL = root.appendingPathComponent("Call.md")
+        let summaryURL = LocalMeetingSummaryStore.summaryURL(for: transcriptURL)
+        let unrelatedURL = root.appendingPathComponent("Other.summary.md")
+        do {
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            try "transcript".write(to: transcriptURL, atomically: true, encoding: .utf8)
+            try """
+            ---
+            capture_type: meeting_summary
+            source_transcript: "Call.md"
+            ---
+
+            # Summary
+            Old summary.
+            """.write(to: summaryURL, atomically: true, encoding: .utf8)
+            try """
+            ---
+            capture_type: meeting_summary
+            source_transcript: "Different.md"
+            ---
+
+            # Summary
+            Other summary.
+            """.write(to: unrelatedURL, atomically: true, encoding: .utf8)
+
+            assertTrue(
+                try LocalMeetingSummaryStore.removeGeneratedSummary(for: transcriptURL),
+                "matching generated summary should be removed"
+            )
+            assertFalse(FileManager.default.fileExists(atPath: summaryURL.path), "matching summary sidecar should be gone")
+            assertTrue(FileManager.default.fileExists(atPath: unrelatedURL.path), "unrelated summary sidecar should stay")
+            assertFalse(
+                try LocalMeetingSummaryStore.removeGeneratedSummary(for: transcriptURL),
+                "removing an already-cleared summary should be a no-op"
+            )
+        } catch {
+            assertionFailure("summary removal fixture should not throw: \(error)")
+        }
+        try? FileManager.default.removeItem(at: root)
+    }
+
     runSuite("LocalMeetingSummaryNormalizer restores missing sections") {
         let normalized = LocalMeetingSummaryNormalizer.normalized("# Summary\nUseful brief.")
         for heading in [

--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -139,6 +139,27 @@ func testRecentCaptureScanners() async {
         )
     }
 
+    runSuite("RecentMeetingSpeakerReviewActionPolicy stays scoped to the row transcript") {
+        let pendingURL = URL(fileURLWithPath: "/tmp/Pending_Call.md")
+        let reviewedURL = URL(fileURLWithPath: "/tmp/Reviewed_Call.md")
+        let pendingReviewTranscriptPaths: Set<String> = [pendingURL.standardizedFileURL.path]
+
+        assertFalse(
+            RecentMeetingSpeakerReviewActionPolicy.shouldShowReviewAction(
+                speakerStatus: .needsReview(1),
+                hasSpeakerReviewWork: pendingReviewTranscriptPaths.contains(reviewedURL.standardizedFileURL.path)
+            ),
+            "A stale generic row should not show Review speakers just because another meeting has pending review work"
+        )
+        assertTrue(
+            RecentMeetingSpeakerReviewActionPolicy.shouldShowReviewAction(
+                speakerStatus: .needsReview(1),
+                hasSpeakerReviewWork: pendingReviewTranscriptPaths.contains(pendingURL.standardizedFileURL.path)
+            ),
+            "The meeting that actually has pending speaker-review work should still show Review speakers"
+        )
+    }
+
     runSuite("RecentMeetingRetranscriptionActionPolicy shows saved-audio speaker ID fallback") {
         assertTrue(
             RecentMeetingRetranscriptionActionPolicy.shouldShowInlineAction(

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2075,6 +2075,10 @@ func testRepoCommandContract() {
             "replacement retranscription cancellation should restore the selected original transcript"
         )
         assertTrue(
+            runnerContents.contains("speakerClipURLs: namingEntries.map(\\.clipURL),\n                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,\n                replacementTranscriptRollback: replacementTranscriptRollback"),
+            "replacement retranscription cancellation during speaker clip extraction should restore the selected original transcript"
+        )
+        assertTrue(
             runnerContents.contains("if deleteSavedTranscript {")
                 && runnerContents.contains("try? FileManager.default.removeItem(at: savedURL)"),
             "new cancelled transcripts should still be removed when they are not replacing an existing file"
@@ -2085,9 +2089,9 @@ func testRepoCommandContract() {
         let statsContents = readRepoTextFile("Sources/TranscriptedCore/Stats/StatsDatabase.swift")
 
         assertTrue(
-            statsContents.contains("let existing = recordingMetadataImpl(id: metadata.id)")
-                && statsContents.contains("updateDailyActivityForSessionChange(from: existing, to: metadata)"),
-            "stats recording should detect same-ID replacements before updating daily totals"
+            statsContents.contains("let existing = recordingMetadataImpl(id: metadata.id)\n                ?? recordingMetadataImpl(transcriptPath: metadata.transcriptPath)")
+                && statsContents.contains("updateDailyActivityForSessionChange(from: existing, to: storedMetadata)"),
+            "stats recording should detect same-ID and same-path replacements before updating daily totals"
         )
         assertTrue(
             statsContents.contains("recordingCountDelta: 0")

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2075,6 +2075,11 @@ func testRepoCommandContract() {
             "replacement retranscription cancellation should restore the selected original transcript"
         )
         assertTrue(
+            runnerContents.contains("let originalFileDates = OriginalFileDates.capture(for: targetURL)")
+                && runnerContents.contains("originalFileDates?.restore(to: url)"),
+            "replacement retranscription rollback should preserve the selected transcript's file dates for Home ordering"
+        )
+        assertTrue(
             runnerContents.contains("speakerClipURLs: namingEntries.map(\\.clipURL),\n                deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation,\n                replacementTranscriptRollback: replacementTranscriptRollback"),
             "replacement retranscription cancellation during speaker clip extraction should restore the selected original transcript"
         )

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2103,6 +2103,7 @@ func testRepoCommandContract() {
     runSuite("Repo command contract - replacement retranscription clears stale local summaries") {
         let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
         let managerContents = readRepoTextFile("Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift")
+        let settingsContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let summaryContents = readRepoTextFile("Sources/Meeting/LocalMeetingSummarizer.swift")
 
         assertTrue(
@@ -2112,8 +2113,14 @@ func testRepoCommandContract() {
         )
         assertTrue(
             controllerContents.contains("onReplacementTranscriptCommitted:")
-                && controllerContents.contains("clearGeneratedSummaryAfterReplacementRetranscription"),
-            "saved-meeting replacement should clear stale local summary sidecars after commit"
+                && controllerContents.contains("handleReplacementTranscriptCommitted")
+                && controllerContents.contains("savedMeetingReplacementCommitCount &+= 1"),
+            "saved-meeting replacement should clear stale local summary sidecars and emit a same-URL refresh signal after commit"
+        )
+        assertTrue(
+            settingsContents.contains(".onChange(of: meetingSession.savedMeetingReplacementCommitCount)")
+                && settingsContents.contains("speakerPeopleModel.refresh()"),
+            "Settings Home should refresh meeting rows and speaker review state after same-URL replacement retranscription"
         )
         assertTrue(
             summaryContents.contains("static func removeGeneratedSummary")

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2065,17 +2065,34 @@ func testRepoCommandContract() {
             "saved-audio replacement should overwrite the selected transcript without archiving duplicate retained audio"
         )
         assertTrue(
-            runnerContents.contains("let deleteSavedTranscriptOnCancellation = targetTranscriptURL == nil"),
-            "replacement retranscription cancellation should not delete the selected original transcript"
+            runnerContents.contains("let replacementTranscriptRollback = try ReplacementTranscriptRollback.capture(for: targetTranscriptURL)")
+                && runnerContents.contains("let transcriptId = replacementTranscriptRollback?.transcriptId ?? UUID()"),
+            "replacement retranscription should snapshot the selected transcript and reuse its existing ID"
         )
         assertTrue(
-            runnerContents.contains("deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation"),
-            "replacement retranscription cancellation policy should be threaded through side-effect checks"
+            runnerContents.contains("replacementTranscriptRollback: replacementTranscriptRollback")
+                && runnerContents.contains("replacementTranscriptRollback.restore()"),
+            "replacement retranscription cancellation should restore the selected original transcript"
         )
         assertTrue(
             runnerContents.contains("if deleteSavedTranscript {")
                 && runnerContents.contains("try? FileManager.default.removeItem(at: savedURL)"),
             "new cancelled transcripts should still be removed when they are not replacing an existing file"
+        )
+    }
+
+    runSuite("Repo command contract - replacement stats do not double-count existing recordings") {
+        let statsContents = readRepoTextFile("Sources/TranscriptedCore/Stats/StatsDatabase.swift")
+
+        assertTrue(
+            statsContents.contains("let existing = recordingMetadataImpl(id: metadata.id)")
+                && statsContents.contains("updateDailyActivityForSessionChange(from: existing, to: metadata)"),
+            "stats recording should detect same-ID replacements before updating daily totals"
+        )
+        assertTrue(
+            statsContents.contains("recordingCountDelta: 0")
+                && statsContents.contains("durationDelta: metadata.durationSeconds - existing.durationSeconds"),
+            "same-day replacement stats should adjust duration without incrementing recording count"
         )
     }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2100,6 +2100,29 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - replacement retranscription clears stale local summaries") {
+        let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let managerContents = readRepoTextFile("Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift")
+        let summaryContents = readRepoTextFile("Sources/Meeting/LocalMeetingSummarizer.swift")
+
+        assertTrue(
+            managerContents.contains("onReplacementTranscriptCommitted")
+                && managerContents.contains("if replacementTranscriptURL != nil {\n                        onReplacementTranscriptCommitted?(transcriptURL)"),
+            "Core should notify the app after a replacement transcript commits"
+        )
+        assertTrue(
+            controllerContents.contains("onReplacementTranscriptCommitted:")
+                && controllerContents.contains("clearGeneratedSummaryAfterReplacementRetranscription"),
+            "saved-meeting replacement should clear stale local summary sidecars after commit"
+        )
+        assertTrue(
+            summaryContents.contains("static func removeGeneratedSummary")
+                && summaryContents.contains("values[\"capture_type\"] == \"meeting_summary\"")
+                && summaryContents.contains("values[\"source_transcript\"] == transcriptURL.lastPathComponent"),
+            "local summary cleanup should only remove generated summaries for the matching transcript"
+        )
+    }
+
     runSuite("Repo command contract - Home failed meeting actions surface failures") {
         let settingsContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2055,6 +2055,30 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - replacement retranscription cancellation keeps original transcript") {
+        let runnerContents = readRepoTextFile("Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift")
+        let managerContents = readRepoTextFile("Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift")
+
+        assertTrue(
+            managerContents.contains("targetTranscriptURL: replacementTranscriptURL")
+                && managerContents.contains("archiveRecordingAudio: replacementTranscriptURL == nil"),
+            "saved-audio replacement should overwrite the selected transcript without archiving duplicate retained audio"
+        )
+        assertTrue(
+            runnerContents.contains("let deleteSavedTranscriptOnCancellation = targetTranscriptURL == nil"),
+            "replacement retranscription cancellation should not delete the selected original transcript"
+        )
+        assertTrue(
+            runnerContents.contains("deleteSavedTranscriptOnCancellation: deleteSavedTranscriptOnCancellation"),
+            "replacement retranscription cancellation policy should be threaded through side-effect checks"
+        )
+        assertTrue(
+            runnerContents.contains("if deleteSavedTranscript {")
+                && runnerContents.contains("try? FileManager.default.removeItem(at: savedURL)"),
+            "new cancelled transcripts should still be removed when they are not replacing an existing file"
+        )
+    }
+
     runSuite("Repo command contract - Home failed meeting actions surface failures") {
         let settingsContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")

--- a/Tests/SpeakerReviewQueueScannerTests.swift
+++ b/Tests/SpeakerReviewQueueScannerTests.swift
@@ -54,6 +54,66 @@ func testSpeakerReviewQueueScanner() {
         assertEqual(items.count, 0, "named profiles should not keep stale db_pending rows in the queue")
     }
 
+    runSuite("SpeakerReviewQueueScanner clears Home review status after deferred speaker naming") {
+        let fm = FileManager.default
+        let directory = fm.temporaryDirectory
+            .appendingPathComponent("SpeakerReviewQueueScannerTests-\(UUID().uuidString)", isDirectory: true)
+        let transcriptURL = directory.appendingPathComponent("Reviewed_Call.md")
+        let speakerId = UUID()
+        try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: directory) }
+
+        try? deferredMarkdown(
+            speakerId: speakerId,
+            title: "Reviewed Call",
+            speakerName: "Speaker 1",
+            sampleText: "This row should be renamed."
+        ).write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+        let before = SpeakerReviewQueueScanner.loadPendingItems(
+            transcriptsDirectory: directory,
+            profiles: [makeReviewQueueProfile(id: speakerId, name: nil)],
+            clipURLsByProfileID: [:]
+        )
+        assertEqual(before.count, 1, "fixture should start with one pending speaker-review row")
+
+        let completedMarkdown = """
+        ---
+        title: "Reviewed Call"
+        date: 2026-05-20
+        time: 09:30:00
+        speakers:
+          - id: "1"
+            channel: system
+            db_id: "\(speakerId.uuidString)"
+            name: "Maya"
+            confidence: confirmed
+            source: user_manual
+        ---
+
+        # Reviewed Call
+
+        ## Transcript
+
+        **00:01** [System/Maya]
+        This row should be renamed.
+        """
+        try? completedMarkdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let updatedMarkdown = (try? String(contentsOf: transcriptURL, encoding: .utf8)) ?? ""
+        let after = SpeakerReviewQueueScanner.loadPendingItems(
+            transcriptsDirectory: directory,
+            profiles: [makeReviewQueueProfile(id: speakerId, name: "Maya")],
+            clipURLsByProfileID: [:]
+        )
+
+        assertEqual(after.count, 0, "completed speaker review should leave no pending queue item")
+        assertEqual(
+            RecentMeetingSpeakerStatus.detect(in: updatedMarkdown),
+            .ready,
+            "Home row speaker status should be ready after the saved label is named"
+        )
+    }
+
     runSuite("SpeakerReviewQueueScanner treats missing channel as legacy system audio") {
         let speakerId = UUID()
         let transcriptURL = URL(fileURLWithPath: "/tmp/Legacy_Deferred.md")

--- a/Tests/TranscriptedCoreTests/StatsDatabaseTests.swift
+++ b/Tests/TranscriptedCoreTests/StatsDatabaseTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SQLite3
 @testable import TranscriptedCore
 
 @available(macOS 14.0, *)
@@ -33,4 +34,62 @@ final class StatsDatabaseTests: XCTestCase {
             try? FileManager.default.removeItem(at: URL(fileURLWithPath: databaseURL.path + suffix))
         }
     }
+
+    func testReplacingRecordingUpdatesDailyActivityInsteadOfDoubleCounting() {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedCoreStatsTests-\(UUID().uuidString).sqlite")
+        let date = Calendar(identifier: .gregorian).date(
+            from: DateComponents(year: 2026, month: 4, day: 5, hour: 9, minute: 0)
+        )!
+
+        do {
+            let database = StatsDatabase(path: databaseURL.path)
+            database.recordSession(RecordingMetadata(
+                id: "same-transcript",
+                date: date,
+                durationSeconds: 60,
+                transcriptPath: "/synthetic/meeting.md"
+            ))
+            database.recordSession(RecordingMetadata(
+                id: "same-transcript",
+                date: date,
+                durationSeconds: 95,
+                transcriptPath: "/synthetic/meeting.md"
+            ))
+            database.queue.sync {}
+
+            XCTAssertEqual(database.getAllRecordings().map(\.durationSeconds), [95])
+            XCTAssertEqual(
+                dailyActivity(at: databaseURL, date: "2026-04-05"),
+                DailyActivity(count: 1, duration: 95)
+            )
+        }
+
+        for suffix in ["", "-shm", "-wal"] {
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: databaseURL.path + suffix))
+        }
+    }
+}
+
+private struct DailyActivity: Equatable {
+    let count: Int
+    let duration: Int
+}
+
+private func dailyActivity(at databaseURL: URL, date: String) -> DailyActivity? {
+    var db: OpaquePointer?
+    guard sqlite3_open(databaseURL.path, &db) == SQLITE_OK else { return nil }
+    defer { sqlite3_close(db) }
+
+    let sql = "SELECT recording_count, total_duration_seconds FROM daily_activity WHERE date = ? LIMIT 1;"
+    var statement: OpaquePointer?
+    guard sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK else { return nil }
+    defer { sqlite3_finalize(statement) }
+
+    sqlite3_bind_text(statement, 1, (date as NSString).utf8String, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+    guard sqlite3_step(statement) == SQLITE_ROW else { return nil }
+    return DailyActivity(
+        count: Int(sqlite3_column_int(statement, 0)),
+        duration: Int(sqlite3_column_int(statement, 1))
+    )
 }

--- a/Tests/TranscriptedCoreTests/StatsDatabaseTests.swift
+++ b/Tests/TranscriptedCoreTests/StatsDatabaseTests.swift
@@ -69,6 +69,43 @@ final class StatsDatabaseTests: XCTestCase {
             try? FileManager.default.removeItem(at: URL(fileURLWithPath: databaseURL.path + suffix))
         }
     }
+
+    func testReplacingLegacyRecordingMatchesByTranscriptPath() {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedCoreStatsTests-\(UUID().uuidString).sqlite")
+        let date = Calendar(identifier: .gregorian).date(
+            from: DateComponents(year: 2026, month: 4, day: 5, hour: 9, minute: 0)
+        )!
+
+        do {
+            let database = StatsDatabase(path: databaseURL.path)
+            database.recordSession(RecordingMetadata(
+                id: "legacy-row-id",
+                date: date,
+                durationSeconds: 60,
+                transcriptPath: "/synthetic/legacy-meeting.md"
+            ))
+            database.recordSession(RecordingMetadata(
+                id: "fresh-replacement-id",
+                date: date,
+                durationSeconds: 95,
+                transcriptPath: "/synthetic/legacy-meeting.md"
+            ))
+            database.queue.sync {}
+
+            let recordings = database.getAllRecordings()
+            XCTAssertEqual(recordings.map(\.id), ["legacy-row-id"])
+            XCTAssertEqual(recordings.map(\.durationSeconds), [95])
+            XCTAssertEqual(
+                dailyActivity(at: databaseURL, date: "2026-04-05"),
+                DailyActivity(count: 1, duration: 95)
+            )
+        }
+
+        for suffix in ["", "-shm", "-wal"] {
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: databaseURL.path + suffix))
+        }
+    }
 }
 
 private struct DailyActivity: Equatable {

--- a/Tests/TranscriptedCoreTests/TranscriptSaverDefaultSaveDirectoryTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptSaverDefaultSaveDirectoryTests.swift
@@ -82,4 +82,84 @@ final class TranscriptSaverDefaultSaveDirectoryTests: XCTestCase {
             CoreStoragePaths.default.transcripts
         )
     }
+
+    func testTargetURLReplacementPreservesOriginalFileDates() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptSaverReplacementDates-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let transcriptURL = directory.appendingPathComponent("Reviewed_Call.md")
+        try "Original transcript".write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+        let originalCreationDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let originalModificationDate = Date(timeIntervalSince1970: 1_700_000_123)
+        try FileManager.default.setAttributes(
+            [
+                .creationDate: originalCreationDate,
+                .modificationDate: originalModificationDate
+            ],
+            ofItemAtPath: transcriptURL.path
+        )
+        let beforeAttributes = try FileManager.default.attributesOfItem(atPath: transcriptURL.path)
+        let expectedCreationDate = try XCTUnwrap(beforeAttributes[.creationDate] as? Date)
+        let expectedModificationDate = try XCTUnwrap(beforeAttributes[.modificationDate] as? Date)
+
+        let result = TranscriptionResult(
+            micUtterances: [],
+            systemUtterances: [
+                TranscriptionUtterance(
+                    start: 0,
+                    end: 2,
+                    channel: 1,
+                    speakerId: 0,
+                    persistentSpeakerId: nil,
+                    matchSimilarity: nil,
+                    transcript: "Updated synthetic transcript."
+                )
+            ],
+            duration: 2,
+            processingTime: 0.5
+        )
+
+        let savedURL = TranscriptSaver.saveTranscript(
+            result,
+            transcriptId: UUID(),
+            directory: directory,
+            meetingTitle: "Reviewed Call",
+            statsStore: TranscriptSaverNoopStatsStore(),
+            recordingDate: Date(),
+            targetURL: transcriptURL,
+            transcriptionEngine: .parakeetLocal
+        )
+
+        XCTAssertEqual(savedURL, transcriptURL)
+        let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
+        XCTAssertTrue(markdown.contains("Updated synthetic transcript."))
+
+        let afterAttributes = try FileManager.default.attributesOfItem(atPath: transcriptURL.path)
+        let afterCreationDate = try XCTUnwrap(afterAttributes[.creationDate] as? Date)
+        let afterModificationDate = try XCTUnwrap(afterAttributes[.modificationDate] as? Date)
+        XCTAssertEqual(
+            afterCreationDate.timeIntervalSince1970,
+            expectedCreationDate.timeIntervalSince1970,
+            accuracy: 1.0
+        )
+        XCTAssertEqual(
+            afterModificationDate.timeIntervalSince1970,
+            expectedModificationDate.timeIntervalSince1970,
+            accuracy: 1.0
+        )
+    }
+}
+
+@available(macOS 14.0, *)
+private final class TranscriptSaverNoopStatsStore: StatsStore {
+    func recordSession(_ metadata: RecordingMetadata) {}
+
+    func getTotalRecordingsCount() -> Int { 0 }
+
+    func getRecordings(from startDate: Date, to endDate: Date) -> [RecordingMetadata] { [] }
+
+    func recordingExists(transcriptPath: String) -> Bool { false }
 }

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -1467,6 +1467,114 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))
     }
 
+    func testSavedAudioRetranscriptionCanReplaceOriginalTranscriptWithoutDuplicateRow() async throws {
+        let originalRecordingDate = localDate(
+            year: 2026,
+            month: 6,
+            day: 5,
+            hour: 18,
+            minute: 39,
+            second: 20
+        )
+        let speech = MetadataStubSpeechToTextEngine(transcript: "Thanks for joining.")
+        let diarization = MetadataStubDiarizationEngine(segments: [
+            SpeakerSegment(
+                speakerId: 1,
+                startTime: 0,
+                endTime: 2,
+                embedding: [Float](repeating: 0.42, count: 256),
+                qualityScore: 0.95
+            )
+        ])
+        let transcriptsDirectory = tempDirectory.appendingPathComponent("transcripts", isDirectory: true)
+        let retainedAudioDirectory = transcriptsDirectory.appendingPathComponent("audio", isDirectory: true)
+        let manager = makeManager(
+            speechToText: speech,
+            diarization: diarization,
+            retainedAudioDirectory: retainedAudioDirectory
+        )
+        try FileManager.default.createDirectory(at: transcriptsDirectory, withIntermediateDirectories: true)
+
+        let originalTranscriptURL = transcriptsDirectory.appendingPathComponent("Reviewed_Call.md")
+        try """
+        ---
+        capture_type: meeting
+        title: "Reviewed Call"
+        date: 2026-06-05
+        time: 18:39:20
+        duration: "00:02"
+        total_word_count: 1
+        mic_utterances: 1
+        system_utterances: 1
+        ---
+
+        # Reviewed Call
+
+        ## Transcript
+
+        **00:01** [System/Speaker 1]
+        Old synthetic line.
+        """.write(to: originalTranscriptURL, atomically: true, encoding: .utf8)
+
+        let savedAudioDirectory = retainedAudioDirectory
+            .appendingPathComponent("Reviewed_Call_audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: savedAudioDirectory, withIntermediateDirectories: true)
+        let micURL = savedAudioDirectory.appendingPathComponent("microphone.wav")
+        let systemURL = savedAudioDirectory.appendingPathComponent("system_audio.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        manager.startSavedAudioRetranscription(
+            micURL: micURL,
+            systemURL: systemURL,
+            outputFolder: transcriptsDirectory,
+            meetingTitle: "Reviewed Call",
+            splitLocalSpeakers: true,
+            replacementTranscriptURL: originalTranscriptURL,
+            recordingDate: originalRecordingDate
+        )
+
+        try await waitUntil {
+            manager.speakerNamingRequest != nil && manager.activeTasks.isEmpty
+        }
+
+        let request = try XCTUnwrap(manager.speakerNamingRequest)
+        let transcriptURL = try XCTUnwrap(manager.lastSavedTranscriptURL)
+        let markdown = try String(contentsOf: originalTranscriptURL, encoding: .utf8)
+        let markdownFiles = try FileManager.default.contentsOfDirectory(
+            at: transcriptsDirectory,
+            includingPropertiesForKeys: nil
+        ).filter { $0.pathExtension == "md" }
+        let retainedAudioFiles = try FileManager.default.contentsOfDirectory(
+            at: savedAudioDirectory,
+            includingPropertiesForKeys: nil
+        ).map(\.lastPathComponent).sorted()
+
+        XCTAssertEqual(transcriptURL, originalTranscriptURL, "replacement retranscription should publish the original row URL")
+        XCTAssertEqual(request.transcriptURL, originalTranscriptURL, "speaker review should continue against the original transcript")
+        XCTAssertEqual(markdownFiles.count, 1, "replacement retranscription should not create a duplicate meeting Markdown row")
+        XCTAssertEqual(
+            markdownFiles.first?.standardizedFileURL.path,
+            originalTranscriptURL.standardizedFileURL.path,
+            "the remaining meeting Markdown row should still be the original transcript"
+        )
+        XCTAssertTrue(
+            markdown.contains("\ndate: \(frontmatterDateString(originalRecordingDate))\n"),
+            "replacement transcript should keep the original meeting date in frontmatter"
+        )
+        XCTAssertTrue(
+            markdown.contains("\ntime: \(frontmatterTimeString(originalRecordingDate))\n"),
+            "replacement transcript should keep the original meeting time in frontmatter"
+        )
+        XCTAssertEqual(
+            retainedAudioFiles,
+            ["microphone.wav", "system_audio.wav"],
+            "replacement retranscription should reuse retained audio instead of copying duplicate files into the same archive"
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))
+    }
+
     func testSavedAudioRetranscriptionRejectsTooShortAudioWithoutDeletingSource() throws {
         let manager = makeManager()
         let savedAudioDirectory = tempDirectory.appendingPathComponent("saved-meeting-audio", isDirectory: true)

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -1486,18 +1486,23 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
                 qualityScore: 0.95
             )
         ])
+        let originalTranscriptId = UUID()
+        let statsStore = MetadataCapturingStatsStore()
         let transcriptsDirectory = tempDirectory.appendingPathComponent("transcripts", isDirectory: true)
         let retainedAudioDirectory = transcriptsDirectory.appendingPathComponent("audio", isDirectory: true)
         let manager = makeManager(
             speechToText: speech,
             diarization: diarization,
-            retainedAudioDirectory: retainedAudioDirectory
+            retainedAudioDirectory: retainedAudioDirectory,
+            statsStore: statsStore
         )
         try FileManager.default.createDirectory(at: transcriptsDirectory, withIntermediateDirectories: true)
 
         let originalTranscriptURL = transcriptsDirectory.appendingPathComponent("Reviewed_Call.md")
         try """
         ---
+        capture_id: "\(originalTranscriptId.uuidString)"
+        transcript_id: "\(originalTranscriptId.uuidString)"
         capture_type: meeting
         title: "Reviewed Call"
         date: 2026-06-05
@@ -1570,6 +1575,11 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             retainedAudioFiles,
             ["microphone.wav", "system_audio.wav"],
             "replacement retranscription should reuse retained audio instead of copying duplicate files into the same archive"
+        )
+        XCTAssertEqual(
+            statsStore.recordedSessions.map(\.id),
+            [originalTranscriptId.uuidString],
+            "replacement retranscription should update stats for the existing transcript ID instead of creating a second history row"
         )
         XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -1528,6 +1528,7 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         let systemURL = savedAudioDirectory.appendingPathComponent("system_audio.wav")
         try writeMonoWAV(to: micURL, duration: 2.5)
         try writeMonoWAV(to: systemURL, duration: 2.5)
+        var committedReplacementURLs: [URL] = []
 
         manager.startSavedAudioRetranscription(
             micURL: micURL,
@@ -1536,7 +1537,10 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             meetingTitle: "Reviewed Call",
             splitLocalSpeakers: true,
             replacementTranscriptURL: originalTranscriptURL,
-            recordingDate: originalRecordingDate
+            recordingDate: originalRecordingDate,
+            onReplacementTranscriptCommitted: { url in
+                committedReplacementURLs.append(url)
+            }
         )
 
         try await waitUntil {
@@ -1580,6 +1584,11 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
             statsStore.recordedSessions.map(\.id),
             [originalTranscriptId.uuidString],
             "replacement retranscription should update stats for the existing transcript ID instead of creating a second history row"
+        )
+        XCTAssertEqual(
+            committedReplacementURLs,
+            [originalTranscriptURL],
+            "replacement retranscription should notify the app only after the selected transcript is committed"
         )
         XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: systemURL.path))


### PR DESCRIPTION
## Summary
- scope Home speaker-review actions to the exact transcript row instead of global pending review state
- make saved-audio retranscription replace the original transcript and preserve the original recording date/time
- avoid duplicate retained-audio copies when retranscribing an existing saved meeting

## Repro
Synthetic saved-meeting fixture with a reviewed transcript plus retained mic/system audio. Retranscribing the saved audio now rewrites the original Markdown row, keeps the original timestamp, and does not mint a second row.

## Verification
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- bash scripts/dev/agent-preflight.sh

Privacy: fixtures are synthetic only; no private transcript/audio content used.