### PR TITLE
[codex] Add agent QA gate strategy

### DIFF
--- a/.agents/qa-gates.yml
+++ b/.agents/qa-gates.yml
@@ -80,6 +80,7 @@ test_layers:
     commands:
       packaging_smoke: "SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>"
       sparkle_verify: "bash scripts/release/verify-sparkle-release.sh <version>"
+      sentry_register: "SENTRY_REQUIRE_DEBUG_FILES=1 bash scripts/release/register-sentry-release.sh <version>"
       cask_update: "bash scripts/release/update-cask.sh <version>"
     proves:
       - "release artifact, Sparkle appcast, Homebrew cask, and Sentry release metadata can be checked before users depend on them"

--- a/.agents/qa-gates.yml
+++ b/.agents/qa-gates.yml
@@ -120,9 +120,10 @@ recommended_gates:
       - "bash run-integration-smoke.sh"
       - "bash run-e2e-smoke.sh"
       - "swift test"
-      - "bash scripts/ops/transcripted-qa-bench.sh --mode deep --strict-artifacts"
+      - "bash scripts/ops/transcripted-qa-bench.sh --mode deep"
       - "SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>"
     add_when_shipping_to_users:
+      - "bash scripts/ops/transcripted-qa-bench.sh --mode deep --strict-artifacts when fixture or private artifact roots are available"
       - "full notarized build-beta.sh"
       - "bash scripts/release/verify-sparkle-release.sh <version>"
       - "bash scripts/release/update-cask.sh <version>"

