### PR TITLE
Update release metadata for 1.1.47

### DIFF
--- a/Casks/transcripted.rb
+++ b/Casks/transcripted.rb
@@ -1,6 +1,6 @@
 cask "transcripted" do
-  version "1.1.46"
-  sha256 "12f9d94caf9f43d93f5739da34bbcf60faba0c61d40e9aeebd94a783b1ba7999"
+  version "1.1.47"
+  sha256 "fcca7d19b42b6163de155723cb7b66805736d8397a48fa79f2cffa15a8de2b60"
 
   url "https://github.com/r3dbars/transcripted/releases/download/v#{version}/Transcripted-#{version}.dmg",
       verified: "github.com/r3dbars/transcripted/"

--- a/docs/appcast.xml
+++ b/docs/appcast.xml
@@ -7,6 +7,17 @@
     <description>Release feed for Transcripted macOS updates.</description>
     <language>en</language>
     <item>
+      <title>1.1.47</title>
+      <pubDate>Mon, 08 Jun 2026 10:57:44 -0500</pubDate>
+      <sparkle:version>1.1.47</sparkle:version>
+      <sparkle:shortVersionString>1.1.47</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
+      <enclosure url="https://github.com/r3dbars/transcripted/releases/download/v1.1.47/Transcripted-1.1.47.dmg" length="535998520" type="application/octet-stream" sparkle:edSignature="2JDN1CcyVUCBh52P4Gvg5Xz79gR1Fo908R6QODgbOHcnQgkwxZlMEsOBM082lXet9zJXEie17KJLp5E7/0RQBw==" />
+      <link>https://github.com/r3dbars/transcripted/releases/tag/v1.1.47</link>
+      <sparkle:releaseNotesLink>https://github.com/r3dbars/transcripted/releases/tag/v1.1.47</sparkle:releaseNotesLink>
+    </item>
+    <item>
       <title>1.1.46</title>
       <pubDate>Tue, 02 Jun 2026 21:46:53 -0500</pubDate>
       <sparkle:version>1.1.46</sparkle:version>


### PR DESCRIPTION
## Summary
- add the signed Sparkle appcast item for Transcripted 1.1.47
- update the Homebrew cask version and SHA-256

## Verification
- bash scripts/release/generate-sparkle-appcast.sh build/updates-1.1.47
- bash scripts/release/update-cask.sh 1.1.47
- released DMG SHA-256: fcca7d19b42b6163de155723cb7b66805736d8397a48fa79f2cffa15a8de2b60