### PR TITLE
Bump Transcripted to 1.1.47

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -11,9 +11,9 @@
 	<key>CFBundleIdentifier</key>
 	<string>com.justinbetker.draft</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.46</string>
+	<string>1.1.47</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.46</string>
+	<string>1.1.47</string>
 	<key>TranscriptedSentryDSN</key>
 	<string>https://137ddd7f72199a8d7a06f1644224dce5@o4511202804170752.ingest.us.sentry.io/4511202823045120</string>
 	<key>TranscriptedSentryEnvironment</key>


### PR DESCRIPTION
## Summary
- bump Transcripted app version metadata to 1.1.47
- built notarized 1.1.47 DMG locally for release prep

## Verification
- NOTARY_PROFILE=Transcripted bash build-beta.sh '' redbars
- dwarfdump UUID match for app and dSYM
- packaged-app-smoke package checks pass; UI AX smoke remains yellow on first-run onboarding primary button proof

Artifact SHA-256: fcca7d19b42b6163de155723cb7b66805736d8397a48fa79f2cffa15a8de2b60