### PR TITLE
Gate meeting AGC idle noise

### DIFF
--- a/Sources/TranscriptedCore/Audio/RealtimeAGC.swift
+++ b/Sources/TranscriptedCore/Audio/RealtimeAGC.swift
@@ -19,11 +19,12 @@ import Accelerate
 /// quiet stretches).
 ///
 /// The default tuning (`targetPeak = 0.45`, `maxGain = 25.0`,
-/// `minPeak = 0.0008`) gives the live mic copy enough headroom for the
-/// more severe issue #500 voice-processing attenuation case while still
-/// refusing to chase near-silence. The post-processing path can normalize
-/// again before final transcription; this real-time pass protects the saved
-/// WAV, live preview, and diagnostics without touching system audio.
+/// `minPeak = 0.0008`, `noiseGatePeak = 0.002`) gives the live mic copy enough
+/// headroom for the more severe issue #500 voice-processing attenuation case
+/// while still refusing to turn USB-mic idle hiss into saved speech-looking
+/// audio. The post-processing path can normalize again before final
+/// transcription; this real-time pass protects the saved WAV, live preview,
+/// and diagnostics without touching system audio.
 ///
 /// Real-time safe: `process(buffer:)` performs zero allocations and no
 /// locking. Safe to invoke from an `AVAudioEngine` tap callback.
