### PR TITLE
Fix sandboxed launch smoke crash

### DIFF
--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -6,6 +6,7 @@ import AppKit
 import AVFoundation
 import Carbon
 import Combine
+import Darwin
 import TranscriptedCore
 import UniformTypeIdentifiers
 
@@ -454,6 +455,9 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
               !reportPath.isEmpty else {
             return
         }
+        defer {
+            scheduleLaunchUISmokeTerminationIfRequested(environment: environment)
+        }
 
         let smokeMenuVisibility = Dictionary(uniqueKeysWithValues: MenuBarOptionalItem.allCases.map { ($0, true) })
         let report = menuPanelController.launchUISmokeReport(
@@ -474,6 +478,18 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             try encoder.encode(report).write(to: reportURL, options: .atomic)
         } catch {
             NSLog("Failed to write launch UI smoke report: \(error.localizedDescription)")
+        }
+    }
+
+    private func scheduleLaunchUISmokeTerminationIfRequested(environment: [String: String]) {
+        guard environment["TRANSCRIPTED_LAUNCH_UI_SMOKE_TERMINATE_AFTER_REPORT"] == "1" else { return }
+
+        let delay = environment["TRANSCRIPTED_LAUNCH_UI_SMOKE_TERMINATE_DELAY_SECONDS"]
+            .flatMap(Double.init)
+            .map { max(0, $0) } ?? 5
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            Darwin.exit(0)
         }
     }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1221,6 +1221,24 @@ func testRepoCommandContract() {
             localBuildScript.contains("TRANSCRIPTED_DISABLE_RUNTIME_DIAGNOSTICS=1"),
             "local launch smoke should not create dirty-shutdown diagnostics markers"
         )
