### PR TITLE
Add packaged app smoke QA

### DIFF
--- a/Tests/README.md
+++ b/Tests/README.md
@@ -2,7 +2,7 @@
 
 ## Test Surfaces
 
-This repo has nine distinct verification layers:
+This repo has ten distinct verification layers:
 
 1. `bash run-tests.sh`
    Curated fast test runner built with raw `swiftc`
@@ -20,7 +20,9 @@ This repo has nine distinct verification layers:
    Local hardware/TCC smoke for app launch plus production mic + system-audio capture
 8. `bash scripts/ops/transcripted-qa-bench.sh --mode ui`
    Accessibility-driven UI smoke for menu bar, Home, Settings, buttons, and basic navigation
-9. `bash scripts/ops/transcripted-qa-bench.sh --mode full`
+9. `bash scripts/ops/transcripted-qa-bench.sh --mode packaged`
+   No-publish `build-beta.sh` package smoke plus built app version, Sparkle, signing, dSYM, DMG, optional menu bar, and local log privacy checks
+10. `bash scripts/ops/transcripted-qa-bench.sh --mode full`
    Deep QA plus release-health fixture proof and local Gemma summary planning when eligible transcripts exist
 
 There is also an orchestrated QA bench for human-style passes:
@@ -30,6 +32,7 @@ bash scripts/ops/transcripted-qa-bench.sh --mode quick
 bash scripts/ops/transcripted-qa-bench.sh --mode deep
 bash scripts/ops/transcripted-qa-bench.sh --mode full
 bash scripts/ops/transcripted-qa-bench.sh --mode ui
+bash scripts/ops/transcripted-qa-bench.sh --mode packaged
 bash scripts/ops/transcripted-qa-bench.sh --mode pasteback-synthetic
 bash scripts/ops/transcripted-qa-bench.sh --mode corpus
 bash scripts/ops/transcripted-qa-bench.sh --mode corpus-compare
@@ -163,6 +166,22 @@ bash run-live-capture-smoke.sh --skip-build
 Accessibility permission for the terminal or Codex runner so it can inspect AX
 identifiers and press controls. Missing permission exits `3` and is reported as
 `INCOMPLETE`, not green.
