### PR TITLE
perf: move meeting-prompt EKEventStore queries off the main actor

### DIFF
--- a/Sources/Meeting/MeetingPromptDetector.swift
+++ b/Sources/Meeting/MeetingPromptDetector.swift
@@ -25,7 +25,12 @@ final class MeetingPromptDetector {
 
     var onPromptRequest: ((Candidate) -> Bool)?
 
-    private let eventStore = EKEventStore()
+    private let calendarReader = MeetingPromptCalendarReader()
+    // Cache of upcoming meeting-link events refreshed off-main by each poll cycle.
+    // Dismiss/markAccepted/title paths must stay synchronous (overlay callbacks and
+    // the recording-start title closure), so they read this cache instead of querying
+    // EKEventStore on the main actor.
+    private var calendarEventSnapshots: [MeetingPromptCalendarEventSnapshot] = []
     private var pollingTask: Task<Void, Never>?
     private var workspaceObservers: [NSObjectProtocol] = []
     private var snoozedUntil: [String: Date] = [:]
@@ -36,10 +41,9 @@ final class MeetingPromptDetector {
     private let defaultSnoozeInterval: TimeInterval = 30 * 60
     private let pendingCooldown: TimeInterval = 90
     private let pollIntervalNanoseconds: UInt64 = 20_000_000_000
-
-    private static let meetingURLDetector = try? NSDataDetector(
-        types: NSTextCheckingResult.CheckingType.link.rawValue
-    )
+    // Single fetch window covering both the near-term prompt window and the
+    // farthest lookahead used for runtime-dismiss resume dates.
+    private let calendarLookaheadInterval: TimeInterval = 12 * 60 * 60
 
     private static let browserBundleIdentifiers: Set<String> = [
         "com.apple.Safari",
@@ -183,6 +187,8 @@ final class MeetingPromptDetector {
     }
 
     private func evaluate() async {
+        await refreshCalendarEventSnapshots()
+
         let now = Date()
         let runningApplications = NSWorkspace.shared.runningApplications
         let runningBundleIDs = Set(runningApplications.compactMap(\.bundleIdentifier))
@@ -211,6 +217,19 @@ final class MeetingPromptDetector {
         if onPromptRequest?(match.candidate) == true {
             pendingUntil[match.candidate.id] = now.addingTimeInterval(pendingCooldown)
         }
+    }
+
+    private func refreshCalendarEventSnapshots() async {
+        guard TranscriptedPermissionAccess.calendarAccessGranted() else {
+            calendarEventSnapshots = []
+            return
+        }
+
+        let now = Date()
+        calendarEventSnapshots = await calendarReader.fetchMeetingEventSnapshots(
+            start: now.addingTimeInterval(-MeetingPromptHeuristics.calendarReminderPostStartGrace),
+            end: now.addingTimeInterval(calendarLookaheadInterval)
+        )
     }
 
     private func installWorkspaceObservers() {
@@ -306,74 +325,66 @@ final class MeetingPromptDetector {
         runningBundleIDs: Set<String>,
         frontmostBundleID: String?
     ) -> [ScoredCandidate] {
-        let searchStart = now.addingTimeInterval(-5 * 60)
-        let searchEnd = now.addingTimeInterval(15 * 60)
-        let predicate = eventStore.predicateForEvents(withStart: searchStart, end: searchEnd, calendars: nil)
-
-        return eventStore.events(matching: predicate)
-            .compactMap { event in
-                scoredCandidate(
-                    from: event,
-                    now: now,
-                    runningBundleIDs: runningBundleIDs,
-                    frontmostBundleID: frontmostBundleID
-                )
-            }
+        calendarEventSnapshots.compactMap { snapshot in
+            scoredCandidate(
+                from: snapshot,
+                now: now,
+                runningBundleIDs: runningBundleIDs,
+                frontmostBundleID: frontmostBundleID
+            )
+        }
     }
 
     private func scoredCandidate(
-        from event: EKEvent,
+        from snapshot: MeetingPromptCalendarEventSnapshot,
         now: Date,
         runningBundleIDs: Set<String>,
         frontmostBundleID: String?
     ) -> ScoredCandidate? {
-        guard !event.isAllDay else { return nil }
-        guard let meetingURL = extractMeetingURL(from: event), let provider = provider(for: meetingURL) else { return nil }
-
-        let startsIn = event.startDate.timeIntervalSince(now)
-        let endsIn = event.endDate.timeIntervalSince(now)
+        let startsIn = snapshot.startDate.timeIntervalSince(now)
+        let endsIn = snapshot.endDate.timeIntervalSince(now)
         let genericWindow = MeetingPromptWindowPolicy.shouldOfferCalendarPrompt(
             startsIn: startsIn,
             endsIn: endsIn
         )
         let runtimeReason = activeRuntimeReason(
-            for: provider,
+            for: snapshot.provider,
             runningBundleIDs: runningBundleIDs,
             frontmostBundleID: frontmostBundleID
         )
         guard genericWindow else { return nil }
 
-        let eventTitle = displayTitle(from: event)
-        let transcriptTitle = suggestedTranscriptTitle(from: event)
+        let eventTitle = displayTitle(from: snapshot)
+        let transcriptTitle = suggestedTranscriptTitle(from: snapshot)
         let detail = buildDetail(eventTitle: eventTitle, startsIn: startsIn, runtimeReason: runtimeReason)
         let score = scoreForCandidate(startsIn: startsIn, runtimeReason: runtimeReason)
 
         return ScoredCandidate(
             candidate: Candidate(
-                id: "calendar:\(event.calendarItemIdentifier)",
+                id: "calendar:\(snapshot.id)",
                 title: "Meeting detected",
                 detail: detail,
-                provider: provider,
+                provider: snapshot.provider,
                 reason: MeetingPromptHeuristics.reason(
                     for: .calendarEvent,
                     hasRuntimeContext: runtimeReason != nil
                 ),
                 source: .calendarEvent,
-                startDate: event.startDate,
-                endDate: event.endDate,
-                meetingURL: meetingURL,
+                startDate: snapshot.startDate,
+                endDate: snapshot.endDate,
+                meetingURL: snapshot.meetingURL,
                 suggestedTranscriptTitle: transcriptTitle
             ),
             score: score
         )
     }
 
-    private func displayTitle(from event: EKEvent) -> String {
-        suggestedTranscriptTitle(from: event) ?? "Upcoming meeting"
+    private func displayTitle(from snapshot: MeetingPromptCalendarEventSnapshot) -> String {
+        suggestedTranscriptTitle(from: snapshot) ?? "Upcoming meeting"
     }
 
-    private func suggestedTranscriptTitle(from event: EKEvent) -> String? {
-        let trimmed = (event.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+    private func suggestedTranscriptTitle(from snapshot: MeetingPromptCalendarEventSnapshot) -> String? {
+        let trimmed = (snapshot.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
 
@@ -444,7 +455,84 @@ final class MeetingPromptDetector {
         }
     }
 
-    private func extractMeetingURL(from event: EKEvent) -> URL? {
+    private func provider(forBundleIdentifier bundleIdentifier: String) -> MeetingPromptProvider? {
+        MeetingPromptProvider.allCases.first { $0.activeBundleIdentifiers.contains(bundleIdentifier) }
+    }
+
+    private func suppressRuntimePrompts(for provider: MeetingPromptProvider, until: Date) {
+        let existing = runtimeSuppressedUntil[provider] ?? .distantPast
+        runtimeSuppressedUntil[provider] = max(existing, until)
+    }
+
+    private func nextRuntimePromptResumeDate(for provider: MeetingPromptProvider, now: Date) -> Date? {
+        guard let snapshot = nextRelevantCalendarSnapshot(for: provider, after: now) else { return nil }
+
+        let promptDate = snapshot.startDate.addingTimeInterval(-MeetingPromptHeuristics.calendarReminderLeadTime)
+        if promptDate > now {
+            return promptDate
+        }
+
+        return snapshot.endDate.addingTimeInterval(MeetingPromptHeuristics.calendarReminderPostStartGrace)
+    }
+
+    private func runtimeSuppressionEndDate(for provider: MeetingPromptProvider, now: Date) -> Date? {
+        nextRelevantCalendarSnapshot(for: provider, after: now)?
+            .endDate
+            .addingTimeInterval(MeetingPromptHeuristics.calendarReminderPostStartGrace)
+    }
+
+    private func nextRelevantCalendarSnapshot(
+        for targetProvider: MeetingPromptProvider,
+        after now: Date
+    ) -> MeetingPromptCalendarEventSnapshot? {
+        guard TranscriptedPermissionAccess.calendarAccessGranted() else { return nil }
+
+        return calendarEventSnapshots
+            .filter { $0.provider == targetProvider && $0.endDate > now }
+            .min { $0.startDate < $1.startDate }
+    }
+
+    private func pruneExpiredEntries(now: Date) {
+        snoozedUntil = snoozedUntil.filter { $0.value > now }
+        pendingUntil = pendingUntil.filter { $0.value > now }
+        runtimeSuppressedUntil = runtimeSuppressedUntil.filter { $0.value > now }
+        recentNativeActivity = recentNativeActivity.filter {
+            now.timeIntervalSince($0.value) <= MeetingPromptHeuristics.runtimeActivityFreshness
+        }
+    }
+}
+
+// Plain-value snapshot of a calendar event carrying a recognized meeting link.
+// Built on the reader's queue because EKEvent objects must not cross threads;
+// all-day events and events without a supported meeting URL are dropped here.
+private struct MeetingPromptCalendarEventSnapshot: Sendable {
+    let id: String
+    let title: String?
+    let startDate: Date
+    let endDate: Date
+    let meetingURL: URL
+    let provider: MeetingPromptProvider
+
+    init?(event: EKEvent) {
+        guard !event.isAllDay,
+              let startDate = event.startDate,
+              let endDate = event.endDate,
+              let meetingURL = Self.extractMeetingURL(from: event),
+              let provider = Self.provider(for: meetingURL) else { return nil }
+
+        self.id = event.calendarItemIdentifier
+        self.title = event.title
+        self.startDate = startDate
+        self.endDate = endDate
+        self.meetingURL = meetingURL
+        self.provider = provider
+    }
+
+    private static let meetingURLDetector = try? NSDataDetector(
+        types: NSTextCheckingResult.CheckingType.link.rawValue
+    )
+
+    private static func extractMeetingURL(from event: EKEvent) -> URL? {
         if let url = event.url, provider(for: url) != nil {
             return url
         }
@@ -458,8 +546,8 @@ final class MeetingPromptDetector {
         return nil
     }
 
-    private func extractFirstMeetingURL(in text: String) -> URL? {
-        guard let detector = Self.meetingURLDetector else { return nil }
+    private static func extractFirstMeetingURL(in text: String) -> URL? {
+        guard let detector = meetingURLDetector else { return nil }
         let range = NSRange(text.startIndex..<text.endIndex, in: text)
         let matches = detector.matches(in: text, options: [], range: range)
         for match in matches {
@@ -469,66 +557,27 @@ final class MeetingPromptDetector {
         return nil
     }
 
-    private func provider(for url: URL) -> MeetingPromptProvider? {
+    private static func provider(for url: URL) -> MeetingPromptProvider? {
         guard let host = url.host else { return nil }
         return MeetingPromptProvider.provider(forMeetingHost: host)
     }
+}
 
-    private func provider(forBundleIdentifier bundleIdentifier: String) -> MeetingPromptProvider? {
-        MeetingPromptProvider.allCases.first { $0.activeBundleIdentifiers.contains(bundleIdentifier) }
-    }
+// Runs the synchronous EKEventStore queries on a background queue so large
+// calendars never block the main actor. @unchecked Sendable is safe because
+// EKEventStore is documented thread-safe and all queries serialize on `queue`.
+private final class MeetingPromptCalendarReader: @unchecked Sendable {
+    private let queue = DispatchQueue(label: "MeetingPromptDetector.calendar-reader", qos: .utility)
+    private let eventStore = EKEventStore()
 
-    private func suppressRuntimePrompts(for provider: MeetingPromptProvider, until: Date) {
-        let existing = runtimeSuppressedUntil[provider] ?? .distantPast
-        runtimeSuppressedUntil[provider] = max(existing, until)
-    }
-
-    private func nextRuntimePromptResumeDate(for provider: MeetingPromptProvider, now: Date) -> Date? {
-        guard let event = nextRelevantCalendarEvent(for: provider, after: now) else { return nil }
-
-        let promptDate = event.startDate.addingTimeInterval(-MeetingPromptHeuristics.calendarReminderLeadTime)
-        if promptDate > now {
-            return promptDate
-        }
-
-        return event.endDate.addingTimeInterval(MeetingPromptHeuristics.calendarReminderPostStartGrace)
-    }
-
-    private func runtimeSuppressionEndDate(for provider: MeetingPromptProvider, now: Date) -> Date? {
-        nextRelevantCalendarEvent(for: provider, after: now)?
-            .endDate
-            .addingTimeInterval(MeetingPromptHeuristics.calendarReminderPostStartGrace)
-    }
-
-    private func nextRelevantCalendarEvent(
-        for targetProvider: MeetingPromptProvider,
-        after now: Date
-    ) -> EKEvent? {
-        guard TranscriptedPermissionAccess.calendarAccessGranted() else { return nil }
-
-        let searchStart = now.addingTimeInterval(-MeetingPromptHeuristics.calendarReminderPostStartGrace)
-        let searchEnd = now.addingTimeInterval(12 * 60 * 60)
-        let predicate = eventStore.predicateForEvents(withStart: searchStart, end: searchEnd, calendars: nil)
-
-        return eventStore.events(matching: predicate)
-            .filter { !$0.isAllDay && $0.endDate > now }
-            .compactMap { event -> (EKEvent, MeetingPromptProvider)? in
-                guard let url = extractMeetingURL(from: event),
-                      let eventProvider = provider(for: url),
-                      eventProvider == targetProvider else { return nil }
-                return (event, eventProvider)
+    func fetchMeetingEventSnapshots(start: Date, end: Date) async -> [MeetingPromptCalendarEventSnapshot] {
+        await withCheckedContinuation { continuation in
+            queue.async {
+                let predicate = self.eventStore.predicateForEvents(withStart: start, end: end, calendars: nil)
+                let snapshots = self.eventStore.events(matching: predicate)
+                    .compactMap { MeetingPromptCalendarEventSnapshot(event: $0) }
+                continuation.resume(returning: snapshots)
             }
-            .map(\.0)
-            .sorted { $0.startDate < $1.startDate }
-            .first
-    }
-
-    private func pruneExpiredEntries(now: Date) {
-        snoozedUntil = snoozedUntil.filter { $0.value > now }
-        pendingUntil = pendingUntil.filter { $0.value > now }
-        runtimeSuppressedUntil = runtimeSuppressedUntil.filter { $0.value > now }
-        recentNativeActivity = recentNativeActivity.filter {
-            now.timeIntervalSince($0.value) <= MeetingPromptHeuristics.runtimeActivityFreshness
         }
     }
 }


### PR DESCRIPTION
## Why

`MeetingPromptDetector` ran synchronous `EKEventStore.events(matching:)` queries on the main actor: every 20s poll, every supported-app activation, and again on each runtime-prompt dismiss via `nextRuntimePromptResumeDate`. On large calendars each query blocks the main thread, causing recurring jank in a menubar app that should be invisible.

## Product Impact

- Affects: `meetings`
- Lane: `meeting reliability`
- Why this matters: prompt detection should never make the whole app stutter every 20 seconds for users with busy calendars.

## What changed

- New `MeetingPromptCalendarReader` owns the `EKEventStore` and runs queries on a background utility queue, bridged with a checked continuation. The store is never queried on the main thread.
- Each poll cycle does one broad fetch (`now-5min .. now+12h`, covering both the prompt window and the 12h dismiss-resume lookahead) instead of a narrow query per poll plus ad-hoc 12h queries on dismiss/accept.
- Events are converted to plain-value `MeetingPromptCalendarEventSnapshot`s on the reader's queue (EKEvent objects must not cross threads); only Sendable values hop back to the main actor. This also moves the NSDataDetector meeting-URL scan off main.
- All paths that must stay synchronous — `dismiss`/`remindSoon`/`markAccepted` backoff decisions and `currentSuggestedTranscriptTitle()` (consumed by `MeetingSessionController`'s sync title closure) — read the main-actor snapshot cache instead of querying live.

Semantics are preserved: the old narrow query window was strictly looser than the `shouldOfferCalendarPrompt` scoring filter, so cache-derived candidates are identical, and prompt scoring, snooze/pending bookkeeping, and `MeetingPromptHeuristics` are untouched. Dismiss resume dates read a cache at most one 20s poll stale — a prompt can only be dismissed after the evaluate cycle that refreshed the cache.

## How I checked it

- [x] `scripts/dev/agent-preflight.sh`
- [x] Selected checks from `.agents/test-matrix.yml` for the files changed (`Sources/Meeting/**` rule: `bash build-deps.sh --force` + build + fast tests + integration smoke, all run bare)
- [x] `bash build.sh --no-open`
- [x] `bash run-tests.sh` — 4655/4655 passed, warning-free compile; `MeetingPromptDetectorTests` and `MeetingPromptHeuristicsTests` green and unmodified
- [x] Performance budget passed (`bash build.sh --no-open` bundle gate)
- [x] `bash run-integration-smoke.sh` if I touched `Sources/Meeting/` or `Sources/TranscriptedCore/`
- [ ] `swift test` — not required (no `Package.swift` / `Sources/TranscriptedCore/` changes)
- [ ] Manual check: none (no UI change)

## Risk Review

- [x] Privacy / local-first behavior reviewed — no off-device payload changes; calendar data stays in-process
- [x] Storage path or migration impact reviewed — none
- [x] Public-facing copy stays concrete and matches current product scope — no copy changes
- [x] Release/update impact reviewed — none
- [x] Agent PRs link the issue/workpad and stay draft until human review
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence — n/a
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

## Notes

One behavior nuance: `currentSuggestedTranscriptTitle()` now reads the latest polled snapshot rather than doing a fresh blocking query, so a recording started within the first second after launch (before the first poll lands) could miss the title hint. In exchange, recording start no longer pays a synchronous calendar query.

## Agent handoff

`COORD_DONE: GREEN | PR URL below | moved MeetingPromptDetector EKEventStore queries to a background reader with a main-actor snapshot cache | none | none | build-deps --force, build.sh --no-open, run-tests.sh (4655 pass), run-integration-smoke.sh | human review + merge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)