### PR TITLE
[codex] Cover slow pasteback retry smoke

### DIFF
--- a/Tests/E2E/SlowPastebackSmoke.swift
+++ b/Tests/E2E/SlowPastebackSmoke.swift
@@ -71,6 +71,7 @@ struct SlowPastebackSmoke {
         for scenario in scenarios {
             results.append(await runScenario(scenario))
         }
+        results.append(await runRetryBeforeRestoreScenario())
 
         let passed = results.filter(\.passed).count
         let failed = results.count - passed
@@ -167,6 +168,116 @@ struct SlowPastebackSmoke {
             freshDictation: freshDictation,
             userCopy: userCopy,
             autoEnterReadyAt: autoEnterReadyAt
+        )
+    }
+
+    @MainActor
+    private static func runRetryBeforeRestoreScenario() async -> SmokeResult {
+        let scenarioID = "production-retry-before-restore"
+        let title = "Retry before fallback restore keeps both fake Cmd+V targets fresh"
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("TranscriptedSlowPasteback-\(scenarioID)-\(UUID().uuidString)"))
+        let paster = ClipboardRestoringTextPaster()
+        let originalClipboard = "synthetic retry old clipboard \(UUID().uuidString)"
+        let firstDictation = "synthetic first dictation \(UUID().uuidString)"
+        let retryDictation = "synthetic retry dictation \(UUID().uuidString)"
+        let firstReadDelay = SmokeDelay.milliseconds(180)
+        let retryStartDelay = SmokeDelay.milliseconds(320)
+        let retryReadDelay = SmokeDelay.milliseconds(950)
+        let fallbackDelay = SmokeDelay.nanoseconds(TranscriptedConstants.clipboardRestoreFallbackDelay)
+        var firstReadTask: Task<String?, Never>?
+        var retryReadTask: Task<String?, Never>?
+
+        func category(for value: String?) -> String {
+            switch value {
+            case firstDictation:
+                return "first_dictation"
+            case retryDictation:
+                return "retry_dictation"
+            case originalClipboard:
+                return "old_clipboard"
+            case nil:
+                return "none"
+            default:
+                return "unexpected"
+            }
+        }
+
+        pasteboard.clearContents()
+        pasteboard.setString(originalClipboard, forType: .string)
+
+        let firstOutcome = paster.paste(
+            firstDictation,
+            pasteboard: pasteboard,
+            accessibilityTrusted: { true },
+            requestAccessibilityTrust: {},
+            pasteDispatcher: {
+                firstReadTask = Task {
+                    try? await Task.sleep(nanoseconds: firstReadDelay.nanoseconds)
+                    return await MainActor.run {
+                        pasteboard.string(forType: .string)
+                    }
+                }
+                return true
+            },
+            restoreDelay: SmokeDelay.milliseconds(120).nanoseconds,
+            fallbackRestoreDelay: fallbackDelay.nanoseconds
+        )
+
+        try? await Task.sleep(nanoseconds: retryStartDelay.nanoseconds)
+        let firstInserted = await firstReadTask?.value
+
+        let retryOutcome = paster.paste(
+            retryDictation,
+            pasteboard: pasteboard,
+            accessibilityTrusted: { true },
+            requestAccessibilityTrust: {},
+            pasteDispatcher: {
+                retryReadTask = Task {
+                    try? await Task.sleep(nanoseconds: retryReadDelay.nanoseconds)
+                    return await MainActor.run {
+                        pasteboard.string(forType: .string)
+                    }
+                }
+                return true
+            },
+            restoreDelay: SmokeDelay.milliseconds(120).nanoseconds,
+            fallbackRestoreDelay: fallbackDelay.nanoseconds
+        )
+
+        let retryInserted = await retryReadTask?.value
+        await paster.waitForPendingClipboardRestore()
+        let finalClipboard = pasteboard.string(forType: .string)
+
+        var failures: [String] = []
+        if firstOutcome != .pasted {
+            failures.append("first paste outcome was \(firstOutcome.diagnosticName)")
+        }
+        if retryOutcome != .pasted {
+            failures.append("retry paste outcome was \(retryOutcome.diagnosticName)")
+        }
+        if firstInserted != firstDictation {
+            failures.append("first target inserted \(category(for: firstInserted))")
+        }
+        if retryInserted != retryDictation {
+            failures.append("retry target inserted \(category(for: retryInserted))")
+        }
+        if finalClipboard != originalClipboard {
+            failures.append("final clipboard was \(category(for: finalClipboard))")
+        }
+
+        let status: SmokeStatus = failures.isEmpty ? .pass : .fail
+        let insertedCategory = firstInserted == firstDictation && retryInserted == retryDictation
+            ? "first_and_retry_fresh"
+            : "\(category(for: firstInserted))_then_\(category(for: retryInserted))"
+        return SmokeResult(
+            scenarioID: scenarioID,
+            status: status,
+            readDelayMS: retryReadDelay.milliseconds,
+            fallbackDelayMS: fallbackDelay.milliseconds,
+            insertedCategory: insertedCategory,
+            finalClipboardCategory: category(for: finalClipboard),
+            autoEnterReadyMS: nil,
+            detail: failures.isEmpty ? title : failures.joined(separator: "; ")
         )
     }
 

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -130,6 +130,7 @@ It verifies:
 
 - a fake Cmd+V target that reads at `950ms` still inserts fresh dictation
 - a fake target near the `2.5s` fallback boundary still inserts fresh dictation
