### PR TITLE
[qa] Ignore local summary sidecars in transcript validation

### DIFF
--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Validators/TranscriptValidator.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Validators/TranscriptValidator.swift
@@ -14,7 +14,11 @@ struct TranscriptValidator {
         let ignoredFilenames = Set(["AGENT.md", "CLAUDE.md", "README.md"])
 
         guard let files = try? fm.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
-            .filter({ $0.pathExtension == "md" && !ignoredFilenames.contains($0.lastPathComponent) }) else {
+            .filter({
+                $0.pathExtension == "md"
+                    && !ignoredFilenames.contains($0.lastPathComponent)
+                    && !isSummarySidecarFilename($0.lastPathComponent)
+            }) else {
             return [.fail("transcript/dir-readable", target: directory.path, detail: "Cannot read directory")]
         }
 
@@ -30,6 +34,10 @@ struct TranscriptValidator {
             }
 
             let yaml = YAMLParser(content: content)
+
+            if yaml.value(for: "capture_type") == "meeting_summary" {
+                continue
+            }
 
             // YAML present
             if yaml.hasFrontmatter {
@@ -130,5 +138,9 @@ struct TranscriptValidator {
         }
 
         return results
+    }
+
+    private func isSummarySidecarFilename(_ filename: String) -> Bool {
+        filename.hasSuffix(".summary.md")
     }
 }

--- a/Tools/TranscriptedQA/Tests/TranscriptedQATests/ValidatorTests.swift
+++ b/Tools/TranscriptedQA/Tests/TranscriptedQATests/ValidatorTests.swift
@@ -127,6 +127,48 @@ final class ValidatorTests: XCTestCase {
         })
     }
 
+    func testTranscriptValidatorIgnoresLocalSummarySidecars() throws {
+        try """
+        ---
+        capture_type: meeting_summary
+        source_transcript: "Call_2026-04-18_14-43-40.md"
+        summary_model: mlx-community/gemma-4-12B-it-4bit
+        ---
+        ## Summary
+        Local summary text.
+        """.write(
+            to: tempRoot.appendingPathComponent("Call_2026-04-18_14-43-40.summary.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        ---
+        title: "Call"
+        date: "2026-04-18"
+        time: "14:43:40"
+        duration: "600"
+        transcription_engine: "parakeet_local"
+        diarization_engine: "pyannote_offline"
+        sources: [mic, system_audio]
+        capture_quality: "excellent"
+        mic_utterances: "1"
+        system_utterances: "1"
+        total_word_count: "12"
+        ---
+        ## Transcript
+        Speaker 1: Hello.
+        """.write(
+            to: tempRoot.appendingPathComponent("Call_2026-04-18_14-43-40.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let results = TranscriptValidator(directory: tempRoot).validate()
+
+        XCTAssertFalse(results.contains { $0.target == "Call_2026-04-18_14-43-40.summary.md" })
+        XCTAssertFalse(results.contains { $0.status == .fail })
+    }
+
     func testLogValidatorAcceptsStableJSONLFields() throws {
         let logURL = tempRoot.appendingPathComponent("app.jsonl")
         try """


### PR DESCRIPTION
## Summary
- skip local Gemma summary sidecars in TranscriptedQA transcript validation
- add regression coverage so *.summary.md files do not fail release artifact validation

## Verification
- swift test --package-path Tools/TranscriptedQA
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa validate-all --format json