### PR TITLE
eval: multi-corpus speaker-naming harness + AMI scale-up

### DIFF
--- a/Tools/SpeakerEvalHarness/AB_DOT_VS_CLOUD.md
+++ b/Tools/SpeakerEvalHarness/AB_DOT_VS_CLOUD.md
@@ -1,0 +1,99 @@
+# Speaker-Matcher A/B: DOT vs CLOUD — Final Verdict
+
+Adversarially-verified A/B (4 explore variants + 3 independent skeptic passes, every number
+re-run and reproduced) comparing the production-style **DOT** matcher against a proposed
+**CLOUD** matcher for cross-meeting speaker re-identification.
+
+**Reproduce:**
+```bash
+# 1. regenerate the 300 single-speaker meetings + cached embeddings (one split):
+bash scripts/download_voxceleb_sample.sh    # VOXCELEB_IDENTITY_CAP=30, singles mode
+CORPUS=voxceleb MATCH="0.6" scripts/run_speaker_eval.sh   # populates data/eval/voxceleb/dumps/
+# 2. run the A/B simulator over the cached embeddings:
+python3 scripts/ab_dot_vs_cloud.py --dumps-dir data/eval/voxceleb/dumps --max-app 8
+#    JSON for one config: ... --matcher cloud --thr 0.46 --cap 10 --json
+```
+`scripts/ab_dot_vs_cloud.py` implements both matchers (DOT = one EMA-averaged vector/profile,
+match by cosine≥thr; CLOUD = keep each profile's sample vectors, match a new clip to its
+*nearest* stored sample). The `cloud+merge` variant below was an explored extension run during
+the workflow; it is not in the committed simulator.
+
+## TL;DR
+Naive CLOUD does **not** decisively beat DOT. At matched ~30-profile parity CLOUD is
+**directionally** better on identity-continuity (reid +5 pts avg) and **cleaner** on
+false-merge, while **tied** on "recognized." But the margin sits **inside the N=30 noise
+floor** — every bootstrap 95% CI crosses zero. The one statistically robust lever found is
+internal to DOT: **tuning its EMA slower (0.3) → +19 pts, CI [+10.7, +27.8]**, a free one-line
+change with no extra memory.
+
+## DOT calibration (faithfulness check)
+Python DOT @ thr0.50/ema0.5 → reid m2..m5 = **33/50/57/43**, profiles_end **37**. Swift
+`SpeakerDatabase` ground truth → ~**36/48/55/33**, profiles ~**32**. Same rise-then-fall shape
+peaking at m4; m2/m3/m4 within ~2–3 pts. The PE overshoot is expected — the Python port omits
+the production `mergeDuplicates` pass and fixes ema=0.5. **DOT is a faithful stand-in.**
+
+## Fair operating points (the only honest comparison)
+Compare **only** where both end near the ideal **30 profiles** with comparable false_merge.
+
+| Config | thr | profiles_end | false_merge | avg reid (m2–m8) | avg recognized |
+|---|---|---|---|---|---|
+| **DOT** (best fair) | 0.45 / ema0.5 | 33 | 7 | 45 | 93 |
+| **CLOUD** (best fair) | 0.46 / cap10 | **30** | **5** | **50** | 94 |
+| cloud+merge | 0.55 / merge0.53 / cap10 | 30 | **0** | 48 | 79 |
+
+CLOUD sits at the **ideal 30 profiles with lower false_merge** than the 33-profile DOT it
+beats — the **stricter** side, so its edge is conservative, not bought with leniency. Forcing
+DOT down to PE=30 (thr~0.40) **doubles its false_merge to 10**.
+
+## Per-meeting comparison (reid-to-anchor = continuity with original identity)
+
+| Meeting | DOT 0.45 | CLOUD 0.46 | CLOUD−DOT | cloud+merge |
+|---|---|---|---|---|
+| m2 (1st return) | 53 | 47 | **−6** | 40 |
+| m3 | 50 | 60 | +10 | 63 |
+| m4 | 53 | 63 | +10 | 50 |
+| m5 | 47 | 47 | 0 | 40 |
+| m6 | 33 | 47 | +14 | 40 |
+| m7 | 37 | 40 | +3 | 50 |
+| m8 | 40 | 43 | +3 | 53 |
+| **avg** | **45** | **50** | **+5** | **48** |
+
+CLOUD wins 5/7 meetings, ties 1, **loses only m2** — the first re-encounter (where DOT also
+leads on "recognized," 83 vs 77). The CLOUD advantage **grows at the tail because DOT decays**
+(EMA blending lets duplicate badges drift and win the nearest-match), not because CLOUD climbs.
+
+## Does the best CLOUD curve climb with more meetings?
+**No.** CLOUD's reid spikes at m3–m4 (~60–63) then plateaus ~43–47. Neither matcher delivers the
+intuitive "better every meeting" — what changes is DOT sagging late while CLOUD holds.
+
+## What the skeptics concluded
+- **fairness-cherrypick — NOT refuted.** CLOUD wins at the ideal 30 profiles with *lower*
+  false_merge than the 33-profile DOT — the opposite of leniency.
+- **metric-artifact — refuted the "decisive" framing.** The +5 pt figure is reid-specific; on
+  "recognized" it's ~+1 pt and DOT wins m2.
+- **noise-overfit — refuted the magnitude.** Every fair pairing's 95% CI crosses zero (best
+  P(cloud>dot)=0.92); the matchers are *identical* for ~half the 30 speakers. The only effect
+  clearing the noise floor is DOT-internal: slow EMA (0.3) vs fast (0.7) = **+19 pp pooled**.
+
+## Recommendation
+1. **First, tune DOT's EMA toward 0.3** — the only change that clears the noise floor; one line,
+   zero memory cost.
+2. **If tail-continuity is the priority, prefer plain CLOUD (thr~0.46, cap10), not cloud+merge.**
+   Plain CLOUD matches DOT's recognized, beats it on reid at the ideal profile count with fewer
+   false-merges, and avoids the per-meeting merge pass. cloud+merge buys fm=0 but at a steep
+   recognized cost (79 vs 93).
+3. **Before any swap, run a larger in-domain eval** (100+ speakers, same-device audio).
+   VoxCeleb's harsh cross-recording variance (within-speaker cosine mean 0.49, p5 0.13 — ~40% of
+   true pairs below threshold) is an **optimistic upper bound**; the CLOUD edge should shrink
+   toward the measured zero on tight same-laptop data.
+
+**Bottom line:** CLOUD is a low-risk, roughly-neutral-to-slightly-positive alternative — safe to
+adopt, not proven to be an upgrade. Spend the cheap EMA win first; gate any matcher swap on a
+bigger, in-domain study.
+
+## Limits / caveats
+- N=30 speakers; per-meeting cells are means of 30 binaries (~9 pp SE) — the dominant constraint.
+- Single-speaker synthetic meetings; false_merge measures only cross-person bleed (no overlap).
+- Python port omits production `mergeDuplicates` + `EmbeddingClusterer` post-pass; fixes ema=0.5.
+- CLOUD memory/compute is ~10×/profile (up to 10 stored vectors vs DOT's 1) — a real cost not
+  captured by accuracy metrics.

--- a/Tools/SpeakerEvalHarness/README.md
+++ b/Tools/SpeakerEvalHarness/README.md
@@ -47,12 +47,63 @@ speaker-eval-harness replay --inputs a.json,b.json,c.json,d.json \
 ## Run the whole thing
 
 ```bash
-bash build-deps.sh            # one-time: native deps -> deps-libs/, deps-modules/, deps-frameworks/
-bash scripts/download_ami.sh     # AMI ES2002 a–d audio + RTTMs (~230 MB, gitignored)
-scripts/run_speaker_eval.sh   # build + dump + sweep + score -> data/eval/reports/SWEEP.md
+bash build-deps.sh                 # one-time: native deps -> deps-libs/, deps-modules/, deps-frameworks/
+bash scripts/download_ami.sh       # AMI ES2002 a–d audio + RTTMs (~230 MB, gitignored)
+scripts/run_speaker_eval.sh        # build + dump + sweep + score -> data/eval/ami/reports/SWEEP.md
 ```
 
-Override the grids via env: `SERIES`, `CONSOLIDATION`, `MATCH`, `COLLAR`.
+One driver, any corpus. `CORPUS` selects the dataset; `dump -> sweep -> score` is shared.
+Outputs land under `data/eval/<CORPUS>/{dumps,results,reports}/` (all gitignored).
+
+## Corpus mix (chosen, compute-capped — diverse identities, not all-of-everything)
+
+The point is a trustworthy near-zero-false-positive number from **diverse identities**,
+without burning multi-day compute. Each corpus has its own downloader; all data is
+gitignored under `data/`. Pick the tier that matches the compute you want to spend.
+
+| Corpus | What it tests | Downloader | Source / license | Footprint | Diarize compute¹ |
+|---|---|---|---|---|---|
+| **AMI** (default `scale`) | cross-meeting re-ID + false-merge, real recurring identities | `scripts/download_ami.sh scale` | AMI Corpus, research-use; RTTMs from pyannote/AMI-diarization-setup | ~1.8 GB (32 mtgs) | ~3 min |
+| **AMI full** | all scenario + non-scenario, ~100 h | `scripts/download_ami.sh full` | same | ~9–10 GB (~170 mtgs) | ~1–2 h |
+| **ICSI** | meeting corpus, heavily recurring lab speakers | `scripts/download_icsi.sh` | ICSI Corpus, research-use; RTTMs from HF `diarizers-community/icsi` (gated) | ~0.5–10 GB | ~10–60 min |
+| **VoxConverse** | in-the-wild YouTube, overlap, unknown counts | `scripts/download_voxconverse.sh` | VoxConverse, CC-BY 4.0; RTTMs from joonson/voxconverse | ~4 GB (dev+test) | ~30–90 min |
+| **VoxCeleb** (sample) | cross-recording re-ID / false-positive at scale | `scripts/download_voxceleb_sample.sh` | VoxCeleb1, CC-BY-SA 4.0 (HF mirror, gated) | bounded by cap (~few GB) | ~20–60 min |
+
+¹ Apple-Silicon diarization, ~100–200× realtime. **Excludes** the one-time CoreML model
+download and the per-corpus dataset download (which can dominate — see footprints).
+
+### Run each corpus / tier (one-liners)
+
+```bash
+# --- AMI: landed + scale-up validated (this is the always-safe tier) ---
+bash scripts/download_ami.sh scale      &&  CORPUS=ami        scripts/run_speaker_eval.sh   # ~32 mtgs, hours-bounded
+
+# --- gated heavy tiers: WIRED, not auto-run. Gate the compute yourself. ---
+bash scripts/download_ami.sh full        &&  CORPUS=ami        scripts/run_speaker_eval.sh   # full ~100 h AMI dump (HOURS)
+bash scripts/download_voxconverse.sh     &&  CORPUS=voxconverse scripts/run_speaker_eval.sh  # ~4 GB, in-the-wild
+bash scripts/download_icsi.sh            &&  CORPUS=icsi       scripts/run_speaker_eval.sh   # needs HF auth for RTTMs
+bash scripts/download_voxceleb_sample.sh &&  CORPUS=voxceleb   scripts/run_speaker_eval.sh   # HARD-CAPPED sample + synthetic sessions
+```
+
+### Env knobs
+
+| Knob | Default | Meaning |
+|---|---|---|
+| `CORPUS` | `ami` | `ami` \| `icsi` \| `voxconverse` \| `voxceleb` — selects audio/rttm dirs |
+| `SERIES` | all RTTMs present | subset of meeting ids to replay (space-separated) |
+| `AMI_SET` | `es2002` | `es2002` \| `scale` (32 mtgs) \| `full` (~170) — `download_ami.sh` preset |
+| `ICSI_SET` | `sample` | `sample` (6) \| `full` (75) — `download_icsi.sh` preset |
+| `VOXCONVERSE_SPLITS` | `dev test` | which VoxConverse splits to fetch |
+| `VOXCELEB_IDENTITY_CAP` | `300` | **HARD CAP** on sampled identities (max 1211; never the full corpus) |
+| `VOXCELEB_CLIPS_PER_ID` | `10` | clips kept per sampled identity |
+| `CONSOLIDATION` | `none 0.82 0.85 0.88 0.91` | within-meeting same-voice merge grid |
+| `MATCH` | `0.50 0.55 0.60 0.65 0.70` | cross-meeting DB match grid |
+| `COLLAR` | `0.25` | DER forgiveness collar (AMI convention) |
+
+**Gating note:** the full AMI dump, VoxConverse, ICSI, and the VoxCeleb sample are wired
+but intentionally **not** auto-run — they are hours-to-days of download + compute. Run the
+one-liner for the tier you want, on purpose. VoxCeleb is **always** sample-only and
+hard-capped; there is no "download all of VoxCeleb" path.
 
 ## Requirements
 
@@ -67,11 +118,18 @@ Override the grids via env: `SERIES`, `CONSOLIDATION`, `MATCH`, `COLLAR`.
 |---|---|
 | `Sources/speaker-eval-harness/main.swift` | `dump` + `replay` commands |
 | `Package.swift` | depends on root `TranscriptedCore`; mirrors deps link flags |
-| `BASELINE_REPORT.md` | measured baseline + threshold recommendations |
-| `../../scripts/run_speaker_eval.sh` | end-to-end driver |
-| `../../scripts/score_speaker_eval.py` | DER + fragmentation + false-merge + re-ID scorer |
+| `BASELINE_REPORT.md` | measured baseline (AMI ES2002) + threshold recommendations |
+| `SCALEUP_REPORT.md` | AMI scale-up (~32 mtgs / dozens of identities) results at scale |
+| `../../scripts/run_speaker_eval.sh` | end-to-end driver, keyed by `CORPUS` |
+| `../../scripts/score_speaker_eval.py` | DER + fragmentation + false-merge + re-ID scorer (corpus-agnostic) |
 | `../../scripts/aggregate_sweep.py` | sweep table + closest-to-ideal picker |
-| `../../scripts/download_ami.sh` | fetch the AMI subset |
+| `../../scripts/download_ami.sh` | AMI audio + RTTMs (`es2002` \| `scale` \| `full`) |
+| `../../scripts/download_icsi.sh` | ICSI audio (Edinburgh) + RTTMs (HF, gated) |
+| `../../scripts/download_voxconverse.sh` | VoxConverse dev+test audio + RTTMs |
+| `../../scripts/download_voxceleb_sample.sh` | VoxCeleb SAMPLE-only (hard-capped) + synthetic sessions |
+| `../../scripts/voxceleb_sample.py` | streaming VoxCeleb sampler with hard identity cap |
+| `../../scripts/build_voxceleb_sessions.py` | stitch sampled identities into multi-speaker sessions + RTTM |
+| `../../scripts/icsi_rttm_from_hf.py` | materialize loose ICSI RTTMs from the HF dataset |
 
 ## Caveats
 

--- a/Tools/SpeakerEvalHarness/README.md
+++ b/Tools/SpeakerEvalHarness/README.md
@@ -123,10 +123,12 @@ hard-capped; there is no "download all of VoxCeleb" path.
 | `Sources/speaker-eval-harness/main.swift` | `dump` + `replay` commands |
 | `Package.swift` | depends on root `TranscriptedCore`; mirrors deps link flags |
 | `BASELINE_REPORT.md` | measured baseline (AMI ES2002) + threshold recommendations |
+| `AB_DOT_VS_CLOUD.md` | dot-vs-cloud matcher A/B (cross-meeting re-ID) |
 | `SCALEUP_REPORT.md` | AMI scale-up (~32 mtgs / dozens of identities) results at scale |
 | `../../scripts/run_speaker_eval.sh` | end-to-end driver, keyed by `CORPUS` |
 | `../../scripts/score_speaker_eval.py` | DER + fragmentation + false-merge + re-ID scorer (corpus-agnostic) |
 | `../../scripts/aggregate_sweep.py` | sweep table + closest-to-ideal picker |
+| `../../scripts/ab_dot_vs_cloud.py` | dot-vs-cloud matcher A/B simulator (runs on cached embeddings) |
 | `../../scripts/download_ami.sh` | AMI audio + RTTMs (`es2002` \| `scale` \| `full`) |
 | `../../scripts/download_icsi.sh` | ICSI audio (Edinburgh) + RTTMs (HF, gated) |
 | `../../scripts/download_voxconverse.sh` | VoxConverse dev+test audio + RTTMs |

--- a/Tools/SpeakerEvalHarness/README.md
+++ b/Tools/SpeakerEvalHarness/README.md
@@ -67,7 +67,7 @@ gitignored under `data/`. Pick the tier that matches the compute you want to spe
 | **AMI full** | all scenario + non-scenario, ~100 h | `scripts/download_ami.sh full` | same | ~9–10 GB (~170 mtgs) | ~1–2 h |
 | **ICSI** | meeting corpus, heavily recurring lab speakers | `scripts/download_icsi.sh` | ICSI Corpus, research-use; RTTMs from HF `diarizers-community/icsi` (gated) | ~0.5–10 GB | ~10–60 min |
 | **VoxConverse** | in-the-wild YouTube, overlap, unknown counts | `scripts/download_voxconverse.sh` | VoxConverse, CC-BY 4.0; RTTMs from joonson/voxconverse | ~4 GB (dev+test) | ~30–90 min |
-| **VoxCeleb** (sample) | cross-recording re-ID / false-positive at scale | `scripts/download_voxceleb_sample.sh` | VoxCeleb1, CC-BY-SA 4.0 (HF mirror, gated) | bounded by cap (~few GB) | ~20–60 min |
+| **VoxCeleb** (sample) | cross-recording re-ID / false-positive (matcher-isolated) | `scripts/download_voxceleb_sample.sh` | VoxCeleb1, CC-BY-SA 4.0 (public `s3prl/mini_voxceleb1` default; larger mirrors gated) | bounded by cap (~few GB) | ~20–60 min |
 
 ¹ Apple-Silicon diarization, ~100–200× realtime. **Excludes** the one-time CoreML model
 download and the per-corpus dataset download (which can dominate — see footprints).
@@ -96,6 +96,8 @@ bash scripts/download_voxceleb_sample.sh &&  CORPUS=voxceleb   scripts/run_speak
 | `VOXCONVERSE_SPLITS` | `dev test` | which VoxConverse splits to fetch |
 | `VOXCELEB_IDENTITY_CAP` | `300` | **HARD CAP** on sampled identities (max 1211; never the full corpus) |
 | `VOXCELEB_CLIPS_PER_ID` | `10` | clips kept per sampled identity |
+| `VOXCELEB_DATASET` | `s3prl/mini_voxceleb1` | HF mirror (public default; swap for a larger/gated one) |
+| `VOXCELEB_MODE` | `singles` | `singles` (1 clip/meeting → isolates the matcher) \| `sessions` (stitched multi-speaker → also stresses diarizer) |
 | `CONSOLIDATION` | `none 0.82 0.85 0.88 0.91` | within-meeting same-voice merge grid |
 | `MATCH` | `0.50 0.55 0.60 0.65 0.70` | cross-meeting DB match grid |
 | `COLLAR` | `0.25` | DER forgiveness collar (AMI convention) |
@@ -110,7 +112,9 @@ hard-capped; there is no "download all of VoxCeleb" path.
 - macOS 14+ on Apple Silicon (CoreML diarizer models, downloaded once from HuggingFace).
 - Prebuilt deps from `build-deps.sh` (`deps-libs/libExternalDeps.a`, `deps-modules/`,
   `deps-frameworks/`). The harness `Package.swift` resolves them relative to the repo root.
-- Python: `pyannote.metrics` (`pip install pyannote.metrics`).
+- Python: `pyannote.metrics` (`pip install pyannote.metrics`) for scoring. The VoxCeleb
+  sampler additionally needs `datasets` + `ffmpeg`; ICSI RTTM materialization needs
+  `datasets` (`pip install datasets`).
 
 ## Files
 

--- a/Tools/SpeakerEvalHarness/SCALEUP_REPORT.md
+++ b/Tools/SpeakerEvalHarness/SCALEUP_REPORT.md
@@ -67,10 +67,12 @@ To get a real near-zero-false-positive number you need corpora where a *single c
 identity per source* removes the diarizer-mixing confound, so the metric isolates the DB
 matcher's cross-recording discipline:
 
-- **VoxCeleb (sample, hard-capped)** — each clip is one clean speaker; synthetic
-  multi-identity sessions give an exact RTTM with **no** within-source mixing, so
-  false-merge measures *only* the matcher fusing two genuinely-different people. This is
-  the cleanest false-positive test. (Wired, gated; `scripts/download_voxceleb_sample.sh`.)
+- **VoxCeleb (sample, hard-capped)** — each clip is one clean speaker. Use **`singles`
+  mode** (one clip = one single-speaker meeting): the diarizer trivially sees one voice, so
+  the metric isolates *only* the DB matcher's cross-recording re-ID / false-positive. This is
+  the cleanest matcher test. (NOTE: the `sessions` mode that stitches clips into multi-speaker
+  recordings re-introduces the diarizer confound — see the Addendum below. Run via
+  `scripts/download_voxceleb_sample.sh`; default public mirror, no HF login.)
 - **VoxConverse** — in-the-wild overlap/codec stress with real RTTMs, the over-segmentation
   regime where the 0.88 consolidation knob can finally fire. (Wired, gated.)
 - **ICSI** — heavily recurring lab speakers across many meetings, a second meeting-domain
@@ -89,3 +91,46 @@ estimates. The gated tiers are wired but intentionally not auto-run.
 
 (Consolidation collapsed because all four values are identical at every match — the inertia
 finding. Full grid in the gitignored `SWEEP.md`.)
+
+---
+
+## Addendum — VoxCeleb matcher-isolation smoke (preliminary, N=6, real audio)
+
+A small real run on the `voxceleb` corpus, **deliberately isolating the matcher** from the
+diarizer, surfaces the opposite failure mode from AMI — and one AMI structurally cannot show.
+
+**Setup.** 6 distinct VoxCeleb1 identities (public `s3prl/mini_voxceleb1`), 4 clips each from
+*different source videos*. Two builders:
+- **`sessions`** (stitched multi-speaker) — even with clean single-identity source clips, the
+  diarizer **collapses 4 voices into 1–2 clusters** (DER 0.47, false-merge 5/6). The diarizer
+  confound returns; this mode does **not** isolate the matcher.
+- **`singles`** (one clip = one single-speaker meeting) — diarizer trivially sees one clean
+  voice (**DER 0.07–0.08**), so the metric is purely the DB matcher's cross-recording behavior.
+
+**Singles result (match sweep, the clean matcher number):**
+
+| match | mean DER | false-merge | frag mean | re-ID #2+ | profiles_end (ideal 6) |
+|---|---|---|---|---|---|
+| 0.55 | 0.070 | 1 | 2.33 | 0.33 | 11 |
+| 0.60 | 0.084 | 2 | 2.33 | 0.27 | 13 |
+| 0.65 | 0.084 | 1 | 2.50 | 0.27 | 18 |
+| 0.70 | 0.084 | 1 | 2.67 | 0.21 | 19 |
+
+**Reading:** with the diarizer out of the way, the matcher's problem is **not** fusing
+different people (false-merge stays 1–2) — it is **fragmentation / poor cross-recording
+re-ID**: 6 real people explode into 11–19 profiles, and re-ID of a returning speaker is only
+~0.2–0.33. The same person recorded in two different sessions lands *below* the 0.60 match
+threshold and is filed as a new person. This is the real-world "why did it make a new speaker
+for the same person?" failure — invisible on AMI (same-room series + diarizer confound), exposed
+here.
+
+**Caveats (do not over-read):** N=6 / 4 clips, so this is directional, not certified. VoxCeleb
+is in-the-wild celebrity audio across decades/mics — *more* cross-recording variability than
+Transcripted's typical same-laptop calls, so it likely overstates the fragmentation. The honest
+takeaway: AMI says "0.60 ends at the right count and false-merge is diarizer-bound"; VoxCeleb-clean
+says "0.60 may be too high to re-identify the same person across genuinely different recordings."
+**Resolving that tension is the next real experiment** — a larger capped VoxCeleb singles run
+(`VOXCELEB_IDENTITY_CAP=300`) plus, ideally, in-domain (Zoom-like) labeled audio.
+
+Repro: `scripts/download_voxceleb_sample.sh` (defaults: public mini mirror, `singles` mode) then
+`CORPUS=voxceleb scripts/run_speaker_eval.sh`.

--- a/Tools/SpeakerEvalHarness/SCALEUP_REPORT.md
+++ b/Tools/SpeakerEvalHarness/SCALEUP_REPORT.md
@@ -1,0 +1,91 @@
+# Speaker-naming eval — AMI scale-up (8 scenario series, ~32 recurring identities)
+
+**Date:** 2026-06-16 · **Corpus:** AMI Meeting Corpus, Mix-Headset, **32 meetings** =
+8 scenario series × sessions a–d (`ES2002, ES2003, ES2005, ES2006, ES2007, ES2008, ES2009,
+ES2010`). Each series is a disjoint group of 4 people who recur across its 4 sessions, so
+the replay carries **32 distinct identities, each appearing 4×** — a few dozen recurring
+identities, the diverse-identity surface the scale-up was meant to exercise.
+**15.85 h of audio. License:** AMI research-use; RTTMs from `pyannote/AMI-diarization-setup`
+`only_words`. Audio/RTTMs/dumps gitignored, never committed.
+
+Reproduce: `bash scripts/download_ami.sh scale && CORPUS=ami CONSOLIDATION="none 0.85 0.88
+0.91" MATCH="0.55 0.60 0.65" scripts/run_speaker_eval.sh`. Full sweep table in
+`data/eval/ami/reports/SWEEP.md` (gitignored).
+
+> **Throughput:** the whole pipeline — diarize 15.85 h of audio + 12-combo threshold sweep
+> + DER/fragmentation/false-merge/re-ID scoring on all 32 meetings — ran in **6.2 minutes**
+> wall-clock (~150× realtime). The scale-up is minutes, not hours; the gated tiers below are
+> dominated by *download*, not compute.
+
+---
+
+## TL;DR at scale (8× the meetings, 8× the identities of the baseline)
+
+| Finding | Baseline (ES2002, 4 mtgs, 4 ids) | **Scale-up (32 mtgs, 32 ids)** | Verdict |
+|---|---|---|---|
+| **Match 0.60 ends at the right profile count** | 4 profiles for 4 people ✓ | **32 profiles for 32 people ✓** (0.55→25 over-merge, 0.65→35 fragment) | **Re-confirmed. Keep 0.60.** |
+| **0.88 consolidation knob** | structurally inert | **inert at scale too** — `none/0.85/0.88/0.91` give *identical* metrics at every match | **Re-confirmed inert on AMI.** Can't be calibrated here. |
+| **DER (diarizer quality)** | mean 0.404 | mean **0.437** (confusion 0.298, miss 0.104) | Diarizer-bound, ~flat — upstream of both thresholds. |
+| **False-merge (false-positive proxy)** | 3 | **22** | **Diarizer-bound, NOT matcher-bound** — see below. |
+| **Cross-meeting re-ID #2+** | 0.42 | **~0.53** (#1 .81, #2 .49, #3 .55, #4 .56) | Improved with more per-identity data. |
+
+**Recommended settings hold at scale: consolidation = 0.88 (safe-but-inert on AMI),
+match = 0.60 (the exact-count sweet spot).** At match 0.60 the run ends with exactly
+**32 profiles for 32 true people** — the matcher's cross-meeting discipline is neither
+collapsing distinct people nor exploding into spurious profiles.
+
+---
+
+## Why false-merge = 22 is a diarizer ceiling, not a matcher failure
+
+All 32 meetings have **4** true speakers. The app's diarizer (grid-searched on 2-party
+Zoom) **under-segments 4-party in-room AMI**:
+
+| hyp profiles per meeting | 2 | 3 | 4 | 5 | 6 |
+|---|---|---|---|---|---|
+| # meetings | 8 | 14 | **5** | 4 | 1 |
+
+**22 of 32 meetings (69%) emit fewer clusters than there are people.** When the diarizer
+hands back 2–3 clusters for 4 speakers, each cluster **already mixes two or three real
+identities before the matcher ever runs** — so the resulting DB profile inevitably spans
+multiple true people. The 22 false-merges decompose as 11 profiles spanning 2 people,
+9 spanning 3, 2 spanning 4 — i.e. they track the 22 under-segmented meetings, not the
+match threshold (false-merge is flat at 22 across all four consolidation values at match
+0.60). DER is dominated by the **confusion** term (0.298 of 0.437), the signature of
+within-meeting speaker mixing, with low miss (0.104).
+
+**Consequence:** AMI — *even scaled to 32 identities* — cannot produce the trustworthy
+near-zero-false-positive number, because its dominant error is the diarizer under-segmenting
+in-room multi-party audio, not the speaker-DB matcher wrongly fusing clean voices. The
+scale-up's value is exactly this: it (1) proves the harness runs end-to-end at scale in
+minutes, (2) re-confirms **both** threshold conclusions at 8× the meetings and identities,
+and (3) quantifies that the false-positive ceiling on AMI is **diarizer-bound**.
+
+## What this motivates (the corpus mix)
+
+To get a real near-zero-false-positive number you need corpora where a *single clean
+identity per source* removes the diarizer-mixing confound, so the metric isolates the DB
+matcher's cross-recording discipline:
+
+- **VoxCeleb (sample, hard-capped)** — each clip is one clean speaker; synthetic
+  multi-identity sessions give an exact RTTM with **no** within-source mixing, so
+  false-merge measures *only* the matcher fusing two genuinely-different people. This is
+  the cleanest false-positive test. (Wired, gated; `scripts/download_voxceleb_sample.sh`.)
+- **VoxConverse** — in-the-wild overlap/codec stress with real RTTMs, the over-segmentation
+  regime where the 0.88 consolidation knob can finally fire. (Wired, gated.)
+- **ICSI** — heavily recurring lab speakers across many meetings, a second meeting-domain
+  re-ID surface. (Wired, gated.)
+
+See **README.md → Corpus mix** for the per-tier one-liners, env knobs, and compute
+estimates. The gated tiers are wired but intentionally not auto-run.
+
+## Per-combo numbers (match × consolidation)
+
+| consolidation | match | mean DER | frag mean | false-merge | re-ID #2+ | profiles_end (ideal 32) |
+|---|---|---|---|---|---|---|
+| none/0.85/0.88/0.91 | 0.55 | 0.436 | 1.72 | 19 | 0.547 | 25 (over-merged) |
+| none/0.85/0.88/0.91 | **0.60** | **0.437** | **1.59** | **22** | **0.532** | **32 ✓** |
+| none/0.85/0.88/0.91 | 0.65 | 0.416 | 1.75 | 24 | 0.519 | 35 (fragmented) |
+
+(Consolidation collapsed because all four values are identical at every match — the inertia
+finding. Full grid in the gitignored `SWEEP.md`.)

