### PR TITLE
Tighten release gate report status

### DIFF
--- a/docs/qa-test-bench.md
+++ b/docs/qa-test-bench.md
@@ -220,6 +220,15 @@ Missing Sentry or PostHog credentials are `YELLOW` / unknown. They are not
 treated as green proof. Actual release-surface drift or required release-health
 failures are `RED`.
 
+The command exit code follows the overall report color: `0` for `GREEN`, `3`
+for `YELLOW`, and `1` for `RED`. That means missing credentials or missing
+manual proof keep automation yellow instead of silently looking green.
+
+Manual-proof rows say `UNKNOWN` until a real local run artifact exists. The
+expected manual lanes are live mic/system-audio capture, meeting-app volume and
+route behavior, sleep/wake and device switching, pasteback feel, speaker
+review/rename feel, and existing-install update behavior.
+
 ## Short Output
 
 Every bench report starts with a plain short answer:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -66,6 +66,7 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
   - Usage: `python3 scripts/ops/release-gate-report.py`
   - Deep RC usage: `python3 scripts/ops/release-gate-report.py --qa-mode deep --strict-artifacts`
   - Writes local Markdown and JSON under `/tmp/transcripted-release-gate/<run-id>/`
+  - Exits `0` for GREEN, `3` for YELLOW/unknown, and `1` for RED
   - Missing Sentry/PostHog credentials are reported as yellow/unknown, not green
 - `scripts/ops/privacy-leak-sweep.py` — synthetic-only privacy sweep for logs/events/reliability JSONL, Sentry/PostHog payloads, QA/local reports, PR/release text, and scanner handoff summaries
   - Usage: `python3 scripts/ops/privacy-leak-sweep.py --write-report build/privacy-leak-sweep-report.json`

--- a/scripts/ops/release-gate-report.py
+++ b/scripts/ops/release-gate-report.py
@@ -512,27 +512,48 @@ def summarize_counts(counts: Counter[str], prefix: str) -> str:
     return f"{prefix} ({parts})" if parts else prefix
 
 
-def manual_items(args: argparse.Namespace) -> list[ReportItem]:
+def evidence_list(paths: list[Path]) -> str:
+    return "; ".join(str(path) for path in paths)
+
+
+def manual_items(args: argparse.Namespace, root: Path, out_dir: Path) -> list[ReportItem]:
+    qa_manual_path = out_dir / "qa-bench" / args.run_id / "manual-scenarios.md"
     items = [
         ReportItem(
             "Meeting-app volume and route matrix",
             "yellow",
-            "Run docs/qa-issue-500-meeting-audio.md across Chrome Meet, Safari Meet, Firefox Meet, Zoom, and real routes.",
+            "UNKNOWN: run docs/qa-issue-500-meeting-audio.md across Chrome Meet, Safari Meet, Firefox Meet, Zoom, and real routes.",
+            evidence_list(
+                [
+                    root / "docs/qa-issue-500-meeting-audio.md",
+                    root / "docs/audio-reliability-daily-check.md",
+                    qa_manual_path,
+                ]
+            ),
+        ),
+        ReportItem(
+            "Sleep/wake and device switching",
+            "yellow",
+            "UNKNOWN: run the daily audio reliability loop for sleep/wake, input-device changes, and Bluetooth/AirPods route changes.",
+            evidence_list([qa_manual_path, root / "docs/audio-reliability-daily-check.md"]),
         ),
         ReportItem(
             "Pasteback feel in real apps",
             "yellow",
-            "Check TextEdit, Notes, and a browser text area with Auto Enter off/on.",
+            "UNKNOWN: check TextEdit, Notes, and a browser text area with Auto Enter off/on.",
+            evidence_list([qa_manual_path, root / "docs/qa-test-bench.md"]),
         ),
         ReportItem(
             "Speaker review and rename feel",
             "yellow",
-            "Verify unknown speakers stay unknown until a human names them, and Markdown keeps the chosen name.",
+            "UNKNOWN: verify unknown speakers stay unknown until a human names them, and Markdown keeps the chosen name.",
+            evidence_list([qa_manual_path, root / "docs/qa-test-bench.md"]),
         ),
         ReportItem(
             "Existing-install update path",
             "yellow",
-            "On a real installed app, verify Sparkle check/install behavior and Homebrew install/upgrade when publishing.",
+            "UNKNOWN: on a real installed app, verify Sparkle check/install behavior and Homebrew install/upgrade when publishing.",
+            evidence_list([root / "docs/sparkle-updates.md", root / "docs/release-packaging.md"]),
         ),
     ]
     if args.qa_mode != "live":
@@ -541,7 +562,8 @@ def manual_items(args: argparse.Namespace) -> list[ReportItem]:
             ReportItem(
                 "Live mic and system-audio capture",
                 "yellow",
-                "Run the live QA bench on this Mac when release claims depend on real audio/TCC proof.",
+                "UNKNOWN: run the live QA bench on this Mac when release claims depend on real audio/TCC proof.",
+                evidence_list([qa_manual_path, root / "docs/qa-test-bench.md"]),
             ),
         )
     return items
@@ -608,6 +630,7 @@ def render_report(
         "",
         "Raw logs, transcripts, audio, device names, tokens, and private paths stay local. This report only writes aggregate status.",
         "Missing Sentry/PostHog credentials are reported as yellow/unknown, not green proof.",
+        "The command exit code follows the overall report color, so manual-only unknowns still exit yellow.",
         "",
         "## Sidecar Boundary",
         "",
@@ -826,7 +849,7 @@ def main() -> int:
     release_surfaces = run_release_surfaces(args, root, out_dir, commands)
     telemetry = run_telemetry(args, root, out_dir, commands)
     local_logs = sweep_local_logs(args)
-    manual = manual_items(args)
+    manual = manual_items(args, root, out_dir)
 
     generated_at = utc_now()
     branch = git_value(root, ["branch", "--show-current"], "detached")
@@ -856,7 +879,7 @@ def main() -> int:
     print(f"Release gate report: {report_path}")
     print(f"Release gate JSON: {json_path}")
     print(f"Verdict: {status_label(payload['status'])}")
-    return EXIT_CODES[payload["process_status"]]
+    return EXIT_CODES[payload["status"]]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make release-gate-report exit with the overall GREEN/YELLOW/RED report status instead of automated-only process status
- mark missing manual proof rows as UNKNOWN/YELLOW and add exact evidence/source paths
- document the release gate exit-code contract

## Tests
- scripts/dev/agent-preflight.sh
- bash -n scripts/ops/transcripted-qa-bench.sh
- env PYTHONPYCACHEPREFIX=/tmp/transcripted-pycache python3 -m py_compile scripts/ops/release-gate-report.py scripts/ops/validate-meeting-corpus.py scripts/ops/compare-meeting-corpus.py
- python3 scripts/ops/release-gate-report.py --self-test
- python3 scripts/ops/release-gate-report.py --dry-run --run-id codex-after-patch (expected YELLOW / exit 3)
- swift test --package-path Tools/TranscriptedQA
- bash build-deps.sh --force
- bash scripts/ops/transcripted-qa-bench.sh --mode quick --run-id codex-release-gate-quick-after-deps

## Notes
- No release was cut or published.
- Quick QA bench report: /tmp/transcripted-qa-bench/codex-release-gate-quick-after-deps/qa-report.md
- Dry-run release report: /tmp/transcripted-release-gate/codex-after-patch/release-gate-report.md