### PR TITLE
[nightly-review] Filter support diagnostics from Sentry health rollups

### DIFF
--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -61,8 +61,10 @@ func testRepoCommandContract() {
         )
         assertTrue(
             contents.contains("sentry_test_event")
-                && contents.contains("select(((.title // \"\") | contains(\"sentry_test_event\")) | not)"),
-            "Sentry probe should filter manual verification events out of health rollups"
+                && contents.contains("support_diagnostic_event")
+                && contents.contains("contains(\"sentry_test_event\")")
+                && contents.contains("contains(\"support_diagnostic_event\")"),
+            "Sentry probe should filter manual verification and support diagnostic events out of health rollups"
         )
         assertFalse(
             contents.contains("/events/"),

--- a/scripts/ops/health-probe.sh
+++ b/scripts/ops/health-probe.sh
@@ -96,7 +96,7 @@ probe_sentry() {
   response=$(curl -s -f -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
     "https://sentry.io/api/0/projects/r3dbars/apple-macos/issues/?query=is:unresolved&limit=10" \
     --header "Content-Type: application/json")
-  response=$(echo "$response" | jq '[.[] | select(((.title // "") | contains("sentry_test_event")) | not)]')
+  response=$(echo "$response" | jq '[.[] | select((((.title // "") | contains("sentry_test_event")) or ((.title // "") | contains("support_diagnostic_event"))) | not)]')
 
   if [[ -z "$response" ]]; then
     echo "Sentry: no unresolved issues"


### PR DESCRIPTION
## Summary
- filter manual `support_diagnostic_event` issues from `scripts/ops/health-probe.sh` Sentry rollups, matching the existing `sentry_test_event` treatment
- tighten the repo command contract so both manual verification and support diagnostic issues stay out of nightly health counts

## Nightly review risks ranked
1. Live Sentry still has `HTTPClientError 502` on `transcripted@1.1.46` as the freshest unresolved issue; current main has 1.1.47 release/update health plumbing, but production 502s need follow-up after 1.1.47 adoption.
2. `meeting.recording_capture_degraded` remains fresh on `transcripted@1.1.46`; keep issue #500 manual route proof separate from synthetic green.
3. The configured automation checkout `/Users/redbars/.codex/worktrees/9b7e/transcripted-latest` was missing again and had to be recreated before review; this risks skipped or stale nightly runs.

## Verification
- `bash -n scripts/ops/health-probe.sh`
- jq sample confirming `sentry_test_event` and `support_diagnostic_event` are filtered while `meeting.recording_capture_degraded` remains
- `bash run-tests.sh` -> 4513 passed, 0 failed
- `set -a; source /Users/redbars/.hermes/.env; set +a; bash scripts/ops/health-probe.sh sentry` -> filtered rollup now starts with 502 and meeting capture degraded, not support diagnostics
- `bash build-deps.sh --force` after fresh-worktree missing deps
- `bash build.sh --no-open`
