### PR TITLE
Harden local summary failure feedback

### DIFF
--- a/Sources/UI/Settings/HomeMeetingSummaryBetaPresentationPolicy.swift
+++ b/Sources/UI/Settings/HomeMeetingSummaryBetaPresentationPolicy.swift
@@ -34,16 +34,76 @@ enum HomeMeetingSummaryBetaPresentationPolicy {
     }
 }
 
+enum HomeLocalSummaryNoticeKind: Equatable {
+    case saved(chunkCount: Int)
+    case failed(message: String)
+}
+
 struct HomeLocalSummaryNotice: Identifiable, Equatable {
     let id = UUID()
     let transcriptURL: URL
-    let chunkCount: Int
+    let meetingTitle: String
+    let kind: HomeLocalSummaryNoticeKind
 
-    var title: String { "AI summary saved" }
-    var status: String { "Saved" }
+    init(transcriptURL: URL, meetingTitle: String, chunkCount: Int) {
+        self.transcriptURL = transcriptURL
+        self.meetingTitle = meetingTitle
+        self.kind = .saved(chunkCount: chunkCount)
+    }
+
+    init(transcriptURL: URL, meetingTitle: String, failureMessage: String) {
+        self.transcriptURL = transcriptURL
+        self.meetingTitle = meetingTitle
+        self.kind = .failed(message: Self.normalizedFailureMessage(failureMessage))
+    }
+
+    var title: String {
+        isFailure ? "AI summary failed" : "AI summary saved"
+    }
+
+    var status: String {
+        switch kind {
+        case .saved:
+            return "Saved"
+        case .failed:
+            return "Needs retry"
+        }
+    }
+
+    var actionTitle: String {
+        isFailure ? "Retry summary" : "Open enhanced transcript"
+    }
+
+    var shouldAutoDismiss: Bool {
+        !isFailure
+    }
+
+    var isFailure: Bool {
+        if case .failed = kind { return true }
+        return false
+    }
+
     var detail: String {
-        let passText = chunkCount == 1 ? "one local Gemma pass" : "\(chunkCount) local Gemma passes"
-        return "The meeting Markdown was enhanced with a generated title and summary preview using \(passText)."
+        switch kind {
+        case .saved(let chunkCount):
+            let passText = chunkCount == 1 ? "one local Gemma pass" : "\(chunkCount) local Gemma passes"
+            return "The meeting Markdown was enhanced with a generated title and summary preview using \(passText)."
+        case .failed(let message):
+            return "The local AI summary did not finish: \(message) Nothing was changed. Retry when setup is ready."
+        }
+    }
+
+    private static func normalizedFailureMessage(_ raw: String) -> String {
+        let message = raw
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        let fallback = message.isEmpty ? "Check Beta setup, then try again." : message
+        let limit = 180
+        guard fallback.count > limit else { return fallback }
+        let shortened = String(fallback.prefix(limit))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return "\(shortened)..."
     }
 }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -499,17 +499,27 @@ struct TranscriptedSettingsView: View {
 
             if let notice = homeLocalSummaryNotice {
                 SettingsActivityCard(
-                    symbolName: "sparkles",
+                    symbolName: notice.isFailure ? "exclamationmark.circle.fill" : "sparkles",
                     title: notice.title,
                     status: notice.status,
                     detail: notice.detail,
-                    tone: .success,
+                    tone: notice.isFailure ? .caution : .success,
                     progress: nil,
-                    actionTitle: "Open enhanced transcript",
+                    actionTitle: notice.actionTitle,
                     action: {
-                        trackSettingsAction("open_local_meeting_summary_notice", page: .home)
-                        clearHomeLocalSummaryNotice(id: notice.id)
-                        NSWorkspace.shared.open(notice.transcriptURL)
+                        if notice.isFailure {
+                            trackSettingsAction("retry_local_meeting_summary_notice", page: .home)
+                            clearHomeLocalSummaryNotice(id: notice.id)
+                            generateLocalSummary(
+                                transcriptURL: notice.transcriptURL,
+                                title: notice.meetingTitle,
+                                hasExistingSummary: false
+                            )
+                        } else {
+                            trackSettingsAction("open_local_meeting_summary_notice", page: .home)
+                            clearHomeLocalSummaryNotice(id: notice.id)
+                            NSWorkspace.shared.open(notice.transcriptURL)
+                        }
                     }
                 )
                 .transition(.move(edge: .top).combined(with: .opacity))
@@ -824,8 +834,21 @@ struct TranscriptedSettingsView: View {
     }
 
     private func generateLocalSummary(for item: RecentMeetingItem) {
+        generateLocalSummary(
+            transcriptURL: item.transcriptURL,
+            title: item.title,
+            hasExistingSummary: item.summaryPreview != nil
+        )
+    }
+
+    private func generateLocalSummary(
+        transcriptURL: URL,
+        title: String,
+        hasExistingSummary: Bool
+    ) {
         guard localMeetingSummariesEnabled else { return }
-        guard homeLocalSummaryTasks[item.id] == nil else { return }
+        let summaryID = transcriptURL.path
+        guard homeLocalSummaryTasks[summaryID] == nil else { return }
         if let unavailableReason = localMeetingSummaryUnavailableReason {
             homeDeleteFailure = HomeDeleteFailure(
                 title: "Could not summarize meeting",
@@ -840,38 +863,38 @@ struct TranscriptedSettingsView: View {
             message: "\(provider.title) meeting summary started",
             context: [
                 "provider": provider.rawValue,
-                "has_existing_summary": item.summaryPreview == nil ? "false" : "true",
+                "has_existing_summary": hasExistingSummary ? "true" : "false",
                 "setup_ready": selectedLocalSummaryProviderIsReady ? "true" : "false",
                 "setup_profile": selectedLocalSummaryProviderProfileName,
             ]
         )
         clearHomeLocalSummaryNotice()
-        homeLocalSummaryJobIDs.insert(item.id)
+        homeLocalSummaryJobIDs.insert(summaryID)
 
         let task = Task.detached(priority: .utility) {
             switch provider {
             case .gemmaMLX:
                 return try await LocalMeetingSummarizer().summarize(
-                    transcriptURL: item.transcriptURL,
-                    title: item.title
+                    transcriptURL: transcriptURL,
+                    title: title
                 )
             case .appleFoundation:
                 return try await AppleFoundationMeetingSummarizer().summarize(
-                    transcriptURL: item.transcriptURL,
-                    title: item.title
+                    transcriptURL: transcriptURL,
+                    title: title
                 )
             }
         }
         let taskToken = UUID()
-        homeLocalSummaryTasks[item.id] = task
-        homeLocalSummaryTaskTokens[item.id] = taskToken
+        homeLocalSummaryTasks[summaryID] = task
+        homeLocalSummaryTaskTokens[summaryID] = taskToken
 
         Task { @MainActor in
             defer {
-                if homeLocalSummaryTaskTokens[item.id] == taskToken {
-                    homeLocalSummaryJobIDs.remove(item.id)
-                    homeLocalSummaryTasks[item.id] = nil
-                    homeLocalSummaryTaskTokens[item.id] = nil
+                if homeLocalSummaryTaskTokens[summaryID] == taskToken {
+                    homeLocalSummaryJobIDs.remove(summaryID)
+                    homeLocalSummaryTasks[summaryID] = nil
+                    homeLocalSummaryTaskTokens[summaryID] = nil
                 }
             }
 
@@ -880,6 +903,7 @@ struct TranscriptedSettingsView: View {
                 guard localMeetingSummariesEnabled else { return }
                 presentHomeLocalSummaryNotice(HomeLocalSummaryNotice(
                     transcriptURL: result.transcriptURL,
+                    meetingTitle: title,
                     chunkCount: result.chunkCount
                 ))
                 recordLocalSummaryEvent(
@@ -912,9 +936,13 @@ struct TranscriptedSettingsView: View {
                         "error": error.localizedDescription,
                     ]
                 )
-                homeDeleteFailure = HomeDeleteFailure(
-                    title: "Could not summarize meeting",
-                    message: error.localizedDescription
+                NSSound.beep()
+                presentHomeLocalSummaryNotice(
+                    HomeLocalSummaryNotice(
+                        transcriptURL: transcriptURL,
+                        meetingTitle: title,
+                        failureMessage: error.localizedDescription
+                    )
                 )
             }
         }
@@ -3070,6 +3098,10 @@ struct TranscriptedSettingsView: View {
     private func presentHomeLocalSummaryNotice(_ notice: HomeLocalSummaryNotice) {
         homeLocalSummaryNotice = notice
         homeLocalSummaryNoticeDismissTask?.cancel()
+        guard notice.shouldAutoDismiss else {
+            homeLocalSummaryNoticeDismissTask = nil
+            return
+        }
         homeLocalSummaryNoticeDismissTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: HomeLocalSummaryNoticeDismissalPolicy.autoDismissDelayNanoseconds)
             guard !Task.isCancelled,

--- a/Tests/HomeMeetingSummaryBetaPresentationPolicyTests.swift
+++ b/Tests/HomeMeetingSummaryBetaPresentationPolicyTests.swift
@@ -72,14 +72,22 @@ func testHomeMeetingSummaryBetaPresentationPolicy() {
     runSuite("HomeLocalSummaryNoticeDismissalPolicy clears only the scheduled notice") {
         let firstNotice = HomeLocalSummaryNotice(
             transcriptURL: URL(fileURLWithPath: "/tmp/first.md"),
+            meetingTitle: "First",
             chunkCount: 1
         )
         let newerNotice = HomeLocalSummaryNotice(
             transcriptURL: URL(fileURLWithPath: "/tmp/newer.md"),
+            meetingTitle: "Newer",
             chunkCount: 2
         )
 
         assertEqual(firstNotice.status, "Saved", "completed summary notices should read as saved, not ongoing")
+        assertEqual(
+            firstNotice.actionTitle,
+            "Open enhanced transcript",
+            "saved summaries should point to the enhanced transcript"
+        )
+        assertTrue(firstNotice.shouldAutoDismiss, "saved summaries should clear themselves after a short scan window")
         assertTrue(
             HomeLocalSummaryNoticeDismissalPolicy.autoDismissDelayNanoseconds >= 4_000_000_000,
             "success notice should stay visible long enough to scan"
@@ -101,6 +109,27 @@ func testHomeMeetingSummaryBetaPresentationPolicy() {
                 scheduledNoticeID: firstNotice.id
             ),
             "an old dismissal timer should not clear a newer summary notice"
+        )
+    }
+
+    runSuite("HomeLocalSummaryNotice keeps failed summaries visible with retry copy") {
+        let notice = HomeLocalSummaryNotice(
+            transcriptURL: URL(fileURLWithPath: "/tmp/failed.md"),
+            meetingTitle: "Failed Setup",
+            failureMessage: "model load failed:\nmissing model cache"
+        )
+
+        assertEqual(notice.title, "AI summary failed", "failure notice should be explicit")
+        assertEqual(notice.status, "Needs retry", "failure notice should not look complete")
+        assertEqual(notice.actionTitle, "Retry summary", "failure notice should offer retry")
+        assertFalse(notice.shouldAutoDismiss, "failure notice should persist until the user acts")
+        assertTrue(
+            notice.detail.contains("model load failed: missing model cache"),
+            "failure detail should collapse noisy line breaks into readable copy"
+        )
+        assertTrue(
+            notice.detail.contains("Nothing was changed"),
+            "failure detail should reassure the user that the transcript was not rewritten"
         )
     }
 }


### PR DESCRIPTION
## Why

Justin found the local Gemma summary beta confusing before the 1.1.47 gate: setup belongs on Beta, and running a meeting summary needs obvious progress/failure feedback.

Current `main` already has the Beta toggle/provider/prep flow and row-level running state. The remaining low-risk gap was failure: a summary error only surfaced through a transient generic alert, then the Home row went back to normal.

## Product Impact

- Affects: `meetings`, `settings`, `beta local AI summaries`
- Lane: `meeting reliability`
- Why this matters: a failed local summary should be visible and retryable without making the user guess whether Gemma is still running, failed, or changed the transcript.

## What changed

- Split Home local-summary notices into saved vs failed states.
- Saved summaries keep the existing success card and auto-dismiss behavior.
- Failed summaries now show a persistent warning activity card with `AI summary failed`, `Needs retry`, clear failure detail, and a `Retry summary` action.
- Failure copy says nothing was changed, so users know the meeting Markdown was not silently rewritten.
- Retry runs the same local summary path again by transcript URL/title.
- Added fast tests for saved notice auto-dismiss and failed notice retry/persistence copy.

## Existing state checked

- Fetched fresh `origin/main`; branch starts at `d1dce554`.
- Inspected open PRs. #1110 touches Home row actions but not summary failure UX; #1119 is auto-call detection; #1114 is speaker naming. No open PR covers this specific Gemma/Beta summary feedback gap.

## How I checked it

- [x] `scripts/dev/agent-preflight.sh`
- [x] `git diff --check`
- [x] `bash run-tests.sh --filter HomeMeetingSummaryBetaPresentationPolicyTests` — 25/25 passed
- [x] `bash build-deps.sh --force` — required after `build.sh` reported stale/missing deps
- [x] `bash build.sh --no-open` — passed, including launch smoke and performance budget
- [x] `bash run-tests.sh` — 5304/5304 passed
- [x] `bash scripts/ops/run-local-summary-fixture.sh` — deterministic direct + chunked local summary fixture passed
- [x] `codex review --uncommitted` — clean; no actionable correctness findings. The review also reran `bash run-tests.sh` and `bash build.sh --no-open` successfully.

## Manual proof still needed

- Real Beta page flow on Justin's Mac: toggle on, prepare Gemma, cancel/retry setup, and confirm setup copy feels clear.
- Real first-run Gemma download / partial-download restart behavior.
- Real meeting summary run on a saved meeting, including corrupt or missing local model cache behavior.
- Visual/manual check that the failure card and retry action feel obvious in the actual Settings Home UI.

## Risk Review

- [x] Privacy/local-first reviewed: no off-device payload change, no transcript/audio/title/path logging added.
- [x] Storage reviewed: no storage-path or model-cache mutation change.
- [x] Release/update reviewed: no version, appcast, packaging, Sparkle, or Homebrew changes.
- [x] Manual proof boundary preserved: automation proves UI state and deterministic summary fixture shape, not real Gemma quality/download behavior.
