### PR TITLE
feat: menu-bar keyboard shortcuts for top daily actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ appcast for in-app Sparkle updates is at
 Entries marked **[CRITICAL]** are flagged as `sparkle:criticalUpdate` and are
 force-installed by Sparkle so existing users recover from a regression.
 
+## [Unreleased]
+
+### Added
+- Keyboard shortcuts in the macOS menu bar for the top daily actions: Start
+  Dictation (⌘D), Start / Stop Meeting Recording (⌘R), Transcribe Audio File
+  (⌘O), jump to Home/Dictations/Speakers/Agent (⌘1–⌘4), and Find Speaker (⌘F,
+  focuses the speaker search). Sidebar rows now show their shortcut as a
+  tooltip. Existing recordable dictation/meeting triggers are unchanged.
+
 ## [1.1.47] - 2026-06-08
 
 ### Added

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -16,6 +16,9 @@ struct TranscriptedApp: App {
 
     var body: some Scene {
         Settings { EmptyView() }
+            .commands {
+                TranscriptedMenuCommands(appDelegate: appDelegate)
+            }
     }
 }
 
@@ -831,6 +834,39 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             properties["backoff_kind"] = backoffKind.rawValue
         }
         return properties
+    }
+
+    // MARK: - Menu Bar Commands
+
+    /// Thin entry points for `TranscriptedMenuCommands`. They live here (rather
+    /// than in an extension) so they can reuse the existing private action
+    /// helpers. Each one mirrors a path users already have via the popover, the
+    /// sidebar, or a recordable trigger — nothing here remaps those triggers.
+
+    func menuStartDictation() {
+        startDictationFromSettings()
+    }
+
+    func menuToggleMeetingRecording() {
+        guard #available(macOS 14.0, *) else {
+            NSSound.beep()
+            return
+        }
+        // Same start/stop toggle the meeting trigger uses, so ⌘R behaves like
+        // the recordable meeting shortcut.
+        meetingOverlayController.toggleFromHotkey()
+    }
+
+    func menuImportAudio() {
+        importAudioFileFromSettings()
+    }
+
+    func menuOpenPage(_ page: TranscriptedSettingsPage) {
+        showSettingsWindow(page: page, source: "menu_command")
+    }
+
+    func menuFindSpeaker() {
+        settingsWindowController.focusSpeakerSearch(source: "menu_command")
     }
 
     // MARK: - NSPopoverDelegate

--- a/Sources/TranscriptedMenuCommands.swift
+++ b/Sources/TranscriptedMenuCommands.swift
@@ -1,0 +1,68 @@
+// TranscriptedMenuCommands.swift
+// macOS menu-bar commands that surface Transcripted's top daily actions with
+// conventional ⌘-based shortcuts.
+//
+// This is purely additive: every action routes through an existing app-delegate
+// entry point, and none of the user's recordable dictation / meeting triggers
+// (push-to-talk, hands-free, meeting, paste-last) are remapped. The commands
+// only fire while the app is active (a window is open), which is exactly when
+// navigation, search, and in-app capture make sense; the global physical
+// triggers remain the background path.
+
+import SwiftUI
+
+struct TranscriptedMenuCommands: Commands {
+    let appDelegate: TranscriptedAppDelegate
+
+    var body: some Commands {
+        // Capture — the two recording actions plus file import.
+        CommandMenu("Capture") {
+            Button("Start Dictation") {
+                appDelegate.menuStartDictation()
+            }
+            .keyboardShortcut("d", modifiers: .command)
+
+            Button("Start / Stop Meeting Recording") {
+                appDelegate.menuToggleMeetingRecording()
+            }
+            .keyboardShortcut("r", modifiers: .command)
+
+            Divider()
+
+            Button("Transcribe Audio File…") {
+                appDelegate.menuImportAudio()
+            }
+            .keyboardShortcut("o", modifiers: .command)
+        }
+
+        // Go — jump straight to a sidebar section (opening the window if needed).
+        CommandMenu("Go") {
+            Button("Home") {
+                appDelegate.menuOpenPage(.home)
+            }
+            .keyboardShortcut("1", modifiers: .command)
+
+            Button("Dictations") {
+                appDelegate.menuOpenPage(.dictations)
+            }
+            .keyboardShortcut("2", modifiers: .command)
+
+            Button("Speakers") {
+                appDelegate.menuOpenPage(.people)
+            }
+            .keyboardShortcut("3", modifiers: .command)
+
+            Button("Agent") {
+                appDelegate.menuOpenPage(.connectAgent)
+            }
+            .keyboardShortcut("4", modifiers: .command)
+
+            Divider()
+
+            Button("Find Speaker…") {
+                appDelegate.menuFindSpeaker()
+            }
+            .keyboardShortcut("f", modifiers: .command)
+        }
+    }
+}

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -67,6 +67,8 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
     @Published var searchText: String = ""
     @Published private(set) var reviewQueueItems: [SpeakerPendingReviewItem] = []
     @Published private(set) var hasLoadedProfiles = false
