### PR TITLE
[codex] Compress failed meeting retry audio

### DIFF
--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -7,7 +7,7 @@
 ## Files
 
 - `FailedMeetingPresentation.swift` — maps `FailedTranscription` into `FailedMeetingItem` view-models with human-readable titles, retained-audio URLs, and retry metadata
-- `MeetingAudioStorageManager.swift` — compresses retained meeting WAVs to M4A, applies audio-retention cleanup, and backfills existing retained audio after launch or Settings changes
+- `MeetingAudioStorageManager.swift` — compresses retained meeting WAVs to M4A, compresses queue-tracked failed-meeting WAVs without deleting untracked orphans, applies audio-retention cleanup, and backfills existing retained audio after launch or Settings changes
 - `MeetingAudioInactivityDetector.swift` — detects prolonged audio silence during meetings and emits warning/cleared events so the UI can prompt the user to confirm the recording is still needed
 - `MeetingCaptureBridge.swift` — `@MainActor` wrapper around core `Audio` that converts start/stop into async flows, waits for both live capture and system-audio-file readiness, and mirrors live levels for the UI
 - `MeetingCaptureBridge+LivePreview.swift` — bridge extension for recording health snapshots plus mic/system live-preview buffer forwarding
@@ -47,7 +47,7 @@
 10. `MeetingSessionController.importAudioFile(...)` routes standalone recordings through `MeetingImportedAudioPreparer` and into the same save / naming / restyling pipeline used by live captures.
 11. `TranscriptionTaskManager` runs one diarize → transcribe → save pipeline at a time. When `LocalSpeakerPreferences` is enabled, queued meeting work also asks the core pipeline to diarize the local mic channel instead of treating it as a single "You" speaker.
 12. A subscription on `taskManager.$lastSavedTranscriptURL` calls `MeetingTranscriptStyler.restyleTranscript(...)` and updates the recent-meetings UI state.
-13. After a transcript is saved, `MeetingAudioStorageManager` compresses retained WAV audio to M4A and applies the user's retention setting. Launch and Settings changes also run a backfill pass over existing Transcripted meeting transcripts.
+13. After a transcript is saved, `MeetingAudioStorageManager` compresses retained WAV audio to M4A and applies the user's retention setting. Launch and Settings changes also run a backfill pass over existing Transcripted meeting transcripts, and queue-tracked failed-meeting audio can be compressed only after the failed queue is updated to point at the converted files.
 14. If the speaker review sheet shows multiple local speakers, the user can either name them individually or collapse them back to a single "You" track via the UI's "Keep as You" path.
 15. Failed meetings can be played, revealed, retried, deleted, or dismissed from Home, with `MeetingFailureKind` providing stable failure categories, `MeetingFailureExplanation` preserving retry/artifact state, and `MeetingFailureCopy` keeping error copy consistent across retryable and non-retryable states.
 
@@ -79,7 +79,7 @@ Meeting capture artifacts live under `<capture-library>/meetings/`:
 - `*.md`
 - `audio/*_audio/` retained mic/system audio copied from successful meeting captures
 - retained audio is compressed from WAV to M4A after transcript save; retention cleanup uses Transcripted transcript frontmatter date, not Markdown edit time
-- retained-audio backfill skips orphaned, failed, non-Transcripted, and symlinked audio folders instead of guessing ownership
+- retained-audio backfill skips orphaned, non-Transcripted, and symlinked audio folders instead of guessing ownership; failed audio is only compressed when it is still referenced by the failed-meeting retry queue
 
 App-owned meeting state lives under `~/Library/Application Support/Transcripted/state/`:
 

