### PR TITLE
fix(overlay): meeting transcription reads as in-progress, not frozen/done

### DIFF
--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -748,6 +748,7 @@ final class MeetingOverlayRootView: NSView {
 
         if isPreparing {
             hideTooltip()
+            setStatusDotPulsing(false)
             warmupTitleLabel.stringValue = currentWarmupStatus.title
             warmupSubtitleLabel.stringValue = currentWarmupStatus.subtitle
             warmupProgress.doubleValue = currentWarmupStatus.progress
@@ -803,8 +804,8 @@ final class MeetingOverlayRootView: NSView {
             closeButton.layer?.borderWidth = 0
             closeButton.layer?.borderColor = nil
         case .transcribing:
-            titleLabel.stringValue = "Saving transcript"
-            updateStatusDot(color: MeetingOverlayTokens.dotPrep)
+            titleLabel.stringValue = "Transcribing meeting…"
+            updateStatusDot(color: MeetingOverlayTokens.dotPrep, haloOpacity: 0.22, haloRadius: 3)
             detailLabel.stringValue = ""
         case .saved:
             titleLabel.stringValue = "Saved to Markdown"
@@ -825,6 +826,12 @@ final class MeetingOverlayRootView: NSView {
             )
             detailLabel.stringValue = copy.detail
         }
+
+        // Transcription has no progress channel to drive a bar, so pulse the
+        // status dot while it runs. Without this the pill reads as finished
+        // ("Saved to Markdown" lookalike) or frozen during the long
+        // transcribe + diarize step that follows stopping a recording.
+        setStatusDotPulsing(state == .transcribing)
 
         if state == .recording {
             timerLabel.stringValue = formatDuration(duration)
@@ -984,6 +991,29 @@ final class MeetingOverlayRootView: NSView {
         statusDot.layer?.shadowColor = color.cgColor
         statusDot.layer?.shadowOpacity = haloOpacity
         statusDot.layer?.shadowRadius = haloRadius
+    }
+
+    /// Gently breathes the status dot's opacity so an in-progress state with
+    /// no determinate progress (transcription) never looks frozen. Idempotent:
+    /// `update(...)` runs on every duration tick, so re-adding the same
+    /// animation is skipped while it's already attached.
+    private func setStatusDotPulsing(_ pulsing: Bool) {
+        let key = "transcribingPulse"
+        guard let layer = statusDot.layer else { return }
+        if pulsing {
+            guard layer.animation(forKey: key) == nil else { return }
+            let pulse = CABasicAnimation(keyPath: "opacity")
+            pulse.fromValue = 1.0
+            pulse.toValue = 0.35
+            pulse.duration = 0.7
+            pulse.autoreverses = true
+            pulse.repeatCount = .infinity
+            pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            layer.add(pulse, forKey: key)
+        } else {
+            layer.removeAnimation(forKey: key)
+            layer.opacity = 1
+        }
     }
 
     private func stopButtonImage() -> NSImage? {


### PR DESCRIPTION
## What

UX-polish pass on long-running operations so the user never sees a screen that looks frozen or finished while work is actually happening.

Audited the three long-running operations and found **one** genuinely ambiguous state; the rest already communicate well (see below). Fix is **UI/state only** — no transcription/summary logic touched.

### The gap: meeting `.transcribing` state

After a meeting recording stops, the pill showed a **static** status dot and the copy **"Saving transcript"**. That reads as nearly-done — but the long transcribe + diarize step is what actually runs here, and the pill sat motionless the whole time, looking frozen or already finished.

**Change** (`Sources/UI/Overlay/MeetingOverlayController.swift`):
- Honest copy: `Saving transcript` → `Transcribing meeting…`
- Status dot gets a halo + a gentle infinite opacity pulse while transcribing, giving the state visible motion. There's no determinate progress channel for transcription, so a pulse (not a bar) is the right cue. The pulse helper is idempotent (`update(...)` runs every duration tick) and is cleared on every other state.

### What was already fine (left alone)
- **Model / dependency download** — `MenuBarModelStatusView` shows `Downloading Parakeet · 45%` with a live progress value.
- **Meeting model warmup** (`.preparing`) — title + subtitle + determinate progress bar.
- **Dictation processing** (`.drafting`) — animated spinner + "Processing…/Transcribing…".
- **AI summary generation** — Home shows a `ProgressView` spinner with "AI summary is running".

## Scope
- Own branch, draft PR, no merge.
- One file, +32/−2.

## Manual proof needed
Start a meeting recording, stop it, and watch the pill during transcription: copy reads "Transcribing meeting…" and the dot visibly pulses until it flips to "Saved to Markdown". Verify the pulse does not persist into any other state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)