--- a/Tools/SpeakerEvalHarness/SCALEUP_REPORT.md
+++ b/Tools/SpeakerEvalHarness/SCALEUP_REPORT.md
@@ -94,43 +94,56 @@ finding. Full grid in the gitignored `SWEEP.md`.)
 
 ---
 
-## Addendum — VoxCeleb matcher-isolation smoke (preliminary, N=6, real audio)
+## Addendum — VoxCeleb matcher-isolation sweep (30 real identities, 300 meetings)
 
-A small real run on the `voxceleb` corpus, **deliberately isolating the matcher** from the
-diarizer, surfaces the opposite failure mode from AMI — and one AMI structurally cannot show.
+A real run on the `voxceleb` corpus, **deliberately isolating the matcher** from the diarizer,
+surfaces the opposite failure mode from AMI — one AMI structurally cannot show — and quantifies
+it across a full match sweep.
 
-**Setup.** 6 distinct VoxCeleb1 identities (public `s3prl/mini_voxceleb1`), 4 clips each from
-*different source videos*. Two builders:
-- **`sessions`** (stitched multi-speaker) — even with clean single-identity source clips, the
-  diarizer **collapses 4 voices into 1–2 clusters** (DER 0.47, false-merge 5/6). The diarizer
-  confound returns; this mode does **not** isolate the matcher.
-- **`singles`** (one clip = one single-speaker meeting) — diarizer trivially sees one clean
-  voice (**DER 0.07–0.08**), so the metric is purely the DB matcher's cross-recording behavior.
+**Setup.** **30 distinct VoxCeleb1 identities** (public `s3prl/mini_voxceleb1`), 10 clips each
+from different recordings = **300 single-speaker "meetings"** (`--mode singles`: one clip = one
+meeting). Each identity appears 10× across the replay. The diarizer trivially sees one clean
+voice — **278/300 meetings = exactly 1 cluster, DER 0.10** — so the metric is purely the DB
+matcher's cross-recording behavior. (Contrast `--mode sessions`, which stitches clips into
+multi-speaker audio: the diarizer then collapses 4 voices into 1–2 clusters, DER 0.47, and the
+diarizer confound returns. Singles is the matcher-isolating mode.)
 
