### PR TITLE
Add golden artifact fixtures

### DIFF
--- a/Tests/E2E/TranscriptedE2ESmoke.swift
+++ b/Tests/E2E/TranscriptedE2ESmoke.swift
@@ -61,9 +61,11 @@ private final class TranscriptedE2ESmokeHarness {
         try await verifyAppFacingDiscovery(fixtures: fixtures)
         try verifyHomePreview(fixtures: fixtures)
         try verifyLocalSummaryArtifact(fixtures: fixtures)
+        try verifyImportedAudioArtifact(fixtures: fixtures)
         try verifyMCPFacingDiscovery(fixtures: fixtures, captureLibrary: captureLibrary)
         try verifyFailedMeetingArtifact(fixtures: fixtures)
         try verifySupportDiagnosticsPrivacy(fixtures: fixtures, logsDir: logsDir)
+        try verifyDeleteRemovesCanonicalArtifacts(fixtures: fixtures, captureLibrary: captureLibrary)
     }
 
     private func writeCaptureFixtures(
@@ -146,6 +148,48 @@ private final class TranscriptedE2ESmokeHarness {
         """
         try summaryMarkdown.write(to: summaryURL, atomically: true, encoding: .utf8)
 
+        let importedMeetingURL = meetingsDir.appendingPathComponent("Imported Partner Brief.md", isDirectory: false)
+        let importedMeetingMarkdown = """
+        ---
+        capture_id: "22222222-2222-2222-2222-222222222222"
+        transcript_id: "22222222-2222-2222-2222-222222222222"
+        title: "Imported Partner Brief"
+        capture_type: meeting
+        date: 2026-05-17
+        time: 16:15:00
+        duration: "00:01:20"
+        processing_time: "0.3s"
+        transcription_engine: parakeet_local
+        diarization_engine: pyannote_offline
+        sources: [system_audio]
+        mic_utterances: 0
+        system_utterances: 2
+        mic_speakers: 0
+        system_speakers: 1
+        total_word_count: 20
+        speakers:
+          - id: "0"
+            channel: system
+            db_id: "22222222-2222-2222-2222-222222222223"
+            name: "Maya Chen"
+            confidence: high
+            source: db_scan
+        ---
+
+        # Imported Partner Brief
+
+        Recorded May 17, 2026 at 4:15 PM  -  1 min, 20 sec  -  20 words  -  2 turns
+
+        ## Transcript
+
+        **00:00**  [System/Maya Chen]
+        The imported recording should keep one canonical meeting note.
+
+        **00:36**  [System/Maya Chen]
+        The retained source audio should stay attached as recording audio.
+        """
+        try importedMeetingMarkdown.write(to: importedMeetingURL, atomically: true, encoding: .utf8)
+
         let dictationURL = dictationsDir.appendingPathComponent("Dictations_2026-05-18.md", isDirectory: false)
         let dictationMarkdown = """
         ---
@@ -189,6 +233,11 @@ private final class TranscriptedE2ESmokeHarness {
         try writeTinyAudioFixture(to: micAudioURL, amplitude: 0.20)
         try writeTinyAudioFixture(to: systemAudioURL, amplitude: 0.35)
 
+        let importedAudioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: importedMeetingURL)
+        try fileManager.createDirectory(at: importedAudioDirectory, withIntermediateDirectories: true)
+        let importedAudioURL = importedAudioDirectory.appendingPathComponent("recording.m4a", isDirectory: false)
+        try writeTinyAudioFixture(to: importedAudioURL, amplitude: 0.28)
+
         let failedQueueURL = stateDir.appendingPathComponent("failed_transcriptions.json", isDirectory: false)
         try await writeFailedQueueWithProductionManager(
             failedQueueURL: failedQueueURL,
@@ -215,12 +264,18 @@ private final class TranscriptedE2ESmokeHarness {
         try eventData.write(to: eventLogURL)
 
         let fixtureDate = try fixedDate("2026-05-18T14:05:00Z")
-        try [meetingURL, dictationURL].forEach { url in
-            try fileManager.setAttributes(
-                [.creationDate: fixtureDate, .modificationDate: fixtureDate],
-                ofItemAtPath: url.path
-            )
-        }
+        try fileManager.setAttributes(
+            [.creationDate: fixtureDate, .modificationDate: fixtureDate],
+            ofItemAtPath: meetingURL.path
+        )
+        try fileManager.setAttributes(
+            [.creationDate: fixtureDate.addingTimeInterval(-120), .modificationDate: fixtureDate.addingTimeInterval(-120)],
+            ofItemAtPath: importedMeetingURL.path
+        )
+        try fileManager.setAttributes(
+            [.creationDate: fixtureDate, .modificationDate: fixtureDate],
+            ofItemAtPath: dictationURL.path
+        )
         try fileManager.setAttributes(
             [.creationDate: fixtureDate.addingTimeInterval(180), .modificationDate: fixtureDate.addingTimeInterval(180)],
             ofItemAtPath: summaryURL.path
@@ -231,13 +286,16 @@ private final class TranscriptedE2ESmokeHarness {
             dictationsDir: dictationsDir,
             meetingURL: meetingURL,
             summaryURL: summaryURL,
+            importedMeetingURL: importedMeetingURL,
             dictationURL: dictationURL,
             micAudioURL: micAudioURL,
             systemAudioURL: systemAudioURL,
+            importedAudioURL: importedAudioURL,
             failedQueueURL: failedQueueURL,
             eventLogURL: eventLogURL,
             meetingMarkdown: meetingMarkdown,
             summaryMarkdown: summaryMarkdown,
+            importedMeetingMarkdown: importedMeetingMarkdown,
             dictationMarkdown: dictationMarkdown
         )
     }
@@ -249,18 +307,29 @@ private final class TranscriptedE2ESmokeHarness {
             includeDictationCounts: true
         )
 
-        try expect(snapshot.meetings.count == 1, "RecentCaptureLoader should discover the saved meeting")
+        try expect(snapshot.meetings.count == 2, "RecentCaptureLoader should discover captured and imported meetings")
         try expect(snapshot.dictations.count == 2, "RecentCaptureLoader should discover both dictation entries")
         try expect(snapshot.dictationCounts.total == 2, "Dictation counts should include both entries")
         try expect(snapshot.dictationCounts.totalWords == 19, "Dictation counts should include saved word totals")
 
-        let meeting = try unwrap(snapshot.meetings.first, "Recent meeting should be present")
+        let meeting = try unwrap(
+            snapshot.meetings.first { $0.transcriptURL.standardizedFileURL == fixtures.meetingURL.standardizedFileURL },
+            "Captured meeting should be present"
+        )
         try expect(meeting.title == "Customer Launch Sync", "Recent meeting title should come from frontmatter")
         try expect(meeting.displayTitle == "Launch Action Review", "Recent meeting display title should come from its attached summary")
         try expect(meeting.transcriptURL.standardizedFileURL == fixtures.meetingURL.standardizedFileURL, "Recent meeting should point at the saved markdown")
         try expect(meeting.summaryPreview?.url.standardizedFileURL == fixtures.summaryURL.standardizedFileURL, "Recent meeting summary preview should point at the matching summary artifact")
         try expect(meeting.speakerStatus == .ready, "Named meeting speakers should be ready")
         try expect(meeting.audio?.urls.count == 2, "Recent meeting should attach retained mic and system audio")
+
+        let importedMeeting = try unwrap(
+            snapshot.meetings.first { $0.transcriptURL.standardizedFileURL == fixtures.importedMeetingURL.standardizedFileURL },
+            "Imported meeting should be present"
+        )
+        try expect(importedMeeting.title == "Imported Partner Brief", "Imported meeting title should come from frontmatter")
+        try expect(importedMeeting.displayTitle == "Imported Partner Brief", "Imported meeting should keep its canonical title without a generated summary")
+        try expect(importedMeeting.audio?.urls.map(\.lastPathComponent) == ["recording.m4a"], "Imported meeting should attach retained single-file recording audio")
 
         let latestDictation = try unwrap(snapshot.dictations.first, "Recent dictation should be present")
         try expect(latestDictation.title == "Recent context proof", "Recent dictation title should be parsed")
@@ -293,10 +362,33 @@ private final class TranscriptedE2ESmokeHarness {
         try expect(frontmatter.values["source_transcript"] == fixtures.meetingURL.lastPathComponent, "Local summary artifact should point at the canonical source transcript")
 
         let meetings = RecentMeetingsScanner.loadRecent(limit: 5, directory: fixtures.meetingsDir)
-        try expect(meetings.count == 1, "Local summary artifacts should not create duplicate Home meeting rows")
-        let meeting = try unwrap(meetings.first, "Recent meeting should remain visible with a summary")
+        let capturedRows = meetings.filter { $0.transcriptURL.standardizedFileURL == fixtures.meetingURL.standardizedFileURL }
+        try expect(capturedRows.count == 1, "Local summary artifacts should not create duplicate Home meeting rows")
+        let meeting = try unwrap(capturedRows.first, "Recent meeting should remain visible with a summary")
         try expect(meeting.transcriptURL.standardizedFileURL == fixtures.meetingURL.standardizedFileURL, "Home row should still point at the canonical saved meeting markdown")
         try expect(meeting.summaryPreview?.summary.contains("release verification") == true, "Home row should expose the matching local summary preview")
+    }
+
+    private func verifyImportedAudioArtifact(fixtures: SmokeFixtures) throws {
+        let frontmatter = try unwrap(
+            TranscriptFrontmatter.document(in: fixtures.importedMeetingMarkdown),
+            "Imported meeting should have frontmatter"
+        )
+        try expect(frontmatter.values["capture_type"] == "meeting", "Imported audio should still save as a meeting artifact")
+        try expect(frontmatter.values["sources"] == "[system_audio]", "Imported audio should record the single source channel")
+        try expect(frontmatter.values["mic_utterances"] == "0", "Imported audio should not invent mic turns")
+
+        let meetings = RecentMeetingsScanner.loadRecent(limit: 5, directory: fixtures.meetingsDir)
+        let imported = try unwrap(
+            meetings.first { $0.transcriptURL.standardizedFileURL == fixtures.importedMeetingURL.standardizedFileURL },
+            "Imported meeting should scan as one canonical Home row"
+        )
+        try expect(imported.audio?.urls.map(\.lastPathComponent) == ["recording.m4a"], "Imported recording audio should be attached to its canonical row")
+        try expect(imported.audio?.retranscriptionInput?.micURL == nil, "Single-file imported audio should not invent a mic retranscription input")
+        try expect(
+            imported.audio?.retranscriptionInput?.systemURL.standardizedFileURL == fixtures.importedAudioURL.standardizedFileURL,
+            "Single-file imported audio should remain the saved-audio retranscription input"
+        )
     }
 
     private func verifyMCPFacingDiscovery(fixtures: SmokeFixtures, captureLibrary: URL) throws {
@@ -338,9 +430,16 @@ private final class TranscriptedE2ESmokeHarness {
             )
         }
 
-        let meetings = try index.listMeetings(count: 5, dateFrom: "2026-05-18", dateTo: "2026-05-18")
-        try expect(meetings.count == 1, "MCP index should list the saved meeting")
-        try expect(meetings.first?.speakers.contains { $0.name == "Jordan Lee" } == true, "MCP index should list meeting speakers")
+        let meetings = try index.listMeetings(count: 5, dateFrom: "2026-05-17", dateTo: "2026-05-18")
+        try expect(meetings.count == 2, "MCP index should list captured and imported meetings")
+        try expect(meetings.contains { $0.speakers.contains { $0.name == "Jordan Lee" } }, "MCP index should list captured meeting speakers")
+        try expect(
+            meetings.contains {
+                $0.filename == fixtures.importedMeetingURL.deletingPathExtension().lastPathComponent
+                    && $0.speakers.contains { $0.name == "Maya Chen" }
+            },
+            "MCP index should list imported meeting artifacts"
+        )
 
         let dictations = try index.listDictationDays(count: 5, dateFrom: "2026-05-18", dateTo: "2026-05-18")
         try expect(dictations.count == 1, "MCP index should list the saved dictation day")
@@ -463,6 +562,54 @@ private final class TranscriptedE2ESmokeHarness {
         try expect(!eventLog.contains(secretTranscript), "Sanitized observability event should not contain transcript text")
     }
 
+    private func verifyDeleteRemovesCanonicalArtifacts(fixtures: SmokeFixtures, captureLibrary: URL) throws {
+        let meetingsBefore = RecentMeetingsScanner.loadRecent(limit: 5, directory: fixtures.meetingsDir)
+        try expect(meetingsBefore.count == 2, "Delete fixture should start with captured and imported rows")
+        let item = try unwrap(
+            meetingsBefore.first { $0.transcriptURL.standardizedFileURL == fixtures.meetingURL.standardizedFileURL },
+            "Delete fixture should find the captured meeting row"
+        )
+        let audioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: fixtures.meetingURL)
+        let importedAudioDirectory = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: fixtures.importedMeetingURL)
+
+        let result = try HomeMeetingDeletion.delete(item)
+
+        try expect(result.removedTranscriptURLs.map(\.lastPathComponent) == ["Customer Launch Sync.md"], "Delete should report the selected canonical transcript")
+        try expect(result.removedSummaryURLs.map(\.lastPathComponent) == ["Customer Launch Sync.summary.md"], "Delete should report the matching generated summary")
+        try expect(result.removedAudioDirectoryURLs.map(\.lastPathComponent) == ["Customer Launch Sync_audio"], "Delete should report the selected retained audio directory")
+        try expect(!fileManager.fileExists(atPath: fixtures.meetingURL.path), "Delete should remove the selected transcript")
+        try expect(!fileManager.fileExists(atPath: fixtures.summaryURL.path), "Delete should remove the matching summary artifact")
+        try expect(!fileManager.fileExists(atPath: audioDirectory.path), "Delete should remove the selected retained audio directory")
+        try expect(fileManager.fileExists(atPath: fixtures.importedMeetingURL.path), "Delete should leave the imported transcript alone")
+        try expect(fileManager.fileExists(atPath: importedAudioDirectory.path), "Delete should leave unrelated imported audio alone")
+
+        let meetingsAfter = RecentMeetingsScanner.loadRecent(limit: 5, directory: fixtures.meetingsDir)
+        try expect(meetingsAfter.count == 1, "Deleting one canonical meeting should leave one Home row")
+        try expect(
+            meetingsAfter.first?.transcriptURL.standardizedFileURL == fixtures.importedMeetingURL.standardizedFileURL,
+            "Remaining Home row should point at the imported meeting"
+        )
+
+        let directories = TranscriptedDataDirectories.resolve(environment: [
+            "TRANSCRIPTED_DATA_DIR": captureLibrary.path,
+            "TRANSCRIPTED_INDEX_DIR": runRoot.appendingPathComponent("mcp-delete-index", isDirectory: true).path,
+        ])
+        try fileManager.createDirectory(at: directories.indexDir, withIntermediateDirectories: true)
+        let index = try TranscriptIndex(indexDir: directories.indexDir)
+        try withLogsSuppressed {
+            try index.reconcile(
+                meetingDirs: directories.meetingDirs,
+                dictationDirs: directories.dictationDirs
+            )
+        }
+        let indexedMeetings = try index.listMeetings(count: 5, dateFrom: "2026-05-17", dateTo: "2026-05-18")
+        try expect(indexedMeetings.count == 1, "Fresh MCP index should not resurrect a deleted meeting row")
+        try expect(
+            indexedMeetings.first?.filename == fixtures.importedMeetingURL.deletingPathExtension().lastPathComponent,
+            "Fresh MCP index should keep the unaffected imported meeting"
+        )
+    }
+
     private func writeFailedQueueWithProductionManager(
         failedQueueURL: URL,
         meetingsDir: URL,
@@ -500,13 +647,16 @@ private struct SmokeFixtures {
     let dictationsDir: URL
     let meetingURL: URL
     let summaryURL: URL
+    let importedMeetingURL: URL
     let dictationURL: URL
     let micAudioURL: URL
     let systemAudioURL: URL
+    let importedAudioURL: URL
     let failedQueueURL: URL
     let eventLogURL: URL
     let meetingMarkdown: String
     let summaryMarkdown: String
+    let importedMeetingMarkdown: String
     let dictationMarkdown: String
 }
 

--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -1613,6 +1613,56 @@ func testRecentCaptureLoader() async {
         }
     }
 
+    await runSuite("RecentMeetingsScanner prefers inline summaries over stale sidecars") {
+        await withTemporaryRecentCaptureLibrary { captureRoot in
+            let meetingsRoot = captureRoot.appendingPathComponent("meetings", isDirectory: true)
+            let transcriptURL = meetingsRoot.appendingPathComponent("inline-wins.md", isDirectory: false)
+            let recordedAt = recentLoaderDate("2026-05-24T14:00:00Z")
+            let baseMarkdown = """
+            ---
+            title: "Quick notes"
+            capture_type: meeting
+            date: "\(recentLoaderFormat(recordedAt, "yyyy-MM-dd"))"
+            time: "\(recentLoaderFormat(recordedAt, "HH:mm:ss"))"
+            duration: "10:00"
+            ---
+
+            # Quick notes
+
+            ## Transcript
+
+            **00:01** [Mic/Justin]
+            We should keep launch pricing simple.
+            """
+            let inlineMarkdown = LocalMeetingSummaryMarkdownUpdater.markdown(
+                byApplying: sampleRecentCaptureLocalSummarySections(),
+                to: baseMarkdown,
+                configuration: .m1Optimized(physicalMemoryBytes: 16 * 1024 * 1024 * 1024),
+                generatedAt: recentLoaderDate("2026-05-24T14:20:00Z"),
+                chunkCount: 1
+            )
+
+            try? inlineMarkdown.write(to: transcriptURL, atomically: true, encoding: .utf8)
+            try? writeRecentLoaderSummary(
+                title: "Stale Sidecar Title",
+                summary: "This stale sidecar should not win.",
+                sourceTranscript: transcriptURL.lastPathComponent,
+                to: LocalMeetingSummaryStore.summaryURL(for: transcriptURL)
+            )
+            setRecentLoaderFileDate(recordedAt, at: transcriptURL)
+            setRecentLoaderFileDate(recordedAt.addingTimeInterval(120), at: LocalMeetingSummaryStore.summaryURL(for: transcriptURL))
+
+            let meetings = RecentMeetingsScanner.loadRecent(limit: 3)
+            let meeting = meetings.first
+
+            assertEqual(meetings.count, 1, "inline plus sidecar summaries should still produce one canonical row")
+            assertEqual(meeting?.transcriptURL.standardizedFileURL, transcriptURL.standardizedFileURL, "summary conflicts should keep the transcript URL canonical")
+            assertEqual(meeting?.displayTitle, "Launch Pricing Review", "inline summary title should win over stale sidecar title")
+            assertEqual(meeting?.summaryPreview?.url.standardizedFileURL, transcriptURL.standardizedFileURL, "inline summary preview should point at the canonical transcript")
+            assertEqual(meeting?.summaryPreview?.summary, "Team agreed to keep launch pricing simple.", "inline summary text should win over stale sidecar text")
+        }
+    }
+
     await runSuite("RecentMeetingsScanner returns empty for non-positive limits") {
         await withTemporaryRecentCaptureLibrary { captureRoot in
             let meetingsRoot = captureRoot.appendingPathComponent("meetings", isDirectory: true)

--- a/Tests/SpeakerReviewQueueScannerTests.swift
+++ b/Tests/SpeakerReviewQueueScannerTests.swift
@@ -120,10 +120,14 @@ func testSpeakerReviewQueueScanner() {
             clipURLsByProfileID: [:]
         )
         assertEqual(before.count, 1, "fixture should start with one pending speaker-review row")
+        let homeBefore = RecentMeetingsScanner.loadRecent(limit: 5, directory: directory)
+        assertEqual(homeBefore.count, 1, "pending speaker review should still surface one canonical Home row")
+        assertEqual(homeBefore.first?.speakerStatus, .needsReview(1), "pending speaker review should mark the canonical row")
 
         let completedMarkdown = """
         ---
         title: "Reviewed Call"
+        capture_type: meeting
         date: 2026-05-20
         time: 09:30:00
         speakers:
@@ -151,6 +155,9 @@ func testSpeakerReviewQueueScanner() {
         )
 
         assertEqual(after.count, 0, "completed speaker review should leave no pending queue item")
+        let homeAfter = RecentMeetingsScanner.loadRecent(limit: 5, directory: directory)
+        assertEqual(homeAfter.count, 1, "completed speaker review should not create duplicate Home rows")
+        assertEqual(homeAfter.first?.transcriptURL.standardizedFileURL, transcriptURL.standardizedFileURL, "completed speaker review should keep the original transcript row")
         assertEqual(
             RecentMeetingSpeakerStatus.detect(in: updatedMarkdown),
             .ready,
@@ -282,6 +289,7 @@ private func deferredMarkdown(
     """
     ---
     title: "\(title)"
+    capture_type: meeting
     date: \(date)
     time: \(time)
     speakers:

--- a/Tests/TranscriptedCoreTests/MeetingRouteArtifactFixtureTests.swift
+++ b/Tests/TranscriptedCoreTests/MeetingRouteArtifactFixtureTests.swift
@@ -100,6 +100,71 @@ final class MeetingRouteArtifactFixtureTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: try XCTUnwrap(retained.micURL)), Data("synthetic mic audio only".utf8))
         XCTAssertEqual(try Data(contentsOf: try XCTUnwrap(retained.systemURL)), Data("synthetic system audio only".utf8))
     }
+
+    func testImportedAudioProducesCanonicalSingleSourceArtifact() throws {
+        let scratch = tempRoot.appendingPathComponent("scratch", isDirectory: true)
+        let meetings = tempRoot.appendingPathComponent("meetings", isDirectory: true)
+        let retainedAudioRoot = meetings.appendingPathComponent("audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: scratch, withIntermediateDirectories: true)
+
+        let importedSourceURL = scratch.appendingPathComponent("partner-brief.wav")
+        try Data("synthetic imported audio only".utf8).write(to: importedSourceURL)
+        let recordingDate = Date(timeIntervalSince1970: 1_754_321_000)
+
+        let result = TranscriptionResult(
+            micUtterances: [],
+            systemUtterances: [
+                TranscriptionUtterance(
+                    start: 0,
+                    end: 1.2,
+                    channel: 1,
+                    speakerId: 0,
+                    persistentSpeakerId: nil,
+                    matchSimilarity: nil,
+                    transcript: "Imported recording stays attached to one meeting artifact."
+                )
+            ],
+            duration: 1.2,
+            processingTime: 0.1
+        )
+
+        let transcriptURL = try XCTUnwrap(
+            TranscriptSaver.saveTranscript(
+                result,
+                transcriptId: UUID(uuidString: "00000000-0000-0000-0000-000000000501")!,
+                directory: meetings,
+                meetingTitle: "Imported Partner Brief",
+                statsStore: MeetingRouteArtifactNoopStatsStore(),
+                recordingDate: recordingDate,
+                transcriptionEngine: .parakeetLocal,
+                formatOptions: TranscriptFormatOptions(audioSources: [.systemAudio])
+            )
+        )
+
+        let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
+        let values = try XCTUnwrap(TranscriptFrontmatter.values(in: markdown))
+        XCTAssertEqual(values["capture_type"], "meeting")
+        XCTAssertEqual(values["sources"], "[system_audio]")
+        XCTAssertEqual(values["mic_utterances"], "0")
+        XCTAssertEqual(values["system_utterances"], "1")
+        XCTAssertEqual(values["mic_speakers"], "0")
+        XCTAssertEqual(values["system_speakers"], "1")
+        XCTAssertEqual(values["date"], fixtureFrontmatterDate(recordingDate))
+        XCTAssertTrue(markdown.contains("Imported recording stays attached to one meeting artifact."))
+        XCTAssertFalse(markdown.contains("#### Local Speaker Breakdown"), "single-file imports should not invent local mic speaker sections")
+        XCTAssertFalse(markdown.contains("/Users/"), "imported fixture transcript must not leak local paths")
+
+        let retained = try RecordingAudioArchiver.archive(
+            micURL: nil,
+            systemURL: importedSourceURL,
+            transcriptURL: transcriptURL,
+            archiveRoot: retainedAudioRoot
+        )
+
+        XCTAssertNil(retained.micURL, "imported single-file audio should not create a microphone archive")
+        XCTAssertEqual(retained.systemURL?.lastPathComponent, "recording.wav")
+        XCTAssertEqual(try Data(contentsOf: try XCTUnwrap(retained.systemURL)), Data("synthetic imported audio only".utf8))
+    }
 }
 
 @available(macOS 14.0, *)
@@ -111,4 +176,10 @@ private final class MeetingRouteArtifactNoopStatsStore: StatsStore {
     func getRecordings(from startDate: Date, to endDate: Date) -> [RecordingMetadata] { [] }
 
     func recordingExists(transcriptPath: String) -> Bool { false }
+}
+
+private func fixtureFrontmatterDate(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter.string(from: date)
 }

--- a/scripts/entrypoints/run-e2e-smoke.sh
+++ b/scripts/entrypoints/run-e2e-smoke.sh
@@ -50,6 +50,7 @@ SWIFT_SOURCES=(
     "Sources/TranscriptedCore/Logging/LogPrivacySanitizer.swift"
     "Sources/TranscriptedCore/Utilities/FilePermissions.swift"
     "Sources/UI/Shared/MeetingAudioArchiveResolver.swift"
+    "Sources/UI/Shared/HomeMeetingDeletion.swift"
     "Sources/UI/Shared/RecentCaptureScanners.swift"
     "Sources/UI/Settings/HomeMeetingPreviewFormatter.swift"
     "Sources/Observability/ObservabilityTextRedactor.swift"


### PR DESCRIPTION
## Summary
- expand deterministic E2E smoke with captured + imported meeting artifacts, local summary metadata, Home discovery, MCP indexing, and delete proof
- add a core imported-audio golden fixture for canonical single-source Markdown + retained recording audio
- add scanner regressions for inline summary precedence and speaker-review row stability

## Tests
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh
- bash run-e2e-smoke.sh
- swift test
- bash run-integration-smoke.sh
- scripts/dev/agent-preflight.sh
- /Users/redbars/.codex/skills/codex-review/scripts/codex-review --mode branch