### PR TITLE
a11y: VoiceOver labels + honor Reduce Motion/Transparency

### DIFF
--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -123,15 +123,17 @@ class FloatingOverlayController {
             defer: true
         )
 
-        // Glassmorphism: NSVisualEffectView behind content
+        // Glassmorphism: NSVisualEffectView behind content. Under Reduce
+        // Transparency we drop the live blur and fall back to a solid backdrop.
+        let reduceTransparency = AccessibilityDisplayPolicy.reduceTransparency
         let blurView = NSVisualEffectView()
         blurView.appearance = NSAppearance(named: .darkAqua)
         blurView.material = .underWindowBackground
         blurView.blendingMode = .behindWindow
-        blurView.state = .active
+        blurView.state = reduceTransparency ? .inactive : .active
         blurView.wantsLayer = true
         blurView.layer?.cornerRadius = OverlayTokens.cornerRadius
-        blurView.layer?.backgroundColor = OverlayTokens.panelBg.cgColor
+        blurView.layer?.backgroundColor = AccessibilityDisplayPolicy.backdropColor(OverlayTokens.panelBg).cgColor
         blurView.layer?.borderWidth = 1
         blurView.layer?.borderColor = OverlayTokens.panelStroke.cgColor
         blurView.frame = panel.contentView?.bounds ?? .zero