-**Singles result (match sweep, the clean matcher number):**
+**Match sweep — 30 true identities, ideal `profiles_end` = 30:**
 
-| match | mean DER | false-merge | frag mean | re-ID #2+ | profiles_end (ideal 6) |
+| match | mean DER | false-merge | frag mean | re-ID #2+ | profiles_end (ideal 30) |
 |---|---|---|---|---|---|
-| 0.55 | 0.070 | 1 | 2.33 | 0.33 | 11 |
-| 0.60 | 0.084 | 2 | 2.33 | 0.27 | 13 |
-| 0.65 | 0.084 | 1 | 2.50 | 0.27 | 18 |
-| 0.70 | 0.084 | 1 | 2.67 | 0.21 | 19 |
+| 0.45 | 0.101 | 5 | 2.10 | 0.367 | 28 (slightly over-merged) |
+| **0.50** | 0.103 | 6 | 2.00 | **0.383** | **32 (closest to 30)** |
+| 0.55 | 0.106 | 6 | 2.07 | 0.330 | 42 |
+| **0.60** (prod) | 0.111 | 6 | 2.23 | 0.286 | **53** |
+| 0.65 | 0.111 | 5 | 2.60 | 0.181 | 81 |
+| 0.70 | 0.112 | 10 | 2.60 | 0.156 | 118 |
+| 0.75 | 0.112 | 10 | 2.90 | 0.067 | 168 |
 
