### PR TITLE
Add UI click-flow automation IDs

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -265,6 +265,14 @@ enum HomeHeroMode: String, CaseIterable, Identifiable {
         }
     }
 
+    var automationIdentifier: String {
+        switch self {
+        case .dictation: return "transcripted.home.mode.dictation"
+        case .meeting: return "transcripted.home.mode.meetings"
+        case .speakers: return "transcripted.home.mode.speakers"
+        }
+    }
+
     var activityTab: HomeActivityTab {
         switch self {
         case .dictation: return .dictations
@@ -552,6 +560,7 @@ private struct HomeHeroModeTab: View {
         .animation(reduceMotion ? nil : SettingsInteractionPalette.animation, value: isHovering)
         .accessibilityLabel(mode.switchTitle)
         .accessibilityValue(isSelected ? "Selected" : "")
+        .accessibilityIdentifier(mode.automationIdentifier)
     }
 
     private var tabFill: Color {
@@ -859,6 +868,7 @@ struct HomeStatsBadge: View {
         }
         .buttonStyle(.plain)
         .help("Show more stats")
+        .accessibilityIdentifier("transcripted.home.stats.view")
     }
 
     private var metricColumns: [GridItem] {
@@ -938,6 +948,7 @@ struct HomeStatsDetailSheet: View {
 
                 Button("Done", action: onDone)
                     .keyboardShortcut(.defaultAction)
+                    .accessibilityIdentifier("transcripted.home.stats.done")
             }
 
             LazyVGrid(columns: columns, alignment: .leading, spacing: 12) {
@@ -1096,11 +1107,13 @@ struct HomeRowActionButtons: View {
         }
         .buttonStyle(SettingsHoverButtonStyle(cornerRadius: 7))
         .help(help)
+        .accessibilityIdentifier("transcripted.home.row.copy")
     }
 }
 
 struct HomeRowMoreMenuButton: NSViewRepresentable {
     let items: [HomeRowMenuItem]
+    var automationIdentifier = "transcripted.home.row.more"
 
     func makeCoordinator() -> Coordinator {
         Coordinator(items: items)
@@ -1119,6 +1132,8 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
         button.action = #selector(Coordinator.showMenu(_:))
         button.setButtonType(.momentaryChange)
         button.setAccessibilityLabel("More options")
+        button.identifier = NSUserInterfaceItemIdentifier(automationIdentifier)
+        button.setAccessibilityIdentifier(automationIdentifier)
         button.wantsLayer = true
         button.layer?.cornerRadius = 7
         return button
@@ -1127,6 +1142,8 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
     func updateNSView(_ button: NSButton, context: Context) {
         context.coordinator.items = items
         button.isEnabled = !items.isEmpty
+        button.identifier = NSUserInterfaceItemIdentifier(automationIdentifier)
+        button.setAccessibilityIdentifier(automationIdentifier)
     }
 
     final class Coordinator: NSObject {
@@ -1427,6 +1444,7 @@ struct HomeDictationRow: View {
                     }
                     .buttonStyle(.plain)
                     .help("Open Markdown")
+                    .accessibilityIdentifier("transcripted.home.dictation.open-markdown")
                 }
 
                 if canExpand {
@@ -1445,6 +1463,7 @@ struct HomeDictationRow: View {
                     .buttonStyle(.plain)
                     .foregroundStyle(Color.accentColor)
                     .help(isExpanded ? "Collapse dictation" : "Expand dictation")
+                    .accessibilityIdentifier("transcripted.home.dictation.expand")
                 }
             }
         }
@@ -1536,6 +1555,7 @@ struct HomeMeetingRow: View {
                 }
                 .buttonStyle(.plain)
                 .help("Preview meeting")
+                .accessibilityIdentifier("transcripted.home.meeting.preview")
 
                 if let summaryPreview = visibleSummaryPreview {
                     if isSummaryExpanded {
@@ -1580,6 +1600,7 @@ struct HomeMeetingRow: View {
                         .buttonStyle(.plain)
                         .foregroundStyle(Color.accentColor)
                         .help(isSummaryExpanded ? "Collapse summary" : "Expand summary")
+                        .accessibilityIdentifier("transcripted.home.meeting.summary-expand")
                     }
                 }
             }
@@ -1632,6 +1653,7 @@ struct HomeMeetingRow: View {
                 reviewDotButton(
                     help: item.speakerStatus.summary,
                     isDisabled: false,
+                    automationIdentifier: "transcripted.home.meeting.review-speakers",
                     action: onReviewSpeakers
                 )
             )
@@ -1647,6 +1669,7 @@ struct HomeMeetingRow: View {
             reviewDotButton(
                 help: retranscriptionUnavailableReason ?? "Identify speakers from retained audio",
                 isDisabled: !canRetranscribe,
+                automationIdentifier: "transcripted.home.meeting.retranscribe-speakers",
                 action: onRetranscribe
             )
         )
@@ -1735,6 +1758,7 @@ struct HomeMeetingRow: View {
     private func reviewDotButton(
         help: String,
         isDisabled: Bool,
+        automationIdentifier: String,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
@@ -1748,6 +1772,7 @@ struct HomeMeetingRow: View {
         .disabled(isDisabled)
         .opacity(isDisabled ? 0.45 : 1)
         .help(help)
+        .accessibilityIdentifier(automationIdentifier)
     }
 
     private func attentionDot(color: Color, help: String, opacity: Double = 1) -> some View {
@@ -1806,12 +1831,14 @@ struct HomeFailedMeetingInlineRow: View {
                 .buttonStyle(.bordered)
                 .controlSize(.small)
                 .help("Show saved audio in Finder")
+                .accessibilityIdentifier("transcripted.home.failed-meeting.show-audio")
             }
 
             if inlinePresentation.canShowRetryAction {
                 HomeAttentionActionButton(
                     title: item.isRetrying ? "Retrying" : "Try again",
                     isDisabled: retryDisabled,
+                    automationIdentifier: "transcripted.home.failed-meeting.retry",
                     action: onRetry
                 )
                 .help(retryHelp)
@@ -1824,7 +1851,7 @@ struct HomeFailedMeetingInlineRow: View {
                     isDestructive: hasRetainedAudioFiles,
                     action: onClear
                 )
-            ])
+            ], automationIdentifier: "transcripted.home.failed-meeting.more")
             .frame(width: 26, height: 26)
             .help("More options")
         }
@@ -1898,6 +1925,7 @@ private struct HomeAttentionActionButton: View {
     let title: String
     let isDisabled: Bool
     var tint: Color = .red
+    var automationIdentifier: String? = nil
     let action: () -> Void
 
     @State private var isHovering = false
@@ -1923,6 +1951,7 @@ private struct HomeAttentionActionButton: View {
         .buttonStyle(.plain)
         .disabled(isDisabled)
         .onHover { isHovering = $0 }
+        .homeAutomationIdentifier(automationIdentifier)
     }
 
     private var foregroundColor: Color {
@@ -1970,6 +1999,18 @@ private struct HomeAudioIconButton: View {
             cornerRadius: 7
         ))
         .accessibilityLabel(title)
+        .accessibilityIdentifier("transcripted.home.audio.\(isPlaying ? "pause" : "play")")
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func homeAutomationIdentifier(_ identifier: String?) -> some View {
+        if let identifier {
+            accessibilityIdentifier(identifier)
+        } else {
+            self
+        }
     }
 }
 
@@ -2027,6 +2068,7 @@ private struct HomeMeetingAudioControl: View {
                 normalStroke: isActive ? Color.accentColor.opacity(0.28) : Color.primary.opacity(0.10)
             ))
             .accessibilityLabel(title)
+            .accessibilityIdentifier("transcripted.home.audio.inline-toggle")
 
             if let scrubber {
                 scrubber
@@ -2503,15 +2545,28 @@ struct HomeMeetingPreviewSheet: View {
             }
 
             HStack {
-                SettingsInlineActionButton(title: "Open Markdown", symbolName: "doc.text") {
+                SettingsInlineActionButton(
+                    title: "Open Markdown",
+                    symbolName: "doc.text",
+                    automationIdentifier: "transcripted.home.meeting-preview.open-markdown"
+                ) {
                     onOpenMarkdown()
                 }
 
-                SettingsInlineActionButton(title: "Copy for agent", symbolName: "square.on.square") {
+                SettingsInlineActionButton(
+                    title: "Copy for agent",
+                    symbolName: "square.on.square",
+                    automationIdentifier: "transcripted.home.meeting-preview.copy-for-agent"
+                ) {
                     onCopyForAgent()
                 }
 
-                SettingsInlineActionButton(title: "Report issue", symbolName: "flag", tone: .warning) {
+                SettingsInlineActionButton(
+                    title: "Report issue",
+                    symbolName: "flag",
+                    tone: .warning,
+                    automationIdentifier: "transcripted.home.meeting-preview.report-issue"
+                ) {
                     onReportIssue()
                 }
 
@@ -2571,7 +2626,8 @@ private struct HomeMeetingPodcastPlayer: View {
                         size: 34,
                         isPrimary: false,
                         isDisabled: !canSeek,
-                        help: "Skip back 15 seconds"
+                        help: "Skip back 15 seconds",
+                        automationIdentifier: "transcripted.home.meeting-preview.audio.skip-back"
                     ) {
                         playback.skip(audio, by: -15)
                     }
@@ -2581,7 +2637,8 @@ private struct HomeMeetingPodcastPlayer: View {
                         size: 46,
                         isPrimary: playback.isActive(audio, choice: selectedPlaybackChoice),
                         isDisabled: false,
-                        help: "\(playback.buttonTitle(for: audio, choice: selectedPlaybackChoice)) meeting audio"
+                        help: "\(playback.buttonTitle(for: audio, choice: selectedPlaybackChoice)) meeting audio",
+                        automationIdentifier: "transcripted.home.meeting-preview.audio.toggle"
                     ) {
                         playback.toggle(audio, choice: selectedPlaybackChoice)
                     }
@@ -2591,7 +2648,8 @@ private struct HomeMeetingPodcastPlayer: View {
                         size: 34,
                         isPrimary: false,
                         isDisabled: !canSeek,
-                        help: "Skip forward 15 seconds"
+                        help: "Skip forward 15 seconds",
+                        automationIdentifier: "transcripted.home.meeting-preview.audio.skip-forward"
                     ) {
                         playback.skip(audio, by: 15)
                     }
@@ -2638,6 +2696,7 @@ private struct HomePodcastPlayerButton: View {
     let isPrimary: Bool
     let isDisabled: Bool
     let help: String
+    let automationIdentifier: String
     let action: () -> Void
 
     var body: some View {
@@ -2660,6 +2719,7 @@ private struct HomePodcastPlayerButton: View {
         .disabled(isDisabled)
         .opacity(isDisabled ? 0.42 : 1)
         .help(help)
+        .accessibilityIdentifier(automationIdentifier)
     }
 
     private var foreground: Color {
@@ -2755,6 +2815,7 @@ private enum HomeMeetingSpeakerColor {
 struct HomeLoadMoreButton: View {
     let title: String
     let isLoading: Bool
+    var automationIdentifier = "transcripted.home.load-more"
     let action: () -> Void
 
     @State private var isHovering = false
@@ -2779,6 +2840,7 @@ struct HomeLoadMoreButton: View {
             .disabled(isLoading)
             .onHover { isHovering = $0 }
             .animation(.easeOut(duration: 0.14), value: isHovering)
+            .accessibilityIdentifier(automationIdentifier)
 
             Spacer(minLength: 0)
         }
@@ -2860,6 +2922,7 @@ struct HomeNeedsAttentionCard: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.small)
+            .accessibilityIdentifier("transcripted.home.needs-attention.review")
         } else {
             Menu {
                 ForEach(issues) { issue in
@@ -2879,6 +2942,7 @@ struct HomeNeedsAttentionCard: View {
             .menuStyle(.borderlessButton)
             .buttonStyle(.bordered)
             .controlSize(.small)
+            .accessibilityIdentifier("transcripted.home.needs-attention.review-menu")
         }
     }
 }
@@ -2904,7 +2968,12 @@ struct HomeFailedMeetingsCard: View {
                     .font(.headline)
                 Spacer()
                 if hiddenCount > 0 {
-                    SettingsInlineActionButton(title: showAllTitle, tone: .warning, action: onShowAll)
+                    SettingsInlineActionButton(
+                        title: showAllTitle,
+                        tone: .warning,
+                        automationIdentifier: "transcripted.home.failed-meetings.show-all",
+                        action: onShowAll
+                    )
                 }
             }
 
@@ -3005,7 +3074,11 @@ private struct HomeFailedMeetingRow: View {
                             }
                         }
 
-                        SettingsInlineActionButton(title: "Show Audio", symbolName: "folder") {
+                        SettingsInlineActionButton(
+                            title: "Show Audio",
+                            symbolName: "folder",
+                            automationIdentifier: "transcripted.home.failed-meetings.show-audio"
+                        ) {
                             onRevealAudio()
                         }
                     } else {
@@ -3020,7 +3093,8 @@ private struct HomeFailedMeetingRow: View {
                         SettingsInlineActionButton(
                             title: item.isRetrying ? "Retrying..." : "Try Again",
                             symbolName: "arrow.clockwise",
-                            tone: .accent
+                            tone: .accent,
+                            automationIdentifier: "transcripted.home.failed-meetings.retry"
                         ) {
                             onRetry()
                         }
@@ -3031,7 +3105,10 @@ private struct HomeFailedMeetingRow: View {
                     SettingsInlineActionButton(
                         title: hasRetainedAudioFiles ? "Delete" : "Dismiss",
                         symbolName: hasRetainedAudioFiles ? "trash" : "xmark",
-                        tone: hasRetainedAudioFiles ? .destructive : .neutral
+                        tone: hasRetainedAudioFiles ? .destructive : .neutral,
+                        automationIdentifier: hasRetainedAudioFiles
+                            ? "transcripted.home.failed-meetings.delete"
+                            : "transcripted.home.failed-meetings.dismiss"
                     ) {
                         onClear()
                     }

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -156,7 +156,8 @@ struct PermissionsOnboardingView: View {
                         detail: "Record calls from the app. No dictation shortcut required.",
                         footnote: "Best if you mainly want meeting notes.",
                         icon: "person.2.wave.2.fill",
-                        isSelected: selectedUseCase == .meetings
+                        isSelected: selectedUseCase == .meetings,
+                        automationIdentifier: "transcripted.onboarding.use-case.meetings"
                     ) {
                         selectedUseCase = .meetings
                     }
@@ -165,7 +166,8 @@ struct PermissionsOnboardingView: View {
                         detail: "Talk to type anywhere with a shortcut.",
                         footnote: "Best if you want paste-back in other apps.",
                         icon: "keyboard",
-                        isSelected: selectedUseCase == .dictation
+                        isSelected: selectedUseCase == .dictation,
+                        automationIdentifier: "transcripted.onboarding.use-case.dictation"
                     ) {
                         selectedUseCase = .dictation
                     }
@@ -197,7 +199,8 @@ struct PermissionsOnboardingView: View {
                     ToggleCard(
                         title: "Leave dictation shortcuts off",
                         detail: "You can still start meetings from the app. Turn dictation on later in Settings > Shortcuts.",
-                        isOn: $leaveDictationShortcutsOff
+                        isOn: $leaveDictationShortcutsOff,
+                        automationIdentifier: "transcripted.onboarding.permissions.leave-dictation-shortcuts-off"
                     )
                     .frame(width: 500)
                     .padding(.top, 2)
@@ -262,6 +265,7 @@ struct PermissionsOnboardingView: View {
                 }
                 .buttonStyle(InkButtonStyle(isSubtle: screenRecordingGranted))
                 .padding(.top, 12)
+                .accessibilityIdentifier("transcripted.onboarding.system-audio.enable")
                 Text("You can skip this now, but meeting transcripts need it to include the other side of the call.")
                     .font(.system(size: 12))
                     .foregroundStyle(OnboardingTheme.muted)
@@ -286,7 +290,8 @@ struct PermissionsOnboardingView: View {
                 ToggleCard(
                     title: "Meeting reminders",
                     detail: "Use read-only calendar access to notice upcoming calls.",
-                    isOn: $meetingPromptsEnabled
+                    isOn: $meetingPromptsEnabled,
+                    automationIdentifier: "transcripted.onboarding.calendar.meeting-reminders"
                 )
                 .frame(maxWidth: 440)
                 .padding(.top, 4)
@@ -301,6 +306,7 @@ struct PermissionsOnboardingView: View {
                 .buttonStyle(InkButtonStyle(isSubtle: calendarGranted || !meetingPromptsEnabled))
                 .disabled(!meetingPromptsEnabled)
                 .padding(.top, 6)
+                .accessibilityIdentifier("transcripted.onboarding.calendar.allow")
                 Text("Read-only. Events stay on your Mac.")
                     .font(.system(size: 12))
                     .foregroundStyle(OnboardingTheme.muted)
@@ -342,11 +348,12 @@ struct PermissionsOnboardingView: View {
                 Kicker("One last thing")
                 Headline(primary: "Help us make it better?", size: 42)
                 BodyCopy("Anonymous diagnostics help us find bugs and fix them fast.", maxWidth: 480)
-                ToggleCard(
-                    title: "Share anonymous diagnostics",
-                    detail: "Crash reports, feature counts, app version, and macOS version. Never audio, transcripts, or anything you type or say.",
-                    isOn: $diagnosticsEnabled
-                )
+                    ToggleCard(
+                        title: "Share anonymous diagnostics",
+                        detail: "Crash reports, feature counts, app version, and macOS version. Never audio, transcripts, or anything you type or say.",
+                        isOn: $diagnosticsEnabled,
+                        automationIdentifier: "transcripted.onboarding.diagnostics.share"
+                    )
                 .frame(width: 480)
                 .padding(.top, 10)
                 .onChange(of: diagnosticsEnabled) { _, newValue in
@@ -381,7 +388,8 @@ struct PermissionsOnboardingView: View {
                 reason: selectedUseCase == .meetings ? "For your side of the meeting." : "So Transcripted can hear you.",
                 icon: "mic.fill",
                 granted: micGranted,
-                actionTitle: "Allow"
+                actionTitle: "Allow",
+                automationIdentifier: "transcripted.onboarding.permissions.microphone"
             ) {
                 requestPermission(.microphone, required: true)
             }
@@ -393,7 +401,8 @@ struct PermissionsOnboardingView: View {
                     reason: "For everyone else on the call.",
                     icon: "speaker.wave.2.fill",
                     granted: screenRecordingGranted,
-                    actionTitle: "Allow"
+                    actionTitle: "Allow",
+                    automationIdentifier: "transcripted.onboarding.permissions.system-audio"
                 ) {
                     requestPermission(.systemAudioRecording, required: true)
                 }
@@ -403,7 +412,8 @@ struct PermissionsOnboardingView: View {
                     reason: "So paste-back works in other apps.",
                     icon: "hand.raised.fill",
                     granted: accessibilityGranted,
-                    actionTitle: "Allow"
+                    actionTitle: "Allow",
+                    automationIdentifier: "transcripted.onboarding.permissions.accessibility"
                 ) {
                     requestPermission(.accessibility, required: true)
                 }
@@ -965,6 +975,7 @@ private struct NavBar: View {
             .buttonStyle(.plain)
             .opacity(canGoBack ? 1 : 0)
             .disabled(!canGoBack)
+            .accessibilityIdentifier("transcripted.onboarding.nav.back")
 
             Spacer()
 
@@ -975,6 +986,7 @@ private struct NavBar: View {
                 .font(.system(size: 13))
                 .buttonStyle(.plain)
                 .foregroundStyle(OnboardingTheme.muted)
+                .accessibilityIdentifier("transcripted.onboarding.nav.skip")
             }
 
             Button {
@@ -995,6 +1007,7 @@ private struct NavBar: View {
             }
             .buttonStyle(.plain)
             .disabled(primaryDisabled)
+            .accessibilityIdentifier("transcripted.onboarding.nav.primary")
         }
         .padding(.horizontal, 32)
         .frame(height: 78)
@@ -1186,6 +1199,7 @@ private struct PermissionGrantRow: View {
     let icon: String
     let granted: Bool
     let actionTitle: String
+    let automationIdentifier: String
     let action: () -> Void
 
     var body: some View {
@@ -1215,6 +1229,7 @@ private struct PermissionGrantRow: View {
             }
             .buttonStyle(InkButtonStyle(isSubtle: granted, compact: true))
             .disabled(granted)
+            .accessibilityIdentifier(automationIdentifier)
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 16)
@@ -1237,6 +1252,7 @@ private struct UseCaseChoiceCard: View {
     let footnote: String
     let icon: String
     let isSelected: Bool
+    let automationIdentifier: String
     let action: () -> Void
 
     var body: some View {
@@ -1286,6 +1302,7 @@ private struct UseCaseChoiceCard: View {
             .shadow(color: .black.opacity(isSelected ? 0.08 : 0.03), radius: isSelected ? 16 : 8, y: 8)
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier(automationIdentifier)
     }
 }
 
@@ -1661,6 +1678,7 @@ private struct ToggleCard: View {
     let title: String
     let detail: String
     @Binding var isOn: Bool
+    var automationIdentifier: String? = nil
 
     var body: some View {
         HStack(spacing: 14) {
@@ -1676,6 +1694,7 @@ private struct ToggleCard: View {
             Toggle("", isOn: $isOn)
                 .toggleStyle(.switch)
                 .labelsHidden()
+                .onboardingAutomationIdentifier(automationIdentifier)
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 16)
@@ -1686,6 +1705,17 @@ private struct ToggleCard: View {
                 .stroke(OnboardingTheme.border, lineWidth: 1)
         )
         .shadow(color: .black.opacity(0.04), radius: 12, y: 6)
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func onboardingAutomationIdentifier(_ identifier: String?) -> some View {
+        if let identifier {
+            accessibilityIdentifier(identifier)
+        } else {
+            self
+        }
     }
 }
 
@@ -1997,7 +2027,8 @@ private struct ConnectAgentStage: View {
                     detail: "Copy the setup steps, then install Transcripted direct tools from Settings > Agent.",
                     glyph: "◆",
                     color: OnboardingTheme.claude,
-                    buttonTitle: copiedItem == .claudeDesktopSetup ? "Copied" : "Copy steps"
+                    buttonTitle: copiedItem == .claudeDesktopSetup ? "Copied" : "Copy steps",
+                    automationIdentifier: "transcripted.onboarding.agent.copy-claude-desktop-steps"
                 ) {
                     onCopy(.claudeDesktopSetup)
                 }
@@ -2008,7 +2039,8 @@ private struct ConnectAgentStage: View {
                     detail: "Copy one prompt for local coding agents that can read your Transcripted Markdown folders.",
                     glyph: "●",
                     color: OnboardingTheme.codex,
-                    buttonTitle: copiedItem == .localAgentPrompt ? "Copied" : "Copy prompt"
+                    buttonTitle: copiedItem == .localAgentPrompt ? "Copied" : "Copy prompt",
+                    automationIdentifier: "transcripted.onboarding.agent.copy-local-agent-prompt"
                 ) {
                     onCopy(.localAgentPrompt)
                 }
@@ -2035,6 +2067,7 @@ private struct AgentOptionCard: View {
     let glyph: String
     let color: Color
     let buttonTitle: String
+    let automationIdentifier: String
     var inverted = false
     let action: () -> Void
 
@@ -2064,6 +2097,7 @@ private struct AgentOptionCard: View {
                 action()
             }
             .buttonStyle(InkButtonStyle(isSubtle: inverted))
+            .accessibilityIdentifier(automationIdentifier)
         }
         .foregroundStyle(inverted ? OnboardingTheme.window : OnboardingTheme.ink)
         .padding(22)

--- a/Sources/UI/Settings/TranscriptedSettingsComponents.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsComponents.swift
@@ -274,6 +274,7 @@ struct SettingsInlineActionButton: View {
     let title: String
     var symbolName: String? = nil
     var tone: SettingsInteractionTone = .neutral
+    var automationIdentifier: String? = nil
     let action: () -> Void
 
     var body: some View {
@@ -299,6 +300,7 @@ struct SettingsInlineActionButton: View {
             normalFill: normalFill,
             normalStroke: normalStroke
         ))
+        .settingsAutomationIdentifier(automationIdentifier)
     }
 
     private var normalFill: Color {
@@ -324,6 +326,17 @@ struct SettingsInlineActionButton: View {
             return Color.orange.opacity(0.16)
         case .destructive:
             return Color.red.opacity(0.14)
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func settingsAutomationIdentifier(_ identifier: String?) -> some View {
+        if let identifier {
+            accessibilityIdentifier(identifier)
+        } else {
+            self
         }
     }
 }
@@ -737,6 +750,7 @@ struct SettingsToggleRow: View {
     let detail: String
     @Binding var isOn: Bool
     var help: String? = nil
+    var automationIdentifier: String? = nil
 
     var body: some View {
         HStack(alignment: .center, spacing: 16) {
@@ -762,6 +776,7 @@ struct SettingsToggleRow: View {
                 .accessibilityLabel(Text(title))
                 .accessibilityValue(Text(isOn ? "On" : "Off"))
                 .accessibilityHint(Text(detail))
+                .settingsAutomationIdentifier(automationIdentifier)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -818,6 +833,7 @@ struct PermissionStatusRow: View {
                 normalFill: Color.primary.opacity(0.025),
                 normalStroke: Color.primary.opacity(0.06)
             ))
+            .accessibilityIdentifier("transcripted.settings.permissions.\(kind.rawValue).action")
         }
     }
 }

--- a/Sources/UI/Settings/TranscriptedSettingsGeneralControls.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsGeneralControls.swift
@@ -67,6 +67,7 @@ struct GeneralInfoButton: View {
         .buttonStyle(.plain)
         .help("Learn about \(info.title)")
         .accessibilityLabel(Text("About \(info.title)"))
+        .accessibilityIdentifier("transcripted.settings.general.info.\(automationSlug(info.title))")
         .popover(isPresented: $isPresented, arrowEdge: .top) {
             VStack(alignment: .leading, spacing: 8) {
                 Text(info.title)
@@ -128,6 +129,7 @@ struct GeneralToggleRow: View {
     @Binding var isOn: Bool
     var help: String
     var info: GeneralInfo? = nil
+    var automationIdentifier: String? = nil
 
     var body: some View {
         HStack(spacing: 10) {
@@ -144,6 +146,7 @@ struct GeneralToggleRow: View {
                 .accessibilityLabel(Text(title))
                 .accessibilityValue(Text(isOn ? "On" : "Off"))
                 .accessibilityHint(Text(help))
+                .generalAutomationIdentifier(automationIdentifier)
         }
         .padding(.horizontal, 14)
         .frame(minHeight: 44)
@@ -186,11 +189,12 @@ struct DictationOverlayModeRow: View {
                 }
             }
             .frame(maxWidth: 374, alignment: .trailing)
-            .help(selection.detail)
-            .accessibilityElement(children: .contain)
-            .accessibilityLabel(Text("Dictation window options"))
-            .accessibilityValue(Text(selection.title))
-            .accessibilityHint(Text("Choose one of two dictation window styles."))
+        .help(selection.detail)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(Text("Dictation window options"))
+        .accessibilityValue(Text(selection.title))
+        .accessibilityHint(Text("Choose one of two dictation window styles."))
+        .accessibilityIdentifier("transcripted.settings.general.dictation-window.options")
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 12)
@@ -218,6 +222,7 @@ private struct DictationOverlayModeChoice: View {
         .accessibilityLabel(Text(mode.title))
         .accessibilityValue(Text(isSelected ? "Selected" : "Not selected"))
         .accessibilityHint(Text(mode.detail))
+        .accessibilityIdentifier("transcripted.settings.general.dictation-window.\(mode.rawValue)")
         .onHover { isHovering = $0 }
     }
 
@@ -389,6 +394,7 @@ struct GeneralActionRow: View {
     let value: String
     let systemImage: String?
     let help: String
+    var automationIdentifier: String? = nil
     let action: () -> Void
 
     @State private var isHovering = false
@@ -430,6 +436,7 @@ struct GeneralActionRow: View {
         .accessibilityLabel(Text(title))
         .accessibilityValue(Text(value))
         .accessibilityHint(Text(help))
+        .generalAutomationIdentifier(automationIdentifier)
     }
 }
 
@@ -438,6 +445,7 @@ struct GeneralDisclosureRow: View {
     let value: String
     @Binding var isExpanded: Bool
     let help: String
+    var automationIdentifier: String? = nil
     let action: () -> Void
 
     @State private var isHovering = false
@@ -483,6 +491,7 @@ struct GeneralDisclosureRow: View {
         .accessibilityLabel(Text(title))
         .accessibilityValue(Text("\(value), \(isExpanded ? "expanded" : "collapsed")"))
         .accessibilityHint(Text(help))
+        .generalAutomationIdentifier(automationIdentifier)
     }
 }
 
@@ -500,4 +509,30 @@ struct GeneralExpandedContent<Content: View>: View {
             Divider()
         }
     }
+}
+
+private extension View {
+    @ViewBuilder
+    func generalAutomationIdentifier(_ identifier: String?) -> some View {
+        if let identifier {
+            accessibilityIdentifier(identifier)
+        } else {
+            self
+        }
+    }
+}
+
+private func automationSlug(_ value: String) -> String {
+    value
+        .lowercased()
+        .map { character -> Character in
+            character.isLetter || character.isNumber ? character : "-"
+        }
+        .reduce(into: "") { result, character in
+            if character == "-", result.last == "-" {
+                return
+            }
+            result.append(character)
+        }
+        .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
 }

--- a/Sources/UI/Settings/TranscriptedSettingsPage.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsPage.swift
@@ -15,6 +15,15 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
+    var automationIdentifier: String {
+        switch self {
+        case .connectAgent:
+            return "transcripted.settings.sidebar.connect-agent"
+        default:
+            return "transcripted.settings.sidebar.\(rawValue)"
+        }
+    }
+
     var analyticsValue: String {
         switch self {
         case .connectAgent:

--- a/Sources/UI/Settings/TranscriptedSettingsSidebar.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsSidebar.swift
@@ -31,6 +31,7 @@ struct SettingsSidebarRow: View {
                 shadow: Color.accentColor.opacity(0.08),
                 shadowRadius: 7
             )
+            .accessibilityIdentifier(page.automationIdentifier)
             .onHover { isHovering = $0 }
     }
 }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -270,6 +270,7 @@ struct TranscriptedSettingsView: View {
         ))
         .disabled(!settingsFooterActionEnabled)
         .help(settingsFooterHelp)
+        .accessibilityIdentifier("transcripted.settings.footer.check-updates")
     }
 
     @ViewBuilder
@@ -1415,7 +1416,8 @@ struct TranscriptedSettingsView: View {
                     info: GeneralInfo(
                         title: "Launch at login",
                         message: "When this is on, macOS opens Transcripted after you sign in, so the menu bar app and shortcuts are ready without opening it yourself."
-                    )
+                    ),
+                    automationIdentifier: "transcripted.settings.general.launch-at-login"
                 )
 
                 GeneralToggleRow(
@@ -1434,7 +1436,8 @@ struct TranscriptedSettingsView: View {
                     info: GeneralInfo(
                         title: "Show in Dock",
                         message: "Turn this off if you want Transcripted to stay out of the Dock while idle. Settings and active recordings can still bring the app forward when needed."
-                    )
+                    ),
+                    automationIdentifier: "transcripted.settings.general.show-in-dock"
                 )
 
                 GeneralToggleRow(
@@ -1453,7 +1456,8 @@ struct TranscriptedSettingsView: View {
                     info: GeneralInfo(
                         title: "Dictation sounds",
                         message: "These short sounds tell you when dictation starts, finishes, or hears no speech. Turn them off if you want Transcripted to stay quiet."
-                    )
+                    ),
+                    automationIdentifier: "transcripted.settings.general.dictation-sounds"
                 )
 
                 GeneralToggleRow(
@@ -1472,7 +1476,8 @@ struct TranscriptedSettingsView: View {
                     info: GeneralInfo(
                         title: "Clean up pasted text",
                         message: "Transcripted lightly fixes filler words, repeated words, and spacing before it pastes your dictation. Turn this off when you want the raw transcript."
-                    )
+                    ),
+                    automationIdentifier: "transcripted.settings.general.cleanup-pasted-text"
                 )
 
                 DictationOverlayModeRow(
@@ -1502,7 +1507,8 @@ struct TranscriptedSettingsView: View {
                     info: GeneralInfo(
                         title: "Confirm meeting quits",
                         message: "When this is on, Transcripted asks before quitting during a live meeting so you do not stop a recording by accident."
-                    )
+                    ),
+                    automationIdentifier: "transcripted.settings.general.confirm-meeting-quits"
                 )
             }
 
@@ -1520,7 +1526,8 @@ struct TranscriptedSettingsView: View {
                         title: "Transcription model",
                         value: effectiveTranscriptionModel.title,
                         isExpanded: $showGeneralModelSettings,
-                        help: showGeneralModelSettings ? "Hide transcription model settings." : "Show transcription model settings."
+                        help: showGeneralModelSettings ? "Hide transcription model settings." : "Show transcription model settings.",
+                        automationIdentifier: "transcripted.settings.general.disclosure.transcription-model"
                     ) {
                         trackSettingsAction("toggle_model_settings", page: .general)
                     }
@@ -1535,7 +1542,8 @@ struct TranscriptedSettingsView: View {
                         title: "Keyboard shortcuts",
                         value: dictationShortcutsEnabled ? "On" : "Off",
                         isExpanded: $showGeneralShortcutSettings,
-                        help: showGeneralShortcutSettings ? "Hide keyboard shortcut settings." : "Show keyboard shortcut settings."
+                        help: showGeneralShortcutSettings ? "Hide keyboard shortcut settings." : "Show keyboard shortcut settings.",
+                        automationIdentifier: "transcripted.settings.general.disclosure.keyboard-shortcuts"
                     ) {
                         trackSettingsAction("toggle_shortcut_settings", page: .general)
                     }
@@ -1550,7 +1558,8 @@ struct TranscriptedSettingsView: View {
                         title: "Privacy",
                         value: generalPrivacyStatusLine,
                         isExpanded: $showGeneralPrivacySettings,
-                        help: showGeneralPrivacySettings ? "Hide privacy settings." : "Show privacy settings."
+                        help: showGeneralPrivacySettings ? "Hide privacy settings." : "Show privacy settings.",
+                        automationIdentifier: "transcripted.settings.general.disclosure.privacy"
                     ) {
                         trackSettingsAction("toggle_privacy_settings", page: .general)
                     }
@@ -1577,7 +1586,8 @@ struct TranscriptedSettingsView: View {
                         title: "Transcribe audio file",
                         value: "Choose",
                         systemImage: "waveform",
-                        help: "Choose an audio file to transcribe."
+                        help: "Choose an audio file to transcribe.",
+                        automationIdentifier: "transcripted.settings.general.transcribe-audio-file"
                     ) {
                         trackSettingsAction("import_recording", page: .general)
                         actions.importAudioFile()
@@ -1587,7 +1597,8 @@ struct TranscriptedSettingsView: View {
                         title: "Corrections",
                         value: customDictionaryStatusLine,
                         isExpanded: $showGeneralCorrections,
-                        help: showGeneralCorrections ? "Hide correction settings." : "Show correction settings."
+                        help: showGeneralCorrections ? "Hide correction settings." : "Show correction settings.",
+                        automationIdentifier: "transcripted.settings.general.disclosure.corrections"
                     ) {
                         trackSettingsAction("toggle_corrections", page: .general)
                     }
@@ -1898,10 +1909,14 @@ struct TranscriptedSettingsView: View {
                 .disabled(!AnalyticsReporter.isAvailable)
 
                 HStack {
-                    SettingsInlineActionButton(title: "Send Test Sentry Event", tone: .warning) {
-                        trackSettingsAction("send_test_sentry_event", page: .general)
-                        sendTestSentryEvent()
-                    }
+                SettingsInlineActionButton(
+                    title: "Send Test Sentry Event",
+                    tone: .warning,
+                    automationIdentifier: "transcripted.settings.general.send-test-sentry-event"
+                ) {
+                    trackSettingsAction("send_test_sentry_event", page: .general)
+                    sendTestSentryEvent()
+                }
                     .disabled(!CrashReporter.isAvailable || !crashReportingEnabled)
 
                     if let sentryTestStatus {
@@ -1977,7 +1992,11 @@ struct TranscriptedSettingsView: View {
 
                 Spacer()
 
-                SettingsInlineActionButton(title: "Clear all", tone: .destructive) {
+                SettingsInlineActionButton(
+                    title: "Clear all",
+                    tone: .destructive,
+                    automationIdentifier: "transcripted.settings.general.corrections.clear-all"
+                ) {
                     trackSettingsAction("clear_corrections", page: .general)
                     clearCorrectionRows()
                 }
@@ -2384,7 +2403,8 @@ struct TranscriptedSettingsView: View {
                                 }
                             }
                         ),
-                        help: "Opt in to local meeting summaries on Home."
+                        help: "Opt in to local meeting summaries on Home.",
+                        automationIdentifier: "transcripted.settings.beta.ai-meeting-summaries"
                     )
 
                     betaLocalSummarySetupStatus
@@ -2407,7 +2427,8 @@ struct TranscriptedSettingsView: View {
                                 handleBetaLiveMeetingSidecarToggle(enabled)
                             }
                         ),
-                        help: "Opt in to the live meeting sidecar workspace."
+                        help: "Opt in to the live meeting sidecar workspace.",
+                        automationIdentifier: "transcripted.settings.beta.live-meeting-sidecar"
                     )
 
                     betaLiveSidecarSetupStatus
@@ -2435,14 +2456,23 @@ struct TranscriptedSettingsView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-                SettingsInlineActionButton(title: "Check setup", symbolName: "arrow.clockwise") {
+                SettingsInlineActionButton(
+                    title: "Check setup",
+                    symbolName: "arrow.clockwise",
+                    automationIdentifier: "transcripted.settings.beta.local-summary.check-setup"
+                ) {
                     trackSettingsAction("check_local_summary_setup", page: .beta)
                     refreshLocalSummarySetupStatus()
                 }
             }
 
             if !localSummarySetupStatus.hasRuntime {
-                SettingsInlineActionButton(title: "Install uv", symbolName: "arrow.down.circle", tone: .warning) {
+                SettingsInlineActionButton(
+                    title: "Install uv",
+                    symbolName: "arrow.down.circle",
+                    tone: .warning,
+                    automationIdentifier: "transcripted.settings.beta.local-summary.install-uv"
+                ) {
                     trackSettingsAction("open_uv_install_guide", page: .beta)
                     openUVInstallGuide()
                 }
@@ -2502,7 +2532,12 @@ struct TranscriptedSettingsView: View {
             }
 
             HStack(spacing: 10) {
-                SettingsInlineActionButton(title: "Open Agent setup", symbolName: "sparkles", tone: .accent) {
+                SettingsInlineActionButton(
+                    title: "Open Agent setup",
+                    symbolName: "sparkles",
+                    tone: .accent,
+                    automationIdentifier: "transcripted.settings.beta.open-agent-setup"
+                ) {
                     trackSettingsAction("open_agent_setup_from_beta", page: .beta)
                     navigation.selectedPage = .connectAgent
                 }

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -57,6 +57,9 @@ func testUIAutomationSurfaceContract() {
 
     runSuite("UI automation surface contract - major settings and Home flows stay mapped") {
         let pagesSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsPage.swift")
+        let settingsSidebarSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsSidebar.swift")
+        let settingsComponentsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsComponents.swift")
+        let generalControlsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsGeneralControls.swift")
         let settingsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let homeSource = readUIAutomationContractFile("Sources/UI/Settings/HomeView.swift")
         let onboardingSource = readUIAutomationContractFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
@@ -80,6 +83,12 @@ func testUIAutomationSurfaceContract() {
             assertTrue(pagesSource.contains(pageCase), "\(pageCase) should stay in the settings navigation surface map")
         }
 
+        assertTrue(
+            pagesSource.contains("var automationIdentifier: String")
+                && settingsSidebarSource.contains(".accessibilityIdentifier(page.automationIdentifier)"),
+            "settings sidebar pages should expose stable automation identifiers"
+        )
+
         for requiredSourceHook in [
             "title: \"Transcribe audio file\"",
             "actions.importAudioFile()",
@@ -102,7 +111,7 @@ func testUIAutomationSurfaceContract() {
         for requiredHomeRendererHook in [
             "title: hasRetainedAudioFiles ? \"Delete\" : \"Dismiss\"",
             "HomeRowMoreMenuButton(items:",
-            "SettingsInlineActionButton(title: \"Copy for agent\"",
+            "title: \"Copy for agent\"",
         ] {
             assertTrue(homeSource.contains(requiredHomeRendererHook), "\(requiredHomeRendererHook) should keep Home action rendering visible")
         }
@@ -147,6 +156,110 @@ func testUIAutomationSurfaceContract() {
                 && deletePolicySource.contains("Delete Failed Meeting"),
             "delete confirmation copy should stay pinned for destructive-flow automation"
         )
+
+        assertTrue(
+            settingsComponentsSource.contains("settingsAutomationIdentifier")
+                && settingsComponentsSource.contains("transcripted.settings.permissions.\\(kind.rawValue).action"),
+            "settings shared controls should support stable automation IDs"
+        )
+
+        assertTrue(
+            generalControlsSource.contains("generalAutomationIdentifier")
+                && generalControlsSource.contains("transcripted.settings.general.dictation-window.options")
+                && generalControlsSource.contains("transcripted.settings.general.dictation-window.\\(mode.rawValue)")
+                && generalControlsSource.contains("transcripted.settings.general.info.\\(automationSlug(info.title))"),
+            "general settings controls should keep scriptable row and choice IDs"
+        )
+    }
+
+    runSuite("UI automation surface contract - deterministic click-flow identifiers stay mapped") {
+        let settingsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
+        let homeSource = readUIAutomationContractFile("Sources/UI/Settings/HomeView.swift")
+        let onboardingSource = readUIAutomationContractFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
+
+        for identifier in [
+            "transcripted.home.mode.meetings",
+            "transcripted.home.mode.dictation",
+            "transcripted.home.mode.speakers",
+            "transcripted.home.stats.view",
+            "transcripted.home.stats.done",
+            "transcripted.home.row.copy",
+            "transcripted.home.row.more",
+            "transcripted.home.dictation.open-markdown",
+            "transcripted.home.dictation.expand",
+            "transcripted.home.meeting.preview",
+            "transcripted.home.meeting.summary-expand",
+            "transcripted.home.meeting.review-speakers",
+            "transcripted.home.meeting.retranscribe-speakers",
+            "transcripted.home.meeting-preview.open-markdown",
+            "transcripted.home.meeting-preview.copy-for-agent",
+            "transcripted.home.meeting-preview.report-issue",
+            "transcripted.home.meeting-preview.audio.skip-back",
+            "transcripted.home.meeting-preview.audio.toggle",
+            "transcripted.home.meeting-preview.audio.skip-forward",
+            "transcripted.home.audio.inline-toggle",
+            "transcripted.home.failed-meeting.show-audio",
+            "transcripted.home.failed-meeting.retry",
+            "transcripted.home.failed-meeting.more",
+            "transcripted.home.failed-meetings.show-all",
+            "transcripted.home.failed-meetings.retry",
+            "transcripted.home.failed-meetings.show-audio",
+            "transcripted.home.failed-meetings.delete",
+            "transcripted.home.failed-meetings.dismiss",
+            "transcripted.home.load-more",
+            "transcripted.home.needs-attention.review",
+            "transcripted.home.needs-attention.review-menu",
+        ] {
+            assertTrue(homeSource.contains(identifier), "\(identifier) should stay attached to Home click-flow controls")
+        }
+
+        assertTrue(
+            homeSource.contains("transcripted.home.audio.\\(isPlaying ?"),
+            "Home audio play/pause action should keep a stable dynamic automation ID"
+        )
+
+        for identifier in [
+            "transcripted.settings.footer.check-updates",
+            "transcripted.settings.general.launch-at-login",
+            "transcripted.settings.general.show-in-dock",
+            "transcripted.settings.general.dictation-sounds",
+            "transcripted.settings.general.cleanup-pasted-text",
+            "transcripted.settings.general.confirm-meeting-quits",
+            "transcripted.settings.general.disclosure.transcription-model",
+            "transcripted.settings.general.disclosure.keyboard-shortcuts",
+            "transcripted.settings.general.disclosure.privacy",
+            "transcripted.settings.general.disclosure.corrections",
+            "transcripted.settings.general.transcribe-audio-file",
+            "transcripted.settings.general.send-test-sentry-event",
+            "transcripted.settings.general.corrections.clear-all",
+            "transcripted.settings.beta.ai-meeting-summaries",
+            "transcripted.settings.beta.live-meeting-sidecar",
+            "transcripted.settings.beta.local-summary.check-setup",
+            "transcripted.settings.beta.local-summary.install-uv",
+            "transcripted.settings.beta.open-agent-setup",
+        ] {
+            assertTrue(settingsSource.contains(identifier), "\(identifier) should stay attached to Settings click-flow controls")
+        }
+
+        for identifier in [
+            "transcripted.onboarding.nav.back",
+            "transcripted.onboarding.nav.skip",
+            "transcripted.onboarding.nav.primary",
+            "transcripted.onboarding.use-case.meetings",
+            "transcripted.onboarding.use-case.dictation",
+            "transcripted.onboarding.permissions.microphone",
+            "transcripted.onboarding.permissions.system-audio",
+            "transcripted.onboarding.permissions.accessibility",
+            "transcripted.onboarding.permissions.leave-dictation-shortcuts-off",
+            "transcripted.onboarding.system-audio.enable",
+            "transcripted.onboarding.calendar.meeting-reminders",
+            "transcripted.onboarding.calendar.allow",
+            "transcripted.onboarding.diagnostics.share",
+            "transcripted.onboarding.agent.copy-claude-desktop-steps",
+            "transcripted.onboarding.agent.copy-local-agent-prompt",
+        ] {
+            assertTrue(onboardingSource.contains(identifier), "\(identifier) should stay attached to onboarding click-flow controls")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add stable automation identifiers for Home tabs, recent capture actions, failed meeting actions, meeting preview controls, Settings navigation/general/permissions/beta controls, and onboarding choices/navigation
- extend UIAutomationSurfaceContractTests so deterministic click-flow IDs stay source-pinned
- keep this to identifier/test plumbing only; no visual redesign or release work

## Verification
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh (4104 tests, 4104 passed)

## Manual-only remains
- real TCC prompts/grant dialogs
- hardware mic/system-audio capture
- real meeting app routing
- actual launched-window click execution and positioning