### PR TITLE
Fix local Gemma summary setup stalls

### DIFF
--- a/Sources/UI/Settings/HomeMeetingSummaryBetaPresentationPolicy.swift
+++ b/Sources/UI/Settings/HomeMeetingSummaryBetaPresentationPolicy.swift
@@ -33,3 +33,27 @@ enum HomeMeetingSummaryBetaPresentationPolicy {
         isEnabled
     }
 }
+
+struct HomeLocalSummaryNotice: Identifiable, Equatable {
+    let id = UUID()
+    let transcriptURL: URL
+    let chunkCount: Int
+
+    var title: String { "AI summary saved" }
+    var status: String { "Saved" }
+    var detail: String {
+        let passText = chunkCount == 1 ? "one local Gemma pass" : "\(chunkCount) local Gemma passes"
+        return "The meeting Markdown was enhanced with a generated title and summary preview using \(passText)."
+    }
+}
+
+enum HomeLocalSummaryNoticeDismissalPolicy {
+    static let autoDismissDelayNanoseconds: UInt64 = 6_000_000_000
+
+    static func shouldDismiss(
+        current: HomeLocalSummaryNotice?,
+        scheduledNoticeID: UUID
+    ) -> Bool {
+        current?.id == scheduledNoticeID
+    }
+}

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -1580,7 +1580,7 @@ struct HomeMeetingRow: View {
                             .controlSize(.mini)
                             .frame(width: 12, height: 12)
 
-                        Text("Generating AI summary...")
+                        Text("Running local AI summary...")
                             .font(.system(size: 11.5, weight: .medium))
                             .foregroundStyle(Color.accentColor)
                             .lineLimit(1)

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -1074,19 +1074,6 @@ struct HomeRowMenuItem: Identifiable {
     }
 }
 
