### PR TITLE
Fix #825: salvage mic merges, heal failed-meeting audio, and recover crash-orphaned recordings

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -295,6 +295,13 @@ final class MeetingSessionController: ObservableObject {
         self.downloader = MeetingModelDownloader(stt: sttAdapter, diarization: diarization)
 
         wireSubscriptions()
+
+        // Recover recordings orphaned by a crash before any failed-queue entry
+        // existed — they become visible, retryable items on Home.
+        let scratchDirectory = storagePaths.audioCaptures
+        Task { [taskManager] in
+            await taskManager.recoverOrphanedRecordings(in: scratchDirectory)
+        }
     }
 
     // MARK: - Public API

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -156,8 +156,10 @@ public class Audio: ObservableObject, @unchecked Sendable {
     }
     func appendMicSegment(_ segment: MicRecordingSegment) {
         micSegmentsLock.lock()
-        defer { micSegmentsLock.unlock() }
         _micSegments.append(segment)
+        let segments = _micSegments
+        micSegmentsLock.unlock()
+        recordingJournal.recordSegments(segments)
     }
 
     // MARK: - Recording Health Tracking (Phase 1: Sleep/Wake + Gap Logging)
@@ -578,8 +580,14 @@ public class Audio: ObservableObject, @unchecked Sendable {
     /// Embedders can redirect captures by passing a custom `CoreStoragePaths` at init.
     let paths: CoreStoragePaths
 
+    /// Durable record of the in-flight recording for crash recovery. Lives
+    /// next to the scratch audio; cleared once the meeting reaches a durable
+    /// state (transcript saved or failed-queue entry persisted).
+    let recordingJournal: MeetingRecordingJournalStore
+
     public init(paths: CoreStoragePaths = .default) {
         self.paths = paths
+        self.recordingJournal = MeetingRecordingJournalStore(directory: paths.audioCaptures)
     }
 
     func ensureCaptureInfrastructureConfigured() {
@@ -950,6 +958,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         guard recordingSessionGeneration == sessionGeneration else { return }
 
         systemAudioFileURL = fileURL
+        recordingJournal.recordSystemAudio(fileURL)
         restoreSystemAudioHealthyStatusAfterSuccessfulStart()
     }
 
@@ -978,6 +987,8 @@ public class Audio: ObservableObject, @unchecked Sendable {
         let micSegmentsSnapshot = self.micSegments
         let finalSystemURL = systemAudioFileURL
         let cueHandler = self.onCaptureLifecycleCue
+
+        recordingJournal.markStopping()
 
         // Update UI state immediately so the meeting widget unfreezes
         // before any of the slow CoreAudio teardown begins. Without this
@@ -1083,6 +1094,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
             cleanupGroup.notify(queue: .global(qos: .utility)) { [weak self] in
                 guard let self else { return }
                 let finalMicURL = self.finalizeMicRecording(primaryURL: primaryMicURL, segments: micSegmentsSnapshot)
+                self.recordingJournal.markFinalized(finalMicURL: finalMicURL)
                 DispatchQueue.main.async {
                     if self.recordingSessionGeneration == stopGeneration {
                         self.originalMicAudioFileURL = nil

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -1057,6 +1057,12 @@ public class Audio: ObservableObject, @unchecked Sendable {
                     if let currentMicFile = self.micAudioFile, currentMicFile === micAudioFileRef {
                         self.micAudioFile = nil
                     }
+                    // Close explicitly so the WAV header is finalized here on
+                    // the serial queue before cleanupGroup.notify hands the
+                    // file to the merger. Waiting for deinit is racy: other
+                    // closure captures can keep the writer alive past notify,
+                    // and an unpatched header reads back as a zero-length file.
+                    micAudioFileRef.close()
                     AppLogger.audioMic.info("Audio file closed", ["file": primaryMicURL?.lastPathComponent ?? self.micAudioFileURL?.lastPathComponent ?? "unknown"])
                 }
                 cleanupGroup.leave()
@@ -1068,6 +1074,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
                     if let currentSystemFile = self.systemAudioFile, currentSystemFile === systemAudioFileRef {
                         self.systemAudioFile = nil
                     }
+                    systemAudioFileRef.close()
                     AppLogger.audioSystem.info("Audio file closed", ["file": finalSystemURL?.lastPathComponent ?? "unknown"])
                 }
                 cleanupGroup.leave()

--- a/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
+++ b/Sources/TranscriptedCore/Audio/AudioDeviceRecovery.swift
@@ -198,6 +198,7 @@ extension Audio {
             if let recoverySegmentURL, !shouldKeepRecoverySegment {
                 micAudioFileQueue.sync {
                     if micAudioFile?.url == recoverySegmentURL {
+                        micAudioFile?.close()
                         micAudioFile = nil
                     }
                 }
@@ -214,7 +215,12 @@ extension Audio {
 
         if sampleRateChanged {
             AppLogger.audioMic.warning("Sample rate changed, closing old file and creating new segment")
-            micAudioFileQueue.sync { micAudioFile = nil }
+            // Close explicitly so the retiring segment's WAV header is
+            // finalized before the merger can ever read it.
+            micAudioFileQueue.sync {
+                micAudioFile?.close()
+                micAudioFile = nil
+            }
 
             // Create new file segment as mono
             let captureDir = self.paths.audioCaptures

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -284,6 +284,7 @@ extension Audio {
                 interleaved: monoFormat.isInterleaved
             )
             FileManager.default.restrictToOwnerOnly(atPath: fileURL.path)
+            recordingJournal.begin(primaryMicURL: fileURL)
             AppLogger.audioMic.info("Saving as mono", ["sampleRate": "\(recordingSnapshot.sampleRate)"])
         } catch {
             throw NSError(domain: "Audio", code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to create mic audio file: \(error.localizedDescription)"])

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -400,22 +400,36 @@ extension Audio {
         guard let primaryURL else { return segments.last?.url }
         guard segments.count > 1 else { return primaryURL }
 
+        let mergeStart = Date()
         do {
-            let mergedURL = try MicRecordingFileMerger.merge(primaryURL: primaryURL, segments: segments)
+            let outcome = try MicRecordingFileMerger.merge(primaryURL: primaryURL, segments: segments)
             let insertedSilenceSamples = segments
                 .dropFirst()
                 .reduce(0) { partialResult, segment in
                     partialResult + MicRecordingMergePlan.silenceSampleCount(before: segment, sampleRate: 16_000)
                 }
-            AppLogger.audioMic.info("Merged mic recovery segments", [
-                "segments": "\(segments.count)",
+            let context: [String: String] = [
+                "segments": "\(outcome.segmentCount)",
+                "appended": "\(outcome.appendedSegments)",
+                "skipped": "\(outcome.skippedSegments)",
+                "repaired": "\(outcome.repairedSegments)",
+                "padded": "\(outcome.paddedSegments)",
+                "durationSeconds": String(format: "%.2f", Date().timeIntervalSince(mergeStart)),
                 "insertedSilenceSeconds": String(format: "%.3f", Double(insertedSilenceSamples) / 16_000),
-                "file": mergedURL?.lastPathComponent ?? primaryURL.lastPathComponent
-            ])
-            return mergedURL
+                "file": outcome.url?.lastPathComponent ?? primaryURL.lastPathComponent
+            ]
+            if outcome.isFullFidelity {
+                AppLogger.audioMic.info("Merged mic recovery segments", context)
+            } else {
+                // Some recorded audio is missing from the merged file; the
+                // source segments stay on disk for recovery.
+                AppLogger.audioMic.error("Merged mic recovery segments with degraded fidelity", context)
+            }
+            return outcome.url
         } catch {
             AppLogger.audioMic.error("Failed to merge mic recovery segments", [
                 "segments": "\(segments.count)",
+                "durationSeconds": String(format: "%.2f", Date().timeIntervalSince(mergeStart)),
                 "error": error.localizedDescription
             ])
             return primaryURL

--- a/Sources/TranscriptedCore/Audio/MeetingRecordingJournal.swift
+++ b/Sources/TranscriptedCore/Audio/MeetingRecordingJournal.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// On-disk record of an in-progress meeting recording, kept next to the audio
+/// in the recordings scratch directory.
+///
+/// The journal exists from recording start until the meeting reaches a durable
+/// state elsewhere (transcript saved, or failed-queue entry persisted). The
+/// failed-transcription queue only records meetings whose preservation code
+/// actually ran — a crash, force-kill, or power loss before that point leaves
+/// audio on disk with no record at all. The journal is that record: the launch
+/// recovery scan reads any journal left behind and turns its audio into a
+/// visible, retryable failed-queue entry.
+struct MeetingRecordingJournal: Codable, Equatable {
+    enum State: String, Codable {
+        case recording
+        case stopping
+        case finalized
+    }
+
+    struct SegmentRecord: Codable, Equatable {
+        var filename: String
+        var gapBefore: TimeInterval
+    }
+
+    var version: Int
+    var state: State
+    var startedAt: Date
+    var updatedAt: Date
+    /// Filenames are relative to the journal's own directory so records stay
+    /// valid if Application Support is relocated.
+    var primaryMicFilename: String?
+    var micSegments: [SegmentRecord]
+    var systemAudioFilename: String?
+    /// Set when finalization completed: the merged file, or the primary.
+    var finalMicFilename: String?
+}
+
+final class MeetingRecordingJournalStore: @unchecked Sendable {
+    static let filenameSuffix = ".recording.json"
+
+    private let directory: URL
+    private let queue = DispatchQueue(label: "com.transcripted.recording-journal", qos: .utility)
+    private var journalURL: URL?
+    private var journal: MeetingRecordingJournal?
+
+    init(directory: URL) {
+        self.directory = directory
+    }
+
+    func begin(primaryMicURL: URL, startedAt: Date = Date()) {
+        queue.async {
+            let name = primaryMicURL.deletingPathExtension().lastPathComponent + Self.filenameSuffix
+            self.journalURL = self.directory.appendingPathComponent(name)
+            self.journal = MeetingRecordingJournal(
+                version: 1,
+                state: .recording,
+                startedAt: startedAt,
+                updatedAt: startedAt,
+                primaryMicFilename: primaryMicURL.lastPathComponent,
+                micSegments: [MeetingRecordingJournal.SegmentRecord(
+                    filename: primaryMicURL.lastPathComponent,
+                    gapBefore: 0
+                )],
+                systemAudioFilename: nil,
+                finalMicFilename: nil
+            )
+            self.persistLocked()
+        }
+    }
+
+    func recordSystemAudio(_ url: URL) {
+        mutate { $0.systemAudioFilename = url.lastPathComponent }
+    }
+
+    func recordSegments(_ segments: [MicRecordingSegment]) {
+        let records = segments.map {
+            MeetingRecordingJournal.SegmentRecord(
+                filename: $0.url.lastPathComponent,
+                gapBefore: $0.gapBeforeDuration
+            )
+        }
+        mutate { $0.micSegments = records }
+    }
+
+    func markStopping() {
+        mutate { $0.state = .stopping }
+    }
+
+    func markFinalized(finalMicURL: URL?) {
+        mutate {
+            $0.state = .finalized
+            $0.finalMicFilename = finalMicURL?.lastPathComponent
+        }
+    }
+
+    /// The meeting reached a durable state elsewhere; the journal's job is done.
+    func clear() {
+        queue.async {
+            if let url = self.journalURL {
+                try? FileManager.default.removeItem(at: url)
+            }
+            self.journal = nil
+            self.journalURL = nil
+        }
+    }
+
+    /// Blocks until queued writes have hit disk. Test seam.
+    func flush() {
+        queue.sync {}
+    }
+
+    private func mutate(_ change: @escaping (inout MeetingRecordingJournal) -> Void) {
+        queue.async {
+            guard var journal = self.journal else { return }
+            change(&journal)
+            journal.updatedAt = Date()
+            self.journal = journal
+            self.persistLocked()
+        }
+    }
+
+    private func persistLocked() {
+        guard let journal, let journalURL else { return }
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        do {
+            let data = try encoder.encode(journal)
+            try data.write(to: journalURL, options: .atomic)
+            FileManager.default.restrictToOwnerOnly(atPath: journalURL.path)
+        } catch {
+            AppLogger.audio.warning("Failed to persist recording journal", [
+                "file": journalURL.lastPathComponent,
+                "error": error.localizedDescription
+            ])
+        }
+    }
+
+    // MARK: - Recovery + handoff helpers
+
+    static func journalURLs(in directory: URL) -> [URL] {
+        let urls = (try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )) ?? []
+        return urls.filter { $0.lastPathComponent.hasSuffix(filenameSuffix) }
+    }
+
+    static func load(at url: URL) -> MeetingRecordingJournal? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(MeetingRecordingJournal.self, from: data)
+    }
+
+    /// Removes the journal matching a meeting's mic audio file, tolerating the
+    /// `_merged` rename the segment merger applies.
+    static func removeJournal(forMicAudioURL micURL: URL) {
+        let directory = micURL.deletingLastPathComponent()
+        let stem = micURL.deletingPathExtension().lastPathComponent
+        var candidates = [stem]
+        if stem.hasSuffix("_merged") {
+            candidates.append(String(stem.dropLast("_merged".count)))
+        }
+        for candidate in candidates {
+            let journalURL = directory.appendingPathComponent(candidate + filenameSuffix)
+            if FileManager.default.fileExists(atPath: journalURL.path) {
+                try? FileManager.default.removeItem(at: journalURL)
+                AppLogger.audio.debug("Removed recording journal after durable handoff", [
+                    "file": journalURL.lastPathComponent
+                ])
+            }
+        }
+    }
+}

--- a/Sources/TranscriptedCore/Audio/MicRecordingFileMerger.swift
+++ b/Sources/TranscriptedCore/Audio/MicRecordingFileMerger.swift
@@ -1,14 +1,59 @@
 import Foundation
 @preconcurrency import AVFoundation
 
+struct MicRecordingMergeOutcome {
+    let url: URL?
+    let segmentCount: Int
+    /// Segments that contributed at least one frame of real audio.
+    let appendedSegments: Int
+    /// Segments dropped entirely (missing, unreadable after repair, or empty).
+    let skippedSegments: Int
+    /// Segments whose unfinalized WAV header was patched before reading.
+    let repairedSegments: Int
+    /// Segments that failed mid-read and had their remainder padded with silence.
+    let paddedSegments: Int
+
+    /// True when every recorded frame made it into the merged file. When false,
+    /// the source segment files are kept on disk for recovery.
+    var isFullFidelity: Bool { skippedSegments == 0 && paddedSegments == 0 }
+
+    static func passthrough(url: URL?, segmentCount: Int) -> MicRecordingMergeOutcome {
+        MicRecordingMergeOutcome(
+            url: url,
+            segmentCount: segmentCount,
+            appendedSegments: 0,
+            skippedSegments: 0,
+            repairedSegments: 0,
+            paddedSegments: 0
+        )
+    }
+}
+
 enum MicRecordingFileMerger {
     private static let outputSampleRate: Double = 16_000
     private static let chunkSize = 16_000 * 30
     private static let chunkDurationSeconds: Double = 30
 
-    static func merge(primaryURL: URL?, segments: [MicRecordingSegment]) throws -> URL? {
-        guard let primaryURL else { return segments.last?.url }
-        guard segments.count > 1 else { return primaryURL }
+    /// Wraps failures writing to the merged output file (disk full, etc.) so
+    /// they abort the merge, unlike source-segment failures which are salvaged.
+    private struct MergedFileWriteError: Error {
+        let underlying: Error
+    }
+
+    private struct SegmentCounters {
+        var appended = 0
+        var skipped = 0
+        var repaired = 0
+        var padded = 0
+    }
+
+    static func merge(primaryURL: URL?, segments: [MicRecordingSegment]) throws -> MicRecordingMergeOutcome {
+        guard let primaryURL else {
+            return .passthrough(url: segments.last?.url, segmentCount: segments.count)
+        }
+        guard segments.count > 1 else {
+            return .passthrough(url: primaryURL, segmentCount: segments.count)
+        }
 
         let mergedFilename = primaryURL.deletingPathExtension().lastPathComponent + "_merged.wav"
         let mergedURL = primaryURL.deletingLastPathComponent().appendingPathComponent(mergedFilename)
@@ -26,64 +71,200 @@ enum MicRecordingFileMerger {
             ])
         }
 
+        let counters: SegmentCounters
         do {
-            let mergedFile = try AVAudioFile(
-                forWriting: mergedURL,
-                settings: outputFormat.settings,
-                commonFormat: outputFormat.commonFormat,
-                interleaved: outputFormat.isInterleaved
-            )
-
-            for (index, segment) in segments.enumerated() {
-                if index > 0 {
-                    let silenceSamples = MicRecordingMergePlan.silenceSampleCount(
-                        before: segment,
-                        sampleRate: outputFormat.sampleRate
-                    )
-                    if silenceSamples > 0 {
-                        try writeSilence(frameCount: silenceSamples, to: mergedFile, format: outputFormat)
-                    }
-                }
-
-                try appendSegment(segment.url, to: mergedFile, outputFormat: outputFormat)
-            }
-
-            FileManager.default.restrictToOwnerOnly(atPath: mergedURL.path)
-            for segment in Set(segments.map(\.url)) {
-                try? FileManager.default.removeItem(at: segment)
-            }
-            return mergedURL
+            counters = try writeMergedFile(at: mergedURL, segments: segments, outputFormat: outputFormat)
+        } catch let error as MergedFileWriteError {
+            try? FileManager.default.removeItem(at: mergedURL)
+            throw error.underlying
         } catch {
             try? FileManager.default.removeItem(at: mergedURL)
             throw error
         }
+
+        // A merged file with no real audio (every segment skipped) is useless;
+        // throwing lets the caller fall back to the primary URL.
+        guard counters.appended > 0 else {
+            try? FileManager.default.removeItem(at: mergedURL)
+            throw PipelineError.emptyAudioFile
+        }
+
+        FileManager.default.restrictToOwnerOnly(atPath: mergedURL.path)
+
+        let outcome = MicRecordingMergeOutcome(
+            url: mergedURL,
+            segmentCount: segments.count,
+            appendedSegments: counters.appended,
+            skippedSegments: counters.skipped,
+            repairedSegments: counters.repaired,
+            paddedSegments: counters.padded
+        )
+
+        if outcome.isFullFidelity {
+            for segment in Set(segments.map(\.url)) {
+                try? FileManager.default.removeItem(at: segment)
+            }
+        }
+
+        return outcome
+    }
+
+    private static func writeMergedFile(
+        at mergedURL: URL,
+        segments: [MicRecordingSegment],
+        outputFormat: AVAudioFormat
+    ) throws -> SegmentCounters {
+        let mergedFile = try AVAudioFile(
+            forWriting: mergedURL,
+            settings: outputFormat.settings,
+            commonFormat: outputFormat.commonFormat,
+            interleaved: outputFormat.isInterleaved
+        )
+        // Finalize the merged file's own header before the caller validates it
+        // or deletes the source segments.
+        defer { mergedFile.close() }
+
+        var counters = SegmentCounters()
+        for (index, segment) in segments.enumerated() {
+            if index > 0 {
+                let silenceSamples = MicRecordingMergePlan.silenceSampleCount(
+                    before: segment,
+                    sampleRate: outputFormat.sampleRate
+                )
+                if silenceSamples > 0 {
+                    try writeSilence(frameCount: silenceSamples, to: mergedFile, format: outputFormat)
+                }
+            }
+
+            try appendSegmentSalvaging(
+                segment.url,
+                to: mergedFile,
+                outputFormat: outputFormat,
+                counters: &counters
+            )
+        }
+        return counters
+    }
+
+    /// Appends one segment, downgrading source-side failures to skips or
+    /// silence padding so a single bad segment cannot abort the whole merge
+    /// and silently drop every other segment's audio. Output-side failures
+    /// still propagate via `MergedFileWriteError`.
+    private static func appendSegmentSalvaging(
+        _ url: URL,
+        to outputFile: AVAudioFile,
+        outputFormat: AVAudioFormat,
+        counters: inout SegmentCounters
+    ) throws {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            counters.skipped += 1
+            AppLogger.audioMic.warning("Skipping missing mic segment during merge", [
+                "file": url.lastPathComponent
+            ])
+            return
+        }
+
+        // A crashed or leaked writer leaves the WAV header sizes unpatched,
+        // which reads back as a zero-length file even though the PCM payload
+        // is on disk. Recompute the sizes from the actual file before reading.
+        do {
+            if try WAVHeaderRepair.repairIfNeeded(at: url) {
+                counters.repaired += 1
+                AppLogger.audioMic.warning("Repaired unfinalized mic segment header before merge", [
+                    "file": url.lastPathComponent
+                ])
+            }
+        } catch {
+            // Not parseable as RIFF/WAVE; the open below decides whether the
+            // segment is readable at all.
+        }
+
+        let sourceFile: AVAudioFile
+        do {
+            sourceFile = try AVAudioFile(forReading: url)
+        } catch {
+            counters.skipped += 1
+            AppLogger.audioMic.warning("Skipping unreadable mic segment during merge", [
+                "file": url.lastPathComponent,
+                "error": error.localizedDescription
+            ])
+            return
+        }
+        defer { sourceFile.close() }
+
+        let sourceFormat = sourceFile.processingFormat
+        guard sourceFile.length > 0 else {
+            counters.skipped += 1
+            AppLogger.audioMic.warning("Skipping empty mic segment during merge", [
+                "file": url.lastPathComponent
+            ])
+            return
+        }
+        guard sourceFile.length <= Int64(AVAudioFrameCount.max),
+              AudioRecordingFormatPolicy.isUsableSampleRate(sourceFormat.sampleRate),
+              AudioRecordingFormatPolicy.isUsableSampleRate(outputFormat.sampleRate),
+              sourceFormat.channelCount > 0 else {
+            counters.skipped += 1
+            AppLogger.audioMic.warning("Skipping mic segment with unusable format during merge", [
+                "file": url.lastPathComponent,
+                "frames": "\(sourceFile.length)",
+                "sampleRate": "\(sourceFormat.sampleRate)",
+                "channels": "\(sourceFormat.channelCount)"
+            ])
+            return
+        }
+
+        let expectedOutputFrames = Int64(
+            (Double(sourceFile.length) / sourceFormat.sampleRate * outputFormat.sampleRate).rounded(.down)
+        )
+        var outputFramesWritten: Int64 = 0
+
+        do {
+            try appendSegment(
+                sourceFile,
+                to: outputFile,
+                outputFormat: outputFormat,
+                outputFramesWritten: &outputFramesWritten
+            )
+            counters.appended += 1
+        } catch let error as MergedFileWriteError {
+            throw error
+        } catch {
+            // Source-side failure partway through. Keep what was read and pad
+            // the remainder with silence so the mic timeline stays aligned
+            // with the system-audio track.
+            if outputFramesWritten > 0 {
+                counters.appended += 1
+            }
+            counters.padded += 1
+            let remaining = max(Int64(0), expectedOutputFrames - outputFramesWritten)
+            if remaining > 0 {
+                try writeSilence(frameCount: Int(remaining), to: outputFile, format: outputFormat)
+            }
+            AppLogger.audioMic.warning("Padded mic segment after mid-read failure during merge", [
+                "file": url.lastPathComponent,
+                "framesKept": "\(outputFramesWritten)",
+                "framesPadded": "\(remaining)",
+                "error": error.localizedDescription
+            ])
+        }
     }
 
     private static func appendSegment(
-        _ url: URL,
+        _ sourceFile: AVAudioFile,
         to outputFile: AVAudioFile,
-        outputFormat: AVAudioFormat
+        outputFormat: AVAudioFormat,
+        outputFramesWritten: inout Int64
     ) throws {
-        let sourceFile = try AVAudioFile(forReading: url)
         let sourceFormat = sourceFile.processingFormat
 
-        guard sourceFile.length > 0 else {
-            throw PipelineError.emptyAudioFile
-        }
-        guard sourceFile.length <= Int64(AVAudioFrameCount.max) else {
-            throw NSError(domain: "MicRecordingFileMerger", code: 4, userInfo: [
-                NSLocalizedDescriptionKey: "Audio segment is too large to merge safely"
-            ])
-        }
-        guard AudioRecordingFormatPolicy.isUsableSampleRate(sourceFormat.sampleRate),
-              AudioRecordingFormatPolicy.isUsableSampleRate(outputFormat.sampleRate),
-              sourceFormat.channelCount > 0 else {
-            throw NSError(domain: "MicRecordingFileMerger", code: 5, userInfo: [
-                NSLocalizedDescriptionKey: "Audio segment has an invalid sample rate or channel count"
-            ])
-        }
         if formatsMatch(sourceFormat, outputFormat) {
-            try appendCompatibleSegment(sourceFile, to: outputFile, format: outputFormat)
+            try appendCompatibleSegment(
+                sourceFile,
+                to: outputFile,
+                format: outputFormat,
+                outputFramesWritten: &outputFramesWritten
+            )
             return
         }
         guard let converter = AVAudioConverter(from: sourceFormat, to: outputFormat) else {
@@ -143,15 +324,20 @@ enum MicRecordingFileMerger {
                 }
             }
 
-            if let conversionError { throw conversionError }
-            if let inputBlockError { throw inputBlockError }
-
             if outputBuffer.frameLength > 0 {
-                try outputFile.write(from: outputBuffer)
+                do {
+                    try outputFile.write(from: outputBuffer)
+                } catch {
+                    throw MergedFileWriteError(underlying: error)
+                }
+                outputFramesWritten += Int64(outputBuffer.frameLength)
                 noProgressIterations = 0
             } else {
                 noProgressIterations += 1
             }
+
+            if let conversionError { throw conversionError }
+            if let inputBlockError { throw inputBlockError }
 
             switch status {
             case .haveData, .inputRanDry:
@@ -185,7 +371,8 @@ enum MicRecordingFileMerger {
     private static func appendCompatibleSegment(
         _ sourceFile: AVAudioFile,
         to outputFile: AVAudioFile,
-        format: AVAudioFormat
+        format: AVAudioFormat,
+        outputFramesWritten: inout Int64
     ) throws {
         while sourceFile.framePosition < sourceFile.length {
             let remainingFrames = sourceFile.length - sourceFile.framePosition
@@ -201,7 +388,12 @@ enum MicRecordingFileMerger {
 
             try sourceFile.read(into: buffer, frameCount: framesToRead)
             if buffer.frameLength > 0 {
-                try outputFile.write(from: buffer)
+                do {
+                    try outputFile.write(from: buffer)
+                } catch {
+                    throw MergedFileWriteError(underlying: error)
+                }
+                outputFramesWritten += Int64(buffer.frameLength)
             }
         }
     }
@@ -229,7 +421,11 @@ enum MicRecordingFileMerger {
                 channelData.initialize(repeating: 0, count: count)
             }
 
-            try file.write(from: buffer)
+            do {
+                try file.write(from: buffer)
+            } catch {
+                throw MergedFileWriteError(underlying: error)
+            }
             remaining -= count
         }
     }

--- a/Sources/TranscriptedCore/Audio/WAVHeaderRepair.swift
+++ b/Sources/TranscriptedCore/Audio/WAVHeaderRepair.swift
@@ -30,8 +30,12 @@ enum WAVHeaderRepair {
         let dataActualSize: Int
 
         var needsRepair: Bool {
-            dataDeclaredSize != UInt32(clamping: dataActualSize)
-                || riffDeclaredSize != UInt32(clamping: fileSize - 8)
+            // Only the two states a crashed/truncated writer produces. A
+            // declared size that is nonzero but smaller than the remaining
+            // bytes is legal — metadata chunks may follow the data chunk —
+            // and "repairing" it would decode that metadata as PCM.
+            if dataDeclaredSize == 0 { return dataActualSize > 0 }
+            return Int(dataDeclaredSize) > dataActualSize
         }
     }
 

--- a/Sources/TranscriptedCore/Audio/WAVHeaderRepair.swift
+++ b/Sources/TranscriptedCore/Audio/WAVHeaderRepair.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+enum WAVHeaderRepairError: Error {
+    case unreadableHeader
+    case notRIFFWave
+    case unsupportedEncoding
+    case missingDataChunk
+}
+
+/// Repairs WAV files whose writer never finalized the RIFF/data chunk sizes.
+///
+/// AVAudioFile only patches the header size fields when the file is closed. A
+/// writer that crashed — or whose deinit ran after a reader already opened the
+/// file — leaves the `data` chunk declared as 0 bytes, so readers see a
+/// zero-length file even though the PCM payload is intact on disk. PCM frames
+/// are fixed-size and append-only, so the true sizes can always be recomputed
+/// from the actual file size.
+enum WAVHeaderRepair {
+    /// Chunk headers always precede the payload; AVAudioFile places `data` at
+    /// 4KB via JUNK/FLLR padding. Scanning further than this means the file is
+    /// not a WAV this app wrote.
+    private static let headerScanLimit = 1 << 20
+
+    struct HeaderInfo {
+        let fileSize: Int
+        let riffDeclaredSize: UInt32
+        let dataSizeFieldOffset: Int
+        let dataDeclaredSize: UInt32
+        /// Payload bytes actually on disk, aligned down to whole PCM frames.
+        let dataActualSize: Int
+
+        var needsRepair: Bool {
+            dataDeclaredSize != UInt32(clamping: dataActualSize)
+                || riffDeclaredSize != UInt32(clamping: fileSize - 8)
+        }
+    }
+
+    /// Patches the RIFF and `data` size fields from the actual file size.
+    /// Returns `true` when the file was modified, `false` when it was already
+    /// consistent. Throws when the file is not parseable PCM RIFF/WAVE.
+    @discardableResult
+    static func repairIfNeeded(at url: URL) throws -> Bool {
+        let info = try probe(at: url)
+        guard info.needsRepair else { return false }
+
+        let handle = try FileHandle(forUpdating: url)
+        defer { try? handle.close() }
+
+        try handle.seek(toOffset: 4)
+        try handle.write(contentsOf: uint32LE(UInt32(clamping: info.fileSize - 8)))
+        try handle.seek(toOffset: UInt64(info.dataSizeFieldOffset))
+        try handle.write(contentsOf: uint32LE(UInt32(clamping: info.dataActualSize)))
+        try handle.synchronize()
+        return true
+    }
+
+    static func probe(at url: URL) throws -> HeaderInfo {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        guard let fileSize = (attributes[.size] as? NSNumber)?.intValue, fileSize >= 44 else {
+            throw WAVHeaderRepairError.unreadableHeader
+        }
+
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        guard let header = try handle.read(upToCount: min(fileSize, headerScanLimit)),
+              header.count >= 44 else {
+            throw WAVHeaderRepairError.unreadableHeader
+        }
+
+        guard fourCC(header, at: 0) == "RIFF", fourCC(header, at: 8) == "WAVE" else {
+            throw WAVHeaderRepairError.notRIFFWave
+        }
+        let riffDeclaredSize = uint32(header, at: 4)
+
+        var formatCode = 0
+        var blockAlign = 0
+        var offset = 12
+        while offset + 8 <= header.count {
+            let chunkID = fourCC(header, at: offset)
+            let declaredSize = Int(uint32(header, at: offset + 4))
+
+            if chunkID == "fmt ", offset + 8 + 16 <= header.count {
+                formatCode = Int(uint16(header, at: offset + 8))
+                blockAlign = Int(uint16(header, at: offset + 8 + 12))
+            }
+
+            if chunkID == "data" {
+                // Linear PCM (1), IEEE float (3), or WAVE_FORMAT_EXTENSIBLE.
+                guard blockAlign > 0, [1, 3, 0xFFFE].contains(formatCode) else {
+                    throw WAVHeaderRepairError.unsupportedEncoding
+                }
+                let dataStart = offset + 8
+                guard dataStart <= fileSize else {
+                    throw WAVHeaderRepairError.missingDataChunk
+                }
+                let payload = fileSize - dataStart
+                return HeaderInfo(
+                    fileSize: fileSize,
+                    riffDeclaredSize: riffDeclaredSize,
+                    dataSizeFieldOffset: offset + 4,
+                    dataDeclaredSize: uint32(header, at: offset + 4),
+                    dataActualSize: payload - payload % blockAlign
+                )
+            }
+
+            offset += 8 + declaredSize + (declaredSize & 1)
+        }
+
+        throw WAVHeaderRepairError.missingDataChunk
+    }
+
+    private static func fourCC(_ data: Data, at offset: Int) -> String {
+        guard offset + 4 <= data.count else { return "" }
+        return String(decoding: data.subdata(in: offset..<offset + 4), as: UTF8.self)
+    }
+
+    private static func uint32(_ data: Data, at offset: Int) -> UInt32 {
+        guard offset + 4 <= data.count else { return 0 }
+        return data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: offset, as: UInt32.self) }
+    }
+
+    private static func uint16(_ data: Data, at offset: Int) -> UInt16 {
+        guard offset + 2 <= data.count else { return 0 }
+        return data.withUnsafeBytes { $0.loadUnaligned(fromByteOffset: offset, as: UInt16.self) }
+    }
+
+    private static func uint32LE(_ value: UInt32) -> Data {
+        withUnsafeBytes(of: value.littleEndian) { Data($0) }
+    }
+}

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -797,6 +797,13 @@ public class TranscriptionTaskManager: ObservableObject {
             }
             return false
         }
+
+        // The failed-queue entry is durable — the crash-recovery journal next
+        // to the original scratch audio is no longer needed.
+        if let originalMicURL {
+            MeetingRecordingJournalStore.removeJournal(forMicAudioURL: originalMicURL)
+        }
+
         guard removeOriginalsAfterArchive else { return true }
 
         if retainedAudio?.micURL != nil {
@@ -808,6 +815,154 @@ public class TranscriptionTaskManager: ObservableObject {
             removeManagedCleanupFile(originalSystemURL, label: "archived failed system scratch")
         }
         return true
+    }
+
+    // MARK: - Orphaned Recording Recovery
+
+    /// Outcome of inspecting one leftover recording journal at launch.
+    private struct OrphanedRecordingCandidate: Sendable {
+        enum Disposition: Sendable {
+            case stale(reason: String)
+            case skip(reason: String)
+            case recover(micURL: URL?, systemURL: URL?, startedAt: Date)
+        }
+        let journalURL: URL
+        let disposition: Disposition
+    }
+
+    /// Audio files written within this window are treated as live: another
+    /// Transcripted process (a dev build next to production) could be
+    /// recording into the same scratch directory right now.
+    nonisolated private static let orphanedRecordingLivenessWindow: TimeInterval = 120
+
+    /// Scans the recordings scratch directory for journals left behind by a
+    /// previous process and turns their audio into visible, retryable
+    /// failed-queue entries. This is the only path that recovers a meeting
+    /// whose preservation code never ran (crash, force-kill, power loss).
+    @discardableResult
+    public func recoverOrphanedRecordings(in scratchDirectory: URL) async -> Int {
+        let candidates = await Task.detached(priority: .utility) {
+            Self.collectOrphanedRecordingCandidates(in: scratchDirectory)
+        }.value
+
+        var recovered = 0
+        for candidate in candidates {
+            switch candidate.disposition {
+            case .skip(let reason):
+                AppLogger.pipeline.info("Left recording journal in place", [
+                    "file": candidate.journalURL.lastPathComponent,
+                    "reason": reason
+                ])
+            case .stale(let reason):
+                try? FileManager.default.removeItem(at: candidate.journalURL)
+                AppLogger.pipeline.info("Removed stale recording journal", [
+                    "file": candidate.journalURL.lastPathComponent,
+                    "reason": reason
+                ])
+            case .recover(let micURL, let systemURL, let startedAt):
+                let didPersist = addFailedTranscriptionRetainingAvailableAudio(
+                    micAudioURL: micURL,
+                    systemAudioURL: systemURL,
+                    errorMessage: "Recording was interrupted before it could be saved. The recovered audio is ready to transcribe.",
+                    recordingDate: startedAt,
+                    archiveAudio: true
+                )
+                if didPersist {
+                    try? FileManager.default.removeItem(at: candidate.journalURL)
+                    recovered += 1
+                    AppLogger.pipeline.info("Recovered orphaned recording into failed queue", [
+                        "journal": candidate.journalURL.lastPathComponent,
+                        "hasMic": "\(micURL != nil)",
+                        "hasSystem": "\(systemURL != nil)"
+                    ])
+                }
+            }
+        }
+        if !candidates.isEmpty {
+            AppLogger.pipeline.info("Recording journal scan finished", [
+                "journals": "\(candidates.count)",
+                "recovered": "\(recovered)"
+            ])
+        }
+        return recovered
+    }
+
+    nonisolated private static func collectOrphanedRecordingCandidates(in directory: URL) -> [OrphanedRecordingCandidate] {
+        MeetingRecordingJournalStore.journalURLs(in: directory).compactMap {
+            inspectOrphanedRecordingJournal(at: $0, directory: directory)
+        }
+    }
+
+    nonisolated private static func inspectOrphanedRecordingJournal(
+        at journalURL: URL,
+        directory: URL
+    ) -> OrphanedRecordingCandidate? {
+        guard let journal = MeetingRecordingJournalStore.load(at: journalURL) else {
+            return OrphanedRecordingCandidate(journalURL: journalURL, disposition: .stale(reason: "unreadable journal"))
+        }
+
+        // Journals store bare filenames; resolve them inside the scratch
+        // directory only so a tampered journal cannot point recovery at
+        // arbitrary files.
+        func resolve(_ filename: String?) -> URL? {
+            guard let filename, !filename.isEmpty,
+                  !filename.contains("/"), !filename.contains("..") else { return nil }
+            let url = directory.appendingPathComponent(filename)
+            return FileManager.default.fileExists(atPath: url.path) ? url : nil
+        }
+
+        let primaryURL = resolve(journal.primaryMicFilename)
+        let segmentRecords = journal.micSegments.compactMap { record -> MicRecordingSegment? in
+            guard let url = resolve(record.filename) else { return nil }
+            return MicRecordingSegment(url: url, gapBeforeDuration: record.gapBefore)
+        }
+        let systemURL = resolve(journal.systemAudioFilename)
+        let finalURL = resolve(journal.finalMicFilename)
+        let mergedSibling: URL? = journal.primaryMicFilename.flatMap { primaryName in
+            resolve((primaryName as NSString).deletingPathExtension + "_merged.wav")
+        }
+
+        let allAudio = ([primaryURL, systemURL, finalURL, mergedSibling] + segmentRecords.map(\.url))
+            .compactMap { $0 }
+        guard !allAudio.isEmpty else {
+            return OrphanedRecordingCandidate(journalURL: journalURL, disposition: .stale(reason: "no audio files remain"))
+        }
+
+        let liveCutoff = Date().addingTimeInterval(-orphanedRecordingLivenessWindow)
+        for url in allAudio {
+            let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+            if let modified = attributes?[.modificationDate] as? Date, modified > liveCutoff {
+                return OrphanedRecordingCandidate(journalURL: journalURL, disposition: .skip(reason: "audio recently written"))
+            }
+        }
+
+        // Crash-orphaned WAVs read as zero-length until their headers are repaired.
+        for url in allAudio where url.pathExtension.lowercased() == "wav" {
+            if (try? WAVHeaderRepair.repairIfNeeded(at: url)) == true {
+                AppLogger.pipeline.info("Repaired orphaned recording WAV header", [
+                    "file": url.lastPathComponent
+                ])
+            }
+        }
+
+        var micURL = finalURL ?? mergedSibling
+        if micURL == nil, segmentRecords.count > 1 {
+            micURL = (try? MicRecordingFileMerger.merge(
+                primaryURL: primaryURL ?? segmentRecords[0].url,
+                segments: segmentRecords
+            ))?.url
+        }
+        if micURL == nil {
+            micURL = primaryURL ?? segmentRecords.first?.url
+        }
+
+        guard micURL != nil || systemURL != nil else {
+            return OrphanedRecordingCandidate(journalURL: journalURL, disposition: .stale(reason: "no usable audio"))
+        }
+        return OrphanedRecordingCandidate(
+            journalURL: journalURL,
+            disposition: .recover(micURL: micURL, systemURL: systemURL, startedAt: journal.startedAt)
+        )
     }
 
     private func removeRetainedFailedAudio(_ retainedAudio: RetainedRecordingAudio) {
@@ -1045,6 +1200,11 @@ public class TranscriptionTaskManager: ObservableObject {
 
     func markTaskTranscriptCommitted(taskId: UUID) {
         committedTranscriptTaskIds.insert(taskId)
+        // Transcript is durably on disk — the crash-recovery journal for this
+        // recording's scratch audio is no longer needed.
+        if let micURL = activeTaskAudio[taskId]?.micURL {
+            MeetingRecordingJournalStore.removeJournal(forMicAudioURL: micURL)
+        }
     }
 
     private func finishCancelledTaskIfNeeded(taskId: UUID, error: Error? = nil) -> Bool {

--- a/Sources/TranscriptedCore/Services/DiarizationService.swift
+++ b/Sources/TranscriptedCore/Services/DiarizationService.swift
@@ -53,6 +53,7 @@ public class DiarizationService: ObservableObject {
     private var offlineDiarizerManager: OfflineDiarizerManager?
     private var offlineModelState: DiarizationModelState = .notLoaded
     private var optionalStreamingWarmupTask: Task<Void, Never>?
+    private var offlineInitializationTask: Task<Void, Never>?
 
     /// Provider that resolves bundled model directories. Embedders can swap this to
     /// redirect lookups (e.g. a shared cache in Application Support). Returning `nil`
@@ -77,6 +78,26 @@ public class DiarizationService: ObservableObject {
             return
         }
 
+        // Deduplicate concurrent loads. Warmup and queued-job recovery can
+        // both call initialize(); without dedup they interleave at the await,
+        // double-load the models, and a losing duplicate that throws would
+        // overwrite modelState to .failed even though the first load
+        // succeeded.
+        if let inFlight = offlineInitializationTask {
+            AppLogger.transcription.debug("Awaiting in-flight offline diarization initialization")
+            await inFlight.value
+            return
+        }
+
+        let task = Task {
+            await self.performOfflineInitialization()
+            self.offlineInitializationTask = nil
+        }
+        offlineInitializationTask = task
+        await task.value
+    }
+
+    private func performOfflineInitialization() async {
         modelState = .loading
         AppLogger.transcription.info("Diarization initializing offline models")
 

--- a/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
+++ b/Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift
@@ -66,12 +66,37 @@ public class FailedTranscriptionManager: ObservableObject {
                 return micSafe && systemSafe
             }
 
-            // Filter out entries where audio files no longer exist
-            failedTranscriptions = sandboxedEntries.filter { $0.audioFilesExist() }
+            // Heal stale audio references before the existence filter. A crash
+            // between the merger's segment cleanup and the queue repoint leaves
+            // an entry pointing at a deleted pre-merge WAV while
+            // `<stem>_merged.wav` sits on disk — dropping that entry here would
+            // make the meeting disappear permanently.
+            var healedCount = 0
+            let healedEntries = sandboxedEntries.map { entry in
+                let healed = healAudioReferences(of: entry)
+                if healed != nil { healedCount += 1 }
+                return healed ?? entry
+            }
 
-            // Save back if we filtered any out
-            if failedTranscriptions.count != loaded.count {
-                AppLogger.pipeline.info("Removed entries with missing audio files or unsafe paths", ["count": "\(loaded.count - failedTranscriptions.count)"])
+            // Filter out entries where audio files no longer exist
+            failedTranscriptions = healedEntries.filter { entry in
+                guard entry.audioFilesExist() else {
+                    AppLogger.pipeline.error("Dropping failed transcription entry with missing audio", [
+                        "id": entry.id.uuidString,
+                        "micFile": entry.micAudioURL.lastPathComponent,
+                        "systemFile": entry.systemAudioURL?.lastPathComponent ?? "none"
+                    ])
+                    return false
+                }
+                return true
+            }
+
+            // Save back if we filtered or healed any
+            if failedTranscriptions.count != loaded.count || healedCount > 0 {
+                AppLogger.pipeline.info("Reconciled failed transcription entries on load", [
+                    "removed": "\(loaded.count - failedTranscriptions.count)",
+                    "healed": "\(healedCount)"
+                ])
                 saveFailedTranscriptions()
             }
 
@@ -89,6 +114,83 @@ public class FailedTranscriptionManager: ObservableObject {
                 ])
             }
             AppLogger.pipeline.error("Corrupt failed transcriptions file, backed up", ["error": "\(error)"])
+        }
+    }
+
+    /// Repairs an entry whose audio references no longer match the disk state.
+    /// Returns the healed entry, or nil when nothing needed healing.
+    private func healAudioReferences(of entry: FailedTranscription) -> FailedTranscription? {
+        let fileManager = FileManager.default
+        var micURL = entry.micAudioURL
+        var systemURL = entry.systemAudioURL
+        var didHeal = false
+
+        // A merge that completed after the entry was written deletes the
+        // pre-merge segments and leaves `<stem>_merged.wav` in their place.
+        if !fileManager.fileExists(atPath: micURL.path) {
+            let mergedCandidate = micURL.deletingLastPathComponent()
+                .appendingPathComponent(micURL.deletingPathExtension().lastPathComponent + "_merged.wav")
+            if fileManager.fileExists(atPath: mergedCandidate.path), isSafeAudioURL(mergedCandidate) {
+                micURL = mergedCandidate
+                didHeal = true
+                AppLogger.pipeline.info("Healed failed transcription mic audio to merged file", [
+                    "id": entry.id.uuidString,
+                    "file": mergedCandidate.lastPathComponent
+                ])
+            }
+        }
+
+        // Keep the meeting retryable with mic audio only rather than dropping
+        // it because the system-audio file went missing.
+        if let existingSystemURL = systemURL,
+           !fileManager.fileExists(atPath: existingSystemURL.path),
+           fileManager.fileExists(atPath: micURL.path) {
+            systemURL = nil
+            didHeal = true
+            AppLogger.pipeline.warning("Dropped missing system audio reference from failed transcription", [
+                "id": entry.id.uuidString,
+                "file": existingSystemURL.lastPathComponent
+            ])
+        }
+
+        // Audio preserved during a quit that interrupted finalization can have
+        // an unpatched WAV header, which reads back as zero-length and makes
+        // every retry fail. Nothing else re-runs finalization after relaunch.
+        repairWAVHeaderIfNeeded(at: micURL, entryId: entry.id)
+        if let systemURL {
+            repairWAVHeaderIfNeeded(at: systemURL, entryId: entry.id)
+        }
+
+        guard didHeal else { return nil }
+        return FailedTranscription(
+            id: entry.id,
+            timestamp: entry.timestamp,
+            recordingDate: entry.recordingDate,
+            micAudioURL: micURL,
+            systemAudioURL: systemURL,
+            errorMessage: entry.errorMessage,
+            meetingTitle: entry.meetingTitle,
+            retryCount: entry.retryCount,
+            lastRetryDate: entry.lastRetryDate
+        )
+    }
+
+    private func repairWAVHeaderIfNeeded(at url: URL, entryId: UUID) {
+        guard url.pathExtension.lowercased() == "wav",
+              FileManager.default.fileExists(atPath: url.path) else { return }
+        do {
+            if try WAVHeaderRepair.repairIfNeeded(at: url) {
+                AppLogger.pipeline.info("Repaired unfinalized WAV header for failed transcription audio", [
+                    "id": entryId.uuidString,
+                    "file": url.lastPathComponent
+                ])
+            }
+        } catch {
+            AppLogger.pipeline.warning("Could not inspect failed transcription WAV header", [
+                "id": entryId.uuidString,
+                "file": url.lastPathComponent,
+                "error": error.localizedDescription
+            ])
         }
     }
 
@@ -294,6 +396,21 @@ public class FailedTranscriptionManager: ObservableObject {
             return
         }
 
+        // Persist the entry removal before touching audio files. Deleting
+        // audio first means a crash in between leaves entries pointing at
+        // missing files, which the load filter then drops silently.
+        let removedIds = Set(oldFailures.map { $0.id })
+        let previousEntries = failedTranscriptions
+        failedTranscriptions.removeAll { removedIds.contains($0.id) }
+        guard saveFailedTranscriptions() else {
+            failedTranscriptions = previousEntries
+            AppLogger.pipeline.error("Skipped old failed transcription cleanup because removal did not persist", [
+                "count": "\(oldFailures.count)",
+                "olderThanDays": "\(days)"
+            ])
+            return
+        }
+
         for failure in oldFailures {
             removeAudioFile(failure.micAudioURL, label: "old failure mic audio")
             if let systemURL = failure.systemAudioURL {
@@ -304,10 +421,6 @@ public class FailedTranscriptionManager: ObservableObject {
                 removeEmptyAudioArchiveDirectoryIfNeeded(containing: systemURL)
             }
         }
-
-        let removedIds = Set(oldFailures.map { $0.id })
-        failedTranscriptions.removeAll { removedIds.contains($0.id) }
-        saveFailedTranscriptions()
 
         AppLogger.pipeline.info("Cleaned up old failed transcriptions", ["count": "\(oldFailures.count)", "olderThanDays": "\(days)"])
     }

--- a/Tests/TranscriptedCoreTests/AudioFileManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioFileManagerTests.swift
@@ -481,7 +481,7 @@ final class AudioFileManagerTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: recovery.path))
     }
 
-    func testFinalizeMicRecordingFallsBackToPrimaryWhenMergeFails() throws {
+    func testFinalizeMicRecordingSalvagesAroundMissingSegment() throws {
         let root = makeRoot()
         defer { try? FileManager.default.removeItem(at: root) }
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -491,8 +491,31 @@ final class AudioFileManagerTests: XCTestCase {
         let missing = root.appendingPathComponent("does-not-exist.wav")
         try writeMonoWAV(to: primary, sampleRate: 48_000, samples: Array(repeating: 0.4, count: 4_800))
 
-        // The merger throws when a segment file is missing; finalizeMicRecording
-        // (AudioFileManager.swift:415) swallows the error and returns the primary.
+        // The merger skips the missing segment instead of aborting, so the
+        // primary's audio still lands in a merged file. Degraded salvage keeps
+        // the source segment on disk for recovery.
+        let result = try XCTUnwrap(audio.finalizeMicRecording(
+            primaryURL: primary,
+            segments: [
+                MicRecordingSegment(url: primary),
+                MicRecordingSegment(url: missing)
+            ]
+        ))
+        XCTAssertEqual(result.lastPathComponent, "primary_merged.wav")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: result.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: primary.path))
+    }
+
+    func testFinalizeMicRecordingFallsBackToPrimaryWhenNothingIsMergeable() throws {
+        let root = makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let audio = makeAudio(root: root)
+
+        // Neither segment exists, so the merger throws and finalizeMicRecording
+        // swallows the error and returns the primary URL unchanged.
+        let primary = root.appendingPathComponent("primary.wav")
+        let missing = root.appendingPathComponent("does-not-exist.wav")
         let result = audio.finalizeMicRecording(
             primaryURL: primary,
             segments: [

--- a/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
+++ b/Tests/TranscriptedCoreTests/FailedTranscriptionManagerTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import XCTest
 @testable import TranscriptedCore
 
@@ -438,6 +439,133 @@ final class FailedTranscriptionManagerTests: XCTestCase {
         )
 
         XCTAssertFalse(failure.isRetryable)
+    }
+
+    func testLoadHealsMissingMicAudioToMergedSibling() throws {
+        let paths = makePaths(root: testRoot)
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+
+        // The pre-merge mic WAV was deleted by a completed merge, but the app
+        // died before the queue entry was repointed at the merged file.
+        let missingMicURL = paths.audioCaptures.appendingPathComponent("meeting-mic.wav")
+        let mergedSiblingURL = paths.audioCaptures.appendingPathComponent("meeting-mic_merged.wav")
+        FileManager.default.createFile(atPath: mergedSiblingURL.path, contents: Data("merged".utf8))
+
+        let entry = FailedTranscription(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            micAudioURL: missingMicURL,
+            systemAudioURL: nil,
+            errorMessage: "Recording stop timed out"
+        )
+        try writeQueue([entry], to: paths)
+
+        let manager = FailedTranscriptionManager(paths: paths)
+
+        XCTAssertEqual(manager.failedTranscriptions.count, 1)
+        XCTAssertEqual(manager.failedTranscriptions.first?.id, entry.id)
+        XCTAssertEqual(manager.failedTranscriptions.first?.micAudioURL, mergedSiblingURL)
+
+        // The heal must be durable, not just in-memory.
+        let persisted = try JSONDecoder.iso8601.decode(
+            [FailedTranscription].self,
+            from: Data(contentsOf: paths.failedQueue)
+        )
+        XCTAssertEqual(persisted.first?.micAudioURL, mergedSiblingURL)
+    }
+
+    func testLoadKeepsEntryWithMicOnlyWhenSystemAudioIsMissing() throws {
+        let paths = makePaths(root: testRoot)
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+
+        let micURL = paths.audioCaptures.appendingPathComponent("meeting-mic.wav")
+        FileManager.default.createFile(atPath: micURL.path, contents: Data("mic".utf8))
+        let missingSystemURL = paths.audioCaptures.appendingPathComponent("meeting-system.wav")
+
+        let entry = FailedTranscription(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            micAudioURL: micURL,
+            systemAudioURL: missingSystemURL,
+            errorMessage: "Recording stop timed out"
+        )
+        try writeQueue([entry], to: paths)
+
+        let manager = FailedTranscriptionManager(paths: paths)
+
+        XCTAssertEqual(manager.failedTranscriptions.count, 1)
+        XCTAssertEqual(manager.failedTranscriptions.first?.micAudioURL, micURL)
+        XCTAssertNil(manager.failedTranscriptions.first?.systemAudioURL)
+    }
+
+    func testLoadRepairsUnfinalizedWAVHeader() throws {
+        let paths = makePaths(root: testRoot)
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+
+        let micURL = paths.audioCaptures.appendingPathComponent("meeting-mic.wav")
+        try writeMonoWAV(to: micURL, sampleRate: 48_000, samples: Array(repeating: 0.5, count: 9_600))
+        try corruptHeaderSizes(at: micURL)
+        XCTAssertEqual(try AVAudioFile(forReading: micURL).length, 0)
+
+        let entry = FailedTranscription(
+            id: UUID(),
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            micAudioURL: micURL,
+            systemAudioURL: nil,
+            errorMessage: "Audio was preserved before quit"
+        )
+        try writeQueue([entry], to: paths)
+
+        let manager = FailedTranscriptionManager(paths: paths)
+
+        XCTAssertEqual(manager.failedTranscriptions.count, 1)
+        XCTAssertEqual(try AVAudioFile(forReading: micURL).length, 9_600)
+    }
+
+    private func writeQueue(_ entries: [FailedTranscription], to paths: CoreStoragePaths) throws {
+        try FileManager.default.createDirectory(
+            at: paths.failedQueue.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try JSONEncoder.iso8601.encode(entries).write(to: paths.failedQueue, options: .atomic)
+    }
+
+    private func writeMonoWAV(to url: URL, sampleRate: Double, samples: [Float]) throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        ))
+        let file = try AVAudioFile(
+            forWriting: url,
+            settings: format.settings,
+            commonFormat: format.commonFormat,
+            interleaved: format.isInterleaved
+        )
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(samples.count)
+        ))
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        let channelData = try XCTUnwrap(buffer.floatChannelData?[0])
+        samples.withUnsafeBufferPointer { pointer in
+            guard let baseAddress = pointer.baseAddress else { return }
+            channelData.update(from: baseAddress, count: samples.count)
+        }
+        try file.write(from: buffer)
+        file.close()
+    }
+
+    private func corruptHeaderSizes(at url: URL) throws {
+        let info = try WAVHeaderRepair.probe(at: url)
+        let handle = try FileHandle(forUpdating: url)
+        defer { try? handle.close() }
+        let headerOnlyRIFFSize = UInt32(info.dataSizeFieldOffset - 4)
+        try handle.seek(toOffset: 4)
+        try handle.write(contentsOf: withUnsafeBytes(of: headerOnlyRIFFSize.littleEndian) { Data($0) })
+        try handle.seek(toOffset: UInt64(info.dataSizeFieldOffset))
+        try handle.write(contentsOf: Data([0, 0, 0, 0]))
     }
 
     private func makePaths(root: URL) -> CoreStoragePaths {

--- a/Tests/TranscriptedCoreTests/MeetingRecordingJournalTests.swift
+++ b/Tests/TranscriptedCoreTests/MeetingRecordingJournalTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import TranscriptedCore
+
+final class MeetingRecordingJournalTests: XCTestCase {
+    private var temporaryDirectory: URL!
+
+    override func setUpWithError() throws {
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MeetingRecordingJournalTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let temporaryDirectory {
+            try? FileManager.default.removeItem(at: temporaryDirectory)
+        }
+        temporaryDirectory = nil
+    }
+
+    func testLifecycleWritesStatesAndClearRemoves() throws {
+        let store = MeetingRecordingJournalStore(directory: temporaryDirectory)
+        let micURL = temporaryDirectory.appendingPathComponent("meeting_2026_mic.wav")
+        let journalURL = temporaryDirectory.appendingPathComponent("meeting_2026_mic.recording.json")
+
+        store.begin(primaryMicURL: micURL, startedAt: Date(timeIntervalSince1970: 1_000))
+        store.flush()
+        var journal = try XCTUnwrap(MeetingRecordingJournalStore.load(at: journalURL))
+        XCTAssertEqual(journal.state, .recording)
+        XCTAssertEqual(journal.primaryMicFilename, "meeting_2026_mic.wav")
+        XCTAssertEqual(journal.micSegments.map(\.filename), ["meeting_2026_mic.wav"])
+
+        store.recordSystemAudio(temporaryDirectory.appendingPathComponent("meeting_2026_system.wav"))
+        store.recordSegments([
+            MicRecordingSegment(url: micURL),
+            MicRecordingSegment(url: temporaryDirectory.appendingPathComponent("recovery.wav"), gapBeforeDuration: 1.5)
+        ])
+        store.markStopping()
+        store.flush()
+        journal = try XCTUnwrap(MeetingRecordingJournalStore.load(at: journalURL))
+        XCTAssertEqual(journal.state, .stopping)
+        XCTAssertEqual(journal.systemAudioFilename, "meeting_2026_system.wav")
+        XCTAssertEqual(journal.micSegments.map(\.filename), ["meeting_2026_mic.wav", "recovery.wav"])
+        XCTAssertEqual(journal.micSegments.last?.gapBefore ?? 0, 1.5, accuracy: 0.001)
+
+        store.markFinalized(finalMicURL: temporaryDirectory.appendingPathComponent("meeting_2026_mic_merged.wav"))
+        store.flush()
+        journal = try XCTUnwrap(MeetingRecordingJournalStore.load(at: journalURL))
+        XCTAssertEqual(journal.state, .finalized)
+        XCTAssertEqual(journal.finalMicFilename, "meeting_2026_mic_merged.wav")
+
+        store.clear()
+        store.flush()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journalURL.path))
+    }
+
+    func testJournalURLsFindsOnlyJournalFiles() throws {
+        FileManager.default.createFile(
+            atPath: temporaryDirectory.appendingPathComponent("a.recording.json").path,
+            contents: Data()
+        )
+        FileManager.default.createFile(
+            atPath: temporaryDirectory.appendingPathComponent("b.wav").path,
+            contents: Data()
+        )
+
+        let found = MeetingRecordingJournalStore.journalURLs(in: temporaryDirectory)
+        XCTAssertEqual(found.map(\.lastPathComponent), ["a.recording.json"])
+    }
+
+    func testRemoveJournalMatchesMergedStem() throws {
+        let journalURL = temporaryDirectory.appendingPathComponent("meeting_2026_mic.recording.json")
+        FileManager.default.createFile(atPath: journalURL.path, contents: Data())
+
+        // The durable handoff often sees the merged file, not the original.
+        MeetingRecordingJournalStore.removeJournal(
+            forMicAudioURL: temporaryDirectory.appendingPathComponent("meeting_2026_mic_merged.wav")
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journalURL.path))
+    }
+
+    func testRemoveJournalMatchesExactStem() throws {
+        let journalURL = temporaryDirectory.appendingPathComponent("meeting_2026_mic.recording.json")
+        FileManager.default.createFile(atPath: journalURL.path, contents: Data())
+
+        MeetingRecordingJournalStore.removeJournal(
+            forMicAudioURL: temporaryDirectory.appendingPathComponent("meeting_2026_mic.wav")
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journalURL.path))
+    }
+}

