### PR TITLE
[codex] Add release gate report preset

### DIFF
--- a/.agents/qa-gates.yml
+++ b/.agents/qa-gates.yml
@@ -101,6 +101,7 @@ test_layers:
   release_health:
     commands:
       release_gate_report: "python3 scripts/ops/release-gate-report.py"
+      release_candidate_report: "python3 scripts/ops/release-gate-report.py --release-candidate"
       packaging_smoke: "SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>"
       sparkle_verify: "bash scripts/release/verify-sparkle-release.sh <version>"
       sentry_register: "SENTRY_REQUIRE_DEBUG_FILES=1 bash scripts/release/register-sentry-release.sh <version>"
@@ -158,13 +159,12 @@ recommended_gates:
   release_candidate:
     required:
       - "bash build-deps.sh --force"
-      - "python3 scripts/ops/release-gate-report.py --qa-mode deep --strict-artifacts"
+      - "python3 scripts/ops/release-gate-report.py --release-candidate"
       - "bash build.sh --no-open"
       - "bash run-tests.sh"
       - "bash run-integration-smoke.sh"
       - "bash run-e2e-smoke.sh"
       - "swift test"
-      - "bash scripts/ops/transcripted-qa-bench.sh --mode full"
       - "SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>"
     add_when_shipping_to_users:
       - "bash scripts/ops/transcripted-qa-bench.sh --mode deep --strict-artifacts when fixture or private artifact roots are available"

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -368,6 +368,13 @@ func testRepoCommandContract() {
             "release gate report should render the expected owner-facing sections"
         )
         assertTrue(
+            report.contains(#"--release-candidate"#)
+                && report.contains(#"choices=["quick", "deep", "full", "live"]"#)
+                && report.contains(#"EXIT_CODES[payload["status"]]"#)
+                && report.contains("Exit code follows the overall report status"),
+            "release gate report should support the full one-command QA mode and exit from the overall green/yellow/red verdict"
+        )
+        assertTrue(
             docs.contains("python3 scripts/ops/release-gate-report.py")
                 && scriptsReadme.contains("release-gate-report.py")
                 && qaGates.contains("release_gate_report"),

--- a/docs/qa-test-bench.md
+++ b/docs/qa-test-bench.md
@@ -216,9 +216,18 @@ For a deeper release-candidate pass:
 python3 scripts/ops/release-gate-report.py --qa-mode deep --strict-artifacts
 ```
 
+For the one-command release gate report, use the full QA bench:
+
+```bash
+python3 scripts/ops/release-gate-report.py --release-candidate
+```
+
+That preset expands to `--qa-mode full --strict-artifacts`.
+
 Missing Sentry or PostHog credentials are `YELLOW` / unknown. They are not
-treated as green proof. Actual release-surface drift or required release-health
-failures are `RED`.
+treated as green proof. Missing manual proof is also `YELLOW`. The command exits
+`0` for `GREEN`, `3` for `YELLOW`, and `1` for `RED`. Actual release-surface
+drift or required release-health failures are `RED`.
 
 ## Short Output
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -65,8 +65,9 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
 - `scripts/ops/release-gate-report.py` — single pre-merge/release gate report that runs the QA bench, Sentry/PostHog probes, appcast/download/release-health checks, and a local log sweep
   - Usage: `python3 scripts/ops/release-gate-report.py`
   - Deep RC usage: `python3 scripts/ops/release-gate-report.py --qa-mode deep --strict-artifacts`
+  - Full one-command release gate: `python3 scripts/ops/release-gate-report.py --release-candidate`
   - Writes local Markdown and JSON under `/tmp/transcripted-release-gate/<run-id>/`
-  - Missing Sentry/PostHog credentials are reported as yellow/unknown, not green
+  - Missing Sentry/PostHog credentials or manual proof are reported as yellow/unknown, not green; exit codes are green=0, yellow=3, red=1
 - `scripts/ops/privacy-leak-sweep.py` — synthetic-only privacy sweep for logs/events/reliability JSONL, Sentry/PostHog payloads, QA/local reports, PR/release text, and scanner handoff summaries
   - Usage: `python3 scripts/ops/privacy-leak-sweep.py --write-report build/privacy-leak-sweep-report.json`
 - `scripts/ops/performance-budget.rb` — fail a built app that exceeds bundle/resource budgets, ships the wrong Parakeet model set, includes old icon assets, or regresses optional runtime latency budgets

--- a/scripts/ops/release-gate-report.py
+++ b/scripts/ops/release-gate-report.py
@@ -596,6 +596,7 @@ def render_report(
         f"{status_label(overall)}: working={len(working)}, regressed={len(regressions)}, needs_human_check={len(needs_human)}.",
         f"Automated gate: {status_label(process_status)}.",
         f"Release: {release_status} - {release_reason}.",
+        "Exit code follows the overall report status: green=0, yellow=3, red=1.",
         "",
         f"- Run id: `{run_id}`",
         f"- Generated: `{generated_at}`",
@@ -660,6 +661,7 @@ def render_report(
         "artifacts": str(out_dir),
         "process_status": process_status,
         "release_status": release_status,
+        "exit_code": EXIT_CODES[overall],
         "manual_status": manual_status,
         "working_count": len(working),
         "regression_count": len(regressions),
@@ -686,7 +688,8 @@ def render_report(
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run Transcripted pre-merge/release gate checks and write one Markdown report.")
-    parser.add_argument("--qa-mode", default="quick", choices=["quick", "deep", "live"], help="QA bench mode to run. Default: quick.")
+    parser.add_argument("--release-candidate", action="store_true", help="Preset for one-command release gate reporting: --qa-mode full --strict-artifacts.")
+    parser.add_argument("--qa-mode", default="quick", choices=["quick", "deep", "full", "live"], help="QA bench mode to run. Default: quick.")
     parser.add_argument("--strict-artifacts", action="store_true", help="Forward --strict-artifacts to the QA bench.")
     parser.add_argument("--skip-qa", action="store_true", help="Skip the build/test QA bench and mark it unknown.")
     parser.add_argument("--skip-live-release-surfaces", action="store_true", help="Skip live appcast/download/crawler checks.")
@@ -698,7 +701,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--log-lines", type=int, default=400, help="Tail lines to inspect per local log file. Default: 400.")
     parser.add_argument("--dry-run", action="store_true", help="Write a yellow report without executing external commands.")
     parser.add_argument("--self-test", action="store_true", help="Run a tiny renderer/classifier self-test and exit.")
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.release_candidate:
+        args.qa_mode = "full"
+        args.strict_artifacts = True
+    return args
 
 
 def self_test() -> int:
@@ -778,7 +785,11 @@ def self_test() -> int:
         manual=[ReportItem("Meeting route proof", "yellow", "Fixture manual item.")],
         commands=[],
     )
-    manual_boundary_ok = manual_payload["status"] == "yellow" and manual_payload["process_status"] == "green"
+    manual_boundary_ok = (
+        manual_payload["status"] == "yellow"
+        and manual_payload["process_status"] == "green"
+        and manual_payload["exit_code"] == EXIT_CODES["yellow"]
+    )
     skipped_title_ok = "GitHub" not in successful_release_surface_title(
         argparse.Namespace(skip_live_release_surfaces=True, github_release_json=None)
     )
@@ -856,7 +867,7 @@ def main() -> int:
     print(f"Release gate report: {report_path}")
     print(f"Release gate JSON: {json_path}")
     print(f"Verdict: {status_label(payload['status'])}")
-    return EXIT_CODES[payload["process_status"]]
+    return EXIT_CODES[payload["status"]]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `python3 scripts/ops/release-gate-report.py --release-candidate` as the one-command release gate preset
- make the report exit from the overall GREEN/YELLOW/RED verdict, so missing manual proof or credentials stay yellow instead of process-green
- document the command and wire it into `.agents/qa-gates.yml`

## Verification
- `scripts/dev/agent-preflight.sh`
- `python3 -m py_compile scripts/ops/release-gate-report.py scripts/ops/validate-meeting-corpus.py scripts/ops/compare-meeting-corpus.py`
- `python3 scripts/ops/release-gate-report.py --self-test`
- `python3 scripts/ops/release-gate-report.py --release-candidate --dry-run --run-id codex-release-gate-dry-run` (expected YELLOW / exit 3)
- `bash -n scripts/ops/transcripted-qa-bench.sh`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `swift test --package-path Tools/TranscriptedQA`
- `bash scripts/ops/transcripted-qa-bench.sh --mode quick`

## Notes
A Codex review found an initial duplicate full-QA invocation in `.agents/qa-gates.yml`; this PR removes that duplicate and keeps `--release-candidate` as the single full-QA report command. A clean rerun of the review helper hung after the fix and was terminated; the repo checks above passed after the fix.