### PR TITLE
[codex] Fix pasteback retry clipboard restore

### DIFF
--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -123,9 +123,18 @@ struct DictationPasteTarget: Equatable {
 final class ClipboardRestoringTextPaster {
     typealias PasteboardSnapshot = [[NSPasteboard.PasteboardType: Data]]
 
+    private struct PendingClipboardRestore {
+        let savedItems: PasteboardSnapshot
+        let temporaryString: String
+        let temporaryChangeCount: Int
+        let pasteboard: any ClipboardPasteboard
+        let generation: Int
+    }
+
     private var clipboardRestoreTask: Task<Void, Never>?
     private var clipboardAutoEnterReadinessTask: Task<Void, Never>?
     private var clipboardAutoEnterReadyGeneration: Int?
+    private var pendingClipboardRestore: PendingClipboardRestore?
     private var temporaryPasteboardDataProvider: TemporaryPasteboardStringProvider?
     private var pasteGeneration = 0
 
@@ -141,6 +150,7 @@ final class ClipboardRestoringTextPaster {
         clipboardAutoEnterReadinessTask?.cancel()
         clipboardAutoEnterReadinessTask = nil
         clipboardAutoEnterReadyGeneration = nil
+        pendingClipboardRestore = nil
         temporaryPasteboardDataProvider = nil
     }
 
@@ -174,12 +184,12 @@ final class ClipboardRestoringTextPaster {
         restoreDelay: UInt64 = TranscriptedConstants.clipboardRestoreDelay,
         fallbackRestoreDelay: UInt64 = TranscriptedConstants.clipboardRestoreFallbackDelay
     ) -> TextPasteOutcome {
-        cancelPendingClipboardRestore()
+        restorePendingClipboardBeforeNewPaste()
 
         if let target,
            !target.matchesCurrentFrontmostApp(),
            !waitForTargetActivation(target, timeout: activationWait) {
-            copyTextToClipboard(text)
+            copyTextToClipboard(text, to: pasteboard)
             return .copied(
                 "Focus changed before Transcripted could paste, so the text was copied.",
                 reason: .focusChanged
@@ -246,6 +256,29 @@ final class ClipboardRestoringTextPaster {
         return .pasted
     }
 
+    private func restorePendingClipboardBeforeNewPaste() {
+        guard let pendingClipboardRestore else {
+            cancelPendingClipboardRestore()
+            return
+        }
+
+        pasteGeneration += 1
+        clipboardRestoreTask?.cancel()
+        clipboardRestoreTask = nil
+        clipboardAutoEnterReadinessTask?.cancel()
+        clipboardAutoEnterReadinessTask = nil
+        clipboardAutoEnterReadyGeneration = nil
+        temporaryPasteboardDataProvider = nil
+        self.pendingClipboardRestore = nil
+
+        restorePasteboardItems(
+            pendingClipboardRestore.savedItems,
+            temporaryString: pendingClipboardRestore.temporaryString,
+            temporaryChangeCount: pendingClipboardRestore.temporaryChangeCount,
+            to: pendingClipboardRestore.pasteboard
+        )
+    }
+
     private func scheduleClipboardRestoreAfterTemporaryRead(
         _ savedItems: PasteboardSnapshot,
         temporaryString: String,
@@ -293,6 +326,13 @@ final class ClipboardRestoringTextPaster {
     ) {
         guard generation == pasteGeneration else { return }
         clipboardRestoreTask?.cancel()
+        pendingClipboardRestore = PendingClipboardRestore(
+            savedItems: savedItems,
+            temporaryString: temporaryString,
+            temporaryChangeCount: temporaryChangeCount,
+            pasteboard: pasteboard,
+            generation: generation
+        )
         clipboardRestoreTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: delay)
             guard let self,
@@ -305,6 +345,9 @@ final class ClipboardRestoringTextPaster {
                 to: pasteboard
             )
             self.temporaryPasteboardDataProvider = nil
+            if self.pendingClipboardRestore?.generation == generation {
+                self.pendingClipboardRestore = nil
+            }
             self.clipboardRestoreTask = nil
             self.clipboardAutoEnterReadinessTask?.cancel()
             self.clipboardAutoEnterReadinessTask = nil

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -486,6 +486,56 @@ func testClipboardRestoringTextPaster() async {
         )
     }
 
+    await runSuite("ClipboardRestoringTextPaster.paste — retry does not snapshot borrowed dictation as the user clipboard") {
+        let originalClipboard = "synthetic original clipboard"
+        let firstPaste = "synthetic first dictation"
+        let secondPaste = "synthetic retry dictation"
+        let paster = await MainActor.run {
+            ClipboardRestoringTextPaster()
+        }
+        let pasteboard = await MainActor.run {
+            FakeClipboardPasteboard(initialString: originalClipboard)
+        }
+
+        let firstOutcome = await MainActor.run {
+            paster.paste(
+                firstPaste,
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: { true },
+                fallbackRestoreDelay: 50_000_000
+            )
+        }
+        let secondOutcome = await MainActor.run {
+            paster.paste(
+                secondPaste,
+                pasteboard: pasteboard,
+                accessibilityTrusted: { true },
+                requestAccessibilityTrust: {},
+                pasteDispatcher: { true },
+                fallbackRestoreDelay: 5_000_000
+            )
+        }
+
+        assertEqual(firstOutcome, .pasted, "first paste should report automatic paste")
+        assertEqual(secondOutcome, .pasted, "retry paste should report automatic paste")
+        let clipboardDuringRetry = await MainActor.run {
+            pasteboard.string(forType: .string)
+        }
+        assertEqual(clipboardDuringRetry, secondPaste, "retry paste should borrow the new dictation text")
+
+        await paster.waitForPendingClipboardRestore()
+        let restoredClipboard = await MainActor.run {
+            pasteboard.string(forType: .string)
+        }
+        assertEqual(
+            restoredClipboard,
+            originalClipboard,
+            "retry paste should restore the user's original clipboard, not the previous borrowed dictation"
+        )
+    }
+
     await runSuite("ClipboardRestoringTextPaster.cancelPendingClipboardRestore — cancels scheduled restore") {
         let pasteText = "synthetic paste text"
         let paster = await MainActor.run {


### PR DESCRIPTION
## Summary

- fixes a pasteback retry edge where a second paste could snapshot the first borrowed dictation as if it were the user's clipboard
- restores any still-borrowed clipboard snapshot before starting a new paste, while preserving explicit cancel behavior
- keeps focus-change copy fallback on the injected pasteboard seam for deterministic coverage

## Why

The existing slow-consumer coverage already protects the 2.5s restore fallback and observer-read behavior. This adds the missing retry path: when another paste starts before the first fallback restore fires, the prior borrowed text should not become the restore target for the new paste.

## Tests

- `bash run-tests.sh` first failed on the new regression: expected original clipboard, got previous borrowed dictation
- `bash run-tests.sh` passed after the fix: 4040 passed, 0 failed
- `bash build-deps.sh --force` to refresh missing fresh-worktree deps
- `bash build.sh --no-open` passed
- `bash scripts/dev/agent-preflight.sh` suggested `bash build.sh --no-open` and `bash run-tests.sh`

## Remaining manual gap

Still needs a real slow-target manual pass on an M1/slow app path to prove user-visible paste ordering outside the deterministic pasteboard harness.