+        assertTrue(
+            localBuildScript.contains("/usr/bin/open -n -g -F -W")
+                && localBuildScript.contains("--env \"TRANSCRIPTED_LAUNCH_UI_SMOKE_REPORT=$ui_report\"")
+                && localBuildScript.contains("--env \"TRANSCRIPTED_LAUNCH_UI_SMOKE_TERMINATE_AFTER_REPORT=1\"")
+                && localBuildScript.contains("\"$APP_BUNDLE\""),
+            "local launch smoke should launch the app bundle through LaunchServices"
+        )
+        assertFalse(
+            localBuildScript.contains("\"$APP_BINARY\" >\"$smoke_log\""),
+            "local launch smoke should not run the app executable directly from sandboxed agent contexts"
+        )
+        let appSource = readRepoTextFile("Sources/TranscriptedApp.swift")
+        assertTrue(
+            appSource.contains("TRANSCRIPTED_LAUNCH_UI_SMOKE_TERMINATE_AFTER_REPORT")
+                && appSource.contains("scheduleLaunchUISmokeTerminationIfRequested")
+                && appSource.contains("Darwin.exit(0)"),
+            "launch smoke should let the app terminate itself instead of depending on process-listing in sandboxed agents"
+        )
 
         let runtimeDiagnostics = readRepoTextFile("Sources/Observability/RuntimeDiagnostics.swift")
         assertTrue(

--- a/scripts/entrypoints/build.sh
+++ b/scripts/entrypoints/build.sh
@@ -158,35 +158,40 @@ verify_signature() {
 }
 
 verify_launch_smoke() {
-    local smoke_log="$BUILD_DIR/launch-smoke.log"
-    local smoke_home="$BUILD_DIR/launch-smoke-home"
-    local ui_report="$BUILD_DIR/launch-ui-smoke.json"
+    local smoke_log="$REPO_ROOT/$BUILD_DIR/launch-smoke.log"
+    local smoke_home="$REPO_ROOT/$BUILD_DIR/launch-smoke-home"
+    local ui_report="$REPO_ROOT/$BUILD_DIR/launch-ui-smoke.json"
+    local open_pid=""
     rm -f "$smoke_log"
     rm -rf "$smoke_home"
     rm -f "$ui_report"
     mkdir -p "$smoke_home"
 
-    CFFIXED_USER_HOME="$smoke_home" \
-    HOME="$smoke_home" \
-    TRANSCRIPTED_DISABLE_FILE_LOGGER=1 \
-    TRANSCRIPTED_DISABLE_RUNTIME_DIAGNOSTICS=1 \
-    TRANSCRIPTED_DISABLE_SINGLE_INSTANCE_GUARD=1 \
-    TRANSCRIPTED_LAUNCH_UI_SMOKE_REPORT="$ui_report" \
-    "$APP_BINARY" >"$smoke_log" 2>&1 &
-    local app_pid=$!
+    /usr/bin/open -n -g -F -W \
+        --stdout "$smoke_log" \
+        --stderr "$smoke_log" \
+        --env "CFFIXED_USER_HOME=$smoke_home" \
+        --env "HOME=$smoke_home" \
+        --env "TRANSCRIPTED_DISABLE_FILE_LOGGER=1" \
+        --env "TRANSCRIPTED_DISABLE_RUNTIME_DIAGNOSTICS=1" \
+        --env "TRANSCRIPTED_DISABLE_SINGLE_INSTANCE_GUARD=1" \
+        --env "TRANSCRIPTED_LAUNCH_UI_SMOKE_REPORT=$ui_report" \
+        --env "TRANSCRIPTED_LAUNCH_UI_SMOKE_TERMINATE_AFTER_REPORT=1" \
+        "$APP_BUNDLE" >>"$smoke_log" 2>&1 &
+    open_pid=$!
 
     for _ in $(seq 1 50); do
         if [ -s "$ui_report" ]; then
             break
         fi
-        if ! kill -0 "$app_pid" 2>/dev/null; then
+        if ! kill -0 "$open_pid" 2>/dev/null; then
             break
         fi
         sleep 0.1
     done
 
-    if ! kill -0 "$app_pid" 2>/dev/null; then
-        wait "$app_pid" || true
+    if ! kill -0 "$open_pid" 2>/dev/null && [ ! -s "$ui_report" ]; then
+        wait "$open_pid" || true
         echo "Transcripted exited during launch smoke."
         echo "Smoke log:"
         cat "$smoke_log"
@@ -197,8 +202,8 @@ verify_launch_smoke() {
         echo "Transcripted launch UI smoke report was not written."
         echo "Smoke log:"
         cat "$smoke_log"
-        kill "$app_pid" 2>/dev/null || true
-        wait "$app_pid" 2>/dev/null || true
+        kill "$open_pid" 2>/dev/null || true
+        wait "$open_pid" 2>/dev/null || true
         exit 1
     fi
 
@@ -272,24 +277,17 @@ if errors:
     sys.exit(1)
 PY
     then
-        kill "$app_pid" 2>/dev/null || true
-        wait "$app_pid" 2>/dev/null || true
+        kill "$open_pid" 2>/dev/null || true
+        wait "$open_pid" 2>/dev/null || true
         exit 1
     fi
 
-    for _ in $(seq 1 50); do
-        if ! kill -0 "$app_pid" 2>/dev/null; then
-            wait "$app_pid" || true
-            echo "Transcripted exited during launch smoke."
-            echo "Smoke log:"
-            cat "$smoke_log"
-            exit 1
-        fi
-        sleep 0.1
-    done
-
-    kill "$app_pid" 2>/dev/null || true
-    wait "$app_pid" 2>/dev/null || true
+    if ! wait "$open_pid"; then
+        echo "Transcripted exited with an error during launch smoke."
+        echo "Smoke log:"
+        cat "$smoke_log"
+        exit 1
+    fi
 }
 
 sign_embedded_code() {


### PR DESCRIPTION
## Summary
- launch the local smoke app bundle through LaunchServices instead of running the executable directly
- add a smoke-only self-exit hook after the UI report is written
- add repo contract coverage so the launch path does not regress

## Verification
- bash build.sh --no-open
- bash run-tests.sh (4425 passed, 0 failed)