### PR TITLE
Add meeting route stop/restart fixture

### DIFF
--- a/.agents/qa-gates.yml
+++ b/.agents/qa-gates.yml
@@ -205,7 +205,7 @@ coverage_gaps:
   audio:
     current_coverage:
       - "synthetic audio reliability matrix"
-      - "deterministic route fixtures for shared mic, missing system audio, quiet mic, output ducking, route churn, stop timeout, and stop/save artifact outcomes"
+      - "deterministic route fixtures for shared mic, missing system audio, quiet mic, output ducking, route churn, stop timeout, stop/restart after route switch, and stop/save artifact outcomes"
       - "live capture smoke for mic and system audio"
       - "fast/core tests for failure policy, recovery state, and archive handling"
     missing_automation:

--- a/Tests/AudioAutomationCoverageContractTests.swift
+++ b/Tests/AudioAutomationCoverageContractTests.swift
@@ -15,6 +15,7 @@ func testAudioAutomationCoverageContract() {
             "synthetic-webrtc-quiet-mic-recovered",
             "synthetic-zoom-system-audio-missing-after-start",
             "synthetic-zoom-output-ducking-route-change-stop-timeout",
+            "synthetic-webrtc-route-switch-stop-restart-recovered",
             "synthetic-webrtc-quiet-mic-unrecovered"
         ]
 
@@ -29,6 +30,13 @@ func testAudioAutomationCoverageContract() {
                 && script.contains("simulated_not_real_zoom_webrtc=true")
                 && script.contains("manual_boundary_documented=true"),
             "synthetic audio reports should separate automated proxies from manual route proof"
+        )
+
+        assertTrue(
+            script.contains("restart_artifacts")
+                && script.contains("restart_attempted=true")
+                && script.contains("restart_succeeded=true"),
+            "synthetic route fixtures should include deterministic stop/restart artifacts"
         )
     }
 

--- a/Tests/MeetingRouteFixtureTests.swift
+++ b/Tests/MeetingRouteFixtureTests.swift
@@ -30,6 +30,30 @@ func testMeetingRouteFixture() {
         }
     }
 
