### PR TITLE
[docs] Update local summary provider docs

### DIFF
--- a/Sources/Meeting/CLAUDE.md
+++ b/Sources/Meeting/CLAUDE.md
@@ -20,7 +20,7 @@
 - `LiveMeetingPreviewServer.swift` — loopback HTTP server that serves the live sidecar preview on a tokenized URL so the page updates in place without full-page refreshes while Transcripted is running
 - `LiveMeetingStreamingUpdatePolicy.swift` — tiny throttling/deduplication policy for provisional live ASR updates before they are appended to the sidecar
 - `LiveMeetingTranscriber.swift` — opt-in streaming ASR bridge that feeds mic/system live PCM copies into FluidAudio's local streaming Parakeet manager and appends provisional sidecar text
-- `LocalMeetingSummarizer.swift` — opt-in local Gemma meeting-summary runner, transcript chunking, managed summary metadata, runtime env sanitizing, and stale-transcript write protection
+- `LocalMeetingSummarizer.swift` — opt-in local meeting-summary runners (Gemma MLX and Apple Foundation Models), transcript chunking, provider metadata, runtime env sanitizing, and stale-transcript write protection
 - `MeetingModelDownloader.swift` — loads the selected STT and diarization models together
 - `MeetingPromptDetector.swift` — polls upcoming Calendar events, watches supported meeting apps, and asks the overlay to offer recording prompts with provider-aware remind/dismiss backoff
 - `MeetingPromptHeuristics.swift` — shared scoring, prompt reasons, and provider-aware remind/dismiss backoff rules for calendar- and runtime-based prompt candidates
@@ -70,7 +70,7 @@
 - `MeetingSessionUIPolicy` is the canonical place for deciding whether background meeting work should still surface as an active transcribing/saving state. Speaker review alone should not keep that state visible.
 - `TranscriptionTaskManager` stays single-flight. App-level queueing belongs in `MeetingSessionController`, not in ad hoc background tasks.
 - Live PCM handlers installed through `MeetingCaptureBridge` run on capture threads. Keep them real-time safe.
-- Local meeting summaries rewrite the saved transcript after a slow local model run. Always re-read the transcript before writing and fail closed if transcript text changed while generation was in flight.
+- Local meeting summaries rewrite the saved transcript after a slow local model run. Always re-read the transcript before writing and fail closed if transcript text changed while generation was in flight. Keep provider-specific setup and metadata explicit so Gemma MLX and Apple Foundation Models summaries remain distinguishable.
 
 ## Storage
 

--- a/Sources/Support/CLAUDE.md
+++ b/Sources/Support/CLAUDE.md
@@ -21,7 +21,7 @@
 - `LaunchAtLoginController.swift` — app-facing wrapper for enabling or disabling launch-at-login behavior
 - `LaunchAtLoginPreferences.swift` — persisted first-run preference state around launch-at-login UX
 - `LiveMeetingCodexPreferences.swift` — persisted opt-in toggle for writing the live-meeting sidecar during meeting recording
-- `LocalMeetingSummaryPreferences.swift` — persisted beta opt-in toggle for local AI meeting summaries on Home
+- `LocalMeetingSummaryPreferences.swift` — persisted beta opt-in toggle and provider selection for local AI meeting summaries on Home
 - `LocalSpeakerPreferences.swift` — persisted toggle for splitting the local mic channel into multiple named speakers during meeting review
 - `MenuBarVisibilityPreferences.swift` — persisted Home toggles for optional menubar popover rows
 - `MicrophoneProcessingPreferences.swift` — persisted meeting-mic processing mode, toggling between default software AGC and optional Apple voice processing (VPIO) for users who need the WebRTC-specific recovery path

--- a/Sources/UI/Settings/CLAUDE.md
+++ b/Sources/UI/Settings/CLAUDE.md
@@ -50,8 +50,9 @@ settings-side agent connection flow.
   `Sources/UI/Shared/` for those ownership seams.
 - Local AI meeting summary actions must stay blocked during active dictation,
   active meeting recording, model prep, background meeting work, and speaker
-  review. Keep those gates in shared policy instead of duplicating state checks
-  across row actions.
+  review. The Beta page owns provider selection between Gemma MLX and Apple
+  on-device summaries. Keep those gates in shared policy instead of duplicating
+  state checks across row actions.
 
 ## Verification
 


### PR DESCRIPTION
## Summary\n- Document that local meeting summaries now support Gemma MLX and Apple Foundation Models providers\n- Record that Support owns the persisted summary provider selection\n- Note that the Settings Beta page owns provider selection while keeping summary action gates shared\n\n## Verification\n- bash scripts/dev/agent-preflight.sh\n- git diff --check