### PR TITLE
[codex] Harden speaker naming accuracy guardrails

### DIFF
--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -5,6 +5,65 @@ import AVFoundation
 
 extension TranscriptionTaskManager {
 
+    struct SpeakerClassificationKnowledge: Sendable {
+        let speakerId: String
+        let profile: SpeakerProfile
+        let similarity: Double
+    }
+
+    nonisolated static func speakerClassificationKnowledge(
+        speakerIds: [String],
+        utterances: [TranscriptionUtterance],
+        contexts: [String: ChannelSpeakerContext],
+        speakerDB: any SpeakerStore
+    ) -> [SpeakerClassificationKnowledge] {
+        var knowledge: [SpeakerClassificationKnowledge] = []
+        var seenIds: Set<String> = []
+
+        for sid in speakerIds where seenIds.insert(sid).inserted {
+            if let context = contexts[sid],
+               let snapshot = context.matchedProfileSnapshot,
+               let similarity = context.matchSimilarity {
+                knowledge.append(SpeakerClassificationKnowledge(
+                    speakerId: sid,
+                    profile: snapshot,
+                    similarity: similarity
+                ))
+                continue
+            }
+
+            if let utterance = utterances.first(where: { String($0.speakerId) == sid }),
+               let persistentId = utterance.persistentSpeakerId,
+               let similarity = utterance.matchSimilarity,
+               let profile = speakerDB.getSpeaker(id: persistentId) {
+                knowledge.append(SpeakerClassificationKnowledge(
+                    speakerId: sid,
+                    profile: profile,
+                    similarity: similarity
+                ))
+            }
+        }
+
+        return knowledge
+    }
+
+    nonisolated static func pendingReviewProfileIds(
+        systemUtterances: [TranscriptionUtterance],
+        micUtterances: [TranscriptionUtterance],
+        systemNeedsActionIds: Set<String>,
+        micQueuedReviewIds: Set<String>
+    ) -> Set<UUID> {
+        let systemIds = systemUtterances.compactMap { utterance -> UUID? in
+            guard systemNeedsActionIds.contains(String(utterance.speakerId)) else { return nil }
+            return utterance.persistentSpeakerId
+        }
+        let micIds = micUtterances.compactMap { utterance -> UUID? in
+            guard micQueuedReviewIds.contains(String(utterance.speakerId)) else { return nil }
+            return utterance.persistentSpeakerId
+        }
+        return Set(systemIds + micIds)
+    }
+
     /// Transcribe a captured meeting using system audio plus optional mic audio.
     /// - Returns: URL of saved transcript with speaker attribution
     /// Note: nonisolated to keep heavy async work off the main thread
@@ -111,18 +170,12 @@ extension TranscriptionTaskManager {
         // Build DB knowledge snapshot: what do we already know about these speakers?
         let speakerIds = Array(result.systemSpeakerIds).sorted()
         let speakerDB = await MainActor.run { transcription.speakerDB }
-        var dbKnowledge: [(speakerId: String, profile: SpeakerProfile, similarity: Double)] = []
-
-        for utterance in result.systemUtterances {
-            let sid = String(utterance.speakerId)
-            // Only process each speaker ID once
-            guard !dbKnowledge.contains(where: { $0.speakerId == sid }) else { continue }
-            if let persistentId = utterance.persistentSpeakerId,
-               let similarity = utterance.matchSimilarity,
-               let profile = speakerDB.getSpeaker(id: persistentId) {
-                dbKnowledge.append((speakerId: sid, profile: profile, similarity: similarity))
-            }
-        }
+        let dbKnowledge = Self.speakerClassificationKnowledge(
+            speakerIds: speakerIds,
+            utterances: result.systemUtterances,
+            contexts: result.systemSpeakerContexts,
+            speakerDB: speakerDB
+        )
 
         // Per-speaker classification: auto-accept high-confidence known speakers,
         // track which ones need naming or confirmation
@@ -190,16 +243,12 @@ extension TranscriptionTaskManager {
         var micAutoAcceptedIds: Set<String> = []
         if splitLocalSpeakers && result.micPersistentSpeakerIds.count > 0 {
             let micSpeakerIds = Array(result.micSpeakerIds).sorted()
-            var micDbKnowledge: [(speakerId: String, profile: SpeakerProfile, similarity: Double)] = []
-            for utterance in result.micUtterances {
-                let sid = String(utterance.speakerId)
-                guard !micDbKnowledge.contains(where: { $0.speakerId == sid }) else { continue }
-                if let persistentId = utterance.persistentSpeakerId,
-                   let similarity = utterance.matchSimilarity,
-                   let profile = speakerDB.getSpeaker(id: persistentId) {
-                    micDbKnowledge.append((speakerId: sid, profile: profile, similarity: similarity))
-                }
-            }
+            let micDbKnowledge = Self.speakerClassificationKnowledge(
+                speakerIds: micSpeakerIds,
+                utterances: result.micUtterances,
+                contexts: result.micSpeakerContexts,
+                speakerDB: speakerDB
+            )
 
             for sid in micSpeakerIds {
                 if let entry = micDbKnowledge.first(where: { $0.speakerId == sid }) {
@@ -240,8 +289,21 @@ extension TranscriptionTaskManager {
             ])
         }
 
-        // Clean up speaker profiles: first merge obvious duplicates, then prune orphans
-        speakerDB.mergeDuplicates()
+        let queuedMicReviewIds: Set<String>
+        if splitLocalSpeakers && micURL != nil && !result.micPersistentSpeakerIds.isEmpty {
+            queuedMicReviewIds = result.micSpeakerIds
+        } else {
+            queuedMicReviewIds = micNeedsActionIds
+        }
+        let protectedReviewProfileIds = Self.pendingReviewProfileIds(
+            systemUtterances: result.systemUtterances,
+            micUtterances: result.micUtterances,
+            systemNeedsActionIds: needsActionIds,
+            micQueuedReviewIds: queuedMicReviewIds
+        )
+
+        // Clean up speaker profiles without deleting IDs still referenced by pending review rows.
+        speakerDB.mergeDuplicates(protecting: protectedReviewProfileIds)
         speakerDB.pruneWeakProfiles()
 
         // Build diarizer-channel-qualified speaker key → persistent DB UUID mapping for YAML.

--- a/Sources/TranscriptedCore/Protocols/SpeakerStore.swift
+++ b/Sources/TranscriptedCore/Protocols/SpeakerStore.swift
@@ -34,6 +34,9 @@ public protocol SpeakerStore: Sendable {
     /// Merge obviously duplicate profiles (high cosine similarity)
     func mergeDuplicates()
 
+    /// Merge obvious duplicates while preserving profiles that are still tied to pending review rows
+    func mergeDuplicates(protecting protectedIds: Set<UUID>)
+
     /// Remove weak/unnamed profiles with low confidence
     func pruneWeakProfiles()
 
@@ -45,4 +48,10 @@ public protocol SpeakerStore: Sendable {
 
     /// Find profiles matching a name (fuzzy, with name variants)
     func findProfilesByName(_ name: String) -> [SpeakerProfile]
+}
+
+public extension SpeakerStore {
+    func mergeDuplicates(protecting protectedIds: Set<UUID>) {
+        mergeDuplicates()
+    }
 }

--- a/Sources/TranscriptedCore/Protocols/SpeakerStore.swift
+++ b/Sources/TranscriptedCore/Protocols/SpeakerStore.swift
@@ -52,6 +52,7 @@ public protocol SpeakerStore: Sendable {
 
 public extension SpeakerStore {
     func mergeDuplicates(protecting protectedIds: Set<UUID>) {
+        guard protectedIds.isEmpty else { return }
         mergeDuplicates()
     }
 }

--- a/Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift
@@ -247,8 +247,12 @@ extension SpeakerDatabase {
     /// Keeps the profile with more calls (better embedding). Transfers display name if the
     /// weaker profile has one and the stronger doesn't. Call after each recording.
     public func mergeDuplicates(threshold: Double = 0.6) {
+        mergeDuplicates(threshold: threshold, protecting: [])
+    }
+
+    public func mergeDuplicates(threshold: Double = 0.6, protecting protectedIds: Set<UUID>) {
         queue.sync {
-            mergeDuplicatesImpl(threshold: threshold)
+            mergeDuplicatesImpl(threshold: threshold, protectedIds: protectedIds)
         }
     }
 
@@ -259,7 +263,11 @@ extension SpeakerDatabase {
         mergeDuplicates(threshold: 0.6)
     }
 
-    private func mergeDuplicatesImpl(threshold: Double) {
+    public func mergeDuplicates(protecting protectedIds: Set<UUID>) {
+        mergeDuplicates(threshold: 0.6, protecting: protectedIds)
+    }
+
+    private func mergeDuplicatesImpl(threshold: Double, protectedIds: Set<UUID>) {
         let speakers = allSpeakersImpl()
         guard speakers.count > 1 else { return }
 
@@ -270,9 +278,11 @@ extension SpeakerDatabase {
         // No outer transaction — SQLite doesn't support nested BEGIN EXCLUSIVE.
         for i in 0..<speakers.count {
             guard !mergedIds.contains(speakers[i].id) else { continue }
+            guard !protectedIds.contains(speakers[i].id) else { continue }
 
             for j in (i + 1)..<speakers.count {
                 guard !mergedIds.contains(speakers[j].id) else { continue }
+                guard !protectedIds.contains(speakers[j].id) else { continue }
                 guard !shouldSkipDuplicateMerge(speakers[i], speakers[j]) else { continue }
 
                 let similarity = cosineSimilarity(speakers[i].embedding, speakers[j].embedding)

--- a/Tests/TranscriptedCoreTests/SpeakerProfileMergerTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerProfileMergerTests.swift
@@ -76,6 +76,16 @@ final class SpeakerProfileMergerTests: XCTestCase {
         XCTAssertNotNil(database.getSpeaker(id: second.id))
     }
 
+    func testDefaultProtectedMergeFallbackSkipsWhenIdsAreProtected() {
+        let store = DefaultMergeFallbackSpeakerStore()
+
+        store.mergeDuplicates(protecting: [UUID()])
+        XCTAssertEqual(store.mergeDuplicatesCallCount, 0)
+
+        store.mergeDuplicates(protecting: [])
+        XCTAssertEqual(store.mergeDuplicatesCallCount, 1)
+    }
+
     func testPruneWeakProfilesKeepsDeferredProfilesWithReviewSamples() throws {
         let profileId = UUID()
         _ = database.addOrUpdateSpeaker(
@@ -106,4 +116,42 @@ final class SpeakerProfileMergerTests: XCTestCase {
             "deferred unnamed profiles with review samples should survive pruning"
         )
     }
+}
+
+@available(macOS 14.0, *)
+private final class DefaultMergeFallbackSpeakerStore: SpeakerStore, @unchecked Sendable {
+    var mergeDuplicatesCallCount = 0
+
+    func matchSpeaker(embedding _: [Float], threshold _: Double) -> SpeakerMatchResult? { nil }
+
+    func addOrUpdateSpeaker(embedding: [Float], existingId: UUID?) -> SpeakerProfile {
+        SpeakerProfile(
+            id: existingId ?? UUID(),
+            displayName: nil,
+            nameSource: nil,
+            embedding: embedding,
+            firstSeen: Date(),
+            lastSeen: Date(),
+            callCount: 1,
+            confidence: 0.5,
+            disputeCount: 0
+        )
+    }
+
+    func getSpeaker(id _: UUID) -> SpeakerProfile? { nil }
+    func allSpeakers() -> [SpeakerProfile] { [] }
+    func setDisplayName(id _: UUID, name _: String, source _: String) {}
+    func restoreProfile(_: SpeakerProfile) {}
+    func deleteSpeaker(id _: UUID) {}
+    func mergeProfiles(sourceId _: UUID, into _: UUID) {}
+    func mergeProfilesByName() {}
+
+    func mergeDuplicates() {
+        mergeDuplicatesCallCount += 1
+    }
+
+    func pruneWeakProfiles() {}
+    func incrementDisputeCount(id _: UUID) {}
+    func resetDisputeCount(id _: UUID) {}
+    func findProfilesByName(_: String) -> [SpeakerProfile] { [] }
 }

--- a/Tests/TranscriptedCoreTests/SpeakerProfileMergerTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerProfileMergerTests.swift
@@ -57,6 +57,25 @@ final class SpeakerProfileMergerTests: XCTestCase {
         XCTAssertNotNil(database.getSpeaker(id: second.id))
     }
 
+    func testMergeDuplicatesPreservesProtectedPendingProfiles() {
+        let first = database.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.25, count: 256),
+            existingId: nil
+        )
+        let second = database.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.25, count: 256),
+            existingId: nil
+        )
+
+        database.mergeDuplicates(threshold: 0.6, protecting: [first.id])
+
+        XCTAssertNotNil(
+            database.getSpeaker(id: first.id),
+            "Profiles referenced by pending speaker review rows must not be absorbed before review completes."
+        )
+        XCTAssertNotNil(database.getSpeaker(id: second.id))
+    }
+
     func testPruneWeakProfilesKeepsDeferredProfilesWithReviewSamples() throws {
         let profileId = UUID()
         _ = database.addOrUpdateSpeaker(

--- a/Tests/TranscriptedCoreTests/TranscriptionPipelineStateTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionPipelineStateTests.swift
@@ -202,6 +202,116 @@ final class TranscriptionPipelineStateTests: XCTestCase {
         XCTAssertTrue(SpeakerNamingPolicy.shouldAutoAccept(profile: profile5, similarity: 0.95))
     }
 
+    func testSpeakerClassificationUsesPreMeetingSnapshotForAutoAcceptMaturity() throws {
+        let profileId = UUID()
+        let preMeetingProfile = speakerProfile(
+            id: profileId,
+            displayName: "Maya",
+            callCount: 4,
+            disputeCount: 0
+        )
+        let updatedProfile = speakerProfile(
+            id: profileId,
+            displayName: "Maya",
+            callCount: 5,
+            disputeCount: 0
+        )
+        let (database, directory) = try temporarySpeakerDatabase()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        _ = database.addOrUpdateSpeaker(embedding: updatedProfile.embedding, existingId: profileId)
+        database.restoreProfile(updatedProfile)
+
+        let knowledge = TranscriptionTaskManager.speakerClassificationKnowledge(
+            speakerIds: ["2"],
+            utterances: [
+                utterance(
+                    start: 0,
+                    end: 1,
+                    speakerId: 2,
+                    persistentSpeakerId: profileId,
+                    matchSimilarity: 0.95,
+                    transcript: "hello"
+                )
+            ],
+            contexts: [
+                "2": ChannelSpeakerContext(
+                    persistentSpeakerId: profileId,
+                    sessionEmbedding: [1, 0],
+                    matchedProfileSnapshot: preMeetingProfile,
+                    matchSimilarity: 0.95
+                )
+            ],
+            speakerDB: database
+        )
+
+        XCTAssertEqual(knowledge.count, 1)
+        XCTAssertEqual(knowledge[0].profile.callCount, 4)
+        XCTAssertFalse(
+            SpeakerNamingPolicy.shouldAutoAccept(
+                profile: knowledge[0].profile,
+                similarity: knowledge[0].similarity
+            ),
+            "A profile that only became mature during this meeting should still require speaker review."
+        )
+    }
+
+    func testSpeakerClassificationFallsBackToStoreWhenSnapshotIsMissing() throws {
+        let profileId = UUID()
+        let profile = speakerProfile(
+            id: profileId,
+            displayName: "Maya",
+            callCount: 5,
+            disputeCount: 0
+        )
+        let (database, directory) = try temporarySpeakerDatabase()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        _ = database.addOrUpdateSpeaker(embedding: profile.embedding, existingId: profileId)
+        database.restoreProfile(profile)
+
+        let knowledge = TranscriptionTaskManager.speakerClassificationKnowledge(
+            speakerIds: ["2"],
+            utterances: [
+                utterance(
+                    start: 0,
+                    end: 1,
+                    speakerId: 2,
+                    persistentSpeakerId: profileId,
+                    matchSimilarity: 0.95,
+                    transcript: "hello"
+                )
+            ],
+            contexts: [:],
+            speakerDB: database
+        )
+
+        XCTAssertEqual(knowledge.count, 1)
+        XCTAssertEqual(knowledge[0].profile.id, profileId)
+        XCTAssertEqual(knowledge[0].profile.callCount, 5)
+    }
+
+    func testPendingReviewProfileIdsCollectsSystemNeedsActionAndQueuedMicSpeakers() {
+        let systemReviewId = UUID()
+        let systemAcceptedId = UUID()
+        let micReviewId = UUID()
+        let micAutoAcceptedButQueuedId = UUID()
+
+        let ids = TranscriptionTaskManager.pendingReviewProfileIds(
+            systemUtterances: [
+                utterance(start: 0, end: 1, speakerId: 1, persistentSpeakerId: systemReviewId, transcript: "review"),
+                utterance(start: 1, end: 2, speakerId: 2, persistentSpeakerId: systemAcceptedId, transcript: "accepted"),
+            ],
+            micUtterances: [
+                utterance(start: 0, end: 1, channel: 0, speakerId: 0, persistentSpeakerId: micReviewId, transcript: "local"),
+                utterance(start: 1, end: 2, channel: 0, speakerId: 1, persistentSpeakerId: micAutoAcceptedButQueuedId, transcript: "known local")
+            ],
+            systemNeedsActionIds: ["1"],
+            micQueuedReviewIds: ["0", "1"]
+        )
+
+        XCTAssertEqual(ids, Set([systemReviewId, micReviewId, micAutoAcceptedButQueuedId]))
+        XCTAssertFalse(ids.contains(systemAcceptedId))
+    }
+
     func testNamingPolicyConfidenceTiers() {
         XCTAssertEqual(SpeakerNamingPolicy.confidence(similarity: 0.90, callCount: 10), .high)
         // Falls back to medium when similarity exactly at 0.85 (strictly >).
@@ -360,12 +470,13 @@ final class TranscriptionPipelineStateTests: XCTestCase {
     }
 
     private func speakerProfile(
+        id: UUID = UUID(),
         displayName: String?,
         callCount: Int,
         disputeCount: Int
     ) -> SpeakerProfile {
         SpeakerProfile(
-            id: UUID(),
+            id: id,
             displayName: displayName,
             nameSource: displayName == nil ? nil : NameSource.userManual,
             embedding: [1, 0],
@@ -375,5 +486,12 @@ final class TranscriptionPipelineStateTests: XCTestCase {
             confidence: 0.8,
             disputeCount: disputeCount
         )
+    }
+
+    private func temporarySpeakerDatabase() throws -> (SpeakerDatabase, URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionPipelineStateTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return (SpeakerDatabase(path: directory.appendingPathComponent("speakers.sqlite").path), directory)
     }
 }


### PR DESCRIPTION
## Summary
- Uses pre-meeting matched speaker snapshots when deciding whether a known speaker can be auto-accepted, so the current meeting cannot mature a profile into skipping review.
- Protects speaker profiles that are still referenced by pending speaker-review rows from automatic duplicate cleanup.
- Keeps the new `SpeakerStore.mergeDuplicates(protecting:)` API source-compatible for custom stores while `SpeakerDatabase` honors the protection set.

## Root Causes Found
- The pipeline updated matched speaker profiles during the current meeting before auto-accept classification. A profile at 4 prior calls could become 5 during processing and skip review as if it were mature before this meeting.
- Duplicate cleanup ran before transcript save and speaker-review clip persistence. That could delete/merge an unnamed profile still referenced by upcoming review rows, leaving stale or missing review targets.
- Mic local-speaker review queues every split local speaker, including auto-accepted speakers, so cleanup protection had to mirror that queue contract rather than only protecting `micNeedsActionIds`.

## Verification
- `bash build-deps.sh --force`
- `swift test --filter TranscriptionPipelineStateTests`
- `swift test --filter SpeakerProfileMergerTests`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `swift test`
- `git diff --check`

## Codex Review
- First `/Users/redbars/.codex/skills/codex-review/scripts/codex-review --mode auto`: found two P2 issues; both accepted and fixed.
- Final `/Users/redbars/.codex/skills/codex-review/scripts/codex-review --mode auto`: clean, no accepted/actionable findings reported. It also independently ran `swift test` and `bash build.sh --no-open`.

## Remaining Risks
- This PR adds deterministic synthetic/protocol coverage, not real manual or simulator speaker-name proof.
- Diarization false splits/false merges and raw embedding quality remain model-level risks.
- The looser public `SpeakerDatabase.matchSpeaker` API still exists for direct callers; the main transcription path uses the more conservative contextual matching path.