--- a/Tests/TranscriptedCoreTests/MicRecordingFileMergerTests.swift
+++ b/Tests/TranscriptedCoreTests/MicRecordingFileMergerTests.swift
@@ -36,16 +36,16 @@ final class MicRecordingFileMergerTests: XCTestCase {
             samples: Array(repeating: 0.2, count: 11_025)
         )
 
-        let mergedURL = try XCTUnwrap(
-            MicRecordingFileMerger.merge(
-                primaryURL: primaryURL,
-                segments: [
-                    MicRecordingSegment(url: primaryURL),
-                    MicRecordingSegment(url: recoveryURL, gapBeforeDuration: 0.15)
-                ]
-            )
+        let outcome = try MicRecordingFileMerger.merge(
+            primaryURL: primaryURL,
+            segments: [
+                MicRecordingSegment(url: primaryURL),
+                MicRecordingSegment(url: recoveryURL, gapBeforeDuration: 0.15)
+            ]
         )
+        let mergedURL = try XCTUnwrap(outcome.url)
 
+        XCTAssertTrue(outcome.isFullFidelity)
         XCTAssertTrue(FileManager.default.fileExists(atPath: mergedURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: primaryURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: recoveryURL.path))
@@ -72,7 +72,7 @@ final class MicRecordingFileMergerTests: XCTestCase {
             MicRecordingFileMerger.merge(
                 primaryURL: primaryURL,
                 segments: [MicRecordingSegment(url: primaryURL)]
-            )
+            ).url
         )
 
         XCTAssertEqual(resolvedURL, primaryURL)
