### PR TITLE
[docs] Update release health docs

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -58,7 +58,7 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
 - `scripts/ops/nightly-security-check.py` — deterministic nightly security/privacy guardrail checker for repo drift, release/update drift, Homebrew cask/appcast parity, PostHog schema drift, raw observability payload keys, entitlements, shell hazards, recent-history secret leaks, and shared sanitizer coverage
   - Usage: `python3 scripts/ops/nightly-security-check.py --write-report build/nightly-security-report.json`
   - Strict gate: `python3 scripts/ops/nightly-security-check.py --strict --write-report build/nightly-security-report.json`
-  - Deterministic release-health fixture gate: `python3 scripts/ops/nightly-security-check.py --strict --automation-toml Tests/Fixtures/nightly-security-automation.toml --github-release-json Tests/Fixtures/release-health-github-release-1.1.46.json --write-report build/nightly-security-report.json`
+  - Deterministic release-health fixture gate: `python3 scripts/ops/nightly-security-check.py --strict --automation-toml Tests/Fixtures/nightly-security-automation.toml --github-release-json Tests/Fixtures/release-health-github-release-1.1.47.json --write-report build/nightly-security-report.json`
   - Live release-surface gate: `python3 scripts/ops/nightly-security-check.py --strict --live-release-surfaces`
   - Sentry release gate: `python3 scripts/ops/nightly-security-check.py --sentry-release-health`
   - Required Sentry release gate: `python3 scripts/ops/nightly-security-check.py --strict --require-sentry-release-health`


### PR DESCRIPTION
## Summary
- update scripts/README.md to point the deterministic release-health fixture command at the renamed 1.1.47 fixture
- keep it aligned with .agents/test-matrix.yml, agent-preflight, and the QA bench command

## Verification
- bash scripts/dev/agent-preflight.sh
- git diff --check
- rg release-health fixture references across scripts/README.md, .agents/test-matrix.yml, scripts/dev/agent-preflight.sh, scripts/ops/transcripted-qa-bench.sh, and Tests/Fixtures