### PR TITLE
[codex] Add local summary fixture QA guard

### DIFF
--- a/.agents/test-matrix.yml
+++ b/.agents/test-matrix.yml
@@ -138,10 +138,13 @@ rules:
 
   - paths:
       - "scripts/ops/transcripted-qa-bench.sh"
+      - "scripts/ops/run-local-summary-fixture.sh"
       - "scripts/ops/validate-meeting-corpus.py"
       - "scripts/ops/compare-meeting-corpus.py"
       - "docs/qa-test-bench.md"
     checks:
+      - "bash -n scripts/ops/run-local-summary-fixture.sh"
+      - "bash scripts/ops/run-local-summary-fixture.sh"
       - "bash scripts/ops/transcripted-qa-bench.sh --mode quick"
       - "python3 -m py_compile scripts/ops/validate-meeting-corpus.py"
       - "python3 -m py_compile scripts/ops/compare-meeting-corpus.py"

--- a/Sources/Meeting/LocalMeetingSummarizer.swift
+++ b/Sources/Meeting/LocalMeetingSummarizer.swift
@@ -335,6 +335,7 @@ struct LocalGemmaSummaryRuntime: @unchecked Sendable {
     var environment: [String: String] = ProcessInfo.processInfo.environment
     var bundle: Bundle = .main
     var fileManager: FileManager = .default
+    var runnerURLOverride: URL?
     var generateBatchOverride: (@Sendable ([LocalGemmaSummaryPrompt], URL) throws -> [String])?
 
     func generate(prompt: String, label: String, maxTokens: Int, workDirectory: URL) throws -> String {
@@ -465,7 +466,10 @@ struct LocalGemmaSummaryRuntime: @unchecked Sendable {
     }
 
     private func runnerURL() -> URL? {
-        bundle.url(
+        if let runnerURLOverride {
+            return runnerURLOverride
+        }
+        return bundle.url(
             forResource: "gemma4_mlx_prompt_runner",
             withExtension: "py",
             subdirectory: "LocalSummarizer"

--- a/Tests/LocalMeetingSummarizerTests.swift
+++ b/Tests/LocalMeetingSummarizerTests.swift
@@ -431,7 +431,18 @@ func testLocalMeetingSummarizer() async {
             assertTrue(currentMarkdown.contains("local_summary_runtime: \"mlx-vlm==0.6.1\""), "output should record the local runtime")
             assertTrue(currentMarkdown.contains("local_summary_profile: \"test\""), "output should record the runtime profile")
             assertTrue(currentMarkdown.contains("local_summary_chunk_count: \"1\""), "output should record the chunk count")
+            assertTrue(currentMarkdown.contains("local_summary_title: \"Launch Summary Review\""), "output should record the generated title")
+            assertTrue(currentMarkdown.contains("local_summary: \"Team agreed to keep the beta launch small and private.\""), "output should record the generated summary body")
+            assertTrue(currentMarkdown.contains("local_summary_decisions: \"Ship the smaller launch first.\""), "output should record generated decisions")
             assertTrue(currentMarkdown.contains("## Local Gemma Summary"), "summary should be written into the saved transcript")
+            assertTrue(
+                currentMarkdown.contains("### Summary\nTeam agreed to keep the beta launch small and private."),
+                "managed summary block should include the generated summary text"
+            )
+            assertTrue(
+                currentMarkdown.contains("### Decisions\nShip the smaller launch first."),
+                "managed summary block should include generated decisions"
+            )
             assertTrue(currentMarkdown.contains("### Action Items"), "managed summary block should keep the expected section shape")
             assertTrue(currentMarkdown.contains("## Transcript"), "original transcript should remain readable")
             assertFalse(
@@ -452,6 +463,45 @@ func testLocalMeetingSummarizer() async {
             assertFalse(capturedPrompt.contains("Ignore these later notes"), "post-transcript sections should not be sent to the model prompt")
         } catch {
             assertTrue(false, "successful summarizer fixture should run: \(error)")
+        }
+    }
+
+    runSuite("LocalGemmaSummaryRuntime stops a hung runner at the configured timeout") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LocalMeetingSummaryTimeoutTests-\(UUID().uuidString)", isDirectory: true)
+        let workDirectory = root.appendingPathComponent("work", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        do {
+            try FileManager.default.createDirectory(at: workDirectory, withIntermediateDirectories: true)
+            let runtime = try localMeetingSummaryProcessRuntime(
+                root: root,
+                runnerSource: """
+                import time
+                time.sleep(5)
+                """,
+                timeout: 0.25
+            )
+
+            let startedAt = Date()
+            do {
+                _ = try runtime.generate(
+                    prompt: "safe prompt",
+                    label: "direct",
+                    maxTokens: 16,
+                    workDirectory: workDirectory
+                )
+                assertTrue(false, "hung runner should time out")
+            } catch {
+                guard case LocalMeetingSummaryError.processTimedOut(let label) = error else {
+                    assertTrue(false, "expected processTimedOut, got \(error)")
+                    return
+                }
+                assertEqual(label, "direct", "timeout should preserve the prompt label")
+                assertTrue(Date().timeIntervalSince(startedAt) < 3, "timeout fixture should not hang the fast suite")
+            }
+        } catch {
+            assertTrue(false, "timeout fixture should run: \(error)")
         }
     }
 
@@ -504,6 +554,62 @@ func testLocalMeetingSummarizer() async {
             }
         } catch {
             assertTrue(false, "runtime-failure fixture should run: \(error)")
+        }
+    }
+
+    await runSuite("LocalMeetingSummarizer leaves transcript untouched when the model is missing") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LocalMeetingSummaryMissingModelTests-\(UUID().uuidString)", isDirectory: true)
+        let transcriptURL = root.appendingPathComponent("Meeting.md")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        do {
+            let originalMarkdown = localMeetingSummaryMarkdown(title: "Launch Review", transcript: localMeetingSummaryLongTranscript())
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            try originalMarkdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+            let runtime = try localMeetingSummaryProcessRuntime(
+                root: root,
+                runnerSource: """
+                import sys
+                sys.stderr.write("model load failed: missing model cache for mlx-community/gemma-4-12B-it-4bit\\n")
+                sys.stderr.write("prompt_file=/tmp/private-direct-prompt.txt\\n")
+                sys.stderr.write("/tmp/private-jobs.json\\n")
+                sys.exit(7)
+                """
+            )
+            let summarizer = LocalMeetingSummarizer(
+                configuration: runtime.configuration,
+                runtime: runtime
+            )
+
+            do {
+                _ = try await summarizer.summarize(
+                    transcriptURL: transcriptURL,
+                    title: "Launch Review",
+                    date: Date(timeIntervalSince1970: 1_780_000_000)
+                )
+                assertTrue(false, "missing model should surface as a runtime failure")
+            } catch {
+                guard case LocalMeetingSummaryError.processFailed(let label, let exitCode, let detail) = error else {
+                    assertTrue(false, "expected processFailed, got \(error)")
+                    return
+                }
+                assertEqual(label, "direct", "missing-model failure should keep its prompt label")
+                assertEqual(exitCode, 7, "missing-model exit code should be preserved")
+                assertTrue(detail.contains("missing model cache"), "missing-model detail should be visible to the degraded state")
+                assertFalse(detail.contains("prompt_file"), "runtime detail should not leak prompt file keys")
+                assertFalse(detail.contains("jobs.json"), "runtime detail should not leak jobs file paths")
+                assertFalse(detail.contains("-prompt.txt"), "runtime detail should not leak prompt file paths")
+                let currentMarkdown = try String(contentsOf: transcriptURL, encoding: .utf8)
+                assertEqual(currentMarkdown, originalMarkdown, "missing model should not rewrite the transcript")
+                assertFalse(
+                    currentMarkdown.contains(LocalMeetingSummaryMarkdownUpdater.startMarker),
+                    "missing model should not write a managed summary block"
+                )
+            }
+        } catch {
+            assertTrue(false, "missing-model fixture should run: \(error)")
         }
     }
 
@@ -736,6 +842,56 @@ private func localMeetingSummaryTestConfiguration() -> LocalGemmaSummaryConfigur
         processNiceValue: 0,
         cpuThreadLimit: 1,
         interJobCooldownSeconds: 0
+    )
+}
+
+private func localMeetingSummaryProcessRuntime(
+    root: URL,
+    runnerSource: String,
+    timeout: TimeInterval = 2
+) throws -> LocalGemmaSummaryRuntime {
+    let runnerURL = root.appendingPathComponent("gemma4_mlx_prompt_runner.py")
+    let uvURL = root.appendingPathComponent("uv")
+    try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    try runnerSource.write(to: runnerURL, atomically: true, encoding: .utf8)
+    try """
+    #!/bin/sh
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "python" ]; then
+        shift
+        exec /usr/bin/python3 "$@"
+      fi
+      shift
+    done
+    echo "missing python runner" >&2
+    exit 127
+    """.write(to: uvURL, atomically: true, encoding: .utf8)
+    chmod(uvURL.path, 0o755)
+
+    let configuration = LocalGemmaSummaryConfiguration(
+        modelID: LocalMeetingSummarySetupStatus.defaultModelID,
+        runtimePackage: LocalMeetingSummarySetupStatus.defaultRuntimePackage,
+        profileName: "process-fixture",
+        minimumPhysicalMemoryBytes: 0,
+        chunkCharacterLimit: 100_000,
+        chunkMaxTokens: 64,
+        directMaxTokens: 64,
+        mergeMaxTokens: 64,
+        maxKVSize: 1_024,
+        processTimeoutSeconds: timeout,
+        processNiceValue: 0,
+        cpuThreadLimit: 1,
+        interJobCooldownSeconds: 0
+    )
+
+    return LocalGemmaSummaryRuntime(
+        configuration: configuration,
+        environment: [
+            "TRANSCRIPTED_UV_PATH": uvURL.path,
+            "PATH": "/usr/bin:/bin",
+            "HOME": root.path
+        ],
+        runnerURLOverride: runnerURL
     )
 }
 

--- a/Tests/NightlySecurityContractTests.swift
+++ b/Tests/NightlySecurityContractTests.swift
@@ -167,8 +167,8 @@ private func runNightlySecurityChecker(arguments: [String]) -> ShellResult {
 
     do {
         try process.run()
-        process.waitUntilExit()
         let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        process.waitUntilExit()
         return ShellResult(status: process.terminationStatus, output: output)
     } catch {
         return ShellResult(status: -127, output: String(describing: error))

--- a/docs/qa-test-bench.md
+++ b/docs/qa-test-bench.md
@@ -22,9 +22,13 @@ This runs:
 - `bash build.sh --no-open`
 - `bash run-tests.sh`
 - `bash run-e2e-smoke.sh`
+- `bash scripts/ops/run-local-summary-fixture.sh`
 
 It proves the app builds, fast tests pass, and deterministic meeting/dictation
-artifact discovery still works without microphone or TCC prompts.
+artifact discovery still works without microphone or TCC prompts. The local
+summary fixture also proves the Gemma summary app path can start, finish, and
+rewrite a saved synthetic meeting into the expected Markdown shape without
+private meeting content or a model download.
 
 ## Deep Run
 
@@ -46,6 +50,10 @@ The synthetic audio step also reports an audio route automation proxy matrix so
 the bench names what is automated for dictation, meeting mic/system audio,
 WebRTC/Zoom contention, Bluetooth/AirPods settling, and privacy/security. It
 does not replace live or manual route proof.
+
+Deep inherits the deterministic local summary fixture from quick. That fixture
+is shape and hang-guard proof only; real Gemma summary quality still needs
+manual or corpus review.
 
 Live artifact validation is non-blocking by default because a development Mac
 may not have saved meetings yet. To make it strict:

--- a/scripts/ops/run-local-summary-fixture.sh
+++ b/scripts/ops/run-local-summary-fixture.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deterministic local-summary fixture smoke.
+# This proves the Transcripted app-side summarizer starts, finishes, and writes
+# the expected Markdown shape without private meeting content or model downloads.
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+OUT_ROOT="${TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_OUT:-${REPO_ROOT}/build/local-summary-fixture}"
+RUN_ID="${TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_RUN_ID:-fixture-$(date +%Y%m%d-%H%M%S)}"
+TIMEOUT_SECONDS="${TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_TIMEOUT:-10}"
+RUN_ROOT="${OUT_ROOT}/${RUN_ID}"
+BUILD_DIR="${RUN_ROOT}/build"
+FAKE_HOME="${RUN_ROOT}/home"
+HARNESS="${BUILD_DIR}/LocalSummaryFixture.swift"
+BIN="${BUILD_DIR}/local-summary-fixture"
+
+mkdir -p "${BUILD_DIR}" "${FAKE_HOME}"
+
+cat > "${HARNESS}" <<'SWIFT'
+import Foundation
+
+private enum FixtureError: Error, CustomStringConvertible {
+    case failed(String)
+
+    var description: String {
+        switch self {
+        case .failed(let message):
+            return message
+        }
+    }
+}
+
+@main
+struct LocalSummaryFixture {
+    static func main() async {
+        do {
+            let runRoot = URL(
+                fileURLWithPath: ProcessInfo.processInfo.environment["TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_RUN_ROOT"]!,
+                isDirectory: true
+            )
+            try await run(in: runRoot)
+        } catch {
+            fputs("[local-summary-fixture] FAIL: \(error)\n", stderr)
+            exit(1)
+        }
+    }
+
+    private static func run(in runRoot: URL) async throws {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: runRoot, withIntermediateDirectories: true)
+
+        let transcriptURL = runRoot.appendingPathComponent("Synthetic Summary Fixture.md")
+        let promptCaptureURL = runRoot.appendingPathComponent("captured-prompt.txt")
+        try fixtureTranscript.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+        let configuration = fixtureConfiguration()
+        let runtime = LocalGemmaSummaryRuntime(
+            configuration: configuration,
+            generateBatchOverride: { prompts, _ in
+                guard prompts.count == 1 else {
+                    throw FixtureError.failed("expected direct one-prompt fixture, got \(prompts.count)")
+                }
+                let promptText = prompts.map(\.prompt).joined(separator: "\n---\n")
+                try promptText.write(to: promptCaptureURL, atomically: true, encoding: .utf8)
+                return [fixtureModelOutput]
+            }
+        )
+
+        let result = try await LocalMeetingSummarizer(
+            configuration: configuration,
+            runtime: runtime
+        ).summarize(
+            transcriptURL: transcriptURL,
+            title: "Synthetic Summary Fixture",
+            date: Date(timeIntervalSince1970: 1_780_000_000)
+        )
+
+        let updatedMarkdown = try String(contentsOf: transcriptURL, encoding: .utf8)
+        let capturedPrompt = try String(contentsOf: promptCaptureURL, encoding: .utf8)
+
+        try expect(result.chunkCount == 1, "fixture should use the direct summary path")
+        try expect(result.profileName == "fixture", "fixture profile should be reported")
+        try expect(capturedPrompt.contains("summary fixture stays local"), "prompt should include synthetic transcript text")
+        try expect(!capturedPrompt.contains("fixture-secret"), "prompt should exclude non-transcript notes")
+        try expect(updatedMarkdown.contains("local_summary_version: \"1\""), "frontmatter should include local summary version")
+        try expect(updatedMarkdown.contains("local_summary_title: \"Fixture Summary Review\""), "frontmatter should include generated title")
+        try expect(updatedMarkdown.contains("local_summary_chunk_count: \"1\""), "frontmatter should include chunk count")
+        try expect(updatedMarkdown.contains(LocalMeetingSummaryMarkdownUpdater.startMarker), "managed summary start marker should be present")
+        try expect(updatedMarkdown.contains("## Local Gemma Summary"), "managed summary heading should be present")
+        try expect(updatedMarkdown.contains("### Summary\nThe fixture proves local summary generation can finish and rewrite the saved meeting."), "summary body should be written")
+        try expect(updatedMarkdown.contains("### Action Items\nQA should keep this fixture in the bench."), "action item body should be written")
+        try expect(updatedMarkdown.contains(LocalMeetingSummaryMarkdownUpdater.endMarker), "managed summary end marker should be present")
+        try expect(!fileManager.fileExists(atPath: LocalMeetingSummaryStore.summaryURL(for: transcriptURL).path), "fixture should not create a sibling summary sidecar")
+
+        print("[local-summary-fixture] PASS: generated deterministic local summary fixture")
+        print("[local-summary-fixture] Transcript: \(transcriptURL.path)")
+    }
+
+    private static func expect(_ condition: Bool, _ message: String) throws {
+        if !condition {
+            throw FixtureError.failed(message)
+        }
+    }
+}
+
+private func fixtureConfiguration() -> LocalGemmaSummaryConfiguration {
+    LocalGemmaSummaryConfiguration(
+        modelID: LocalMeetingSummarySetupStatus.defaultModelID,
+        runtimePackage: LocalMeetingSummarySetupStatus.defaultRuntimePackage,
+        profileName: "fixture",
+        minimumPhysicalMemoryBytes: 0,
+        chunkCharacterLimit: 100_000,
+        chunkMaxTokens: 64,
+        directMaxTokens: 64,
+        mergeMaxTokens: 64,
+        maxKVSize: 1_024,
+        processTimeoutSeconds: 5,
+        processNiceValue: 0,
+        cpuThreadLimit: 1,
+        interJobCooldownSeconds: 0
+    )
+}
+
+private let fixtureTranscript = """
+---
+capture_type: meeting
+title: "Synthetic Summary Fixture"
+private_note: "fixture-secret"
+---
+
+# Synthetic Summary Fixture
+
+## Notes
+
+This fixture-secret note should never be sent to the summarizer prompt.
+
+## Transcript
+
+**00:01** [Mic/Alex]
+The summary fixture stays local and should prove that generation starts, finishes, and updates the saved meeting Markdown.
+
+**00:20** [System/Riley]
+QA should keep this fixture in the bench so missing output shape is caught before release.
+
+**00:42** [Mic/Alex]
+The open question is whether real Gemma quality still needs manual review, but the fixture can prove the app path does not hang.
+"""
+
+private let fixtureModelOutput = """
+# Title
+Fixture Summary Review
+
+# Summary
+The fixture proves local summary generation can finish and rewrite the saved meeting.
+
+# Decisions
+Keep the fixture local and deterministic.
+
+# Action Items
+QA should keep this fixture in the bench.
+
+# Open Questions
+Real Gemma summary quality still needs manual review.
+
+# Risks or Follow-ups
+The release gate should not treat fixture output as quality proof.
+
+# Accuracy Notes
+Synthetic fixture only.
+"""
+SWIFT
+
+swiftc \
+  "${HARNESS}" \
+  "${REPO_ROOT}/Sources/Support/TranscriptedStoragePaths.swift" \
+  "${REPO_ROOT}/Sources/Meeting/LocalMeetingSummarizer.swift" \
+  "${REPO_ROOT}/Sources/TranscriptedCore/Storage/TranscriptFrontmatter.swift" \
+  -parse-as-library \
+  -o "${BIN}"
+
+run_with_timeout() {
+  local deadline pid status
+  deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+  "$@" &
+  pid=$!
+
+  while kill -0 "${pid}" 2>/dev/null; do
+    if [[ "$(date +%s)" -ge "${deadline}" ]]; then
+      kill "${pid}" 2>/dev/null || true
+      wait "${pid}" 2>/dev/null || true
+      echo "[local-summary-fixture] FAIL: fixture exceeded ${TIMEOUT_SECONDS}s watchdog" >&2
+      return 124
+    fi
+    sleep 0.2
+  done
+
+  wait "${pid}"
+  status=$?
+  return "${status}"
+}
+
+echo "[local-summary-fixture] Run root: ${RUN_ROOT}"
+export CFFIXED_USER_HOME="${FAKE_HOME}"
+export HOME="${FAKE_HOME}"
+export TRANSCRIPTED_DISABLE_FILE_LOGGER=1
+export TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_RUN_ROOT="${RUN_ROOT}"
+run_with_timeout "${BIN}"

--- a/scripts/ops/transcripted-qa-bench.sh
+++ b/scripts/ops/transcripted-qa-bench.sh
@@ -461,6 +461,8 @@ run_quick() {
 
   run_step "02-fast-tests" "Fast tests" "yes" "bash run-tests.sh"
   run_step "03-e2e-smoke" "Deterministic E2E smoke" "yes" "bash run-e2e-smoke.sh"
+  run_step "04-local-summary-fixture" "Local Gemma summary fixture smoke" "yes" \
+    "bash scripts/ops/run-local-summary-fixture.sh"
 }
 
 run_artifact_validation() {


### PR DESCRIPTION
## Summary

- adds a deterministic local Gemma summary fixture command that compiles the app-side summarizer and rewrites a synthetic meeting transcript
- adds fast coverage for generated title/body/frontmatter shape, missing-model failure behavior, and subprocess timeout handling
- wires the fixture into the quick QA bench and documents what it proves versus what remains manual/model-quality proof
- fixes a fast-test pipe deadlock in the nightly security checker helper that blocked `run-tests.sh`

## Verification

- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `bash scripts/ops/run-local-summary-fixture.sh`
- `bash scripts/ops/transcripted-qa-bench.sh --mode quick`
