### PR TITLE
[codex] Fix speaker inbox affordance

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -2273,6 +2273,9 @@ struct HomeActivityTabsCard: View {
     }
 
     private func hasSpeakerReviewWork(for meeting: RecentMeetingItem) -> Bool {
+        guard speakerPeopleModel.hasLoadedProfiles else {
+            return meeting.speakerStatus.needsReview
+        }
         return speakerPeopleModel.hasPendingReview(forTranscript: meeting.transcriptURL)
     }
 

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -1682,6 +1682,7 @@ struct HomeMeetingRow: View {
             return AnyView(
                 reviewDotButton(
                     help: item.speakerStatus.summary,
+                    accessibilityLabel: "Review speaker labels",
                     isDisabled: false,
                     automationIdentifier: "transcripted.home.meeting.review-speakers",
                     action: onReviewSpeakers
@@ -1698,6 +1699,7 @@ struct HomeMeetingRow: View {
         return AnyView(
             reviewDotButton(
                 help: retranscriptionUnavailableReason ?? "Identify speakers from retained audio",
+                accessibilityLabel: "Identify speakers from retained audio",
                 isDisabled: !canRetranscribe,
                 automationIdentifier: "transcripted.home.meeting.retranscribe-speakers",
                 action: onRetranscribe
@@ -1787,14 +1789,15 @@ struct HomeMeetingRow: View {
 
     private func reviewDotButton(
         help: String,
+        accessibilityLabel: String,
         isDisabled: Bool,
         automationIdentifier: String,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            Circle()
-                .fill(Color.orange)
-                .frame(width: 7, height: 7)
+            Image(systemName: "person.crop.circle.badge.questionmark")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Color.orange)
                 .frame(width: 18, height: 26)
                 .contentShape(Rectangle())
         }
@@ -1802,6 +1805,8 @@ struct HomeMeetingRow: View {
         .disabled(isDisabled)
         .opacity(isDisabled ? 0.45 : 1)
         .help(help)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint(help)
         .accessibilityIdentifier(automationIdentifier)
     }
 
@@ -2160,6 +2165,7 @@ struct HomeDayGroupedList<Item, Row: View>: View {
 struct HomeActivityTabsCard: View {
     let selectedTab: HomeActivityTab
     @ObservedObject var speakerPeopleModel: SpeakerPeopleSettingsViewModel
+    let onShowSpeakerInbox: () -> Void
     let dictationSections: [HomeDaySection<SavedDictationEntry>]
     let meetingSections: [HomeDaySection<HomeMeetingListItem>]
     let isLoading: Bool
@@ -2259,7 +2265,7 @@ struct HomeActivityTabsCard: View {
                         }
                     }
                 case .speakers:
-                    HomeSpeakersTab(model: speakerPeopleModel)
+                    HomeSpeakersTab(model: speakerPeopleModel, onShowInbox: onShowSpeakerInbox)
                 }
             }
         }
@@ -2267,9 +2273,6 @@ struct HomeActivityTabsCard: View {
     }
 
     private func hasSpeakerReviewWork(for meeting: RecentMeetingItem) -> Bool {
-        guard speakerPeopleModel.hasLoadedProfiles else {
-            return meeting.speakerStatus.needsReview
-        }
         return speakerPeopleModel.hasPendingReview(forTranscript: meeting.transcriptURL)
     }
 
@@ -2307,6 +2310,7 @@ struct HomeActivityTabsCard: View {
 
 struct HomeSpeakersTab: View {
     @ObservedObject var model: SpeakerPeopleSettingsViewModel
+    let onShowInbox: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -2320,7 +2324,7 @@ struct HomeSpeakersTab: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            SpeakerPeopleSettingsSection(model: model)
+            SpeakerPeopleSettingsSection(model: model, onShowInbox: onShowInbox)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -634,7 +634,12 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
 }
 
 struct SpeakerPeopleSettingsSection: View {
+    enum ScrollTarget: Hashable {
+        case reviewQueue
+    }
+
     @ObservedObject var model: SpeakerPeopleSettingsViewModel
+    var onShowInbox: (() -> Void)?
 
     var body: some View {
         SettingsSection(
@@ -648,7 +653,11 @@ struct SpeakerPeopleSettingsSection: View {
                 speakerCount: model.profiles.count,
                 meetingCount: model.totalMeetingCount,
                 onShowNeedsReview: {
+                    model.searchText = ""
                     model.profileFilter = .needsReview
+                    if model.reviewQueueCount > 0 {
+                        onShowInbox?()
+                    }
                 }
             )
         }
@@ -669,6 +678,8 @@ struct SpeakerPeopleSettingsSection: View {
                     }
                 }
             }
+            .id(ScrollTarget.reviewQueue)
+            .accessibilityIdentifier("transcripted.speakers.inbox")
         }
 
         if !model.duplicateCandidates.isEmpty {
@@ -725,7 +736,7 @@ struct SpeakerPeopleSettingsSection: View {
 
     private var actionSectionDetail: String {
         if model.reviewQueueCount > 0 {
-            return "Deferred speaker reviews are ready to finish."
+            return "Speaker labels saved for later are ready to name."
         }
         if model.needsReviewCount > 0 {
             return "Start here when a speaker needs a name or a duplicate needs merging."
@@ -983,11 +994,32 @@ private struct SpeakerPeopleStatusRow: View {
     @ViewBuilder
     private var reviewButton: some View {
         if hasWork {
-            SettingsInlineActionButton(title: reviewQueueCount > 0 ? "Show Inbox" : "Show Review", tone: .warning) {
+            SettingsInlineActionButton(
+                title: actionTitle,
+                tone: .warning,
+                automationIdentifier: actionAutomationIdentifier
+            ) {
                 onShowNeedsReview()
             }
             .fixedSize(horizontal: true, vertical: false)
+            .help(actionHelp)
+            .accessibilityHint(actionHelp)
         }
+    }
+
+    private var actionTitle: String {
+        reviewQueueCount > 0 ? "Show Inbox" : "Show Review"
+    }
+
+    private var actionAutomationIdentifier: String {
+        reviewQueueCount > 0 ? "transcripted.speakers.show-inbox" : "transcripted.speakers.show-review"
+    }
+
+    private var actionHelp: String {
+        if reviewQueueCount > 0 {
+            return "Jump to the saved-call speaker labels that still need names."
+        }
+        return "Show only saved speakers that need review."
     }
 
     private var hasWork: Bool {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -90,6 +90,7 @@ struct TranscriptedSettingsView: View {
     @State private var localSummaryModelPreparationToken: UUID?
     @State private var isLocalSummaryModelPreparing = false
     @State private var settingsColumnVisibility: NavigationSplitViewVisibility = .all
+    @State private var speakerInboxScrollRequest = 0
 
     init(
         appState: TranscriptedAppState,
@@ -142,17 +143,27 @@ struct TranscriptedSettingsView: View {
                 )
                 .ignoresSafeArea()
 
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 28) {
-                        pageBody
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 28) {
+                            pageBody
+                        }
+                        .padding(.horizontal, 28)
+                        .padding(.top, settingsContentTopPadding)
+                        .padding(.bottom, 28)
+                        .frame(maxWidth: 860, alignment: .leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
-                    .padding(.horizontal, 28)
-                    .padding(.top, settingsContentTopPadding)
-                    .padding(.bottom, 28)
-                    .frame(maxWidth: 860, alignment: .leading)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .onChange(of: speakerInboxScrollRequest) { _, _ in
+                        Task { @MainActor in
+                            await Task.yield()
+                            withAnimation(.snappy(duration: 0.22)) {
+                                proxy.scrollTo(SpeakerPeopleSettingsSection.ScrollTarget.reviewQueue, anchor: .top)
+                            }
+                        }
+                    }
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
         }
         .frame(minWidth: 880, minHeight: 640)
@@ -420,6 +431,7 @@ struct TranscriptedSettingsView: View {
                 HomeActivityTabsCard(
                     selectedTab: homeActivityTab,
                     speakerPeopleModel: speakerPeopleModel,
+                    onShowSpeakerInbox: requestSpeakerInboxFocus,
                     dictationSections: homeViewModel.dictationDaySections,
                     meetingSections: meetingSections,
                     isLoading: homeViewModel.isLoading,
@@ -624,6 +636,11 @@ struct TranscriptedSettingsView: View {
         navigation.selectedPage = .home
         homeActivityTab = .speakers
         homeHeroMode = .speakers
+        requestSpeakerInboxFocus()
+    }
+
+    private func requestSpeakerInboxFocus() {
+        speakerInboxScrollRequest += 1
     }
 
     private func handleCopyDictation(_ entry: SavedDictationEntry) {
@@ -2209,10 +2226,13 @@ struct TranscriptedSettingsView: View {
         VStack(alignment: .leading, spacing: 24) {
             SettingsPageIntro(
                 title: "Speakers",
-                summary: "Name deferred speaker reviews, play samples, and clean up duplicates."
+                summary: "Name speaker labels saved for later, play samples, and clean up duplicates."
             )
 
-            SpeakerPeopleSettingsSection(model: speakerPeopleModel)
+            SpeakerPeopleSettingsSection(
+                model: speakerPeopleModel,
+                onShowInbox: requestSpeakerInboxFocus
+            )
         }
     }
 

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -47,7 +47,7 @@ enum RecentMeetingSpeakerStatus: Equatable, Sendable {
         case .ready:
             return "Speakers ready"
         case .needsReview(let count):
-            return count == 1 ? "1 speaker needs review" : "\(count) speakers need review"
+            return count == 1 ? "1 speaker label needs a name" : "\(count) speaker labels need names"
         }
     }
 

--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -102,8 +102,13 @@ func testRecentCaptureScanners() async {
         )
         assertEqual(
             RecentMeetingSpeakerStatus.needsReview(1).summary,
-            "1 speaker needs review",
+            "1 speaker label needs a name",
             "singular speaker summary should read naturally"
+        )
+        assertEqual(
+            RecentMeetingSpeakerStatus.needsReview(2).summary,
+            "2 speaker labels need names",
+            "plural speaker summary should explain the orange review affordance"
         )
         assertEqual(
             RecentMeetingSpeakerStatus.ready.summary,

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -186,6 +186,7 @@ func testUIAutomationSurfaceContract() {
     runSuite("UI automation surface contract - deterministic click-flow identifiers stay mapped") {
         let settingsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let homeSource = readUIAutomationContractFile("Sources/UI/Settings/HomeView.swift")
+        let speakerPeopleSource = readUIAutomationContractFile("Sources/UI/Settings/SpeakerPeopleSettingsSection.swift")
         let onboardingSource = readUIAutomationContractFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
 
         for identifier in [
@@ -251,6 +252,23 @@ func testUIAutomationSurfaceContract() {
         ] {
             assertTrue(settingsSource.contains(identifier), "\(identifier) should stay attached to Settings click-flow controls")
         }
+
+        assertTrue(
+            speakerPeopleSource.contains("transcripted.speakers.show-inbox")
+                && speakerPeopleSource.contains("transcripted.speakers.inbox")
+                && speakerPeopleSource.contains("onShowInbox?()")
+                && settingsSource.contains("proxy.scrollTo(SpeakerPeopleSettingsSection.ScrollTarget.reviewQueue"),
+            "Speaker Inbox should keep a stable Show Inbox action that scrolls to the pending-name rows"
+        )
+
+        assertTrue(
+            homeSource.contains("person.crop.circle.badge.questionmark")
+                && homeSource.contains(".accessibilityLabel(accessibilityLabel)")
+                && homeSource.contains(".accessibilityHint(help)")
+                && homeSource.contains("transcripted.home.meeting.review-speakers")
+                && homeSource.contains("transcripted.home.meeting.retranscribe-speakers"),
+            "Home speaker review affordances should explain the orange icon while keeping stable automation IDs"
+        )
 
         for identifier in [
             "transcripted.onboarding.nav.back",


### PR DESCRIPTION
## Summary
- Make Home speaker-review affordances use a small speaker/question icon with explicit accessibility label and hint instead of an unexplained orange dot.
- Wire Speaker Inbox `Show Inbox` to scroll to the pending speaker-name rows from Home > Meetings, Home > Speakers, and the Speakers settings page.
- Keep the Home row review affordance visible during initial profile loading, then tighten it to the same pending-review queue as Speaker Inbox once profiles load.
- Update tooltip/copy to say speaker labels need names.

## Verification
- `bash build-deps.sh --force` (needed once because this fresh worktree was missing dependency artifacts)
- `bash build.sh --no-open`
- `bash run-tests.sh` (4516 passed)
- `bash scripts/dev/agent-preflight.sh`
- `/Users/redbars/.codex/skills/codex-review/scripts/codex-review --mode branch` (clean; reran build + fast tests)
- GitHub `repo-hygiene` passed

## Notes
- I inspected the current open PRs (#1045-#1048); none touch speaker review navigation or this UI surface.
- The first review caught a transient loading fallback regression; commit `c5531939` restores it.