### PR TITLE
Add permission-state runtime gates

### DIFF
--- a/.agents/qa-gates.yml
+++ b/.agents/qa-gates.yml
@@ -70,7 +70,9 @@ test_layers:
     proves:
       - "Codex/computer-use host permissions are ready before screenshots, clicks, or Apple Events are counted"
       - "Transcripted app bundle identity matches the expected TCC bundle id"
+      - "Duplicate or wrong running Transcripted app instances are caught before UI targeting is trusted"
     agent_notes:
+      - "The command prints the expected manual grant state for computer-use and live-capture modes."
       - "Permission blockers are INCOMPLETE, not green."
       - "Use --mode live-capture before local mic/system-audio capture proof."
 

--- a/Tests/PermissionStateHarnessContractTests.swift
+++ b/Tests/PermissionStateHarnessContractTests.swift
@@ -17,7 +17,8 @@ func testPermissionStateHarnessContract() {
                 && command.contains("CGPreflightListenEventAccess")
                 && command.contains("AXIsProcessTrusted")
                 && command.contains("AVCaptureDevice.authorizationStatus")
-                && command.contains("AEDeterminePermissionToAutomateTarget"),
+                && command.contains("AEDeterminePermissionToAutomateTarget")
+                && command.contains("PermissionRunningApplication"),
             "permission-state should keep the no-prompt Codex permission probe matrix intact"
         )
     }
@@ -40,6 +41,10 @@ func testPermissionStateHarnessContract() {
             qaBench.contains("INCOMPLETE: harness permission blocked")
                 && qaBench.contains("prove a visible state change after each click"),
             "manual scenarios should stop false-green UI automation when macOS blocks events"
+        )
+        assertTrue(
+            qaBench.contains("No duplicate or wrong running Transcripted app instance"),
+            "manual scenarios should make duplicate running apps incomplete instead of ambiguous UI proof"
         )
     }
 

--- a/Tools/TranscriptedQA/CLAUDE.md
+++ b/Tools/TranscriptedQA/CLAUDE.md
@@ -127,6 +127,7 @@ For agent and automation use, the JSON form also includes:
 - **Round-trip testing**: `round-trip` validates that validators correctly catch injected corruption
 - **Stress testing**: `stress-test` generates large datasets to surface performance and correctness issues
 - **UI smoke**: `ui-smoke` checks stable AX identifiers and exits `3` for Accessibility/TCC blockers
+- **Permission state**: `permission-state` prints the expected manual grant state, checks Codex host Accessibility/Event Posting/Input Monitoring/Screen Recording/Automation, verifies the Transcripted app bundle id, and warns on duplicate or wrong running Transcripted app instances
 
 ## Gotchas
 

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PermissionState.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PermissionState.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import AppKit
 import ArgumentParser
 import Carbon
 import CoreGraphics
