### PR TITLE
feat: helpful empty states for Meetings and Dictations

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -1629,11 +1629,61 @@ private struct HomeMeetingAudioControl: View {
 
 }
 
+// MARK: - Empty state
+
+/// Friendly first-run empty state for a capture list: a single line describing
+/// what the screen is for plus one clear primary action.
+struct HomeListEmptyState {
+    let symbolName: String
+    let title: String
+    let message: String
+    let actionTitle: String
+    let automationIdentifier: String
+    let action: () -> Void
+}
+
+private struct HomeEmptyStateView: View {
+    let state: HomeListEmptyState
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: state.symbolName)
+                .font(.system(size: 30, weight: .light))
+                .foregroundStyle(.tertiary)
+
+            VStack(spacing: 5) {
+                Text(state.title)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Color.primary)
+
+                Text(state.message)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: 360)
+            }
+
+            Button(action: state.action) {
+                Text(state.actionTitle)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .padding(.top, 2)
+            .accessibilityIdentifier(state.automationIdentifier)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 40)
+        .padding(.horizontal, 16)
+    }
+}
+
 // MARK: - Day-grouped list
 
 struct HomeDayGroupedList<Item, Row: View>: View {
     let sections: [HomeDaySection<Item>]
     let emptyMessage: String
+    var emptyState: HomeListEmptyState? = nil
     let getID: (Item) -> AnyHashable
     var sectionSpacing: CGFloat = 12
     var headerSpacing: CGFloat = 2
@@ -1641,14 +1691,18 @@ struct HomeDayGroupedList<Item, Row: View>: View {
 
     var body: some View {
         if sections.isEmpty {
-            HStack {
-                Text(emptyMessage)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                Spacer()
+            if let emptyState {
+                HomeEmptyStateView(state: emptyState)
+            } else {
+                HStack {
+                    Text(emptyMessage)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                .padding(.vertical, 28)
+                .padding(.horizontal, 4)
             }
-            .padding(.vertical, 28)
-            .padding(.horizontal, 4)
         } else {
             LazyVStack(alignment: .leading, spacing: sectionSpacing) {
                 ForEach(sections) { section in
@@ -1681,6 +1735,7 @@ struct HomeDayGroupedList<Item, Row: View>: View {
 struct HomeCaptureListSection<Item, Row: View>: View {
     let sections: [HomeDaySection<Item>]
     let emptyMessage: String
+    var emptyState: HomeListEmptyState? = nil
     let isLoading: Bool
     let isLoadingMore: Bool
     let canLoadMore: Bool
@@ -1704,6 +1759,7 @@ struct HomeCaptureListSection<Item, Row: View>: View {
                 HomeDayGroupedList(
                     sections: sections,
                     emptyMessage: emptyMessage,
+                    emptyState: emptyState,
                     getID: getID,
                     sectionSpacing: 14,
                     headerSpacing: 2,

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -588,6 +588,17 @@ struct TranscriptedSettingsView: View {
         HomeCaptureListSection(
             sections: homeMeetingDaySections,
             emptyMessage: HomeCaptureListCopy.emptyMeetings,
+            emptyState: HomeListEmptyState(
+                symbolName: "waveform",
+                title: "No meetings yet",
+                message: "Record a meeting and Transcripted transcribes it, labels each speaker, and saves the transcript here. You can also transcribe an existing audio file from General.",
+                actionTitle: "Start a meeting",
+                automationIdentifier: "transcripted.home.meetings.empty.start",
+                action: {
+                    trackSettingsAction("empty_start_meeting", page: .home)
+                    actions.startMeeting()
+                }
+            ),
             isLoading: homeViewModel.isLoading,
             isLoadingMore: homeViewModel.isLoadingMore,
             canLoadMore: homeViewModel.canLoadMoreMeetings,
@@ -644,6 +655,17 @@ struct TranscriptedSettingsView: View {
         HomeCaptureListSection(
             sections: homeViewModel.dictationDaySections,
             emptyMessage: HomeCaptureListCopy.emptyDictations,
+            emptyState: HomeListEmptyState(
+                symbolName: "mic",
+                title: "No dictations yet",
+                message: "Hold your dictation shortcut and speak in any app — Transcripted types it out for you and keeps a copy here.",
+                actionTitle: "Start a dictation",
+                automationIdentifier: "transcripted.home.dictations.empty.start",
+                action: {
+                    trackSettingsAction("empty_start_dictation", page: .dictations)
+                    actions.startDictation()
+                }
+            ),
             isLoading: homeViewModel.isLoading,
             isLoadingMore: homeViewModel.isLoadingMore,
             canLoadMore: homeViewModel.canLoadMoreDictations,


### PR DESCRIPTION
## What

Make the main capture lists' empty states helpful instead of bland.

Before, when a user had no content yet:
- **Meetings (Home)** showed one line: *"No recent meetings. Record one or transcribe an audio file from General."*
- **Dictations** showed just *"No recent dictations."* — no guidance, no action.

Now each shows a friendly empty state: an icon, one line explaining what the screen is for, and a clear primary action button.

| Screen | Title | Primary action |
|--------|-------|----------------|
| Meetings (Home) | "No meetings yet" | **Start a meeting** → `actions.startMeeting()` |
| Dictations | "No dictations yet" | **Start a dictation** → `actions.startDictation()` |

**Speakers** already had a thoughtful empty state ("No speakers yet. After your next meeting, the people in it will appear here.") — left unchanged.

## How

Extended the existing `HomeDayGroupedList` / `HomeCaptureListSection` with an optional `HomeListEmptyState` (icon + title + message + primary button). When no empty state is supplied, the prior single-line text fallback is unchanged, so this is additive and scoped to the empty/first-run state only — no screen restyling.

The two CTAs reuse the same `startMeeting` / `startDictation` actions already wired to the menu bar's primary actions, and emit `empty_start_meeting` / `empty_start_dictation` settings-action telemetry. New automation identifiers: `transcripted.home.meetings.empty.start`, `transcripted.home.dictations.empty.start`.

## Verification

- `bash build.sh --no-open` — builds clean
- `bash run-tests.sh` — 5413 tests, all pass

### Manual proof still needed
Visual check on a fresh/empty library: open Settings → Home and Dictations with no captures, confirm the empty states render correctly and the buttons start a meeting / dictation. (Could not capture screenshots headlessly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)