### PR TITLE
Publish the 2026-06-12 pre-release QA pass report

### DIFF
--- a/docs/qa-pass-2026-06-12.md
+++ b/docs/qa-pass-2026-06-12.md
@@ -1,0 +1,277 @@
+# QA pass — 2026-06-12: v1.1.47..main, pre-release gate for the #1075 release
+
+Date: 2026-06-12. Full QA sweep over everything merged since the v1.1.47 tag
+(192 files; PRs #1066–#1079), run from a clean worktree at main HEAD
+(`0137e403`), before cutting the release that ships #1074/#1075/#1077/#1078.
+
+> **Status:** all automated gates green; 8-subsystem deep code audit complete.
+> Four follow-up fix bundles identified (none regressions against v1.1.47,
+> none release-blocking). Still open before the release ships: the issue #500
+> positive-path hardware QA (section 6) and the P5 telemetry dashboard check
+> from `issue-500-quiet-mic-investigation-2026-06-11.md`.
+
+## 1. Scope
+
+- **#1074** — WAV header repair, mic-merge salvage, recording journal + launch
+  recovery for orphaned meetings (issue #825 phases 0–2)
+- **#1075** — quiet-mic live detection + consented mic boost (issue #500)
+- **#1076** — investigation docs (docs only)
+- **#1077** — one-click agent connect (`AgentMCPConnector` seam)
+- **#1078** — live transcript drawer + meeting pill rest/bloom rebuild
+- **#1079** — e2e smoke compile-list fix
+- **#1066–#1073** — capture-shortcut docs/tests, local summary participants,
+  paste-last shortcut, Speakers section simplification, CaptureKit extraction
+  follow-ups, Home/Settings polish
+
+Baselines at test time: 159 meeting captures, 63 dictation files, production
+app dogfooding a post-#1075 build all day (47/47 dictations completed, live
+drawer segments flowing, zero errors).
+
+## 2. Gate results
+
+| Gate | Result |
+|---|---|
+| `build-deps.sh` + `build.sh --no-open` (fresh worktree) | PASS |
+| `run-tests.sh` fast suite | **4885/4885** |
+| `swift test` (TranscriptedCore) | 424 pass, 1 skipped (live smoke, env-gated) |
+| Tools packages (CaptureKit / CLI / MCP / QA) | 19 / 45 / 74 / 34 pass, exit codes verified bare |
+| `run-integration-smoke.sh` | PASS |
+| `run-e2e-smoke.sh` | PASS (deterministic capture contract) |
+| `transcripted-qa validate-all` (real library) | **1844 checks, 0 failed**, 14 benign warnings¹ |
+| `transcripted-qa round-trip` | 87 clean checks + 22/22 corruptions caught |
+| Log + crash analysis | 0 error-level entries, 0 crash reports |
+| `run-live-capture-smoke.sh` | NOT RUN — mic TCC "not determined" for the agent shell; preflight failed cleanly as designed. Needs a mic-granted terminal. |
+
+¹ 13 legacy transcripts predate the `capture_quality` key; 1 informational
+"no JSON sidecars" note — current format is Markdown-first by design.
+
+## 3. Verified clean (the load-bearing checks)
+
+- **Real-time audio thread rule** — the detector feed adds no locks or
+  allocations to tap paths; journal writes all run off audio threads.
+- **WAVHeaderRepair** — RIFF/data size math correct (align-down to whole
+  frames, clamping); repair fires only on crash/truncation signatures;
+  trailing-metadata foreign WAVs untouched; no path corrupts a healthy file.
+- **Merge salvage** — no failure mode deletes source segments; sources are
+  removed only on full-fidelity merges; disk-full aborts instead of
+  "salvaging" a truncated file.
+- **Delete-before-persist** — the #1074 ordering holds end to end: transcript
+  saved → audio archived (copies) → side effects committed → scratch deleted
+  last. No remaining window found.
+- **Privacy contract** — every new Sentry/PostHog key (`mic_boost_prompt`,
+  `meeting_mic_boost_prompt_shown/_actioned`, meeting health fields,
+  `update_installed`) traces to enum rawValues or buckets at every call site;
+  sanitizers still drop paths/transcript text; error strings stay UI-only.
+- **MCP server** — read-only contract verified (no writes reachable from tool
+  handlers); path traversal solid (`../`, absolute paths, symlink plants all
+  rejected).
+- **#1075 prompt × #1078 pill rebuild** — the boost prompt blooms from
+  condensed rest, hides the drawer while showing, is never occluded, and is
+  clickable in every pill state. The rebuild did not break the prompt.
+- **Recovered entries are retryable** — the launch-recovery error string
+  classifies retryable through both classification paths.
+- **DiarizationService init dedup** — atomic on the main actor; first-failure
+  retries cleanly.
+- **`recordingDate` plumbing, `audio_health` frontmatter** — optional/defaulted
+  Codable (old queues decode), YAML escaping correct, flat keys collide with
+  nothing, omitted for healthy meetings, CaptureKit parser tolerates them.
+
+## 4. Findings
+
+Severity reflects worst plausible impact; "probe-verified" means the auditor
+reproduced it with a compiled test program.
+
+### 4.1 High
+
+1. **Journal session-identity hole** (new in #1074; two audits converged).
+   `MeetingRecordingJournalStore.mutate` (`MeetingRecordingJournal.swift:112-136`)
+   mutates whatever journal is in memory — no session check — and the store's
+   memory is never cleared in production (`clear()` has no production callers;
+   handoff uses the static `removeJournal`).
+   - Cross-session corruption: a multi-segment recording's late
+     `markFinalized` (fires from `cleanupGroup.notify`, `Audio.swift:1162`)
+     after a bridge stop-timeout can rewrite the *next* recording's journal;
+     a crash then makes `recoverOrphanedRecordings` attach recording A's
+     merged audio to recording B's entry and delete it from scratch while A's
+     heal path still needs it.
+   - Resurrection: `stop()` calls `markStopping()` unconditionally
+     (`Audio.swift:1057`); a failed start re-persists the previous meeting's
+     already-removed journal → duplicate failed-queue entry next launch (no
+     dedupe in `addFailedTranscriptionRetainingAvailableAudio`).
+   - Fix shape: session token captured at `begin()`, `mutate` no-ops on
+     mismatch; null store state on removal; make `stop()` journal-idempotent.
+2. **CaptureKit `extractTitle` crash** (probe-verified, exit 133; pre-existing,
+   now centralized). `CaptureMarkdown.swift:53-58` searches the closing fence
+   from offset 3 but slices from offset 4 — content starting `---\n---\n`
+   traps. A file starting `---\n---\n---\n…` gets indexed, then
+   `list_meetings`/`recap`/`search` title hydration kills the MCP server on
+   every call while the file exists (persistent DoS); CLI crashes the same
+   way via `readMeetingTitle`.
+3. **CaptureKit speaker parser drops all speaker metadata** (probe-verified;
+   pre-existing parity bug). `parseFrontmatterSpeakers`
+   (`CaptureMarkdownParser.swift:271`) breaks at the first `channel:` line —
+   which the app has written inside every speaker entry since PR #312
+   (`TranscriptFormatter.swift:145`). Result: `persistentSpeakerId` and
+   `confidence` are nil in MCP/CLI output for every current-format meeting,
+   and system speaker IDs degrade to generated `system_0…`. Hidden because
+   all kit/MCP fixtures omit `channel:`.
+4. **Agent connect: Codex TOML duplicate-table corruption**
+   (`AgentMCPConnector.swift:300-341`). The existing-table match is exact
+   (`[mcp_servers.transcripted]` only); legal variants — trailing comment,
+   inner whitespace, quoted key, root-level dotted assignment — fall through
+   to append, producing a duplicate table that makes Codex reject the entire
+   config (all the user's servers die). No backup before TOML writes.
+5. **Agent connect: malformed Claude Desktop JSON silently clobbered**
+   (`ClaudeDesktopIntegrationInstaller.swift:299-326, 381-399`). Unreadable
+   JSON → empty root → transcripted-only config written. A backup IS taken
+   but is invisible: `attentionMessage` has zero UI consumers and `backupURL`
+   is discarded at both call sites. Hand-edited configs (trailing comma) lose
+   every other MCP server with a green "Connected".
+6. **Mic-boost cue can race the stop sequence**
+   (`MeetingSessionController.swift:827-834` vs the clear at `:590` and the
+   await at `:608`). A detector streak completing on the racing tick re-latches
+   `isMicBoostPromptVisible` mid-stop; nothing clears it until the next start.
+   Low probability (one 0.2s tick window after a 30s streak), mostly
+   self-healing in the overlay; rated high by the auditor as a state-machine
+   hole, realistically medium impact.
+
+### 4.2 Medium
+
+- **Recovery liveness is mtime-only** (`TranscriptionTaskManager.swift:836,
+  931-937`): journal `state`/`updatedAt` ignored; a capture stalled >120s
+  (sleep mid-meeting) looks orphaned — a second app instance (dev build next
+  to prod) can archive + delete files the live process has open.
+- **Crash + quick relaunch (<120s) hides the meeting until the second
+  restart** — skipped journals are never rescanned within a session.
+- **Recovery archive-copies multi-GB WAVs synchronously on the main actor at
+  launch** (`TranscriptionTaskManager.swift:862-869 → RecordingAudioArchiver`).
+- **Heal gap**: mic missing + no `_merged` sibling + system audio present →
+  entry silently dropped, system WAV orphaned forever
+  (`FailedTranscriptionManager.swift:122-176`); the silent-mic placeholder
+  mechanism exists but heal doesn't use it.
+- **Core-initiated stops never clear the boost prompt**
+  (`MeetingSessionController.swift:1479-1491` sink): watchdog give-up or
+  disk-full stop leaves the prompt up; accepting flips the global VPIO
+  preference while nothing records.
+- **Accepted boost can silently no-op** when device recovery is in flight
+  (`Audio.swift:1186` early-return before the flag is set): outcome
+  "accepted", preference persisted, meeting stays quiet, one-shot policy
+  means no re-offer. Related: accept → `engine.start()` failure routes to a
+  full `stop()` with no waiting continuation — controller stays
+  `state == .recording` while Core is stopped.
+- **`isMicRecovering` is check-then-act** (`AudioDeviceRecovery.swift:84-88`);
+  the `.processingChange` restart adds a second producer — concurrent
+  recoveries possible if a device dies as the user clicks Boost.
+- **Settings never observes `.microphoneProcessingPrefsDidChange`** — after a
+  mid-meeting boost accept, an open Settings window shows the toggle Off and
+  Home keeps the hint until re-presented (`TranscriptedSettingsView.swift:61`,
+  refresh only on presentation; the notification is posted at
+  `MicrophoneProcessingPreferences.swift:45`).
+- **Hotkey recorder collision**: while re-recording a shortcut, the global
+  event tap stays armed (`ContextCaptureEngine.swift:173-176, 266, 335`) —
+  pressing the current meeting chord starts a real recording (mic capture)
+  instead of being captured by the recorder. No duplicate-binding validation
+  anywhere; duplicates resolve first-match-wins silently.
+- **`update_installed` undercounts install-on-quit updates**
+  (`SparkleUpdaterController.swift:576-586` vs `:617-624`): the marker is
+  written only on relaunch; the willInstallUpdateOnQuit path never fires it —
+  auto-update adoption will look systematically worse than it is.
+- **`runSelfTest` has no timeout + pipe-deadlock pattern**
+  (`ClaudeDesktopIntegrationInstaller.swift:336-350`): `waitUntilExit()` then
+  `readDataToEndOfFile()`; a hung helper or >64KB output pins the row at
+  "Connecting…" until app restart. `drained.wait()` in `runCLI`
+  (`AgentMCPConnector.swift:484`) is similarly unbounded if a grandchild
+  holds the pipe. GUI launch env also breaks npm-based `claude` installs
+  (no `node` on PATH; stderr is surfaced, so it fails loudly).
+- **Sentry `reason` is now a global diagnostic-tag key**
+  (`SentryEventPolicy.swift:59`): every current writer is an enum rawValue,
+  but free-form `reason` strings exist on non-allowlisted events; nothing
+  pins the key set, so a future allowlisting leaks free text. Pin the
+  allowlist in a test or scope the key.
+- **`transcripted-qa check-health` ignores a relocated capture library**
+  (QADataDirectories doesn't consult `mcp-directories.json` /
+  `transcriptSaveLocation`) — false FAIL for users who moved their library.
+- **Live drawer: per-ASR-update full-document relayout while open**
+  (`MeetingOverlayController.swift:1522-1612`): O(visible transcript) per
+  partial, ~5–20×/sec; bounded by the 200-entry cap, but incremental append
+  would cut most of it. Also: prompts that clear set `state = .recording`
+  without `flushPendingTranscriptIfNeeded()` (`:1665-1681, 2279-2303`) — after
+  a silence-triggered inactivity prompt the drawer can show stale text for
+  minutes.
+- **Rotation has zero behavioral test coverage**
+  (`ObservabilityLogRotation.swift`): threshold/rename/permissions and the
+  flush-boundary fix are asserted only by source-text greps.
+
+### 4.3 Low / notable info
+
+- "Mic boost enabled" transient shows even when VPIO silently failed to arm
+  (`AudioDeviceRecovery.swift:307` vs the silent skip in `Audio.swift:807-812`);
+  diagnostics stay honest, UX doesn't.
+- Cancel-path diagnostics omit `mic_boost_prompt`
+  (`MeetingSessionController.swift:978` vs `:628`).
+- **Home hint blind spot (design note)**: stop classification uses
+  session-max peaks, so late-onset attenuation — call app joins mid-meeting,
+  arguably the common case — never gets the `audio_health` frontmatter or the
+  Home backstop. The live prompt is the only net for it.
+- Discard + degraded merge can resurrect a user-discarded recording into the
+  failed queue at next launch (journal references retained source segments;
+  `stopAndDiscardFiles` removes only the merged + system files). Privacy
+  expectation: discard should mean gone.
+- Failed-start orphan journal → junk "Recording was interrupted" entry next
+  launch (0-frame WAV); degraded-merge source segments are permanent orphans
+  (no scratch age-sweeper exists).
+- Detector `init(tickInterval: 0)` traps (`Int(+inf)`) — no production caller,
+  public API; clamp it.
+- `QuietMicAttenuationDetector` glue (interval drain zeroing, `sawBuffer`
+  forcing, timer consume) has no tests; the policy itself is well covered
+  (13 tests incl. cross-target threshold pinning).
+- Stale time-derived UI (greeting, Today/Yesterday labels) across midnight
+  with the window open; three Gemma-hardcoded strings show for the Apple
+  summary provider; attention-pill `.summaries` destination is a no-op;
+  `HomeAttentionPillsRow` doesn't wrap at min width.
+- `ParakeetAudioDeviceLookup` CFString leak fix verified correct
+  (`takeRetainedValue` for the +1 get-rule).
+- MCP/CLI: `audio_health` isn't exposed in structured outputs (raw markdown
+  shows it); resolver rejections are silent (no stderr note); recommend both.
+- Tools fixtures don't mirror writer output (`channel:`, `gap_events`,
+  `audio_health`) — exactly what hid finding 4.1.3.
+
+## 5. Recommended fix bundles (in priority order)
+
+1. **Journal session-identity guard** — findings 4.1.1 + liveness/rescan
+   mediums. Core data-integrity work; do before or immediately after release.
+2. **CaptureKit parser fixes + writer-faithful fixtures** — findings 4.1.2,
+   4.1.3. Small fixes, big agent-facing payoff (MCP stability + speaker
+   identity restored).
+3. **Agent-connect config safety** — findings 4.1.4, 4.1.5 + self-test
+   timeout. Protects other apps' configs.
+4. **Mic-boost prompt edge-path lifecycle** — clear-on-capture-stop, cue/stop
+   guard, stale-accept guard, cancel diagnostics, drawer flush, Settings
+   `.onReceive`.
+
+## 6. Still open before the release
+
+1. **Issue #500 positive-path hardware QA** (gates the release per
+   `issue-500-quiet-mic-investigation-2026-06-11.md` §5). Not runnable from an
+   agent shell: `run-live-capture-smoke.sh` preflight needs mic TCC, and the
+   screen-control permission requests timed out. ~3 minutes by hand:
+   join an empty FaceTime link (or Safari + empty Google Meet) with the
+   internal mic → start a Transcripted meeting recording → talk normally →
+   the "Boost Mic" banner should appear within ~30s → accept → voice returns
+   to normal level mid-recording and appears in the transcript → decline run:
+   nothing changes, other apps' playback loudness unchanged.
+   Negative path already has real evidence: 11+ post-#1075 dogfood recordings
+   on 2026-06-12, zero false prompt fires, `attenuation_kind` all `none`.
+2. **P5 dashboard check** (post-ship): watch `attenuation_kind` /
+   `quiet_mic_unrecovered` / `mic_boost_prompt` distributions in
+   Sentry/PostHog to size the affected population and confirm accepted
+   prompts drive `quiet_mic_unrecovered` to ~0.
+
+## 7. Method
+
+Eight parallel audit agents (audio core, pipeline/recovery, meeting session,
+live drawer/pill, agent connect, observability, Home/Settings UI, Tools), each
+working from `git diff v1.1.47..HEAD` plus surrounding code, with findings
+spot-verified in source by the coordinating session (both agent-connect highs
+re-verified by hand; CaptureKit highs probe-verified by the auditor). Gates
+run bare — no pipes — per the repo's exit-code rule.


