### PR TITLE
[codex] Make meeting deletes update Home immediately

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -48,6 +48,28 @@ final class HomeViewModel: ObservableObject {
         loadCurrentLimits(isInitialLoad: false)
     }
 
+    func removeVisibleMeeting(id: String) {
+        var didRemove = false
+        meetingDaySections = meetingDaySections.compactMap { section in
+            let remainingItems = section.items.filter { item in
+                let shouldKeep = item.id != id
+                if !shouldKeep {
+                    didRemove = true
+                }
+                return shouldKeep
+            }
+            guard !remainingItems.isEmpty else { return nil }
+            return HomeDaySection(day: section.day, label: section.label, items: remainingItems)
+        }
+
+        guard didRemove else { return }
+        recentMeetingCount = max(0, recentMeetingCount - 1)
+        todayMeetingCount = meetingDaySections
+            .flatMap(\.items)
+            .filter { Calendar.current.isDateInToday($0.date) }
+            .count
+    }
+
     func loadMoreDictations() {
         guard !isLoading, !isLoadingMore, canLoadMoreDictations else { return }
         dictationLimit += initialDictationLimit

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1172,6 +1172,11 @@ struct TranscriptedSettingsView: View {
     }
 
     private func deleteMeeting(_ item: RecentMeetingItem) {
+        if homeMeetingPreview?.transcriptURL == item.transcriptURL {
+            homeMeetingPreview = nil
+        }
+        homeViewModel.removeVisibleMeeting(id: item.id)
+
         let deletionTask = Task.detached(priority: .userInitiated) {
             let plan = HomeMeetingDeletion.plan(for: item)
             await MainActor.run {
@@ -1185,6 +1190,7 @@ struct TranscriptedSettingsView: View {
                 _ = try await deletionTask.value
                 refreshRecentCaptures(force: true)
             } catch {
+                refreshRecentCaptures(force: true)
                 presentHomeDeleteFailure(
                     title: "Could not delete meeting",
                     error: error

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2865,6 +2865,7 @@ func testRepoCommandContract() {
     }
 
     runSuite("Repo command contract - Home meeting deletion runs off the Settings UI path") {
+        let homeContents = readRepoTextFile("Sources/UI/Settings/HomeView.swift")
         let settingsContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let deleteBlock = sourceSlice(
             settingsContents,
@@ -2882,6 +2883,17 @@ func testRepoCommandContract() {
                 deleteBlock.contains("try HomeMeetingDeletion.delete(plan)") &&
                 deleteBlock.contains("_ = try await deletionTask.value"),
             "Home delete should run filesystem cleanup away from the main Settings UI path"
+        )
+        assertTrue(
+            homeContents.contains("func removeVisibleMeeting(id: String)")
+                && deleteBlock.contains("homeViewModel.removeVisibleMeeting(id: item.id)")
+                && deleteBlock.contains("if homeMeetingPreview?.transcriptURL == item.transcriptURL"),
+            "confirmed Home delete should immediately close stale preview state and remove the visible meeting row before the filesystem refresh"
+        )
+        assertTrue(
+            deleteBlock.contains("} catch {\n                refreshRecentCaptures(force: true)")
+                && deleteBlock.contains("presentHomeDeleteFailure("),
+            "failed Home delete should force a reload so an optimistically hidden row is restored with a visible error"
         )
     }
 


### PR DESCRIPTION
## Summary
- Remove a confirmed deleted meeting from the visible Home list immediately.
- Close any open preview for that meeting before the background filesystem cleanup runs.
- Force a Home refresh if deletion fails so the optimistically hidden row comes back with an error.
- Add a repo contract guard for the Home delete UX path.

## Why
Meeting deletion could look like it did nothing while the background delete and reload were still in flight. This makes the confirmed action visibly respond right away without changing the canonical file deletion service.

## Validation
- `bash run-tests.sh` — 4887 passed
- `bash build-deps.sh --force`
- `bash build.sh --no-open`