### PR TITLE
Pin Home meeting artifact row targets

### DIFF
--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1100,7 +1100,9 @@ struct TranscriptedSettingsView: View {
                     surface: .homeMenu,
                     artifactDate: item.date
                 )
-                NSWorkspace.shared.activateFileViewerSelecting([item.transcriptURL])
+                NSWorkspace.shared.activateFileViewerSelecting(
+                    HomeMeetingRowActionTargets.transcriptRevealURLs(for: item)
+                )
             }
         ])
 
@@ -1140,28 +1142,31 @@ struct TranscriptedSettingsView: View {
             )
         }
 
-        if let audio = item.audio, let firstAudio = audio.urls.first {
-            if audio.retranscriptionInput != nil {
+        if let audio = item.audio {
+            let audioRevealURLs = HomeMeetingRowActionTargets.audioRevealURLs(for: item)
+            if !audioRevealURLs.isEmpty {
+                if audio.retranscriptionInput != nil {
+                    items.append(
+                        HomeRowMenuItem(
+                            title: "Re-transcribe with speaker ID",
+                            symbolName: "person.2.fill",
+                            isEnabled: RecentMeetingRetranscriptionMenuActionPolicy.isEnabled(
+                                globalUnavailableReason: savedMeetingRetranscriptionUnavailableReason,
+                                hasSpeakerReviewWork: hasPendingSpeakerReview
+                            )
+                        ) {
+                            handleRetranscribeMeeting(item)
+                        }
+                    )
+                }
+
                 items.append(
-                    HomeRowMenuItem(
-                        title: "Re-transcribe with speaker ID",
-                        symbolName: "person.2.fill",
-                        isEnabled: RecentMeetingRetranscriptionMenuActionPolicy.isEnabled(
-                            globalUnavailableReason: savedMeetingRetranscriptionUnavailableReason,
-                            hasSpeakerReviewWork: hasPendingSpeakerReview
-                        )
-                    ) {
-                        handleRetranscribeMeeting(item)
+                    HomeRowMenuItem(title: "Show audio in Finder", symbolName: "waveform") {
+                        trackSettingsAction("reveal_meeting_audio_in_finder", page: .home)
+                        NSWorkspace.shared.activateFileViewerSelecting(audioRevealURLs)
                     }
                 )
             }
-
-            items.append(
-                HomeRowMenuItem(title: "Show audio in Finder", symbolName: "waveform") {
-                    trackSettingsAction("reveal_meeting_audio_in_finder", page: .home)
-                    NSWorkspace.shared.activateFileViewerSelecting([firstAudio])
-                }
-            )
         }
 
         items.append(
@@ -1256,11 +1261,12 @@ struct TranscriptedSettingsView: View {
     }
 
     private func revealFailedMeetingAudio(_ item: MeetingSessionController.FailedMeetingItem) {
-        guard let firstAudioURL = item.audioURLs.first else {
+        let audioRevealURLs = HomeMeetingRowActionTargets.audioRevealURLs(audioURLs: item.audioURLs)
+        guard !audioRevealURLs.isEmpty else {
             NSSound.beep()
             return
         }
-        NSWorkspace.shared.activateFileViewerSelecting([firstAudioURL])
+        NSWorkspace.shared.activateFileViewerSelecting(audioRevealURLs)
     }
 
     private func requestClearFailedMeeting(_ item: MeetingSessionController.FailedMeetingItem) {

--- a/Sources/UI/Shared/HomeMeetingRowActionTargets.swift
+++ b/Sources/UI/Shared/HomeMeetingRowActionTargets.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum HomeMeetingRowActionTargets {
+    static func transcriptRevealURLs(for item: RecentMeetingItem) -> [URL] {
+        [item.transcriptURL]
+    }
+
+    static func audioRevealURLs(for item: RecentMeetingItem) -> [URL] {
+        audioRevealURLs(audioURLs: item.audio?.urls ?? [])
+    }
+
+    static func audioRevealURLs(audioURLs: [URL]) -> [URL] {
+        guard let firstAudioURL = audioURLs.first else { return [] }
+        return [firstAudioURL]
+    }
+}

--- a/Tests/FailedMeetingPresentationTests.swift
+++ b/Tests/FailedMeetingPresentationTests.swift
@@ -183,6 +183,26 @@ func testFailedMeetingPresentation() {
         )
     }
 
+    runSuite("Home failed meeting row reveals partial audio separately from retry readiness") {
+        let homeSource = (try? String(
+            contentsOf: repoFixtureURL("Sources/UI/Settings/HomeView.swift"),
+            encoding: .utf8
+        )) ?? ""
+
+        assertTrue(
+            homeSource.contains("if hasRetainedAudioFiles {\n                Button {\n                    onRevealAudio()"),
+            "failed rows should keep Show Audio visible when any retained audio URL exists"
+        )
+        assertTrue(
+            homeSource.contains("private var retryDisabled: Bool {\n        !canRetry || !item.isRetryable || !item.hasAudioFiles || item.isRetrying"),
+            "failed rows should keep retry readiness tied to complete retryable audio, not mere visibility"
+        )
+        assertTrue(
+            homeSource.contains("private var hasRetainedAudioFiles: Bool {\n        !item.audioURLs.isEmpty"),
+            "failed rows should use available retained audio URLs for the reveal affordance"
+        )
+    }
+
     runSuite("FailedMeetingPresentation labels retained WAVs as raw audio") {
         let source = (try? String(
             contentsOf: repoFixtureURL("Sources/Meeting/FailedMeetingPresentation.swift"),

--- a/Tests/RecentCaptureScannersTests.swift
+++ b/Tests/RecentCaptureScannersTests.swift
@@ -268,6 +268,43 @@ func testRecentCaptureScanners() async {
         )
     }
 
+    runSuite("HomeMeetingRowActionTargets reveal exact transcript and first retained audio") {
+        let transcriptURL = URL(fileURLWithPath: "/tmp/2026-06-13 Conversación técnica Observabilidad.md")
+        let audioDirectory = URL(fileURLWithPath: "/tmp/audio/2026-06-13 Conversación técnica Observabilidad_audio", isDirectory: true)
+        let systemURL = audioDirectory.appendingPathComponent("system_audio.m4a")
+        let micURL = audioDirectory.appendingPathComponent("microphone.m4a")
+        let item = sampleRecentMeetingTitleItem(
+            title: "Conversación técnica Observabilidad",
+            transcriptURL: transcriptURL,
+            audio: MeetingAudioAttachment(
+                directoryURL: audioDirectory,
+                urls: [systemURL, micURL]
+            ),
+            summaryPreview: nil
+        )
+
+        assertEqual(
+            HomeMeetingRowActionTargets.transcriptRevealURLs(for: item),
+            [transcriptURL],
+            "Show transcript should select the exact markdown URL from the scanned row"
+        )
+        assertEqual(
+            HomeMeetingRowActionTargets.audioRevealURLs(for: item),
+            [systemURL],
+            "Show audio should select the first retained audio URL exposed by the row attachment"
+        )
+        assertEqual(
+            HomeMeetingRowActionTargets.audioRevealURLs(audioURLs: [micURL, systemURL]),
+            [micURL],
+            "failed-meeting reveal targets should preserve the presentation order"
+        )
+        assertEqual(
+            HomeMeetingRowActionTargets.audioRevealURLs(audioURLs: []),
+            [],
+            "missing retained audio should not fabricate a Finder target"
+        )
+    }
+
     runSuite("SavedMeetingRetranscriptionAvailabilityPolicy blocks while models prepare") {
         assertEqual(
             SavedMeetingRetranscriptionAvailabilityPolicy.unavailableReason(
@@ -1967,6 +2004,8 @@ func testRecentCaptureLoader() async {
 
 private func sampleRecentMeetingTitleItem(
     title: String,
+    transcriptURL: URL = FileManager.default.temporaryDirectory.appendingPathComponent("synthetic-meeting.md"),
+    audio: MeetingAudioAttachment? = nil,
     summaryPreview: RecentMeetingSummaryPreview?
 ) -> RecentMeetingItem {
     RecentMeetingItem(
@@ -1974,8 +2013,8 @@ private func sampleRecentMeetingTitleItem(
         date: Date(timeIntervalSinceReferenceDate: 10),
         startDate: nil,
         endDate: nil,
-        transcriptURL: FileManager.default.temporaryDirectory.appendingPathComponent("synthetic-meeting.md"),
-        audio: nil,
+        transcriptURL: transcriptURL,
+        audio: audio,
         speakerStatus: .ready,
         summaryPreview: summaryPreview
     )

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -298,8 +298,10 @@ func testUIAutomationSurfaceContract() {
 
         assertTrue(
             settingsSource.contains("HomeRowMenuItem(title: \"Review speakers\"")
-                && settingsSource.contains("HomeRowMenuItem(\n                        title: \"Re-transcribe with speaker ID\""),
-            "meeting speaker review and re-transcribe actions should stay reachable from the row menu"
+                && settingsSource.contains("let audioRevealURLs = HomeMeetingRowActionTargets.audioRevealURLs(for: item)")
+                && settingsSource.contains("if !audioRevealURLs.isEmpty")
+                && settingsSource.contains("title: \"Re-transcribe with speaker ID\""),
+            "meeting speaker review and re-transcribe actions should stay reachable from the row menu when retained audio has a Finder target"
         )
 
         for identifier in [

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -360,6 +360,7 @@ APP_SOURCES=(
     "Sources/UI/Settings/HomeDeleteConfirmationPolicy.swift"
     "Sources/UI/Settings/HomeCanvasGreeting.swift"
     "Sources/UI/Shared/HomeMeetingDeletion.swift"
+    "Sources/UI/Shared/HomeMeetingRowActionTargets.swift"
     "Sources/UI/Shared/HomeMeetingRename.swift"
     "Sources/UI/Settings/HomeMeetingSummaryBetaPresentationPolicy.swift"
     "Sources/UI/Settings/HomeFailedMeetingInlinePresentation.swift"


### PR DESCRIPTION
## Summary
- Add a small Home meeting row target helper so transcript/audio Finder actions resolve through one tested path.
- Route saved and failed meeting reveal actions through that helper, while keeping retranscribe gated on retained audio that has a real Finder target.
- Add deterministic fast coverage for exact transcript/audio reveal targets and failed-audio visibility vs retry readiness.

## Validation
- scripts/dev/agent-preflight.sh
- bash -n run-tests.sh
- bash -n scripts/entrypoints/run-tests.sh
- bash build-deps.sh --force (needed because build guard reported missing/stale deps)
- bash build.sh --no-open
- bash run-tests.sh --filter RecentCaptureScanners
- bash run-tests.sh --filter FailedMeetingPresentation
- bash run-tests.sh --filter UIAutomationSurfaceContract
- bash run-tests.sh (5304/5304 passed)

## Review
- codex review --base origin/main was attempted, but local Codex usage was exhausted before a verdict.
- Fallback independent review: Claude Code 2.1.157 reviewed the branch diff. It found only P3/low notes; the retranscribe/audio-target guard note was addressed before final validation. Remaining low note: audio reveal intentionally selects the first retained audio URL, preserving existing behavior.

## Notes
- PR #1110 already covers the Home menu target/hover/focus fix path, so this PR does not duplicate that patch.
- Existing package coverage already proves replacement retranscription keeps the original URL/date and does not create duplicate Markdown rows.