-**Reading:** with the diarizer out of the way, the matcher's problem is **not** fusing
-different people (false-merge stays 1–2) — it is **fragmentation / poor cross-recording
-re-ID**: 6 real people explode into 11–19 profiles, and re-ID of a returning speaker is only
-~0.2–0.33. The same person recorded in two different sessions lands *below* the 0.60 match
-threshold and is filed as a new person. This is the real-world "why did it make a new speaker
-for the same person?" failure — invisible on AMI (same-room series + diarizer confound), exposed
-here.
+**Reading.** With the diarizer out of the way, the matcher does **not** mostly fuse different
+people (false-merge stays 5–6 until 0.70). Its dominant failure is **fragmentation / weak
+cross-recording re-ID**: at the production **match 0.60, 30 real people explode into 53
+profiles** (≈1.8 profiles/person) and a returning speaker is re-identified to their first
+profile only **29%** of the time. Raising the threshold makes it dramatically worse (0.75 →
+**168 profiles for 30 people**, re-ID 0.07); the same person in a *different* recording lands
+below threshold and is filed as a new person. The count-optimal operating point here is
+**match ≈ 0.50** (32 profiles ≈ 30, best re-ID 0.38, false-merge no worse than 0.60's).
 
-**Caveats (do not over-read):** N=6 / 4 clips, so this is directional, not certified. VoxCeleb
-is in-the-wild celebrity audio across decades/mics — *more* cross-recording variability than
-Transcripted's typical same-laptop calls, so it likely overstates the fragmentation. The honest
-takeaway: AMI says "0.60 ends at the right count and false-merge is diarizer-bound"; VoxCeleb-clean
-says "0.60 may be too high to re-identify the same person across genuinely different recordings."
-**Resolving that tension is the next real experiment** — a larger capped VoxCeleb singles run
-(`VOXCELEB_IDENTITY_CAP=300`) plus, ideally, in-domain (Zoom-like) labeled audio.
+**The quantified tension.** AMI (consistent in-room recordings) says *"0.60 ends at exactly the
+right count; false-merge is diarizer-bound."* VoxCeleb-clean (cross-recording) says *"0.60 is too
+high to re-identify the same person across different recordings — it fragments them ~1.8×; ~0.50
+is better."* Both are real; they disagree because they stress different things. Transcripted's
+true optimum is likely **between** them, since its same-laptop calls are *more* consistent than
+VoxCeleb's celebrity-audio-across-decades but *less* consistent than AMI's single-session series.
 
-Repro: `scripts/download_voxceleb_sample.sh` (defaults: public mini mirror, `singles` mode) then
-`CORPUS=voxceleb scripts/run_speaker_eval.sh`.
+**Caveats.** 30 ids / 10 clips is a solid sample but VoxCeleb's cross-recording variability is
+harsher than typical Transcripted usage, so this likely *overstates* the fragmentation — read
+the **direction** (0.60 over-fragments cross-recording; lower helps), not the exact profile count.
+The public `mini_voxceleb1` mirror caps at 30 ids; scaling to hundreds needs a larger (gated) HF
+mirror or webdataset handling — and unauthenticated bulk fetches get HF-rate-limited (set
+`HF_TOKEN`). The decisive next experiment is **in-domain (Zoom-like) labeled audio**, where the
+matcher's real operating point can be set without VoxCeleb's domain gap.
+
+Repro: `scripts/download_voxceleb_sample.sh` (public mini mirror, `singles` mode; for the full
+sweep `VOXCELEB_CLIPS_PER_ID=10 VOXCELEB_IDENTITY_CAP=30`) then
+`CORPUS=voxceleb MATCH="0.45 0.50 0.55 0.60 0.65 0.70 0.75" scripts/run_speaker_eval.sh`.

--- a/scripts/ab_dot_vs_cloud.py
+++ b/scripts/ab_dot_vs_cloud.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Controlled dot-vs-cloud speaker-matcher A/B on cached VoxCeleb embeddings.
+
+Replays the SAME single-speaker meetings (sorted order = round-robin across speakers)
+through two matchers, everything else identical:
+  DOT   - one EMA-averaged 256-d vector/profile; match cosine>=thr (today's design).
+  CLOUD - keep each profile's sample vectors; match a new clip to its NEAREST stored sample.
+
+Metrics per matcher:
+  reid_to_anchor[k] = % of meeting-k clips assigned to the profile created at the person's
+                      FIRST meeting (continuity with original identity).
+  recognized[k]     = % of meeting-k clips matched to ANY existing profile (not a brand-new
+                      badge) -> "did we treat them as a returning person at all".
+  profiles_end      = badges created for n_true real people (ideal = n_true).
+  false_merge       = profiles whose mass spans >=2 distinct true speakers (>=10% each).
+
+Modes:
+  (no --matcher) -> human-readable sweep table for both matchers.
+  --matcher dot|cloud --thr T [--ema E|--cap C] --json -> one JSON result (for agents).
+"""
+import argparse, glob, json, math, os, sys
+from collections import defaultdict
+
+def cluster_mean(segs):
+    def mean(embs):
+        if not embs: return None
+        dim=len(embs[0]); s=[0.0]*dim
+        for e in embs:
+            if len(e)==dim:
+                for i in range(dim): s[i]+=e[i]
+        n=len(embs); s=[x/n for x in s]
+        nrm=math.sqrt(sum(x*x for x in s)) or 1.0
+        return [x/nrm for x in s]
+    good=[sg["embedding"] for sg in segs if sg.get("embedding") and sg["quality"]>=0.3 and (sg["end"]-sg["start"])>=1.0]
+    if good: return mean(good)
+    allv=[sg["embedding"] for sg in segs if sg.get("embedding")]
+    return mean(allv)
+
+def load_meetings(dumps_dir):
+    out=[]
+    for f in sorted(glob.glob(os.path.join(dumps_dir,"*.json"))):
+        d=json.load(open(f)); m=d["meeting"]; spk=m.split("_",1)[1]
+        emb=cluster_mean(d["segments"])
+        if emb is not None: out.append((m,spk,emb))
+    return out
+
+def cos(a,b): return sum(x*y for x,y in zip(a,b))
+def l2norm(v):
+    n=math.sqrt(sum(x*x for x in v)) or 1.0
+    return [x/n for x in v]
+
+class DotDB:
+    def __init__(self,thr,ema): self.thr=thr; self.ema=ema; self.P=[]
+    def assign(self,emb,true):
+        best,bi=-2,-1
+        for i,p in enumerate(self.P):
+            c=cos(emb,p["vec"])
+            if c>best: best,bi=c,i
+        new = not (bi>=0 and best>=self.thr)
+        if not new:
+            p=self.P[bi]; p["vec"]=l2norm([(1-self.ema)*o+self.ema*e for o,e in zip(p["vec"],emb)]); p["counts"][true]+=1
+            return bi,False
+        self.P.append({"vec":emb[:],"counts":defaultdict(int)}); self.P[-1]["counts"][true]+=1
+        return len(self.P)-1,True
+
+class CloudDB:
+    def __init__(self,thr,cap): self.thr=thr; self.cap=cap; self.P=[]
+    def assign(self,emb,true):
+        best,bi=-2,-1
+        for i,p in enumerate(self.P):
+            c=max(cos(emb,s) for s in p["samples"])
+            if c>best: best,bi=c,i
+        new = not (bi>=0 and best>=self.thr)
+        if not new:
+            p=self.P[bi]; p["samples"].append(emb)
+            if len(p["samples"])>self.cap: p["samples"].pop(0)
+            p["counts"][true]+=1
+            return bi,False
+        self.P.append({"samples":[emb[:]],"counts":defaultdict(int)}); self.P[-1]["counts"][true]+=1
+        return len(self.P)-1,True
+
+def evaluate(meetings, db, max_app):
+    anchor={}; appear=defaultdict(int)
+    to_anchor=defaultdict(list); recog=defaultdict(list)
+    for (m,spk,emb) in meetings:
+        pid,is_new=db.assign(emb,spk)
+        appear[spk]+=1; k=appear[spk]
+        if k==1: anchor[spk]=pid
+        else:
+            to_anchor[k].append(1 if pid==anchor[spk] else 0)
+            recog[k].append(0 if is_new else 1)
+    cur=lambda d:{k:round(100*sum(v)/len(v)) for k,v in sorted(d.items()) if k<=max_app}
+    fm=0
+    for p in db.P:
+        tot=sum(p["counts"].values()) or 1
+        if sum(1 for t,c in p["counts"].items() if c/tot>=0.10)>=2: fm+=1
+    return cur(to_anchor), cur(recog), len(db.P), fm
+
+def run(meetings, matcher, thr, ema, cap, max_app):
+    db = DotDB(thr,ema) if matcher=="dot" else CloudDB(thr,cap)
+    a,r,pe,fm = evaluate(meetings, db, max_app)
+    return {"matcher":matcher,"thr":thr,"ema":ema if matcher=="dot" else None,
+            "cap":cap if matcher=="cloud" else None,
+            "reid_to_anchor":a,"recognized":r,"profiles_end":pe,"false_merge":fm}
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument("--dumps-dir",default="data/eval/voxceleb/dumps")
+    ap.add_argument("--matcher",choices=["dot","cloud"])
+    ap.add_argument("--thr",type=float); ap.add_argument("--ema",type=float,default=0.5)
+    ap.add_argument("--cap",type=int,default=10); ap.add_argument("--max-app",type=int,default=8)
+    ap.add_argument("--json",action="store_true")
+    args=ap.parse_args()
+    M=load_meetings(args.dumps_dir)
+    n_true=len(set(s for _,s,_ in M))
+    if args.matcher and args.thr is not None:
+        res=run(M,args.matcher,args.thr,args.ema,args.cap,args.max_app); res["n_true"]=n_true; res["n_meetings"]=len(M)
+        print(json.dumps(res)); return
+    print(f"loaded {len(M)} meetings, {n_true} true speakers (ideal profiles={n_true})\n")
+    print("DOT (one EMA vector):  reid-to-anchor by meeting #")
+    for thr in (0.45,0.50,0.55,0.60):
+        r=run(M,"dot",thr,args.ema,args.cap,args.max_app)
+        cells=" ".join(f"m{k}:{r['reid_to_anchor'].get(k,'-'):>3}" for k in range(2,args.max_app+1))
+        print(f"  thr={thr:.2f} | {cells} | profiles={r['profiles_end']:>3} fm={r['false_merge']}")
+    print("\nCLOUD (nearest stored sample):  reid-to-anchor by meeting #")
+    for thr in (0.55,0.60,0.65,0.70,0.75):
+        r=run(M,"cloud",thr,args.ema,args.cap,args.max_app)
+        cells=" ".join(f"m{k}:{r['reid_to_anchor'].get(k,'-'):>3}" for k in range(2,args.max_app+1))
+        print(f"  thr={thr:.2f} | {cells} | profiles={r['profiles_end']:>3} fm={r['false_merge']}")
+
+if __name__=="__main__": main()

--- a/scripts/aggregate_sweep.py
+++ b/scripts/aggregate_sweep.py
@@ -6,6 +6,7 @@ import argparse, json
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--scores", required=True, help="comma-separated score JSON paths")
+    ap.add_argument("--corpus", default="AMI", help="corpus name for the report title")
     ap.add_argument("--out-md")
     args = ap.parse_args()
 
@@ -34,9 +35,10 @@ def main():
     n_true = rows[0]["n_true"] if rows else 0
 
     out = []
-    out.append("# Speaker-naming threshold sweep — AMI ES2002 (a–d), one recurring 4-person series\n")
-    out.append(f"True speakers in series: **{n_true}**. Ideal profiles_end = {n_true}. "
-               "Ideal fragmentation = 1.0/person. Ideal false-merge = 0. Ideal re-ID = 1.0.\n")
+    out.append(f"# Speaker-naming threshold sweep — {args.corpus}\n")
+    out.append(f"Distinct true speakers across the replay: **{n_true}**. Ideal profiles_end = "
+               f"{n_true} (one profile per real person). Ideal fragmentation = 1.0/person. "
+               "Ideal false-merge = 0 (the near-zero-false-positive bar). Ideal re-ID = 1.0.\n")
     out.append("| consolidation | match | mean DER | frag mean | frag max | false-merge | re-ID #2+ | profiles_end |")
     out.append("|---|---|---|---|---|---|---|---|")
     for r in rows:

--- a/scripts/build_voxceleb_sessions.py
+++ b/scripts/build_voxceleb_sessions.py
@@ -48,10 +48,51 @@ def make_silence(path, sr, dur):
          "-i", f"anullsrc=r={sr}:cl=mono", "-c:a", "pcm_s16le", path])
 
 
+def build_singles(ids, clips, raw_dir, out_dir, sr):
+    """One clip = one single-speaker 'meeting'. The diarizer trivially sees one clean
+    voice (no within-session mixing to confound it), so the eval isolates the DB matcher:
+    does it keep N people as N profiles, re-identify each across their clips, and never
+    fuse two different people? This is the clean cross-recording re-ID / false-positive
+    test. Meetings are emitted round-robin across identities so sorted replay order
+    interleaves them (each identity's appearances spread across the run)."""
+    audio_dir = os.path.join(out_dir, "audio")
+    rttm_dir = os.path.join(out_dir, "rttm")
+    os.makedirs(audio_dir, exist_ok=True)
+    os.makedirs(rttm_dir, exist_ok=True)
+    cursor = {s: 0 for s in ids}
+    remaining = sum(len(clips[s]) for s in ids)
+    n = 0
+    appear = {}
+    while remaining > 0:
+        for spk in ids:
+            i = cursor[spk]
+            if i >= len(clips[spk]):
+                continue
+            cursor[spk] += 1
+            remaining -= 1
+            src = os.path.join(raw_dir, spk, clips[spk][i])
+            mid = f"m{n:04d}_{spk}"
+            dst = os.path.join(audio_dir, f"{mid}.wav")
+            try:
+                normalize(src, dst, sr)
+                dur = ffprobe_duration(dst)
+            except subprocess.CalledProcessError:
+                continue
+            with open(os.path.join(rttm_dir, f"{mid}.rttm"), "w") as f:
+                f.write(f"SPEAKER {mid} 1 0.000 {dur:.3f} <NA> <NA> {spk} <NA> <NA>\n")
+            appear[spk] = appear.get(spk, 0) + 1
+            n += 1
+    print(json.dumps({"mode": "singles", "meetings": n, "distinct_identities": len(appear),
+                      "clips_per_identity": appear}, indent=2))
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--raw-dir", required=True, help="data/voxceleb/raw/<spk>/*.wav")
     ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--mode", choices=["sessions", "singles"], default="sessions",
+                    help="sessions = stitched multi-speaker (stresses diarizer too); "
+                         "singles = one clip/meeting (isolates the DB matcher — clean re-ID/false-positive)")
     ap.add_argument("--num-sessions", type=int, default=20)
     ap.add_argument("--speakers-per-session", type=int, default=4)
     ap.add_argument("--clips-per-speaker", type=int, default=3)
@@ -67,6 +108,13 @@ def main():
     clips = {s: sorted(f for f in os.listdir(os.path.join(args.raw_dir, s))
                        if f.lower().endswith(".wav")) for s in ids}
     ids = [s for s in ids if clips[s]]
+
+    if args.mode == "singles":
+        if len(ids) < 2:
+            print(f"error: only {len(ids)} identities; need >= 2", file=sys.stderr); sys.exit(1)
+        build_singles(ids, clips, args.raw_dir, args.out_dir, args.sr)
+        return
+
     spk_n = args.speakers_per_session
     if len(ids) < spk_n:
         print(f"error: only {len(ids)} identities; need >= {spk_n}", file=sys.stderr); sys.exit(1)

--- a/scripts/build_voxceleb_sessions.py
+++ b/scripts/build_voxceleb_sessions.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Build synthetic multi-identity "sessions" (WAV + ground-truth RTTM) from sampled
+VoxCeleb identities, for the cross-recording re-ID / false-positive test.
+
+Why synthetic sessions: VoxCeleb gives many short single-speaker clips per identity but no
+multi-speaker recordings. We stitch clips from several identities into conversational
+sessions and emit an exact RTTM (we know who speaks when). Sessions are constructed so that:
+
+  * the SAME identities RECUR across sessions, using DIFFERENT clips each time
+    -> measures cross-recording re-ID (does the DB re-identify a person from new audio?).
+  * MANY distinct identities appear overall, and within a session each identity is a
+    different person -> measures false-merge / false-positive (does the DB wrongly fuse
+    two different people into one profile?).
+
+Deterministic (no RNG): identity pools slide over the sorted id list with overlap; clip
+choice is round-robin per identity, so re-appearances use fresh audio.
+
+Output:
+  data/voxceleb/sessions/audio/sess000.wav ...
+  data/voxceleb/sessions/rttm/sess000.rttm ...
+
+Requires ffmpeg + ffprobe (audio concat + duration probing).
+
+Usage:
+  python3 scripts/build_voxceleb_sessions.py --raw-dir data/voxceleb/raw \
+      --out-dir data/voxceleb/sessions \
+      --num-sessions 20 --speakers-per-session 4 --clips-per-speaker 3 --gap 0.3
+"""
+import argparse, json, os, shutil, subprocess, sys, tempfile
+
+
+def ffprobe_duration(path):
+    out = subprocess.check_output(
+        ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+         "-of", "default=nw=1:nk=1", path], text=True).strip()
+    return float(out)
+
+
+def normalize(src, dst, sr):
+    subprocess.check_call(
+        ["ffmpeg", "-v", "error", "-y", "-i", src, "-ac", "1", "-ar", str(sr),
+         "-c:a", "pcm_s16le", dst])
+
+
+def make_silence(path, sr, dur):
+    subprocess.check_call(
+        ["ffmpeg", "-v", "error", "-y", "-f", "lavfi", "-t", f"{dur}",
+         "-i", f"anullsrc=r={sr}:cl=mono", "-c:a", "pcm_s16le", path])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--raw-dir", required=True, help="data/voxceleb/raw/<spk>/*.wav")
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--num-sessions", type=int, default=20)
+    ap.add_argument("--speakers-per-session", type=int, default=4)
+    ap.add_argument("--clips-per-speaker", type=int, default=3)
+    ap.add_argument("--gap", type=float, default=0.3, help="silence (s) between turns")
+    ap.add_argument("--sr", type=int, default=16000)
+    args = ap.parse_args()
+
+    if not shutil.which("ffmpeg") or not shutil.which("ffprobe"):
+        print("error: ffmpeg + ffprobe required", file=sys.stderr); sys.exit(2)
+
+    ids = sorted(d for d in os.listdir(args.raw_dir)
+                 if os.path.isdir(os.path.join(args.raw_dir, d)))
+    clips = {s: sorted(f for f in os.listdir(os.path.join(args.raw_dir, s))
+                       if f.lower().endswith(".wav")) for s in ids}
+    ids = [s for s in ids if clips[s]]
+    spk_n = args.speakers_per_session
+    if len(ids) < spk_n:
+        print(f"error: only {len(ids)} identities; need >= {spk_n}", file=sys.stderr); sys.exit(1)
+
+    audio_dir = os.path.join(args.out_dir, "audio")
+    rttm_dir = os.path.join(args.out_dir, "rttm")
+    os.makedirs(audio_dir, exist_ok=True)
+    os.makedirs(rttm_dir, exist_ok=True)
+
+    overlap = max(1, spk_n // 2)         # consecutive sessions share `overlap` identities
+    stride = max(1, spk_n - overlap)
+    clip_cursor = {s: 0 for s in ids}    # round-robin clip pointer per identity
+
+    for si in range(args.num_sessions):
+        start = (si * stride) % len(ids)
+        session_ids = [ids[(start + j) % len(ids)] for j in range(spk_n)]
+        mid = f"sess{si:03d}"
+        tmp = tempfile.mkdtemp(prefix=f"voxsess_{mid}_")
+        sil = os.path.join(tmp, "sil.wav")
+        make_silence(sil, args.sr, args.gap)
+
+        concat_lines, rttm_lines = [], []
+        t = 0.0
+        # interleave: round-robin one clip per speaker per turn
+        for turn in range(args.clips_per_speaker):
+            for spk in session_ids:
+                cl = clips[spk]
+                c = cl[clip_cursor[spk] % len(cl)]
+                clip_cursor[spk] += 1
+                src = os.path.join(args.raw_dir, spk, c)
+                norm = os.path.join(tmp, f"{spk}_{turn}.wav")
+                try:
+                    normalize(src, norm, args.sr)
+                    dur = ffprobe_duration(norm)
+                except subprocess.CalledProcessError:
+                    continue
+                concat_lines.append(f"file '{norm}'")
+                rttm_lines.append(
+                    f"SPEAKER {mid} 1 {t:.3f} {dur:.3f} <NA> <NA> {spk} <NA> <NA>")
+                t += dur
+                concat_lines.append(f"file '{sil}'")
+                t += args.gap
+
+        listing = os.path.join(tmp, "list.txt")
+        with open(listing, "w") as f:
+            f.write("\n".join(concat_lines) + "\n")
+        out_wav = os.path.join(audio_dir, f"{mid}.wav")
+        subprocess.check_call(
+            ["ffmpeg", "-v", "error", "-y", "-f", "concat", "-safe", "0",
+             "-i", listing, "-c:a", "pcm_s16le", out_wav])
+        with open(os.path.join(rttm_dir, f"{mid}.rttm"), "w") as f:
+            f.write("\n".join(rttm_lines) + "\n")
+        shutil.rmtree(tmp, ignore_errors=True)
+        print(f"[voxsess] {mid}: {spk_n} ids {session_ids} -> {t:.1f}s")
+
+    # recurrence summary
+    appear = {}
+    for si in range(args.num_sessions):
+        start = (si * stride) % len(ids)
+        for j in range(spk_n):
+            s = ids[(start + j) % len(ids)]
+            appear[s] = appear.get(s, 0) + 1
+    recurring = sum(1 for v in appear.values() if v >= 2)
+    print(json.dumps({
+        "sessions": args.num_sessions, "distinct_identities": len(appear),
+        "recurring_identities(>=2 sessions)": recurring,
+        "max_appearances": max(appear.values()) if appear else 0,
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/download_ami.sh
+++ b/scripts/download_ami.sh
@@ -1,20 +1,69 @@
 #!/bin/bash
-# Download AMI ES2002 scenario series (a/b/c/d) — Mix-Headset audio + ground-truth RTTMs.
+# Download AMI Meeting Corpus subsets — Mix-Headset audio + ground-truth RTTMs.
+#
 # AMI Meeting Corpus: research-use license (https://groups.inf.ed.ac.uk/ami/corpus/).
-# Internal eval only — NOT redistributed. Everything lands under data/ami/ (gitignored).
+# Ground-truth RTTMs: pyannote/AMI-diarization-setup `only_words` set
+# (https://github.com/pyannote/AMI-diarization-setup, MIT-licensed tooling over the
+# AMI annotations). Internal eval only — NOT redistributed. Everything lands under
+# data/ami/ (gitignored).
+#
+# AMI speaker IDs are GLOBALLY UNIQUE per real person (FEE005, MEE006, ...). Within a
+# scenario series the same 4 people recur across sessions a–d; different series are
+# different people. So a multi-series pull yields many distinct *recurring* identities
+# — ideal for the cross-meeting re-ID / false-positive test.
+#
+# Usage:
+#   scripts/download_ami.sh                 # default: ES2002 a–d  (4 meetings, 1 group)
+#   scripts/download_ami.sh scale           # 8 scenario series   (~32 meetings, ~32 ids)
+#   scripts/download_ami.sh full            # ALL scenario+non-scenario (~170 meetings, ~100h)
+#   scripts/download_ami.sh ES2002a ES2003a # explicit meeting ids
+#   AMI_SET=scale scripts/download_ami.sh   # same via env
+#
+# Compute/footprint guide (Mix-Headset 16 kHz mono ≈ 1.7 MB/audio-min):
+#   default  4 meetings  ~230 MB   download minutes
+#   scale   32 meetings  ~1.8 GB   download ~tens of min on the Edinburgh mirror
+#   full   ~170 meetings ~9–10 GB  download HOURS — gated heavy tier, do not run blind
 set -euo pipefail
 cd "$(dirname "$0")/.."
 DEST="data/ami"
 mkdir -p "$DEST/audio" "$DEST/rttm"
-SERIES="${1:-ES2002a ES2002b ES2002c ES2002d}"
+
 AUDIO_BASE="http://groups.inf.ed.ac.uk/ami/AMICorpusMirror/amicorpus"
-RTTM_BASE="https://raw.githubusercontent.com/pyannote/AMI-diarization-setup/main/only_words/rttms/train"
-for m in $SERIES; do
-  echo "[ami] $m audio..."
-  curl -fsSL --retry 3 -o "$DEST/audio/$m.Mix-Headset.wav" "$AUDIO_BASE/$m/audio/$m.Mix-Headset.wav"
-  echo "[ami] $m rttm..."
-  curl -fsSL --retry 3 -o "$DEST/rttm/$m.rttm" "$RTTM_BASE/$m.rttm" \
-    || curl -fsSL --retry 3 -o "$DEST/rttm/$m.rttm" "${RTTM_BASE/train/dev}/$m.rttm"
+RTTM_BASE="https://raw.githubusercontent.com/pyannote/AMI-diarization-setup/main/only_words/rttms"
+LIST_BASE="https://raw.githubusercontent.com/pyannote/AMI-diarization-setup/main/lists"
+
+# ---- resolve the meeting set ---------------------------------------------------------
+expand_series() { for s in "$@"; do for x in a b c d; do printf '%s%s ' "$s" "$x"; done; done; }
+
+ARG="${1:-${AMI_SET:-es2002}}"
+case "$ARG" in
+  es2002)  MEETINGS="ES2002a ES2002b ES2002c ES2002d" ;;
+  # 8 train-split scenario series, 4 disjoint people each -> ~32 distinct recurring ids.
+  scale)   MEETINGS="$(expand_series ES2002 ES2003 ES2005 ES2006 ES2007 ES2008 ES2009 ES2010)" ;;
+  # Everything pyannote ships RTTMs for (train+dev+test), scenario + non-scenario.
+  full)    MEETINGS="$(for sp in train dev test; do \
+              curl -fsSL "$LIST_BASE/$sp.meetings.txt"; done | tr '\n' ' ')" ;;
+  *)       MEETINGS="$*" ;;   # explicit meeting ids
+esac
+
+echo "[ami] set='$ARG' -> $(echo "$MEETINGS" | wc -w | tr -d ' ') meeting(s)"
+
+# ---- fetch -----------------------------------------------------------------------------
+for m in $MEETINGS; do
+  wav="$DEST/audio/$m.Mix-Headset.wav"
+  rttm="$DEST/rttm/$m.rttm"
+  if [ ! -s "$wav" ]; then
+    echo "[ami] $m audio..."
+    curl -fsSL --retry 3 -o "$wav" "$AUDIO_BASE/$m/audio/$m.Mix-Headset.wav" \
+      || { echo "[ami] !! audio fetch failed for $m" >&2; rm -f "$wav"; }
+  fi
+  if [ ! -s "$rttm" ]; then
+    echo "[ami] $m rttm..."
+    fetched=0
+    for sp in train dev test; do
+      if curl -fsSL --retry 3 -o "$rttm" "$RTTM_BASE/$sp/$m.rttm" 2>/dev/null; then fetched=1; break; fi
+    done
+    [ "$fetched" = 1 ] || { echo "[ami] !! rttm not found for $m in train/dev/test" >&2; rm -f "$rttm"; }
+  fi
 done
-echo "[ami] done."
-ls -la "$DEST/audio" "$DEST/rttm"
+echo "[ami] done: $(ls "$DEST/audio" | wc -l | tr -d ' ') audio, $(ls "$DEST/rttm" | wc -l | tr -d ' ') rttm under $DEST"

--- a/scripts/download_icsi.sh
+++ b/scripts/download_icsi.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Download ICSI Meeting Corpus subsets — interaction-mix audio + ground-truth RTTMs.
+#
+# ICSI Meeting Corpus: research-use license (https://groups.inf.ed.ac.uk/ami/icsi/,
+# license at .../icsi/license.shtml). 75 meetings of the same lab's research groups, so
+# speakers RECUR heavily across meetings (global IDs like mn005/fe008) — a strong
+# cross-meeting re-ID surface with real, varied identities. NOT redistributed.
+# Everything lands under data/icsi/ (gitignored).
+#
+#   - Audio : Edinburgh ICSIsignals mirror, beamformed interaction mix (no auth).
+#             https://groups.inf.ed.ac.uk/ami/ICSIsignals/NXT/<MTG>.interaction.wav
+#   - RTTMs : HF dataset `diarizers-community/icsi` (diarization-ready ground truth).
+#             GATED: needs `huggingface-cli login` + accepting the dataset terms, plus
+#             `pip install datasets soundfile`. Materialized to loose <MTG>.rttm by
+#             scripts/icsi_rttm_from_hf.py.
+#
+# GATED HEAVY TIER — interaction WAVs are ~70–190 MB each (long meetings). Wire it,
+# don't run it blind. One-liners:
+#   scripts/download_icsi.sh                       # default 6-meeting sample
+#   ICSI_SET="Bmr001 Bmr002 Bmr005 Bro003 Bro004"  scripts/download_icsi.sh
+#   ICSI_SET=full scripts/download_icsi.sh         # all 75 meetings (~10 GB)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+DEST="data/icsi"
+mkdir -p "$DEST/audio" "$DEST/rttm"
+
+AUDIO_BASE="https://groups.inf.ed.ac.uk/ami/ICSIsignals/NXT"
+
+# Default sample: two Bmr-series + Bro/Bed/Bns/Btr meetings — overlapping attendee pools
+# so the same researchers recur across recordings.
+DEFAULT_SAMPLE="Bmr001 Bmr002 Bro003 Bed002 Bns001 Btr001"
+# The 75-meeting ICSI list (Bdb/Bed/Bmr/Bns/Bro/Bsr/Btr/Buw families).
+FULL_LIST="Bdb001 Bed002 Bed003 Bed004 Bed005 Bed006 Bed008 Bed009 Bed010 Bed011 Bed012 \
+Bed013 Bed014 Bed015 Bed016 Bed017 Bmr001 Bmr002 Bmr003 Bmr005 Bmr006 Bmr007 Bmr008 Bmr009 \
+Bmr010 Bmr011 Bmr012 Bmr013 Bmr014 Bmr015 Bmr016 Bmr018 Bmr019 Bmr020 Bmr021 Bmr022 Bmr023 \
+Bmr024 Bmr025 Bmr026 Bmr027 Bmr029 Bmr030 Bmr031 Bns001 Bns002 Bns003 Bro003 Bro004 Bro005 \
+Bro007 Bro008 Bro010 Bro011 Bro012 Bro013 Bro014 Bro015 Bro016 Bro017 Bro018 Bro019 Bro021 \
+Bro022 Bro023 Bro024 Bro025 Bro026 Bro027 Bro028 Bsr001 Btr001 Btr002 Buw001"
+
+ARG="${1:-${ICSI_SET:-sample}}"
+case "$ARG" in
+  sample) MEETINGS="$DEFAULT_SAMPLE" ;;
+  full)   MEETINGS="$FULL_LIST" ;;
+  *)      MEETINGS="$*" ;;
+esac
+echo "[icsi] set='$ARG' -> $(echo "$MEETINGS" | wc -w | tr -d ' ') meeting(s)"
+
+for m in $MEETINGS; do
+  wav="$DEST/audio/$m.wav"
+  if [ ! -s "$wav" ]; then
+    echo "[icsi] $m audio..."
+    curl -fsSL --retry 3 -o "$wav" "$AUDIO_BASE/$m.interaction.wav" \
+      || { echo "[icsi] !! audio fetch failed for $m" >&2; rm -f "$wav"; }
+  fi
+done
+
+echo "[icsi] materializing RTTMs from HF diarizers-community/icsi (needs HF auth + datasets)..."
+python3 scripts/icsi_rttm_from_hf.py --out-dir "$DEST/rttm" --meetings "$MEETINGS" \
+  || echo "[icsi] !! RTTM step skipped/failed — see scripts/icsi_rttm_from_hf.py header for auth setup" >&2
+
+echo "[icsi] done: $(ls "$DEST/audio" 2>/dev/null | wc -l | tr -d ' ') audio, $(ls "$DEST/rttm" 2>/dev/null | wc -l | tr -d ' ') rttm under $DEST"

--- a/scripts/download_voxceleb_sample.sh
+++ b/scripts/download_voxceleb_sample.sh
@@ -1,40 +1,53 @@
 #!/bin/bash
-# SAMPLE-ONLY VoxCeleb1 fetch + synthetic multi-identity session build.
+# SAMPLE-ONLY VoxCeleb1 fetch + multi-identity "session" build for the speaker-DB test.
 #
 # VoxCeleb1: CC-BY-SA 4.0 (https://www.robots.ox.ac.uk/~vgg/data/voxceleb/). ~1200
-# identities — we NEVER pull all of it. This streams a HF mirror and stops at a HARD CAP
-# of distinct identities, then stitches them into conversational sessions with exact RTTMs
-# for the cross-recording re-ID / false-positive test. Everything under data/voxceleb/
-# (gitignored).
+# identities — we NEVER pull all of it. This STREAMS a HF mirror and stops at a HARD CAP
+# of distinct identities. Default mirror `s3prl/mini_voxceleb1` is PUBLIC (no HF login);
+# point VOXCELEB_DATASET at a larger/gated mirror to exceed mini's identity count.
+# Everything under data/voxceleb/ (gitignored).
 #
-# GATED TIER — VoxCeleb on HF is access-gated: `huggingface-cli login` (or HF_TOKEN) +
-# accept terms, and `pip install datasets soundfile`. Footprint is bounded by the cap
-# (default 300 ids × 10 clips ≈ a few GB streamed, NOT the full ~30 GB corpus).
+# Needs `pip install datasets` + `ffmpeg` (audio read via fsspec, transcoded by ffmpeg —
+# no torch/soundfile). Footprint bounded by the cap, NOT the full ~30 GB corpus.
+#
+# MODE (why singles is the default): `singles` makes each clip its own single-speaker
+# "meeting", so the diarizer trivially sees one clean voice and the eval isolates the DB
+# MATCHER (cross-recording re-ID / false-positive). `sessions` stitches clips into
+# multi-speaker recordings — more realistic, but it routes through the diarizer, whose
+# under-segmentation then dominates the metric (measured: it collapses 4 voices to 1–2
+# clusters), re-introducing the AMI confound. Use singles to test the matcher; sessions
+# to stress the whole pipeline.
 #
 # Env knobs:
 #   VOXCELEB_IDENTITY_CAP   distinct identities to sample (default 300; HARD CAP, max 1211)
 #   VOXCELEB_CLIPS_PER_ID   clips kept per identity (default 10)
-#   VOXCELEB_SESSIONS       synthetic sessions to build (default 20)
-#   VOXCELEB_SPK_PER_SESS   identities per session (default 4)
+#   VOXCELEB_DATASET        HF mirror (default s3prl/mini_voxceleb1, public)
+#   VOXCELEB_MODE           singles | sessions (default singles)
+#   VOXCELEB_SESSIONS       sessions-mode: # sessions to build (default 20)
+#   VOXCELEB_SPK_PER_SESS   sessions-mode: identities per session (default 4)
 #
 # One-liner:
-#   scripts/download_voxceleb_sample.sh
-#   VOXCELEB_IDENTITY_CAP=50 scripts/download_voxceleb_sample.sh   # tiny smoke sample
+#   scripts/download_voxceleb_sample.sh                              # 300-cap, singles
+#   VOXCELEB_IDENTITY_CAP=6 scripts/download_voxceleb_sample.sh      # tiny smoke sample
+#   VOXCELEB_MODE=sessions scripts/download_voxceleb_sample.sh       # multi-speaker sessions
 set -euo pipefail
 cd "$(dirname "$0")/.."
 DEST="data/voxceleb"
 RAW="$DEST/raw"
 CAP="${VOXCELEB_IDENTITY_CAP:-300}"
 CLIPS="${VOXCELEB_CLIPS_PER_ID:-10}"
+DATASET="${VOXCELEB_DATASET:-s3prl/mini_voxceleb1}"
+MODE="${VOXCELEB_MODE:-singles}"
 SESSIONS="${VOXCELEB_SESSIONS:-20}"
 SPK="${VOXCELEB_SPK_PER_SESS:-4}"
 
-echo "[voxceleb] HARD CAP = $CAP identities × $CLIPS clips (sample-only; never the full corpus)"
+echo "[voxceleb] HARD CAP = $CAP identities × $CLIPS clips from $DATASET (sample-only; never the full corpus)"
 python3 scripts/voxceleb_sample.py --out-dir "$RAW" \
-  --identity-cap "$CAP" --clips-per-id "$CLIPS"
+  --identity-cap "$CAP" --clips-per-id "$CLIPS" --dataset "$DATASET"
 
-echo "[voxceleb] building $SESSIONS synthetic sessions ($SPK identities each)..."
+echo "[voxceleb] building '$MODE' meetings..."
 python3 scripts/build_voxceleb_sessions.py --raw-dir "$RAW" \
-  --out-dir "$DEST/sessions" --num-sessions "$SESSIONS" --speakers-per-session "$SPK"
+  --out-dir "$DEST/sessions" --mode "$MODE" \
+  --num-sessions "$SESSIONS" --speakers-per-session "$SPK"
 
-echo "[voxceleb] done: sessions under $DEST/sessions (audio/ + rttm/)"
+echo "[voxceleb] done: meetings under $DEST/sessions (audio/ + rttm/). Run: CORPUS=voxceleb scripts/run_speaker_eval.sh"

--- a/scripts/download_voxceleb_sample.sh
+++ b/scripts/download_voxceleb_sample.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# SAMPLE-ONLY VoxCeleb1 fetch + synthetic multi-identity session build.
+#
+# VoxCeleb1: CC-BY-SA 4.0 (https://www.robots.ox.ac.uk/~vgg/data/voxceleb/). ~1200
+# identities — we NEVER pull all of it. This streams a HF mirror and stops at a HARD CAP
+# of distinct identities, then stitches them into conversational sessions with exact RTTMs
+# for the cross-recording re-ID / false-positive test. Everything under data/voxceleb/
+# (gitignored).
+#
+# GATED TIER — VoxCeleb on HF is access-gated: `huggingface-cli login` (or HF_TOKEN) +
+# accept terms, and `pip install datasets soundfile`. Footprint is bounded by the cap
+# (default 300 ids × 10 clips ≈ a few GB streamed, NOT the full ~30 GB corpus).
+#
+# Env knobs:
+#   VOXCELEB_IDENTITY_CAP   distinct identities to sample (default 300; HARD CAP, max 1211)
+#   VOXCELEB_CLIPS_PER_ID   clips kept per identity (default 10)
+#   VOXCELEB_SESSIONS       synthetic sessions to build (default 20)
+#   VOXCELEB_SPK_PER_SESS   identities per session (default 4)
+#
+# One-liner:
+#   scripts/download_voxceleb_sample.sh
+#   VOXCELEB_IDENTITY_CAP=50 scripts/download_voxceleb_sample.sh   # tiny smoke sample
+set -euo pipefail
+cd "$(dirname "$0")/.."
+DEST="data/voxceleb"
+RAW="$DEST/raw"
+CAP="${VOXCELEB_IDENTITY_CAP:-300}"
+CLIPS="${VOXCELEB_CLIPS_PER_ID:-10}"
+SESSIONS="${VOXCELEB_SESSIONS:-20}"
+SPK="${VOXCELEB_SPK_PER_SESS:-4}"
+
+echo "[voxceleb] HARD CAP = $CAP identities × $CLIPS clips (sample-only; never the full corpus)"
+python3 scripts/voxceleb_sample.py --out-dir "$RAW" \
+  --identity-cap "$CAP" --clips-per-id "$CLIPS"
+
+echo "[voxceleb] building $SESSIONS synthetic sessions ($SPK identities each)..."
+python3 scripts/build_voxceleb_sessions.py --raw-dir "$RAW" \
+  --out-dir "$DEST/sessions" --num-sessions "$SESSIONS" --speakers-per-session "$SPK"
+
+echo "[voxceleb] done: sessions under $DEST/sessions (audio/ + rttm/)"

--- a/scripts/download_voxconverse.sh
+++ b/scripts/download_voxconverse.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Download VoxConverse (in-the-wild multi-speaker diarization) — audio + ground-truth RTTMs.
+#
+# VoxConverse: CC-BY 4.0 (https://www.robots.ox.ac.uk/~vgg/data/voxconverse/).
+#   - Audio  : official KAIST mirror, dev + test WAV zips.
+#   - RTTMs  : github.com/joonson/voxconverse (dev/ + test/ .rttm).
+# In-the-wild YouTube audio: overlapping speech, varied recording conditions, unknown
+# speaker counts — the hardest diarizer stress + a clean re-ID/false-positive surface.
+# Everything lands under data/voxconverse/ (gitignored).
+#
+# GATED HEAVY TIER — ~4 GB download. Wire it, don't run it blind. One-liner:
+#   scripts/download_voxconverse.sh            # dev (216 files) + test (232 files)
+#   VOXCONVERSE_SPLITS="dev" scripts/download_voxconverse.sh   # dev only (~2 GB)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+DEST="data/voxconverse"
+mkdir -p "$DEST/audio" "$DEST/rttm" "$DEST/_tmp"
+
+SPLITS="${VOXCONVERSE_SPLITS:-dev test}"
+AUDIO_BASE="https://mm.kaist.ac.kr/datasets/voxconverse/data"
+RTTM_TARBALL="https://github.com/joonson/voxconverse/archive/refs/heads/master.tar.gz"
+
+echo "[vox] fetching ground-truth RTTMs (joonson/voxconverse)..."
+curl -fsSL --retry 3 -o "$DEST/_tmp/vc.tar.gz" "$RTTM_TARBALL"
+tar -xzf "$DEST/_tmp/vc.tar.gz" -C "$DEST/_tmp"
+for sp in $SPLITS; do
+  if [ -d "$DEST/_tmp/voxconverse-master/$sp" ]; then
+    cp "$DEST/_tmp/voxconverse-master/$sp"/*.rttm "$DEST/rttm/" 2>/dev/null || true
+  fi
+done
+echo "[vox] rttm files: $(ls "$DEST/rttm" | wc -l | tr -d ' ')"
+
+for sp in $SPLITS; do
+  zip="$DEST/_tmp/voxconverse_${sp}_wav.zip"
+  echo "[vox] $sp audio zip..."
+  curl -fsSL --retry 3 -o "$zip" "$AUDIO_BASE/voxconverse_${sp}_wav.zip"
+  echo "[vox] $sp extracting..."
+  unzip -oq "$zip" -d "$DEST/_tmp/${sp}_extract"
+  # zips extract to .../audio/<id>.wav — flatten into data/voxconverse/audio/
+  find "$DEST/_tmp/${sp}_extract" -name '*.wav' -exec cp {} "$DEST/audio/" \;
+done
+
+rm -rf "$DEST/_tmp"
+echo "[vox] done: $(ls "$DEST/audio" | wc -l | tr -d ' ') audio, $(ls "$DEST/rttm" | wc -l | tr -d ' ') rttm under $DEST"

--- a/scripts/icsi_rttm_from_hf.py
+++ b/scripts/icsi_rttm_from_hf.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Materialize loose per-meeting ICSI RTTMs from the HF `diarizers-community/icsi` dataset.
+
+GATED: requires accepting the dataset terms on HuggingFace and authenticating
+(`huggingface-cli login`, or HF_TOKEN env), plus `pip install datasets`.
+
+The diarizers-community speaker-diarization datasets expose, per row (one meeting):
+  - `timestamps_start` : list[float]
+  - `timestamps_end`   : list[float]
+  - `speakers`         : list[str]   (global ICSI speaker ids, recurring across meetings)
+plus an `audio` column (which we ignore — audio comes from the Edinburgh mirror).
+
+We emit standard SPEAKER-line RTTMs keyed by meeting id, matching the AMI scorer's
+expectations (score_speaker_eval.py reads cols 4=start, 5=dur, 8=speaker).
+
+Usage:
+  python3 scripts/icsi_rttm_from_hf.py --out-dir data/icsi/rttm --meetings "Bmr001 Bro003"
+  python3 scripts/icsi_rttm_from_hf.py --out-dir data/icsi/rttm   # all meetings in the dataset
+"""
+import argparse, os, sys
+
+
+def meeting_id_of(row):
+    """Best-effort meeting id from a dataset row (id/meeting/file/audio path)."""
+    for k in ("id", "meeting_id", "meeting", "file", "filename", "name"):
+        v = row.get(k)
+        if isinstance(v, str) and v:
+            return os.path.splitext(os.path.basename(v))[0]
+    a = row.get("audio")
+    if isinstance(a, dict) and a.get("path"):
+        return os.path.splitext(os.path.basename(a["path"]))[0]
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--meetings", default="", help="space-separated meeting ids; empty = all")
+    ap.add_argument("--dataset", default="diarizers-community/icsi")
+    ap.add_argument("--splits", default="train,validation,test")
+    args = ap.parse_args()
+
+    try:
+        from datasets import load_dataset
+    except Exception as e:
+        print(f"error: `datasets` not installed ({e}); pip install datasets", file=sys.stderr)
+        sys.exit(2)
+
+    wanted = set(args.meetings.split()) if args.meetings.strip() else None
+    os.makedirs(args.out_dir, exist_ok=True)
+    written = 0
+
+    for split in args.splits.split(","):
+        split = split.strip()
+        if not split:
+            continue
+        try:
+            ds = load_dataset(args.dataset, split=split)
+        except Exception as e:
+            print(f"warn: split '{split}' unavailable ({e})", file=sys.stderr)
+            continue
+        # Avoid decoding audio bytes — we only need the timing columns.
+        try:
+            ds = ds.remove_columns([c for c in ds.column_names if c == "audio"])
+        except Exception:
+            pass
+        for row in ds:
+            mid = meeting_id_of(row)
+            if mid is None:
+                continue
+            if wanted is not None and mid not in wanted:
+                continue
+            starts = row.get("timestamps_start") or []
+            ends = row.get("timestamps_end") or []
+            spks = row.get("speakers") or []
+            n = min(len(starts), len(ends), len(spks))
+            if n == 0:
+                continue
+            path = os.path.join(args.out_dir, f"{mid}.rttm")
+            with open(path, "w") as f:
+                for i in range(n):
+                    s, e, spk = float(starts[i]), float(ends[i]), str(spks[i])
+                    if e > s:
+                        f.write(f"SPEAKER {mid} 1 {s:.3f} {e - s:.3f} <NA> <NA> {spk} <NA> <NA>\n")
+            written += 1
+            print(f"[icsi-rttm] {mid}: {n} segments -> {path}")
+
+    print(f"[icsi-rttm] wrote {written} RTTM file(s) to {args.out_dir}")
+    if written == 0:
+        print("[icsi-rttm] nothing written — check HF auth/terms and meeting ids", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_speaker_eval.sh
+++ b/scripts/run_speaker_eval.sh
@@ -1,48 +1,83 @@
 #!/bin/bash
-# Re-runnable speaker-naming eval against AMI ground truth.
+# Re-runnable speaker-naming eval against ground-truth RTTMs — ANY corpus, one driver.
 #
 #   1. build the harness (reuses prebuilt deps under deps-libs/ etc.)
-#   2. dump-diarize each AMI session once (cached in data/eval/dumps/)
-#   3. replay the session series IN ORDER through the real clusterer + DB matcher
+#   2. dump-diarize each session once (cached in data/eval/<CORPUS>/dumps/)
+#   3. replay the sessions IN ORDER through the real clusterer + DB matcher
 #      for every (consolidation × match) threshold combo
-#   4. score each combo vs the AMI RTTMs and aggregate a sweep table
+#   4. score each combo vs the RTTMs (DER, fragmentation, false-merge, re-ID curve)
+#      and aggregate a sweep table
+#
+# The CORPUS env var selects the dataset; everything else (dump -> sweep -> score) is shared.
+# Each corpus just needs WAVs in its audio dir and matching <meeting>.rttm in its rttm dir,
+# fetched by the per-corpus downloader (download_ami.sh / download_icsi.sh /
+# download_voxconverse.sh / download_voxceleb_sample.sh).
 #
 # Usage:
-#   scripts/run_speaker_eval.sh                 # full sweep on the default ES2002 series
-#   SERIES="ES2002a ES2002b ES2002c ES2002d" scripts/run_speaker_eval.sh
+#   scripts/run_speaker_eval.sh                              # CORPUS=ami, all downloaded RTTMs
+#   CORPUS=ami SERIES="ES2002a ES2002b ES2002c ES2002d" scripts/run_speaker_eval.sh
+#   CORPUS=voxconverse scripts/run_speaker_eval.sh
+#   CORPUS=voxceleb scripts/run_speaker_eval.sh             # synthetic re-ID/false-positive sessions
 #   CONSOLIDATION="none 0.85 0.88" MATCH="0.55 0.6 0.65" scripts/run_speaker_eval.sh
+#
+# Env knobs: CORPUS, SERIES (subset; default = all meetings with RTTMs), CONSOLIDATION,
+#            MATCH, COLLAR.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 ROOT="$(pwd)"
 
-SERIES="${SERIES:-ES2002a ES2002b ES2002c ES2002d}"
+CORPUS="${CORPUS:-ami}"
+
+# ---- per-corpus layout: audio dir, rttm dir, audio filename suffix ----
+case "$CORPUS" in
+  ami)         AUDIO_DIR="data/ami/audio";              RTTM_DIR="data/ami/rttm";              SUFFIX=".Mix-Headset.wav" ;;
+  icsi)        AUDIO_DIR="data/icsi/audio";             RTTM_DIR="data/icsi/rttm";             SUFFIX=".wav" ;;
+  voxconverse) AUDIO_DIR="data/voxconverse/audio";      RTTM_DIR="data/voxconverse/rttm";      SUFFIX=".wav" ;;
+  voxceleb)    AUDIO_DIR="data/voxceleb/sessions/audio"; RTTM_DIR="data/voxceleb/sessions/rttm"; SUFFIX=".wav" ;;
+  *) echo "unknown CORPUS='$CORPUS' (ami|icsi|voxconverse|voxceleb)"; exit 2 ;;
+esac
+
+# Meeting list: explicit SERIES, else every meeting that has an RTTM (sorted -> stable
+# replay order; for AMI this keeps each series' a–d consecutive).
+if [ -n "${SERIES:-}" ]; then
+  MEETINGS="$SERIES"
+else
+  MEETINGS="$(ls "$ROOT/$RTTM_DIR" 2>/dev/null | sed 's/\.rttm$//' | sort | tr '\n' ' ')"
+fi
+[ -n "${MEETINGS// /}" ] || { echo "no meetings found for CORPUS=$CORPUS (run the downloader first; looked in $RTTM_DIR)"; exit 1; }
+
 # Sweep grids — consolidation around the 0.88 same-voice bar, match around 0.6.
 CONSOLIDATION="${CONSOLIDATION:-none 0.82 0.85 0.88 0.91}"
 MATCH="${MATCH:-0.50 0.55 0.60 0.65 0.70}"
 COLLAR="${COLLAR:-0.25}"
 
 BIN="$ROOT/Tools/SpeakerEvalHarness/.build/release/speaker-eval-harness"
-DUMPS="$ROOT/data/eval/dumps"
-RESULTS="$ROOT/data/eval/results"
-REPORTS="$ROOT/data/eval/reports"
+DUMPS="$ROOT/data/eval/$CORPUS/dumps"
+RESULTS="$ROOT/data/eval/$CORPUS/results"
+REPORTS="$ROOT/data/eval/$CORPUS/reports"
 mkdir -p "$DUMPS" "$RESULTS" "$REPORTS"
+
+echo "==> CORPUS=$CORPUS  meetings=$(echo "$MEETINGS" | wc -w | tr -d ' ')  (audio=$AUDIO_DIR rttm=$RTTM_DIR)"
 
 echo "==> build harness"
 ( cd "$ROOT/Tools/SpeakerEvalHarness" && swift build -c release 2>&1 | grep -vE "\.pcm|while processing" | tail -1 )
 
 echo "==> dump-diarize sessions (cached)"
 INPUTS=""
-for m in $SERIES; do
+for m in $MEETINGS; do
   dump="$DUMPS/$m.json"
+  audio="$ROOT/$AUDIO_DIR/$m$SUFFIX"
   if [ ! -s "$dump" ]; then
+    if [ ! -s "$audio" ]; then echo "    !! missing audio $audio — skipping $m" >&2; continue; fi
     echo "    diarizing $m ..."
-    "$BIN" dump --audio "$ROOT/data/ami/audio/$m.Mix-Headset.wav" --meeting "$m" --out "$dump" \
+    "$BIN" dump --audio "$audio" --meeting "$m" --out "$dump" \
       2>&1 | grep -E "^\[dump\] $m:" | grep -v processing || true
   else
     echo "    cached $m"
   fi
-  INPUTS="${INPUTS:+$INPUTS,}$dump"
+  [ -s "$dump" ] && INPUTS="${INPUTS:+$INPUTS,}$dump"
 done
+[ -n "$INPUTS" ] || { echo "no dumps produced — check audio files"; exit 1; }
 
 echo "==> threshold sweep (consolidation × match)"
 SWEEP_JSONS=""
@@ -53,12 +88,13 @@ for cons in $CONSOLIDATION; do
     score="$REPORTS/$tag.json"
     "$BIN" replay --inputs "$INPUTS" --consolidation "$cons" --match "$mt" --out "$res" \
       2>&1 | grep -vE "\.pcm|while processing" | tail -1
-    python3 "$ROOT/scripts/score_speaker_eval.py" --result "$res" --rttm-dir "$ROOT/data/ami/rttm" \
+    python3 "$ROOT/scripts/score_speaker_eval.py" --result "$res" --rttm-dir "$ROOT/$RTTM_DIR" \
       --collar "$COLLAR" --out-json "$score" >/dev/null
     SWEEP_JSONS="${SWEEP_JSONS:+$SWEEP_JSONS,}$score"
   done
 done
 
 echo "==> aggregate"
-python3 "$ROOT/scripts/aggregate_sweep.py" --scores "$SWEEP_JSONS" --out-md "$REPORTS/SWEEP.md"
+python3 "$ROOT/scripts/aggregate_sweep.py" --scores "$SWEEP_JSONS" --corpus "$CORPUS" \
+  --out-md "$REPORTS/SWEEP.md"
 echo "==> wrote $REPORTS/SWEEP.md"

--- a/scripts/voxceleb_sample.py
+++ b/scripts/voxceleb_sample.py
@@ -119,9 +119,22 @@ def main():
             if tmp:
                 os.unlink(tmp.name)
 
-    kept = {}            # speaker -> count kept
+    # Resume: seed counts from clips already on disk so repeated calls (e.g. one per split)
+    # ACCUMULATE clips per identity instead of overwriting. clips-per-id / identity-cap then
+    # apply to the running totals.
+    kept = {}            # speaker -> count kept (existing + new)
     os.makedirs(args.out_dir, exist_ok=True)
+    for spk in os.listdir(args.out_dir):
+        d = os.path.join(args.out_dir, spk)
+        if os.path.isdir(d):
+            n = len([f for f in os.listdir(d) if f.endswith(".wav")])
+            if n:
+                kept[spk] = n
+    if kept:
+        print(f"[voxceleb] resuming: {len(kept)} ids already on disk "
+              f"({sum(kept.values())} clips)")
     total = 0
+    failed = 0
     for row in ds:
         audio = row.get(audio_col) if audio_col else None
         spk = speaker_of(row, audio)
@@ -138,6 +151,7 @@ def main():
         os.makedirs(d, exist_ok=True)
         idx = kept.get(spk, 0)
         if not write_clip(row.get(audio_col), os.path.join(d, f"{idx:03d}.wav"), args.sr):
+            failed += 1
             continue
         kept[spk] = idx + 1
         total += 1
@@ -145,6 +159,12 @@ def main():
             print(f"[voxceleb] {len(kept)} ids, {total} clips...")
 
     print(f"[voxceleb] done: {len(kept)} identities, {total} clips -> {args.out_dir}")
+    if failed:
+        # Silent read failures are usually unauthenticated HF rate-limiting on bulk per-clip
+        # fetches — surface it instead of mysteriously yielding too few clips.
+        print(f"[voxceleb] WARNING: {failed} clip read(s) failed — likely HF rate-limiting. "
+              "Set HF_TOKEN / `huggingface-cli login` for higher limits and re-run "
+              "(resume picks up where this left off).", file=sys.stderr)
     if not kept:
         print("[voxceleb] nothing sampled — check HF auth/terms and dataset schema", file=sys.stderr)
         sys.exit(1)

--- a/scripts/voxceleb_sample.py
+++ b/scripts/voxceleb_sample.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""SAMPLE-ONLY VoxCeleb1 identity sampler with a HARD CAP.
+
+VoxCeleb1 (CC-BY-SA 4.0, https://www.robots.ox.ac.uk/~vgg/data/voxceleb/) is huge
+(~1200 identities / ~150k clips / ~30 GB). We NEVER pull all of it. Instead we STREAM a
+HuggingFace VoxCeleb1 mirror and stop as soon as we have `--identity-cap` distinct
+speakers, each with up to `--clips-per-id` clips. Streaming means the wire footprint is
+bounded by (cap × clips × ~clip-size), not the full corpus.
+
+GATED: VoxCeleb on HF is usually access-gated — needs `huggingface-cli login` (or HF_TOKEN)
+and accepting the dataset terms, plus `pip install datasets soundfile`.
+
+Output layout (16 kHz mono WAV, the app's target rate):
+  data/voxceleb/raw/<speaker_id>/<clip_index>.wav
+
+Usage:
+  python3 scripts/voxceleb_sample.py --out-dir data/voxceleb/raw \
+      --identity-cap 300 --clips-per-id 10
+"""
+import argparse, os, sys
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--identity-cap", type=int, default=300,
+                    help="HARD CAP on distinct identities (default 300). Never pull all of VoxCeleb.")
+    ap.add_argument("--clips-per-id", type=int, default=10, help="max clips kept per identity")
+    ap.add_argument("--dataset", default="confit/voxceleb1",
+                    help="HF VoxCeleb1 mirror exposing per-clip audio + speaker label")
+    ap.add_argument("--split", default="train")
+    ap.add_argument("--sr", type=int, default=16000)
+    args = ap.parse_args()
+
+    if args.identity_cap <= 0 or args.identity_cap > 1211:
+        print(f"refusing identity-cap={args.identity_cap}: must be 1..1211 (VoxCeleb1 size). "
+              "This is a SAMPLE-only tool.", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        from datasets import load_dataset
+        import soundfile as sf
+        import numpy as np
+    except Exception as e:
+        print(f"error: needs `datasets` + `soundfile` ({e}); pip install datasets soundfile",
+              file=sys.stderr)
+        sys.exit(2)
+
+    print(f"[voxceleb] STREAMING {args.dataset}:{args.split} — cap {args.identity_cap} ids "
+          f"× {args.clips_per_id} clips (hard cap; not pulling the full corpus)")
+    ds = load_dataset(args.dataset, split=args.split, streaming=True)
+
+    def speaker_of(row):
+        for k in ("speaker", "speaker_id", "label", "id", "client_id"):
+            v = row.get(k)
+            if v is not None:
+                return str(v)
+        return None
+
+    kept = {}            # speaker -> count kept
+    os.makedirs(args.out_dir, exist_ok=True)
+    total = 0
+    for row in ds:
+        spk = speaker_of(row)
+        if spk is None:
+            continue
+        if spk not in kept and len(kept) >= args.identity_cap:
+            # cap reached for new identities; only top up identities we already have
+            if all(c >= args.clips_per_id for c in kept.values()):
+                break
+            continue
+        if kept.get(spk, 0) >= args.clips_per_id:
+            continue
+        audio = row.get("audio")
+        if not isinstance(audio, dict) or "array" not in audio:
+            continue
+        arr = np.asarray(audio["array"], dtype="float32")
+        sr = int(audio.get("sampling_rate", args.sr))
+        d = os.path.join(args.out_dir, spk)
+        os.makedirs(d, exist_ok=True)
+        idx = kept.get(spk, 0)
+        sf.write(os.path.join(d, f"{idx:03d}.wav"), arr, sr)
+        kept[spk] = idx + 1
+        total += 1
+        if total % 100 == 0:
+            print(f"[voxceleb] {len(kept)} ids, {total} clips...")
+
+    print(f"[voxceleb] done: {len(kept)} identities, {total} clips -> {args.out_dir}")
+    if not kept:
+        print("[voxceleb] nothing sampled — check HF auth/terms and dataset schema", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/voxceleb_sample.py
+++ b/scripts/voxceleb_sample.py
@@ -7,15 +7,20 @@ HuggingFace VoxCeleb1 mirror and stop as soon as we have `--identity-cap` distin
 speakers, each with up to `--clips-per-id` clips. Streaming means the wire footprint is
 bounded by (cap × clips × ~clip-size), not the full corpus.
 
-GATED: VoxCeleb on HF is usually access-gated — needs `huggingface-cli login` (or HF_TOKEN)
-and accepting the dataset terms, plus `pip install datasets soundfile`.
+Needs `pip install datasets` + `ffmpeg` on PATH (audio is read via fsspec and transcoded
+by ffmpeg — no torch/soundfile/torchcodec needed). The default mirror `s3prl/mini_voxceleb1`
+is PUBLIC (no HF login). Larger mirrors may be access-gated (`huggingface-cli login` /
+HF_TOKEN + accept terms); point `--dataset` at one to scale past mini's identity count.
+
+Speaker id comes from the dataset's speaker column if populated, else from the VoxCeleb
+filename convention (`id10012-<video>-00001.wav` -> `id10012`).
 
 Output layout (16 kHz mono WAV, the app's target rate):
   data/voxceleb/raw/<speaker_id>/<clip_index>.wav
 
 Usage:
   python3 scripts/voxceleb_sample.py --out-dir data/voxceleb/raw \
-      --identity-cap 300 --clips-per-id 10
+      --identity-cap 300 --clips-per-id 10 --dataset s3prl/mini_voxceleb1
 """
 import argparse, os, sys
 
@@ -26,8 +31,9 @@ def main():
     ap.add_argument("--identity-cap", type=int, default=300,
                     help="HARD CAP on distinct identities (default 300). Never pull all of VoxCeleb.")
     ap.add_argument("--clips-per-id", type=int, default=10, help="max clips kept per identity")
-    ap.add_argument("--dataset", default="confit/voxceleb1",
-                    help="HF VoxCeleb1 mirror exposing per-clip audio + speaker label")
+    ap.add_argument("--dataset", default="s3prl/mini_voxceleb1",
+                    help="HF VoxCeleb1 mirror exposing per-clip audio (public default; "
+                         "swap for a larger/gated mirror to exceed mini's identity count)")
     ap.add_argument("--split", default="train")
     ap.add_argument("--sr", type=int, default=16000)
     args = ap.parse_args()
@@ -38,30 +44,87 @@ def main():
         sys.exit(2)
 
     try:
-        from datasets import load_dataset
-        import soundfile as sf
-        import numpy as np
+        from datasets import load_dataset, Audio
     except Exception as e:
-        print(f"error: needs `datasets` + `soundfile` ({e}); pip install datasets soundfile",
-              file=sys.stderr)
+        print(f"error: needs `datasets` ({e}); pip install datasets", file=sys.stderr)
+        sys.exit(2)
+    import shutil, subprocess, tempfile
+    if not shutil.which("ffmpeg"):
+        print("error: ffmpeg required to transcode clips", file=sys.stderr)
         sys.exit(2)
 
     print(f"[voxceleb] STREAMING {args.dataset}:{args.split} — cap {args.identity_cap} ids "
           f"× {args.clips_per_id} clips (hard cap; not pulling the full corpus)")
     ds = load_dataset(args.dataset, split=args.split, streaming=True)
+    # Disable HF audio decoding (datasets 4.x needs torchcodec to decode arrays). We grab
+    # the raw encoded bytes/path instead and let ffmpeg transcode to 16 kHz mono — no
+    # torch/soundfile dependency, and robust across mirrors.
+    audio_col = "audio" if "audio" in (ds.column_names or []) else None
+    if audio_col:
+        ds = ds.cast_column(audio_col, Audio(decode=False))
 
-    def speaker_of(row):
-        for k in ("speaker", "speaker_id", "label", "id", "client_id"):
+    import re
+    try:
+        import fsspec
+    except Exception:
+        fsspec = None
+
+    def speaker_of(row, audio):
+        # 1) an explicit speaker column, if populated
+        for k in ("speaker", "speaker_id", "client_id", "speaker_label", "label", "id"):
             v = row.get(k)
-            if v is not None:
+            if v is not None and str(v) != "":
                 return str(v)
+        # 2) VoxCeleb encodes the speaker in the filename: id10012-<video>-00001.wav
+        path = audio.get("path") if isinstance(audio, dict) else None
+        if path:
+            base = os.path.basename(path)
+            m = re.match(r"(id\d+)", base)
+            if m:
+                return m.group(1)
+            # else fall back to the leading path segment
+            parts = base.split("-")
+            if parts:
+                return parts[0]
         return None
+
+    def write_clip(audio, dst, sr):
+        """audio is {'bytes':..,'path':..} (decode=False). Read bytes (local, or hf://
+        via fsspec) and transcode to 16 kHz mono WAV with ffmpeg."""
+        src, tmp = None, None
+        if isinstance(audio, dict):
+            data = audio.get("bytes")
+            path = audio.get("path")
+            if not data and path and "://" in path and fsspec is not None:
+                try:
+                    with fsspec.open(path, "rb") as f:
+                        data = f.read()
+                except Exception:
+                    data = None
+            if data:
+                tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".bin")
+                tmp.write(data); tmp.close(); src = tmp.name
+            elif path and "://" not in path:
+                src = path
+        if not src:
+            return False
+        try:
+            subprocess.check_call(["ffmpeg", "-v", "error", "-y", "-i", src, "-ac", "1",
+                                   "-ar", str(sr), "-c:a", "pcm_s16le", dst],
+                                  stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+        finally:
+            if tmp:
+                os.unlink(tmp.name)
 
     kept = {}            # speaker -> count kept
     os.makedirs(args.out_dir, exist_ok=True)
     total = 0
     for row in ds:
-        spk = speaker_of(row)
+        audio = row.get(audio_col) if audio_col else None
+        spk = speaker_of(row, audio)
         if spk is None:
             continue
         if spk not in kept and len(kept) >= args.identity_cap:
@@ -71,15 +134,11 @@ def main():
             continue
         if kept.get(spk, 0) >= args.clips_per_id:
             continue
-        audio = row.get("audio")
-        if not isinstance(audio, dict) or "array" not in audio:
-            continue
-        arr = np.asarray(audio["array"], dtype="float32")
-        sr = int(audio.get("sampling_rate", args.sr))
         d = os.path.join(args.out_dir, spk)
         os.makedirs(d, exist_ok=True)
         idx = kept.get(spk, 0)
-        sf.write(os.path.join(d, f"{idx:03d}.wav"), arr, sr)
+        if not write_clip(row.get(audio_col), os.path.join(d, f"{idx:03d}.wav"), args.sr):
+            continue
         kept[spk] = idx + 1
         total += 1
         if total % 100 == 0:


### PR DESCRIPTION
Builds on the landed `SpeakerEvalHarness` (#1141) to turn the speaker-naming eval into a **permanent, scaled, re-runnable** asset across a **chosen, compute-capped corpus mix** — diverse identities for a trustworthy near-zero-false-positive number, without multi-day compute. **No app-behavior changes** — only `scripts/` + harness docs; all datasets gitignored under `data/`.

## Corpus mix (each downloader documents source + license)
- **AMI** — `download_ami.sh` presets `es2002` | `scale` (8 series, ~32 recurring ids) | `full` (~170 mtgs, ~100h); train/dev/test RTTM fallback.
- **ICSI** — `download_icsi.sh` + `icsi_rttm_from_hf.py` (Edinburgh audio + HF `diarizers-community/icsi` RTTMs, gated).
- **VoxConverse** — `download_voxconverse.sh` (dev+test audio from KAIST + RTTMs from joonson/voxconverse), CC-BY 4.0.
- **VoxCeleb** — `download_voxceleb_sample.sh` + `voxceleb_sample.py` + `build_voxceleb_sessions.py`: **SAMPLE-ONLY, HARD identity cap** (`VOXCELEB_IDENTITY_CAP=300`, HF-streamed so the full corpus is never pulled) → synthetic multi-identity sessions for the cross-recording re-ID / false-positive test.

## Generalized driver
`run_speaker_eval.sh` is now keyed by `CORPUS` (`ami|icsi|voxconverse|voxceleb`): one shared `dump → sweep → score` (DER, fragmentation, false-merge, re-ID curve). Scorer was already corpus-agnostic; aggregate title parameterized. Env knobs: `CORPUS, SERIES, AMI_SET, ICSI_SET, VOXCELEB_IDENTITY_CAP, VOXCONVERSE_SPLITS, CONSOLIDATION, MATCH, COLLAR`.

## AMI scale-up (proof, hours-bounded → actually 6 min)
**32 meetings / 32 distinct recurring identities, 15.85 h audio, processed end-to-end in 6.2 min** (~150× realtime). At 8× the baseline's meetings and identities:
- **match 0.60 re-confirmed** — ends at exactly **32 profiles for 32 people** (0.55 over-merges → 25, 0.65 fragments → 35).
- **0.88 consolidation knob inert at scale** — `none/0.85/0.88/0.91` give identical metrics.
- **false-merge = 22 is diarizer-bound, not matcher-bound** — 22/32 meetings under-segment (<4 clusters for 4 speakers), mixing identities before the matcher runs (DER confusion 0.298 ≫ miss 0.104). AMI even scaled can't give the near-zero-false-positive number → motivates the cleaner-identity tiers.

Full writeup: `Tools/SpeakerEvalHarness/SCALEUP_REPORT.md`. Per-tier run commands + compute estimates: `README.md → Corpus mix`.

## Gating
Full AMI / VoxConverse / ICSI / VoxCeleb tiers are **wired with one-line commands but intentionally not auto-run** (hours-to-days of download + compute). VoxCeleb is always sample-only and hard-capped — there is no "download all of VoxCeleb" path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)