### PR TITLE
[codex] Add 1.1.47 manual QA shrink

### DIFF
--- a/docs/release-candidate-1.1.47.md
+++ b/docs/release-candidate-1.1.47.md
@@ -70,3 +70,54 @@ long-meeting retry visibility, and the reported speaker-collapse fix.
   `transcripted@1.1.46`.
 - Confirm PostHog latest-release meeting health snapshots do not show unrecovered
   quiet mic or output-ducking clusters.
+
+## Manual QA Shrink
+
+Run this only after the release-candidate build and automated gate are ready.
+Keep the pass short and use synthetic speech only:
+
+```text
+Transcripted release QA test one two three.
+```
+
+1. Pasteback feel, 2 minutes:
+   - Dictate into Notes or TextEdit, then a browser text area.
+   - Try Auto Enter off, then on in the safe text area.
+   - Pass: fresh text appears, no stale clipboard paste, and Auto Enter only
+     fires in the intended target.
+2. Real WebRTC route, 4 minutes:
+   - Run Chrome Meet with built-in mic and speakers.
+   - Start meeting recording, speak the phrase, play meeting or system audio,
+     then stop.
+   - Pass: the meeting stays audible, saved Markdown exists, mic audio is
+     usable, and system audio is present or clearly unavailable.
+3. Zoom plus AirPods/Bluetooth route, 4 minutes:
+   - Run Zoom with AirPods or a Bluetooth route.
+   - Repeat the short recording.
+   - Pass: output does not get quieter, recording stops cleanly, saved Markdown
+     exists, and a second attempt works if route settling delays the first.
+4. Local Gemma beta workflow, 3-5 minutes:
+   - On the saved synthetic meeting, enable the beta summary path and trigger a
+     summary from Home.
+   - Pass: the UI stays responsive, the summary attaches to the right meeting,
+     Markdown is not corrupted, and any missing-model/runtime failure is clear.
+
+Capture one short evidence row for each item: pass/fail, app and route, saved
+Markdown path, screenshot if useful, and relevant `events.jsonl` fields such as
+`mic_processed_peak`, `system_peak`, volume before/during/after, and
+`output_ducking_detected`.
+
+This checklist intentionally stays smaller than the full issue 500 matrix. The
+automated gate already covers build/tests, E2E artifacts, synthetic slow
+pasteback, local summary fixture shape, mocked meeting-route fixtures, mocked
+Bluetooth/AirPods contracts, permission-state gates, UI harness, and release
+reporting.
+
+Block `1.1.47` if any real meeting gets quieter, Zoom/WebRTC lacks usable saved
+audio or Markdown, AirPods/Bluetooth gets stuck, pasteback inserts stale text or
+Auto Enter fires in the wrong target, or Gemma corrupts the wrong transcript or
+freezes Home.
+
+If follow-up QA automation PRs merge before the release candidate is built,
+rerun the release-candidate gate, but keep this same human checklist unless one
+of those PRs changes release packaging or the user-facing manual flow itself.


### PR DESCRIPTION
## Summary

- Adds a compact 10-15 minute manual QA script to the `1.1.47` release-candidate notes.
- Separates what automation already proves from the remaining human checks: pasteback feel, real WebRTC/Zoom routes, AirPods/Bluetooth, and local Gemma beta workflow.
- Adds explicit release stop criteria for the remaining manual gate.

## Validation

- `git diff --check`
- `scripts/dev/agent-preflight.sh`

No release was cut or published.