@@ -101,7 +101,7 @@ final class MicRecordingFileMergerTests: XCTestCase {
                     MicRecordingSegment(url: primaryURL),
                     MicRecordingSegment(url: recoveryURL)
                 ]
-            )
+            ).url
         )
 
         let merged = try AudioResampler.loadWAV(url: mergedURL)
@@ -133,7 +133,7 @@ final class MicRecordingFileMergerTests: XCTestCase {
             MicRecordingFileMerger.merge(
                 primaryURL: urls[0],
                 segments: segments
-            )
+            ).url
         )
 
         let merged = try AudioResampler.loadWAV(url: mergedURL)
@@ -147,6 +147,97 @@ final class MicRecordingFileMergerTests: XCTestCase {
         for url in urls {
             XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
         }
+    }
+
+    func testMergeSalvagesAroundMissingMiddleSegment() throws {
+        let primaryURL = temporaryDirectory.appendingPathComponent("primary.wav")
+        let missingURL = temporaryDirectory.appendingPathComponent("vanished.wav")
+        let recoveryURL = temporaryDirectory.appendingPathComponent("recovery.wav")
+
+        try writeMonoWAV(to: primaryURL, sampleRate: 48_000, samples: Array(repeating: 0.3, count: 4_800))
+        try writeMonoWAV(to: recoveryURL, sampleRate: 48_000, samples: Array(repeating: 0.6, count: 4_800))
+
+        let outcome = try MicRecordingFileMerger.merge(
+            primaryURL: primaryURL,
+            segments: [
+                MicRecordingSegment(url: primaryURL),
+                MicRecordingSegment(url: missingURL, gapBeforeDuration: 0.05),
+                MicRecordingSegment(url: recoveryURL, gapBeforeDuration: 0.05)
+            ]
+        )
+
+        XCTAssertEqual(outcome.skippedSegments, 1)
+        XCTAssertEqual(outcome.appendedSegments, 2)
+        XCTAssertFalse(outcome.isFullFidelity)
+
+        // Degraded salvage keeps the source segments on disk for recovery.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: primaryURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recoveryURL.path))
+
+        // Both surviving segments' audio must be present in order:
+        // 1600 frames of 0.3, two 800-frame gaps, then 1600 frames of 0.6.
+        let merged = try AudioResampler.loadWAV(url: try XCTUnwrap(outcome.url))
+        XCTAssertEqual(merged.sampleRate, 16_000, accuracy: 0.5)
+        XCTAssertEqual(average(of: merged.samples, range: 200..<1_400), 0.3, accuracy: 0.02)
+        XCTAssertLessThan(averageAbsolute(of: merged.samples, range: 1_800..<3_000), 0.001)
+        XCTAssertEqual(average(of: merged.samples, range: 3_500..<4_500), 0.6, accuracy: 0.02)
+    }
+
+    func testMergeRepairsSegmentWithUnfinalizedHeader() throws {
+        let primaryURL = temporaryDirectory.appendingPathComponent("primary.wav")
+        let recoveryURL = temporaryDirectory.appendingPathComponent("recovery.wav")
+
+        try writeMonoWAV(to: primaryURL, sampleRate: 48_000, samples: Array(repeating: 0.3, count: 4_800))
+        try writeMonoWAV(to: recoveryURL, sampleRate: 48_000, samples: Array(repeating: 0.6, count: 4_800))
+        try corruptHeaderSizes(at: recoveryURL)
+
+        // The corrupted segment must read as empty without repair — the exact
+        // state a crashed or leaked writer leaves behind.
+        XCTAssertEqual(try AVAudioFile(forReading: recoveryURL).length, 0)
+
+        let outcome = try MicRecordingFileMerger.merge(
+            primaryURL: primaryURL,
+            segments: [
+                MicRecordingSegment(url: primaryURL),
+                MicRecordingSegment(url: recoveryURL)
+            ]
+        )
+
+        XCTAssertEqual(outcome.repairedSegments, 1)
+        XCTAssertEqual(outcome.appendedSegments, 2)
+        XCTAssertEqual(outcome.skippedSegments, 0)
+        XCTAssertTrue(outcome.isFullFidelity)
+
+        let merged = try AudioResampler.loadWAV(url: try XCTUnwrap(outcome.url))
+        XCTAssertEqual(merged.samples.count, 3_200)
+        XCTAssertEqual(average(of: merged.samples, range: 200..<1_400), 0.3, accuracy: 0.02)
+        XCTAssertEqual(average(of: merged.samples, range: 1_800..<3_000), 0.6, accuracy: 0.02)
+    }
+
+    func testMergeThrowsWhenNoSegmentContributesAudio() throws {
+        let primaryURL = temporaryDirectory.appendingPathComponent("primary.wav")
+        let recoveryURL = temporaryDirectory.appendingPathComponent("recovery.wav")
+
+        XCTAssertThrowsError(
+            try MicRecordingFileMerger.merge(
+                primaryURL: primaryURL,
+                segments: [
+                    MicRecordingSegment(url: primaryURL),
+                    MicRecordingSegment(url: recoveryURL)
+                ]
+            )
+        )
+    }
+
+    private func corruptHeaderSizes(at url: URL) throws {
+        let info = try WAVHeaderRepair.probe(at: url)
+        let handle = try FileHandle(forUpdating: url)
+        defer { try? handle.close() }
+        let headerOnlyRIFFSize = UInt32(info.dataSizeFieldOffset - 4)
+        try handle.seek(toOffset: 4)
+        try handle.write(contentsOf: withUnsafeBytes(of: headerOnlyRIFFSize.littleEndian) { Data($0) })
+        try handle.seek(toOffset: UInt64(info.dataSizeFieldOffset))
+        try handle.write(contentsOf: Data([0, 0, 0, 0]))
     }
 
     private func writeMonoWAV(to url: URL, sampleRate: Double, samples: [Float]) throws {

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerRecoveryTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerRecoveryTests.swift
@@ -1,0 +1,244 @@
+import AVFoundation
+import Combine
+import FluidAudio
+import XCTest
+@testable import TranscriptedCore
+
+@available(macOS 14.0, *)
+@MainActor
+final class TranscriptionTaskManagerRecoveryTests: XCTestCase {
+    private var tempDirectory: URL!
+
+    override func setUpWithError() throws {
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RecoveryTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+        tempDirectory = nil
+    }
+
+    func testRecoversOrphanedRecordingWithCorruptHeader() async throws {
+        let (manager, paths) = makeManager()
+
+        let micURL = paths.audioCaptures.appendingPathComponent("meeting_crash_mic.wav")
+        try writeMonoWAV(to: micURL, sampleRate: 48_000, samples: Array(repeating: 0.5, count: 9_600))
+        try corruptHeaderSizes(at: micURL)
+        try backdate(micURL)
+        XCTAssertEqual(try AVAudioFile(forReading: micURL).length, 0)
+
+        let startedAt = Date(timeIntervalSince1970: 1_750_000_000)
+        let journalURL = try writeJournal(
+            in: paths.audioCaptures,
+            primaryMicFilename: "meeting_crash_mic.wav",
+            segments: [.init(filename: "meeting_crash_mic.wav", gapBefore: 0)],
+            startedAt: startedAt
+        )
+
+        let recovered = await manager.recoverOrphanedRecordings(in: paths.audioCaptures)
+
+        XCTAssertEqual(recovered, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journalURL.path))
+
+        let entry = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertEqual(entry.micAudioURL, micURL)
+        XCTAssertEqual(entry.recordingDate, startedAt)
+        XCTAssertTrue(entry.isRetryable)
+
+        // The header repair must make the recovered audio actually readable.
+        XCTAssertEqual(try AVAudioFile(forReading: micURL).length, 9_600)
+    }
+
+    func testSkipsJournalWhoseAudioIsRecentlyWritten() async throws {
+        let (manager, paths) = makeManager()
+
+        let micURL = paths.audioCaptures.appendingPathComponent("meeting_live_mic.wav")
+        try writeMonoWAV(to: micURL, sampleRate: 48_000, samples: Array(repeating: 0.5, count: 4_800))
+        // No backdating: the file looks actively written, as it would if a
+        // second Transcripted process were recording into the shared scratch.
+        let journalURL = try writeJournal(
+            in: paths.audioCaptures,
+            primaryMicFilename: "meeting_live_mic.wav",
+            segments: [.init(filename: "meeting_live_mic.wav", gapBefore: 0)],
+            startedAt: Date()
+        )
+
+        let recovered = await manager.recoverOrphanedRecordings(in: paths.audioCaptures)
+
+        XCTAssertEqual(recovered, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: journalURL.path))
+        XCTAssertTrue(manager.failedTranscriptionManager.failedTranscriptions.isEmpty)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: micURL.path))
+    }
+
+    func testRemovesStaleJournalWithNoAudio() async throws {
+        let (manager, paths) = makeManager()
+
+        let journalURL = try writeJournal(
+            in: paths.audioCaptures,
+            primaryMicFilename: "meeting_gone_mic.wav",
+            segments: [.init(filename: "meeting_gone_mic.wav", gapBefore: 0)],
+            startedAt: Date(timeIntervalSince1970: 1_000)
+        )
+
+        let recovered = await manager.recoverOrphanedRecordings(in: paths.audioCaptures)
+
+        XCTAssertEqual(recovered, 0)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journalURL.path))
+        XCTAssertTrue(manager.failedTranscriptionManager.failedTranscriptions.isEmpty)
+    }
+
+    func testRecoversMultiSegmentRecordingByMerging() async throws {
+        let (manager, paths) = makeManager()
+
+        let primaryURL = paths.audioCaptures.appendingPathComponent("meeting_multi_mic.wav")
+        let recoveryURL = paths.audioCaptures.appendingPathComponent("meeting_multi_mic_recovery.wav")
+        try writeMonoWAV(to: primaryURL, sampleRate: 48_000, samples: Array(repeating: 0.3, count: 4_800))
+        try writeMonoWAV(to: recoveryURL, sampleRate: 48_000, samples: Array(repeating: 0.6, count: 4_800))
+        try backdate(primaryURL)
+        try backdate(recoveryURL)
+
+        _ = try writeJournal(
+            in: paths.audioCaptures,
+            primaryMicFilename: "meeting_multi_mic.wav",
+            segments: [
+                .init(filename: "meeting_multi_mic.wav", gapBefore: 0),
+                .init(filename: "meeting_multi_mic_recovery.wav", gapBefore: 0.1)
+            ],
+            startedAt: Date(timeIntervalSince1970: 1_000)
+        )
+
+        let recovered = await manager.recoverOrphanedRecordings(in: paths.audioCaptures)
+
+        XCTAssertEqual(recovered, 1)
+        let entry = try XCTUnwrap(manager.failedTranscriptionManager.failedTranscriptions.first)
+        XCTAssertEqual(entry.micAudioURL.lastPathComponent, "meeting_multi_mic_merged.wav")
+
+        let merged = try AVAudioFile(forReading: entry.micAudioURL)
+        XCTAssertGreaterThan(merged.length, 3_000)
+    }
+
+    // MARK: - Fixtures
+
+    private func makeManager() -> (TranscriptionTaskManager, CoreStoragePaths) {
+        let paths = CoreStoragePaths(
+            transcripts: tempDirectory.appendingPathComponent("transcripts"),
+            speakerDB: tempDirectory.appendingPathComponent("speakers.sqlite"),
+            statsDB: tempDirectory.appendingPathComponent("stats.sqlite"),
+            failedQueue: tempDirectory.appendingPathComponent("failed_transcriptions.json"),
+            speakerClips: tempDirectory.appendingPathComponent("speaker_clips"),
+            audioCaptures: tempDirectory.appendingPathComponent("audio"),
+            logs: tempDirectory.appendingPathComponent("logs")
+        )
+        try? FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(at: paths.speakerClips, withIntermediateDirectories: true)
+
+        let manager = TranscriptionTaskManager(
+            failedTranscriptionManager: FailedTranscriptionManager(paths: paths),
+            speechToText: RecoveryStubSpeechToTextEngine(),
+            diarization: RecoveryStubDiarizationEngine(),
+            speakerStore: SpeakerDatabase(path: paths.speakerDB.path),
+            speakerClipsDirectory: paths.speakerClips,
+            cleanupDirectories: [paths.audioCaptures, paths.speakerClips]
+        )
+        return (manager, paths)
+    }
+
+    private func writeJournal(
+        in directory: URL,
+        primaryMicFilename: String,
+        segments: [MeetingRecordingJournal.SegmentRecord],
+        startedAt: Date,
+        state: MeetingRecordingJournal.State = .recording,
+        systemAudioFilename: String? = nil
+    ) throws -> URL {
+        let journal = MeetingRecordingJournal(
+            version: 1,
+            state: state,
+            startedAt: startedAt,
+            updatedAt: startedAt,
+            primaryMicFilename: primaryMicFilename,
+            micSegments: segments,
+            systemAudioFilename: systemAudioFilename,
+            finalMicFilename: nil
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let stem = (primaryMicFilename as NSString).deletingPathExtension
+        let url = directory.appendingPathComponent(stem + MeetingRecordingJournalStore.filenameSuffix)
+        try encoder.encode(journal).write(to: url, options: .atomic)
+        return url
+    }
+
+    private func backdate(_ url: URL) throws {
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -3_600)],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private func corruptHeaderSizes(at url: URL) throws {
+        let info = try WAVHeaderRepair.probe(at: url)
+        let handle = try FileHandle(forUpdating: url)
+        defer { try? handle.close() }
+        let headerOnlyRIFFSize = UInt32(info.dataSizeFieldOffset - 4)
+        try handle.seek(toOffset: 4)
+        try handle.write(contentsOf: withUnsafeBytes(of: headerOnlyRIFFSize.littleEndian) { Data($0) })
+        try handle.seek(toOffset: UInt64(info.dataSizeFieldOffset))
+        try handle.write(contentsOf: Data([0, 0, 0, 0]))
+    }
+
+    private func writeMonoWAV(to url: URL, sampleRate: Double, samples: [Float]) throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        ))
+        let file = try AVAudioFile(
+            forWriting: url,
+            settings: format.settings,
+            commonFormat: format.commonFormat,
+            interleaved: format.isInterleaved
+        )
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(samples.count)
+        ))
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        let channelData = try XCTUnwrap(buffer.floatChannelData?[0])
+        samples.withUnsafeBufferPointer { pointer in
+            guard let baseAddress = pointer.baseAddress else { return }
+            channelData.update(from: baseAddress, count: samples.count)
+        }
+        try file.write(from: buffer)
+        file.close()
+    }
+}
+
+@available(macOS 14.0, *)
+@MainActor
+private final class RecoveryStubSpeechToTextEngine: SpeechToTextEngine {
+    nonisolated let objectWillChange = ObservableObjectPublisher()
+    var isReady = true
+
+    func initialize() async {}
+    func transcribeSegment(samples: [Float], source: AudioSource) async throws -> String { "" }
+    func cleanup() {}
+}
+
+@available(macOS 14.0, *)
+@MainActor
+private final class RecoveryStubDiarizationEngine: DiarizationEngine {
+    nonisolated let objectWillChange = ObservableObjectPublisher()
+    var isReady = true
+
+    func initialize() async {}
+    func diarizeOffline(samples: [Float], sampleRate: Int) async throws -> [SpeakerSegment] { [] }
+    func diarizeOffline(audioURL: URL) async throws -> [SpeakerSegment] { [] }
+    func cleanup() {}
+}

