### PR TITLE
[codex] Apply mic boost to dictation starts

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -1456,6 +1456,10 @@ class ParakeetEngine: ObservableObject {
             let tapRemoveStartedAt = CFAbsoluteTimeGetCurrent()
             inputNode.removeTap(onBus: 0)
             stageTimings["audio_tap_remove_ms"] = Self.elapsedMilliseconds(since: tapRemoveStartedAt)
+            let voiceProcessingRequested = MicrophoneProcessingPreferences.isVoiceProcessingEnabled()
+            let voiceProcessingStartedAt = CFAbsoluteTimeGetCurrent()
+            Self.applyDictationVoiceProcessingPreference(voiceProcessingRequested, to: inputNode)
+            stageTimings["audio_voice_processing_apply_ms"] = Self.elapsedMilliseconds(since: voiceProcessingStartedAt)
             let tapInstallStartedAt = CFAbsoluteTimeGetCurrent()
             inputNode.installTap(onBus: 0, bufferSize: TranscriptedConstants.audioTapBufferSize, format: nil) { [weak self] buffer, _ in
                 guard let self = self,
@@ -1554,6 +1558,39 @@ class ParakeetEngine: ObservableObject {
             audioEngine.inputNode.removeTap(onBus: 0)
         }
         inputTapInstalled = false
+    }
+
+    /// Share the user-consented issue #500 VPIO path with dictation. Meeting
+    /// capture owns the prompt; dictation just honors the stable mic-processing
+    /// preference on each new recording start.
+    private nonisolated static func applyDictationVoiceProcessingPreference(
+        _ enabled: Bool,
+        to inputNode: AVAudioInputNode
+    ) {
+        guard inputNode.isVoiceProcessingEnabled != enabled else { return }
+        do {
+            try inputNode.setVoiceProcessingEnabled(enabled)
+            if enabled {
+                inputNode.isVoiceProcessingAGCEnabled = true
+                if #available(macOS 14.0, *) {
+                    inputNode.voiceProcessingOtherAudioDuckingConfiguration = AVAudioVoiceProcessingOtherAudioDuckingConfiguration(
+                        enableAdvancedDucking: false,
+                        duckingLevel: .min
+                    )
+                }
+            }
+        } catch {
+            let action = enabled ? "enable" : "disable"
+            Task { @MainActor in
+                EventReporter.shared.capture(
+                    level: .warning,
+                    engine: "parakeet",
+                    event: "dictation_voice_processing_unavailable",
+                    message: "Could not \(action) dictation voice processing; continuing with current input node mode",
+                    context: ["requested": "\(enabled)"]
+                )
+            }
+        }
     }
 
     private func stopAudioEngine() async {

--- a/Sources/Support/MicrophoneProcessingPreferences.swift
+++ b/Sources/Support/MicrophoneProcessingPreferences.swift
@@ -1,26 +1,28 @@
 // Support/MicrophoneProcessingPreferences.swift
-// Preference flag for the meeting microphone's voice-processing strategy.
+// Preference flag for Transcripted's microphone voice-processing strategy.
 //
-// Two paths exist for cleaning up the meeting mic so transcripts come out at
-// usable volume:
+// Two paths exist for cleaning up the mic so meeting and dictation transcripts
+// come out at usable volume:
 //
-//   - Software AGC (default): a real-time RealtimeAGC instance in the mic tap
-//     callback applies gain to compensate for attenuated streams (e.g. when
-//     Safari/Firefox WebRTC has activated VPIO on the same physical mic and
-//     the shared device hands us a quiet copy). No system-wide side effects.
+//   - Software AGC (default): meeting capture runs a real-time RealtimeAGC
+//     instance in the mic tap callback to compensate for attenuated streams
+//     (e.g. when Safari/Firefox WebRTC has activated VPIO on the same physical
+//     mic and the shared device hands us a quiet copy). No system-wide side
+//     effects.
 //
 //   - Apple voice processing (VPIO): we enable
-//     setVoiceProcessingEnabled(true) on our AVAudioEngine input node so we
+//     setVoiceProcessingEnabled(true) on our AVAudioEngine input nodes so we
 //     get our own AGC'd copy from the OS. This fixes issue #500 most
-//     completely for Safari/Firefox calls, but macOS treats any VPIO holder
-//     as a voice-comms app and ducks audio playback from other apps. Users
-//     on Zoom or other native voice apps will hear those apps get quieter
-//     while Transcripted is recording.
+//     completely for Safari/Firefox calls and now covers dictation starts after
+//     the user accepts the in-meeting boost. macOS treats any VPIO holder as a
+//     voice-comms app and can duck audio playback from other apps. Users on
+//     Zoom or other native voice apps may hear those apps get quieter while
+//     Transcripted is recording.
 //
 // Default-off so existing users on v1.1.24 (where VPIO was unconditionally
 // armed) get the un-ducked behavior on upgrade. Users who specifically need
 // the VPIO path for Safari/Firefox WebRTC meetings can opt in via the
-// Meetings settings page.
+// Meetings settings page or the in-meeting boost prompt.
 
 import Foundation
 
@@ -28,9 +30,10 @@ enum MicrophoneProcessingPreferences {
 
     static let voiceProcessingEnabledKey = "meeting-mic-voice-processing-enabled"
 
-    /// Whether Apple's AUVoiceProcessingIO (VPIO) is armed on the meeting
-    /// mic engine. Default: false. Read once at recording start; changes
-    /// during a session do not take effect until the next recording.
+    /// Whether Apple's AUVoiceProcessingIO (VPIO) is armed on Transcripted's
+    /// mic engines. Default: false. Read once at recording start; changes
+    /// during a session do not take effect until the next recording, except
+    /// meeting capture can explicitly restart its engine after prompt consent.
     /// Tests can inject a sandboxed `UserDefaults` to avoid touching
     /// `.standard` global state.
     static func isVoiceProcessingEnabled(userDefaults: UserDefaults = .standard) -> Bool {

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1562,6 +1562,33 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - dictation honors the shared mic boost preference") {
+        let contents = readRepoTextFile("Sources/Speech/ParakeetEngine.swift")
+        let startBlock = sourceSlice(
+            contents,
+            from: "private func installTapAndStartEngine",
+            to: "private func removeRecordingTap"
+        )
+
+        guard
+            let preferenceRead = startBlock.range(of: "MicrophoneProcessingPreferences.isVoiceProcessingEnabled()"),
+            let applyCall = startBlock.range(of: "Self.applyDictationVoiceProcessingPreference"),
+            let tapInstall = startBlock.range(of: "inputNode.installTap(onBus: 0")
+        else {
+            assertionFailure("Dictation start should read the shared mic-processing preference before installing the tap")
+            return
+        }
+
+        assertTrue(
+            preferenceRead.lowerBound < applyCall.lowerBound && applyCall.lowerBound < tapInstall.lowerBound,
+            "dictation should apply the accepted meeting mic boost before recording audio"
+        )
+        assertTrue(
+            contents.contains("dictation_voice_processing_unavailable"),
+            "dictation should report VPIO setup failures without blocking recording"
+        )
+    }
+
     runSuite("Repo command contract - mini cursor stays compact from startup through paste") {
         let overlayContents = readRepoTextFile("Sources/UI/Overlay/FloatingOverlayController.swift")
         let sizeBlock = sourceSlice(


### PR DESCRIPTION
## Summary

- Applies the user-consented mic boost / VPIO preference to new dictation recordings before the dictation tap is installed.
- Updates the mic-processing preference comments so the shared meeting + dictation behavior is clear while keeping the existing storage key stable.
- Adds a repo contract test that guards dictation against drifting back to meeting-only boost behavior.

## Why

Manual Safari + Google Meet proof showed the in-meeting Boost Mic flow recovers meeting audio. This closes the adjacent gap where someone accepts that boost during a meeting and then starts dictation while still in the same call context.

## Validation

- `bash build-deps.sh --force`
- `bash run-tests.sh` — 4887 passed
- `bash build.sh --no-open` — passed; existing unrelated `MeetingOverlayController.swift` actor-isolation warnings remain
- `codex review --base origin/main` — no actionable bugs; review also reran `bash build.sh --no-open` successfully

## Notes

Manual live dictation-in-meeting proof is still the best final confidence check before calling the whole route fully proven.