### PR TITLE
Improve local summary beta prep feedback

### DIFF
--- a/Sources/Meeting/LocalMeetingSummarizer.swift
+++ b/Sources/Meeting/LocalMeetingSummarizer.swift
@@ -640,6 +640,26 @@ struct LocalMeetingSummarizer: @unchecked Sendable {
         )
     }
 
+    func prepareModelForFirstSummary() async throws -> String {
+        try configuration.validateHardware()
+        try Task.checkCancellation()
+
+        let workDirectory = try makeWorkDirectory()
+        defer { try? fileManager.removeItem(at: workDirectory) }
+
+        _ = try runtime.generate(
+            prompt: """
+            You are Transcripted's local meeting summarizer. Reply with exactly:
+            Ready.
+            """,
+            label: "setup",
+            maxTokens: 8,
+            workDirectory: workDirectory
+        )
+
+        return configuration.profileName
+    }
+
     private func makeWorkDirectory() throws -> URL {
         let root = FileManager.default.transcriptedTemporaryDir
             .appendingPathComponent("local-summaries", isDirectory: true)

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -44,6 +44,10 @@ final class HomeViewModel: ObservableObject {
         loadCurrentLimits(isInitialLoad: true)
     }
 
+    func reloadVisibleContent() {
+        loadCurrentLimits(isInitialLoad: false)
+    }
+
     func loadMoreDictations() {
         guard !isLoading, !isLoadingMore, canLoadMoreDictations else { return }
         dictationLimit += initialDictationLimit
@@ -1067,6 +1071,19 @@ struct HomeRowMenuItem: Identifiable {
         self.isEnabled = isEnabled
         self.isDestructive = isDestructive
         self.action = action
+    }
+}
+
+struct HomeLocalSummaryNotice: Identifiable, Equatable {
+    let id = UUID()
+    let transcriptURL: URL
+    let chunkCount: Int
+
+    var title: String { "AI summary saved" }
+    var status: String { "Ready" }
+    var detail: String {
+        let passText = chunkCount == 1 ? "one local Gemma pass" : "\(chunkCount) local Gemma passes"
+        return "The meeting Markdown was enhanced with a generated title and summary preview using \(passText)."
     }
 }
 

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -1545,7 +1545,7 @@ struct HomeMeetingRow: View {
             showsLeadingTimeColumn: false,
             opensOnRowClick: false
         ) {
-            VStack(alignment: .leading, spacing: visibleSummaryPreview == nil ? 0 : 5) {
+            VStack(alignment: .leading, spacing: rowContentSpacing) {
                 Button(action: onOpen) {
                     VStack(alignment: .leading, spacing: 3) {
                         Text(timeRangeString)
@@ -1573,6 +1573,21 @@ struct HomeMeetingRow: View {
                 .buttonStyle(.plain)
                 .help("Preview meeting")
                 .accessibilityIdentifier("transcripted.home.meeting.preview")
+
+                if isSummarizingSummary {
+                    HStack(spacing: 6) {
+                        ProgressView()
+                            .controlSize(.mini)
+                            .frame(width: 12, height: 12)
+
+                        Text("Generating AI summary...")
+                            .font(.system(size: 11.5, weight: .medium))
+                            .foregroundStyle(Color.accentColor)
+                            .lineLimit(1)
+                    }
+                    .help("Transcripted is running the local Gemma summary for this meeting.")
+                    .accessibilityIdentifier("transcripted.home.meeting.summary-loading")
+                }
 
                 if let summaryPreview = visibleSummaryPreview {
                     if isSummaryExpanded {
@@ -1632,6 +1647,11 @@ struct HomeMeetingRow: View {
         var id: String { title }
     }
 
+    private var rowContentSpacing: CGFloat {
+        if isSummarizingSummary { return 5 }
+        return visibleSummaryPreview == nil ? 0 : 5
+    }
+
     private var meetingAttentionAccessories: AnyView? {
         let accessories = [aiSummaryAccessory, reviewSpeakersAccessory].compactMap { $0 }
         guard !accessories.isEmpty else { return nil }
@@ -1650,13 +1670,19 @@ struct HomeMeetingRow: View {
             for: item,
             isEnabled: localMeetingSummariesEnabled
         ) else { return nil }
+        if isSummarizingSummary {
+            return AnyView(
+                ProgressView()
+                    .controlSize(.mini)
+                    .frame(width: 18, height: 26)
+                    .help("AI summary is running")
+                    .accessibilityIdentifier("transcripted.home.meeting.summary-loading-dot")
+            )
+        }
         return AnyView(
             attentionDot(
                 color: .blue,
-                help: isSummarizingSummary
-                    ? "AI summary is running"
-                    : "AI summary available from More options",
-                opacity: isSummarizingSummary ? 0.45 : 1
+                help: "AI summary available from More options"
             )
         )
     }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -78,11 +78,16 @@ struct TranscriptedSettingsView: View {
     @State private var homeLocalSummaryJobIDs: Set<String> = []
     @State private var homeLocalSummaryTasks: [String: Task<LocalMeetingSummaryResult, Error>] = [:]
     @State private var homeLocalSummaryTaskTokens: [String: UUID] = [:]
+    @State private var homeLocalSummaryNotice: HomeLocalSummaryNotice?
     @AppStorage(LocalMeetingSummaryPreferences.enabledKey) private var localMeetingSummariesEnabled = LocalMeetingSummaryPreferences.defaultEnabled
     @AppStorage(LiveMeetingCodexPreferences.enabledKey) private var betaLiveMeetingCodexEnabled = LiveMeetingCodexPreferences.defaultEnabled
     @State private var betaFeatureStatus: String?
     @State private var localSummarySetupStatus = LocalMeetingSummarySetupStatus.current()
     @State private var showLocalSummarySetupDetails = false
+    @State private var localSummaryModelPreparationStatus: String?
+    @State private var localSummaryModelPreparationTask: Task<String, Error>?
+    @State private var localSummaryModelPreparationToken: UUID?
+    @State private var isLocalSummaryModelPreparing = false
     @State private var settingsColumnVisibility: NavigationSplitViewVisibility = .all
 
     init(
@@ -211,6 +216,8 @@ struct TranscriptedSettingsView: View {
             homeDashboardRefreshInFlight = false
             homeMeetingPreviewLoadTask?.cancel()
             homeMeetingPreviewLoadTask = nil
+            localSummaryModelPreparationTask?.cancel()
+            localSummaryModelPreparationTask = nil
             homeViewModel.cancel()
         }
     }
@@ -383,6 +390,23 @@ struct TranscriptedSettingsView: View {
                             )
                             NSWorkspace.shared.open(transcriptURL)
                         }
+                    }
+                )
+                .transition(.move(edge: .top).combined(with: .opacity))
+            }
+
+            if let notice = homeLocalSummaryNotice {
+                SettingsActivityCard(
+                    symbolName: "sparkles",
+                    title: notice.title,
+                    status: notice.status,
+                    detail: notice.detail,
+                    tone: .success,
+                    progress: 1.0,
+                    actionTitle: "Open enhanced transcript",
+                    action: {
+                        trackSettingsAction("open_local_meeting_summary_notice", page: .home)
+                        NSWorkspace.shared.open(notice.transcriptURL)
                     }
                 )
                 .transition(.move(edge: .top).combined(with: .opacity))
@@ -712,6 +736,17 @@ struct TranscriptedSettingsView: View {
             return
         }
         trackSettingsAction("generate_local_meeting_summary", page: .home)
+        recordLocalSummaryEvent(
+            event: "local_meeting_summary_started",
+            message: "Local Gemma meeting summary started",
+            context: [
+                "has_existing_summary": item.summaryPreview == nil ? "false" : "true",
+                "setup_ready": localSummarySetupStatus.isReady ? "true" : "false",
+                "setup_profile": localSummarySetupStatus.profileName,
+                "has_runtime": localSummarySetupStatus.hasRuntime ? "true" : "false",
+            ]
+        )
+        homeLocalSummaryNotice = nil
         homeLocalSummaryJobIDs.insert(item.id)
 
         let task = Task.detached(priority: .utility) {
@@ -734,13 +769,37 @@ struct TranscriptedSettingsView: View {
             }
 
             do {
-                _ = try await task.value
+                let result = try await task.value
                 guard localMeetingSummariesEnabled else { return }
-                refreshRecentCaptures(force: true)
+                homeLocalSummaryNotice = HomeLocalSummaryNotice(
+                    transcriptURL: result.transcriptURL,
+                    chunkCount: result.chunkCount
+                )
+                recordLocalSummaryEvent(
+                    event: "local_meeting_summary_completed",
+                    message: "Local Gemma meeting summary saved",
+                    context: [
+                        "chunk_count": "\(result.chunkCount)",
+                        "profile": result.profileName,
+                    ]
+                )
+                refreshRecentCapturesAfterLocalSummary()
             } catch is CancellationError {
+                recordLocalSummaryEvent(
+                    event: "local_meeting_summary_cancelled",
+                    message: "Local Gemma meeting summary cancelled"
+                )
                 return
             } catch {
                 guard localMeetingSummariesEnabled else { return }
+                recordLocalSummaryEvent(
+                    level: .error,
+                    event: "local_meeting_summary_failed",
+                    message: "Local Gemma meeting summary failed",
+                    context: [
+                        "error": error.localizedDescription,
+                    ]
+                )
                 homeDeleteFailure = HomeDeleteFailure(
                     title: "Could not summarize meeting",
                     message: error.localizedDescription
@@ -2397,10 +2456,7 @@ struct TranscriptedSettingsView: View {
                                 localMeetingSummariesEnabled = enabled
                                 LocalMeetingSummaryPreferences.setEnabled(enabled)
                                 trackSettingsToggle("local_ai_meeting_summaries", enabled: enabled, page: .beta)
-                                refreshLocalSummarySetupStatus()
-                                if !enabled {
-                                    cancelLocalSummaryJobs()
-                                }
+                                handleLocalMeetingSummaryToggle(enabled)
                             }
                         ),
                         help: "Opt in to local meeting summaries on Home.",
@@ -2464,6 +2520,18 @@ struct TranscriptedSettingsView: View {
                     trackSettingsAction("check_local_summary_setup", page: .beta)
                     refreshLocalSummarySetupStatus()
                 }
+
+                if localMeetingSummariesEnabled, localSummarySetupStatus.isReady {
+                    SettingsInlineActionButton(
+                        title: isLocalSummaryModelPreparing ? "Preparing Gemma..." : "Prepare Gemma",
+                        symbolName: "tray.and.arrow.down",
+                        automationIdentifier: "transcripted.settings.beta.local-summary.prepare-model"
+                    ) {
+                        trackSettingsAction("prepare_local_summary_model", page: .beta)
+                        prepareLocalSummaryModelFromBeta()
+                    }
+                    .disabled(isLocalSummaryModelPreparing)
+                }
             }
 
             if !localSummarySetupStatus.hasRuntime {
@@ -2476,6 +2544,13 @@ struct TranscriptedSettingsView: View {
                     trackSettingsAction("open_uv_install_guide", page: .beta)
                     openUVInstallGuide()
                 }
+            }
+
+            if let localSummaryModelPreparationStatus {
+                Text(localSummaryModelPreparationStatus)
+                    .font(.caption)
+                    .foregroundStyle(isLocalSummaryModelPreparing ? Color.accentColor : .secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             DisclosureGroup("Setup details", isExpanded: $showLocalSummarySetupDetails) {
@@ -2589,6 +2664,99 @@ struct TranscriptedSettingsView: View {
         }
     }
 
+    private func handleLocalMeetingSummaryToggle(_ enabled: Bool) {
+        refreshLocalSummarySetupStatus()
+        if enabled {
+            prepareLocalSummaryModelFromBeta()
+        } else {
+            cancelLocalSummaryJobs()
+            cancelLocalSummaryModelPreparation()
+            localSummaryModelPreparationStatus = nil
+        }
+    }
+
+    private func prepareLocalSummaryModelFromBeta() {
+        refreshLocalSummarySetupStatus()
+        localSummaryModelPreparationTask?.cancel()
+
+        guard localSummarySetupStatus.hasEnoughMemory else {
+            localSummaryModelPreparationStatus = "Gemma needs more memory than this Mac reports."
+            return
+        }
+
+        guard localSummarySetupStatus.hasRuntime else {
+            localSummaryModelPreparationStatus = "Install uv first, then Transcripted can download Gemma here."
+            return
+        }
+
+        isLocalSummaryModelPreparing = true
+        localSummaryModelPreparationStatus = "Preparing Gemma 4 12B locally. First run may download several GB from Hugging Face."
+        recordLocalSummaryEvent(
+            event: "local_meeting_summary_model_prepare_started",
+            message: "Local Gemma model preparation started",
+            context: [
+                "setup_profile": localSummarySetupStatus.profileName,
+                "has_runtime": "true",
+            ]
+        )
+
+        let taskToken = UUID()
+        let task = Task.detached(priority: .utility) {
+            try await LocalMeetingSummarizer().prepareModelForFirstSummary()
+        }
+        localSummaryModelPreparationTask = task
+        localSummaryModelPreparationToken = taskToken
+
+        Task { @MainActor in
+            do {
+                let profile = try await task.value
+                guard !Task.isCancelled, localSummaryModelPreparationToken == taskToken else { return }
+                isLocalSummaryModelPreparing = false
+                localSummaryModelPreparationTask = nil
+                localSummaryModelPreparationToken = nil
+                localSummaryModelPreparationStatus = "Gemma is ready. The first real summary should start without a surprise setup step."
+                recordLocalSummaryEvent(
+                    event: "local_meeting_summary_model_prepare_completed",
+                    message: "Local Gemma model preparation completed",
+                    context: [
+                        "profile": profile,
+                    ]
+                )
+            } catch is CancellationError {
+                guard localSummaryModelPreparationToken == taskToken else { return }
+                isLocalSummaryModelPreparing = false
+                localSummaryModelPreparationTask = nil
+                localSummaryModelPreparationToken = nil
+                localSummaryModelPreparationStatus = nil
+                recordLocalSummaryEvent(
+                    event: "local_meeting_summary_model_prepare_cancelled",
+                    message: "Local Gemma model preparation cancelled"
+                )
+            } catch {
+                guard localSummaryModelPreparationToken == taskToken else { return }
+                isLocalSummaryModelPreparing = false
+                localSummaryModelPreparationTask = nil
+                localSummaryModelPreparationToken = nil
+                localSummaryModelPreparationStatus = "Gemma setup failed: \(error.localizedDescription)"
+                recordLocalSummaryEvent(
+                    level: .error,
+                    event: "local_meeting_summary_model_prepare_failed",
+                    message: "Local Gemma model preparation failed",
+                    context: [
+                        "error": error.localizedDescription,
+                    ]
+                )
+            }
+        }
+    }
+
+    private func cancelLocalSummaryModelPreparation() {
+        localSummaryModelPreparationTask?.cancel()
+        localSummaryModelPreparationTask = nil
+        localSummaryModelPreparationToken = nil
+        isLocalSummaryModelPreparing = false
+    }
+
     private func prepareBetaLiveMeetingSidecarWorkspaceForUse() throws -> URL {
         let workspaceURL = try AgentConnectionGuide.ensureLiveMeetingCodexWorkspace()
         if #available(macOS 14.0, *) {
@@ -2614,6 +2782,33 @@ struct TranscriptedSettingsView: View {
         homeLocalSummaryTasks.removeAll()
         homeLocalSummaryTaskTokens.removeAll()
         homeLocalSummaryJobIDs.removeAll()
+    }
+
+    private func refreshRecentCapturesAfterLocalSummary() {
+        guard navigation.selectedPage == .home else {
+            refreshRecentCaptures(force: true)
+            return
+        }
+        homeViewModel.reloadVisibleContent()
+        Task { @MainActor in
+            await statsService.refreshStats()
+        }
+    }
+
+    private func recordLocalSummaryEvent(
+        level: EventLevel = .info,
+        event: String,
+        message: String,
+        context: [String: String] = [:]
+    ) {
+        DiagnosticsTrail.record(
+            logger: appLogger,
+            level: level,
+            engine: "meeting",
+            event: event,
+            message: message,
+            context: context
+        )
     }
 
     private func openUVInstallGuide() {

--- a/Tests/LocalMeetingSummarizerTests.swift
+++ b/Tests/LocalMeetingSummarizerTests.swift
@@ -466,6 +466,42 @@ func testLocalMeetingSummarizer() async {
         }
     }
 
+    await runSuite("LocalMeetingSummarizer prepares Gemma without transcript text") {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LocalMeetingSummaryPrepareTests-\(UUID().uuidString)", isDirectory: true)
+        let promptCaptureURL = directory.appendingPathComponent("prepare-prompt.txt")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let runtime = LocalGemmaSummaryRuntime(
+                configuration: localMeetingSummaryTestConfiguration(),
+                generateBatchOverride: { prompts, _ in
+                    try prompts.map(\.prompt).joined(separator: "\n---\n").write(
+                        to: promptCaptureURL,
+                        atomically: true,
+                        encoding: .utf8
+                    )
+                    return prompts.map { _ in "Ready." }
+                }
+            )
+            let summarizer = LocalMeetingSummarizer(
+                configuration: localMeetingSummaryTestConfiguration(),
+                runtime: runtime
+            )
+
+            let profile = try await summarizer.prepareModelForFirstSummary()
+            let capturedPrompt = try String(contentsOf: promptCaptureURL, encoding: .utf8)
+
+            assertEqual(profile, "test", "prepare should return the active profile")
+            assertTrue(capturedPrompt.contains("Reply with exactly"), "prepare should use a tiny setup prompt")
+            assertFalse(capturedPrompt.contains("## Transcript"), "prepare should not include meeting markdown")
+            assertFalse(capturedPrompt.contains("Action Items"), "prepare should not include summary prompt sections")
+        } catch {
+            assertTrue(false, "unexpected prepare failure: \(error)")
+        }
+    }
+
     runSuite("LocalGemmaSummaryRuntime stops a hung runner at the configured timeout") {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("LocalMeetingSummaryTimeoutTests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary
- prepares/downloads Gemma from the Beta page when AI meeting summaries are enabled
- adds privacy-safe local summary start/success/failure diagnostics
- shows a Home success card after an inline Gemma summary is written
- refreshes Home without fully blanking the recent meeting rows after summary generation

## Verification
- bash build.sh --no-open
- bash run-tests.sh
- bash run-integration-smoke.sh
- bash scripts/ops/run-local-summary-fixture.sh