### PR TITLE
fix(audio): stop dictation engine before removing input tap (isSink || tap != nullptr crash)

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -232,11 +232,33 @@ class ParakeetEngine: ObservableObject {
         }
     }
 
-    private static func cleanUpLateAudioStart(on audioEngine: AVAudioEngine) {
-        audioEngine.inputNode.removeTap(onBus: 0)
-        if audioEngine.isRunning {
-            audioEngine.stop()
+    /// Remove the input tap without tripping AVAudioEngine's
+    /// `required condition is false: isSink || tap != nullptr` assertion.
+    ///
+    /// Removing a tap while the engine is still running leaves the input node
+    /// with neither a tap nor a downstream sink; the next IO-thread
+    /// `InputAvailable` callback then crashes the process. Stop the engine and
+    /// let in-flight input callbacks drain BEFORE removing the tap, mirroring
+    /// the meeting/mic path's `Audio.tearDownInputTapSafely` via the shared
+    /// `AudioInputTapTeardownPolicy`.
+    ///
+    /// Must be called on `audioEngineQueue` (callers already hop there); the
+    /// drain step briefly blocks that queue, never the CoreAudio render thread.
+    private nonisolated static func safelyRemoveInputTap(on audioEngine: AVAudioEngine) {
+        for step in AudioInputTapTeardownPolicy.steps(engineIsRunning: audioEngine.isRunning) {
+            switch step {
+            case .stopEngine:
+                audioEngine.stop()
+            case .waitForStoppedInputCallbacks:
+                Thread.sleep(forTimeInterval: AudioInputTapTeardownPolicy.inputCallbackDrainDelay)
+            case .removeInputTap:
+                audioEngine.inputNode.removeTap(onBus: 0)
+            }
         }
+    }
+
+    private static func cleanUpLateAudioStart(on audioEngine: AVAudioEngine) {
+        safelyRemoveInputTap(on: audioEngine)
         audioEngine.reset()
     }
 
@@ -1555,7 +1577,11 @@ class ParakeetEngine: ObservableObject {
     private func removeRecordingTap(force: Bool = false) async {
         guard force || inputTapInstalled else { return }
         await runAudioEngineWork { audioEngine in
-            audioEngine.inputNode.removeTap(onBus: 0)
+            // Stop + drain before removing the tap; the canonical stop path
+            // (`removeRecordingTap()` then `stopAudioEngine()`) otherwise removes
+            // the tap while the engine is still recording and can crash the
+            // audio IO thread with `isSink || tap != nullptr`.
+            Self.safelyRemoveInputTap(on: audioEngine)
         }
         inputTapInstalled = false
     }
@@ -1615,10 +1641,7 @@ class ParakeetEngine: ObservableObject {
         }
         audioGraphGeneration += 1
         await runAudioEngineWork { audioEngine in
-            audioEngine.inputNode.removeTap(onBus: 0)
-            if audioEngine.isRunning {
-                audioEngine.stop()
-            }
+            Self.safelyRemoveInputTap(on: audioEngine)
             audioEngine.reset()
         }
         inputTapInstalled = false
@@ -1630,10 +1653,7 @@ class ParakeetEngine: ObservableObject {
         removeAudioEngineConfigObserver()
         let retiredEngine = audioEngine
         await runAudioEngineWork { audioEngine in
-            audioEngine.inputNode.removeTap(onBus: 0)
-            if audioEngine.isRunning {
-                audioEngine.stop()
-            }
+            Self.safelyRemoveInputTap(on: audioEngine)
             audioEngine.reset()
         }
         guard audioEngine === retiredEngine else { return }
@@ -3074,10 +3094,7 @@ class ParakeetEngine: ObservableObject {
         }
         unregisterDefaultInputDeviceListener(inputDeviceChangeListener)
         audioEngineQueue.async { [audioEngine] in
-            audioEngine.inputNode.removeTap(onBus: 0)
-            if audioEngine.isRunning {
-                audioEngine.stop()
-            }
+            ParakeetEngine.safelyRemoveInputTap(on: audioEngine)
             audioEngine.reset()
         }
         ParakeetRetiredAudioEngineStore.shared.retire(audioEngine, reason: "deinit")

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -107,16 +107,24 @@ enum AudioRecordingFormatPolicy {
     }
 }
 
-enum AudioInputTapTeardownStep: Equatable {
+public enum AudioInputTapTeardownStep: Equatable, Sendable {
     case stopEngine
     case waitForStoppedInputCallbacks
     case removeInputTap
 }
 
-enum AudioInputTapTeardownPolicy {
-    static let inputCallbackDrainDelay: TimeInterval = 0.05
+/// Single source of truth for the order in which an AVAudioEngine input tap may
+/// be torn down. A running graph MUST stop and let in-flight input callbacks
+/// drain BEFORE the tap is removed; otherwise CoreAudio can deliver input to a
+/// node that has neither a tap nor a sink and trips the fatal assertion
+/// `required condition is false: isSink || tap != nullptr`.
+///
+/// Shared by the meeting/mic capture path (`Audio.tearDownInputTapSafely`) and
+/// the dictation path (`ParakeetEngine`) so both honor the same ordering.
+public enum AudioInputTapTeardownPolicy {
+    public static let inputCallbackDrainDelay: TimeInterval = 0.05
 
-    static func steps(engineIsRunning: Bool) -> [AudioInputTapTeardownStep] {
+    public static func steps(engineIsRunning: Bool) -> [AudioInputTapTeardownStep] {
         engineIsRunning
             ? [.stopEngine, .waitForStoppedInputCallbacks, .removeInputTap]
             : [.removeInputTap]

--- a/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
@@ -95,6 +95,33 @@ final class AudioInitializationTests: XCTestCase {
         )
     }
 
+    /// Regression guard for the fatal audio-thread crash
+    /// `com.apple.coreaudio.avfaudio: required condition is false: isSink || tap != nullptr`
+    /// (Sentry r3dbars/apple-macos issue 7479438309). Both the meeting/mic path
+    /// (`Audio.tearDownInputTapSafely`) and the dictation path
+    /// (`ParakeetEngine.safelyRemoveInputTap`) now route every input-tap teardown
+    /// through this policy, so for any running engine the tap must never be
+    /// removed before the engine is stopped — otherwise CoreAudio can deliver
+    /// input to a tap-less, sink-less node and crash the process.
+    func testRunningEngineTeardownNeverRemovesTapBeforeStopping() {
+        let steps = AudioInputTapTeardownPolicy.steps(engineIsRunning: true)
+        let stopIndex = steps.firstIndex(of: .stopEngine)
+        let removeIndex = steps.firstIndex(of: .removeInputTap)
+
+        let stop = try? XCTUnwrap(stopIndex, "Running-engine teardown must stop the engine")
+        let remove = try? XCTUnwrap(removeIndex, "Teardown must remove the input tap")
+
+        if let stop, let remove {
+            XCTAssertLessThan(
+                stop,
+                remove,
+                "Stopping the engine must come before removing the tap to avoid the isSink || tap != nullptr assertion"
+            )
+        } else {
+            XCTFail("Running-engine teardown must contain both .stopEngine and .removeInputTap")
+        }
+    }
+
     func testStopOnIdleAudioDoesNotCrashAndBumpsGeneration() {
         // The stop refactor moves engine teardown to a background queue.
         // On a fresh Audio with no engine, stop() should still:


### PR DESCRIPTION
## Crash being fixed

Fatal audio-thread crash, found via Sentry telemetry (org `r3dbars`, project `apple-macos`):

> `com.apple.coreaudio.avfaudio: required condition is false: isSink || tap != nullptr`

Sentry issue **7479438309** (`level=fatal`, `mechanism=nsexception`, `handled=no`). Crash context: `session_kind=meeting/dictation`, `session_stage=recording`. Stack terminates in `AVAudioEngineGraph::InputAvailable` → `+[NSException raise:format:]` on the CoreAudio IO thread.

This crash family correlates with the **#1 error event** `parakeet.device_change_rewarm_failed` (×207 / 14d) and `parakeet.zombie_engine_recovery_failed` — all in the dictation engine's restart/teardown path. Native audio-thread crashes are systematically under-reported, and `app.unclean_shutdown_detected` (×166) indicates many more uncaptured aborts.

## Root cause

`ParakeetEngine` removed the `AVAudioEngine` input tap **while the engine was still running**, then stopped the engine afterward. The canonical stop path is:

```swift
await removeRecordingTap()   // removes tap while engine STILL recording
await stopAudioEngine()      // stops engine afterward
```

Between those two steps (and in four explicit teardown sites that did `removeTap()` → `stop()` → `reset()`), CoreAudio's IO thread can deliver an `InputAvailable` callback to an input node that now has **neither a tap nor a downstream sink**, which trips AVFoundation's fatal `isSink || tap != nullptr` assertion and aborts the process.

The meeting/mic capture path already does this correctly via `AudioInputTapTeardownPolicy` (**stop → drain in-flight callbacks → removeTap**). The dictation path did not.

## Fix

- Promote `AudioInputTapTeardownPolicy` / `AudioInputTapTeardownStep` to `public` so both capture paths share one source of truth.
- Add `ParakeetEngine.safelyRemoveInputTap(on:)` applying that policy, and route **all five** dictation teardown sites through it:
  - `removeRecordingTap` (the dominant stop path)
  - `cleanUpLateAudioStart`
  - `resetAudioGraphAfterStartFailure`
  - `rebuildAudioEngine`
  - `deinit`
- The start-path `removeTap` immediately preceding `installTap` (prewarm optimization) is intentionally left as-is; see "Residual" below.

## Test

Added `testRunningEngineTeardownNeverRemovesTapBeforeStopping` asserting a running-engine teardown never removes the tap before `.stopEngine`. Both capture paths now share this policy, so the contract guards both. (Direct `ParakeetEngine` unit tests aren't feasible — it requires a live `AVAudioEngine` and isn't part of the SPM test target.)

## Verification

- All changed files pass `swiftc -frontend -parse`.
- Full `swift test` requires the heavy `build-deps.sh` ML toolchain (multi-GB, network) which wasn't completed in the authoring sandbox; the fix mirrors the already-shipping, already-tested meeting path exactly. Please confirm CI green before merge.

## Residual / follow-ups (not in this PR)

- `installTapAndStartEngine` removes then immediately re-installs the tap while the (prewarmed) engine may be running — a much smaller race kept to preserve prewarm latency. Worth a follow-up.
- Other fatal Sentry crashes ranked for follow-up: `EXC_BAD_ACCESS` in `objc_release` (×3, no in-app frames), `NSInvalidArgumentException` unrecognized-selector on an NSButton action (×2, selector name scrubbed by privacy sanitizer), `EXC_BREAKPOINT` in `TdtDecoderV3.runJointPrepared` (×1, CoreML-internal, likely OOM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)