@@ -317,14 +319,17 @@ class FloatingOverlayController {
         panel.orderFrontRegardless()
 
         if !isCursorMiniPanelMode, let contentLayer = panel.contentView?.layer {
-            let spring = CASpringAnimation(keyPath: "transform.scale")
-            spring.fromValue = 0.88
-            spring.toValue = 1.0
-            spring.damping = 18
-            spring.stiffness = 280
-            spring.initialVelocity = 3
-            spring.duration = spring.settlingDuration
-            contentLayer.add(spring, forKey: "entranceScale")
+            // Skip the entrance spring entirely under Reduce Motion.
+            if !AccessibilityDisplayPolicy.reduceMotion {
+                let spring = CASpringAnimation(keyPath: "transform.scale")
+                spring.fromValue = 0.88
+                spring.toValue = 1.0
+                spring.damping = 18
+                spring.stiffness = 280
+                spring.initialVelocity = 3
+                spring.duration = spring.settlingDuration
+                contentLayer.add(spring, forKey: "entranceScale")
+            }
         }
 
         NSAnimationContext.runAnimationGroup({ ctx in
@@ -395,7 +400,7 @@ class FloatingOverlayController {
             }
         })
 
-        if let contentLayer = panel.contentView?.layer {
+        if !AccessibilityDisplayPolicy.reduceMotion, let contentLayer = panel.contentView?.layer {
             let shrink = CABasicAnimation(keyPath: "transform.scale")
             shrink.fromValue = 1.0
             shrink.toValue = 0.93

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -91,7 +91,9 @@ final class MeetingOverlayTooltipView: NSView {
         wantsLayer = true
         layer?.cornerRadius = 7
         layer?.masksToBounds = true
-        layer?.backgroundColor = NSColor(calibratedWhite: 0.10, alpha: 0.98).cgColor
+        layer?.backgroundColor = AccessibilityDisplayPolicy.backdropColor(
+            NSColor(calibratedWhite: 0.10, alpha: 0.98)
+        ).cgColor
         layer?.borderWidth = 0.5
         layer?.borderColor = NSColor.white.withAlphaComponent(0.16).cgColor
 
@@ -200,7 +202,7 @@ final class MeetingOverlayRootView: NSView {
         wantsLayer = true
         layer?.cornerRadius = MeetingOverlayTokens.cornerRadius
         layer?.masksToBounds = true
-        layer?.backgroundColor = MeetingOverlayTokens.panelBg.cgColor
+        layer?.backgroundColor = AccessibilityDisplayPolicy.backdropColor(MeetingOverlayTokens.panelBg).cgColor
         layer?.borderWidth = 0.5
         layer?.borderColor = MeetingOverlayTokens.panelStroke.cgColor
 
@@ -2495,7 +2497,7 @@ final class MeetingOverlayController: NSObject {
         }
 
         NSAnimationContext.runAnimationGroup { ctx in
-            ctx.duration = 0.20
+            ctx.duration = AccessibilityDisplayPolicy.motionDuration(0.20)
             ctx.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
             panel.animator().setFrame(target, display: true)
         }

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -754,6 +754,7 @@ struct HomeRowActionButtons: View {
         }
         .buttonStyle(SettingsHoverButtonStyle(cornerRadius: 7))
         .help(help)
+        .accessibilityLabel(Text(help))
         .accessibilityIdentifier("transcripted.home.row.copy")
     }
 }
@@ -2228,6 +2229,7 @@ private struct HomePodcastPlayerButton: View {
         .disabled(isDisabled)
         .opacity(isDisabled ? 0.42 : 1)
         .help(help)
+        .accessibilityLabel(Text(help))
         .accessibilityIdentifier(automationIdentifier)
     }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -7,6 +7,7 @@ import UniformTypeIdentifiers
 struct TranscriptedSettingsView: View {
     @Bindable var navigation: TranscriptedSettingsNavigationModel
     @ObservedObject var speakerPeopleModel: SpeakerPeopleSettingsViewModel
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @ObservedObject private var sttRouter: STTRouter
     @ObservedObject private var meetingSession: MeetingSessionController
     @ObservedObject private var sparkleUpdater: SparkleUpdaterController
@@ -121,7 +122,14 @@ struct TranscriptedSettingsView: View {
                     settingsPagesToggle
                     settingsSidebarFooter
                 }
-                .background(.thinMaterial)
+                .background {
+                    // Solid backdrop when the user opts into Reduce Transparency.
+                    if reduceTransparency {
+                        Color(nsColor: .windowBackgroundColor)
+                    } else {
+                        Rectangle().fill(.thinMaterial)
+                    }
+                }
             }
         } detail: {
             ZStack {

--- a/Sources/UI/Shared/AccessibilityDisplayPolicy.swift
+++ b/Sources/UI/Shared/AccessibilityDisplayPolicy.swift
@@ -1,0 +1,39 @@
+import AppKit
+import SwiftUI
+
+/// Small shared policy for honoring the system **Reduce Motion** and
+/// **Reduce Transparency** accessibility settings on Transcripted's main
+/// surfaces (the dictation overlay, the meeting overlay, and the Settings
+/// window).
+///
+/// AppKit surfaces read these booleans directly; SwiftUI surfaces can keep
+/// using `@Environment(\.accessibilityReduceMotion)` /
+/// `\.accessibilityReduceTransparency`. The helpers here keep the "calm under
+/// Reduce Motion, solid under Reduce Transparency" rules in one place instead
+/// of being re-derived at each call site.
+enum AccessibilityDisplayPolicy {
+
+    /// System "Reduce Motion" preference (System Settings ▸ Accessibility ▸ Display).
+    static var reduceMotion: Bool {
+        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+    }
+
+    /// System "Reduce Transparency" preference.
+    static var reduceTransparency: Bool {
+        NSWorkspace.shared.accessibilityDisplayShouldReduceTransparency
+    }
+
+    /// Returns an opaque version of `color` when Reduce Transparency is on,
+    /// otherwise the color unchanged. Use for layer backdrops that would
+    /// otherwise let the desktop bleed through a translucent panel.
+    static func backdropColor(_ color: NSColor) -> NSColor {
+        guard reduceTransparency else { return color }
+        return (color.usingColorSpace(.deviceRGB) ?? color).withAlphaComponent(1.0)
+    }
+
+    /// Collapses an animation duration to an instant when Reduce Motion is on,
+    /// so the same code path stays calm for users who opt out of motion.
+    static func motionDuration(_ duration: TimeInterval) -> TimeInterval {
+        reduceMotion ? 0 : duration
+    }
+}


### PR DESCRIPTION
## What

A small, additive accessibility pass on Transcripted's main surfaces. Labels only + honoring the two system display settings — no redesign, no layout/behavior changes beyond a11y.

### VoiceOver labels
The app is already heavily labeled (AppKit `setAccessibilityLabel` / SwiftUI `.accessibilityLabel` throughout). Found and fixed the two remaining genuine icon-only gaps — both had `.help`/`.accessibilityIdentifier` but no `accessibilityLabel`:
- Meeting/dictation row **copy** button (`HomeRowActionButtons`)
- Meeting-audio **player** buttons (`HomePodcastPlayerButton`)

### Reduce Motion / Reduce Transparency
New small shared core policy `AccessibilityDisplayPolicy` (mirrors the SteadyType small-core-policy approach) reading the system `NSWorkspace` flags, with `backdropColor(_:)` and `motionDuration(_:)` helpers.

**Reduce Transparency → solid backdrops:**
- Dictation overlay pill: live blur dropped to `.inactive` + opaque fill (`FloatingOverlayController`)
- Meeting overlay panel + tooltip (`MeetingOverlayController`)
- Settings sidebar footer: `.thinMaterial` → solid (`TranscriptedSettingsView`, via `@Environment(\.accessibilityReduceTransparency)`)

**Reduce Motion → calm the big animations:**
- Dictation pill entrance spring + confirm-shrink skipped
- Meeting pill resize/morph made instant

(Existing reduce-motion handling — overlay cursor-follow and Settings hover-glow — left as-is.)

## Verification
- `bash build.sh --no-open` ✅
- `bash run-tests.sh` ✅ 5413/5413 passed

## Manual proof still needed
Requires a human with the real app + system toggles:
1. **VoiceOver** (⌘F5): tab through Home meeting/dictation rows — copy and audio-player buttons should now announce their action.
2. **System Settings ▸ Accessibility ▸ Display ▸ Reduce transparency**: dictation pill, meeting pill, and Settings sidebar footer should render with solid (non-translucent) backdrops.
3. **Reduce motion**: dictation pill should appear without the entrance spring / confirm-shrink; meeting pill should resize instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)