### PR TITLE
Fix agent-connect config-safety bugs from the 2026-06-12 audit

### DIFF
--- a/Sources/Support/AgentMCPConnector.swift
+++ b/Sources/Support/AgentMCPConnector.swift
@@ -101,6 +101,7 @@ enum AgentMCPConnectorError: LocalizedError, Equatable {
     case agentCLIFailed(AgentMCPAgent, status: Int32, output: String)
     case agentCLITimedOut(AgentMCPAgent)
     case codexConfigUsesInlineServers
+    case codexConfigDefinesServerInUnsupportedForm
 
     var errorDescription: String? {
         switch self {
@@ -115,8 +116,18 @@ enum AgentMCPConnectorError: LocalizedError, Equatable {
             return "\(agent.displayName) did not respond. Try again, or register Transcripted from the \(agent.displayName) side."
         case .codexConfigUsesInlineServers:
             return "Your Codex config defines mcp_servers inline. Add Transcripted there manually, or convert it to [mcp_servers.transcripted] table form."
+        case .codexConfigDefinesServerInUnsupportedForm:
+            return "Your Codex config already defines mcp_servers.transcripted in a form Transcripted can't safely edit. Remove or update that entry in ~/.codex/config.toml, then connect again."
         }
     }
+}
+
+/// Outcome of a connect. Most connects edit the agent's config in place, but
+/// when an existing config file is unreadable it is backed up and replaced —
+/// callers must surface that, because the rewritten file no longer carries
+/// the user's other MCP servers.
+struct AgentMCPConnectResult: Equatable {
+    let replacedConfigBackupURL: URL?
 }
 
 enum AgentMCPConnector {
@@ -201,17 +212,19 @@ enum AgentMCPConnector {
     /// its own full install + self-test flow; for every other agent the
     /// helper must already be installed (callers run `ensureHelperInstalled`
     /// first).
+    @discardableResult
     static func connect(
         _ agent: AgentMCPAgent,
         helperCommandPath: String = ClaudeDesktopIntegrationInstaller.installedMCPBinaryURL.path,
         paths: AgentMCPConnectorPaths = AgentMCPConnectorPaths(),
         fileManager: FileManager = .default,
         cliTimeout: TimeInterval = defaultCLITimeout
-    ) throws {
+    ) throws -> AgentMCPConnectResult {
         switch agent {
         case .claudeDesktop:
             // Claude Desktop keeps its dedicated install + self-test flow.
-            _ = try ClaudeDesktopIntegrationInstaller.installForClaudeDesktop(fileManager: fileManager)
+            let result = try ClaudeDesktopIntegrationInstaller.installForClaudeDesktop(fileManager: fileManager)
+            return AgentMCPConnectResult(replacedConfigBackupURL: result.backupURL)
         case .claudeCode:
             try connectClaudeCode(
                 helperCommandPath: helperCommandPath,
@@ -219,15 +232,28 @@ enum AgentMCPConnector {
                 fileManager: fileManager,
                 cliTimeout: cliTimeout
             )
+            return AgentMCPConnectResult(replacedConfigBackupURL: nil)
         case .codex:
             try connectCodex(helperCommandPath: helperCommandPath, paths: paths, fileManager: fileManager)
+            // The Codex path takes routine safety backups but never replaces
+            // an unreadable config (it throws instead), so there is no
+            // replacement to surface.
+            return AgentMCPConnectResult(replacedConfigBackupURL: nil)
         case .cursor:
-            try ClaudeDesktopIntegrationInstaller.writeMCPServersConfig(
+            let backupURL = try ClaudeDesktopIntegrationInstaller.writeMCPServersConfig(
                 commandPath: helperCommandPath,
                 configURL: paths.cursorConfigURL,
                 fileManager: fileManager
             )
+            return AgentMCPConnectResult(replacedConfigBackupURL: backupURL)
         }
+    }
+
+    /// Notice for the agent row after a connect had to replace an unreadable
+    /// config. The backup must be named in UI — without it the rewrite
+    /// silently drops every other MCP server the user had configured.
+    static func replacedConfigNotice(for agent: AgentMCPAgent, backupURL: URL) -> String {
+        "Your previous \(agent.displayName) config wasn't readable, so it was backed up as \(backupURL.lastPathComponent) next to the config file and replaced. Re-add any other MCP servers from that backup."
     }
 
     // MARK: - Claude Code
@@ -285,6 +311,14 @@ enum AgentMCPConnector {
 
         let existing = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
         let updated = try codexConfigText(updating: existing, commandPath: helperCommandPath)
+        guard updated != existing else {
+            fileManager.restrictFileToOwnerOnly(at: configURL)
+            return
+        }
+
+        // The text-level TOML edit is conservative, but the file belongs to
+        // Codex — keep a copy of what was there before the first byte changes.
+        _ = try ClaudeDesktopIntegrationInstaller.backupConfig(at: configURL, fileManager: fileManager)
         try updated.write(to: configURL, atomically: true, encoding: .utf8)
         fileManager.restrictFileToOwnerOnly(at: configURL)
     }
@@ -294,9 +328,10 @@ enum AgentMCPConnector {
     /// Conservative text-level TOML edit: replaces the `command` entry inside
     /// the `[mcp_servers.transcripted]` table, or appends the table when it is
     /// missing. Everything else in the user's config is preserved byte for
-    /// byte. Throws instead of appending when the config defines `mcp_servers`
-    /// as an inline table — appending a table header after that would corrupt
-    /// the file with a duplicate-key error.
+    /// byte. Throws instead of appending when any TOML spelling of the server
+    /// table already exists or when `mcp_servers` is defined without table
+    /// headers — appending a table header after either would corrupt the file
+    /// with a duplicate-table error.
     static func codexConfigText(updating existing: String, commandPath: String) throws -> String {
         let commandLine = "command = \(tomlBasicString(commandPath))"
         var lines = existing.components(separatedBy: "\n")
@@ -320,15 +355,7 @@ enum AgentMCPConnector {
             return lines.joined(separator: "\n")
         }
 
-        let definesInlineServers = lines.contains { line in
-            let trimmed = trimmedTOMLLine(line)
-            guard trimmed.hasPrefix("mcp_servers") else { return false }
-            let remainder = trimmed.dropFirst("mcp_servers".count).trimmingCharacters(in: .whitespaces)
-            return remainder.hasPrefix("=")
-        }
-        guard !definesInlineServers else {
-            throw AgentMCPConnectorError.codexConfigUsesInlineServers
-        }
+        try ensureCodexConfigSafeToAppendServerTable(lines: lines)
 
         var text = existing
         if !text.isEmpty, !text.hasSuffix("\n") {
@@ -341,6 +368,43 @@ enum AgentMCPConnector {
         return text
     }
 
+    /// The append path is only safe when no TOML spelling of the Transcripted
+    /// server table exists anywhere in the config. TOML accepts spellings this
+    /// text-level editor does not rewrite — `[ mcp_servers.transcripted ]`,
+    /// `[mcp_servers."transcripted"] # comment`, dotted assignments like
+    /// `mcp_servers.transcripted.command = "…"` — and appending a second
+    /// definition would make Codex reject the whole file, disabling every MCP
+    /// server in it. Throw a manual-edit error instead.
+    private static func ensureCodexConfigSafeToAppendServerTable(lines: [String]) throws {
+        var currentSection: [String] = []
+
+        for rawLine in lines {
+            let line = trimmedTOMLLine(rawLine)
+
+            if line.hasPrefix("[") {
+                // An unparseable header line leaves the config invalid TOML on
+                // its own; appending cannot make it less valid.
+                guard let headerPath = tomlTableHeaderKeyPath(line) else { continue }
+                currentSection = headerPath
+                if headerPath.starts(with: codexServerTableKeyPath) {
+                    throw AgentMCPConnectorError.codexConfigDefinesServerInUnsupportedForm
+                }
+                continue
+            }
+
+            guard let keyPath = tomlAssignmentKeyPath(line) else { continue }
+            if (currentSection + keyPath).starts(with: codexServerTableKeyPath) {
+                throw AgentMCPConnectorError.codexConfigDefinesServerInUnsupportedForm
+            }
+            // Root-level `mcp_servers = …` or `mcp_servers.other = …` defines
+            // the server map without table headers; appending a table header
+            // after either is corruption-prone, so route to manual edit.
+            if currentSection.isEmpty, keyPath.first == "mcp_servers" {
+                throw AgentMCPConnectorError.codexConfigUsesInlineServers
+            }
+        }
+    }
+
     static func codexConfiguredCommandPath(inConfigText text: String) -> String? {
         var inServerTable = false
 
@@ -348,7 +412,11 @@ enum AgentMCPConnector {
             let line = trimmedTOMLLine(rawLine)
 
             if line.hasPrefix("[") {
-                inServerTable = line == codexServerTableHeader
+                // Recognize every legal spelling of the table header (inner
+                // whitespace, quoted key, trailing comment) so an existing
+                // hand-written entry reads as connected instead of luring a
+                // Connect click into the duplicate-table guard.
+                inServerTable = tomlTableHeaderKeyPath(line) == codexServerTableKeyPath
                 continue
             }
 
@@ -375,6 +443,165 @@ enum AgentMCPConnector {
         let remainder = trimmedLine.dropFirst("command".count)
             .trimmingCharacters(in: .whitespaces)
         return remainder.hasPrefix("=")
+    }
+
+    private static var codexServerTableKeyPath: [String] {
+        ["mcp_servers", serverName]
+    }
+
+    /// Normalized dotted-key path of a `[table]` or `[[array-of-tables]]`
+    /// header line, or nil when the line is not a well-formed header.
+    private static func tomlTableHeaderKeyPath(_ trimmedLine: String) -> [String]? {
+        guard trimmedLine.hasPrefix("[") else { return nil }
+        var inner = trimmedLine.dropFirst()
+        var isArrayOfTables = false
+        if inner.hasPrefix("[") {
+            isArrayOfTables = true
+            inner = inner.dropFirst()
+        }
+
+        let characters = Array(inner)
+        var keyText = ""
+        var quote: Character?
+        var index = 0
+        var closeIndex: Int?
+        while index < characters.count {
+            let character = characters[index]
+            if let activeQuote = quote {
+                if activeQuote == "\"", character == "\\" {
+                    guard index + 1 < characters.count else { return nil }
+                    keyText.append(character)
+                    keyText.append(characters[index + 1])
+                    index += 2
+                    continue
+                }
+                if character == activeQuote {
+                    quote = nil
+                }
+                keyText.append(character)
+            } else if character == "\"" || character == "'" {
+                quote = character
+                keyText.append(character)
+            } else if character == "]" {
+                closeIndex = index
+                break
+            } else {
+                keyText.append(character)
+            }
+            index += 1
+        }
+
+        guard var afterClose = closeIndex.map({ $0 + 1 }) else { return nil }
+        if isArrayOfTables {
+            guard afterClose < characters.count, characters[afterClose] == "]" else { return nil }
+            afterClose += 1
+        }
+        let remainder = String(characters[afterClose...]).trimmingCharacters(in: .whitespaces)
+        guard remainder.isEmpty || remainder.hasPrefix("#") else { return nil }
+
+        return tomlDottedKeyParts(keyText)
+    }
+
+    /// Normalized dotted-key path on the left-hand side of a TOML assignment
+    /// line, or nil when the line carries no top-level `=`.
+    private static func tomlAssignmentKeyPath(_ trimmedLine: String) -> [String]? {
+        guard !trimmedLine.isEmpty,
+              !trimmedLine.hasPrefix("#"),
+              !trimmedLine.hasPrefix("[") else {
+            return nil
+        }
+
+        let characters = Array(trimmedLine)
+        var quote: Character?
+        var index = 0
+        while index < characters.count {
+            let character = characters[index]
+            if let activeQuote = quote {
+                if activeQuote == "\"", character == "\\" {
+                    index += 2
+                    continue
+                }
+                if character == activeQuote {
+                    quote = nil
+                }
+            } else if character == "\"" || character == "'" {
+                quote = character
+            } else if character == "=" {
+                return tomlDottedKeyParts(String(characters[..<index]))
+            }
+            index += 1
+        }
+        return nil
+    }
+
+    /// Splits a TOML dotted key (`mcp_servers . "transcripted" . command`)
+    /// into normalized parts. Returns nil for anything that is not a
+    /// well-formed dotted key, so unparseable lines never match.
+    private static func tomlDottedKeyParts(_ text: String) -> [String]? {
+        let characters = Array(text)
+        var parts: [String] = []
+        var index = 0
+
+        func skipWhitespace() {
+            while index < characters.count, characters[index] == " " || characters[index] == "\t" {
+                index += 1
+            }
+        }
+
+        while true {
+            skipWhitespace()
+            guard index < characters.count else { return nil }
+
+            var part = ""
+            let leading = characters[index]
+            if leading == "\"" || leading == "'" {
+                let quote = leading
+                index += 1
+                var closed = false
+                while index < characters.count {
+                    let character = characters[index]
+                    if quote == "\"", character == "\\" {
+                        guard index + 1 < characters.count else { return nil }
+                        switch characters[index + 1] {
+                        case "\\": part.append("\\")
+                        case "\"": part.append("\"")
+                        case "n": part.append("\n")
+                        case "r": part.append("\r")
+                        case "t": part.append("\t")
+                        default: return nil
+                        }
+                        index += 2
+                        continue
+                    }
+                    if character == quote {
+                        closed = true
+                        index += 1
+                        break
+                    }
+                    part.append(character)
+                    index += 1
+                }
+                guard closed else { return nil }
+            } else {
+                while index < characters.count, isTOMLBareKeyCharacter(characters[index]) {
+                    part.append(characters[index])
+                    index += 1
+                }
+                guard !part.isEmpty else { return nil }
+            }
+
+            parts.append(part)
+            skipWhitespace()
+            guard index < characters.count else { return parts }
+            guard characters[index] == "." else { return nil }
+            index += 1
+        }
+    }
+
+    private static func isTOMLBareKeyCharacter(_ character: Character) -> Bool {
+        (character.isASCII && (character.isLetter || character.isNumber))
+            || character == "_"
+            || character == "-"
     }
 
     static func tomlBasicString(_ value: String) -> String {
@@ -445,43 +672,17 @@ enum AgentMCPConnector {
         agent: AgentMCPAgent = .claudeCode,
         timeout: TimeInterval = defaultCLITimeout
     ) throws -> (status: Int32, output: String) {
-        let process = Process()
-        process.executableURL = executable
-        process.arguments = arguments
-
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.standardOutput = stdout
-        process.standardError = stderr
-
-        let finished = DispatchSemaphore(value: 0)
-        process.terminationHandler = { _ in finished.signal() }
-
-        try process.run()
-
-        // Drain both pipes off-thread so a chatty CLI cannot fill a pipe
-        // buffer and stall before its exit is observed.
-        final class PipeOutputBox: @unchecked Sendable {
-            var data = Data()
-        }
-        let stdoutBox = PipeOutputBox()
-        let stderrBox = PipeOutputBox()
-        let drained = DispatchGroup()
-        for (pipe, box) in [(stdout, stdoutBox), (stderr, stderrBox)] {
-            drained.enter()
-            DispatchQueue.global(qos: .utility).async {
-                box.data = pipe.fileHandleForReading.readDataToEndOfFile()
-                drained.leave()
-            }
-        }
-
-        if finished.wait(timeout: .now() + timeout) == .timedOut {
-            process.terminate()
-            _ = finished.wait(timeout: .now() + 2)
+        let result: BoundedProcessRunner.Output
+        do {
+            result = try BoundedProcessRunner.run(
+                executable: executable,
+                arguments: arguments,
+                timeout: timeout
+            )
+        } catch is BoundedProcessRunner.RunError {
             throw AgentMCPConnectorError.agentCLITimedOut(agent)
         }
 
-        drained.wait()
-        return (process.terminationStatus, String(decoding: stdoutBox.data + stderrBox.data, as: UTF8.self))
+        return (result.status, String(decoding: result.stdoutData + result.stderrData, as: UTF8.self))
     }
 }

--- a/Sources/Support/AgentMCPConnector.swift
+++ b/Sources/Support/AgentMCPConnector.swift
@@ -384,9 +384,9 @@ enum AgentMCPConnector {
             if line.hasPrefix("[") {
                 // An unparseable header line leaves the config invalid TOML on
                 // its own; appending cannot make it less valid.
-                guard let headerPath = tomlTableHeaderKeyPath(line) else { continue }
-                currentSection = headerPath
-                if headerPath.starts(with: codexServerTableKeyPath) {
+                guard let header = tomlTableHeader(line) else { continue }
+                currentSection = header.keyPath
+                if header.keyPath.starts(with: codexServerTableKeyPath) {
                     throw AgentMCPConnectorError.codexConfigDefinesServerInUnsupportedForm
                 }
                 continue
@@ -416,7 +416,11 @@ enum AgentMCPConnector {
                 // whitespace, quoted key, trailing comment) so an existing
                 // hand-written entry reads as connected instead of luring a
                 // Connect click into the duplicate-table guard.
-                inServerTable = tomlTableHeaderKeyPath(line) == codexServerTableKeyPath
+                if let header = tomlTableHeader(line) {
+                    inServerTable = !header.isArrayOfTables && header.keyPath == codexServerTableKeyPath
+                } else {
+                    inServerTable = false
+                }
                 continue
             }
 
@@ -450,8 +454,8 @@ enum AgentMCPConnector {
     }
 
     /// Normalized dotted-key path of a `[table]` or `[[array-of-tables]]`
-    /// header line, or nil when the line is not a well-formed header.
-    private static func tomlTableHeaderKeyPath(_ trimmedLine: String) -> [String]? {
+    /// header line, plus whether the header used array-of-tables form.
+    private static func tomlTableHeader(_ trimmedLine: String) -> (keyPath: [String], isArrayOfTables: Bool)? {
         guard trimmedLine.hasPrefix("[") else { return nil }
         var inner = trimmedLine.dropFirst()
         var isArrayOfTables = false
@@ -499,7 +503,8 @@ enum AgentMCPConnector {
         let remainder = String(characters[afterClose...]).trimmingCharacters(in: .whitespaces)
         guard remainder.isEmpty || remainder.hasPrefix("#") else { return nil }
 
-        return tomlDottedKeyParts(keyText)
+        guard let keyPath = tomlDottedKeyParts(keyText) else { return nil }
+        return (keyPath: keyPath, isArrayOfTables: isArrayOfTables)
     }
 
     /// Normalized dotted-key path on the left-hand side of a TOML assignment

--- a/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
+++ b/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
@@ -79,6 +79,7 @@ enum ClaudeDesktopIntegrationError: LocalizedError, Equatable {
     case selfTestFailed(status: Int32, output: String)
     case selfTestReportedUnhealthy(output: String)
     case selfTestOutputUnreadable(String)
+    case selfTestTimedOut
 
     var errorDescription: String? {
         switch self {
@@ -98,6 +99,8 @@ enum ClaudeDesktopIntegrationError: LocalizedError, Equatable {
             return "Transcripted direct tools did not pass the local check."
         case .selfTestOutputUnreadable:
             return "Transcripted direct tools ran, but the health check output could not be read."
+        case .selfTestTimedOut:
+            return "Transcripted direct tools did not respond to the local check. Try connecting again."
         }
     }
 }
@@ -325,39 +328,41 @@ enum ClaudeDesktopIntegrationInstaller {
         return backupURL
     }
 
+    static let selfTestTimeout: TimeInterval = 30
+
     static func runSelfTest(
         binaryURL: URL,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        timeout: TimeInterval = selfTestTimeout,
+        pipeDrainTimeout: TimeInterval = BoundedProcessRunner.defaultPipeDrainTimeout
     ) throws -> TranscriptedMCPSelfTest {
         guard fileManager.isExecutableFile(atPath: binaryURL.path) else {
             throw ClaudeDesktopIntegrationError.installedBinaryNotExecutable(binaryURL)
         }
 
-        let process = Process()
-        process.executableURL = binaryURL
-        process.arguments = ["--self-test"]
+        let result: BoundedProcessRunner.Output
+        do {
+            result = try BoundedProcessRunner.run(
+                executable: binaryURL,
+                arguments: ["--self-test"],
+                timeout: timeout,
+                pipeDrainTimeout: pipeDrainTimeout
+            )
+        } catch is BoundedProcessRunner.RunError {
+            throw ClaudeDesktopIntegrationError.selfTestTimedOut
+        }
 
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.standardOutput = stdout
-        process.standardError = stderr
+        let output = String(decoding: result.stdoutData + result.stderrData, as: UTF8.self)
 
-        try process.run()
-        process.waitUntilExit()
-
-        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
-        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
-        let output = String(decoding: stdoutData + stderrData, as: UTF8.self)
-
-        guard process.terminationStatus == 0 else {
+        guard result.status == 0 else {
             throw ClaudeDesktopIntegrationError.selfTestFailed(
-                status: process.terminationStatus,
+                status: result.status,
                 output: output
             )
         }
 
         do {
-            let selfTest = try JSONDecoder().decode(TranscriptedMCPSelfTest.self, from: stdoutData)
+            let selfTest = try JSONDecoder().decode(TranscriptedMCPSelfTest.self, from: result.stdoutData)
             guard selfTest.ok else {
                 throw ClaudeDesktopIntegrationError.selfTestReportedUnhealthy(output: output)
             }
@@ -427,7 +432,10 @@ enum ClaudeDesktopIntegrationInstaller {
         return fileManager.contentsEqual(atPath: installedBinaryURL.path, andPath: bundledBinaryURL.path)
     }
 
-    private static func backupConfig(at configURL: URL, fileManager: FileManager) throws -> URL? {
+    /// Timestamped sibling copy of a config file. Shared with the Codex TOML
+    /// path in `AgentMCPConnector`, so every agent-config rewrite leaves the
+    /// original recoverable.
+    static func backupConfig(at configURL: URL, fileManager: FileManager) throws -> URL? {
         guard fileManager.fileExists(atPath: configURL.path) else { return nil }
 
         let timestamp = ISO8601DateFormatter().string(from: Date())
@@ -436,5 +444,95 @@ enum ClaudeDesktopIntegrationInstaller {
             .appendingPathComponent("\(configURL.lastPathComponent).backup-\(timestamp)", isDirectory: false)
         try fileManager.copyItem(at: configURL, to: backupURL)
         return backupURL
+    }
+}
+
+/// Runs a short-lived helper or CLI process with every wait bounded: the exit
+/// wait is capped by `timeout`, both pipes are drained off-thread into
+/// lock-protected buffers so a chatty child cannot stall against a full pipe
+/// buffer, and the post-exit drain is capped by `pipeDrainTimeout` so a
+/// grandchild that inherited the pipe write ends cannot block the caller
+/// after the child itself has exited.
+enum BoundedProcessRunner {
+    struct Output {
+        let status: Int32
+        let stdoutData: Data
+        let stderrData: Data
+    }
+
+    enum RunError: Error, Equatable {
+        case timedOut
+    }
+
+    static let defaultPipeDrainTimeout: TimeInterval = 5
+
+    private final class LockedDataBuffer: @unchecked Sendable {
+        private let lock = NSLock()
+        private var buffer = Data()
+
+        func append(_ chunk: Data) {
+            lock.lock()
+            buffer.append(chunk)
+            lock.unlock()
+        }
+
+        func snapshot() -> Data {
+            lock.lock()
+            defer { lock.unlock() }
+            return buffer
+        }
+    }
+
+    static func run(
+        executable: URL,
+        arguments: [String],
+        timeout: TimeInterval,
+        pipeDrainTimeout: TimeInterval = defaultPipeDrainTimeout
+    ) throws -> Output {
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = arguments
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        let finished = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in finished.signal() }
+
+        try process.run()
+
+        let stdoutBuffer = LockedDataBuffer()
+        let stderrBuffer = LockedDataBuffer()
+        let drained = DispatchGroup()
+        for (pipe, buffer) in [(stdout, stdoutBuffer), (stderr, stderrBuffer)] {
+            drained.enter()
+            DispatchQueue.global(qos: .utility).async {
+                let handle = pipe.fileHandleForReading
+                while true {
+                    let chunk = handle.availableData
+                    if chunk.isEmpty { break }
+                    buffer.append(chunk)
+                }
+                drained.leave()
+            }
+        }
+
+        if finished.wait(timeout: .now() + timeout) == .timedOut {
+            process.terminate()
+            _ = finished.wait(timeout: .now() + 2)
+            throw RunError.timedOut
+        }
+
+        // EOF only arrives once every inherited write end closes, and a
+        // leaked grandchild can hold them open long after the child exited.
+        // Take whatever has been drained so far instead of waiting forever.
+        _ = drained.wait(timeout: .now() + pipeDrainTimeout)
+        return Output(
+            status: process.terminationStatus,
+            stdoutData: stdoutBuffer.snapshot(),
+            stderrData: stderrBuffer.snapshot()
+        )
     }
 }

--- a/Sources/UI/Settings/AgentConnectionSettingsPage.swift
+++ b/Sources/UI/Settings/AgentConnectionSettingsPage.swift
@@ -21,6 +21,7 @@ struct AgentConnectionSettingsPage: View {
     @State private var detectedAgents: Set<AgentMCPAgent> = []
     @State private var connectedAgents: Set<AgentMCPAgent> = []
     @State private var rowPhases: [AgentMCPAgent: RowPhase] = [:]
+    @State private var configRepairNotices: [AgentMCPAgent: String] = [:]
     @State private var claudeDesktopSelfTest: TranscriptedMCPSelfTest?
     @State private var copiedLocalAgentPrompt = false
     @State private var copiedClaudeDesktopConfig = false
@@ -120,6 +121,13 @@ struct AgentConnectionSettingsPage: View {
 
             if case .failed(let message) = phase {
                 Label(message, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let configRepairNotice = configRepairNotices[agent] {
+                Label(configRepairNotice, systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.orange)
                     .fixedSize(horizontal: false, vertical: true)
@@ -426,6 +434,7 @@ struct AgentConnectionSettingsPage: View {
     private func connect(_ agent: AgentMCPAgent) {
         guard rowPhases[agent] != .connecting else { return }
         rowPhases[agent] = .connecting
+        configRepairNotices[agent] = nil
         if agent == .claudeDesktop {
             claudeDesktopSelfTest = nil
         }
@@ -434,19 +443,26 @@ struct AgentConnectionSettingsPage: View {
 
         Task {
             do {
-                let selfTest = try await Task.detached(priority: .userInitiated) { () -> TranscriptedMCPSelfTest? in
+                let outcome = try await Task.detached(priority: .userInitiated) { () -> (selfTest: TranscriptedMCPSelfTest?, replacedConfigBackupURL: URL?) in
                     if agent == .claudeDesktop {
-                        return try ClaudeDesktopIntegrationInstaller.installForClaudeDesktop().selfTest
+                        let result = try ClaudeDesktopIntegrationInstaller.installForClaudeDesktop()
+                        return (result.selfTest, result.backupURL)
                     }
                     let helper = try AgentMCPConnector.ensureHelperInstalled()
-                    try AgentMCPConnector.connect(agent, helperCommandPath: helper.path)
-                    return nil
+                    let result = try AgentMCPConnector.connect(agent, helperCommandPath: helper.path)
+                    return (nil, result.replacedConfigBackupURL)
                 }.value
 
                 rowPhases[agent] = .connected
                 connectedAgents.insert(agent)
                 if agent == .claudeDesktop {
-                    claudeDesktopSelfTest = selfTest
+                    claudeDesktopSelfTest = outcome.selfTest
+                }
+                if let backupURL = outcome.replacedConfigBackupURL {
+                    // An unreadable config was backed up and replaced — that
+                    // dropped the user's other MCP servers, so say so instead
+                    // of reporting a clean "Connected".
+                    configRepairNotices[agent] = AgentMCPConnector.replacedConfigNotice(for: agent, backupURL: backupURL)
                 }
                 trackConnect(agent, priorStatus: priorStatus, result: .success)
             } catch {

--- a/Tests/AgentMCPConnectorTests.swift
+++ b/Tests/AgentMCPConnectorTests.swift
@@ -105,6 +105,206 @@ func testAgentMCPConnector() {
         }
     }
 
+    runSuite("AgentMCPConnector.codexConfigText — refuses every alternate spelling of an existing server table") {
+        let variants: [(label: String, config: String)] = [
+            ("comment after header", "[mcp_servers.transcripted] # managed by transcripted\ncommand = \"/old/transcripted-mcp\"\n"),
+            ("whitespace inside brackets", "[ mcp_servers.transcripted ]\ncommand = \"/old/transcripted-mcp\"\n"),
+            ("quoted key", "[mcp_servers.\"transcripted\"]\ncommand = \"/old/transcripted-mcp\"\n"),
+            ("literal-quoted key", "[mcp_servers.'transcripted']\ncommand = \"/old/transcripted-mcp\"\n"),
+            ("array of tables", "[[mcp_servers.transcripted]]\ncommand = \"/old/transcripted-mcp\"\n"),
+            ("sub-table header only", "[mcp_servers.transcripted.env]\nFOO = \"bar\"\n"),
+            ("root dotted inline table", "mcp_servers.transcripted = { command = \"/old/transcripted-mcp\" }\n"),
+            ("root dotted command key", "mcp_servers.transcripted.command = \"/old/transcripted-mcp\"\n"),
+            ("root dotted quoted key", "mcp_servers.\"transcripted\".command = \"/old/transcripted-mcp\"\n"),
+            ("assignment under [mcp_servers]", "[mcp_servers]\ntranscripted = { command = \"/old/transcripted-mcp\" }\n"),
+        ]
+
+        for variant in variants {
+            do {
+                _ = try AgentMCPConnector.codexConfigText(updating: variant.config, commandPath: "/tmp/transcripted-mcp")
+                assertTrue(false, "\(variant.label) should throw instead of appending a duplicate table")
+            } catch let error as AgentMCPConnectorError {
+                assertEqual(
+                    error,
+                    .codexConfigDefinesServerInUnsupportedForm,
+                    "\(variant.label) should raise the unsupported-form error"
+                )
+            } catch {
+                assertTrue(false, "\(variant.label) raised an unexpected error type: \(error)")
+            }
+        }
+    }
+
+    runSuite("AgentMCPConnector.codexConfigText — refuses root-level dotted mcp_servers assignments") {
+        let existing = "mcp_servers.other = { command = \"/usr/local/bin/other-mcp\" }\n"
+
+        do {
+            _ = try AgentMCPConnector.codexConfigText(updating: existing, commandPath: "/tmp/transcripted-mcp")
+            assertTrue(false, "root dotted mcp_servers assignment should refuse instead of appending")
+        } catch let error as AgentMCPConnectorError {
+            assertEqual(error, .codexConfigUsesInlineServers, "dotted root assignment should reuse the inline-servers guidance")
+        } catch {
+            assertTrue(false, "unexpected error type: \(error)")
+        }
+    }
+
+    runSuite("AgentMCPConnector.codexConfigText — still appends alongside other table-form servers") {
+        for existing in [
+            "[mcp_servers.other]\ncommand = \"/usr/local/bin/other-mcp\"\n",
+            "[mcp_servers]\nother = { command = \"/usr/local/bin/other-mcp\" }\n",
+        ] {
+            let updated = (try? AgentMCPConnector.codexConfigText(
+                updating: existing,
+                commandPath: "/tmp/transcripted-mcp"
+            )) ?? ""
+
+            assertTrue(updated.hasPrefix(existing), "existing server entries should be preserved byte for byte")
+            assertTrue(
+                updated.contains("command = \"/usr/local/bin/other-mcp\""),
+                "other MCP servers should survive the append"
+            )
+            assertEqual(
+                AgentMCPConnector.codexConfiguredCommandPath(inConfigText: updated),
+                "/tmp/transcripted-mcp",
+                "appended table should read back the helper path"
+            )
+        }
+    }
+
+    runSuite("AgentMCPConnector.codexConfiguredCommandPath — reads alternate header spellings") {
+        for config in [
+            "[ mcp_servers.transcripted ]\ncommand = \"/tmp/transcripted-mcp\"\n",
+            "[mcp_servers.\"transcripted\"] # managed elsewhere\ncommand = \"/tmp/transcripted-mcp\"\n",
+        ] {
+            assertEqual(
+                AgentMCPConnector.codexConfiguredCommandPath(inConfigText: config),
+                "/tmp/transcripted-mcp",
+                "a hand-written header spelling should read as connected: \(config)"
+            )
+        }
+    }
+
+    runSuite("AgentMCPConnector.connect(.codex) — leaves a variant-spelled config untouched") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedCodexVariantTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let paths = AgentMCPConnectorPaths(homeDirectory: tempRoot, applicationDirectories: [])
+        let codexDirectory = paths.codexConfigURL.deletingLastPathComponent()
+        let existing = "[ mcp_servers.transcripted ]\ncommand = \"/old/transcripted-mcp\"\n"
+
+        try? FileManager.default.createDirectory(at: codexDirectory, withIntermediateDirectories: true)
+        try? existing.write(to: paths.codexConfigURL, atomically: true, encoding: .utf8)
+
+        do {
+            try AgentMCPConnector.connect(.codex, helperCommandPath: "/tmp/transcripted-mcp", paths: paths)
+            assertTrue(false, "variant-spelled server table should refuse to connect")
+        } catch let error as AgentMCPConnectorError {
+            assertEqual(error, .codexConfigDefinesServerInUnsupportedForm, "variant spelling should raise the unsupported-form error")
+        } catch {
+            assertTrue(false, "unexpected error type: \(error)")
+        }
+
+        assertEqual(
+            (try? String(contentsOf: paths.codexConfigURL, encoding: .utf8)) ?? "",
+            existing,
+            "refused connect must leave the config untouched"
+        )
+        let leftoverBackups = ((try? FileManager.default.contentsOfDirectory(atPath: codexDirectory.path)) ?? [])
+            .filter { $0.contains(".backup-") }
+        assertEqual(leftoverBackups.count, 0, "refused connect should not leave backup files behind")
+    }
+
+    runSuite("AgentMCPConnector.connect(.codex) — backs up the existing config before the first write") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedCodexBackupTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let paths = AgentMCPConnectorPaths(homeDirectory: tempRoot, applicationDirectories: [])
+        let codexDirectory = paths.codexConfigURL.deletingLastPathComponent()
+
+        try? FileManager.default.createDirectory(at: codexDirectory, withIntermediateDirectories: true)
+        try? "model = \"o4\"\n".write(to: paths.codexConfigURL, atomically: true, encoding: .utf8)
+
+        do {
+            try AgentMCPConnector.connect(.codex, helperCommandPath: "/tmp/transcripted-mcp", paths: paths)
+        } catch {
+            assertTrue(false, "Codex connect should not throw: \(error)")
+        }
+
+        func backupNames() -> [String] {
+            ((try? FileManager.default.contentsOfDirectory(atPath: codexDirectory.path)) ?? [])
+                .filter { $0.hasPrefix("config.toml.backup-") }
+        }
+
+        let backups = backupNames()
+        assertEqual(backups.count, 1, "modifying an existing Codex config should leave exactly one backup")
+        if let backupName = backups.first {
+            let backupURL = codexDirectory.appendingPathComponent(backupName, isDirectory: false)
+            assertEqual(
+                (try? String(contentsOf: backupURL, encoding: .utf8)) ?? "",
+                "model = \"o4\"\n",
+                "backup should preserve the pre-write config bytes"
+            )
+        }
+
+        do {
+            try AgentMCPConnector.connect(.codex, helperCommandPath: "/tmp/transcripted-mcp", paths: paths)
+        } catch {
+            assertTrue(false, "repeat Codex connect should not throw: \(error)")
+        }
+        assertEqual(backupNames().count, 1, "an unchanged reconnect should not pile up more backups")
+    }
+
+    runSuite("AgentMCPConnector.connect(.cursor) — surfaces the backup when an unreadable config is replaced") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedCursorRepairTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let paths = AgentMCPConnectorPaths(homeDirectory: tempRoot, applicationDirectories: [])
+
+        try? FileManager.default.createDirectory(
+            at: paths.cursorConfigURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try? "{ not json".write(to: paths.cursorConfigURL, atomically: true, encoding: .utf8)
+
+        let result = try? AgentMCPConnector.connect(.cursor, helperCommandPath: "/tmp/transcripted-mcp", paths: paths)
+        assertNotNil(result?.replacedConfigBackupURL, "replacing an unreadable config must surface the backup to callers")
+        if let backupURL = result?.replacedConfigBackupURL {
+            assertEqual(
+                (try? String(contentsOf: backupURL, encoding: .utf8)) ?? "",
+                "{ not json",
+                "backup should preserve the unreadable config"
+            )
+        }
+        assertTrue(
+            AgentMCPConnector.isConnected(.cursor, helperCommandPath: "/tmp/transcripted-mcp", paths: paths),
+            "Cursor should be connected after the repair"
+        )
+
+        let repeatResult = try? AgentMCPConnector.connect(.cursor, helperCommandPath: "/tmp/transcripted-mcp", paths: paths)
+        assertNotNil(repeatResult, "reconnect over a valid config should succeed")
+        assertNil(
+            repeatResult?.replacedConfigBackupURL,
+            "a readable config should connect without reporting a replacement backup"
+        )
+    }
+
+    runSuite("AgentMCPConnector.replacedConfigNotice — names the agent, the backup file, and the loss") {
+        let notice = AgentMCPConnector.replacedConfigNotice(
+            for: .claudeDesktop,
+            backupURL: URL(fileURLWithPath: "/cfg/claude_desktop_config.json.backup-2026-06-12T00-00-00Z")
+        )
+
+        assertTrue(notice.contains("Claude Desktop"), "notice should name the agent whose config was replaced")
+        assertTrue(
+            notice.contains("claude_desktop_config.json.backup-2026-06-12T00-00-00Z"),
+            "notice should name the backup file so users can find it"
+        )
+        assertTrue(
+            notice.lowercased().contains("re-add"),
+            "notice should tell users their other MCP servers need re-adding"
+        )
+    }
+
     runSuite("AgentMCPConnector.codexConfigText — never touches keys that merely start with 'command'") {
         let existing = """
         [mcp_servers.transcripted]

--- a/Tests/AgentMCPConnectorTests.swift
+++ b/Tests/AgentMCPConnectorTests.swift
@@ -184,6 +184,18 @@ func testAgentMCPConnector() {
         }
     }
 
+    runSuite("AgentMCPConnector.codexConfiguredCommandPath — ignores array-of-tables server entries") {
+        let config = """
+        [[mcp_servers.transcripted]]
+        command = "/tmp/transcripted-mcp"
+        """
+
+        assertNil(
+            AgentMCPConnector.codexConfiguredCommandPath(inConfigText: config),
+            "array-of-tables entries are unsupported by connect and should not read as connected"
+        )
+    }
+
     runSuite("AgentMCPConnector.connect(.codex) — leaves a variant-spelled config untouched") {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("TranscriptedCodexVariantTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/ClaudeDesktopIntegrationInstallerTests.swift
+++ b/Tests/ClaudeDesktopIntegrationInstallerTests.swift
@@ -1621,6 +1621,110 @@ func testClaudeDesktopIntegrationInstaller() {
         )
         assertEqual(helpersResult?.path, helperURL.path, "Helpers location should be accepted")
     }
+
+    runSuite("ClaudeDesktopIntegrationInstaller.runSelfTest — times out a hung helper instead of waiting forever") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeSelfTestHangTests-\(UUID().uuidString)", isDirectory: true)
+        let helperURL = tempRoot
+            .appendingPathComponent("mcp", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try? FileManager.default.createDirectory(at: helperURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? "#!/bin/sh\nsleep 30\n".write(to: helperURL, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: helperURL.path)
+
+        let started = Date()
+        do {
+            _ = try ClaudeDesktopIntegrationInstaller.runSelfTest(binaryURL: helperURL, timeout: 0.4)
+            assertTrue(false, "hung helper should throw a timeout error")
+        } catch let error as ClaudeDesktopIntegrationError {
+            assertEqual(error, .selfTestTimedOut, "hung helper should raise selfTestTimedOut")
+        } catch {
+            assertTrue(false, "unexpected error type: \(error)")
+        }
+        assertTrue(
+            Date().timeIntervalSince(started) < 10,
+            "timeout should fire promptly instead of waiting out the helper"
+        )
+    }
+
+    runSuite("ClaudeDesktopIntegrationInstaller.runSelfTest — survives a grandchild holding the output pipes") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeSelfTestGrandchildTests-\(UUID().uuidString)", isDirectory: true)
+        let helperURL = tempRoot
+            .appendingPathComponent("mcp", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        // The backgrounded sleep inherits the helper's stdout/stderr pipe
+        // write ends, so EOF does not arrive until long after the helper
+        // itself exits — exactly the shape that pinned rows at "Connecting…".
+        let script = """
+        #!/bin/sh
+        cat <<'JSON'
+        {"ok":true,"meetings_directory":"meetings","dictations_directory":"dictations","index_directory":"index","meeting_file_count":8,"dictation_file_count":9}
+        JSON
+        sleep 30 &
+        exit 0
+        """
+        try? FileManager.default.createDirectory(at: helperURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? script.write(to: helperURL, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: helperURL.path)
+
+        let started = Date()
+        do {
+            let result = try ClaudeDesktopIntegrationInstaller.runSelfTest(
+                binaryURL: helperURL,
+                timeout: 5,
+                pipeDrainTimeout: 1
+            )
+            assertEqual(result.ok, true, "output written before exit should still decode")
+            assertEqual(result.meetingFileCount, 8, "drained output should be complete despite the held pipe")
+        } catch {
+            assertTrue(false, "a grandchild holding the pipes should not fail the self-test: \(error)")
+        }
+        assertTrue(
+            Date().timeIntervalSince(started) < 10,
+            "a grandchild holding the pipes must not block the self-test"
+        )
+    }
+
+    runSuite("ClaudeDesktopIntegrationInstaller.runSelfTest — drains helpers that write more than a pipe buffer") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeSelfTestBigOutputTests-\(UUID().uuidString)", isDirectory: true)
+        let helperURL = tempRoot
+            .appendingPathComponent("mcp", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        // ~400KB of stderr diagnostics — far past the 64KB pipe buffer that
+        // used to deadlock waitUntilExit-before-read.
+        let script = """
+        #!/bin/sh
+        awk 'BEGIN { for (i = 0; i < 8000; i++) printf "stderr-noise-%d-........................................\\n", i }' >&2
+        cat <<'JSON'
+        {"ok":true,"meetings_directory":"meetings","dictations_directory":"dictations","index_directory":"index","meeting_file_count":3,"dictation_file_count":4}
+        JSON
+        exit 0
+        """
+        try? FileManager.default.createDirectory(at: helperURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? script.write(to: helperURL, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: helperURL.path)
+
+        let started = Date()
+        do {
+            let result = try ClaudeDesktopIntegrationInstaller.runSelfTest(binaryURL: helperURL, timeout: 10)
+            assertEqual(result.ok, true, "oversized stderr output should not poison stdout decoding")
+            assertEqual(result.meetingFileCount, 3, "self-test JSON should decode despite oversized stderr")
+        } catch {
+            assertTrue(false, "oversized helper output should drain instead of deadlocking: \(error)")
+        }
+        assertTrue(
+            Date().timeIntervalSince(started) < 10,
+            "oversized helper output should drain promptly"
+        )
+    }
 }
 
 private func writeSelfTestHelper(


### PR DESCRIPTION
## Why

The 2026-06-12 audit of the agent-connect feature (PR #1077) found three config-safety bugs in code that writes into other apps' MCP config files. Worst case was full config loss for Codex users: a legal-but-unrecognized TOML spelling of the server table made Connect append a duplicate table, and Codex rejects the entire config — killing every MCP server the user had.

## Product Impact

- Affects: `agent artifacts`
- Lane: `agent workflow`
- Why this matters: Connect must never corrupt or silently rewrite another app's config. These fixes make the Codex writer refuse instead of corrupt, make the malformed-JSON backup visible to the user, and stop a stuck helper from pinning the row at "Connecting…" until app restart.

## What changed

- **Codex TOML duplicate-table corruption (high)** — `AgentMCPConnector.codexConfigText` only matched the exact canonical `[mcp_servers.transcripted]` header. Legal spellings (`[ mcp_servers.transcripted ]`, trailing comment, `[mcp_servers."transcripted"]`, `[[…]]`, sub-table headers, root dotted assignments like `mcp_servers.transcripted.command = "…"`, `transcripted = {…}` under `[mcp_servers]`) fell through to append → duplicate table → Codex rejects the whole config. The append path now runs a conservative line-level TOML scan (normalized header/assignment key paths with section tracking) and throws a new `codexConfigDefinesServerInUnsupportedForm` error for any spelling of the server table; root-level dotted `mcp_servers.*` assignments route to the existing inline-servers error. `connectCodex` also takes a timestamped backup before the first byte changes and skips no-op writes, and the status reader now recognizes variant header spellings so a hand-written entry pointing at our helper reads as Connected instead of luring a Connect click into the guard.
- **Malformed Claude Desktop/Cursor JSON silently clobbered (high)** — the backup taken when an unreadable config is replaced was invisible: `attentionMessage` had no UI consumers and the returned `backupURL` was discarded at both call sites. `AgentMCPConnector.connect` now returns `AgentMCPConnectResult` with `replacedConfigBackupURL` (Cursor forwards it from `writeMCPServersConfig`, Claude Desktop from the install result), and the settings row shows a warning naming the backup file and telling the user their other MCP servers need re-adding from it.
- **`runSelfTest` hang/deadlock (medium)** — `waitUntilExit()` then `readDataToEndOfFile()` deadlocked on >64KB helper output and hung forever on a stuck helper, with the re-entry guard blocking retry until app restart. Extracted a shared `BoundedProcessRunner` (timeout-capped exit wait, lock-protected chunked off-thread pipe draining, bounded post-exit drain so a grandchild holding the inherited pipe write ends can't block forever) and routed both `runSelfTest` (new `selfTestTimedOut` error, injectable timeouts) and `AgentMCPConnector.runCLI` through it — bounding the previously unbounded `drained.wait()` from commit 36d34626.

No new source files, so no build-script, fast-test-runner, or e2e source-list changes.

## How I checked it

- [x] `scripts/dev/agent-preflight.sh` — suggests exactly the two gates below
- [x] Selected checks from `.agents/test-matrix.yml` for the files changed (Sources/** + Tests/* → build + fast tests)
- [x] `bash build.sh --no-open` — green, run bare after a fresh `bash build-deps.sh`
- [x] `bash run-tests.sh` — **4926 tests, 4926 passed, 0 failed**
- [x] Performance budget passed (`bash build.sh --no-open` ran the bundle gate: "Performance budget OK")
- [ ] `bash run-integration-smoke.sh` — n/a (no `Sources/Meeting/` or `Sources/TranscriptedCore/` changes)
- [ ] `swift test` — n/a (no `Package.swift` / core seam changes)
- [x] Manual check: n/a — covered by new fast tests (TOML variant family all throw with config untouched, append-path negatives, codex backup behavior, cursor malformed-JSON backup surfacing, replaced-config notice copy, reader variant recognition, runSelfTest timeout / grandchild-held-pipes / oversized-output)

## Risk Review

- [x] Privacy / local-first behavior reviewed — all writes stay local; new error copy and notices contain no transcript or personal data
- [x] Storage path or migration impact reviewed — only sibling `.backup-<timestamp>` files next to existing agent configs
- [x] Public-facing copy stays concrete and matches current product scope
- [x] Release/update impact reviewed — none
- [x] Agent PRs link the issue/workpad and stay draft until human review
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence — settings-row warning label only, reuses the existing failure-label styling
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

## Notes

- Deliberate behavior choice: header *variants* throw a manual-edit error rather than being edited in place (per the audit's prescription "detect and throw"). In-place editing under variant headers would be a safe future improvement if the refusal shows up in the wild.
- Root-level dotted `mcp_servers.other = {…}` also refuses now (conservative): appending a table header after it is spec-legal TOML, but the cost of a parser disagreeing is total config loss, so refusal wins.
- Codex-path backups are routine safety copies and are *not* surfaced as a "replaced" notice; only unreadable-JSON replacements are, since those actually drop user servers.

## Agent handoff

`COORD_DONE: GREEN | https://github.com/r3dbars/transcripted/pull/1085 | 3 audit fixes + tests in AgentMCPConnector/ClaudeDesktopIntegrationInstaller/AgentConnectionSettingsPage | none | none | build.sh --no-open + run-tests.sh (4926/4926) both green, run bare | human review of TOML scan + BoundedProcessRunner threading`

🤖 Generated with [Claude Code](https://claude.com/claude-code)