### PR TITLE
[nightly-build] Fix meeting overlay animation actor warnings

### DIFF
--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -871,10 +871,11 @@ final class MeetingOverlayRootView: NSView {
                 view.animator().alphaValue = fadeOut ? 0 : 1
             }
         }, completionHandler: { [weak self] in
-            guard let self, self.isCondensed == fadeOut else { return }
-            if fadeOut {
-                for view in fadeViews {
-                    view.isHidden = true
+            Task { @MainActor [weak self] in
+                guard let self, self.isCondensed == fadeOut else { return }
+                if fadeOut {
+                    self.audioWaveform.isHidden = true
+                    self.closeButton.isHidden = true
                 }
             }
         })
@@ -923,8 +924,10 @@ final class MeetingOverlayRootView: NSView {
                 ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
                 transcriptDrawer.animator().alphaValue = 0
             }, completionHandler: { [weak self] in
-                guard let self, !self.isDrawerVisible else { return }
-                self.transcriptDrawer.isHidden = true
+                Task { @MainActor [weak self] in
+                    guard let self, !self.isDrawerVisible else { return }
+                    self.transcriptDrawer.isHidden = true
+                }
             })
         }
     }


### PR DESCRIPTION
## Summary
- Bounce meeting overlay animation completion handlers back onto `@MainActor` before reading actor-isolated state.
- Clears the new `MeetingOverlayController.swift` compile warnings seen in the nightly gate.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh` (initial run reproduced the warnings)
- `bash build.sh` (after fix; warnings gone)
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `swift test`