@@ -68,6 +69,9 @@ struct PermissionStateProbe {
     var microphoneStatusProvider: () -> AVAuthorizationStatus = { AVCaptureDevice.authorizationStatus(for: .audio) }
     var automationStatusProvider: (String) -> AutomationStatus = { determineAutomationStatus(targetBundleID: $0) }
     var defaultsProvider: DefaultsProvider = { UserDefaults(suiteName: $0) }
+    var runningApplicationsProvider: (String) -> [PermissionRunningApplication] = {
+        PermissionRunningApplication.runningApplications(bundleIdentifier: $0)
+    }
 
     func validate() -> [ValidationResult] {
         var results: [ValidationResult] = []
@@ -77,7 +81,9 @@ struct PermissionStateProbe {
             target: processNameProvider(),
             detail: "These checks apply to the process running this command. If Codex computer-use runs from a different app, grant that app too."
         ))
+        results.append(expectedManualGrantStateResult())
         results.append(appBundleIdentityResult())
+        results.append(runningAppInstancesResult())
 
         results.append(permissionResult(
             check: "permissions/codex/accessibility",
@@ -119,6 +125,32 @@ struct PermissionStateProbe {
         return results
     }
 
+    private func expectedManualGrantStateResult() -> ValidationResult {
+        let shared = [
+            "Accessibility",
+            "Event Posting",
+            "Input Monitoring",
+            "Screen Recording",
+            "Automation/System Events for \(automationTargetBundleID)",
+            "Transcripted app bundle id \(transcriptedBundleID)",
+            "no duplicate or wrong Transcripted app instance"
+        ].joined(separator: ", ")
+
+        let modeSpecific: String
+        switch mode {
+        case .computerUse:
+            modeSpecific = "Microphone and Transcripted System Audio Recording are not required for click-only computer-use QA."
+        case .liveCapture:
+            modeSpecific = "Live-capture QA also requires Microphone for the runner and Transcripted System Audio Recording to be known/granted."
+        }
+
+        return .permissionPass(
+            "permissions/expected-manual-grants",
+            target: mode.rawValue,
+            detail: "Expected manual grant state before counting this lane: \(shared). \(modeSpecific)"
+        )
+    }
+
     private func permissionResult(
         check: String,
         target: String,
@@ -152,6 +184,51 @@ struct PermissionStateProbe {
             "permissions/app-bundle",
             target: appBundlePath,
             detail: "Built app bundle id is \(bundleIdentifier), expected \(transcriptedBundleID). TCC grants may apply to a different app identity."
+        )
+    }
+
+    private func runningAppInstancesResult() -> ValidationResult {
+        let runningApps = runningApplicationsProvider(transcriptedBundleID)
+        let expectedPath = normalizedPath(appBundlePath)
+        let check = "permissions/app/running-instances"
+
+        guard !runningApps.isEmpty else {
+            return .permissionPass(
+                check,
+                target: transcriptedBundleID,
+                detail: "No running Transcripted app with this bundle id. OK before launch; launch the intended app before UI proof."
+            )
+        }
+
+        if runningApps.count > 1 {
+            return .warn(
+                check,
+                target: transcriptedBundleID,
+                detail: "Duplicate Transcripted apps are running: \(summarize(runningApps)). Quit duplicates before UI QA so Codex does not target the wrong status item."
+            )
+        }
+
+        let app = runningApps[0]
+        guard let runningPath = app.bundlePath, !runningPath.isEmpty else {
+            return .warn(
+                check,
+                target: transcriptedBundleID,
+                detail: "A Transcripted app is running but macOS did not expose its bundle path: \(app.summary). Confirm it is the intended app before UI QA."
+            )
+        }
+
+        if normalizedPath(runningPath) == expectedPath {
+            return .permissionPass(
+                check,
+                target: transcriptedBundleID,
+                detail: "One running Transcripted app matches \(expectedPath)."
+            )
+        }
+
+        return .warn(
+            check,
+            target: transcriptedBundleID,
+            detail: "A Transcripted app is already running from \(runningPath), but this run expects \(expectedPath). Quit it or pass --app-bundle for the app under test before UI QA."
         )
     }
 
@@ -308,6 +385,50 @@ struct PermissionStateProbe {
             return nil
         }
         return plist["CFBundleIdentifier"] as? String
+    }
+
+    private func normalizedPath(_ path: String) -> String {
+        URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL.path
+    }
+
+    private func summarize(_ apps: [PermissionRunningApplication]) -> String {
+        let listed = apps.prefix(4).map(\.summary).joined(separator: "; ")
+        if apps.count > 4 {
+            return "\(listed); ... \(apps.count - 4) more"
+        }
+        return listed
+    }
+}
+
+struct PermissionRunningApplication: Equatable {
+    let processIdentifier: pid_t
+    let localizedName: String?
+    let bundleIdentifier: String?
+    let bundlePath: String?
+
+    var summary: String {
+        var parts = ["pid=\(processIdentifier)"]
+        if let localizedName, !localizedName.isEmpty {
+            parts.append("name=\(localizedName)")
+        }
+        if let bundlePath, !bundlePath.isEmpty {
+            parts.append("path=\(bundlePath)")
+        }
+        return parts.joined(separator: " ")
+    }
+
+    static func runningApplications(bundleIdentifier: String) -> [PermissionRunningApplication] {
+        NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
+            .filter { $0.processIdentifier != ProcessInfo.processInfo.processIdentifier }
+            .map {
+                PermissionRunningApplication(
+                    processIdentifier: $0.processIdentifier,
+                    localizedName: $0.localizedName,
+                    bundleIdentifier: $0.bundleIdentifier,
+                    bundlePath: $0.bundleURL?.standardizedFileURL.path
+                )
+            }
+            .sorted { $0.processIdentifier < $1.processIdentifier }
     }
 }
 

--- a/Tools/TranscriptedQA/Tests/TranscriptedQATests/PermissionStateProbeTests.swift
+++ b/Tools/TranscriptedQA/Tests/TranscriptedQATests/PermissionStateProbeTests.swift
@@ -103,7 +103,8 @@ final class PermissionStateProbeTests: XCTestCase {
             screenCaptureTrustedProvider: { screenCaptureTrusted },
             microphoneStatusProvider: { microphoneStatus },
             automationStatusProvider: { _ in automationStatus },
-            defaultsProvider: { _ in defaults }
+            defaultsProvider: { _ in defaults },
+            runningApplicationsProvider: { _ in [] }
         )
     }
 

