### PR TITLE
Close mic-boost prompt edge paths so the prompt never outlives its recording

### DIFF
--- a/Sources/Meeting/MeetingMicBoostPromptPolicy.swift
+++ b/Sources/Meeting/MeetingMicBoostPromptPolicy.swift
@@ -16,11 +16,33 @@ enum MeetingMicBoostPromptOutcome: String {
 enum MeetingMicBoostPromptPolicy {
     /// Consent-only gate: present at most once per recording, and never when
     /// the user already enabled Apple voice processing in Settings.
+    ///
+    /// Invariant: the prompt flag is never true while nothing is recording.
+    /// A late cue can land mid-stop — capture teardown awaits file handles
+    /// while the published recording flags are still settling — so
+    /// presentation also requires that no stop/cancel/termination teardown is
+    /// in flight and that the session state machine still says recording.
     static func shouldPresent(
         isRecording: Bool,
+        isFinishingRecording: Bool,
+        sessionStateIsRecording: Bool,
         voiceProcessingPreferenceEnabled: Bool,
         currentOutcome: MeetingMicBoostPromptOutcome
     ) -> Bool {
-        isRecording && !voiceProcessingPreferenceEnabled && currentOutcome == .notShown
+        isRecording
+            && !isFinishingRecording
+            && sessionStateIsRecording
+            && !voiceProcessingPreferenceEnabled
+            && currentOutcome == .notShown
+    }
+
+    /// Stale-action gate: accepting or declining a prompt that outlived its
+    /// recording must only dismiss it — never persist the global VPIO
+    /// preference or record a prompt outcome for a dead recording.
+    static func shouldApplyPromptAction(
+        isPromptVisible: Bool,
+        isRecording: Bool
+    ) -> Bool {
+        isPromptVisible && isRecording
     }
 }

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -827,6 +827,8 @@ final class MeetingSessionController: ObservableObject {
     private func handleMicAttenuationCue() {
         guard MeetingMicBoostPromptPolicy.shouldPresent(
             isRecording: isRecording,
+            isFinishingRecording: isFinishingRecording,
+            sessionStateIsRecording: state == .recording,
             voiceProcessingPreferenceEnabled: MicrophoneProcessingPreferences.isVoiceProcessingEnabled(),
             currentOutcome: micBoostPromptOutcome
         ) else { return }
@@ -853,7 +855,15 @@ final class MeetingSessionController: ObservableObject {
     }
 
     func acceptMicBoostPrompt() {
-        guard isMicBoostPromptVisible else { return }
+        guard MeetingMicBoostPromptPolicy.shouldApplyPromptAction(
+            isPromptVisible: isMicBoostPromptVisible,
+            isRecording: isRecording
+        ) else {
+            // Stale accept: the recording died under the prompt. Dismiss only;
+            // never persist the global VPIO preference for a dead recording.
+            isMicBoostPromptVisible = false
+            return
+        }
         micBoostPromptOutcome = .accepted
         isMicBoostPromptVisible = false
         capture.armVoiceProcessingForActiveRecording()
@@ -879,7 +889,15 @@ final class MeetingSessionController: ObservableObject {
     }
 
     func declineMicBoostPrompt() {
-        guard isMicBoostPromptVisible else { return }
+        guard MeetingMicBoostPromptPolicy.shouldApplyPromptAction(
+            isPromptVisible: isMicBoostPromptVisible,
+            isRecording: isRecording
+        ) else {
+            // Stale decline: dismiss without recording an outcome for a
+            // recording that already ended.
+            isMicBoostPromptVisible = false
+            return
+        }
         micBoostPromptOutcome = .declined
         isMicBoostPromptVisible = false
         DiagnosticsTrail.record(
@@ -975,10 +993,13 @@ final class MeetingSessionController: ObservableObject {
         let files = (micURL: stopResult.micURL, systemURL: stopResult.systemURL)
         finishLiveCodexSessionForActiveRecording(status: .cancelled, shouldAwaitFinalTranscript: false)
         let afterStopVolumeContext = capture.routeVolumeDiagnosticsContext(currentPhase: "after")
-        let cancelCaptureDiagnostics = MeetingCaptureVolumeDiagnostics.annotatedStopContext(
+        var cancelCaptureDiagnostics = MeetingCaptureVolumeDiagnostics.annotatedStopContext(
             baseContext: meetingCaptureAnalyticsProperties(snapshot: recordingSnapshot.pipelineSnapshot),
             afterStopContext: afterStopVolumeContext
         )
+        // Mirror stopRecording(): cancelled meetings carry the prompt outcome
+        // too, so diagnostics can correlate cancellations with the prompt.
+        cancelCaptureDiagnostics["mic_boost_prompt"] = micBoostPromptOutcome.rawValue
         activeRecordingTrigger = .unknown
         activeRecordingSuggestedTitle = nil
         activeRecordingStartedAt = nil
@@ -1485,6 +1506,11 @@ final class MeetingSessionController: ObservableObject {
                     event = self.audioInactivityDetector.startRecording(at: self.recordingDuration)
                 } else {
                     event = self.audioInactivityDetector.stopRecording()
+                    // Capture can stop underneath the controller (device
+                    // watchdog give-up, disk-full guard) without any app-side
+                    // stop path running. The boost prompt must never outlive
+                    // the recording it offered to fix.
+                    self.isMicBoostPromptVisible = false
                 }
                 self.applyAudioInactivityEvent(event)
             }

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -1673,6 +1673,10 @@ final class MeetingOverlayController: NSObject {
             state = .recording
             showPanel()
             pushToView()
+            // Transcript updates that arrived while the prompt was up were
+            // deferred (the drawer only renders in .recording); flush them
+            // now instead of waiting for the next ASR update.
+            flushPendingTranscriptIfNeeded()
             scheduleRestIfNeeded()
         } else {
             state = .idle
@@ -2287,6 +2291,10 @@ final class MeetingOverlayController: NSObject {
             state = .recording
             showPanel()
             pushToView()
+            // The silence that raised this prompt can hold it up for minutes;
+            // flush transcript updates deferred behind it instead of waiting
+            // for the next ASR update.
+            flushPendingTranscriptIfNeeded()
             scheduleRestIfNeeded()
             // A mic-boost prompt may have fired while the inactivity prompt
             // was up (suppressed by precedence) or been replaced by it. The

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -279,6 +279,11 @@ struct TranscriptedSettingsView: View {
         .onReceive(NotificationCenter.default.publisher(for: .localSpeakerPrefsDidChange)) { _ in
             splitLocalSpeakersEnabled = LocalSpeakerPreferences.isEnabled()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .microphoneProcessingPrefsDidChange)) { _ in
+            // Accepting the mid-meeting mic-boost prompt flips this preference
+            // outside Settings; keep an open window's toggle in sync.
+            meetingVoiceProcessingEnabled = MicrophoneProcessingPreferences.isVoiceProcessingEnabled()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .transcriptedPermissionsDidChange)) { _ in
             refreshPermissions()
         }

--- a/Tests/MeetingMicBoostPromptPolicyTests.swift
+++ b/Tests/MeetingMicBoostPromptPolicyTests.swift
@@ -1,10 +1,15 @@
 import Foundation
 
+// Invariant under test: the mic-boost prompt flag is never true while nothing
+// is recording, and no prompt action may persist state for a dead recording.
+
 func testMeetingMicBoostPromptPolicy() {
     runSuite("MeetingMicBoostPromptPolicy.shouldPresent — presents only for fresh recordings with the preference off") {
         assertTrue(
             MeetingMicBoostPromptPolicy.shouldPresent(
                 isRecording: true,
+                isFinishingRecording: false,
+                sessionStateIsRecording: true,
                 voiceProcessingPreferenceEnabled: false,
                 currentOutcome: .notShown
             ),
@@ -16,6 +21,8 @@ func testMeetingMicBoostPromptPolicy() {
         assertFalse(
             MeetingMicBoostPromptPolicy.shouldPresent(
                 isRecording: true,
+                isFinishingRecording: false,
+                sessionStateIsRecording: true,
                 voiceProcessingPreferenceEnabled: true,
                 currentOutcome: .notShown
             ),
@@ -27,6 +34,8 @@ func testMeetingMicBoostPromptPolicy() {
         assertFalse(
             MeetingMicBoostPromptPolicy.shouldPresent(
                 isRecording: true,
+                isFinishingRecording: false,
+                sessionStateIsRecording: true,
                 voiceProcessingPreferenceEnabled: false,
                 currentOutcome: .shown
             ),
@@ -35,6 +44,8 @@ func testMeetingMicBoostPromptPolicy() {
         assertFalse(
             MeetingMicBoostPromptPolicy.shouldPresent(
                 isRecording: true,
+                isFinishingRecording: false,
+                sessionStateIsRecording: true,
                 voiceProcessingPreferenceEnabled: false,
                 currentOutcome: .accepted
             ),
@@ -43,6 +54,8 @@ func testMeetingMicBoostPromptPolicy() {
         assertFalse(
             MeetingMicBoostPromptPolicy.shouldPresent(
                 isRecording: true,
+                isFinishingRecording: false,
+                sessionStateIsRecording: true,
                 voiceProcessingPreferenceEnabled: false,
                 currentOutcome: .declined
             ),
@@ -54,10 +67,59 @@ func testMeetingMicBoostPromptPolicy() {
         assertFalse(
             MeetingMicBoostPromptPolicy.shouldPresent(
                 isRecording: false,
+                isFinishingRecording: false,
+                sessionStateIsRecording: false,
                 voiceProcessingPreferenceEnabled: false,
                 currentOutcome: .notShown
             ),
             "a late cue after stop should not surface a prompt"
+        )
+    }
+
+    runSuite("MeetingMicBoostPromptPolicy.shouldPresent — the prompt flag is never re-latched mid-stop") {
+        assertFalse(
+            MeetingMicBoostPromptPolicy.shouldPresent(
+                isRecording: true,
+                isFinishingRecording: true,
+                sessionStateIsRecording: true,
+                voiceProcessingPreferenceEnabled: false,
+                currentOutcome: .notShown
+            ),
+            "a cue landing while stop/cancel/termination teardown awaits capture files must not re-latch the prompt the stop path already cleared"
+        )
+        assertFalse(
+            MeetingMicBoostPromptPolicy.shouldPresent(
+                isRecording: true,
+                isFinishingRecording: false,
+                sessionStateIsRecording: false,
+                voiceProcessingPreferenceEnabled: false,
+                currentOutcome: .notShown
+            ),
+            "a cue landing after the session state machine left .recording must not surface a prompt even if the capture flag has not settled yet"
+        )
+    }
+
+    runSuite("MeetingMicBoostPromptPolicy.shouldApplyPromptAction — stale actions never persist for a dead recording") {
+        assertTrue(
+            MeetingMicBoostPromptPolicy.shouldApplyPromptAction(
+                isPromptVisible: true,
+                isRecording: true
+            ),
+            "actioning a visible prompt during a live recording applies normally"
+        )
+        assertFalse(
+            MeetingMicBoostPromptPolicy.shouldApplyPromptAction(
+                isPromptVisible: true,
+                isRecording: false
+            ),
+            "a stale accept after capture stopped must not flip the global VPIO preference or record an outcome"
+        )
+        assertFalse(
+            MeetingMicBoostPromptPolicy.shouldApplyPromptAction(
+                isPromptVisible: false,
+                isRecording: true
+            ),
+            "an action with no visible prompt stays a no-op"
         )
     }
 


### PR DESCRIPTION
## What

2026-06-12 audits of the #1075 mic-boost prompt found the happy path solid but several edge-path holes. This closes them as one cohesive pass, all anchored on one invariant now encoded in `MeetingMicBoostPromptPolicy`: **the prompt flag is never true while nothing is recording.**

### Controller (`MeetingSessionController`)

- **Core-initiated stops clear the prompt.** The `capture.$isRecording` sink now clears `isMicBoostPromptVisible` when capture stops underneath the controller (device watchdog give-up, disk-full guard). Previously the prompt stayed up and accepting it flipped the global VPIO preference while nothing recorded.
- **No mid-stop re-latch.** `handleMicAttenuationCue` is now gated on `!isFinishingRecording && state == .recording` (via the extended policy), so a late attenuation cue landing during `stopAndAwaitFiles` in stop/cancel/termination can't re-raise the prompt after the stop path cleared it.
- **Stale actions never persist.** `acceptMicBoostPrompt()` / `declineMicBoostPrompt()` go through a new `shouldApplyPromptAction` gate: a stale action (prompt visible, recording dead) dismisses the prompt only — no VPIO preference flip, no outcome, no analytics for a dead recording.
- **Cancel-path diagnostics carry `mic_boost_prompt`.** `cancelRecording()` now mirrors `stopRecording()` so cancelled-meeting events can correlate prompt outcomes. The property was already allowlisted for `meeting_recording_cancelled` via the shared `meetingCaptureDiagnosticProperties` set — no policy change needed.

### Overlay (`MeetingOverlayController`)

- `clearMicBoostPrompt()` and `clearAudioInactivityPrompt()` now call `flushPendingTranscriptIfNeeded()` when returning to `.recording`, matching `applySessionState(.recording)`. Transcript updates deferred behind a prompt render immediately instead of waiting for the next ASR update — which, after a silence-triggered inactivity prompt, could be minutes away.

### Settings (`TranscriptedSettingsView`)

- New `.onReceive` for `.microphoneProcessingPrefsDidChange` (the notification existed but had no observer), so accepting the boost mid-meeting updates the VPIO toggle in an open Settings window instead of leaving it stale until re-presentation.

### Tests

`Tests/MeetingMicBoostPromptPolicyTests.swift` extended for the new policy surface: mid-stop re-latch suppression, state-machine-left-recording suppression, and the stale-action gate. Controller/overlay paths aren't compiled into the fast-test runner, so the gates live in the dependency-free policy where they are testable.

## Verification

- `bash build.sh --no-open` — pass (fresh worktree, deps rebuilt via `build-deps.sh`)
- `bash run-tests.sh` — 4890 tests, 4890 passed, 0 failed

App-side only; `Sources/TranscriptedCore/` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)