### PR TITLE
copy: humanize two cryptic user-facing error messages

### DIFF
--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -841,7 +841,7 @@ class DictationSessionController: ObservableObject {
                       self.currentDictationSessionID == taskSessionID else { return }
                 guard appState.sttRouter.isModelLoaded else {
                     appState.logger.log("DICTATION | voice model failed to load for transcription")
-                    overlayController.showError("Voice model failed to load")
+                    overlayController.showError("The voice model didn't load. Please try dictating again in a moment.")
                     isDictating = false
                     appState.runtimeDiagnostics.clearSession(kind: "dictation", outcome: "model_unavailable")
                     return

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1406,7 +1406,7 @@ struct TranscriptedSettingsView: View {
         if !didClear {
             presentHomeActionFailure(
                 title: failureTitle,
-                message: "Transcripted could not update the failed-meeting queue. Check the capture folder, then try again."
+                message: "Transcripted couldn't remove this meeting. Check that your capture folder is available, then try again."
             )
         }
     }


### PR DESCRIPTION
## What

Copy-only polish of two user-facing error strings that read as cryptic or leaked internal vocabulary. No error-handling logic changed.

| Where | Before | After |
|---|---|---|
| Dictation overlay (`DictationSessionController.swift:844`) — voice model not loaded | `Voice model failed to load` | `The voice model didn't load. Please try dictating again in a moment.` |
| Home delete/dismiss failure alert (`TranscriptedSettingsView.swift:1409`) — one of the recently-added reveal/delete failure surfaces | `Transcripted could not update the failed-meeting queue. Check the capture folder, then try again.` | `Transcripted couldn't remove this meeting. Check that your capture folder is available, then try again.` |

## Why

- **Voice model:** the old string was a dead-end status with no next step. The new copy says what happened + what to do, matching the sibling `"Dictation is still loading. Please try again in a moment."` voice.
- **Delete/dismiss failure:** `"failed-meeting queue"` is an internal data-structure term users won't recognize. Reworded to plain language while keeping `capture folder`, which is consistent user-facing vocabulary elsewhere in the app.

## Scope notes

- Reviewed the full error-copy surface. The app already has a strong humanizing layer (`MeetingFailureCopy`, the `TranscriptionTaskManager` error-message mapper, the dictation presentation policies), so most user-facing errors are already calm and actionable — these two were the genuinely cryptic static strings left.
- **Left intentionally untouched** (would require logic changes, out of scope for copy-only):
  - Dynamic failure bodies that interpolate `error.localizedDescription` / `shortErrorMessage` (delete/rename failures, `MeetingFailureCopy` fallbacks) — rewriting to static copy would drop the error detail.
  - `revealFailedMeetingAudio` with no audio is a silent `NSSound.beep()`; surfacing a message there needs new logic.

## Verification

No tests assert on the changed literals. Manual proof still needed: build the macOS app (`bash build.sh --no-open`) and confirm the two alerts render the new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)