### PR TITLE
[docs] Update UI coverage docs

### DIFF
--- a/Sources/UI/CLAUDE.md
+++ b/Sources/UI/CLAUDE.md
@@ -188,6 +188,8 @@ Relevant direct coverage:
 - `Tests/FirstRunExperienceTests.swift`
 - `Tests/HomeMeetingPreviewFormatterTests.swift`
 - `Tests/MeetingAudioArchiveResolverTests.swift`
+- `Tests/RecentCaptureScannersTests.swift`
+- `Tests/SettingsContentLayoutPolicyTests.swift`
 - `Tests/SettingsRecentCaptureRefreshPolicyTests.swift`
 - `Tests/SpeakerReviewQueueScannerTests.swift`
 - `Tests/SupportDiagnosticsBundleTests.swift`


### PR DESCRIPTION
## Summary
- add missing UI direct coverage entries for recent capture scanning and settings layout policy tests

## Verification
- bash scripts/dev/agent-preflight.sh
- git diff --check
- rg -n "RecentCaptureScannersTests|SettingsContentLayoutPolicyTests" Sources/UI/CLAUDE.md Tests/FastTests.manifest