### PR TITLE
[docs] Update QA gate docs

### DIFF
--- a/.agents/qa-gates.yml
+++ b/.agents/qa-gates.yml
@@ -4,7 +4,7 @@
 # - test-matrix.yml maps changed paths to local verification commands.
 # - qa-gates.yml maps product risk and agent lanes to the gate that proves it.
 
-last_reviewed: 2026-06-07
+last_reviewed: 2026-06-08
 
 source_docs:
   - AGENTS.md
@@ -53,7 +53,7 @@ test_layers:
       deep: "bash scripts/ops/transcripted-qa-bench.sh --mode deep"
       full: "bash scripts/ops/transcripted-qa-bench.sh --mode full"
       ui: "bash scripts/ops/transcripted-qa-bench.sh --mode ui"
-      package: "bash scripts/ops/transcripted-qa-bench.sh --mode package"
+      packaged: "bash scripts/ops/transcripted-qa-bench.sh --mode packaged"
       artifact: "bash scripts/ops/transcripted-qa-bench.sh --mode artifact"
       audio_synthetic: "bash scripts/ops/transcripted-qa-bench.sh --mode audio-synthetic"
       corpus: "bash scripts/ops/transcripted-qa-bench.sh --mode corpus"
@@ -170,7 +170,7 @@ recommended_gates:
       - "bash run-e2e-smoke.sh"
       - "swift test"
       - "SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>"
-      - "bash scripts/ops/transcripted-qa-bench.sh --mode package"
+      - "bash scripts/ops/transcripted-qa-bench.sh --mode packaged"
     add_when_shipping_to_users:
       - "bash scripts/ops/transcripted-qa-bench.sh --mode deep --strict-artifacts when fixture or private artifact roots are available"
       - "full notarized build-beta.sh"


### PR DESCRIPTION
## Summary
- Rename the QA bench packaged gate key to match the supported packaged mode.
- Update the release-candidate QA bench command from --mode package to --mode packaged.
- Refresh last_reviewed after checking the current QA bench mode list.

## Verification
- bash scripts/dev/agent-preflight.sh
- bash -n scripts/ops/transcripted-qa-bench.sh && bash scripts/ops/transcripted-qa-bench.sh --help >/tmp/transcripted-qa-bench-help-doc-writer.txt
- rg stale package-mode references; only the unrelated core_package label remains.