@@ -41,6 +42,12 @@ public final class RealtimeAGC {
     /// Below this peak the input is treated as silence; current gain holds
     /// rather than dropping back to 1.0. Prevents pumping during pauses.
     public let minPeak: Float
+
+    /// Below this raw peak, the buffer is treated as ambient idle noise and
+    /// muted before gain is applied. This stays below the quiet-speech band
+    /// used by issue #500 detection, but keeps held max gain from amplifying
+    /// Blue Yeti-style USB mic self-noise during pauses.
+    public let noiseGatePeak: Float
 
     /// Number of recent buffers used for the windowed peak. With ~85ms
     /// buffers (4096 frames at 48 kHz), 16 buffers ≈ 1.4 s of history —
@@ -68,6 +75,9 @@ public final class RealtimeAGC {
     ///     without opting into Apple's system-wide voice-processing ducking.
     ///   - minPeak: Silence threshold for hold behavior. 0.0008 matches
     ///     AudioSignalRecovery's lower bound for WebRTC-attenuated input.
+    ///   - noiseGatePeak: Raw idle-noise threshold. 0.002 matches the
+    ///     activity floor used by `QuietMicAttenuationDetector`; values below
+    ///     this are not treated as voice-like input.
     ///   - windowSize: Buffers of peak history.
     ///   - attackTimeMs: Time constant for *reducing* gain when input
     ///     suddenly grows. Fast attack avoids clipping. 20ms.
@@ -80,6 +90,7 @@ public final class RealtimeAGC {
         targetPeak: Float = 0.45,
         maxGain: Float = 25.0,
         minPeak: Float = 0.0008,
+        noiseGatePeak: Float = 0.002,
         windowSize: Int = 16,
         attackTimeMs: Float = 20,
         releaseTimeMs: Float = 300,
@@ -88,6 +99,7 @@ public final class RealtimeAGC {
         self.targetPeak = max(0.0001, min(1.0, targetPeak))
         self.maxGain = max(1.0, maxGain)
         self.minPeak = max(0.000001, minPeak)
+        self.noiseGatePeak = max(self.minPeak, noiseGatePeak)
         self.windowSize = max(1, windowSize)
         self.recentPeaks = [Float](repeating: 0, count: max(1, windowSize))
         // α = 1 − exp(−Δt / τ). When Δt ≥ τ we approach 1.0 (snap to target);
@@ -141,7 +153,17 @@ public final class RealtimeAGC {
             }
         }
 
-        // 2. Slot into rolling peak window and pick window peak.
+        // 2. Gate sub-activity ambient noise before it can be amplified.
+        // Keep the gain state steady so the next real utterance still starts
+        // from the current recovery level instead of pumping up from unity.
+        if bufferPeak > 0, bufferPeak < noiseGatePeak {
+            clear(buffer: buffer, frameCount: frameCount, channelCount: channelCount)
+            recentPeaks[nextPeakIndex] = 0
+            nextPeakIndex = (nextPeakIndex + 1) % recentPeaks.count
+            return
+        }
+
+        // 3. Slot into rolling peak window and pick window peak.
         recentPeaks[nextPeakIndex] = bufferPeak
         nextPeakIndex = (nextPeakIndex + 1) % recentPeaks.count
         var windowPeak: Float = 0
@@ -149,7 +171,7 @@ public final class RealtimeAGC {
             if value > windowPeak { windowPeak = value }
         }
 
-        // 3. Target gain. Hold during silence so a long pause doesn't make
+        // 4. Target gain. Hold during silence so a long pause doesn't make
         // gain race back to 1.0 and then jump up again on the next word.
         let targetGain: Float
         if windowPeak < minPeak {
@@ -158,12 +180,12 @@ public final class RealtimeAGC {
             targetGain = max(1.0, min(maxGain, targetPeak / windowPeak))
         }
 
-        // 4. Smooth gain via one-pole IIR. Fast when reducing (attack),
+        // 5. Smooth gain via one-pole IIR. Fast when reducing (attack),
         // slow when raising (release).
         let coef = (targetGain < currentGain) ? attackCoef : releaseCoef
         currentGain = currentGain + coef * (targetGain - currentGain)
 
-        // 5. Apply gain in place. vDSP_vsmul works for both interleaved
+        // 6. Apply gain in place. vDSP_vsmul works for both interleaved
         // (treat as a single contiguous block) and non-interleaved (per
         // channel pointer).
         var gain = currentGain
@@ -176,7 +198,7 @@ public final class RealtimeAGC {
             }
         }
 
-        // 6. Hard-clip to [-1, 1]. With targetPeak = 0.45 and a maxGain of
+        // 7. Hard-clip to [-1, 1]. With targetPeak = 0.45 and a maxGain of
         // 25.0 we shouldn't exceed unity often; this is a safety net for
         // transients above the windowed peak.
         var lo: Float = -1.0
@@ -187,6 +209,18 @@ public final class RealtimeAGC {
         } else {
             for ch in 0..<channelCount {
                 vDSP_vclip(channelData[ch], 1, &lo, &hi, channelData[ch], 1, frameCount)
+            }
+        }
+    }
+
+    private func clear(buffer: AVAudioPCMBuffer, frameCount: vDSP_Length, channelCount: Int) {
+        guard let channelData = buffer.floatChannelData else { return }
+        if buffer.format.isInterleaved {
+            let totalLength = frameCount * vDSP_Length(channelCount)
+            vDSP_vclr(channelData[0], 1, totalLength)
+        } else {
+            for ch in 0..<channelCount {
+                vDSP_vclr(channelData[ch], 1, frameCount)
             }
         }
     }

--- a/Tests/TranscriptedCoreTests/QuietMicAttenuationDetectorTests.swift
+++ b/Tests/TranscriptedCoreTests/QuietMicAttenuationDetectorTests.swift
@@ -189,6 +189,11 @@ final class QuietMicAttenuationDetectorTests: XCTestCase {
             agc.minPeak,
             "activity floor must stay above the AGC ambient/silence floor so a silent room never prompts"
         )
+        XCTAssertGreaterThanOrEqual(
+            QuietMicAttenuationDetector.activityRawPeakFloor,
+            agc.noiseGatePeak,
+            "activity floor must stay at or above the AGC noise gate so #500 prompts remain reachable"
+        )
     }
 
     func testThresholdsMatchStopTimeClassification() {

--- a/Tests/TranscriptedCoreTests/RealtimeAGCTests.swift
+++ b/Tests/TranscriptedCoreTests/RealtimeAGCTests.swift
@@ -186,6 +186,45 @@ final class RealtimeAGCTests: XCTestCase {
                        "Once silence-hold engages, gain must be exactly steady to avoid pumping the next utterance")
     }
 
+    func testSubActivityNoiseIsMutedInsteadOfBoostedDuringPauses() {
+        // A real USB mic feedback report described hiss/squeal getting much
+        // worse in silence. After the AGC has built up gain for quiet speech,
+        // sub-activity idle noise must not be multiplied into the retained
+        // mic file.
+        let agc = RealtimeAGC()
+        for _ in 0..<32 {
+            let buffer = makeMonoBuffer(samples: sineSamples(peak: 0.005))
+            agc.process(buffer: buffer)
+        }
+        let heldGain = agc.appliedGain
+        XCTAssertGreaterThan(heldGain, 5.0, "Should have built up significant gain on attenuated input")
+
+        let idleNoise = makeMonoBuffer(samples: sineSamples(peak: 0.001))
+        agc.process(buffer: idleNoise)
+
+        XCTAssertEqual(peak(of: samples(from: idleNoise)), 0, accuracy: 0.000001,
+                       "Sub-activity idle noise should be muted instead of boosted into audible hiss")
+        XCTAssertEqual(agc.appliedGain, heldGain, accuracy: 0.0001,
+                       "Noise gating should not pump or reset the current recovery gain")
+    }
+
+    func testIssue500QuietSpeechBandStillPassesThroughNoiseGate() {
+        // The noise gate must stay below the issue #500 quiet-speech band:
+        // voice-like raw peaks around 0.003 should still be recoverable and
+        // visible to the live attenuation detector.
+        let agc = RealtimeAGC()
+        var lastPeak: Float = 0
+        for _ in 0..<32 {
+            let buffer = makeMonoBuffer(samples: sineSamples(peak: 0.003))
+            agc.process(buffer: buffer)
+            lastPeak = peak(of: samples(from: buffer))
+        }
+
+        XCTAssertGreaterThan(lastPeak, 0.05, "Quiet voice-like input should still pass through and receive gain")
+        XCTAssertLessThanOrEqual(agc.noiseGatePeak, 0.002 + 0.0001,
+                                 "The default gate should stay below the quiet-speech detector's activity floor")
+    }
+
     func testResetReturnsGainToUnity() {
         let agc = RealtimeAGC()
         for _ in 0..<32 {


### PR DESCRIPTION
## Summary
- add a sub-activity noise gate to `RealtimeAGC` so held max gain does not amplify USB mic idle noise during pauses
- keep gain state steady and preserve the issue #500 quiet-speech band above the 0.002 activity floor
- add core tests for idle-noise muting and detector/gate consistency

## Stephen Maeder evidence
Gmail thread found: `Transcripted Meeting Feedback`, sent June 11 to help@transcripted.app. ZIP attachment exists, but the Gmail connector cannot read `application/zip`, and I did not find the ZIP in local Downloads/Desktop/tmp.

Report says Transcripted `microphone.m4a` had hiss, high-pitched squeal, and electronic noise, worse in silence; Zoom recording was clean; `playback.m4a` had skipping/clipping not present in the mic file.

## Diagnosis
Likely unfixed on current main before this patch for the mic-noise part: default meeting capture writes the AGC-processed mic copy to disk, and the previous AGC could hold high gain through quiet buffers. #1074 covers salvage/orphan recovery. #1075 covers quiet/gated mic detection plus consented VPIO. Neither directly gates USB idle noise in the default software-AGC path.

Playback mix skipping/clipping remains unknown until we can inspect the ZIP or manually reproduce the Blue Yeti route.

## Verification
- `bash build-deps.sh --force`
- `swift test --filter RealtimeAGCTests`
- `swift test --filter QuietMicAttenuationDetectorTests`
- `bash build.sh --no-open`
- `bash run-tests.sh` (4885/4885)
- `bash run-integration-smoke.sh`
- `swift test` (426 tests, 1 skipped, 0 failures)
- `codex review --uncommitted`: no actionable findings

## Remaining manual proof
- inspect Stephen ZIP locally, especially `Transcripted-microphone.m4a`, `Zoom-recording.m4a`, and `playback.m4a`
- run a Blue Yeti/Zoom empty-call test with speech plus silence and compare raw/processed peaks
- confirm playback mix has no skipping or clipping after this change
