### PR TITLE
Guard meeting recording-journal writes with a per-session ownership token

### DIFF
--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -167,7 +167,25 @@ public class Audio: ObservableObject, @unchecked Sendable {
         _micSegments.append(segment)
         let segments = _micSegments
         micSegmentsLock.unlock()
-        recordingJournal.recordSegments(segments)
+        recordingJournal.recordSegments(segments, session: journalSession)
+    }
+
+    // Journal ownership for the in-flight recording session. Issued by the
+    // store when the start path calls `begin()`; consumed (read-and-cleared)
+    // by `stop()` so only the stop that ends an active session can write the
+    // stopping/finalized journal states.
+    private var _journalSession: MeetingRecordingJournalSession?
+    private let journalSessionLock = NSLock()
+    var journalSession: MeetingRecordingJournalSession? {
+        get { journalSessionLock.lock(); defer { journalSessionLock.unlock() }; return _journalSession }
+        set { journalSessionLock.lock(); defer { journalSessionLock.unlock() }; _journalSession = newValue }
+    }
+    func takeJournalSession() -> MeetingRecordingJournalSession? {
+        journalSessionLock.lock()
+        defer { journalSessionLock.unlock() }
+        let session = _journalSession
+        _journalSession = nil
+        return session
     }
 
     // MARK: - Recording Health Tracking (Phase 1: Sleep/Wake + Gap Logging)
@@ -869,6 +887,9 @@ public class Audio: ObservableObject, @unchecked Sendable {
         consecutiveSystemWriteErrors = 0
         systemAudioFailed = false
         micSegments = []
+        // Any leftover journal ownership belongs to a session that never
+        // stopped cleanly; the new session gets a fresh token at begin().
+        journalSession = nil
     }
 
     private func beginStartIntent() -> UUID {
@@ -1024,7 +1045,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         guard recordingSessionGeneration == sessionGeneration else { return }
 
         systemAudioFileURL = fileURL
-        recordingJournal.recordSystemAudio(fileURL)
+        recordingJournal.recordSystemAudio(fileURL, session: journalSession)
         restoreSystemAudioHealthyStatusAfterSuccessfulStart()
     }
 
