### PR TITLE
[nightly-security] Harden agent config backups

### DIFF
--- a/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
+++ b/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
@@ -443,6 +443,7 @@ enum ClaudeDesktopIntegrationInstaller {
         let backupURL = configURL.deletingLastPathComponent()
             .appendingPathComponent("\(configURL.lastPathComponent).backup-\(timestamp)", isDirectory: false)
         try fileManager.copyItem(at: configURL, to: backupURL)
+        fileManager.restrictFileToOwnerOnly(at: backupURL)
         return backupURL
     }
 }

--- a/Tests/AgentMCPConnectorTests.swift
+++ b/Tests/AgentMCPConnectorTests.swift
@@ -235,6 +235,7 @@ func testAgentMCPConnector() {
 
         try? FileManager.default.createDirectory(at: codexDirectory, withIntermediateDirectories: true)
         try? "model = \"o4\"\n".write(to: paths.codexConfigURL, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: NSNumber(value: 0o644)], ofItemAtPath: paths.codexConfigURL.path)
 
         do {
             try AgentMCPConnector.connect(.codex, helperCommandPath: "/tmp/transcripted-mcp", paths: paths)
@@ -255,6 +256,11 @@ func testAgentMCPConnector() {
                 (try? String(contentsOf: backupURL, encoding: .utf8)) ?? "",
                 "model = \"o4\"\n",
                 "backup should preserve the pre-write config bytes"
+            )
+            assertEqual(
+                filePermissions(at: backupURL)?.intValue,
+                0o600,
+                "config backups should be owner-only even when the original file was loose"
             )
         }
 
@@ -702,4 +708,9 @@ func testAgentMCPConnector() {
             "ensure should refresh a stale installed helper"
         )
     }
+}
+
+private func filePermissions(at url: URL) -> NSNumber? {
+    let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
+    return attributes?[.posixPermissions] as? NSNumber
 }


### PR DESCRIPTION
## Summary
- Restrict agent config backup copies to owner-only permissions after copying.
- Add regression coverage for backups created from a loose original config.

## Verification
- nightly-security-check source: 100/100
- nightly-security-check app bundle: 100/100
- privacy leak sweep: PASS
- Sparkle release verification: PASS for 1.1.47
- build-deps, app build, integration smoke, run-tests, root swift test: PASS
- TranscriptedQA, CaptureKit, MCP, and CLI package tests: PASS
- packaged app smoke: WARN only for local-build distribution artifacts and entitlements proof
