### PR TITLE
Fix Home row menu actions

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -767,6 +767,7 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
 
     final class Coordinator: NSObject {
         var items: [HomeRowMenuItem]
+        private var menuActionTargets: [MenuActionTarget] = []
 
         init(items: [HomeRowMenuItem]) {
             self.items = items
@@ -774,17 +775,19 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
 
         @objc func showMenu(_ sender: NSButton) {
             let menu = NSMenu()
+            menuActionTargets = []
             // Without this, AppKit auto-enables every item whose target responds
             // to the action, overriding the per-item isEnabled set below.
             menu.autoenablesItems = false
             for item in items {
+                let target = MenuActionTarget(item: item)
+                menuActionTargets.append(target)
                 let menuItem = NSMenuItem(
                     title: item.title,
-                    action: #selector(performMenuItem(_:)),
+                    action: #selector(MenuActionTarget.perform(_:)),
                     keyEquivalent: ""
                 )
-                menuItem.target = self
-                menuItem.representedObject = item.id
+                menuItem.target = target
                 menuItem.isEnabled = item.isEnabled
                 if let image = NSImage(systemSymbolName: item.symbolName, accessibilityDescription: item.title) {
                     image.isTemplate = true
@@ -807,15 +810,19 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
                 in: sender
             )
         }
+    }
 
-        @objc private func performMenuItem(_ sender: NSMenuItem) {
-            guard let id = sender.representedObject as? UUID,
-                  let item = items.first(where: { $0.id == id }),
-                  item.isEnabled else {
-                return
-            }
+    final class MenuActionTarget: NSObject {
+        private let item: HomeRowMenuItem
+
+        init(item: HomeRowMenuItem) {
+            self.item = item
+        }
+
+        @objc func perform(_ sender: NSMenuItem) {
+            guard item.isEnabled else { return }
             DispatchQueue.main.async {
-                item.action()
+                self.item.action()
             }
         }
     }

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -111,11 +111,16 @@ func testUIAutomationSurfaceContract() {
         for requiredHomeRendererHook in [
             "title: hasRetainedAudioFiles ? \"Delete\" : \"Dismiss\"",
             "HomeRowMoreMenuButton(items:",
-            "DispatchQueue.main.async {\n                item.action()",
+            "MenuActionTarget(item: item)",
+            "DispatchQueue.main.async {\n                self.item.action()",
             "title: \"Copy for agent\"",
         ] {
             assertTrue(homeSource.contains(requiredHomeRendererHook), "\(requiredHomeRendererHook) should keep Home action rendering visible")
         }
+        assertFalse(
+            homeSource.contains("representedObject = item.id"),
+            "Home row menus should not depend on unstable SwiftUI-generated menu item IDs"
+        )
 
         for requiredOnboardingHook in [
             "Enable system audio",


### PR DESCRIPTION
## Summary
- Fix Home row overflow menu actions by retaining a per-menu AppKit action target.
- Remove the fragile lookup through transient SwiftUI-generated menu item UUIDs.
- Pin the regression in the UI automation surface contract.

## Root cause
Home row menu items stored a random `UUID` in `NSMenuItem.representedObject`, then looked that ID up in the coordinator's latest `items` array when the menu fired. SwiftUI can rebuild those menu item structs while the AppKit menu is open, producing fresh IDs and making the lookup silently miss.

## Validation
- `bash build.sh --no-open`
- `bash run-tests.sh` (`4941 passed, 0 failed`)


## Codex review
- `codex review --base origin/main`: no actionable bugs found.
