### PR TITLE
[codex] Tighten M1 Gemma summary path

### DIFF
--- a/Sources/Meeting/LocalMeetingSummarizer.swift
+++ b/Sources/Meeting/LocalMeetingSummarizer.swift
@@ -78,7 +78,7 @@ struct LocalGemmaSummaryConfiguration: Equatable, Sendable {
                 minimumPhysicalMemoryBytes: 12 * gib,
                 chunkCharacterLimit: 9_000,
                 chunkMaxTokens: 300,
-                directMaxTokens: 900,
+                directMaxTokens: 360,
                 mergeMaxTokens: 2_400,
                 maxKVSize: 6_144,
                 processTimeoutSeconds: 900,
@@ -816,8 +816,9 @@ enum LocalMeetingSummaryNormalizer {
 
     static func section(_ heading: String, in raw: String) -> String? {
         let lines = raw.components(separatedBy: .newlines)
+        let targetTitle = normalizedHeadingTitle(heading)
         guard let startIndex = lines.firstIndex(where: {
-            $0.trimmingCharacters(in: .whitespacesAndNewlines) == heading
+            normalizedHeadingTitle($0) == targetTitle
         }) else {
             return nil
         }
@@ -838,9 +839,18 @@ enum LocalMeetingSummaryNormalizer {
     }
 
     private static func containsHeading(_ heading: String, in text: String) -> Bool {
-        text.components(separatedBy: .newlines).contains { line in
-            line.trimmingCharacters(in: .whitespacesAndNewlines) == heading
+        let targetTitle = normalizedHeadingTitle(heading)
+        return text.components(separatedBy: .newlines).contains { line in
+            normalizedHeadingTitle(line) == targetTitle
         }
+    }
+
+    private static func normalizedHeadingTitle(_ line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("#") else { return nil }
+        let title = trimmed.drop { $0 == "#" }
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return title.isEmpty ? nil : title
     }
 
     private static func firstGeneratedTitleHeading(in raw: String) -> String? {

--- a/Tests/LocalMeetingSummarizerTests.swift
+++ b/Tests/LocalMeetingSummarizerTests.swift
@@ -61,6 +61,7 @@ func testLocalMeetingSummarizer() async {
         let m1Config = LocalGemmaSummaryConfiguration.m1Optimized(physicalMemoryBytes: 16 * gib)
         assertEqual(m1Config.profileName, "m1-low-memory", "16GB Apple Silicon should use the low-memory profile")
         assertTrue(m1Config.chunkCharacterLimit <= 9_000, "M1 profile should keep chunks small enough for 16GB unified-memory Macs")
+        assertTrue(m1Config.directMaxTokens <= 360, "M1 one-chunk summaries should stay bounded so setup-ready runs do not look stuck")
         assertTrue(m1Config.maxKVSize <= 6_144, "M1 profile should keep KV cache below the hotter baseline")
         assertTrue(m1Config.mergeMaxTokens >= 2_400, "M1 profile should leave enough merge budget for long-meeting final merges")
         assertTrue(m1Config.processNiceValue >= 10, "M1 profile should lower local Gemma process priority")
@@ -328,6 +329,30 @@ func testLocalMeetingSummarizer() async {
             LocalMeetingSummaryNormalizer.summaryTitle(in: normalized),
             nil,
             "Chunk labels should not become generated meeting titles"
+        )
+    }
+
+    runSuite("LocalMeetingSummaryNormalizer accepts Apple heading levels") {
+        let normalized = LocalMeetingSummaryNormalizer.normalized("""
+        ## Apple Summary
+
+        ## Summary
+        Apple returned second-level headings.
+
+        ## Decisions
+        Keep parsing provider output.
+        """)
+        let sections = LocalMeetingSummaryNormalizer.sections(in: normalized)
+
+        assertEqual(
+            sections.summary,
+            "Apple returned second-level headings.",
+            "Apple ## Summary heading should parse"
+        )
+        assertEqual(
+            sections.decisions,
+            "Keep parsing provider output.",
+            "Apple ## Decisions heading should parse"
         )
     }
 


### PR DESCRIPTION
## Summary
- cap the M1 low-memory direct Gemma summary output at 360 tokens so setup-ready one-chunk summaries are less likely to look stuck
- accept provider output headings like `## Summary` / `## Decisions` when normalizing local summary markdown
- add fast-test coverage for both regressions

## Root Cause
Feedback diagnostics showed setup ready and a completed one-chunk summary, but the M1 path still used the heavy direct summary budget. The prior setup/UI fix did not reduce that one-pass generation cost.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (`4516` passed)
- `bash run-integration-smoke.sh`
