### PR TITLE
fix(audio): abandon wedged engine queue on device-change rewarm hang

### DIFF
--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -1027,6 +1027,11 @@ class ParakeetEngine: ObservableObject {
                 }
             } catch {
                 guard !self.recoveryState.isStale(generation: myGeneration) else { return }
+                // A timed-out audio-engine operation means the serial engine queue
+                // is wedged behind a CoreAudio call that never returned (the AirPods
+                // / Bluetooth route-switch hang). Rebuilding on that same queue would
+                // never run, so fail safe by abandoning the blocked graph instead.
+                let audioEngineQueueBlocked = error is ParakeetAudioEngineWorkError
                 let failureAction = ParakeetDeviceRecoveryFailurePolicy.action(wasRecording: shouldRestartRecording)
                 if self.recoveryState.finishRecovery(success: false, generation: myGeneration) {
                     self.cancelConfigRecoveryTimeout()
@@ -1081,7 +1086,14 @@ class ParakeetEngine: ObservableObject {
                             ]
                         ))
                 }
-                await self.rebuildAudioEngine(reason: "device_change_rewarm_failed")
+                switch ParakeetDeviceRecoveryFailurePolicy.rebuildStrategy(
+                    audioEngineQueueBlocked: audioEngineQueueBlocked
+                ) {
+                case .queuedOnAudioEngineQueue:
+                    await self.rebuildAudioEngine(reason: "device_change_rewarm_failed")
+                case .abandonBlockedAudioGraph:
+                    self.abandonBlockedAudioEngine(reason: "device_change_rewarm_failed")
+                }
                 if failureAction.schedulePrewarmRetry {
                     self.prewarmRetryCount = 0
                     self.schedulePrewarmRetry()

--- a/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
+++ b/Sources/Speech/ParakeetStartRecordingFailurePolicy.swift
@@ -60,6 +60,25 @@ enum ParakeetDeviceRecoveryFailurePolicy {
             schedulePrewarmRetry: true
         )
     }