+- a retry before fallback restore lets both fake Cmd+V targets insert fresh dictation, then restores the original clipboard
 - an old `900ms` fallback control is detected as stale instead of hidden
 - a reader beyond the current fallback is detected as stale
 - paste-dispatch failure leaves fresh dictation copied

--- a/docs/qa-test-bench.md
+++ b/docs/qa-test-bench.md
@@ -40,7 +40,8 @@ bash scripts/ops/transcripted-qa-bench.sh --mode pasteback-synthetic
 This runs only the fake slow Cmd+V target smoke. It writes a markdown subreport
 beside the QA report and JSON under `raw/`. It proves the target-buffer result
 for synthetic slow readers without using real dictation audio or the real
-clipboard.
+clipboard. It also covers a retry before fallback restore, so a second
+pasteback cannot snapshot the first borrowed dictation as the user's clipboard.
 
 ## UI Run
 


### PR DESCRIPTION
## What changed

- Added a `production-retry-before-restore` scenario to the deterministic slow pasteback smoke.
- The new scenario runs two pastebacks on the same synthetic pasteboard before the fallback restore fires, proves both fake Cmd+V targets read fresh dictation, then proves the original clipboard is restored.
- Updated `Tests/README.md` and `docs/qa-test-bench.md` so the pasteback synthetic gate names retry-before-restore coverage.

## Why

Clipboard/pasteback regressions should be caught by automation instead of manual feel-testing. The existing smoke covered slow consumers, the old 900ms stale control, beyond-boundary stale detection, dispatcher failure, user-copy preservation, and Auto Enter timing. This adds the retry case to the production-timing fake target gate.

## Validation

- PASS: `bash run-slow-pasteback-smoke.sh`
- PASS: `bash scripts/ops/transcripted-qa-bench.sh --mode pasteback-synthetic`
- FAIL, unrelated environment blocker: `bash run-tests.sh` reached `4418/4422` passing, then failed `TranscriptedStoragePathsTests` because the local `tests` UserDefaults domain has a stale `transcriptSaveLocation` pointing at another worktree (`f003`). A rerun with isolated `HOME`/`CFFIXED_USER_HOME` still picked up that CFPreferences value and crashed when the sandbox could not write into that old worktree. I did not delete local defaults.

No release was cut or published.