### PR TITLE
Add audio route automation contract

### DIFF
--- a/Tests/AudioAutomationCoverageContractTests.swift
+++ b/Tests/AudioAutomationCoverageContractTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+func testAudioAutomationCoverageContract() {
+    runSuite("Audio automation coverage contract - synthetic matrix names each route lane") {
+        let script = readAudioAutomationContractFile("scripts/ops/daily-audio-reliability-check.sh")
+
+        let expectedSyntheticRows = [
+            "synthetic-dictation-pasteback-lifecycle",
+            "synthetic-meeting-mic-system-split",
+            "synthetic-webrtc-zoom-contention-proxy",
+            "synthetic-bluetooth-airpods-route-settling-proxy",
+            "synthetic-audio-privacy-security"
+        ]
+
+        for row in expectedSyntheticRows {
+            assertTrue(script.contains(row), "synthetic audio matrix should include \(row)")
+        }
+
+        assertTrue(
+            script.contains("Audio Route Automation Proxy Matrix")
+                && script.contains("manual_boundary_documented=true"),
+            "synthetic audio reports should separate automated proxies from manual route proof"
+        )
+    }
+
+    runSuite("Audio automation coverage contract - issue 500 manual proof stays explicit") {
+        let script = readAudioAutomationContractFile("scripts/ops/daily-audio-reliability-check.sh")
+        let issue500 = readAudioAutomationContractFile("docs/qa-issue-500-meeting-audio.md")
+        let qaBench = readAudioAutomationContractFile("scripts/ops/transcripted-qa-bench.sh")
+
+        for manualProof in ["Safari Meet", "Firefox Meet", "Chrome Meet", "Zoom", "AirPods/Bluetooth"] {
+            assertTrue(script.contains(manualProof), "synthetic report should name \(manualProof) as manual proof")
+            assertTrue(issue500.contains(manualProof), "issue 500 QA matrix should still include \(manualProof)")
+        }
+
+        assertTrue(
+            qaBench.contains("Use `docs/qa-issue-500-meeting-audio.md`")
+                && qaBench.contains("human proof lanes that require GUI, TCC, hardware, meeting apps, or feel checks"),
+            "QA bench should keep route proof in the generated manual scenario packet"
+        )
+    }
+
+    runSuite("Audio automation coverage contract - deterministic E2E smoke keeps saved-artifact source dependencies") {
+        let e2e = readAudioAutomationContractFile("scripts/entrypoints/run-e2e-smoke.sh")
+
+        assertTrue(
+            e2e.contains("Sources/Meeting/MeetingTranscriptStyler.swift")
+                && e2e.contains("Sources/Meeting/LocalMeetingSummarizer.swift"),
+            "E2E smoke should compile the local summary updater used by meeting transcript styling"
+        )
+    }
+}
+
+private func readAudioAutomationContractFile(_ relativePath: String) -> String {
+    let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+        .appendingPathComponent(relativePath)
+    return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+}

--- a/Tests/FastTests.manifest
+++ b/Tests/FastTests.manifest
@@ -2,6 +2,7 @@
 # Format: <TestFile.swift>:<top-level entry function>
 
 ActivationPolicyControllerTests.swift:testActivationPolicyController
+AudioAutomationCoverageContractTests.swift:testAudioAutomationCoverageContract
 AgentConnectionGuideTests.swift:testAgentConnectionGuide
 AudioStoragePreferencesTests.swift:testAudioStoragePreferences
 ClaudeDesktopIntegrationInstallerTests.swift:testClaudeDesktopIntegrationInstaller

--- a/docs/audio-reliability-daily-check.md
+++ b/docs/audio-reliability-daily-check.md
@@ -121,6 +121,11 @@ matrix for the state-machine contract:
 - user-visible state
 - the seven meeting-failure questions
 