+
+    /// Choose how to recover the audio graph after a device-change rewarm fails.
+    ///
+    /// A rewarm fails when the recovery snapshot throws. The only non-stale throw
+    /// it can produce is a timed-out audio-engine operation — which means the
+    /// serial `audioEngineQueue` is wedged behind a CoreAudio call that never
+    /// returned (the classic AirPods/Bluetooth route-switch hang). Queuing a
+    /// `rebuildAudioEngine` on that same blocked queue would never run, so the
+    /// recovery task hangs forever and the engine stays dead until the user
+    /// force-quits (surfacing as `app.unclean_shutdown_detected`).
+    ///
+    /// When the queue is blocked, abandon the wedged graph instead: swap in a
+    /// fresh `AVAudioEngine` and a fresh queue synchronously, mirroring the
+    /// recovery-timeout path (`ParakeetDeviceRecoveryTimeoutPolicy`) and the
+    /// start-recording timeout path. Non-blocked failures can still rebuild on
+    /// the existing queue.
+    static func rebuildStrategy(audioEngineQueueBlocked: Bool) -> ParakeetAudioEngineRebuildStrategy {
+        audioEngineQueueBlocked ? .abandonBlockedAudioGraph : .queuedOnAudioEngineQueue
+    }
 }
 
 enum ParakeetDeviceRecoveryReadinessPolicy {

--- a/Tests/ParakeetStartRecordingFailurePolicyTests.swift
+++ b/Tests/ParakeetStartRecordingFailurePolicyTests.swift
@@ -109,6 +109,37 @@ func testParakeetStartRecordingFailurePolicy() {
         assertTrue(action.schedulePrewarmRetry, "recording recovery should still schedule a follow-up prewarm")
     }
 
+    runSuite("ParakeetDeviceRecoveryFailurePolicy abandons the wedged queue on a blocked rewarm") {
+        // A timed-out recovery snapshot means the serial audio-engine queue is
+        // stuck behind a CoreAudio call that never returned (the AirPods/Bluetooth
+        // route-switch hang). Rebuilding on that same queue would never run, so the
+        // recovery must hard-reset onto a fresh engine + queue instead.
+        assertEqual(
+            ParakeetDeviceRecoveryFailurePolicy.rebuildStrategy(audioEngineQueueBlocked: true),
+            .abandonBlockedAudioGraph,
+            "a blocked engine queue must be abandoned, not queued behind, or rewarm hangs until force-quit"
+        )
+    }
+
+    runSuite("ParakeetDeviceRecoveryFailurePolicy rebuilds on the live queue when it is not blocked") {
+        assertEqual(
+            ParakeetDeviceRecoveryFailurePolicy.rebuildStrategy(audioEngineQueueBlocked: false),
+            .queuedOnAudioEngineQueue,
+            "a responsive queue can still rebuild the engine in place"
+        )
+    }
+
+    runSuite("ParakeetDeviceRecoveryFailurePolicy blocked-rewarm strategy matches the timeout path") {
+        // The recovery-timeout path already abandons the blocked graph. A blocked
+        // rewarm is the same wedged-queue condition reached a different way, so the
+        // two must agree — otherwise rewarm and timeout diverge on the same hang.
+        assertEqual(
+            ParakeetDeviceRecoveryFailurePolicy.rebuildStrategy(audioEngineQueueBlocked: true),
+            ParakeetDeviceRecoveryTimeoutPolicy.action(wasRecording: true).rebuildStrategy,
+            "blocked rewarm recovery must use the same hard reset as the recovery-timeout path"
+        )
+    }
+
     runSuite("ParakeetDeviceRecoveryReadinessPolicy waits on unsettled route formats") {
         assertEqual(
             ParakeetDeviceRecoveryReadinessPolicy.action(for: .routeNotSettled),
@@ -623,6 +654,48 @@ func testParakeetStartRecordingFailurePolicy() {
         assertTrue(suppressConfigChanges.lowerBound < removeTap.lowerBound, "zombie reset should suppress self-induced config changes before graph teardown")
         assertTrue(pendingRestartGuard.lowerBound < retryStart.lowerBound, "zombie retry should be gated by the pending restart flag so user stop can cancel it")
         assertTrue(clearPendingBeforeRetry.lowerBound < retryStart.lowerBound, "zombie retry should clear pending restart state before attempting the recovery start")
+    }
+
+    runSuite("ParakeetEngine device-change rewarm abandons the wedged queue instead of re-queuing on it") {
+        // Simulates a route change mid-stream: handleAudioConfigChange tears down
+        // and schedules attemptDeviceRecovery; if the recovery snapshot times out
+        // (queue wedged on a CoreAudio call during the AirPods/Bluetooth switch),
+        // the catch block must hard-reset the graph rather than await
+        // rebuildAudioEngine on the same blocked queue (which never returns and
+        // strands the recording until the user force-quits).
+        //
+        // ParakeetEngine's recovery control flow is CoreAudio-wired and not
+        // compiled into this Foundation-only runner, so this pins source structure.
+        // It guards a REAL invariant behind the device_change_rewarm_failed (x207)
+        // and app.unclean_shutdown_detected (x166) Sentry pair. If you move/rename
+        // attemptDeviceRecovery or reorder its catch handling, update this together.
+        let source = readParakeetEngineSource()
+        guard let recoveryStart = source.range(of: "private func attemptDeviceRecovery()"),
+              let recoveryEnd = source.range(of: "private func scheduleConfigRecoveryTimeout", range: recoveryStart.upperBound..<source.endIndex) else {
+            assertTrue(false, "test should find the attemptDeviceRecovery body")
+            return
+        }
+        let recovery = String(source[recoveryStart.lowerBound..<recoveryEnd.lowerBound])
+
+        guard let catchClause = recovery.range(of: "} catch {"),
+              let blockedProbe = recovery.range(of: "error is ParakeetAudioEngineWorkError", range: catchClause.upperBound..<recovery.endIndex),
+              let strategySwitch = recovery.range(of: "ParakeetDeviceRecoveryFailurePolicy.rebuildStrategy(", range: catchClause.upperBound..<recovery.endIndex),
+              let abandonCase = recovery.range(of: "self.abandonBlockedAudioEngine(reason: \"device_change_rewarm_failed\")", range: catchClause.upperBound..<recovery.endIndex),
+              let queuedRebuildCase = recovery.range(of: "await self.rebuildAudioEngine(reason: \"device_change_rewarm_failed\")", range: catchClause.upperBound..<recovery.endIndex) else {
+            assertTrue(false, "rewarm catch must branch the graph recovery on whether the engine queue is blocked")
+            return
+        }
+
+        assertTrue(blockedProbe.lowerBound < strategySwitch.lowerBound, "rewarm catch should detect a wedged engine queue before choosing a rebuild strategy")
+        assertTrue(strategySwitch.lowerBound < abandonCase.lowerBound, "rewarm catch should route through the rebuild-strategy policy before abandoning the graph")
+        assertTrue(strategySwitch.lowerBound < queuedRebuildCase.lowerBound, "the in-place rebuild must also sit behind the rebuild-strategy switch, not run unconditionally")
+
+        // The blocked-queue rebuild MUST be the synchronous abandon path. An
+        // `await rebuildAudioEngine` reached unconditionally (the old bug) would
+        // hang on the wedged queue, so the awaited rebuild may only appear inside
+        // the strategy switch alongside the abandon case.
+        let queuedCount = recovery.components(separatedBy: "await self.rebuildAudioEngine(reason: \"device_change_rewarm_failed\")").count - 1
+        assertEqual(queuedCount, 1, "there should be exactly one guarded in-place rebuild in the rewarm catch")
     }
 
     runSuite("ParakeetEngine stopRecording cancels pending zombie restart while idle") {


### PR DESCRIPTION
## Problem

Sentry shows two events that are really the **same** AirPods / Bluetooth / built-in route-switch failure:

- `parakeet.device_change_rewarm_failed` — **x207**
- `app.unclean_shutdown_detected` — **x166**

This is the real-world device-change path failing when users swap audio devices mid-recording.

## Root cause

On a device change, `ParakeetEngine.handleAudioConfigChange()` tears down the tap/engine and schedules `attemptDeviceRecovery()`. Recovery reads the new device format via `audioInputSnapshot()` → `runTimedAudioEngineWork()`, which hops onto the serial `audioEngineQueue`.

During a Bluetooth/AirPods switch CoreAudio can wedge that queue behind a HAL call that never returns. `runTimedAudioEngineWork` has its own watchdog, so it correctly throws `ParakeetAudioEngineWorkError.timedOut` (the only non-stale throw this path can produce). But the `catch` block then did:

```swift
await self.rebuildAudioEngine(reason: "device_change_rewarm_failed")
```

`rebuildAudioEngine` calls the **untimed** `runAudioEngineWork` continuation, which enqueues onto the **same blocked queue** — so it never returns. The recovery task hangs, the engine stays dead, recording is stranded, and the user force-quits → `app.unclean_shutdown_detected`. That is the 207 ↔ 166 link.

The start-recording path (`audio_format_read_timeout`) and the recovery-**timeout** path (`ParakeetDeviceRecoveryTimeoutPolicy` → `.abandonBlockedAudioGraph`) already handle exactly this wedged-queue condition by abandoning the graph. **Only the rewarm `catch` was inconsistent** and re-queued on the dead queue.

## Fix

- Add `ParakeetDeviceRecoveryFailurePolicy.rebuildStrategy(audioEngineQueueBlocked:)` (pure logic).
- Branch the rewarm `catch` on whether the failure was a timed-out (blocked-queue) operation (`error is ParakeetAudioEngineWorkError`):
  - **blocked queue** → `abandonBlockedAudioEngine` — fresh `AVAudioEngine` + fresh queue, synchronous (same hard reset as the timeout/start paths)
  - **responsive queue** → `rebuildAudioEngine` as before

Rewarm now **fails safe**: instead of hanging the engine forever, it abandons the wedged graph, surfaces interruption state (`recording_interrupted` when recording), and schedules a prewarm retry on the fresh queue.

Builds **on** #1135's `AudioInputTapTeardownPolicy` (stop + drain before `removeTap`); that teardown ordering is untouched.

## Tests

- Pure-logic coverage for the new strategy decision, including **parity** with the recovery-timeout path.
- Source-contract test pinning the rewarm `catch` wiring (route-change-mid-stream → blocked queue → **abandon**, not re-queue; exactly one guarded in-place rebuild), matching this file's existing ParakeetEngine contract-test idiom.
- **Full fast suite: 5420/5420.** App build: clean (0 errors), launch smoke OK.

## Manual proof still required

Unit/contract tests pin the decision and wiring; they do **not** reproduce a real CoreAudio hang. Validate on hardware:

1. Start a dictation/meeting recording on the built-in mic.
2. Connect AirPods (or any Bluetooth headset) mid-recording → confirm recovery, no hang.
3. Disconnect / switch back to built-in mid-recording → confirm recovery.
4. Rapid toggle a few times → engine recovers each time; no stuck "recovering" state, no force-quit, no `unclean_shutdown` on next launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)