### PR TITLE
[docs] Update route QA docs

### DIFF
--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -124,6 +124,7 @@ Relevant direct coverage:
 - `Tests/MeetingSessionUIPolicyTests.swift`
 - `Tests/MeetingAudioStorageManagerTests.swift`
 - `Tests/MeetingTranscriptStylerTests.swift`
+- `Tests/MeetingRouteFixtureTests.swift`
 - `Tests/LiveMeetingCodexSessionTests.swift`
 - `Tests/LiveMeetingPreviewServerTests.swift`
 - `Tests/LiveMeetingStreamingUpdatePolicyTests.swift`

--- a/Sources/Speech/CLAUDE.md
+++ b/Sources/Speech/CLAUDE.md
@@ -61,6 +61,7 @@ Relevant direct coverage:
 - `Tests/DictationAudioRecoveryTests.swift`
 - `Tests/DictationInputDeviceSelectionPolicyTests.swift`
 - `Tests/DictationReadinessWaitPolicyTests.swift`
+- `Tests/BluetoothRouteContractTests.swift`
 - `Tests/ParakeetModelInitDiagnosticsTests.swift`
 - `Tests/ParakeetPrewarmPolicyTests.swift`
 - `Tests/ParakeetRecoveryStateTests.swift`

--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -85,12 +85,14 @@ Current direct core coverage includes:
 
 - `Tests/TranscriptedCoreTests/AudioInitializationTests.swift`
 - `Tests/TranscriptedCoreTests/AudioDiagnosticsSnapshotTests.swift`
+- `Tests/TranscriptedCoreTests/BluetoothMeetingRouteContractTests.swift`
 - `Tests/TranscriptedCoreTests/CoreStoragePathsTests.swift`
 - `Tests/TranscriptedCoreTests/DatabaseFilePermissionsTests.swift`
 - `Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift`
 - `Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift`
 - `Tests/TranscriptedCoreTests/FileLoggerTests.swift`
 - `Tests/TranscriptedCoreTests/MeetingInputDeviceSelectionPolicyTests.swift`
+- `Tests/TranscriptedCoreTests/MeetingRouteArtifactFixtureTests.swift`
 - `Tests/TranscriptedCoreTests/MicRecordingFileMergerTests.swift`
 - `Tests/MicRecordingMergePlanTests.swift`
 - `Tests/TranscriptedCoreTests/RealtimeAGCTests.swift`


### PR DESCRIPTION
## Summary
- list Bluetooth route contract coverage in Speech docs
- list meeting route fixture coverage in Meeting docs
- list new Bluetooth/route artifact package tests in TranscriptedCore docs

## Verification
- bash scripts/dev/agent-preflight.sh
- git diff --check

Note: preflight also suggested source-level checks because subsystem CLAUDE files match broad source-directory globs; this PR only changes docs.