--- a/.agents/qa-gates.yml
+++ b/.agents/qa-gates.yml
@@ -1,0 +1,216 @@
+# Agent-first QA gates for Transcripted.
+#
+# This complements .agents/test-matrix.yml:
+# - test-matrix.yml maps changed paths to local verification commands.
+# - qa-gates.yml maps product risk and agent lanes to the gate that proves it.
+
+last_reviewed: 2026-06-06
+
+source_docs:
+  - AGENTS.md
+  - Tests/README.md
+  - docs/qa-test-bench.md
+  - docs/release-packaging.md
+  - docs/sparkle-updates.md
+  - docs/storage-paths.md
+
+test_layers:
+  fast_custom_runner:
+    command: "bash run-tests.sh"
+    proves:
+      - "manifest-registered app policy and persistence tests still pass"
+      - "privacy sanitizers, observability policy, speaker policy, storage helpers, and UI policy stay coherent"
+    agent_notes:
+      - "Root Tests/*Tests.swift files must be registered in Tests/FastTests.manifest."
+      - "Use bash run-tests.sh --coverage when the lane needs LLVM fast-test coverage output."
+
+  app_build:
+    command: "bash build.sh --no-open"
+    proves:
+      - "the menubar app target compiles through the authoritative raw-swiftc build"
+      - "the app-side source list and bundled helpers still link"
+
+  core_package:
+    command: "swift test"
+    proves:
+      - "TranscriptedCore package seams, storage, audio, speaker, and pipeline contracts still pass"
+    agent_notes:
+      - "This is separate from the app build. Run it for Package.swift, Sources/TranscriptedCore, or public core seam changes."
+
+  integration_smoke:
+    command: "bash run-integration-smoke.sh"
+    proves:
+      - "app/core linkage, wake recovery smoke, and selected core smoke tests still work together"
+
+  deterministic_e2e_smoke:
+    command: "bash run-e2e-smoke.sh"
+    proves:
+      - "release-critical dictation and meeting Markdown artifact contracts work without mic, TCC, or app UI"
+
+  qa_bench:
+    commands:
+      quick: "bash scripts/ops/transcripted-qa-bench.sh --mode quick"
+      deep: "bash scripts/ops/transcripted-qa-bench.sh --mode deep"
+      artifact: "bash scripts/ops/transcripted-qa-bench.sh --mode artifact"
+      audio_synthetic: "bash scripts/ops/transcripted-qa-bench.sh --mode audio-synthetic"
+      corpus: "bash scripts/ops/transcripted-qa-bench.sh --mode corpus"
+      corpus_compare: "bash scripts/ops/transcripted-qa-bench.sh --mode corpus-compare"
+      live: "bash scripts/ops/transcripted-qa-bench.sh --mode live"
+    proves:
+      - "one local QA report can combine build, fast tests, E2E, integration, QA CLI, synthetic audio, corpus, and live capture proof"
+    agent_notes:
+      - "Reports live under /tmp/transcripted-qa-bench/<run-id>/qa-report.md."
+      - "Corpus and live modes depend on private local data, permissions, and hardware. Permission blockers are INCOMPLETE, not green."
+
+  live_capture_smoke:
+    command: "bash run-live-capture-smoke.sh"
+    proves:
+      - "real production mic and system-audio capture can start, stop, and write scratch WAVs on this Mac"
+    agent_notes:
+      - "Requires local microphone and System Audio Recording permissions."
+
+  corpus_validation:
+    commands:
+      validate: "python3 scripts/ops/validate-meeting-corpus.py"
+      compare: "python3 scripts/ops/compare-meeting-corpus.py"
+    proves:
+      - "private meeting corpus is readable and Transcripted Markdown can be scored against Zoom truth without printing private transcript text"
+
+  release_health:
+    commands:
+      packaging_smoke: "SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>"
+      sparkle_verify: "bash scripts/release/verify-sparkle-release.sh <version>"
+      cask_update: "bash scripts/release/update-cask.sh <version>"
+    proves:
+      - "release artifact, Sparkle appcast, Homebrew cask, and Sentry release metadata can be checked before users depend on them"
+
+recommended_gates:
+  pre_merge:
+    default:
+      - "scripts/dev/agent-preflight.sh"
+      - "Run the union of checks from .agents/test-matrix.yml for the changed paths."
+    add_when_broad_or_risky:
+      - "bash scripts/ops/transcripted-qa-bench.sh --mode quick"
+    cannot_be_green_if:
+      - "required path-mapped checks were skipped without a clear blocker"
+      - "new root fast tests are missing from Tests/FastTests.manifest"
+      - "manual-only proof is claimed as automated proof"
+
+  nightly:
+    default:
+      - "repo hygiene workflow or equivalent local syntax/preflight pass"
+      - "bash scripts/ops/transcripted-qa-bench.sh --mode quick"
+      - "python3 scripts/ops/nightly-security-check.py --write-report build/nightly-security-report.json"
+    rotate_or_schedule:
+      - "bash scripts/ops/transcripted-qa-bench.sh --mode deep"
+      - "bash scripts/ops/transcripted-qa-bench.sh --mode audio-synthetic"
+      - "bash scripts/ops/transcripted-qa-bench.sh --mode corpus"
+      - "bash scripts/ops/transcripted-qa-bench.sh --mode corpus-compare"
+    cannot_be_green_if:
+      - "the latest report path is missing"
+      - "private corpus or live hardware blockers are hidden instead of reported"
+      - "nightly output does not name the first human action"
+
+  release_candidate:
+    required:
+      - "bash build-deps.sh --force"
+      - "bash build.sh --no-open"
+      - "bash run-tests.sh"
+      - "bash run-integration-smoke.sh"
+      - "bash run-e2e-smoke.sh"
+      - "swift test"
+      - "bash scripts/ops/transcripted-qa-bench.sh --mode deep --strict-artifacts"
+      - "SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>"
+    add_when_shipping_to_users:
+      - "full notarized build-beta.sh"
+      - "bash scripts/release/verify-sparkle-release.sh <version>"
+      - "bash scripts/release/update-cask.sh <version>"
+      - "live download/appcast/Homebrew/Sentry truth check"
+    cannot_be_green_if:
+      - "Sparkle metadata was expected but not updated"
+      - "Homebrew was expected but not updated"
+      - "live capture, route, or meeting-volume proof is missing for a release that claims audio reliability"
+
+  manual_proof:
+    required_for:
+      - "real meeting-app volume behavior"
+      - "mic and system-audio TCC behavior"
+      - "Bluetooth or input-device switching"
+      - "sleep/wake during capture"
+      - "pasteback feel in real apps"
+      - "speaker review and manual rename feel"
+      - "update install behavior on existing installs"
+    output_contract:
+      - "name the exact scenario and date"
+      - "say PASS, FAIL, or INCOMPLETE"
+      - "include local evidence path when one exists"
+      - "never paste private transcript text, audio, meeting titles, speaker names, emails, tokens, absolute paths, private URLs, or raw device names"
+
+coverage_gaps:
+  ui:
+    current_coverage:
+      - "fast policy tests for settings/menu/home state"
+      - "build launch smoke with menu-bar JSON snapshot"
+    missing_automation:
+      - "stable UI automation identifiers across main menu/settings flows"
+      - "sanitized screenshot or accessibility-tree review for first-value, meeting, dictation, speaker review, and agent-connect flows"
+
+  audio:
+    current_coverage:
+      - "synthetic audio reliability matrix"
+      - "live capture smoke for mic and system audio"
+      - "fast/core tests for failure policy, recovery state, and archive handling"
+    missing_automation:
+      - "repeatable route matrix for built-in mic, Bluetooth, quiet mic, system audio unavailable, and fast stop"
+      - "trend report over local events for start latency, stop latency, recovery attempts, and route changes"
+
+  storage:
+    current_coverage:
+      - "fast/core storage path tests"
+      - "deterministic E2E artifact smoke"
+      - "TranscriptedQA artifact validation"
+    missing_automation:
+      - "relocated capture-library fixture"
+      - "retention/compression invariant checks for retained meeting audio"
+      - "migration/fallback checks across Transcripted, legacy Draft, and Documents fallback paths"
+
+  release:
+    current_coverage:
+      - "packaging docs and release scripts"
+      - "nightly security/release drift checks"
+      - "repo hygiene syntax checks"
+    missing_automation:
+      - "single release-health report comparing Info.plist, latest GitHub release, appcast, cask, live download, and crawler-facing text"
+      - "stored proof that Sentry release/dist and dSYM UUID match the shipped artifact"
+
+  privacy:
+    current_coverage:
+      - "Sentry and analytics allowlist tests"
+      - "payload sanitizer tests"
+      - "E2E support diagnostics redaction"
+      - "nightly security check"
+    missing_automation:
+      - "one private-data leakage sweep across QA bench reports, local logs, release notes, and generated PR bodies"
+
+  summaries:
+    current_coverage:
+      - "fast tests for local summary preferences and summarizer behavior"
+    missing_automation:
+      - "quality fixtures for user-initiated local summaries"
+      - "regression check that beta summaries stay opt-in until runtime and quality proof exists"
+
+  support_bugs:
+    current_coverage:
+      - "issue-specific manual docs for high-risk audio bugs"
+      - "fast tests for diagnostics and recovery policies"
+    missing_automation:
+      - "bug seed registry that maps support issue -> reproducer -> automated guard -> manual proof needed"
+
+agent_output_contract:
+  every_lane:
+    - "lead with GREEN, YELLOW, or RED"
+    - "name exact checks run and exact checks skipped"
+    - "name local report paths"
+    - "separate automated proof from manual proof"
+    - "state privacy boundary if logs, corpus, audio, or transcripts were involved"
+    - "end with the smallest next action"

