### PR TITLE
[docs] Update speaker eval docs

### DIFF
--- a/.agents/test-matrix.yml
+++ b/.agents/test-matrix.yml
@@ -175,6 +175,14 @@ rules:
       - "python3 -m py_compile scripts/ops/compare-meeting-corpus.py"
 
   - paths:
+      - "scripts/ops/speaker-naming-simulator.py"
+    checks:
+      - "scripts/dev/agent-preflight.sh"
+      - "python3 -m py_compile scripts/ops/speaker-naming-simulator.py"
+      - "scripts/ops/speaker-naming-simulator.py"
+      - "scripts/ops/speaker-naming-simulator.py --sweep"
+
+  - paths:
       - "scripts/ops/dictation-stop-autoeval.sh"
       - "scripts/ops/dictation-recovery-autoeval.rb"
       - "docs/autoeval-dictation-stop-speed-*.md"

--- a/.agents/test-matrix.yml
+++ b/.agents/test-matrix.yml
@@ -279,6 +279,21 @@ rules:
       - "swift test --package-path Tools/TranscriptedQA"
 
   - paths:
+      - "Tools/SpeakerEvalHarness/**"
+      - "scripts/download_ami.sh"
+      - "scripts/run_speaker_eval.sh"
+      - "scripts/score_speaker_eval.py"
+      - "scripts/aggregate_sweep.py"
+    checks:
+      - "scripts/dev/agent-preflight.sh"
+      - "bash -n scripts/download_ami.sh"
+      - "bash -n scripts/run_speaker_eval.sh"
+      - "python3 -m py_compile scripts/score_speaker_eval.py"
+      - "python3 -m py_compile scripts/aggregate_sweep.py"
+      - "bash build-deps.sh --force"
+      - "swift build --package-path Tools/SpeakerEvalHarness"
+
+  - paths:
       - "README.md"
       - "AGENT_START.md"
       - "AGENTS.md"

--- a/Tools/README.md
+++ b/Tools/README.md
@@ -8,11 +8,13 @@
 - `TranscriptedCLI/` — local context and offline diarization CLI
 - `TranscriptedMCP/` — read-only MCP server for saved meetings and dictations
 - `TranscriptedQA/` — artifact validation and QA CLI
+- `SpeakerEvalHarness/` — headless AMI speaker-naming eval harness for diarization, embedding, clustering, and cross-meeting match sweeps
 
 ## Read first
 
 Each package has its own local `CLAUDE.md` and `Package.swift`.
 
+- `Tools/SpeakerEvalHarness/CLAUDE.md`
 - `Tools/TranscriptedCaptureKit/CLAUDE.md`
 - `Tools/TranscriptedCLI/CLAUDE.md`
 - `Tools/TranscriptedMCP/CLAUDE.md`

--- a/Tools/SpeakerEvalHarness/CLAUDE.md
+++ b/Tools/SpeakerEvalHarness/CLAUDE.md
@@ -1,0 +1,24 @@
+# SpeakerEvalHarness
+
+## What this package owns
+
+`Tools/SpeakerEvalHarness/` is a standalone Swift package for headless speaker-naming evaluation against the AMI Meeting Corpus. It dumps app diarizer segments and WeSpeaker embeddings, then replays threshold sweeps through `TranscriptedCore` clustering and cross-meeting speaker matching.
+
+AMI audio, RTTMs, dumps, and eval reports are local-only and gitignored. Do not commit corpus data or raw eval artifacts.
+
+## Key files
+
+- `Package.swift` wires the harness to root `TranscriptedCore` and the repo-level native dependency bundle.
+- `Sources/speaker-eval-harness/main.swift` owns the `dump` and `replay` commands.
+- `README.md` describes setup, commands, and corpus requirements.
+- `BASELINE_REPORT.md` records the current measured baseline and tuning notes.
+- `../../scripts/download_ami.sh`, `../../scripts/run_speaker_eval.sh`, `../../scripts/score_speaker_eval.py`, and `../../scripts/aggregate_sweep.py` drive the end-to-end AMI sweep.
+
+## Verification
+
+- `bash build-deps.sh --force`
+- `swift build --package-path Tools/SpeakerEvalHarness`
+- `bash -n scripts/download_ami.sh`
+- `bash -n scripts/run_speaker_eval.sh`
+- `python3 -m py_compile scripts/score_speaker_eval.py`
+- `python3 -m py_compile scripts/aggregate_sweep.py`

--- a/Tools/SpeakerEvalHarness/README.md
+++ b/Tools/SpeakerEvalHarness/README.md
@@ -71,7 +71,7 @@ Override the grids via env: `SERIES`, `CONSOLIDATION`, `MATCH`, `COLLAR`.
 | `../../scripts/run_speaker_eval.sh` | end-to-end driver |
 | `../../scripts/score_speaker_eval.py` | DER + fragmentation + false-merge + re-ID scorer |
 | `../../scripts/aggregate_sweep.py` | sweep table + closest-to-ideal picker |
-| `../../data/ami/download.sh` | fetch the AMI subset |
+| `../../scripts/download_ami.sh` | fetch the AMI subset |
 
 ## Caveats
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,6 +36,10 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
 
 - `scripts/dev/agent-preflight.sh` — summarize branch state, changed paths, trusted docs, and suggested checks from the agent test matrix
 - `scripts/dev/benchmark-home-recent-captures.sh` — compile and run the Settings Home recent-capture loader benchmark