+It also writes an audio route automation proxy matrix for dictation pasteback,
+meeting mic/system audio, WebRTC/Zoom contention, Bluetooth/AirPods settling,
+and privacy/security. Those rows document deterministic coverage only; real
+Zoom/Meet/AirPods volume proof still uses `docs/qa-issue-500-meeting-audio.md`.
+
 The same seven-field contract is covered by fast tests in:
 
 ```text

--- a/docs/qa-test-bench.md
+++ b/docs/qa-test-bench.md
@@ -42,6 +42,11 @@ This adds:
 - `TranscriptedQA` health and live artifact validation
 - `bash run-daily-audio-reliability.sh --synthetic`
 
+The synthetic audio step also reports an audio route automation proxy matrix so
+the bench names what is automated for dictation, meeting mic/system audio,
+WebRTC/Zoom contention, Bluetooth/AirPods settling, and privacy/security. It
+does not replace live or manual route proof.
+
 Live artifact validation is non-blocking by default because a development Mac
 may not have saved meetings yet. To make it strict:
 

--- a/scripts/entrypoints/run-e2e-smoke.sh
+++ b/scripts/entrypoints/run-e2e-smoke.sh
@@ -37,6 +37,7 @@ SWIFT_SOURCES=(
     "Sources/Dictation/DictationTranscriptWriter.swift"
     "Sources/Dictation/DictationTranscriptStore.swift"
     "Sources/Meeting/MeetingStoragePaths.swift"
+    "Sources/Meeting/LocalMeetingSummarizer.swift"
     "Sources/Meeting/MeetingTranscriptStyler.swift"
     "Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift"
     "Sources/TranscriptedCore/Models/TranscriptionTypes.swift"

--- a/scripts/ops/daily-audio-reliability-check.sh
+++ b/scripts/ops/daily-audio-reliability-check.sh
@@ -346,6 +346,85 @@ record_synthetic_failure() {
   } >> "${REPORT}"
 }
 
+record_route_automation_proxy() {
+  local scenario="$1"
+  local lane="$2"
+  local automated_proxy="$3"
+  local owned_check="$4"
+  local manual_boundary="$5"
+
+  printf "%s\t%s\tpass\n" "${scenario}" "lane=${lane}" >> "${ANSWERS}"
+  printf "%s\t%s\tpass\n" "${scenario}" "automated_proxy=${automated_proxy}" >> "${ANSWERS}"
+  printf "%s\t%s\tpass\n" "${scenario}" "owned_check=${owned_check}" >> "${ANSWERS}"
+  printf "%s\t%s\tpass\n" "${scenario}" "manual_boundary_documented=true" >> "${ANSWERS}"
+
+  {
+    echo
+    echo "### ${scenario}"
+    echo
+    echo "- lane: ${lane}"
+    echo "- automated_proxy: ${automated_proxy}"
+    echo "- owned_check: \`${owned_check}\`"
+    echo "- manual_boundary: ${manual_boundary}"
+  } >> "${REPORT}"
+}
+
+run_route_automation_proxy_suite() {
+  {
+    echo
+    echo "## Audio Route Automation Proxy Matrix"
+    echo
+    echo "These rows make the automation boundary explicit. They prove deterministic"
+    echo "policy coverage exists for each audio lane, while real route proof still"
+    echo "requires the manual matrix in \`docs/qa-issue-500-meeting-audio.md\`."
+  } >> "${REPORT}"
+
+  record_route_automation_proxy \
+    "synthetic-dictation-pasteback-lifecycle" \
+    "dictation pasteback/audio lifecycle" \
+    "clipboard restore, slow paste consumers, no-speech recovery, route-preserved buffered audio" \
+    "bash run-tests.sh" \
+    "TextEdit, Notes, and browser text-area pasteback still need focused-app manual proof."
+
+  record_route_automation_proxy \
+    "synthetic-meeting-mic-system-split" \
+    "meeting mic/system audio" \
+    "mic/system failure-shape matrix plus retained-artifact state-machine checks" \
+    "bash run-daily-audio-reliability.sh --synthetic" \
+    "real mic plus System Audio Recording capture still needs live smoke or manual TCC proof."
+
+  record_route_automation_proxy \
+    "synthetic-webrtc-zoom-contention-proxy" \
+    "WebRTC/Zoom route proxy" \
+    "quiet-mic attenuation classification, software AGC recovery, output-ducking diagnostics" \
+    "bash run-tests.sh" \
+    "Safari Meet, Firefox Meet, Chrome Meet, and Zoom volume behavior still need real app proof."
+
+  record_route_automation_proxy \
+    "synthetic-bluetooth-airpods-route-settling-proxy" \
+    "Bluetooth/AirPods route settling" \
+    "Bluetooth headset fallback policy, stale-route readiness, zombie-recovery state transitions" \
+    "bash run-tests.sh" \
+    "connected AirPods/Bluetooth hardware routes still need Justin-run manual proof."
+
+  record_route_automation_proxy \
+    "synthetic-audio-privacy-security" \
+    "audio privacy/security" \
+    "privacy-safe diagnostics, sanitizer allowlists, local-only artifact validation" \
+    "bash run-tests.sh" \
+    "support bundles and logs still need local-only review before any sharing."
+
+  {
+    echo
+    echo "Manual route proof still required before issue #500 can be called green:"
+    echo
+    echo "- Safari Meet, Firefox Meet, Chrome Meet, and Zoom with real app audio"
+    echo "- AirPods/Bluetooth and any available USB route"
+    echo "- user-perceived meeting volume before/during/after capture"
+    echo "- saved transcript proof that uses the processed mic path"
+  } >> "${REPORT}"
+}
+
 run_synthetic_suite() {
   append_scenario "synthetic-fixtures" "Synthetic Audio Fixtures" "Generated local audio covers silence, quiet audio, short audio, corrupted input, and speaker-like tones."
   generate_synthetic_fixtures
@@ -363,6 +442,7 @@ run_synthetic_suite() {
   record_synthetic_failure "synthetic-transcription-crash" "transcription_inference_failed" "transcription" "recoverable_failure" "retryable" "retained_failed_queue_entry" "retry_available" "yes" "yes" "yes" "no" "no" "yes" "yes"
   record_synthetic_failure "synthetic-save-failed" "save_failed" "save" "recoverable_failure" "retryable_after_user_action" "retained_failed_queue_entry" "needs_user_action" "yes" "yes" "no" "no" "yes" "yes" "yes"
   record_synthetic_failure "synthetic-diarization-degraded" "diarization_failed" "diarization" "degraded_success" "retryable" "retained_partial_transcript" "transcript_saved_without_speakers" "yes" "yes" "no" "yes" "no" "yes" "yes"
+  run_route_automation_proxy_suite
   collect_logs "synthetic"
 }
 


### PR DESCRIPTION
## Summary
- Add a synthetic audio route automation proxy matrix for dictation pasteback, meeting mic/system audio, WebRTC/Zoom contention, Bluetooth/AirPods settling, and audio privacy/security.
- Add a fast contract test so the automated-vs-manual route boundary cannot silently drift.
- Fix deterministic E2E smoke by compiling the local summary updater dependency used by `MeetingTranscriptStyler`.
- Update QA docs to describe the new proxy matrix without replacing live/manual route proof.

## Verification
- `scripts/dev/agent-preflight.sh`
- `bash -n scripts/entrypoints/run-e2e-smoke.sh`
- `bash -n scripts/ops/daily-audio-reliability-check.sh`
- `bash -n run-tests.sh`
- `bash -n scripts/entrypoints/run-tests.sh`
- `bash -n run-daily-audio-reliability.sh`
- `python3 -m py_compile scripts/ops/validate-meeting-corpus.py`
- `python3 -m py_compile scripts/ops/compare-meeting-corpus.py`
- `bash run-tests.sh` — 3919 passed
- `bash run-e2e-smoke.sh` — passed
- `bash run-daily-audio-reliability.sh --synthetic` — 92 passed, 0 failed, 0 skipped
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-integration-smoke.sh`
- `swift test` — 370 passed, 1 skipped live-capture test
- `bash scripts/ops/transcripted-qa-bench.sh --mode quick` — 4/4 passed

## Still manual
- Real Safari Meet, Firefox Meet, Chrome Meet, Zoom, and AirPods/Bluetooth route proof.
- User-perceived meeting volume before/during/after capture.
- Live saved-transcript proof from real hardware/app routes.
