### PR TITLE
Fix Home delete menu actions

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -814,7 +814,9 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
                   item.isEnabled else {
                 return
             }
-            item.action()
+            DispatchQueue.main.async {
+                item.action()
+            }
         }
     }
 

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -111,6 +111,7 @@ func testUIAutomationSurfaceContract() {
         for requiredHomeRendererHook in [
             "title: hasRetainedAudioFiles ? \"Delete\" : \"Dismiss\"",
             "HomeRowMoreMenuButton(items:",
+            "DispatchQueue.main.async {\n                item.action()",
             "title: \"Copy for agent\"",
         ] {
             assertTrue(homeSource.contains(requiredHomeRendererHook), "\(requiredHomeRendererHook) should keep Home action rendering visible")


### PR DESCRIPTION
## Summary
- Defer Home row AppKit menu actions onto the next main-queue tick so SwiftUI delete confirmations can present reliably.
- Add a UI automation surface contract check for that menu-action dispatch behavior.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` — 4939 passed, 0 failed
- `codex review --base origin/main --title "Fix Home delete menu actions"` — clean, no actionable regression found

## UI Smoke
- `bash scripts/ops/transcripted-qa-bench.sh --mode ui` was attempted. First run was incomplete because an existing Transcripted process made menu-bar AX targeting ambiguous.
- Direct `transcripted-qa ui-smoke` after quitting the app had Accessibility access and got 4/5 checks, but failed on the first-run onboarding primary button selector. That appears unrelated to this delete-menu change.
