### PR TITLE
Fix Home dashboard row actions, hover reveal, and stats focus ring

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -430,6 +430,7 @@ struct HomeCanvasHeader: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .focusEffectDisabled()
             .opacity(isHovering ? 1 : 0.9)
             .onHover { isHovering = $0 }
             .animation(.easeOut(duration: 0.12), value: isHovering)
@@ -799,7 +800,6 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
 
     final class Coordinator: NSObject {
         var items: [HomeRowMenuItem]
-        private var menuActionTargets: [MenuActionTarget] = []
 
         init(items: [HomeRowMenuItem]) {
             self.items = items
@@ -807,20 +807,11 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
 
         @objc func showMenu(_ sender: NSButton) {
             let menu = NSMenu()
-            menuActionTargets = []
             // Without this, AppKit auto-enables every item whose target responds
             // to the action, overriding the per-item isEnabled set below.
             menu.autoenablesItems = false
             for item in items {
-                let target = MenuActionTarget(item: item)
-                menuActionTargets.append(target)
-                let menuItem = NSMenuItem(
-                    title: item.title,
-                    action: #selector(MenuActionTarget.perform(_:)),
-                    keyEquivalent: ""
-                )
-                menuItem.target = target
-                menuItem.isEnabled = item.isEnabled
+                let menuItem = ClosureMenuItem(menuItem: item)
                 if let image = NSImage(systemSymbolName: item.symbolName, accessibilityDescription: item.title) {
                     image.isTemplate = true
                     menuItem.image = image.withSymbolConfiguration(
@@ -844,18 +835,33 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
         }
     }
 
-    final class MenuActionTarget: NSObject {
-        private let item: HomeRowMenuItem
+    /// A menu item that owns its action closure and acts as its own target.
+    ///
+    /// The menu retains its items for the whole `popUp` tracking loop, so the
+    /// handler stays alive and fires no matter how SwiftUI tears down and
+    /// recreates this representable's coordinator while the menu is open. The
+    /// earlier design stored a separate target on the (weakly referenced)
+    /// `NSMenuItem.target` and deferred the call with `DispatchQueue.main.async`;
+    /// the target could be deallocated before the deferred block ran, so the
+    /// closures silently never fired (delete, reveal, and report all no-op'd).
+    final class ClosureMenuItem: NSMenuItem {
+        private let handler: () -> Void
 
-        init(item: HomeRowMenuItem) {
-            self.item = item
+        init(menuItem: HomeRowMenuItem) {
+            self.handler = menuItem.action
+            super.init(title: menuItem.title, action: #selector(invoke), keyEquivalent: "")
+            target = self
+            isEnabled = menuItem.isEnabled
         }
 
-        @objc func perform(_ sender: NSMenuItem) {
-            guard item.isEnabled else { return }
-            DispatchQueue.main.async {
-                self.item.action()
-            }
+        @available(*, unavailable)
+        required init(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        @objc private func invoke() {
+            guard isEnabled else { return }
+            handler()
         }
     }
 
@@ -989,6 +995,10 @@ private struct HomeActivityRowShell<Content: View>: View {
                     .padding(.vertical, compact ? 7 : 9)
             }
         }
+        // The idle row background is Color.clear, so without an explicit hit
+        // shape only the opaque title/time text triggers hover — actions then
+        // reveal in a narrow band instead of across the full row.
+        .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .animation(SettingsInteractionPalette.animation, value: isHovering)
     }

--- a/Tests/HomeMeetingDeletionTests.swift
+++ b/Tests/HomeMeetingDeletionTests.swift
@@ -59,6 +59,33 @@ func testHomeMeetingDeletion() {
         }
     }
 
+    runSuite("HomeMeetingDeletion resolves the on-disk URL for date-prefixed, accented filenames") {
+        withTemporaryHomeMeetingDeletionLibrary { meetingsRoot in
+            // Mirror a real capture-library filename: date-prefixed title with
+            // diacritics. The scanned RecentMeetingItem.transcriptURL must point
+            // at the exact on-disk file so delete and reveal resolve it.
+            let transcriptURL = meetingsRoot.appendingPathComponent(
+                "2026-06-13 Conversación técnica Observabilidad.md"
+            )
+            try writeDeletionMeeting(title: "Conversación técnica Observabilidad", transcriptURL: transcriptURL)
+
+            guard let item = deletionMeetingItem(transcriptURL) else {
+                assertionFailure("accented meeting should scan")
+                return
+            }
+
+            assertEqual(item.transcriptURL.path, transcriptURL.path, "scanned URL should match the on-disk path byte-for-byte")
+            assertTrue(FileManager.default.fileExists(atPath: item.transcriptURL.path), "scanned URL should resolve to an existing file")
+
+            do {
+                _ = try HomeMeetingDeletion.delete(item)
+                assertFalse(FileManager.default.fileExists(atPath: transcriptURL.path), "accented transcript should be deleted")
+            } catch {
+                assertionFailure("delete should not throw: \(error)")
+            }
+        }
+    }
+
     runSuite("HomeMeetingDeletion removes duplicate app-owned retranscriptions with matching retained audio") {
         withTemporaryHomeMeetingDeletionLibrary { meetingsRoot in
             let firstURL = meetingsRoot.appendingPathComponent("Quick notes.md")

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -125,8 +125,8 @@ func testUIAutomationSurfaceContract() {
             "tone: hasRetainedAudioFiles ? .destructive : .neutral",
             "HomeRowMoreMenuButton(items:",
             "retainedActionTarget = context.coordinator",
-            "MenuActionTarget(item: item)",
-            "DispatchQueue.main.async {\n                self.item.action()",
+            "final class ClosureMenuItem: NSMenuItem",
+            "ClosureMenuItem(menuItem: item)",
             "title: \"Copy for agent\"",
         ] {
             assertTrue(homeSource.contains(requiredHomeRendererHook), "\(requiredHomeRendererHook) should keep Home action rendering visible")
@@ -134,6 +134,20 @@ func testUIAutomationSurfaceContract() {
         assertFalse(
             homeSource.contains("representedObject = item.id"),
             "Home row menus should not depend on unstable SwiftUI-generated menu item IDs"
+        )
+
+        // Row-interaction affordances from fix/home-row-actions, which have no
+        // behavioral coverage in the fast suite (it greps source, never runs the
+        // UI). The overflow actions only reveal on hover, so the row needs a
+        // full-width hit shape (its idle background is Color.clear) and the
+        // canvas-header action button must not draw a focus ring.
+        assertTrue(
+            homeSource.contains(".focusEffectDisabled()"),
+            "the Home canvas-header action button should keep .focusEffectDisabled() so it draws no focus ring"
+        )
+        assertTrue(
+            homeSource.contains("across the full row.\n        .contentShape(Rectangle())"),
+            "recent-capture rows should keep their full-width .contentShape(Rectangle()) so hover reveals row actions everywhere, not only over the title text"
         )
 
         for requiredOnboardingHook in [


### PR DESCRIPTION
## Why

Three pre-existing Home dashboard bugs (unrelated to the meeting-naming work): the recent-meeting row overflow (⋯) menu actions silently did nothing (Delete, Show transcript/audio in Finder, Report issue), per-row hover only revealed actions in a narrow band over the title text, and the stats line ("Nd streak · …") kept a permanent blue focus ring.

Root cause for the dead menu actions: `HomeRowMoreMenuButton` set the `NSMenuItem.target` to a separately-retained `MenuActionTarget` (a **weak** reference) whose lifetime was tied to the SwiftUI representable's coordinator, then deferred the call via `DispatchQueue.main.async` — the target could be deallocated before the block ran, so the closures never fired. Delete and "Show in Finder" were one bug, not two, and not the URL/custom-library mismatch first suspected (the scanner already resolves the real on-disk URL).

## Product Impact

- Affects: `meetings`
- Lane: `meeting reliability`
- Why this matters: the overflow-menu actions on Home recent meetings (delete, reveal in Finder, report) were completely non-functional, including for capture libraries in custom/legacy locations.

## What changed

- Replace the menu dispatch with a self-targeting `ClosureMenuItem: NSMenuItem` that the `NSMenu` retains for the whole `popUp` loop and invokes synchronously — fixes Delete, Show in Finder, and Report issue. Composes with `main`'s `retainedActionTarget` coordinator-retention fix: the button keeps `showMenu` alive, the menu item owns its handler.
- Give recent-capture rows a full-width `.contentShape(Rectangle())` so hover reveals actions across the whole row instead of only the opaque title text.
- Disable the stats-line button focus ring (`.focusEffectDisabled()`).
- Add a `HomeMeetingDeletion` test covering scan→delete URL resolution for a date-prefixed, accented filename.
- Update the UI automation surface contract to match the merged code, and add source-contract guards for the two affordances that previously had no test coverage at all (`.focusEffectDisabled()` and the full-row row hit shape).

### Changed vs the original PR (after rebasing on latest `main`)

This branch originally also routed delete confirmations through an AppKit `NSAlert` (`presentHomeDeleteConfirmation`), on the basis that SwiftUI `.alert(item:)` didn't present reliably on Home. `main` has since gone the other way — the failed-meeting delete was moved back to the SwiftUI `homeDeleteConfirmation` state, with a test asserting the hand-built NSAlert must not be used. On rebase this branch **drops its NSAlert path entirely** and defers to `main`'s SwiftUI delete confirmation for all deletes, so `TranscriptedSettingsView.swift` ends up unchanged from `main`.

## How I checked it

- [x] `bash build.sh --no-open`
- [x] `bash run-tests.sh` — full fast suite green (**5260/5260**, UI automation contract 159/159). The `DictationTranscriptWriterTests` timezone flakiness noted in the original PR is gone now that this sits on top of #1108.
- [x] Performance budget passed (bundle gate via `build.sh --no-open`)
- [ ] `bash run-integration-smoke.sh` — N/A (no `Sources/Meeting/` or `Sources/TranscriptedCore/` changes in this branch)
- [ ] `swift test` — N/A (no `Package.swift`/core-seam changes)
- [ ] **Manual re-verification needed**: delete confirmation now goes through `main`'s SwiftUI `.alert(item:)`, which this branch had previously switched away from. Re-verify the Home delete → confirm → delete flow in the built app on latest `main`. Menu firing, full-row hover, and focus-ring fixes are unaffected and were live-verified earlier.

## Risk Review

- [x] Privacy / local-first behavior reviewed (no off-device payload or analytics shape changes)
- [x] Storage path or migration impact reviewed (delete/reveal resolve the real on-disk URL, incl. custom libraries; no migration)
- [x] Public-facing copy stays concrete (delete-confirmation copy unchanged — still `HomeDeleteConfirmationPolicy`)
- [x] Release/update impact reviewed (none)
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included
- [ ] Open item: delete-confirmation presentation now relies on `main`'s SwiftUI alert (see manual re-verification above)

## Notes

- Rebased onto latest `main` (`0c72c29c`), which now carries the meeting-rename feature, the `retainedActionTarget` menu fix, and the SwiftUI failed-meeting delete revert. Conflicts resolved by keeping this branch's `ClosureMenuItem` + hover/focus-ring fixes and adopting `main`'s SwiftUI delete confirmation.
