### PR TITLE
[codex] Cover mic/output mismatch diagnostics

### DIFF
--- a/Tests/AudioAutomationCoverageContractTests.swift
+++ b/Tests/AudioAutomationCoverageContractTests.swift
@@ -7,6 +7,7 @@ func testAudioAutomationCoverageContract() {
         let expectedSyntheticRows = [
             "synthetic-dictation-pasteback-lifecycle",
             "synthetic-meeting-mic-system-split",
+            "synthetic-mic-output-mismatch-diagnostics",
             "synthetic-webrtc-zoom-contention-proxy",
             "synthetic-bluetooth-airpods-route-settling-proxy",
             "synthetic-audio-privacy-security"

--- a/Tests/MeetingCaptureVolumeDiagnosticsTests.swift
+++ b/Tests/MeetingCaptureVolumeDiagnosticsTests.swift
@@ -90,6 +90,38 @@ func testMeetingCaptureVolumeDiagnostics() {
         assertEqual(context["output_ducking_detected"], "true", "during-recording output drops should still mark possible ducking")
     }
 
+    runSuite("MeetingCaptureVolumeDiagnostics keeps mic/output mismatch facts separate") {
+        let context = MeetingCaptureVolumeDiagnostics.annotatedStopContext(
+            baseContext: [
+                "captured_input_volume_before": "0.650",
+                "captured_input_volume_during": "0.650",
+                "default_input_volume_before": "0.500",
+                "default_input_volume_during": "0.500",
+                "default_output_volume_before": "0.750",
+                "default_output_volume_during": "0.750",
+                "default_system_output_volume_before": "0.750",
+                "default_system_output_volume_during": "0.750",
+                "input_device_class": "built_in",
+                "mic_processed_peak": "0.30000",
+                "mic_raw_peak": "0.02000",
+                "output_device_class": "bluetooth",
+                "system_output_device_class": "bluetooth",
+            ],
+            afterStopContext: [
+                "default_input_volume_after": "0.500",
+                "default_output_volume_after": "0.750",
+                "default_system_output_volume_after": "0.400",
+            ]
+        )
+
+        assertEqual(context["captured_input_volume_dropped"], "false", "selected mic scalar should not inherit output-route drops")
+        assertEqual(context["default_input_volume_dropped"], "false", "default input scalar should stay separate from output volume")
+        assertEqual(context["default_output_volume_dropped"], "false", "normal output volume should not hide system-output ducking")
+        assertEqual(context["default_system_output_volume_dropped"], "true", "system output drop should stay queryable")
+        assertEqual(context["output_ducking_detected"], "true", "mismatched Bluetooth output ducking should be visible")
+        assertEqual(context["attenuation_kind"], "voice_processed", "quiet mic without an input scalar drop should stay classified as voice-processing attenuation")
+    }
+
     runSuite("MeetingCaptureVolumeDiagnostics classifies quiet mic recovery") {
         let context = MeetingCaptureVolumeDiagnostics.annotatedStopContext(
             baseContext: [

--- a/Tests/ReliabilityPacketRecorderTests.swift
+++ b/Tests/ReliabilityPacketRecorderTests.swift
@@ -73,6 +73,57 @@ func testReliabilityPacketRecorder() {
         assertNil(ReliabilityPacketRecorder.packet(from: event), "boring app launch should not create a packet")
     }
 
+    runSuite("ReliabilityPacketRecorder preserves mic/output mismatch diagnostics safely") {
+        let event = ObservabilityEvent(
+            timestamp: "2026-06-06T18:15:11.605Z",
+            level: "info",
+            engine: "meeting",
+            event: "meeting_recording_stopped",
+            message: "Meeting recording stopped",
+            context: [
+                "audio_device": "Private AirPods Pro",
+                "captured_input_volume_before": "0.650",
+                "captured_input_volume_changed": "false",
+                "captured_input_volume_dropped": "false",
+                "captured_input_volume_during": "0.650",
+                "default_input_volume_after": "0.500",
+                "default_input_volume_before": "0.500",
+                "default_input_volume_dropped": "false",
+                "default_input_volume_during": "0.500",
+                "default_output_volume_after": "0.750",
+                "default_output_volume_before": "0.750",
+                "default_output_volume_dropped": "false",
+                "default_output_volume_during": "0.750",
+                "default_system_output_volume_after": "0.400",
+                "default_system_output_volume_before": "0.750",
+                "default_system_output_volume_dropped": "true",
+                "default_system_output_volume_during": "0.750",
+                "input_device_class": "built_in",
+                "input_volume_scalar_available": "true",
+                "mic_processed_peak": "0.30000",
+                "mic_raw_peak": "0.02000",
+                "output_device_class": "bluetooth",
+                "output_ducking_detected": "true",
+                "system_output_device_class": "bluetooth",
+                "transcript_text": "private words",
+            ],
+            appVersion: "1.1.46",
+            osVersion: "Version 26.5.0"
+        )
+
+        let packet = ReliabilityPacketRecorder.packet(from: event)
+
+        assertNotNil(packet, "meeting stop should produce a reliability packet")
+        assertEqual(packet?.context["input_device_class"], "built_in", "coarse selected mic class should survive")
+        assertEqual(packet?.context["output_device_class"], "bluetooth", "coarse output class should survive")
+        assertEqual(packet?.context["system_output_device_class"], "bluetooth", "coarse system output class should survive")
+        assertEqual(packet?.context["captured_input_volume_dropped"], "false", "captured mic scalar should stay separate from default route facts")
+        assertEqual(packet?.context["default_system_output_volume_dropped"], "true", "system-output ducking should stay queryable")
+        assertEqual(packet?.context["output_ducking_detected"], "true", "derived ducking flag should survive")
+        assertNil(packet?.context["audio_device"], "raw device names should not be copied into reliability packets")
+        assertNil(packet?.context["transcript_text"], "transcript text should not be copied into reliability packets")
+    }
+
     runSuite("ReliabilityPacketRecorder maps dictation microphone timeout route shape safely") {
         let event = ObservabilityEvent(
             timestamp: "2026-06-02T14:18:42.771Z",

--- a/docs/audio-reliability-daily-check.md
+++ b/docs/audio-reliability-daily-check.md
@@ -122,9 +122,10 @@ matrix for the state-machine contract:
 - the seven meeting-failure questions
 
 It also writes an audio route automation proxy matrix for dictation pasteback,
-meeting mic/system audio, WebRTC/Zoom contention, Bluetooth/AirPods settling,
-and privacy/security. Those rows document deterministic coverage only; real
-Zoom/Meet/AirPods volume proof still uses `docs/qa-issue-500-meeting-audio.md`.
+meeting mic/system audio, mic/output mismatch diagnostics, WebRTC/Zoom
+contention, Bluetooth/AirPods settling, and privacy/security. Those rows
+document deterministic coverage only; real Zoom/Meet/AirPods volume proof still
+uses `docs/qa-issue-500-meeting-audio.md`.
 
 The same seven-field contract is covered by fast tests in:
 

--- a/scripts/ops/daily-audio-reliability-check.sh
+++ b/scripts/ops/daily-audio-reliability-check.sh
@@ -394,6 +394,13 @@ run_route_automation_proxy_suite() {
     "real mic plus System Audio Recording capture still needs live smoke or manual TCC proof."
 
   record_route_automation_proxy \
+    "synthetic-mic-output-mismatch-diagnostics" \
+    "mic/output mismatch diagnostics" \
+    "captured-input scalar classification, built-in mic to Bluetooth output route shape, system-output ducking flags" \
+    "bash run-tests.sh" \
+    "real mismatched mic/output routes still need user-perceived volume and saved-transcript manual proof."
+
+  record_route_automation_proxy \
     "synthetic-webrtc-zoom-contention-proxy" \
     "WebRTC/Zoom route proxy" \
     "quiet-mic attenuation classification, software AGC recovery, output-ducking diagnostics" \
@@ -420,6 +427,7 @@ run_route_automation_proxy_suite() {
     echo
     echo "- Safari Meet, Firefox Meet, Chrome Meet, and Zoom with real app audio"
     echo "- AirPods/Bluetooth and any available USB route"
+    echo "- mismatched mic/output routes such as built-in mic with Bluetooth output"
     echo "- user-perceived meeting volume before/during/after capture"
     echo "- saved transcript proof that uses the processed mic path"
   } >> "${REPORT}"


### PR DESCRIPTION
## Summary

Adds deterministic coverage for the mic/output mismatch lane left after the broader audio route automation contract:

- adds a synthetic route proxy row for mic/output mismatch diagnostics
- proves captured-input scalar facts stay separate from output/system-output drops
- proves reliability packets preserve coarse built-in-mic/Bluetooth-output mismatch diagnostics while dropping raw device names and transcript text
- updates the daily audio reliability docs to name the mismatch proxy explicitly

## Verification

- `bash -n scripts/ops/daily-audio-reliability-check.sh && bash -n run-daily-audio-reliability.sh`
- `bash scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force` (needed because `build.sh` initially reported stale deps)
- `bash build.sh --no-open`
- `bash run-tests.sh` — 4052 passed, 0 failed
- `bash run-daily-audio-reliability.sh --synthetic` — 96 passed, 0 failed, 0 skipped; report: `/tmp/transcripted-repro-lab/audio-daily-20260606-144543/daily-audio-reliability-report.md`

## Manual proof still needed

This does not prove issue #500 fixed. Real Safari Meet, Firefox Meet, Chrome Meet, Zoom, AirPods/Bluetooth, USB where available, and mismatched mic/output route checks still need Justin-run manual volume and saved-transcript proof via `docs/qa-issue-500-meeting-audio.md`.