### PR DESCRIPTION
## What this is

The document of record for today's full QA sweep over everything merged since v1.1.47 (PRs #1066–#1079), run before cutting the release that ships #1074 (crash recovery), #1075 (quiet-mic boost for #500), #1077 (agent connect), and #1078 (live transcript drawer).

[docs/qa-pass-2026-06-12.md](https://github.com/r3dbars/transcripted/blob/claude/serene-poitras-4b844a/docs/qa-pass-2026-06-12.md) contains:

- **Gate results** — all green: build, fast suite 4885/4885, swift test 424, all four tool packages, integration + e2e smokes, 1844 artifact checks, 22/22 corruption round-trip, zero log errors/crashes.
- **Verified-clean list** — the load-bearing checks that passed audit: real-time-thread rule, WAV repair math/gating, merge salvage never deletes sources, delete-before-persist closed, privacy allowlists, MCP path traversal, and the #1075 prompt surviving the #1078 pill rebuild.
- **Findings by severity** — 6 highs (journal session-identity hole, two probe-verified CaptureKit parser bugs, two agent-connect config-corruption paths, one prompt/stop race), plus the medium/low tail, each with file:line refs.
- **Recommended fix bundles** in priority order (none regressions vs 1.1.47, none release-blocking).
- **Still open before release** — the issue #500 positive-path hardware QA (~3 min manual recipe included) and the post-ship P5 dashboard check.

Follows the dated-docs pattern from #1076. Doc-only change; `scripts/dev/agent-preflight.sh` run per the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)