### PR TITLE
[nightly-telemetry] Drop native image paths from Sentry crashes

### DIFF
--- a/Sources/Observability/CrashReporter.swift
+++ b/Sources/Observability/CrashReporter.swift
@@ -234,6 +234,11 @@ final class CrashReporter {
         }
 
         sanitize(stacktrace: event.stacktrace)
+        if let debugMeta = event.debugMeta {
+            for debugImage in debugMeta {
+                debugImage.codeFile = nil
+            }
+        }
 
         event.request = nil
         event.user = nil
@@ -260,9 +265,7 @@ final class CrashReporter {
             if let module = frame.module {
                 frame.module = SentryPayloadSanitizer.sanitizeText(module)
             }
-            if let package = frame.package {
-                frame.package = SentryPayloadSanitizer.sanitizeText(package)
-            }
+            frame.package = nil
         }
     }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -77,6 +77,33 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - Sentry crash scrubber drops native image paths") {
+        let contents = readRepoTextFile("Sources/Observability/CrashReporter.swift")
+        let eventBlock = sourceSlice(
+            contents,
+            from: "private func sanitize(event: Event) -> Event {",
+            to: "private func sanitize(stacktrace: SentryStacktrace?)"
+        )
+        let stacktraceBlock = sourceSlice(
+            contents,
+            from: "private func sanitize(stacktrace: SentryStacktrace?)",
+            to: "private func sentryLevel(for level: EventLevel) -> SentryLevel"
+        )
+
+        assertTrue(
+            eventBlock.contains("debugImage.codeFile = nil"),
+            "Sentry debug image code-file paths should be dropped before crash events leave the app"
+        )
+        assertTrue(
+            stacktraceBlock.contains("frame.package = nil"),
+            "Sentry native frame package paths should be dropped before crash events leave the app"
+        )
+        assertFalse(
+            stacktraceBlock.contains("frame.package = SentryPayloadSanitizer.sanitizeText(package)"),
+            "native package paths should be removed, not merely redacted after SDK capture"
+        )
+    }
+
     runSuite("Repo command contract - PostHog health probe uses the query API") {
         let contents = readRepoTextFile("scripts/ops/health-probe.sh")
 


### PR DESCRIPTION
## Summary
- Drop native Sentry `debugImage.codeFile` values before crash events leave the app.
- Drop native Sentry `frame.package` values instead of trying to sanitize them as text.
- Add a repo contract test so path-shaped native crash metadata stays out of future payloads.

## Nightly evidence
Top candidate: current-release Sentry crash metadata privacy/debugging blind spot, score 92/100.

Evidence used:
- Sentry production issue `APPLE-MACOS-1X` appeared on `transcripted@1.1.48` with 2 fatal events in the last 24h.
- The event looked like local build/smoke noise rather than a clean public-user crash, but native crash metadata still carried path-shaped frame/debug image fields.
- PostHog for 1.1.48 had launch/update/dictation coverage, but no matching workflow context that made this crash actionable.

Why this won:
- User pain/workflow distortion: 24/30
- Debugging/confusion severity: 25/25
- Current-release relevance: 15/15
- Small-patch safety: 14/15
- Privacy/payload confidence: 14/15

Why the next candidates lost:
- Home delete confirmation UX: real user-facing issue, but #1126 is already open with the targeted fix and tests.
- Update install proof gap: useful telemetry gap, but weaker direct evidence than the current-release Sentry payload issue and a less obvious tiny patch.

## Verification
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (5353 passed)
- `bash scripts/dev/agent-preflight.sh Sources/Observability/CrashReporter.swift Tests/RepoCommandContractTests.swift`
- `codex-review --mode local` (Swift changes built/tested; only noted unrelated untracked local Wrangler cache, not staged)

## Privacy
No new telemetry. This removes path-shaped native crash fields from off-device Sentry payloads.