### PR TITLE
[codex] Fix speaker clip playback state

### DIFF
--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -148,9 +148,19 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         SpeakerClipPlayback.play(url)
     }
 
+    func isPlayingSample(for speakerId: UUID) -> Bool {
+        guard let url = clipURL(for: speakerId) else { return false }
+        return SpeakerClipPlayback.isPlaying(url)
+    }
+
     func playSample(for item: SpeakerPendingReviewItem) {
         guard let url = item.clipURL else { return }
         SpeakerClipPlayback.play(url)
+    }
+
+    func isPlayingSample(for item: SpeakerPendingReviewItem) -> Bool {
+        guard let url = item.clipURL else { return false }
+        return SpeakerClipPlayback.isPlaying(url)
     }
 
     func openTranscript(for item: SpeakerPendingReviewItem) {
@@ -610,72 +620,81 @@ struct SpeakerPeopleSettingsSection: View {
     }
 
     @ObservedObject var model: SpeakerPeopleSettingsViewModel
+    @State private var playbackStateVersion = 0
 
     var body: some View {
-        let voiceGroups = model.pendingVoiceGroups
+        Group {
+            let voiceGroups = model.pendingVoiceGroups
 
-        if !voiceGroups.isEmpty {
+            if !voiceGroups.isEmpty {
+                SettingsSection(
+                    title: voicesToNameTitle(count: voiceGroups.count),
+                    detail: "Play a clip. If you recognize the voice, type their name — it updates every meeting they're in."
+                ) {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(Array(voiceGroups.enumerated()), id: \.element.id) { index, group in
+                            SpeakerVoiceToNameRow(group: group, model: model)
+
+                            if index < voiceGroups.count - 1 {
+                                Divider()
+                                    .padding(.vertical, 12)
+                            }
+                        }
+                    }
+                }
+                .id(ScrollTarget.reviewQueue)
+                .accessibilityIdentifier("transcripted.speakers.inbox")
+            }
+
+            if !model.duplicateCandidates.isEmpty {
+                SettingsSection(
+                    title: "Possible duplicates",
+                    detail: duplicatesDetail
+                ) {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(Array(model.duplicateCandidates.enumerated()), id: \.element.id) { index, candidate in
+                            SpeakerDuplicateCandidateRow(candidate: candidate, model: model)
+
+                            if index < model.duplicateCandidates.count - 1 {
+                                Divider()
+                                    .padding(.vertical, 10)
+                            }
+                        }
+                    }
+                }
+            }
+
             SettingsSection(
-                title: voicesToNameTitle(count: voiceGroups.count),
-                detail: "Play a clip. If you recognize the voice, type their name — it updates every meeting they're in."
+                title: "All speakers",
+                detail: allSpeakersDetail
             ) {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(voiceGroups.enumerated()), id: \.element.id) { index, group in
-                        SpeakerVoiceToNameRow(group: group, model: model)
-
-                        if index < voiceGroups.count - 1 {
-                            Divider()
-                                .padding(.vertical, 12)
-                        }
-                    }
+                if !model.profiles.isEmpty {
+                    SpeakerSearchRow(model: model)
                 }
-            }
-            .id(ScrollTarget.reviewQueue)
-            .accessibilityIdentifier("transcripted.speakers.inbox")
-        }
 
-        if !model.duplicateCandidates.isEmpty {
-            SettingsSection(
-                title: "Possible duplicates",
-                detail: duplicatesDetail
-            ) {
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(model.duplicateCandidates.enumerated()), id: \.element.id) { index, candidate in
-                        SpeakerDuplicateCandidateRow(candidate: candidate, model: model)
+                if model.filteredProfiles.isEmpty {
+                    Text(emptyPeopleMessage)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    let profiles = model.filteredProfiles
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(Array(profiles.enumerated()), id: \.element.id) { index, profile in
+                            SpeakerPersonRow(profile: profile, model: model)
 
-                        if index < model.duplicateCandidates.count - 1 {
-                            Divider()
-                                .padding(.vertical, 10)
+                            if index < profiles.count - 1 {
+                                Divider()
+                            }
                         }
                     }
                 }
             }
         }
