### PR TITLE
[operator] Align scorecard UI smoke globs

### DIFF
--- a/.agents/board-scorecard.yml
+++ b/.agents/board-scorecard.yml
@@ -42,7 +42,7 @@ boards:
     automatable: auto
     weight: 1.0
     ui:
-      check_globs: ["ui/home*", "ui/navigation*", "ui/popover*"]
+      check_globs: ["settings-home"]
     functional:
       check_globs: ["index/*", "stats/*", "health/*"]
 
@@ -85,7 +85,7 @@ boards:
     automatable: auto
     weight: 1.0
     ui:
-      check_globs: ["ui/general*", "ui/settings.general*"]
+      check_globs: ["settings-pages-toggle", "settings-navigation", "settings-general"]
     functional:
       check_globs: ["artifact/dictionary*", "artifact/preferences*"]
 

--- a/scripts/ops/test-score-boards.py
+++ b/scripts/ops/test-score-boards.py
@@ -290,6 +290,31 @@ boards:
             payload = json.loads(out_json.read_text())
             self.assertEqual(payload["boards"][0]["score"], 100.0)
 
+    def test_repo_registry_matches_current_ui_smoke_ids(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            (tmp / "ui.json").write_text(json.dumps({"checks": [
+                {"id": "settings-home", "title": "Home", "status": "PASS", "target": "Transcripted Settings"},
+                {"id": "settings-pages-toggle", "title": "Settings area opens", "status": "PASS", "target": "Transcripted Settings"},
+                {"id": "settings-navigation", "title": "Settings tabs navigate", "status": "PASS", "target": "General"},
+                {"id": "settings-general", "title": "General controls are visible", "status": "PASS", "target": "General"},
+            ]}))
+
+            out_json = tmp / "scorecard.json"
+            out_md = tmp / "scorecard.md"
+            proc = run("score-boards.py",
+                       "--registry", self._registry(),
+                       "--ui-json", str(tmp / "ui.json"),
+                       "--json-out", str(out_json),
+                       "--markdown-out", str(out_md))
+            self.assertIn(proc.returncode, (0, 3), proc.stdout + proc.stderr)
+            payload = json.loads(out_json.read_text())
+            boards = {board["id"]: board for board in payload["boards"]}
+            home_ui = {dim["name"]: dim for dim in boards["home"]["dimensions"]}["ui"]
+            general_ui = {dim["name"]: dim for dim in boards["settings-general"]["dimensions"]}["ui"]
+            self.assertEqual(home_ui["score"], 100.0)
+            self.assertEqual(general_ui["score"], 100.0)
+
     def test_yaml_parser_handles_bare_list_and_bare_mapping_item(self):
         score_boards = load_score_boards_module()
         rows = score_boards.tokenize_registry("""


### PR DESCRIPTION
## Why

Issue #1120 calls out that `.agents/board-scorecard.yml` still has best-effort UI evidence globs. The current `transcripted-qa ui-smoke` report emits concrete IDs for Home and Settings General, but the registry still looked for guessed `ui/home*` and `ui/general*` names.

## What changed

- Updated the Home board UI evidence glob to match `settings-home`.
- Updated the Settings General board UI evidence globs to match `settings-pages-toggle`, `settings-navigation`, and `settings-general`.
- Added a pure scorecard regression that feeds those current UI smoke IDs into the repo registry and asserts Home and Settings General get UI scores.

## Safety

- Proof/test plumbing only.
- No app runtime behavior, audio path, storage/deletion path, release metadata, telemetry payload, or privacy behavior changed.
- Checked current open PRs first and avoided speaker/audio/Home resolver/web surfaces.

Refs #1120.

## Verification

- `scripts/dev/agent-preflight.sh`
- `python3 scripts/ops/test-score-boards.py`
- `python3 -m py_compile scripts/ops/test-score-boards.py`
- `git diff --check -- .agents/board-scorecard.yml scripts/ops/test-score-boards.py`

## Follow-up

#1120 still needs a real Mac `transcripted-qa ui-smoke --report ...` plus scorecard run to confirm the full board packet on live app evidence.