### PR TITLE
Fix CaptureKit title-extraction crash and dropped speaker metadata

### DIFF
--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -293,8 +293,9 @@ final class ContextStoreTests: XCTestCase {
         duration: "0:18"
         speakers:
           - id: "0"
-            name: Linus
+            channel: system
             db_id: "80FB272B-6061-4FC4-8408-3F7A974C59DB"
+            name: Linus
         ---
 
         # Hardware chat
@@ -342,11 +343,13 @@ final class ContextStoreTests: XCTestCase {
         duration: "0:18"
         speakers:
           - id: "0"
-            name: Speaker 1
+            channel: system
             db_id: "system-1"
+            name: Speaker 1
           - id: "1"
-            name: Linus
+            channel: mic
             db_id: "linus-1"
+            name: Linus
         ---
 
         # Hardware chat
@@ -452,11 +455,13 @@ final class ContextStoreTests: XCTestCase {
         duration: "0:18"
         speakers:
           - id: "0"
-            name: Alex
+            channel: system
             db_id: "80FB272B-6061-4FC4-8408-3F7A974C59DB"
-          - id: "1"
             name: Alex
+          - id: "1"
+            channel: system
             db_id: "4F57C98D-B6B7-449F-95B9-3521FA99D7DA"
+            name: Alex
         ---
 
         # Duplicate names

--- a/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdown.swift
+++ b/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdown.swift
@@ -49,11 +49,15 @@ public enum CaptureMarkdown {
 
     /// Extract the `title:` value from YAML frontmatter, if present.
     public static func extractTitle(from content: String) -> String? {
-        // Minimum valid frontmatter is "---\n...\n---\n" (8+ chars)
+        // Minimum valid frontmatter is "---\n...\n---\n" (8+ chars). The closing
+        // delimiter search must start at offset 4 (past the opening "---\n", same
+        // as CaptureMarkdownParser.parseFrontmatter): from offset 3, a file
+        // beginning "---\n---\n" matches at index 3 and the YAML slice below
+        // becomes an inverted range, which traps.
         guard content.count >= 8, content.hasPrefix("---"),
               let endRange = content.range(
                 of: "\n---\n",
-                range: content.index(content.startIndex, offsetBy: 3)..<content.endIndex
+                range: content.index(content.startIndex, offsetBy: 4)..<content.endIndex
               ) else { return nil }
         let yaml = String(content[content.index(content.startIndex, offsetBy: 4)..<endRange.lowerBound])
         for line in yaml.components(separatedBy: "\n") {

--- a/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdownParser.swift
+++ b/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdownParser.swift
@@ -268,7 +268,12 @@ public enum CaptureMarkdownParser {
                 currentConfidence = trimmed
                     .replacingOccurrences(of: "confidence:", with: "")
                     .trimmingCharacters(in: .whitespacesAndNewlines)
-            } else if !trimmed.hasPrefix("-"), !trimmed.hasPrefix("source:"), !trimmed.isEmpty {
+            } else if !trimmed.isEmpty, !trimmed.hasPrefix("-"),
+                      !(rawLine.first?.isWhitespace ?? false) {
+                // Only a new top-level frontmatter key ends the speakers block.
+                // Indented keys the parser doesn't model (channel:, source:,
+                // future writer fields) belong to the current entry and are
+                // skipped, not treated as terminators.
                 break
             }
         }

--- a/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureMarkdownParserTests.swift
+++ b/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureMarkdownParserTests.swift
@@ -2,6 +2,9 @@ import XCTest
 @testable import TranscriptedCaptureKit
 
 final class CaptureMarkdownParserTests: XCTestCase {
+    // Frontmatter mirrors what TranscriptFormatter.formatTranscriptMarkdown
+    // actually writes: recording-health keys and gap_events before speakers,
+    // channel-qualified speaker entries, and Obsidian tags/aliases after.
     func testParseMeetingLegacyTranscriptAssignsSpeakerIdsAndMetadata() throws {
         let markdown = """
         ---
@@ -12,12 +15,28 @@ final class CaptureMarkdownParserTests: XCTestCase {
         dropped_segments: 2
         transcription_engine: parakeet_local
         diarization_engine: pyannote_offline
+        capture_quality: degraded
+        audio_gaps: 1
+        device_switches: 0
+        gap_events:
+          - "Audio gap at 00:42 (1.5s)"
+        audio_health: mic_attenuated_by_call_app
+        mic_boost_prompt: "Mic level was boosted after a call app attenuated it."
         speakers:
           - id: "0"
+            channel: system
             db_id: "80FB272B-6061-4FC4-8408-3F7A974C59DB"
             name: "Jenny Wen"
             confidence: high
             source: db_scan
+        tags:
+          - transcripted
+          - meeting
+          - speaker/jenny-wen
+        aliases:
+          - "Meeting 2026-04-18 09:15:00"
+        cssclasses:
+          - transcripted
         ---
 
         # Meeting Fixture
@@ -120,9 +139,11 @@ final class CaptureMarkdownParserTests: XCTestCase {
         time: 09:15:00
         speakers:
           - id: "0"
+            channel: system
             db_id: "AAA"
             name: "Alex"
           - id: "1"
+            channel: system
             db_id: "BBB"
             name: "Alex"
         ---
@@ -221,6 +242,24 @@ final class CaptureMarkdownParserTests: XCTestCase {
         """
         XCTAssertEqual(CaptureMarkdown.extractTitle(from: markdown), "Product review")
         XCTAssertNil(CaptureMarkdown.extractTitle(from: "no frontmatter"))
+    }
+
+    // A file of nothing but "---" delimiter lines passes parseFrontmatter (and
+    // file-level capture detection), so it reaches title hydration in both
+    // standalone tools. extractTitle used to trap on the inverted-range slice.
+    func testDegenerateDelimiterOnlyFrontmatterDoesNotTrap() {
+        XCTAssertNil(CaptureMarkdown.extractTitle(from: "---\n---\n"))
+        XCTAssertNil(CaptureMarkdown.extractTitle(from: "---\n---\n---\n"))
+        XCTAssertNil(CaptureMarkdown.extractTitle(from: "---\n---\n---\n\n# Body\n"))
+
+        let degenerate = "---\n---\n---\n"
+        XCTAssertNotNil(CaptureMarkdownParser.parseFrontmatter(from: degenerate))
+        let meeting = CaptureMarkdownParser.parseMeeting(from: degenerate)
+        XCTAssertNotNil(meeting)
+        XCTAssertEqual(meeting?.utterances.count, 0)
+        XCTAssertEqual(meeting?.speakers.count, 0)
+
+        XCTAssertNil(CaptureMarkdownParser.parseMeeting(from: "---\n---\n"))
     }
 
     func testLooksLikeCaptureMarkdown() throws {

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TestHelpers.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TestHelpers.swift
@@ -23,12 +23,14 @@ func makeFixtureJSON(
     let micSpeakerCount = Set(micUtterances.map(\.speakerId)).count
     let systemSpeakerCount = Set(systemUtterances.map(\.speakerId)).count
 
+    // Entry shape and key order mirror TranscriptFormatter.formatTranscriptMarkdown.
     let speakerLines = speakers
         .filter { $0.id.hasPrefix("system_") }
         .map { speaker -> String in
             let rawId = speaker.id.replacingOccurrences(of: "system_", with: "")
             var lines = [
-                "  - id: \"\(rawId)\""
+                "  - id: \"\(rawId)\"",
+                "    channel: system"
             ]
             if let persistentId = speaker.persistentId {
                 lines.append("    db_id: \"\(persistentId)\"")
@@ -77,8 +79,22 @@ func makeFixtureJSON(
     mic_speakers: \(micSpeakerCount)
     system_speakers: \(systemSpeakerCount)
     total_word_count: \(totalWordCount)
+    capture_quality: degraded
+    audio_gaps: 1
+    device_switches: 0
+    gap_events:
+      - "Audio gap at 00:42 (1.5s)"
+    audio_health: mic_attenuated_by_call_app
+    mic_boost_prompt: "Mic level was boosted after a call app attenuated it."
     speakers:
     \(speakerLines)
+    tags:
+      - transcripted
+      - meeting
+    aliases:
+      - "Meeting \(dateComponents.date) \(dateComponents.time)"
+    cssclasses:
+      - transcripted
     ---
 
     # Meeting Fixture


### PR DESCRIPTION
## Summary

A 2026-06-12 audit of `Tools/TranscriptedCaptureKit` found two verified bugs. Both are pre-existing but centralized in the shared kit, so this one change covers the CLI and the MCP server together.

**1. Fatal crash in `CaptureMarkdown.extractTitle` (verified, exit 133).** The closing `\n---\n` search started at offset 3 while the YAML slice started at offset 4, so a file beginning `---\n---\n` matched at index 3 and trapped on the inverted range ("Range requires lowerBound <= upperBound"). Reachable end-to-end: a file starting `---\n---\n---\n...` passes `parseFrontmatter` and gets indexed, then `list_meetings`/`recap`/`search` title hydration crashes the MCP server — and crashes it again on every retry while the file exists (persistent DoS from one odd file). The CLI crashed the same way via `readMeetingTitle`. The search now starts at offset 4, matching `parseFrontmatter`.

**2. Speaker metadata silently dropped for every current-format meeting.** The terminator branch in `parseFrontmatterSpeakers` broke on any unrecognized line, and the app writer has emitted `channel: mic|system` inside each speaker entry since #312 (`TranscriptFormatter.swift`). The scan died at the first entry: zero speakers parsed, `persistentSpeakerId`/`confidence` nil in MCP output and the SQLite index, system speaker IDs degraded to generated `system_0...`. The scan now ends only at a new top-level frontmatter key and skips unmodeled indented entry keys.

## Tests

- Kit, CLI, and MCP fixtures are now writer-faithful, mirroring `TranscriptFormatter.formatTranscriptMarkdown`: `channel:` in writer key order, `gap_events`, `audio_health`/`mic_boost_prompt`, and trailing `tags:`/`aliases:`/`cssclasses:`. The writer-unfaithful fixtures are exactly what hid bug 2.
- New `testDegenerateDelimiterOnlyFrontmatterDoesNotTrap` covers the `---\n---\n...` crash shapes.
- Negative proof: with only the parser fix reverted, the updated kit fixture fails with the audit's exact symptom (`persistentSpeakerId`/`confidence` nil).
- App-side `TranscriptFrontmatter` already searches from offset 4, so the crash was kit-only.

## Verification (gates run bare, no pipes)

- `swift test --package-path Tools/TranscriptedCaptureKit` — 20/20
- `swift test --package-path Tools/TranscriptedCLI` — 45/45
- `swift test --package-path Tools/TranscriptedMCP` — 74/74
- `bash run-e2e-smoke.sh` — `[e2e] OK - deterministic capture contract passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)