@@ -1054,7 +1075,14 @@ public class Audio: ObservableObject, @unchecked Sendable {
         let finalSystemURL = systemAudioFileURL
         let cueHandler = self.onCaptureLifecycleCue
 
-        recordingJournal.markStopping()
+        // Take (read-and-clear) journal ownership: only the stop that ends an
+        // active session may write the stopping/finalized states. With no
+        // active session — a double stop, or cleanup after a start that failed
+        // before the journal began — the token is nil and the journal store
+        // drops both writes, so a previous meeting's already-handed-off
+        // journal cannot be resurrected into the next launch's recovery scan.
+        let journalSession = takeJournalSession()
+        recordingJournal.markStopping(session: journalSession)
 
         // Update UI state immediately so the meeting widget unfreezes
         // before any of the slow CoreAudio teardown begins. Without this
@@ -1160,7 +1188,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
             cleanupGroup.notify(queue: .global(qos: .utility)) { [weak self] in
                 guard let self else { return }
                 let finalMicURL = self.finalizeMicRecording(primaryURL: primaryMicURL, segments: micSegmentsSnapshot)
-                self.recordingJournal.markFinalized(finalMicURL: finalMicURL)
+                self.recordingJournal.markFinalized(finalMicURL: finalMicURL, session: journalSession)
                 DispatchQueue.main.async {
                     if self.recordingSessionGeneration == stopGeneration {
                         self.originalMicAudioFileURL = nil

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -284,7 +284,7 @@ extension Audio {
                 interleaved: monoFormat.isInterleaved
             )
             FileManager.default.restrictToOwnerOnly(atPath: fileURL.path)
-            recordingJournal.begin(primaryMicURL: fileURL)
+            journalSession = recordingJournal.begin(primaryMicURL: fileURL)
             AppLogger.audioMic.info("Saving as mono", ["sampleRate": "\(recordingSnapshot.sampleRate)"])
         } catch {
             throw NSError(domain: "Audio", code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to create mic audio file: \(error.localizedDescription)"])

--- a/Sources/TranscriptedCore/Audio/MeetingRecordingJournal.swift
+++ b/Sources/TranscriptedCore/Audio/MeetingRecordingJournal.swift
@@ -35,6 +35,19 @@ struct MeetingRecordingJournal: Codable, Equatable {
     var finalMicFilename: String?
 }
 
+/// Opaque ownership token for one recording session's journal writes. Issued
+/// by `begin()`; every mutation must present the matching token or it is
+/// dropped. Stop-path finalization can land seconds after `stop()` returns
+/// (multi-segment merges), so without the token a previous session's late
+/// writes would corrupt the journal of the recording that is now active.
+struct MeetingRecordingJournalSession: Equatable, Sendable {
+    private let id: UUID
+
+    init() {
+        self.id = UUID()
+    }
+}
+
 final class MeetingRecordingJournalStore: @unchecked Sendable {
     static let filenameSuffix = ".recording.json"
 
@@ -42,14 +55,18 @@ final class MeetingRecordingJournalStore: @unchecked Sendable {
     private let queue = DispatchQueue(label: "com.transcripted.recording-journal", qos: .utility)
     private var journalURL: URL?
     private var journal: MeetingRecordingJournal?
+    private var activeSession: MeetingRecordingJournalSession?
 
     init(directory: URL) {
         self.directory = directory
     }
 
-    func begin(primaryMicURL: URL, startedAt: Date = Date()) {
+    @discardableResult
+    func begin(primaryMicURL: URL, startedAt: Date = Date()) -> MeetingRecordingJournalSession {
+        let session = MeetingRecordingJournalSession()
         queue.async {
             let name = primaryMicURL.deletingPathExtension().lastPathComponent + Self.filenameSuffix
+            self.activeSession = session
             self.journalURL = self.directory.appendingPathComponent(name)
             self.journal = MeetingRecordingJournal(
                 version: 1,
@@ -66,28 +83,29 @@ final class MeetingRecordingJournalStore: @unchecked Sendable {
             )
             self.persistLocked()
         }
+        return session
     }
 
-    func recordSystemAudio(_ url: URL) {
-        mutate { $0.systemAudioFilename = url.lastPathComponent }
+    func recordSystemAudio(_ url: URL, session: MeetingRecordingJournalSession?) {
+        mutate(session: session) { $0.systemAudioFilename = url.lastPathComponent }
     }
 
-    func recordSegments(_ segments: [MicRecordingSegment]) {
+    func recordSegments(_ segments: [MicRecordingSegment], session: MeetingRecordingJournalSession?) {
         let records = segments.map {
             MeetingRecordingJournal.SegmentRecord(
                 filename: $0.url.lastPathComponent,
                 gapBefore: $0.gapBeforeDuration
             )
         }
-        mutate { $0.micSegments = records }
+        mutate(session: session) { $0.micSegments = records }
     }
 
-    func markStopping() {
-        mutate { $0.state = .stopping }
+    func markStopping(session: MeetingRecordingJournalSession?) {
+        mutate(session: session) { $0.state = .stopping }
     }
 
-    func markFinalized(finalMicURL: URL?) {
-        mutate {
+    func markFinalized(finalMicURL: URL?, session: MeetingRecordingJournalSession?) {
+        mutate(session: session) {
             $0.state = .finalized
             $0.finalMicFilename = finalMicURL?.lastPathComponent
         }
@@ -101,6 +119,7 @@ final class MeetingRecordingJournalStore: @unchecked Sendable {
             }
             self.journal = nil
             self.journalURL = nil
+            self.activeSession = nil
         }
     }
 
@@ -109,9 +128,26 @@ final class MeetingRecordingJournalStore: @unchecked Sendable {
         queue.sync {}
     }
 
-    private func mutate(_ change: @escaping (inout MeetingRecordingJournal) -> Void) {
+    private func mutate(
+        session: MeetingRecordingJournalSession?,
+        _ change: @escaping (inout MeetingRecordingJournal) -> Void
+    ) {
         queue.async {
-            guard var journal = self.journal else { return }
+            // Only the session that began this journal may write to it. A nil
+            // session (a stop with no active recording) owns nothing.
+            guard let session, session == self.activeSession else { return }
+            guard var journal = self.journal, let journalURL = self.journalURL else { return }
+            // The file vanishing means the meeting already reached a durable
+            // state and `removeJournal(forMicAudioURL:)` deleted it without
+            // access to this instance. Drop the in-memory copy instead of
+            // re-persisting: a resurrected journal becomes a duplicate
+            // failed-queue entry on the next launch's recovery scan.
+            guard FileManager.default.fileExists(atPath: journalURL.path) else {
+                self.journal = nil
+                self.journalURL = nil
+                self.activeSession = nil
+                return
+            }
             change(&journal)
             journal.updatedAt = Date()
             self.journal = journal

--- a/Tests/TranscriptedCoreTests/MeetingRecordingJournalTests.swift
+++ b/Tests/TranscriptedCoreTests/MeetingRecordingJournalTests.swift
@@ -22,19 +22,19 @@ final class MeetingRecordingJournalTests: XCTestCase {
         let micURL = temporaryDirectory.appendingPathComponent("meeting_2026_mic.wav")
         let journalURL = temporaryDirectory.appendingPathComponent("meeting_2026_mic.recording.json")
 
-        store.begin(primaryMicURL: micURL, startedAt: Date(timeIntervalSince1970: 1_000))
+        let session = store.begin(primaryMicURL: micURL, startedAt: Date(timeIntervalSince1970: 1_000))
         store.flush()
         var journal = try XCTUnwrap(MeetingRecordingJournalStore.load(at: journalURL))
         XCTAssertEqual(journal.state, .recording)
         XCTAssertEqual(journal.primaryMicFilename, "meeting_2026_mic.wav")
         XCTAssertEqual(journal.micSegments.map(\.filename), ["meeting_2026_mic.wav"])
 
-        store.recordSystemAudio(temporaryDirectory.appendingPathComponent("meeting_2026_system.wav"))
+        store.recordSystemAudio(temporaryDirectory.appendingPathComponent("meeting_2026_system.wav"), session: session)
         store.recordSegments([
             MicRecordingSegment(url: micURL),
             MicRecordingSegment(url: temporaryDirectory.appendingPathComponent("recovery.wav"), gapBeforeDuration: 1.5)
-        ])
-        store.markStopping()
+        ], session: session)
+        store.markStopping(session: session)
         store.flush()
         journal = try XCTUnwrap(MeetingRecordingJournalStore.load(at: journalURL))
         XCTAssertEqual(journal.state, .stopping)
@@ -42,7 +42,7 @@ final class MeetingRecordingJournalTests: XCTestCase {
         XCTAssertEqual(journal.micSegments.map(\.filename), ["meeting_2026_mic.wav", "recovery.wav"])
         XCTAssertEqual(journal.micSegments.last?.gapBefore ?? 0, 1.5, accuracy: 0.001)
 
-        store.markFinalized(finalMicURL: temporaryDirectory.appendingPathComponent("meeting_2026_mic_merged.wav"))
+        store.markFinalized(finalMicURL: temporaryDirectory.appendingPathComponent("meeting_2026_mic_merged.wav"), session: session)
         store.flush()
         journal = try XCTUnwrap(MeetingRecordingJournalStore.load(at: journalURL))
         XCTAssertEqual(journal.state, .finalized)
@@ -51,6 +51,99 @@ final class MeetingRecordingJournalTests: XCTestCase {
         store.clear()
         store.flush()
         XCTAssertFalse(FileManager.default.fileExists(atPath: journalURL.path))
+    }
+
+    func testLateFinalizeFromPreviousSessionLeavesNewJournalUntouched() throws {
+        let store = MeetingRecordingJournalStore(directory: temporaryDirectory)
+        let micA = temporaryDirectory.appendingPathComponent("meeting_A_mic.wav")
+        let micB = temporaryDirectory.appendingPathComponent("meeting_B_mic.wav")
+        let journalAURL = temporaryDirectory.appendingPathComponent("meeting_A_mic.recording.json")
+        let journalBURL = temporaryDirectory.appendingPathComponent("meeting_B_mic.recording.json")
+
+        let sessionA = store.begin(primaryMicURL: micA)
+        store.markStopping(session: sessionA)
+
+        // Recording B begins while A's finalize is still in flight — the
+        // multi-segment merge in stop()'s cleanup can land seconds after a
+        // timed-out bridge stop already let the next recording start.
+        store.begin(primaryMicURL: micB)
+        store.markFinalized(
+            finalMicURL: temporaryDirectory.appendingPathComponent("meeting_A_mic_merged.wav"),
+            session: sessionA
+        )
+        store.flush()
+
+        let journalB = try XCTUnwrap(MeetingRecordingJournalStore.load(at: journalBURL))
+        XCTAssertEqual(journalB.state, .recording)
+        XCTAssertNil(journalB.finalMicFilename, "A's late finalize must not write A's merged file into B's journal")
+
+        let journalA = try XCTUnwrap(MeetingRecordingJournalStore.load(at: journalAURL))
+        XCTAssertEqual(journalA.state, .stopping)
+        XCTAssertNil(journalA.finalMicFilename, "A's journal keeps its last owned state for the recovery scan")
+    }
+
+    func testLateWriteAfterJournalRemovalDoesNotResurrectIt() throws {
+        let store = MeetingRecordingJournalStore(directory: temporaryDirectory)
+        let micURL = temporaryDirectory.appendingPathComponent("meeting_done_mic.wav")
+        let journalURL = temporaryDirectory.appendingPathComponent("meeting_done_mic.recording.json")
+
+        let session = store.begin(primaryMicURL: micURL)
+        store.markStopping(session: session)
+        store.flush()
+        XCTAssertTrue(FileManager.default.fileExists(atPath: journalURL.path))
+
+        // Durable handoff (failed-queue entry persisted, or transcript saved)
+        // removes the file through the static helper, which has no access to
+        // this store instance's in-memory state.
+        MeetingRecordingJournalStore.removeJournal(forMicAudioURL: micURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journalURL.path))
+
+        // A late write from the same session must drop, not re-create the file.
+        store.markFinalized(finalMicURL: micURL, session: session)
+        store.flush()
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: journalURL.path),
+            "a write after durable handoff must not resurrect the journal"
+        )
+    }
+
+    func testStopWithNoActiveSessionDoesNotResurrectRemovedJournal() throws {
+        let paths = CoreStoragePaths(
+            transcripts: temporaryDirectory.appendingPathComponent("transcripts", isDirectory: true),
+            speakerDB: temporaryDirectory.appendingPathComponent("speakers.sqlite"),
+            statsDB: temporaryDirectory.appendingPathComponent("stats.sqlite"),
+            failedQueue: temporaryDirectory.appendingPathComponent("failed_transcriptions.json"),
+            speakerClips: temporaryDirectory.appendingPathComponent("speaker_clips", isDirectory: true),
+            audioCaptures: temporaryDirectory.appendingPathComponent("audio", isDirectory: true),
+            logs: temporaryDirectory.appendingPathComponent("logs", isDirectory: true)
+        )
+        try FileManager.default.createDirectory(at: paths.audioCaptures, withIntermediateDirectories: true)
+
+        let audio = Audio(paths: paths)
+        let micURL = paths.audioCaptures.appendingPathComponent("meeting_prev_mic.wav")
+        let journalURL = paths.audioCaptures.appendingPathComponent("meeting_prev_mic.recording.json")
+
+        // A previous meeting finished and reached durable handoff: its journal
+        // file is removed, but the store instance still holds the journal in
+        // memory because nothing in production calls clear().
+        let session = audio.recordingJournal.begin(primaryMicURL: micURL)
+        audio.recordingJournal.markFinalized(finalMicURL: micURL, session: session)
+        audio.recordingJournal.flush()
+        MeetingRecordingJournalStore.removeJournal(forMicAudioURL: micURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journalURL.path))
+
+        // A failed start (e.g. bridge start timeout) calls stop() without an
+        // active recording session.
+        let stopFinished = expectation(description: "stop completion fired")
+        audio.onRecordingComplete = { _, _ in stopFinished.fulfill() }
+        audio.stop()
+        wait(for: [stopFinished], timeout: 5.0)
+        audio.recordingJournal.flush()
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: journalURL.path),
+            "stop() with no active session must not re-persist the previous meeting's journal"
+        )
     }
 
     func testJournalURLsFindsOnlyJournalFiles() throws {

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerRecoveryTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerRecoveryTests.swift
@@ -122,6 +122,45 @@ final class TranscriptionTaskManagerRecoveryTests: XCTestCase {
         XCTAssertGreaterThan(merged.length, 3_000)
     }
 
+    func testLateJournalWriteAfterRecoveryHandoffDoesNotDuplicateFailedEntry() async throws {
+        let (manager, paths) = makeManager()
+
+        let micURL = paths.audioCaptures.appendingPathComponent("meeting_dup_mic.wav")
+        try writeMonoWAV(to: micURL, sampleRate: 48_000, samples: Array(repeating: 0.5, count: 4_800))
+        try backdate(micURL)
+
+        // Go through a live store so its in-memory journal survives the
+        // handoff the way it does in the app process.
+        let store = MeetingRecordingJournalStore(directory: paths.audioCaptures)
+        let session = store.begin(primaryMicURL: micURL)
+        store.markStopping(session: session)
+        store.flush()
+        let journalURL = paths.audioCaptures.appendingPathComponent(
+            "meeting_dup_mic" + MeetingRecordingJournalStore.filenameSuffix
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: journalURL.path))
+
+        let recovered = await manager.recoverOrphanedRecordings(in: paths.audioCaptures)
+        XCTAssertEqual(recovered, 1)
+        XCTAssertEqual(manager.failedTranscriptionManager.failedTranscriptions.count, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journalURL.path))
+
+        // A late stop-path write from the stale session (a timed-out bridge
+        // stop finishing its merge) must not resurrect the journal...
+        store.markFinalized(finalMicURL: micURL, session: session)
+        store.flush()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: journalURL.path))
+
+        // ...so the next scan finds nothing and the failed queue keeps a
+        // single entry for this recording.
+        let recoveredAgain = await manager.recoverOrphanedRecordings(in: paths.audioCaptures)
+        XCTAssertEqual(recoveredAgain, 0)
+        XCTAssertEqual(
+            manager.failedTranscriptionManager.failedTranscriptions.count, 1,
+            "a resurrected journal would re-recover the same audio into a duplicate failed-queue entry"
+        )
+    }
+
     // MARK: - Fixtures
 
     private func makeManager() -> (TranscriptionTaskManager, CoreStoragePaths) {


### PR DESCRIPTION
## Why

Two independent code audits on 2026-06-12 converged on a session-identity hole in the meeting recording journal added by PR #1074. `MeetingRecordingJournalStore.mutate` wrote to whatever journal was in memory with no ownership check, and the store's in-memory state was never cleared in production (`clear()` had zero callers; the durable handoff uses the static `removeJournal(forMicAudioURL:)`, which deletes the file but not the in-memory state).

Two concrete failure chains:

1. **Cross-session corruption (high):** `Audio.stop()` runs `markFinalized` from `cleanupGroup.notify`, which for multi-segment recordings can land seconds after stop returns. If the bridge stop timed out and recording B already called `begin()`, A's late finalize persisted A's `finalMicFilename` into B's journal — a later crash recovery would attach A's merged audio to B's recovered entry and delete it while A's heal path still needed it.
2. **Journal resurrection (medium):** `stop()` called `markStopping()` unconditionally, so a failed start of meeting B (e.g. bridge start timeout calling `stop()`) re-persisted meeting A's already-removed journal from stale in-memory state → duplicate failed-queue entry for A on the next launch's recovery scan.

## Product Impact

- Affects: `meetings`
- Lane: `meeting reliability`
- Why this matters: a recording started right after a slow/timed-out stop could lose the previous meeting's merged audio through crash recovery, and failed starts could surface phantom duplicate "interrupted recording" entries.

## What changed

- `MeetingRecordingJournal.swift`: `begin()` now issues an opaque `MeetingRecordingJournalSession` ownership token; `recordSystemAudio` / `recordSegments` / `markStopping` / `markFinalized` all require it, and `mutate` drops writes whose token doesn't match the active session (nil never matches). `mutate` also self-heals: if the journal file was already deleted by the durable handoff, it nulls the in-memory state instead of re-persisting.
- `Audio.swift`: holds the token in a lock-guarded property, consumes it atomically (read-and-clear) in `stop()` so double stops and failed-start cleanups never touch the journal; `prepareForNewRecordingStart()` drops any leftover token from a session that never stopped cleanly.
- `AudioFileManager.swift`: the start path stores the token returned by `begin()`.
- Tests: interleaved `begin(B)` + late `markFinalized(A)` leaves B untouched; `stop()` with no active session against a removed journal (through real `Audio.stop()`); same-session late write after handoff self-heals; full duplicate-entry chain through `recoverOrphanedRecordings` (second scan recovers 0, failed queue keeps exactly one entry).

## How I checked it

- [ ] `scripts/dev/agent-preflight.sh`
- [x] Selected checks from `.agents/test-matrix.yml` for the files changed (`bash build-deps.sh --force` included)
- [x] `bash build.sh --no-open`
- [x] `bash run-tests.sh` — 4885/4885
- [x] Performance budget passed (`bash build.sh --no-open` runs the bundle gate)
- [x] `bash run-integration-smoke.sh` if I touched `Sources/Meeting/` or `Sources/TranscriptedCore/`
- [x] `swift test` if I touched `Package.swift`, `Sources/TranscriptedCore/`, or the public core seam — 428 tests, 0 failures (1 pre-existing live-capture skip)
- [ ] Manual check: not run — race-window behavior is covered by the new unit/recovery tests

## Risk Review

- [x] Privacy / local-first behavior reviewed — journal stays local scratch metadata; no new off-device payloads
- [x] Storage path or migration impact reviewed — journal file format and paths unchanged; only write-gating added
- [x] Public-facing copy stays concrete and matches current product scope — no copy changes
- [x] Release/update impact reviewed — none
- [x] Agent PRs link the issue/workpad and stay draft until human review — follows from audit findings on PR #1074
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence — no UI changes
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

## Notes

Follow-up hardening to the crash-recovery journal from PR #1074. The on-disk journal format is unchanged, so journals written by older builds still recover normally.

## Agent handoff

`COORD_DONE: GREEN | https://github.com/r3dbars/transcripted/pull/1084 | session-token-guarded journal writes + in-memory self-heal + idempotent stop, 4 new tests | none | none | build-deps --force, build.sh --no-open, run-tests.sh (4885), run-integration-smoke.sh, swift test (428) | review + merge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)