+- `scripts/download_ami.sh` — fetch the gitignored AMI ES2002 audio/RTTM subset used by `Tools/SpeakerEvalHarness`
+- `scripts/run_speaker_eval.sh` — build and run the AMI speaker-naming sweep, writing local reports under `data/eval/`
+- `scripts/score_speaker_eval.py` — score speaker-eval hypotheses against AMI RTTM labels without printing private transcript text
+- `scripts/aggregate_sweep.py` — aggregate speaker-eval sweep scores and highlight closest-to-target threshold combinations
 - `scripts/release/generate-dmg-background.swift` — regenerate the committed DMG install background art
 - `scripts/release/generate-sparkle-appcast.sh` — generate a Sparkle appcast from an updates folder and copy it into `docs/appcast.xml`
 - `scripts/release/verify-sparkle-release.sh` — verify a GitHub release DMG, Sparkle appcast entry, and app updater settings line up

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -111,6 +111,10 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
   - Corpus compare usage: `bash scripts/ops/transcripted-qa-bench.sh --mode corpus-compare --corpus-ids meeting-0024,meeting-0025`
   - Live usage: `bash scripts/ops/transcripted-qa-bench.sh --mode live`
   - Writes local evidence under `/tmp/transcripted-qa-bench/<run-id>/`
+- `scripts/ops/speaker-naming-simulator.py` — deterministic synthetic speaker-review simulator for tuning `EmbeddingClusterer` same-voice consolidation without audio or private transcripts
+  - Usage: `scripts/ops/speaker-naming-simulator.py`
+  - Sweep usage: `scripts/ops/speaker-naming-simulator.py --sweep`
+  - JSON usage: `scripts/ops/speaker-naming-simulator.py --json`
 - `scripts/ops/validate-meeting-corpus.py` — local-only validator for the private meeting corpus in `~/Downloads/meeting-corpus`; parses metadata, audio presence/duration, and Zoom caption structure without printing transcript text
 - `scripts/ops/compare-meeting-corpus.py` — local-only comparator for Transcripted Markdown against private Zoom caption truth; reports redacted recall and speaker-label scores without printing transcript text or speaker names
 - `scripts/ops/nightly-transcripted-archive-miner.sh` — thin nightly wrapper that runs `build-codex-memory-index.py` with `--since-hours 24 --nightly-report`

--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -210,6 +210,13 @@ if [ -n "$changed_paths" ]; then
             add_command "python3 -m py_compile scripts/ops/compare-meeting-corpus.py"
         fi
 
+        if matches_any "$path" "scripts/ops/speaker-naming-simulator.py"; then
+            add_command "scripts/dev/agent-preflight.sh"
+            add_command "python3 -m py_compile scripts/ops/speaker-naming-simulator.py"
+            add_command "scripts/ops/speaker-naming-simulator.py"
+            add_command "scripts/ops/speaker-naming-simulator.py --sweep"
+        fi
+
         if matches_any "$path" "scripts/ops/dictation-stop-autoeval.sh" "scripts/ops/dictation-recovery-autoeval.rb" "docs/autoeval-dictation-stop-speed-*.md" "docs/autoeval-dictation-recovery-time-*.md"; then
             add_command "scripts/dev/agent-preflight.sh"
             add_command "bash -n scripts/ops/dictation-stop-autoeval.sh"
@@ -260,6 +267,16 @@ if [ -n "$changed_paths" ]; then
 
         if matches_any "$path" "Tools/TranscriptedQA/*"; then
             add_command "swift test --package-path Tools/TranscriptedQA"
+        fi
+
+        if matches_any "$path" "Tools/SpeakerEvalHarness/*" "Tools/SpeakerEvalHarness/*/*" "Tools/SpeakerEvalHarness/*/*/*" "scripts/download_ami.sh" "scripts/run_speaker_eval.sh" "scripts/score_speaker_eval.py" "scripts/aggregate_sweep.py"; then
+            add_command "scripts/dev/agent-preflight.sh"
+            add_command "bash -n scripts/download_ami.sh"
+            add_command "bash -n scripts/run_speaker_eval.sh"
+            add_command "python3 -m py_compile scripts/score_speaker_eval.py"
+            add_command "python3 -m py_compile scripts/aggregate_sweep.py"
+            add_command "bash build-deps.sh --force"
+            add_command "swift build --package-path Tools/SpeakerEvalHarness"
         fi
 
         if matches_any "$path" "build-beta.sh" "scripts/entrypoints/build-beta.sh" "scripts/release/*" "docs/release-packaging.md" "docs/sparkle-updates.md" "Casks/*" "docs/appcast.xml"; then


### PR DESCRIPTION
## Summary
- Add the speaker-naming simulator to the scripts guide.
- Add simulator compile/default/sweep checks to the agent test matrix.

## Verification
- bash scripts/dev/agent-preflight.sh
- git diff --check
- python3 -m py_compile scripts/ops/speaker-naming-simulator.py
- scripts/ops/speaker-naming-simulator.py
- scripts/ops/speaker-naming-simulator.py --sweep

## Notes
- Claude Code was called with the requested one-shot prompt but did not return useful output before being interrupted; this patch was reviewed manually against the recent origin/main changes.