--- a/Tools/TranscriptedQA/Tests/TranscriptedQATests/PermissionStateRuntimeGateTests.swift
+++ b/Tools/TranscriptedQA/Tests/TranscriptedQATests/PermissionStateRuntimeGateTests.swift
@@ -1,0 +1,150 @@
+import AVFoundation
+import XCTest
+@testable import transcripted_qa
+
+final class PermissionStateRuntimeGateTests: XCTestCase {
+    func testExpectedManualGrantStateNamesComputerUseAndLiveCaptureRequirements() {
+        let computerUse = makeProbe(mode: .computerUse).validate()
+        let computerUseDetail = detail(from: computerUse, check: "permissions/expected-manual-grants")
+
+        XCTAssertTrue(computerUseDetail.contains("Accessibility"))
+        XCTAssertTrue(computerUseDetail.contains("Screen Recording"))
+        XCTAssertTrue(computerUseDetail.contains("Automation/System Events"))
+        XCTAssertTrue(computerUseDetail.contains("no duplicate or wrong Transcripted app instance"))
+        XCTAssertTrue(computerUseDetail.contains("not required for click-only computer-use QA"))
+
+        let liveCapture = makeProbe(mode: .liveCapture).validate()
+        let liveCaptureDetail = detail(from: liveCapture, check: "permissions/expected-manual-grants")
+
+        XCTAssertTrue(liveCaptureDetail.contains("Microphone"))
+        XCTAssertTrue(liveCaptureDetail.contains("System Audio Recording"))
+        XCTAssertTrue(liveCaptureDetail.contains("known/granted"))
+    }
+
+    func testNoRunningTranscriptedAppIsPassBeforeLaunch() {
+        let results = makeProbe(mode: .computerUse, runningApplications: []).validate()
+
+        XCTAssertEqual(results.first { $0.check == "permissions/app/running-instances" }?.status, .pass)
+    }
+
+    func testDuplicateRunningTranscriptedAppsAreIncompleteWarnings() {
+        let results = makeProbe(
+            mode: .computerUse,
+            runningApplications: [
+                PermissionRunningApplication(
+                    processIdentifier: 1201,
+                    localizedName: "Transcripted",
+                    bundleIdentifier: "com.justinbetker.draft",
+                    bundlePath: "/Applications/Transcripted.app"
+                ),
+                PermissionRunningApplication(
+                    processIdentifier: 1202,
+                    localizedName: "Transcripted",
+                    bundleIdentifier: "com.justinbetker.draft",
+                    bundlePath: "/tmp/Transcripted.app"
+                )
+            ]
+        ).validate()
+        let result = results.first { $0.check == "permissions/app/running-instances" }
+
+        XCTAssertEqual(result?.status, .warn)
+        XCTAssertTrue(result?.detail?.contains("Duplicate Transcripted apps") == true)
+        XCTAssertTrue(result?.detail?.contains("Quit duplicates") == true)
+    }
+
+    func testWrongRunningTranscriptedAppIsIncompleteWarning() {
+        let results = makeProbe(
+            mode: .computerUse,
+            appBundlePath: "/tmp/Expected/Transcripted.app",
+            runningApplications: [
+                PermissionRunningApplication(
+                    processIdentifier: 1301,
+                    localizedName: "Transcripted",
+                    bundleIdentifier: "com.justinbetker.draft",
+                    bundlePath: "/Applications/Transcripted.app"
+                )
+            ]
+        ).validate()
+        let result = results.first { $0.check == "permissions/app/running-instances" }
+
+        XCTAssertEqual(result?.status, .warn)
+        XCTAssertTrue(result?.detail?.contains("already running from") == true)
+        XCTAssertTrue(result?.detail?.contains("pass --app-bundle") == true)
+    }
+
+    func testExpectedRunningTranscriptedAppIsPass() {
+        let expected = "/tmp/Expected/Transcripted.app"
+        let results = makeProbe(
+            mode: .computerUse,
+            appBundlePath: expected,
+            runningApplications: [
+                PermissionRunningApplication(
+                    processIdentifier: 1401,
+                    localizedName: "Transcripted",
+                    bundleIdentifier: "com.justinbetker.draft",
+                    bundlePath: expected
+                )
+            ]
+        ).validate()
+
+        XCTAssertEqual(results.first { $0.check == "permissions/app/running-instances" }?.status, .pass)
+    }
+
+    private func makeProbe(
+        mode: PermissionStateMode,
+        appBundlePath: String = "build/Transcripted.app",
+        runningApplications: [PermissionRunningApplication] = []
+    ) -> PermissionStateProbe {
+        PermissionStateProbe(
+            mode: mode,
+            automationTargetBundleID: "com.apple.systemevents",
+            transcriptedBundleID: "com.justinbetker.draft",
+            appBundlePath: appBundlePath,
+            transcriptedDefaultsDomain: "com.justinbetker.draft",
+            processNameProvider: { "transcripted-qa-tests" },
+            appBundleIdentifierProvider: { _ in "com.justinbetker.draft" },
+            accessibilityTrustedProvider: { true },
+            eventPostingTrustedProvider: { true },
+            eventListeningTrustedProvider: { true },
+            screenCaptureTrustedProvider: { true },
+            microphoneStatusProvider: { .authorized },
+            automationStatusProvider: { _ in .allowed },
+            defaultsProvider: { _ in StubPermissionDefaults(known: true, granted: true) },
+            runningApplicationsProvider: { _ in runningApplications }
+        )
+    }
+
+    private func detail(from results: [ValidationResult], check: String) -> String {
+        results.first { $0.check == check }?.detail ?? ""
+    }
+}
+
+private final class StubPermissionDefaults: PermissionDefaultsReading {
+    private let known: Bool
+    private let granted: Bool
+
+    init(known: Bool, granted: Bool) {
+        self.known = known
+        self.granted = granted
+    }
+
+    func bool(forKey defaultName: String) -> Bool {
+        if defaultName == "systemAudioRecordingPermissionKnown" {
+            return known
+        }
+        if defaultName == "systemAudioRecordingPermissionGranted" {
+            return granted
+        }
+        return false
+    }
+
+    func object(forKey defaultName: String) -> Any? {
+        if defaultName == "systemAudioRecordingPermissionKnown" {
+            return known
+        }
+        if defaultName == "systemAudioRecordingPermissionGranted" {
+            return granted
+        }
+        return nil
+    }
+}