-struct HomeLocalSummaryNotice: Identifiable, Equatable {
-    let id = UUID()
-    let transcriptURL: URL
-    let chunkCount: Int
-
-    var title: String { "AI summary saved" }
-    var status: String { "Ready" }
-    var detail: String {
-        let passText = chunkCount == 1 ? "one local Gemma pass" : "\(chunkCount) local Gemma passes"
-        return "The meeting Markdown was enhanced with a generated title and summary preview using \(passText)."
-    }
-}
-
 struct HomeRowActionButtons: View {
     let isCopied: Bool
     let onCopy: () -> Void

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -79,6 +79,7 @@ struct TranscriptedSettingsView: View {
     @State private var homeLocalSummaryTasks: [String: Task<LocalMeetingSummaryResult, Error>] = [:]
     @State private var homeLocalSummaryTaskTokens: [String: UUID] = [:]
     @State private var homeLocalSummaryNotice: HomeLocalSummaryNotice?
+    @State private var homeLocalSummaryNoticeDismissTask: Task<Void, Never>?
     @AppStorage(LocalMeetingSummaryPreferences.enabledKey) private var localMeetingSummariesEnabled = LocalMeetingSummaryPreferences.defaultEnabled
     @AppStorage(LiveMeetingCodexPreferences.enabledKey) private var betaLiveMeetingCodexEnabled = LiveMeetingCodexPreferences.defaultEnabled
     @State private var betaFeatureStatus: String?
@@ -402,10 +403,11 @@ struct TranscriptedSettingsView: View {
                     status: notice.status,
                     detail: notice.detail,
                     tone: .success,
-                    progress: 1.0,
+                    progress: nil,
                     actionTitle: "Open enhanced transcript",
                     action: {
                         trackSettingsAction("open_local_meeting_summary_notice", page: .home)
+                        clearHomeLocalSummaryNotice(id: notice.id)
                         NSWorkspace.shared.open(notice.transcriptURL)
                     }
                 )
@@ -746,7 +748,7 @@ struct TranscriptedSettingsView: View {
                 "has_runtime": localSummarySetupStatus.hasRuntime ? "true" : "false",
             ]
         )
-        homeLocalSummaryNotice = nil
+        clearHomeLocalSummaryNotice()
         homeLocalSummaryJobIDs.insert(item.id)
 
         let task = Task.detached(priority: .utility) {
@@ -771,10 +773,10 @@ struct TranscriptedSettingsView: View {
             do {
                 let result = try await task.value
                 guard localMeetingSummariesEnabled else { return }
-                homeLocalSummaryNotice = HomeLocalSummaryNotice(
+                presentHomeLocalSummaryNotice(HomeLocalSummaryNotice(
                     transcriptURL: result.transcriptURL,
                     chunkCount: result.chunkCount
-                )
+                ))
                 recordLocalSummaryEvent(
                     event: "local_meeting_summary_completed",
                     message: "Local Gemma meeting summary saved",
@@ -2688,6 +2690,7 @@ struct TranscriptedSettingsView: View {
             prepareLocalSummaryModelFromBeta()
         } else {
             cancelLocalSummaryJobs()
+            clearHomeLocalSummaryNotice()
             cancelLocalSummaryModelPreparation()
             localSummaryModelPreparationStatus = nil
         }
@@ -2800,6 +2803,28 @@ struct TranscriptedSettingsView: View {
         homeLocalSummaryTasks.removeAll()
         homeLocalSummaryTaskTokens.removeAll()
         homeLocalSummaryJobIDs.removeAll()
+    }
+
+    private func presentHomeLocalSummaryNotice(_ notice: HomeLocalSummaryNotice) {
+        homeLocalSummaryNotice = notice
+        homeLocalSummaryNoticeDismissTask?.cancel()
+        homeLocalSummaryNoticeDismissTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: HomeLocalSummaryNoticeDismissalPolicy.autoDismissDelayNanoseconds)
+            guard !Task.isCancelled,
+                  HomeLocalSummaryNoticeDismissalPolicy.shouldDismiss(
+                    current: homeLocalSummaryNotice,
+                    scheduledNoticeID: notice.id
+                  ) else { return }
+            homeLocalSummaryNotice = nil
+            homeLocalSummaryNoticeDismissTask = nil
+        }
+    }
+
+    private func clearHomeLocalSummaryNotice(id: UUID? = nil) {
+        if let id, homeLocalSummaryNotice?.id != id { return }
+        homeLocalSummaryNoticeDismissTask?.cancel()
+        homeLocalSummaryNoticeDismissTask = nil
+        homeLocalSummaryNotice = nil
     }
 
     private func refreshRecentCapturesAfterLocalSummary() {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -942,14 +942,23 @@ struct TranscriptedSettingsView: View {
         var items: [HomeRowMenuItem] = []
         let hasSummary = item.summaryPreview != nil
         let isSummarizing = homeLocalSummaryJobIDs.contains(item.id)
+        let isPreparingLocalGemma = isLocalSummaryModelPreparing
         let canGenerateSummary = localMeetingSummaryUnavailableReason == nil
+        let summaryActionTitle: String
+        if isSummarizing {
+            summaryActionTitle = "Running AI summary..."
+        } else if hasSummary {
+            summaryActionTitle = "Open enhanced transcript"
+        } else if isPreparingLocalGemma {
+            summaryActionTitle = "Preparing Gemma..."
+        } else {
+            summaryActionTitle = "Run AI summary"
+        }
 
         if HomeMeetingSummaryBetaPresentationPolicy.shouldShowSummaryMenuActions(isEnabled: localMeetingSummariesEnabled) {
             items.append(
                 HomeRowMenuItem(
-                    title: isSummarizing
-                        ? "Running AI summary..."
-                        : (hasSummary ? "Open enhanced transcript" : "Run AI summary"),
+                    title: summaryActionTitle,
                     symbolName: hasSummary ? "doc.text" : "sparkles",
                     isEnabled: !isSummarizing && (hasSummary || canGenerateSummary)
                 ) {
@@ -979,7 +988,9 @@ struct TranscriptedSettingsView: View {
            hasSummary {
             items.append(
                 HomeRowMenuItem(
-                    title: isSummarizing ? "Regenerating AI summary..." : "Regenerate AI summary",
+                    title: isSummarizing
+                        ? "Regenerating AI summary..."
+                        : (isPreparingLocalGemma ? "Preparing Gemma..." : "Regenerate AI summary"),
                     symbolName: "arrow.clockwise",
                     isEnabled: !isSummarizing && canGenerateSummary
                 ) {
@@ -1317,6 +1328,7 @@ struct TranscriptedSettingsView: View {
             isDictationActive: sttRouter.isRecording || sttRouter.isTranscribing,
             isMeetingRecording: meetingSession.isRecording,
             isPreparingModels: meetingSession.state == .loadingModels,
+            isPreparingLocalSummaryModel: isLocalSummaryModelPreparing,
             hasMeetingWork: meetingSession.hasRuntimeDiagnosticsWork,
             isSpeakerReviewPending: meetingSession.isSpeakerReviewPending
         )
@@ -2523,14 +2535,20 @@ struct TranscriptedSettingsView: View {
 
                 if localMeetingSummariesEnabled, localSummarySetupStatus.isReady {
                     SettingsInlineActionButton(
-                        title: isLocalSummaryModelPreparing ? "Preparing Gemma..." : "Prepare Gemma",
-                        symbolName: "tray.and.arrow.down",
+                        title: isLocalSummaryModelPreparing ? "Cancel setup" : "Prepare Gemma",
+                        symbolName: isLocalSummaryModelPreparing ? "xmark.circle" : "tray.and.arrow.down",
+                        tone: isLocalSummaryModelPreparing ? .warning : .neutral,
                         automationIdentifier: "transcripted.settings.beta.local-summary.prepare-model"
                     ) {
-                        trackSettingsAction("prepare_local_summary_model", page: .beta)
-                        prepareLocalSummaryModelFromBeta()
+                        if isLocalSummaryModelPreparing {
+                            trackSettingsAction("cancel_local_summary_model_prepare", page: .beta)
+                            cancelLocalSummaryModelPreparation()
+                            localSummaryModelPreparationStatus = "Gemma setup cancelled. You can try Prepare Gemma again when this Mac is idle."
+                        } else {
+                            trackSettingsAction("prepare_local_summary_model", page: .beta)
+                            prepareLocalSummaryModelFromBeta()
+                        }
                     }
-                    .disabled(isLocalSummaryModelPreparing)
                 }
             }
 
@@ -2690,7 +2708,7 @@ struct TranscriptedSettingsView: View {
         }
 
         isLocalSummaryModelPreparing = true
-        localSummaryModelPreparationStatus = "Preparing Gemma 4 12B locally. First run may download several GB from Hugging Face."
+        localSummaryModelPreparationStatus = "Preparing Gemma 4 12B locally. First run may download several GB from Hugging Face and can take several minutes on M1 Macs."
         recordLocalSummaryEvent(
             event: "local_meeting_summary_model_prepare_started",
             message: "Local Gemma model preparation started",
@@ -2817,26 +2835,35 @@ struct TranscriptedSettingsView: View {
     }
 
     private var localSummarySetupStatusTitle: String {
+        if isLocalSummaryModelPreparing {
+            return "Preparing Gemma locally"
+        }
         if !localSummarySetupStatus.hasEnoughMemory {
             return "Not supported on this Mac"
         }
         if !localSummarySetupStatus.hasRuntime {
             return "Setup needed"
         }
-        return "Ready for first summary"
+        return "Runtime ready"
     }
 
     private var localSummarySetupStatusDetail: String {
+        if isLocalSummaryModelPreparing {
+            return "Transcripted is downloading or warming the local Gemma runner. Home summaries stay paused so this Mac only runs one Gemma job at a time."
+        }
         if !localSummarySetupStatus.hasEnoughMemory {
             return "This Mac reports \(localSummarySetupStatus.physicalMemoryGB) GB memory. Local Gemma summaries need at least \(localSummarySetupStatus.minimumMemoryGB) GB to avoid heavy swapping."
         }
         if !localSummarySetupStatus.hasRuntime {
             return "Install uv first. The first summary may download a large local Gemma model, then future summaries reuse the local cache."
         }
-        return "uv is installed. The first summary may download a large local Gemma model; after that, summaries reuse the local cache."
+        return "uv is installed. Use Prepare Gemma to download or warm the local model before running a meeting summary."
     }
 
     private var localSummarySetupStatusSymbol: String {
+        if isLocalSummaryModelPreparing {
+            return "arrow.triangle.2.circlepath"
+        }
         if localSummarySetupStatus.isReady {
             return "checkmark.circle.fill"
         }
@@ -2844,6 +2871,9 @@ struct TranscriptedSettingsView: View {
     }
 
     private var localSummarySetupStatusColor: Color {
+        if isLocalSummaryModelPreparing {
+            return Color.accentColor
+        }
         if localSummarySetupStatus.isReady {
             return .green
         }

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -196,6 +196,7 @@ enum LocalMeetingSummaryAvailabilityPolicy {
         isDictationActive: Bool,
         isMeetingRecording: Bool,
         isPreparingModels: Bool,
+        isPreparingLocalSummaryModel: Bool = false,
         hasMeetingWork: Bool,
         isSpeakerReviewPending: Bool
     ) -> String? {
@@ -207,6 +208,9 @@ enum LocalMeetingSummaryAvailabilityPolicy {
         }
         if isPreparingModels {
             return "Preparing models..."
+        }
+        if isPreparingLocalSummaryModel {
+            return "Gemma is still preparing. Wait for setup to finish, or cancel setup from Beta settings before summarizing."
         }
         if hasMeetingWork {
             return "Wait for the current meeting to finish saving or transcribing before summarizing."

--- a/Tests/HomeMeetingSummaryBetaPresentationPolicyTests.swift
+++ b/Tests/HomeMeetingSummaryBetaPresentationPolicyTests.swift
@@ -68,6 +68,41 @@ func testHomeMeetingSummaryBetaPresentationPolicy() {
             "unsummarized meetings should not show the local-summary sparkle"
         )
     }
+
+    runSuite("HomeLocalSummaryNoticeDismissalPolicy clears only the scheduled notice") {
+        let firstNotice = HomeLocalSummaryNotice(
+            transcriptURL: URL(fileURLWithPath: "/tmp/first.md"),
+            chunkCount: 1
+        )
+        let newerNotice = HomeLocalSummaryNotice(
+            transcriptURL: URL(fileURLWithPath: "/tmp/newer.md"),
+            chunkCount: 2
+        )
+
+        assertEqual(firstNotice.status, "Saved", "completed summary notices should read as saved, not ongoing")
+        assertTrue(
+            HomeLocalSummaryNoticeDismissalPolicy.autoDismissDelayNanoseconds >= 4_000_000_000,
+            "success notice should stay visible long enough to scan"
+        )
+        assertTrue(
+            HomeLocalSummaryNoticeDismissalPolicy.autoDismissDelayNanoseconds <= 10_000_000_000,
+            "success notice should not linger like a stuck activity card"
+        )
+        assertTrue(
+            HomeLocalSummaryNoticeDismissalPolicy.shouldDismiss(
+                current: firstNotice,
+                scheduledNoticeID: firstNotice.id
+            ),
+            "the scheduled notice should be dismissible"
+        )
+        assertFalse(
+            HomeLocalSummaryNoticeDismissalPolicy.shouldDismiss(
+                current: newerNotice,
+                scheduledNoticeID: firstNotice.id
+            ),
+            "an old dismissal timer should not clear a newer summary notice"
+        )
+    }
 }
 
 private func sampleHomeMeetingSummaryBetaItem(

--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -325,6 +325,19 @@ func testRecentCaptureScanners() async {
             "Preparing models...",
             "local meeting summaries should not start while model prep is in flight"
         )
+
+        assertEqual(
+            LocalMeetingSummaryAvailabilityPolicy.unavailableReason(
+                isDictationActive: false,
+                isMeetingRecording: false,
+                isPreparingModels: false,
+                isPreparingLocalSummaryModel: true,
+                hasMeetingWork: false,
+                isSpeakerReviewPending: false
+            ),
+            "Gemma is still preparing. Wait for setup to finish, or cancel setup from Beta settings before summarizing.",
+            "local Gemma setup should stay single-flight with Home summary generation on M1 Macs"
+        )
     }
 
     runSuite("LocalMeetingSummaryAvailabilityPolicy blocks during live work") {


### PR DESCRIPTION
## Summary
- prevent Home from starting a local AI meeting summary while Gemma setup is already running
- replace the disabled 'Preparing Gemma...' button with a cancelable setup action
- clarify Beta/Home copy so 'uv installed' is not presented as the model being fully ready
- add coverage for the local Gemma setup single-flight block

## Diagnosis
Justin's M1 feedback screenshots showed Beta stuck on 'Preparing Gemma...' while Home simultaneously showed a meeting stuck on 'Generating AI summary...'. That meant the app could run setup/warmup and an actual summary at the same time, which is especially rough on M1/16GB machines and makes the UI feel frozen.

## Verification
- PASS: bash build.sh --no-open
- RED unrelated: bash run-tests.sh completed 4496 tests with 4494 passing; the only failures were existing release-contract checks in NightlySecurityContractTests.swift:136 and :138 about release fixture / cask vs GitHub asset digest drift, outside this change.