--- a/.agents/qa-gates.yml
+++ b/.agents/qa-gates.yml
@@ -71,8 +71,8 @@ test_layers:
 
   corpus_validation:
     commands:
-      validate: "python3 scripts/ops/validate-meeting-corpus.py"
-      compare: "python3 scripts/ops/compare-meeting-corpus.py"
+      validate: "bash scripts/ops/transcripted-qa-bench.sh --mode corpus"
+      compare: "bash scripts/ops/transcripted-qa-bench.sh --mode corpus-compare"
     proves:
       - "private meeting corpus is readable and Transcripted Markdown can be scored against Zoom truth without printing private transcript text"
 

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -58,10 +58,14 @@ For the active directory map and command surface, prefer `docs/repo-layout.md`.
   Verification surfaces and fast-test runner rules.
 - `.agents/test-matrix.yml`
   Machine-readable path-to-verification map for agents.
+- `.agents/qa-gates.yml`
+  Machine-readable map from product risk and QA lane to proof gate.
 - `.github/`
   GitHub issue templates, PR checklist, and workflow automation.
 - `docs/storage-paths.md`
   Canonical app, tool, and fallback storage layout.
+- `docs/test-automation-strategy.md`
+  Agent-first QA coverage map, gate strategy, and automation roadmap.
 - `docs/activation-lane.md`
   Current activation routing: saved Markdown, agent payoff, and return-use loop.
 - `docs/agent-closeout.md`
@@ -77,7 +81,7 @@ For the active directory map and command surface, prefer `docs/repo-layout.md`.
 
 When docs disagree, split the decision:
 
-- workflow contracts: `AGENTS.md`, `.agents/test-matrix.yml`, then `scripts/dev/agent-preflight.sh`
+- workflow contracts: `AGENTS.md`, `.agents/test-matrix.yml`, `.agents/qa-gates.yml`, then `scripts/dev/agent-preflight.sh`
 - runtime behavior and file existence: current source files
 - subsystem intent: current local `CLAUDE.md` files whose file lists match the tree
 - historical context: `docs/archive/` only
