### PR TITLE
Fix E2E smoke source list

### DIFF
--- a/scripts/entrypoints/run-e2e-smoke.sh
+++ b/scripts/entrypoints/run-e2e-smoke.sh
@@ -39,7 +39,6 @@ SWIFT_SOURCES=(
     "Sources/Meeting/MeetingStoragePaths.swift"
     "Sources/Meeting/LocalMeetingSummarizer.swift"
     "Sources/Meeting/MeetingTranscriptStyler.swift"
-    "Sources/Meeting/LocalMeetingSummarizer.swift"
     "Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift"
     "Sources/TranscriptedCore/Models/TranscriptionTypes.swift"
     "Sources/TranscriptedCore/Models/FailedTranscription.swift"


### PR DESCRIPTION
## Summary
- remove duplicate LocalMeetingSummarizer source entry from deterministic E2E smoke compile list

## Verification
- git diff --check
- bash scripts/entrypoints/run-e2e-smoke.sh
- bash run-tests.sh