### PR TITLE
[codex] Fix failed meeting delete action

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -871,6 +871,150 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
     }
 }
 
+struct HomeFailedMeetingClearButton: NSViewRepresentable {
+    let title: String
+    let symbolName: String
+    let tone: SettingsInteractionTone
+    let automationIdentifier: String
+    let action: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(action: action)
+    }
+
+    func makeNSView(context: Context) -> NSButton {
+        let button = HoverActionButton()
+        button.isBordered = false
+        button.imagePosition = .imageLeading
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.perform(_:))
+        button.setButtonType(.momentaryChange)
+        button.bezelStyle = .rounded
+        button.wantsLayer = true
+        button.layer?.cornerRadius = 8
+        button.layer?.masksToBounds = true
+        configure(button, context: context)
+        return button
+    }
+
+    func updateNSView(_ button: NSButton, context: Context) {
+        context.coordinator.action = action
+        configure(button, context: context)
+    }
+
+    private func configure(_ button: NSButton, context: Context) {
+        button.title = title
+        button.font = NSFont.systemFont(ofSize: 11, weight: .semibold)
+        button.contentTintColor = tintColor
+        button.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: title)?
+            .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 11, weight: .semibold))
+        button.identifier = NSUserInterfaceItemIdentifier(automationIdentifier)
+        button.setAccessibilityIdentifier(automationIdentifier)
+        button.setAccessibilityLabel(title)
+        button.setAccessibilityRole(.button)
+        if let hoverButton = button as? HoverActionButton {
+            hoverButton.tone = tone
+        }
+    }
+
+    private var tintColor: NSColor {
+        switch tone {
+        case .destructive:
+            return .systemRed
+        case .warning:
+            return .systemOrange
+        case .accent:
+            return .controlAccentColor
+        case .neutral:
+            return .secondaryLabelColor
+        }
+    }
+
+    final class Coordinator: NSObject {
+        var action: () -> Void
+
+        init(action: @escaping () -> Void) {
+            self.action = action
+        }
+
+        @objc func perform(_ sender: NSButton) {
+            DispatchQueue.main.async {
+                self.action()
+            }
+        }
+    }
+
+    final class HoverActionButton: NSButton {
+        var tone: SettingsInteractionTone = .neutral {
+            didSet { updateAppearance() }
+        }
+
+        private var trackingAreaRef: NSTrackingArea?
+        private var isHovering = false {
+            didSet { updateAppearance() }
+        }
+
+        override var isHighlighted: Bool {
+            didSet { updateAppearance() }
+        }
+
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            if let trackingAreaRef {
+                removeTrackingArea(trackingAreaRef)
+            }
+            let area = NSTrackingArea(
+                rect: bounds,
+                options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+                owner: self,
+                userInfo: nil
+            )
+            addTrackingArea(area)
+            trackingAreaRef = area
+        }
+
+        override func mouseEntered(with event: NSEvent) {
+            isHovering = true
+        }
+
+        override func mouseExited(with event: NSEvent) {
+            isHovering = false
+        }
+
+        override func accessibilityPerformPress() -> Bool {
+            performClick(nil)
+            return true
+        }
+
+        private func updateAppearance() {
+            let alpha: CGFloat
+            if isHighlighted {
+                alpha = 0.15
+            } else if isHovering {
+                alpha = 0.10
+            } else {
+                alpha = 0.06
+            }
+            layer?.backgroundColor = baseColor.withAlphaComponent(alpha).cgColor
+            layer?.borderColor = baseColor.withAlphaComponent(isHovering || isHighlighted ? 0.24 : 0.14).cgColor
+            layer?.borderWidth = 1
+        }
+
+        private var baseColor: NSColor {
+            switch tone {
+            case .destructive:
+                return .systemRed
+            case .warning:
+                return .systemOrange
+            case .accent:
+                return .controlAccentColor
+            case .neutral:
+                return .labelColor
+            }
+        }
+    }
+}
+
 // MARK: - Activity rows
 
 private enum HomeActivityRowFormatting {
@@ -2398,7 +2542,7 @@ private struct HomeFailedMeetingRow: View {
                         .help(retryHelp)
                     }
 
-                    SettingsInlineActionButton(
+                    HomeFailedMeetingClearButton(
                         title: hasRetainedAudioFiles ? "Delete" : "Dismiss",
                         symbolName: hasRetainedAudioFiles ? "trash" : "xmark",
                         tone: hasRetainedAudioFiles ? .destructive : .neutral,
@@ -2408,6 +2552,7 @@ private struct HomeFailedMeetingRow: View {
                     ) {
                         onClear()
                     }
+                    .frame(minWidth: hasRetainedAudioFiles ? 78 : 82, minHeight: 30)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -871,150 +871,6 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
     }
 }
 
-struct HomeFailedMeetingClearButton: NSViewRepresentable {
-    let title: String
-    let symbolName: String
-    let tone: SettingsInteractionTone
-    let automationIdentifier: String
-    let action: () -> Void
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(action: action)
-    }
-
-    func makeNSView(context: Context) -> NSButton {
-        let button = HoverActionButton()
-        button.isBordered = false
-        button.imagePosition = .imageLeading
-        button.target = context.coordinator
-        button.action = #selector(Coordinator.perform(_:))
-        button.setButtonType(.momentaryChange)
-        button.bezelStyle = .rounded
-        button.wantsLayer = true
-        button.layer?.cornerRadius = 8
-        button.layer?.masksToBounds = true
-        configure(button, context: context)
-        return button
-    }
-
-    func updateNSView(_ button: NSButton, context: Context) {
-        context.coordinator.action = action
-        configure(button, context: context)
-    }
-
-    private func configure(_ button: NSButton, context: Context) {
-        button.title = title
-        button.font = NSFont.systemFont(ofSize: 11, weight: .semibold)
-        button.contentTintColor = tintColor
-        button.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: title)?
-            .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 11, weight: .semibold))
-        button.identifier = NSUserInterfaceItemIdentifier(automationIdentifier)
-        button.setAccessibilityIdentifier(automationIdentifier)
-        button.setAccessibilityLabel(title)
-        button.setAccessibilityRole(.button)
-        if let hoverButton = button as? HoverActionButton {
-            hoverButton.tone = tone
-        }
-    }
-
-    private var tintColor: NSColor {
-        switch tone {
-        case .destructive:
-            return .systemRed
-        case .warning:
-            return .systemOrange
-        case .accent:
-            return .controlAccentColor
-        case .neutral:
-            return .secondaryLabelColor
-        }
-    }
-
-    final class Coordinator: NSObject {
-        var action: () -> Void
-
-        init(action: @escaping () -> Void) {
-            self.action = action
-        }
-
-        @objc func perform(_ sender: NSButton) {
-            DispatchQueue.main.async {
-                self.action()
-            }
-        }
-    }
-
-    final class HoverActionButton: NSButton {
-        var tone: SettingsInteractionTone = .neutral {
-            didSet { updateAppearance() }
-        }
-
-        private var trackingAreaRef: NSTrackingArea?
-        private var isHovering = false {
-            didSet { updateAppearance() }
-        }
-
-        override var isHighlighted: Bool {
-            didSet { updateAppearance() }
-        }
-
-        override func updateTrackingAreas() {
-            super.updateTrackingAreas()
-            if let trackingAreaRef {
-                removeTrackingArea(trackingAreaRef)
-            }
-            let area = NSTrackingArea(
-                rect: bounds,
-                options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
-                owner: self,
-                userInfo: nil
-            )
-            addTrackingArea(area)
-            trackingAreaRef = area
-        }
-
-        override func mouseEntered(with event: NSEvent) {
-            isHovering = true
-        }
-
-        override func mouseExited(with event: NSEvent) {
-            isHovering = false
-        }
-
-        override func accessibilityPerformPress() -> Bool {
-            performClick(nil)
-            return true
-        }
-
-        private func updateAppearance() {
-            let alpha: CGFloat
-            if isHighlighted {
-                alpha = 0.15
-            } else if isHovering {
-                alpha = 0.10
-            } else {
-                alpha = 0.06
-            }
-            layer?.backgroundColor = baseColor.withAlphaComponent(alpha).cgColor
-            layer?.borderColor = baseColor.withAlphaComponent(isHovering || isHighlighted ? 0.24 : 0.14).cgColor
-            layer?.borderWidth = 1
-        }
-
-        private var baseColor: NSColor {
-            switch tone {
-            case .destructive:
-                return .systemRed
-            case .warning:
-                return .systemOrange
-            case .accent:
-                return .controlAccentColor
-            case .neutral:
-                return .labelColor
-            }
-        }
-    }
-}
-
 // MARK: - Activity rows
 
 private enum HomeActivityRowFormatting {
@@ -2542,7 +2398,7 @@ private struct HomeFailedMeetingRow: View {
                         .help(retryHelp)
                     }
 
-                    HomeFailedMeetingClearButton(
+                    SettingsInlineActionButton(
                         title: hasRetainedAudioFiles ? "Delete" : "Dismiss",
                         symbolName: hasRetainedAudioFiles ? "trash" : "xmark",
                         tone: hasRetainedAudioFiles ? .destructive : .neutral,
@@ -2552,7 +2408,7 @@ private struct HomeFailedMeetingRow: View {
                     ) {
                         onClear()
                     }
-                    .frame(minWidth: hasRetainedAudioFiles ? 78 : 82, minHeight: 30)
+                    .frame(width: hasRetainedAudioFiles ? 78 : 82, height: 30)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1225,11 +1225,7 @@ struct TranscriptedSettingsView: View {
         if !item.audioURLs.isEmpty {
             trackSettingsAction("home_delete_failed_meeting_request", page: .home)
             let presentation = HomeDeleteConfirmationPolicy.failedMeeting
-            homeDeleteConfirmation = HomeDeleteConfirmation(
-                title: presentation.title,
-                message: presentation.message,
-                confirmTitle: presentation.confirmTitle
-            ) {
+            presentFailedMeetingDeleteConfirmation(presentation) {
                 trackSettingsAction("home_delete_failed_meeting_confirm", page: .home)
                 clearFailedMeeting(item)
             }
@@ -1238,6 +1234,27 @@ struct TranscriptedSettingsView: View {
 
         trackSettingsAction("home_dismiss_failed_meeting", page: .home)
         clearFailedMeeting(item)
+    }
+
+    private func presentFailedMeetingDeleteConfirmation(
+        _ presentation: HomeDeleteConfirmationPresentation,
+        onConfirm: @escaping () -> Void
+    ) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = presentation.title
+        alert.informativeText = presentation.message
+        alert.addButton(withTitle: presentation.confirmTitle)
+        alert.addButton(withTitle: "Cancel")
+
+        if let window = NSApplication.shared.keyWindow ?? NSApplication.shared.mainWindow {
+            alert.beginSheetModal(for: window) { response in
+                guard response == .alertFirstButtonReturn else { return }
+                onConfirm()
+            }
+        } else if alert.runModal() == .alertFirstButtonReturn {
+            onConfirm()
+        }
     }
 
     private func clearFailedMeeting(_ item: MeetingSessionController.FailedMeetingItem) {

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -109,14 +109,15 @@ func testUIAutomationSurfaceContract() {
             "HomeRowMenuItem(title: \"Open Markdown\"",
             "HomeRowMenuItem(title: \"Report issue\"",
             "HomeRowMenuItem(title: \"Delete meeting\"",
+            "presentFailedMeetingDeleteConfirmation(presentation)",
         ] {
             assertTrue(settingsSource.contains(requiredHomeActionHook), "\(requiredHomeActionHook) should keep Home action coverage visible")
         }
 
         for requiredHomeRendererHook in [
             "title: hasRetainedAudioFiles ? \"Delete\" : \"Dismiss\"",
-            "HomeFailedMeetingClearButton(",
-            "override func accessibilityPerformPress() -> Bool",
+            "SettingsInlineActionButton(",
+            "tone: hasRetainedAudioFiles ? .destructive : .neutral",
             "HomeRowMoreMenuButton(items:",
             "MenuActionTarget(item: item)",
             "DispatchQueue.main.async {\n                self.item.action()",

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -115,6 +115,8 @@ func testUIAutomationSurfaceContract() {
 
         for requiredHomeRendererHook in [
             "title: hasRetainedAudioFiles ? \"Delete\" : \"Dismiss\"",
+            "HomeFailedMeetingClearButton(",
+            "override func accessibilityPerformPress() -> Bool",
             "HomeRowMoreMenuButton(items:",
             "MenuActionTarget(item: item)",
             "DispatchQueue.main.async {\n                self.item.action()",


### PR DESCRIPTION
## Summary

- Uses the standard `SettingsInlineActionButton` for the failed-meeting Delete/Dismiss control with a fixed hit frame.
- Moves failed-meeting delete confirmation to an AppKit `NSAlert` sheet so the visible Home recovery-card Delete button reliably opens confirmation.
- Keeps the existing `deleteFailedMeeting` / `dismissFailedMeeting` clear path and adds UI contract coverage for the pressable surface.

## Root Cause

The recovery card's original visible Delete control was present in the UI but did not reliably invoke the clear action from the Home card. Testing the built app showed the first AppKit-backed replacement also exposed a button without actually firing the confirmation. The working path is the same SwiftUI inline button used by the neighboring Show Audio control, plus an AppKit confirmation sheet for the failed-meeting delete request.

## Validation

- Launched `build/Transcripted.app`, opened Home, pressed `transcripted.home.failed-meetings.delete`, confirmed `Delete Failed Meeting`, and verified `~/Library/Application Support/Transcripted/state/failed_transcriptions.json` changed from 1 failed entry to 0.
- `bash build.sh --no-open` passed.
- `bash run-tests.sh --filter UIAutomationSurfaceContractTests` passed: 154 tests.
- `bash run-tests.sh` passed: 5223 tests.
- `codex review --base origin/main` clean: no actionable bugs; reviewer also reran the fast suite.

## Notes

The failed meeting shown in the Home recovery card was actually deleted during manual verification. A backup captured before destructive testing exists at `/tmp/failed_transcriptions.pre-delete-test.20260613095657.json`.