@@ -85,7 +89,8 @@ When docs disagree, split the decision:
 ## Validation Layers
 
 This repo has multiple verification surfaces. Treat them as distinct, and use
-`Tests/README.md` plus `.agents/test-matrix.yml` as the full current map:
+`Tests/README.md`, `.agents/test-matrix.yml`, and `.agents/qa-gates.yml` as the
+full current map:
 
 - `bash build.sh`
   The authoritative app build. Use `bash build.sh --no-open` for agent verification.

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -57,7 +57,7 @@ For helper and legacy scripts, see `scripts/README.md`.
 
 ## Directory Map
 
-- `.agents/` — machine-readable agent maps, currently the path-to-verification matrix
+- `.agents/` — machine-readable agent maps for path verification and QA gates
 - `.agent-review/` — sanitized review evidence for agent PRs, not current UI truth
 - `.github/` — issue templates, PR template, and repository workflows
 - `Sources/` — macOS app target
@@ -108,12 +108,14 @@ Use these docs for these jobs:
 - `docs/storage-paths.md` — canonical storage and fallback path map
 - `docs/audio-reliability-daily-check.md` — daily manual audio reliability loop and evidence contract
 - `docs/qa-test-bench.md` — orchestrated QA tester bench for quick, deep, corpus, corpus-compare, live, artifact, and synthetic audio passes
+- `docs/test-automation-strategy.md` — agent-first QA coverage map, gate strategy, and automation roadmap
 - `docs/qa-issue-500-meeting-audio.md` — manual WebRTC / meeting-volume QA matrix for issue #500
 - `docs/release-packaging.md` — release packaging flow
 - `docs/sparkle-updates.md` — Sparkle update contract
 - `docs/qa-parakeet-start-failure-smoke.md` — historical BET-88 validation checklist for the closed Parakeet start-failure recovery gate
 - `Tests/README.md` — verification surfaces and fast-test runner behavior
 - `.agents/test-matrix.yml` — quick path-to-verification map for agents
+- `.agents/qa-gates.yml` — product-risk-to-proof gate map for agents
 - `Sources/*/CLAUDE.md` — subsystem-local ownership and verification notes
 
 ## Historical Zones

