### PR TITLE
docs: "what next" strategy deep dives + synthesis

### DIFF
--- a/docs/strategy/SYNTHESIS-2026-06-14.md
+++ b/docs/strategy/SYNTHESIS-2026-06-14.md
@@ -1,0 +1,58 @@
+# Strategy synthesis — what to do next (2026-06-14)
+
+Capstone over three deep dives:
+
+- [agent-loop-activation-2026-06-14.md](agent-loop-activation-2026-06-14.md) — the moat (product)
+- [growth-positioning-2026-06-14.md](growth-positioning-2026-06-14.md) — the position (market)
+- [codebase-architecture-health-2026-06-14.md](codebase-architecture-health-2026-06-14.md) — the foundation (engineering)
+
+## The one-line answer
+
+**The moat, the pitch, and the one big refactor you owe are the same project: turn Transcripted into agent-memory across your whole history, and make that connection the hero of the product.**
+
+All three reports point at the same arrow, from three directions.
+
+## The convergence
+
+| | Says | Implication |
+|---|---|---|
+| Product (#1) | Plumbing is strong, but "ask my history" across meetings barely exists — lexical FTS5 only, `recap` returns raw lines, and the summarizer already extracts Decisions/Action Items/Open Questions that are **never indexed**. The moat *inverts* as the library grows. | Build cross-meeting intelligence. Most of the raw material already exists. |
+| Market (#2) | The only defensible position is "memory for your AI agent." Don't fight Granola on AI-notes ($125M / $1.5B). #1 move: make the MCP/agent connection the **hero feature**, not a settings footnote. | The pitch IS the agent loop. The local-summary beta as a *product* is a trap. |
+| Foundation (#3) | Health B. Clean bones, but four god objects are the velocity tax. The worst is `TranscriptedSettingsView.swift` (4503 LOC, 187 commits) — and the agent-connect UI lives inside it. | The moat work is mostly in clean code. The one exception is exactly the positioning move. |
+
+### The two collisions that decide sequencing
+
+1. **The summary paradox, reconciled.** #2 says the Gemma AI-notes beta is a trap *as a destination product*. #1 says the summary *extraction* (Decisions / Action Items / Open Questions) is gold *if you index it*. Both are right: **keep the extraction, drop the notes-product ambition, point its output into the index.** Same code, opposite framing — feed the agent, don't compete with it.
+
+2. **The hero move is trapped in the worst god object.** #2's highest-value UX move (hero-ize the agent connection) lands in `TranscriptedSettingsView.swift`, which is #3's #1 refactor target. So that refactor isn't "tech debt we'll get to" — it's **on the critical path of the headline bet.**
+
+## The plan (sequenced)
+
+### Phase 0 — cheap wins, this week
+- `recap` summary-aware: prefer the in-file summary block over raw transcript lines. **[S]** — instant quality jump on the most "ask-my-history"-shaped tool.
+- Core-formatter ⇄ CaptureKit-parser **agreement test**. **[S]** — free insurance before any index/format work; today the two sides are only kept in sync by a "remember to update both" doc note.
+- Re-hero positioning copy around "memory for your AI agent"; demote free/local/OSS to the proof line. **[S]** — runs in parallel, it's a decision not a build.
+
+### Phase 1 — build the moat (mostly in clean code)
+- **Index the structured summary fields** into SQLite. **[M, no new ML]** — the single biggest unlock; it's wiring, not machine learning.
+- Add cross-meeting MCP tools: `list_action_items`, `list_decisions`, `digest`. **[M]**
+- **Always-on cheap extraction at save time** so cross-meeting tools aren't gated on the 12GB+ opt-in summarizer. Touches the meeting save path (god object #2) and the Core summarizer — this is where product work meets debt and where model choice matters.
+- **Local semantic search** over utterances + summaries (bundle a small embedding model + vector table). **[L]** — closes the paraphrase gap where cloud RAG wins, while staying local.
+
+### Phase 2 — hero-ize the connection (requires the refactor)
+- **Decompose `TranscriptedSettingsView` + unify the Home/Settings split-brain.** **[L, very high payoff]** — kills the #1 and #4 change-magnets and unblocks the next move.
+- Make MCP/agent connect the most polished, most documented path in the product. **[M]**
+
+### Phase 3 — go to market (only after the demo is real)
+- Show HN with the agent-memory framing (NOT "local transcription app"), seeded into r/LocalLLaMA, r/ClaudeAI, r/ObsidianMD, MCP/Claude-Code communities, with a ready "how this differs from macparakeet/Granola" answer. **[S, spiky]**
+
+## Don't do
+- **Don't launch before the cross-meeting demo works** — you'd be launching a moat that inverts with scale.
+- **Don't build a Granola-style AI-notes product.** The agent writes the summary from the files, for free. Building it dilutes the one winning sentence and half-competes with your own pitch.
+- **Don't paywall transcription or privacy.** If money is ever needed, the only fitting model is a paid Team tier (E2EE sync + shared speaker dictionary + org policy) — open-core on the *collaboration* surface, never the *privacy* surface.
+
+## Open flags before committing
+- **Live metrics not pulled.** No current GitHub star / download numbers were gathered (activation-lane doc warns to keep live-release truth separate from source). Check real numbers before any launch-timing call.
+- **Window is contested.** Granola and Plaud both shipped MCP servers in 2026. The agent-memory seam is open but not indefinitely.
+- **Model strategy is now on the critical path.** Two Phase-1 builds are model decisions — the always-on extraction model (Apple Foundation Models on macOS 26? small local LLM?) and the bundled embedding model for semantic search. Worth its own deep dive.
+- **Swift 6 / strict concurrency is deferred debt.** 19 `@unchecked Sendable` are hand-audited, not compiler-checked. Gate the migration behind the god-object refactors or it's brutal.

--- a/docs/strategy/agent-loop-activation-2026-06-14.md
+++ b/docs/strategy/agent-loop-activation-2026-06-14.md
@@ -1,0 +1,282 @@
+# Agent Loop Activation — deep dive (2026-06-14)
+
+Scope: is the capture -> agent -> answer -> return loop actually good today, where is it
+shallow, and what's the next leap. Grounded in the source, not the pitch.
+
+## Executive summary
+
+The plumbing is genuinely strong. Transcripted writes clean, frontmattered Markdown to
+disk, ships a real read-only MCP server with nine tools backed by a SQLite + FTS5 index,
+and the agent-connect onboarding is a true one-click-per-agent flow (Claude Desktop,
+Claude Code, Codex, Cursor) with a sane copy-prompt fallback for everyone else. For
+single-meeting questions — "summarize my latest call", "what did Jenny say about pricing"
+— the loop works well and the agent quotes instead of guessing. That's real, and it's
+ahead of "point at a folder and pray."
+
+But the moat — "ask my history" across many meetings over time — is where reality falls
+short of the promise. The retrieval layer is **lexical keyword search only**. There are no
+embeddings, no semantic ranking, no topic/decision/action-item index, no entity graph
+across meetings + dictations, and no cross-capture "memory" abstraction. `who_is` is
+meeting-only and never touches dictations. `recap` returns the first ~15 raw transcript
+lines as a "preview," not a summary. So a question like "what did I promise across all my
+calls this month and what's still open?" forces the agent to brute-force read full
+transcripts, and a paraphrased query ("the budget conversation") misses the meeting that
+only ever said "spend" and "headcount." The structured intelligence that would make
+cross-meeting answers fast and reliable already exists in the product — the Gemma/Apple
+local summarizer extracts Decisions, Action Items, Open Questions per meeting — but **that
+structured output is not indexed and not queryable through MCP.** The single biggest leap
+is to close that gap: index the summary fields and expose a structured cross-meeting query
+surface. That turns a folder of transcripts into an actual answerable memory.
+
+## Current state — what works (grounded)
+
+### The saved Markdown is well-shaped for agents, not just humans
+
+Meeting files (`Sources/TranscriptedCore/Storage/TranscriptFormatter.swift`) carry real
+YAML frontmatter: `capture_id`, `capture_type: meeting`, `date`, `time`, `duration`,
+`transcription_engine`, per-channel utterance/speaker counts, `total_word_count`, optional
+`title`, recording-health keys, and a structured `speakers:` block with channel-qualified
+ids, `db_id` (persistent speaker UUID), `name`, `confidence`, `source`
+(`TranscriptFormatter.swift:84-176`). Optional Obsidian mode adds `tags`, `aliases`,
+`cssclasses`, and `[[wiki-link]]` speaker names (`:155-293`). The body has a Channel &
+Speaker Analytics section and a `## Full Transcript` with `[MM:SS] [Source/Speaker] text`
+lines. Dictations (`Sources/Dictation/DictationTranscriptWriter.swift`) are one append-only
+file per day with `capture_type: dictation_day` frontmatter and per-entry metadata (Entry
+ID, ISO `Captured:` timestamp, source app + bundle id, delivery outcome, word/char counts).
+
+This is above the bar. Timestamps, speaker attribution, persistent speaker ids, stable
+capture ids, and a parser-friendly shape are all there. The format is the strongest part
+of the moat.
+
+### The MCP server is a real index, not a folder pointer
+
+`Tools/TranscriptedMCP` builds a SQLite index (`TranscriptIndex.swift`) with FTS5 virtual
+tables over both meeting utterances and dictation entries, a `FileWatcher` for incremental
+reindex, corruption recovery (`PRAGMA quick_check`), WAL mode, and owner-only file perms.
+Nine read-only tools (`ToolHandlers.swift:22-237`): `list_meetings`, `read_meeting`
+(with `full`/`transcript`/`speakers` sections), `list_dictations`, `read_dictation`
+(whole day or one `entry_id`), `search` (utterance FTS, speaker + date filters), `who_is`,
+`recap`, plus the unified `search_context` and `recent_context` that span meetings and
+dictations together. Name matching is fuzzy via `NameVariants` (Mike -> Michael) and
+substring (Jenny -> Jenny Wen). Path reads are hardened against traversal/symlink escape
+(`PathSecurity`). The connect doc and starter prompt steer agents to use direct tools
+first and fall back to reading the folders if MCP isn't connected
+(`AgentConnectionGuide.starterPrompt`). This is a well-built retrieval layer for what it
+covers.
+
+### Agent-connect onboarding is smooth and broad
+
+`AgentMCPConnector.swift` gives one `Connect` button per detected agent. Claude Desktop
+runs the dedicated installer + self-test; Claude Code registers through the `claude` CLI
+(it never hand-edits `~/.claude.json`); Codex gets a careful text-level TOML edit of only
+`[mcp_servers.transcripted]` that refuses to corrupt inline/dotted configs; Cursor gets the
+same safe `mcpServers` JSON merge as Claude Desktop. The bundled helper self-heals at
+launch (replaces a stale copy). For agents we can't configure, the universal copy-prompt
+row and a `portableMeetingBundle` (embeds one meeting + skill instructions for any web
+chat) cover the long tail. There's also an opt-in live-meeting sidecar for Codex/Cowork.
+First-prompt copy is concrete and good: "Summarize my latest meeting. Tell me which
+Transcripted source you used... then list decisions and action items."
+
+### Return-use surfacing exists
+
+Home (`HomeView` + `RecentCaptureScanners.swift`) shows day-grouped recent meetings and
+dictations with hover-reveal actions, audio playback, failed-meeting recovery, and an
+inline AI-summary lead when a local summary exists. `ActivationTelemetry.swift` is honest
+about its limits — it tracks artifact actions, agent setup/prompt CTAs, and a
+`return_proxy_observed` event bucketed by time-since-prior-artifact as a coarse proxy for
+"did they come back." That's a sensible MVP of measurement.
+
+### Local summaries already produce the structured gold
+
+`LocalMeetingSummarizer.swift` (Gemma MLX or Apple Foundation Models, opt-in beta) chunks
+the transcript, runs a tightly-prompted extraction, and writes back into the same meeting
+file a managed block with Title, Summary, Decisions, Action Items, Open Questions, Risks/
+Follow-ups, Accuracy Notes, plus flattened `local_summary_*` frontmatter keys
+(`LocalMeetingSummaryMarkdownUpdater`, `:1592-1830`). The prompts are careful (owner-first
+action items, decisions-name-outcome-first, "None found." discipline, anti-hallucination
+rules). This is exactly the structured layer a cross-meeting memory needs.
+
+## The gaps (ranked, with evidence)
+
+### 1. Cross-capture intelligence is the crux, and it's missing. [biggest]
+
+The payoff question is "ask my history across many meetings" — and the index can't answer
+it well. Every query path is single-file or flat-list:
+
+- `search`/`search_context` return matching utterances grouped by meeting, ordered by FTS
+  `rank`, capped at the first ~200 rows then top-N meetings (`TranscriptIndex.swift:399-501`).
+  Good for "find the pricing discussion," useless for "synthesize what we decided about
+  pricing across Q2."
+- `recap` (`ToolHandlers.swift:514-562`) returns each meeting's first ~15 raw transcript
+  lines as `preview` — it is explicitly *not* a summary, so "what did I miss Mon-Wed"
+  dumps raw dialogue openings, not decisions/action items.
+- There is no tool for "all open action items," "all decisions about X," "everything I
+  committed to this week." The agent must `list_meetings` then `read_meeting` each one in
+  full and reason over raw transcripts. That's slow, blows context windows, and gets less
+  reliable the more history you have — the moat *inverts* as the library grows.
+
+### 2. Retrieval is lexical only — no semantic search. [high]
+
+Both FTS tables use `tokenize='porter unicode61'` (`TranscriptIndex.swift:126-153`) and
+queries are tokenized into quoted AND terms (`:401-402`, `:604-605`). There are no
+embeddings, vectors, or semantic ranking anywhere in the tree (confirmed by grep). A user
+who asks "the conversation about cutting costs" will miss a meeting that only said
+"reduce headcount" and "trim the budget." This is precisely where cloud-RAG competitors
+win, and it's the difference between "search" and "memory."
+
+### 3. The structured summary output is generated but never indexed. [high]
+
+The Gemma/Apple summarizer writes Decisions / Action Items / Open Questions into the file
+and frontmatter, but `TranscriptIndex` indexes only `meetings`, `meeting_speakers`,
+`utterances`, `dictation_days`, `dictation_entries` (`:62-176`). No table for summaries,
+decisions, or action items. So the one place with clean structured facts is invisible to
+MCP. `recap` even re-derives a raw preview instead of reading the summary that may already
+exist in the file. The product already paid the compute cost to extract this — it's just
+not wired into retrieval.
+
+### 4. `who_is` and the people graph stop at meetings. [high]
+
+`who_is` (`getPersonProfile`, `:971-1029`) is meeting-only: meeting count, speaking time,
+frequent co-speakers, representative quotes. Dictations are never associated with people,
+and there's no "what did this person commit to / what do I owe them" view — even though
+action items with owners exist in the summaries (gap #3). There's a persistent speaker id
+(`db_id`) in frontmatter, but no cross-meeting entity/topic graph is built from it. "Prep
+me for my 1:1 with Sam" can list past co-occurrence but can't surface open threads.
+
+### 5. The agent has to be told how to drive the tools; there's no server-side guidance. [med]
+
+The tool *descriptions* are good, but the retrieval strategy lives in a client-side
+starter prompt (`AgentConnectionGuide.starterPrompt`) that only lands if the user pasted
+it. A freshly-connected MCP agent gets nine tools and has to figure out the right
+sequence (list -> read, or search -> read) itself. There's no MCP `prompts` capability,
+no "recommended retrieval recipes" surfaced by the server, and no resources. For
+power-prompted Claude it's fine; for weaker agents it's a coin flip on whether they pick
+`recap` vs `search` vs reading everything.
+
+### 6. Measurement can't see the actual answer. [med]
+
+`ActivationTelemetry` tracks setup clicks and a coarse return-proxy, but by privacy design
+nothing observes whether the agent gave a *useful* answer, which tool it called, or
+whether retrieval returned hits. The team is flying blind on the middle of the loop ("did
+they get one useful answer") — the exact step the activation lane says is the real
+question. Hard to improve retrieval ranking with zero signal on retrieval quality. (This
+is a deliberate privacy tradeoff, not an oversight — but it's still a blind spot.)
+
+### 7. Dictation-side intelligence is thin. [low]
+
+Dictations are full-text searchable but have no summary, no entity extraction, no titles
+beyond the first 7 words. They're second-class in `who_is` and in any future cross-capture
+synthesis, even though "what did I promise" lives as much in voice memos as in meetings.
+
+## The biggest leap: a structured cross-meeting memory layer over MCP
+
+**Recommendation:** index the structured summary fields (Decisions, Action Items + owner,
+Open Questions, Risks) into the SQLite index, and add cross-meeting query tools on top:
+`list_action_items` (filter by owner/status/date), `list_decisions` (filter by topic/date),
+and a `synthesize`/`digest` tool that returns the *structured* summary block per meeting in
+a range instead of raw transcript previews. Pair it with semantic search (a local
+embeddings table over utterances + summaries with a vector ANN/cosine query) so
+paraphrased questions hit.
+
+**Why it's the moat-maker.** The promise is "your AI stops guessing and starts quoting,"
+but the deeper promise is "ask your history." Today the agent can quote *one* file well and
+brute-forces the rest. This leap makes the across-time questions — the only ones a folder
+of files can't already answer with a glob — fast, cheap, and reliable, and it does it
+*locally*. It also flips the moat from "degrades as the library grows" to "compounds as the
+library grows," which is the whole point of a memory product. Crucially, most of the hard
+part is done: the summarizer already extracts the structured facts; this is wiring, schema,
+and one embedding model, not new ML.
+
+**Rough effort: L** (a focused L, not a moonshot). Schema + indexing of existing summary
+frontmatter and 2-3 new structured tools is **M**. Adding a local embeddings table +
+semantic search tool is the L part (model bundling, backfill, ANN query), but the
+embedding model is small and the corpus is one user's transcripts. Phase it: structured
+indexing first (proves the cross-meeting value immediately on top of existing summaries),
+embeddings second.
+
+**One sharp dependency / caveat:** structured cross-meeting tools are only as good as
+summary coverage, and summaries are an opt-in beta gated on Gemma/Apple availability and
+12GB+ RAM. To make this the default experience you likely need a lightweight always-on
+extraction pass (even a cheap rules+small-model action-item/decision tagger at save time),
+not just the heavy opt-in summarizer. Otherwise the new tools return "no summary indexed"
+for most users.
+
+## Ranked next moves
+
+1. **Index existing `local_summary_*` fields into SQLite.** [effort: M] [impact: high]
+   Add `meeting_summaries` (+ optional `action_items`, `decisions`) tables populated from
+   the frontmatter the summarizer already writes; reconcile in `FileWatcher`. Unlocks
+   everything below. Zero new ML.
+
+2. **Add cross-meeting structured tools: `list_action_items`, `list_decisions`, `digest`.**
+   [effort: M] [impact: high] `digest` replaces `recap`'s raw-line preview with the
+   structured summary block per meeting in a date range. This is the literal "what did I
+   promise / decide this week" answer the pitch sells.
+
+3. **Make `recap` summary-aware now, even before full indexing.** [effort: S] [impact: high]
+   `recap` already opens each meeting file (`ToolHandlers.swift:530-540`); have it prefer
+   the in-file `## Local ... Summary` block / `local_summary_*` frontmatter when present
+   instead of the first 15 transcript lines. Cheap, immediate quality jump for the most
+   "ask my history"-shaped tool.
+
+4. **Local semantic search over utterances + summaries.** [effort: L] [impact: high]
+   Bundle a small embedding model, add a vector table, expose `semantic_search` (or fold
+   ranking into `search_context`). Closes the paraphrase gap that cloud RAG wins on, while
+   staying local. The true differentiator.
+
+5. **Extend `who_is` into a people-and-commitments view.** [effort: M] [impact: med]
+   Once action items are indexed (move #1), add "what {person} owes / what I owe {person}"
+   and link dictations mentioning a name. Turns `who_is` from trivia into meeting prep.
+
+6. **Ship MCP `prompts` / retrieval recipes from the server.** [effort: S] [impact: med]
+   Expose the good starter recipes as MCP prompts so any connected agent — not just ones
+   that got the pasted prompt — knows to `search` then `read`, or call `digest` for a
+   week. Improves first-answer quality for weaker agents at near-zero cost.
+
+7. **Always-on lightweight extraction at save time.** [effort: M] [impact: med]
+   A cheap decision/action-item tagger run on every saved meeting (not gated on the 12GB
+   Gemma beta) so the structured tools have coverage for everyone, not just summary-beta
+   users. Removes the dependency that otherwise caps moves #1-3.
+
+8. **Add coarse, privacy-safe retrieval-quality telemetry.** [effort: S] [impact: med]
+   Even bucketed signals (tool called, hit-count bucket, zero-result rate) would let the
+   team tune ranking and see the middle of the loop without sending content. Today there's
+   no signal on whether retrieval even returned anything.
+
+## Honest competitive note
+
+Versus Granola / Limitless / Notion AI:
+
+- **Where local-first wins:** the files are *yours* and any agent can read them — no vendor
+  lock to one chat UI, works offline, no transcript text leaving the Mac, and it plugs into
+  the agent the user already lives in (Claude Code, Codex, Cursor) rather than a walled
+  app. The Markdown format and persistent speaker ids are genuinely better substrate than a
+  competitor's opaque cloud store. For a privacy-sensitive or agent-native user this is a
+  real, defensible edge.
+- **Where local-first loses today:** the competitors' core feature *is* cross-meeting RAG —
+  semantic search and "ask everything you've ever recorded" answered in one box. Transcripted
+  ships the storage and single-file retrieval but not the cross-meeting synthesis or
+  semantic recall, so on the headline "ask my history" demo it currently looks weaker than a
+  cloud RAG product even though its data substrate is stronger. The leap above is what
+  closes that gap — and closing it *locally* is the version of this nobody else has.
+
+## Honest risks
+
+- **Summary-coverage dependency.** Structured cross-meeting tools are worthless without
+  broad summary coverage; the heavy summarizer is opt-in and RAM-gated. Move #7 (cheap
+  always-on extraction) is effectively a prerequisite for #1-3 to feel good for most users.
+- **Extraction quality is the ceiling.** Local action-item/decision extraction will be
+  noisier than a frontier cloud model. Wrong "you promised X" is worse than no answer.
+  Keep the accuracy-notes discipline and cite source lines/timestamps so the agent can
+  verify rather than trust blindly.
+- **Index scale + backfill.** Semantic indexing and structured backfill over a large
+  existing library is a one-time cost that must stay off the main actor and not jank the
+  app; reconcile/backfill paths need care (the index already does incremental reconcile,
+  but embeddings backfill is heavier).
+- **Privacy-vs-measurement tension is real.** Better retrieval needs feedback the current
+  privacy stance forbids. Even coarse bucketed signals must clear the allowlist/sanitizer
+  bar — design the telemetry with that constraint up front, not as a retrofit.
+- **Don't over-build the MCP before the format question is answered.** If always-on
+  extraction changes the written Markdown shape, `TranscriptedCaptureKit` parsers, the
+  formatter, and tests must all move together (the repo already enforces this coupling) —
+  scope the format change deliberately so the standalone tools don't drift.

--- a/docs/strategy/codebase-architecture-health-2026-06-14.md
+++ b/docs/strategy/codebase-architecture-health-2026-06-14.md
@@ -1,0 +1,280 @@
+# Codebase Architecture Health — 2026-06-14
+
+Principal-engineer deep audit of Transcripted (`main`). Read-only pass: LOC sweep,
+structural reads of the heaviest files, git churn analysis, build/test-system review.
+Goal is velocity, not style: what structural stuff makes the next 6 months of feature
+work slow, risky, or bug-prone, and what's worth fixing.
+
+## Executive summary
+
+Overall health grade: **B**
+
+Transcripted is in genuinely good shape for a native app of this size and ambition.
+The hard parts — the raw-swiftc build, the CoreAudio real-time discipline, the
+prebuilt-deps archive, the test runner — are deliberately engineered and well
+guarded. There is almost no rot: **zero TODO/FIXME/HACK markers across ~83k LOC**,
+near-zero Draft-era dead code, no reverse dependencies from the Core library into the
+app shell, and a clean DI seam (`MeetingSTTAdapter`) that is exactly what the docs
+promise. The build system that looks scary on paper is actually mostly self-correcting.
+
+What pulls the grade down to a B is one concentrated, worsening problem: **a handful of
+god objects that are simultaneously the largest, most-coupled, and most-frequently-edited
+files in the repo.** The top four files by LOC are also the top four by commit count
+since January. That correlation is the whole story — these files are change-magnets,
+they create merge contention, and they're where the next feature's bug will hide. The
+worst offender, `TranscriptedSettingsView.swift`, is 4503 lines and has been touched in
+**187 commits since Jan** — more than 1 in 5 working days. Plus a low-grade structural
+risk: the whole thing builds in **Swift 5 language mode with no strict-concurrency
+checking**, so 19 `@unchecked Sendable` escape hatches are trust-me-bro, not
+compiler-verified — and a Swift 6 migration is a someday-tax that gets heavier the
+longer the audio threading grows.
+
+This is **not** a debt cliff. It's a "decompose the four hot files before they
+calcify, then keep shipping" situation. There is no architectural dead-end forcing a
+rewrite; the seams are sound, the bones are good.
+
+## God objects (ranked)
+
+The decisive signal: **LOC rank ≈ git-churn rank.** Big and hot is the worst quadrant.
+Churn numbers are commits touching the file since 2026-01-01.
+
+| Rank | File | LOC | Commits | Responsibilities crammed in | Risk |
+|------|------|-----|---------|------------------------------|------|
+| 1 | `Sources/UI/Settings/TranscriptedSettingsView.swift` | 4503 | **187** | One `TranscriptedSettingsView` struct holding **246 private funcs/vars** and **156 `home`-prefixed members**. Renders the settings sidebar AND reimplements the entire Home surface inline (`homePage`, `homeMeetingsListSection`, `homeFailedMeetingsCard`) plus every Home action: delete/rename/retranscribe/summary/feedback/failed-meeting management. | **Critical.** Hottest file in the repo, split-brain with HomeView. Every settings/home tweak risks an unrelated section. Merge-conflict epicenter. |
+| 2 | `Sources/Meeting/MeetingSessionController.swift` | 3104 | 137 | A `@MainActor` state machine with ~35 mutable private vars, including a sprawl of `liveCodex*` flags (7+ booleans coordinating one feature). Owns: permission gating, model warmup, capture start/stop, imported-audio handoff, app-level transcription queueing, local-speaker split, failed-meeting actions, mic-boost prompt, audio-inactivity, transcript restyling, live-codex sidecar coordination. | **High.** The brain of the meeting feature. Boolean-flag coordination of the live sidecar is the kind of state soup that breeds heisenbugs. |
+| 3 | `Sources/Speech/ParakeetEngine.swift` | 3088 | 114 | One class spanning 7 MARK sections: model init, input readiness, recording, EOU streaming (live display), transcription, pure-sample transcription (meeting path), cleanup. Holds the CoreAudio input tap. | **High.** Mixes RT-audio lifecycle with two distinct transcription paths (dictation streaming + meeting pure-sample). Touching one path risks the other. |
+| 4 | `Sources/UI/Settings/HomeView.swift` | 2559 | 96 | `HomeViewModel` + ~13 `Home*` value/view types + 26 view structs. The *other half* of Home, paralleling the home logic that also lives in #1. | **High.** Split-brain with #1: home logic spread across two 2.5k–4.5k-line files that move together (187 + 96 commits). |
+| 5 | `Sources/UI/Overlay/MeetingOverlayController.swift` | 2525 | 41 | Panel + root view + pill body + design tokens + controller + state + subscriptions + rest/wake + context menu + view-push, all in one file (16 MARK sections, multiple top-level types). | **Medium.** Large but cohesive (it's one feature surface). Lower churn than 1–4. |
+| 6 | `Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift` | 1524 | 55 | Task queue + lifecycle + orphaned-recording recovery + completion/cleanup. | **Medium.** Large but decomposed by clear responsibility across the 3-file pipeline (`TaskManager` + `Pipeline` 1027 + `Runner` 884). Reasonable. |
+| 7 | `Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift` | 1999 | 33 | Retroactive transcript rewriting on speaker rename/merge. | **Low-med.** Big but bounded domain, lower churn, has direct SPM test coverage. |
+
+The pattern: **everything in rows 1–4 is in the big-and-hot quadrant.** Rows 5–7 are big
+but cooler or better-bounded. Fix 1–4 and the velocity tax mostly evaporates.
+
+## Build / test system assessment
+
+Verdict: **the raw-swiftc build is worth its constraints and should NOT be migrated.**
+It's the single most over-feared thing in the repo. The actual footguns are narrower
+than the lore suggests.
+
+### What's actually fine (debunking the lore)
+
+- **Adding a new app source file is zero-friction.** The app build
+  (`scripts/entrypoints/lib/swiftc-app-args.sh:68-72`) globs
+  `find Sources -name '*.swift' -not -path 'Sources/TranscriptedCore/*'`. New files are
+  auto-discovered. The "you must manually register sources" fear does NOT apply to the
+  main build.
+- **The fast-test runner is well-guarded, not brittle.** `run-tests.sh` explicitly
+  diffs `Tests/FastTests.manifest` against `find Tests` and **fails with a precise
+  message** if they drift (`scripts/entrypoints/run-tests.sh:108-131`). It catches
+  manifest typos *before* swiftc with a targeted error
+  (`...:201-213`), and prints a "check the manifest before chasing swiftc output"
+  banner on compile failure (`...:446-449`). 126 manifest entries currently match 126
+  root test files exactly. This is good scaffolding. The failure mode is a clear error,
+  not a silent skip.
+- **Build correctness guards are strong.** Deps-staleness detection by mtime
+  (`build.sh:85-128`), a launch UI smoke that boots the signed app and asserts menubar
+  structure (`build.sh:160-323`), a performance budget gate (`:522-527`), and a shared
+  `swiftc-app-args.sh` so dev and beta builds **cannot diverge** on
+  frameworks/linker/sources — the header comment notes they HAD diverged once and this
+  fixed it. That's mature.
+
+### The real, narrow footguns
+
+1. **`run-e2e-smoke.sh` has a hand-curated 34-entry `SWIFT_SOURCES` list**
+   (`scripts/entrypoints/run-e2e-smoke.sh:33-68`). This is the one place the "add your
+   file manually" gotcha is real: if a listed source grows a new dependency, you must
+   add it by hand or get a cryptic swiftc error. Documented, but still a per-change
+   trap when touching the e2e-covered storage/sanitizer paths.
+2. **A new *root* test file must be registered in the manifest.** Friction is real but
+   the runner tells you exactly what to do. One-line fix when it bites.
+3. **Whole-module `-O` build is all-or-nothing.** `build.sh:468-476` compiles every app
+   source in one `swiftc` invocation with WMO. No incremental object caching for the app
+   target — every app build is a full rebuild. As `Sources/UI` (29.5k LOC) grows, app
+   build time grows monotonically. Not a correctness issue, a wall-clock tax. The
+   god-object files make this worse (one giant file = one giant type-check unit).
+
+### Test architecture
+
+The strategy is **"extract pure policy → unit-test the policy → leave a thin shell."**
+It works beautifully for the small policy types (`MeetingRecordingStartGate`,
+`MeetingFailureKind`, `STTRouterPolicy`, etc.) — 126 fast tests + 45 Core SPM tests,
+mostly fast and deterministic. But the shells aren't thin: the god objects are
+3000–4500 lines, so a lot of *orchestration* behavior lives in untested code. God-object
+references in tests are mostly to *extracted helper types*
+(`MeetingSessionController.FailedMeetingItem`), not the controller's wiring logic.
+
+Coverage gaps (the strategy doc already flags these, and the numbers confirm):
+
+- **SwiftUI rendering: essentially zero.** Only 4 of 126 root tests touch a View type,
+  and those are contract checks, not render tests. The 7k+ LOC of Settings/Home view
+  code is verified only by the launch smoke's structural assertions.
+- **Real-audio path: 2 integration + 2 e2e tests**, gated behind `run-live-capture-smoke`
+  which needs hardware/TCC. The RT-callback and device-recovery logic — the riskiest
+  code in the app — is largely manual-QA-verified.
+
+## Boundary, threading, concurrency findings
+
+### Core library boundary — mostly clean, one aspirational claim
+
+- **The DI seam is exactly right.** `MeetingSTTAdapter.swift` is a 63-line protocol
+  adapter from the app's `STTRouter` to `TranscriptedCore.SpeechToTextEngine`. Textbook.
+- **No reverse dependency.** Core never imports app modules. The one layering nit:
+  `Sources/TranscriptedCore/Audio/Audio.swift:4` imports **AppKit** — but only for
+  `NSWorkspace` sleep/wake notifications (`:694`, `:704`). Narrow and macOS-justified;
+  it just means Core isn't truly platform-portable. Acceptable.
+- **The "consumed only through `Sources/Meeting/`" claim is aspirational, not enforced.**
+  `Sources/UI/` (11 files), `Sources/Speech/ParakeetEngine.swift`, and
+  `Sources/Dictation/` all `import TranscriptedCore` directly and use its public types
+  (SpeakerProfile, scanners, RecentMeetingItem, etc.) without going through the Meeting
+  bridge. This is reaching *public model* types, not internals, so it's a soft leak, not
+  a rot — but the doc overstates the discipline. Real risk: a Core public-API change now
+  ripples into UI directly, defeating the point of the bridge.
+- **Format-mirror duplication with no cross-validation test.** Core's
+  `TranscriptFormatter`/`TranscriptFrontmatter` and `Tools/TranscriptedCaptureKit`'s
+  `CaptureMarkdownParser` independently implement the same Markdown contract. Each has
+  its own tests; **nothing asserts they agree.** The only guard is a CLAUDE.md note
+  saying "update both in the same change." That's discipline-only — a real drift risk
+  for the CLI/MCP tools the moment someone changes the saved format and forgets.
+
+### Threading — discipline is genuinely held
+
+The CoreAudio real-time rules are respected where it counts. The raw IOProc in
+`SystemAudioProcessTap.swift:104-139` is exemplary: no-copy `AVAudioPCMBuffer` wrapper,
+`CACurrentMediaTime()` (allocation-free) for the watchdog, no logging in the hot path,
+and an explicit comment (`:99-103`) documenting that the only locks are short stat-counter
+increments and "anything heavier must be deferred." The engine taps
+(`ParakeetEngine.swift:1464`, `Audio.swift:1261`, `AudioFileManager.swift:305`) follow the
+same `[weak self]` no-blocking-work pattern. This is the part of the codebase I'd trust
+most.
+
+### Concurrency — Swift 5 mode, hand-audited Sendable
+
+The structural risk. **The whole app builds in Swift 5 language mode**: `Package.swift` is
+`swift-tools-version: 5.9` with `swiftSettings` containing only `-F`/`-I` framework paths
+— **no `.enableUpcomingFeature("StrictConcurrency")`, no Swift 6 mode** — and the
+raw-swiftc build sets no strict-concurrency flag either. So the **19 `@unchecked Sendable`**
+declarations (incl. `Audio`, `SpeakerDatabase`, `SCKAudioCapture`, `FileLogger`,
+`AppLogger`, several in `LocalMeetingSummarizer`) are programmer promises the compiler is
+**not** checking. Each is plausibly correct today (most wrap an internal lock/queue), but:
+
+- There is no compiler net catching a *new* data race introduced next to one of these.
+- A Swift 6 migration is inevitable and gets more expensive every month the audio +
+  meeting-session concurrency surface grows. Doing it after #1–#4 are decomposed will be
+  far cheaper than doing it now against 3000-line `@MainActor` god objects.
+
+No global mutable state of concern: the `static var` sweep is almost entirely computed
+URL/string getters; the one mutable static (`MeetingSessionController.runtimeDiagnosticsRecorder`)
+is a test seam. `nonisolated(unsafe)` appears only 5 times. Good.
+
+## Debt inventory (ranked)
+
+1. **God-object concentration (1–4 above).** Biggest + hottest + most-coupled files.
+   The velocity tax. *Everything else is a footnote next to this.*
+2. **Settings/Home split-brain.** Home logic lives in BOTH
+   `TranscriptedSettingsView.swift` (156 home-prefixed members, reimplements home
+   inline — does NOT embed `HomeView`) and `HomeView.swift`. Two huge files that move
+   together. Duplicated surface, doubled change cost.
+3. **Swift 5 mode + 19 unchecked-Sendable.** No compiler net for data races; deferred
+   Swift 6 migration debt that compounds.
+4. **Format-mirror drift risk.** Core formatter vs CaptureKit parser, no agreement test.
+   Will silently break CLI/MCP tools on a format change.
+5. **e2e-smoke curated source list.** 34 hand-listed files; the one real "add it
+   manually" footgun.
+6. **App build is full-rebuild WMO.** Wall-clock tax that grows with UI LOC; amplified
+   by god-object type-check units.
+7. **Soft Core boundary leak.** UI/Speech/Dictation import Core directly; the
+   "Meeting-only" claim isn't enforced.
+8. **Thin UI + real-audio test coverage.** Documented; the riskiest code is manual-QA.
+
+Notably absent from this list: dead code, Draft-era rot, circular deps, reverse
+dependencies. The repo is clean on all of those. (`OverlayDraftingView`, `CorrectionDraftRow`,
+and `libDraftDeps.a` are legacy *names*, not legacy *code* — the archive `-O` is the
+prebuilt deps + Core objects, just historically named.)
+
+## The #1 highest-ROI refactor
+
+**Decompose `TranscriptedSettingsView.swift` + collapse the Settings/Home split-brain.**
+
+Why this one: it is the single hottest file in the entire repo (187 commits since Jan),
+it's 4503 lines, and it *duplicates* the responsibility of the 4th-hottest file
+(`HomeView.swift`, 96 commits). Fixing it kills the worst merge-contention point AND the
+worst split-brain in one move. Every settings or home feature for the next 6 months
+routes through this file today; cutting it down is leverage on essentially all near-term
+UI work.
+
+Concrete shape:
+- Extract each settings page (`homePage`, `dictationsPage`, etc.) into its own `View`
+  file with a focused view-model. The `private var <thing>Page: some View` members are
+  already the natural seams.
+- Pull the ~156 `home*` members and Home action handlers (delete/rename/retranscribe/
+  summary/feedback/failed-meeting) out of the settings struct and unify them with the
+  existing `HomeViewModel` in `HomeView.swift` — one Home owner, not two.
+- Leave `TranscriptedSettingsView` as a thin shell: sidebar + page routing.
+
+Effort: **L** (3000+ lines of UI to carve, but mechanical — extract-and-route, low
+algorithmic risk; the launch UI smoke + 6 existing test files give a safety net).
+Velocity payoff: **very high.** Removes the #1 and #4 change-magnets, eliminates the
+split-brain, and makes the most-edited area of the app safe to touch in parallel. Also
+shrinks the worst WMO type-check unit, helping build time.
+
+## Ranked remediation moves
+
+1. **Decompose `TranscriptedSettingsView` + unify Home.** `[effort: L]` `[risk: med]`
+   `[payoff: very high]` — The #1 refactor above. Do this first. Med risk only because
+   it's a lot of UI surface; mitigated by the launch smoke and existing tests.
+
+2. **Split `MeetingSessionController` along its seams.** `[effort: L]` `[risk: med]`
+   `[payoff: high]` — Extract the live-codex sidecar coordination (the 7+ `liveCodex*`
+   booleans) into its own `@MainActor` coordinator, and the app-level transcription
+   queue into a dedicated queue object. Leaves a smaller session state machine. Kills
+   the 2nd change-magnet and the worst boolean-flag soup.
+
+3. **Add a Core-formatter ⇄ CaptureKit-parser agreement test.** `[effort: S]`
+   `[risk: low]` `[payoff: med-high]` — One golden-fixture round-trip test: format a
+   transcript with Core, parse it with CaptureKit, assert equality. Cheap insurance that
+   turns a silent CLI/MCP-breaking drift into a red build. Highest ROI-per-hour on the
+   list.
+
+4. **Carve dual transcription paths out of `ParakeetEngine`.** `[effort: M]`
+   `[risk: med]` `[payoff: high]` — Separate the streaming-dictation path from the
+   pure-sample meeting path so a change to one can't break the other. Keep the RT tap
+   lifecycle in a focused core; the discipline there is good, don't disturb it.
+
+5. **Plan (don't yet execute) the Swift 6 migration; gate it on #1–#4.** `[effort: L]`
+   `[risk: high if done now]` `[payoff: high, deferred]` — Turn on
+   `StrictConcurrency` warnings in CI as a *non-blocking* signal now to measure the
+   surface, then migrate after the god objects shrink. Doing it against 3000-line
+   `@MainActor` files first would be brutal; sequencing it after #1–#4 makes it
+   tractable. Each `@unchecked Sendable` becomes a verified or fixed claim.
+
+6. **Make the Core boundary real or drop the claim.** `[effort: M]` `[risk: low]`
+   `[payoff: med]` — Either route UI's Core access through Meeting-owned view-model
+   types, or update the docs to say "Core public types are app-wide, Meeting owns the
+   *pipeline* seam." Today the doc oversells the enforcement; pick one and make it true.
+
+7. **Auto-generate the e2e-smoke source list (or shrink its surface).** `[effort: S]`
+   `[risk: low]` `[payoff: low-med]` — Replace the hand-curated 34-entry list with a
+   dependency-driven include where feasible, removing the one real "add it manually"
+   footgun.
+
+8. **Add a few SwiftUI snapshot/contract tests for the new extracted Home views.**
+   `[effort: M]` `[risk: low]` `[payoff: med]` — Best done *after* #1, when the views are
+   small enough to test. Closes the biggest coverage gap on the most-edited surface.
+
+## Ship vs pay down — the call
+
+**Keep shipping — but make moves #1–#3 the price of admission for the next big UI bet.**
+
+There's no debt cliff and no architectural dead-end forcing a pause. The build, the
+boundaries, the threading discipline, and the absence of rot all say "this team can keep
+moving." The risk is narrow and named: four god objects that are getting bigger and
+hotter every week. They won't cause a crisis next month, but every feature shipped
+*into* them without decomposing makes the eventual carve harder and the Swift 6 migration
+worse.
+
+Recommended sequencing: ship #3 (the format-agreement test, an afternoon) immediately as
+free insurance. Then, before or alongside the next significant Settings/Home feature, do
+#1 — don't add the 188th commit to a 4503-line file. Tackle #2 when the next meeting
+feature lands. Treat #5 (Swift 6) as a tracked, deferred item gated on #1–#4. That keeps
+feature velocity high while bending the god-object curve down instead of up.

--- a/docs/strategy/growth-positioning-2026-06-14.md
+++ b/docs/strategy/growth-positioning-2026-06-14.md
@@ -1,0 +1,393 @@
+# Transcripted — Growth & Positioning, 2026-06-14
+
+A senior growth/positioning take. Honest, opinionated, grounded in the repo and
+in current competitor facts. Written for the team, not for a deck.
+
+---
+
+## Executive summary
+
+Transcripted has a gorgeous trust position and a muddy distribution and business
+story. The trust position is real: 100% local transcription, no bot in the call,
+MIT/free, no account, plain Markdown files you own. The problem is that
+**"free + local + OSS Mac transcription" is no longer a moat** — it's a crowded
+shelf. In 2026 the same pitch is made by macparakeet, OpenWhisper, OpenWhispr,
+Meetily, whisper-mac, BB Recorder, Aiko, and several more, most of them free and
+open-source, several of them also on Apple Silicon with Parakeet/Whisper. If we
+lead with "local and free," we're one of fifteen.
+
+The one thing Transcripted does that the pack does *not* package well is the
+**agent layer**: every capture is plain Markdown you own, plus a read-only MCP
+server (`search`, `recap`, `who_is`, `recent_context`) that turns a pile of
+meetings into a queryable personal memory your agent reads. That is the wedge.
+Not "transcription." Not "meeting notes." **"The local memory layer your AI
+agent reads."**
+
+The beachhead is not the meeting-notes mainstream — that's Granola's turf and
+Granola is now a $1.5B unicorn moving up-market into enterprise. The beachhead
+is the **developer / AI-power-user who already lives in Claude Code, Codex, and
+Cursor**, already keeps an Obsidian or CLAUDE.md "second brain," and already
+wires MCP servers into their agent. That person feels the pain of "my agent has
+no idea what we decided on yesterday's call" every single day, trusts local-first
+on reflex, and is exactly who shares a `Show HN` and a Homebrew one-liner.
+
+Monetization: keep the core free forever (it's the trust engine and the
+distribution engine), and if money is ever needed, the *only* model that doesn't
+betray the position is a **paid Team/sync tier for shared local-first capture
+libraries** (encrypted sync, shared speaker dictionary, org policy) — never a
+paywall on transcription, never cloud upload of transcripts, never selling
+attention or data. Open-core on the *collaboration* surface, not the *privacy*
+surface.
+
+The single biggest mistake available to us: **chasing Granola on AI-notes
+polish** (summaries, "invisible notes," CRM pushes). We will lose that race, it
+dilutes the trust story, and it pulls engineering toward the one area where a
+$192M-funded competitor is strongest. Own the local/agent niche instead.
+
+---
+
+## Sharpest positioning + beachhead user
+
+### The positioning statement (pick one, lead everywhere with it)
+
+> **The local memory layer for your AI agent. Every meeting and voice note
+> becomes a plain file on your Mac that Claude, Codex, or Cursor can read — so
+> your agent finally knows what you actually said.**
+
+Supporting line, already nearly perfect in the README: *"Your AI stops guessing
+and starts quoting."* That sentence is the whole product. Promote it from the
+middle of the README to the hero.
+
+What this does:
+
+- It moves the noun from **"transcription"** (commodity, fifteen competitors) to
+  **"agent memory / personal context"** (a category that is exploding in 2026
+  and that almost no one owns for *spoken* input).
+- It makes local-first a *consequence* ("of course it's local — it's your
+  memory") rather than the headline feature everyone else also claims.
+- It rides the single biggest tailwind in the user's world: agents that read and
+  write your files (Claude Code, the CLAUDE.md convention, MCP-into-Obsidian).
+  That workflow is described in 2026 coverage as used by "thousands of knowledge
+  workers." Transcripted is the missing *voice* input to that exact loop.
+
+### Beachhead user
+
+**The agent-native builder.** Concretely: a developer, indie hacker, founder, or
+technical PM who:
+
+- already runs Claude Code / Codex / Cursor daily and wires MCP servers in,
+- already keeps notes in Markdown (Obsidian vault, repo docs, CLAUDE.md),
+- is on an Apple Silicon Mac on a current macOS (this user upgrades fast — see
+  TAM section),
+- reflexively distrusts "your audio goes to our cloud,"
+- and has the exact pain the README opens with: *"You ask your AI about
+  yesterday's call, and it has no idea what you're talking about."*
+
+This user is the beachhead for four reasons: (1) the pain is acute and daily,
+(2) they already have the agent, so activation is "point it at the folder" not
+"learn a new app," (3) they're the people who write the `Show HN`, star the
+repo, and run `brew install`, and (4) they don't need hand-holding on
+permissions/setup, which is currently the rough edge.
+
+Expansion ring *after* the beachhead: privacy-sensitive professionals (lawyers,
+therapists, doctors, journalists, finance, defense) for whom "nothing leaves your
+Mac, no bot in the call" is a compliance requirement, not a preference. That's a
+real second market — but it's a *follow-on*, not the wedge, because they don't
+self-serve through Homebrew and HN.
+
+---
+
+## Competitive map
+
+| Competitor | Their wedge (2026) | Where Transcripted **wins** | Where Transcripted **loses** |
+|---|---|---|---|
+| **Granola** — $1.5B, $192M raised, 250% rev growth, moving to enterprise "Spaces" + API | "Invisible" AI notes, no bot, polished summaries; on-device *audio* but cloud transcript processing; **Google account required**; trains on your data unless you opt out (Enterprise) | Fully local (transcript too, not just audio); no account; no data-training; keeps audio; MIT/free; open file format you own. Granola's own 2026 backlash (cloud dependency, Google-account requirement) is pushing users to private alternatives | AI-note polish, summaries, team collaboration, integrations, brand, funding, mindshare. Granola *is* the default "smart meeting notes" |
+| **Otter.ai** | Real-time live captions, mainstream meeting transcription, free tier (300 min/mo) | Local + free-forever + no minute cap + agent-readable files | Mainstream brand recognition, live captions, mobile, team features |
+| **Fathom** | Most generous free tier (unlimited recording), highest G2 rating (5.0, 6k+ reviews), sales-team summaries | Local + no bot + you own the files; Fathom is cloud + bot-joins | Free-tier generosity narrative, CRM/sales workflow, polish, reviews |
+| **Fireflies** | CRM/integration breadth, sales teams, $10–29/user | Local, no bot, no per-seat cost, agent-native | Integrations, CRM sync, team/sales GTM |
+| **Notion AI meeting notes** | Notes live where your docs already live | Voice + local + agent-readable without locking into Notion's DB | Distribution inside Notion's huge installed base |
+| **Plaud (hardware)** | Intentional button-press capture, dedicated device, MCP/CLI for AI access | Software-only, no $159 device, no cloud round-trip, free | Dedicated always-with-you hardware; Plaud also shipped an MCP, so the "AI access" angle is contested |
+| **Limitless / Rewind (pendant)** | *Dead.* Acquired by Meta Dec 2025; capture cut off; market rejected always-on recording as socially/legally hazardous | N/A — their collapse *validates* intentional, local, user-owned capture | N/A |
+| **Wispr Flow** | Best-in-class cloud dictation, $15/mo; "if your audio can leave your machine, use this" | Local + free; Transcripted does dictation *and* meetings *and* agent memory | Pure dictation speed/accuracy polish, cross-platform, mobile |
+| **Superwhisper** | Local dictation, $9.99/mo or **$849 lifetime** (raised 240% in 2026), free tier with small models | Free vs $849 lifetime; adds meetings + agent memory on top of dictation | Dictation-specific polish, modes, model selection, brand among dictation users |
+| **MacWhisper** | Local file transcription, ~$59 one-time / Pro $8.49/mo | Free + meetings + dictation + agent layer (MacWhisper is mostly file transcription) | Established brand for "drop a file, get a transcript" |
+| **macparakeet** (OSS) | **Nearly identical pitch**: free, OSS, Parakeet TDT on Apple Silicon, dictation + file/URL + meeting recording + calendar | Transcripted's agent/MCP layer and "ask your history" memory framing; cleaner file-ownership story | This is the closest direct OSS competitor and proves "free local Parakeet on Mac" is *table stakes*, not a moat |
+| **OpenWhispr / OpenWhisper / Meetily / whisper-mac / BB Recorder** (OSS/local) | Free, local, on-device transcription + diarization; Meetily self-hosted; BB Recorder uses Apple Intelligence | Same trust position as all of them — Transcripted must win on the agent layer + UX polish + the memory framing, not on "local" | "Local + free + OSS" is a *category*, not a differentiator; several of these exist |
+
+**The single most important read of this table:** Transcripted's competitors
+split into two groups, and Transcripted beats neither group on its *own* axis.
+The funded cloud players (Granola/Otter/Fathom/Fireflies) win on AI polish and
+GTM. The free local OSS pack (macparakeet/OpenWhispr/Meetily/…) ties us on
+local+free+OSS. Transcripted only wins by occupying the *seam between them*:
+**the local-first tool that is built first-class for AI agents to read** — files
+you own + a read-only MCP memory server. Nobody owns that seam yet for spoken
+input. Granola and Plaud both shipped MCP servers in 2026, so the window to own
+"agent-native voice memory" is real but **not indefinite**.
+
+---
+
+## Distribution: the realistic acquisition wedge (ranked)
+
+The honest truth: free + OSS gives away the strongest paid-marketing lever
+(there's no LTV to fund ads), so distribution has to be earned, technical, and
+word-of-mouth. Ranked by realistic yield for the beachhead user:
+
+1. **The "works with your AI agent" content + integration wedge — #1, the actual
+   front door.** Lead every channel with "give your Claude/Codex/Cursor the
+   memory of every call you've had." Ship and *document loudly*: the one-click
+   Claude install, the MCP server, and copy-paste setup for Codex and Cursor.
+   Write the canonical "How to give your coding agent voice memory" post. This is
+   the highest-yield wedge because it's where the beachhead already is, it's a
+   genuinely under-served query in 2026, and it differentiates from the entire
+   free-local pack at once. **Effort M, impact high.**
+
+2. **Show HN + the OSS/local-first community — the launch spike.** This audience
+   *is* the beachhead. The title is the whole game: not "local transcription app"
+   (dead on arrival, fifteen exist) but **"Show HN: Give your AI agent the memory
+   of every meeting — 100% local, files you own."** Lead with the agent angle and
+   the no-cloud/no-bot trust story; the local Parakeet-on-Apple-Silicon detail is
+   credibility, not headline. Expect the top comment to be "how is this different
+   from macparakeet/OpenWhispr" — have the answer ready (agent memory + MCP +
+   file ownership). **Effort S, impact high (spiky).**
+
+3. **Homebrew cask + GitHub as the trust/retention substrate.** Already shipped
+   (`brew install --cask transcripted`). This isn't a discovery channel on its
+   own, but it's the *conversion* surface for everyone the other channels send.
+   Keep the README's "a star helps others find it" ask; stars are social proof
+   that feeds back into HN/Reddit/search ranking. Invest in the GitHub repo
+   *as marketing*: the README is genuinely strong — make the agent angle the
+   hero. **Effort S, impact med (compounding).**
+
+4. **Targeted subreddits + niche communities** — r/LocalLLaMA, r/ClaudeAI,
+   r/ObsidianMD, r/macapps, the Claude Code / Cursor / MCP Discord and forums.
+   These are small but *exactly* the beachhead, and they reward "I built a thing
+   that solves a real pain" over marketing. Higher hit-rate per post than broad
+   channels. **Effort S, impact med.**
+
+5. **Word of mouth via the "ask your history" demo moment.** The product's own
+   magic moment — *"What did I commit to in the product review?" → agent quotes
+   the file* — is the most shareable thing here. The 18-second hero GIF is the
+   right instinct. Make that the artifact people send each other. **Effort S
+   (already mostly built), impact med.**
+
+6. **Privacy/compliance-vertical content (second-ring, post-beachhead).** Once
+   the agent wedge is working, publish vertical-specific "local, no-bot,
+   HIPAA-shaped" pages for therapists/lawyers/journalists. Different GTM (SEO +
+   word of mouth in professional circles), slower, but real and defensible.
+   **Effort M, impact med, later.**
+
+7. **Product Hunt — do it, but don't over-index.** PH skews to a SaaS/no-code
+   crowd that under-values "local + free + no account" and over-values polish.
+   Worth a launch for backlinks and a spike; not the wedge. **Effort S, impact
+   low–med.**
+
+**Do NOT** burn effort chasing mainstream meeting-notes SEO ("best AI meeting
+notes 2026"). That SERP is owned by Granola/Otter/Fathom/Fireflies with content
+budgets we can't match, and it sends the wrong (non-beachhead) user who bounces
+on the macOS-26 requirement.
+
+---
+
+## TAM reality check: macOS 26 + Apple Silicon only
+
+Honest framing: this constraint is real but **right for the beachhead, and
+softening fast on its own.**
+
+- Apple Silicon is already the overwhelming majority of *active* Macs and rising;
+  macOS Tahoe (26) reached ~52% adoption by Jan 2026 and 26.5 alone hit ~46% by
+  end of May 2026. Apple users upgrade faster than any other platform, and macOS
+  27 (WWDC June 2026) is Apple-Silicon-only — the whole platform is converging on
+  exactly Transcripted's requirements.
+- The beachhead user (developer / AI-power-user) is the *most* likely cohort to
+  be on a current macOS and Apple Silicon. The requirement filters out almost
+  none of the people we actually want first.
+- It's the right call because the on-device-ML stack (Neural Engine, MLX,
+  Parakeet via CoreML) is *what makes the local promise credible and fast*.
+  Loosening to Intel or old macOS would trade the core differentiator for a
+  thin slice of low-fit users.
+
+Where it bites: it caps the *mainstream* TAM and makes any future "team rollout"
+story harder (mixed fleets). That's a real reason the **business model should not
+bet on broad mainstream** — see below.
+
+Net: keep the requirement. Don't apologize for it in copy; frame it as the
+reason it's fast and private ("runs on Apple's on-device ML stack — that's what
+keeps it instant and local"), which the README already does well.
+
+---
+
+## Business model: honest options + the pick + what to avoid
+
+Frame first: **what is this, really?** Most likely it's a
+**credibility/portfolio + ecosystem-bet piece** today — a beautifully-built
+proof that voice-to-agent-memory can be 100% local, which builds reputation and
+plants a flag in the "agent personal context" category before that category
+consolidates. That's a legitimate goal and it doesn't *need* revenue to succeed.
+But if monetization is ever required, here are the honest options:
+
+**Options, ranked by trust-compatibility:**
+
+1. **Paid Team / sync tier (open-core on collaboration) — THE PICK.** Core stays
+   free, local, OSS forever. The paid surface is *multi-user* features that are
+   genuinely hard and genuinely worth money, and that don't touch the privacy
+   axis: end-to-end-encrypted sync of a *local-first* capture library across a
+   user's own devices and teammates, shared speaker dictionary, shared/team
+   meeting library with access control, org policy (retention, allowed agents),
+   priority support. This is open-core on the *collaboration* surface, never the
+   *privacy* surface — the exact line Granola is *failing* (cloud + Google
+   account + data-training), so it's also a sharp contrast. It fits because
+   sync/teams is the one thing local-first users will actually pay to solve and
+   it never requires uploading transcript content to *our* servers (E2EE).
+   **This is the only model that scales without betraying the position.**
+
+2. **GitHub Sponsors / donations / "buy me a coffee."** Zero trust cost, trivial
+   to add, near-zero revenue. Worth turning on as a goodwill/sustainability
+   signal; not a business. **Do it, don't count on it.**
+
+3. **Paid pro features on the *single-user* convenience axis** (advanced
+   summaries, premium voice models, fancy exports) — *acceptable but risky*. The
+   moment "the good model costs money," we look like Superwhisper ($849 lifetime)
+   and the "free forever, no pro tier" promise in the FAQ breaks. If ever done,
+   it must be additive convenience, never gating the core capture/transcribe/own
+   loop. **Lukewarm; only if Team tier isn't enough.**
+
+4. **Compliance/enterprise local-deployment licensing** (support + SLA + audit
+   docs for regulated orgs running it fully on-prem/on-device). Real money in the
+   privacy-vertical second ring, fully trust-compatible (you're selling
+   *assurance and support*, not taking anything away). Slower, sales-led, later.
+   **Good follow-on, wrong for now.**
+
+**What I would NOT do, ever:**
+
+- **Cloud upload of transcripts/audio** in any tier. It's the whole brand. Death.
+- **Paywall on transcription itself** or on the core capture→own→agent loop. The
+  README's "No account, no trial, no 'pro' tier" line is a *promise*; breaking it
+  is the single fastest way to lose the OSS goodwill.
+- **Ads / data monetization / training on user content.** This is precisely
+  Granola's 2026 vulnerability — don't walk into it.
+- **Per-seat SaaS pricing on the core app.** Contradicts free+OSS and invites a
+  fork.
+- **A relicense away from MIT / a rug-pull (BSL switch on the whole app).** Kills
+  the trust that *is* the distribution engine.
+
+**The one-line stance:** *Free, local, MIT core forever; if we ever charge, we
+charge teams for encrypted sync and shared libraries — never individuals for
+privacy.*
+
+---
+
+## The biggest positioning risk
+
+**Drifting into a head-on fight with Granola on AI-notes polish.** It is
+seductive — there's already a local Gemma summary beta in 1.1.47, and "better
+summaries" feels like obvious progress. But:
+
+- It moves us onto the axis where a $1.5B, $192M-funded competitor with 250%
+  revenue growth is strongest, and where we are weakest.
+- It dilutes the one sentence that wins ("your agent quotes your files") into
+  "another app with AI summaries," which is the most crowded shelf in software.
+- It spends scarce engineering on a feature the *agent already does for free*
+  — the whole point is the user's own Claude/Codex writes the summary from the
+  Markdown, on demand, in their context. Building our own summarizer half-competes
+  with our own pitch.
+
+Secondary risk: **leading with "free + local + OSS" as the headline.** It's true
+and it matters, but it's now table stakes shared with macparakeet, OpenWhispr,
+Meetily, and the rest. Leading with it makes us *one of the local pack* instead
+of *the agent-memory product that happens to be local*. Local is the proof, not
+the pitch.
+
+Tertiary risk: **over-investing in the privacy-vertical (lawyers/therapists) GTM
+before the agent beachhead is won.** That market is real but doesn't self-serve
+through the channels we can actually run; chasing it early splits focus and slows
+the wedge.
+
+---
+
+## Ranked next moves
+
+1. **Re-hero the positioning around "memory for your AI agent."** Promote *"Your
+   AI stops guessing and starts quoting"* and the "ask your history" demo to the
+   top of README, site hero, and every launch post. Demote "free/local/OSS" to
+   the proof line beneath it. This is a copy/sequencing change, not a code change.
+   **[effort: S] [impact: high]**
+
+2. **Make the agent connection the most polished, most documented path in the
+   product** — one-click Claude install front-and-center, plus dead-simple
+   copy-paste setup blocks for Codex and Cursor, plus a single canonical
+   "give your agent voice memory" guide. The MCP server (`search`, `recap`,
+   `who_is`, `recent_context`) is the moat; treat its setup UX as the hero
+   feature, not a settings footnote. **[effort: M] [impact: high]**
+
+3. **Launch on Show HN with the agent-memory framing**, prepped with a crisp
+   "how this differs from macparakeet/OpenWhispr/Granola" answer (agent memory +
+   MCP + files you own + transcript stays local too). Seed r/LocalLLaMA,
+   r/ClaudeAI, r/ObsidianMD, and the MCP/Claude-Code/Cursor communities the same
+   week. **[effort: S] [impact: high (spiky)]**
+
+4. **Hold the line against building our own AI-notes/summary product.** Keep the
+   local Gemma summary as a *convenience*, clearly secondary; do not let it become
+   the headline or the roadmap center of gravity. Every summary feature should be
+   reframed as "your agent does this from your files." **[effort: S (a decision,
+   not a build)] [impact: high (avoids the fatal drift)]**
+
+5. **Ship and validate the activation loop end-to-end for the beachhead.** The
+   `docs/activation-lane.md` north star (saved Markdown → agent use → return) is
+   exactly right — instrument and tighten the "first useful answer from an agent"
+   moment specifically for Claude Code / Codex users, since that's the cohort the
+   wedge brings in. Reduce permission/setup friction on that path. **[effort: M]
+   [impact: high]**
+
+6. **Turn on GitHub Sponsors and keep the "a star helps" ask** as a low-cost
+   sustainability + social-proof signal. Stars feed HN/search ranking and OSS
+   credibility; sponsors fund the "is this maintained?" answer. **[effort: S]
+   [impact: med]**
+
+7. **Spec (don't build yet) the paid Team/E2EE-sync tier** as the designated
+   monetization path, so every architecture decision keeps that door open without
+   compromising local-first. Write it down so no one accidentally ships a
+   trust-breaking model under deadline pressure. **[effort: S] [impact: med]**
+
+8. **Prepare the privacy-vertical second ring as a follow-on**, not now: draft
+   the "local, no-bot, nothing-leaves-your-Mac" angle for regulated professionals
+   so it's ready when the agent beachhead is established. **[effort: M] [impact:
+   med, later]**
+
+---
+
+### Sources
+
+- Granola $125M / $1.5B Series C, enterprise + Spaces + API, $14/$35 pricing,
+  250% rev growth: [TechCrunch](https://techcrunch.com/2026/03/25/granola-raises-125m-hits-1-5b-valuation-as-it-expands-from-meeting-notetaker-to-enterprise-ai-app/),
+  [SiliconANGLE](https://siliconangle.com/2026/03/25/granola-raises-125m-1-5b-valuation-ai-note-taking-app/)
+- Granola privacy/backlash (cloud dependency, Google account, data-training,
+  users moving to private alternatives):
+  [Hedy AI](https://www.hedy.ai/post/granola-redesign-alternative-hedy/),
+  [BuildBetter](https://blog.buildbetter.ai/best-granola-alternatives-private-meeting-notes-2026/),
+  [work-management.org](https://work-management.org/productivity-tools/granola-ai-review/)
+- Otter/Fathom/Fireflies pricing & positioning:
+  [tooldirectory.ai](https://tooldirectory.ai/blog/ai-notetakers-2026-otter-fireflies-granola-fathom-read),
+  [outdoo.ai](https://www.outdoo.ai/blog/otter-vs-fireflies)
+- Dictation pricing (Wispr Flow $15, Superwhisper $9.99 / $849 lifetime,
+  MacWhisper): [getvoibe](https://www.getvoibe.com/resources/wispr-flow-vs-superwhisper/),
+  [spokenly](https://spokenly.app/blog/superwhisper-review),
+  [jamesm.blog](https://jamesm.blog/ai/mac-dictation-tools-comparison/)
+- Limitless/Rewind acquired by Meta, hardware dead, market rejected always-on:
+  [TechTimes](https://www.techtimes.com/articles/314655/20260216/best-ai-notetaking-devices-2026-comparing-rewind-pendant-plaud-ai-recorder-other-wearable-mics.htm),
+  [UMEVO](https://www.umevo.ai/blogs/ume-all-posts/wearable-ai-wars-2026-limitless-pendant-vs-bee-pioneer-vs-plaud-notepin)
+- Plaud MCP/CLI for AI access:
+  [Plaud](https://www.plaud.ai/blogs/news/introducing-plaud-mcp-and-cli)
+- Granola MCP (Claude/ChatGPT/Cursor):
+  [Granola](https://www.granola.ai/blog/granola-mcp-claude-chatgpt-cursor)
+- Free/local OSS Mac competitors (macparakeet, OpenWhispr, Meetily, whisper-mac,
+  BB Recorder): [macparakeet](https://github.com/moona3k/macparakeet),
+  [OpenWhisper Show HN](https://news.ycombinator.com/item?id=47006248),
+  [meetily.ai](https://meetily.ai/vs/granola)
+- macOS 26 adoption / Apple-Silicon-only trajectory:
+  [TelemetryDeck](https://telemetrydeck.com/survey/apple/macOS/versions/),
+  [eMarketer](https://emarketer.com/content/apple-ends-intel-mac-era--forces-enterprise-hardware-refresh-by-2028)
+- Obsidian/CLAUDE.md/MCP "second brain" agent workflow adoption:
+  [nxcode.io](https://www.nxcode.io/resources/news/obsidian-ai-second-brain-complete-guide-2026)
+- OSS monetization models (open-core, sponsors, E2EE/sync tiers):
+  [reo.dev](https://www.reo.dev/blog/monetize-open-source-software),
+  [work-bench](https://www.work-bench.com/post/open-source-playbook-proven-monetization-strategies)


### PR DESCRIPTION
## Why

A focused \"what should we do next\" session. We looked at the app, then ran three grounded background deep dives — product moat, market position, and codebase health — and wrote them up alongside a capstone synthesis so the direction is durable and reviewable, not just chat scrollback.

## Product Impact

- Affects: `docs only`
- Lane: `agent workflow`
- Why this matters: the three lenses converge on one answer (lean into the agent-memory loop), and capturing that with its evidence and sequencing makes the next planning step concrete instead of vibes.

## What changed

- `docs/strategy/agent-loop-activation-2026-06-14.md` — product/moat deep dive. The captures→agent→answer loop is the moat but is shallow today: lexical FTS5 only (no semantic), `recap` returns raw transcript lines, and the summarizer's structured Decisions/Action-Items/Open-Questions are extracted but never indexed — so the moat inverts as the library grows.
- `docs/strategy/growth-positioning-2026-06-14.md` — market deep dive. The defensible position is \"memory for your AI agent\"; make the MCP/agent connection the hero feature; don't fight Granola on AI-notes; free + local + MIT forever, with a Team-tier (E2EE sync) as the only trust-safe monetization if ever needed.
- `docs/strategy/codebase-architecture-health-2026-06-14.md` — engineering deep dive. Overall health B; clean bones but four god objects are the velocity tax (worst: `TranscriptedSettingsView.swift`, 4503 LOC / 187 commits). Raw-swiftc build is worth keeping; Swift 6 strict-concurrency is deferred debt.
- `docs/strategy/SYNTHESIS-2026-06-14.md` — capstone. All three converge: the moat, the pitch, and the one big refactor are the same project. Includes the two key collisions (the summary paradox; the hero move trapped in the worst god object), a sequenced plan (Phase 0 quick wins → index the summaries + cross-meeting MCP tools → semantic search + Settings decomposition → launch), and explicit don'ts.

These are analysis artifacts under a new `docs/strategy/` subtree. No product code, no contract/test changes, no runtime behavior change.

## How I checked it

- [x] `scripts/dev/agent-preflight.sh` — docs-only change; only suggested check is preflight, which is clean
- [ ] Selected checks from `.agents/test-matrix.yml` — n/a (no code, no agent-contract files touched)
- [ ] `bash build.sh --no-open` — n/a (docs only)
- [ ] `bash run-tests.sh` — n/a (docs only)
- [x] Manual check: rendered Markdown + internal links between the four docs

## Risk Review

- [x] Privacy / local-first behavior reviewed — analysis only; no telemetry/payload changes
- [x] Storage path or migration impact reviewed — none
- [x] Public-facing copy stays concrete and matches current product scope — internal strategy docs, not user-facing copy
- [x] Release/update impact reviewed — none
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included — synthesized analysis only; competitor figures are public

## Notes

Recommendations only — no direction is locked by this PR. Open flags called out in the synthesis: live GitHub star/download metrics were not pulled (keep live-release truth separate before any launch-timing call), the agent-memory window is contested (Granola + Plaud shipped MCP servers in 2026), and model strategy (extraction model + bundled embedding model) is now on the critical path and worth its own follow-up deep dive.

## Agent handoff

`COORD_DONE: GREEN | https://github.com/r3dbars/transcripted/pull/<this> | added docs/strategy/ (3 deep dives + synthesis) | none | pick next step: model-strategy deep dive, spec the agent-memory build, or start Phase 0 quick wins | agent-preflight (clean), manual link/render check | start recap-summary-aware + formatter↔parser agreement test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)