--- a/Tests/TranscriptedCoreTests/WAVHeaderRepairTests.swift
+++ b/Tests/TranscriptedCoreTests/WAVHeaderRepairTests.swift
@@ -74,6 +74,25 @@ final class WAVHeaderRepairTests: XCTestCase {
         XCTAssertEqual(repaired.length, 9_600 - 2_000)
     }
 
+    func testLeavesForeignWAVWithTrailingMetadataChunkAlone() throws {
+        let url = temporaryDirectory.appendingPathComponent("foreign.wav")
+        try writeMonoWAV(to: url, sampleRate: 48_000, samples: Array(repeating: 0.5, count: 9_600))
+
+        // Imported WAVs can carry metadata chunks after the data chunk, so the
+        // declared data size is legitimately smaller than the remaining bytes.
+        // "Repairing" such a file would decode the metadata as PCM.
+        let handle = try FileHandle(forUpdating: url)
+        _ = try handle.seekToEnd()
+        var trailing = Data("LIST".utf8)
+        trailing.append(contentsOf: withUnsafeBytes(of: UInt32(16).littleEndian) { Data($0) })
+        trailing.append(Data(repeating: 0x55, count: 16))
+        try handle.write(contentsOf: trailing)
+        try handle.close()
+
+        XCTAssertFalse(try WAVHeaderRepair.repairIfNeeded(at: url))
+        XCTAssertEqual(try AVAudioFile(forReading: url).length, 9_600)
+    }
+
     func testNonWAVFileThrows() throws {
         let url = temporaryDirectory.appendingPathComponent("not-audio.wav")
         try Data(repeating: 0x41, count: 256).write(to: url)

--- a/Tests/TranscriptedCoreTests/WAVHeaderRepairTests.swift
+++ b/Tests/TranscriptedCoreTests/WAVHeaderRepairTests.swift
@@ -1,0 +1,124 @@
+import AVFoundation
+import XCTest
+@testable import TranscriptedCore
+
+final class WAVHeaderRepairTests: XCTestCase {
+    private var temporaryDirectory: URL!
+
+    override func setUp() {
+        super.setUp()
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WAVHeaderRepairTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        if let temporaryDirectory {
+            try? FileManager.default.removeItem(at: temporaryDirectory)
+        }
+        temporaryDirectory = nil
+        super.tearDown()
+    }
+
+    func testFinalizedFileNeedsNoRepair() throws {
+        let url = temporaryDirectory.appendingPathComponent("clean.wav")
+        try writeMonoWAV(to: url, sampleRate: 48_000, samples: Array(repeating: 0.5, count: 9_600))
+
+        XCTAssertFalse(try WAVHeaderRepair.repairIfNeeded(at: url))
+
+        let file = try AVAudioFile(forReading: url)
+        XCTAssertEqual(file.length, 9_600)
+    }
+
+    func testRepairsCrashOrphanedHeaderAndRecoversAudio() throws {
+        let url = temporaryDirectory.appendingPathComponent("orphaned.wav")
+        try writeMonoWAV(to: url, sampleRate: 48_000, samples: Array(repeating: 0.5, count: 9_600))
+
+        // Simulate a writer killed before finalizing: zero the RIFF and data
+        // size fields the way an unflushed AVAudioFile header looks on disk.
+        try zeroHeaderSizes(at: url)
+        let unreadable = try AVAudioFile(forReading: url)
+        XCTAssertEqual(unreadable.length, 0, "zeroed header must read as empty to model the crash state")
+
+        XCTAssertTrue(try WAVHeaderRepair.repairIfNeeded(at: url))
+
+        let repaired = try AVAudioFile(forReading: url)
+        XCTAssertEqual(repaired.length, 9_600)
+
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(
+            pcmFormat: repaired.processingFormat,
+            frameCapacity: 9_600
+        ))
+        try repaired.read(into: buffer)
+        XCTAssertEqual(buffer.frameLength, 9_600)
+        let samples = try XCTUnwrap(buffer.floatChannelData?[0])
+        XCTAssertEqual(samples[4_000], 0.5, accuracy: 0.001)
+
+        // Idempotent: a second pass finds nothing to do.
+        XCTAssertFalse(try WAVHeaderRepair.repairIfNeeded(at: url))
+    }
+
+    func testRepairsTruncatedFileByShrinkingDeclaredSize() throws {
+        let url = temporaryDirectory.appendingPathComponent("truncated.wav")
+        try writeMonoWAV(to: url, sampleRate: 48_000, samples: Array(repeating: 0.5, count: 9_600))
+
+        // Chop the tail off so the declared data size exceeds the bytes on disk.
+        let handle = try FileHandle(forUpdating: url)
+        let originalSize = try handle.seekToEnd()
+        try handle.truncate(atOffset: originalSize - 8_000)
+        try handle.close()
+
+        XCTAssertTrue(try WAVHeaderRepair.repairIfNeeded(at: url))
+
+        let repaired = try AVAudioFile(forReading: url)
+        XCTAssertEqual(repaired.length, 9_600 - 2_000)
+    }
+
+    func testNonWAVFileThrows() throws {
+        let url = temporaryDirectory.appendingPathComponent("not-audio.wav")
+        try Data(repeating: 0x41, count: 256).write(to: url)
+
+        XCTAssertThrowsError(try WAVHeaderRepair.repairIfNeeded(at: url))
+    }
+
+    /// Rewrites the size fields the way a SIGKILL'd AVAudioFile leaves them on
+    /// disk (verified experimentally): the RIFF size covers only the chunks up
+    /// to the data header, and the data chunk declares 0 bytes.
+    private func zeroHeaderSizes(at url: URL) throws {
+        let info = try WAVHeaderRepair.probe(at: url)
+        let handle = try FileHandle(forUpdating: url)
+        defer { try? handle.close() }
+        let headerOnlyRIFFSize = UInt32(info.dataSizeFieldOffset - 4)
+        try handle.seek(toOffset: 4)
+        try handle.write(contentsOf: withUnsafeBytes(of: headerOnlyRIFFSize.littleEndian) { Data($0) })
+        try handle.seek(toOffset: UInt64(info.dataSizeFieldOffset))
+        try handle.write(contentsOf: Data([0, 0, 0, 0]))
+    }
+
+    private func writeMonoWAV(to url: URL, sampleRate: Double, samples: [Float]) throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        ))
+        let file = try AVAudioFile(
+            forWriting: url,
+            settings: format.settings,
+            commonFormat: format.commonFormat,
+            interleaved: format.isInterleaved
+        )
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(samples.count)
+        ))
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        let channelData = try XCTUnwrap(buffer.floatChannelData?[0])
+        samples.withUnsafeBufferPointer { pointer in
+            guard let baseAddress = pointer.baseAddress else { return }
+            channelData.update(from: baseAddress, count: samples.count)
+        }
+        try file.write(from: buffer)
+        file.close()
+    }
+}