--- a/Sources/Meeting/FailedMeetingPresentation.swift
+++ b/Sources/Meeting/FailedMeetingPresentation.swift
@@ -20,7 +20,7 @@ enum FailedMeetingPresentation {
             timestamp: failed.timestamp,
             title: title(for: failed, fallback: copy.title),
             detail: copy.detail,
-            meta: meta(for: failed, hasAudioFiles: !availableAudioURLs.isEmpty, isRetrying: isRetrying),
+            meta: meta(for: failed, availableAudioURLs: availableAudioURLs, isRetrying: isRetrying),
             failureKind: failureKind,
             isRetryable: failed.isRetryable,
             isRetrying: isRetrying,
@@ -44,15 +44,18 @@ enum FailedMeetingPresentation {
             .filter { fileManager.fileExists(atPath: $0.path) }
     }
 
-    private static func meta(for failed: FailedTranscription, hasAudioFiles: Bool, isRetrying: Bool) -> String {
+    private static func meta(for failed: FailedTranscription, availableAudioURLs: [URL], isRetrying: Bool) -> String {
         var parts = [failed.formattedTimestamp]
 
-        if hasAudioFiles {
+        if !availableAudioURLs.isEmpty {
             let sizeText = failed.formattedFileSize
+            let hasRawAudio = availableAudioURLs.contains {
+                $0.pathExtension.localizedCaseInsensitiveCompare("wav") == .orderedSame
+            }
             if sizeText == "Unknown" {
-                parts.append("Audio kept")
+                parts.append(hasRawAudio ? "Raw audio kept" : "Audio kept")
             } else {
-                parts.append("\(sizeText) kept")
+                parts.append(hasRawAudio ? "\(sizeText) raw audio kept" : "\(sizeText) kept")
             }
         }
 

--- a/Sources/Meeting/MeetingAudioStorageManager.swift
+++ b/Sources/Meeting/MeetingAudioStorageManager.swift
@@ -435,6 +435,24 @@ struct MeetingAudioStorageMaintenanceResult: Equatable {
     let prunedDirectories: Int
 }
 
+struct FailedMeetingAudioCompressionCandidate: Equatable {
+    let id: UUID
+    let micAudioURL: URL
+    let systemAudioURL: URL?
+}
+
+struct FailedMeetingAudioCompressionUpdate: Equatable {
+    let id: UUID
+    let micAudioURL: URL
+    let systemAudioURL: URL?
+}
+
+struct FailedMeetingAudioCompressionResult: Equatable {
+    let scannedEntries: Int
+    let convertedFiles: Int
+    let updatedEntries: Int
+}
+
 enum MeetingAudioStorageManager {
     private static let frontmatterPreviewByteLimit = 64 * 1024
     private static let staleTemporaryAudioAge: TimeInterval = 6 * 60 * 60
@@ -709,6 +727,101 @@ enum MeetingAudioStorageManager {
     }
 
     @discardableResult
+    static func compressFailedTranscriptionAudio(
+        candidates: [FailedMeetingAudioCompressionCandidate],
+        audioArchiveRoot: URL,
+        now: Date = Date(),
+        fileManager: FileManager = .default,
+        converter: MeetingAudioFileConverting = AVFoundationMeetingAudioConverter(),
+        validator: MeetingAudioFileValidating = AVFoundationMeetingAudioValidator(),
+        persistUpdate: (FailedMeetingAudioCompressionUpdate) async -> Bool
+    ) async -> FailedMeetingAudioCompressionResult {
+        var scannedEntries = 0
+        var convertedFiles = 0
+        var updatedEntries = 0
+
+        for candidate in candidates {
+            guard !Task.isCancelled else { break }
+            guard failedAudioCandidateIsArchiveOwned(
+                candidate,
+                audioArchiveRoot: audioArchiveRoot,
+                fileManager: fileManager
+            ) else {
+                continue
+            }
+
+            scannedEntries += 1
+
+            let micResolution = await resolveCompressedFailedAudioURL(
+                candidate.micAudioURL,
+                now: now,
+                fileManager: fileManager,
+                converter: converter,
+                validator: validator
+            )
+            let systemResolution: FailedAudioCompressionResolution?
+            if let systemAudioURL = candidate.systemAudioURL {
+                systemResolution = await resolveCompressedFailedAudioURL(
+                    systemAudioURL,
+                    now: now,
+                    fileManager: fileManager,
+                    converter: converter,
+                    validator: validator
+                )
+            } else {
+                systemResolution = nil
+            }
+
+            let updatedMicURL = micResolution.updatedURL
+            let updatedSystemURL = systemResolution?.updatedURL
+            guard updatedMicURL != candidate.micAudioURL
+                || updatedSystemURL != candidate.systemAudioURL else {
+                continue
+            }
+
+            var promotedFiles = [FailedAudioPromotion]()
+            if let promotedFile = micResolution.promotedFile {
+                promotedFiles.append(promotedFile)
+            }
+            if let promotedFile = systemResolution?.promotedFile {
+                promotedFiles.append(promotedFile)
+            }
+            guard !Task.isCancelled else {
+                for promoted in promotedFiles where promoted.wasConverted {
+                    try? fileManager.removeItem(at: promoted.destinationURL)
+                }
+                break
+            }
+
+            let didPersist = await persistUpdate(FailedMeetingAudioCompressionUpdate(
+                id: candidate.id,
+                micAudioURL: updatedMicURL,
+                systemAudioURL: updatedSystemURL
+            ))
+
+            if didPersist {
+                for promoted in promotedFiles {
+                    try? fileManager.removeItem(at: promoted.sourceURL)
+                    if promoted.wasConverted {
+                        convertedFiles += 1
+                    }
+                }
+                updatedEntries += 1
+            } else {
+                for promoted in promotedFiles where promoted.wasConverted {
+                    try? fileManager.removeItem(at: promoted.destinationURL)
+                }
+            }
+        }
+
+        return FailedMeetingAudioCompressionResult(
+            scannedEntries: scannedEntries,
+            convertedFiles: convertedFiles,
+            updatedEntries: updatedEntries
+        )
+    }
+
+    @discardableResult
     static func removeStaleTemporaryAudioFiles(
         in audioDirectory: URL,
         now: Date = Date(),
@@ -899,6 +1012,122 @@ enum MeetingAudioStorageManager {
         }
     }
 
+    private struct FailedAudioPromotion {
+        let sourceURL: URL
+        let destinationURL: URL
+        let wasConverted: Bool
+    }
+
+    private struct FailedAudioCompressionResolution {
+        let updatedURL: URL
+        let promotedFile: FailedAudioPromotion?
+    }
+
+    private static func failedAudioCandidateIsArchiveOwned(
+        _ candidate: FailedMeetingAudioCompressionCandidate,
+        audioArchiveRoot: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        var urls = [candidate.micAudioURL]
+        if let systemAudioURL = candidate.systemAudioURL {
+            urls.append(systemAudioURL)
+        }
+        return urls.allSatisfy { url in
+            isManagedFailedAudioFile(url, audioArchiveRoot: audioArchiveRoot, fileManager: fileManager)
+        }
+    }
+
+    private static func resolveCompressedFailedAudioURL(
+        _ sourceURL: URL,
+        now: Date,
+        fileManager: FileManager,
+        converter: MeetingAudioFileConverting,
+        validator: MeetingAudioFileValidating
+    ) async -> FailedAudioCompressionResolution {
+        let audioDirectory = sourceURL.deletingLastPathComponent()
+        removeStaleTemporaryAudioFiles(in: audioDirectory, now: now, fileManager: fileManager)
+
+        guard isWAVFile(sourceURL, fileManager: fileManager) else {
+            if sourceURL.pathExtension.localizedCaseInsensitiveCompare("m4a") == .orderedSame,
+               isManagedFailedAudioPayloadFile(sourceURL, fileManager: fileManager) {
+                fileManager.restrictFileToOwnerOnly(at: sourceURL)
+            }
+            return FailedAudioCompressionResolution(updatedURL: sourceURL, promotedFile: nil)
+        }
+
+        let destinationURL = sourceURL.deletingPathExtension().appendingPathExtension("m4a")
+        if validator.isUsableAudioFile(at: destinationURL, fileManager: fileManager) {
+            fileManager.restrictFileToOwnerOnly(at: destinationURL)
+            return FailedAudioCompressionResolution(
+                updatedURL: destinationURL,
+                promotedFile: FailedAudioPromotion(
+                    sourceURL: sourceURL,
+                    destinationURL: destinationURL,
+                    wasConverted: false
+                )
+            )
+        }
+
+        let tempURL = audioDirectory
+            .appendingPathComponent(".\(sourceURL.deletingPathExtension().lastPathComponent)-\(UUID().uuidString)")
+            .appendingPathExtension("m4a")
+
+        do {
+            try await converter.convertWAVToM4A(sourceURL: sourceURL, destinationURL: tempURL)
+            guard !Task.isCancelled else {
+                try? fileManager.removeItem(at: tempURL)
+                return FailedAudioCompressionResolution(updatedURL: sourceURL, promotedFile: nil)
+            }
+            guard validator.isUsableAudioFile(at: tempURL, fileManager: fileManager) else {
+                throw MeetingAudioStorageError.emptyConvertedFile
+            }
+            if fileManager.fileExists(atPath: destinationURL.path) {
+                try fileManager.removeItem(at: destinationURL)
+            }
+            try fileManager.moveItem(at: tempURL, to: destinationURL)
+            fileManager.restrictFileToOwnerOnly(at: destinationURL)
+            return FailedAudioCompressionResolution(
+                updatedURL: destinationURL,
+                promotedFile: FailedAudioPromotion(
+                    sourceURL: sourceURL,
+                    destinationURL: destinationURL,
+                    wasConverted: true
+                )
+            )
+        } catch {
+            try? fileManager.removeItem(at: tempURL)
+            return FailedAudioCompressionResolution(updatedURL: sourceURL, promotedFile: nil)
+        }
+    }
+
+    private static func isManagedFailedAudioFile(
+        _ url: URL,
+        audioArchiveRoot: URL,
+        fileManager: FileManager
+    ) -> Bool {
+        guard isManagedFailedAudioPayloadFile(url, fileManager: fileManager) else { return false }
+        let directory = url.deletingLastPathComponent()
+        guard directory.lastPathComponent.hasPrefix("Failed_"),
+              directory.lastPathComponent.hasSuffix("_audio"),
+              isSafeNonSymlinkDirectory(directory, fileManager: fileManager) else {
+            return false
+        }
+        return isFile(directory, containedIn: audioArchiveRoot)
+    }
+
+    private static func isManagedFailedAudioPayloadFile(_ url: URL, fileManager: FileManager) -> Bool {
+        if isManagedRetainedAudioFile(url, fileManager: fileManager) {
+            return true
+        }
+        guard ["wav", "m4a"].contains(where: { url.pathExtension.localizedCaseInsensitiveCompare($0) == .orderedSame }) else {
+            return false
+        }
+        guard !isSymbolicLink(url, fileManager: fileManager) else { return false }
+        let values = try? url.resourceValues(forKeys: [.isRegularFileKey])
+        guard values?.isRegularFile == true else { return false }
+        return url.deletingPathExtension().lastPathComponent == "microphone_placeholder"
+    }
+
     private static func isStaleTemporaryAudioFile(
         _ url: URL,
         now: Date,
@@ -943,5 +1172,16 @@ enum MeetingAudioStorageManager {
 
         let values = try? url.resourceValues(forKeys: [.isSymbolicLinkKey])
         return values?.isSymbolicLink == true
+    }
+
+    private static func isFile(_ fileURL: URL, containedIn directoryURL: URL) -> Bool {
+        let filePath = canonicalURL(fileURL).path
+        let directoryPath = canonicalURL(directoryURL).path
+        let normalizedDirectoryPath = directoryPath.hasSuffix("/") ? directoryPath : directoryPath + "/"
+        return filePath == directoryPath || filePath.hasPrefix(normalizedDirectoryPath)
+    }
+
+    private static func canonicalURL(_ url: URL) -> URL {
+        url.standardizedFileURL.resolvingSymlinksInPath()
     }
 }

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -204,6 +204,8 @@ final class MeetingSessionController: ObservableObject {
     private var liveCodexFinalTranscriptNeedsQueuedJobID = false
     private var liveCodexAwaitedTranscriptionJobID: UUID?
     private var activeQueuedTranscriptionJobID: UUID?
+    private var failedAudioCompressionTask: Task<Void, Never>?
+    private var failedAudioCompressionNeedsReschedule = false
 
     var shouldConfirmQuitForActiveCapture: Bool {
         isCaptureSessionActive || isFinishingRecording
@@ -1184,6 +1186,7 @@ final class MeetingSessionController: ObservableObject {
             return false
         }
 
+        failedAudioCompressionTask?.cancel()
         retryingFailedMeetingIDs.insert(id)
         activeTranscriptionTrigger = .unknown
         refreshFailedMeetings()
@@ -2621,6 +2624,61 @@ final class MeetingSessionController: ObservableObject {
                     isRetrying: retryingFailedMeetingIDs.contains(failed.id)
                 )
             }
+        scheduleFailedAudioCompression(for: failedTranscriptions)
+    }
+
+    private func scheduleFailedAudioCompression(for failedTranscriptions: [FailedTranscription]) {
+        guard failedAudioCompressionTask == nil else {
+            failedAudioCompressionNeedsReschedule = true
+            return
+        }
+
+        let candidates = failedTranscriptions.compactMap { failed -> FailedMeetingAudioCompressionCandidate? in
+            guard !retryingFailedMeetingIDs.contains(failed.id) else { return nil }
+            var urls = [failed.micAudioURL]
+            if let systemAudioURL = failed.systemAudioURL {
+                urls.append(systemAudioURL)
+            }
+            guard urls.contains(where: { $0.pathExtension.localizedCaseInsensitiveCompare("wav") == .orderedSame }) else {
+                return nil
+            }
+            return FailedMeetingAudioCompressionCandidate(
+                id: failed.id,
+                micAudioURL: failed.micAudioURL,
+                systemAudioURL: failed.systemAudioURL
+            )
+        }
+        guard !candidates.isEmpty else { return }
+
+        failedAudioCompressionNeedsReschedule = false
+        let audioArchiveRoot = MeetingStoragePaths.audioArchiveFolder
+        failedAudioCompressionTask = Task { [weak self] in
+            _ = await MeetingAudioStorageManager.compressFailedTranscriptionAudio(
+                candidates: candidates,
+                audioArchiveRoot: audioArchiveRoot,
+                persistUpdate: { [weak self] update in
+                    await MainActor.run {
+                        guard let self,
+                              !self.retryingFailedMeetingIDs.contains(update.id) else {
+                            return false
+                        }
+                        return self.failedManager.updateFailedTranscriptionAudio(
+                            id: update.id,
+                            micAudioURL: update.micAudioURL,
+                            systemAudioURL: update.systemAudioURL
+                        )
+                    }
+                }
+            )
+            await MainActor.run { [weak self] in
+                let shouldReschedule = self?.failedAudioCompressionNeedsReschedule == true
+                self?.failedAudioCompressionTask = nil
+                self?.failedAudioCompressionNeedsReschedule = false
+                if shouldReschedule, let self {
+                    self.scheduleFailedAudioCompression(for: self.failedManager.failedTranscriptions)
+                }
+            }
+        }
     }
 }
 

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -182,6 +182,27 @@ func testFailedMeetingPresentation() {
             "partial retained audio should not enable the retry action"
         )
     }
+
+    runSuite("FailedMeetingPresentation labels retained WAVs as raw audio") {
+        let source = (try? String(
+            contentsOf: repoFixtureURL("Sources/Meeting/FailedMeetingPresentation.swift"),
+            encoding: .utf8
+        )) ?? ""
+
+        assertTrue(
+            source.contains("pathExtension.localizedCaseInsensitiveCompare(\"wav\")"),
+            "failed meeting metadata should detect retained WAV audio"
+        )
+        assertTrue(
+            source.contains("availableAudioURLs.contains"),
+            "failed meeting metadata should label raw audio from files that still exist"
+        )
+        assertTrue(
+            source.contains("\"Raw audio kept\"")
+                && source.contains("\"\\(sizeText) raw audio kept\""),
+            "failed meeting metadata should label retained WAVs as raw audio"
+        )
+    }
 }
 
 private func makeFailedMeetingPresentationTestDirectory() -> URL {

--- a/Tests/MeetingAudioStorageManagerTests.swift
+++ b/Tests/MeetingAudioStorageManagerTests.swift
@@ -649,6 +649,166 @@ func testMeetingAudioStorageManager() async {
         assertTrue(FileManager.default.fileExists(atPath: wavURL.path), "failed WAV should remain for the retry/delete flow")
     }
 
+    await runSuite("MeetingAudioStorageManager compresses queue-tracked failed audio") {
+        let directory = makeMeetingAudioStorageTestDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let audioRoot = directory.appendingPathComponent("audio", isDirectory: true)
+        let failedAudioDirectory = audioRoot
+            .appendingPathComponent("Failed_2026-05-08_15-29-13_83A63B2D_audio", isDirectory: true)
+        try? FileManager.default.createDirectory(at: failedAudioDirectory, withIntermediateDirectories: true)
+        let micWAV = failedAudioDirectory.appendingPathComponent("microphone.wav")
+        let systemWAV = failedAudioDirectory.appendingPathComponent("system_audio.wav")
+        try! Data("wav".utf8).write(to: micWAV)
+        try! Data("wav".utf8).write(to: systemWAV)
+
+        var updates = [FailedMeetingAudioCompressionUpdate]()
+        let id = UUID()
+        let result = await MeetingAudioStorageManager.compressFailedTranscriptionAudio(
+            candidates: [
+                FailedMeetingAudioCompressionCandidate(
+                    id: id,
+                    micAudioURL: micWAV,
+                    systemAudioURL: systemWAV
+                )
+            ],
+            audioArchiveRoot: audioRoot,
+            converter: FakeMeetingAudioConverter(),
+            validator: FakeMeetingAudioValidator()
+        ) { update in
+            updates.append(update)
+            return true
+        }
+
+        assertEqual(
+            result,
+            FailedMeetingAudioCompressionResult(scannedEntries: 1, convertedFiles: 2, updatedEntries: 1),
+            "queue-tracked failed WAVs should be compressed and persisted"
+        )
+        assertFalse(FileManager.default.fileExists(atPath: micWAV.path), "mic WAV should be removed after the queue points at M4A")
+        assertFalse(FileManager.default.fileExists(atPath: systemWAV.path), "system WAV should be removed after the queue points at M4A")
+        assertEqual(updates.count, 1, "failed queue should be updated once for the pair")
+        assertEqual(updates.first?.id, id, "failed queue update should keep the original failed meeting id")
+        assertEqual(updates.first?.micAudioURL.lastPathComponent, "microphone.m4a", "failed queue should point retries at compressed mic audio")
+        assertEqual(updates.first?.systemAudioURL?.lastPathComponent, "system_audio.m4a", "failed queue should point retries at compressed system audio")
+    }
+
+    await runSuite("MeetingAudioStorageManager compresses system-only failed audio with placeholder mic") {
+        let directory = makeMeetingAudioStorageTestDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let audioRoot = directory.appendingPathComponent("audio", isDirectory: true)
+        let failedAudioDirectory = audioRoot
+            .appendingPathComponent("Failed_2026-05-08_15-29-13_83A63B2D_audio", isDirectory: true)
+        try? FileManager.default.createDirectory(at: failedAudioDirectory, withIntermediateDirectories: true)
+        let placeholderWAV = failedAudioDirectory.appendingPathComponent("microphone_placeholder.wav")
+        let systemWAV = failedAudioDirectory.appendingPathComponent("system_audio.wav")
+        try! Data("wav".utf8).write(to: placeholderWAV)
+        try! Data("wav".utf8).write(to: systemWAV)
+
+        var updates = [FailedMeetingAudioCompressionUpdate]()
+        let id = UUID()
+        let result = await MeetingAudioStorageManager.compressFailedTranscriptionAudio(
+            candidates: [
+                FailedMeetingAudioCompressionCandidate(
+                    id: id,
+                    micAudioURL: placeholderWAV,
+                    systemAudioURL: systemWAV
+                )
+            ],
+            audioArchiveRoot: audioRoot,
+            converter: FakeMeetingAudioConverter(),
+            validator: FakeMeetingAudioValidator()
+        ) { update in
+            updates.append(update)
+            return true
+        }
+
+        assertEqual(
+            result,
+            FailedMeetingAudioCompressionResult(scannedEntries: 1, convertedFiles: 2, updatedEntries: 1),
+            "system-only failed audio should not be skipped by the placeholder mic track"
+        )
+        assertFalse(FileManager.default.fileExists(atPath: placeholderWAV.path), "placeholder WAV should be removed after persistence")
+        assertFalse(FileManager.default.fileExists(atPath: systemWAV.path), "system WAV should be removed after persistence")
+        assertEqual(updates.first?.micAudioURL.lastPathComponent, "microphone_placeholder.m4a", "placeholder mic should stay retryable after compression")
+        assertEqual(updates.first?.systemAudioURL?.lastPathComponent, "system_audio.m4a", "system audio should be compressed")
+    }
+
+    await runSuite("MeetingAudioStorageManager keeps failed WAVs if queue update fails") {
+        let directory = makeMeetingAudioStorageTestDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let audioRoot = directory.appendingPathComponent("audio", isDirectory: true)
+        let failedAudioDirectory = audioRoot
+            .appendingPathComponent("Failed_2026-05-08_15-29-13_83A63B2D_audio", isDirectory: true)
+        try? FileManager.default.createDirectory(at: failedAudioDirectory, withIntermediateDirectories: true)
+        let micWAV = failedAudioDirectory.appendingPathComponent("microphone.wav")
+        try! Data("wav".utf8).write(to: micWAV)
+
+        let result = await MeetingAudioStorageManager.compressFailedTranscriptionAudio(
+            candidates: [
+                FailedMeetingAudioCompressionCandidate(
+                    id: UUID(),
+                    micAudioURL: micWAV,
+                    systemAudioURL: nil
+                )
+            ],
+            audioArchiveRoot: audioRoot,
+            converter: FakeMeetingAudioConverter(),
+            validator: FakeMeetingAudioValidator()
+        ) { _ in
+            false
+        }
+
+        assertEqual(
+            result,
+            FailedMeetingAudioCompressionResult(scannedEntries: 1, convertedFiles: 0, updatedEntries: 0),
+            "conversion should not count if the retry queue cannot be updated"
+        )
+        assertTrue(FileManager.default.fileExists(atPath: micWAV.path), "WAV should remain retryable if queue persistence fails")
+        assertFalse(
+            FileManager.default.fileExists(atPath: failedAudioDirectory.appendingPathComponent("microphone.m4a").path),
+            "failed persistence should not leave an untracked converted sibling"
+        )
+    }
+
+    await runSuite("MeetingAudioStorageManager skips failed audio outside the archive") {
+        let directory = makeMeetingAudioStorageTestDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let audioRoot = directory.appendingPathComponent("audio", isDirectory: true)
+        let scratchDirectory = directory.appendingPathComponent("tmp", isDirectory: true)
+        try? FileManager.default.createDirectory(at: scratchDirectory, withIntermediateDirectories: true)
+        let scratchWAV = scratchDirectory.appendingPathComponent("microphone.wav")
+        try! Data("wav".utf8).write(to: scratchWAV)
+
+        var didUpdate = false
+        let result = await MeetingAudioStorageManager.compressFailedTranscriptionAudio(
+            candidates: [
+                FailedMeetingAudioCompressionCandidate(
+                    id: UUID(),
+                    micAudioURL: scratchWAV,
+                    systemAudioURL: nil
+                )
+            ],
+            audioArchiveRoot: audioRoot,
+            converter: FakeMeetingAudioConverter(),
+            validator: FakeMeetingAudioValidator()
+        ) { _ in
+            didUpdate = true
+            return true
+        }
+
+        assertEqual(
+            result,
+            FailedMeetingAudioCompressionResult(scannedEntries: 0, convertedFiles: 0, updatedEntries: 0),
+            "scratch failed audio should stay out of retained-audio compression"
+        )
+        assertFalse(didUpdate, "scratch audio should not update the failed queue")
+        assertTrue(FileManager.default.fileExists(atPath: scratchWAV.path), "scratch WAV should remain untouched")
+    }
+
     await runSuite("MeetingAudioStorageManager prunes old WAVs before backfill conversion") {
         let directory = makeMeetingAudioStorageTestDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1922,6 +1922,38 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - failed audio compression reschedules queue changes") {
+        let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let schedulerBlock = sourceSlice(
+            controllerContents,
+            from: "private func scheduleFailedAudioCompression(",
+            to: "private extension MeetingSessionController.State"
+        )
+        let retryBlock = sourceSlice(
+            controllerContents,
+            from: "func retryFailedMeeting(id: UUID) -> Bool",
+            to: "Task { [weak self] in"
+        )
+
+        assertTrue(
+            controllerContents.contains("failedAudioCompressionNeedsReschedule"),
+            "failed audio compression should track queue changes that arrive during an active pass"
+        )
+        assertTrue(
+            schedulerBlock.contains("failedAudioCompressionNeedsReschedule = true"),
+            "an active compression pass should mark that the failed queue needs another scan"
+        )
+        assertTrue(
+            schedulerBlock.contains("self.scheduleFailedAudioCompression(for: self.failedManager.failedTranscriptions)"),
+            "compression completion should re-check the latest failed queue before going idle"
+        )
+        assertTrue(
+            retryBlock.contains("failedAudioCompressionTask?.cancel()")
+                && !retryBlock.contains("failedAudioCompressionTask = nil"),
+            "retry should cancel active failed-audio compression without allowing a concurrent rescan before cleanup finishes"
+        )
+    }
+
     runSuite("Repo command contract - stop-timeout failed meetings refresh Home immediately") {
         let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
         let timeoutBlock = sourceSlice(

--- a/docs/storage-paths.md
+++ b/docs/storage-paths.md
@@ -41,10 +41,12 @@ succeeds. The Storage settings page controls whether retained audio is deleted
 after 7 days, 30 days, or never. Markdown transcripts are not removed by audio
 retention cleanup.
 
-On launch, Transcripted also performs the same best-effort compression pass for
-existing retained audio folders that already have matching Markdown transcripts.
-Failed or orphaned audio without a saved transcript is left alone for the
-failed-meeting retry/delete flow.
+On launch, Transcripted also performs best-effort compression for existing
+retained audio folders that already have matching Markdown transcripts. Failed
+audio that is still referenced by the failed-meeting retry queue can also be
+compressed in place, with the queue updated to point at the new `.m4a` files
+before the original `.wav` files are removed. Orphaned audio without a saved
+transcript or failed-queue entry is left alone instead of guessing ownership.
 
 App-owned meeting state is stored separately under:
 


### PR DESCRIPTION
## Summary
- Compress queue-tracked failed meeting WAV audio to M4A in the retained audio archive, including system-only failures with `microphone_placeholder.wav`.
- Persist the failed-queue audio URL update before removing the original WAV, and leave scratch/orphaned audio untouched instead of guessing ownership.
- Mark failed-meeting Home metadata as raw only when the still-existing retained files are WAV-backed.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (4538/4538)
- `bash run-integration-smoke.sh`
- `bash scripts/dev/agent-preflight.sh`
- `~/.codex/skills/codex-review/scripts/codex-review --full-access` clean after accepted fixes

## Residual risk
- Orphaned failed audio with no failed-queue entry is intentionally left alone. That still needs an explicit diagnostic/quarantine/delete flow before we touch user data.