### PR TITLE
Fix Home action button target retention

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -733,6 +733,7 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
         )
         button.contentTintColor = .secondaryLabelColor
         button.target = context.coordinator
+        button.retainedActionTarget = context.coordinator
         button.action = #selector(Coordinator.showMenu(_:))
         button.setButtonType(.momentaryChange)
         button.setAccessibilityLabel("More options")
@@ -745,6 +746,10 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
 
     func updateNSView(_ button: NSButton, context: Context) {
         context.coordinator.items = items
+        if let hoverButton = button as? HoverMenuButton {
+            hoverButton.retainedActionTarget = context.coordinator
+        }
+        button.target = context.coordinator
         button.isEnabled = !items.isEmpty
         button.identifier = NSUserInterfaceItemIdentifier(automationIdentifier)
         button.setAccessibilityIdentifier(automationIdentifier)
@@ -813,6 +818,7 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
     }
 
     final class HoverMenuButton: NSButton {
+        var retainedActionTarget: AnyObject?
         private var trackingAreaRef: NSTrackingArea?
         private var isHovering = false {
             didSet { updateAppearance() }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1225,7 +1225,11 @@ struct TranscriptedSettingsView: View {
         if !item.audioURLs.isEmpty {
             trackSettingsAction("home_delete_failed_meeting_request", page: .home)
             let presentation = HomeDeleteConfirmationPolicy.failedMeeting
-            presentFailedMeetingDeleteConfirmation(presentation) {
+            homeDeleteConfirmation = HomeDeleteConfirmation(
+                title: presentation.title,
+                message: presentation.message,
+                confirmTitle: presentation.confirmTitle
+            ) {
                 trackSettingsAction("home_delete_failed_meeting_confirm", page: .home)
                 clearFailedMeeting(item)
             }
@@ -1234,27 +1238,6 @@ struct TranscriptedSettingsView: View {
 
         trackSettingsAction("home_dismiss_failed_meeting", page: .home)
         clearFailedMeeting(item)
-    }
-
-    private func presentFailedMeetingDeleteConfirmation(
-        _ presentation: HomeDeleteConfirmationPresentation,
-        onConfirm: @escaping () -> Void
-    ) {
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = presentation.title
-        alert.informativeText = presentation.message
-        alert.addButton(withTitle: presentation.confirmTitle)
-        alert.addButton(withTitle: "Cancel")
-
-        if let window = NSApplication.shared.keyWindow ?? NSApplication.shared.mainWindow {
-            alert.beginSheetModal(for: window) { response in
-                guard response == .alertFirstButtonReturn else { return }
-                onConfirm()
-            }
-        } else if alert.runModal() == .alertFirstButtonReturn {
-            onConfirm()
-        }
     }
 
     private func clearFailedMeeting(_ item: MeetingSessionController.FailedMeetingItem) {

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -109,16 +109,22 @@ func testUIAutomationSurfaceContract() {
             "HomeRowMenuItem(title: \"Open Markdown\"",
             "HomeRowMenuItem(title: \"Report issue\"",
             "HomeRowMenuItem(title: \"Delete meeting\"",
-            "presentFailedMeetingDeleteConfirmation(presentation)",
+            "HomeDeleteConfirmationPolicy.failedMeeting",
+            "homeDeleteConfirmation = HomeDeleteConfirmation(",
         ] {
             assertTrue(settingsSource.contains(requiredHomeActionHook), "\(requiredHomeActionHook) should keep Home action coverage visible")
         }
+        assertFalse(
+            settingsSource.contains("presentFailedMeetingDeleteConfirmation("),
+            "failed-meeting delete confirmation should use SwiftUI alert state instead of a hand-built NSAlert"
+        )
 
         for requiredHomeRendererHook in [
             "title: hasRetainedAudioFiles ? \"Delete\" : \"Dismiss\"",
             "SettingsInlineActionButton(",
             "tone: hasRetainedAudioFiles ? .destructive : .neutral",
             "HomeRowMoreMenuButton(items:",
+            "retainedActionTarget = context.coordinator",
             "MenuActionTarget(item: item)",
             "DispatchQueue.main.async {\n                self.item.action()",
             "title: \"Copy for agent\"",

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/UISmoke.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/UISmoke.swift
@@ -163,7 +163,9 @@ final class UIAutomationSmokeRunner {
                 executableURL: executableURL,
                 isolatedHome: isolatedHome,
                 logFileName: "ui-smoke-app.log",
-                launchReportFileName: "launch-ui-smoke.json"
+                launchReportFileName: "launch-ui-smoke.json",
+                onboardingCompleted: true,
+                forceOnboarding: false
             )
             launchedProcess = launched.process
             builder.appLogPath = launched.logURL.path
@@ -437,7 +439,9 @@ final class UIAutomationSmokeRunner {
                 executableURL: executableURL,
                 isolatedHome: onboardingHome,
                 logFileName: "ui-smoke-onboarding-app.log",
-                launchReportFileName: "launch-ui-smoke-onboarding.json"
+                launchReportFileName: "launch-ui-smoke-onboarding.json",
+                onboardingCompleted: false,
+                forceOnboarding: true
             )
             builder.onboardingAppLogPath = launched.logURL.path
         } catch {
@@ -457,6 +461,7 @@ final class UIAutomationSmokeRunner {
         let appAX = AXUIElementCreateApplication(launched.process.processIdentifier)
         AXUIElementSetMessagingTimeout(appAX, 2)
         let appInspector = AXInspector(root: appAX)
+        let onboardingMaxDepth = 24
 
         guard waitUntil(timeout: timeout, description: "onboarding AX tree", condition: {
             launched.process.isRunning && !appInspector.snapshot(maxDepth: 4, maxNodes: 40).isEmpty
@@ -471,13 +476,13 @@ final class UIAutomationSmokeRunner {
         }
 
         let navPrimaryID = "transcripted.onboarding.nav.primary"
-        guard let welcomeObserved = waitForObservedElements([navPrimaryID], inspector: appInspector) else {
+        guard let welcomeObserved = waitForObservedElements([navPrimaryID], inspector: appInspector, maxDepth: onboardingMaxDepth) else {
             builder.add(.fail(
                 "onboarding-window",
                 "First-run onboarding window is visible",
                 target: navPrimaryID,
                 detail: "The first-run onboarding primary button was not found.",
-                observed: observedElements(for: [navPrimaryID], inspector: appInspector)
+                observed: observedElements(for: [navPrimaryID], inspector: appInspector, maxDepth: onboardingMaxDepth)
             ))
             return false
         }
@@ -488,7 +493,7 @@ final class UIAutomationSmokeRunner {
             observed: welcomeObserved
         ))
 
-        guard appInspector.performPressOrClick(identifier: navPrimaryID) else {
+        guard appInspector.performPressOrClick(identifier: navPrimaryID, maxDepth: onboardingMaxDepth) else {
             builder.add(.fail(
                 "onboarding-navigation",
                 "Onboarding primary navigation advances to use-case choice",
@@ -499,7 +504,7 @@ final class UIAutomationSmokeRunner {
         }
         pauseForUITransition()
 
-        guard appInspector.performPressOrClick(identifier: navPrimaryID) else {
+        guard appInspector.performPressOrClick(identifier: navPrimaryID, maxDepth: onboardingMaxDepth) else {
             builder.add(.fail(
                 "onboarding-navigation",
                 "Onboarding primary navigation advances to use-case choice",
@@ -516,13 +521,13 @@ final class UIAutomationSmokeRunner {
             navPrimaryID,
             "transcripted.onboarding.nav.back",
         ]
-        guard let useCaseObserved = waitForObservedElements(useCaseIDs, inspector: appInspector) else {
+        guard let useCaseObserved = waitForObservedElements(useCaseIDs, inspector: appInspector, maxDepth: onboardingMaxDepth) else {
             builder.add(.fail(
                 "onboarding-use-case",
                 "Onboarding exposes meeting and dictation use-case choices",
                 target: "Transcripted onboarding",
                 detail: "The use-case step did not expose the expected automation identifiers.",
-                observed: observedElements(for: useCaseIDs, inspector: appInspector)
+                observed: observedElements(for: useCaseIDs, inspector: appInspector, maxDepth: onboardingMaxDepth)
             ))
             return false
         }
@@ -533,7 +538,7 @@ final class UIAutomationSmokeRunner {
             observed: useCaseObserved
         ))
 
-        guard appInspector.performPressOrClick(identifier: "transcripted.onboarding.use-case.dictation") else {
+        guard appInspector.performPressOrClick(identifier: "transcripted.onboarding.use-case.dictation", maxDepth: onboardingMaxDepth) else {
             builder.add(.fail(
                 "onboarding-dictation-path",
                 "Onboarding can choose the dictation setup path",
@@ -544,7 +549,7 @@ final class UIAutomationSmokeRunner {
         }
         pauseForUITransition()
 
-        guard appInspector.performPressOrClick(identifier: navPrimaryID) else {
+        guard appInspector.performPressOrClick(identifier: navPrimaryID, maxDepth: onboardingMaxDepth) else {
             builder.add(.fail(
                 "onboarding-dictation-path",
                 "Onboarding can choose the dictation setup path",
@@ -559,13 +564,13 @@ final class UIAutomationSmokeRunner {
             "transcripted.onboarding.permissions.microphone",
             "transcripted.onboarding.permissions.accessibility",
         ]
-        guard let dictationObserved = waitForObservedElements(dictationPermissionIDs, inspector: appInspector) else {
+        guard let dictationObserved = waitForObservedElements(dictationPermissionIDs, inspector: appInspector, maxDepth: onboardingMaxDepth) else {
             builder.add(.fail(
                 "onboarding-dictation-permissions",
                 "Dictation onboarding exposes required permission actions",
                 target: "Transcripted onboarding",
                 detail: "The dictation permission step did not expose microphone and accessibility actions.",
-                observed: observedElements(for: dictationPermissionIDs, inspector: appInspector)
+                observed: observedElements(for: dictationPermissionIDs, inspector: appInspector, maxDepth: onboardingMaxDepth)
             ))
             return false
         }
@@ -576,7 +581,7 @@ final class UIAutomationSmokeRunner {
             observed: dictationObserved
         ))
 
-        guard appInspector.performPressOrClick(identifier: "transcripted.onboarding.nav.back") else {
+        guard appInspector.performPressOrClick(identifier: "transcripted.onboarding.nav.back", maxDepth: onboardingMaxDepth) else {
             builder.add(.fail(
                 "onboarding-meeting-path",
                 "Onboarding can return and choose the meetings setup path",
@@ -587,8 +592,8 @@ final class UIAutomationSmokeRunner {
         }
         pauseForUITransition()
 
-        guard waitForObservedElements(useCaseIDs, inspector: appInspector) != nil,
-              appInspector.performPressOrClick(identifier: "transcripted.onboarding.use-case.meetings") else {
+        guard waitForObservedElements(useCaseIDs, inspector: appInspector, maxDepth: onboardingMaxDepth) != nil,
+              appInspector.performPressOrClick(identifier: "transcripted.onboarding.use-case.meetings", maxDepth: onboardingMaxDepth) else {
             builder.add(.fail(
                 "onboarding-meeting-path",
                 "Onboarding can return and choose the meetings setup path",
@@ -599,7 +604,7 @@ final class UIAutomationSmokeRunner {
         }
         pauseForUITransition()
 
-        guard appInspector.performPressOrClick(identifier: navPrimaryID) else {
+        guard appInspector.performPressOrClick(identifier: navPrimaryID, maxDepth: onboardingMaxDepth) else {
             builder.add(.fail(
                 "onboarding-meeting-path",
                 "Onboarding can return and choose the meetings setup path",
@@ -615,13 +620,13 @@ final class UIAutomationSmokeRunner {
             "transcripted.onboarding.permissions.system-audio",
             "transcripted.onboarding.permissions.leave-dictation-shortcuts-off",
         ]
-        guard let meetingObserved = waitForObservedElements(meetingPermissionIDs, inspector: appInspector) else {
+        guard let meetingObserved = waitForObservedElements(meetingPermissionIDs, inspector: appInspector, maxDepth: onboardingMaxDepth) else {
             builder.add(.fail(
                 "onboarding-meeting-permissions",
                 "Meeting onboarding exposes required permission actions",
                 target: "Transcripted onboarding",
                 detail: "The meeting permission step did not expose microphone, system audio, and shortcut preference actions.",
-                observed: observedElements(for: meetingPermissionIDs, inspector: appInspector)
+                observed: observedElements(for: meetingPermissionIDs, inspector: appInspector, maxDepth: onboardingMaxDepth)
             ))
             return false
         }
@@ -671,10 +676,22 @@ final class UIAutomationSmokeRunner {
         executableURL: URL,
         isolatedHome: URL,
         logFileName: String,
-        launchReportFileName: String
+        launchReportFileName: String,
+        onboardingCompleted: Bool,
+        forceOnboarding: Bool
     ) throws -> LaunchedApp {
         let process = Process()
         process.executableURL = executableURL
+        process.arguments = [
+            "-permissionsOnboardingCompleted",
+            onboardingCompleted ? "YES" : "NO",
+            "-forcePermissionsOnboarding",
+            forceOnboarding ? "YES" : "NO",
+            "-observability-anonymous-analytics-enabled",
+            "NO",
+            "-observability-crash-reporting-enabled",
+            "NO",
+        ]
 
         let logsDirectory = isolatedHome.appendingPathComponent("Library/Application Support/Transcripted/logs", isDirectory: true)
         try fileManager.createDirectory(at: logsDirectory, withIntermediateDirectories: true)
@@ -682,6 +699,7 @@ final class UIAutomationSmokeRunner {
         var environment = ProcessInfo.processInfo.environment
         environment["HOME"] = isolatedHome.path
         environment["CFFIXED_USER_HOME"] = isolatedHome.path
+        environment.removeValue(forKey: "__CFBundleIdentifier")
         environment["TRANSCRIPTED_DISABLE_FILE_LOGGER"] = "1"
         environment["TRANSCRIPTED_DISABLE_RUNTIME_DIAGNOSTICS"] = "1"
         environment["TRANSCRIPTED_DISABLE_SINGLE_INSTANCE_GUARD"] = "1"
@@ -719,8 +737,8 @@ final class UIAutomationSmokeRunner {
         })
     }
 
-    private func observedElements(for identifiers: [String], inspector: AXInspector) -> [AXObservedElement] {
-        let nodes = inspector.snapshotNodes(maxDepth: 12)
+    private func observedElements(for identifiers: [String], inspector: AXInspector, maxDepth: Int = 12) -> [AXObservedElement] {
+        let nodes = inspector.snapshotNodes(maxDepth: maxDepth)
         return identifiers.map { identifier in
             nodes.first { $0.observed.identifier == identifier }?.observed
                 ?? AXObservedElement(identifier: identifier, title: nil, role: nil, description: nil, help: nil, isEnabled: nil, frame: nil)
@@ -796,8 +814,8 @@ private struct LaunchedApp {
 private struct AXInspector {
     let root: AXUIElement
 
-    func first(identifier: String) -> AXNode? {
-        snapshotNodes(maxDepth: 12).first { $0.observed.identifier == identifier }
+    func first(identifier: String, maxDepth: Int = 12, maxNodes: Int = 2_000) -> AXNode? {
+        snapshotNodes(maxDepth: maxDepth, maxNodes: maxNodes).first { $0.observed.identifier == identifier }
     }
 
     func performPress(identifier: String, maxDepth: Int = 12, maxNodes: Int = 2_000) -> Bool {
@@ -834,7 +852,7 @@ private struct AXInspector {
         if performPress(identifier: identifier, maxDepth: maxDepth, maxNodes: maxNodes) {
             return true
         }
-        guard let frame = first(identifier: identifier)?.observed.frame else {
+        guard let frame = first(identifier: identifier, maxDepth: maxDepth, maxNodes: maxNodes)?.observed.frame else {
             return false
         }
         return Self.performClick(frame: frame)


### PR DESCRIPTION
## Summary
- Retain the AppKit target for the Home row more/options button so stale SwiftUI coordinator teardown cannot leave an NSButton sending actions to a dead target.
- Route failed-meeting delete confirmation back through the existing SwiftUI alert state instead of a hand-built NSAlert path.
- Stabilize the TranscriptedQA UI smoke launch so first-run onboarding is forced through process arguments, inherited Codex bundle identifiers are stripped, and deeper SwiftUI onboarding controls are found/clicked consistently.
- Add source-contract coverage for the Home action target and delete-confirmation guards.

## Sentry
- Investigates APPLE-MACOS-1X on transcripted@1.1.48.
- Likely crash shape: NSButtonCell sends an action to a stale target after Home action UI rebuild.

## Review
- codex review --uncommitted: first pass found the deeper-click fallback issue in UISmoke; fixed it.
- codex review --uncommitted: clean after the fix, no actionable bugs.

## Verification
- bash build.sh --no-open
- bash run-tests.sh --filter UIAutomationSurfaceContractTests: 157/157 passed
- bash run-tests.sh: 5227/5227 passed
- swift test --package-path Tools/TranscriptedQA: 34/34 passed
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa ui-smoke --app build/Transcripted.app --timeout 30 --report /tmp/ui-smoke-after-args-fix.json: 17/17 passed
- bash scripts/ops/transcripted-qa-bench.sh --mode ui: PASS, 3/3 checks, report /tmp/transcripted-qa-bench/qa-20260613-134803/qa-report.md

## Boundary
- This proves the Home/delete crash fix and deterministic UI surfaces. Full release/live hardware proof is still outside this PR gate.