--- a/docs/qa-test-bench.md
+++ b/docs/qa-test-bench.md
@@ -143,9 +143,12 @@ TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA
 ```
 
 It requires local microphone permission, System Audio Recording proof, and the
-Codex/computer-use host permissions needed for screenshots and clicks. If macOS
-blocks the harness, report `INCOMPLETE: harness permission blocked` with the
-exact permission reason. Do not treat a TCC blocker as product proof.
+Codex/computer-use host permissions needed for screenshots and clicks. It also
+checks that the intended Transcripted app bundle identity is being tested and
+that duplicate or wrong running Transcripted apps are not making UI targeting
+ambiguous. If macOS blocks the harness, report
+`INCOMPLETE: harness permission blocked` with the exact permission reason. Do
+not treat a TCC blocker as product proof.
 
 ## Audio Synthetic Run
 

--- a/docs/test-automation-strategy.md
+++ b/docs/test-automation-strategy.md
@@ -26,7 +26,9 @@ As of 2026-06-06, the repo has these automated layers:
 - `swift run --package-path Tools/TranscriptedQA transcripted-qa permission-state`:
   no-prompt Codex/computer-use permission preflight for Accessibility, event
   posting, input monitoring, screen capture, Automation, microphone state, and
-  Transcripted app identity.
+  Transcripted app identity. It also prints the expected manual grant state and
+  warns when duplicate or wrong running Transcripted app instances make UI
+  targeting ambiguous.
 - `bash scripts/ops/transcripted-qa-bench.sh --mode ...`: orchestrated QA
   reports for `quick`, `deep`, `full`, `ui`, `artifact`, `audio-synthetic`,
   `corpus`, `corpus-compare`, and `live`.

--- a/scripts/ops/transcripted-qa-bench.sh
+++ b/scripts/ops/transcripted-qa-bench.sh
@@ -302,6 +302,7 @@ TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA
 Pass bar:
 - Accessibility, Event Posting, Input Monitoring, Screen Recording, and Automation are ready for the app that runs Codex or the terminal host.
 - Transcripted app bundle identity matches the expected bundle id.
+- No duplicate or wrong running Transcripted app instance makes UI targeting ambiguous.
 - Every automated click proves a visible state change after the event.
 
 If this command warns, report `INCOMPLETE: harness permission blocked`.


### PR DESCRIPTION
## Summary
- add an expected manual grant-state row to the TranscriptedQA permission-state probe
- warn when duplicate or wrong running Transcripted app instances make UI targeting ambiguous
- pin the new behavior in package and fast contract tests, plus QA bench/docs/gate wording

## Related
- Adjacent to #1019. That draft PR adds extra guardrail tests; this PR adds the runtime running-app/expected-grant reporting path.

## Checks run
- bash scripts/dev/agent-preflight.sh
- bash -n scripts/ops/transcripted-qa-bench.sh
- python3 -m py_compile scripts/ops/validate-meeting-corpus.py
- python3 -m py_compile scripts/ops/compare-meeting-corpus.py
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh
- swift test --package-path Tools/TranscriptedQA
- bash scripts/ops/transcripted-qa-bench.sh --mode quick
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa permission-state --mode computer-use (exit 3 as expected on this Mac: wrong running Transcripted app instance plus System Events Automation OSStatus -600)