### PR DESCRIPTION
## What this fixes

The durable fix for #825 (long meetings disappearing), in two commits. A deep investigation against current main found the originally-reported gaps mostly fixed by #833/#840/#841, but surfaced a different set of still-real silent-loss paths. A kill-mid-write experiment confirmed the core mechanism: a crashed or leaked `AVAudioFile` writer leaves the WAV header declaring `data size = 0` while all PCM audio sits intact on disk — every reader then sees a zero-length file.

### Commit 1 — salvage + heal (Phase 0/1)

- **`WAVHeaderRepair` (new)** — probes RIFF chunks and recomputes the RIFF/data sizes from the actual bytes on disk. Crash-orphaned and truncated WAVs become fully readable again (verified losslessly in the spike: a 9-byte patch recovered 151s of "empty" audio).
- **Merge salvage** — `MicRecordingFileMerger` previously aborted the whole merge if any single segment was empty/unreadable, then silently fell back to the first segment only: a complete-looking transcript missing everything after the first device switch. It now repairs unfinalized headers, skips truly-dead segments, pads mid-read failures with silence (keeping the mic timeline aligned with system audio), and only deletes source segments after a full-fidelity merge.
- **Heal-on-load** — `FailedTranscriptionManager` silently dropped (and persisted the drop of) any entry whose audio file was missing. A crash between the merger's segment cleanup and the queue repoint made the meeting disappear permanently while `_merged.wav` sat orphaned on disk. Load now repoints to the merged sibling, degrades to mic-only when system audio vanished, and repairs unfinalized WAV headers — making "preserved before quit" audio actually retryable after relaunch.
- **Ordering** — the 30-day failed-audio cleanup persists entry removal before deleting audio.
- **Writer lifetime** — `Audio.stop()` and device-recovery rotation `close()` writers explicitly on their serial queues, so headers are finalized before the merger can ever read a segment.
- **Diarization init dedup** — concurrent `initialize()` calls share one task instead of double-loading models, where a losing duplicate could overwrite a successful load to `.failed`.
- **Telemetry** — finalize/merge logs carry duration plus salvage counters; degraded merges log at error level.