+    runSuite("Deterministic meeting route fixtures prove stop/restart after route switch") {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("transcripted-route-fixtures-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        guard let restartScenario = MeetingRouteFixtureScenario.issue500Scenarios.first(where: {
+            $0.id == "webrtc-route-switch-stop-restart-recovered"
+        }) else {
+            assertionFailure("fixture list should include a stop/restart route-switch scenario")
+            return
+        }
+
+        let result = restartScenario.run(in: root)
+
+        assertEqual(result.diagnostics["restart_attempted"], "true", "restart fixture should record a second capture attempt")
+        assertEqual(result.diagnostics["restart_succeeded"], "true", "restart fixture should record the second capture succeeding")
+        assertEqual(result.diagnostics["route_change_count"], "2", "restart fixture should preserve route-switch count")
+        assertEqual(result.explanation.outcomeKind, .success, "route-switch restart should still save successfully")
+        assertTrue(result.artifacts.restartTranscriptExists, "restart transcript artifact should exist")
+        assertTrue(result.artifacts.restartMicAudioExists, "restart mic artifact should exist")
+        assertTrue(result.artifacts.restartSystemAudioExists, "restart system artifact should exist")
+        assertTrue(result.isPrivacySafe, "restart fixture should keep synthetic content local-safe")
+    }
+
     runSuite("Deterministic meeting route fixtures prove saved transcript frontmatter") {
         let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("transcripted-route-fixtures-\(UUID().uuidString)", isDirectory: true)
@@ -266,6 +290,54 @@ private struct MeetingRouteFixtureScenario {
             )
         ),
         MeetingRouteFixtureScenario(
+            id: "webrtc-route-switch-stop-restart-recovered",
+            displayName: "WebRTC route switch, clean stop, and successful restart",
+            baseContext: [
+                "input_device_class": "built_in",
+                "output_device_class": "built_in",
+                "system_output_device_class": "built_in",
+                "default_output_volume_before": "0.730",
+                "default_output_volume_during": "0.730",
+                "default_system_output_volume_before": "0.730",
+                "default_system_output_volume_during": "0.730",
+                "mic_raw_peak": "0.16000",
+                "mic_processed_peak": "0.28000",
+                "system_peak": "0.21000",
+                "system_stream_present": "true",
+                "route_change_count": "2",
+                "gap_count": "1",
+                "restart_attempted": "true",
+                "restart_succeeded": "true"
+            ],
+            afterStopContext: [
+                "default_output_volume_after": "0.730",
+                "default_system_output_volume_after": "0.730"
+            ],
+            failureKind: nil,
+            stage: .save,
+            isRetryable: false,
+            transcriptSaved: true,
+            failedQueueEntryRetained: false,
+            expectedDiagnostics: ExpectedRouteDiagnostics(
+                quietMicRecovered: "false",
+                quietMicUnrecovered: "false",
+                attenuationKind: "none",
+                outputDuckingDetected: "false",
+                systemStreamPresent: "true",
+                routeChangeCount: "2"
+            ),
+            expectedOutcome: .success,
+            expectedArtifactRetention: .retainedPartialTranscript,
+            expectedUserVisibleState: .transcriptSaved,
+            expectedRetryability: .permanent,
+            expectedArtifacts: ExpectedRouteArtifacts(
+                transcript: true,
+                micAudio: true,
+                systemAudio: true,
+                failedQueueEntry: false
+            )
+        ),
+        MeetingRouteFixtureScenario(
             id: "webrtc-quiet-mic-unrecovered",
             displayName: "WebRTC quiet mic not recovered",
             baseContext: [
@@ -318,6 +390,9 @@ private struct MeetingRouteFixtureScenario {
         let systemURL = scenarioRoot.appendingPathComponent("system.synthetic.wav")
         let transcriptURL = scenarioRoot.appendingPathComponent("transcript.md")
         let failureURL = scenarioRoot.appendingPathComponent("failed-meeting.json")
+        let restartMicURL = scenarioRoot.appendingPathComponent("restart-mic.synthetic.wav")
+        let restartSystemURL = scenarioRoot.appendingPathComponent("restart-system.synthetic.wav")
+        let restartTranscriptURL = scenarioRoot.appendingPathComponent("restart-transcript.md")
 
         if expectedArtifacts.micAudio {
             try? Self.syntheticWAV(amplitude: 2_400).write(to: micURL)
@@ -332,6 +407,12 @@ private struct MeetingRouteFixtureScenario {
         if failedQueueEntryRetained {
             try? failedQueueJSON(micURL: expectedArtifacts.micAudio ? micURL : nil, systemURL: expectedArtifacts.systemAudio ? systemURL : nil)
                 .write(to: failureURL, atomically: true, encoding: .utf8)
+        }
+        if baseContext["restart_attempted"] == "true", baseContext["restart_succeeded"] == "true" {
+            try? Self.syntheticWAV(amplitude: 2_600).write(to: restartMicURL)
+            try? Self.syntheticWAV(amplitude: 3_400).write(to: restartSystemURL)
+            try? transcriptMarkdown(micURL: restartMicURL, systemURL: restartSystemURL, phase: "restart")
+                .write(to: restartTranscriptURL, atomically: true, encoding: .utf8)
         }
 
         let diagnostics = MeetingCaptureVolumeDiagnostics.annotatedStopContext(
@@ -350,10 +431,14 @@ private struct MeetingRouteFixtureScenario {
 
         let artifacts = MeetingRouteFixtureArtifacts(
             transcriptURL: transcriptSaved ? transcriptURL : nil,
+            restartTranscriptURL: FileManager.default.fileExists(atPath: restartTranscriptURL.path) ? restartTranscriptURL : nil,
             failedQueueEntryURL: failedQueueEntryRetained ? failureURL : nil,
             transcriptExists: FileManager.default.fileExists(atPath: transcriptURL.path),
             micAudioExists: FileManager.default.fileExists(atPath: micURL.path),
             systemAudioExists: FileManager.default.fileExists(atPath: systemURL.path),
+            restartTranscriptExists: FileManager.default.fileExists(atPath: restartTranscriptURL.path),
+            restartMicAudioExists: FileManager.default.fileExists(atPath: restartMicURL.path),
+            restartSystemAudioExists: FileManager.default.fileExists(atPath: restartSystemURL.path),
             failedQueueEntryExists: FileManager.default.fileExists(atPath: failureURL.path)
         )
 
@@ -365,13 +450,14 @@ private struct MeetingRouteFixtureScenario {
         )
     }
 
-    private func transcriptMarkdown(micURL: URL, systemURL: URL?) -> String {
+    private func transcriptMarkdown(micURL: URL, systemURL: URL?, phase: String = "initial") -> String {
         """
         ---
         capture_type: meeting
         fixture_kind: deterministic_meeting_route
         route_fixture_id: \(id)
         route_fixture_name: \(displayName)
+        route_fixture_phase: \(phase)
         mic_audio: \(micURL.lastPathComponent)
         system_audio: \(systemURL?.lastPathComponent ?? "unavailable")
         ---
@@ -396,7 +482,7 @@ private struct MeetingRouteFixtureScenario {
     }
 
     private func isPrivacySafe(artifacts: MeetingRouteFixtureArtifacts) -> Bool {
-        let textURLs = [artifacts.transcriptURL, artifacts.failedQueueEntryURL].compactMap { $0 }
+        let textURLs = [artifacts.transcriptURL, artifacts.restartTranscriptURL, artifacts.failedQueueEntryURL].compactMap { $0 }
         let forbiddenFragments = [
             "/Users/",
             "@",
@@ -471,10 +557,14 @@ private struct ExpectedRouteArtifacts {
 
 private struct MeetingRouteFixtureArtifacts {
     let transcriptURL: URL?
+    let restartTranscriptURL: URL?
     let failedQueueEntryURL: URL?
     let transcriptExists: Bool
     let micAudioExists: Bool
     let systemAudioExists: Bool
+    let restartTranscriptExists: Bool
+    let restartMicAudioExists: Bool
+    let restartSystemAudioExists: Bool
     let failedQueueEntryExists: Bool
 }
 

--- a/docs/audio-reliability-daily-check.md
+++ b/docs/audio-reliability-daily-check.md
@@ -123,9 +123,10 @@ matrix for the state-machine contract:
 
 It also creates deterministic meeting-route fixture folders under the report
 directory. These simulate shared mic, system audio present/missing, quiet mic
-recovery, output ducking, route churn, stop timeout, and retained failed-queue
-states. The saved-artifact path is covered by fast/Core tests; the generated
-fixtures are synthetic proof, not real Zoom or browser proof.
+recovery, output ducking, route churn, stop timeout, stop/restart after a route
+switch, and retained failed-queue states. The saved-artifact path is covered by
+fast/Core tests; the generated fixtures are synthetic proof, not real Zoom or
+browser proof.
 
 It also writes an audio route automation proxy matrix for dictation pasteback,
 meeting mic/system audio, mic/output mismatch diagnostics, WebRTC/Zoom

--- a/docs/qa-test-bench.md
+++ b/docs/qa-test-bench.md
@@ -84,8 +84,8 @@ the bench names what is automated for dictation, meeting mic/system audio,
 WebRTC/Zoom contention, Bluetooth/AirPods settling, and privacy/security. It
 also generates deterministic meeting-route fixtures for shared mic, missing
 system audio, quiet mic recovery/failure, output ducking, route churn, stop
-timeout, and stop/save artifact outcomes. This does not replace live or manual
-route proof.
+timeout, stop/restart after a route switch, and stop/save artifact outcomes.
+This does not replace live or manual route proof.
 Mocked Bluetooth/AirPods route contracts are automated policy proof, not hardware proof.
 Real connected AirPods/Bluetooth hardware remains manual proof.
 

--- a/docs/test-automation-strategy.md
+++ b/docs/test-automation-strategy.md
@@ -43,8 +43,9 @@ As of 2026-06-06, the repo has these automated layers:
   count. Deeper sheets, media controls, and sanitized screenshots still need
   coverage.
 - Audio: synthetic fixtures now cover shared mic, missing system audio, quiet
-  mic, output ducking, route churn, stop timeout, and stop/save outcomes. Real
-  Zoom/WebRTC/Bluetooth perceived-volume proof is still manual.
+  mic, output ducking, route churn, stop timeout, stop/restart after route
+  switch, and stop/save outcomes. Real Zoom/WebRTC/Bluetooth perceived-volume
+  proof is still manual.
 - Storage: current/default paths are covered, but relocated libraries,
   retention/compression invariants, and legacy fallback paths need broader
   automated fixtures.

--- a/scripts/ops/daily-audio-reliability-check.sh
+++ b/scripts/ops/daily-audio-reliability-check.sh
@@ -348,6 +348,15 @@ scenarios = [
         "failure_kind": "stop_timeout",
     },
     {
+        "id": "webrtc-route-switch-stop-restart-recovered",
+        "condition": "WebRTC-like route switch, clean stop, then successful restart",
+        "outcome": "transcript_saved_after_restart",
+        "mic": True,
+        "system": True,
+        "restart": True,
+        "failure_kind": "none",
+    },
+    {
         "id": "webrtc-quiet-mic-unrecovered",
         "condition": "shared mic, quiet raw mic not recovered enough for transcription",
         "outcome": "retained_failed_queue_entry",
@@ -375,18 +384,22 @@ for scenario in scenarios:
     system_file = scenario_dir / "system.synthetic.wav"
     transcript_file = scenario_dir / "transcript.md"
     failure_file = scenario_dir / "failed-meeting.json"
+    restart_mic_file = scenario_dir / "restart-mic.synthetic.wav"
+    restart_system_file = scenario_dir / "restart-system.synthetic.wav"
+    restart_transcript_file = scenario_dir / "restart-transcript.md"
 
     if scenario["mic"]:
         write_wav(mic_file, 2400)
     if scenario["system"]:
         write_wav(system_file, 3200)
 
-    if scenario["outcome"] == "transcript_saved":
+    if scenario["outcome"].startswith("transcript_saved"):
         transcript_file.write_text(
             "---\n"
             "capture_type: meeting\n"
             "fixture_kind: deterministic_meeting_route\n"
             f"route_fixture_id: {scenario['id']}\n"
+            "route_fixture_phase: initial\n"
             "sources: [mic, system_audio]\n"
             "---\n\n"
             "# Synthetic Meeting Route Fixture\n\n"
@@ -394,6 +407,24 @@ for scenario in scenarios:
             "Speaker 1: Synthetic system audio fixture tone.\n",
             encoding="utf-8",
         )
+        if scenario.get("restart"):
+            write_wav(restart_mic_file, 2600)
+            write_wav(restart_system_file, 3400)
+            restart_transcript_file.write_text(
+                "---\n"
+                "capture_type: meeting\n"
+                "fixture_kind: deterministic_meeting_route\n"
+                f"route_fixture_id: {scenario['id']}\n"
+                "route_fixture_phase: restart\n"
+                "restart_attempted: true\n"
+                "restart_succeeded: true\n"
+                "sources: [mic, system_audio]\n"
+                "---\n\n"
+                "# Synthetic Meeting Route Restart Fixture\n\n"
+                "You: Transcripted route fixture restart one two three.\n"
+                "Speaker 1: Synthetic restarted system audio fixture tone.\n",
+                encoding="utf-8",
+            )
     else:
         failure_file.write_text(
             json.dumps(
@@ -420,13 +451,14 @@ for scenario in scenarios:
                 scenario["outcome"],
                 "yes" if scenario["mic"] else "no",
                 "yes" if scenario["system"] else "no",
+                "yes" if scenario.get("restart") else "no",
                 scenario["failure_kind"],
             ]
         )
     )
 
 (root / "manifest.tsv").write_text(
-    "scenario\tcondition\toutcome\tmic_audio\tsystem_audio\tfailure_kind\n"
+    "scenario\tcondition\toutcome\tmic_audio\tsystem_audio\trestart_artifacts\tfailure_kind\n"
     + "\n".join(manifest_rows)
     + "\n",
     encoding="utf-8",
@@ -441,9 +473,9 @@ PY
     echo "These are file and classifier fixtures only: they do not launch Zoom,"
     echo "open a browser, touch TCC, or measure user-perceived meeting volume."
     echo
-    echo "| Scenario | Outcome | Mic audio | System audio | Classification |"
-    echo "| --- | --- | --- | --- | --- |"
-    awk -F '\t' 'NR > 1 { printf "| `%s` | %s | %s | %s | `%s` |\n", $1, $3, $4, $5, $6 }' "${fixture_dir}/manifest.tsv"
+    echo "| Scenario | Outcome | Mic audio | System audio | Restart artifacts | Classification |"
+    echo "| --- | --- | --- | --- | --- | --- |"
+    awk -F '\t' 'NR > 1 { printf "| `%s` | %s | %s | %s | %s | `%s` |\n", $1, $3, $4, $5, $6, $7 }' "${fixture_dir}/manifest.tsv"
   } >> "${REPORT}"
 }
 
@@ -553,6 +585,13 @@ run_meeting_route_fixture_suite() {
     "mic synthetic WAV + system synthetic WAV + retained failed queue entry" \
     "recoverable_failure / failure_kind=stop_timeout / output_ducking_detected=true" \
     "real output volume before/during/after and user-perceived meeting volume"
+
+  record_meeting_route_fixture \
+    "synthetic-webrtc-route-switch-stop-restart-recovered" \
+    "WebRTC-like route switch, clean stop, then successful restart" \
+    "initial transcript + restart transcript + mic/system synthetic WAVs" \
+    "success / restart_attempted=true / restart_succeeded=true / route_change_count=2" \
+    "real app stop/restart after route churn still needs live route proof"
 
   record_meeting_route_fixture \
     "synthetic-webrtc-quiet-mic-unrecovered" \


### PR DESCRIPTION
## Summary

- Add a deterministic meeting-route stop/restart fixture for a WebRTC-like route switch followed by a clean stop and successful restart.
- Extend the synthetic daily-audio report manifest with restart artifacts.
- Update the QA docs/contracts so this remains synthetic proof, not real Zoom/WebRTC/Bluetooth proof.

## Verification

- `bash -n run-daily-audio-reliability.sh`
- `bash -n scripts/ops/daily-audio-reliability-check.sh`
- `scripts/dev/agent-preflight.sh`
- `bash run-daily-audio-reliability.sh --synthetic`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `bash -n scripts/ops/transcripted-qa-bench.sh`
- `python3 -m py_compile scripts/ops/validate-meeting-corpus.py`
- `python3 -m py_compile scripts/ops/compare-meeting-corpus.py`
- `swift test --package-path Tools/TranscriptedQA`
- `bash scripts/ops/transcripted-qa-bench.sh --mode quick`
- `bash run-integration-smoke.sh`

## Notes

- Synthetic report: `/tmp/transcripted-repro-lab/audio-daily-20260608-054151/daily-audio-reliability-report.md`
- Quick QA bench: `/tmp/transcripted-qa-bench/qa-20260608-055632/qa-report.md`
- Manual leftovers: real Zoom/Meet/browser WebRTC, AirPods/Bluetooth, TCC, and user-perceived volume proof still use `docs/qa-issue-500-meeting-audio.md`.