+
+## Packaged App Smoke
+
+`bash scripts/ops/transcripted-qa-bench.sh --mode packaged` runs a no-publish
+package smoke with `SKIP_NOTARIZATION=1`, then runs:
+
+```bash
+swift run --package-path Tools/TranscriptedQA transcripted-qa packaged-app-smoke --app build/Transcripted.app --dsym build/Transcripted.app.dSYM --run-ui-smoke
+```
+
+It validates the built app version/config against source `Info.plist`, Sparkle
+feed URL/public key/update flags, HTTPS observability endpoints, code signing,
+the bundled Sparkle framework and MCP helper, matching app/dSYM UUIDs, the
+versioned DMG, optional menu bar UI, and local log privacy patterns. UI/TCC
+blockers exit `3` as `INCOMPLETE`, not green proof. Notarization and publishing
+remain manual release steps.
 
 ## Codex UI Permission-State Smoke
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -255,7 +255,7 @@ func testRepoCommandContract() {
         let matrix = readRepoTextFile(".agents/test-matrix.yml")
 
         assertTrue(
-            qaBench.contains("quick|deep|full|ui|artifact|audio-synthetic|pasteback-synthetic|corpus|corpus-compare|live")
+            qaBench.contains("quick|deep|full|ui|packaged|artifact|audio-synthetic|pasteback-synthetic|corpus|corpus-compare|live")
                 && qaBench.contains("run_full_tail")
                 && qaBench.contains("60-release-health")
                 && qaBench.contains("61-gemma-summary-plan")

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -308,7 +308,7 @@ func testUIAutomationSurfaceContract() {
         }
 
         assertTrue(
-            qaBenchSource.contains("quick|deep|full|ui|artifact")
+            qaBenchSource.contains("quick|deep|full|ui|packaged|artifact")
                 && qaBenchSource.contains("run_ui_tail")
                 && qaBenchSource.contains("transcripted-qa ui-smoke")
                 && qaBenchSource.contains("ui-automation-smoke.json"),

--- a/Tools/TranscriptedQA/CLAUDE.md
+++ b/Tools/TranscriptedQA/CLAUDE.md
@@ -1,6 +1,6 @@
 # TranscriptedQA - QA Testing CLI Tool
 
-QA testing suite for Transcripted. 27 Swift files total: `Package.swift`, 24 files under `Sources/TranscriptedQA/`, and 2 test files under `Tests/TranscriptedQATests/`.
+QA testing suite for Transcripted. 29 Swift files total: `Package.swift`, 25 files under `Sources/TranscriptedQA/`, and 3 test files under `Tests/TranscriptedQATests/`.
 
 The current package is intentionally small:
 
@@ -16,13 +16,14 @@ The current package is intentionally small:
 |------|---------|
 | `TranscriptedQA.swift` | CLI entry point (`@main`), shared path helpers, and subcommand registration |
 
-### Commands/ (11 files)
+### Commands/ (12 files)
 
 | File | Purpose |
 |------|---------|
 | `CheckHealth.swift` | Quick health check: DB integrity, model presence, disk space |
 | `GenerateFixtures.swift` | Generate valid test data (transcripts, legacy JSON artifacts, DB records) for CI or manual verification |
 | `PermissionState.swift` | No-prompt macOS permission-state probe for Codex computer-use and live QA blockers |
+| `PackagedAppSmoke.swift` | Pre-publish packaged app smoke for app bundle metadata, Sparkle config, signing, dSYM, DMG, optional UI, and privacy-safe local logs |
 | `RoundTrip.swift` | Generate test data, validate, corrupt, re-validate, and confirm validators catch real defects |
 | `StressTest.swift` | Generate large datasets and validate performance + correctness |
 | `UISmoke.swift` | Launch a built app and validate menu bar, Home, Settings, and General navigation through macOS Accessibility |
@@ -68,6 +69,7 @@ The current package is intentionally small:
 
 | File | Purpose |
 |------|---------|
+| `PackagedAppSmokeTests.swift` | package-level coverage for packaged app metadata, Sparkle config, dSYM UUIDs, DMG, and log privacy checks |
 | `PermissionStateProbeTests.swift` | package-level coverage for permission-state probe modes and blocker classification |
 | `ValidatorTests.swift` | package-level coverage for YAML parsing, legacy index validation, JSON sidecar validation, and `ValidationReport` exit-code behavior |
 
@@ -88,6 +90,7 @@ swift run transcripted-qa validate-index
 swift run transcripted-qa validate-logs
 swift run transcripted-qa check-health
 swift run transcripted-qa permission-state --mode computer-use
+swift run transcripted-qa packaged-app-smoke --app ../../build/Transcripted.app --dsym ../../build/Transcripted.app.dSYM --run-ui-smoke
 
 # UI automation smoke, local Accessibility permission required
 swift run transcripted-qa ui-smoke --app ../../build/Transcripted.app
@@ -127,6 +130,7 @@ For agent and automation use, the JSON form also includes:
 - **Round-trip testing**: `round-trip` validates that validators correctly catch injected corruption
 - **Stress testing**: `stress-test` generates large datasets to surface performance and correctness issues
 - **UI smoke**: `ui-smoke` checks stable AX identifiers and exits `3` for Accessibility/TCC blockers
+- **Packaged app smoke**: `packaged-app-smoke` validates a no-publish `build-beta.sh` artifact, including version/config parity, Sparkle keys, signing, dSYM UUIDs, DMG readability, optional menu bar UI, and local log privacy
 
 ## Gotchas
 

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PackagedAppSmoke.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PackagedAppSmoke.swift
@@ -1,0 +1,825 @@
+import ArgumentParser
+import Foundation
+
+struct PackagedAppSmoke: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "packaged-app-smoke",
+        abstract: "Validate a built or packaged Transcripted.app before publishing a release."
+    )
+
+    @Option(name: .long, help: "Path to the built Transcripted.app bundle.")
+    var app: String = "build/Transcripted.app"
+
+    @Option(name: .long, help: "Path to the source Info.plist expected to match the built app.")
+    var sourceInfoPlist: String = "Info.plist"
+
+    @Option(name: .long, help: "Path to the release dSYM bundle.")
+    var dsym: String = "build/Transcripted.app.dSYM"
+
+    @Option(name: .long, help: "Path to the built DMG. Defaults to build/Transcripted-<CFBundleShortVersionString>.dmg.")
+    var dmg: String?
+
+    @Option(name: .long, help: "Path to the committed Sparkle appcast.")
+    var appcast: String = "docs/appcast.xml"
+
+    @Option(name: .long, parsing: .upToNextOption, help: "Local log files to scan for obvious privacy leaks.")
+    var logPath: [String] = []
+
+    @Option(name: .long, help: "Write a local JSON evidence report to this path.")
+    var report: String?
+
+    @Option(name: .long, help: "Write UI smoke JSON evidence to this path when --run-ui-smoke is set.")
+    var uiReport: String?
+
+    @Option(name: .long, help: "Seconds to wait for each UI smoke surface.")
+    var uiTimeout: Double = 12
+
+    @Flag(name: .long, help: "Warn instead of fail when the dSYM is missing or unverifiable.")
+    var allowMissingDSYM = false
+
+    @Flag(name: .long, help: "Warn instead of fail when the DMG is missing or unreadable.")
+    var allowMissingDMG = false
+
+    @Flag(name: .long, help: "Launch the built app and validate the menu bar through Accessibility.")
+    var runUISmoke = false
+
+    @Flag(name: .long, help: "Allow a pre-existing Transcripted process during --run-ui-smoke.")
+    var allowExistingInstance = false
+
+    @Flag(name: .long, help: "Ask macOS to show the Accessibility prompt during --run-ui-smoke if needed.")
+    var promptForAccessibility = false
+
+    @Flag(name: .long, help: "Skip codesign verification. This downgrades signing proof to INCOMPLETE.")
+    var skipCodeSignatureCheck = false
+
+    func run() throws {
+        let runner = PackagedAppSmokeRunner(
+            appBundlePath: app,
+            sourceInfoPlistPath: sourceInfoPlist,
+            dSYMPath: dsym,
+            dmgPath: dmg,
+            appcastPath: appcast,
+            logPaths: logPath,
+            reportPath: report,
+            uiReportPath: uiReport,
+            uiTimeout: uiTimeout,
+            requireDSYM: !allowMissingDSYM,
+            requireDMG: !allowMissingDMG,
+            runUISmoke: runUISmoke,
+            allowExistingInstance: allowExistingInstance,
+            promptForAccessibility: promptForAccessibility,
+            verifyCodeSignature: !skipCodeSignatureCheck
+        )
+        let smokeReport = runner.run()
+        smokeReport.printText()
+        try smokeReport.writeIfRequested()
+
+        if smokeReport.exitCode != 0 {
+            throw ExitCode(smokeReport.exitCode)
+        }
+    }
+}
+
+final class PackagedAppSmokeRunner {
+    private let appBundleURL: URL
+    private let sourceInfoPlistURL: URL
+    private let dSYMURL: URL
+    private let explicitDMGPath: String?
+    private let appcastURL: URL
+    private let initialLogPaths: [String]
+    private let reportPath: String?
+    private let uiReportPath: String?
+    private let uiTimeout: Double
+    private let requireDSYM: Bool
+    private let requireDMG: Bool
+    private let runUISmoke: Bool
+    private let allowExistingInstance: Bool
+    private let promptForAccessibility: Bool
+    private let verifyCodeSignature: Bool
+    private let fileManager: FileManager
+    private let commandRunner: PackagedAppSmokeCommandRunning
+    private let runID = UUID().uuidString
+
+    init(
+        appBundlePath: String,
+        sourceInfoPlistPath: String,
+        dSYMPath: String,
+        dmgPath: String?,
+        appcastPath: String,
+        logPaths: [String],
+        reportPath: String?,
+        uiReportPath: String?,
+        uiTimeout: Double,
+        requireDSYM: Bool,
+        requireDMG: Bool,
+        runUISmoke: Bool,
+        allowExistingInstance: Bool,
+        promptForAccessibility: Bool,
+        verifyCodeSignature: Bool,
+        fileManager: FileManager = .default,
+        commandRunner: PackagedAppSmokeCommandRunning = ProcessPackagedAppSmokeCommandRunner()
+    ) {
+        self.appBundleURL = URL(fileURLWithPath: appBundlePath).standardizedFileURL
+        self.sourceInfoPlistURL = URL(fileURLWithPath: sourceInfoPlistPath).standardizedFileURL
+        self.dSYMURL = URL(fileURLWithPath: dSYMPath).standardizedFileURL
+        self.explicitDMGPath = dmgPath
+        self.appcastURL = URL(fileURLWithPath: appcastPath).standardizedFileURL
+        self.initialLogPaths = logPaths
+        self.reportPath = reportPath
+        self.uiReportPath = uiReportPath
+        self.uiTimeout = uiTimeout
+        self.requireDSYM = requireDSYM
+        self.requireDMG = requireDMG
+        self.runUISmoke = runUISmoke
+        self.allowExistingInstance = allowExistingInstance
+        self.promptForAccessibility = promptForAccessibility
+        self.verifyCodeSignature = verifyCodeSignature
+        self.fileManager = fileManager
+        self.commandRunner = commandRunner
+    }
+
+    func run(generatedAt: Date = Date()) -> PackagedAppSmokeReport {
+        var checks: [PackagedAppSmokeCheck] = []
+        var scannedLogPaths = initialLogPaths
+        var uiEvidencePath: String?
+
+        guard fileManager.fileExists(atPath: appBundleURL.path) else {
+            checks.append(.fail("app-bundle", target: appBundleURL.path, detail: "Run SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name> first, or pass --app."))
+            return buildReport(checks: checks, dmgPath: nil, logPaths: scannedLogPaths, uiEvidencePath: uiEvidencePath, generatedAt: generatedAt)
+        }
+        checks.append(.pass("app-bundle", target: appBundleURL.path, detail: "Built app bundle exists."))
+
+        let executableURL = appBundleURL.appendingPathComponent("Contents/MacOS/Transcripted", isDirectory: false)
+        if fileManager.isExecutableFile(atPath: executableURL.path) {
+            checks.append(.pass("app-executable", target: executableURL.path, detail: "Built app executable is present and executable."))
+        } else {
+            checks.append(.fail("app-executable", target: executableURL.path, detail: "Transcripted.app is missing Contents/MacOS/Transcripted or it is not executable."))
+        }
+
+        let builtInfoURL = appBundleURL.appendingPathComponent("Contents/Info.plist", isDirectory: false)
+        let sourceInfo = loadPlist(sourceInfoPlistURL, check: "source-info-plist", checks: &checks)
+        let builtInfo = loadPlist(builtInfoURL, check: "built-info-plist", checks: &checks)
+
+        if let sourceInfo, let builtInfo {
+            checks.append(contentsOf: validateInfoPlist(sourceInfo: sourceInfo, builtInfo: builtInfo))
+            checks.append(contentsOf: validateSparkleConfig(sourceInfo: sourceInfo, builtInfo: builtInfo))
+            checks.append(contentsOf: validateObservabilityConfig(builtInfo: builtInfo))
+
+            let version = stringValue(builtInfo["CFBundleShortVersionString"]) ?? "unknown"
+            let dmgURL = resolvedDMGURL(version: version)
+            checks.append(validateDMG(at: dmgURL))
+            return buildReport(checks: checksAfterTail(checks, scannedLogPaths: &scannedLogPaths, uiEvidencePath: &uiEvidencePath, executableURL: executableURL), dmgPath: dmgURL.path, logPaths: scannedLogPaths, uiEvidencePath: uiEvidencePath, generatedAt: generatedAt)
+        } else {
+            checks.append(.fail("version-config", target: builtInfoURL.path, detail: "Cannot validate version/Sparkle config until both source and built Info.plist files are readable."))
+            let dmgURL = resolvedDMGURL(version: "unknown")
+            checks.append(validateDMG(at: dmgURL))
+            return buildReport(checks: checksAfterTail(checks, scannedLogPaths: &scannedLogPaths, uiEvidencePath: &uiEvidencePath, executableURL: executableURL), dmgPath: dmgURL.path, logPaths: scannedLogPaths, uiEvidencePath: uiEvidencePath, generatedAt: generatedAt)
+        }
+    }
+
+    private func checksAfterTail(
+        _ initialChecks: [PackagedAppSmokeCheck],
+        scannedLogPaths: inout [String],
+        uiEvidencePath: inout String?,
+        executableURL: URL
+    ) -> [PackagedAppSmokeCheck] {
+        var checks = initialChecks
+        checks.append(validateBundledFramework(relativePath: "Contents/Frameworks/Sparkle.framework", check: "sparkle-framework"))
+        checks.append(validateBundledHelper(relativePath: "Contents/Helpers/transcripted-mcp", check: "mcp-helper"))
+        checks.append(validateCodeSignature())
+        checks.append(validateDSYM(binaryURL: executableURL))
+
+        if runUISmoke {
+            let defaultUIReport = reportPath.map { path in
+                URL(fileURLWithPath: path)
+                    .deletingLastPathComponent()
+                    .appendingPathComponent("packaged-app-ui-smoke.json", isDirectory: false)
+                    .path
+            }
+            let uiReportTarget = uiReportPath ?? defaultUIReport
+            let uiRunner = UIAutomationSmokeRunner(
+                appBundlePath: appBundleURL.path,
+                reportPath: uiReportTarget,
+                timeout: uiTimeout,
+                allowExistingInstance: allowExistingInstance,
+                promptForAccessibility: promptForAccessibility,
+                keepRunning: false
+            )
+            let uiReport = uiRunner.run()
+            try? uiReport.writeIfRequested()
+            uiEvidencePath = uiReport.reportPath
+            if let appLogPath = uiReport.appLogPath {
+                scannedLogPaths.append(appLogPath)
+            }
+            checks.append(validateUISmoke(uiReport))
+        } else {
+            checks.append(.warn("ui-smoke", target: appBundleURL.path, detail: "Menu bar launch proof was not run. Rerun with --run-ui-smoke on a host with Accessibility permission."))
+        }
+
+        checks.append(contentsOf: validateLogPrivacy(paths: scannedLogPaths))
+        checks.append(validateAppcastFile())
+
+        return checks
+    }
+
+    private func buildReport(
+        checks: [PackagedAppSmokeCheck],
+        dmgPath: String?,
+        logPaths: [String],
+        uiEvidencePath: String?,
+        generatedAt: Date
+    ) -> PackagedAppSmokeReport {
+        PackagedAppSmokeReport(
+            runID: runID,
+            generatedAt: ISO8601DateFormatter().string(from: generatedAt),
+            appBundlePath: appBundleURL.path,
+            sourceInfoPlistPath: sourceInfoPlistURL.path,
+            dSYMPath: dSYMURL.path,
+            dmgPath: dmgPath,
+            appcastPath: appcastURL.path,
+            logPaths: logPaths,
+            uiReportPath: uiEvidencePath,
+            reportPath: reportPath,
+            checks: checks
+        )
+    }
+
+    private func loadPlist(_ url: URL, check: String, checks: inout [PackagedAppSmokeCheck]) -> [String: Any]? {
+        guard fileManager.fileExists(atPath: url.path) else {
+            checks.append(.fail(check, target: url.path, detail: "Info.plist is missing."))
+            return nil
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            guard let plist = try PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any] else {
+                checks.append(.fail(check, target: url.path, detail: "Info.plist is not a dictionary."))
+                return nil
+            }
+            checks.append(.pass(check, target: url.path, detail: "Info.plist is readable."))
+            return plist
+        } catch {
+            checks.append(.fail(check, target: url.path, detail: error.localizedDescription))
+            return nil
+        }
+    }
+
+    private func validateInfoPlist(sourceInfo: [String: Any], builtInfo: [String: Any]) -> [PackagedAppSmokeCheck] {
+        var checks: [PackagedAppSmokeCheck] = []
+        let keys = [
+            "CFBundleIdentifier",
+            "CFBundleName",
+            "CFBundleDisplayName",
+            "CFBundleExecutable",
+            "CFBundleShortVersionString",
+            "CFBundleVersion",
+            "LSMinimumSystemVersion",
+        ]
+        let drift = keys.compactMap { key -> String? in
+            let source = stringValue(sourceInfo[key])
+            let built = stringValue(builtInfo[key])
+            return source == built ? nil : "\(key): source=\(source ?? "nil") built=\(built ?? "nil")"
+        }
+        if drift.isEmpty {
+            checks.append(.pass("bundle-info-parity", target: appBundleURL.path, detail: "Built Info.plist matches source release identity keys."))
+        } else {
+            checks.append(.fail("bundle-info-parity", target: appBundleURL.path, detail: drift.joined(separator: "; ")))
+        }
+
+        if let version = stringValue(builtInfo["CFBundleShortVersionString"]), !version.isEmpty,
+           let build = stringValue(builtInfo["CFBundleVersion"]), !build.isEmpty {
+            checks.append(.pass("bundle-version", target: "Transcripted \(version) (\(build))", detail: "Version and dist are present."))
+        } else {
+            checks.append(.fail("bundle-version", target: appBundleURL.path, detail: "CFBundleShortVersionString or CFBundleVersion is empty."))
+        }
+
+        if stringValue(builtInfo["CFBundleIdentifier"]) == "com.justinbetker.draft" {
+            checks.append(.pass("bundle-identifier", target: "com.justinbetker.draft", detail: "Bundle id preserves the current Transcripted TCC identity."))
+        } else {
+            checks.append(.fail("bundle-identifier", target: stringValue(builtInfo["CFBundleIdentifier"]) ?? "missing", detail: "Unexpected bundle id; changing it is a release migration."))
+        }
+
+        if stringValue(builtInfo["LSMinimumSystemVersion"]) == "26.0" {
+            checks.append(.pass("minimum-system-version", target: "macOS 26.0", detail: "Packaged app matches the current release floor."))
+        } else {
+            checks.append(.fail("minimum-system-version", target: stringValue(builtInfo["LSMinimumSystemVersion"]) ?? "missing", detail: "Expected LSMinimumSystemVersion 26.0."))
+        }
+
+        return checks
+    }
+
+    private func validateSparkleConfig(sourceInfo: [String: Any], builtInfo: [String: Any]) -> [PackagedAppSmokeCheck] {
+        var checks: [PackagedAppSmokeCheck] = []
+        let keys = ["SUFeedURL", "SUPublicEDKey", "SUEnableAutomaticChecks", "SUAllowsAutomaticUpdates", "SUScheduledCheckInterval"]
+        let drift = keys.compactMap { key -> String? in
+            plistValuesEqual(sourceInfo[key], builtInfo[key]) ? nil : "\(key) drifted"
+        }
+        if drift.isEmpty {
+            checks.append(.pass("sparkle-config-parity", target: "Info.plist", detail: "Built Sparkle settings match source Info.plist."))
+        } else {
+            checks.append(.fail("sparkle-config-parity", target: "Info.plist", detail: drift.joined(separator: "; ")))
+        }
+
+        let feedURL = stringValue(builtInfo["SUFeedURL"]) ?? ""
+        if feedURL == "https://raw.githubusercontent.com/r3dbars/transcripted/main/docs/appcast.xml" {
+            checks.append(.pass("sparkle-feed-url", target: feedURL, detail: "Updater points at the committed appcast feed."))
+        } else {
+            checks.append(.fail("sparkle-feed-url", target: feedURL.isEmpty ? "missing" : feedURL, detail: "Expected the canonical Transcripted appcast URL."))
+        }
+
+        let publicKey = stringValue(builtInfo["SUPublicEDKey"]) ?? ""
+        if publicKey.count >= 32, Data(base64Encoded: publicKey) != nil {
+            checks.append(.pass("sparkle-public-key", target: "SUPublicEDKey", detail: "Public EdDSA key is present and base64-decodable."))
+        } else {
+            checks.append(.fail("sparkle-public-key", target: "SUPublicEDKey", detail: "Missing or malformed Sparkle public key."))
+        }
+
+        if boolValue(builtInfo["SUEnableAutomaticChecks"]) == true {
+            checks.append(.pass("sparkle-auto-checks", target: "SUEnableAutomaticChecks", detail: "Automatic update checks are enabled."))
+        } else {
+            checks.append(.fail("sparkle-auto-checks", target: "SUEnableAutomaticChecks", detail: "Automatic update checks are disabled or missing."))
+        }
+
+        if boolValue(builtInfo["SUAllowsAutomaticUpdates"]) == true {
+            checks.append(.pass("sparkle-auto-downloads", target: "SUAllowsAutomaticUpdates", detail: "Automatic update downloads can be enabled by the user."))
+        } else {
+            checks.append(.fail("sparkle-auto-downloads", target: "SUAllowsAutomaticUpdates", detail: "Automatic update downloads are disabled or missing."))
+        }
+
+        if intValue(builtInfo["SUScheduledCheckInterval"]).map({ $0 > 0 }) == true {
+            checks.append(.pass("sparkle-check-interval", target: "SUScheduledCheckInterval", detail: "Scheduled update interval is present."))
+        } else {
+            checks.append(.fail("sparkle-check-interval", target: "SUScheduledCheckInterval", detail: "Scheduled update interval is missing or invalid."))
+        }
+
+        return checks
+    }
+
+    private func validateObservabilityConfig(builtInfo: [String: Any]) -> [PackagedAppSmokeCheck] {
+        var checks: [PackagedAppSmokeCheck] = []
+        let sentryDSN = stringValue(builtInfo["TranscriptedSentryDSN"]) ?? ""
+        if sentryDSN.hasPrefix("https://") {
+            checks.append(.pass("sentry-dsn", target: "TranscriptedSentryDSN", detail: "Sentry DSN uses HTTPS."))
+        } else {
+            checks.append(.fail("sentry-dsn", target: "TranscriptedSentryDSN", detail: "Sentry DSN is missing or not HTTPS."))
+        }
+
+        let prefix = stringValue(builtInfo["TranscriptedSentryReleasePrefix"]) ?? ""
+        let version = stringValue(builtInfo["CFBundleShortVersionString"]) ?? ""
+        let dist = stringValue(builtInfo["CFBundleVersion"]) ?? ""
+        if !prefix.isEmpty, !version.isEmpty, !dist.isEmpty {
+            checks.append(.pass("sentry-release-metadata", target: "\(prefix)@\(version) dist \(dist)", detail: "Sentry release name and dist can be derived locally without registering a release."))
+        } else {
+            checks.append(.fail("sentry-release-metadata", target: "Info.plist", detail: "Missing release prefix, version, or dist."))
+        }
+
+        let postHogHost = stringValue(builtInfo["TranscriptedPostHogHost"]) ?? ""
+        if postHogHost.hasPrefix("https://") {
+            checks.append(.pass("posthog-host", target: "TranscriptedPostHogHost", detail: "PostHog host uses HTTPS."))
+        } else {
+            checks.append(.fail("posthog-host", target: "TranscriptedPostHogHost", detail: "PostHog host is missing or not HTTPS."))
+        }
+        return checks
+    }
+
+    private func validateBundledFramework(relativePath: String, check: String) -> PackagedAppSmokeCheck {
+        let url = appBundleURL.appendingPathComponent(relativePath, isDirectory: true)
+        if fileManager.fileExists(atPath: url.path) {
+            return .pass(check, target: relativePath, detail: "Required bundled framework exists.")
+        }
+        return .fail(check, target: relativePath, detail: "Required bundled framework is missing.")
+    }
+
+    private func validateBundledHelper(relativePath: String, check: String) -> PackagedAppSmokeCheck {
+        let url = appBundleURL.appendingPathComponent(relativePath, isDirectory: false)
+        if fileManager.isExecutableFile(atPath: url.path) {
+            return .pass(check, target: relativePath, detail: "Bundled helper exists and is executable.")
+        }
+        return .fail(check, target: relativePath, detail: "Bundled helper is missing or not executable.")
+    }
+
+    private func validateCodeSignature() -> PackagedAppSmokeCheck {
+        guard verifyCodeSignature else {
+            return .warn("code-signature", target: appBundleURL.path, detail: "Code signature verification was skipped by request.")
+        }
+        let result = commandRunner.run("/usr/bin/codesign", ["--verify", "--deep", "--strict", appBundleURL.path])
+        if result.exitCode == 0 {
+            return .pass("code-signature", target: appBundleURL.path, detail: "codesign --verify --deep --strict passed.")
+        }
+        return .fail("code-signature", target: appBundleURL.path, detail: result.combinedOutput.trimmedForReport)
+    }
+
+    private func validateDSYM(binaryURL: URL) -> PackagedAppSmokeCheck {
+        guard fileManager.fileExists(atPath: dSYMURL.path) else {
+            return requiredOrWarn("release-dsym", target: dSYMURL.path, detail: "Release dSYM is missing. build-beta.sh normally writes build/Transcripted.app.dSYM.", required: requireDSYM)
+        }
+
+        let dwarfURL = dSYMURL.appendingPathComponent("Contents/Resources/DWARF/Transcripted", isDirectory: false)
+        guard fileManager.fileExists(atPath: dwarfURL.path) else {
+            return requiredOrWarn("release-dsym", target: dSYMURL.path, detail: "dSYM exists but is missing Contents/Resources/DWARF/Transcripted.", required: requireDSYM)
+        }
+
+        let binaryUUIDs = uuidSet(for: binaryURL)
+        let debugUUIDs = uuidSet(for: dSYMURL)
+        if binaryUUIDs.uuids.isEmpty || debugUUIDs.uuids.isEmpty {
+            return requiredOrWarn(
+                "release-dsym-uuid",
+                target: dSYMURL.path,
+                detail: "Could not read UUIDs. binary=\(binaryUUIDs.error.trimmedForReport) dSYM=\(debugUUIDs.error.trimmedForReport)",
+                required: requireDSYM
+            )
+        }
+        if binaryUUIDs.uuids == debugUUIDs.uuids {
+            return .pass("release-dsym-uuid", target: dSYMURL.path, detail: "dSYM UUID matches the app binary.")
+        }
+        return .fail(
+            "release-dsym-uuid",
+            target: dSYMURL.path,
+            detail: "Binary UUIDs \(binaryUUIDs.uuids.sorted()) do not match dSYM UUIDs \(debugUUIDs.uuids.sorted())."
+        )
+    }
+
+    private func uuidSet(for url: URL) -> (uuids: Set<String>, error: String) {
+        let result = commandRunner.run("/usr/bin/dwarfdump", ["--uuid", url.path])
+        guard result.exitCode == 0 else {
+            return ([], result.combinedOutput)
+        }
+        var uuids = Set<String>()
+        let pattern = #"UUID:\s+([A-Fa-f0-9-]+)\s"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return ([], "internal regex error")
+        }
+        let range = NSRange(result.stdout.startIndex..<result.stdout.endIndex, in: result.stdout)
+        for match in regex.matches(in: result.stdout, range: range) {
+            if let uuidRange = Range(match.range(at: 1), in: result.stdout) {
+                uuids.insert(String(result.stdout[uuidRange]).uppercased())
+            }
+        }
+        return (uuids, "")
+    }
+
+    private func validateDMG(at url: URL) -> PackagedAppSmokeCheck {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return requiredOrWarn("release-dmg", target: url.path, detail: "DMG is missing. build-beta.sh normally writes build/Transcripted-<version>.dmg.", required: requireDMG)
+        }
+        do {
+            let values = try url.resourceValues(forKeys: [.fileSizeKey])
+            if (values.fileSize ?? 0) <= 0 {
+                return requiredOrWarn("release-dmg", target: url.path, detail: "DMG exists but is empty.", required: requireDMG)
+            }
+        } catch {
+            return requiredOrWarn("release-dmg", target: url.path, detail: error.localizedDescription, required: requireDMG)
+        }
+
+        let result = commandRunner.run("/usr/bin/hdiutil", ["imageinfo", url.path])
+        if result.exitCode == 0 {
+            return .pass("release-dmg", target: url.path, detail: "DMG exists, is non-empty, and hdiutil can read image metadata.")
+        }
+        return requiredOrWarn("release-dmg", target: url.path, detail: "DMG exists, but hdiutil imageinfo failed: \(result.combinedOutput.trimmedForReport)", required: requireDMG)
+    }
+
+    private func validateUISmoke(_ report: UIAutomationSmokeReport) -> PackagedAppSmokeCheck {
+        switch report.status {
+        case .pass:
+            return .pass("ui-smoke", target: appBundleURL.path, detail: "App launched, menu bar appeared, and core menu/settings controls were visible.")
+        case .incomplete:
+            return .warn("ui-smoke", target: appBundleURL.path, detail: firstFlagDetail(in: report) ?? "UI smoke was incomplete.")
+        case .fail:
+            return .fail("ui-smoke", target: appBundleURL.path, detail: firstFlagDetail(in: report) ?? "UI smoke failed.")
+        }
+    }
+
+    private func validateLogPrivacy(paths: [String]) -> [PackagedAppSmokeCheck] {
+        let uniquePaths = Array(Set(paths.filter { !$0.isEmpty })).sorted()
+        guard !uniquePaths.isEmpty else {
+            return [.warn("logs/privacy-scan", target: "local logs", detail: "No log path was provided and UI smoke did not produce an app log to scan.")]
+        }
+
+        return uniquePaths.map { path in
+            let url = URL(fileURLWithPath: path).standardizedFileURL
+            guard fileManager.fileExists(atPath: url.path) else {
+                return .warn("logs/privacy-scan", target: url.path, detail: "Log file does not exist.")
+            }
+            do {
+                let content = try String(contentsOf: url, encoding: .utf8)
+                let findings = PrivacyLogScanner.findings(in: content)
+                if findings.isEmpty {
+                    return .pass("logs/privacy-scan", target: url.path, detail: "No obvious raw transcript/audio/title/path/email/token leak patterns found.")
+                }
+                return .fail("logs/privacy-scan", target: url.path, detail: findings.prefix(3).joined(separator: "; "))
+            } catch {
+                return .fail("logs/privacy-scan", target: url.path, detail: error.localizedDescription)
+            }
+        }
+    }
+
+    private func validateAppcastFile() -> PackagedAppSmokeCheck {
+        guard fileManager.fileExists(atPath: appcastURL.path) else {
+            return .warn("appcast-source", target: appcastURL.path, detail: "Committed appcast is missing. Existing installs will not discover unpublished builds until appcast is regenerated and pushed.")
+        }
+        guard let content = try? String(contentsOf: appcastURL, encoding: .utf8) else {
+            return .fail("appcast-source", target: appcastURL.path, detail: "Committed appcast exists but is not readable.")
+        }
+        if content.contains("sparkle:edSignature"), content.contains("<enclosure") {
+            return .pass("appcast-source", target: appcastURL.path, detail: "Committed appcast has signed enclosure metadata. This smoke does not publish or verify live GitHub assets.")
+        }
+        return .warn("appcast-source", target: appcastURL.path, detail: "Committed appcast is readable but latest signed enclosure metadata was not obvious.")
+    }
+
+    private func requiredOrWarn(_ check: String, target: String, detail: String, required: Bool) -> PackagedAppSmokeCheck {
+        required ? .fail(check, target: target, detail: detail) : .warn(check, target: target, detail: detail)
+    }
+
+    private func resolvedDMGURL(version: String) -> URL {
+        if let explicitDMGPath, !explicitDMGPath.isEmpty {
+            return URL(fileURLWithPath: explicitDMGPath).standardizedFileURL
+        }
+        return URL(fileURLWithPath: "build/Transcripted-\(version).dmg").standardizedFileURL
+    }
+
+    private func firstFlagDetail(in report: UIAutomationSmokeReport) -> String? {
+        report.checks.first { $0.status != .pass }.map { check in
+            "\(check.id): \(check.detail ?? check.target)"
+        }
+    }
+}
+
+struct PackagedAppSmokeCheck: Codable, Equatable {
+    let id: String
+    let status: ValidationStatus
+    let target: String
+    let detail: String
+
+    static func pass(_ id: String, target: String, detail: String) -> PackagedAppSmokeCheck {
+        PackagedAppSmokeCheck(id: id, status: .pass, target: target, detail: detail)
+    }
+
+    static func warn(_ id: String, target: String, detail: String) -> PackagedAppSmokeCheck {
+        PackagedAppSmokeCheck(id: id, status: .warn, target: target, detail: detail)
+    }
+
+    static func fail(_ id: String, target: String, detail: String) -> PackagedAppSmokeCheck {
+        PackagedAppSmokeCheck(id: id, status: .fail, target: target, detail: detail)
+    }
+}
+
+struct PackagedAppSmokeReport: Codable, Equatable {
+    struct Summary: Codable, Equatable {
+        let passed: Int
+        let failed: Int
+        let warnings: Int
+    }
+
+    let runID: String
+    let generatedAt: String
+    let appBundlePath: String
+    let sourceInfoPlistPath: String
+    let dSYMPath: String
+    let dmgPath: String?
+    let appcastPath: String
+    let logPaths: [String]
+    let uiReportPath: String?
+    let reportPath: String?
+    let checks: [PackagedAppSmokeCheck]
+
+    var summary: Summary {
+        Summary(
+            passed: checks.filter { $0.status == .pass }.count,
+            failed: checks.filter { $0.status == .fail }.count,
+            warnings: checks.filter { $0.status == .warn }.count
+        )
+    }
+
+    var status: ValidationStatus {
+        if summary.failed > 0 { return .fail }
+        if summary.warnings > 0 { return .warn }
+        return .pass
+    }
+
+    var exitCode: Int32 {
+        switch status {
+        case .pass: return 0
+        case .fail: return 1
+        case .warn: return 3
+        }
+    }
+
+    func printText() {
+        let passed = summary.passed
+        let total = checks.count
+        switch status {
+        case .pass:
+            print("PASS: tested \(passed)/\(total) packaged-app checks. App bundle, Sparkle config, signing, artifacts, and logs look coherent.")
+        case .fail:
+            print("FAIL: tested \(passed)/\(total) packaged-app checks. \(summary.failed + summary.warnings) flagged.")
+        case .warn:
+            print("INCOMPLETE: tested \(passed)/\(total) packaged-app checks. \(summary.warnings) warning(s).")
+        }
+
+        for check in checks where check.status != .pass {
+            print("\(check.status.rawValue): \(check.id) - \(check.detail)")
+        }
+        if let uiReportPath {
+            print("UI report: \(uiReportPath)")
+        }
+        if let reportPath {
+            print("Report: \(reportPath)")
+        }
+    }
+
+    func writeIfRequested() throws {
+        guard let reportPath, !reportPath.isEmpty else { return }
+        let url = URL(fileURLWithPath: reportPath)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(self).write(to: url, options: .atomic)
+    }
+}
+
+protocol PackagedAppSmokeCommandRunning {
+    func run(_ executable: String, _ arguments: [String]) -> PackagedAppSmokeCommandResult
+}
+
+struct PackagedAppSmokeCommandResult {
+    let exitCode: Int32
+    let stdout: String
+    let stderr: String
+
+    var combinedOutput: String {
+        [stdout, stderr].filter { !$0.isEmpty }.joined(separator: "\n")
+    }
+}
+
+struct ProcessPackagedAppSmokeCommandRunner: PackagedAppSmokeCommandRunning {
+    func run(_ executable: String, _ arguments: [String]) -> PackagedAppSmokeCommandResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            return PackagedAppSmokeCommandResult(exitCode: process.terminationStatus, stdout: stdout, stderr: stderr)
+        } catch {
+            return PackagedAppSmokeCommandResult(exitCode: 127, stdout: "", stderr: error.localizedDescription)
+        }
+    }
+}
+
+enum PrivacyLogScanner {
+    private static let sensitiveKeys = Set([
+        "transcript",
+        "transcript_text",
+        "raw_transcript",
+        "audio_path",
+        "audio_url",
+        "meeting_title",
+        "speaker_name",
+        "speaker_names",
+        "email",
+        "token",
+        "authorization",
+        "password",
+        "secret",
+        "url",
+        "file_path",
+        "absolute_path",
+        "device_name",
+        "source_app",
+    ])
+
+    static func findings(in content: String) -> [String] {
+        var findings: [String] = []
+        let lines = content.split(separator: "\n", omittingEmptySubsequences: true)
+        for (index, lineSlice) in lines.enumerated() {
+            let line = String(lineSlice)
+            if let jsonFinding = jsonFinding(in: line, lineNumber: index + 1) {
+                findings.append(jsonFinding)
+                continue
+            }
+            if containsEmail(line) {
+                findings.append("line \(index + 1) contains an email-like value")
+            }
+            if containsTokenAssignment(line) {
+                findings.append("line \(index + 1) contains a token/secret-looking assignment")
+            }
+            if line.contains("/Users/") || line.contains("file://") {
+                findings.append("line \(index + 1) contains an absolute local path")
+            }
+        }
+        return findings
+    }
+
+    private static func jsonFinding(in line: String, lineNumber: Int) -> String? {
+        guard let data = line.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) else {
+            return nil
+        }
+        if let key = firstSensitiveKey(in: object) {
+            return "line \(lineNumber) contains sensitive key \(key)"
+        }
+        if containsSensitiveValue(in: object) {
+            return "line \(lineNumber) contains an email, URL, or absolute local path"
+        }
+        return nil
+    }
+
+    private static func firstSensitiveKey(in object: Any) -> String? {
+        if let dictionary = object as? [String: Any] {
+            for (key, value) in dictionary {
+                if sensitiveKeys.contains(normalized(key)) {
+                    return key
+                }
+                if let nested = firstSensitiveKey(in: value) {
+                    return nested
+                }
+            }
+        }
+        if let array = object as? [Any] {
+            for value in array {
+                if let nested = firstSensitiveKey(in: value) {
+                    return nested
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func containsSensitiveValue(in object: Any) -> Bool {
+        if let string = object as? String {
+            return containsEmail(string) || string.contains("/Users/") || string.contains("file://")
+        }
+        if let dictionary = object as? [String: Any] {
+            return dictionary.values.contains(where: containsSensitiveValue)
+        }
+        if let array = object as? [Any] {
+            return array.contains(where: containsSensitiveValue)
+        }
+        return false
+    }
+
+    private static func normalized(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: " ", with: "_")
+            .lowercased()
+    }
+
+    private static func containsEmail(_ value: String) -> Bool {
+        value.range(of: #"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}"#, options: [.regularExpression, .caseInsensitive]) != nil
+    }
+
+    private static func containsTokenAssignment(_ value: String) -> Bool {
+        value.range(of: #"(?i)(token|api[_-]?key|authorization|bearer|secret|password)\s*[:=]"#, options: .regularExpression) != nil
+    }
+}
+
+private func stringValue(_ value: Any?) -> String? {
+    value as? String
+}
+
+private func boolValue(_ value: Any?) -> Bool? {
+    if let value = value as? Bool { return value }
+    if let value = value as? NSNumber { return value.boolValue }
+    return nil
+}
+
+private func intValue(_ value: Any?) -> Int? {
+    if let value = value as? Int { return value }
+    if let value = value as? NSNumber { return value.intValue }
+    if let value = value as? String { return Int(value) }
+    return nil
+}
+
+private func plistValuesEqual(_ lhs: Any?, _ rhs: Any?) -> Bool {
+    switch (lhs, rhs) {
+    case let (left as String, right as String):
+        return left == right
+    case let (left as Bool, right as Bool):
+        return left == right
+    case let (left as NSNumber, right as NSNumber):
+        return left == right
+    case (nil, nil):
+        return true
+    default:
+        return false
+    }
+}
+
+private extension String {
+    var trimmedForReport: String {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.count <= 240 {
+            return trimmed.isEmpty ? "no output" : trimmed
+        }
+        let end = trimmed.index(trimmed.startIndex, offsetBy: 240)
+        return String(trimmed[..<end]) + "..."
+    }
+}

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/UISmoke.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/UISmoke.swift
@@ -46,7 +46,7 @@ struct UISmoke: ParsableCommand {
     }
 }
 
-private final class UIAutomationSmokeRunner {
+final class UIAutomationSmokeRunner {
     private let appBundleURL: URL
     private let reportPath: String?
     private let timeout: TimeInterval

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/TranscriptedQA.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/TranscriptedQA.swift
@@ -127,6 +127,7 @@ struct TranscriptedQA: ParsableCommand {
             RoundTrip.self,
             StressTest.self,
             UISmoke.self,
+            PackagedAppSmoke.self,
         ],
         defaultSubcommand: ValidateAll.self
     )

--- a/Tools/TranscriptedQA/Tests/TranscriptedQATests/PackagedAppSmokeTests.swift
+++ b/Tools/TranscriptedQA/Tests/TranscriptedQATests/PackagedAppSmokeTests.swift
@@ -1,0 +1,248 @@
+import XCTest
+@testable import transcripted_qa
+
+final class PackagedAppSmokeTests: XCTestCase {
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PackagedAppSmokeTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+    }
+
+    func testPackagedAppSmokePassesStaticFixtureWithOnlyUISmokeWarning() throws {
+        let fixture = try makeFixture()
+        let report = makeRunner(fixture: fixture).run(generatedAt: Date(timeIntervalSince1970: 1_777_777_777))
+
+        XCTAssertFalse(report.checks.contains { $0.status == .fail })
+        XCTAssertTrue(report.checks.contains { $0.id == "bundle-version" && $0.status == .pass })
+        XCTAssertTrue(report.checks.contains { $0.id == "sparkle-feed-url" && $0.status == .pass })
+        XCTAssertTrue(report.checks.contains { $0.id == "release-dsym-uuid" && $0.status == .pass })
+        XCTAssertTrue(report.checks.contains { $0.id == "release-dmg" && $0.status == .pass })
+        XCTAssertTrue(report.checks.contains { $0.id == "logs/privacy-scan" && $0.status == .pass })
+        XCTAssertEqual(report.status, .warn)
+        XCTAssertEqual(report.exitCode, 3)
+    }
+
+    func testMissingDSYMFailsByDefault() throws {
+        let fixture = try makeFixture()
+        try FileManager.default.removeItem(at: fixture.dSYM)
+
+        let report = makeRunner(fixture: fixture).run()
+
+        XCTAssertTrue(report.checks.contains {
+            $0.id == "release-dsym" && $0.status == .fail
+        })
+        XCTAssertEqual(report.exitCode, 1)
+    }
+
+    func testMissingDSYMCanBeAllowedForPartialLocalSmoke() throws {
+        let fixture = try makeFixture()
+        try FileManager.default.removeItem(at: fixture.dSYM)
+
+        let report = makeRunner(fixture: fixture, requireDSYM: false).run()
+
+        XCTAssertTrue(report.checks.contains {
+            $0.id == "release-dsym" && $0.status == .warn
+        })
+        XCTAssertFalse(report.checks.contains {
+            $0.id == "release-dsym" && $0.status == .fail
+        })
+    }
+
+    func testDsymUUIDMismatchFails() throws {
+        let fixture = try makeFixture()
+        let commandRunner = FakePackagedAppSmokeCommandRunner(dSYMUUID: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")
+
+        let report = makeRunner(fixture: fixture, commandRunner: commandRunner).run()
+
+        XCTAssertTrue(report.checks.contains {
+            $0.id == "release-dsym-uuid" && $0.status == .fail
+        })
+    }
+
+    func testBundleIdentifierMismatchFails() throws {
+        let fixture = try makeFixture(bundleIdentifier: "com.example.other")
+
+        let report = makeRunner(fixture: fixture).run()
+
+        XCTAssertTrue(report.checks.contains {
+            $0.id == "bundle-identifier" && $0.status == .fail
+        })
+    }
+
+    func testMissingSparklePublicKeyFails() throws {
+        let fixture = try makeFixture(publicKey: "")
+
+        let report = makeRunner(fixture: fixture).run()
+
+        XCTAssertTrue(report.checks.contains {
+            $0.id == "sparkle-public-key" && $0.status == .fail
+        })
+    }
+
+    func testPrivacyLogScannerRejectsSensitiveKeysAndValues() {
+        let findings = PrivacyLogScanner.findings(in: """
+        {"t":"2026-06-08T12:00:00Z","l":"info","s":"app","m":"saved","transcript_text":"private words"}
+        {"t":"2026-06-08T12:00:01Z","l":"info","s":"app","m":"path","context":"/Users/redbars/private.wav"}
+        token=super-secret
+        """)
+
+        XCTAssertTrue(findings.contains { $0.contains("transcript_text") })
+        XCTAssertTrue(findings.contains { $0.contains("absolute local path") || $0.contains("context") })
+        XCTAssertTrue(findings.contains { $0.contains("token/secret") })
+    }
+
+    func testMissingExecutableFails() throws {
+        let fixture = try makeFixture()
+        try FileManager.default.removeItem(at: fixture.app.appendingPathComponent("Contents/MacOS/Transcripted"))
+
+        let report = makeRunner(fixture: fixture).run()
+
+        XCTAssertTrue(report.checks.contains {
+            $0.id == "app-executable" && $0.status == .fail
+        })
+    }
+
+    private func makeRunner(
+        fixture: Fixture,
+        requireDSYM: Bool = true,
+        requireDMG: Bool = true,
+        commandRunner: PackagedAppSmokeCommandRunning = FakePackagedAppSmokeCommandRunner()
+    ) -> PackagedAppSmokeRunner {
+        PackagedAppSmokeRunner(
+            appBundlePath: fixture.app.path,
+            sourceInfoPlistPath: fixture.sourceInfoPlist.path,
+            dSYMPath: fixture.dSYM.path,
+            dmgPath: fixture.dmg.path,
+            appcastPath: fixture.appcast.path,
+            logPaths: [fixture.log.path],
+            reportPath: nil,
+            uiReportPath: nil,
+            uiTimeout: 1,
+            requireDSYM: requireDSYM,
+            requireDMG: requireDMG,
+            runUISmoke: false,
+            allowExistingInstance: false,
+            promptForAccessibility: false,
+            verifyCodeSignature: true,
+            commandRunner: commandRunner
+        )
+    }
+
+    private func makeFixture(
+        bundleIdentifier: String = "com.justinbetker.draft",
+        publicKey: String = "Ib6MHm4eeZYjhsZblNT0DEo3LzK9fYvBLkmqvw/Vo7Q="
+    ) throws -> Fixture {
+        let app = tempRoot.appendingPathComponent("build/Transcripted.app", isDirectory: true)
+        let contents = app.appendingPathComponent("Contents", isDirectory: true)
+        let macOS = contents.appendingPathComponent("MacOS", isDirectory: true)
+        let frameworks = contents.appendingPathComponent("Frameworks", isDirectory: true)
+        let helpers = contents.appendingPathComponent("Helpers", isDirectory: true)
+        try FileManager.default.createDirectory(at: macOS, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: frameworks.appendingPathComponent("Sparkle.framework", isDirectory: true), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: helpers, withIntermediateDirectories: true)
+
+        let executable = macOS.appendingPathComponent("Transcripted", isDirectory: false)
+        try "binary".write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let helper = helpers.appendingPathComponent("transcripted-mcp", isDirectory: false)
+        try "helper".write(to: helper, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: helper.path)
+
+        let sourceInfoPlist = tempRoot.appendingPathComponent("Info.plist", isDirectory: false)
+        let builtInfoPlist = contents.appendingPathComponent("Info.plist", isDirectory: false)
+        let plist = infoPlist(bundleIdentifier: bundleIdentifier, publicKey: publicKey)
+        try writePlist(plist, to: sourceInfoPlist)
+        try writePlist(plist, to: builtInfoPlist)
+
+        let dSYM = tempRoot.appendingPathComponent("build/Transcripted.app.dSYM", isDirectory: true)
+        let dwarf = dSYM.appendingPathComponent("Contents/Resources/DWARF", isDirectory: true)
+        try FileManager.default.createDirectory(at: dwarf, withIntermediateDirectories: true)
+        try "debug".write(to: dwarf.appendingPathComponent("Transcripted", isDirectory: false), atomically: true, encoding: .utf8)
+
+        let dmg = tempRoot.appendingPathComponent("build/Transcripted-1.1.46.dmg", isDirectory: false)
+        try Data([0x64, 0x6d, 0x67]).write(to: dmg)
+
+        let appcast = tempRoot.appendingPathComponent("docs/appcast.xml", isDirectory: false)
+        try FileManager.default.createDirectory(at: appcast.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try """
+        <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+          <channel>
+            <item><enclosure sparkle:edSignature="abc" /></item>
+          </channel>
+        </rss>
+        """.write(to: appcast, atomically: true, encoding: .utf8)
+
+        let log = tempRoot.appendingPathComponent("app.jsonl", isDirectory: false)
+        try """
+        {"t":"2026-06-08T12:00:00Z","l":"info","s":"app","m":"packaged smoke fixture"}
+        """.write(to: log, atomically: true, encoding: .utf8)
+
+        return Fixture(app: app, sourceInfoPlist: sourceInfoPlist, dSYM: dSYM, dmg: dmg, appcast: appcast, log: log)
+    }
+
+    private func infoPlist(bundleIdentifier: String, publicKey: String) -> [String: Any] {
+        [
+            "CFBundleName": "Transcripted",
+            "CFBundleDisplayName": "Transcripted",
+            "CFBundleIdentifier": bundleIdentifier,
+            "CFBundleExecutable": "Transcripted",
+            "CFBundleShortVersionString": "1.1.46",
+            "CFBundleVersion": "1.1.46",
+            "LSMinimumSystemVersion": "26.0",
+            "SUFeedURL": "https://raw.githubusercontent.com/r3dbars/transcripted/main/docs/appcast.xml",
+            "SUPublicEDKey": publicKey,
+            "SUEnableAutomaticChecks": true,
+            "SUAllowsAutomaticUpdates": true,
+            "SUScheduledCheckInterval": 14_400,
+            "TranscriptedSentryDSN": "https://example@sentry.example/1",
+            "TranscriptedSentryReleasePrefix": "transcripted",
+            "TranscriptedPostHogHost": "https://us.i.posthog.com",
+        ]
+    }
+
+    private func writePlist(_ plist: [String: Any], to url: URL) throws {
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: url, options: .atomic)
+    }
+}
+
+private struct Fixture {
+    let app: URL
+    let sourceInfoPlist: URL
+    let dSYM: URL
+    let dmg: URL
+    let appcast: URL
+    let log: URL
+}
+
+private struct FakePackagedAppSmokeCommandRunner: PackagedAppSmokeCommandRunning {
+    var binaryUUID: String = "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA"
+    var dSYMUUID: String = "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA"
+    var codesignExitCode: Int32 = 0
+    var hdiutilExitCode: Int32 = 0
+
+    func run(_ executable: String, _ arguments: [String]) -> PackagedAppSmokeCommandResult {
+        if executable.contains("codesign") {
+            return PackagedAppSmokeCommandResult(exitCode: codesignExitCode, stdout: "", stderr: codesignExitCode == 0 ? "" : "bad signature")
+        }
+        if executable.contains("dwarfdump") {
+            let path = arguments.last ?? ""
+            let uuid = path.contains(".dSYM") ? dSYMUUID : binaryUUID
+            return PackagedAppSmokeCommandResult(exitCode: 0, stdout: "UUID: \(uuid) (arm64) \(path)\n", stderr: "")
+        }
+        if executable.contains("hdiutil") {
+            return PackagedAppSmokeCommandResult(exitCode: hdiutilExitCode, stdout: hdiutilExitCode == 0 ? "Format Description: UDZO\n" : "", stderr: hdiutilExitCode == 0 ? "" : "bad dmg")
+        }
+        return PackagedAppSmokeCommandResult(exitCode: 127, stdout: "", stderr: "unexpected command \(executable)")
+    }
+}

--- a/docs/qa-test-bench.md
+++ b/docs/qa-test-bench.md
@@ -63,6 +63,29 @@ This requires Accessibility permission for the terminal or Codex runner. If
 macOS blocks AX observation/control, the result is `INCOMPLETE` with exit code
 `3`. Do not treat that as product proof.
 
+## Packaged Run
+
+```bash
+bash scripts/ops/transcripted-qa-bench.sh --mode packaged
+```
+
+This runs a no-publish package smoke:
+
+- `bash scripts/dev/agent-preflight.sh`
+- `SKIP_NOTARIZATION=1 ... bash build-beta.sh '' <user-name>`
+- `swift run --package-path Tools/TranscriptedQA transcripted-qa packaged-app-smoke --app build/Transcripted.app --dsym build/Transcripted.app.dSYM --run-ui-smoke`
+
+The build step uses explicit thin-smoke model opt-outs so the lane can run on a
+dev Mac without pretending it is a full model-bundled release artifact. The
+smoke validates the built app version/config, Sparkle feed URL/public key and
+automatic update flags, HTTPS observability endpoints, bundled Sparkle and MCP
+helper payloads, code signing, matching app/dSYM UUIDs, the versioned DMG,
+optional menu bar UI, and local log privacy patterns.
+
+This mode does not notarize, publish GitHub releases, register Sentry releases,
+update `docs/appcast.xml`, or update the Homebrew cask. Accessibility blockers
+from the optional UI/menu proof are `INCOMPLETE`/exit `3`, not green.
+
 ## Deep Run
 
 ```bash

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -205,6 +205,27 @@ For a dry run that still validates the signed app and DMG assembly:
 SKIP_NOTARIZATION=1 bash build-beta.sh <beta-token> <user-name>
 ```
 
+After the dry-run package exists, run the packaged app smoke before any upload,
+appcast, cask, or Sentry release work:
+
+```bash
+swift run --package-path Tools/TranscriptedQA transcripted-qa packaged-app-smoke --app build/Transcripted.app --dsym build/Transcripted.app.dSYM --run-ui-smoke
+```
+
+Or use the QA bench wrapper:
+
+```bash
+bash scripts/ops/transcripted-qa-bench.sh --mode packaged
+```
+
+That smoke checks local app/package evidence only: app version/config parity,
+Sparkle feed URL/public key/update flags, signing, bundled helper/framework
+presence, dSYM UUID match, versioned DMG readability, optional menu bar UI, and
+local log privacy patterns. It does not notarize, publish, register Sentry
+releases, update `docs/appcast.xml`, or update the Homebrew cask. If the UI
+portion is blocked by Accessibility/TCC, the result is incomplete/yellow rather
+than green.
+
 ## Expected Validation
 
 `build-beta.sh` should complete all of the following:

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -50,26 +50,35 @@ Future agents should treat this as a release requirement:
 ## Release flow
 
 1. Build a signed/notarized Transcripted archive, typically with `build-beta.sh`.
-2. Put the release archive in a local updates folder.
-3. Run:
+2. Before publishing, run the local packaged app smoke:
+
+```bash
+swift run --package-path Tools/TranscriptedQA transcripted-qa packaged-app-smoke --app build/Transcripted.app --dsym build/Transcripted.app.dSYM --run-ui-smoke
+```
+
+This checks the built app's Sparkle feed URL, public key, automatic update
+flags, dSYM, DMG, optional menu bar launch, and local log privacy without
+uploading or modifying `docs/appcast.xml`.
+3. Put the release archive in a local updates folder.
+4. Run:
 
 ```bash
 bash scripts/release/generate-sparkle-appcast.sh /path/to/updates-folder
 ```
 
-4. The script keeps the current feed history, takes the newest generated item,
+5. The script keeps the current feed history, takes the newest generated item,
    rewrites its enclosure URL to the matching GitHub release asset, aligns the
    minimum macOS version with `Info.plist`, and then writes the merged result
    back to `docs/appcast.xml`.
-5. Upload the release archive to GitHub Releases.
-6. Verify the published update path:
+6. Upload the release archive to GitHub Releases.
+7. Verify the published update path:
 
 ```bash
 bash scripts/release/verify-sparkle-release.sh <version>
 ```
 
-7. Commit and push the updated `docs/appcast.xml`.
-8. After the final appcast push and any expected Homebrew/Sentry release
+8. Commit and push the updated `docs/appcast.xml`.
+9. After the final appcast push and any expected Homebrew/Sentry release
    surfaces are live, run the strict live-surface gate:
 
 ```bash

--- a/scripts/ops/transcripted-qa-bench.sh
+++ b/scripts/ops/transcripted-qa-bench.sh
@@ -26,10 +26,11 @@ fi
 CORPUS_CANDIDATE_MAP="${TRANSCRIPTED_QA_CORPUS_CANDIDATE_MAP:-}"
 CORPUS_MIN_RECALL="${TRANSCRIPTED_QA_CORPUS_MIN_RECALL:-0.45}"
 CORPUS_MIN_CONTENT_RECALL="${TRANSCRIPTED_QA_CORPUS_MIN_CONTENT_RECALL:-0.35}"
+PACKAGED_USER_NAME="${TRANSCRIPTED_QA_PACKAGED_USER_NAME:-${USER:-codex}}"
 
 usage() {
   cat <<'USAGE'
-Usage: bash scripts/ops/transcripted-qa-bench.sh [--mode quick|deep|full|ui|artifact|audio-synthetic|pasteback-synthetic|corpus|corpus-compare|live] [options]
+Usage: bash scripts/ops/transcripted-qa-bench.sh [--mode quick|deep|full|ui|packaged|artifact|audio-synthetic|pasteback-synthetic|corpus|corpus-compare|live] [options]
 
 Runs a local Transcripted QA bench and writes:
   /tmp/transcripted-qa-bench/<run-id>/qa-report.md
@@ -39,6 +40,7 @@ Modes:
   deep             quick + integration, Core tests, QA CLI, synthetic audio
   full             deep + release-health and local Gemma summary dry-run gates
   ui               build + Accessibility-driven menu bar/Home/Settings smoke
+  packaged         no-publish build-beta smoke + packaged app/version/Sparkle/dSYM/log checks
   artifact         validate current saved Transcripted artifacts strictly
   audio-synthetic  run only the deterministic audio failure-shape matrix
   pasteback-synthetic
@@ -175,7 +177,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 case "$MODE" in
-  quick|deep|full|ui|artifact|audio-synthetic|pasteback-synthetic|corpus|corpus-compare|live) ;;
+  quick|deep|full|ui|packaged|artifact|audio-synthetic|pasteback-synthetic|corpus|corpus-compare|live) ;;
   *)
     echo "Unknown mode: $MODE" >&2
     usage >&2
@@ -368,7 +370,7 @@ MARKDOWN
 write_report() {
   local fail_count warn_count skip_count pass_count flag_count total_count verdict branch commit app_version started finished short_summary
   local working_status regressed_status needs_human_status release_status
-  local ui_status artifact_status audio_status gemma_status release_health_status live_status
+  local ui_status artifact_status packaged_status audio_status gemma_status release_health_status live_status
 
   fail_count="$(awk -F '\t' '$3 == "FAIL" { count++ } END { print count + 0 }' "${RESULTS}")"
   warn_count="$(awk -F '\t' '$3 == "WARN" { count++ } END { print count + 0 }' "${RESULTS}")"
@@ -426,6 +428,7 @@ write_report() {
 
   ui_status="$(result_status "04-ui-smoke")"
   artifact_status="$(result_status "03-e2e-smoke")"
+  packaged_status="$(result_status "70-packaged-app-smoke")"
   audio_status="$(result_status "30-audio-synthetic")"
   gemma_status="$(result_status "61-gemma-summary-plan")"
   release_health_status="$(result_status "60-release-health")"
@@ -478,6 +481,7 @@ write_report() {
     echo "## Proof Map"
     echo
     echo "- UI automation smoke: ${ui_status} via \`transcripted-qa ui-smoke\`"
+    echo "- Packaged app smoke: ${packaged_status} via \`transcripted-qa packaged-app-smoke\`"
     echo "- Meeting and dictation artifact contract: ${artifact_status} via \`bash run-e2e-smoke.sh\`"
     echo "- Meeting route and Bluetooth mock/proxy matrix: ${audio_status} via \`bash run-daily-audio-reliability.sh --synthetic\`"
     echo "- Local Gemma summary dry-run plan: ${gemma_status} via \`scripts/ops/local-gemma-summary-autoeval.py\`"
@@ -701,6 +705,18 @@ run_ui_tail() {
     "TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa ui-smoke --app build/Transcripted.app --report $(shell_quote "${RAW_DIR}/ui-automation-smoke.json")"
 }
 
+run_packaged_tail() {
+  if [[ "${SKIP_BUILD}" -eq 1 ]]; then
+    skip_step "69-build-beta-smoke" "No-publish build-beta package smoke"
+  else
+    run_step "69-build-beta-smoke" "No-publish build-beta package smoke" "yes" \
+      "SKIP_NOTARIZATION=1 REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 REQUIRE_BUNDLED_DIARIZER_MODELS=0 BUNDLE_DIARIZER_MODELS=0 bash build-beta.sh '' $(shell_quote "${PACKAGED_USER_NAME}")"
+  fi
+
+  run_step "70-packaged-app-smoke" "Packaged app smoke" "yes" \
+    "TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa packaged-app-smoke --app build/Transcripted.app --dsym build/Transcripted.app.dSYM --run-ui-smoke --report $(shell_quote "${RAW_DIR}/packaged-app-smoke.json") --ui-report $(shell_quote "${RAW_DIR}/packaged-app-ui-smoke.json")"
+}
+
 run_corpus_tail() {
   local selected_ids="${1:-${CORPUS_IDS}}"
   local ids_arg=""
@@ -757,6 +773,10 @@ case "${MODE}" in
       run_step "01-build" "Build app" "yes" "bash build.sh --no-open"
     fi
     run_ui_tail
+    ;;
+  packaged)
+    run_step "00-preflight" "Agent preflight" "no" "bash scripts/dev/agent-preflight.sh"
+    run_packaged_tail
     ;;
   artifact)
     run_step "00-preflight" "Agent preflight" "no" "bash scripts/dev/agent-preflight.sh"


### PR DESCRIPTION
## Summary
- adds `transcripted-qa packaged-app-smoke` for built app/package checks before publishing
- wires `scripts/ops/transcripted-qa-bench.sh --mode packaged` to run no-publish build-beta plus packaged smoke
- documents the pre-publish package smoke in QA, release packaging, Sparkle, and test docs

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `swift test --package-path Tools/TranscriptedQA`
- `bash run-tests.sh`
- `PYTHONPYCACHEPREFIX=/tmp/transcripted-pycache python3 -m py_compile scripts/ops/validate-meeting-corpus.py`
- `PYTHONPYCACHEPREFIX=/tmp/transcripted-pycache python3 -m py_compile scripts/ops/compare-meeting-corpus.py`
- `bash scripts/ops/transcripted-qa-bench.sh --mode packaged` (yellow: existing Transcripted instance blocked unambiguous UI/menu proof, so no isolated app log was produced)
- `bash scripts/ops/transcripted-qa-bench.sh --mode quick`

No release was cut or published.