### PR TITLE
[codex] Fix Home summary notice dismissal

### DIFF
--- a/Sources/UI/Settings/HomeMeetingSummaryBetaPresentationPolicy.swift
+++ b/Sources/UI/Settings/HomeMeetingSummaryBetaPresentationPolicy.swift
@@ -50,6 +50,13 @@ struct HomeLocalSummaryNotice: Identifiable, Equatable {
 enum HomeLocalSummaryNoticeDismissalPolicy {
     static let autoDismissDelayNanoseconds: UInt64 = 6_000_000_000
 
+    static func noticeAfterAutoDismiss(
+        current: HomeLocalSummaryNotice?,
+        scheduledNoticeID: UUID
+    ) -> HomeLocalSummaryNotice? {
+        shouldDismiss(current: current, scheduledNoticeID: scheduledNoticeID) ? nil : current
+    }
+
     static func shouldDismiss(
         current: HomeLocalSummaryNotice?,
         scheduledNoticeID: UUID

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -3101,7 +3101,10 @@ struct TranscriptedSettingsView: View {
                     current: homeLocalSummaryNotice,
                     scheduledNoticeID: notice.id
                   ) else { return }
-            homeLocalSummaryNotice = nil
+            homeLocalSummaryNotice = HomeLocalSummaryNoticeDismissalPolicy.noticeAfterAutoDismiss(
+                current: homeLocalSummaryNotice,
+                scheduledNoticeID: notice.id
+            )
             homeLocalSummaryNoticeDismissTask = nil
         }
     }

--- a/Tests/HomeMeetingSummaryBetaPresentationPolicyTests.swift
+++ b/Tests/HomeMeetingSummaryBetaPresentationPolicyTests.swift
@@ -95,12 +95,28 @@ func testHomeMeetingSummaryBetaPresentationPolicy() {
             ),
             "the scheduled notice should be dismissible"
         )
+        assertEqual(
+            HomeLocalSummaryNoticeDismissalPolicy.noticeAfterAutoDismiss(
+                current: firstNotice,
+                scheduledNoticeID: firstNotice.id
+            ),
+            nil,
+            "the scheduled notice should clear after its auto-dismiss delay"
+        )
         assertFalse(
             HomeLocalSummaryNoticeDismissalPolicy.shouldDismiss(
                 current: newerNotice,
                 scheduledNoticeID: firstNotice.id
             ),
             "an old dismissal timer should not clear a newer summary notice"
+        )
+        assertEqual(
+            HomeLocalSummaryNoticeDismissalPolicy.noticeAfterAutoDismiss(
+                current: newerNotice,
+                scheduledNoticeID: firstNotice.id
+            ),
+            newerNotice,
+            "an old dismissal timer should leave a newer summary notice visible"
         )
     }
 }


### PR DESCRIPTION
## Summary
- tighten the Home local-summary notice dismissal path so the timer resolves the next notice state through the shared policy
- extend the focused Home summary notice test to prove the scheduled notice clears while an older timer leaves a newer notice visible

## Repro signal
The June 8 self-sent `Transcripted Feedback` email showed `meeting.local_meeting_summary_completed` with `chunk_count=1`, while the green `AI summary saved` Home notice stayed on screen. That points at the Home notice lifecycle after completion, not the Gemma generation path itself.

## Nearby follow-up
The same report also says Gemma setup can show ready while Home remains in `Generating AI summary` for a long time. I kept this PR scoped to the stuck saved notice; that slower generating state should be handled separately.

## Verification
- `bash run-tests.sh --filter HomeMeetingSummaryBetaPresentationPolicyTests`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`