### PR TITLE
[docs] Update packaged QA docs

### DIFF
--- a/.agents/qa-gates.yml
+++ b/.agents/qa-gates.yml
@@ -106,7 +106,7 @@ test_layers:
       release_gate_report: "python3 scripts/ops/release-gate-report.py"
       release_candidate_report: "python3 scripts/ops/release-gate-report.py --release-candidate"
       packaging_smoke: "SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>"
-      packaged_app_smoke: "bash scripts/ops/transcripted-qa-bench.sh --mode package"
+      packaged_app_smoke: "bash scripts/ops/transcripted-qa-bench.sh --mode packaged"
       sparkle_verify: "bash scripts/release/verify-sparkle-release.sh <version>"
       sentry_register: "SENTRY_REQUIRE_DEBUG_FILES=1 bash scripts/release/register-sentry-release.sh <version>"
       cask_update: "bash scripts/release/update-cask.sh <version>"

--- a/Tools/TranscriptedQA/CLAUDE.md
+++ b/Tools/TranscriptedQA/CLAUDE.md
@@ -1,6 +1,6 @@
 # TranscriptedQA - QA Testing CLI Tool
 
-QA testing suite for Transcripted. 29 Swift files total: `Package.swift`, 25 files under `Sources/TranscriptedQA/`, and 3 test files under `Tests/TranscriptedQATests/`.
+QA testing suite for Transcripted. 30 Swift files total: `Package.swift`, 25 files under `Sources/TranscriptedQA/`, and 4 test files under `Tests/TranscriptedQATests/`.
 
 The current package is intentionally small:
 
@@ -65,12 +65,13 @@ The current package is intentionally small:
 |------|---------|
 | `ValidationResult.swift` | shared `ValidationResult`, `ValidationReport`, and PASS/WARN/FAIL status types used for structured text or JSON validator output |
 
-### Tests/ (2 files)
+### Tests/ (4 files)
 
 | File | Purpose |
 |------|---------|
 | `PackagedAppSmokeTests.swift` | package-level coverage for packaged app metadata, Sparkle config, dSYM UUIDs, DMG, and log privacy checks |
 | `PermissionStateProbeTests.swift` | package-level coverage for permission-state probe modes and blocker classification |
+| `PermissionStateRuntimeGateTests.swift` | package-level coverage for duplicate/wrong-running-app runtime gate warnings |
 | `ValidatorTests.swift` | package-level coverage for YAML parsing, legacy index validation, JSON sidecar validation, and `ValidationReport` exit-code behavior |
 
 ## Usage


### PR DESCRIPTION
## Summary
- Fix packaged QA bench mode in qa gates from `package` to `packaged`
- Update TranscriptedQA guide counts and runtime-gate test coverage

## Verification
- `bash scripts/dev/agent-preflight.sh`
- `swift test --package-path Tools/TranscriptedQA`
- `git diff --check`

Claude Code was invoked for the requested docs proposal but produced no output before being terminated.