### PR TITLE
[docs] Update mic processing docs

### DIFF
--- a/Sources/CLAUDE.md
+++ b/Sources/CLAUDE.md
@@ -20,7 +20,7 @@ Important entry points:
 - `Support/CustomDictionaryPreferences.swift` — persisted custom spoken-term replacements applied to final dictation and meeting transcript text
 - `Support/DockVisibilityPreferences.swift` — persisted General toggle for whether Transcripted keeps a Dock icon while idle
 - `Support/LocalSpeakerPreferences.swift` — persisted toggle that decides whether meeting transcription should split the local mic into multiple named speakers or keep it as a single "You" track
-- `Support/MicrophoneProcessingPreferences.swift` — persisted meeting-mic processing mode, defaulting to software AGC and exposing optional Apple voice processing when users need the WebRTC-specific recovery path
+- `Support/MicrophoneProcessingPreferences.swift` — persisted mic processing mode for meetings and dictation, defaulting to software AGC and exposing optional Apple voice processing for the WebRTC-specific recovery path through Settings or the in-meeting boost prompt
 - `Support/TranscriptionModelPreferences.swift` — persisted local model selection shared by dictation and meetings (`Parakeet`, `Whisper Large V3 Turbo`, `Whisper Large V3`)
 - `Support/ActivationPolicyController.swift` — main-actor policy for combining the Dock toggle with recording-state safety so active capture stays force-quit-visible
 - `Support/TranscriptedConstants.swift` — shared timing and behavior constants used across the app target


### PR DESCRIPTION
## Summary
- Update Sources/CLAUDE.md so MicrophoneProcessingPreferences is described as shared by meetings and dictation.
- Note that Apple voice processing can be enabled through Settings or the in-meeting boost prompt.

## Verification
- bash scripts/dev/agent-preflight.sh
- git diff --check

## Notes
- Claude Code was called with the requested docs prompt and proposed this one-line drift fix; Codex verified it against the source and nearest Support docs before applying.