### Commit 2 — recording journal + launch recovery (Phase 2)

The failed-transcription queue only records meetings whose preservation code actually ran. A crash, force-kill, or power loss before that point left audio in `tmp/recordings` with no queue entry, no Home item, and no scan — the meeting just vanished. This was the last unfixed "2h meeting disappeared" path.

- **`MeetingRecordingJournal` (new)** — a JSON sidecar next to the scratch audio, written at every lifecycle transition (recording start, segment rotation, system-audio assignment, stopping, finalized) and removed only at durable endpoints: transcript committed, or failed-queue entry persisted.
- **`recoverOrphanedRecordings(in:)`** — launch scan that repairs WAV headers, merges leftover segments via the salvaging merger, and turns journaled audio into visible, retryable failed-queue entries. Stale journals are cleaned up.
- **Liveness guard** — journals whose audio was written in the last 2 minutes are left alone, so a dev build sharing Application Support can't steal audio from a concurrently-recording production app.
- **Security** — journals store bare filenames resolved only inside the scratch directory; a tampered journal can't redirect recovery at arbitrary files.

Invariant after this PR: **from recording start onward, there is no moment where meeting audio exists on disk without a durable, discoverable record the app can act on at next launch.**

### Verification (run for both commits)

- `bash build-deps.sh --force` ✅
- `bash build.sh --no-open` ✅
- `bash run-tests.sh` ✅ (4655 tests, 0 failed)
- `bash run-integration-smoke.sh` ✅
- `swift test` ✅ (403 tests, 0 failures — 18 new tests across header repair, merge salvage, heal-on-load, journal lifecycle, and recovery scan)

### Follow-ups (separate PRs)

Auto-retry once models become ready; move the segment merge off the stop path into the queued job; Home fallback row for unparseable transcripts; "expiring soon" notice before the 30-day failed-audio cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)