### PR TITLE
Fix meeting retranscribe dates and review loop

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -80,7 +80,8 @@ final class MeetingSessionController: ObservableObject {
                 micURL: URL,
                 systemURL: URL?,
                 healthInfo: RecordingHealthInfo,
-                meetingTitle: String?
+                meetingTitle: String?,
+                recordingDate: Date
             )
             case imported(
                 audioURL: URL,
@@ -108,6 +109,7 @@ final class MeetingSessionController: ObservableObject {
         let healthInfo: RecordingHealthInfo
         let pipelineSnapshot: AudioPipelineDiagnosticsSnapshot
         let suggestedTitle: String?
+        let recordingStartedAt: Date?
     }
 
     private struct BackgroundTranscriptionWorkSnapshot {
@@ -190,6 +192,7 @@ final class MeetingSessionController: ObservableObject {
     private var lastTerminalTranscriptionOutcome: TerminalTranscriptionOutcome?
     private var activeRecordingTrigger: StartTrigger = .unknown
     private var activeRecordingSuggestedTitle: String?
+    private var activeRecordingStartedAt: Date?
     private var activeTranscriptionTrigger: StartTrigger = .unknown
     private var isFinishingRecording = false
     private var shouldSurfaceMeetingWarmupFailure = false
@@ -404,6 +407,7 @@ final class MeetingSessionController: ObservableObject {
             finishLiveCodexSessionForActiveRecording(status: .failed, shouldAwaitFinalTranscript: false)
             activeRecordingTrigger = .unknown
             activeRecordingSuggestedTitle = nil
+            activeRecordingStartedAt = nil
             let failureMessage = capture.errorMessage ?? "Meeting recording couldn't start. Check Transcripted's permissions and audio setup, then try again."
             let pipelineSnapshot = capture.pipelineDiagnosticsSnapshot()
             let failureProperties = meetingCaptureAnalyticsProperties(snapshot: pipelineSnapshot).merging(
@@ -429,6 +433,7 @@ final class MeetingSessionController: ObservableObject {
             return false
         }
 
+        activeRecordingStartedAt = Date()
         state = .recording
         Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "recording")
         let pipelineSnapshot = capture.pipelineDiagnosticsSnapshot()
@@ -601,6 +606,7 @@ final class MeetingSessionController: ObservableObject {
         )
         activeRecordingTrigger = .unknown
         activeRecordingSuggestedTitle = nil
+        activeRecordingStartedAt = nil
         state = .transcribing
         Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "transcribing")
         let stopDiagnosticsContext = stopCaptureDiagnostics.merging(
@@ -669,7 +675,8 @@ final class MeetingSessionController: ObservableObject {
                 micAudioURL: nil,
                 systemAudioURL: files.systemURL,
                 errorMessage: "Recording stopped without microphone audio.",
-                meetingTitle: recordingSnapshot.suggestedTitle
+                meetingTitle: recordingSnapshot.suggestedTitle,
+                recordingDate: recordingSnapshot.recordingStartedAt
             )
             DiagnosticsTrail.record(
                 level: .error,
@@ -715,6 +722,7 @@ final class MeetingSessionController: ObservableObject {
                 systemAudioURL: files.systemURL,
                 errorMessage: "Recording stop timed out before audio files were finalized.",
                 meetingTitle: recordingSnapshot.suggestedTitle,
+                recordingDate: recordingSnapshot.recordingStartedAt,
                 archiveAudio: false
             )
             DiagnosticsTrail.record(
@@ -739,6 +747,7 @@ final class MeetingSessionController: ObservableObject {
             systemURL: files.systemURL,
             healthInfo: recordingSnapshot.healthInfo,
             meetingTitle: recordingSnapshot.suggestedTitle,
+            recordingDate: recordingSnapshot.recordingStartedAt ?? Date(),
             startTrigger: recordingSnapshot.trigger
         )
 
@@ -852,6 +861,7 @@ final class MeetingSessionController: ObservableObject {
         )
         activeRecordingTrigger = .unknown
         activeRecordingSuggestedTitle = nil
+        activeRecordingStartedAt = nil
         restoreStateAfterRecordingEndedWithoutNewWork()
         AppSoundPlayer.shared.play(.dictationCancelled)
         Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "cancelled")
@@ -1030,12 +1040,13 @@ final class MeetingSessionController: ObservableObject {
 
         for job in queuedJobs + [preparingJob].compactMap({ $0 }) {
             switch job.kind {
-            case .recorded(let micURL, let systemURL, _, let meetingTitle):
+            case .recorded(let micURL, let systemURL, _, let meetingTitle, let recordingDate):
                 preserveFailedMeetingForRetry(
                     micAudioURL: micURL,
                     systemAudioURL: systemURL,
                     errorMessage: "Transcription cancelled",
-                    meetingTitle: meetingTitle
+                    meetingTitle: meetingTitle,
+                    recordingDate: recordingDate
                 )
             case .imported(let audioURL, _, _):
                 try? FileManager.default.removeItem(at: audioURL)
@@ -1086,8 +1097,10 @@ final class MeetingSessionController: ObservableObject {
             stopTimedOut = files.didTimeOut
             finishLiveCodexSessionForActiveRecording(status: .failed, shouldAwaitFinalTranscript: false)
             let meetingTitle = activeRecordingSuggestedTitle
+            let recordingDate = activeRecordingStartedAt
             activeRecordingTrigger = .unknown
             activeRecordingSuggestedTitle = nil
+            activeRecordingStartedAt = nil
 
             if files.micURL != nil || files.systemURL != nil {
                 didPreserveRecording = preserveFailedMeetingForRetry(
@@ -1096,6 +1109,7 @@ final class MeetingSessionController: ObservableObject {
                     systemAudioURL: files.systemURL,
                     errorMessage: "Meeting saved before quit. Audio is safe; finish the transcript from Home after reopening.",
                     meetingTitle: meetingTitle,
+                    recordingDate: recordingDate,
                     archiveAudio: !files.didTimeOut
                 )
             }
@@ -1159,12 +1173,13 @@ final class MeetingSessionController: ObservableObject {
         var preservedCount = 0
         for job in jobs {
             switch job.kind {
-            case .recorded(let micURL, let systemURL, _, let meetingTitle):
+            case .recorded(let micURL, let systemURL, _, let meetingTitle, let recordingDate):
                 if preserveFailedMeetingForRetry(
                     micAudioURL: micURL,
                     systemAudioURL: systemURL,
                     errorMessage: errorMessage,
-                    meetingTitle: meetingTitle
+                    meetingTitle: meetingTitle,
+                    recordingDate: recordingDate
                 ) {
                     preservedCount += 1
                 }
@@ -1867,6 +1882,7 @@ final class MeetingSessionController: ObservableObject {
         systemURL: URL?,
         healthInfo: RecordingHealthInfo,
         meetingTitle: String?,
+        recordingDate: Date,
         startTrigger: StartTrigger
     ) -> QueueInsertionOutcome {
         let job = QueuedTranscriptionJob(
@@ -1874,7 +1890,8 @@ final class MeetingSessionController: ObservableObject {
                 micURL: micURL,
                 systemURL: systemURL,
                 healthInfo: healthInfo,
-                meetingTitle: meetingTitle
+                meetingTitle: meetingTitle,
+                recordingDate: recordingDate
             ),
             startTrigger: startTrigger,
             sttModel: sttRouter.selectedModel
@@ -2020,7 +2037,7 @@ final class MeetingSessionController: ObservableObject {
         activeQueuedTranscriptionJobID = job.id
 
         switch job.kind {
-        case .recorded(let micURL, let systemURL, let healthInfo, let meetingTitle):
+        case .recorded(let micURL, let systemURL, let healthInfo, let meetingTitle, let recordingDate):
             taskManager.startTranscription(
                 taskId: job.id,
                 micURL: micURL,
@@ -2028,7 +2045,8 @@ final class MeetingSessionController: ObservableObject {
                 outputFolder: MeetingStoragePaths.transcriptsFolder,
                 healthInfo: healthInfo,
                 meetingTitle: meetingTitle,
-                splitLocalSpeakers: LocalSpeakerPreferences.isEnabled()
+                splitLocalSpeakers: LocalSpeakerPreferences.isEnabled(),
+                recordingDate: recordingDate
             )
         case .imported(let audioURL, let suggestedTitle, let recordingDate):
             taskManager.startImportedTranscription(
@@ -2053,12 +2071,13 @@ final class MeetingSessionController: ObservableObject {
         }
 
         switch job.kind {
-        case .recorded(let micURL, let systemURL, _, let meetingTitle):
+        case .recorded(let micURL, let systemURL, _, let meetingTitle, let recordingDate):
             preserveFailedMeetingForRetry(
                 micAudioURL: micURL,
                 systemAudioURL: systemURL,
                 errorMessage: message,
-                meetingTitle: meetingTitle
+                meetingTitle: meetingTitle,
+                recordingDate: recordingDate
             )
         case .imported(let audioURL, _, _):
             try? FileManager.default.removeItem(at: audioURL)
@@ -2512,7 +2531,8 @@ final class MeetingSessionController: ObservableObject {
             pipelineSnapshot: capture.pipelineDiagnosticsSnapshot(
                 overrideSystemAudioStatus: systemAudioStatus
             ),
-            suggestedTitle: activeRecordingSuggestedTitle
+            suggestedTitle: activeRecordingSuggestedTitle,
+            recordingStartedAt: activeRecordingStartedAt
         )
     }
 
@@ -2560,6 +2580,7 @@ final class MeetingSessionController: ObservableObject {
         systemAudioURL: URL?,
         errorMessage: String,
         meetingTitle: String?,
+        recordingDate: Date? = nil,
         archiveAudio: Bool = true
     ) -> Bool {
         let preserved = taskManager.addFailedTranscriptionRetainingAvailableAudio(
@@ -2568,6 +2589,7 @@ final class MeetingSessionController: ObservableObject {
             errorMessage: errorMessage,
             taskId: taskId,
             meetingTitle: meetingTitle,
+            recordingDate: recordingDate,
             archiveAudio: archiveAudio
         )
         if preserved {

--- a/Sources/TranscriptedCore/Models/DisplayStatus.swift
+++ b/Sources/TranscriptedCore/Models/DisplayStatus.swift
@@ -88,6 +88,7 @@ public struct TranscriptionTask: Identifiable {
     public let healthInfo: RecordingHealthInfo?
     public let splitLocalSpeakers: Bool
     public let meetingTitle: String?
+    public let recordingDate: Date?
 
     public init(
         id: UUID = UUID(),
@@ -96,7 +97,8 @@ public struct TranscriptionTask: Identifiable {
         outputFolder: URL,
         healthInfo: RecordingHealthInfo? = nil,
         splitLocalSpeakers: Bool = false,
-        meetingTitle: String? = nil
+        meetingTitle: String? = nil,
+        recordingDate: Date? = nil
     ) {
         self.id = id
         self.micURL = micURL
@@ -106,5 +108,6 @@ public struct TranscriptionTask: Identifiable {
         self.healthInfo = healthInfo
         self.splitLocalSpeakers = splitLocalSpeakers
         self.meetingTitle = meetingTitle
+        self.recordingDate = recordingDate
     }
 }

--- a/Sources/TranscriptedCore/Models/FailedTranscription.swift
+++ b/Sources/TranscriptedCore/Models/FailedTranscription.swift
@@ -4,6 +4,7 @@ import Foundation
 public struct FailedTranscription: Identifiable, Codable, Equatable {
     public let id: UUID
     public let timestamp: Date
+    public let recordingDate: Date?
     public let micAudioURL: URL
     public let systemAudioURL: URL?
     public let errorMessage: String
@@ -14,6 +15,7 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
     public init(
         id: UUID = UUID(),
         timestamp: Date = Date(),
+        recordingDate: Date? = nil,
         micAudioURL: URL,
         systemAudioURL: URL?,
         errorMessage: String,
@@ -23,6 +25,7 @@ public struct FailedTranscription: Identifiable, Codable, Equatable {
     ) {
         self.id = id
         self.timestamp = timestamp
+        self.recordingDate = recordingDate
         self.micAudioURL = micAudioURL
         self.systemAudioURL = systemAudioURL
         self.errorMessage = errorMessage

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -16,6 +16,7 @@ extension TranscriptionTaskManager {
         healthInfo: RecordingHealthInfo?,
         splitLocalSpeakers: Bool = false,
         meetingTitle: String? = nil,
+        recordingDate: Date? = nil,
         sourceFailedTranscriptionId: UUID? = nil,
         removeSourceAudioAfterArchive: Bool = true
     ) async throws -> URL {
@@ -33,6 +34,7 @@ extension TranscriptionTaskManager {
             healthInfo: healthInfo,
             splitLocalSpeakers: splitLocalSpeakers,
             meetingTitle: meetingTitle,
+            recordingDate: recordingDate,
             sourceFailedTranscriptionId: sourceFailedTranscriptionId,
             removeSourceAudioAfterArchive: removeSourceAudioAfterArchive
         )

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -24,7 +24,7 @@ public class TranscriptionTaskManager: ObservableObject {
     private var savedTranscriptTaskIdsByTranscriptId: [UUID: UUID] = [:]
     private var savedTranscriptTaskIdsByURL: [URL: UUID] = [:]
     var activeTasks: [UUID: Task<Void, Never>] = [:]
-    private var activeTaskAudio: [UUID: (micURL: URL, systemURL: URL?, meetingTitle: String?)] = [:]
+    private var activeTaskAudio: [UUID: (micURL: URL, systemURL: URL?, meetingTitle: String?, recordingDate: Date?)] = [:]
     private var preservedTaskIdsForShutdown: Set<UUID> = []
     private var intentionallyCancelledTaskIds: Set<UUID> = []
     private var committedTranscriptTaskIds: Set<UUID> = []
@@ -85,7 +85,8 @@ public class TranscriptionTaskManager: ObservableObject {
         outputFolder: URL,
         healthInfo: RecordingHealthInfo? = nil,
         meetingTitle: String? = nil,
-        splitLocalSpeakers: Bool = false
+        splitLocalSpeakers: Bool = false,
+        recordingDate: Date? = nil
     ) {
 
         // Guard: reject concurrent pipelines to prevent model contention
@@ -95,7 +96,8 @@ public class TranscriptionTaskManager: ObservableObject {
                 micAudioURL: micURL,
                 systemAudioURL: systemURL,
                 errorMessage: "Transcription already in progress",
-                meetingTitle: meetingTitle
+                meetingTitle: meetingTitle,
+                recordingDate: recordingDate
             )
             publishFailure(
                 displayMessage: "Transcription already in progress",
@@ -112,7 +114,8 @@ public class TranscriptionTaskManager: ObservableObject {
                 micAudioURL: micURL,
                 systemAudioURL: nil,
                 errorMessage: errorMessage,
-                meetingTitle: meetingTitle
+                meetingTitle: meetingTitle,
+                recordingDate: recordingDate
             )
             publishFailure(
                 displayMessage: "System audio required",
@@ -174,12 +177,18 @@ public class TranscriptionTaskManager: ObservableObject {
             outputFolder: outputFolder,
             healthInfo: healthInfo,
             splitLocalSpeakers: splitLocalSpeakers,
-            meetingTitle: meetingTitle
+            meetingTitle: meetingTitle,
+            recordingDate: recordingDate
         )
 
         activeCount += 1
         backgroundTaskCount += 1
-        activeTaskAudio[task.id] = (micURL: micURL, systemURL: systemURL, meetingTitle: meetingTitle)
+        activeTaskAudio[task.id] = (
+            micURL: micURL,
+            systemURL: systemURL,
+            meetingTitle: meetingTitle,
+            recordingDate: recordingDate
+        )
         publishNonFailureStatus(.gettingReady)
 
         AppLogger.pipeline.info("Starting transcription task", [
@@ -201,7 +210,8 @@ public class TranscriptionTaskManager: ObservableObject {
                     taskId: task.id,
                     healthInfo: task.healthInfo,
                     splitLocalSpeakers: task.splitLocalSpeakers,
-                    meetingTitle: task.meetingTitle
+                    meetingTitle: task.meetingTitle,
+                    recordingDate: task.recordingDate
                 )
 
                 await MainActor.run {
@@ -229,7 +239,8 @@ public class TranscriptionTaskManager: ObservableObject {
                         systemAudioURL: systemURL,
                         errorMessage: error.localizedDescription,
                         taskId: task.id,
-                        meetingTitle: task.meetingTitle
+                        meetingTitle: task.meetingTitle,
+                        recordingDate: task.recordingDate
                     )
                     self.sendFailureNotification(errorMessage: error.localizedDescription)
                     self.handleTaskCompletion(taskId: task.id)
@@ -652,6 +663,7 @@ public class TranscriptionTaskManager: ObservableObject {
         errorMessage: String,
         taskId: UUID = UUID(),
         meetingTitle: String? = nil,
+        recordingDate: Date? = nil,
         archiveAudio: Bool = true
     ) {
         _ = addFailedTranscriptionRetainingAvailableAudio(
@@ -660,6 +672,7 @@ public class TranscriptionTaskManager: ObservableObject {
             errorMessage: errorMessage,
             taskId: taskId,
             meetingTitle: meetingTitle,
+            recordingDate: recordingDate,
             archiveAudio: archiveAudio
         )
     }
@@ -719,6 +732,7 @@ public class TranscriptionTaskManager: ObservableObject {
         errorMessage: String,
         taskId: UUID = UUID(),
         meetingTitle: String? = nil,
+        recordingDate: Date? = nil,
         archiveAudio: Bool = true
     ) -> Bool {
         guard micAudioURL != nil || systemAudioURL != nil else {
@@ -742,6 +756,7 @@ public class TranscriptionTaskManager: ObservableObject {
             originalSystemURL: systemAudioURL,
             errorMessage: errorMessage,
             meetingTitle: meetingTitle,
+            recordingDate: recordingDate,
             removeOriginalsAfterArchive: archiveAudio
         )
     }
@@ -754,6 +769,7 @@ public class TranscriptionTaskManager: ObservableObject {
         originalSystemURL: URL?,
         errorMessage: String,
         meetingTitle: String?,
+        recordingDate: Date?,
         removeOriginalsAfterArchive: Bool
     ) -> Bool {
         let failedSystemURL = retainedAudio?.systemURL ?? originalSystemURL
@@ -772,7 +788,8 @@ public class TranscriptionTaskManager: ObservableObject {
             micAudioURL: failedMicURL,
             systemAudioURL: failedSystemURL,
             errorMessage: errorMessage,
-            meetingTitle: meetingTitle
+            meetingTitle: meetingTitle,
+            recordingDate: recordingDate
         )
         guard didPersist else {
             if let retainedAudio {
@@ -917,6 +934,7 @@ public class TranscriptionTaskManager: ObservableObject {
                 healthInfo: nil,
                 splitLocalSpeakers: false,
                 meetingTitle: failed.meetingTitle,
+                recordingDate: failed.recordingDate ?? failed.timestamp,
                 sourceFailedTranscriptionId: failedId
             )
 
@@ -1109,7 +1127,8 @@ public class TranscriptionTaskManager: ObservableObject {
                 systemAudioURL: audio.systemURL,
                 errorMessage: errorMessage,
                 taskId: taskId,
-                meetingTitle: audio.meetingTitle
+                meetingTitle: audio.meetingTitle,
+                recordingDate: audio.recordingDate
             ) {
                 preservedCount += 1
             }

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -114,7 +114,8 @@ public class FailedTranscriptionManager: ObservableObject {
         micAudioURL: URL,
         systemAudioURL: URL?,
         errorMessage: String,
-        meetingTitle: String? = nil
+        meetingTitle: String? = nil,
+        recordingDate: Date? = nil
     ) -> Bool {
         // Security: validate incoming audio URLs before they ever reach the queue.
         // The on-disk load path already re-checks sandboxing, but without this guard an
@@ -130,6 +131,7 @@ public class FailedTranscriptionManager: ObservableObject {
 
         let failed = FailedTranscription(
             id: id,
+            recordingDate: recordingDate,
             micAudioURL: micAudioURL,
             systemAudioURL: systemAudioURL,
             errorMessage: errorMessage,
@@ -171,6 +173,7 @@ public class FailedTranscriptionManager: ObservableObject {
         failedTranscriptions[index] = FailedTranscription(
             id: existing.id,
             timestamp: existing.timestamp,
+            recordingDate: existing.recordingDate,
             micAudioURL: micAudioURL,
             systemAudioURL: systemAudioURL,
             errorMessage: existing.errorMessage,
@@ -220,6 +223,7 @@ public class FailedTranscriptionManager: ObservableObject {
         failedTranscriptions[index] = FailedTranscription(
             id: existing.id,
             timestamp: existing.timestamp,
+            recordingDate: existing.recordingDate,
             micAudioURL: existing.micAudioURL,
             systemAudioURL: existing.systemAudioURL,
             errorMessage: errorMessage,

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -695,6 +695,11 @@ struct TranscriptedSettingsView: View {
     }
 
     private func handleRetranscribeMeeting(_ item: RecentMeetingItem) {
+        guard !hasSpeakerReviewWork(for: item) else {
+            openHomeSpeakerReview(actionName: "open_speaker_review_before_retranscribe")
+            return
+        }
+
         guard let input = item.audio?.retranscriptionInput else {
             NSSound.beep()
             return
@@ -946,6 +951,7 @@ struct TranscriptedSettingsView: View {
         let isSummarizing = homeLocalSummaryJobIDs.contains(item.id)
         let isPreparingLocalGemma = isLocalSummaryModelPreparing
         let canGenerateSummary = localMeetingSummaryUnavailableReason == nil
+        let hasPendingSpeakerReview = hasSpeakerReviewWork(for: item)
         let summaryActionTitle: String
         if isSummarizing {
             summaryActionTitle = "Running AI summary..."
@@ -1007,7 +1013,10 @@ struct TranscriptedSettingsView: View {
                     HomeRowMenuItem(
                         title: "Re-transcribe with speaker ID",
                         symbolName: "person.2.fill",
-                        isEnabled: canRetranscribeSavedMeetings
+                        isEnabled: RecentMeetingRetranscriptionMenuActionPolicy.isEnabled(
+                            globalUnavailableReason: savedMeetingRetranscriptionUnavailableReason,
+                            hasSpeakerReviewWork: hasPendingSpeakerReview
+                        )
                     ) {
                         handleRetranscribeMeeting(item)
                     }
@@ -1293,6 +1302,13 @@ struct TranscriptedSettingsView: View {
 
     private var canRetryFailedMeetings: Bool {
         failedMeetingRetryUnavailableReason == nil
+    }
+
+    private func hasSpeakerReviewWork(for meeting: RecentMeetingItem) -> Bool {
+        guard speakerPeopleModel.hasLoadedProfiles else {
+            return meeting.speakerStatus.needsReview
+        }
+        return speakerPeopleModel.hasPendingReview(forTranscript: meeting.transcriptURL)
     }
 
     private var canRetranscribeSavedMeetings: Bool {

--- a/Sources/UI/Shared/RecentCaptureScanners.swift
+++ b/Sources/UI/Shared/RecentCaptureScanners.swift
@@ -164,6 +164,15 @@ enum RecentMeetingRetranscriptionActionPolicy {
     }
 }
 
+enum RecentMeetingRetranscriptionMenuActionPolicy {
+    static func isEnabled(
+        globalUnavailableReason: String?,
+        hasSpeakerReviewWork: Bool
+    ) -> Bool {
+        globalUnavailableReason == nil && !hasSpeakerReviewWork
+    }
+}
+
 enum SavedMeetingRetranscriptionAvailabilityPolicy {
     static func unavailableReason(
         isDictationActive: Bool,
@@ -359,10 +368,11 @@ enum RecentMeetingsScanner {
                 frontmatter: frontmatter,
                 fallbackDate: entry.date
             )
+            let displayDate = timing.start ?? entry.date
             recentItems.append(
                 RecentMeetingItem(
                     title: styled.title,
-                    date: entry.date,
+                    date: displayDate,
                     startDate: timing.start,
                     endDate: timing.end,
                     transcriptURL: styled.url,

--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -239,6 +239,30 @@ func testRecentCaptureScanners() async {
         )
     }
 
+    runSuite("RecentMeetingRetranscriptionMenuActionPolicy blocks rows with pending speaker review") {
+        assertFalse(
+            RecentMeetingRetranscriptionMenuActionPolicy.isEnabled(
+                globalUnavailableReason: nil,
+                hasSpeakerReviewWork: true
+            ),
+            "The row menu should not re-transcribe the same meeting while speaker review is still pending"
+        )
+        assertFalse(
+            RecentMeetingRetranscriptionMenuActionPolicy.isEnabled(
+                globalUnavailableReason: "Wait for the current meeting to finish saving or transcribing before re-transcribing saved audio.",
+                hasSpeakerReviewWork: false
+            ),
+            "Global meeting work should still disable the row menu re-transcribe action"
+        )
+        assertTrue(
+            RecentMeetingRetranscriptionMenuActionPolicy.isEnabled(
+                globalUnavailableReason: nil,
+                hasSpeakerReviewWork: false
+            ),
+            "Reviewed saved meetings should remain re-transcribable from the row menu"
+        )
+    }
+
     runSuite("SavedMeetingRetranscriptionAvailabilityPolicy blocks while models prepare") {
         assertEqual(
             SavedMeetingRetranscriptionAvailabilityPolicy.unavailableReason(
@@ -1715,11 +1739,12 @@ func testRecentCaptureLoader() async {
         }
     }
 
-    await runSuite("RecentMeetingsScanner orders rows by filesystem recency") {
+    await runSuite("RecentMeetingsScanner orders rows by filesystem recency but exposes frontmatter dates") {
         await withTemporaryRecentCaptureLibrary { captureRoot in
             let meetingsRoot = captureRoot.appendingPathComponent("meetings", isDirectory: true)
             let freshFileDate = recentLoaderDate("2026-05-29T14:00:00Z")
             let olderFileDate = recentLoaderDate("2026-05-28T14:00:00Z")
+            let freshRecordedAt = recentLoaderFrontmatterDate("2026-05-01 14:00:00")
 
             try? writeRecentLoaderMeeting(
                 title: "Fresh Copied Meeting",
@@ -1737,7 +1762,8 @@ func testRecentCaptureLoader() async {
             let meetings = RecentMeetingsScanner.loadRecent(limit: 2)
 
             assertEqual(meetings.map(\.title), ["Fresh Copied Meeting", "Older Newer-Frontmatter Meeting"], "Home recency should follow filesystem dates, not stale or future transcript metadata")
-            assertEqual(meetings.first?.date, freshFileDate, "meeting row dates should use the scanner date that controls ordering")
+            assertEqual(meetings.first?.date, freshRecordedAt, "meeting row dates should use frontmatter recording time so Home grouping does not move touched retranscripts to Today")
+            assertEqual(meetings.first?.startDate, freshRecordedAt, "row start date should match the frontmatter recording time")
         }
     }
 
@@ -1952,6 +1978,13 @@ private func setRecentLoaderFileDate(_ date: Date, at url: URL) {
 
 private func recentLoaderDate(_ string: String) -> Date {
     ISO8601DateFormatter().date(from: string) ?? Date(timeIntervalSince1970: 0)
+}
+
+private func recentLoaderFrontmatterDate(_ string: String) -> Date {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    return formatter.date(from: string) ?? Date(timeIntervalSince1970: 0)
 }
 
 private func recentLoaderFormat(_ date: Date, _ pattern: String) -> String {

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -1331,6 +1331,70 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         )
     }
 
+    func testStartTranscriptionUsesRecordingDateForSavedMetadata() async throws {
+        let recordingDate = localDate(
+            year: 2026,
+            month: 6,
+            day: 5,
+            hour: 11,
+            minute: 43,
+            second: 12
+        )
+        let statsStore = MetadataCapturingStatsStore()
+        let manager = makeManager(
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "Live meeting artifact."),
+            diarization: MetadataStubDiarizationEngine(segments: [
+                SpeakerSegment(
+                    speakerId: 1,
+                    startTime: 0,
+                    endTime: 2,
+                    embedding: [Float](repeating: 0.42, count: 256),
+                    qualityScore: 0.95
+                )
+            ]),
+            statsStore: statsStore
+        )
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("live-recording-date-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("live-recording-date-system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+
+        manager.startTranscription(
+            micURL: micURL,
+            systemURL: systemURL,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts"),
+            meetingTitle: "Live customer call",
+            recordingDate: recordingDate
+        )
+
+        try await waitUntil {
+            manager.lastSavedTranscriptURL != nil && manager.activeTasks.isEmpty
+        }
+
+        let transcriptURL = try XCTUnwrap(manager.lastSavedTranscriptURL)
+        let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
+        XCTAssertTrue(
+            transcriptURL.lastPathComponent.hasPrefix("Call_\(DateFormattingHelper.formatFilename(recordingDate))"),
+            "live recording filenames should use the recording start date"
+        )
+        XCTAssertTrue(
+            markdown.contains("\ndate: \(frontmatterDateString(recordingDate))\n"),
+            "frontmatter date should use the live recording start date"
+        )
+        XCTAssertTrue(
+            markdown.contains("\ntime: \(frontmatterTimeString(recordingDate))\n"),
+            "frontmatter time should use the live recording start time"
+        )
+        XCTAssertEqual(statsStore.recordedSessions.count, 1)
+        let metadata = try XCTUnwrap(statsStore.recordedSessions.first)
+        XCTAssertLessThan(
+            abs(metadata.date.timeIntervalSince(recordingDate)),
+            0.001,
+            "stats metadata should use the live recording start date"
+        )
+    }
+
     func testStartImportedTranscriptionSurfacesNoSpeechWhenNoUtterances() async throws {
         let manager = makeManager(
             speechToText: MetadataStubSpeechToTextEngine(transcript: "ignored")
@@ -1792,6 +1856,68 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: retainedMicURL.path), "successful failed-meeting retry should delete retained mic audio")
         XCTAssertFalse(FileManager.default.fileExists(atPath: retainedSystemURL.path), "successful failed-meeting retry should delete retained system audio")
         XCTAssertFalse(FileManager.default.fileExists(atPath: retainedDirectory.path), "successful failed-meeting retry should remove the now-empty retained audio directory")
+    }
+
+    func testRetryFailedTranscriptionUsesOriginalRecordingDateForSavedMetadata() async throws {
+        let recordingDate = localDate(
+            year: 2026,
+            month: 6,
+            day: 5,
+            hour: 11,
+            minute: 43,
+            second: 12
+        )
+        let statsStore = MetadataCapturingStatsStore()
+        let manager = makeManager(
+            speechToText: MetadataStubSpeechToTextEngine(transcript: "Recovered meeting artifact."),
+            diarization: MetadataStubDiarizationEngine(segments: [
+                SpeakerSegment(
+                    speakerId: 1,
+                    startTime: 0,
+                    endTime: 2,
+                    embedding: [Float](repeating: 0.42, count: 256),
+                    qualityScore: 0.95
+                )
+            ]),
+            statsStore: statsStore
+        )
+        let scratchDirectory = tempDirectory.appendingPathComponent("audio")
+        let micURL = scratchDirectory.appendingPathComponent("failed-date-mic.wav")
+        let systemURL = scratchDirectory.appendingPathComponent("failed-date-system.wav")
+        try writeMonoWAV(to: micURL, duration: 2.5)
+        try writeMonoWAV(to: systemURL, duration: 2.5)
+        XCTAssertTrue(manager.failedTranscriptionManager.addFailedTranscription(
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: "Parakeet inference failed",
+            meetingTitle: "Recovered customer call",
+            recordingDate: recordingDate
+        ))
+        let failedId = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first?.id)
+
+        let didRetry = await manager.retryFailedTranscription(
+            failedId: failedId,
+            outputFolder: tempDirectory.appendingPathComponent("transcripts")
+        )
+
+        XCTAssertTrue(didRetry)
+        try await waitUntil {
+            manager.lastSavedTranscriptURL != nil && manager.activeTasks.isEmpty
+        }
+        let transcriptURL = try XCTUnwrap(manager.lastSavedTranscriptURL)
+        let markdown = try String(contentsOf: transcriptURL, encoding: .utf8)
+        XCTAssertTrue(
+            transcriptURL.lastPathComponent.hasPrefix("Call_\(DateFormattingHelper.formatFilename(recordingDate))"),
+            "failed meeting retry filenames should use the original recording date"
+        )
+        XCTAssertTrue(markdown.contains("\ndate: \(frontmatterDateString(recordingDate))\n"))
+        XCTAssertTrue(markdown.contains("\ntime: \(frontmatterTimeString(recordingDate))\n"))
+        let metadata = try XCTUnwrap(statsStore.recordedSessions.first)
+        XCTAssertLessThan(
+            abs(metadata.date.timeIntervalSince(recordingDate)),
+            0.001,
+            "retry stats metadata should use the original recording date"
+        )
     }
 
     func testRetryKeepsFailedAudioWhenSpeakerNameFinalizationSucceedsAfterArchiveFailure() async throws {


### PR DESCRIPTION
## Summary
- carry live recording start dates through meeting transcription, failed queues, and retry saves
- group Home meeting rows by transcript recording date while preserving file-recency scan order
- disable saved-meeting re-transcribe for rows with pending speaker review and route users to Speakers first

## Tests
- bash build-deps.sh --force
- swift test --filter TranscriptionTaskManagerMetadataTests/testStartTranscriptionUsesRecordingDateForSavedMetadata
- swift test --filter TranscriptionTaskManagerMetadataTests/testRetryFailedTranscriptionUsesOriginalRecordingDateForSavedMetadata
- bash build.sh --no-open
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- ~/.codex/skills/codex-review/scripts/codex-review --full-access

## Residual risk
- Existing duplicate Markdown rows already created on a user machine are not auto-collapsed by this patch.
- Manual UI proof against Matthew's exact local library was not run; coverage is code-level and scanner/core tests.