### PR TITLE
Add WAVHeaderRepair.swift to the E2E smoke compile list

### DIFF
--- a/scripts/entrypoints/run-e2e-smoke.sh
+++ b/scripts/entrypoints/run-e2e-smoke.sh
@@ -46,6 +46,7 @@ SWIFT_SOURCES=(
     "Sources/TranscriptedCore/Speaker/SpeakerProfile.swift"
     "Sources/TranscriptedCore/Services/CoreStoragePaths.swift"
     "Sources/TranscriptedCore/Services/FailedTranscriptionManager.swift"
+    "Sources/TranscriptedCore/Audio/WAVHeaderRepair.swift"
     "Sources/TranscriptedCore/Logging/AppLogger.swift"
     "Sources/TranscriptedCore/Logging/FileLogger.swift"
     "Sources/TranscriptedCore/Logging/LogPrivacySanitizer.swift"


### PR DESCRIPTION
run-e2e-smoke.sh compiles from an explicit source list. FailedTranscriptionManager started calling WAVHeaderRepair in #1074, but the list never picked up the new file, so the smoke failed to compile. Surfaced while verifying main after merging the 10 open PRs.

Verified: `bash run-e2e-smoke.sh` passes with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)