+    /// Bumped to ask the "Search speakers" field to take focus (⌘F).
+    @Published private(set) var searchFocusRequestToken = 0
 
     private let speakerDatabase: SpeakerDatabase
     private let preferredClipsDirectory: URL
@@ -118,6 +120,12 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
             return profile.id.uuidString.lowercased().contains(query)
         }
         return SpeakerPeopleReviewPolicy.sortedForPeopleSettings(matches, duplicateIds: duplicateIds)
+    }
+
+    /// Asks the "Search speakers" field to take keyboard focus. Drives the ⌘F
+    /// "Find Speaker" menu command.
+    func requestSearchFocus() {
+        searchFocusRequestToken += 1
     }
 
     func refresh() {
@@ -1006,11 +1014,20 @@ private struct SpeakerDuplicateNameChip: View {
 
 private struct SpeakerSearchRow: View {
     @ObservedObject var model: SpeakerPeopleSettingsViewModel
+    @FocusState private var isSearchFocused: Bool
 
     var body: some View {
         HStack(spacing: 8) {
             TextField("Search speakers", text: $model.searchText)
                 .textFieldStyle(.roundedBorder)
+                .focused($isSearchFocused)
+                // Fires on first appearance and whenever ⌘F bumps the token,
+                // so "Find Speaker" focuses the field whether or not the
+                // Speakers page was already open.
+                .task(id: model.searchFocusRequestToken) {
+                    guard model.searchFocusRequestToken > 0 else { return }
+                    isSearchFocused = true
+                }
 
             Button {
                 model.refresh()

--- a/Sources/UI/Settings/TranscriptedSettingsPage.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsPage.swift
@@ -89,6 +89,26 @@ enum TranscriptedSettingsPage: String, CaseIterable, Identifiable {
         }
     }
 
+    /// Conventional ⌘ shortcut for the primary sidebar sections, surfaced in
+    /// the "Go" menu and as the sidebar row tooltip. `nil` for gear-gated
+    /// settings pages, which have no navigation shortcut.
+    var navigationShortcutKey: String? {
+        switch self {
+        case .home: return "1"
+        case .dictations: return "2"
+        case .people: return "3"
+        case .connectAgent: return "4"
+        default: return nil
+        }
+    }
+
+    /// Tooltip text for a sidebar row, including its navigation shortcut when
+    /// one exists (e.g. "Speakers  ⌘3").
+    var navigationHelp: String {
+        guard let key = navigationShortcutKey else { return summary }
+        return "\(title)  ⌘\(key)"
+    }
+
     var systemImage: String {
         switch self {
         case .home: return "house.fill"

--- a/Sources/UI/Settings/TranscriptedSettingsSidebar.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsSidebar.swift
@@ -43,6 +43,7 @@ struct SettingsSidebarRow: View {
                 shadowRadius: 7
             )
             .accessibilityIdentifier(page.automationIdentifier)
+            .help(page.navigationHelp)
             .onHover { isHovering = $0 }
     }
 }

--- a/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
@@ -64,6 +64,13 @@ final class TranscriptedSettingsWindowController: NSWindowController, NSWindowDe
         NSApp.activate(ignoringOtherApps: true)
     }
 
+    /// Opens (or surfaces) the window on the Speakers page and asks the search
+    /// field to take focus. Backs the ⌘F "Find Speaker" menu command.
+    func focusSpeakerSearch(source: String) {
+        present(page: .people, source: source)
+        speakerPeopleModel.requestSearchFocus()
+    }
+
     func windowWillClose(_ notification: Notification) {
         SpeakerClipPlayback.stop()
     }


### PR DESCRIPTION
## What

Adds conventional ⌘-based keyboard shortcuts to the macOS menu bar for the top actions a daily Transcripted user reaches for, so the app is drivable from the keyboard.

### Capture menu
| Action | Shortcut |
|---|---|
| Start Dictation | ⌘D |
| Start / Stop Meeting Recording | ⌘R |
| Transcribe Audio File… | ⌘O |

### Go menu (sidebar navigation)
| Section | Shortcut |
|---|---|
| Home | ⌘1 |
| Dictations | ⌘2 |
| Speakers | ⌘3 |
| Agent | ⌘4 |
| Find Speaker… | ⌘F (navigates to Speakers + focuses the search field) |

Each `Go` command opens the window if it isn't already up. Sidebar rows now show their navigation shortcut as a **tooltip** (e.g. "Speakers  ⌘3") for discoverability, on top of the visible shortcuts in the menu bar itself.

## How

- New `TranscriptedMenuCommands: Commands` attached to the app's `Settings` scene via `.commands { }`. The app is a SwiftUI `App` (with an `NSApplicationDelegateAdaptor`), so this is the idiomatic, additive way to populate the menu bar.
- Each command routes through a thin `menu*` method on `TranscriptedAppDelegate` that reuses an existing private action helper (`startDictationFromSettings`, `importAudioFileFromSettings`, `showSettingsWindow(page:)`, `meetingOverlayController.toggleFromHotkey()`).
- ⌘F focus: a `searchFocusRequestToken` on `SpeakerPeopleSettingsViewModel` + `@FocusState` on the search field (`.task(id:)` so it focuses whether or not the Speakers page was already open).

## Scope / guarantees

- **Additive only.** No existing shortcut is remapped. The user's recordable dictation/meeting triggers (push-to-talk, hands-free, meeting, paste-last) are untouched, and the standard ⌘, (Settings) / ⌘W (Close) / ⌘Q (Quit) bindings are unchanged.
- **No invented chords** — all single ⌘+key, conflict-free within the app.

## What already existed
- Standard ⌘, / ⌘W / ⌘Q from the SwiftUI `App` scaffold.
- User-recordable **physical** triggers for dictation/meeting/paste (configured in Settings → Shortcuts) — these are a different mechanism and are deliberately left alone.

## Deliberately deferred
- **Delete (⌘⌫) with confirm:** the per-row delete-with-confirm exists for speakers and Home captures, but those lists are hover-action `LazyVStack`s with no row-selection model. A keyboard delete would require inventing selection state — out of scope for a small, additive change. Flagged for a follow-up.
- **Close/Escape:** ⌘W already closes the window (standard) and Escape dismisses popovers/sheets, so no new binding was added to avoid duplicate-shortcut conflicts.

## Verification
- `bash build.sh --no-open` ✅ (compiles, signs, passes launch smoke check)
- `bash run-tests.sh` ✅ (5413 tests, 0 failures)
- **Manual proof still needed:** open the app, confirm the Capture/Go menus render with the shortcuts and that each fires (start dictation, toggle meeting, import, ⌘1–4 navigation, ⌘F focuses speaker search). A UI/AX smoke pass (`bash scripts/ops/transcripted-qa-bench.sh --mode ui`) is the natural follow-up where Accessibility permission is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)