### PR TITLE
Deduplicate speaker review rows

### DIFF
--- a/Sources/UI/Shared/SpeakerReviewQueueScanner.swift
+++ b/Sources/UI/Shared/SpeakerReviewQueueScanner.swift
@@ -113,7 +113,7 @@ enum SpeakerReviewQueueScanner {
         )
         let recordedAt = TranscriptFrontmatter.recordedAt(values: document.values)
 
-        return frontmatterSpeakers(from: document.lines).compactMap { speaker in
+        let items: [SpeakerPendingReviewItem] = frontmatterSpeakers(from: document.lines).compactMap { speaker in
             guard speaker.source == "db_pending",
                   let dbId = speaker.dbId,
                   let profile = profilesById[dbId],
@@ -140,6 +140,13 @@ enum SpeakerReviewQueueScanner {
                 sourceName: speaker.name
             )
         }
+
+        return deduplicatedPendingItems(items)
+    }
+
+    private static func deduplicatedPendingItems(_ items: [SpeakerPendingReviewItem]) -> [SpeakerPendingReviewItem] {
+        var seen = Set<String>()
+        return items.filter { seen.insert($0.id).inserted }
     }
 
     private struct FrontmatterSpeaker {

--- a/Tests/SpeakerReviewQueueScannerTests.swift
+++ b/Tests/SpeakerReviewQueueScannerTests.swift
@@ -54,6 +54,50 @@ func testSpeakerReviewQueueScanner() {
         assertEqual(items.count, 0, "named profiles should not keep stale db_pending rows in the queue")
     }
 
+    runSuite("SpeakerReviewQueueScanner deduplicates repeated deferred speaker metadata") {
+        let speakerId = UUID()
+        let transcriptURL = URL(fileURLWithPath: "/tmp/Duplicate_Review.md")
+        let markdown = """
+        ---
+        title: "Duplicate Review"
+        date: 2026-05-20
+        time: 09:30:00
+        speakers:
+          - id: "1"
+            channel: system
+            db_id: "\(speakerId.uuidString)"
+            name: "Speaker 1"
+            confidence: unknown
+            source: db_pending
+          - id: "1"
+            channel: system
+            db_id: "\(speakerId.uuidString)"
+            name: "Speaker 1"
+            confidence: unknown
+            source: db_pending
+        ---
+
+        # Duplicate Review
+
+        ## Transcript
+
+        **00:01** [System/Speaker 1]
+        This duplicated metadata should produce one row.
+        """
+
+        let items = SpeakerReviewQueueScanner.pendingItems(
+            in: markdown,
+            transcriptURL: transcriptURL,
+            profilesById: [
+                speakerId: makeReviewQueueProfile(id: speakerId, name: nil)
+            ],
+            clipURLsByProfileID: [:]
+        )
+
+        assertEqual(items.count, 1, "duplicate frontmatter for the same pending speaker should not create duplicate review rows")
+        assertEqual(items.first?.sampleText, "This duplicated metadata should produce one row.", "deduplicated rows should keep the transcript sample")
+    }
+
     runSuite("SpeakerReviewQueueScanner clears Home review status after deferred speaker naming") {
         let fm = FileManager.default
         let directory = fm.temporaryDirectory


### PR DESCRIPTION
## Summary
- inventories the next artifact-library gap after the recent duplicate/delete coverage
- deduplicates speaker review queue items by their existing stable row id
- adds a synthetic duplicate frontmatter fixture so repeated db_pending speaker metadata produces one review row

## Coverage inventory
- Home duplicate/delete: HomeMeetingDeletionTests covers selected transcript, summary, retained audio, matching duplicate retranscriptions, non-owned rows, same-audio different titles, and swapped audio roles.
- Speaker review rows: existing tests covered extraction, named-profile hiding, stale Home status clearing, legacy channel fallback, sorting, UTF-8 preview safety, and Home badge dedupe; this PR adds duplicated frontmatter metadata.
- Retained audio/retranscription: RecentCaptureScannersTests, MeetingAudioArchiveResolverTests, MeetingAudioStorageManagerTests, and TranscriptionTaskManagerMetadataTests already cover retained audio attachment, retranscription input, compression, cleanup, and replacement-row behavior.
- Markdown artifacts: E2E smoke already proves summaries do not become duplicate Home rows and MCP/Home discovery stays pointed at the saved Markdown.

## Tests
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh

No release cut.