### PR TITLE
Preserve scheduled meeting prompt context

### DIFF
--- a/Sources/Meeting/MeetingPromptDetector.swift
+++ b/Sources/Meeting/MeetingPromptDetector.swift
@@ -394,10 +394,17 @@ final class MeetingPromptDetector {
     private func preferredCandidate(from sortedCandidates: [ScoredCandidate]) -> ScoredCandidate? {
         guard let first = sortedCandidates.first else { return nil }
         guard first.candidate.reason == .micInput else { return first }
-        guard first.candidate.provider != .googleMeet else { return first }
-        return sortedCandidates.first {
+        let calendarCandidate = sortedCandidates.first {
             $0.candidate.source == .calendarEvent &&
                 $0.candidate.provider == first.candidate.provider
+        }
+        guard first.candidate.provider == .googleMeet else {
+            return calendarCandidate ?? first
+        }
+        return sortedCandidates.first {
+            $0.candidate.source == .calendarEvent &&
+                $0.candidate.provider == first.candidate.provider &&
+                (pendingUntil[$0.candidate.id] != nil || snoozedUntil[$0.candidate.id] != nil)
         } ?? first
     }
 

--- a/Tests/MeetingPromptDetectorTests.swift
+++ b/Tests/MeetingPromptDetectorTests.swift
@@ -400,6 +400,39 @@ func testMeetingPromptDetector() async {
         assertEqual(box.candidate?.source, .runtimeApp, "generic browser mic evidence should not borrow an unrelated Meet calendar event")
         assertNil(box.candidate?.suggestedTranscriptTitle, "browser mic prompts should stay neutral because they could be Meet, Zoom-web, or Teams-web")
     }
+
+    await runSuite("MeetingPromptDetector.updateMicInputUsers — browser mic does not replace pending calendar prompt") {
+        let now = Date()
+        let detector = MeetingPromptDetector(
+            calendarAccessGranted: { true },
+            calendarEventSnapshots: [
+                makeMeetingPromptCalendarSnapshot(
+                    id: "scheduled-meet",
+                    provider: .googleMeet,
+                    startsIn: 30,
+                    now: now
+                )
+            ],
+            refreshesCalendarEventSnapshots: false
+        )
+        detector.isOwnCaptureActive = { false }
+        let box = CandidateBox()
+        detector.onPromptRequest = { candidate in
+            box.candidate = candidate
+            box.promptCount += 1
+            return true
+        }
+
+        detector.start()
+        await waitForPromptEvaluation()
+        detector.updateMicInputUsers(["com.google.Chrome.helper"])
+        await waitForPromptEvaluation()
+        detector.stop()
+
+        assertEqual(box.promptCount, 1, "generic browser mic should not bypass an already-pending calendar prompt")
+        assertEqual(box.candidate?.source, .calendarEvent, "the visible scheduled prompt should keep its calendar context")
+        assertEqual(box.candidate?.suggestedTranscriptTitle, "Design review", "the scheduled prompt should keep the meeting title hint")
+    }
 }
 
 @available(macOS 14.0, *)


### PR DESCRIPTION
## Why

Follow-up to PR #1119 after pre-merge review found the browser mic prompt edge needed a safer handoff with scheduled calendar prompts.

## What changed

- Native mic candidates still prefer matching calendar context.
- Generic browser mic candidates stay neutral for fresh prompts.
- If a scheduled calendar prompt is already pending or snoozed, browser mic activity cannot bypass it with a second generic prompt.
- Added regression coverage for the pending scheduled Meet case.

## Proof

- codex-review against PR #1119 branch found the original P2 issue.
- bash run-tests.sh --filter MeetingPromptDetector passed, 39 of 39.
- bash build-deps.sh --force passed.
- bash build.sh --no-open passed.
- bash run-tests.sh passed, 5342 of 5342.
- bash run-integration-smoke.sh passed.
- final codex-review --mode local was clean with no accepted/actionable findings.