--- a/docs/test-automation-strategy.md
+++ b/docs/test-automation-strategy.md
@@ -1,0 +1,126 @@
+# Test Automation Strategy
+
+This is the agent-first map for making Transcripted QA output more useful over
+time. Use it with `.agents/test-matrix.yml` and `.agents/qa-gates.yml`.
+
+`test-matrix.yml` answers: "I changed these files. What do I run?"
+
+`qa-gates.yml` answers: "This risk matters. What proof counts?"
+
+## Current Inventory
+
+As of 2026-06-06, the repo has these automated layers:
+
+- `bash run-tests.sh`: manifest-driven fast runner for app-facing logic. The
+  root `Tests/` set has 101 Swift test files and must stay aligned with
+  `Tests/FastTests.manifest`.
+- `bash build.sh --no-open`: authoritative menubar app build.
+- `swift test`: Swift Package tests for `TranscriptedCore`; currently 32 core
+  test files under `Tests/TranscriptedCoreTests/`.
+- `bash run-integration-smoke.sh`: app/core linkage, wake recovery, and selected
+  core smoke coverage from `Tests/Integration/`.
+- `bash run-e2e-smoke.sh`: deterministic artifact smoke for release-critical
+  dictation, meeting, MCP, retained-audio, and diagnostics contracts.
+- `bash run-live-capture-smoke.sh`: local mic plus system-audio smoke. This is a
+  local hardware/TCC gate, not default CI.
+- `bash scripts/ops/transcripted-qa-bench.sh --mode ...`: orchestrated QA
+  reports for `quick`, `deep`, `artifact`, `audio-synthetic`, `corpus`,
+  `corpus-compare`, and `live`.
+- `.github/workflows/repo-hygiene.yml`: PR/workflow-dispatch hygiene that runs
+  preflight plus shell, Ruby, and Python syntax checks.
+- BET-88 GitHub workflows: historical label-gated fixtures for the closed QA
+  gate, not the general product gate.
+
+## Main Gaps
+
+- UI: there are good policy tests, but not enough stable UI automation
+  identifiers, accessibility-tree checks, or sanitized screenshots for the core
+  user flows.
+- Audio: synthetic and live smoke exist, but there is not yet a repeated route
+  matrix over built-in mic, Bluetooth, quiet mic, missing system audio, wake, and
+  fast stop.
+- Storage: current/default paths are covered, but relocated libraries,
+  retention/compression invariants, and legacy fallback paths need broader
+  automated fixtures.
+- Release: release docs and scripts exist, but agents need one release-health
+  report that compares source truth with GitHub release, appcast, cask, live
+  download, crawler text, and Sentry metadata.
+- Privacy: sanitizer tests exist, but QA bench reports, generated PR text, local
+  logs, and release notes need a single leakage sweep.
+- Summaries: summary preferences and local summarizer behavior have tests, but
+  quality fixtures and the opt-in beta guard need a clearer recurring check.
+- Support bugs: issue-specific docs exist, but there is no bug seed registry
+  mapping support bug -> reproducer -> automated guard -> manual proof still
+  required.
+
+## Recommended Gates
+
+Pre-merge should stay path-based:
+
+- Run `scripts/dev/agent-preflight.sh`.
+- Run the union from `.agents/test-matrix.yml`.
+- Add `bash scripts/ops/transcripted-qa-bench.sh --mode quick` when the diff is
+  broad, cross-module, or user-visible.
+- Do not mark green if a required check was skipped without a blocker reason.
+
+Nightly should produce a report, not just raw logs:
+
+- Run repo hygiene or the local equivalent.
+- Run QA bench `quick`.
+- Run `python3 scripts/ops/nightly-security-check.py --write-report build/nightly-security-report.json`.
+- Rotate deeper lanes: `deep`, `audio-synthetic`, `corpus`, and
+  `corpus-compare`.
+- Always name the first human action if something needs manual proof.
+
+Release-candidate should prove the shipped path:
+
+- Run `bash build-deps.sh --force`.
+- Run `bash build.sh --no-open`.
+- Run `bash run-tests.sh`.
+- Run `bash run-integration-smoke.sh`.
+- Run `bash run-e2e-smoke.sh`.
+- Run `swift test`.
+- Run `bash scripts/ops/transcripted-qa-bench.sh --mode deep --strict-artifacts`.
+- Run `SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>` for packaging
+  smoke, or the full notarized path for a real release.
+- If users should receive the build, also verify Sparkle, Homebrew, live
+  download, and Sentry release metadata.
+
+Manual proof is still required for:
+
+- real meeting-app volume behavior
+- microphone and System Audio Recording permission behavior
+- Bluetooth or input-device switching
+- sleep/wake during capture
+- pasteback feel in real apps
+- speaker review and manual rename feel
+- update install behavior on existing installs
+
+## Agent Output Contract
+
+Every QA lane should say:
+
+- GREEN, YELLOW, or RED
+- exact commands run
+- exact checks skipped and why
+- local report paths
+- what is automated proof vs manual proof
+- whether private logs, corpus, audio, or transcripts were involved
+- the smallest next action
+
+Keep private data local. Do not paste transcript text, audio, meeting titles,
+speaker names, emails, tokens, absolute paths, private URLs, or raw device names
+into PRs, issues, or agent reports.
+
+## Next High-Value Automations
+
+1. Add UI automation surface IDs and a sanitized UI snapshot gate for first
+   value, meeting, dictation, speaker review, and agent connect.
+2. Add an audio route matrix that can run synthetic in CI-like automation and
+   live on Justin's Mac.
+3. Add a release-health report that compares source, GitHub, appcast, cask,
+   live download, crawler text, and Sentry metadata.
+4. Add storage invariants for relocated capture libraries, retained-audio
+   cleanup, compression, and fallback paths.
+5. Add a support bug seed registry so future agents know which bugs have an
+   automated guard and which still need manual proof.


### PR DESCRIPTION
## Summary

- Add `.agents/qa-gates.yml` as an agent-readable map from product risk to proof gate.
- Add `docs/test-automation-strategy.md` with current test inventory, coverage gaps, recommended pre-merge/nightly/release/manual gates, and next automation steps.
- Link the new QA gate surfaces from `docs/repo-layout.md` and `docs/agent-onboarding.md`.

## Why

Future Codex lanes need one compact place to distinguish path-based verification from product-risk proof. This keeps broad QA strategy out of production code and avoids overlapping the concrete UI/audio/release automation PRs already open.

## Validation

- `scripts/dev/agent-preflight.sh`
- `git diff --check`
- `git diff --cached --check`
- `ruby -e 'require "yaml"; YAML.load_file(".agents/qa-gates.yml"); puts "qa-gates.yml ok"'`
- ASCII check for new files

## Notes

No production code changed. No live capture, corpus, release, or packaging gates were run for this docs-only strategy patch.