-
-        SettingsSection(
-            title: "All speakers",
-            detail: allSpeakersDetail
-        ) {
-            if !model.profiles.isEmpty {
-                SpeakerSearchRow(model: model)
-            }
-
-            if model.filteredProfiles.isEmpty {
-                Text(emptyPeopleMessage)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            } else {
-                let profiles = model.filteredProfiles
-                LazyVStack(alignment: .leading, spacing: 0) {
-                    ForEach(Array(profiles.enumerated()), id: \.element.id) { index, profile in
-                        SpeakerPersonRow(profile: profile, model: model)
-
-                        if index < profiles.count - 1 {
-                            Divider()
-                        }
-                    }
-                }
-            }
+        .onReceive(NotificationCenter.default.publisher(for: SpeakerClipPlayback.stateDidChangeNotification)) { _ in
+            playbackStateVersion += 1
+        }
+        .onDisappear {
+            SpeakerClipPlayback.stop()
         }
     }
 
@@ -720,6 +739,7 @@ private struct SpeakerVoiceToNameRow: View {
             HStack(alignment: .top, spacing: 12) {
                 SpeakerPlayClipButton(
                     hasClip: group.representative.clipURL != nil,
+                    isPlaying: model.isPlayingSample(for: group.representative),
                     action: { model.playSample(for: group.representative) }
                 )
 
@@ -848,11 +868,12 @@ private struct SpeakerVoiceToNameRow: View {
 
 private struct SpeakerPlayClipButton: View {
     let hasClip: Bool
+    let isPlaying: Bool
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: "play.fill")
+            Image(systemName: isPlaying ? "pause.fill" : "play.fill")
                 .font(.system(size: 13, weight: .bold))
                 .foregroundStyle(hasClip ? Color.white : Color.secondary)
                 .frame(width: 36, height: 36)
@@ -860,8 +881,13 @@ private struct SpeakerPlayClipButton: View {
         }
         .buttonStyle(.plain)
         .disabled(!hasClip)
-        .help(hasClip ? "Play a short clip of this voice" : "No voice clip was saved for this speaker")
-        .accessibilityLabel("Play voice sample")
+        .help(helpText)
+        .accessibilityLabel(isPlaying ? "Pause voice sample" : "Play voice sample")
+    }
+
+    private var helpText: String {
+        guard hasClip else { return "No voice clip was saved for this speaker" }
+        return isPlaying ? "Pause this voice sample" : "Play a short clip of this voice"
     }
 }
 
@@ -931,7 +957,7 @@ private struct SpeakerDuplicateNameChip: View {
             model.playSample(for: profile.id)
         } label: {
             HStack(spacing: 4) {
-                Image(systemName: hasClip ? "play.circle.fill" : "person.crop.circle")
+                Image(systemName: iconName)
                     .font(.system(size: 11, weight: .semibold))
 
                 Text(chipTitle)
@@ -948,7 +974,7 @@ private struct SpeakerDuplicateNameChip: View {
             normalStroke: Color.primary.opacity(0.08)
         ))
         .disabled(!hasClip)
-        .help(hasClip ? "Play this voice" : "No voice clip saved")
+        .help(helpText)
     }
 
     private var chipTitle: String {
@@ -959,6 +985,20 @@ private struct SpeakerDuplicateNameChip: View {
 
     private var hasClip: Bool {
         model.clipURL(for: profile.id) != nil
+    }
+
+    private var isPlaying: Bool {
+        model.isPlayingSample(for: profile.id)
+    }
+
+    private var iconName: String {
+        guard hasClip else { return "person.crop.circle" }
+        return isPlaying ? "pause.circle.fill" : "play.circle.fill"
+    }
+
+    private var helpText: String {
+        guard hasClip else { return "No voice clip saved" }
+        return isPlaying ? "Pause this voice" : "Play this voice"
     }
 }
 
@@ -1029,14 +1069,14 @@ private struct SpeakerPersonRow: View {
                     Button {
                         model.playSample(for: profile.id)
                     } label: {
-                        Image(systemName: "play.circle.fill")
+                        Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
                             .font(.system(size: 15, weight: .semibold))
                             .foregroundStyle(Color.accentColor)
                             .padding(6)
                     }
                     .buttonStyle(SettingsHoverButtonStyle(tone: .accent, cornerRadius: 8))
-                    .help("Play this voice")
-                    .accessibilityLabel("Play voice sample")
+                    .help(isPlaying ? "Pause this voice" : "Play this voice")
+                    .accessibilityLabel(isPlaying ? "Pause voice sample" : "Play voice sample")
                 }
 
                 rowMenu
@@ -1184,6 +1224,10 @@ private struct SpeakerPersonRow: View {
 
     private var hasClip: Bool {
         model.clipURL(for: profile.id) != nil
+    }
+
+    private var isPlaying: Bool {
+        model.isPlayingSample(for: profile.id)
     }
 
     private func mergeLabel(for target: SpeakerProfile) -> String {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -244,7 +244,10 @@ struct TranscriptedSettingsView: View {
             expandGeneralDisclosureForPresentedPage()
             trackSettingsPageViewed(navigation.selectedPage, source: "presentation")
         }
-        .onChange(of: navigation.selectedPage) { _, page in
+        .onChange(of: navigation.selectedPage) { oldPage, page in
+            if oldPage == .people && page != .people {
+                SpeakerClipPlayback.stop()
+            }
             refreshRecentCaptures()
             if page == .people {
                 speakerPeopleModel.refresh()

--- a/Sources/UI/Shared/SpeakerClipPlayback.swift
+++ b/Sources/UI/Shared/SpeakerClipPlayback.swift
@@ -5,6 +5,15 @@ import Foundation
 enum SpeakerClipPlayback {
     static let stateDidChangeNotification = Notification.Name("SpeakerClipPlaybackStateDidChange")
 
+    private final class PlaybackDelegate: NSObject, NSSoundDelegate {
+        func sound(_ sound: NSSound, didFinishPlaying flag: Bool) {
+            Task { @MainActor in
+                SpeakerClipPlayback.finishIfActive(sound)
+            }
+        }
+    }
+
+    private static let playbackDelegate = PlaybackDelegate()
     private static var activeSound: NSSound?
     private static var activeURL: URL?
 
@@ -17,6 +26,7 @@ enum SpeakerClipPlayback {
         activeSound?.stop()
         activeURL = url
         activeSound = NSSound(contentsOf: url, byReference: false)
+        activeSound?.delegate = playbackDelegate
         if activeSound?.play() == true {
             notifyStateDidChange()
         } else {
@@ -29,7 +39,16 @@ enum SpeakerClipPlayback {
     }
 
     static func stop() {
+        activeSound?.delegate = nil
         activeSound?.stop()
+        activeSound = nil
+        activeURL = nil
+        notifyStateDidChange()
+    }
+
+    private static func finishIfActive(_ sound: NSSound) {
+        guard activeSound === sound else { return }
+        activeSound?.delegate = nil
         activeSound = nil
         activeURL = nil
         notifyStateDidChange()


### PR DESCRIPTION
## Summary

Fixes the Speakers settings preview controls so speaker clip playback reflects the active state and stops when leaving the Speakers page.

## What changed

- Speaker clip playback now notifies listeners when a clip finishes naturally.
- Speakers rows, duplicate chips, and saved speaker rows show pause labels/icons while their clip is active.
- Settings stops speaker clip playback when navigating away from Speakers or when the Speakers section disappears.

## Root cause

The shared speaker clip player could start/stop audio, but the Speakers SwiftUI page was not observing playback state. The player also did not notify the UI when `NSSound` finished by itself, so controls could not reliably flip back.

## Validation

- `bash build-deps.sh --force`
- `bash build.sh --no-open` passed
- `bash run-tests.sh` passed, 4885/4885
- `bash scripts/ops/transcripted-qa-bench.sh --mode ui` was INCOMPLETE because an existing Transcripted instance was already running, so the harness refused duplicate menu bar targeting. Build inside the bench passed.