### PR TITLE
refactor: extract shared TranscriptedCaptureKit for CLI and MCP tools

### DIFF
--- a/.agents/test-matrix.yml
+++ b/.agents/test-matrix.yml
@@ -245,6 +245,14 @@ rules:
       - "SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>"
 
   - paths:
+      - "Tools/TranscriptedCaptureKit/**"
+    checks:
+      - "swift test --package-path Tools/TranscriptedCaptureKit"
+      - "swift test --package-path Tools/TranscriptedCLI"
+      - "swift test --package-path Tools/TranscriptedMCP"
+      - "bash run-e2e-smoke.sh"
+
+  - paths:
       - "Tools/TranscriptedCLI/**"
     checks:
       - "swift test --package-path Tools/TranscriptedCLI"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Verification rules (mirror `.agents/test-matrix.yml`; if a change matches multip
 - Touched `Package.swift`, `Sources/TranscriptedCore/**`, or `Tests/TranscriptedCoreTests/**` → `bash build-deps.sh --force` + `bash build.sh --no-open` + `bash run-tests.sh` + `bash run-integration-smoke.sh` + `swift test`
 - Touched `Sources/Observability/**`, `Info.plist`, `docs/sparkle-updates.md`, or `docs/appcast.xml` → `bash build.sh --no-open` + `bash run-tests.sh`
 - Touched release path (`build-beta.sh`, `scripts/entrypoints/build-beta.sh`, `scripts/release/**`, `docs/release-packaging.md`, `docs/sparkle-updates.md`, `Casks/**`, `docs/appcast.xml`) → `bash build.sh --no-open` + `bash run-tests.sh` + `SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>`
+- Touched `Tools/TranscriptedCaptureKit/**` → `swift test --package-path Tools/TranscriptedCaptureKit` + `swift test --package-path Tools/TranscriptedCLI` + `swift test --package-path Tools/TranscriptedMCP` + `bash run-e2e-smoke.sh`
 - Touched `Tools/TranscriptedCLI/**` → `swift test --package-path Tools/TranscriptedCLI`
 - Touched `Tools/TranscriptedMCP/**` → `swift test --package-path Tools/TranscriptedMCP`
 - Touched `Tools/TranscriptedQA/**` → `swift test --package-path Tools/TranscriptedQA`
@@ -103,6 +104,7 @@ Subsystem boundaries (each has a local `CLAUDE.md`):
 | `Sources/Support/` | app paths, permissions metadata, hotkey/trigger preferences, paste, dictionary, launch-at-login |
 | `Sources/TranscriptedCore/` | reusable meeting transcription library — strict library boundary, consumed only through `Sources/Meeting/` |
 | `Sources/UI/` | `Overlay/`, `MenuBar/`, `Settings/`, `AgentConnect/`, `Shared/` |
+| `Tools/TranscriptedCaptureKit` | shared capture-library resolution + capture-Markdown parsing library for the CLI and MCP tools |
 | `Tools/TranscriptedCLI` | standalone local-context and offline diarization CLI |
 | `Tools/TranscriptedMCP` | read-only MCP server for saved meetings/dictations |
 | `Tools/TranscriptedQA` | standalone artifact validation and QA CLI |

--- a/Sources/Dictation/CLAUDE.md
+++ b/Sources/Dictation/CLAUDE.md
@@ -52,6 +52,6 @@ bash run-tests.sh
 
 ## Agent notes
 
-- If you change the markdown layout, update the tests.
+- If you change the markdown layout, update the tests. The `Dictations_YYYY-MM-DD.md` day-file format is also parsed by the standalone tools through `Tools/TranscriptedCaptureKit` — update its parser and tests in the same change.
 - Dictation artifacts are append-only by day; do not assume one file per session.
 - This directory owns dictation persistence plus the newest-saved-dictation lookup seam. Recording lifecycle changes still belong in `Sources/UI/Overlay/DictationSessionController.swift` and `Sources/Speech/`.

--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -61,6 +61,8 @@ default path.
 
 `TranscriptSaver.saveTranscript(...)` writes a markdown transcript, including YAML speaker metadata and recording-health fields like `capture_quality`, `audio_gaps`, and `device_switches` when the host provides them.
 
+The standalone CLI/MCP tools parse this same Markdown format through a dependency-free mirror in `Tools/TranscriptedCaptureKit` (it intentionally does not link Core). If `TranscriptFormatter` or `TranscriptFrontmatter` changes the written format, update the kit's parsers and tests in the same change.
+
 ## Editing rules
 
 - Keep app-shell UI types out of this directory.

--- a/Tools/README.md
+++ b/Tools/README.md
@@ -4,6 +4,7 @@
 
 ## Packages
 
+- `TranscriptedCaptureKit/` — shared library for capture-library resolution and capture-Markdown parsing, used by the CLI and MCP packages
 - `TranscriptedCLI/` — local context and offline diarization CLI
 - `TranscriptedMCP/` — read-only MCP server for saved meetings and dictations
 - `TranscriptedQA/` — artifact validation and QA CLI
@@ -12,6 +13,7 @@
 
 Each package has its own local `CLAUDE.md` and `Package.swift`.
 
+- `Tools/TranscriptedCaptureKit/CLAUDE.md`
 - `Tools/TranscriptedCLI/CLAUDE.md`
 - `Tools/TranscriptedMCP/CLAUDE.md`
 - `Tools/TranscriptedQA/CLAUDE.md`

--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -44,10 +44,10 @@ They also honor:
 
 | File | Purpose |
 |------|---------|
-| `Package.swift` | Swift package manifest; links against repo dependency artifacts |
+| `Package.swift` | Swift package manifest; depends on `../TranscriptedCaptureKit` and links against repo dependency artifacts |
 | `TranscriptedCLI.swift` | `@main` command root and subcommand registration |
 | `ContextCommands.swift` | CLI entry points for recent/search/read context commands |
-| `ContextStore.swift` | Shared file-loading and filtering logic for local context |
+| `ContextStore.swift` | File-loading and filtering logic for local context; directory resolution and markdown parsing delegate to `TranscriptedCaptureKit` |
 | `ContextModels.swift` | Codable models used by the context commands |
 | `DiarizeCommand.swift` | Single-file diarization command |
 | `BatchCommand.swift` | Directory diarization command |
@@ -121,3 +121,4 @@ with `TRANSCRIPTEDCLI_ENABLE_DIARIZATION=1` when diarization is needed.
 - when the user moved the capture library in Transcripted Settings, the CLI should follow that app-selected path before defaulting back to `~/Library/Application Support/Transcripted/captures`
 - `context-recent` is intentionally a mixed feed; if the user asks for the latest meeting specifically, add `--kind meeting`
 - changes here should be verified independently from the app build
+- directory resolution and capture-Markdown parsing live in `Tools/TranscriptedCaptureKit` and are shared with `Tools/TranscriptedMCP`; change them there, not by re-inlining logic into `ContextStore.swift`

--- a/Tools/TranscriptedCLI/Package.swift
+++ b/Tools/TranscriptedCLI/Package.swift
@@ -26,12 +26,14 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+        .package(path: "../TranscriptedCaptureKit"),
     ],
     targets: [
         .executableTarget(
             name: "transcripted-cli",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "TranscriptedCaptureKit", package: "TranscriptedCaptureKit"),
             ],
             path: "Sources/TranscriptedCLI",
             swiftSettings: hasDiarizationDeps ? [

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -1,17 +1,6 @@
 import ArgumentParser
 import Foundation
-
-private struct CLIAppDirectoryManifest: Decodable {
-    let version: Int
-    let captureLibraryDirectory: String
-    let meetingsDirectory: String
-    let dictationsDirectory: String
-}
-
-private struct CLIConfiguredCaptureDirectories {
-    let meetings: URL
-    let dictations: URL
-}
+import TranscriptedCaptureKit
 
 struct CLIContextDirectories {
     let meetingDirs: [URL]
@@ -43,245 +32,18 @@ struct CLIContextDirectories {
         fileManager: FileManager = .default,
         homeDirectory: URL? = nil
     ) -> CLIContextDirectories {
-        if let dataDir, !dataDir.isEmpty {
-            let shared = URL(fileURLWithPath: dataDir)
-            if fileManager.fileExists(atPath: shared.appendingPathComponent("meetings", isDirectory: true).path)
-                || fileManager.fileExists(atPath: shared.appendingPathComponent("dictations", isDirectory: true).path) {
-                return CLIContextDirectories(
-                    meetingsDir: shared.appendingPathComponent("meetings", isDirectory: true),
-                    dictationsDir: shared.appendingPathComponent("dictations", isDirectory: true)
-                )
-            }
-            return CLIContextDirectories(meetingsDir: shared, dictationsDir: shared)
-        }
-
-        if let shared = environment["TRANSCRIPTED_DATA_DIR"], !shared.isEmpty {
-            let sharedURL = URL(fileURLWithPath: shared)
-            if fileManager.fileExists(atPath: sharedURL.appendingPathComponent("meetings", isDirectory: true).path)
-                || fileManager.fileExists(atPath: sharedURL.appendingPathComponent("dictations", isDirectory: true).path) {
-                return CLIContextDirectories(
-                    meetingsDir: sharedURL.appendingPathComponent("meetings", isDirectory: true),
-                    dictationsDir: sharedURL.appendingPathComponent("dictations", isDirectory: true)
-                )
-            }
-            return CLIContextDirectories(meetingsDir: sharedURL, dictationsDir: sharedURL)
-        }
-
-        let home = homeDirectory ?? fileManager.homeDirectoryForCurrentUser
-        let transcriptedRoot = home
-            .appendingPathComponent("Library", isDirectory: true)
-            .appendingPathComponent("Application Support", isDirectory: true)
-            .appendingPathComponent("Transcripted", isDirectory: true)
-        let defaultCaptures = transcriptedRoot.appendingPathComponent("captures", isDirectory: true)
-        let defaultMeetings = defaultCaptures.appendingPathComponent("meetings", isDirectory: true)
-        let defaultDictations = defaultCaptures.appendingPathComponent("dictations", isDirectory: true)
-
-        let draftRoot = home
-            .appendingPathComponent("Library", isDirectory: true)
-            .appendingPathComponent("Application Support", isDirectory: true)
-            .appendingPathComponent("Draft", isDirectory: true)
-        let legacyDraftMeetings = draftRoot
-            .appendingPathComponent("meetings", isDirectory: true)
-            .appendingPathComponent("transcripts", isDirectory: true)
-        let legacyDraftDictations = draftRoot
-            .appendingPathComponent("dictations", isDirectory: true)
-            .appendingPathComponent("transcripts", isDirectory: true)
-        let legacyShared = home
-            .appendingPathComponent("Documents", isDirectory: true)
-            .appendingPathComponent("Transcripted", isDirectory: true)
-
-        let appConfiguredCaptureDirectories = configuredCaptureDirectories(
-            homeDirectory: home,
-            fileManager: fileManager
+        let resolved = CaptureLibraryResolver.resolve(
+            dataDir: dataDir,
+            meetingsDir: meetingsDir,
+            dictationsDir: dictationsDir,
+            environment: environment,
+            fileManager: fileManager,
+            homeDirectory: homeDirectory
         )
-        let meetingsURL = meetingsDir.map(URL.init(fileURLWithPath:))
-            ?? environment["TRANSCRIPTED_MEETINGS_DIR"].map(URL.init(fileURLWithPath:))
-        let dictationsURL = dictationsDir.map(URL.init(fileURLWithPath:))
-            ?? environment["TRANSCRIPTED_DICTATIONS_DIR"].map(URL.init(fileURLWithPath:))
-        let meetingDirs = meetingsURL.map { [$0] }
-            ?? appConfiguredCaptureDirectories.map {
-                captureDirectories(
-                    primary: $0.meetings,
-                    legacyCandidates: [legacyDraftMeetings, legacyShared],
-                    fileManager: fileManager
-                )
-            }
-            ?? captureDirectories(
-                primary: defaultMeetings,
-                legacyCandidates: [legacyDraftMeetings, legacyShared],
-                fileManager: fileManager
-            )
-        let dictationDirs = dictationsURL.map { [$0] }
-            ?? appConfiguredCaptureDirectories.map {
-                captureDirectories(
-                    primary: $0.dictations,
-                    legacyCandidates: [legacyDraftDictations, legacyShared],
-                    fileManager: fileManager
-                )
-            }
-            ?? captureDirectories(
-                primary: defaultDictations,
-                legacyCandidates: [legacyDraftDictations, legacyShared],
-                fileManager: fileManager
-            )
-
         return CLIContextDirectories(
-            meetingDirs: meetingDirs,
-            dictationDirs: dictationDirs
+            meetingDirs: resolved.meetingDirs,
+            dictationDirs: resolved.dictationDirs
         )
-    }
-
-    private static func captureDirectories(primary: URL, legacyCandidates: [URL], fileManager: FileManager) -> [URL] {
-        var directories = [primary]
-        var seen = Set([primary.standardizedFileURL.path])
-
-        for candidate in legacyCandidates where directoryHasCaptureMarkdownFiles(candidate, fileManager: fileManager) {
-            let path = candidate.standardizedFileURL.path
-            guard !seen.contains(path) else { continue }
-            seen.insert(path)
-            directories.append(candidate)
-        }
-
-        return directories
-    }
-
-    private static func directoryHasCaptureMarkdownFiles(_ directory: URL, fileManager: FileManager) -> Bool {
-        guard let contents = try? fileManager.contentsOfDirectory(
-            at: directory,
-            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return false
-        }
-
-        return contents.contains { url in
-            guard url.pathExtension == "md",
-                  let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
-            else {
-                return false
-            }
-            guard values.isRegularFile == true, values.isSymbolicLink != true else {
-                return false
-            }
-            return looksLikeCaptureMarkdown(url)
-        }
-    }
-
-    private static func looksLikeCaptureMarkdown(_ url: URL) -> Bool {
-        let filename = url.deletingPathExtension().lastPathComponent
-        if filename.hasPrefix("Dictations_") {
-            return true
-        }
-
-        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
-            return false
-        }
-
-        return content.hasPrefix("---\n") && content.contains("\n---\n")
-    }
-
-    private static func configuredCaptureDirectories(
-        homeDirectory home: URL,
-        fileManager: FileManager
-    ) -> CLIConfiguredCaptureDirectories? {
-        manifestCaptureDirectories(homeDirectory: home, fileManager: fileManager)
-            ?? appPreferenceCaptureDirectories(homeDirectory: home)
-    }
-
-    private static func manifestCaptureDirectories(
-        homeDirectory home: URL,
-        fileManager: FileManager
-    ) -> CLIConfiguredCaptureDirectories? {
-        let manifestURL = home
-            .appendingPathComponent("Library", isDirectory: true)
-            .appendingPathComponent("Application Support", isDirectory: true)
-            .appendingPathComponent("Transcripted", isDirectory: true)
-            .appendingPathComponent("mcp-directories.json", isDirectory: false)
-
-        guard fileManager.fileExists(atPath: manifestURL.path),
-              let data = try? Data(contentsOf: manifestURL),
-              let manifest = try? JSONDecoder().decode(CLIAppDirectoryManifest.self, from: data),
-              manifest.version >= 1,
-              let captureLibrary = validatedConfiguredDirectory(manifest.captureLibraryDirectory, homeDirectory: home),
-              let meetings = validatedConfiguredDirectory(manifest.meetingsDirectory, homeDirectory: home),
-              let dictations = validatedConfiguredDirectory(manifest.dictationsDirectory, homeDirectory: home),
-              isManifestDirectory(meetings, named: "meetings", under: captureLibrary),
-              isManifestDirectory(dictations, named: "dictations", under: captureLibrary) else {
-            return nil
-        }
-
-        return CLIConfiguredCaptureDirectories(meetings: meetings, dictations: dictations)
-    }
-
-    private static func appPreferenceCaptureDirectories(homeDirectory home: URL) -> CLIConfiguredCaptureDirectories? {
-        for domain in appPreferenceDomains {
-            let preferenceURL = home
-                .appendingPathComponent("Library", isDirectory: true)
-                .appendingPathComponent("Preferences", isDirectory: true)
-                .appendingPathComponent("\(domain).plist", isDirectory: false)
-
-            guard let data = try? Data(contentsOf: preferenceURL),
-                  let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
-                  let values = plist as? [String: Any],
-                  let rawPath = values["transcriptSaveLocation"] as? String,
-                  let captureLibrary = validatedConfiguredDirectory(rawPath, homeDirectory: home) else {
-                continue
-            }
-
-            return CLIConfiguredCaptureDirectories(
-                meetings: captureLibrary.appendingPathComponent("meetings", isDirectory: true),
-                dictations: captureLibrary.appendingPathComponent("dictations", isDirectory: true)
-            )
-        }
-
-        return nil
-    }
-
-    private static var appPreferenceDomains: [String] {
-        [
-            "com.justinbetker.draft",
-            "app.transcripted.Transcripted",
-        ]
-    }
-
-    private static func validatedConfiguredDirectory(_ rawPath: String, homeDirectory home: URL) -> URL? {
-        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, trimmed.hasPrefix("/") else {
-            return nil
-        }
-
-        let directory = URL(fileURLWithPath: trimmed, isDirectory: true).standardizedFileURL
-        guard directory.path != "/", !directory.pathComponents.contains("..") else {
-            return nil
-        }
-
-        let resolvedDirectory = directory.resolvingSymlinksInPath().standardizedFileURL
-        let resolvedHome = home.resolvingSymlinksInPath().standardizedFileURL
-        let isUnderHome = resolvedDirectory.path == resolvedHome.path
-            || resolvedDirectory.path.hasPrefix(resolvedHome.path + "/")
-        let forbiddenPrefixes = ["/System", "/Library", "/usr", "/bin", "/sbin", "/private"]
-        let isForbidden = forbiddenPrefixes.contains { prefix in
-            resolvedDirectory.path == prefix || resolvedDirectory.path.hasPrefix(prefix + "/")
-        }
-
-        guard !isForbidden || isUnderHome else {
-            return nil
-        }
-
-        return directory
-    }
-
-    private static func isManifestDirectory(_ directory: URL, named name: String, under captureLibrary: URL) -> Bool {
-        let expected = captureLibrary
-            .appendingPathComponent(name, isDirectory: true)
-            .standardizedFileURL
-            .resolvingSymlinksInPath()
-            .standardizedFileURL
-        let actual = directory
-            .standardizedFileURL
-            .resolvingSymlinksInPath()
-            .standardizedFileURL
-        return actual.path == expected.path
     }
 }
 
@@ -451,7 +213,7 @@ enum CLIContextStore {
 
         guard let markdownURL,
               let content = try? String(contentsOf: markdownURL, encoding: .utf8),
-              looksLikeCaptureMarkdown(markdownURL),
+              CaptureMarkdown.looksLikeCaptureMarkdown(markdownURL),
               !markdownURL.deletingPathExtension().lastPathComponent.hasPrefix("Dictations_") else {
             throw ValidationError("Meeting not found: \(filename)")
         }
@@ -617,41 +379,69 @@ enum CLIContextStore {
             guard url.pathExtension == "md" else { return nil }
             switch CLIPathSecurity.validateExistingFile(url, under: directory) {
             case .valid(let safeURL):
-                return looksLikeCaptureMarkdown(safeURL) ? safeURL : nil
+                return CaptureMarkdown.looksLikeCaptureMarkdown(safeURL) ? safeURL : nil
             case .missing, .invalid: return nil
             }
         }
     }
 
-    private static func looksLikeCaptureMarkdown(_ url: URL) -> Bool {
-        let filename = url.deletingPathExtension().lastPathComponent
-        if filename.hasPrefix("Dictations_") {
-            return true
-        }
+    private static func loadMeeting(at url: URL) -> CLIAgentTranscript? {
+        guard let content = try? String(contentsOf: url, encoding: .utf8),
+              let parsed = CaptureMarkdownParser.parseMeeting(from: content) else { return nil }
 
-        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
-            return false
-        }
-
-        return content.hasPrefix("---\n") && content.contains("\n---\n")
+        return CLIAgentTranscript(
+            version: "2.0",
+            recording: CLIAgentRecording(
+                date: parsed.datetime,
+                durationSeconds: parsed.durationSeconds
+            ),
+            speakers: parsed.speakers.map { speaker in
+                CLIActorSpeaker(
+                    id: speaker.id,
+                    name: speaker.name,
+                    persistentSpeakerId: speaker.persistentSpeakerId,
+                    wordCount: speaker.wordCount
+                )
+            },
+            utterances: parsed.utterances.map { utterance in
+                CLIUtterance(
+                    start: utterance.start,
+                    end: utterance.end,
+                    speakerId: utterance.speakerId,
+                    text: utterance.text
+                )
+            }
+        )
     }
 
     private static func loadDictationDay(at url: URL) -> (payload: CLIAgentDictationDay, entries: [CLIClientDictationEntry])? {
         guard let content = try? String(contentsOf: url, encoding: .utf8),
-              let frontmatter = parseFrontmatter(from: content) else { return nil }
+              let parsed = CaptureMarkdownParser.parseDictationDay(from: content, markdownURL: url) else { return nil }
 
-        let entries = parseDictationEntries(from: frontmatter.body)
+        let entries = parsed.entries.map { entry in
+            CLIClientDictationEntry(
+                id: entry.id,
+                createdAt: entry.createdAt,
+                title: entry.title,
+                text: entry.text,
+                sourceAppName: entry.sourceAppName,
+                sourceAppBundleId: entry.sourceAppBundleId,
+                delivery: entry.delivery,
+                wordCount: entry.wordCount,
+                characterCount: entry.characterCount
+            )
+        }
         let payload = CLIAgentDictationDay(
             version: "2.0",
-            captureType: frontmatter.values["capture_type"] ?? "dictation_day",
-            date: frontmatter.values["date"] ?? url.deletingPathExtension().lastPathComponent.replacingOccurrences(of: "Dictations_", with: ""),
-            markdownFilename: url.lastPathComponent,
-            entryCount: entries.count,
-            wordCount: entries.reduce(0) { $0 + $1.wordCount },
-            entries: entries.sorted { $0.createdAt < $1.createdAt }
+            captureType: parsed.captureType,
+            date: parsed.date,
+            markdownFilename: parsed.markdownFilename,
+            entryCount: parsed.entryCount,
+            wordCount: parsed.wordCount,
+            entries: entries
         )
 
-        return (payload, payload.entries)
+        return (payload, entries)
     }
 
     private static func readMeetingTitle(filename: String, from directory: URL) -> String {
@@ -659,7 +449,7 @@ enum CLIContextStore {
         guard let content = try? String(contentsOf: mdURL, encoding: .utf8) else {
             return filename
         }
-        return extractTitle(from: content) ?? filename
+        return CaptureMarkdown.extractTitle(from: content) ?? filename
     }
 
     private static func recentMeetingPreview(for meeting: MeetingRecord, preferredSpeaker: String? = nil) -> String {
@@ -678,20 +468,6 @@ enum CLIContextStore {
         }
         let speakers = meeting.speakers.joined(separator: ", ")
         return speakers.isEmpty ? "No transcript captured." : speakers
-    }
-
-    private static func extractTitle(from content: String) -> String? {
-        guard content.count >= 8, content.hasPrefix("---"),
-              let endRange = content.range(of: "\n---\n", range: content.index(content.startIndex, offsetBy: 3)..<content.endIndex) else { return nil }
-        let yaml = String(content[content.index(content.startIndex, offsetBy: 4)..<endRange.lowerBound])
-        for line in yaml.components(separatedBy: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("title:") {
-                let title = String(trimmed.dropFirst(6)).trimmingCharacters(in: CharacterSet(charactersIn: "\"' "))
-                return title.isEmpty ? nil : title
-            }
-        }
-        return nil
     }
 
     private static func matches(date: String, dateFrom: String?, dateTo: String?) -> Bool {
@@ -715,422 +491,5 @@ enum CLIContextStore {
         }
 
         return ordered
-    }
-
-    private struct ParsedFrontmatter {
-        let values: [String: String]
-        let body: String
-    }
-
-    private struct ParsedTranscriptEntry {
-        let timestamp: String
-        let startSeconds: Double
-        let source: String
-        let label: String
-        let text: String
-    }
-
-    private struct ParsedFrontmatterSpeaker {
-        let rawId: String
-        let name: String
-        let persistentSpeakerId: String?
-    }
-
-    private static func loadMeeting(at url: URL) -> CLIAgentTranscript? {
-        guard let content = try? String(contentsOf: url, encoding: .utf8),
-              let frontmatter = parseFrontmatter(from: content) else { return nil }
-
-        let entries = parseTranscriptEntries(from: frontmatter.body)
-        let speakerMetadata = parseFrontmatterSpeakers(from: content)
-        let speakerMetadataByName = uniqueSpeakerMetadataByNormalizedName(speakerMetadata)
-
-        var generatedIDsByLabel: [String: String] = [:]
-        var nextMicId = 0
-        var nextSystemId = 0
-        var utterances: [CLIUtterance] = []
-
-        for index in entries.indices {
-            let entry = entries[index]
-            let normalizedLabel = normalizeSpeakerLabel(entry.label)
-            let speakerId: String
-
-            if entry.source == "Mic" {
-                if let existing = generatedIDsByLabel["mic:\(normalizedLabel)"] {
-                    speakerId = existing
-                } else {
-                    speakerId = "mic_\(nextMicId)"
-                    generatedIDsByLabel["mic:\(normalizedLabel)"] = speakerId
-                    nextMicId += 1
-                }
-            } else if let metadata = speakerMetadataByName[normalizedLabel] {
-                speakerId = "system_\(metadata.rawId)"
-            } else if let existing = generatedIDsByLabel["system:\(normalizedLabel)"] {
-                speakerId = existing
-            } else {
-                speakerId = "system_\(nextSystemId)"
-                generatedIDsByLabel["system:\(normalizedLabel)"] = speakerId
-                nextSystemId += 1
-            }
-
-            let nextEntry = index + 1 < entries.count ? entries[index + 1] : nil
-            utterances.append(CLIUtterance(
-                start: entry.startSeconds,
-                end: estimatedEndSeconds(for: entry, next: nextEntry),
-                speakerId: speakerId,
-                text: entry.text
-            ))
-        }
-
-        let grouped = Dictionary(grouping: zip(entries, utterances), by: { $0.1.speakerId })
-        let speakers = grouped.keys.sorted().map { speakerId in
-            let groupedUtterances = grouped[speakerId] ?? []
-            let displayName = groupedUtterances.first?.0.label ?? speakerId
-            let metadata = speakerMetadata.first(where: {
-                "system_\($0.rawId)" == speakerId || normalizeSpeakerLabel($0.name) == normalizeSpeakerLabel(displayName)
-            })
-            let wordCount = groupedUtterances.reduce(0) { $0 + $1.0.text.split(whereSeparator: \.isWhitespace).count }
-            return CLIActorSpeaker(
-                id: speakerId,
-                name: displayName,
-                persistentSpeakerId: metadata?.persistentSpeakerId,
-                wordCount: wordCount
-            )
-        }
-
-        let date = frontmatter.values["date"] ?? "1970-01-01"
-        let time = frontmatter.values["time"] ?? "00:00:00"
-        return CLIAgentTranscript(
-            version: "2.0",
-            recording: CLIAgentRecording(
-                date: "\(date)T\(time)",
-                durationSeconds: parseDurationSeconds(frontmatter.values["duration"])
-            ),
-            speakers: speakers,
-            utterances: utterances
-        )
-    }
-
-    private static func parseFrontmatter(from content: String) -> ParsedFrontmatter? {
-        guard content.hasPrefix("---\n"),
-              let endRange = content.range(
-                of: "\n---\n",
-                range: content.index(content.startIndex, offsetBy: 4)..<content.endIndex
-              ) else {
-            return nil
-        }
-
-        let frontmatterText = String(content[content.index(content.startIndex, offsetBy: 4)..<endRange.lowerBound])
-        var values: [String: String] = [:]
-
-        for line in frontmatterText.components(separatedBy: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            guard !trimmed.hasPrefix("- "),
-                  let separator = trimmed.firstIndex(of: ":") else { continue }
-            let key = String(trimmed[..<separator]).trimmingCharacters(in: .whitespaces)
-            let value = String(trimmed[trimmed.index(after: separator)...])
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            values[key] = value
-        }
-
-        return ParsedFrontmatter(values: values, body: String(content[endRange.upperBound...]))
-    }
-
-    private static func parseFrontmatterSpeakers(from content: String) -> [ParsedFrontmatterSpeaker] {
-        guard content.hasPrefix("---\n"),
-              let endRange = content.range(
-                of: "\n---\n",
-                range: content.index(content.startIndex, offsetBy: 4)..<content.endIndex
-              ) else {
-            return []
-        }
-
-        let frontmatter = String(content[content.index(content.startIndex, offsetBy: 4)..<endRange.lowerBound])
-        guard let sectionRange = frontmatter.range(of: "speakers:\n") else { return [] }
-        let speakerLines = String(frontmatter[sectionRange.upperBound...]).components(separatedBy: "\n")
-
-        var speakers: [ParsedFrontmatterSpeaker] = []
-        var currentId: String?
-        var currentName: String?
-        var currentPersistentSpeakerId: String?
-
-        func flush() {
-            if let currentId, let currentName {
-                speakers.append(ParsedFrontmatterSpeaker(
-                    rawId: currentId,
-                    name: currentName,
-                    persistentSpeakerId: currentPersistentSpeakerId
-                ))
-            }
-            currentId = nil
-            currentName = nil
-            currentPersistentSpeakerId = nil
-        }
-
-        for rawLine in speakerLines {
-            let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("- id:") {
-                flush()
-                currentId = trimmed
-                    .replacingOccurrences(of: "- id:", with: "")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            } else if trimmed.hasPrefix("name:") {
-                currentName = trimmed
-                    .replacingOccurrences(of: "name:", with: "")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            } else if trimmed.hasPrefix("db_id:") {
-                currentPersistentSpeakerId = trimmed
-                    .replacingOccurrences(of: "db_id:", with: "")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            } else if !trimmed.hasPrefix("-"), !trimmed.hasPrefix("name:"), !trimmed.hasPrefix("db_id:"), !trimmed.hasPrefix("confidence:"), !trimmed.hasPrefix("source:"), !trimmed.isEmpty {
-                break
-            }
-        }
-        flush()
-
-        return speakers
-    }
-
-    private static func uniqueSpeakerMetadataByNormalizedName(
-        _ speakers: [ParsedFrontmatterSpeaker]
-    ) -> [String: ParsedFrontmatterSpeaker] {
-        var grouped: [String: [ParsedFrontmatterSpeaker]] = [:]
-        for speaker in speakers {
-            grouped[normalizeSpeakerLabel(speaker.name), default: []].append(speaker)
-        }
-
-        var unique: [String: ParsedFrontmatterSpeaker] = [:]
-        for (name, matches) in grouped where matches.count == 1 {
-            unique[name] = matches[0]
-        }
-        return unique
-    }
-
-    private static func parseTranscriptEntries(from body: String) -> [ParsedTranscriptEntry] {
-        if let range = body.range(of: "## Transcript\n\n") {
-            let transcriptBody = String(body[range.upperBound...])
-            let chunks = transcriptBody
-                .components(separatedBy: "\n\n")
-                .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-            let entries = chunks.compactMap(parseStyledTranscriptEntry)
-            if !entries.isEmpty { return entries }
-        }
-
-        if let range = body.range(of: "## Full Transcript\n\n") {
-            let transcriptBody = String(body[range.upperBound...])
-            return transcriptBody.components(separatedBy: "\n").compactMap(parseLegacyTranscriptLine)
-        }
-
-        return body.components(separatedBy: "\n").compactMap(parseLegacyTranscriptLine)
-    }
-
-    private static func parseLegacyTranscriptLine(_ line: String) -> ParsedTranscriptEntry? {
-        let trimmed = line.trimmingCharacters(in: .whitespaces)
-        guard trimmed.hasPrefix("["),
-              let timestampEnd = trimmed.firstIndex(of: "]") else { return nil }
-        let timestamp = String(trimmed[trimmed.index(after: trimmed.startIndex)..<timestampEnd])
-        let afterTimestamp = trimmed[trimmed.index(after: timestampEnd)...]
-        guard afterTimestamp.hasPrefix(" ["),
-              let sourceStart = trimmed.index(timestampEnd, offsetBy: 3, limitedBy: trimmed.endIndex) else { return nil }
-        guard let labelEnd = trimmed.range(of: "] ", range: sourceStart..<trimmed.endIndex) else { return nil }
-        let sourceLabel = trimmed[sourceStart..<labelEnd.lowerBound]
-        guard let separator = sourceLabel.firstIndex(of: "/") else { return nil }
-
-        let source = String(sourceLabel[..<separator])
-        let label = unwrapSpeakerLabel(String(sourceLabel[sourceLabel.index(after: separator)...]))
-        return ParsedTranscriptEntry(
-            timestamp: timestamp,
-            startSeconds: parseTimestampSeconds(timestamp),
-            source: source,
-            label: label,
-            text: String(trimmed[labelEnd.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
-        )
-    }
-
-    private static func parseStyledTranscriptEntry(_ chunk: String) -> ParsedTranscriptEntry? {
-        let lines = chunk.components(separatedBy: "\n").filter { !$0.isEmpty }
-        guard let header = lines.first else { return nil }
-        let normalizedHeader = header.replacingOccurrences(of: "**", with: "").trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let regex = try? NSRegularExpression(pattern: #"^([0-9:]+)\s+\[(.+?)\]$"#) else { return nil }
-        let nsHeader = normalizedHeader as NSString
-        let range = NSRange(location: 0, length: nsHeader.length)
-        guard let match = regex.firstMatch(in: normalizedHeader, range: range),
-              match.numberOfRanges >= 3 else { return nil }
-        let timestamp = nsHeader.substring(with: match.range(at: 1))
-        let sourceLabel = nsHeader.substring(with: match.range(at: 2))
-        guard let separator = sourceLabel.firstIndex(of: "/") else { return nil }
-
-        let source = String(sourceLabel[..<separator])
-        let label = unwrapSpeakerLabel(String(sourceLabel[sourceLabel.index(after: separator)...]))
-        return ParsedTranscriptEntry(
-            timestamp: timestamp,
-            startSeconds: parseTimestampSeconds(timestamp),
-            source: source,
-            label: label,
-            text: lines.dropFirst().joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
-        )
-    }
-
-    private static func parseDictationEntries(from body: String) -> [CLIClientDictationEntry] {
-        let lines = body.components(separatedBy: "\n")
-        var sections: [String] = []
-        var currentSection: [String] = []
-
-        for line in lines {
-            if line.hasPrefix("## ") {
-                if !currentSection.isEmpty {
-                    sections.append(currentSection.joined(separator: "\n"))
-                }
-                currentSection = [line]
-            } else if !currentSection.isEmpty {
-                currentSection.append(line)
-            }
-        }
-
-        if !currentSection.isEmpty {
-            sections.append(currentSection.joined(separator: "\n"))
-        }
-
-        return sections.compactMap { section in
-            let lines = section.components(separatedBy: "\n")
-            guard let heading = lines.first, heading.hasPrefix("## ") else { return nil }
-            let title = heading.replacingOccurrences(of: "## ", with: "")
-                .components(separatedBy: " - ")
-                .dropFirst()
-                .joined(separator: " - ")
-
-            var entryId = ""
-            var createdAt = ""
-            var sourceAppName = "Unknown"
-            var sourceAppBundleId: String?
-            var delivery = "failed"
-            var wordCount = 0
-            var characterCount = 0
-            var bodyLines: [String] = []
-            var inBody = false
-            var sawMetadata = false
-
-            for line in lines.dropFirst() {
-                let trimmed = line.trimmingCharacters(in: .whitespaces)
-                if trimmed.isEmpty {
-                    if !inBody, sawMetadata {
-                        inBody = true
-                    } else if inBody {
-                        bodyLines.append("")
-                    }
-                    continue
-                }
-
-                if inBody {
-                    bodyLines.append(line)
-                    continue
-                }
-
-                if trimmed.hasPrefix("Entry ID:") {
-                    sawMetadata = true
-                    entryId = trimmed.replacingOccurrences(of: "Entry ID:", with: "")
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "`"))
-                } else if trimmed.hasPrefix("Captured:") {
-                    sawMetadata = true
-                    createdAt = trimmed.replacingOccurrences(of: "Captured:", with: "")
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                } else if trimmed.hasPrefix("Source app:") {
-                    sawMetadata = true
-                    sourceAppName = trimmed.replacingOccurrences(of: "Source app:", with: "")
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                } else if trimmed.hasPrefix("Bundle ID:") {
-                    sawMetadata = true
-                    sourceAppBundleId = trimmed.replacingOccurrences(of: "Bundle ID:", with: "")
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "`"))
-                } else if trimmed.hasPrefix("Delivery:") {
-                    sawMetadata = true
-                    delivery = trimmed.replacingOccurrences(of: "Delivery:", with: "")
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                } else if trimmed.hasPrefix("Words:") {
-                    sawMetadata = true
-                    wordCount = Int(trimmed.replacingOccurrences(of: "Words:", with: "").trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
-                } else if trimmed.hasPrefix("Characters:") {
-                    sawMetadata = true
-                    characterCount = Int(trimmed.replacingOccurrences(of: "Characters:", with: "").trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
-                } else if trimmed.hasPrefix("Timestamp:") {
-                    sawMetadata = true
-                    createdAt = trimmed.replacingOccurrences(of: "Timestamp:", with: "")
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                } else if !sawMetadata {
-                    inBody = true
-                    bodyLines.append(line)
-                }
-            }
-
-            let text = bodyLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-            return CLIClientDictationEntry(
-                id: entryId.isEmpty ? "dictation-\(UUID().uuidString)" : entryId,
-                createdAt: createdAt.isEmpty ? "1970-01-01T00:00:00Z" : createdAt,
-                title: title.isEmpty ? heading.replacingOccurrences(of: "## ", with: "") : title,
-                text: text,
-                sourceAppName: sourceAppName,
-                sourceAppBundleId: sourceAppBundleId,
-                delivery: delivery,
-                wordCount: wordCount == 0 ? text.split(whereSeparator: \.isWhitespace).count : wordCount,
-                characterCount: characterCount == 0 ? text.count : characterCount
-            )
-        }
-    }
-
-    private static func estimatedEndSeconds(for entry: ParsedTranscriptEntry, next: ParsedTranscriptEntry?) -> Double {
-        if let next, next.startSeconds > entry.startSeconds {
-            return next.startSeconds
-        }
-        let estimatedDuration = max(1.0, min(20.0, Double(entry.text.split(whereSeparator: \.isWhitespace).count) / 2.5))
-        return entry.startSeconds + estimatedDuration
-    }
-
-    private static func parseDurationSeconds(_ rawDuration: String?) -> Int {
-        guard let rawDuration else { return 0 }
-        let rawComponents = rawDuration.split(separator: ":", omittingEmptySubsequences: false)
-        let components = rawComponents.compactMap { Int($0) }
-        guard components.count == rawComponents.count,
-              !components.contains(where: { $0 < 0 }) else {
-            return 0
-        }
-        switch components.count {
-        case 1:
-            return components[0]
-        case 2:
-            return components[0] * 60 + components[1]
-        case 3:
-            return components[0] * 3600 + components[1] * 60 + components[2]
-        default:
-            return 0
-        }
-    }
-
-    private static func parseTimestampSeconds(_ timestamp: String) -> Double {
-        let components = timestamp.split(separator: ":").compactMap { Double($0) }
-        switch components.count {
-        case 2:
-            return components[0] * 60 + components[1]
-        case 3:
-            return components[0] * 3600 + components[1] * 60 + components[2]
-        default:
-            return 0
-        }
-    }
-
-    private static func unwrapSpeakerLabel(_ label: String) -> String {
-        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasPrefix("[["), trimmed.hasSuffix("]]") {
-            return String(trimmed.dropFirst(2).dropLast(2))
-        }
-        return trimmed
-    }
-
-    private static func normalizeSpeakerLabel(_ label: String) -> String {
-        unwrapSpeakerLabel(label).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -178,9 +178,9 @@ final class ContextStoreTests: XCTestCase {
 
         XCTAssertEqual(items.count, 2)
 
-        let contextStoreSourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-            .appendingPathComponent("Sources/TranscriptedCLI/ContextStore.swift")
-        let source = try String(contentsOf: contextStoreSourceURL, encoding: .utf8)
+        let parserSourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("../TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdownParser.swift")
+        let source = try String(contentsOf: parserSourceURL, encoding: .utf8)
         XCTAssertTrue(source.contains("split(separator: \":\", omittingEmptySubsequences: false)"))
         XCTAssertTrue(source.contains("components.count == rawComponents.count"))
         XCTAssertTrue(source.contains("!components.contains(where: { $0 < 0 })"))

--- a/Tools/TranscriptedCaptureKit/CLAUDE.md
+++ b/Tools/TranscriptedCaptureKit/CLAUDE.md
@@ -1,0 +1,54 @@
+# TranscriptedCaptureKit
+
+`Tools/TranscriptedCaptureKit/` is the shared library behind the standalone tools. It is the single source of truth for:
+
+- capture-library directory resolution (env overrides, app manifest, `transcriptSaveLocation` preference, legacy Draft / `~/Documents/Transcripted` fallback)
+- capture-Markdown detection (`looksLikeCaptureMarkdown`, directory probing, frontmatter title extraction)
+- capture-Markdown parsing (meeting transcripts and dictation day files)
+
+Both `Tools/TranscriptedCLI` and `Tools/TranscriptedMCP` depend on it via a relative `.package(path: "../TranscriptedCaptureKit")` dependency. Before this package existed, that logic was duplicated nearly verbatim in both tools and had already drifted; do not re-inline it.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `Package.swift` | Library-only Swift package manifest (no external dependencies) |
+| `Sources/TranscriptedCaptureKit/CaptureLibraryResolver.swift` | `CaptureLibraryResolver.resolve(...)` → `ResolvedCaptureDirectories` (meeting dirs, dictation dirs, optional shared data root) |
+| `Sources/TranscriptedCaptureKit/CaptureMarkdown.swift` | Capture-Markdown detection and frontmatter `title:` extraction |
+| `Sources/TranscriptedCaptureKit/CaptureMarkdownParser.swift` | Frontmatter, meeting transcript, and dictation day parsing into `ParsedMeetingCapture` / `ParsedDictationDayCapture` |
+
+## Test Files
+
+| File | Purpose |
+|------|---------|
+| `Tests/TranscriptedCaptureKitTests/CaptureLibraryResolverTests.swift` | Resolution precedence: shared data dir, per-kind overrides, manifest, preference, legacy fallback, symlinked legacy roots |
+| `Tests/TranscriptedCaptureKitTests/CaptureMarkdownParserTests.swift` | Legacy + styled transcript parsing, speaker metadata, durations, dictation entries, detection helpers |
+
+## Build and test
+
+```bash
+swift test --package-path Tools/TranscriptedCaptureKit
+```
+
+Changes here must also keep the consumers green (see `.agents/test-matrix.yml`):
+
+```bash
+swift test --package-path Tools/TranscriptedCLI
+swift test --package-path Tools/TranscriptedMCP
+bash run-e2e-smoke.sh
+```
+
+The e2e smoke matters because `scripts/entrypoints/run-e2e-smoke.sh` compiles this package with raw `swiftc` into a standalone module (`-emit-module` + static library) and links it into the smoke binary alongside MCP sources.
+
+## Design rules
+
+- No filesystem-layout opinions beyond resolution: parsers take Markdown content (plus the source URL for filename-derived fallbacks) and never write.
+- `ParsedMeetingCapture` / `ParsedDictationDayCapture` carry the superset of fields both tools need; each tool maps them into its own output models (`CLIAgentTranscript`, `AgentTranscript`, ...). Add fields here rather than re-parsing in a tool.
+- Keep this package dependency-free so the raw-`swiftc` smoke compile stays a two-liner.
+- The app target has its own scanner (`Sources/TranscriptedCore/Storage/TranscriptScanner.swift`); this package intentionally does not link into the app.
+
+## Gotchas
+
+- Legacy candidate directories are only included when they actually contain capture Markdown; the directory root is symlink-resolved before enumeration (this was a CLI/MCP drift point — the resolved behavior is canonical now).
+- Speaker metadata from frontmatter is matched by `system_<rawId>` or unique normalized display name for all speakers, including mic speakers.
+- Dictation day entries are returned sorted ascending by `createdAt`.

--- a/Tools/TranscriptedCaptureKit/Package.swift
+++ b/Tools/TranscriptedCaptureKit/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "TranscriptedCaptureKit",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(name: "TranscriptedCaptureKit", targets: ["TranscriptedCaptureKit"]),
+    ],
+    targets: [
+        .target(
+            name: "TranscriptedCaptureKit",
+            path: "Sources/TranscriptedCaptureKit"
+        ),
+        .testTarget(
+            name: "TranscriptedCaptureKitTests",
+            dependencies: ["TranscriptedCaptureKit"],
+            path: "Tests/TranscriptedCaptureKitTests"
+        ),
+    ]
+)

--- a/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureLibraryResolver.swift
+++ b/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureLibraryResolver.swift
@@ -1,0 +1,256 @@
+import Foundation
+
+private struct CaptureDirectoryManifest: Decodable {
+    let version: Int
+    let captureLibraryDirectory: String
+    let meetingsDirectory: String
+    let dictationsDirectory: String
+}
+
+private struct ConfiguredCaptureDirectories {
+    let meetings: URL
+    let dictations: URL
+}
+
+/// Resolved capture-library locations for meetings and dictations.
+public struct ResolvedCaptureDirectories {
+    public let meetingDirs: [URL]
+    public let dictationDirs: [URL]
+    /// Set when resolution used an explicit shared data directory
+    /// (a `--data-dir` style argument or `TRANSCRIPTED_DATA_DIR`).
+    public let sharedDataRoot: URL?
+
+    public init(meetingDirs: [URL], dictationDirs: [URL], sharedDataRoot: URL? = nil) {
+        self.meetingDirs = meetingDirs
+        self.dictationDirs = dictationDirs
+        self.sharedDataRoot = sharedDataRoot
+    }
+}
+
+/// Shared capture-library resolution for the standalone tools.
+///
+/// Resolution order:
+/// 1. explicit shared data dir argument, then `TRANSCRIPTED_DATA_DIR`
+///    (uses `meetings/` + `dictations/` subfolders when either exists)
+/// 2. explicit per-kind argument, then `TRANSCRIPTED_MEETINGS_DIR` /
+///    `TRANSCRIPTED_DICTATIONS_DIR`
+/// 3. the app-selected capture library (`mcp-directories.json` manifest, then
+///    the `transcriptSaveLocation` preference)
+/// 4. the default Transcripted captures folders, followed by legacy Draft
+///    exports and `~/Documents/Transcripted` when those contain capture
+///    Markdown
+public enum CaptureLibraryResolver {
+    public static func resolve(
+        dataDir: String? = nil,
+        meetingsDir: String? = nil,
+        dictationsDir: String? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default,
+        homeDirectory: URL? = nil
+    ) -> ResolvedCaptureDirectories {
+        let explicitShared = dataDir.flatMap { $0.isEmpty ? nil : $0 }
+        let environmentShared = environment["TRANSCRIPTED_DATA_DIR"].flatMap { $0.isEmpty ? nil : $0 }
+        if let sharedPath = explicitShared ?? environmentShared {
+            let sharedURL = URL(fileURLWithPath: sharedPath)
+            let sharedMeetings = sharedURL.appendingPathComponent("meetings", isDirectory: true)
+            let sharedDictations = sharedURL.appendingPathComponent("dictations", isDirectory: true)
+            if fileManager.fileExists(atPath: sharedMeetings.path)
+                || fileManager.fileExists(atPath: sharedDictations.path) {
+                return ResolvedCaptureDirectories(
+                    meetingDirs: [sharedMeetings],
+                    dictationDirs: [sharedDictations],
+                    sharedDataRoot: sharedURL
+                )
+            }
+            return ResolvedCaptureDirectories(
+                meetingDirs: [sharedURL],
+                dictationDirs: [sharedURL],
+                sharedDataRoot: sharedURL
+            )
+        }
+
+        let home = homeDirectory ?? fileManager.homeDirectoryForCurrentUser
+        let transcriptedRoot = home
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Transcripted", isDirectory: true)
+        let defaultCaptures = transcriptedRoot.appendingPathComponent("captures", isDirectory: true)
+        let defaultMeetings = defaultCaptures.appendingPathComponent("meetings", isDirectory: true)
+        let defaultDictations = defaultCaptures.appendingPathComponent("dictations", isDirectory: true)
+
+        let draftRoot = home
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Draft", isDirectory: true)
+        let legacyDraftMeetings = draftRoot
+            .appendingPathComponent("meetings", isDirectory: true)
+            .appendingPathComponent("transcripts", isDirectory: true)
+        let legacyDraftDictations = draftRoot
+            .appendingPathComponent("dictations", isDirectory: true)
+            .appendingPathComponent("transcripts", isDirectory: true)
+        let legacyShared = home
+            .appendingPathComponent("Documents", isDirectory: true)
+            .appendingPathComponent("Transcripted", isDirectory: true)
+
+        let appConfigured = configuredCaptureDirectories(
+            homeDirectory: home,
+            fileManager: fileManager
+        )
+        let meetingsOverride = meetingsDir.map(URL.init(fileURLWithPath:))
+            ?? environment["TRANSCRIPTED_MEETINGS_DIR"].map(URL.init(fileURLWithPath:))
+        let dictationsOverride = dictationsDir.map(URL.init(fileURLWithPath:))
+            ?? environment["TRANSCRIPTED_DICTATIONS_DIR"].map(URL.init(fileURLWithPath:))
+
+        let meetingDirs = meetingsOverride.map { [$0] }
+            ?? appConfigured.map {
+                captureDirectories(
+                    primary: $0.meetings,
+                    legacyCandidates: [legacyDraftMeetings, legacyShared],
+                    fileManager: fileManager
+                )
+            }
+            ?? captureDirectories(
+                primary: defaultMeetings,
+                legacyCandidates: [legacyDraftMeetings, legacyShared],
+                fileManager: fileManager
+            )
+        let dictationDirs = dictationsOverride.map { [$0] }
+            ?? appConfigured.map {
+                captureDirectories(
+                    primary: $0.dictations,
+                    legacyCandidates: [legacyDraftDictations, legacyShared],
+                    fileManager: fileManager
+                )
+            }
+            ?? captureDirectories(
+                primary: defaultDictations,
+                legacyCandidates: [legacyDraftDictations, legacyShared],
+                fileManager: fileManager
+            )
+
+        return ResolvedCaptureDirectories(
+            meetingDirs: meetingDirs,
+            dictationDirs: dictationDirs,
+            sharedDataRoot: nil
+        )
+    }
+
+    private static func captureDirectories(primary: URL, legacyCandidates: [URL], fileManager: FileManager) -> [URL] {
+        var directories = [primary]
+        var seen = Set([primary.standardizedFileURL.path])
+
+        for candidate in legacyCandidates
+        where CaptureMarkdown.directoryHasCaptureMarkdownFiles(candidate, fileManager: fileManager) {
+            let path = candidate.standardizedFileURL.path
+            guard !seen.contains(path) else { continue }
+            seen.insert(path)
+            directories.append(candidate)
+        }
+
+        return directories
+    }
+
+    private static func configuredCaptureDirectories(
+        homeDirectory home: URL,
+        fileManager: FileManager
+    ) -> ConfiguredCaptureDirectories? {
+        manifestCaptureDirectories(homeDirectory: home, fileManager: fileManager)
+            ?? appPreferenceCaptureDirectories(homeDirectory: home)
+    }
+
+    private static func manifestCaptureDirectories(
+        homeDirectory home: URL,
+        fileManager: FileManager
+    ) -> ConfiguredCaptureDirectories? {
+        let manifestURL = home
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("Transcripted", isDirectory: true)
+            .appendingPathComponent("mcp-directories.json", isDirectory: false)
+
+        guard fileManager.fileExists(atPath: manifestURL.path),
+              let data = try? Data(contentsOf: manifestURL),
+              let manifest = try? JSONDecoder().decode(CaptureDirectoryManifest.self, from: data),
+              manifest.version >= 1,
+              let captureLibrary = validatedConfiguredDirectory(manifest.captureLibraryDirectory, homeDirectory: home),
+              let meetings = validatedConfiguredDirectory(manifest.meetingsDirectory, homeDirectory: home),
+              let dictations = validatedConfiguredDirectory(manifest.dictationsDirectory, homeDirectory: home),
+              isManifestDirectory(meetings, named: "meetings", under: captureLibrary),
+              isManifestDirectory(dictations, named: "dictations", under: captureLibrary) else {
+            return nil
+        }
+
+        return ConfiguredCaptureDirectories(meetings: meetings, dictations: dictations)
+    }
+
+    private static func appPreferenceCaptureDirectories(homeDirectory home: URL) -> ConfiguredCaptureDirectories? {
+        for domain in appPreferenceDomains {
+            let preferenceURL = home
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("Preferences", isDirectory: true)
+                .appendingPathComponent("\(domain).plist", isDirectory: false)
+
+            guard let data = try? Data(contentsOf: preferenceURL),
+                  let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
+                  let values = plist as? [String: Any],
+                  let rawPath = values["transcriptSaveLocation"] as? String,
+                  let captureLibrary = validatedConfiguredDirectory(rawPath, homeDirectory: home) else {
+                continue
+            }
+
+            return ConfiguredCaptureDirectories(
+                meetings: captureLibrary.appendingPathComponent("meetings", isDirectory: true),
+                dictations: captureLibrary.appendingPathComponent("dictations", isDirectory: true)
+            )
+        }
+
+        return nil
+    }
+
+    private static var appPreferenceDomains: [String] {
+        [
+            "com.justinbetker.draft",
+            "app.transcripted.Transcripted",
+        ]
+    }
+
+    private static func validatedConfiguredDirectory(_ rawPath: String, homeDirectory home: URL) -> URL? {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.hasPrefix("/") else {
+            return nil
+        }
+
+        let directory = URL(fileURLWithPath: trimmed, isDirectory: true).standardizedFileURL
+        guard directory.path != "/", !directory.pathComponents.contains("..") else {
+            return nil
+        }
+
+        let resolvedDirectory = directory.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedHome = home.resolvingSymlinksInPath().standardizedFileURL
+        let isUnderHome = resolvedDirectory.path == resolvedHome.path
+            || resolvedDirectory.path.hasPrefix(resolvedHome.path + "/")
+        let forbiddenPrefixes = ["/System", "/Library", "/usr", "/bin", "/sbin", "/private"]
+        let isForbidden = forbiddenPrefixes.contains { prefix in
+            resolvedDirectory.path == prefix || resolvedDirectory.path.hasPrefix(prefix + "/")
+        }
+
+        guard !isForbidden || isUnderHome else {
+            return nil
+        }
+
+        return directory
+    }
+
+    private static func isManifestDirectory(_ directory: URL, named name: String, under captureLibrary: URL) -> Bool {
+        let expected = captureLibrary
+            .appendingPathComponent(name, isDirectory: true)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let actual = directory
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        return actual.path == expected.path
+    }
+}

--- a/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdown.swift
+++ b/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdown.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Detection helpers for Transcripted capture Markdown artifacts (meetings and
+/// dictation day files). Shared by TranscriptedCLI and TranscriptedMCP.
+public enum CaptureMarkdown {
+    /// Whether a Markdown file looks like a Transcripted capture artifact:
+    /// either a dictation day file by name, or a file with YAML frontmatter.
+    public static func looksLikeCaptureMarkdown(_ url: URL) -> Bool {
+        let filename = url.deletingPathExtension().lastPathComponent
+        if filename.hasPrefix("Dictations_") {
+            return true
+        }
+
+        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+            return false
+        }
+
+        return content.hasPrefix("---\n") && content.contains("\n---\n")
+    }
+
+    /// Whether a directory directly contains at least one regular (non-symlink)
+    /// capture Markdown file. The directory itself may be a symlink; it is
+    /// resolved before enumeration.
+    public static func directoryHasCaptureMarkdownFiles(
+        _ directory: URL,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        let enumerationRoot = directory.resolvingSymlinksInPath().standardizedFileURL
+        guard let contents = try? fileManager.contentsOfDirectory(
+            at: enumerationRoot,
+            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return false
+        }
+
+        return contents.contains { url in
+            guard url.pathExtension == "md",
+                  let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+            else {
+                return false
+            }
+            guard values.isRegularFile == true, values.isSymbolicLink != true else {
+                return false
+            }
+            return looksLikeCaptureMarkdown(url)
+        }
+    }
+
+    /// Extract the `title:` value from YAML frontmatter, if present.
+    public static func extractTitle(from content: String) -> String? {
+        // Minimum valid frontmatter is "---\n...\n---\n" (8+ chars)
+        guard content.count >= 8, content.hasPrefix("---"),
+              let endRange = content.range(
+                of: "\n---\n",
+                range: content.index(content.startIndex, offsetBy: 3)..<content.endIndex
+              ) else { return nil }
+        let yaml = String(content[content.index(content.startIndex, offsetBy: 4)..<endRange.lowerBound])
+        for line in yaml.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed == "---" { break }
+            if trimmed.hasPrefix("title:") {
+                let title = String(trimmed.dropFirst(6)).trimmingCharacters(in: CharacterSet(charactersIn: "\"' "))
+                return title.isEmpty ? nil : title
+            }
+        }
+        return nil
+    }
+}

--- a/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdownParser.swift
+++ b/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdownParser.swift
@@ -1,0 +1,529 @@
+import Foundation
+
+/// YAML frontmatter values plus the Markdown body that follows it.
+public struct ParsedCaptureDocument {
+    public let values: [String: String]
+    public let body: String
+}
+
+/// Parsed meeting transcript. Carries the superset of fields the standalone
+/// tools need; each tool maps this into its own output models.
+public struct ParsedMeetingCapture {
+    public struct Speaker {
+        public let id: String
+        public let name: String
+        public let persistentSpeakerId: String?
+        public let confidence: String?
+        public let wordCount: Int
+        public let speakingSeconds: Double
+    }
+
+    public struct Utterance {
+        public let start: Double
+        public let end: Double
+        public let speakerId: String
+        public let text: String
+    }
+
+    /// "YYYY-MM-DDTHH:MM:SS" assembled from the frontmatter date and time.
+    public let datetime: String
+    public let durationSeconds: Int
+    public let droppedSegments: Int
+    public let sttEngine: String
+    public let diarizationEngine: String
+    public let speakers: [Speaker]
+    public let utterances: [Utterance]
+}
+
+/// Parsed dictation day file.
+public struct ParsedDictationDayCapture {
+    public struct Entry {
+        public let id: String
+        public let createdAt: String
+        public let title: String
+        public let text: String
+        public let sourceAppName: String
+        public let sourceAppBundleId: String?
+        public let delivery: String
+        public let wordCount: Int
+        public let characterCount: Int
+    }
+
+    public let captureType: String
+    public let date: String
+    public let markdownFilename: String
+    public let entryCount: Int
+    public let wordCount: Int
+    /// Sorted ascending by `createdAt`.
+    public let entries: [Entry]
+}
+
+/// Shared parser for Transcripted capture Markdown (meeting transcripts and
+/// dictation day files). Single source of truth for TranscriptedCLI and
+/// TranscriptedMCP.
+public enum CaptureMarkdownParser {
+    private struct ParsedTranscriptEntry {
+        let timestamp: String
+        let startSeconds: Double
+        let source: String
+        let label: String
+        let text: String
+    }
+
+    private struct ParsedFrontmatterSpeaker {
+        let rawId: String
+        let name: String
+        let persistentSpeakerId: String?
+        let confidence: String?
+    }
+
+    // MARK: - Frontmatter
+
+    public static func parseFrontmatter(from content: String) -> ParsedCaptureDocument? {
+        guard content.hasPrefix("---\n"),
+              let endRange = content.range(
+                of: "\n---\n",
+                range: content.index(content.startIndex, offsetBy: 4)..<content.endIndex
+              ) else {
+            return nil
+        }
+
+        let frontmatterText = String(content[content.index(content.startIndex, offsetBy: 4)..<endRange.lowerBound])
+        var values: [String: String] = [:]
+
+        for line in frontmatterText.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.hasPrefix("- "),
+                  let separator = trimmed.firstIndex(of: ":") else { continue }
+            let key = String(trimmed[..<separator]).trimmingCharacters(in: .whitespaces)
+            let value = String(trimmed[trimmed.index(after: separator)...])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+            values[key] = value
+        }
+
+        return ParsedCaptureDocument(values: values, body: String(content[endRange.upperBound...]))
+    }
+
+    // MARK: - Meetings
+
+    public static func parseMeeting(from content: String) -> ParsedMeetingCapture? {
+        guard let document = parseFrontmatter(from: content) else { return nil }
+
+        let entries = parseTranscriptEntries(from: document.body)
+        let speakerMetadata = parseFrontmatterSpeakers(from: content)
+        let speakerMetadataByName = uniqueSpeakerMetadataByNormalizedName(speakerMetadata)
+
+        var generatedIDsByLabel: [String: String] = [:]
+        var nextMicId = 0
+        var nextSystemId = 0
+        var utterances: [ParsedMeetingCapture.Utterance] = []
+        utterances.reserveCapacity(entries.count)
+
+        for index in entries.indices {
+            let entry = entries[index]
+            let normalizedLabel = normalizeSpeakerLabel(entry.label)
+            let speakerId: String
+
+            if entry.source == "Mic" {
+                if let existing = generatedIDsByLabel["mic:\(normalizedLabel)"] {
+                    speakerId = existing
+                } else {
+                    speakerId = "mic_\(nextMicId)"
+                    generatedIDsByLabel["mic:\(normalizedLabel)"] = speakerId
+                    nextMicId += 1
+                }
+            } else if let metadata = speakerMetadataByName[normalizedLabel] {
+                speakerId = "system_\(metadata.rawId)"
+            } else if let existing = generatedIDsByLabel["system:\(normalizedLabel)"] {
+                speakerId = existing
+            } else {
+                speakerId = "system_\(nextSystemId)"
+                generatedIDsByLabel["system:\(normalizedLabel)"] = speakerId
+                nextSystemId += 1
+            }
+
+            let nextEntry = index + 1 < entries.count ? entries[index + 1] : nil
+            utterances.append(ParsedMeetingCapture.Utterance(
+                start: entry.startSeconds,
+                end: estimatedEndSeconds(for: entry, next: nextEntry),
+                speakerId: speakerId,
+                text: entry.text
+            ))
+        }
+
+        let grouped = Dictionary(grouping: zip(entries, utterances), by: { $0.1.speakerId })
+        let speakers = grouped.keys.sorted().map { speakerId -> ParsedMeetingCapture.Speaker in
+            let groupedUtterances = grouped[speakerId] ?? []
+            let displayName = groupedUtterances.first?.0.label ?? speakerId
+            let metadata = speakerMetadata.first(where: {
+                "system_\($0.rawId)" == speakerId
+                    || normalizeSpeakerLabel($0.name) == normalizeSpeakerLabel(displayName)
+            })
+            let wordCount = groupedUtterances.reduce(0) { $0 + $1.0.text.split(whereSeparator: \.isWhitespace).count }
+            let speakingSeconds = groupedUtterances.reduce(0.0) { $0 + max(0, $1.1.end - $1.1.start) }
+            return ParsedMeetingCapture.Speaker(
+                id: speakerId,
+                name: displayName,
+                persistentSpeakerId: metadata?.persistentSpeakerId,
+                confidence: metadata?.confidence,
+                wordCount: wordCount,
+                speakingSeconds: (speakingSeconds * 10).rounded() / 10
+            )
+        }
+
+        let date = document.values["date"] ?? "1970-01-01"
+        let time = document.values["time"] ?? "00:00:00"
+        return ParsedMeetingCapture(
+            datetime: "\(date)T\(time)",
+            durationSeconds: parseDurationSeconds(document.values["duration"]),
+            droppedSegments: Int(document.values["dropped_segments"] ?? "") ?? 0,
+            sttEngine: document.values["transcription_engine"] ?? "unknown",
+            diarizationEngine: document.values["diarization_engine"] ?? "unknown",
+            speakers: speakers,
+            utterances: utterances
+        )
+    }
+
+    // MARK: - Dictation days
+
+    public static func parseDictationDay(from content: String, markdownURL url: URL) -> ParsedDictationDayCapture? {
+        guard let document = parseFrontmatter(from: content) else { return nil }
+
+        let entries = parseDictationEntries(from: document.body)
+        let fallbackDate = url.deletingPathExtension().lastPathComponent
+            .replacingOccurrences(of: "Dictations_", with: "")
+
+        return ParsedDictationDayCapture(
+            captureType: document.values["capture_type"] ?? "dictation_day",
+            date: document.values["date"] ?? fallbackDate,
+            markdownFilename: url.lastPathComponent,
+            entryCount: entries.count,
+            wordCount: entries.reduce(0) { $0 + $1.wordCount },
+            entries: entries
+        )
+    }
+
+    // MARK: - Frontmatter speakers
+
+    private static func parseFrontmatterSpeakers(from content: String) -> [ParsedFrontmatterSpeaker] {
+        guard content.hasPrefix("---\n"),
+              let endRange = content.range(
+                of: "\n---\n",
+                range: content.index(content.startIndex, offsetBy: 4)..<content.endIndex
+              ) else {
+            return []
+        }
+
+        let frontmatter = String(content[content.index(content.startIndex, offsetBy: 4)..<endRange.lowerBound])
+        let speakerLines: [String]
+        if frontmatter.hasPrefix("speakers:\n") {
+            speakerLines = String(frontmatter.dropFirst("speakers:\n".count)).components(separatedBy: "\n")
+        } else if let sectionRange = frontmatter.range(of: "\nspeakers:\n") {
+            speakerLines = String(frontmatter[sectionRange.upperBound...]).components(separatedBy: "\n")
+        } else {
+            return []
+        }
+
+        var speakers: [ParsedFrontmatterSpeaker] = []
+        var currentId: String?
+        var currentName: String?
+        var currentPersistentSpeakerId: String?
+        var currentConfidence: String?
+
+        func flush() {
+            if let currentId, let currentName {
+                speakers.append(ParsedFrontmatterSpeaker(
+                    rawId: currentId,
+                    name: currentName,
+                    persistentSpeakerId: currentPersistentSpeakerId,
+                    confidence: currentConfidence
+                ))
+            }
+            currentId = nil
+            currentName = nil
+            currentPersistentSpeakerId = nil
+            currentConfidence = nil
+        }
+
+        for rawLine in speakerLines {
+            let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("- id:") {
+                flush()
+                currentId = trimmed
+                    .replacingOccurrences(of: "- id:", with: "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+            } else if trimmed.hasPrefix("name:") {
+                currentName = trimmed
+                    .replacingOccurrences(of: "name:", with: "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+            } else if trimmed.hasPrefix("db_id:") {
+                currentPersistentSpeakerId = trimmed
+                    .replacingOccurrences(of: "db_id:", with: "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+            } else if trimmed.hasPrefix("confidence:") {
+                currentConfidence = trimmed
+                    .replacingOccurrences(of: "confidence:", with: "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            } else if !trimmed.hasPrefix("-"), !trimmed.hasPrefix("source:"), !trimmed.isEmpty {
+                break
+            }
+        }
+        flush()
+
+        return speakers
+    }
+
+    private static func uniqueSpeakerMetadataByNormalizedName(
+        _ speakers: [ParsedFrontmatterSpeaker]
+    ) -> [String: ParsedFrontmatterSpeaker] {
+        var grouped: [String: [ParsedFrontmatterSpeaker]] = [:]
+        for speaker in speakers {
+            grouped[normalizeSpeakerLabel(speaker.name), default: []].append(speaker)
+        }
+
+        var unique: [String: ParsedFrontmatterSpeaker] = [:]
+        for (name, matches) in grouped where matches.count == 1 {
+            unique[name] = matches[0]
+        }
+        return unique
+    }
+
+    // MARK: - Transcript entries
+
+    private static func parseTranscriptEntries(from body: String) -> [ParsedTranscriptEntry] {
+        if let range = body.range(of: "## Transcript\n\n") {
+            let transcriptBody = String(body[range.upperBound...])
+            let chunks = transcriptBody
+                .components(separatedBy: "\n\n")
+                .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            let entries = chunks.compactMap(parseStyledTranscriptEntry)
+            if !entries.isEmpty { return entries }
+        }
+
+        if let range = body.range(of: "## Full Transcript\n\n") {
+            let transcriptBody = String(body[range.upperBound...])
+            return transcriptBody.components(separatedBy: "\n").compactMap(parseLegacyTranscriptLine)
+        }
+
+        return body.components(separatedBy: "\n").compactMap(parseLegacyTranscriptLine)
+    }
+
+    private static func parseLegacyTranscriptLine(_ line: String) -> ParsedTranscriptEntry? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("["),
+              let timestampEnd = trimmed.firstIndex(of: "]") else { return nil }
+        let timestamp = String(trimmed[trimmed.index(after: trimmed.startIndex)..<timestampEnd])
+        let afterTimestamp = trimmed[trimmed.index(after: timestampEnd)...]
+        guard afterTimestamp.hasPrefix(" ["),
+              let sourceStart = trimmed.index(timestampEnd, offsetBy: 3, limitedBy: trimmed.endIndex) else { return nil }
+        guard let labelEnd = trimmed.range(of: "] ", range: sourceStart..<trimmed.endIndex) else { return nil }
+        let sourceLabel = trimmed[sourceStart..<labelEnd.lowerBound]
+        guard let separator = sourceLabel.firstIndex(of: "/") else { return nil }
+
+        let source = String(sourceLabel[..<separator])
+        let label = unwrapSpeakerLabel(String(sourceLabel[sourceLabel.index(after: separator)...]))
+        return ParsedTranscriptEntry(
+            timestamp: timestamp,
+            startSeconds: parseTimestampSeconds(timestamp),
+            source: source,
+            label: label,
+            text: String(trimmed[labelEnd.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    private static func parseStyledTranscriptEntry(_ chunk: String) -> ParsedTranscriptEntry? {
+        let lines = chunk.components(separatedBy: "\n").filter { !$0.isEmpty }
+        guard let header = lines.first else { return nil }
+        let normalizedHeader = header
+            .replacingOccurrences(of: "**", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let regex = try? NSRegularExpression(pattern: #"^([0-9:]+)\s+\[(.+?)\]$"#) else { return nil }
+        let nsHeader = normalizedHeader as NSString
+        let range = NSRange(location: 0, length: nsHeader.length)
+        guard let match = regex.firstMatch(in: normalizedHeader, range: range),
+              match.numberOfRanges >= 3 else { return nil }
+        let timestamp = nsHeader.substring(with: match.range(at: 1))
+        let sourceLabel = nsHeader.substring(with: match.range(at: 2))
+        guard let separator = sourceLabel.firstIndex(of: "/") else { return nil }
+
+        let source = String(sourceLabel[..<separator])
+        let label = unwrapSpeakerLabel(String(sourceLabel[sourceLabel.index(after: separator)...]))
+        return ParsedTranscriptEntry(
+            timestamp: timestamp,
+            startSeconds: parseTimestampSeconds(timestamp),
+            source: source,
+            label: label,
+            text: lines.dropFirst().joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    // MARK: - Dictation entries
+
+    private static func parseDictationEntries(from body: String) -> [ParsedDictationDayCapture.Entry] {
+        let lines = body.components(separatedBy: "\n")
+        var sections: [String] = []
+        var currentSection: [String] = []
+
+        for line in lines {
+            if line.hasPrefix("## ") {
+                if !currentSection.isEmpty {
+                    sections.append(currentSection.joined(separator: "\n"))
+                }
+                currentSection = [line]
+            } else if !currentSection.isEmpty {
+                currentSection.append(line)
+            }
+        }
+
+        if !currentSection.isEmpty {
+            sections.append(currentSection.joined(separator: "\n"))
+        }
+
+        return sections.compactMap { section -> ParsedDictationDayCapture.Entry? in
+            let lines = section.components(separatedBy: "\n")
+            guard let heading = lines.first, heading.hasPrefix("## ") else { return nil }
+            let title = heading.replacingOccurrences(of: "## ", with: "")
+                .components(separatedBy: " - ")
+                .dropFirst()
+                .joined(separator: " - ")
+
+            var entryId = ""
+            var createdAt = ""
+            var sourceAppName = "Unknown"
+            var sourceAppBundleId: String?
+            var delivery = "failed"
+            var wordCount = 0
+            var characterCount = 0
+            var bodyLines: [String] = []
+            var inBody = false
+            var sawMetadata = false
+
+            for line in lines.dropFirst() {
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if trimmed.isEmpty {
+                    if !inBody, sawMetadata {
+                        inBody = true
+                    } else if inBody {
+                        bodyLines.append("")
+                    }
+                    continue
+                }
+
+                if inBody {
+                    bodyLines.append(line)
+                    continue
+                }
+
+                if trimmed.hasPrefix("Entry ID:") {
+                    sawMetadata = true
+                    entryId = trimmed.replacingOccurrences(of: "Entry ID:", with: "")
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .trimmingCharacters(in: CharacterSet(charactersIn: "`"))
+                } else if trimmed.hasPrefix("Captured:") {
+                    sawMetadata = true
+                    createdAt = trimmed.replacingOccurrences(of: "Captured:", with: "")
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                } else if trimmed.hasPrefix("Source app:") {
+                    sawMetadata = true
+                    sourceAppName = trimmed.replacingOccurrences(of: "Source app:", with: "")
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                } else if trimmed.hasPrefix("Bundle ID:") {
+                    sawMetadata = true
+                    sourceAppBundleId = trimmed.replacingOccurrences(of: "Bundle ID:", with: "")
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .trimmingCharacters(in: CharacterSet(charactersIn: "`"))
+                } else if trimmed.hasPrefix("Delivery:") {
+                    sawMetadata = true
+                    delivery = trimmed.replacingOccurrences(of: "Delivery:", with: "")
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                } else if trimmed.hasPrefix("Words:") {
+                    sawMetadata = true
+                    wordCount = Int(trimmed.replacingOccurrences(of: "Words:", with: "").trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+                } else if trimmed.hasPrefix("Characters:") {
+                    sawMetadata = true
+                    characterCount = Int(trimmed.replacingOccurrences(of: "Characters:", with: "").trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
+                } else if trimmed.hasPrefix("Timestamp:") {
+                    sawMetadata = true
+                    // Backward compatibility with pre-refactor dictation markdown.
+                    createdAt = trimmed.replacingOccurrences(of: "Timestamp:", with: "")
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                } else if !sawMetadata {
+                    inBody = true
+                    bodyLines.append(line)
+                }
+            }
+
+            let text = bodyLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+            return ParsedDictationDayCapture.Entry(
+                id: entryId.isEmpty ? "dictation-\(UUID().uuidString)" : entryId,
+                createdAt: createdAt.isEmpty ? "1970-01-01T00:00:00Z" : createdAt,
+                title: title.isEmpty ? heading.replacingOccurrences(of: "## ", with: "") : title,
+                text: text,
+                sourceAppName: sourceAppName,
+                sourceAppBundleId: sourceAppBundleId,
+                delivery: delivery,
+                wordCount: wordCount == 0 ? text.split(whereSeparator: \.isWhitespace).count : wordCount,
+                characterCount: characterCount == 0 ? text.count : characterCount
+            )
+        }
+        .sorted { $0.createdAt < $1.createdAt }
+    }
+
+    // MARK: - Shared scalar parsing
+
+    private static func estimatedEndSeconds(for entry: ParsedTranscriptEntry, next: ParsedTranscriptEntry?) -> Double {
+        if let next, next.startSeconds > entry.startSeconds {
+            return next.startSeconds
+        }
+        let estimatedDuration = max(1.0, min(20.0, Double(entry.text.split(whereSeparator: \.isWhitespace).count) / 2.5))
+        return entry.startSeconds + estimatedDuration
+    }
+
+    private static func parseDurationSeconds(_ rawDuration: String?) -> Int {
+        guard let rawDuration else { return 0 }
+        let rawComponents = rawDuration.split(separator: ":", omittingEmptySubsequences: false)
+        let components = rawComponents.compactMap { Int($0) }
+        guard components.count == rawComponents.count,
+              !components.contains(where: { $0 < 0 }) else {
+            return 0
+        }
+        switch components.count {
+        case 1:
+            return components[0]
+        case 2:
+            return components[0] * 60 + components[1]
+        case 3:
+            return components[0] * 3600 + components[1] * 60 + components[2]
+        default:
+            return 0
+        }
+    }
+
+    private static func parseTimestampSeconds(_ timestamp: String) -> Double {
+        let components = timestamp.split(separator: ":").compactMap { Double($0) }
+        switch components.count {
+        case 2:
+            return components[0] * 60 + components[1]
+        case 3:
+            return components[0] * 3600 + components[1] * 60 + components[2]
+        default:
+            return 0
+        }
+    }
+
+    private static func unwrapSpeakerLabel(_ label: String) -> String {
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("[["), trimmed.hasSuffix("]]") {
+            return String(trimmed.dropFirst(2).dropLast(2))
+        }
+        return trimmed
+    }
+
+    private static func normalizeSpeakerLabel(_ label: String) -> String {
+        unwrapSpeakerLabel(label).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}

--- a/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureLibraryResolverTests.swift
+++ b/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureLibraryResolverTests.swift
@@ -1,0 +1,247 @@
+import XCTest
+@testable import TranscriptedCaptureKit
+
+final class CaptureLibraryResolverTests: XCTestCase {
+    func testResolveIncludesLegacyDraftMarkdownAfterCurrentDefaults() throws {
+        let tempHome = makeTempDir()
+        defer { removeTempDir(tempHome) }
+
+        let defaultMeetings = tempHome.appendingPathComponent(
+            "Library/Application Support/Transcripted/captures/meetings", isDirectory: true)
+        let legacyDraftMeetings = tempHome.appendingPathComponent(
+            "Library/Application Support/Draft/meetings/transcripts", isDirectory: true)
+        try FileManager.default.createDirectory(at: defaultMeetings, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: legacyDraftMeetings, withIntermediateDirectories: true)
+        try sampleMeetingMarkdown.write(
+            to: legacyDraftMeetings.appendingPathComponent("Call_old.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let resolved = CaptureLibraryResolver.resolve(
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(resolved.meetingDirs.map(\.standardizedFileURL.path), [
+            defaultMeetings.standardizedFileURL.path,
+            legacyDraftMeetings.standardizedFileURL.path,
+        ])
+        XCTAssertNil(resolved.sharedDataRoot)
+    }
+
+    func testResolveSkipsLegacyCandidatesWithoutCaptureMarkdown() throws {
+        let tempHome = makeTempDir()
+        defer { removeTempDir(tempHome) }
+
+        let legacyShared = tempHome.appendingPathComponent("Documents/Transcripted", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyShared, withIntermediateDirectories: true)
+        try "# Notes".write(to: legacyShared.appendingPathComponent("CLAUDE.md"), atomically: true, encoding: .utf8)
+
+        let resolved = CaptureLibraryResolver.resolve(
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertFalse(resolved.meetingDirs.map(\.standardizedFileURL.path)
+            .contains(legacyShared.standardizedFileURL.path))
+        XCTAssertFalse(resolved.dictationDirs.map(\.standardizedFileURL.path)
+            .contains(legacyShared.standardizedFileURL.path))
+    }
+
+    func testResolveIncludesSymlinkedLegacyDirectoryWithCaptureMarkdown() throws {
+        let tempHome = makeTempDir()
+        let realLibrary = makeTempDir()
+        defer {
+            removeTempDir(tempHome)
+            removeTempDir(realLibrary)
+        }
+
+        try sampleMeetingMarkdown.write(
+            to: realLibrary.appendingPathComponent("Shared meeting.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let documents = tempHome.appendingPathComponent("Documents", isDirectory: true)
+        try FileManager.default.createDirectory(at: documents, withIntermediateDirectories: true)
+        let legacyShared = documents.appendingPathComponent("Transcripted", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: legacyShared, withDestinationURL: realLibrary)
+
+        let resolved = CaptureLibraryResolver.resolve(
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertTrue(resolved.meetingDirs.map(\.standardizedFileURL.path)
+            .contains(legacyShared.standardizedFileURL.path))
+    }
+
+    func testResolveSharedDataDirUsesSubfoldersAndReportsSharedRoot() throws {
+        let tempHome = makeTempDir()
+        defer { removeTempDir(tempHome) }
+
+        let sharedRoot = tempHome.appendingPathComponent("shared-context", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: sharedRoot.appendingPathComponent("meetings", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let resolved = CaptureLibraryResolver.resolve(
+            environment: ["TRANSCRIPTED_DATA_DIR": sharedRoot.path],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(resolved.meetingDirs.map(\.standardizedFileURL.path), [
+            sharedRoot.appendingPathComponent("meetings", isDirectory: true).standardizedFileURL.path,
+        ])
+        XCTAssertEqual(resolved.dictationDirs.map(\.standardizedFileURL.path), [
+            sharedRoot.appendingPathComponent("dictations", isDirectory: true).standardizedFileURL.path,
+        ])
+        XCTAssertEqual(resolved.sharedDataRoot?.standardizedFileURL.path, sharedRoot.standardizedFileURL.path)
+    }
+
+    func testResolveExplicitDataDirWinsOverEnvironment() throws {
+        let tempHome = makeTempDir()
+        defer { removeTempDir(tempHome) }
+
+        let explicitRoot = tempHome.appendingPathComponent("explicit", isDirectory: true)
+        let envRoot = tempHome.appendingPathComponent("environment", isDirectory: true)
+        try FileManager.default.createDirectory(at: explicitRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: envRoot, withIntermediateDirectories: true)
+
+        let resolved = CaptureLibraryResolver.resolve(
+            dataDir: explicitRoot.path,
+            environment: ["TRANSCRIPTED_DATA_DIR": envRoot.path],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(resolved.meetingDirs.map(\.standardizedFileURL.path), [
+            explicitRoot.standardizedFileURL.path,
+        ])
+        XCTAssertEqual(resolved.sharedDataRoot?.standardizedFileURL.path, explicitRoot.standardizedFileURL.path)
+    }
+
+    func testResolveExplicitPerKindOverridesSkipLegacyCandidates() throws {
+        let tempHome = makeTempDir()
+        defer { removeTempDir(tempHome) }
+
+        let overrideMeetings = tempHome.appendingPathComponent("override-meetings", isDirectory: true)
+        let legacyDraftMeetings = tempHome.appendingPathComponent(
+            "Library/Application Support/Draft/meetings/transcripts", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyDraftMeetings, withIntermediateDirectories: true)
+        try sampleMeetingMarkdown.write(
+            to: legacyDraftMeetings.appendingPathComponent("Call_old.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let resolved = CaptureLibraryResolver.resolve(
+            meetingsDir: overrideMeetings.path,
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(resolved.meetingDirs.map(\.standardizedFileURL.path), [
+            overrideMeetings.standardizedFileURL.path,
+        ])
+    }
+
+    func testResolveUsesAppDirectoryManifestBeforeDefaultCaptures() throws {
+        let tempHome = makeTempDir()
+        defer { removeTempDir(tempHome) }
+
+        let transcriptedRoot = tempHome.appendingPathComponent(
+            "Library/Application Support/Transcripted", isDirectory: true)
+        let manifestMeetings = tempHome.appendingPathComponent("custom-captures/meetings", isDirectory: true)
+        let manifestDictations = tempHome.appendingPathComponent("custom-captures/dictations", isDirectory: true)
+        try FileManager.default.createDirectory(at: transcriptedRoot, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: manifestMeetings, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: manifestDictations, withIntermediateDirectories: true)
+
+        try """
+        {
+          "version": 1,
+          "captureLibraryDirectory": "\(tempHome.appendingPathComponent("custom-captures", isDirectory: true).path)",
+          "meetingsDirectory": "\(manifestMeetings.path)",
+          "dictationsDirectory": "\(manifestDictations.path)"
+        }
+        """.write(
+            to: transcriptedRoot.appendingPathComponent("mcp-directories.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let resolved = CaptureLibraryResolver.resolve(
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(resolved.meetingDirs.map(\.standardizedFileURL.path), [
+            manifestMeetings.standardizedFileURL.path,
+        ])
+        XCTAssertEqual(resolved.dictationDirs.map(\.standardizedFileURL.path), [
+            manifestDictations.standardizedFileURL.path,
+        ])
+    }
+
+    func testResolveUsesAppCaptureLibraryPreferenceWhenManifestIsMissing() throws {
+        let tempHome = makeTempDir()
+        defer { removeTempDir(tempHome) }
+
+        let preferencesDir = tempHome.appendingPathComponent("Library/Preferences", isDirectory: true)
+        let customCaptureLibrary = tempHome.appendingPathComponent("preferred-captures", isDirectory: true)
+        try FileManager.default.createDirectory(at: preferencesDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: customCaptureLibrary.appendingPathComponent("meetings", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+
+        let plistData = try PropertyListSerialization.data(
+            fromPropertyList: ["transcriptSaveLocation": customCaptureLibrary.path],
+            format: .xml,
+            options: 0
+        )
+        try plistData.write(to: preferencesDir.appendingPathComponent("app.transcripted.Transcripted.plist"))
+
+        let resolved = CaptureLibraryResolver.resolve(
+            environment: [:],
+            fileManager: .default,
+            homeDirectory: tempHome
+        )
+
+        XCTAssertEqual(resolved.meetingDirs.map(\.standardizedFileURL.path), [
+            customCaptureLibrary.appendingPathComponent("meetings", isDirectory: true).standardizedFileURL.path,
+        ])
+        XCTAssertEqual(resolved.dictationDirs.map(\.standardizedFileURL.path), [
+            customCaptureLibrary.appendingPathComponent("dictations", isDirectory: true).standardizedFileURL.path,
+        ])
+    }
+
+    private let sampleMeetingMarkdown = """
+    ---
+    capture_type: meeting
+    date: 2026-04-07
+    time: 09:00:00
+    ---
+
+    # Old meeting
+    """
+
+    private func makeTempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func removeTempDir(_ dir: URL) {
+        try? FileManager.default.removeItem(at: dir)
+    }
+}

--- a/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureMarkdownParserTests.swift
+++ b/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureMarkdownParserTests.swift
@@ -1,0 +1,245 @@
+import XCTest
+@testable import TranscriptedCaptureKit
+
+final class CaptureMarkdownParserTests: XCTestCase {
+    func testParseMeetingLegacyTranscriptAssignsSpeakerIdsAndMetadata() throws {
+        let markdown = """
+        ---
+        capture_type: meeting
+        date: 2026-04-18
+        time: 09:15:00
+        duration: "30:00"
+        dropped_segments: 2
+        transcription_engine: parakeet_local
+        diarization_engine: pyannote_offline
+        speakers:
+          - id: "0"
+            db_id: "80FB272B-6061-4FC4-8408-3F7A974C59DB"
+            name: "Jenny Wen"
+            confidence: high
+            source: db_scan
+        ---
+
+        # Meeting Fixture
+
+        ## Full Transcript
+
+        [00:00] [Mic/You] Good morning everyone
+
+        [00:05] [System/Jenny Wen] Let's discuss the product roadmap
+        """
+
+        let parsed = try XCTUnwrap(CaptureMarkdownParser.parseMeeting(from: markdown))
+
+        XCTAssertEqual(parsed.datetime, "2026-04-18T09:15:00")
+        XCTAssertEqual(parsed.durationSeconds, 1800)
+        XCTAssertEqual(parsed.droppedSegments, 2)
+        XCTAssertEqual(parsed.sttEngine, "parakeet_local")
+        XCTAssertEqual(parsed.diarizationEngine, "pyannote_offline")
+        XCTAssertEqual(parsed.utterances.count, 2)
+        XCTAssertEqual(parsed.utterances.map(\.speakerId), ["mic_0", "system_0"])
+
+        let system = try XCTUnwrap(parsed.speakers.first(where: { $0.id == "system_0" }))
+        XCTAssertEqual(system.name, "Jenny Wen")
+        XCTAssertEqual(system.persistentSpeakerId, "80FB272B-6061-4FC4-8408-3F7A974C59DB")
+        XCTAssertEqual(system.confidence, "high")
+        XCTAssertEqual(system.wordCount, 5)
+    }
+
+    func testParseMeetingStyledTranscriptSection() throws {
+        let markdown = """
+        ---
+        capture_type: meeting
+        date: 2026-04-18
+        time: 09:15:00
+        duration: "0:18"
+        ---
+
+        ## Transcript
+
+        **00:03 [Mic/You]**
+        Styled entry text here.
+
+        **00:07 [System/Alex]**
+        Reply from the other side.
+        """
+
+        let parsed = try XCTUnwrap(CaptureMarkdownParser.parseMeeting(from: markdown))
+
+        XCTAssertEqual(parsed.utterances.count, 2)
+        XCTAssertEqual(parsed.utterances.first?.text, "Styled entry text here.")
+        XCTAssertEqual(parsed.utterances.first?.start, 3)
+        XCTAssertEqual(parsed.utterances.first?.end, 7)
+    }
+
+    func testParseMeetingSkipsMalformedLegacyRows() throws {
+        let markdown = """
+        ---
+        capture_type: meeting
+        date: 2026-04-18
+        time: 09:15:00
+        duration: "0:18"
+        ---
+
+        ## Full Transcript
+
+        [00:00]
+        [00:01]x
+        [00:02] [
+        [00:03] [Mic/You] Still works.
+        """
+
+        let parsed = try XCTUnwrap(CaptureMarkdownParser.parseMeeting(from: markdown))
+
+        XCTAssertEqual(parsed.utterances.count, 1)
+        XCTAssertEqual(parsed.utterances.first?.text, "Still works.")
+    }
+
+    func testMalformedDurationFallsBackToZero() throws {
+        for duration in ["1:bad", "-1:02"] {
+            let markdown = """
+            ---
+            date: 2026-04-18
+            time: 09:15:00
+            duration: "\(duration)"
+            ---
+
+            ## Full Transcript
+
+            [00:03] [Mic/You] Still works.
+            """
+            let parsed = CaptureMarkdownParser.parseMeeting(from: markdown)
+            XCTAssertEqual(parsed?.durationSeconds, 0)
+        }
+    }
+
+    func testParseMeetingDuplicateSpeakerNamesDoesNotCrash() throws {
+        let markdown = """
+        ---
+        date: 2026-04-18
+        time: 09:15:00
+        speakers:
+          - id: "0"
+            db_id: "AAA"
+            name: "Alex"
+          - id: "1"
+            db_id: "BBB"
+            name: "Alex"
+        ---
+
+        ## Full Transcript
+
+        [00:00] [System/Alex] First speaker with the shared display name.
+
+        [00:04] [System/Alex] Second speaker with the shared display name.
+        """
+
+        let parsed = try XCTUnwrap(CaptureMarkdownParser.parseMeeting(from: markdown))
+        XCTAssertEqual(parsed.utterances.count, 2)
+    }
+
+    func testParseMeetingMalformedContentReturnsNil() {
+        XCTAssertNil(CaptureMarkdownParser.parseMeeting(from: "not markdown at all"))
+    }
+
+    func testParseDictationDayEntriesSortedByCreatedAt() throws {
+        let markdown = """
+        ---
+        title: "Dictations for 2026-04-07"
+        date: 2026-04-07
+        capture_type: dictation_day
+        ---
+
+        # Dictations for 2026-04-07
+
+        ## 6:30 PM - Evening note
+
+        Entry ID: `dictation-2`
+        Captured: 2026-04-07T18:30:00Z
+        Source app: Mail
+        Delivery: pasted
+        Words: 7
+
+        Remember to send the recap before dinner
+
+        ## 9:15 AM - Morning note
+
+        Entry ID: `dictation-1`
+        Captured: 2026-04-07T09:15:00Z
+        Source app: Slack
+        Bundle ID: `com.example.slack`
+        Delivery: copied
+        Words: 7
+
+        Ship the follow-up note to product today
+        """
+
+        let url = URL(fileURLWithPath: "/tmp/Dictations_2026-04-07.md")
+        let parsed = try XCTUnwrap(CaptureMarkdownParser.parseDictationDay(from: markdown, markdownURL: url))
+
+        XCTAssertEqual(parsed.captureType, "dictation_day")
+        XCTAssertEqual(parsed.date, "2026-04-07")
+        XCTAssertEqual(parsed.markdownFilename, "Dictations_2026-04-07.md")
+        XCTAssertEqual(parsed.entryCount, 2)
+        XCTAssertEqual(parsed.entries.map(\.id), ["dictation-1", "dictation-2"])
+        XCTAssertEqual(parsed.entries.first?.title, "Morning note")
+        XCTAssertEqual(parsed.entries.first?.sourceAppBundleId, "com.example.slack")
+        XCTAssertEqual(parsed.wordCount, 14)
+    }
+
+    func testParseDictationDayWithoutFrontmatterReturnsNil() {
+        let url = URL(fileURLWithPath: "/tmp/Dictations_2026-04-07.md")
+        XCTAssertNil(CaptureMarkdownParser.parseDictationDay(from: "# No frontmatter", markdownURL: url))
+    }
+
+    func testParseDictationDayDateFallsBackToFilename() throws {
+        let markdown = """
+        ---
+        capture_type: dictation_day
+        ---
+
+        ## 9:15 AM - Note
+
+        Entry ID: `dictation-1`
+        Captured: 2026-04-08T09:15:00Z
+
+        Some text
+        """
+        let url = URL(fileURLWithPath: "/tmp/Dictations_2026-04-08.md")
+        let parsed = try XCTUnwrap(CaptureMarkdownParser.parseDictationDay(from: markdown, markdownURL: url))
+        XCTAssertEqual(parsed.date, "2026-04-08")
+    }
+
+    func testExtractTitleTrimsQuotes() {
+        let markdown = """
+        ---
+        title: "Product review"
+        date: 2026-04-18
+        ---
+
+        body
+        """
+        XCTAssertEqual(CaptureMarkdown.extractTitle(from: markdown), "Product review")
+        XCTAssertNil(CaptureMarkdown.extractTitle(from: "no frontmatter"))
+    }
+
+    func testLooksLikeCaptureMarkdown() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let dictation = tempDir.appendingPathComponent("Dictations_2026-04-07.md")
+        try "anything".write(to: dictation, atomically: true, encoding: .utf8)
+        XCTAssertTrue(CaptureMarkdown.looksLikeCaptureMarkdown(dictation))
+
+        let meeting = tempDir.appendingPathComponent("Call_test.md")
+        try "---\ndate: 2026-04-18\n---\n\nbody".write(to: meeting, atomically: true, encoding: .utf8)
+        XCTAssertTrue(CaptureMarkdown.looksLikeCaptureMarkdown(meeting))
+
+        let notes = tempDir.appendingPathComponent("CLAUDE.md")
+        try "# Notes".write(to: notes, atomically: true, encoding: .utf8)
+        XCTAssertFalse(CaptureMarkdown.looksLikeCaptureMarkdown(notes))
+
+        XCTAssertTrue(CaptureMarkdown.directoryHasCaptureMarkdownFiles(tempDir))
+    }
+}

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -46,10 +46,10 @@ that mode the SQLite index also defaults to the shared root unless
 | File | Purpose |
 |------|---------|
 | `Main.swift` | `@main` entry point; resolves directories, builds the index, starts file watchers, then starts the MCP stdio server |
-| `DataDirectories.swift` | Default-path and env-override resolution for meetings, dictations, and index storage |
+| `DataDirectories.swift` | Index-dir resolution plus a thin wrapper over `TranscriptedCaptureKit`'s shared capture-library resolver |
 | `ToolHandlers.swift` | Registers every MCP tool and routes requests to the correct loader or index method |
 | `TranscriptIndex.swift` | SQLite-backed index, incremental updates, and query methods across meetings and dictations |
-| `TranscriptLoader.swift` | Loads markdown meeting transcripts and dictation day files directly from disk |
+| `TranscriptLoader.swift` | Loads markdown meeting transcripts and dictation day files from disk; parsing delegates to `TranscriptedCaptureKit` |
 | `Models.swift` | Codable input/output models and `MCPIndexError` |
 | `NameVariants.swift` | Speaker-name fuzzy matching for speaker-aware queries |
 | `PathSecurity.swift` | Guards direct file reads against traversal, symlinks, and out-of-root paths |
@@ -159,6 +159,7 @@ The in-app Claude Desktop installer copies that helper into:
 
 - reads meeting markdown transcripts written by `Sources/TranscriptedCore/Storage/TranscriptSaver.swift`
 - reads dictation markdown day files written by `Sources/Dictation/DictationTranscriptWriter.swift`
+- shares capture-library resolution and capture-Markdown parsing with `Tools/TranscriptedCLI` through `Tools/TranscriptedCaptureKit`; change that logic in the kit, not here
 - mirrors speaker-name matching logic from the app with `NameVariants.swift`
 - has no compile-time dependency on the main Transcripted app target
 

--- a/Tools/TranscriptedMCP/Package.swift
+++ b/Tools/TranscriptedMCP/Package.swift
@@ -6,12 +6,14 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", exact: "0.12.0"),
+        .package(path: "../TranscriptedCaptureKit"),
     ],
     targets: [
         .executableTarget(
             name: "transcripted-mcp",
             dependencies: [
                 .product(name: "MCP", package: "swift-sdk"),
+                .product(name: "TranscriptedCaptureKit", package: "TranscriptedCaptureKit"),
             ],
             path: "Sources/TranscriptedMCP",
             linkerSettings: [.linkedLibrary("sqlite3")]

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/DataDirectories.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/DataDirectories.swift
@@ -1,16 +1,5 @@
 import Foundation
-
-private struct AppDirectoryManifest: Decodable {
-    let version: Int
-    let captureLibraryDirectory: String
-    let meetingsDirectory: String
-    let dictationsDirectory: String
-}
-
-private struct ConfiguredCaptureDirectories {
-    let meetings: URL
-    let dictations: URL
-}
+import TranscriptedCaptureKit
 
 struct TranscriptedDataDirectories {
     let meetingDirs: [URL]
@@ -56,244 +45,32 @@ struct TranscriptedDataDirectories {
         fileManager: FileManager = .default,
         homeDirectory: URL? = nil
     ) -> TranscriptedDataDirectories {
-        if let sharedPath = environment["TRANSCRIPTED_DATA_DIR"], !sharedPath.isEmpty {
-            let sharedURL = URL(fileURLWithPath: sharedPath)
-            let meetingsURL: URL
-            let dictationsURL: URL
-            if fileManager.fileExists(atPath: sharedURL.appendingPathComponent("meetings", isDirectory: true).path)
-                || fileManager.fileExists(atPath: sharedURL.appendingPathComponent("dictations", isDirectory: true).path) {
-                meetingsURL = sharedURL.appendingPathComponent("meetings", isDirectory: true)
-                dictationsURL = sharedURL.appendingPathComponent("dictations", isDirectory: true)
-            } else {
-                meetingsURL = sharedURL
-                dictationsURL = sharedURL
-            }
-            let indexURL = environment["TRANSCRIPTED_INDEX_DIR"].map(URL.init(fileURLWithPath:))
-                ?? sharedURL
+        let resolved = CaptureLibraryResolver.resolve(
+            environment: environment,
+            fileManager: fileManager,
+            homeDirectory: homeDirectory
+        )
+        let indexOverride = environment["TRANSCRIPTED_INDEX_DIR"].map(URL.init(fileURLWithPath:))
+
+        if let sharedDataRoot = resolved.sharedDataRoot {
             return TranscriptedDataDirectories(
-                meetingsDir: meetingsURL,
-                dictationsDir: dictationsURL,
-                indexDir: indexURL
+                meetingDirs: resolved.meetingDirs,
+                dictationDirs: resolved.dictationDirs,
+                indexDir: indexOverride ?? sharedDataRoot
             )
         }
 
         let home = homeDirectory ?? fileManager.homeDirectoryForCurrentUser
-        let transcriptedRoot = home
+        let defaultIndex = home
             .appendingPathComponent("Library", isDirectory: true)
             .appendingPathComponent("Application Support", isDirectory: true)
             .appendingPathComponent("Transcripted", isDirectory: true)
-        let defaultCaptures = transcriptedRoot.appendingPathComponent("captures", isDirectory: true)
-        let defaultMeetings = defaultCaptures.appendingPathComponent("meetings", isDirectory: true)
-        let defaultDictations = defaultCaptures.appendingPathComponent("dictations", isDirectory: true)
-        let defaultIndex = transcriptedRoot.appendingPathComponent("cache", isDirectory: true)
-
-        let draftRoot = home
-            .appendingPathComponent("Library", isDirectory: true)
-            .appendingPathComponent("Application Support", isDirectory: true)
-            .appendingPathComponent("Draft", isDirectory: true)
-
-        let legacyDraftMeetings = draftRoot
-            .appendingPathComponent("meetings", isDirectory: true)
-            .appendingPathComponent("transcripts", isDirectory: true)
-        let legacyDraftDictations = draftRoot
-            .appendingPathComponent("dictations", isDirectory: true)
-            .appendingPathComponent("transcripts", isDirectory: true)
-        let legacyShared = home
-            .appendingPathComponent("Documents", isDirectory: true)
-            .appendingPathComponent("Transcripted", isDirectory: true)
-
-        let appConfiguredCaptureDirectories = configuredCaptureDirectories(
-            homeDirectory: home,
-            fileManager: fileManager
-        )
-        let meetingsOverride = environment["TRANSCRIPTED_MEETINGS_DIR"].map(URL.init(fileURLWithPath:))
-        let dictationsOverride = environment["TRANSCRIPTED_DICTATIONS_DIR"].map(URL.init(fileURLWithPath:))
-        let indexOverride = environment["TRANSCRIPTED_INDEX_DIR"].map(URL.init(fileURLWithPath:))
-        let meetingDirs = meetingsOverride.map { [$0] }
-            ?? appConfiguredCaptureDirectories.map {
-                captureDirectories(
-                    primary: $0.meetings,
-                    legacyCandidates: [legacyDraftMeetings, legacyShared],
-                    fileManager: fileManager
-                )
-            }
-            ?? captureDirectories(
-                primary: defaultMeetings,
-                legacyCandidates: [legacyDraftMeetings, legacyShared],
-                fileManager: fileManager
-            )
-        let dictationDirs = dictationsOverride.map { [$0] }
-            ?? appConfiguredCaptureDirectories.map {
-                captureDirectories(
-                    primary: $0.dictations,
-                    legacyCandidates: [legacyDraftDictations, legacyShared],
-                    fileManager: fileManager
-                )
-            }
-            ?? captureDirectories(
-                primary: defaultDictations,
-                legacyCandidates: [legacyDraftDictations, legacyShared],
-                fileManager: fileManager
-            )
+            .appendingPathComponent("cache", isDirectory: true)
 
         return TranscriptedDataDirectories(
-            meetingDirs: meetingDirs,
-            dictationDirs: dictationDirs,
+            meetingDirs: resolved.meetingDirs,
+            dictationDirs: resolved.dictationDirs,
             indexDir: indexOverride ?? defaultIndex
         )
-    }
-
-    private static func captureDirectories(primary: URL, legacyCandidates: [URL], fileManager: FileManager) -> [URL] {
-        var directories = [primary]
-        var seen = Set([primary.standardizedFileURL.path])
-
-        for candidate in legacyCandidates where directoryHasCaptureMarkdownFiles(candidate, fileManager: fileManager) {
-            let path = candidate.standardizedFileURL.path
-            guard !seen.contains(path) else { continue }
-            seen.insert(path)
-            directories.append(candidate)
-        }
-
-        return directories
-    }
-
-    private static func directoryHasCaptureMarkdownFiles(_ directory: URL, fileManager: FileManager) -> Bool {
-        let enumerationRoot = directory.resolvingSymlinksInPath().standardizedFileURL
-        guard let contents = try? fileManager.contentsOfDirectory(
-            at: enumerationRoot,
-            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return false
-        }
-
-        return contents.contains { url in
-            guard url.pathExtension == "md",
-                  let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
-            else {
-                return false
-            }
-            guard values.isRegularFile == true, values.isSymbolicLink != true else {
-                return false
-            }
-            return looksLikeCaptureMarkdown(url)
-        }
-    }
-
-    private static func looksLikeCaptureMarkdown(_ url: URL) -> Bool {
-        let filename = url.deletingPathExtension().lastPathComponent
-        if filename.hasPrefix("Dictations_") {
-            return true
-        }
-
-        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
-            return false
-        }
-
-        return content.hasPrefix("---\n") && content.contains("\n---\n")
-    }
-
-    private static func configuredCaptureDirectories(
-        homeDirectory home: URL,
-        fileManager: FileManager
-    ) -> ConfiguredCaptureDirectories? {
-        manifestCaptureDirectories(homeDirectory: home, fileManager: fileManager)
-            ?? appPreferenceCaptureDirectories(homeDirectory: home)
-    }
-
-    private static func manifestCaptureDirectories(
-        homeDirectory home: URL,
-        fileManager: FileManager
-    ) -> ConfiguredCaptureDirectories? {
-        let manifestURL = home
-            .appendingPathComponent("Library", isDirectory: true)
-            .appendingPathComponent("Application Support", isDirectory: true)
-            .appendingPathComponent("Transcripted", isDirectory: true)
-            .appendingPathComponent("mcp-directories.json", isDirectory: false)
-
-        guard fileManager.fileExists(atPath: manifestURL.path),
-              let data = try? Data(contentsOf: manifestURL),
-              let manifest = try? JSONDecoder().decode(AppDirectoryManifest.self, from: data),
-              manifest.version >= 1,
-              let captureLibrary = validatedConfiguredDirectory(manifest.captureLibraryDirectory, homeDirectory: home),
-              let meetings = validatedConfiguredDirectory(manifest.meetingsDirectory, homeDirectory: home),
-              let dictations = validatedConfiguredDirectory(manifest.dictationsDirectory, homeDirectory: home),
-              isManifestDirectory(meetings, named: "meetings", under: captureLibrary),
-              isManifestDirectory(dictations, named: "dictations", under: captureLibrary) else {
-            return nil
-        }
-
-        return ConfiguredCaptureDirectories(meetings: meetings, dictations: dictations)
-    }
-
-    private static func appPreferenceCaptureDirectories(homeDirectory home: URL) -> ConfiguredCaptureDirectories? {
-        for domain in appPreferenceDomains {
-            let preferenceURL = home
-                .appendingPathComponent("Library", isDirectory: true)
-                .appendingPathComponent("Preferences", isDirectory: true)
-                .appendingPathComponent("\(domain).plist", isDirectory: false)
-
-            guard let data = try? Data(contentsOf: preferenceURL),
-                  let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
-                  let values = plist as? [String: Any],
-                  let rawPath = values["transcriptSaveLocation"] as? String,
-                  let captureLibrary = validatedConfiguredDirectory(rawPath, homeDirectory: home) else {
-                continue
-            }
-
-            return ConfiguredCaptureDirectories(
-                meetings: captureLibrary.appendingPathComponent("meetings", isDirectory: true),
-                dictations: captureLibrary.appendingPathComponent("dictations", isDirectory: true)
-            )
-        }
-
-        return nil
-    }
-
-    private static var appPreferenceDomains: [String] {
-        [
-            "com.justinbetker.draft",
-            "app.transcripted.Transcripted",
-        ]
-    }
-
-    private static func validatedConfiguredDirectory(_ rawPath: String, homeDirectory home: URL) -> URL? {
-        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, trimmed.hasPrefix("/") else {
-            return nil
-        }
-
-        let directory = URL(fileURLWithPath: trimmed, isDirectory: true).standardizedFileURL
-        guard directory.path != "/", !directory.pathComponents.contains("..") else {
-            return nil
-        }
-
-        let resolvedDirectory = directory.resolvingSymlinksInPath().standardizedFileURL
-        let resolvedHome = home.resolvingSymlinksInPath().standardizedFileURL
-        let isUnderHome = resolvedDirectory.path == resolvedHome.path
-            || resolvedDirectory.path.hasPrefix(resolvedHome.path + "/")
-        let forbiddenPrefixes = ["/System", "/Library", "/usr", "/bin", "/sbin", "/private"]
-        let isForbidden = forbiddenPrefixes.contains { prefix in
-            resolvedDirectory.path == prefix || resolvedDirectory.path.hasPrefix(prefix + "/")
-        }
-
-        guard !isForbidden || isUnderHome else {
-            return nil
-        }
-
-        return directory
-    }
-
-    private static func isManifestDirectory(_ directory: URL, named name: String, under captureLibrary: URL) -> Bool {
-        let expected = captureLibrary
-            .appendingPathComponent(name, isDirectory: true)
-            .standardizedFileURL
-            .resolvingSymlinksInPath()
-            .standardizedFileURL
-        let actual = directory
-            .standardizedFileURL
-            .resolvingSymlinksInPath()
-            .standardizedFileURL
-        return actual.path == expected.path
     }
 }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MCP
+import TranscriptedCaptureKit
 
 // MARK: - Helpers
 
@@ -313,19 +314,7 @@ private func handleListDictations(params: CallTool.Parameters, index: Transcript
 
 /// Extract title from markdown YAML frontmatter
 private func extractTitle(from content: String) -> String? {
-    // Minimum valid frontmatter is "---\n...\n---\n" (8+ chars)
-    guard content.count >= 8, content.hasPrefix("---"),
-          let endRange = content.range(of: "\n---\n", range: content.index(content.startIndex, offsetBy: 3)..<content.endIndex) else { return nil }
-    let yaml = String(content[content.index(content.startIndex, offsetBy: 4)..<endRange.lowerBound])
-    for line in yaml.components(separatedBy: "\n") {
-        let trimmed = line.trimmingCharacters(in: .whitespaces)
-        if trimmed == "---" { break }
-        if trimmed.hasPrefix("title:") {
-            let title = String(trimmed.dropFirst(6)).trimmingCharacters(in: CharacterSet(charactersIn: "\"' "))
-            return title.isEmpty ? nil : title
-        }
-    }
-    return nil
+    CaptureMarkdown.extractTitle(from: content)
 }
 
 /// Returns non-empty transcript dialogue lines from the `## Full Transcript` section, filtering boilerplate.

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TranscriptedCaptureKit
 
 private let logSuppressionLock = NSLock()
 private var logSuppressionDepth = 0
@@ -14,26 +15,6 @@ struct ContextArtifactFile {
     let kind: ContextArtifactKind
 }
 
-private struct MarkdownFrontmatter {
-    let values: [String: String]
-    let body: String
-}
-
-private struct ParsedTranscriptEntry {
-    let timestamp: String
-    let startSeconds: Double
-    let source: String
-    let label: String
-    let text: String
-}
-
-private struct ParsedFrontmatterSpeaker {
-    let rawId: String
-    let persistentSpeakerId: String?
-    let name: String
-    let confidence: String?
-}
-
 enum TranscriptLoader {
     static func load(_ url: URL) -> AgentTranscript? {
         loadMeeting(url)
@@ -41,120 +22,75 @@ enum TranscriptLoader {
 
     static func loadMeeting(_ url: URL) -> AgentTranscript? {
         guard let content = try? String(contentsOf: url, encoding: .utf8),
-              let document = parseFrontmatter(from: content) else {
+              let parsed = CaptureMarkdownParser.parseMeeting(from: content) else {
             log("Cannot read markdown meeting: \(url.lastPathComponent)")
             return nil
         }
 
-        let entries = parseTranscriptEntries(from: document.body)
-        let speakerMetadata = parseSpeakerMetadata(from: content)
-        let speakerMetadataByName = uniqueSpeakerMetadataByNormalizedName(speakerMetadata)
-
-        var generatedIDsByLabel: [String: String] = [:]
-        var nextMicId = 0
-        var nextSystemId = 0
-        var utterances: [AgentUtterance] = []
-        utterances.reserveCapacity(entries.count)
-
-        for entry in entries {
-            let normalizedLabel = normalizeSpeakerLabel(entry.label)
-            let speakerId: String
-
-            if entry.source == "Mic" {
-                if let existing = generatedIDsByLabel["mic:\(normalizedLabel)"] {
-                    speakerId = existing
-                } else {
-                    speakerId = "mic_\(nextMicId)"
-                    generatedIDsByLabel["mic:\(normalizedLabel)"] = speakerId
-                    nextMicId += 1
-                }
-            } else {
-                if let metadata = speakerMetadataByName[normalizedLabel] {
-                    speakerId = "system_\(metadata.rawId)"
-                } else if let existing = generatedIDsByLabel["system:\(normalizedLabel)"] {
-                    speakerId = existing
-                } else {
-                    speakerId = "system_\(nextSystemId)"
-                    generatedIDsByLabel["system:\(normalizedLabel)"] = speakerId
-                    nextSystemId += 1
-                }
-            }
-
-            let estimatedEnd = estimatedEndSeconds(for: entry, next: utterances.count < entries.count - 1 ? entries[utterances.count + 1] : nil)
-            utterances.append(AgentUtterance(
-                start: entry.startSeconds,
-                end: estimatedEnd,
-                speakerId: speakerId,
-                text: entry.text
-            ))
-        }
-
-        let groupedUtterances = Dictionary(grouping: zip(entries, utterances), by: { $0.1.speakerId })
-        var speakers: [AgentSpeaker] = []
-
-        for (speakerId, grouped) in groupedUtterances.sorted(by: { $0.key < $1.key }) {
-            let displayName = grouped.first?.0.label ?? speakerId
-            let metadata = speakerId.hasPrefix("system_")
-                ? speakerMetadata.first(where: { "system_\($0.rawId)" == speakerId || normalizeSpeakerLabel($0.name) == normalizeSpeakerLabel(displayName) })
-                : nil
-            let wordCount = grouped.reduce(0) { $0 + $1.0.text.split(whereSeparator: \.isWhitespace).count }
-            let speakingSeconds = grouped.reduce(0.0) { $0 + max(0, $1.1.end - $1.1.start) }
-
-            speakers.append(AgentSpeaker(
-                id: speakerId,
-                persistentSpeakerId: metadata?.persistentSpeakerId,
-                name: displayName,
-                confidence: metadata?.confidence,
-                wordCount: wordCount,
-                speakingSeconds: (speakingSeconds * 10).rounded() / 10
-            ))
-        }
-
-        let date = document.values["date"] ?? "1970-01-01"
-        let time = document.values["time"] ?? "00:00:00"
-        let datetime = "\(date)T\(time)"
-        let durationSeconds = parseDurationSeconds(document.values["duration"])
-        let droppedSegments = Int(document.values["dropped_segments"] ?? "") ?? 0
-
         return AgentTranscript(
             version: "2.0",
             recording: AgentRecording(
-                date: datetime,
-                durationSeconds: durationSeconds,
-                droppedSegments: droppedSegments,
+                date: parsed.datetime,
+                durationSeconds: parsed.durationSeconds,
+                droppedSegments: parsed.droppedSegments,
                 engines: AgentEngines(
-                    stt: document.values["transcription_engine"] ?? "unknown",
-                    diarization: document.values["diarization_engine"] ?? "unknown"
+                    stt: parsed.sttEngine,
+                    diarization: parsed.diarizationEngine
                 )
             ),
-            speakers: speakers,
-            utterances: utterances
+            speakers: parsed.speakers.map { speaker in
+                AgentSpeaker(
+                    id: speaker.id,
+                    persistentSpeakerId: speaker.persistentSpeakerId,
+                    name: speaker.name,
+                    confidence: speaker.confidence,
+                    wordCount: speaker.wordCount,
+                    speakingSeconds: speaker.speakingSeconds
+                )
+            },
+            utterances: parsed.utterances.map { utterance in
+                AgentUtterance(
+                    start: utterance.start,
+                    end: utterance.end,
+                    speakerId: utterance.speakerId,
+                    text: utterance.text
+                )
+            }
         )
     }
 
     static func loadDictationDay(_ url: URL) -> AgentDictationDay? {
         guard let content = try? String(contentsOf: url, encoding: .utf8),
-              let document = parseFrontmatter(from: content) else {
+              let parsed = CaptureMarkdownParser.parseDictationDay(from: content, markdownURL: url) else {
             log("Cannot read markdown dictation day: \(url.lastPathComponent)")
             return nil
         }
 
-        let entries = parseDictationEntries(from: document.body)
-        let date = document.values["date"] ?? url.deletingPathExtension().lastPathComponent.replacingOccurrences(of: "Dictations_", with: "")
-
         return AgentDictationDay(
             version: "2.0",
-            captureType: document.values["capture_type"] ?? "dictation_day",
-            date: date,
-            markdownFilename: url.lastPathComponent,
-            entryCount: entries.count,
-            wordCount: entries.reduce(0) { $0 + $1.wordCount },
-            entries: entries
+            captureType: parsed.captureType,
+            date: parsed.date,
+            markdownFilename: parsed.markdownFilename,
+            entryCount: parsed.entryCount,
+            wordCount: parsed.wordCount,
+            entries: parsed.entries.map { entry in
+                AgentDictationEntry(
+                    id: entry.id,
+                    createdAt: entry.createdAt,
+                    title: entry.title,
+                    text: entry.text,
+                    sourceAppName: entry.sourceAppName,
+                    sourceAppBundleId: entry.sourceAppBundleId,
+                    delivery: entry.delivery,
+                    wordCount: entry.wordCount,
+                    characterCount: entry.characterCount
+                )
+            }
         )
     }
 
     static func artifactKind(for url: URL) -> ContextArtifactKind? {
-        guard url.pathExtension == "md", looksLikeCaptureMarkdown(url) else { return nil }
+        guard url.pathExtension == "md", CaptureMarkdown.looksLikeCaptureMarkdown(url) else { return nil }
 
         let filename = url.deletingPathExtension().lastPathComponent
         if filename.hasPrefix("Dictations_") {
@@ -182,380 +118,12 @@ enum TranscriptLoader {
         }
     }
 
-    private static func looksLikeCaptureMarkdown(_ url: URL) -> Bool {
-        let filename = url.deletingPathExtension().lastPathComponent
-        if filename.hasPrefix("Dictations_") {
-            return true
-        }
-
-        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
-            return false
-        }
-
-        return content.hasPrefix("---\n") && content.contains("\n---\n")
-    }
-
     static func speakerLookup(from transcript: AgentTranscript) -> [String: (name: String, persistentId: String?)] {
         var lookup: [String: (name: String, persistentId: String?)] = [:]
         for speaker in transcript.speakers {
             lookup[speaker.id] = (speaker.name, speaker.persistentSpeakerId)
         }
         return lookup
-    }
-
-    private static func parseFrontmatter(from content: String) -> MarkdownFrontmatter? {
-        guard content.hasPrefix("---\n"),
-              let endRange = content.range(
-                of: "\n---\n",
-                range: content.index(content.startIndex, offsetBy: 4)..<content.endIndex
-              ) else {
-            return nil
-        }
-
-        let frontmatterText = String(content[content.index(content.startIndex, offsetBy: 4)..<endRange.lowerBound])
-        var values: [String: String] = [:]
-        for line in frontmatterText.components(separatedBy: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            guard !trimmed.hasPrefix("- "),
-                  let separator = trimmed.firstIndex(of: ":") else { continue }
-            let key = String(trimmed[..<separator]).trimmingCharacters(in: .whitespaces)
-            let value = String(trimmed[trimmed.index(after: separator)...])
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            values[key] = value
-        }
-
-        return MarkdownFrontmatter(values: values, body: String(content[endRange.upperBound...]))
-    }
-
-    private static func parseSpeakerMetadata(from content: String) -> [ParsedFrontmatterSpeaker] {
-        guard parseFrontmatter(from: content) != nil,
-              content.range(of: "\nspeakers:\n") != nil else {
-            return []
-        }
-
-        let frontmatterEnd = content.range(
-            of: "\n---\n",
-            range: content.index(content.startIndex, offsetBy: 4)..<content.endIndex
-        )?.lowerBound ?? content.endIndex
-        let frontmatter = String(content[content.startIndex..<frontmatterEnd])
-        guard let sectionRange = frontmatter.range(of: "speakers:\n") else { return [] }
-        let speakerLines = frontmatter[sectionRange.upperBound...].components(separatedBy: "\n")
-
-        var speakers: [ParsedFrontmatterSpeaker] = []
-        var currentId: String?
-        var currentPersistentId: String?
-        var currentName: String?
-        var currentConfidence: String?
-
-        func flush() {
-            if let currentId, let currentName {
-                speakers.append(ParsedFrontmatterSpeaker(
-                    rawId: currentId,
-                    persistentSpeakerId: currentPersistentId,
-                    name: currentName,
-                    confidence: currentConfidence
-                ))
-            }
-            currentId = nil
-            currentPersistentId = nil
-            currentName = nil
-            currentConfidence = nil
-        }
-
-        for rawLine in speakerLines {
-            let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("- id:") {
-                flush()
-                currentId = trimmed
-                    .replacingOccurrences(of: "- id:", with: "")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            } else if trimmed.hasPrefix("db_id:") {
-                currentPersistentId = trimmed
-                    .replacingOccurrences(of: "db_id:", with: "")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            } else if trimmed.hasPrefix("name:") {
-                currentName = trimmed
-                    .replacingOccurrences(of: "name:", with: "")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            } else if trimmed.hasPrefix("confidence:") {
-                currentConfidence = trimmed
-                    .replacingOccurrences(of: "confidence:", with: "")
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-            } else if !trimmed.hasPrefix("-"), !trimmed.hasPrefix("db_id:"), !trimmed.hasPrefix("name:"), !trimmed.hasPrefix("confidence:"), !trimmed.hasPrefix("source:"), !trimmed.isEmpty {
-                break
-            }
-        }
-        flush()
-        return speakers
-    }
-
-    private static func uniqueSpeakerMetadataByNormalizedName(
-        _ speakers: [ParsedFrontmatterSpeaker]
-    ) -> [String: ParsedFrontmatterSpeaker] {
-        var grouped: [String: [ParsedFrontmatterSpeaker]] = [:]
-        for speaker in speakers {
-            grouped[normalizeSpeakerLabel(speaker.name), default: []].append(speaker)
-        }
-
-        var unique: [String: ParsedFrontmatterSpeaker] = [:]
-        for (name, matches) in grouped where matches.count == 1 {
-            unique[name] = matches[0]
-        }
-        return unique
-    }
-
-    private static func parseTranscriptEntries(from body: String) -> [ParsedTranscriptEntry] {
-        if let range = body.range(of: "## Transcript\n\n") {
-            let transcriptBody = String(body[range.upperBound...])
-            let chunks = transcriptBody
-                .components(separatedBy: "\n\n")
-                .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
-            let entries = chunks.compactMap(parseStyledTranscriptEntry)
-            if !entries.isEmpty { return entries }
-        }
-
-        if let range = body.range(of: "## Full Transcript\n\n") {
-            let transcriptBody = String(body[range.upperBound...])
-            return transcriptBody
-                .components(separatedBy: "\n")
-                .compactMap(parseLegacyTranscriptLine)
-        }
-
-        return body.components(separatedBy: "\n").compactMap(parseLegacyTranscriptLine)
-    }
-
-    private static func parseLegacyTranscriptLine(_ line: String) -> ParsedTranscriptEntry? {
-        let trimmed = line.trimmingCharacters(in: .whitespaces)
-        guard trimmed.hasPrefix("["),
-              let timestampEnd = trimmed.firstIndex(of: "]") else {
-            return nil
-        }
-
-        let timestamp = String(trimmed[trimmed.index(after: trimmed.startIndex)..<timestampEnd])
-        let afterTimestamp = trimmed[trimmed.index(after: timestampEnd)...]
-        guard afterTimestamp.hasPrefix(" ["),
-              let sourceStart = trimmed.index(timestampEnd, offsetBy: 3, limitedBy: trimmed.endIndex) else {
-            return nil
-        }
-        guard let labelEnd = trimmed.range(of: "] ", range: sourceStart..<trimmed.endIndex) else {
-            return nil
-        }
-
-        let sourceLabel = trimmed[sourceStart..<labelEnd.lowerBound]
-        guard let separator = sourceLabel.firstIndex(of: "/") else { return nil }
-        let source = String(sourceLabel[..<separator])
-        let label = unwrapSpeakerLabel(String(sourceLabel[sourceLabel.index(after: separator)...]))
-        let text = String(trimmed[labelEnd.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
-        return ParsedTranscriptEntry(
-            timestamp: timestamp,
-            startSeconds: parseTimestampSeconds(timestamp),
-            source: source,
-            label: label,
-            text: text
-        )
-    }
-
-    private static func parseStyledTranscriptEntry(_ chunk: String) -> ParsedTranscriptEntry? {
-        let lines = chunk.components(separatedBy: "\n").filter { !$0.isEmpty }
-        guard let header = lines.first else { return nil }
-        let normalizedHeader = header
-            .replacingOccurrences(of: "**", with: "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let regex = try? NSRegularExpression(pattern: #"^([0-9:]+)\s+\[(.+?)\]$"#) else {
-            return nil
-        }
-        let nsHeader = normalizedHeader as NSString
-        let range = NSRange(location: 0, length: nsHeader.length)
-        guard let match = regex.firstMatch(in: normalizedHeader, range: range),
-              match.numberOfRanges >= 3 else {
-            return nil
-        }
-        let timestamp = nsHeader.substring(with: match.range(at: 1))
-        let sourceLabel = nsHeader.substring(with: match.range(at: 2))
-        guard let separator = sourceLabel.firstIndex(of: "/") else { return nil }
-
-        let source = String(sourceLabel[..<separator])
-        let label = unwrapSpeakerLabel(String(sourceLabel[sourceLabel.index(after: separator)...]))
-        let text = lines.dropFirst().joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
-        return ParsedTranscriptEntry(
-            timestamp: timestamp,
-            startSeconds: parseTimestampSeconds(timestamp),
-            source: source,
-            label: label,
-            text: text
-        )
-    }
-
-    private static func parseDictationEntries(from body: String) -> [AgentDictationEntry] {
-        let lines = body.components(separatedBy: "\n")
-        var sections: [String] = []
-        var currentSection: [String] = []
-
-        for line in lines {
-            if line.hasPrefix("## ") {
-                if !currentSection.isEmpty {
-                    sections.append(currentSection.joined(separator: "\n"))
-                }
-                currentSection = [line]
-            } else if !currentSection.isEmpty {
-                currentSection.append(line)
-            }
-        }
-
-        if !currentSection.isEmpty {
-            sections.append(currentSection.joined(separator: "\n"))
-        }
-
-        return sections.compactMap { rawSection in
-            let section = rawSection
-            let lines = section.components(separatedBy: "\n")
-            guard let heading = lines.first, heading.hasPrefix("## ") else { return nil }
-            let title = heading.replacingOccurrences(of: "## ", with: "")
-                .components(separatedBy: " - ")
-                .dropFirst()
-                .joined(separator: " - ")
-
-            var entryId = ""
-            var createdAt = ""
-            var sourceAppName = "Unknown"
-            var sourceAppBundleId: String?
-            var delivery = "failed"
-            var wordCount = 0
-            var characterCount = 0
-            var bodyLines: [String] = []
-            var inBody = false
-            var sawMetadata = false
-
-            for line in lines.dropFirst() {
-                let trimmed = line.trimmingCharacters(in: .whitespaces)
-                if trimmed.isEmpty {
-                    if !inBody, sawMetadata {
-                        inBody = true
-                    } else if inBody {
-                        bodyLines.append("")
-                    }
-                    continue
-                }
-
-                if inBody {
-                    bodyLines.append(line)
-                    continue
-                }
-
-                if trimmed.hasPrefix("Entry ID:") {
-                    sawMetadata = true
-                    entryId = trimmed.replacingOccurrences(of: "Entry ID:", with: "")
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "`"))
-                } else if trimmed.hasPrefix("Captured:") {
-                    sawMetadata = true
-                    createdAt = trimmed.replacingOccurrences(of: "Captured:", with: "")
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                } else if trimmed.hasPrefix("Source app:") {
-                    sawMetadata = true
-                    sourceAppName = trimmed.replacingOccurrences(of: "Source app:", with: "")
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                } else if trimmed.hasPrefix("Bundle ID:") {
-                    sawMetadata = true
-                    sourceAppBundleId = trimmed.replacingOccurrences(of: "Bundle ID:", with: "")
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "`"))
-                } else if trimmed.hasPrefix("Delivery:") {
-                    sawMetadata = true
-                    delivery = trimmed.replacingOccurrences(of: "Delivery:", with: "")
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                } else if trimmed.hasPrefix("Words:") {
-                    sawMetadata = true
-                    wordCount = Int(trimmed.replacingOccurrences(of: "Words:", with: "").trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
-                } else if trimmed.hasPrefix("Characters:") {
-                    sawMetadata = true
-                    characterCount = Int(trimmed.replacingOccurrences(of: "Characters:", with: "").trimmingCharacters(in: .whitespacesAndNewlines)) ?? 0
-                } else if trimmed.hasPrefix("Timestamp:") {
-                    sawMetadata = true
-                    // Backward compatibility with pre-refactor dictation markdown.
-                    createdAt = trimmed.replacingOccurrences(of: "Timestamp:", with: "")
-                        .trimmingCharacters(in: .whitespacesAndNewlines)
-                } else if !sawMetadata {
-                    inBody = true
-                    bodyLines.append(line)
-                }
-            }
-
-            let text = bodyLines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-            let finalWordCount = wordCount == 0 ? text.split(whereSeparator: \.isWhitespace).count : wordCount
-            let finalCharacterCount = characterCount == 0 ? text.count : characterCount
-            let finalEntryId = entryId.isEmpty ? "dictation-\(UUID().uuidString)" : entryId
-            let finalCreatedAt = createdAt.isEmpty ? "1970-01-01T00:00:00Z" : createdAt
-
-            return AgentDictationEntry(
-                id: finalEntryId,
-                createdAt: finalCreatedAt,
-                title: title.isEmpty ? heading.replacingOccurrences(of: "## ", with: "") : title,
-                text: text,
-                sourceAppName: sourceAppName,
-                sourceAppBundleId: sourceAppBundleId,
-                delivery: delivery,
-                wordCount: finalWordCount,
-                characterCount: finalCharacterCount
-            )
-        }
-        .sorted { $0.createdAt < $1.createdAt }
-    }
-
-    private static func estimatedEndSeconds(for entry: ParsedTranscriptEntry, next: ParsedTranscriptEntry?) -> Double {
-        if let next, next.startSeconds > entry.startSeconds {
-            return next.startSeconds
-        }
-        let estimatedDuration = max(1.0, min(20.0, Double(entry.text.split(whereSeparator: \.isWhitespace).count) / 2.5))
-        return entry.startSeconds + estimatedDuration
-    }
-
-    private static func parseDurationSeconds(_ rawDuration: String?) -> Int {
-        guard let rawDuration else { return 0 }
-        let rawComponents = rawDuration.split(separator: ":", omittingEmptySubsequences: false)
-        let components = rawComponents.compactMap { Int($0) }
-        guard components.count == rawComponents.count,
-              !components.contains(where: { $0 < 0 }) else {
-            return 0
-        }
-        switch components.count {
-        case 1:
-            return components[0]
-        case 2:
-            return components[0] * 60 + components[1]
-        case 3:
-            return components[0] * 3600 + components[1] * 60 + components[2]
-        default:
-            return 0
-        }
-    }
-
-    private static func parseTimestampSeconds(_ timestamp: String) -> Double {
-        let components = timestamp.split(separator: ":").compactMap { Double($0) }
-        switch components.count {
-        case 2:
-            return components[0] * 60 + components[1]
-        case 3:
-            return components[0] * 3600 + components[1] * 60 + components[2]
-        default:
-            return 0
-        }
-    }
-
-    private static func unwrapSpeakerLabel(_ label: String) -> String {
-        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasPrefix("[["), trimmed.hasSuffix("]]") {
-            return String(trimmed.dropFirst(2).dropLast(2))
-        }
-        return trimmed
-    }
-
-    private static func normalizeSpeakerLabel(_ label: String) -> String {
-        unwrapSpeakerLabel(label).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }
 

--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -168,6 +168,8 @@ When the issue is vague, classify it before editing:
   Overlay, menubar, onboarding, settings, and agent-connect ownership.
 - `Sources/Capture/CLAUDE.md`
   Global trigger and hotkey routing behavior.
+- `Tools/TranscriptedCaptureKit/CLAUDE.md`
+  Shared capture-library resolution and capture-Markdown parsing for the CLI and MCP tools.
 - `Tools/TranscriptedCLI/CLAUDE.md`
   Standalone local-context and offline diarization CLI.
 - `Tools/TranscriptedMCP/CLAUDE.md`

--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -224,6 +224,13 @@ if [ -n "$changed_paths" ]; then
             add_command "swift test"
         fi
 
+        if matches_any "$path" "Tools/TranscriptedCaptureKit/*"; then
+            add_command "swift test --package-path Tools/TranscriptedCaptureKit"
+            add_command "swift test --package-path Tools/TranscriptedCLI"
+            add_command "swift test --package-path Tools/TranscriptedMCP"
+            add_command "bash run-e2e-smoke.sh"
+        fi
+
         if matches_any "$path" "Tools/TranscriptedCLI/*"; then
             add_command "swift test --package-path Tools/TranscriptedCLI"
         fi

--- a/scripts/entrypoints/run-e2e-smoke.sh
+++ b/scripts/entrypoints/run-e2e-smoke.sh
@@ -33,6 +33,7 @@ mkdir -p "$FAKE_HOME" "$WORK_ROOT"
 SWIFT_SOURCES=(
     "Tests/E2E/TranscriptedE2ESmoke.swift"
     "Sources/Support/TranscriptedStoragePaths.swift"
+    "Sources/Support/LocalMeetingSummaryPreferences.swift"
     "Sources/Dictation/DictationStoragePaths.swift"
     "Sources/Dictation/DictationTranscriptWriter.swift"
     "Sources/Dictation/DictationTranscriptStore.swift"
@@ -65,9 +66,23 @@ SWIFT_SOURCES=(
     "Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift"
 )
 
+CAPTURE_KIT_BUILD_DIR="$BUILD_DIR/capture-kit"
+mkdir -p "$CAPTURE_KIT_BUILD_DIR"
+
+echo "Compiling TranscriptedCaptureKit module..."
+swiftc \
+    Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/*.swift \
+    -module-name TranscriptedCaptureKit \
+    -emit-module -emit-module-path "$CAPTURE_KIT_BUILD_DIR/TranscriptedCaptureKit.swiftmodule" \
+    -emit-library -static -o "$CAPTURE_KIT_BUILD_DIR/libTranscriptedCaptureKit.a" \
+    -parse-as-library
+
 echo "Compiling deterministic E2E smoke..."
 swiftc \
     "${SWIFT_SOURCES[@]}" \
+    -I "$CAPTURE_KIT_BUILD_DIR" \
+    -L "$CAPTURE_KIT_BUILD_DIR" \
+    -lTranscriptedCaptureKit \
     -framework AppKit \
     -lsqlite3 \
     -parse-as-library \


### PR DESCRIPTION
## Why

Capture-library resolution and markdown transcript parsing were duplicated nearly verbatim between `Tools/TranscriptedCLI` (`ContextStore.swift`) and `Tools/TranscriptedMCP` (`DataDirectories.swift` + `TranscriptLoader.swift`), and drift had already started: MCP resolved symlinks before enumerating legacy candidates while the CLI did not, MCP only attached frontmatter speaker metadata to system speakers, and `looksLikeCaptureMarkdown` existed four times (plus a third copy of `extractTitle` hiding in `ToolHandlers.swift`). One implementation now serves both tools so future fixes land once.

## Product Impact

- Affects: `agent artifacts`
- Lane: `agent workflow`
- Why this matters: the CLI and MCP server are how agents read saved captures; silent drift between them means the same library resolves or parses differently depending on which tool an agent uses.

## What changed

- New `Tools/TranscriptedCaptureKit` local SPM package (dependency-free), consumed by both tools via `.package(path: "../TranscriptedCaptureKit")`:
  - `CaptureLibraryResolver` — full resolution chain (shared data dir, per-kind overrides, `mcp-directories.json` manifest, `transcriptSaveLocation` preference, defaults + legacy Draft/`~/Documents/Transcripted` fallback), returning `sharedDataRoot` so MCP derives its index dir
  - `CaptureMarkdown` — capture-markdown detection, directory probing, frontmatter `title:` extraction
  - `CaptureMarkdownParser` — frontmatter, speaker metadata, styled + legacy transcript entries, dictation day entries, producing superset models each tool maps into its own output types
- Both tools keep their facade types (`CLIContextDirectories`, `CLIContextStore`, `TranscriptedDataDirectories`, `TranscriptLoader`), so public APIs are unchanged; `ContextStore.swift` drops from ~1,140 to ~480 lines
- Drift unified to the safer variant of each: symlink-resolved legacy enumeration (MCP behavior) and metadata matching by system id or unique normalized name for all speakers (CLI behavior, a superset); both pinned by kit tests
- `run-e2e-smoke.sh` pre-compiles the kit as a swiftmodule + static lib before its raw `swiftc` compile (same pattern as `TranscriptedCore`)
- Fixes a pre-existing e2e smoke breakage on `main` (verified via `git stash`): `SWIFT_SOURCES` was missing `Sources/Support/LocalMeetingSummaryPreferences.swift`, which defines `LocalMeetingSummaryProvider` used by `LocalMeetingSummarizer.swift`
- Verification map: new `Tools/TranscriptedCaptureKit/**` rule in `.agents/test-matrix.yml` + `agent-preflight.sh` (kit tests + both consumer suites + e2e smoke); docs updated (`CLAUDE.md`, `Tools/README.md`, tool `CLAUDE.md`s, `docs/agent-onboarding.md`, new kit `CLAUDE.md`)
- One CLI test edit: `testMalformedDurationFallsBackToZero` asserts on parser source text; repointed at the kit file where the guards now live

## How I checked it

- [x] `scripts/dev/agent-preflight.sh` (suggests the new rule union correctly)
- [x] Selected checks from `.agents/test-matrix.yml` for the files changed
- [ ] `bash build.sh --no-open` (no `Sources/**` or root-test changes; not required by the matrix for these paths)
- [ ] `bash run-tests.sh` (same)
- [ ] Performance budget (not runtime-sensitive)
- [ ] `bash run-integration-smoke.sh` (no `Sources/Meeting/` or `Sources/TranscriptedCore/` changes)
- [ ] `swift test` for the core seam (root `Package.swift` untouched)
- [x] Manual check: `swift test --package-path Tools/TranscriptedCaptureKit` 19/19, `swift test --package-path Tools/TranscriptedCLI` 40/40, `swift test --package-path Tools/TranscriptedMCP` 68/68 (zero MCP test edits), `bash run-e2e-smoke.sh` green, `swift build -c release --package-path Tools/TranscriptedMCP` (the path `build.sh` uses for the bundled helper) green, `transcripted-mcp --self-test` against a temp `TRANSCRIPTED_DATA_DIR` resolves correctly through the kit

## Risk Review

- [x] Privacy / local-first behavior reviewed (read-only refactor; no new data flows)
- [x] Storage path or migration impact reviewed (resolution order unchanged; behavior pinned by existing + new tests)
- [x] Public-facing copy stays concrete and matches current product scope
- [x] Release/update impact reviewed (`build.sh`/`build-beta.sh` build the MCP helper via `swift build`, which handles the path dependency transparently — verified release build)
- [ ] Agent PRs link the issue/workpad and stay draft until human review (no linked issue; session-initiated)
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence (no UI changes)
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

## Notes

- The e2e smoke was failing on unmodified `main` before this branch (missing source in `SWIFT_SOURCES` from the recent Gemma summary work); this PR fixes it since a green smoke was needed to verify the script change.
- The app target still has its own near-duplicate detection in `Sources/TranscriptedCore/Storage/TranscriptScanner.swift`; left out of scope deliberately (build-system boundary) and flagged as a follow-up.

## Agent handoff

`COORD_DONE: GREEN | https://github.com/r3dbars/transcripted/pull/1073 | extracted shared TranscriptedCaptureKit, refactored CLI+MCP to consume it, fixed pre-existing e2e smoke breakage, updated test matrix + docs | none | none | kit 19/19, CLI 40/40, MCP 68/68, e2e smoke green, MCP release build + self-test green, preflight | review and merge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
