### PR TITLE
Harden agent config setup safety

### DIFF
--- a/Sources/Support/AgentMCPConnector.swift
+++ b/Sources/Support/AgentMCPConnector.swift
@@ -101,6 +101,8 @@ enum AgentMCPConnectorError: LocalizedError, Equatable {
     case agentCLIFailed(AgentMCPAgent, status: Int32, output: String)
     case agentCLITimedOut(AgentMCPAgent)
     case codexConfigUsesInlineServers
+    case codexConfigHasDuplicateTranscriptedTables
+    case codexConfigUsesUnsupportedTranscriptedServer
 
     var errorDescription: String? {
         switch self {
@@ -115,6 +117,10 @@ enum AgentMCPConnectorError: LocalizedError, Equatable {
             return "\(agent.displayName) did not respond. Try again, or register Transcripted from the \(agent.displayName) side."
         case .codexConfigUsesInlineServers:
             return "Your Codex config defines mcp_servers inline. Add Transcripted there manually, or convert it to [mcp_servers.transcripted] table form."
+        case .codexConfigHasDuplicateTranscriptedTables:
+            return "Your Codex config already has more than one Transcripted MCP table. Remove the duplicate, then connect again."
+        case .codexConfigUsesUnsupportedTranscriptedServer:
+            return "Your Codex config already defines Transcripted through a TOML variant Transcripted cannot safely edit. Add or update it manually."
         }
     }
 }
@@ -285,6 +291,9 @@ enum AgentMCPConnector {
 
         let existing = (try? String(contentsOf: configURL, encoding: .utf8)) ?? ""
         let updated = try codexConfigText(updating: existing, commandPath: helperCommandPath)
+        if fileManager.fileExists(atPath: configURL.path), updated != existing {
+            try backupCodexConfig(at: configURL, fileManager: fileManager)
+        }
         try updated.write(to: configURL, atomically: true, encoding: .utf8)
         fileManager.restrictFileToOwnerOnly(at: configURL)
     }
@@ -300,11 +309,18 @@ enum AgentMCPConnector {
     static func codexConfigText(updating existing: String, commandPath: String) throws -> String {
         let commandLine = "command = \(tomlBasicString(commandPath))"
         var lines = existing.components(separatedBy: "\n")
+        let serverHeaderIndexes = lines.enumerated()
+            .filter { isCodexServerTableHeader($0.element) }
+            .map(\.offset)
 
-        if let headerIndex = lines.firstIndex(where: { trimmedTOMLLine($0) == codexServerTableHeader }) {
+        guard serverHeaderIndexes.count <= 1 else {
+            throw AgentMCPConnectorError.codexConfigHasDuplicateTranscriptedTables
+        }
+
+        if let headerIndex = serverHeaderIndexes.first {
             var tableEnd = lines.count
             for index in (headerIndex + 1)..<lines.count
-            where trimmedTOMLLine(lines[index]).hasPrefix("[") {
+            where isTOMLTableHeaderLine(lines[index]) {
                 tableEnd = index
                 break
             }
@@ -320,14 +336,13 @@ enum AgentMCPConnector {
             return lines.joined(separator: "\n")
         }
 
-        let definesInlineServers = lines.contains { line in
-            let trimmed = trimmedTOMLLine(line)
-            guard trimmed.hasPrefix("mcp_servers") else { return false }
-            let remainder = trimmed.dropFirst("mcp_servers".count).trimmingCharacters(in: .whitespaces)
-            return remainder.hasPrefix("=")
-        }
-        guard !definesInlineServers else {
+        switch codexUnsupportedServerVariant(in: lines) {
+        case .inlineServers:
             throw AgentMCPConnectorError.codexConfigUsesInlineServers
+        case .transcriptedServer:
+            throw AgentMCPConnectorError.codexConfigUsesUnsupportedTranscriptedServer
+        case nil:
+            break
         }
 
         var text = existing
@@ -347,14 +362,16 @@ enum AgentMCPConnector {
         for rawLine in text.components(separatedBy: "\n") {
             let line = trimmedTOMLLine(rawLine)
 
-            if line.hasPrefix("[") {
-                inServerTable = line == codexServerTableHeader
+            if isTOMLTableHeaderLine(rawLine) {
+                inServerTable = isCodexServerTableHeader(rawLine)
                 continue
             }
 
             guard inServerTable, lineDefinesTOMLCommandKey(line) else { continue }
-            guard let equalsIndex = line.firstIndex(of: "=") else { continue }
-            let value = String(line[line.index(after: equalsIndex)...])
+            let commentFreeLine = tomlLineWithoutComment(rawLine)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let equalsIndex = firstUnquotedEqualsIndex(in: commentFreeLine) else { continue }
+            let value = String(commentFreeLine[commentFreeLine.index(after: equalsIndex)...])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             return tomlBasicStringValue(value)
         }
@@ -371,10 +388,212 @@ enum AgentMCPConnector {
     /// True only for the bare `command` key — not `command_timeout` or any
     /// other key that merely starts with "command".
     private static func lineDefinesTOMLCommandKey(_ trimmedLine: String) -> Bool {
-        guard trimmedLine.hasPrefix("command") else { return false }
-        let remainder = trimmedLine.dropFirst("command".count)
-            .trimmingCharacters(in: .whitespaces)
-        return remainder.hasPrefix("=")
+        assignmentKeySegments(in: trimmedLine) == ["command"]
+    }
+
+    private enum CodexUnsupportedServerVariant {
+        case inlineServers
+        case transcriptedServer
+    }
+
+    private static func codexUnsupportedServerVariant(in lines: [String]) -> CodexUnsupportedServerVariant? {
+        var currentTable: [String] = []
+
+        for line in lines {
+            if let table = parsedTOMLTableHeader(line) {
+                currentTable = table.segments
+                continue
+            }
+
+            guard let keySegments = assignmentKeySegments(in: line) else { continue }
+            let absoluteKeySegments = currentTable + keySegments
+
+            if absoluteKeySegments == ["mcp_servers"] {
+                return .inlineServers
+            }
+
+            if absoluteKeySegments.starts(with: ["mcp_servers", "transcripted"]) {
+                return .transcriptedServer
+            }
+        }
+
+        return nil
+    }
+
+    private static func isCodexServerTableHeader(_ line: String) -> Bool {
+        guard let header = parsedTOMLTableHeader(line), !header.isArray else {
+            return false
+        }
+        return header.segments == ["mcp_servers", "transcripted"]
+    }
+
+    private static func isTOMLTableHeaderLine(_ line: String) -> Bool {
+        parsedTOMLTableHeader(line) != nil
+    }
+
+    private static func parsedTOMLTableHeader(_ line: String) -> (segments: [String], isArray: Bool)? {
+        let stripped = tomlLineWithoutComment(line).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard stripped.hasPrefix("[") else { return nil }
+
+        let isArray = stripped.hasPrefix("[[")
+        let closing = isArray ? "]]" : "]"
+        let openingCount = isArray ? 2 : 1
+        guard stripped.hasSuffix(closing), stripped.count > openingCount + closing.count else {
+            return nil
+        }
+
+        let contentStart = stripped.index(stripped.startIndex, offsetBy: openingCount)
+        let contentEnd = stripped.index(stripped.endIndex, offsetBy: -closing.count)
+        let content = String(stripped[contentStart..<contentEnd])
+        guard let segments = parseTOMLKeySegments(content), !segments.isEmpty else {
+            return nil
+        }
+        return (segments, isArray)
+    }
+
+    private static func assignmentKeySegments(in line: String) -> [String]? {
+        let stripped = tomlLineWithoutComment(line).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let equalsIndex = firstUnquotedEqualsIndex(in: stripped) else {
+            return nil
+        }
+
+        let keyText = String(stripped[..<equalsIndex])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return parseTOMLKeySegments(keyText)
+    }
+
+    private static func firstUnquotedEqualsIndex(in text: String) -> String.Index? {
+        var inString = false
+        var pendingEscape = false
+
+        for index in text.indices {
+            let character = text[index]
+
+            if pendingEscape {
+                pendingEscape = false
+                continue
+            }
+
+            if inString {
+                if character == "\\" {
+                    pendingEscape = true
+                } else if character == "\"" {
+                    inString = false
+                }
+                continue
+            }
+
+            if character == "\"" {
+                inString = true
+            } else if character == "=" {
+                return index
+            }
+        }
+
+        return nil
+    }
+
+    private static func tomlLineWithoutComment(_ line: String) -> String {
+        var output = ""
+        var inString = false
+        var pendingEscape = false
+
+        for character in line {
+            if pendingEscape {
+                output.append(character)
+                pendingEscape = false
+                continue
+            }
+
+            if inString {
+                output.append(character)
+                if character == "\\" {
+                    pendingEscape = true
+                } else if character == "\"" {
+                    inString = false
+                }
+                continue
+            }
+
+            if character == "#" {
+                break
+            }
+
+            output.append(character)
+            if character == "\"" {
+                inString = true
+            }
+        }
+
+        return output
+    }
+
+    private static func parseTOMLKeySegments(_ text: String) -> [String]? {
+        var segments: [String] = []
+        var index = text.startIndex
+
+        func skipWhitespace() {
+            while index < text.endIndex, text[index].isWhitespace {
+                index = text.index(after: index)
+            }
+        }
+
+        while true {
+            skipWhitespace()
+            guard index < text.endIndex else {
+                return segments.isEmpty ? nil : segments
+            }
+
+            let segment: String
+            if text[index] == "\"" {
+                var quoted = "\""
+                index = text.index(after: index)
+                var pendingEscape = false
+                var foundClosingQuote = false
+
+                while index < text.endIndex {
+                    let character = text[index]
+                    quoted.append(character)
+                    index = text.index(after: index)
+
+                    if pendingEscape {
+                        pendingEscape = false
+                    } else if character == "\\" {
+                        pendingEscape = true
+                    } else if character == "\"" {
+                        foundClosingQuote = true
+                        break
+                    }
+                }
+
+                guard foundClosingQuote, let parsedSegment = tomlBasicStringValue(quoted) else {
+                    return nil
+                }
+                segment = parsedSegment
+            } else {
+                let start = index
+                while index < text.endIndex,
+                      text[index] != ".",
+                      !text[index].isWhitespace {
+                    index = text.index(after: index)
+                }
+
+                guard start < index else { return nil }
+                segment = String(text[start..<index])
+            }
+
+            segments.append(segment)
+            skipWhitespace()
+
+            guard index < text.endIndex else {
+                return segments
+            }
+
+            guard text[index] == "." else {
+                return nil
+            }
+            index = text.index(after: index)
+        }
     }
 
     static func tomlBasicString(_ value: String) -> String {
@@ -483,5 +702,24 @@ enum AgentMCPConnector {
 
         drained.wait()
         return (process.terminationStatus, String(decoding: stdoutBox.data + stderrBox.data, as: UTF8.self))
+    }
+
+    @discardableResult
+    private static func backupCodexConfig(at configURL: URL, fileManager: FileManager) throws -> URL {
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+        let baseName = "\(configURL.lastPathComponent).backup-\(timestamp)"
+        var backupURL = configURL.deletingLastPathComponent()
+            .appendingPathComponent(baseName, isDirectory: false)
+        var suffix = 2
+
+        while fileManager.fileExists(atPath: backupURL.path) {
+            backupURL = configURL.deletingLastPathComponent()
+                .appendingPathComponent("\(baseName)-\(suffix)", isDirectory: false)
+            suffix += 1
+        }
+
+        try fileManager.copyItem(at: configURL, to: backupURL)
+        return backupURL
     }
 }

--- a/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
+++ b/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
@@ -79,6 +79,7 @@ enum ClaudeDesktopIntegrationError: LocalizedError, Equatable {
     case selfTestFailed(status: Int32, output: String)
     case selfTestReportedUnhealthy(output: String)
     case selfTestOutputUnreadable(String)
+    case selfTestTimedOut(URL)
 
     var errorDescription: String? {
         switch self {
@@ -98,6 +99,8 @@ enum ClaudeDesktopIntegrationError: LocalizedError, Equatable {
             return "Transcripted direct tools did not pass the local check."
         case .selfTestOutputUnreadable:
             return "Transcripted direct tools ran, but the health check output could not be read."
+        case .selfTestTimedOut:
+            return "Transcripted direct tools did not respond to the local check. Try again, or reinstall the helper."
         }
     }
 }
@@ -327,7 +330,8 @@ enum ClaudeDesktopIntegrationInstaller {
 
     static func runSelfTest(
         binaryURL: URL,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        timeout: TimeInterval = 30
     ) throws -> TranscriptedMCPSelfTest {
         guard fileManager.isExecutableFile(atPath: binaryURL.path) else {
             throw ClaudeDesktopIntegrationError.installedBinaryNotExecutable(binaryURL)
@@ -342,11 +346,37 @@ enum ClaudeDesktopIntegrationInstaller {
         process.standardOutput = stdout
         process.standardError = stderr
 
-        try process.run()
-        process.waitUntilExit()
+        let finished = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in finished.signal() }
 
-        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
-        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+        try process.run()
+
+        // Drain both pipes while the helper runs so a noisy self-test cannot
+        // fill a pipe buffer and stall before the timeout can fire.
+        final class PipeOutputBox: @unchecked Sendable {
+            var data = Data()
+        }
+        let stdoutBox = PipeOutputBox()
+        let stderrBox = PipeOutputBox()
+        let drained = DispatchGroup()
+        for (pipe, box) in [(stdout, stdoutBox), (stderr, stderrBox)] {
+            drained.enter()
+            DispatchQueue.global(qos: .utility).async {
+                box.data = pipe.fileHandleForReading.readDataToEndOfFile()
+                drained.leave()
+            }
+        }
+
+        if finished.wait(timeout: .now() + timeout) == .timedOut {
+            process.terminate()
+            _ = finished.wait(timeout: .now() + 2)
+            throw ClaudeDesktopIntegrationError.selfTestTimedOut(binaryURL)
+        }
+
+        drained.wait()
+
+        let stdoutData = stdoutBox.data
+        let stderrData = stderrBox.data
         let output = String(decoding: stdoutData + stderrData, as: UTF8.self)
 
         guard process.terminationStatus == 0 else {
@@ -432,8 +462,17 @@ enum ClaudeDesktopIntegrationInstaller {
 
         let timestamp = ISO8601DateFormatter().string(from: Date())
             .replacingOccurrences(of: ":", with: "-")
-        let backupURL = configURL.deletingLastPathComponent()
-            .appendingPathComponent("\(configURL.lastPathComponent).backup-\(timestamp)", isDirectory: false)
+        let baseName = "\(configURL.lastPathComponent).backup-\(timestamp)"
+        var backupURL = configURL.deletingLastPathComponent()
+            .appendingPathComponent(baseName, isDirectory: false)
+        var suffix = 2
+
+        while fileManager.fileExists(atPath: backupURL.path) {
+            backupURL = configURL.deletingLastPathComponent()
+                .appendingPathComponent("\(baseName)-\(suffix)", isDirectory: false)
+            suffix += 1
+        }
+
         try fileManager.copyItem(at: configURL, to: backupURL)
         return backupURL
     }

--- a/Sources/UI/Settings/AgentConnectionSettingsPage.swift
+++ b/Sources/UI/Settings/AgentConnectionSettingsPage.swift
@@ -22,6 +22,7 @@ struct AgentConnectionSettingsPage: View {
     @State private var connectedAgents: Set<AgentMCPAgent> = []
     @State private var rowPhases: [AgentMCPAgent: RowPhase] = [:]
     @State private var claudeDesktopSelfTest: TranscriptedMCPSelfTest?
+    @State private var claudeDesktopConfigBackupURL: URL?
     @State private var copiedLocalAgentPrompt = false
     @State private var copiedClaudeDesktopConfig = false
     @State private var copiedFolderPaths = false
@@ -129,6 +130,18 @@ struct AgentConnectionSettingsPage: View {
                 Text("\(claudeDesktopSelfTest.meetingFileCount) meetings, \(claudeDesktopSelfTest.dictationFileCount) dictation files visible.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            }
+
+            if agent == .claudeDesktop, let claudeDesktopConfigBackupURL {
+                HStack(spacing: 8) {
+                    Label("Previous config backed up.", systemImage: "doc.badge.clock")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    SettingsInlineActionButton(title: "Show Backup", symbolName: "folder") {
+                        reveal(claudeDesktopConfigBackupURL)
+                    }
+                }
             }
         }
         .modifier(AgentRowCard())
@@ -428,25 +441,28 @@ struct AgentConnectionSettingsPage: View {
         rowPhases[agent] = .connecting
         if agent == .claudeDesktop {
             claudeDesktopSelfTest = nil
+            claudeDesktopConfigBackupURL = nil
         }
         let priorStatus: ActivationTelemetry.AgentSetupPriorStatus =
             connectedAgents.contains(agent) ? .installed : .notInstalled
 
         Task {
             do {
-                let selfTest = try await Task.detached(priority: .userInitiated) { () -> TranscriptedMCPSelfTest? in
+                let result = try await Task.detached(priority: .userInitiated) { () -> AgentConnectResult in
                     if agent == .claudeDesktop {
-                        return try ClaudeDesktopIntegrationInstaller.installForClaudeDesktop().selfTest
+                        let install = try ClaudeDesktopIntegrationInstaller.installForClaudeDesktop()
+                        return AgentConnectResult(selfTest: install.selfTest, backupURL: install.backupURL)
                     }
                     let helper = try AgentMCPConnector.ensureHelperInstalled()
                     try AgentMCPConnector.connect(agent, helperCommandPath: helper.path)
-                    return nil
+                    return AgentConnectResult()
                 }.value
 
                 rowPhases[agent] = .connected
                 connectedAgents.insert(agent)
                 if agent == .claudeDesktop {
-                    claudeDesktopSelfTest = selfTest
+                    claudeDesktopSelfTest = result.selfTest
+                    claudeDesktopConfigBackupURL = result.backupURL
                 }
                 trackConnect(agent, priorStatus: priorStatus, result: .success)
             } catch {
@@ -770,6 +786,19 @@ struct AgentConnectionSettingsPage: View {
     private func reveal(_ url: URL) {
         let target = folderExists(url) ? url : url.deletingLastPathComponent()
         NSWorkspace.shared.activateFileViewerSelecting([target])
+    }
+}
+
+private struct AgentConnectResult {
+    let selfTest: TranscriptedMCPSelfTest?
+    let backupURL: URL?
+
+    init(
+        selfTest: TranscriptedMCPSelfTest? = nil,
+        backupURL: URL? = nil
+    ) {
+        self.selfTest = selfTest
+        self.backupURL = backupURL
     }
 }
 

--- a/Tests/AgentMCPConnectorTests.swift
+++ b/Tests/AgentMCPConnectorTests.swift
@@ -57,6 +57,82 @@ func testAgentMCPConnector() {
         assertFalse(updated.contains("/old/path"), "stale path should be gone")
     }
 
+    runSuite("AgentMCPConnector.codexConfigText — updates legal table header variants without appending duplicates") {
+        let existing = """
+        [ mcp_servers . "transcripted" ] # installed manually
+        command = "/old/path/transcripted-mcp"
+        startup_timeout_ms = 20000
+
+        [mcp_servers.other]
+        command = "/usr/local/bin/other-mcp"
+        """
+
+        let updated = (try? AgentMCPConnector.codexConfigText(
+            updating: existing,
+            commandPath: "/new/path/transcripted-mcp"
+        )) ?? ""
+
+        assertTrue(
+            updated.contains(#"[ mcp_servers . "transcripted" ] # installed manually"#),
+            "legal existing table header spelling should be preserved"
+        )
+        assertFalse(
+            updated.contains("\n[mcp_servers.transcripted]\ncommand = \"/new/path/transcripted-mcp\"\n"),
+            "connect should not append a duplicate canonical table when a legal variant exists"
+        )
+        assertEqual(
+            AgentMCPConnector.codexConfiguredCommandPath(inConfigText: updated),
+            "/new/path/transcripted-mcp",
+            "legal table variants should read back through the normal connection check"
+        )
+        assertTrue(
+            updated.contains("startup_timeout_ms = 20000"),
+            "other keys in the legal table variant should survive"
+        )
+    }
+
+    runSuite("AgentMCPConnector.codexConfigText — updates quoted command keys in existing table variants") {
+        let existing = """
+        ["mcp_servers"."transcripted"]
+        "command" = "/old/path/transcripted-mcp"
+        """
+
+        let updated = (try? AgentMCPConnector.codexConfigText(
+            updating: existing,
+            commandPath: "/new/path/transcripted-mcp"
+        )) ?? ""
+
+        assertEqual(
+            AgentMCPConnector.codexConfiguredCommandPath(inConfigText: updated),
+            "/new/path/transcripted-mcp",
+            "quoted TOML keys should be treated as the same Transcripted server command"
+        )
+        assertFalse(updated.contains(#""command" = "/old/path/transcripted-mcp""#), "stale quoted command should be replaced")
+    }
+
+    runSuite("AgentMCPConnector.codexConfigText — refuses duplicate logical Transcripted tables") {
+        let existing = """
+        [mcp_servers.transcripted]
+        command = "/first/transcripted-mcp"
+
+        [ "mcp_servers" . "transcripted" ]
+        command = "/second/transcripted-mcp"
+        """
+
+        do {
+            _ = try AgentMCPConnector.codexConfigText(updating: existing, commandPath: "/new/transcripted-mcp")
+            assertTrue(false, "duplicate logical Transcripted tables should throw instead of rewriting one copy")
+        } catch let error as AgentMCPConnectorError {
+            assertEqual(
+                error,
+                .codexConfigHasDuplicateTranscriptedTables,
+                "duplicate logical tables should use the dedicated safety error"
+            )
+        } catch {
+            assertTrue(false, "unexpected error type: \(error)")
+        }
+    }
+
     runSuite("AgentMCPConnector.codexConfigText — starts a fresh config cleanly") {
         let updated = (try? AgentMCPConnector.codexConfigText(updating: "", commandPath: "/tmp/transcripted-mcp")) ?? ""
 
@@ -100,6 +176,46 @@ func testAgentMCPConnector() {
             assertTrue(false, "inline mcp_servers should throw instead of appending a duplicate table")
         } catch let error as AgentMCPConnectorError {
             assertEqual(error, .codexConfigUsesInlineServers, "inline servers should raise the dedicated error")
+        } catch {
+            assertTrue(false, "unexpected error type: \(error)")
+        }
+    }
+
+    runSuite("AgentMCPConnector.codexConfigText — refuses dotted Transcripted definitions instead of appending a conflicting table") {
+        let existing = """
+        model = "o4"
+        mcp_servers.transcripted.command = "/old/transcripted-mcp"
+        """
+
+        do {
+            _ = try AgentMCPConnector.codexConfigText(updating: existing, commandPath: "/tmp/transcripted-mcp")
+            assertTrue(false, "dotted Transcripted server definitions should throw instead of appending a duplicate table")
+        } catch let error as AgentMCPConnectorError {
+            assertEqual(
+                error,
+                .codexConfigUsesUnsupportedTranscriptedServer,
+                "dotted Transcripted definitions should use the unsupported-variant safety error"
+            )
+        } catch {
+            assertTrue(false, "unexpected error type: \(error)")
+        }
+    }
+
+    runSuite("AgentMCPConnector.codexConfigText — refuses inline Transcripted server inside mcp_servers table") {
+        let existing = """
+        [mcp_servers]
+        transcripted = { command = "/old/transcripted-mcp" }
+        """
+
+        do {
+            _ = try AgentMCPConnector.codexConfigText(updating: existing, commandPath: "/tmp/transcripted-mcp")
+            assertTrue(false, "inline Transcripted server under [mcp_servers] should throw instead of appending a conflicting table")
+        } catch let error as AgentMCPConnectorError {
+            assertEqual(
+                error,
+                .codexConfigUsesUnsupportedTranscriptedServer,
+                "inline Transcripted server under [mcp_servers] should use the unsupported-variant safety error"
+            )
         } catch {
             assertTrue(false, "unexpected error type: \(error)")
         }
@@ -326,6 +442,19 @@ func testAgentMCPConnector() {
         )
     }
 
+    runSuite("AgentMCPConnector.codexConfiguredCommandPath — tolerates command comments") {
+        let config = """
+        [mcp_servers.transcripted] # managed manually
+        command = "/tmp/transcripted-mcp" # installed helper
+        """
+
+        assertEqual(
+            AgentMCPConnector.codexConfiguredCommandPath(inConfigText: config),
+            "/tmp/transcripted-mcp",
+            "inline comments after a legal command value should not hide an existing Codex entry"
+        )
+    }
+
     runSuite("AgentMCPConnector.connect(.cursor) — writes and reads back the Cursor MCP config") {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("TranscriptedCursorConnectTests-\(UUID().uuidString)", isDirectory: true)
@@ -386,6 +515,49 @@ func testAgentMCPConnector() {
         assertFalse(
             AgentMCPConnector.isConnected(.codex, helperCommandPath: "/other/helper", paths: paths),
             "Codex connection state should be path-exact"
+        )
+    }
+
+    runSuite("AgentMCPConnector.connect(.codex) — backs up existing config before editing") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedCodexBackupTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let paths = AgentMCPConnectorPaths(homeDirectory: tempRoot, applicationDirectories: [])
+        let existing = """
+        model = "o4"
+
+        [projects."/Users/me/code"]
+        trust_level = "trusted"
+        """
+
+        try? FileManager.default.createDirectory(at: paths.codexConfigURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? existing.write(to: paths.codexConfigURL, atomically: true, encoding: .utf8)
+
+        do {
+            try AgentMCPConnector.connect(.codex, helperCommandPath: "/tmp/transcripted-mcp", paths: paths)
+        } catch {
+            assertTrue(false, "Codex connect should back up and edit a normal config: \(error)")
+        }
+
+        let configDirectory = paths.codexConfigURL.deletingLastPathComponent()
+        let backupNames = ((try? FileManager.default.contentsOfDirectory(atPath: configDirectory.path)) ?? [])
+            .filter { $0.hasPrefix("config.toml.backup-") }
+            .sorted()
+        assertEqual(backupNames.count, 1, "Codex connect should leave one backup for the pre-edit config")
+
+        if let backupName = backupNames.first {
+            let backupURL = configDirectory.appendingPathComponent(backupName, isDirectory: false)
+            assertEqual(
+                (try? String(contentsOf: backupURL, encoding: .utf8)) ?? "",
+                existing,
+                "Codex backup should preserve the exact original config text"
+            )
+        }
+
+        assertEqual(
+            AgentMCPConnector.codexConfiguredCommandPath(inConfigText: (try? String(contentsOf: paths.codexConfigURL, encoding: .utf8)) ?? ""),
+            "/tmp/transcripted-mcp",
+            "edited Codex config should still connect successfully"
         )
     }
 

--- a/Tests/ClaudeDesktopIntegrationInstallerTests.swift
+++ b/Tests/ClaudeDesktopIntegrationInstallerTests.swift
@@ -1545,6 +1545,39 @@ func testClaudeDesktopIntegrationInstaller() {
         }
     }
 
+    runSuite("ClaudeDesktopIntegrationInstaller.runSelfTest — times out a hung helper") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeSelfTestTimeoutTests-\(UUID().uuidString)", isDirectory: true)
+        let helperURL = tempRoot
+            .appendingPathComponent("mcp", isDirectory: true)
+            .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try? FileManager.default.createDirectory(at: helperURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? "#!/bin/sh\nsleep 30\n".write(to: helperURL, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o755)], ofItemAtPath: helperURL.path)
+
+        let started = Date()
+        do {
+            _ = try ClaudeDesktopIntegrationInstaller.runSelfTest(binaryURL: helperURL, timeout: 0.4)
+            assertTrue(false, "hung helper self-test should throw a timeout error")
+        } catch let error as ClaudeDesktopIntegrationError {
+            assertEqual(error, .selfTestTimedOut(helperURL), "hung helper should raise selfTestTimedOut")
+            assertEqual(
+                error.errorDescription,
+                "Transcripted direct tools did not respond to the local check. Try again, or reinstall the helper.",
+                "timeout should have a clear user-facing message"
+            )
+        } catch {
+            assertTrue(false, "hung helper should throw ClaudeDesktopIntegrationError: \(error)")
+        }
+
+        assertTrue(
+            Date().timeIntervalSince(started) < 10,
+            "self-test timeout should fire promptly instead of waiting for the full helper sleep"
+        )
+    }
+
     runSuite("ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig — backs up non-object config") {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("TranscriptedClaudeNonObjectConfigTests-\(UUID().uuidString)", isDirectory: true)
@@ -1569,6 +1602,46 @@ func testClaudeDesktopIntegrationInstaller() {
             assertTrue(false, "non-object config backup should be readable")
         }
         assertEqual(transcriptedCommandPath(inConfigAt: configURL), "/tmp/transcripted-mcp", "replacement config should contain the Transcripted helper")
+    }
+
+    runSuite("ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig — creates unique backups without overwriting malformed config history") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeUniqueBackupTests-\(UUID().uuidString)", isDirectory: true)
+        let configURL = tempRoot
+            .appendingPathComponent("Claude", isDirectory: true)
+            .appendingPathComponent("claude_desktop_config.json", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try? FileManager.default.createDirectory(at: configURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try? "{ invalid json one".write(to: configURL, atomically: true, encoding: .utf8)
+        let firstBackup = try? ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig(
+            commandPath: "/tmp/transcripted-mcp",
+            configURL: configURL
+        )
+
+        try? "{ invalid json two".write(to: configURL, atomically: true, encoding: .utf8)
+        let secondBackup = try? ClaudeDesktopIntegrationInstaller.writeClaudeDesktopConfig(
+            commandPath: "/tmp/transcripted-mcp",
+            configURL: configURL
+        )
+
+        assertNotNil(firstBackup, "first malformed config should create a backup")
+        assertNotNil(secondBackup, "second malformed config should create a backup")
+        assertFalse(firstBackup?.path == secondBackup?.path, "backup names should be unique even within the same test run")
+
+        if let firstBackup,
+           let secondBackup {
+            assertEqual(
+                (try? String(contentsOf: firstBackup, encoding: .utf8)) ?? "",
+                "{ invalid json one",
+                "first backup should preserve the first malformed config"
+            )
+            assertEqual(
+                (try? String(contentsOf: secondBackup, encoding: .utf8)) ?? "",
+                "{ invalid json two",
+                "second backup should preserve the second malformed config"
+            )
+        }
     }
 
     runSuite("ClaudeDesktopIntegrationInstaller.bundledMCPBinaryURL — uses Helpers bundle location only") {


### PR DESCRIPTION
## Summary
- harden Codex MCP TOML updates against duplicate Transcripted tables, legal table/key variants, and unsupported inline/dotted server forms
- back up Codex config before edits and make Claude Desktop config backups collision-safe
- add Claude Desktop self-test timeout plus async pipe draining, and show the backup location in Agent Connect settings
- add regression coverage for malformed JSON preservation, TOML duplicate avoidance, backup preservation, and self-test timeout

## Verification
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh
- bash scripts/dev/agent-preflight.sh
- codex-review --mode local: clean, no accepted/actionable findings; review-owned fast suite passed

## Notes
- Initial build asked for build-deps refresh; rerun passed after build-deps.
- build.sh still prints existing MeetingOverlayController main-actor warnings unrelated to this patch.