### PR TITLE
[nightly-review] Keep Apple summaries tied to transcript participants

### DIFF
--- a/Sources/Meeting/LocalMeetingSummarizer.swift
+++ b/Sources/Meeting/LocalMeetingSummarizer.swift
@@ -35,6 +35,10 @@ struct LocalMeetingSummarySections: Equatable, Sendable {
             accuracyNotes: accuracyNotes
         )
     }
+
+    func withTranscriptParticipants(from transcript: String) -> LocalMeetingSummarySections {
+        withParticipants(LocalMeetingSummaryParticipantExtractor.participants(from: transcript))
+    }
 }
 
 enum LocalMeetingSummaryError: LocalizedError, Equatable {
@@ -1039,9 +1043,8 @@ struct LocalMeetingSummarizer: @unchecked Sendable {
 
         try Task.checkCancellation()
         let normalizedBody = LocalMeetingSummaryNormalizer.normalized(summaryBody)
-        let participants = LocalMeetingSummaryParticipantExtractor.participants(from: transcript)
         let sections = LocalMeetingSummaryNormalizer.sections(in: normalizedBody)
-            .withParticipants(participants)
+            .withTranscriptParticipants(from: transcript)
         let latestMarkdown = try String(contentsOf: transcriptURL, encoding: .utf8)
         let latestTranscript = LocalMeetingTranscriptExtractor.transcriptText(from: latestMarkdown)
         guard latestTranscript == transcript else {
@@ -1151,6 +1154,7 @@ struct AppleFoundationMeetingSummarizer: @unchecked Sendable {
         try Task.checkCancellation()
         let normalizedBody = LocalMeetingSummaryNormalizer.normalized(summaryBody)
         let sections = LocalMeetingSummaryNormalizer.sections(in: normalizedBody)
+            .withTranscriptParticipants(from: transcript)
         let latestMarkdown = try String(contentsOf: transcriptURL, encoding: .utf8)
         let latestTranscript = LocalMeetingTranscriptExtractor.transcriptText(from: latestMarkdown)
         guard latestTranscript == transcript else {

--- a/Tests/LocalMeetingSummarizerTests.swift
+++ b/Tests/LocalMeetingSummarizerTests.swift
@@ -317,6 +317,47 @@ func testLocalMeetingSummarizer() async {
         )
     }
 
+    runSuite("LocalMeetingSummarySections uses transcript participants for every provider") {
+        let transcript = """
+        **00:01** [Mic/Justin]
+        Justin opened the meeting.
+
+        **00:04** [System/Maya]
+        Maya joined from Zoom.
+        """
+        let sections = LocalMeetingSummaryNormalizer.sections(in: """
+        # Title
+        Launch Review
+
+        # Participants
+        None found.
+
+        # Summary
+        Team reviewed launch work.
+
+        # Decisions
+        None found.
+
+        # Action Items
+        None found.
+
+        # Open Questions
+        None found.
+
+        # Risks or Follow-ups
+        None found.
+
+        # Accuracy Notes
+        None found.
+        """).withTranscriptParticipants(from: transcript)
+
+        assertEqual(
+            sections.participants,
+            "- Justin\n- Maya",
+            "summary providers should write canonical participants from transcript speaker labels"
+        )
+    }
+
     runSuite("LocalMeetingSummaryNormalizer extracts generated titles") {
         let normalized = LocalMeetingSummaryNormalizer.normalized("""
         # Title


### PR DESCRIPTION
## Summary
- keep local summary participant metadata sourced from transcript speaker labels for every provider
- apply the same transcript-derived participant override to the Apple on-device summary path that Gemma already used
- add a fast regression covering provider output that omits participants

## Nightly evidence
- recent health signal still shows meeting degradation/speaker-finalization events, but those are pre- or not-yet-shipped relative to yesterday's instrumentation patch
- the highest-confidence current-main bug found tonight was in the new local summary provider split: Apple summaries could write `None found.` participants even when the transcript had canonical speaker labels

## Verification
- `bash scripts/dev/agent-preflight.sh Sources/Meeting/LocalMeetingSummarizer.swift Tests/LocalMeetingSummarizerTests.swift`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (4,656 passed)
- `bash run-integration-smoke.sh`
- `/Users/redbars/.codex/skills/codex-review/scripts/codex-review --mode local --output /tmp/transcripted-nightly-codex-review-20260611.txt` (clean)
