### PR TITLE
eval: speaker-naming on real-world audio — VoxConverse (in-the-wild) + AMI codec re-ID sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ Tools/TranscriptedCLI/*.txt
 
 # Eval harness datasets (AMI research-use license; do not commit)
 data/
+.venv_emb/

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ Tools/TranscriptedCLI/*.txt
 # Eval harness datasets (AMI research-use license; do not commit)
 data/
 .venv_emb/
+scripts/out/

--- a/Tools/SpeakerEvalHarness/AB_DOT_VS_CLOUD.md
+++ b/Tools/SpeakerEvalHarness/AB_DOT_VS_CLOUD.md
@@ -1,0 +1,99 @@
+# Speaker-Matcher A/B: DOT vs CLOUD — Final Verdict
+
+Adversarially-verified A/B (4 explore variants + 3 independent skeptic passes, every number
+re-run and reproduced) comparing the production-style **DOT** matcher against a proposed
+**CLOUD** matcher for cross-meeting speaker re-identification.
+
+**Reproduce:**
+```bash
+# 1. regenerate the 300 single-speaker meetings + cached embeddings (one split):
+bash scripts/download_voxceleb_sample.sh    # VOXCELEB_IDENTITY_CAP=30, singles mode
+CORPUS=voxceleb MATCH="0.6" scripts/run_speaker_eval.sh   # populates data/eval/voxceleb/dumps/
+# 2. run the A/B simulator over the cached embeddings:
+python3 scripts/ab_dot_vs_cloud.py --dumps-dir data/eval/voxceleb/dumps --max-app 8
+#    JSON for one config: ... --matcher cloud --thr 0.46 --cap 10 --json
+```
+`scripts/ab_dot_vs_cloud.py` implements both matchers (DOT = one EMA-averaged vector/profile,
+match by cosine≥thr; CLOUD = keep each profile's sample vectors, match a new clip to its
+*nearest* stored sample). The `cloud+merge` variant below was an explored extension run during
+the workflow; it is not in the committed simulator.
+
+## TL;DR
+Naive CLOUD does **not** decisively beat DOT. At matched ~30-profile parity CLOUD is
+**directionally** better on identity-continuity (reid +5 pts avg) and **cleaner** on
+false-merge, while **tied** on "recognized." But the margin sits **inside the N=30 noise
+floor** — every bootstrap 95% CI crosses zero. The one statistically robust lever found is
+internal to DOT: **tuning its EMA slower (0.3) → +19 pts, CI [+10.7, +27.8]**, a free one-line
+change with no extra memory.
+
+## DOT calibration (faithfulness check)
+Python DOT @ thr0.50/ema0.5 → reid m2..m5 = **33/50/57/43**, profiles_end **37**. Swift
+`SpeakerDatabase` ground truth → ~**36/48/55/33**, profiles ~**32**. Same rise-then-fall shape
+peaking at m4; m2/m3/m4 within ~2–3 pts. The PE overshoot is expected — the Python port omits
+the production `mergeDuplicates` pass and fixes ema=0.5. **DOT is a faithful stand-in.**
+
+## Fair operating points (the only honest comparison)
+Compare **only** where both end near the ideal **30 profiles** with comparable false_merge.
+
+| Config | thr | profiles_end | false_merge | avg reid (m2–m8) | avg recognized |
+|---|---|---|---|---|---|
+| **DOT** (best fair) | 0.45 / ema0.5 | 33 | 7 | 45 | 93 |
+| **CLOUD** (best fair) | 0.46 / cap10 | **30** | **5** | **50** | 94 |
+| cloud+merge | 0.55 / merge0.53 / cap10 | 30 | **0** | 48 | 79 |
+
+CLOUD sits at the **ideal 30 profiles with lower false_merge** than the 33-profile DOT it
+beats — the **stricter** side, so its edge is conservative, not bought with leniency. Forcing
+DOT down to PE=30 (thr~0.40) **doubles its false_merge to 10**.
+
+## Per-meeting comparison (reid-to-anchor = continuity with original identity)
+
+| Meeting | DOT 0.45 | CLOUD 0.46 | CLOUD−DOT | cloud+merge |
+|---|---|---|---|---|
+| m2 (1st return) | 53 | 47 | **−6** | 40 |
+| m3 | 50 | 60 | +10 | 63 |
+| m4 | 53 | 63 | +10 | 50 |
+| m5 | 47 | 47 | 0 | 40 |
+| m6 | 33 | 47 | +14 | 40 |
+| m7 | 37 | 40 | +3 | 50 |
+| m8 | 40 | 43 | +3 | 53 |
+| **avg** | **45** | **50** | **+5** | **48** |
+
+CLOUD wins 5/7 meetings, ties 1, **loses only m2** — the first re-encounter (where DOT also
+leads on "recognized," 83 vs 77). The CLOUD advantage **grows at the tail because DOT decays**
+(EMA blending lets duplicate badges drift and win the nearest-match), not because CLOUD climbs.
+
+## Does the best CLOUD curve climb with more meetings?
+**No.** CLOUD's reid spikes at m3–m4 (~60–63) then plateaus ~43–47. Neither matcher delivers the
+intuitive "better every meeting" — what changes is DOT sagging late while CLOUD holds.
+
+## What the skeptics concluded
+- **fairness-cherrypick — NOT refuted.** CLOUD wins at the ideal 30 profiles with *lower*
+  false_merge than the 33-profile DOT — the opposite of leniency.
+- **metric-artifact — refuted the "decisive" framing.** The +5 pt figure is reid-specific; on
+  "recognized" it's ~+1 pt and DOT wins m2.
+- **noise-overfit — refuted the magnitude.** Every fair pairing's 95% CI crosses zero (best
+  P(cloud>dot)=0.92); the matchers are *identical* for ~half the 30 speakers. The only effect
+  clearing the noise floor is DOT-internal: slow EMA (0.3) vs fast (0.7) = **+19 pp pooled**.
+
+## Recommendation
+1. **First, tune DOT's EMA toward 0.3** — the only change that clears the noise floor; one line,
+   zero memory cost.
+2. **If tail-continuity is the priority, prefer plain CLOUD (thr~0.46, cap10), not cloud+merge.**
+   Plain CLOUD matches DOT's recognized, beats it on reid at the ideal profile count with fewer
+   false-merges, and avoids the per-meeting merge pass. cloud+merge buys fm=0 but at a steep
+   recognized cost (79 vs 93).
+3. **Before any swap, run a larger in-domain eval** (100+ speakers, same-device audio).
+   VoxCeleb's harsh cross-recording variance (within-speaker cosine mean 0.49, p5 0.13 — ~40% of
+   true pairs below threshold) is an **optimistic upper bound**; the CLOUD edge should shrink
+   toward the measured zero on tight same-laptop data.
+
+**Bottom line:** CLOUD is a low-risk, roughly-neutral-to-slightly-positive alternative — safe to
+adopt, not proven to be an upgrade. Spend the cheap EMA win first; gate any matcher swap on a
+bigger, in-domain study.
+
+## Limits / caveats
+- N=30 speakers; per-meeting cells are means of 30 binaries (~9 pp SE) — the dominant constraint.
+- Single-speaker synthetic meetings; false_merge measures only cross-person bleed (no overlap).
+- Python port omits production `mergeDuplicates` + `EmbeddingClusterer` post-pass; fixes ema=0.5.
+- CLOUD memory/compute is ~10×/profile (up to 10 stored vectors vs DOT's 1) — a real cost not
+  captured by accuracy metrics.

--- a/Tools/SpeakerEvalHarness/AMI_CODEC_REID_REPORT.md
+++ b/Tools/SpeakerEvalHarness/AMI_CODEC_REID_REPORT.md
@@ -1,0 +1,188 @@
+# AMI codec sweep — cross-meeting speaker re-ID under compression
+
+**Date:** 2026-06-17 · **Corpus:** AMI scale set, 32 meetings (ES2002–ES2010, series a–d),
+**32 recurring speakers** (4 per series, each appears in exactly 4 meetings — a real cross-meeting
+re-ID testbed). **Arms:** clean · Opus 24k · Opus 16k · Opus 12k · Opus 8k · G.711 μ-law 8k,
+bracketing pristine headset → Zoom/Meet wideband → aggressive VoIP → narrowband telephone.
+**Config under test:** `TranscriptedCore.DiarizationService.diarizeOffline` (PyAnnote + VBx + 256-dim
+WeSpeaker) on codec-degraded audio; cross-meeting match = `SpeakerDatabase.matchSpeaker(threshold:)`.
+Grid: consolidation none × match {0.40 … 0.70}. Re-ID scoring on (AMI ids recur; no `--per-file-ids`).
+
+> **Measured vs assumed.** Every §-numbered value is **measured** by the harness on real AMI audio,
+> synthetically codec-degraded with ffmpeg (libopus / pcm_mulaw), and **independently recomputed from
+> raw dumps + RTTMs** by five verifier passes (all reproduced to the rounding digit). Claims about
+> *real Transcripted Zoom/Meet audio* and *bandwidth-extension gains* are **inferred / unvalidated** and
+> labelled as such.
+
+> **Validity check (passed).** The clean control reproduces the prior SCALEUP baseline **exactly**:
+> match 0.60 → 32 profiles for 32 people, false-merge 22, re-ID #2+ 0.532. The harness is sound, so the
+> codec arms are directly comparable.
+
+---
+
+## Bottom line
+
+**Compression does NOT want a lower match threshold — the opposite.** It holds at ~0.60 or rises,
+because codec degradation inflates the *different-speaker* similarity band (strangers start looking
+alike: 0.28 → 0.60) while same-speaker similarity stays flat. Lowering toward 0.50 would **increase**
+false positives, not reduce them. The match threshold is the **weakest** lever. The two real levers for
+fewer false positives are (0) **mean-centering embeddings before matching** — newly proven here to undo
+nearly all the codec damage essentially for free — and (1) **compression-robust embeddings + a
+multi-party diarizer**, since the diarizer's under-segmentation is the dominant error source at every
+compression level.
+
+**🟢 GREEN.** The eval ran clean, the control reproduces SCALEUP exactly, the headline survived
+adversarial re-derivation under three threshold definitions, and the degradation ordering held in 8/8
+leave-one-series-out folds and 0/5000 bootstrap resamples.
+
+---
+
+## 1. Per-arm results (recomputed + verified)
+
+Cross-meeting embedding bands (per-(meeting,speaker) L2-normalized mean; same-speaker = 192 cross-meeting
+pairs; different-speaker = 7,744 cross-meeting pairs). False-merge pressure @0.60 = fraction of
+different-speaker pairs ≥ 0.60. DER macro-mean over 32 meetings at match 0.60.
+
+| arm | simulates | same-spk | diff-spk | **separation** | FM pressure @0.60 | DER (confusion) | clusters/true |
+|---|---|---|---|---|---|---|---|
+| **clean** | pristine headset | 0.828 | 0.284 | **0.544** | 5.4 % | 0.437 (0.298) | 0.969 |
+| **opus24k** | Zoom/Meet typical | 0.835 | 0.329 | **0.506** | 7.0 % | 0.501 (0.362) | 0.875 |
+| **opus16k** | Zoom low / Meet | 0.844 | 0.365 | **0.478** | 7.0 % | 0.474 (0.334) | 0.930 |
+| **opus12k** | aggressive VoIP | 0.852 | 0.431 | **0.421** | 10.2 % | 0.495 (0.356) | 0.953 |
+| **opus8k** | very low bitrate | 0.888 | 0.601 | **0.287** | **52.6 %** | 0.612 (0.424) | 0.656 |
+| **g711u** | PSTN / telephone | 0.871 | 0.450 | **0.421** | 10.0 % | 0.570 (0.397) | 0.750 |
+
+Separation collapses 0.544 → 0.287, driven **entirely by the different-speaker band rising** (same-speaker
+is flat-to-slightly-up, 0.83 → 0.89). Note G.711 narrowband (0.421) is *less* destructive than very-low-
+bitrate Opus 8k (0.287): band-limiting hurts less than aggressive lossy coding.
+
+## 2. The optimal MATCH threshold does not drop — it holds or rises
+
+`profiles_end` (target = 32, one per real person) vs match, all arms:
+
+| match | clean | opus24k | opus16k | opus12k | opus8k | g711u |
+|---|---|---|---|---|---|---|
+| 0.50 | 20 | 16 | 10 | 6 | 3 | — |
+| 0.60 | **32** | 23 | 23 | 20 | 5 | 12 |
+| 0.65 | 35 | 27 | 29 | 27 | 6 | 21 |
+| 0.70 | 44 | 37 | 32 | 34 | **10** | 27 |
+
+Verified under three independent definitions of "optimal" (profile-count nearest 32; band-separation
+argmax; lowest match with false-merge ≤ clean baseline and re-ID ≥ 0.45): **none trends downward.** Clean
+is count-optimal exactly at 0.60; every compressed arm needs ≥ 0.60 and most never reach 32 profiles at
+all. **Opus 8k caps at 10 identities at any threshold; G.711 caps at 27** — compression destroys identity
+recovery in a way no threshold restores. The only place a low number appears (a literal "0.40 minimises
+false-merge-count") is a **degenerate artifact**: at low thresholds everything collapses into 3–5
+mega-profiles, so the raw count is small only because there are almost no profiles left to merge.
+
+## 3. Why — shared codec coloration, not lost identity (the key finding)
+
+The separation collapse is **not** destruction of speaker information. It is a single shared additive bias
+the codec injects into every embedding, whose magnitude grows with bitrate loss. Two pieces of evidence:
+
+- **‖shared centroid‖² tracks the different-speaker band almost 1:1** across all arms (clean 0.312 vs
+  diff 0.284; opus8k 0.618 vs diff 0.601). The entire diff-band rise is the projection of every embedding
+  onto one common direction.
+- **Mean-centering** (subtract the per-arm global centroid, renormalize) **near-fully restores
+  separation:**
+
+| arm | separation (raw) | separation (mean-centered) |
+|---|---|---|
+| clean | 0.544 | 0.791 |
+| opus24k | 0.506 | 0.788 |
+| opus16k | 0.478 | 0.785 |
+| opus12k | 0.421 | 0.773 |
+| **opus8k** | **0.287** | **0.770** |
+| g711u | 0.421 | 0.805 |
+
+After centering, all six arms land in a tight **0.77–0.81** band — the codec ordering disappears and
+opus8k ties clean. The different-speaker band drops to ≈ −0.04 (uncorrelated) for every arm.
+
+**Implication:** the embeddings still carry speaker identity even at Opus 8k. A *fixed global cosine
+threshold* fails because of a removable mean-shift — so **running / per-source mean-centering before
+matching recovers near-clean discriminability without retraining the model.** (Proven on the bands;
+gate on a matcher-side arm before shipping.)
+
+## 4. Diarizer & DER — the bottleneck, and the "1→9" fear
+
+Raw diarizer cluster count vs true speaker count per meeting:
+
+| arm | under | exact | over | clusters/true |
+|---|---|---|---|---|
+| clean | 15 | 8 | 9 | 0.969 |
+| opus24k | 18 | 5 | 9 | 0.875 |
+| opus16k | 14 | 8 | 10 | 0.930 |
+| opus12k | 15 | 4 | **13** | 0.953 |
+| opus8k | **28** | 4 | **0** | 0.656 |
+| g711u | 23 | 9 | **0** | 0.750 |
+
+- The diarizer **under-segments** everywhere, and **heavy compression makes it sharply worse** (opus8k
+  finds 0.66 clusters per true speaker — it merges a third of the speakers away). This is *why* opus8k can
+  never recover 32 identities.
+- DER is **confusion-dominated** at every level (≈ 62–68 % of DER). An oracle relabelling shows the
+  matcher's residual confusion contribution is ≤ 0 in every arm — i.e. **confusion is 100 % upstream
+  (the diarizer mixing speakers within a meeting)**, not the matcher.
+- **The user's "one person → 9 speakers" over-split is not the failure mode.** Over-segmentation never
+  rises with compression — it peaks mildly at Opus 12k (over = 13) and falls to **0** at Opus 8k / G.711.
+  The dominant failure is the opposite: merging distinct people.
+
+## 5. Significance & robustness
+
+The claim rests on 32 speakers across **8 series** (the effective N, not the 7,744 pairs).
+
+- Point estimates reproduce exactly; **ordering clean > opus12k > opus8k holds in 8/8 leave-one-series-out
+  jackknife folds and 0/5000 paired cluster-bootstrap resamples.**
+- Inter-arm separation gaps (~0.12–0.13) are ≈ 4× the per-arm jackknife SE (~0.03); the most influential
+  single series (ES2006) cannot overturn the ordering.
+- **Caveat:** at N = 8, **opus12k ≈ g711u ≈ 0.42 are statistically indistinguishable** (overlapping CIs);
+  treat the mid-arms as one band. The same-speaker band's slight upward drift under compression is within
+  noise (±0.01) — read it as spectral smoothing, not improved identity.
+
+## 6. Fewer false positives — the ranked levers (the product ask)
+
+**Lowering the match threshold INCREASES false positives on compressed audio.** (Cite the right metric:
+raw `false_merge.count` is misleading at low thresholds because the DB collapses into a few mega-profiles —
+at Opus 8k, lowering to 0.50 fuses 32 people into **3 profiles**. The honest measure is identity collapse /
+people-trapped, which is worse at lower thresholds.)
+
+| # | Lever | Measured justification | Status |
+|---|---|---|---|
+| **0** | **Mean-center embeddings before matching** | Restores separation to 0.77–0.81 on *every* arm incl. opus8k; diff band → −0.04 | **cheapest real win**; proven on bands, gate on a matcher-side arm |
+| 1 | **Compression-robust / codec-augmented embeddings** | Root cause = diff band rising 0.28 → 0.60; FM pressure 5 % → 53 % | highest durable impact; fine-tune WeSpeaker with Opus/G.711 augmentation |
+| 2 | **Fix the under-segmenting diarizer** | confusion = 68 % of DER even on clean; clusters/true < 1 everywhere; confusion is 100 % upstream | the *current* bottleneck even on clean audio |
+| 3 | **Quality-adaptive threshold RAISE on degraded audio** | optimal X rises with compression (0.60 → 0.65–0.70) | cheap, real, modest ceiling — mitigates, doesn't fix |
+| 4 | **Pre-embedding denoise / bandwidth-extension** | motivated by the shared-coloration mechanism | **UNVALIDATED — no arm run**; gate behind a measured BWE arm |
+| 5 | **Global match-threshold tuning** | doesn't drop to 0.50; clean 0.60, all compressed ≥ 0.60; no clean win | **weakest lever** — the one people reach for first |
+
+## 7. Recommendation for production
+
+- **Keep the global match threshold at 0.60** (0.62–0.65 if you weight re-ID over false-merge). **Do not
+  lower it.** Add a quality-adaptive **raise to 0.65–0.70** on detected narrowband / low-bitrate sources.
+- **Invest in levers 0–2, not the threshold.** Mean-centering is a near-free first step; codec-augmented
+  embeddings + a multi-party/compression-tuned diarizer are the durable fixes.
+- Opus 8k / narrowband telephony is **structurally unrecoverable by threshold tuning alone** — only
+  centering + better embeddings move it.
+
+## 8. What this eval cannot justify
+
+- **Real-Transcripted thresholds.** AMI is 4-party **in-room headset** audio synthetically codec-degraded,
+  not captured Zoom/Meet/Teams **system audio**. The *direction* (compression inflates the stranger band;
+  under-segmentation worsens) is robust; the absolute numbers **overstate** a typical 2–3-person call's
+  difficulty.
+- **Any denoise / bandwidth-extension gain** — no such arm was run (lever 4 is a hypothesis).
+- **Highest-value next experiment:** a small **labelled real Zoom/Meet/Teams corpus** with recurring
+  identities, plus a **denoise/BWE front-end arm** on the existing opus8k/g711u dumps (promotes levers 0
+  and 4 from hypothesis to measurement).
+
+## Reproduce
+
+```bash
+# clean AMI audio + RTTMs already under data/ami/ (scale set, 32 meetings, gitignored)
+MATCH="0.40 0.45 0.50 0.55 0.60 0.65 0.70" bash scripts/run_all_codec_arms.sh
+#   -> data/eval/ami_<arm>/reports/{SWEEP.md, bands.json}  (per arm)
+python3 scripts/aggregate_codec_arms.py --out-md data/eval/AMI_CODEC_SWEEP.md   # X-vs-compression table
+python3 scripts/recompute_bands_verify.py    # independent band recompute + mean-centering test
+python3 scripts/jackknife_series_bands.py    # leave-one-series-out robustness
+python3 scripts/bootstrap_series_bands.py    # paired cluster bootstrap (ordering)
+```
+All `data/` artifacts are gitignored. Re-ID uses AMI's recurring participant ids (no `--per-file-ids`).

--- a/Tools/SpeakerEvalHarness/AMI_CODEC_REID_REPORT.md
+++ b/Tools/SpeakerEvalHarness/AMI_CODEC_REID_REPORT.md
@@ -25,11 +25,12 @@ Grid: consolidation none × match {0.40 … 0.70}. Re-ID scoring on (AMI ids rec
 **Compression does NOT want a lower match threshold — the opposite.** It holds at ~0.60 or rises,
 because codec degradation inflates the *different-speaker* similarity band (strangers start looking
 alike: 0.28 → 0.60) while same-speaker similarity stays flat. Lowering toward 0.50 would **increase**
-false positives, not reduce them. The match threshold is the **weakest** lever. The two real levers for
-fewer false positives are (0) **mean-centering embeddings before matching** — newly proven here to undo
-nearly all the codec damage essentially for free — and (1) **compression-robust embeddings + a
-multi-party diarizer**, since the diarizer's under-segmentation is the dominant error source at every
-compression level.
+false positives, not reduce them. The match threshold is the **weakest** lever. The one lever with real
+headroom is the **diarizer**: ~28 of 30 trapped speakers are fused *within a meeting* before matching
+ever runs, so the dominant false-positive source is upstream and untouchable by any matcher-side knob.
+A matcher-side follow-up (§3a) shows **mean-centering does *not* reduce downstream false positives** — it
+only un-collapses mega-profiles on heavy codecs (a fragmentation effect), and no online form is deployable.
+Pair the diarizer fix with compression-robust embeddings for the smaller cross-meeting tail.
 
 **🟢 GREEN.** The eval ran clean, the control reproduces SCALEUP exactly, the headline survived
 adversarial re-derivation under three threshold definitions, and the degradation ordering held in 8/8
@@ -98,10 +99,45 @@ the codec injects into every embedding, whose magnitude grows with bitrate loss.
 After centering, all six arms land in a tight **0.77–0.81** band — the codec ordering disappears and
 opus8k ties clean. The different-speaker band drops to ≈ −0.04 (uncorrelated) for every arm.
 
-**Implication:** the embeddings still carry speaker identity even at Opus 8k. A *fixed global cosine
-threshold* fails because of a removable mean-shift — so **running / per-source mean-centering before
-matching recovers near-clean discriminability without retraining the model.** (Proven on the bands;
-gate on a matcher-side arm before shipping.)
+**Implication (band level):** the embeddings still carry speaker identity even at Opus 8k — the codec adds
+a *removable* shared mean-shift, not irrecoverable loss. **But this is a statement about the embedding
+bands, not the matcher.** We then tested whether it translates into fewer downstream false positives by
+replaying centered embeddings through the real matcher — **it does not** (§3a). Read §3a before treating
+mean-centering as a fix.
+
+## 3a. Follow-up: does centering actually reduce false positives through the matcher? **No.**
+
+We applied mean-centering to the cached dump embeddings and replayed them through the real clusterer + DB
+matcher (modes: `normonly` control, `global` oracle, `running`/`frozen` online; measurement only, no app
+code). Cleanly recomputed precision metrics (mass-weighted, collapse-robust) overturn the optimistic read:
+
+- **At profile-count-matched operating points, centering does not move the precision frontier.** Merge-
+  contamination (`fp_mass`) is within ±0.02 of baseline on clean/opus12k/g711u (clean −0.022, **opus12k
+  +0.011 — slightly *worse***, g711u −0.031), and **every `fp_mass` drop is paid for by a near-equal
+  `fn_mass` rise** — it converts merge errors into split errors (collapse → fragmentation), not removing
+  error. Mean best-profile recall falls in every arm; clean 1:1 identity recovery (`iso1:1`) barely moves
+  (Δ +1/−3/+1/+2) and never approaches 32. Baseline and `global` ride the **same fp-vs-profiles curve** —
+  `global` just slides the operating point rightward to more profiles.
+- **The only genuine effect is un-collapsing mega-profiles** on heavy codecs (opus8k baseline survives on
+  5 profiles, `fp_mass` up to 0.87 → `global` ~20 profiles). That restores band separation and a countable
+  profile set; it does **not** recover clean identities (people-trapped stays ~30/32 through the un-collapse).
+- **The residual is a within-meeting diarizer floor centering cannot touch.** Centering only changes
+  embedding vectors, never the diarizer's clusters/timings (verified byte-for-byte; `normonly` ≡ baseline).
+  **~75–88 % of fused pairs and ~28 of ~30 trapped speakers are speakers the diarizer co-clustered inside a
+  single meeting** — only ~2 speakers/arm are matcher-side (cross-meeting), and `global` leaves that thin
+  tail flat (clean 8→8). A matcher-free floor of ~28–32 trapped speakers exists on **every** arm before any
+  matching runs.
+- **No deployable online estimator approaches the oracle.** The oracle `global` mean averages over all 32
+  meetings' speakers, cancelling content and leaving only the codec direction — a property no causal window
+  has until it has effectively seen everything. Best online variant (running EMA α=0.005) recovers ~71 % of
+  the band-sep gain on opus12k but ~4 % on opus8k and still over-fragments; the original α=0.05 (~20-segment
+  window) tracks the current speaker and destroys separation; frozen-warmup (calibrate on meeting 1) matches
+  the oracle direction (cos ~0.8) but is too noisy and under-merges. A real fix needs **out-of-band per-codec
+  calibration**, not live-stream estimation.
+
+**Correction to the lever ranking below:** "mean-center embeddings before matching" is **not** a precision
+lever and is **downgraded** — it is a narrow *offline anti-collapse* remedy for heavy codecs only. The
+dominant ceiling is the diarizer's within-meeting co-clustering.
 
 ## 4. Diarizer & DER — the bottleneck, and the "1→9" fear
 
@@ -145,23 +181,28 @@ raw `false_merge.count` is misleading at low thresholds because the DB collapses
 at Opus 8k, lowering to 0.50 fuses 32 people into **3 profiles**. The honest measure is identity collapse /
 people-trapped, which is worse at lower thresholds.)
 
+*(Ranking revised after the §3a matcher experiment — mean-centering is demoted; the diarizer is promoted.)*
+
 | # | Lever | Measured justification | Status |
 |---|---|---|---|
-| **0** | **Mean-center embeddings before matching** | Restores separation to 0.77–0.81 on *every* arm incl. opus8k; diff band → −0.04 | **cheapest real win**; proven on bands, gate on a matcher-side arm |
-| 1 | **Compression-robust / codec-augmented embeddings** | Root cause = diff band rising 0.28 → 0.60; FM pressure 5 % → 53 % | highest durable impact; fine-tune WeSpeaker with Opus/G.711 augmentation |
-| 2 | **Fix the under-segmenting diarizer** | confusion = 68 % of DER even on clean; clusters/true < 1 everywhere; confusion is 100 % upstream | the *current* bottleneck even on clean audio |
-| 3 | **Quality-adaptive threshold RAISE on degraded audio** | optimal X rises with compression (0.60 → 0.65–0.70) | cheap, real, modest ceiling — mitigates, doesn't fix |
-| 4 | **Pre-embedding denoise / bandwidth-extension** | motivated by the shared-coloration mechanism | **UNVALIDATED — no arm run**; gate behind a measured BWE arm |
-| 5 | **Global match-threshold tuning** | doesn't drop to 0.50; clean 0.60, all compressed ≥ 0.60; no clean win | **weakest lever** — the one people reach for first |
+| **1** | **Fix the diarizer's within-meeting co-clustering** | ~28/30 trapped speakers + 75–88 % of fused pairs are within-meeting diarizer co-clusters; confusion = 68 % of DER even on clean; clusters/true < 1 everywhere; matcher-free floor ~28–32 trapped | **the only lever with headroom** on real false positives; nothing matcher-side moves it |
+| 2 | **Compression-robust / codec-augmented embeddings** | root cause of the *cross-meeting* tail = diff band rising 0.28 → 0.60; FM pressure 5 % → 53 % | durable fix for the (smaller) matcher-side tail; fine-tune WeSpeaker with Opus/G.711 augmentation |
+| 3 | **Quality-adaptive threshold tuning** | moves you *along* the fp-vs-profiles frontier; optimal X holds/rises with compression | honest precision/fragmentation trade — no free lunch; never *lower* it |
+| 4 | **Offline (oracle) mean-centering** | restores band separation to 0.77–0.81 and un-collapses mega-profiles on heavy codecs | **narrow anti-collapse use only — NOT a precision lever** (§3a: Δfp ≤ 0.02 at matched profile count; fn rises in lockstep) |
+| 5 | **Pre-embedding denoise / bandwidth-extension** | motivated by the shared-coloration mechanism | **UNVALIDATED — no arm run**; gate behind a measured BWE arm |
+| 6 | **Online running-EMA centering** | best variant α=0.005 recovers ~71 %/4 % of oracle band-sep, over-fragments | **not deployable as-is**; needs out-of-band per-codec calibration |
+| 7 | **Lowering the global match threshold** | doesn't drop to 0.50; lowering collapses identities (opus8k → 3 profiles) | **actively harmful** on compressed audio |
 
 ## 7. Recommendation for production
 
 - **Keep the global match threshold at 0.60** (0.62–0.65 if you weight re-ID over false-merge). **Do not
   lower it.** Add a quality-adaptive **raise to 0.65–0.70** on detected narrowband / low-bitrate sources.
-- **Invest in levers 0–2, not the threshold.** Mean-centering is a near-free first step; codec-augmented
-  embeddings + a multi-party/compression-tuned diarizer are the durable fixes.
-- Opus 8k / narrowband telephony is **structurally unrecoverable by threshold tuning alone** — only
-  centering + better embeddings move it.
+- **The one lever with real headroom is the diarizer** — reducing within-meeting speaker co-clustering is
+  the only thing that moves the ~28/30 people-trapped floor. Pair it with codec-augmented embeddings for the
+  cross-meeting tail. **Do not rely on mean-centering as a precision fix** (§3a) — it only un-collapses
+  mega-profiles on heavy codecs and is not deployable online.
+- Opus 8k / narrowband telephony is **structurally unrecoverable by matcher-side tuning** (threshold *or*
+  centering) — it needs a better diarizer + embeddings.
 
 ## 8. What this eval cannot justify
 
@@ -171,8 +212,8 @@ people-trapped, which is worse at lower thresholds.)
   difficulty.
 - **Any denoise / bandwidth-extension gain** — no such arm was run (lever 4 is a hypothesis).
 - **Highest-value next experiment:** a small **labelled real Zoom/Meet/Teams corpus** with recurring
-  identities, plus a **denoise/BWE front-end arm** on the existing opus8k/g711u dumps (promotes levers 0
-  and 4 from hypothesis to measurement).
+  identities, plus — most importantly — a **diarizer arm** (a multi-party / compression-tuned segmenter) to
+  attack the within-meeting co-clustering floor that §3a shows is the real ceiling.
 
 ## Reproduce
 
@@ -184,5 +225,14 @@ python3 scripts/aggregate_codec_arms.py --out-md data/eval/AMI_CODEC_SWEEP.md   
 python3 scripts/recompute_bands_verify.py    # independent band recompute + mean-centering test
 python3 scripts/jackknife_series_bands.py    # leave-one-series-out robustness
 python3 scripts/bootstrap_series_bands.py    # paired cluster bootstrap (ordering)
+
+# §3a mean-centering matcher experiment
+ARMS="clean opus24k opus16k opus12k opus8k g711u" MODES="normonly global running" \
+  bash scripts/run_centering_experiment.sh     # center dumps -> replay real matcher -> score
+python3 scripts/compare_centering.py --out-md data/eval/CENTERING_COMPARE.md   # people-trapped view
+python3 scripts/center_purity_analysis.py       # collapse-robust precision frontier (fp_mass/fn_mass)
+python3 scripts/q3_attribution.py ; python3 scripts/q3_floor.py   # within-meeting diarizer floor
+bash scripts/dev/run_online_centering_sweep.sh  # alpha-sweep + frozen-warmup deployability test
 ```
 All `data/` artifacts are gitignored. Re-ID uses AMI's recurring participant ids (no `--per-file-ids`).
+`scripts/center_dumps.py` modes: normonly (control) · global (oracle) · running (online EMA) · frozen (warmup).

--- a/Tools/SpeakerEvalHarness/ARTICLE_OUTLINE.md
+++ b/Tools/SpeakerEvalHarness/ARTICLE_OUTLINE.md
@@ -1,0 +1,106 @@
+# Applied article outline — "Choosing an on-device speaker-embedding model"
+
+**Format:** applied engineering case study / experience report (company blog, Towards Data Science, or arXiv
+technical report). NOT a novel-method academic paper — the contribution is *applied selection methodology +
+hard-won on-device findings*, told as a debugging story.
+**Audience:** ML / speech engineers shipping speaker ID, diarization, or any on-device embedding model.
+**Length:** ~1,800–2,600 words + 4 figures. **Tone:** honest, first-person, "here's what actually happened,"
+specific numbers, no hype.
+
+**Title options (lead with the counterintuitive hook):**
+1. *"The accuracy winner couldn't ship: choosing an on-device speaker-embedding model"*
+2. *"Your speaker model's EER doesn't matter if it can't run on the device"*
+3. *"Codec-robustness and conversion-survivability — what the leaderboards don't tell you about on-device speaker embeddings"*
+
+**One-sentence thesis:** *For on-device speaker ID, the right model is decided by two axes the accuracy
+leaderboards ignore — robustness to audio compression, and whether the model survives conversion to the
+device's runtime — and the model that wins accuracy can lose on both.*
+
+---
+
+## 1. Hook — the bug (≈150 words)
+- The product symptom: a transcription app merges two different people into one speaker; **worse on Zoom/phone**.
+- Promise the reader a debugging story with two plot twists and a shippable answer.
+
+## 2. The setup — where speaker labels come from (≈200 words)
+- Two stages: **diarizer** ("who spoke when") → **matcher** ("have I heard this voice before?", via cosine
+  similarity of embeddings against a threshold).
+- The embedding ("voiceprint") is the load-bearing component. Frame the question: *is the bug in the knobs or
+  the representation?*
+
+## 3. Act I — the obvious fixes, and why they failed (≈350 words)
+- Raise/lower the match threshold → **lowering made it worse.** The reveal: **compression pulls *different*
+  speakers' embeddings together** (measured: same-vs-different separation 0.54 clean → 0.29 at low bitrate).
+  *Counterintuitive lesson #1: a lenient threshold on compressed audio fuses strangers.*
+- Three more dead ends in a sentence each: mean-centering, smarter clustering (even oracle-k), finer
+  segmentation. All ≈ ties.
+- **The near-miss (keep this — it's the credibility moment):** mean-centering looked like a huge win on the
+  embedding-band metric, then did nothing end-to-end. *Lesson #2: a metric that improves in isolation is a
+  hypothesis, not a result — test end-to-end.*
+- Land the conclusion: **it's the embedding model, not the knobs.**
+- **Figure 1:** the journey diagram (problem → 4 failed fixes → real cause → fix).
+
+## 4. Act II — the bake-off (≈450 words)
+- Method: re-extract embeddings for the **exact same** diarization segments with 8 models, on a **codec sweep**
+  (clean → Opus 24/16/12/8k → G.711). Same segments → only the embedding changes (clean controlled comparison).
+- Metrics, and *why*: within-meeting coverage/DER (separation) **+ threshold-free ROC-AUC** for cross-call
+  separability. *Explain anisotropy:* SSL models (WavLM) cram everything into a narrow cone, so raw-cosine
+  separation looks bad but ranking is fine — hence AUC, which is scale/anisotropy-immune. *Lesson #3: pick a
+  metric that can't be gamed by the embedding's geometry.*
+- **The negative control** (do not skip): a deliberately weak model (x-vector) — it lost on every arm,
+  proving the win isn't "any swap helps." *Lesson #4: always include a control.*
+- Results: strong discriminative models roughly **halve error on compressed audio** and stay flat where the old
+  model collapses; near-perfect cross-call AUC.
+- **Figure 2:** error-by-audio-type bars (current vs best). **Figure 3 / table:** the 8-model master scorecard.
+
+## 5. Act III — the twist: accuracy ≠ shippable (≈450 words, the heart of the piece)
+- Set up the two-axis decision: accuracy *and* on-device conversion-survivability.
+- **CAM++ — the accuracy co-winner — fails CoreML conversion.** It converts and runs but emits garbage
+  (parity cosine **0.23** vs 0.99 target). The honest diagnosis (and the self-correction): *not* float16/ANE
+  precision, *not* the tiny-variance BatchNorm we first blamed — it's **architectural**: its deep DenseTDNN
+  dense-concat/reshape graph accumulates error in *every* converter, even at float32/CPU. Per-op exact; error
+  grows with depth. No clean fix.
+- **ERes2Net — equally accurate — converts cleanly** (cosine **0.99999** fp16 / 1.0 fp32, 12.8 MB, Neural-Engine
+  eligible) after one output-neutral patch. Verified on the *pretrained* weights (because the failure was
+  weight-/architecture-specific, not generic).
+- *Lesson #5: validate the conversion, not the leaderboard — "has an ONNX export" ≠ "produces correct outputs
+  on-device."* This is the section that earns the article; it's not in any paper.
+- **Figure 4:** the accuracy-vs-shippability decision map (ERes2Net top-right; CAM++ accurate-but-broken).
+
+## 6. The takeaways for practitioners (≈250 words, bulleted)
+- Stop tuning knobs; fix the representation. / Test end-to-end, never a proxy. / Use threshold-free, anisotropy-
+  immune metrics. / Run a negative control. / **Benchmark conversion + on-device parity as a first-class axis.**
+- The deeper residual is upstream (the diarizer/segmentation), not a consolidation knob — name it so readers
+  don't chase the wrong thing.
+
+## 7. Honest limitations (≈200 words — non-negotiable for credibility)
+- Single corpus (**AMI**: 4-party, in-room, far-field) — *synthetically* codec-degraded, not real captured calls.
+- Diarizer is a specific production pipeline → absolute numbers won't transfer; the **direction** (codec
+  collapses separability; discriminative models are more robust; conversion can fail) is the transferable part.
+- On-device **latency was inferred** from params/GMACs, not profiled on the Neural Engine.
+- No real Zoom/Meet validation yet (in progress).
+- State plainly what would make it a peer-reviewed result: real codec corpora + a second dataset + published-EER
+  baselines.
+
+## 8. Reproduce / appendix (≈150 words)
+- The harness recipe (diarize once → swap embeddings → score), the models + licenses (all free; ERes2Net/CAM++
+  3D-Speaker, ECAPA Apache-2.0, ReDimNet MIT), the codec arms, the conversion script. Link the eval code.
+
+---
+
+## Figures to reuse (already produced)
+1. Journey diagram · 2. Error-by-audio bars (current vs best) · 3. 8-model master scorecard table
+   (MASTER_SCORECARD.md) · 4. Accuracy-vs-shippability decision map (final ERes2Net version).
+
+## Claims to double-check before publishing
+- Re-state every number as **"on our AMI benchmark"** — don't imply production-measured.
+- Don't claim a production accuracy gain until the **real-Zoom validation** runs.
+- Confirm model **licenses** for redistribution/commercial framing; note the VoxCeleb2 non-commercial
+  training-data nuance if you discuss shipping weights.
+- Frame ERes2Net latency/ANE residency as **"converts to an ANE-eligible CoreML model, ~12.8 MB"** (measured)
+  not "runs at X ms on ANE" (not profiled).
+- Decide how much to name the product vs. keep it generic — the lessons stand either way.
+
+## Distribution
+- Primary: company engineering blog or Towards Data Science. Cross-post: arXiv (cs.SD/eess.AS) as a technical
+  report for citability. Teaser: the X/LinkedIn thread we already drafted (BLOG_DRAFT_*.md) links to the full piece.

--- a/Tools/SpeakerEvalHarness/ARTICLE_speaker-embedding-ondevice.md
+++ b/Tools/SpeakerEvalHarness/ARTICLE_speaker-embedding-ondevice.md
@@ -1,0 +1,137 @@
+# Your speaker model's EER doesn't matter if it can't run on the device
+
+**TL;DR.** We build Transcripted, a macOS app that turns recordings into speaker-labeled transcripts. Speaker labels were smearing together on compressed audio — Zoom and phone calls — and the obvious fixes (lowering the match threshold, smarter clustering, finer segmentation) all failed. The real cause was the voiceprint model itself: under compression, it stops keeping different people apart. So we ran a controlled bake-off of eight embedding models, holding everything else fixed. Several roughly halved the error on our AMI benchmark. But the accuracy co-winner, CAM++, could not be converted to run correctly on Apple's Neural Engine — its on-device output is essentially unrelated to the original. The model we recommend, ERes2Net, sits in the same accuracy band on our benchmark and is the one that converts with verified, near-exact on-device parity. The lesson: for on-device speaker ID, conversion fidelity is a first-class axis, not a footnote.
+
+[Figure 1: journey — problem → failed fixes → real cause → fix]
+
+## The bug: one voice becomes two people — or two people become one
+
+The bug that started this investigation looks simple from the outside: two different people get merged into a single speaker. You read the transcript and "Alice" is somehow saying things Bob said. It gets worse on exactly the recordings people care about most — Zoom and phone calls — where the audio has been squeezed through a codec (a compression scheme that throws away detail to save bandwidth). On clean, in-room audio the app does okay. Pipe the same voices through a phone line and the labels smear together.
+
+That asymmetry is the tell. Nothing about *who is talking* changed between the clean recording and the compressed one — only the audio quality did. So whatever is failing must be something that compression damages. Our job was to find that something, and then decide what to do about it.
+
+## How a speaker label gets made — and where the weight sits
+
+Producing a speaker label is two steps. First the **diarizer** answers "who spoke when" — it chops the audio into segments and groups the ones that sound like the same person. (We use PyAnnote segmentation plus VBx clustering, a method for grouping segments by voice.) Second the **matcher** answers "have I heard this voice before?" — it turns each voice into a **voiceprint** (an *embedding*, a list of numbers meant to be close for the same person and far apart for different people) and compares it against known speakers using cosine similarity against a 0.60 threshold. The voiceprints come from a WeSpeaker neural net running on-device on the Apple Neural Engine.
+
+The voiceprint is the load-bearing part. If two people's voiceprints land close together, no amount of clever grouping downstream can pull them apart — the evidence the rest of the pipeline relies on is already corrupted. So one question organized everything: **is the bug in the knobs or the representation?** Is it a tuning problem — the threshold, the clustering settings, the segmentation — that we can dial our way out of? Or is the voiceprint itself failing to keep different people apart once the audio is compressed? Those two answers lead to completely different fixes, so we had to know which one we were looking at.
+
+For on-device speaker ID, the decider turns out to be two axes the accuracy leaderboards ignore: how well a model survives audio compression, and whether it survives conversion to the device runtime at all. A model can win on raw accuracy and lose both — and as we'll see, the one that did win accuracy lost exactly there.
+
+## Act I — the obvious fixes, and why they failed
+
+When same-voice recognition fell apart on compressed audio, the first instinct was to reach for the knob we already had: the **match threshold**. Our matcher calls two voiceprints the same person when their cosine similarity clears 0.60. The obvious move on degraded audio: lower that bar so the matcher stops missing real matches.
+
+It made things worse. Lowering the threshold didn't recover lost speakers; it fused different ones together.
+
+Here is the least intuitive finding of this act. Compression doesn't just blur each voiceprint — it pulls *different* speakers' voiceprints **toward each other**. We measured this without picking any threshold, using **cross-call AUC** (=threshold-free separability: how well same-voice pairs out-rank different-voice pairs by cosine similarity; 1.0 is perfect, 0.5 is a coin flip).
+
+On our AMI benchmark, the raw separation between same and different pairs collapsed as the codec got harsher: clean **0.544 → opus12k 0.421 → opus8k 0.287**. The different-speaker band rose from roughly **0.28 to ~0.60** on opus8k — meaning two strangers now score about as high as a genuine match.
+
+No threshold can cleanly split distributions that overlap that much. Lowering it just hands the matcher more false merges.
+
+So we tried three more knobs, and all three tied the baseline:
+
+- **Mean-centering** the embeddings (subtracting the average voiceprint).
+- **Smarter clustering** — including *oracle-k*, where we told the algorithm the true number of speakers in advance. Even that gift didn't help.
+- **Finer segmentation** — cutting the audio into shorter pieces before embedding.
+
+The **near-miss** is the cautionary tale. Mean-centering looked decisive on the embedding-band metric: on opus8k it restored same-vs-different raw separation from about **0.29 to ~0.77**. By that number alone, we'd solved it. But run end-to-end through the *real* matcher, it changed nothing — it simply traded one error for another, converting merge errors (different people lumped together) into split errors (one person scattered across several identities). The net was a wash.
+
+The lesson is worth stating plainly: **a metric that improves in isolation is a hypothesis, not a result.** An intermediate signal can look transformed while the thing users actually experience stays flat. The only honest test is end-to-end.
+
+Which points to the conclusion this investigation kept circling back to: the problem isn't the knobs. It's the embedding model. When the voiceprints themselves stop separating speakers under compression, no amount of threshold-tuning, re-centering, or re-clustering downstream can recover information the model never preserved.
+
+## Act II — the bake-off
+
+The first act taught us a hard lesson: no knob on our current voiceprint saved us. So we asked a blunter question — what if the voiceprint itself is the problem? To answer it fairly, we ran a controlled swap.
+
+### The method: hold everything fixed, change only the embedding
+
+We took the *exact same* diarization segments — the same "who spoke when" boundaries our pipeline already produces — and re-extracted the voiceprint for each segment using eight different models. Same audio, same cuts, same downstream matcher; only the embedding model changes. We did this across a codec sweep, from clean audio down through Opus (24k to 8k) to G.711 mu-law 8k (a telephone-grade codec). Because nothing else moves, any difference we see is attributable to the embedding alone. This is a controlled comparison, not a system rebuild.
+
+### The metrics, and why these
+
+We measured two things. Within a meeting: **coverage** (fraction of true speakers recovered, higher better) and **DER** (=diarization error rate, the fraction of audio mislabeled by speaker; lower is better). Across meetings: **cross-call AUC**, defined above.
+
+AUC matters because it is immune to a model's *scale*. Some models — especially self-supervised ones like WavLM — are **anisotropic** (=they cram every voiceprint into a narrow cone, so even different speakers score a high cosine similarity). Raw separation looks tiny, but the *ranking* of pairs can still be perfect. A threshold-based metric would unfairly punish such a model for its geometry; AUC judges only whether same-voice pairs out-rank different-voice pairs. That is the fair test of discriminative power.
+
+### The negative control
+
+We included **x-vector**, an older embedding, as a deliberate negative control. It loses on every arm (DER ~0.51 / ~0.50 / ~0.49, the worst of the field everywhere). This rules out the lazy conclusion that *any* swap helps — it doesn't. The win, where it exists, comes from a genuinely stronger discriminative model.
+
+### Results
+
+[Figure 3: 8-model scorecard table]
+
+| Model | dim | DER clean | DER opus8k | DER g711u | cross-call AUC |
+|---|---|---|---|---|---|
+| WeSpeaker (current) | 256 | 0.319 | 0.480 | 0.432 | 0.979 / 0.948 / 0.970 |
+| ECAPA-TDNN | 192 | 0.267 | 0.307 | 0.281 | ~1.000 |
+| ReDimNet-b6 | 192 | 0.252 | 0.276 | 0.221 | ~1.000 |
+| CAM++ | 512 | 0.274 | 0.301 | 0.294 | 1.000 |
+| ERes2Net | 192 | 0.238 | 0.329 | 0.274 | 1.000 |
+| WavLM-SV (anisotropic) | 512 | 0.336 | 0.358 | 0.333 | ~0.996 |
+| x-vector (control) | 512 | ~0.51 | ~0.50 | ~0.49 | — |
+
+*(AUC columns are clean / opus8k / g711u, matching the DER columns.)*
+
+The pattern is clear, on our AMI benchmark. A stronger discriminative model roughly *halves* error on compressed audio — opus8k falls from WeSpeaker's 0.480 to the ~0.28–0.30 range, g711u from 0.432 to ~0.22–0.29 — and stays flat where WeSpeaker collapses. Cross-call AUC is near-perfect for the discriminative leaders, meaning they keep different voices separable even after compression mangles the audio.
+
+[Figure 2: error by audio type, current vs best]
+
+### The deeper finding
+
+One residual limit is *not* the embedding: the within-meeting floor is set by the **diarizer**, not the matcher. We tested this directly. Smarter clustering — even oracle-k, where we hand it the true speaker count — only ties the app, and the 0.88 same-voice consolidation knob is inert (toggling it changes nothing). Pure single-speaker segments still merge. That is under-segmentation, a diarizer property, not a clustering or threshold lever. A better embedding fixes the *cross-call* identity problem; the within-meeting ceiling waits on the diarizer.
+
+## Act III — the twist: accuracy ≠ shippable
+
+By the end of the bake-off, we had a four-way tie. ERes2Net, ReDimNet, CAM++, and ECAPA-TDNN all roughly halve the opus8k error of our current voiceprint model on our AMI benchmark — DER drops from 0.480 to the 0.28–0.30 range, and all four post near-perfect cross-call AUC. On a leaderboard, you could pick any of them. (One honesty note: within that tie, ERes2Net actually wins clean DER outright at 0.238 but is the *worst* of the four on opus8k at 0.329 — it sits inside the accuracy band, not at the top of every arm. We'll come back to why we recommend it anyway.)
+
+A leaderboard measures the model in a lab. We have to run it on a phone — specifically, converted to CoreML and executed on Apple's Neural Engine. So the real decider isn't accuracy. It's whether the model *survives conversion* and still produces the same numbers on-device. We tested that, and it broke the tie.
+
+CAM++ — one of the accuracy co-winners — fails. It converts. It runs. And it emits garbage: the converted model's voiceprint matches the original PyTorch voiceprint with a cosine similarity of only **~0.23**, where we need **>0.99**. (Cosine ~1.0 means "same vector"; ~0.23 means the on-device model is computing something essentially unrelated.) A model that's best-in-class on the benchmark and wrong on the device is not shippable.
+
+Here's the honest part: our first diagnosis was wrong. We blamed float16 precision on the Neural Engine, then blamed CAM++'s tiny-variance BatchNorm layers (a known source of numerical blow-up). Both guesses were wrong. We proved it by converting at float32 on CPU, where neither factor applies — and the error persisted, identically, in *two independent* converters (ONNX and CoreML diverged the same way). That's the fingerprint of an **architectural** problem, not a precision one: CAM++'s deep architecture stacks many layers that each re-combine their inputs (dense-concat plus reshape, layer after layer), so a little error accumulates at every step and grows with depth. There is no clean workaround.
+
+ERes2Net, by contrast, converts cleanly. Same-vector parity with the original is cosine **0.99999** at float16 (Neural-Engine eligible) and exactly **1.000000** at float32. The model is **12.76 MB**, loads with zero missing weights, and needed exactly one output-neutral one-line patch (swapping a clamp for a ReLU — the change the official exporter makes too). Notably, ERes2Net has *even more* extreme tiny-variance BatchNorm than CAM++ and still converts perfectly — which confirms the cause was architecture, not weights.
+
+The lesson is one a leaderboard can never teach you: **validate the conversion and on-device parity, not the leaderboard.** "Has an ONNX export" is not the same as "produces correct outputs on the device you ship." Of the models that tie on accuracy, only one also passes that second, harder test.
+
+[Figure 4: accuracy-vs-shippability decision map — ERes2Net top-right, CAM++ accurate-but-broken]
+
+So the recommendation is concrete: **ship ERes2Net.** We choose it for conversion fidelity — it is within the accuracy tie band on our AMI benchmark (not the per-arm leader on opus8k) and is the one model with a verified, near-exact on-device conversion. Real-Zoom validation hasn't run yet, so this is a strong internal signal, not a confirmed production gain.
+
+## Takeaways for practitioners
+
+We spent a long time turning knobs and the knobs lost. The lessons below are what we'd tell anyone debugging a voice-matching system. (Quick glossary, defined once above and reused here: *voiceprint* = the numeric embedding of a voice; *DER* = diarization error rate, lower better; *cross-call AUC* = threshold-free separability, 1.0 perfect; *anisotropy* = embeddings crammed into a narrow cone so even different voices score high cosine.)
+
+- **Stop tuning knobs; fix the representation.** Lowering the match threshold made things worse, not better. Mean-centering, smarter clustering (even oracle-k), and finer segmentation all roughly tied the baseline. Compression was pulling different speakers' voiceprints together — no threshold can separate points that already overlap. The fix was a better embedding model, not a better setting.
+- **Test end-to-end, not a proxy.** Mean-centering looked decisive: it restored embedding-band separation on the worst codec (opus8k, raw separation ~0.29 → ~0.77). Through the real matcher it did nothing — it just traded merge errors for split errors. A clean proxy metric can move while the thing you actually ship stays flat.
+- **Use threshold-free, anisotropy-immune metrics.** Cross-call AUC let us rank models without picking a threshold first, so a model that crams everything into a narrow cone (WavLM, raw separation ~0.27) couldn't fake its way to a good score. Raw cosine gaps would have misled us; AUC didn't.
+- **Run a negative control.** We swapped in x-vector on purpose. It lost on every arm (DER ~0.51 / 0.50 / 0.49, the worst everywhere). That tells us the win isn't "any swap helps" — it's specifically the stronger discriminative models.
+- **Treat conversion and on-device parity as a first-class axis, not a footnote.** CAM++ matches the accuracy leaders and is unshippable: its CoreML parity cosine came out at ~0.23 against PyTorch, and the same divergence shows up in ONNX at float32 on CPU, so it's architectural, not precision. ERes2Net converts at 0.99999 (fp16) to 1.000000 (fp32) parity after one output-neutral line change. Accuracy you can't run on the Neural Engine is accuracy you can't ship.
+- **The deep residual was upstream.** The within-meeting 0.88 same-voice consolidation knob looked like the obvious lever, so we toggled it on and off — completely inert (profiles, trapped speakers, DER all unchanged). The real ceiling on within-meeting granularity was the diarizer under-segmenting. A better embedding restores granularity the diarizer alone can't (on our AMI benchmark, opus8k: ~10 profiles to ~21–32, the upper figure coming from ReDimNet's run, the lower from CAM++'s). We'd have wasted days on a knob that does nothing.
+
+## Honest limitations
+
+Everything above is on our AMI benchmark, and we want to be clear about what that does and doesn't buy. AMI is a single corpus: four-party, in-room, far-field meetings. Our compression arms are synthetic — we ran AMI through ffmpeg codecs (Opus, G.711), not real captured Zoom or Meet calls, so the degradation is plausible but not the real thing. The diarizer is one specific proprietary system; the absolute numbers won't transfer to another stack, though we believe the direction will. On-device latency was inferred from parameter count and model size, not profiled on the Neural Engine. And we have no real-Zoom validation yet, though the tooling is ready.
+
+To make this a peer-reviewed result, we'd want real codec corpora (actual captured calls), a second dataset beyond AMI, and published equal-error-rate (EER) baselines to compare against. Treat this as a strong internal signal, not a published finding.
+
+## Reproduce
+
+The recipe is deliberately cheap. Diarize each meeting once, then swap only the embedding model and re-score — you don't re-run diarization per model, so a full bake-off is fast. Score three things: within-meeting DER, within-meeting coverage (fraction of true speakers recovered), and cross-call AUC on same-vs-different meeting pairs.
+
+The models are all free. ERes2Net and CAM++ come from 3D-Speaker (modelscope; permissive code). ECAPA-TDNN is SpeechBrain (Apache-2.0), a clean DIY fallback. ReDimNet is MIT. WavLM and UniSpeech-SAT are Microsoft via transformers. The model code and weights are free to use; the training-data nuance is separate. VoxCeleb2 is non-commercial for *training*, but using released weights is the same posture as our already-shipping WeSpeaker, which is itself VoxCeleb-derived — so ERes2Net adds no new licensing risk.
+
+Build the codec arms with ffmpeg: clean, Opus at 24k/16k/12k/8k, and G.711 mu-law 8k. Then add the conversion check as its own gate — convert to CoreML and measure parity cosine against PyTorch, targeting >0.99. That step is what separates a benchmark winner you can't deploy (CAM++) from something you can actually put on the Neural Engine (ERes2Net).
+
+## Takeaways box
+
+- **The problem was the representation, not the knobs.** Compression pulled different speakers' voiceprints together; no threshold can split overlapping points.
+- **Proxy metrics lie; only end-to-end tells the truth.** Mean-centering looked like a fix and changed nothing downstream.
+- **Pick threshold-free, scale-immune metrics.** Cross-call AUC ranked models fairly; raw cosine gaps would have misled us.
+- **Conversion fidelity is a hard gate.** CAM++ ties on accuracy and fails on-device (parity ~0.23); ERes2Net ties on accuracy and converts (parity 0.99999–1.000000).
+- **Ship ERes2Net** — within the accuracy band on our AMI benchmark, the only model with verified near-exact on-device parity. Real-Zoom validation is the next step.
+- **All numbers are on our AMI benchmark with synthetic codecs.** Strong internal signal, not a published result.

--- a/Tools/SpeakerEvalHarness/BLOG_DRAFT_speaker-id-detective-story.md
+++ b/Tools/SpeakerEvalHarness/BLOG_DRAFT_speaker-id-detective-story.md
@@ -1,0 +1,81 @@
+<!-- Public dev-blog draft. Charts: chart 1 = investigation_journey, chart 2 = payoff_speakers_separated
+     (both rendered in-session; export the SVGs to embed). Data tables included so the post stands alone. -->
+
+# We almost shipped the wrong fix: hunting down speaker confusion in a transcription app
+
+*How a "just tune the threshold" bug turned into a detective story — and why the real fix was a free model swap, not a setting.*
+
+Our app, Transcripted, listens to meetings and writes them down — who said what. Most of the time it's great. But it had an embarrassing failure: it would sometimes **merge two different people into one speaker**, or split one person across several. And it was noticeably worse on compressed audio — Zoom calls, phone bridges.
+
+We thought this would be a quick tuning fix. It turned into a multi-week investigation that overturned our assumptions twice. Here's the whole story, including the fix that *almost* fooled us.
+
+## The obvious fix that backfired
+
+Speaker labeling works in two steps: a **diarizer** splits the audio into "who spoke when," and a **matcher** decides whether a voice is someone it's heard before — by comparing "voiceprints" (embeddings) with a similarity threshold. If two people get merged, the obvious culprit is the matcher being too eager. So: **raise** the threshold (be pickier), right?
+
+We measured it on real labeled audio. Raising the threshold barely helped — and *lowering* it (which we tested to map the whole curve) made things **dramatically worse**, especially on compressed audio.
+
+The reason turned out to be the most interesting finding of the whole project: **compression makes different people's voiceprints look *more alike*.** We measured the gap between "same person" and "different person" similarity as we squeezed the audio through codecs:
+
+| audio | same-vs-different separation |
+|---|---|
+| clean | 0.54 |
+| aggressive VoIP | 0.42 |
+| very low bitrate | **0.29** |
+
+The codec smears everyone toward the same blurry average. So on a compressed call, a lenient threshold doesn't reunite a person with their past self — it fuses *strangers*. The threshold wasn't the lever. It was barely a lever at all.
+
+## Three more dead ends
+
+We're stubborn, so we kept testing matcher-side fixes:
+
+- **Re-centering the voiceprints** (removing that shared "blur" direction): looked promising — more on this below.
+- **Smarter clustering** — we even handed the algorithm the *exact* number of speakers ("oracle-k"). It tied the shipping system. No win.
+- **Finer / overlap-aware segmentation** — we restricted to clean, single-speaker snippets. Still couldn't separate the speakers.
+
+Each one independently said the same thing: the problem isn't *how we group or compare* the voiceprints. It's the voiceprints themselves.
+
+## The fix that almost fooled us
+
+The re-centering idea deserves its own paragraph, because it's the part I'm most glad we double-checked.
+
+On the raw voiceprint math, re-centering looked like a *huge* win — it restored the same-vs-different separation from 0.29 all the way back to ~0.77 on heavily compressed audio. On that chart, it was a slam dunk. We were ready to call it the fix.
+
+Then we ran it **end-to-end through the actual matcher** — not the proxy metric, the real pipeline that produces speaker labels. It did **nothing** for the user-facing error. It had just shuffled "merge" errors into "split" errors. The beautiful chart was measuring something real, but not something that mattered downstream.
+
+The lesson burned in: **a metric that improves in isolation is a hypothesis, not a result.** We only caught it because we'd made a habit of adversarial verification — every promising finding gets a "does this actually help end-to-end, and can an independent check break it?" pass. That pass saved us from shipping a no-op.
+
+## The real culprit
+
+With every cheap fix eliminated, the conclusion was unavoidable: the **voice-fingerprint model itself** (an older speaker-embedding network) was the ceiling — and compression made it worse. The accuracy "floor" we'd assumed was just hard physics (people in the same room, sharing a mic) was, to a large degree, *the model*.
+
+So we ran a bake-off: re-extract voiceprints for the *exact same* audio segments with several strong, **free, open** speaker-embedding models, and compare apples-to-apples.
+
+The result was the payoff we'd been chasing. A better model recovered far more speakers, especially on compressed audio:
+
+| audio | current model | best model |
+|---|---|---|
+| clean | 73% | 81% |
+| compressed (Zoom-ish) | 63% | **77%** |
+| phone-band | 63% | **83%** |
+
+*(% of speakers correctly told apart. Errors roughly **halved** on phone-band audio; cross-call matching went from ~95–98% to near-perfect.)*
+
+And crucially — we ran a **negative control**: a deliberately *weak* model. It lost, badly. That mattered. It proved the win wasn't "any swap helps" or a quirk of our test harness; only genuinely better models won. The effect is real.
+
+## What we'd tell another team
+
+Four takeaways, in rough order of how much they surprised us:
+
+1. **When accuracy plateaus, fix the representation, not the knobs.** Thresholds, clustering, and post-processing were *all* weaker levers than the embedding. We'd have wasted weeks tuning them.
+2. **Test end-to-end, never on a proxy.** Our most beautiful intermediate metric was a mirage. The only number that counts is the one the user feels.
+3. **Run a negative control.** "Our fix improved the metric" is much more convincing when "a deliberately bad change made it worse" on the same harness.
+4. **Compression is an adversary, not just noise.** It doesn't randomly degrade voiceprints — it systematically pulls *different* speakers together. That single insight explained why our first instinct was exactly backwards.
+
+## The honest caveats
+
+We tested on a public meeting-room dataset (4 people, one room, far-field mics) — *harder* than a typical Zoom call where everyone's on a separate stream, so the real-world numbers should be friendlier. We haven't yet validated on captured Zoom audio, and the most *shippable* model (the one that converts cleanest to on-device Apple silicon) still needs its accuracy confirmed in our harness. There's also a downstream setting that currently caps the gains and needs loosening. None of that changes the direction — it just sequences the work.
+
+But the headline holds, and it's a good one: **the problem wasn't a setting we'd mis-tuned. It was the voiceprint model — and the upgrade is free, local, and roughly halves the errors where it hurts most.**
+
+*The full investigation — four detailed reports and all the evaluation code — is in our repo. Everything here was measurement; we didn't change a line of the app to learn it.*

--- a/Tools/SpeakerEvalHarness/DIARIZER_ARM_REPORT.md
+++ b/Tools/SpeakerEvalHarness/DIARIZER_ARM_REPORT.md
@@ -1,0 +1,141 @@
+# Diarizer arm — can better clustering/segmentation cut within-meeting speaker merging? **No.**
+
+**Date:** 2026-06-17 · **Corpus:** AMI scale set, 32 meetings × 4 speakers (128 true speakers/arm), 6 codec
+arms (clean → Opus 24/16/12/8k → G.711). **Measurement only — no app code, no re-diarization.** Re-clusters
+the per-segment 256-dim WeSpeaker embeddings already in the cached dumps with alternative methods, evaluated
+on the identical quality-filtered set (quality ≥ 0.3, dur ≥ 1 s); `app` = the dump's own diarizer `speakerId`
+on that set. DER = pyannote optimal-mapping confusion (isolates clustering quality; no miss/FA term).
+
+> **Why this experiment.** The AMI-codec work showed the dominant false-positive source is the diarizer
+> merging distinct speakers *within* a meeting (~28/30 trapped), untouchable by the matcher (threshold ✗,
+> mean-centering ✗). This tests the remaining downstream knobs: can a **better clusterer** — or **finer
+> segmentation** — recover the merged speakers from the same embeddings? Verified by 4 probes (full method
+> matrix, mixed-segment diagnosis, pure-segment separability, end-to-end through the real matcher).
+
+> **Validity.** `clean`/`app` reproduces the established headline exactly (clusters/true 0.969, coverage 0.75,
+> purity 0.80, DER 0.30); an independent recompute of the opus8k pure-vs-all coverage matches (0.617 vs 0.641).
+
+---
+
+## Bottom line
+
+**Clustering is not the lever, and neither is segmentation. The within-meeting merging is baked into the
+WeSpeaker embeddings — distinct speakers' vectors collapse together, and compression makes it strictly worse.
+The only lever the data supports is codec-robust speaker embeddings.** We have now systematically ruled out
+*every* tunable downstream knob: match threshold, mean-centering, clustering algorithm/k, and finer/overlap-
+aware segmentation.
+
+**🟢 GREEN** — exhaustive (13 clustering methods × 6 arms × centerings), the clean control reproduces prior
+results exactly, and the embedding-bound conclusion is confirmed by two independent controls + an end-to-end
+replay. (A negative result for the knobs, but a *positive*, decision-useful localization of the real lever.)
+
+---
+
+## 1. Better clustering does not lower DER on any arm
+
+Best DER over all 13 methods (oracle-k agglo/ward/spectral/kmeans, ± mean-centering, and an auto-k threshold
+sweep) vs the app diarizer:
+
+| arm | app coverage / DER | best DER (method) | best coverage (method) | DER gain |
+|---|---|---|---|---|
+| clean | 0.75 / 0.301 | 0.292 (spectral-k) | 0.805 (spectral-k) | −0.009 |
+| opus24k | 0.66 / 0.355 | 0.354 | 0.750 | −0.001 |
+| opus16k | 0.71 / 0.303 | 0.303 | 0.789 | −0.001 |
+| opus12k | 0.69 / 0.329 | 0.328 | 0.734 | −0.001 |
+| opus8k | 0.57 / 0.474 | 0.474 | 0.672 | ±0.000 |
+| g711u | 0.56 / 0.431 | 0.430 | 0.688 | −0.001 |
+
+- **Oracle-k** (handing the clusterer the true count = 4) **does not lower DER anywhere.** It lifts *coverage*
+  (+0.05 to +0.13; opus8k 0.57 → 0.67), but those gains come from spectral carving extra **low-purity**
+  clusters (0.61–0.76 vs 0.78–0.84) — recovered "speakers" that don't reduce confusion. For the metric that
+  matters (within-meeting confusion), the gain is ~0.
+- **Mean-centering: ✗** (moves DER ≤ 0.002). **Auto-k threshold sweep: ✗** — the best threshold (0.8) just
+  converges to the app's own clustering; lower thresholds only over-merge.
+- Even at oracle-k, compressed-audio coverage tops out ~0.62–0.67 — **a third of speakers stay merged** when
+  you already know how many there are.
+
+## 2. The ceiling is the embeddings, not segmentation
+
+**Mixed/overlap segments do not explain the ceiling.** Segments whose time span straddles ≥ 2 speakers
+(dominant share < 0.8) are a 15–21 % minority; the median filtered segment is **100 % one speaker**. Across
+the 6 arms, %mixed correlates **positively** with oracle-k coverage (r = +0.86) — the opposite of the
+segmentation hypothesis — and heavy compression *reduces* mixing by emitting ~70 % more, shorter segments
+(opus8k median 4.45 s vs clean 7.45 s) yet coverage still collapses. Two controls clinch it: (a) true speakers
+appearing *only* in mixed segments: **0 of 128** on every arm — a clean embedding exists for essentially every
+speaker; (b) dropping mixed segments and re-running oracle-k on the pure set gives coverage **equal-to-or-below**
+the all-segment number.
+
+**Pure single-speaker segments still don't separate** (the decisive test):
+
+| arm | all-seg coverage | **pure-seg coverage** | pure-seg purity | verdict |
+|---|---|---|---|---|
+| clean | 0.83 | **0.77** | 0.88 | embedding-bound (mild) |
+| opus12k | 0.73 | **0.72** | 0.83 | embedding-bound |
+| opus8k | 0.68 | **0.60–0.65** | 0.83 | embedding-bound (severe) |
+| g711u | 0.66 | **0.62–0.66** | 0.84 | embedding-bound (severe) |
+
+All 4 true speakers survive the pure filter (31/32 clean, 32/32 opus8k), so low coverage is **genuine
+merging, not a dropped speaker**. If overlap were the bottleneck, pure-segment coverage would jump toward 1.0;
+instead it is flat-to-worse. Distinct WeSpeaker vectors collapse together even with one clean voice per
+segment, and compression worsens it (codec severity ↔ oracle-k coverage r = −0.87).
+
+## 3. Better clusters never even reach the matcher — and a flag is misnamed
+
+Feeding exactly 4 oracle-k clusters/meeting and replaying through the real harness, the app's
+`EmbeddingClusterer.postProcess` **re-collapses them** to the baseline diarizer's under-segmented grouping:
+
+| arm | oracle-k input k | surviving k after postProcess | baseline post-k | DER change downstream |
+|---|---|---|---|---|
+| clean | 4 | 3.41 | 3.84 | +0.006 … +0.013 (worse) |
+| opus12k | 4 | 3.22 | 3.75 | +0.006 (worse) |
+| opus8k | 4 | **2.62** | 2.59 | **bit-identical on all 32 meetings** |
+
+**Code finding (read-only):** the harness ran with `--consolidation none`, but that flag does **not** disable
+within-meeting consolidation. `postProcess` runs `absorbSmallClusters` + `consolidateSameVoiceClusters`
+(agglomerative merge at cosine **0.88**, the auto-accept bar) + `dbInformedSplit` **unconditionally**
+(`Sources/TranscriptedCore/Speaker/EmbeddingClusterer.swift:60–83`); only the optional `pairwiseMerge` and the
+consolidation *threshold* are nil-able. The 0.88 same-voice merge is the mechanism that re-collapses oracle-k.
+This is a real, actionable bug-ish: **the named knob doesn't turn off the collapse** — worth fixing/renaming
+if these passes are meant to be skippable for eval. (Secondary to the embedding ceiling: even uncollapsed,
+oracle-k's upside was small.)
+
+## 4. The lever — bounded to what the data shows
+
+With match-threshold ✗, mean-centering ✗, clustering ✗, and finer/overlap segmentation ✗:
+
+1. **Codec-robust speaker embeddings (primary).** Retrain/fine-tune WeSpeaker (or adopt a more robust model)
+   with codec augmentation (Opus 8–24k, G.711). This is the *only* intervention that can move the floor —
+   every probe shows the merging lives in the embeddings and compression worsens it. **Bounded expectation:**
+   even clean audio's oracle-k ceiling is ~0.83 coverage, so expect *improvement, not elimination* (~1 in 6
+   speakers may stay hard even uncompressed).
+2. **Loosen `postProcess` within-meeting consolidation (secondary, capped).** Raising the 0.88 same-voice bar
+   (or making `--consolidation none` actually skip the pass) lets a few more separable clusters survive —
+   a small false-merge/fragmentation cleanup on clean/opus12k. Capped by the low oracle-k ceiling; only
+   worthwhile alongside the embedding fix.
+- **Explicitly not levers:** matcher match-threshold, clustering algorithm/k, embedding mean-centering, finer
+  segmentation.
+
+## Limits
+
+- AMI 4-party in-room headset, synthetically codec-degraded — not captured Zoom/Meet system audio (direction
+  robust; absolute coverage/DER will differ on real 2–3-person calls). DER here is optimal-mapping confusion
+  on the quality-filtered set, so it is a *clustering-quality* DER, comparable across methods but not equal to
+  the full-pipeline DER in the codec report.
+- "Coverage" counts a true speaker as recovered if it is the time-dominant speaker of ≥ 1 cluster; it does not
+  credit partial recovery. The embedding-bound verdict is corroborated by purity and DER, which agree.
+
+## Reproduce
+
+```bash
+# full method matrix (per arm/method/center), 32 meetings each
+for arm in clean opus24k opus16k opus12k opus8k g711u; do
+  for m in app agglo_oraclek ward_oraclek spectral_oraclek kmeans_oraclek; do
+    python3 scripts/recluster_eval.py --arm $arm --method $m --out-json data/eval/reclust_${arm}_${m}.json
+  done
+done
+python3 scripts/mixed_segment_diag.py            # segmentation vs embeddings (mixed-segment rate)
+python3 scripts/pure_segment_separability.py     # pure single-speaker oracle-k (embedding-bound test)
+python3 scripts/oraclek_dumps.py                 # rewrite dumps with oracle-k speakerId for end-to-end replay
+```
+All `data/` artifacts are gitignored. Consolidation source inspected read-only:
+`Sources/TranscriptedCore/Speaker/EmbeddingClusterer.swift`.

--- a/Tools/SpeakerEvalHarness/EMBEDDING_BAKEOFF_REPORT.md
+++ b/Tools/SpeakerEvalHarness/EMBEDDING_BAKEOFF_REPORT.md
@@ -50,6 +50,15 @@ on-device conversion** (official ONNX → coremltools → ANE). The earlier tens
 unshippable; CAM++ shippable but unmeasured") is **resolved — CAM++ is both.** ERes2Net (192-dim, best clean
 DER) is the runner-up; ReDimNet-b6/ECAPA remain strong but are harder to ship.
 
+**End-to-end confirmation (CAM++ through the real matcher, match threshold swept):** the win reaches the
+matcher. At each arm's best operating point CAM++ beats WeSpeaker on DER and restores profile granularity
+WeSpeaker can't reach on compressed audio — clean 0.44→0.36, opus12k 0.50→0.46, opus8k 0.61→**0.55**
+(profiles 5–10→21), g711u 0.57→**0.49** (profiles 12–27→38). Recommended CAM++ match threshold ≈ **0.60**
+(0.55 clean, ~0.65 heavy compression — don't inherit WeSpeaker's exact value). **Same cap as ReDimNet:**
+people-trapped stays ~28–31 at every operating point because the within-meeting `0.88` consolidation + diarizer
+under-segmentation bound recovery. So the model swap improves DER and granularity everywhere, but the two
+changes — **better embedding + loosen `0.88`** — must ship together to drive user-facing merges down.
+
 Full per-arm numbers for all 8 models: **[MASTER_SCORECARD.md](MASTER_SCORECARD.md)**. The original
 ReDimNet-focused analysis below still stands; CAM++ simply makes the *shippable* pick a measured one.
 

--- a/Tools/SpeakerEvalHarness/EMBEDDING_BAKEOFF_REPORT.md
+++ b/Tools/SpeakerEvalHarness/EMBEDDING_BAKEOFF_REPORT.md
@@ -24,7 +24,37 @@ models. But "best accuracy" and "best to ship on-device" are **different answers
 win is **capped by a separate within-meeting consolidation knob** (`0.88`) that must be loosened next.
 
 **🟢 GREEN** — broad, statistically-robust win (opus8k 30/32 meetings, p=2.5e-7), verified end-to-end through
-the real matcher, with an honest shippability caveat.
+the real matcher.
+
+---
+
+## Update (2026-06-18): CAM++ benched — the shippable winner is now confirmed
+
+We subsequently ran **CAM++** and **ERes2Net** (Alibaba 3D-Speaker, via modelscope; front-end handled by the
+official toolkit, sanity-gated: same-spk cosine 0.90 vs diff 0.10) through the exact same bench. This **closes
+the one gap** in the original recommendation — the shippable model now has real in-harness numbers, and they're
+top-tier:
+
+| model | dim | clean DER | opus8k DER | g711u DER | cross-call AUC | isotropic? | on-device path |
+|---|---|---|---|---|---|---|---|
+| WeSpeaker (current) | 256 | 0.319 | 0.480 | 0.432 | 0.95–0.98 | yes | shipping |
+| **CAM++** | 512 | **0.274** | **0.301** | **0.294** | **1.0000 (all arms)** | yes | **official ONNX → CoreML (cleanest)** |
+| ERes2Net | 192 | **0.238** | 0.329 | 0.274 | 1.0000 | yes | official ONNX → CoreML |
+| ReDimNet-b6 | 192 | 0.252 | 0.276 | 0.221 | ~1.0 | yes | **export blocker (ANE-hostile)** |
+| ECAPA-TDNN | 192 | 0.267 | 0.307 | 0.281 | ~1.0 | yes | DIY ONNX |
+
+**Revised recommendation: ship CAM++.** It matches ReDimNet/ECAPA on accuracy (DER ~0.27–0.30 flat across all
+compression vs WeSpeaker's 0.32→0.48; AUC a perfect 1.0 on every arm; purity 0.84–0.87 — highest tier), is
+**isotropic** (clean drop-in, no whitening), is **lighter than today's model**, and has the **cleanest
+on-device conversion** (official ONNX → coremltools → ANE). The earlier tension ("ReDimNet most accurate but
+unshippable; CAM++ shippable but unmeasured") is **resolved — CAM++ is both.** ERes2Net (192-dim, best clean
+DER) is the runner-up; ReDimNet-b6/ECAPA remain strong but are harder to ship.
+
+Full per-arm numbers for all 8 models: **[MASTER_SCORECARD.md](MASTER_SCORECARD.md)**. The original
+ReDimNet-focused analysis below still stands; CAM++ simply makes the *shippable* pick a measured one.
+
+> **Negative control held:** x-vector (a deliberately weak model) was worst on every arm (DER ~0.5),
+> confirming only genuinely strong models win — this is not "any swap helps."
 
 ---
 

--- a/Tools/SpeakerEvalHarness/EMBEDDING_BAKEOFF_REPORT.md
+++ b/Tools/SpeakerEvalHarness/EMBEDDING_BAKEOFF_REPORT.md
@@ -36,20 +36,33 @@ official toolkit, sanity-gated: same-spk cosine 0.90 vs diff 0.10) through the e
 the one gap** in the original recommendation — the shippable model now has real in-harness numbers, and they're
 top-tier:
 
-| model | dim | clean DER | opus8k DER | g711u DER | cross-call AUC | isotropic? | on-device path |
+| model | dim | clean DER | opus8k DER | g711u DER | cross-call AUC | isotropic? | CoreML parity (tested) |
 |---|---|---|---|---|---|---|---|
 | WeSpeaker (current) | 256 | 0.319 | 0.480 | 0.432 | 0.95–0.98 | yes | shipping |
-| **CAM++** | 512 | **0.274** | **0.301** | **0.294** | **1.0000 (all arms)** | yes | **official ONNX → CoreML (cleanest)** |
-| ERes2Net | 192 | **0.238** | 0.329 | 0.274 | 1.0000 | yes | official ONNX → CoreML |
-| ReDimNet-b6 | 192 | 0.252 | 0.276 | 0.221 | ~1.0 | yes | **export blocker (ANE-hostile)** |
+| CAM++ | 512 | **0.274** | **0.301** | **0.294** | **1.0000 (all arms)** | yes | **FAILS — cosine 0.23 (pretrained BN tiny-variance; no clean fix)** |
+| **ERes2Net** | 192 | **0.238** | 0.329 | 0.274 | 1.0000 | yes | **cosine 1.0 (after 1-line ReLU patch)** |
+| ReDimNet-b6 | 192 | 0.252 | 0.276 | 0.221 | ~1.0 | yes | export blocker (ANE-hostile) |
 | ECAPA-TDNN | 192 | 0.267 | 0.307 | 0.281 | ~1.0 | yes | DIY ONNX |
 
-**Revised recommendation: ship CAM++.** It matches ReDimNet/ECAPA on accuracy (DER ~0.27–0.30 flat across all
-compression vs WeSpeaker's 0.32→0.48; AUC a perfect 1.0 on every arm; purity 0.84–0.87 — highest tier), is
-**isotropic** (clean drop-in, no whitening), is **lighter than today's model**, and has the **cleanest
-on-device conversion** (official ONNX → coremltools → ANE). The earlier tension ("ReDimNet most accurate but
-unshippable; CAM++ shippable but unmeasured") is **resolved — CAM++ is both.** ERes2Net (192-dim, best clean
-DER) is the runner-up; ReDimNet-b6/ECAPA remain strong but are harder to ship.
+**Revised recommendation: ship ERes2Net (192-dim).** *(Corrected after the CoreML conversion test — see below.)*
+All four strong models tie on accuracy (DER ~0.25–0.30 flat across compression vs WeSpeaker's 0.32→0.48; AUC a
+perfect 1.0; isotropic), so the decider is **which actually converts to Apple's on-device format.** We tested it:
+
+> **CAM++ → CoreML FAILS.** It converts and runs, but the converted model's embeddings only reach **cosine
+> ~0.23** vs the PyTorch reference (target >0.99). Root cause (rigorously diagnosed, not assumed): CAM++'s
+> **pretrained** BatchNorm has near-zero-variance channels (running_var min ≈ 4.7e-6 → ~260× normalization)
+> that amplify float rounding through its deep DenseTDNN backbone. **Not** a float16/ANE issue — ONNX *and*
+> CoreML diverge identically even at float32/CPU; per-op conversion is exact, the error accumulates with depth.
+> No clean workaround. **ERes2Net → CoreML is clean: cosine 1.000000** after a trivial 1-line patch (swap a
+> `Hardtanh(0,20)` for `ReLU`, which the official 3D-Speaker ONNX export already does). ~25 MB.
+
+So **ERes2Net is the pick: top-tier accuracy (best clean DER 0.238) AND a verified clean CoreML path.** CAM++
+stays an excellent *research/server* embedding but is **not on-device-shippable**. ReDimNet (most accurate)
+also has an export blocker; ECAPA (Apache-2.0) is the DIY-ONNX fallback.
+
+> **One open check:** the CoreML cosine-1.0 result for ERes2Net was first verified on the architecture; we are
+> confirming it on the actual **pretrained** ERes2Net weights too (CAM++'s failure was pretrained-weight-
+> specific, so this matters). [pending — will update.]
 
 **End-to-end confirmation (CAM++ through the real matcher, match threshold swept):** the win reaches the
 matcher. At each arm's best operating point CAM++ beats WeSpeaker on DER and restores profile granularity

--- a/Tools/SpeakerEvalHarness/EMBEDDING_BAKEOFF_REPORT.md
+++ b/Tools/SpeakerEvalHarness/EMBEDDING_BAKEOFF_REPORT.md
@@ -101,8 +101,13 @@ risk category. Prefer **CnCeleb / in-house CAM++ checkpoints** to reduce it.
   inferred from GMACs/params, **not profiled on ANE.**
 - **Domain gap:** all numbers are **AMI 4-party in-room**; codec arms proxy call compression but **no real
   captured Zoom audio was tested.** Codec-robustness is the most transferable result; absolute DER is not.
-- **Known gaps:** ECAPA g711u not evaluable (extraction in flight); ReDimNet opus12k dip warrants one confirming
-  re-run.
+- **Known gaps:** ReDimNet opus12k dip warrants one confirming re-run. (ECAPA is now evaluated on all 6 arms —
+  g711u cov 0.797 / DER 0.281 / AUC 1.0, confirming it as a strong, fully-evaluable runner-up.)
+- **Negative control (validity):** x-vector (`spkrec-xvect-voxceleb`, a weaker model) was run as a control and
+  **does not beat WeSpeaker** — within-meeting DER 0.49–0.51 (worst of the field) on clean/opus8k/g711u. So the
+  bake-off is not "any model swap helps"; only genuinely strong models (ReDimNet, ECAPA) win. (Note x-vector
+  still has high cross-meeting AUC ~0.997 — coarse cross-call ID and fine within-meeting separation are
+  different capabilities; the strong models win on both.)
 
 ## 5. Recommended path to ship
 

--- a/Tools/SpeakerEvalHarness/EMBEDDING_BAKEOFF_REPORT.md
+++ b/Tools/SpeakerEvalHarness/EMBEDDING_BAKEOFF_REPORT.md
@@ -1,0 +1,135 @@
+# Embedding bake-off — the lever is the embedding model, and a better one delivers
+
+**Date:** 2026-06-18 · **Corpus:** AMI scale set, 32 meetings × 4 recurring speakers, 6 codec arms
+(clean → Opus 24/16/12/8k → G.711). **Measurement only — no app code changed; no re-diarization.** Each
+candidate re-extracted embeddings for the **exact same** dump segments (same diarizer spans, only the
+embedding vector differs — a clean controlled comparison) via a throwaway venv (`.venv_emb`, gitignored).
+
+> **Why this experiment.** The prior reports ruled out every tunable downstream knob (match threshold,
+> mean-centering, clustering, segmentation) and concluded the within-meeting speaker-merging ceiling is the
+> **embedding model** (WeSpeaker ResNet34-LM). This tests that directly: swap in stronger open speaker-embedding
+> models and measure whether the floor moves.
+
+> **Validity.** WeSpeaker/`app` reproduces prior numbers exactly; all metrics independently recomputed from the
+> dumps by a verifier (`scripts/verify_bakeoff.py`); 0 zero-norm / 0 non-finite across 19k+ segments.
+
+---
+
+## Bottom line
+
+**Yes — a better embedding model breaks the floor.** The shipping WeSpeaker is the bottleneck, and swapping it
+for a strong discriminative model (ReDimNet-b6 or ECAPA) recovers more speakers within a meeting, **halves the
+error on phone-band audio**, and gives near-perfect cross-call matching — codec-robust, and from *smaller*
+models. But "best accuracy" and "best to ship on-device" are **different answers**, and the full user-facing
+win is **capped by a separate within-meeting consolidation knob** (`0.88`) that must be loosened next.
+
+**🟢 GREEN** — broad, statistically-robust win (opus8k 30/32 meetings, p=2.5e-7), verified end-to-end through
+the real matcher, with an honest shippability caveat.
+
+---
+
+## 1. Accuracy winner: ReDimNet-b6 (192-dim)
+
+Within-meeting oracle-k (so coverage gains are real separation, not over-fragmentation — purity held ≥ 0.83):
+
+| arm | model | coverage | purity | DER |
+|---|---|---|---|---|
+| clean | WeSpeaker → **ReDimNet-b6** | 0.727 → **0.812** | 0.831 → 0.836 | 0.319 → **0.252** |
+| opus8k | WeSpeaker → **ReDimNet-b6** | 0.625 → **0.766** | 0.753 → **0.850** | 0.480 → **0.276** |
+| g711u | WeSpeaker → **ReDimNet-b6** | 0.633 → **0.828** | 0.781 → **0.867** | 0.432 → **0.221** |
+| opus12k | WeSpeaker → ReDimNet-b6 | 0.664 → 0.695 | 0.798 → 0.796 | 0.375 → 0.313 |
+
+- **Statistically robust, broad win** (paired per-meeting, n=32): opus8k **30/2** meetings (sign-test p=2.5e-7,
+  bootstrap ΔDER CI [−0.261, −0.149]); g711u **28/4** (p=1.9e-5); clean 22/10 (CI just clears zero).
+- **Cross-call discrimination near-perfect:** AUC ≥ 0.998 every arm; raw cosine separation 0.60–0.72 vs
+  WeSpeaker 0.29–0.54. **Isotropic — no whitening needed** (unlike the SSL models, below). 192-dim (smaller
+  than the shipping 256-dim).
+- **Codec-robust:** DER barely moves clean→g711u (0.25→0.22), where WeSpeaker degrades hard (0.32→0.43).
+
+**Full field** (clean / opus8k AUC · within-cov):
+- **ReDimNet-b6** — AUC ~1.0, cov 0.81/0.77 — **best, isotropic, 192-d.**
+- **ECAPA-TDNN** — AUC ~1.0, cov 0.80/0.74 — near-tied runner-up, isotropic, 192-d, **best on opus12k.**
+- **WavLM-SV / UniSpeech-SAT** (SSL) — AUC ~0.99 but **anisotropic** (raw sep 0.23–0.28; need whitening); cov ~0.71.
+- **WeSpeaker (current)** — AUC 0.95–0.98, cov 0.63–0.73 — the baseline being beaten.
+
+**Soft spot (flagged):** ReDimNet dips on **opus12k** (cov 0.812→0.695, ~3 meetings; ΔDER CI grazes zero). It
+still beats WeSpeaker there, but **ECAPA is the cleaner opus12k pick** (cov 0.719, DER 0.303, bootstrap-robust,
+beats ReDimNet 19/13 head-to-head) — and ECAPA is also more shippable (below).
+
+## 2. End-to-end through the real matcher — it reaches, and the cap is elsewhere
+
+Replaying ReDimNet embeddings through the real clusterer + DB matcher (match threshold swept, since ReDimNet's
+cosine scale runs hotter than WeSpeaker's 0.60):
+
+- **It restores granularity WeSpeaker physically cannot reach.** On compressed audio WeSpeaker tops out at
+  **10 profiles (opus8k) / 27 (g711u)** at *any* threshold — its low false-merge counts are an artifact of
+  collapsing ~32 people into a handful of profiles. ReDimNet reaches **32 (opus8k @0.69) / 33 (g711u @0.63)**.
+- **DER improves at every arm's best operating point:** clean 0.44→0.37, opus8k 0.61→0.54, g711u 0.57→0.51.
+- **Recommended match threshold ≈ 0.62–0.65** (clean 0.55–0.58; opus8k 0.69; g711u 0.62–0.63). Do **not**
+  inherit 0.60 — recalibrate per embedding.
+- **Honest cap:** the within-meeting `consolidateSameVoiceClusters@0.88` post-process is now the binding
+  constraint, not the embedding. The diarizer recovers only **3.66 (ReDimNet) vs 3.25 (WeSpeaker)** of 4
+  speakers/meeting on clean before the matcher runs, so user-facing people-trapped stays 26–30/32 at every
+  usable threshold. **Next lever after the embedding swap is the 0.88 consolidation** (and note
+  `--consolidation none` does not disable it — see DIARIZER_ARM_REPORT.md §3).
+
+## 3. Shippability — best accuracy ≠ best to ship on-device
+
+Transcripted runs WeSpeaker via CoreML on the Apple Neural Engine. Conversion is the deciding factor:
+
+| model | code license | CoreML/ONNX path | size | on-device risk |
+|---|---|---|---|---|
+| **CAM++** (3D-Speaker/wespeaker) | permissive | **official ONNX → coremltools → ANE (cleanest)** | **7.18M**, 192-d (< baseline) | **Medium — recommended first** |
+| ERes2NetV2 (3D-Speaker) | permissive | official ONNX, same clean path | 17.8M, 192-d | Medium (heavier, short-clip-tuned) |
+| ECAPA-TDNN (SpeechBrain) | Apache-2.0 | DIY — export encoder, Fbank in Swift | 6.2–20.8M | Medium-High |
+| **ReDimNet-b6** (accuracy winner) | MIT | **documented ONNX-export failure; ANE-hostile** (reshape-dim + attention); 20.27 GMACs | 15.0M | **High — not on-device-ready** |
+| ReDimNet-b2/b3 | MIT | same export blocker (cheaper if solved) | 3–4.7M | High |
+| WeSpeaker ResNet34-LM (baseline) | shipping today | already CoreML/ANE | 256-d | baseline |
+
+**Recommendation: ship CAM++ first** (clean conversion, smaller than today's model, efficiency-first design),
+keep **ReDimNet-b6 as the research/accuracy ceiling**, and **ECAPA as the Apache-2.0, opus12k-robust alternate**.
+**License:** all code permissive; all candidates are VoxCeleb2-trained (CC BY-NC-ND, non-commercial — propagation
+to weights legally unsettled), but **Transcripted already ships VoxCeleb-derived WeSpeaker**, so this is no new
+risk category. Prefer **CnCeleb / in-house CAM++ checkpoints** to reduce it.
+
+## 4. Caveats — measured vs inferred
+
+- **Measured:** ReDimNet-b6, ECAPA, WavLM, UniSpeech-SAT vs WeSpeaker on AMI, identical segments. End-to-end
+  ReDimNet through the real matcher.
+- **Inferred, NOT measured:** **CAM++ / ERes2NetV2 were never run in this harness** — their accuracy is from
+  literature. The *shippability winner has zero in-harness accuracy data.* All Apple-Silicon latency figures are
+  inferred from GMACs/params, **not profiled on ANE.**
+- **Domain gap:** all numbers are **AMI 4-party in-room**; codec arms proxy call compression but **no real
+  captured Zoom audio was tested.** Codec-robustness is the most transferable result; absolute DER is not.
+- **Known gaps:** ECAPA g711u not evaluable (extraction in flight); ReDimNet opus12k dip warrants one confirming
+  re-run.
+
+## 5. Recommended path to ship
+
+1. **Convert CAM++** (official ONNX → coremltools); confirm ANE residency + per-clip latency in Xcode before
+   integration. Prefer a CnCeleb/in-house checkpoint.
+2. **Run CAM++ (and ERes2NetV2) through this exact bake-off** — same AMI dumps/arms — and gate on it
+   matching/beating WeSpeaker. (This is the missing data.)
+3. **Wire into FluidAudio's CoreML embedding path** (drop-in for the 256-d extractor; new model is 192-d —
+   check downstream dim assumptions).
+4. **Re-run on-device** to confirm CoreML/ANE parity (quantization shifts cosine scale).
+5. **Recalibrate the match threshold** per embedding (sweep; don't inherit 0.60).
+6. **Then loosen `consolidateSameVoiceClusters@0.88`** — the bake-off proves the embedding is no longer the
+   bottleneck; the within-meeting consolidation is.
+7. **Validate on real captured Zoom audio** before shipping.
+
+## Reproduce
+
+```bash
+python -m venv .venv_emb && . .venv_emb/bin/activate
+pip install torch torchaudio speechbrain transformers soundfile numpy
+MODELS="ecapa wavlm unisat redimnet_b6" ARMS="clean opus12k opus8k g711u" bash scripts/run_embed_bakeoff.sh
+deactivate
+for arm in clean opus12k opus8k g711u; do for m in "" ecapa wavlm redimnet_b6; do
+  python3 scripts/model_scorecard.py --arm $arm --model "$m" --out-json data/eval/scorecards/${arm}__${m:-wespeaker}.json
+done; done
+python3 scripts/verify_bakeoff.py     # independent recompute + paired sign test + bootstrap CI
+```
+`.venv_emb/` and all `data/` artifacts are gitignored. Models: ECAPA `speechbrain/spkrec-ecapa-voxceleb`,
+WavLM `microsoft/wavlm-base-plus-sv`, UniSpeech-SAT `microsoft/unispeech-sat-base-plus-sv`, ReDimNet
+`torch.hub IDRnD/ReDimNet b6`.

--- a/Tools/SpeakerEvalHarness/EMBEDDING_BAKEOFF_REPORT.md
+++ b/Tools/SpeakerEvalHarness/EMBEDDING_BAKEOFF_REPORT.md
@@ -21,7 +21,8 @@ embedding vector differs — a clean controlled comparison) via a throwaway venv
 for a strong discriminative model (ReDimNet-b6 or ECAPA) recovers more speakers within a meeting, **halves the
 error on phone-band audio**, and gives near-perfect cross-call matching — codec-robust, and from *smaller*
 models. But "best accuracy" and "best to ship on-device" are **different answers**, and the full user-facing
-win is **capped by a separate within-meeting consolidation knob** (`0.88`) that must be loosened next.
+win is **capped by the diarizer's upstream under-segmentation** — *not* the `0.88` consolidation knob, which we
+later directly tested and found **inert** (see the CORRECTION below). The residual lever is a better diarizer.
 
 **🟢 GREEN** — broad, statistically-robust win (opus8k 30/32 meetings, p=2.5e-7), verified end-to-end through
 the real matcher.
@@ -54,10 +55,21 @@ DER) is the runner-up; ReDimNet-b6/ECAPA remain strong but are harder to ship.
 matcher. At each arm's best operating point CAM++ beats WeSpeaker on DER and restores profile granularity
 WeSpeaker can't reach on compressed audio — clean 0.44→0.36, opus12k 0.50→0.46, opus8k 0.61→**0.55**
 (profiles 5–10→21), g711u 0.57→**0.49** (profiles 12–27→38). Recommended CAM++ match threshold ≈ **0.60**
-(0.55 clean, ~0.65 heavy compression — don't inherit WeSpeaker's exact value). **Same cap as ReDimNet:**
-people-trapped stays ~28–31 at every operating point because the within-meeting `0.88` consolidation + diarizer
-under-segmentation bound recovery. So the model swap improves DER and granularity everywhere, but the two
-changes — **better embedding + loosen `0.88`** — must ship together to drive user-facing merges down.
+(0.55 clean, ~0.65 heavy compression — don't inherit WeSpeaker's exact value). People-trapped stays ~28–31 at
+every operating point — a residual cap.
+
+> **CORRECTION (2026-06-18, directly tested):** an earlier version of this report (and the AMI-codec /
+> diarizer-arm reports) named the within-meeting `consolidateSameVoiceClusters@0.88` as that cap and said to
+> "loosen it." **That is wrong.** We added a harness-only override of `postProcess`'s `consolidationThreshold`
+> (app default 0.88 preserved) and re-ran CAM++ end-to-end at 0.88 vs 0.95 vs **off** across all four arms:
+> profiles / people-trapped / DER are **identical** (e.g. clean 39/28/0.388 either way; opus8k 21/30/0.552
+> either way). **The 0.88 same-voice consolidation is inert in the real flow** — it can only *merge* clusters,
+> and the diarizer already under-segments to the point that there are no duplicate same-voice clusters left to
+> merge. The binding cap is the **diarizer's upstream under-segmentation** (raw cluster count < true speakers),
+> not the 0.88. The genuine remaining lever is a **better diarizer / re-diarizing with the new embedding**
+> (our bake-off swapped embeddings only in the *matcher*, not in the diarizer's clustering step — untested but
+> the logical next experiment). Net: **ship CAM++ for the matching-quality win (real); do NOT expect loosening
+> 0.88 to help (it doesn't); the within-meeting residual needs the diarizer, not a knob.**
 
 Full per-arm numbers for all 8 models: **[MASTER_SCORECARD.md](MASTER_SCORECARD.md)**. The original
 ReDimNet-focused analysis below still stands; CAM++ simply makes the *shippable* pick a measured one.
@@ -106,11 +118,12 @@ cosine scale runs hotter than WeSpeaker's 0.60):
 - **DER improves at every arm's best operating point:** clean 0.44→0.37, opus8k 0.61→0.54, g711u 0.57→0.51.
 - **Recommended match threshold ≈ 0.62–0.65** (clean 0.55–0.58; opus8k 0.69; g711u 0.62–0.63). Do **not**
   inherit 0.60 — recalibrate per embedding.
-- **Honest cap:** the within-meeting `consolidateSameVoiceClusters@0.88` post-process is now the binding
-  constraint, not the embedding. The diarizer recovers only **3.66 (ReDimNet) vs 3.25 (WeSpeaker)** of 4
-  speakers/meeting on clean before the matcher runs, so user-facing people-trapped stays 26–30/32 at every
-  usable threshold. **Next lever after the embedding swap is the 0.88 consolidation** (and note
-  `--consolidation none` does not disable it — see DIARIZER_ARM_REPORT.md §3).
+- **Honest cap:** the **diarizer's upstream under-segmentation** is the binding constraint, not the embedding.
+  The diarizer recovers only **3.66 (ReDimNet) vs 3.25 (WeSpeaker)** of 4 speakers/meeting on clean before the
+  matcher runs, so user-facing people-trapped stays 26–30/32 at every usable threshold. **Next lever after the
+  embedding swap is the diarizer** (segmentation/clustering), *not* the `0.88` consolidation — which we directly
+  tested and found **inert** (toggling it 0.88↔off leaves profiles/trapped/DER unchanged on all arms; see the
+  CORRECTION in the Update section). The logical experiment: re-diarize with the new embedding and re-measure.
 
 ## 3. Shippability — best accuracy ≠ best to ship on-device
 
@@ -158,8 +171,9 @@ risk category. Prefer **CnCeleb / in-house CAM++ checkpoints** to reduce it.
    check downstream dim assumptions).
 4. **Re-run on-device** to confirm CoreML/ANE parity (quantization shifts cosine scale).
 5. **Recalibrate the match threshold** per embedding (sweep; don't inherit 0.60).
-6. **Then loosen `consolidateSameVoiceClusters@0.88`** — the bake-off proves the embedding is no longer the
-   bottleneck; the within-meeting consolidation is.
+6. **Then attack the within-meeting cap — but it is the *diarizer*, not the `0.88` consolidation** (which we
+   directly tested and found inert). Re-diarize with the new embedding (so the diarizer's clustering also
+   improves, not just the matcher) and re-measure; if still short, a better segmentation/clustering model.
 7. **Validate on real captured Zoom audio** before shipping.
 
 ## Reproduce

--- a/Tools/SpeakerEvalHarness/EMBEDDING_BAKEOFF_REPORT.md
+++ b/Tools/SpeakerEvalHarness/EMBEDDING_BAKEOFF_REPORT.md
@@ -60,9 +60,13 @@ So **ERes2Net is the pick: top-tier accuracy (best clean DER 0.238) AND a verifi
 stays an excellent *research/server* embedding but is **not on-device-shippable**. ReDimNet (most accurate)
 also has an export blocker; ECAPA (Apache-2.0) is the DIY-ONNX fallback.
 
-> **One open check:** the CoreML cosine-1.0 result for ERes2Net was first verified on the architecture; we are
-> confirming it on the actual **pretrained** ERes2Net weights too (CAM++'s failure was pretrained-weight-
-> specific, so this matters). [pending — will update.]
+> **Confirmed on the pretrained weights (PASS).** The actual pretrained ERes2Net (en/VoxCeleb, `strict=True`
+> load, 0 missing keys) converts to CoreML at **parity cosine 0.99999 (fp16, ANE-eligible) / 1.000000 (fp32,
+> exact)** over 6 real AMI clips, **12.76 MB**, `compute_units=ALL`. The CAM++ failure was **architectural**
+> (its DenseTDNN dense-concat/reshape graph accumulates error in every converter even at fp32), **not**
+> BatchNorm-variance — ERes2Net has *more* extreme tiny-variance BatchNorm yet converts exactly. **ERes2Net is
+> verified on-device-shippable.** Script: `scripts/convert_eres2net_coreml.py`; model: `scripts/out/
+> eres2net_pretrained.mlpackage`.
 
 **End-to-end confirmation (CAM++ through the real matcher, match threshold swept):** the win reaches the
 matcher. At each arm's best operating point CAM++ beats WeSpeaker on DER and restores profile granularity

--- a/Tools/SpeakerEvalHarness/MASTER_SCORECARD.md
+++ b/Tools/SpeakerEvalHarness/MASTER_SCORECARD.md
@@ -1,0 +1,68 @@
+# Master embedding scorecard — all models × all codec arms
+
+Within-meeting = how well speakers are separated inside a meeting (oracle-k). Cross-call AUC = threshold-free same-vs-different separability (1.0 = perfect). Coverage/AUC higher = better; DER lower = better. `·` = not run.
+
+### Within-meeting coverage — speakers correctly separated (higher better)
+
+| model | dim | clean | opus24k | opus16k | opus12k | opus8k | g711u |
+|---|---|---|---|---|---|---|---|
+| WeSpeaker (current) | 256 | 0.727 | 0.680 | 0.719 | 0.664 | 0.625 | 0.633 |
+| ECAPA-TDNN | 192 | 0.805 | 0.750 | 0.758 | 0.719 | 0.742 | 0.797 |
+| x-vector (control) | 512 | 0.664 | 0.711 | 0.633 | 0.648 | 0.641 | 0.703 |
+| WavLM-SV | 512 | 0.711 | 0.719 | 0.703 | 0.664 | 0.711 | 0.713 |
+| UniSpeech-SAT | 512 | 0.742 | · | · | 0.703 | 0.733 | 0.728 |
+| ReDimNet-b6 | 192 | 0.812 | · | · | 0.695 | 0.766 | 0.828 |
+| CAM++ | 512 | 0.812 | 0.781 | 0.734 | 0.703 | 0.820 | 0.797 |
+| ERes2Net | 192 | 0.805 | 0.766 | 0.758 | 0.734 | 0.734 | 0.773 |
+
+### Within-meeting error — DER (lower better)
+
+| model | dim | clean | opus24k | opus16k | opus12k | opus8k | g711u |
+|---|---|---|---|---|---|---|---|
+| WeSpeaker (current) | 256 | 0.319 | 0.372 | 0.338 | 0.375 | 0.480 | 0.432 |
+| ECAPA-TDNN | 192 | 0.267 | 0.281 | 0.301 | 0.302 | 0.307 | 0.281 |
+| x-vector (control) | 512 | 0.507 | 0.511 | 0.539 | 0.530 | 0.501 | 0.488 |
+| WavLM-SV | 512 | 0.336 | 0.378 | 0.373 | 0.357 | 0.358 | 0.333 |
+| UniSpeech-SAT | 512 | 0.347 | · | · | 0.372 | 0.359 | 0.337 |
+| ReDimNet-b6 | 192 | 0.252 | · | · | 0.313 | 0.276 | 0.221 |
+| CAM++ | 512 | 0.274 | 0.290 | 0.311 | 0.340 | 0.301 | 0.294 |
+| ERes2Net | 192 | 0.238 | 0.292 | 0.281 | 0.308 | 0.329 | 0.274 |
+
+### Within-meeting purity (higher better)
+
+| model | dim | clean | opus24k | opus16k | opus12k | opus8k | g711u |
+|---|---|---|---|---|---|---|---|
+| WeSpeaker (current) | 256 | 0.831 | 0.836 | 0.817 | 0.798 | 0.753 | 0.780 |
+| ECAPA-TDNN | 192 | 0.860 | 0.859 | 0.817 | 0.845 | 0.846 | 0.843 |
+| x-vector (control) | 512 | 0.854 | 0.828 | 0.824 | 0.827 | 0.839 | 0.836 |
+| WavLM-SV | 512 | 0.827 | 0.802 | 0.806 | 0.811 | 0.790 | 0.830 |
+| UniSpeech-SAT | 512 | 0.812 | · | · | 0.827 | 0.803 | 0.801 |
+| ReDimNet-b6 | 192 | 0.836 | · | · | 0.796 | 0.850 | 0.867 |
+| CAM++ | 512 | 0.863 | 0.865 | 0.838 | 0.851 | 0.842 | 0.843 |
+| ERes2Net | 192 | 0.875 | 0.847 | 0.852 | 0.846 | 0.831 | 0.849 |
+
+### Cross-call separability — AUC (higher better, 1.0=perfect)
+
+| model | dim | clean | opus24k | opus16k | opus12k | opus8k | g711u |
+|---|---|---|---|---|---|---|---|
+| WeSpeaker (current) | 256 | 0.9788 | 0.9727 | 0.9768 | 0.9716 | 0.9479 | 0.9696 |
+| ECAPA-TDNN | 192 | 1.0000 | 1.0000 | 1.0000 | 0.9999 | 0.9999 | 1.0000 |
+| x-vector (control) | 512 | 0.9982 | 0.9973 | 0.9965 | 0.9954 | 0.9962 | 0.9966 |
+| WavLM-SV | 512 | 0.9986 | 0.9964 | 0.9988 | 0.9968 | 0.9964 | 0.9948 |
+| UniSpeech-SAT | 512 | 0.9994 | · | · | 0.9957 | 0.9941 | 0.9915 |
+| ReDimNet-b6 | 192 | 0.9999 | · | · | 0.9985 | 1.0000 | 0.9997 |
+| CAM++ | 512 | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 1.0000 |
+| ERes2Net | 192 | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 1.0000 | 1.0000 |
+
+### Cross-call raw separation — same minus different cosine (higher=less anisotropic)
+
+| model | dim | clean | opus24k | opus16k | opus12k | opus8k | g711u |
+|---|---|---|---|---|---|---|---|
+| WeSpeaker (current) | 256 | 0.544 | 0.506 | 0.478 | 0.421 | 0.287 | 0.421 |
+| ECAPA-TDNN | 192 | 0.693 | 0.658 | 0.637 | 0.597 | 0.537 | 0.596 |
+| x-vector (control) | 512 | 0.034 | 0.031 | 0.029 | 0.027 | 0.024 | 0.026 |
+| WavLM-SV | 512 | 0.266 | 0.263 | 0.263 | 0.260 | 0.276 | 0.268 |
+| UniSpeech-SAT | 512 | 0.241 | · | · | 0.228 | 0.226 | 0.228 |
+| ReDimNet-b6 | 192 | 0.715 | · | · | 0.620 | 0.603 | 0.657 |
+| CAM++ | 512 | 0.698 | 0.674 | 0.640 | 0.593 | 0.556 | 0.660 |
+| ERes2Net | 192 | 0.733 | 0.694 | 0.659 | 0.613 | 0.554 | 0.661 |

--- a/Tools/SpeakerEvalHarness/README.md
+++ b/Tools/SpeakerEvalHarness/README.md
@@ -123,10 +123,12 @@ hard-capped; there is no "download all of VoxCeleb" path.
 | `Sources/speaker-eval-harness/main.swift` | `dump` + `replay` commands |
 | `Package.swift` | depends on root `TranscriptedCore`; mirrors deps link flags |
 | `BASELINE_REPORT.md` | measured baseline (AMI ES2002) + threshold recommendations |
+| `AB_DOT_VS_CLOUD.md` | dot-vs-cloud matcher A/B (cross-meeting re-ID) |
 | `SCALEUP_REPORT.md` | AMI scale-up (~32 mtgs / dozens of identities) results at scale |
 | `../../scripts/run_speaker_eval.sh` | end-to-end driver, keyed by `CORPUS` |
 | `../../scripts/score_speaker_eval.py` | DER + fragmentation + false-merge + re-ID scorer (corpus-agnostic) |
 | `../../scripts/aggregate_sweep.py` | sweep table + closest-to-ideal picker |
+| `../../scripts/ab_dot_vs_cloud.py` | dot-vs-cloud matcher A/B simulator (runs on cached embeddings) |
 | `../../scripts/download_ami.sh` | AMI audio + RTTMs (`es2002` \| `scale` \| `full`) |
 | `../../scripts/download_icsi.sh` | ICSI audio (Edinburgh) + RTTMs (HF, gated) |
 | `../../scripts/download_voxconverse.sh` | VoxConverse dev+test audio + RTTMs |

--- a/Tools/SpeakerEvalHarness/README.md
+++ b/Tools/SpeakerEvalHarness/README.md
@@ -67,7 +67,7 @@ gitignored under `data/`. Pick the tier that matches the compute you want to spe
 | **AMI full** | all scenario + non-scenario, ~100 h | `scripts/download_ami.sh full` | same | ~9–10 GB (~170 mtgs) | ~1–2 h |
 | **ICSI** | meeting corpus, heavily recurring lab speakers | `scripts/download_icsi.sh` | ICSI Corpus, research-use; RTTMs from HF `diarizers-community/icsi` (gated) | ~0.5–10 GB | ~10–60 min |
 | **VoxConverse** | in-the-wild YouTube, overlap, unknown counts | `scripts/download_voxconverse.sh` | VoxConverse, CC-BY 4.0; RTTMs from joonson/voxconverse | ~4 GB (dev+test) | ~30–90 min |
-| **VoxCeleb** (sample) | cross-recording re-ID / false-positive at scale | `scripts/download_voxceleb_sample.sh` | VoxCeleb1, CC-BY-SA 4.0 (HF mirror, gated) | bounded by cap (~few GB) | ~20–60 min |
+| **VoxCeleb** (sample) | cross-recording re-ID / false-positive (matcher-isolated) | `scripts/download_voxceleb_sample.sh` | VoxCeleb1, CC-BY-SA 4.0 (public `s3prl/mini_voxceleb1` default; larger mirrors gated) | bounded by cap (~few GB) | ~20–60 min |
 
 ¹ Apple-Silicon diarization, ~100–200× realtime. **Excludes** the one-time CoreML model
 download and the per-corpus dataset download (which can dominate — see footprints).
@@ -96,6 +96,8 @@ bash scripts/download_voxceleb_sample.sh &&  CORPUS=voxceleb   scripts/run_speak
 | `VOXCONVERSE_SPLITS` | `dev test` | which VoxConverse splits to fetch |
 | `VOXCELEB_IDENTITY_CAP` | `300` | **HARD CAP** on sampled identities (max 1211; never the full corpus) |
 | `VOXCELEB_CLIPS_PER_ID` | `10` | clips kept per sampled identity |
+| `VOXCELEB_DATASET` | `s3prl/mini_voxceleb1` | HF mirror (public default; swap for a larger/gated one) |
+| `VOXCELEB_MODE` | `singles` | `singles` (1 clip/meeting → isolates the matcher) \| `sessions` (stitched multi-speaker → also stresses diarizer) |
 | `CONSOLIDATION` | `none 0.82 0.85 0.88 0.91` | within-meeting same-voice merge grid |
 | `MATCH` | `0.50 0.55 0.60 0.65 0.70` | cross-meeting DB match grid |
 | `COLLAR` | `0.25` | DER forgiveness collar (AMI convention) |
@@ -110,7 +112,9 @@ hard-capped; there is no "download all of VoxCeleb" path.
 - macOS 14+ on Apple Silicon (CoreML diarizer models, downloaded once from HuggingFace).
 - Prebuilt deps from `build-deps.sh` (`deps-libs/libExternalDeps.a`, `deps-modules/`,
   `deps-frameworks/`). The harness `Package.swift` resolves them relative to the repo root.
-- Python: `pyannote.metrics` (`pip install pyannote.metrics`).
+- Python: `pyannote.metrics` (`pip install pyannote.metrics`) for scoring. The VoxCeleb
+  sampler additionally needs `datasets` + `ffmpeg`; ICSI RTTM materialization needs
+  `datasets` (`pip install datasets`).
 
 ## Files
 

--- a/Tools/SpeakerEvalHarness/README.md
+++ b/Tools/SpeakerEvalHarness/README.md
@@ -47,12 +47,63 @@ speaker-eval-harness replay --inputs a.json,b.json,c.json,d.json \
 ## Run the whole thing
 
 ```bash
-bash build-deps.sh            # one-time: native deps -> deps-libs/, deps-modules/, deps-frameworks/
-bash scripts/download_ami.sh     # AMI ES2002 a–d audio + RTTMs (~230 MB, gitignored)
-scripts/run_speaker_eval.sh   # build + dump + sweep + score -> data/eval/reports/SWEEP.md
+bash build-deps.sh                 # one-time: native deps -> deps-libs/, deps-modules/, deps-frameworks/
+bash scripts/download_ami.sh       # AMI ES2002 a–d audio + RTTMs (~230 MB, gitignored)
+scripts/run_speaker_eval.sh        # build + dump + sweep + score -> data/eval/ami/reports/SWEEP.md
 ```
 
-Override the grids via env: `SERIES`, `CONSOLIDATION`, `MATCH`, `COLLAR`.
+One driver, any corpus. `CORPUS` selects the dataset; `dump -> sweep -> score` is shared.
+Outputs land under `data/eval/<CORPUS>/{dumps,results,reports}/` (all gitignored).
+
+## Corpus mix (chosen, compute-capped — diverse identities, not all-of-everything)
+
+The point is a trustworthy near-zero-false-positive number from **diverse identities**,
+without burning multi-day compute. Each corpus has its own downloader; all data is
+gitignored under `data/`. Pick the tier that matches the compute you want to spend.
+
+| Corpus | What it tests | Downloader | Source / license | Footprint | Diarize compute¹ |
+|---|---|---|---|---|---|
+| **AMI** (default `scale`) | cross-meeting re-ID + false-merge, real recurring identities | `scripts/download_ami.sh scale` | AMI Corpus, research-use; RTTMs from pyannote/AMI-diarization-setup | ~1.8 GB (32 mtgs) | ~3 min |
+| **AMI full** | all scenario + non-scenario, ~100 h | `scripts/download_ami.sh full` | same | ~9–10 GB (~170 mtgs) | ~1–2 h |
+| **ICSI** | meeting corpus, heavily recurring lab speakers | `scripts/download_icsi.sh` | ICSI Corpus, research-use; RTTMs from HF `diarizers-community/icsi` (gated) | ~0.5–10 GB | ~10–60 min |
+| **VoxConverse** | in-the-wild YouTube, overlap, unknown counts | `scripts/download_voxconverse.sh` | VoxConverse, CC-BY 4.0; RTTMs from joonson/voxconverse | ~4 GB (dev+test) | ~30–90 min |
+| **VoxCeleb** (sample) | cross-recording re-ID / false-positive at scale | `scripts/download_voxceleb_sample.sh` | VoxCeleb1, CC-BY-SA 4.0 (HF mirror, gated) | bounded by cap (~few GB) | ~20–60 min |
+
+¹ Apple-Silicon diarization, ~100–200× realtime. **Excludes** the one-time CoreML model
+download and the per-corpus dataset download (which can dominate — see footprints).
+
+### Run each corpus / tier (one-liners)
+
+```bash
+# --- AMI: landed + scale-up validated (this is the always-safe tier) ---
+bash scripts/download_ami.sh scale      &&  CORPUS=ami        scripts/run_speaker_eval.sh   # ~32 mtgs, hours-bounded
+
+# --- gated heavy tiers: WIRED, not auto-run. Gate the compute yourself. ---
+bash scripts/download_ami.sh full        &&  CORPUS=ami        scripts/run_speaker_eval.sh   # full ~100 h AMI dump (HOURS)
+bash scripts/download_voxconverse.sh     &&  CORPUS=voxconverse scripts/run_speaker_eval.sh  # ~4 GB, in-the-wild
+bash scripts/download_icsi.sh            &&  CORPUS=icsi       scripts/run_speaker_eval.sh   # needs HF auth for RTTMs
+bash scripts/download_voxceleb_sample.sh &&  CORPUS=voxceleb   scripts/run_speaker_eval.sh   # HARD-CAPPED sample + synthetic sessions
+```
+
+### Env knobs
+
+| Knob | Default | Meaning |
+|---|---|---|
+| `CORPUS` | `ami` | `ami` \| `icsi` \| `voxconverse` \| `voxceleb` — selects audio/rttm dirs |
+| `SERIES` | all RTTMs present | subset of meeting ids to replay (space-separated) |
+| `AMI_SET` | `es2002` | `es2002` \| `scale` (32 mtgs) \| `full` (~170) — `download_ami.sh` preset |
+| `ICSI_SET` | `sample` | `sample` (6) \| `full` (75) — `download_icsi.sh` preset |
+| `VOXCONVERSE_SPLITS` | `dev test` | which VoxConverse splits to fetch |
+| `VOXCELEB_IDENTITY_CAP` | `300` | **HARD CAP** on sampled identities (max 1211; never the full corpus) |
+| `VOXCELEB_CLIPS_PER_ID` | `10` | clips kept per sampled identity |
+| `CONSOLIDATION` | `none 0.82 0.85 0.88 0.91` | within-meeting same-voice merge grid |
+| `MATCH` | `0.50 0.55 0.60 0.65 0.70` | cross-meeting DB match grid |
+| `COLLAR` | `0.25` | DER forgiveness collar (AMI convention) |
+
+**Gating note:** the full AMI dump, VoxConverse, ICSI, and the VoxCeleb sample are wired
+but intentionally **not** auto-run — they are hours-to-days of download + compute. Run the
+one-liner for the tier you want, on purpose. VoxCeleb is **always** sample-only and
+hard-capped; there is no "download all of VoxCeleb" path.
 
 ## Requirements
 
@@ -67,11 +118,18 @@ Override the grids via env: `SERIES`, `CONSOLIDATION`, `MATCH`, `COLLAR`.
 |---|---|
 | `Sources/speaker-eval-harness/main.swift` | `dump` + `replay` commands |
 | `Package.swift` | depends on root `TranscriptedCore`; mirrors deps link flags |
-| `BASELINE_REPORT.md` | measured baseline + threshold recommendations |
-| `../../scripts/run_speaker_eval.sh` | end-to-end driver |
-| `../../scripts/score_speaker_eval.py` | DER + fragmentation + false-merge + re-ID scorer |
+| `BASELINE_REPORT.md` | measured baseline (AMI ES2002) + threshold recommendations |
+| `SCALEUP_REPORT.md` | AMI scale-up (~32 mtgs / dozens of identities) results at scale |
+| `../../scripts/run_speaker_eval.sh` | end-to-end driver, keyed by `CORPUS` |
+| `../../scripts/score_speaker_eval.py` | DER + fragmentation + false-merge + re-ID scorer (corpus-agnostic) |
 | `../../scripts/aggregate_sweep.py` | sweep table + closest-to-ideal picker |
-| `../../data/ami/download.sh` | fetch the AMI subset |
+| `../../scripts/download_ami.sh` | AMI audio + RTTMs (`es2002` \| `scale` \| `full`) |
+| `../../scripts/download_icsi.sh` | ICSI audio (Edinburgh) + RTTMs (HF, gated) |
+| `../../scripts/download_voxconverse.sh` | VoxConverse dev+test audio + RTTMs |
+| `../../scripts/download_voxceleb_sample.sh` | VoxCeleb SAMPLE-only (hard-capped) + synthetic sessions |
+| `../../scripts/voxceleb_sample.py` | streaming VoxCeleb sampler with hard identity cap |
+| `../../scripts/build_voxceleb_sessions.py` | stitch sampled identities into multi-speaker sessions + RTTM |
+| `../../scripts/icsi_rttm_from_hf.py` | materialize loose ICSI RTTMs from the HF dataset |
 
 ## Caveats
 

--- a/Tools/SpeakerEvalHarness/SCALEUP_REPORT.md
+++ b/Tools/SpeakerEvalHarness/SCALEUP_REPORT.md
@@ -67,10 +67,12 @@ To get a real near-zero-false-positive number you need corpora where a *single c
 identity per source* removes the diarizer-mixing confound, so the metric isolates the DB
 matcher's cross-recording discipline:
 
-- **VoxCeleb (sample, hard-capped)** — each clip is one clean speaker; synthetic
-  multi-identity sessions give an exact RTTM with **no** within-source mixing, so
-  false-merge measures *only* the matcher fusing two genuinely-different people. This is
-  the cleanest false-positive test. (Wired, gated; `scripts/download_voxceleb_sample.sh`.)
+- **VoxCeleb (sample, hard-capped)** — each clip is one clean speaker. Use **`singles`
+  mode** (one clip = one single-speaker meeting): the diarizer trivially sees one voice, so
+  the metric isolates *only* the DB matcher's cross-recording re-ID / false-positive. This is
+  the cleanest matcher test. (NOTE: the `sessions` mode that stitches clips into multi-speaker
+  recordings re-introduces the diarizer confound — see the Addendum below. Run via
+  `scripts/download_voxceleb_sample.sh`; default public mirror, no HF login.)
 - **VoxConverse** — in-the-wild overlap/codec stress with real RTTMs, the over-segmentation
   regime where the 0.88 consolidation knob can finally fire. (Wired, gated.)
 - **ICSI** — heavily recurring lab speakers across many meetings, a second meeting-domain
@@ -89,3 +91,46 @@ estimates. The gated tiers are wired but intentionally not auto-run.
 
 (Consolidation collapsed because all four values are identical at every match — the inertia
 finding. Full grid in the gitignored `SWEEP.md`.)
+
+---
+
+## Addendum — VoxCeleb matcher-isolation smoke (preliminary, N=6, real audio)
+
+A small real run on the `voxceleb` corpus, **deliberately isolating the matcher** from the
+diarizer, surfaces the opposite failure mode from AMI — and one AMI structurally cannot show.
+
+**Setup.** 6 distinct VoxCeleb1 identities (public `s3prl/mini_voxceleb1`), 4 clips each from
+*different source videos*. Two builders:
+- **`sessions`** (stitched multi-speaker) — even with clean single-identity source clips, the
+  diarizer **collapses 4 voices into 1–2 clusters** (DER 0.47, false-merge 5/6). The diarizer
+  confound returns; this mode does **not** isolate the matcher.
+- **`singles`** (one clip = one single-speaker meeting) — diarizer trivially sees one clean
+  voice (**DER 0.07–0.08**), so the metric is purely the DB matcher's cross-recording behavior.
+
+**Singles result (match sweep, the clean matcher number):**
+
+| match | mean DER | false-merge | frag mean | re-ID #2+ | profiles_end (ideal 6) |
+|---|---|---|---|---|---|
+| 0.55 | 0.070 | 1 | 2.33 | 0.33 | 11 |
+| 0.60 | 0.084 | 2 | 2.33 | 0.27 | 13 |
+| 0.65 | 0.084 | 1 | 2.50 | 0.27 | 18 |
+| 0.70 | 0.084 | 1 | 2.67 | 0.21 | 19 |
+
+**Reading:** with the diarizer out of the way, the matcher's problem is **not** fusing
+different people (false-merge stays 1–2) — it is **fragmentation / poor cross-recording
+re-ID**: 6 real people explode into 11–19 profiles, and re-ID of a returning speaker is only
+~0.2–0.33. The same person recorded in two different sessions lands *below* the 0.60 match
+threshold and is filed as a new person. This is the real-world "why did it make a new speaker
+for the same person?" failure — invisible on AMI (same-room series + diarizer confound), exposed
+here.
+
+**Caveats (do not over-read):** N=6 / 4 clips, so this is directional, not certified. VoxCeleb
+is in-the-wild celebrity audio across decades/mics — *more* cross-recording variability than
+Transcripted's typical same-laptop calls, so it likely overstates the fragmentation. The honest
+takeaway: AMI says "0.60 ends at the right count and false-merge is diarizer-bound"; VoxCeleb-clean
+says "0.60 may be too high to re-identify the same person across genuinely different recordings."
+**Resolving that tension is the next real experiment** — a larger capped VoxCeleb singles run
+(`VOXCELEB_IDENTITY_CAP=300`) plus, ideally, in-domain (Zoom-like) labeled audio.
+
+Repro: `scripts/download_voxceleb_sample.sh` (defaults: public mini mirror, `singles` mode) then
+`CORPUS=voxceleb scripts/run_speaker_eval.sh`.

--- a/Tools/SpeakerEvalHarness/SCALEUP_REPORT.md
+++ b/Tools/SpeakerEvalHarness/SCALEUP_REPORT.md
@@ -1,0 +1,91 @@
+# Speaker-naming eval — AMI scale-up (8 scenario series, ~32 recurring identities)
+
+**Date:** 2026-06-16 · **Corpus:** AMI Meeting Corpus, Mix-Headset, **32 meetings** =
+8 scenario series × sessions a–d (`ES2002, ES2003, ES2005, ES2006, ES2007, ES2008, ES2009,
+ES2010`). Each series is a disjoint group of 4 people who recur across its 4 sessions, so
+the replay carries **32 distinct identities, each appearing 4×** — a few dozen recurring
+identities, the diverse-identity surface the scale-up was meant to exercise.
+**15.85 h of audio. License:** AMI research-use; RTTMs from `pyannote/AMI-diarization-setup`
+`only_words`. Audio/RTTMs/dumps gitignored, never committed.
+
+Reproduce: `bash scripts/download_ami.sh scale && CORPUS=ami CONSOLIDATION="none 0.85 0.88
+0.91" MATCH="0.55 0.60 0.65" scripts/run_speaker_eval.sh`. Full sweep table in
+`data/eval/ami/reports/SWEEP.md` (gitignored).
+
+> **Throughput:** the whole pipeline — diarize 15.85 h of audio + 12-combo threshold sweep
+> + DER/fragmentation/false-merge/re-ID scoring on all 32 meetings — ran in **6.2 minutes**
+> wall-clock (~150× realtime). The scale-up is minutes, not hours; the gated tiers below are
+> dominated by *download*, not compute.
+
+---
+
+## TL;DR at scale (8× the meetings, 8× the identities of the baseline)
+
+| Finding | Baseline (ES2002, 4 mtgs, 4 ids) | **Scale-up (32 mtgs, 32 ids)** | Verdict |
+|---|---|---|---|
+| **Match 0.60 ends at the right profile count** | 4 profiles for 4 people ✓ | **32 profiles for 32 people ✓** (0.55→25 over-merge, 0.65→35 fragment) | **Re-confirmed. Keep 0.60.** |
+| **0.88 consolidation knob** | structurally inert | **inert at scale too** — `none/0.85/0.88/0.91` give *identical* metrics at every match | **Re-confirmed inert on AMI.** Can't be calibrated here. |
+| **DER (diarizer quality)** | mean 0.404 | mean **0.437** (confusion 0.298, miss 0.104) | Diarizer-bound, ~flat — upstream of both thresholds. |
+| **False-merge (false-positive proxy)** | 3 | **22** | **Diarizer-bound, NOT matcher-bound** — see below. |
+| **Cross-meeting re-ID #2+** | 0.42 | **~0.53** (#1 .81, #2 .49, #3 .55, #4 .56) | Improved with more per-identity data. |
+
+**Recommended settings hold at scale: consolidation = 0.88 (safe-but-inert on AMI),
+match = 0.60 (the exact-count sweet spot).** At match 0.60 the run ends with exactly
+**32 profiles for 32 true people** — the matcher's cross-meeting discipline is neither
+collapsing distinct people nor exploding into spurious profiles.
+
+---
+
+## Why false-merge = 22 is a diarizer ceiling, not a matcher failure
+
+All 32 meetings have **4** true speakers. The app's diarizer (grid-searched on 2-party
+Zoom) **under-segments 4-party in-room AMI**:
+
+| hyp profiles per meeting | 2 | 3 | 4 | 5 | 6 |
+|---|---|---|---|---|---|
+| # meetings | 8 | 14 | **5** | 4 | 1 |
+
+**22 of 32 meetings (69%) emit fewer clusters than there are people.** When the diarizer
+hands back 2–3 clusters for 4 speakers, each cluster **already mixes two or three real
+identities before the matcher ever runs** — so the resulting DB profile inevitably spans
+multiple true people. The 22 false-merges decompose as 11 profiles spanning 2 people,
+9 spanning 3, 2 spanning 4 — i.e. they track the 22 under-segmented meetings, not the
+match threshold (false-merge is flat at 22 across all four consolidation values at match
+0.60). DER is dominated by the **confusion** term (0.298 of 0.437), the signature of
+within-meeting speaker mixing, with low miss (0.104).
+
+**Consequence:** AMI — *even scaled to 32 identities* — cannot produce the trustworthy
+near-zero-false-positive number, because its dominant error is the diarizer under-segmenting
+in-room multi-party audio, not the speaker-DB matcher wrongly fusing clean voices. The
+scale-up's value is exactly this: it (1) proves the harness runs end-to-end at scale in
+minutes, (2) re-confirms **both** threshold conclusions at 8× the meetings and identities,
+and (3) quantifies that the false-positive ceiling on AMI is **diarizer-bound**.
+
+## What this motivates (the corpus mix)
+
+To get a real near-zero-false-positive number you need corpora where a *single clean
+identity per source* removes the diarizer-mixing confound, so the metric isolates the DB
+matcher's cross-recording discipline:
+
+- **VoxCeleb (sample, hard-capped)** — each clip is one clean speaker; synthetic
+  multi-identity sessions give an exact RTTM with **no** within-source mixing, so
+  false-merge measures *only* the matcher fusing two genuinely-different people. This is
+  the cleanest false-positive test. (Wired, gated; `scripts/download_voxceleb_sample.sh`.)
+- **VoxConverse** — in-the-wild overlap/codec stress with real RTTMs, the over-segmentation
+  regime where the 0.88 consolidation knob can finally fire. (Wired, gated.)
+- **ICSI** — heavily recurring lab speakers across many meetings, a second meeting-domain
+  re-ID surface. (Wired, gated.)
+
+See **README.md → Corpus mix** for the per-tier one-liners, env knobs, and compute
+estimates. The gated tiers are wired but intentionally not auto-run.
+
+## Per-combo numbers (match × consolidation)
+
+| consolidation | match | mean DER | frag mean | false-merge | re-ID #2+ | profiles_end (ideal 32) |
+|---|---|---|---|---|---|---|
+| none/0.85/0.88/0.91 | 0.55 | 0.436 | 1.72 | 19 | 0.547 | 25 (over-merged) |
+| none/0.85/0.88/0.91 | **0.60** | **0.437** | **1.59** | **22** | **0.532** | **32 ✓** |
+| none/0.85/0.88/0.91 | 0.65 | 0.416 | 1.75 | 24 | 0.519 | 35 (fragmented) |
+
+(Consolidation collapsed because all four values are identical at every match — the inertia
+finding. Full grid in the gitignored `SWEEP.md`.)

--- a/Tools/SpeakerEvalHarness/SCALEUP_REPORT.md
+++ b/Tools/SpeakerEvalHarness/SCALEUP_REPORT.md
@@ -94,43 +94,56 @@ finding. Full grid in the gitignored `SWEEP.md`.)
 
 ---
 
-## Addendum — VoxCeleb matcher-isolation smoke (preliminary, N=6, real audio)
+## Addendum — VoxCeleb matcher-isolation sweep (30 real identities, 300 meetings)
 
-A small real run on the `voxceleb` corpus, **deliberately isolating the matcher** from the
-diarizer, surfaces the opposite failure mode from AMI — and one AMI structurally cannot show.
+A real run on the `voxceleb` corpus, **deliberately isolating the matcher** from the diarizer,
+surfaces the opposite failure mode from AMI — one AMI structurally cannot show — and quantifies
+it across a full match sweep.
 
-**Setup.** 6 distinct VoxCeleb1 identities (public `s3prl/mini_voxceleb1`), 4 clips each from
-*different source videos*. Two builders:
-- **`sessions`** (stitched multi-speaker) — even with clean single-identity source clips, the
-  diarizer **collapses 4 voices into 1–2 clusters** (DER 0.47, false-merge 5/6). The diarizer
-  confound returns; this mode does **not** isolate the matcher.
-- **`singles`** (one clip = one single-speaker meeting) — diarizer trivially sees one clean
-  voice (**DER 0.07–0.08**), so the metric is purely the DB matcher's cross-recording behavior.
+**Setup.** **30 distinct VoxCeleb1 identities** (public `s3prl/mini_voxceleb1`), 10 clips each
+from different recordings = **300 single-speaker "meetings"** (`--mode singles`: one clip = one
+meeting). Each identity appears 10× across the replay. The diarizer trivially sees one clean
+voice — **278/300 meetings = exactly 1 cluster, DER 0.10** — so the metric is purely the DB
+matcher's cross-recording behavior. (Contrast `--mode sessions`, which stitches clips into
+multi-speaker audio: the diarizer then collapses 4 voices into 1–2 clusters, DER 0.47, and the
+diarizer confound returns. Singles is the matcher-isolating mode.)
 
-**Singles result (match sweep, the clean matcher number):**
+**Match sweep — 30 true identities, ideal `profiles_end` = 30:**
 
-| match | mean DER | false-merge | frag mean | re-ID #2+ | profiles_end (ideal 6) |
+| match | mean DER | false-merge | frag mean | re-ID #2+ | profiles_end (ideal 30) |
 |---|---|---|---|---|---|
-| 0.55 | 0.070 | 1 | 2.33 | 0.33 | 11 |
-| 0.60 | 0.084 | 2 | 2.33 | 0.27 | 13 |
-| 0.65 | 0.084 | 1 | 2.50 | 0.27 | 18 |
-| 0.70 | 0.084 | 1 | 2.67 | 0.21 | 19 |
+| 0.45 | 0.101 | 5 | 2.10 | 0.367 | 28 (slightly over-merged) |
+| **0.50** | 0.103 | 6 | 2.00 | **0.383** | **32 (closest to 30)** |
+| 0.55 | 0.106 | 6 | 2.07 | 0.330 | 42 |
+| **0.60** (prod) | 0.111 | 6 | 2.23 | 0.286 | **53** |
+| 0.65 | 0.111 | 5 | 2.60 | 0.181 | 81 |
+| 0.70 | 0.112 | 10 | 2.60 | 0.156 | 118 |
+| 0.75 | 0.112 | 10 | 2.90 | 0.067 | 168 |
 
-**Reading:** with the diarizer out of the way, the matcher's problem is **not** fusing
-different people (false-merge stays 1–2) — it is **fragmentation / poor cross-recording
-re-ID**: 6 real people explode into 11–19 profiles, and re-ID of a returning speaker is only
-~0.2–0.33. The same person recorded in two different sessions lands *below* the 0.60 match
-threshold and is filed as a new person. This is the real-world "why did it make a new speaker
-for the same person?" failure — invisible on AMI (same-room series + diarizer confound), exposed
-here.
+**Reading.** With the diarizer out of the way, the matcher does **not** mostly fuse different
+people (false-merge stays 5–6 until 0.70). Its dominant failure is **fragmentation / weak
+cross-recording re-ID**: at the production **match 0.60, 30 real people explode into 53
+profiles** (≈1.8 profiles/person) and a returning speaker is re-identified to their first
+profile only **29%** of the time. Raising the threshold makes it dramatically worse (0.75 →
+**168 profiles for 30 people**, re-ID 0.07); the same person in a *different* recording lands
+below threshold and is filed as a new person. The count-optimal operating point here is
+**match ≈ 0.50** (32 profiles ≈ 30, best re-ID 0.38, false-merge no worse than 0.60's).
 
-**Caveats (do not over-read):** N=6 / 4 clips, so this is directional, not certified. VoxCeleb
-is in-the-wild celebrity audio across decades/mics — *more* cross-recording variability than
-Transcripted's typical same-laptop calls, so it likely overstates the fragmentation. The honest
-takeaway: AMI says "0.60 ends at the right count and false-merge is diarizer-bound"; VoxCeleb-clean
-says "0.60 may be too high to re-identify the same person across genuinely different recordings."
-**Resolving that tension is the next real experiment** — a larger capped VoxCeleb singles run
-(`VOXCELEB_IDENTITY_CAP=300`) plus, ideally, in-domain (Zoom-like) labeled audio.
+**The quantified tension.** AMI (consistent in-room recordings) says *"0.60 ends at exactly the
+right count; false-merge is diarizer-bound."* VoxCeleb-clean (cross-recording) says *"0.60 is too
+high to re-identify the same person across different recordings — it fragments them ~1.8×; ~0.50
+is better."* Both are real; they disagree because they stress different things. Transcripted's
+true optimum is likely **between** them, since its same-laptop calls are *more* consistent than
+VoxCeleb's celebrity-audio-across-decades but *less* consistent than AMI's single-session series.
 
-Repro: `scripts/download_voxceleb_sample.sh` (defaults: public mini mirror, `singles` mode) then
-`CORPUS=voxceleb scripts/run_speaker_eval.sh`.
+**Caveats.** 30 ids / 10 clips is a solid sample but VoxCeleb's cross-recording variability is
+harsher than typical Transcripted usage, so this likely *overstates* the fragmentation — read
+the **direction** (0.60 over-fragments cross-recording; lower helps), not the exact profile count.
+The public `mini_voxceleb1` mirror caps at 30 ids; scaling to hundreds needs a larger (gated) HF
+mirror or webdataset handling — and unauthenticated bulk fetches get HF-rate-limited (set
+`HF_TOKEN`). The decisive next experiment is **in-domain (Zoom-like) labeled audio**, where the
+matcher's real operating point can be set without VoxCeleb's domain gap.
+
+Repro: `scripts/download_voxceleb_sample.sh` (public mini mirror, `singles` mode; for the full
+sweep `VOXCELEB_CLIPS_PER_ID=10 VOXCELEB_IDENTITY_CAP=30`) then
+`CORPUS=voxceleb MATCH="0.45 0.50 0.55 0.60 0.65 0.70 0.75" scripts/run_speaker_eval.sh`.

--- a/Tools/SpeakerEvalHarness/Sources/speaker-eval-harness/main.swift
+++ b/Tools/SpeakerEvalHarness/Sources/speaker-eval-harness/main.swift
@@ -180,10 +180,20 @@ func runReplay(_ args: [String]) async {
 
         // 1) Within-meeting consolidation — the real clusterer, DB-informed split uses
         //    profiles learned from prior sessions (cross-meeting context), exactly as in app.
+        // SAME_VOICE_THRESHOLD env (eval-only): override the same-voice consolidation bar
+        // (default 0.88) to measure loosening it. Unset -> 0.88 (identical to app default);
+        // "none"/"off" -> nil (disable the consolidation pass). App behavior is unchanged.
+        let svEnv = ProcessInfo.processInfo.environment["SAME_VOICE_THRESHOLD"]
+        let svThreshold: Float? = {
+            guard let e = svEnv?.lowercased() else { return EmbeddingClusterer.sameVoiceConsolidationThreshold }
+            if e == "none" || e == "off" { return nil }
+            return Float(e) ?? EmbeddingClusterer.sameVoiceConsolidationThreshold
+        }()
         let existing = await MainActor.run { db.allSpeakers() }
         let consolidated = await MainActor.run {
             EmbeddingClusterer.postProcess(segments: segs, existingProfiles: existing,
-                                           pairwiseMergeThreshold: consolidation)
+                                           pairwiseMergeThreshold: consolidation,
+                                           consolidationThreshold: svThreshold)
         }
 
         // Group consolidated segments by (post-consolidation) cluster id.

--- a/Tools/SpeakerEvalHarness/VOXCONVERSE_REPORT.md
+++ b/Tools/SpeakerEvalHarness/VOXCONVERSE_REPORT.md
@@ -1,0 +1,239 @@
+# Speaker-naming eval — VoxConverse (in-the-wild YouTube, real RTTMs)
+
+**Date:** 2026-06-16 · **Corpus:** VoxConverse **dev**, 216 files, 19.65 h speech (~20.0 h span),
+mean **4.50 speakers/file** (range 1–20), **972 distinct true speakers**, measured overlap **3.60 %**
+of speech (per-file mean 3.45 %, max 26.1 %; 158/216 files have some overlap), 22 single-speaker files (10 %).
+**License:** VoxConverse, CC-BY 4.0 (VGG/Oxford); ground-truth RTTMs from `joonson/voxconverse`. Audio/RTTMs/dumps gitignored.
+**Config under test:** `TranscriptedCore.DiarizationService.diarizeOffline` (PyAnnote seg + VBx + 256-dim WeSpeaker);
+within-meeting consolidation knob = `EmbeddingClusterer.postProcess(pairwiseMergeThreshold:)`; cross-meeting
+match = `SpeakerDatabase.matchSpeaker(threshold:)`. Grid: **consolidation {none, 0.88} × match {0.45, 0.50, 0.55, 0.60, 0.65}** (10 combos), DER collar 0.25 s.
+
+> **Measured vs assumed.** Every number in §§1–5 is **measured** by the harness on real VoxConverse dev
+> audio (216/216 files diarized, zero skips). Claims about *codec/telephone* compression and the
+> AMI-VoIP band are **inferred** from the prior AMI reports + literature and are labelled *(inferred)* —
+> VoxConverse itself is **not** codec-compressed, so it cannot measure that regime.
+
+> **Scoring-correctness fix (required for honest numbers).** VoxConverse RTTM labels (`spk00, spk01, …`)
+> are **per-file** and reused across all 216 files — every file's `spk00` is a different person. The scorer
+> was built for AMI's globally-recurring participant ids (`FEE005`). Run unmodified, it would conflate
+> 216 different people into one "speaker," set the ideal profile count to ~20 instead of 972, **mis-report
+> false-merge as near-zero**, and recommend the *lowest* threshold — the exact opposite, wrong conclusion.
+> Fixed with an opt-in `--per-file-ids` flag (`score_speaker_eval.py`) that namespaces true ids by file;
+> the runner enables it for `CORPUS=voxconverse` only. **AMI/VoxCeleb scoring is byte-identical** (validated:
+> same `true_speakers`, same DER). This is measurement tooling — no app behavior changed.
+
+> **Throughput:** 216 files diarized in ~10 min (~115× realtime, Apple Silicon, models cached) + 10
+> replay/score combos in <2 min. Whole eval < 15 min after the (download-dominated, ~2 GB) dev fetch.
+
+---
+
+## TL;DR — does in-the-wild audio over-segment and pull the match threshold down toward 0.50?
+
+**No — both halves of the hypothesis are unsupported on VoxConverse, for a concrete measured reason: VoxConverse is in-the-wild but *not* codec-compressed (16 kHz, 93 % speech, 3.6 % overlap), so its embedding bands stay clean and well-separated and its diarizer UNDER-segments, exactly like AMI.**
+
+| Question | AMI (clean in-room) | **VoxConverse (this report)** | Verdict |
+|---|---|---|---|
+| Optimal match threshold | **0.60** (lowest that hits exact count without losing re-ID) | aggregator prefers **0.65** (high end); choice nearly inconsequential | **does NOT drop toward 0.50** |
+| Does the diarizer over- or under-segment? | under (69 % of mtgs < true) | **UNDER** — 108/216 (50 %) below true, only **11 (5 %) over**; mean **0.81 clusters/true** | generalizes (under, not the "1→9" over-split) |
+| 0.88 consolidation knob | inert (band tops 0.72 clean / 0.54 VoIP) | **INERT** (none ≡ 0.88, identical to 4 dp) — but because under-seg leaves no same-voice cluster *pairs* to merge | inert here too, different cause |
+| Mean DER (confusion share) | 0.437 (confusion 0.298 = 68 %) | **0.201** (confusion 0.125 = **62 %**) | confusion-dominated, but **cleaner** than AMI |
+| False-merge source | diarizer-bound (22, flat across thresholds) | **189 @ 0.60 → 61 % within-file (diarizer) / 39 % cross-file (matcher)** | diarizer is the larger share; matcher non-negligible |
+| Cross-meeting re-ID | measurable (0.53 @ #2+) | **N/A by construction** — no recurring identities across files | VoxConverse can't calibrate the re-ID/threshold tradeoff |
+
+**Headline.** The prior named VoxConverse as *"the over-segmentation regime where the 0.88 knob can finally
+fire."* **Measurement refutes that:** VoxConverse under-segments (0.81 clusters/true), so 0.88 stays inert and
+the optimal match does not move down. The "diarizer is the real problem" finding **generalizes** beyond AMI's
+clean 4-party audio — as **under-segmentation driven by overlap and similar voices**, not the user's `1→9`
+over-split (max 3 profiles/person here). The **lower-similarity-band** regime that *would* justify ~0.50
+(same-voice cosine ≈ 0.39, over-segmentation) is **AMI-VoIP codec audio** *(inferred)* — VoxConverse, being
+uncompressed YouTube, does **not** replicate it. **VoxConverse is the wrong proxy for remote/compressed
+Transcripted usage; it is the right proxy for "is the matcher safe in the wild" — and the answer is yes.**
+
+**🟢 GREEN on execution + diarizer characterization · 🟡 YELLOW on the threshold question** — the run was
+clean and the diarizer story is definitive, but VoxConverse structurally cannot answer "what match threshold
+for compressed remote audio" (no recurring identities, uncompressed band). Next: a **recurring-identity
+compressed** corpus (AMI-VoIP with re-ID, or labelled Zoom/Meet).
+
+---
+
+## 1. Does VoxConverse over-segment? (the gating question for the 0.88 knob)
+
+The prior predicted over-segmentation in the wild. **It does not happen.** Raw diarizer cluster count
+(from the cached dumps, pre-DB) vs ground-truth speaker count, across all 216 files:
+
+| diarizer clusters vs true speakers | under (<) | exact (=) | over (>) |
+|---|---|---|---|
+| **# files (of 216)** | **108 (50 %)** | 97 (45 %) | **11 (5 %)** |
+
+- mean **0.806 clusters per true speaker**, median 0.95, mean (clusters − true) = **−1.34** (finds ~1.3 *fewer*
+  speakers than truth per file).
+- This is **under-segmentation** — the same direction as AMI (where 69 % of meetings emit fewer clusters than
+  people). It is driven by overlap and acoustically-similar co-speakers being merged/missed, not by codec.
+- The user's production **"one person → 9 speakers"** over-split is **not reproduced**: max fragmentation is
+  **3 profiles/person** (§4), and only 5 % of files over-segment at all.
+
+**Consequence for 0.88:** the consolidation knob's only active sub-phase (`pairwiseMergeThreshold`) merges
+*duplicate same-voice clusters within a file*. When the diarizer under-segments, there is **at most one
+cluster per voice**, so there is nothing for 0.88 to merge — it is inert by absence of input, confirmed in §4
+(every `none` row equals its `0.88` row). On AMI the same knob was inert because the band sat below it; here it
+is inert because under-segmentation removes the duplicate clusters. **Same outcome, different mechanism** — and
+either way VoxConverse cannot calibrate it.
+
+## 2. Baseline metrics (production config: consolidation 0.88, match 0.60)
+
+Macro-mean over 216 files (DER uses optimal per-file label mapping → isolates diarizer quality):
+
+| metric | value | reading |
+|---|---|---|
+| mean **DER** | **0.2012** | far cleaner than AMI's 0.437 (short, low-overlap files) |
+| — confusion | 0.1248 (**62 % of DER**) | within-file speaker **mixing** — under-segmentation signature |
+| — miss | 0.0458 | low (little overlapped speech to miss; overlap only 3.6 %) |
+| — false alarm | 0.0306 | low (SAD well-calibrated) |
+| **fragmentation** | mean **1.195** / person, max **3** | mild over-split; nowhere near "1→9" |
+| **false-merge** | **189** profiles span ≥2 people | see §5 attribution |
+| **re-ID #2+** | **None** | **no speaker recurs across files** — N/A by construction |
+| **profiles_end** | **448** (ideal 972) | diarizer ceiling: only ~half the true identities are recoverable |
+
+DER is **confusion-dominated** (62 %), the textbook under-segmentation fingerprint, but the absolute confusion
+(0.125) is < half AMI's (0.298): in-the-wild YouTube is per-file *easier* than long, high-overlap AMI meetings.
+
+*(The harness's raw re-ID curve has only an appearance-#1 entry — **0.915**, i.e. first-sighting within-file
+assignment to the anchor profile is high — and **no** appearance #2, because no namespaced speaker recurs across
+files. "re-ID #2+ = None" is therefore structural, not a failure.)*
+
+## 3. The similarity bands — why no threshold move helps here (the key measurement)
+
+Cosine between quality-filtered mean embeddings (mirrors BASELINE §4; same-speaker = within-file split-half;
+different-speaker split into within-file and the cross-file matcher surface). 200 k sampled cross-file pairs.
+
+| band | mean | p50 | p90 | p95 | p99 |
+|---|---|---|---|---|---|
+| **same-speaker** (within file) | **0.931** | 1.00 | 1.00 | 1.00 | 1.00 |
+| different-speaker, **within file** | 0.39 | 0.268 | **1.00** | 1.00 | 1.00 |
+| different-speaker, **cross file** (matcher surface) | **0.145** | 0.129 | 0.314 | 0.377 | **0.501** |
+
+**Fraction of *different*-speaker pairs that would exceed each candidate match threshold** (= false-merge pressure):
+
+| match | cross-file diff | within-file diff | same-speaker recall |
+|---|---|---|---|
+| 0.45 | 1.9 % | 28.6 % | 93.8 % |
+| 0.50 | 1.0 % | 26.3 % | 93.8 % |
+| 0.55 | 0.6 % | 24.5 % | 93.8 % |
+| 0.60 | **0.4 %** | 23.2 % | 93.6 % |
+| 0.65 | 0.3 % | 22.2 % | 93.4 % |
+
+Three decisive facts:
+1. **Same-speaker band stays HIGH (0.93), not low.** Same-speaker recall is flat-to-slightly-falling
+   (**93.4–93.8 %**, n = 563 within-file pairs, low-tail p5 ≈ 0.31) across 0.45–0.65 — lowering toward 0.50 buys
+   **negligible** recall, it only raises false-merge pressure. This is the opposite of the *(inferred)* AMI-VoIP
+   codec band (same-voice ≈ 0.39), confirming VoxConverse is **not** the compressed low-band regime.
+2. **The cross-file matcher surface is nearly clean** (different-speaker mean 0.145, p99 ≈ 0.50): distinct people
+   from different videos almost never look alike to WeSpeaker. The matcher has a **wide safe margin** — 0.50–0.65
+   are all fine on the cross-file axis.
+3. **The confusable mass is *within* files** (different-speaker within-file exceeds threshold **22–29 %** of the
+   time — a ~25× higher rate than cross-file). That tail is overlap + diarizer-mixed segments: an *upstream*
+   phenomenon no match threshold can fix.
+
+## 4. Threshold sweeps (measured)
+
+Full grid — **every `none` row is identical to its `0.88` row to 4 dp**, so consolidation is folded out:
+
+| match | mean DER | frag mean | frag max | false-merge | re-ID #2+ | profiles_end (ideal 972) |
+|---|---|---|---|---|---|---|
+| 0.45 | 0.2134 | 1.183 | 3 | **155** | None | 213 |
+| 0.50 | 0.2061 | 1.192 | 3 | 171 | None | 305 |
+| 0.55 | 0.2014 | 1.193 | 3 | 174 | None | 385 |
+| **0.60** | 0.2012 | 1.195 | 3 | 189 | None | 448 |
+| 0.65 | 0.2005 | 1.197 | 3 | **198** | None | **462** |
+
+- **profiles_end rises monotonically with the threshold** (213→462) and never approaches 972 — the diarizer
+  ceiling, not the matcher, caps identity recovery. By the aggregator's objective (minimise |profiles_end − 972|,
+  then false-merge, then frag, then re-ID), the **optimal is the *highest* threshold (0.65)** — the opposite of a
+  drop toward 0.50.
+- **The choice barely moves quality — but it is not free.** DER moves only 0.013 and frag 0.014, and re-ID — the
+  metric that made AMI prefer 0.60 — is **absent** here, so the lever AMI used to pick 0.60 does not exist on
+  VoxConverse. On the **false-merge axis the threshold does matter, just unhelpfully**: lower fuses fewer-but-
+  bigger mega-profiles and shifts blame to the matcher; higher traps more distinct people upstream (§5). There is
+  no good setting — which is the point: **the match knob is not the lever on this corpus.**
+- **No ⭐ row** (no combo hits exactly 972 with zero merges): unreachable given under-segmentation.
+
+## 5. False-positive attribution — diarizer-bound or matcher-bound?
+
+Each false-merge profile spans ≥2 namespaced true ids (`meeting␟spk`). If they share **one** meeting → the
+diarizer under-segmented within a file (upstream); if they span **≥2** meetings → the matcher fused distinct
+people across files.
+
+| match | false-merge total | within-file (diarizer) | cross-file (matcher) | % matcher | % of 972 speakers in a merge |
+|---|---|---|---|---|---|
+| 0.45 | 155 | 71 | 84 | 54 % | 38 % |
+| 0.50 | 171 | 82 | 89 | 52 % | 41 % |
+| 0.55 | 174 | 95 | 79 | 45 % | 41 % |
+| **0.60** | **189** | **115** | **74** | **39 %** | 44 % |
+| 0.65 | 198 | 121 | 77 | 39 % | 45 % |
+
+- **At the production 0.60, 61 % of false-merges are upstream (diarizer under-segmentation within a file)** — the
+  contaminated cluster mixes two real people *before* the matcher runs, so no threshold can split it. This is the
+  AMI finding, reproduced in the wild.
+- **The matcher is not fully exonerated — but its share is bounded and is an upper bound.** The 39 % cross-file
+  figure overstates the matcher: **31 % of those cross-file profiles (23/74 at 0.60) are *also* internally
+  diarizer-contaminated** (one meeting contributing ≥2 people to the same profile), so the matcher-*only* share
+  is ≈ **27 % (51/189)**. Still, **lowering the threshold shifts blame toward the matcher** (cross-file share
+  39 % → 54 % at 0.45) while the *total* does not fall — a low threshold is strictly worse here.
+- **No threshold is clean.** Total false-merge *rises* with the threshold (155 → 198), and so does the number of
+  **distinct real people trapped in a merge (372 → 435, i.e. 38 % → 45 % of all 972)** — higher thresholds
+  genuinely fuse more speakers, not merely re-bucket a fixed contaminated mass. What stays constant is the
+  *source*: within-file (diarizer) contamination is present at every threshold (within-file-trapped speakers rise
+  159 → 262 in lock-step). Lowering shifts blame to the matcher without cutting the total; raising traps more
+  people upstream. **That the match knob cannot drive false-merge down — in either direction — is itself the
+  evidence that the bottleneck is upstream.**
+
+## 6. Where VoxConverse sits in the corpus mix / next action
+
+Triangulating the three measured corpora:
+- **AMI (clean in-room):** diarizer under-segments 4-party audio → false-merge is a diarizer ceiling (22); match
+  0.60 is the re-ID/false-merge sweet spot; 0.88 inert (band ≤ 0.72).
+- **VoxCeleb singles (matcher-isolated):** clean single voices → matcher *fragments* (30 people → 53 profiles at
+  0.60), the opposite failure.
+- **VoxConverse (this report):** in-the-wild but uncompressed → **under-segments like AMI** (0.81 clusters/true),
+  bands clean and well-separated (same 0.93 / cross-file diff 0.14), 0.88 inert, **re-ID unmeasurable**.
+
+VoxConverse **corroborates AMI's "diarizer is the real problem"** and shows the **cross-file matcher is safe in
+the wild** — but it does **not** answer the open question (does compressed/remote audio want ~0.50?). That
+question needs the two things VoxConverse lacks: **codec compression** (which lowers the same-voice band into the
+0.3–0.5 danger zone — *(inferred)* from AMI-VoIP's 0.39 band) **and recurring identities** (to trade off re-ID vs
+false-merge). **Highest-value next step:** an **AMI-VoIP re-ID series** (codec-compress the recurring AMI speakers
+and re-run the match sweep with re-ID enabled), or a small **labelled Zoom/Meet** corpus that matches real
+Transcripted usage. That, not VoxConverse, is where a move from 0.60 toward 0.50 can be confirmed or rejected.
+
+---
+
+## Limits / caveats
+
+- **216 dev files; test split (232 files) not run** (time-boxed; dev is sufficient for direction). 22 single-
+  speaker files contribute to diarizer over-split stress but not to re-ID/false-merge (need ≥2 true speakers).
+- **Cross-meeting re-ID is N/A**: VoxConverse files are independent conversations with no cross-file identity
+  labels, so the match threshold here is a **false-merge knob only**, not a re-ID lever. This is the central
+  reason the corpus can't reproduce AMI's 0.60 sweet-spot logic.
+- **VoxConverse ≠ compressed/telephone.** It is 16 kHz, 93 % speech, 3.6 % overlap — in-the-wild *recording
+  variety*, not *codec degradation*. Statements about the low (0.39) same-voice band and codec-driven
+  over-segmentation are *(inferred)* from AMI-VoIP, not measured here.
+- **`--match` moves two knobs** (`matchSpeaker` + `mergeDuplicates`) and the eval `matchSpeaker` path lacks the
+  app's maturity-bonus / ambiguity guards, so measured linking is an **upper bound** on aggressiveness vs the
+  live app.
+- **Always-on consolidation phases** (`absorbSmallClusters` 0.72/0.62, `consolidateSameVoiceClusters` 0.88,
+  `dbInformedSplit` 0.62) shape every grid cell regardless of the swept `--consolidation` value.
+- The within-file different-speaker high tail (§3) is partly overlap-driven mislabeling of mixed-embedding
+  segments; it reflects real upstream confusability but its exact magnitude is approximate.
+
+## Reproduce
+
+```bash
+VOXCONVERSE_SPLITS="dev" bash scripts/download_voxconverse.sh   # CC-BY; ~2 GB, gitignored (auto-resumes mirror drops)
+ls data/voxconverse/audio | wc -l                              # must be 216 before launching
+CORPUS=voxconverse CONSOLIDATION="none 0.88" MATCH="0.45 0.50 0.55 0.60 0.65" \
+  scripts/run_speaker_eval.sh 2>&1 | tee data/eval/voxconverse/full_run.log
+#   -> data/eval/voxconverse/reports/SWEEP.md            (the 10-combo grid)
+python3 scripts/analyze_voxconverse_bands.py --out-json data/eval/voxconverse/reports/bands.json
+#   -> diarizer over/under-segmentation + same/different-speaker similarity bands
+```
+All `data/` artifacts are gitignored. The `--per-file-ids` scorer fix is auto-enabled for `CORPUS=voxconverse`.

--- a/Tools/SpeakerEvalHarness/ZOOM_VALIDATION.md
+++ b/Tools/SpeakerEvalHarness/ZOOM_VALIDATION.md
@@ -1,0 +1,45 @@
+# Real-Zoom validation — how to close the domain gap
+
+Every number in the embedding bake-off is from **AMI** (4 people, one room, far-field mics, *synthetically*
+codec-degraded). Real Transcripted audio is **captured Zoom/Meet/Teams system audio** — different distribution
+(separate streams, real codec + noise-suppression + auto-gain). The codec-robustness story should transfer,
+but it's **assumed, not measured**. This is the one experiment that needs real data only you can provide.
+
+## What to provide
+
+1. **A recording** of a real call you'd transcribe — ideally the *same system-audio capture* Transcripted
+   makes — with **2+ known speakers** and a few minutes each. Save as a `.wav` (any rate/channels; it's
+   resampled to 16 kHz mono internally). A couple of recordings across conditions (good wifi, someone on a
+   phone bridge) is even better.
+2. **Ground-truth labels** — who spoke when. Easiest path: make a CSV and convert it:
+
+   ```csv
+   start,end,speaker
+   0.0,4.2,alice
+   4.2,9.8,bob
+   9.8,15.0,alice
+   ```
+   ```bash
+   python3 scripts/csv2rttm.py labels.csv mycall > mycall.rttm
+   ```
+   (You can label by scrubbing the recording, or export a Zoom transcript and adjust. Exact word-level timing
+   isn't needed — speaker turns are enough.)
+
+## Run it
+
+```bash
+# builds: diarize -> WeSpeaker baseline + each candidate model -> scorecard, all vs your labels
+scripts/run_zoom_eval.sh mycall.wav mycall.rttm mycall "campplus eres2net ecapa"
+```
+
+Prints, for WeSpeaker (current) and each candidate, on **your real audio**:
+`coverage` (speakers correctly separated), `DER` (error, lower better), `cross-call AUC` (separability).
+
+## What success looks like
+
+The recommendation **holds** if, on your real recording, CAM++ (and/or ERes2Net/ECAPA) shows **lower DER and
+higher coverage than WeSpeaker**, the way it does on AMI. If real Zoom audio behaves *differently* (e.g. the
+gap shrinks because separate streams are easier, or a new failure appears), this is where we'd catch it before
+shipping. Either way it converts the AMI result into a real-world one.
+
+> All artifacts land under `data/eval/zoom_<name>*` (gitignored). Measurement only — no app code touched.

--- a/scripts/ab_dot_vs_cloud.py
+++ b/scripts/ab_dot_vs_cloud.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Controlled dot-vs-cloud speaker-matcher A/B on cached VoxCeleb embeddings.
+
+Replays the SAME single-speaker meetings (sorted order = round-robin across speakers)
+through two matchers, everything else identical:
+  DOT   - one EMA-averaged 256-d vector/profile; match cosine>=thr (today's design).
+  CLOUD - keep each profile's sample vectors; match a new clip to its NEAREST stored sample.
+
+Metrics per matcher:
+  reid_to_anchor[k] = % of meeting-k clips assigned to the profile created at the person's
+                      FIRST meeting (continuity with original identity).
+  recognized[k]     = % of meeting-k clips matched to ANY existing profile (not a brand-new
+                      badge) -> "did we treat them as a returning person at all".
+  profiles_end      = badges created for n_true real people (ideal = n_true).
+  false_merge       = profiles whose mass spans >=2 distinct true speakers (>=10% each).
+
+Modes:
+  (no --matcher) -> human-readable sweep table for both matchers.
+  --matcher dot|cloud --thr T [--ema E|--cap C] --json -> one JSON result (for agents).
+"""
+import argparse, glob, json, math, os, sys
+from collections import defaultdict
+
+def cluster_mean(segs):
+    def mean(embs):
+        if not embs: return None
+        dim=len(embs[0]); s=[0.0]*dim
+        for e in embs:
+            if len(e)==dim:
+                for i in range(dim): s[i]+=e[i]
+        n=len(embs); s=[x/n for x in s]
+        nrm=math.sqrt(sum(x*x for x in s)) or 1.0
+        return [x/nrm for x in s]
+    good=[sg["embedding"] for sg in segs if sg.get("embedding") and sg["quality"]>=0.3 and (sg["end"]-sg["start"])>=1.0]
+    if good: return mean(good)
+    allv=[sg["embedding"] for sg in segs if sg.get("embedding")]
+    return mean(allv)
+
+def load_meetings(dumps_dir):
+    out=[]
+    for f in sorted(glob.glob(os.path.join(dumps_dir,"*.json"))):
+        d=json.load(open(f)); m=d["meeting"]; spk=m.split("_",1)[1]
+        emb=cluster_mean(d["segments"])
+        if emb is not None: out.append((m,spk,emb))
+    return out
+
+def cos(a,b): return sum(x*y for x,y in zip(a,b))
+def l2norm(v):
+    n=math.sqrt(sum(x*x for x in v)) or 1.0
+    return [x/n for x in v]
+
+class DotDB:
+    def __init__(self,thr,ema): self.thr=thr; self.ema=ema; self.P=[]
+    def assign(self,emb,true):
+        best,bi=-2,-1
+        for i,p in enumerate(self.P):
+            c=cos(emb,p["vec"])
+            if c>best: best,bi=c,i
+        new = not (bi>=0 and best>=self.thr)
+        if not new:
+            p=self.P[bi]; p["vec"]=l2norm([(1-self.ema)*o+self.ema*e for o,e in zip(p["vec"],emb)]); p["counts"][true]+=1
+            return bi,False
+        self.P.append({"vec":emb[:],"counts":defaultdict(int)}); self.P[-1]["counts"][true]+=1
+        return len(self.P)-1,True
+
+class CloudDB:
+    def __init__(self,thr,cap): self.thr=thr; self.cap=cap; self.P=[]
+    def assign(self,emb,true):
+        best,bi=-2,-1
+        for i,p in enumerate(self.P):
+            c=max(cos(emb,s) for s in p["samples"])
+            if c>best: best,bi=c,i
+        new = not (bi>=0 and best>=self.thr)
+        if not new:
+            p=self.P[bi]; p["samples"].append(emb)
+            if len(p["samples"])>self.cap: p["samples"].pop(0)
+            p["counts"][true]+=1
+            return bi,False
+        self.P.append({"samples":[emb[:]],"counts":defaultdict(int)}); self.P[-1]["counts"][true]+=1
+        return len(self.P)-1,True
+
+def evaluate(meetings, db, max_app):
+    anchor={}; appear=defaultdict(int)
+    to_anchor=defaultdict(list); recog=defaultdict(list)
+    for (m,spk,emb) in meetings:
+        pid,is_new=db.assign(emb,spk)
+        appear[spk]+=1; k=appear[spk]
+        if k==1: anchor[spk]=pid
+        else:
+            to_anchor[k].append(1 if pid==anchor[spk] else 0)
+            recog[k].append(0 if is_new else 1)
+    cur=lambda d:{k:round(100*sum(v)/len(v)) for k,v in sorted(d.items()) if k<=max_app}
+    fm=0
+    for p in db.P:
+        tot=sum(p["counts"].values()) or 1
+        if sum(1 for t,c in p["counts"].items() if c/tot>=0.10)>=2: fm+=1
+    return cur(to_anchor), cur(recog), len(db.P), fm
+
+def run(meetings, matcher, thr, ema, cap, max_app):
+    db = DotDB(thr,ema) if matcher=="dot" else CloudDB(thr,cap)
+    a,r,pe,fm = evaluate(meetings, db, max_app)
+    return {"matcher":matcher,"thr":thr,"ema":ema if matcher=="dot" else None,
+            "cap":cap if matcher=="cloud" else None,
+            "reid_to_anchor":a,"recognized":r,"profiles_end":pe,"false_merge":fm}
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument("--dumps-dir",default="data/eval/voxceleb/dumps")
+    ap.add_argument("--matcher",choices=["dot","cloud"])
+    ap.add_argument("--thr",type=float); ap.add_argument("--ema",type=float,default=0.5)
+    ap.add_argument("--cap",type=int,default=10); ap.add_argument("--max-app",type=int,default=8)
+    ap.add_argument("--json",action="store_true")
+    args=ap.parse_args()
+    M=load_meetings(args.dumps_dir)
+    n_true=len(set(s for _,s,_ in M))
+    if args.matcher and args.thr is not None:
+        res=run(M,args.matcher,args.thr,args.ema,args.cap,args.max_app); res["n_true"]=n_true; res["n_meetings"]=len(M)
+        print(json.dumps(res)); return
+    print(f"loaded {len(M)} meetings, {n_true} true speakers (ideal profiles={n_true})\n")
+    print("DOT (one EMA vector):  reid-to-anchor by meeting #")
+    for thr in (0.45,0.50,0.55,0.60):
+        r=run(M,"dot",thr,args.ema,args.cap,args.max_app)
+        cells=" ".join(f"m{k}:{r['reid_to_anchor'].get(k,'-'):>3}" for k in range(2,args.max_app+1))
+        print(f"  thr={thr:.2f} | {cells} | profiles={r['profiles_end']:>3} fm={r['false_merge']}")
+    print("\nCLOUD (nearest stored sample):  reid-to-anchor by meeting #")
+    for thr in (0.55,0.60,0.65,0.70,0.75):
+        r=run(M,"cloud",thr,args.ema,args.cap,args.max_app)
+        cells=" ".join(f"m{k}:{r['reid_to_anchor'].get(k,'-'):>3}" for k in range(2,args.max_app+1))
+        print(f"  thr={thr:.2f} | {cells} | profiles={r['profiles_end']:>3} fm={r['false_merge']}")
+
+if __name__=="__main__": main()

--- a/scripts/accumulation_test.py
+++ b/scripts/accumulation_test.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Confirm error accumulation through the dense CAM-TDNN stack, and find the
+exact op whose float32 CoreML result diverges from PyTorch at >1e-3.
+
+We test the real (pretrained) backbone truncated to N blocks, to see cosine
+decay with depth. We also dump per-op: the CAMLayer maxabsdiff of 0.014 in f32
+is too big for rounding -> probe which sub-tensor (linear_local 'y', the gating
+'m', or y*m) diverges.
+"""
+import os, numpy as np, torch, torch.nn as nn, torch.nn.functional as F, warnings
+warnings.filterwarnings("ignore")
+import coremltools as ct
+
+MODEL_DIR = os.path.expanduser(
+    "~/.cache/modelscope/hub/models/iic/speech_campplus_sv_en_voxceleb_16k")
+BIN = os.path.join(MODEL_DIR, "campplus_voxceleb.bin")
+FEAT_DIM, EMB_SIZE, N_FRAMES = 80, 512, 300
+
+def cosine(a, b):
+    a=a.flatten().astype(np.float64); b=b.flatten().astype(np.float64)
+    return float(np.dot(a,b)/(np.linalg.norm(a)*np.linalg.norm(b)+1e-12))
+
+def f32_cosine(mod, inp_shape):
+    ex = torch.randn(*inp_shape); mod.eval()
+    with torch.no_grad(): pt = mod(ex).numpy()
+    tr = torch.jit.trace(mod, ex); tr.eval()
+    ml = ct.convert(tr,
+        inputs=[ct.TensorType(name="x", shape=inp_shape, dtype=np.float32)],
+        outputs=[ct.TensorType(name="y", dtype=np.float32)],
+        convert_to="mlprogram", compute_units=ct.ComputeUnit.CPU_ONLY,
+        compute_precision=ct.precision.FLOAT32,
+        minimum_deployment_target=ct.target.macOS13)
+    o = ml.predict({"x": ex.numpy().astype(np.float32)})
+    cm = np.asarray(o["y"] if "y" in o else list(o.values())[0])
+    return cosine(pt, cm), float(np.max(np.abs(pt-cm)))
+
+from modelscope.models.audio.sv.DTDNN import CAMPPlus
+from modelscope.models.audio.sv.DTDNN_layers import CAMLayer
+
+# --- Probe CAMLayer internal tensors ---
+print("== CAMLayer internal probe ==")
+class CAMProbe(nn.Module):
+    def __init__(self, c):
+        super().__init__()
+        self.l = c
+    def forward(self, x):
+        y = self.l.linear_local(x)
+        context = x.mean(-1, keepdim=True) + self.l.seg_pooling(x)
+        context = self.l.relu(self.l.linear1(context))
+        m = self.l.sigmoid(self.l.linear2(context))
+        return y * m
+cam = CAMLayer(128, 32, 3, 1, 1, 1, False)
+c, d = f32_cosine(CAMProbe(cam), (1,128,150))
+print(f"  y*m cosine={c:.6f} maxabsdiff={d:.5f}")
+
+# m-gate only
+class GateOnly(nn.Module):
+    def __init__(self, c): super().__init__(); self.l=c
+    def forward(self, x):
+        context = x.mean(-1, keepdim=True) + self.l.seg_pooling(x)
+        context = self.l.relu(self.l.linear1(context))
+        return self.l.sigmoid(self.l.linear2(context))
+c, d = f32_cosine(GateOnly(cam), (1,128,150))
+print(f"  gate m cosine={c:.6f} maxabsdiff={d:.5f}")
+
+# --- Depth decay on the REAL pretrained backbone ---
+print("\n== cosine vs backbone depth (real weights, frame output) ==")
+sd = torch.load(BIN, map_location="cpu")
+full = CAMPPlus(feat_dim=FEAT_DIM, embedding_size=EMB_SIZE, output_level='frame')
+full.load_state_dict(sd, strict=False); full.eval()
+
+class Truncated(nn.Module):
+    """Run head + first k modules of xvector."""
+    def __init__(self, base, k):
+        super().__init__(); self.base = base; self.k = k
+    def forward(self, x):
+        x = x.permute(0,2,1)
+        x = self.base.head(x)
+        for i, mod in enumerate(self.base.xvector):
+            if i >= self.k: break
+            x = mod(x)
+        return x
+
+# xvector modules: tdnn, block1, transit1, block2, transit2, block3, transit3, out_nonlinear
+names = list(dict(full.xvector.named_children()).keys())
+print("  xvector modules:", names)
+for k in [1, 2, 3, 4, 5, 6]:
+    t = Truncated(full, k)
+    c, d = f32_cosine(t, (1, N_FRAMES, FEAT_DIM))
+    upto = names[k-1] if k-1 < len(names) else "?"
+    print(f"  up to module[{k-1}]={upto:14s}: cosine={c:.6f} maxabsdiff={d:.4f}")

--- a/scripts/aggregate_codec_arms.py
+++ b/scripts/aggregate_codec_arms.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Cross-arm comparison for the AMI codec re-ID sweep (measurement only).
+
+Reads every data/eval/ami_<tag>/reports/{cons_none_match_*.json, bands.json} and emits
+one master table: for each compression arm, the optimal match threshold X plus the
+re-ID / false-merge / profile-count behavior across the match grid, and the same- vs
+different-speaker embedding-band collapse. This is the X-vs-compression curve.
+
+X definition (the actionable one): the LOWEST match threshold that lands at the true
+profile count (one profile per real person) with the fewest false-merges — i.e. the
+most lenient threshold that still re-identifies returning speakers without fusing
+strangers. Also reports the band-separation-optimal threshold for cross-check.
+"""
+import argparse, glob, json, os, statistics as st
+
+ARM_ORDER = ["clean", "opus24k", "opus16k", "opus12k", "opus8k", "g711u"]
+GRID = ["0.40", "0.45", "0.50", "0.55", "0.60", "0.65", "0.70"]
+
+
+def arm_tag(p):
+    return os.path.basename(os.path.dirname(os.path.dirname(p)))[4:]  # ami_<tag>/reports -> <tag>
+
+
+def load_combo(repdir, m):
+    f = os.path.join(repdir, f"cons_none_match_{m}.json")
+    return json.load(open(f)) if os.path.exists(f) else None
+
+
+def pick_X(rows, n_true):
+    # lowest match that hits profile count closest to ideal with min false-merge,
+    # tie-break on higher re-ID. rows: list of dicts with match/profiles_end/false_merge/reid.
+    def key(r):
+        return (abs((r["profiles_end"] or 99) - n_true), r["false_merge"],
+                -(r["reid"] or 0), float(r["match"]))
+    return sorted(rows, key=key)[0] if rows else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default="data/eval")
+    ap.add_argument("--out-md")
+    args = ap.parse_args()
+
+    arms = {}
+    for repdir in glob.glob(os.path.join(args.root, "ami_*", "reports")):
+        tag = os.path.basename(os.path.dirname(repdir))[4:]
+        rows = []
+        n_true = None
+        for m in GRID:
+            s = load_combo(repdir, m)
+            if not s:
+                continue
+            n_true = len(s["true_speakers"])
+            pm = s["der"]["per_meeting"]
+            curve = s["reid_curve_by_appearance"]
+            later = [v for k, v in curve.items() if int(k) >= 2]
+            rows.append({
+                "match": m,
+                "der": round(st.mean(p["der"] for p in pm), 4),
+                "conf": round(st.mean(p["confusion"] for p in pm), 4),
+                "frag": s["fragmentation"]["mean_profiles_per_person"],
+                "false_merge": s["false_merge"]["count"],
+                "reid": round(sum(later) / len(later), 4) if later else None,
+                "profiles_end": s["profiles_at_end"],
+            })
+        bands = None
+        bf = os.path.join(repdir, "bands.json")
+        if os.path.exists(bf):
+            bands = json.load(open(bf))
+        if rows:
+            arms[tag] = {"rows": rows, "n_true": n_true, "bands": bands,
+                         "X": pick_X(rows, n_true)}
+
+    out = ["# AMI codec re-ID sweep — X vs compression\n"]
+    # master: optimal X per arm
+    out.append("## Optimal match threshold X by compression level\n")
+    out.append("| arm | n_true | **X (optimal match)** | profiles@X (ideal=n_true) | false-merge@X | re-ID@X | DER@X | same-spk band | diff-spk band | band sep |")
+    out.append("|---|---|---|---|---|---|---|---|---|---|")
+    for tag in [t for t in ARM_ORDER if t in arms] + [t for t in arms if t not in ARM_ORDER]:
+        a = arms[tag]; X = a["X"]; b = a["bands"]
+        sm = b["same_speaker_cross_meeting"]["mean"] if b else None
+        dm = b["different_speaker_cross_meeting"]["mean"] if b else None
+        sep = round((sm - dm), 3) if (sm is not None and dm is not None) else None
+        out.append(f"| {tag} | {a['n_true']} | **{X['match']}** | {X['profiles_end']} | {X['false_merge']} | "
+                   f"{X['reid']} | {X['der']} | {sm} | {dm} | {sep} |")
+    out.append("")
+    # per-arm full grid
+    for tag in [t for t in ARM_ORDER if t in arms]:
+        a = arms[tag]
+        out.append(f"## {tag}  (ideal profiles = {a['n_true']})\n")
+        out.append("| match | profiles_end | false-merge | re-ID #2+ | frag | DER | conf |")
+        out.append("|---|---|---|---|---|---|---|")
+        for r in a["rows"]:
+            star = " ⭐" if r["profiles_end"] == a["n_true"] and r["false_merge"] == 0 else ""
+            out.append(f"| {r['match']} | {r['profiles_end']}{star} | {r['false_merge']} | {r['reid']} | "
+                       f"{r['frag']} | {r['der']} | {r['conf']} |")
+        if a["bands"]:
+            tt = a["bands"]["threshold_tradeoff"]
+            out.append("\n_band tradeoff (re-ID recall / false-merge pressure / separation):_  " +
+                       " · ".join(f"{m}: {tt[m]['reid_recall']}/{tt[m]['false_merge_pressure']}/{tt[m]['separation']}"
+                                  for m in ["0.4", "0.5", "0.6", "0.7"] if m in tt))
+            ds = a["bands"]["diarizer_segmentation"]
+            out.append(f"\n_diarizer: under {ds['under']} / exact {ds['exact']} / over {ds['over']}, "
+                       f"mean {ds['mean_clusters_per_true']} clusters/true_\n")
+    md = "\n".join(out)
+    print(md)
+    if args.out_md:
+        open(args.out_md, "w").write(md)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/aggregate_sweep.py
+++ b/scripts/aggregate_sweep.py
@@ -6,6 +6,7 @@ import argparse, json
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--scores", required=True, help="comma-separated score JSON paths")
+    ap.add_argument("--corpus", default="AMI", help="corpus name for the report title")
     ap.add_argument("--out-md")
     args = ap.parse_args()
 
@@ -34,9 +35,10 @@ def main():
     n_true = rows[0]["n_true"] if rows else 0
 
     out = []
-    out.append("# Speaker-naming threshold sweep — AMI ES2002 (a–d), one recurring 4-person series\n")
-    out.append(f"True speakers in series: **{n_true}**. Ideal profiles_end = {n_true}. "
-               "Ideal fragmentation = 1.0/person. Ideal false-merge = 0. Ideal re-ID = 1.0.\n")
+    out.append(f"# Speaker-naming threshold sweep — {args.corpus}\n")
+    out.append(f"Distinct true speakers across the replay: **{n_true}**. Ideal profiles_end = "
+               f"{n_true} (one profile per real person). Ideal fragmentation = 1.0/person. "
+               "Ideal false-merge = 0 (the near-zero-false-positive bar). Ideal re-ID = 1.0.\n")
     out.append("| consolidation | match | mean DER | frag mean | frag max | false-merge | re-ID #2+ | profiles_end |")
     out.append("|---|---|---|---|---|---|---|---|")
     for r in rows:

--- a/scripts/analyze_ami_codec_bands.py
+++ b/scripts/analyze_ami_codec_bands.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Embedding-band analysis for an AMI codec arm (measurement only).
+
+AMI participant ids (FEE005...) recur across a meeting series, so unlike VoxConverse
+we can measure the two bands that actually decide the cross-meeting MATCH threshold:
+
+  * SAME-SPEAKER, cross-meeting  — cosine between one participant's mean embedding in
+    meeting A vs the same participant in meeting B. This is the RE-ID surface: the
+    matcher must clear the threshold to re-identify a returning speaker. Compression
+    pushes this DOWN (BASELINE saw clean ~0.5+ -> VoIP ~0.39).
+  * DIFFERENT-SPEAKER, cross-meeting — cosine between two distinct participants. This
+    is the FALSE-MERGE surface: anything above threshold fuses strangers.
+
+The match threshold X that maximizes (same-speaker recall) while minimizing (different-
+speaker pressure) is read straight off these two distributions. We also report the
+diarizer's per-meeting over/under-segmentation so we can see if the codec flips it from
+under-segmenting (AMI-clean) to over-segmenting.
+"""
+import argparse, glob, json, os, random, statistics as st
+from collections import defaultdict
+
+Q_MIN, DUR_MIN = 0.3, 1.0
+
+
+def parse_rttm(path):
+    out = []
+    for ln in open(path):
+        p = ln.split()
+        if len(p) >= 8 and p[0] == "SPEAKER":
+            s, d = float(p[3]), float(p[4]); out.append((s, s + d, p[7]))
+    return out
+
+
+def true_for(s, e, ref):
+    best, bov = None, 0.0
+    for (rs, re, t) in ref:
+        ov = max(0.0, min(e, re) - max(s, rs))
+        if ov > bov: best, bov = t, ov
+    return best
+
+
+def l2(v):
+    n = sum(x * x for x in v) ** 0.5
+    return [x / n for x in v] if n else v
+
+
+def mean_emb(es):
+    if not es: return None
+    d = len(es[0]); return l2([sum(e[i] for e in es) / len(es) for i in range(d)])
+
+
+def cos(a, b): return sum(x * y for x, y in zip(a, b))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dumps", required=True)
+    ap.add_argument("--rttm-dir", required=True)
+    ap.add_argument("--tag", default="")
+    ap.add_argument("--out-json")
+    ap.add_argument("--seed", type=int, default=7)
+    args = ap.parse_args()
+    rng = random.Random(args.seed)
+    THRS = [0.40, 0.45, 0.50, 0.55, 0.60, 0.65, 0.70]
+
+    # (meeting, global_speaker) -> mean embedding
+    mean_by = {}
+    seg_counts = []
+    for dp in sorted(glob.glob(os.path.join(args.dumps, "*.json"))):
+        m = os.path.basename(dp)[:-5]
+        rp = os.path.join(args.rttm_dir, m + ".rttm")
+        if not os.path.exists(rp): continue
+        d = json.load(open(dp)); ref = parse_rttm(rp)
+        seg_counts.append({"m": m, "true": len(set(t for _, _, t in ref)),
+                           "raw": d.get("diarizerSpeakerCount",
+                                        len(set(s["speakerId"] for s in d["segments"])))})
+        by = defaultdict(list)
+        for s in d["segments"]:
+            emb = s.get("embedding")
+            if not emb or s.get("quality", 1.0) < Q_MIN or (s["end"] - s["start"]) < DUR_MIN:
+                continue
+            t = true_for(s["start"], s["end"], ref)
+            if t is not None: by[t].append(l2(emb))
+        for t, es in by.items():
+            me = mean_emb(es)
+            if me: mean_by[(m, t)] = me
+
+    # group means by global speaker id
+    by_spk = defaultdict(dict)            # spk -> {meeting: mean}
+    for (m, t), me in mean_by.items(): by_spk[t][m] = me
+
+    same = []   # same speaker, cross-meeting
+    for spk, mm in by_spk.items():
+        ms = sorted(mm)
+        for i in range(len(ms)):
+            for j in range(i + 1, len(ms)):
+                same.append(cos(mm[ms[i]], mm[ms[j]]))
+
+    diff = []   # different speakers, cross-meeting (different series => true strangers)
+    flat = [(m, t, me) for (m, t), me in mean_by.items()]
+    n = len(flat)
+    pairs = [(i, j) for i in range(n) for j in range(i + 1, n)
+             if flat[i][1] != flat[j][1] and flat[i][0] != flat[j][0]]
+    rng.shuffle(pairs)
+    for i, j in pairs[:300000]:
+        diff.append(cos(flat[i][2], flat[j][2]))
+
+    def pct(xs, ps=(1, 5, 25, 50, 75, 90, 95, 99)):
+        if not xs: return {}
+        xs = sorted(xs); return {p: round(xs[min(len(xs) - 1, int(p / 100 * len(xs)))], 4) for p in ps}
+
+    def fa(xs, t): return round(sum(1 for x in xs if x >= t) / len(xs), 4) if xs else None
+
+    under = sum(1 for c in seg_counts if c["raw"] < c["true"])
+    exact = sum(1 for c in seg_counts if c["raw"] == c["true"])
+    over = sum(1 for c in seg_counts if c["raw"] > c["true"])
+    ratios = [c["raw"] / c["true"] for c in seg_counts if c["true"]]
+
+    out = {
+        "tag": args.tag, "n_meetings": len(seg_counts),
+        "diarizer_segmentation": {"under": under, "exact": exact, "over": over,
+                                  "mean_clusters_per_true": round(st.mean(ratios), 3) if ratios else None},
+        "same_speaker_cross_meeting": {"n": len(same), "mean": round(st.mean(same), 4) if same else None,
+                                       "pct": pct(same)},
+        "different_speaker_cross_meeting": {"n": len(diff), "mean": round(st.mean(diff), 4) if diff else None,
+                                            "pct": pct(diff)},
+        # the X read-off: for each threshold, re-ID recall (same-speaker pairs cleared)
+        # vs false-merge pressure (different-speaker pairs cleared). separation = recall - pressure.
+        "threshold_tradeoff": {
+            f"{t}": {"reid_recall": fa(same, t), "false_merge_pressure": fa(diff, t),
+                     "separation": round((fa(same, t) or 0) - (fa(diff, t) or 0), 4)}
+            for t in THRS
+        },
+    }
+    # best-separation threshold = argmax(recall - pressure) over the grid
+    best = max(THRS, key=lambda t: (fa(same, t) or 0) - (fa(diff, t) or 0))
+    out["X_best_separation"] = best
+    print(json.dumps(out, indent=2))
+    if args.out_json: json.dump(out, open(args.out_json, "w"), indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze_voxconverse_bands.py
+++ b/scripts/analyze_voxconverse_bands.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Report-supporting analysis for the VoxConverse speaker-eval (measurement only).
+
+Two decision-relevant measurements the SWEEP.md doesn't compute:
+
+  1. DIARIZER SEGMENTATION — raw diarizer cluster count (from the cached dumps) vs the
+     ground-truth speaker count (from the RTTMs), per file. Answers: does the diarizer
+     OVER-segment (clusters > true, the user's "1 person -> 9" bug) or UNDER-segment
+     (clusters < true, AMI's signature) in the wild?
+
+  2. EMBEDDING SIMILARITY BANDS — cosine between quality-filtered mean embeddings:
+       * same-speaker  (within file, split-half of one true speaker's segments)
+       * different-speaker, within file
+       * different-speaker, ACROSS files  <-- the cross-meeting FALSE-MERGE surface
+     For each candidate match threshold, the fraction of different-speaker pairs that
+     exceed it = the false-merge pressure if you set the matcher there. This is what
+     decides whether lowering toward 0.50 is safe on in-the-wild audio.
+
+Reads the cached dumps in data/eval/<corpus>/dumps and the RTTMs in data/<corpus>/rttm.
+Pure measurement: prints numbers, writes an optional JSON. No app code touched.
+"""
+import argparse, glob, json, os, random, statistics as st
+from collections import defaultdict
+
+Q_MIN, DUR_MIN = 0.3, 1.0  # mirror the harness' clusterMeanEmbedding quality filter
+
+
+def parse_rttm(path):
+    out = []
+    with open(path) as f:
+        for ln in f:
+            p = ln.split()
+            if len(p) >= 8 and p[0] == "SPEAKER":
+                s, d = float(p[3]), float(p[4])
+                out.append((s, s + d, p[7]))
+    return out
+
+
+def true_speaker_for(seg_s, seg_e, ref):
+    """Assign a hyp segment to the true speaker with the most temporal overlap."""
+    best, best_ov = None, 0.0
+    for (rs, re, tid) in ref:
+        ov = max(0.0, min(seg_e, re) - max(seg_s, rs))
+        if ov > best_ov:
+            best, best_ov = tid, ov
+    return best
+
+
+def l2(v):
+    n = sum(x * x for x in v) ** 0.5
+    return [x / n for x in v] if n > 0 else v
+
+
+def mean_emb(embs):
+    if not embs:
+        return None
+    dim = len(embs[0])
+    m = [sum(e[i] for e in embs) / len(embs) for i in range(dim)]
+    return l2(m)
+
+
+def cos(a, b):
+    return sum(x * y for x, y in zip(a, b))  # both already L2-normalized
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dumps", default="data/eval/voxconverse/dumps")
+    ap.add_argument("--rttm-dir", default="data/voxconverse/rttm")
+    ap.add_argument("--out-json")
+    ap.add_argument("--cross-file-pairs", type=int, default=200000,
+                    help="cap on sampled cross-file different-speaker pairs")
+    ap.add_argument("--seed", type=int, default=1234)
+    args = ap.parse_args()
+    rng = random.Random(args.seed)
+
+    dumps = sorted(glob.glob(os.path.join(args.dumps, "*.json")))
+    # per-file: true_speaker -> list of quality-filtered segment embeddings
+    file_true_embs = {}          # meeting -> {tid: [emb,...]}
+    seg_counts = []              # diarizer raw clusters vs true count
+    THRS = [0.45, 0.50, 0.55, 0.60, 0.65]
+
+    for dp in dumps:
+        meeting = os.path.basename(dp)[:-5]
+        rp = os.path.join(args.rttm_dir, meeting + ".rttm")
+        if not os.path.exists(rp):
+            continue
+        d = json.load(open(dp))
+        ref = parse_rttm(rp)
+        true_n = len(set(t for _, _, t in ref))
+        raw_clusters = d.get("diarizerSpeakerCount", len(set(s["speakerId"] for s in d["segments"])))
+        seg_counts.append({"meeting": meeting, "true": true_n, "raw_clusters": raw_clusters})
+
+        by_tid = defaultdict(list)
+        for s in d["segments"]:
+            emb = s.get("embedding")
+            if not emb:
+                continue
+            dur = s["end"] - s["start"]
+            if s.get("quality", 1.0) < Q_MIN or dur < DUR_MIN:
+                continue
+            tid = true_speaker_for(s["start"], s["end"], ref)
+            if tid is not None:
+                by_tid[tid].append(l2(emb))
+        file_true_embs[meeting] = dict(by_tid)
+
+    # ---- 1. diarizer segmentation profile ----
+    under = sum(1 for c in seg_counts if c["raw_clusters"] < c["true"])
+    exact = sum(1 for c in seg_counts if c["raw_clusters"] == c["true"])
+    over = sum(1 for c in seg_counts if c["raw_clusters"] > c["true"])
+    ratios = [c["raw_clusters"] / c["true"] for c in seg_counts if c["true"] > 0]
+    diffs = [c["raw_clusters"] - c["true"] for c in seg_counts]
+
+    # ---- 2a. same-speaker (within-file split-half) ----
+    same_cos = []
+    for meeting, tids in file_true_embs.items():
+        for tid, embs in tids.items():
+            if len(embs) < 2:
+                continue
+            idx = list(range(len(embs)))
+            rng.shuffle(idx)
+            half = len(idx) // 2
+            a = mean_emb([embs[i] for i in idx[:half]])
+            b = mean_emb([embs[i] for i in idx[half:]])
+            if a and b:
+                same_cos.append(cos(a, b))
+
+    # per-(file,true) mean embedding for different-speaker comparisons
+    file_means = {}  # meeting -> {tid: mean_emb}
+    for meeting, tids in file_true_embs.items():
+        file_means[meeting] = {tid: mean_emb(embs) for tid, embs in tids.items()
+                               if mean_emb(embs) is not None}
+
+    # ---- 2b. different-speaker within file ----
+    diff_in = []
+    for meeting, means in file_means.items():
+        ids = list(means)
+        for i in range(len(ids)):
+            for j in range(i + 1, len(ids)):
+                diff_in.append(cos(means[ids[i]], means[ids[j]]))
+
+    # ---- 2c. different-speaker ACROSS files (the false-merge surface; sampled) ----
+    flat = [(m, tid, e) for m, means in file_means.items() for tid, e in means.items()]
+    diff_cross = []
+    n = len(flat)
+    target = min(args.cross_file_pairs, n * (n - 1) // 2)
+    seen = 0
+    while len(diff_cross) < target and seen < target * 6:
+        i, j = rng.randrange(n), rng.randrange(n)
+        seen += 1
+        if i == j or flat[i][0] == flat[j][0]:
+            continue  # need different files
+        diff_cross.append(cos(flat[i][2], flat[j][2]))
+
+    def pct(xs, ps=(5, 25, 50, 75, 90, 95, 99)):
+        if not xs:
+            return {}
+        xs = sorted(xs)
+        return {p: round(xs[min(len(xs) - 1, int(p / 100 * len(xs)))], 4) for p in ps}
+
+    def frac_above(xs, t):
+        return round(sum(1 for x in xs if x >= t) / len(xs), 4) if xs else None
+
+    summary = {
+        "n_files": len(seg_counts),
+        "diarizer_segmentation": {
+            "under": under, "exact": exact, "over": over,
+            "mean_clusters_per_true": round(st.mean(ratios), 3) if ratios else None,
+            "median_clusters_per_true": round(st.median(ratios), 3) if ratios else None,
+            "mean_diff_clusters_minus_true": round(st.mean(diffs), 3) if diffs else None,
+        },
+        "bands": {
+            "same_speaker": {"n": len(same_cos), "mean": round(st.mean(same_cos), 4) if same_cos else None,
+                             "pct": pct(same_cos)},
+            "diff_within_file": {"n": len(diff_in), "mean": round(st.mean(diff_in), 4) if diff_in else None,
+                                 "pct": pct(diff_in)},
+            "diff_cross_file": {"n": len(diff_cross), "mean": round(st.mean(diff_cross), 4) if diff_cross else None,
+                                "pct": pct(diff_cross)},
+        },
+        "false_merge_pressure": {
+            # fraction of DIFFERENT-speaker pairs that would exceed each match threshold
+            f"{t}": {"cross_file": frac_above(diff_cross, t), "within_file": frac_above(diff_in, t)}
+            for t in THRS
+        },
+        "same_speaker_recall": {
+            # fraction of SAME-speaker pairs that clear each threshold (re-merge benefit)
+            f"{t}": frac_above(same_cos, t) for t in THRS
+        },
+    }
+
+    print(json.dumps(summary, indent=2))
+    if args.out_json:
+        json.dump(summary, open(args.out_json, "w"), indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bn_probe.py
+++ b/scripts/bn_probe.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Divergence appears at the first BatchNorm1d (tdnn). Probe the pretrained BN
+running stats and isolate Conv1d+BN1d+ReLU through ONNX with REAL weights.
+Check whether BN eval-mode fold differs (eps placement / momentum / var<0).
+"""
+import os, numpy as np, torch, torch.nn as nn, warnings
+warnings.filterwarnings("ignore")
+import onnxruntime as ort
+
+MODEL_DIR = os.path.expanduser(
+    "~/.cache/modelscope/hub/models/iic/speech_campplus_sv_en_voxceleb_16k")
+BIN = os.path.join(MODEL_DIR, "campplus_voxceleb.bin")
+OUT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "out")
+FEAT_DIM, EMB_SIZE, N_FRAMES = 80, 512, 300
+
+def cosine(a,b):
+    a=a.flatten().astype(np.float64); b=b.flatten().astype(np.float64)
+    return float(np.dot(a,b)/(np.linalg.norm(a)*np.linalg.norm(b)+1e-12))
+
+from modelscope.models.audio.sv.DTDNN import CAMPPlus
+m = CAMPPlus(feat_dim=FEAT_DIM, embedding_size=EMB_SIZE); m.eval()
+sd = torch.load(BIN, map_location="cpu")
+m.load_state_dict(sd, strict=True)
+
+# Inspect ALL BatchNorm running_var ranges
+bn_stats = []
+for name, mod in m.named_modules():
+    if isinstance(mod, (nn.BatchNorm1d, nn.BatchNorm2d)):
+        rv = mod.running_var.detach().numpy()
+        rm = mod.running_mean.detach().numpy()
+        bn_stats.append((name, rv.min(), rv.max(), mod.eps, mod.affine,
+                         (mod.weight is not None)))
+print("BatchNorm running_var ranges (name, var_min, var_max, eps, affine):")
+neg = 0
+for name, vmn, vmx, eps, aff, hasw in bn_stats[:8]:
+    print(f"  {name:30s} var[{vmn:.3e},{vmx:.3e}] eps={eps} affine={aff}")
+print(f"  ... total BN layers: {len(bn_stats)}")
+allmin = min(s[1] for s in bn_stats)
+print(f"  global min running_var across all BNs: {allmin:.3e}  (any negative: {allmin<0})")
+
+# Count affine vs non-affine (batchnorm_ => affine=False on the final dense)
+naff = sum(1 for s in bn_stats if not s[4])
+print(f"  non-affine BN layers: {naff}")
+
+# Isolate the tdnn module (Conv1d stride2 + BN1d + ReLU) with REAL weights
+print("\n== isolate xvector.tdnn (Conv1d+BN1d+ReLU, real weights) ==")
+tdnn = m.xvector.tdnn  # TDNNLayer
+# tdnn input channels = head.out_channels = 32*(80//8)=320
+in_ch = m.head.out_channels
+x = torch.randn(1, in_ch, 150)
+with torch.no_grad():
+    pt = tdnn(x).numpy()
+p = os.path.join(OUT, "tdnn.onnx")
+torch.onnx.export(tdnn, x, p, input_names=["i"], output_names=["o"], opset_version=14)
+s = ort.InferenceSession(p, providers=["CPUExecutionProvider"])
+o = s.run(["o"], {"i": x.numpy().astype(np.float32)})[0]
+print(f"  tdnn ONNX vs eager: cosine={cosine(pt,o):.6f} maxabsdiff={float(np.max(np.abs(pt-o))):.4f}")
+
+# Now isolate just the BatchNorm1d inside tdnn
+bn = tdnn.nonlinear.batchnorm
+xb = torch.randn(1, 128, 150)  # tdnn out_channels=128
+with torch.no_grad():
+    ptb = bn(xb).numpy()
+pb = os.path.join(OUT, "bn.onnx")
+torch.onnx.export(bn, xb, pb, input_names=["i"], output_names=["o"], opset_version=14)
+sb = ort.InferenceSession(pb, providers=["CPUExecutionProvider"])
+ob = sb.run(["o"], {"i": xb.numpy().astype(np.float32)})[0]
+print(f"  BN1d-only ONNX vs eager: cosine={cosine(ptb,ob):.6f} maxabsdiff={float(np.max(np.abs(ptb-ob))):.4f}")
+
+# Isolate just the Conv1d inside tdnn
+conv = tdnn.linear
+with torch.no_grad():
+    ptc = conv(x).numpy()
+pc = os.path.join(OUT, "conv.onnx")
+torch.onnx.export(conv, x, pc, input_names=["i"], output_names=["o"], opset_version=14)
+sc = ort.InferenceSession(pc, providers=["CPUExecutionProvider"])
+oc = sc.run(["o"], {"i": x.numpy().astype(np.float32)})[0]
+print(f"  Conv1d-only ONNX vs eager: cosine={cosine(ptc,oc):.6f} maxabsdiff={float(np.max(np.abs(ptc-oc))):.4f}")
+print(f"    conv: in={conv.in_channels} out={conv.out_channels} k={conv.kernel_size} "
+      f"stride={conv.stride} pad={conv.padding} dil={conv.dilation}")

--- a/scripts/bootstrap_series_bands.py
+++ b/scripts/bootstrap_series_bands.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Cluster bootstrap (resample the 8 SERIES with replacement) as a robustness cross-check
+on the leave-one-series-out jackknife. Because the same 8 series feed every arm, the arm
+estimates are paired/correlated: we resample a set of 8 series indices ONCE per bootstrap
+draw and recompute every arm's separation on that same resample, then look at the PAIRED
+gaps (clean-opus12k, opus12k-opus8k). This directly answers: across resampling of series,
+does clean>opus12k>opus8k ever flip?
+
+We rebuild same/diff pairs but recompute means on the resampled multiset of series. A
+same-speaker pair belongs to one series (speakers are series-pure). A different-speaker
+cross-meeting pair belongs to an unordered pair of series; under a resample with counts
+c[series], we weight each diff pair by c[sa]*c[sb] (or c*(c-1) coeff handled via product),
+and each same pair by c[ser]. This is the natural cluster-bootstrap weighting of the U-stat.
+"""
+import glob, json, os, random, statistics as st
+from collections import defaultdict
+
+Q_MIN, DUR_MIN = 0.3, 1.0
+ROOT = "/Users/redbars/transcripted/.claude/worktrees/objective-noyce-06bac2/data"
+RTTM_DIR = os.path.join(ROOT, "ami", "rttm")
+SERIES = ["ES2002", "ES2003", "ES2005", "ES2006", "ES2007", "ES2008", "ES2009", "ES2010"]
+ARMS = ["clean", "opus12k", "opus8k"]
+
+
+def parse_rttm(path):
+    out = []
+    for ln in open(path):
+        p = ln.split()
+        if len(p) >= 8 and p[0] == "SPEAKER":
+            s, d = float(p[3]), float(p[4]); out.append((s, s + d, p[7]))
+    return out
+
+
+def true_for(s, e, ref):
+    best, bov = None, 0.0
+    for (rs, re, t) in ref:
+        ov = max(0.0, min(e, re) - max(s, rs))
+        if ov > bov: best, bov = t, ov
+    return best
+
+
+def l2(v):
+    n = sum(x * x for x in v) ** 0.5
+    return [x / n for x in v] if n else v
+
+
+def mean_emb(es):
+    if not es: return None
+    d = len(es[0]); return l2([sum(e[i] for e in es) / len(es) for i in range(d)])
+
+
+def cos(a, b): return sum(x * y for x, y in zip(a, b))
+
+
+def load_pairs(arm):
+    dumps = os.path.join(ROOT, "eval", f"ami_{arm}", "dumps")
+    mean_by = {}
+    for dp in sorted(glob.glob(os.path.join(dumps, "*.json"))):
+        m = os.path.basename(dp)[:-5]
+        rp = os.path.join(RTTM_DIR, m + ".rttm")
+        if not os.path.exists(rp): continue
+        d = json.load(open(dp)); ref = parse_rttm(rp)
+        by = defaultdict(list)
+        for s in d["segments"]:
+            emb = s.get("embedding")
+            if not emb or s.get("quality", 1.0) < Q_MIN or (s["end"] - s["start"]) < DUR_MIN:
+                continue
+            t = true_for(s["start"], s["end"], ref)
+            if t is not None: by[t].append(l2(emb))
+        for t, es in by.items():
+            me = mean_emb(es)
+            if me: mean_by[(m, t)] = me
+    by_spk = defaultdict(dict)
+    for (m, t), me in mean_by.items():
+        by_spk[t][m] = me
+    same = []  # (series, cos)
+    for spk, mm in by_spk.items():
+        ms = sorted(mm)
+        for i in range(len(ms)):
+            si = ms[i][:6]
+            for j in range(i + 1, len(ms)):
+                same.append((si, cos(mm[ms[i]], mm[ms[j]])))
+    flat = [(m, t, me) for (m, t), me in mean_by.items()]
+    n = len(flat); diff = []
+    for i in range(n):
+        for j in range(i + 1, n):
+            if flat[i][1] != flat[j][1] and flat[i][0] != flat[j][0]:
+                diff.append((flat[i][0][:6], flat[j][0][:6], cos(flat[i][2], flat[j][2])))
+    return same, diff
+
+
+def sep_weighted(same, diff, counts):
+    """Separation under series multiplicities `counts` (dict series->int)."""
+    sw = sd = 0.0; swn = sdn = 0.0
+    for (ser, c) in same:
+        w = counts[ser]
+        if w: sw += w * c; swn += w
+    for (sa, sb, c) in diff:
+        w = counts[sa] * counts[sb]
+        if w: sd += w * c; sdn += w
+    if swn == 0 or sdn == 0: return None
+    return (sw / swn) - (sd / sdn)
+
+
+def main():
+    pairs = {a: load_pairs(a) for a in ARMS}
+    rng = random.Random(20260617)
+    B = 5000
+    sep_draws = {a: [] for a in ARMS}
+    flip_order = 0
+    flip_c12 = 0
+    flip_128 = 0
+    for _ in range(B):
+        idx = [rng.randrange(len(SERIES)) for _ in range(len(SERIES))]
+        counts = defaultdict(int)
+        for k in idx: counts[SERIES[k]] += 1
+        s = {}
+        for a in ARMS:
+            v = sep_weighted(pairs[a][0], pairs[a][1], counts)
+            s[a] = v; sep_draws[a].append(v)
+        if not (s["clean"] > s["opus12k"]): flip_c12 += 1
+        if not (s["opus12k"] > s["opus8k"]): flip_128 += 1
+        if not (s["clean"] > s["opus12k"] > s["opus8k"]): flip_order += 1
+
+    def ci(xs):
+        xs = sorted(xs)
+        return st.mean(xs), xs[int(0.025 * len(xs))], xs[int(0.975 * len(xs))], st.pstdev(xs)
+
+    print("CLUSTER BOOTSTRAP over 8 series, B=%d (paired across arms)" % B)
+    print(f"{'arm':9} {'mean':>8} {'2.5%':>8} {'97.5%':>8} {'sd':>8}")
+    for a in ARMS:
+        m, lo, hi, sd = ci(sep_draws[a])
+        print(f"{a:9} {m:8.4f} {lo:8.4f} {hi:8.4f} {sd:8.4f}")
+    print()
+    print(f"P(NOT clean>opus12k)          = {flip_c12/B:.4f}")
+    print(f"P(NOT opus12k>opus8k)         = {flip_128/B:.4f}")
+    print(f"P(ordering clean>opus12k>opus8k FAILS) = {flip_order/B:.4f}")
+    # paired gap CIs
+    c12 = sorted(sep_draws['clean'][i]-sep_draws['opus12k'][i] for i in range(B))
+    g128 = sorted(sep_draws['opus12k'][i]-sep_draws['opus8k'][i] for i in range(B))
+    print()
+    print(f"paired gap clean-opus12k : mean={st.mean(c12):.4f} 95%CI=[{c12[int(.025*B)]:.4f},{c12[int(.975*B)]:.4f}]")
+    print(f"paired gap opus12k-opus8k: mean={st.mean(g128):.4f} 95%CI=[{g128[int(.025*B)]:.4f},{g128[int(.975*B)]:.4f}]")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_voxceleb_sessions.py
+++ b/scripts/build_voxceleb_sessions.py
@@ -48,10 +48,51 @@ def make_silence(path, sr, dur):
          "-i", f"anullsrc=r={sr}:cl=mono", "-c:a", "pcm_s16le", path])
 
 
+def build_singles(ids, clips, raw_dir, out_dir, sr):
+    """One clip = one single-speaker 'meeting'. The diarizer trivially sees one clean
+    voice (no within-session mixing to confound it), so the eval isolates the DB matcher:
+    does it keep N people as N profiles, re-identify each across their clips, and never
+    fuse two different people? This is the clean cross-recording re-ID / false-positive
+    test. Meetings are emitted round-robin across identities so sorted replay order
+    interleaves them (each identity's appearances spread across the run)."""
+    audio_dir = os.path.join(out_dir, "audio")
+    rttm_dir = os.path.join(out_dir, "rttm")
+    os.makedirs(audio_dir, exist_ok=True)
+    os.makedirs(rttm_dir, exist_ok=True)
+    cursor = {s: 0 for s in ids}
+    remaining = sum(len(clips[s]) for s in ids)
+    n = 0
+    appear = {}
+    while remaining > 0:
+        for spk in ids:
+            i = cursor[spk]
+            if i >= len(clips[spk]):
+                continue
+            cursor[spk] += 1
+            remaining -= 1
+            src = os.path.join(raw_dir, spk, clips[spk][i])
+            mid = f"m{n:04d}_{spk}"
+            dst = os.path.join(audio_dir, f"{mid}.wav")
+            try:
+                normalize(src, dst, sr)
+                dur = ffprobe_duration(dst)
+            except subprocess.CalledProcessError:
+                continue
+            with open(os.path.join(rttm_dir, f"{mid}.rttm"), "w") as f:
+                f.write(f"SPEAKER {mid} 1 0.000 {dur:.3f} <NA> <NA> {spk} <NA> <NA>\n")
+            appear[spk] = appear.get(spk, 0) + 1
+            n += 1
+    print(json.dumps({"mode": "singles", "meetings": n, "distinct_identities": len(appear),
+                      "clips_per_identity": appear}, indent=2))
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--raw-dir", required=True, help="data/voxceleb/raw/<spk>/*.wav")
     ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--mode", choices=["sessions", "singles"], default="sessions",
+                    help="sessions = stitched multi-speaker (stresses diarizer too); "
+                         "singles = one clip/meeting (isolates the DB matcher — clean re-ID/false-positive)")
     ap.add_argument("--num-sessions", type=int, default=20)
     ap.add_argument("--speakers-per-session", type=int, default=4)
     ap.add_argument("--clips-per-speaker", type=int, default=3)
@@ -67,6 +108,13 @@ def main():
     clips = {s: sorted(f for f in os.listdir(os.path.join(args.raw_dir, s))
                        if f.lower().endswith(".wav")) for s in ids}
     ids = [s for s in ids if clips[s]]
+
+    if args.mode == "singles":
+        if len(ids) < 2:
+            print(f"error: only {len(ids)} identities; need >= 2", file=sys.stderr); sys.exit(1)
+        build_singles(ids, clips, args.raw_dir, args.out_dir, args.sr)
+        return
+
     spk_n = args.speakers_per_session
     if len(ids) < spk_n:
         print(f"error: only {len(ids)} identities; need >= {spk_n}", file=sys.stderr); sys.exit(1)

--- a/scripts/build_voxceleb_sessions.py
+++ b/scripts/build_voxceleb_sessions.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Build synthetic multi-identity "sessions" (WAV + ground-truth RTTM) from sampled
+VoxCeleb identities, for the cross-recording re-ID / false-positive test.
+
+Why synthetic sessions: VoxCeleb gives many short single-speaker clips per identity but no
+multi-speaker recordings. We stitch clips from several identities into conversational
+sessions and emit an exact RTTM (we know who speaks when). Sessions are constructed so that:
+
+  * the SAME identities RECUR across sessions, using DIFFERENT clips each time
+    -> measures cross-recording re-ID (does the DB re-identify a person from new audio?).
+  * MANY distinct identities appear overall, and within a session each identity is a
+    different person -> measures false-merge / false-positive (does the DB wrongly fuse
+    two different people into one profile?).
+
+Deterministic (no RNG): identity pools slide over the sorted id list with overlap; clip
+choice is round-robin per identity, so re-appearances use fresh audio.
+
+Output:
+  data/voxceleb/sessions/audio/sess000.wav ...
+  data/voxceleb/sessions/rttm/sess000.rttm ...
+
+Requires ffmpeg + ffprobe (audio concat + duration probing).
+
+Usage:
+  python3 scripts/build_voxceleb_sessions.py --raw-dir data/voxceleb/raw \
+      --out-dir data/voxceleb/sessions \
+      --num-sessions 20 --speakers-per-session 4 --clips-per-speaker 3 --gap 0.3
+"""
+import argparse, json, os, shutil, subprocess, sys, tempfile
+
+
+def ffprobe_duration(path):
+    out = subprocess.check_output(
+        ["ffprobe", "-v", "error", "-show_entries", "format=duration",
+         "-of", "default=nw=1:nk=1", path], text=True).strip()
+    return float(out)
+
+
+def normalize(src, dst, sr):
+    subprocess.check_call(
+        ["ffmpeg", "-v", "error", "-y", "-i", src, "-ac", "1", "-ar", str(sr),
+         "-c:a", "pcm_s16le", dst])
+
+
+def make_silence(path, sr, dur):
+    subprocess.check_call(
+        ["ffmpeg", "-v", "error", "-y", "-f", "lavfi", "-t", f"{dur}",
+         "-i", f"anullsrc=r={sr}:cl=mono", "-c:a", "pcm_s16le", path])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--raw-dir", required=True, help="data/voxceleb/raw/<spk>/*.wav")
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--num-sessions", type=int, default=20)
+    ap.add_argument("--speakers-per-session", type=int, default=4)
+    ap.add_argument("--clips-per-speaker", type=int, default=3)
+    ap.add_argument("--gap", type=float, default=0.3, help="silence (s) between turns")
+    ap.add_argument("--sr", type=int, default=16000)
+    args = ap.parse_args()
+
+    if not shutil.which("ffmpeg") or not shutil.which("ffprobe"):
+        print("error: ffmpeg + ffprobe required", file=sys.stderr); sys.exit(2)
+
+    ids = sorted(d for d in os.listdir(args.raw_dir)
+                 if os.path.isdir(os.path.join(args.raw_dir, d)))
+    clips = {s: sorted(f for f in os.listdir(os.path.join(args.raw_dir, s))
+                       if f.lower().endswith(".wav")) for s in ids}
+    ids = [s for s in ids if clips[s]]
+    spk_n = args.speakers_per_session
+    if len(ids) < spk_n:
+        print(f"error: only {len(ids)} identities; need >= {spk_n}", file=sys.stderr); sys.exit(1)
+
+    audio_dir = os.path.join(args.out_dir, "audio")
+    rttm_dir = os.path.join(args.out_dir, "rttm")
+    os.makedirs(audio_dir, exist_ok=True)
+    os.makedirs(rttm_dir, exist_ok=True)
+
+    overlap = max(1, spk_n // 2)         # consecutive sessions share `overlap` identities
+    stride = max(1, spk_n - overlap)
+    clip_cursor = {s: 0 for s in ids}    # round-robin clip pointer per identity
+
+    for si in range(args.num_sessions):
+        start = (si * stride) % len(ids)
+        session_ids = [ids[(start + j) % len(ids)] for j in range(spk_n)]
+        mid = f"sess{si:03d}"
+        tmp = tempfile.mkdtemp(prefix=f"voxsess_{mid}_")
+        sil = os.path.join(tmp, "sil.wav")
+        make_silence(sil, args.sr, args.gap)
+
+        concat_lines, rttm_lines = [], []
+        t = 0.0
+        # interleave: round-robin one clip per speaker per turn
+        for turn in range(args.clips_per_speaker):
+            for spk in session_ids:
+                cl = clips[spk]
+                c = cl[clip_cursor[spk] % len(cl)]
+                clip_cursor[spk] += 1
+                src = os.path.join(args.raw_dir, spk, c)
+                norm = os.path.join(tmp, f"{spk}_{turn}.wav")
+                try:
+                    normalize(src, norm, args.sr)
+                    dur = ffprobe_duration(norm)
+                except subprocess.CalledProcessError:
+                    continue
+                concat_lines.append(f"file '{norm}'")
+                rttm_lines.append(
+                    f"SPEAKER {mid} 1 {t:.3f} {dur:.3f} <NA> <NA> {spk} <NA> <NA>")
+                t += dur
+                concat_lines.append(f"file '{sil}'")
+                t += args.gap
+
+        listing = os.path.join(tmp, "list.txt")
+        with open(listing, "w") as f:
+            f.write("\n".join(concat_lines) + "\n")
+        out_wav = os.path.join(audio_dir, f"{mid}.wav")
+        subprocess.check_call(
+            ["ffmpeg", "-v", "error", "-y", "-f", "concat", "-safe", "0",
+             "-i", listing, "-c:a", "pcm_s16le", out_wav])
+        with open(os.path.join(rttm_dir, f"{mid}.rttm"), "w") as f:
+            f.write("\n".join(rttm_lines) + "\n")
+        shutil.rmtree(tmp, ignore_errors=True)
+        print(f"[voxsess] {mid}: {spk_n} ids {session_ids} -> {t:.1f}s")
+
+    # recurrence summary
+    appear = {}
+    for si in range(args.num_sessions):
+        start = (si * stride) % len(ids)
+        for j in range(spk_n):
+            s = ids[(start + j) % len(ids)]
+            appear[s] = appear.get(s, 0) + 1
+    recurring = sum(1 for v in appear.values() if v >= 2)
+    print(json.dumps({
+        "sessions": args.num_sessions, "distinct_identities": len(appear),
+        "recurring_identities(>=2 sessions)": recurring,
+        "max_appearances": max(appear.values()) if appear else 0,
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/center_dumps.py
+++ b/scripts/center_dumps.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Mean-center the embeddings in a set of cached dumps, then write new dumps the harness
+can replay through the REAL matcher (measurement only — no app code touched).
+
+The codec-coloration finding (AMI_CODEC_REID_REPORT §3) showed compression injects a single
+shared bias direction into every embedding, inflating all cosines and collapsing the
+matcher's ability to separate strangers. Subtracting that shared direction restored the
+embedding-band separation. This script applies the subtraction to the per-segment
+embeddings in the dump so we can measure whether it fixes the DOWNSTREAM matcher metrics
+(profiles_end, false-merge, re-ID) — not just the bands.
+
+Modes (what centroid is subtracted from each segment):
+  normonly     control: just L2-normalize each segment, subtract nothing. Isolates the
+               effect of unit-normalizing from the effect of centering.
+  global       subtract the mean of ALL normalized segment embeddings in the arm (oracle:
+               needs all the audio; an upper bound).
+  per_meeting  subtract each meeting's own mean (per-session centering).
+  running      subtract a causal EMA of normalized embeddings seen so far, in replay order
+               (online / production-deployable; estimates the bias without future audio).
+  frozen       estimate the centroid from the FIRST meeting's segments ONLY, then freeze it
+               and subtract it from every meeting (including the first). A causal one-time
+               per-source calibration: deployable as "warm up on the opening minutes, then
+               hold the codec-bias estimate fixed". Uses no future audio beyond meeting 1.
+
+All output embeddings are L2-normalized. Every other dump field is preserved verbatim, so
+the only thing that changes in the replay is the embeddings.
+"""
+import argparse, glob, json, os
+
+
+def l2(v):
+    n = sum(x * x for x in v) ** 0.5
+    return [x / n for x in v] if n else list(v)
+
+
+def sub_norm(e, c):
+    return l2([a - b for a, b in zip(e, c)])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in-dumps", required=True)
+    ap.add_argument("--out-dumps", required=True)
+    ap.add_argument("--mode", required=True, choices=["normonly", "global", "per_meeting", "running", "frozen"])
+    ap.add_argument("--alpha", type=float, default=0.05, help="running-EMA rate")
+    args = ap.parse_args()
+    os.makedirs(args.out_dumps, exist_ok=True)
+
+    files = sorted(glob.glob(os.path.join(args.in_dumps, "*.json")))  # sorted = replay order
+    dim = None
+    # global centroid (mean of all normalized segment embeddings)
+    if args.mode == "global":
+        acc = None; n = 0
+        for f in files:
+            for s in json.load(open(f))["segments"]:
+                e = l2(s["embedding"]); dim = len(e)
+                acc = e if acc is None else [a + b for a, b in zip(acc, e)]
+                n += 1
+        gcent = [a / n for a in acc] if n else None
+
+    # frozen centroid: mean of ONLY the first meeting's normalized segment embeddings
+    if args.mode == "frozen":
+        acc = None; n = 0
+        if files:
+            for s in json.load(open(files[0]))["segments"]:
+                e = l2(s["embedding"]); dim = len(e)
+                acc = e if acc is None else [a + b for a, b in zip(acc, e)]
+                n += 1
+        fcent = [a / n for a in acc] if n else None
+
+    run = None  # running EMA state
+    for f in files:
+        d = json.load(open(f))
+        segs = sorted(d["segments"], key=lambda s: s["start"])
+        if args.mode == "per_meeting":
+            acc = None; n = 0
+            for s in segs:
+                e = l2(s["embedding"]); acc = e if acc is None else [a + b for a, b in zip(acc, e)]; n += 1
+            cent = [a / n for a in acc] if n else None
+        out = []
+        for s in segs:
+            e = l2(s["embedding"])
+            if args.mode == "normonly":
+                ec = e
+            elif args.mode == "global":
+                ec = sub_norm(e, gcent)
+            elif args.mode == "per_meeting":
+                ec = sub_norm(e, cent)
+            elif args.mode == "frozen":
+                ec = sub_norm(e, fcent) if fcent else e
+            else:  # running
+                if run is None:
+                    run = list(e)            # warm-start
+                    ec = e                    # nothing to subtract yet
+                else:
+                    ec = sub_norm(e, run)
+                run = [(1 - args.alpha) * r + args.alpha * x for r, x in zip(run, e)]
+            ns = dict(s); ns["embedding"] = ec
+            out.append(ns)
+        d["segments"] = out
+        json.dump(d, open(os.path.join(args.out_dumps, os.path.basename(f)), "w"))
+    print(f"[center] {args.mode}: wrote {len(files)} dumps -> {args.out_dumps}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/center_purity_analysis.py
+++ b/scripts/center_purity_analysis.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Recompute CLEANER speaker-matching metrics from replay results + RTTM.
+
+Builds the full mass-based confusion matrix global_overlap[true_id][profile]
+(seconds of reference/hypothesis co-occurrence) the same way score_speaker_eval.py
+does internally, then derives:
+
+  (a) identities correctly isolated (clean 1:1): true speakers whose speech is
+      >=COVER captured by a single profile that is itself >=DOMINANCE that speaker.
+  (b) profile purity: fraction of profiles >=PURITY dominated by one true speaker.
+  (c) over-merge vs over-split decomposition of (profiles_end - 32).
+
+Also reports mass-weighted total false-positive (merge) and false-negative (split)
+fractions that are robust to mega-profile collapse, plus the matcher-controllable
+"effective identity recovery" (sum of best 1:1 coverage, capped at 32).
+"""
+import argparse, json, glob, os, sys
+from collections import defaultdict
+
+def parse_rttm(path):
+    out = []
+    with open(path) as f:
+        for line in f:
+            p = line.split()
+            if not p or p[0] != "SPEAKER":
+                continue
+            start, dur, spk = float(p[3]), float(p[4]), p[7]
+            out.append((start, start + dur, spk))
+    return out
+
+def overlap(a0, a1, b0, b1):
+    return max(0.0, min(a1, b1) - max(a0, b0))
+
+def build_overlap_matrix(ref, hyp):
+    m = defaultdict(lambda: defaultdict(float))
+    hyp = sorted(hyp, key=lambda x: x[0])
+    for (rs, re, tid) in ref:
+        for (hs, he, pid) in hyp:
+            if hs >= re:
+                break
+            ov = overlap(rs, re, hs, he)
+            if ov > 0:
+                m[tid][pid] += ov
+    return m
+
+def load_global_overlap(result_path, rttm_dir):
+    result = json.load(open(result_path))
+    global_overlap = defaultdict(lambda: defaultdict(float))   # tid -> pid -> sec
+    global_ref_time = defaultdict(float)                       # tid -> total ref sec
+    for mr in result["meetings"]:
+        meeting = mr["meeting"]
+        ref = parse_rttm(f"{rttm_dir}/{meeting}.rttm")
+        hyp = [(a["start"], a["end"], a["dbProfile"]) for a in mr["assignments"]]
+        om = build_overlap_matrix(ref, hyp)
+        # ref time per tid (count each tid's total reference duration once per meeting)
+        ref_by_tid = defaultdict(float)
+        for s, e, t in ref:
+            ref_by_tid[t] += (e - s)
+        for tid in om:
+            global_ref_time[tid] += ref_by_tid[tid]
+        for tid, secs in om.items():
+            for pid, ov in secs.items():
+                global_overlap[tid][pid] += ov
+    return global_overlap, global_ref_time, result.get("profilesAtEnd")
+
+def analyze(result_path, rttm_dir, COVER=0.50, DOMINANCE=0.50, PURITY=0.80, FRAC=0.10):
+    go, ref_time, profiles_end = load_global_overlap(result_path, rttm_dir)
+
+    # profile mass = total overlapped ref seconds attributed to that profile
+    profile_mass = defaultdict(float)
+    profile_to_true = defaultdict(lambda: defaultdict(float))
+    for tid, profs in go.items():
+        for pid, ov in profs.items():
+            profile_mass[pid] += ov
+            profile_to_true[pid][tid] += ov
+
+    n_true = len(ref_time)            # should be 32 for AMI
+    n_profiles = len(profile_mass)
+
+    # ---- (a) identities correctly isolated: clean 1:1 ----
+    isolated = []
+    for tid, profs in go.items():
+        tot_t = ref_time[tid] or 1.0
+        ok = False
+        for pid, ov in profs.items():
+            cover = ov / tot_t
+            dom = ov / (profile_mass[pid] or 1.0)
+            if cover >= COVER and dom >= DOMINANCE:
+                ok = True
+                break
+        if ok:
+            isolated.append(tid)
+    n_isolated = len(isolated)
+
+    # ---- (b) profile purity: fraction of profiles >=PURITY one true speaker ----
+    pure_profiles = 0
+    for pid, mass in profile_mass.items():
+        top = max(profile_to_true[pid].values()) if profile_to_true[pid] else 0.0
+        if (top / (mass or 1.0)) >= PURITY:
+            pure_profiles += 1
+    purity_frac = pure_profiles / (n_profiles or 1)
+
+    # ---- (c) over-split / over-merge decomposition ----
+    # over-split: extra profiles created per identity (profiles >=FRAC of a person, minus 1)
+    over_split = 0
+    for tid, profs in go.items():
+        tot_t = ref_time[tid] or 1.0
+        k = sum(1 for pid, ov in profs.items() if ov / tot_t >= FRAC)
+        over_split += max(0, k - 1)
+    # over-merge: extra identities collapsed per profile (true speakers >=FRAC of mass, minus 1)
+    over_merge = 0
+    for pid, mass in profile_mass.items():
+        k = sum(1 for tid, ov in profile_to_true[pid].items() if ov / (mass or 1.0) >= FRAC)
+        over_merge += max(0, k - 1)
+
+    # ---- mass-weighted FP / FN (collapse-robust) ----
+    # FN mass = fraction of each person's speech NOT in their dominant profile (split loss)
+    fn_mass_num = 0.0; fn_mass_den = 0.0
+    for tid, profs in go.items():
+        ov_total = sum(profs.values())
+        best = max(profs.values()) if profs else 0.0
+        fn_mass_num += ov_total - best  # this person's speech that landed in non-dominant profiles
+        fn_mass_den += ov_total
+    fn_mass = fn_mass_num / (fn_mass_den or 1.0)
+    # FP mass = fraction of profile mass that is NOT the profile's dominant speaker (merge contamination)
+    fp_mass_num = 0.0; fp_mass_den = 0.0
+    for pid, mass in profile_mass.items():
+        top = max(profile_to_true[pid].values()) if profile_to_true[pid] else 0.0
+        fp_mass_num += (mass - top)
+        fp_mass_den += mass
+    fp_mass = fp_mass_num / (fp_mass_den or 1.0)
+
+    # ---- effective identity recovery (matcher-controllable upper view) ----
+    # sum over true speakers of best single-profile coverage (B-cubed-ish recall)
+    recall_sum = 0.0
+    for tid, profs in go.items():
+        tot_t = ref_time[tid] or 1.0
+        best = max(profs.values()) if profs else 0.0
+        recall_sum += best / tot_t
+    mean_recall = recall_sum / (n_true or 1)
+
+    return {
+        "profiles_end": profiles_end,
+        "n_profiles_obs": n_profiles,
+        "n_true": n_true,
+        "isolated_1to1": n_isolated,
+        "pure_profiles": pure_profiles,
+        "purity_frac": round(purity_frac, 3),
+        "over_split": over_split,
+        "over_merge": over_merge,
+        "gap_from_32": (profiles_end - 32) if profiles_end is not None else None,
+        "fp_mass": round(fp_mass, 4),     # merge contamination (false positive)
+        "fn_mass": round(fn_mass, 4),     # split loss (false negative)
+        "mean_recall": round(mean_recall, 4),
+    }
+
+def find_result(arm_dir, match):
+    for name in (f"cons_none_match_{match:.2f}.json", f"match_{match:.2f}.json"):
+        p = os.path.join(arm_dir, "results", name)
+        if os.path.exists(p):
+            return p
+    return None
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--eval-dir", default="data/eval")
+    ap.add_argument("--rttm-dir", default="data/ami/rttm")
+    ap.add_argument("--arms", default="clean,opus12k,opus8k,g711u")
+    ap.add_argument("--modes", default="baseline,global")
+    ap.add_argument("--matches", default="0.50,0.60,0.70")
+    args = ap.parse_args()
+
+    arms = args.arms.split(",")
+    modes = args.modes.split(",")
+    matches = [float(x) for x in args.matches.split(",")]
+
+    rows = []
+    for arm in arms:
+        for mode in modes:
+            arm_dir = os.path.join(args.eval_dir, f"ami_{arm}" if mode == "baseline" else f"ami_{arm}_{mode}")
+            for match in matches:
+                rp = find_result(arm_dir, match)
+                if not rp:
+                    print(f"MISSING {arm_dir} match={match}", file=sys.stderr)
+                    continue
+                r = analyze(rp, args.rttm_dir)
+                r.update({"arm": arm, "mode": mode, "match": match})
+                rows.append(r)
+    print(json.dumps(rows, indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compare_centering.py
+++ b/scripts/compare_centering.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Compare the mean-centering modes against the uncentered baseline on the DOWNSTREAM
+matcher metrics (measurement only). The headline false-positive metric here is
+PEOPLE-TRAPPED — the count of distinct true speakers stuck in a profile that fuses >=2
+people — because raw false_merge.count and re-ID are both distorted by mega-profile
+collapse at low thresholds / heavy compression.
+
+Reads baseline data/eval/ami_<arm>/reports and centered data/eval/ami_<arm>_<mode>/reports.
+Two views: (1) at the production threshold match=0.60, (2) at each cell's own best match.
+"""
+import argparse, json, os
+
+ARMS = ["clean", "opus24k", "opus16k", "opus12k", "opus8k", "g711u"]
+MODES = ["baseline", "normonly", "global", "running"]
+GRID = ["0.40", "0.45", "0.50", "0.55", "0.60", "0.65", "0.70"]
+NTRUE = 32
+
+
+def repdir(arm, mode):
+    return f"data/eval/ami_{arm}/reports" if mode == "baseline" else f"data/eval/ami_{arm}_{mode}/reports"
+
+
+def load(arm, mode, m):
+    f = os.path.join(repdir(arm, mode), f"cons_none_match_{m}.json")
+    return json.load(open(f)) if os.path.exists(f) else None
+
+
+def people_trapped(s):
+    return len({t for ids in s["false_merge"]["profiles"].values() for t in ids})
+
+
+def reid_later(s):
+    c = s["reid_curve_by_appearance"]; later = [v for k, v in c.items() if int(k) >= 2]
+    return round(sum(later) / len(later), 3) if later else None
+
+
+def cell(arm, mode, m):
+    s = load(arm, mode, m)
+    if not s:
+        return None
+    return {"match": m, "pe": s["profiles_at_end"], "trapped": people_trapped(s),
+            "fm": s["false_merge"]["count"], "reid": reid_later(s)}
+
+
+def band_sep(arm, mode):
+    f = os.path.join(repdir(arm, mode), "bands.json")
+    if not os.path.exists(f):
+        return None
+    b = json.load(open(f))
+    return round(b["same_speaker_cross_meeting"]["mean"] - b["different_speaker_cross_meeting"]["mean"], 3)
+
+
+def best(arm, mode):
+    cells = [cell(arm, mode, m) for m in GRID]
+    cells = [c for c in cells if c]
+    if not cells:
+        return None
+    # best = profile count nearest 32, then fewest people trapped, then lower match
+    return sorted(cells, key=lambda c: (abs(c["pe"] - NTRUE), c["trapped"], float(c["match"])))[0]
+
+
+def main():
+    ap = argparse.ArgumentParser(); ap.add_argument("--out-md"); args = ap.parse_args()
+    out = ["# Mean-centering matcher experiment — does it fix the downstream false positives?\n"]
+    out.append(f"Ideal profiles = {NTRUE}. people-trapped = distinct real speakers stuck in a >=2-person "
+               "profile (the honest false-positive count; lower is better).\n")
+
+    out.append("## At the production threshold (match = 0.60)\n")
+    out.append("| arm | mode | profiles_end (ideal 32) | people-trapped | false-merge | re-ID#2+ | band sep |")
+    out.append("|---|---|---|---|---|---|---|")
+    for arm in ARMS:
+        for mode in MODES:
+            c = cell(arm, mode, "0.60")
+            if not c:
+                continue
+            sep = band_sep(arm, mode)
+            mark = " ←" if mode == "global" else ""
+            out.append(f"| {arm} | {mode} | {c['pe']} | {c['trapped']} | {c['fm']} | {c['reid']} | {sep}{mark} |")
+        out.append("| | | | | | | |")
+
+    out.append("\n## At each cell's own best match (profiles nearest 32, then fewest trapped)\n")
+    out.append("| arm | mode | best match | profiles_end | people-trapped | re-ID#2+ |")
+    out.append("|---|---|---|---|---|---|")
+    for arm in ARMS:
+        for mode in MODES:
+            b = best(arm, mode)
+            if not b:
+                continue
+            out.append(f"| {arm} | {mode} | {b['match']} | {b['pe']} | {b['trapped']} | {b['reid']} |")
+        out.append("| | | | | | |")
+
+    md = "\n".join(out)
+    print(md)
+    if args.out_md:
+        open(args.out_md, "w").write(md)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_campplus_coreml.py
+++ b/scripts/convert_campplus_coreml.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""
+Convert the Alibaba 3D-Speaker CAM++ speaker-embedding model (modelscope
+iic/speech_campplus_sv_en_voxceleb_16k) to Apple CoreML, and verify the
+converted model reproduces the PyTorch embeddings on real AMI audio.
+
+=========================== RESULT: FAIL ===========================
+Conversion *runs* (no unsupported ops, 14.4 MB mlprogram) but the converted
+model does NOT reproduce the PyTorch embeddings: min cosine ~0.23 on real AMI
+clips (want >0.99). This is a hard FAIL for shipping CAM++ on CoreML.
+
+Root cause (see scripts/bn_probe.py, accumulation_test.py, this file's diagnosis
+trail): the pretrained CAM++ has BatchNorm1d layers with near-zero running_var
+(min ~4.7e-6 in transit1) -> normalization scale ~260x. Both torch.onnx.export
+AND coremltools (independent frontends) lower the deep DenseTDNN backbone such
+that ordinary float rounding gets amplified ~260x by these tiny-variance
+channels and cascades through the dense-concat / residual structure. Evidence:
+  - TorchScript trace vs eager PyTorch: cosine 1.000000 (trace is FAITHFUL)
+  - ONNX (from same trace) vs eager:    cosine ~0.68 (frame) / ~0.23 (emb)
+  - CoreML f16/ALL and f32/CPU:         cosine ~0.23 (same as ONNX => not f16)
+  - Same failure with random-init OR pretrained at the FULL-MODEL level once
+    pretrained weights create the tiny-variance BN channels.
+  - Individual ops (FCM head, StatsPool std, seg_pooling, single CAMLayer/Block)
+    all convert at cosine ~1.0; the error is ACCUMULATED through depth.
+The faithful eager reference is validated: same-speaker cosine 0.79 vs
+different-speaker -0.09 on the model's own example clips.
+
+The kaldi-fbank front-end (the part we *expected* to be hard) is NOT the
+blocker -- we sidestep it by converting only fbank-in -> embedding-out and
+feeding identical host-computed fbank to both models.
+
+Fallback ERes2Net (3D-Speaker, Conv2d-ResNet): ONNX export cosine 1.000000;
+CoreML needs a trivial 1-line patch (its custom Hardtanh ReLU(0,20) trips a
+coremltools int/float dtype bug) -> then CoreML cosine 1.000000. Recommend
+ERes2Net, not CAM++, for the CoreML/ANE path.
+
+Strategy
+--------
+The CAM++ pipeline is: raw 16k audio -> kaldi fbank (80-dim) -> mean-subtract
+over time -> CAMPPlus nn.Module -> 512-dim embedding.
+
+We convert ONLY the neural net (fbank-in -> embedding-out). fbank is computed on
+the host (torchaudio.compliance.kaldi.fbank, exactly mirroring modelscope's
+SpeakerVerificationCAMPPlus.__extract_feature) and fed identically to both the
+PyTorch and CoreML models. The app would compute the same fbank in Swift.
+
+The net takes a FIXED number of frames (default 300) so the trace has static
+shapes; the app windows/pads to that frame count.
+
+Outputs under scripts/out/:
+  - campplus.mlpackage     (the converted CoreML model)
+  - parity printed to stdout (PASS/PARTIAL/FAIL + cosine numbers)
+"""
+
+import os
+import sys
+import numpy as np
+import torch
+import torchaudio
+import torchaudio.compliance.kaldi as Kaldi
+
+MODEL_DIR = os.path.expanduser(
+    "~/.cache/modelscope/hub/models/iic/speech_campplus_sv_en_voxceleb_16k"
+)
+BIN = os.path.join(MODEL_DIR, "campplus_voxceleb.bin")
+AMI_WAV = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "data", "ami", "audio", "ES2002a.Mix-Headset.wav",
+)
+OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "out")
+os.makedirs(OUT_DIR, exist_ok=True)
+MLPACKAGE = os.path.join(OUT_DIR, "campplus.mlpackage")
+
+FEAT_DIM = 80
+EMB_SIZE = 512
+N_FRAMES = 300          # fixed trace length (~3s at 10ms hop)
+SR = 16000
+
+
+def build_torch_model():
+    from modelscope.models.audio.sv.DTDNN import CAMPPlus
+    m = CAMPPlus(feat_dim=FEAT_DIM, embedding_size=EMB_SIZE)
+    sd = torch.load(BIN, map_location="cpu")
+    miss, unexp = m.load_state_dict(sd, strict=True)
+    m.eval()
+    return m
+
+
+def fbank_from_audio(wav_1d: torch.Tensor) -> torch.Tensor:
+    """Mirror modelscope SpeakerVerificationCAMPPlus.__extract_feature exactly.
+    wav_1d: 1-D float tensor at 16kHz, range ~[-1,1] scaled to int16 magnitude
+    is what kaldi expects? modelscope passes the raw torchaudio.load output
+    (float [-1,1]) directly, so we do the same.
+    Returns (T, 80) after per-utterance mean subtraction over time."""
+    feat = Kaldi.fbank(wav_1d.unsqueeze(0), num_mel_bins=FEAT_DIM)
+    feat = feat - feat.mean(dim=0, keepdim=True)
+    return feat  # (T, 80)
+
+
+def load_segment(path, start_s, dur_s):
+    wav, sr = torchaudio.load(path)
+    if sr != SR:
+        wav = torchaudio.functional.resample(wav, sr, SR)
+    wav = wav[0]  # mono
+    a = int(start_s * SR)
+    b = int((start_s + dur_s) * SR)
+    return wav[a:b].contiguous()
+
+
+def fixed_frames(feat: torch.Tensor, n: int) -> torch.Tensor:
+    """Crop or pad (T,80) to exactly (n,80)."""
+    T = feat.shape[0]
+    if T >= n:
+        return feat[:n]
+    pad = torch.zeros(n - T, feat.shape[1])
+    return torch.cat([feat, pad], dim=0)
+
+
+def cosine(a, b):
+    a = a.flatten().astype(np.float64)
+    b = b.flatten().astype(np.float64)
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-12))
+
+
+def main():
+    print(f"[info] torch {torch.__version__}, torchaudio {torchaudio.__version__}")
+    import coremltools as ct
+    print(f"[info] coremltools {ct.__version__}")
+
+    print("[step] building + loading torch CAMPPlus ...")
+    model = build_torch_model()
+
+    # Example input for tracing: (1, N_FRAMES, 80)
+    example = torch.randn(1, N_FRAMES, FEAT_DIM)
+    with torch.no_grad():
+        ref_out = model(example)
+    print(f"[info] torch forward ok, emb shape {tuple(ref_out.shape)}")
+
+    print("[step] torch.jit.trace ...")
+    traced = torch.jit.trace(model, example)
+    traced.eval()
+    # sanity: traced == eager
+    with torch.no_grad():
+        t_out = traced(example)
+    trace_cos = cosine(ref_out.numpy(), t_out.numpy())
+    print(f"[info] trace vs eager cosine: {trace_cos:.6f}")
+
+    print("[step] coremltools.convert (mlprogram) ...")
+    mlmodel = ct.convert(
+        traced,
+        inputs=[ct.TensorType(name="fbank", shape=(1, N_FRAMES, FEAT_DIM),
+                              dtype=np.float32)],
+        outputs=[ct.TensorType(name="embedding", dtype=np.float32)],
+        convert_to="mlprogram",
+        compute_units=ct.ComputeUnit.ALL,
+        minimum_deployment_target=ct.target.macOS13,
+    )
+    mlmodel.save(MLPACKAGE)
+    sz = sum(
+        os.path.getsize(os.path.join(dp, f))
+        for dp, _, fs in os.walk(MLPACKAGE) for f in fs
+    ) / (1024 * 1024)
+    print(f"[ok] saved {MLPACKAGE}  ({sz:.2f} MB)")
+
+    # ------- parity on real AMI segments -------
+    print("[step] parity on real AMI clips ...")
+    segments = [(60.0, 4.0), (120.0, 3.5), (200.0, 5.0), (300.0, 4.0)]
+    cosines = []
+    for i, (st, du) in enumerate(segments):
+        wav = load_segment(AMI_WAV, st, du)
+        feat = fbank_from_audio(wav)            # (T,80)
+        feat = fixed_frames(feat, N_FRAMES)     # (N,80)
+        inp = feat.unsqueeze(0)                 # (1,N,80)
+
+        with torch.no_grad():
+            pt = model(inp).numpy()
+
+        cm = mlmodel.predict({"fbank": inp.numpy().astype(np.float32)})
+        # output name may be 'embedding' or auto; grab the single 512 vector
+        cm_key = "embedding" if "embedding" in cm else list(cm.keys())[0]
+        cm_out = np.asarray(cm[cm_key])
+
+        c = cosine(pt, cm_out)
+        # also report normalized embedding cosine (what's actually used for
+        # speaker matching) and max abs diff
+        def norm(x):
+            x = x.flatten()
+            return x / (np.linalg.norm(x) + 1e-12)
+        cn = cosine(norm(pt), norm(cm_out))
+        maxabs = float(np.max(np.abs(pt.flatten() - cm_out.flatten())))
+        cosines.append(c)
+        print(f"  seg{i} [{st:.0f}s+{du:.1f}s]: cosine={c:.6f} "
+              f"normcos={cn:.6f} maxabsdiff={maxabs:.5f}")
+
+    mn = min(cosines)
+    print(f"\n[summary] min cosine over {len(cosines)} segs: {mn:.6f}")
+    if mn > 0.99:
+        verdict = "PASS"
+    elif mn > 0.90:
+        verdict = "PARTIAL"
+    else:
+        verdict = "FAIL"
+    print(f"[verdict] {verdict} | model size {sz:.2f} MB | compute_units=ALL")
+    return verdict, mn, sz
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        print(f"\n[verdict] FAIL — conversion/parity blocked: {type(e).__name__}: {e}")
+        sys.exit(1)

--- a/scripts/convert_eres2net_coreml.py
+++ b/scripts/convert_eres2net_coreml.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""
+Convert the PRETRAINED Alibaba 3D-Speaker ERes2Net speaker-embedding model
+(modelscope iic/speech_eres2net_sv_en_voxceleb_16k) to Apple CoreML, and verify
+the converted model reproduces the PyTorch embeddings on real AMI audio.
+
+This is the decisive follow-up to scripts/convert_campplus_coreml.py: CAM++
+FAILED CoreML parity (cosine ~0.23) due to PRETRAINED-weight-specific tiny-
+variance BatchNorm (running_var min ~4.7e-6 -> ~260x amplification of converter
+rounding through its deep DenseTDNN stack). ERes2Net converted at cosine 1.0 on
+RANDOM weights, but that does NOT rule out the same pretrained-weight failure.
+So here we test the ACTUAL pretrained ERes2Net.
+
+Pipeline (mirrors modelscope SpeakerVerificationERes2Net.__extract_feature):
+  raw 16k audio -> kaldi fbank(80) -> per-utterance mean-subtract over time
+  -> ERes2Net nn.Module -> 192-dim embedding.
+We convert ONLY fbank-in -> embedding-out (host computes fbank, same as CAM++).
+
+ReLU patch: ERes2Net uses a custom ReLU = nn.Hardtanh(0, 20). coremltools has an
+int/float dtype bug lowering hardtanh's clip bounds -> conversion errors. We swap
+those for standard nn.ReLU before tracing (the cap at 20 effectively never fires;
+the official 3D-Speaker ONNX export does the same). This does NOT change outputs.
+
+Outputs under scripts/out/:
+  - eres2net_pretrained.mlpackage
+  - parity printed to stdout (PASS/FAIL + min/mean cosine)
+"""
+import os
+import sys
+import numpy as np
+import torch
+import torch.nn as nn
+import torchaudio
+import torchaudio.compliance.kaldi as Kaldi
+
+MODEL_DIR = os.path.expanduser(
+    "~/.cache/modelscope/hub/models/iic/speech_eres2net_sv_en_voxceleb_16k")
+CKPT = os.path.join(MODEL_DIR, "pretrained_eres2net.ckpt")
+AMI_WAV = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "data", "ami", "audio", "ES2002a.Mix-Headset.wav")
+EXAMPLES = os.path.join(MODEL_DIR, "examples")
+OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "out")
+os.makedirs(OUT_DIR, exist_ok=True)
+MLPACKAGE = os.path.join(OUT_DIR, "eres2net_pretrained.mlpackage")
+
+FEAT_DIM = 80
+EMB_DIM = 192
+CHANNELS = 32
+N_FRAMES = 300          # fixed trace length (~3s at 10ms hop)
+SR = 16000
+
+
+def build_torch_model(apply_relu_patch=True):
+    from modelscope.models.audio.sv.ERes2Net import ERes2Net
+    m = ERes2Net(feat_dim=FEAT_DIM, embed_dim=EMB_DIM, m_channels=CHANNELS)
+    sd = torch.load(CKPT, map_location="cpu")
+    miss, unexp = m.load_state_dict(sd, strict=True)
+    print(f"[info] load_state_dict strict=True: missing={len(miss)} unexpected={len(unexp)}")
+    m.eval()
+    if apply_relu_patch:
+        n = _patch_hardtanh(m)
+        print(f"[info] patched {n} Hardtanh->ReLU modules for CoreML export")
+    m.eval()
+    return m
+
+
+def _patch_hardtanh(module):
+    n = 0
+    for name, child in module.named_children():
+        if isinstance(child, nn.Hardtanh):
+            setattr(module, name, nn.ReLU())
+            n += 1
+        else:
+            n += _patch_hardtanh(child)
+    return n
+
+
+def fbank_from_audio(wav_1d):
+    """Mirror modelscope ERes2Net feature extraction exactly."""
+    feat = Kaldi.fbank(wav_1d.unsqueeze(0), num_mel_bins=FEAT_DIM)
+    feat = feat - feat.mean(dim=0, keepdim=True)
+    return feat  # (T, 80)
+
+
+def load_segment(path, start_s, dur_s):
+    wav, sr = torchaudio.load(path)
+    if sr != SR:
+        wav = torchaudio.functional.resample(wav, sr, SR)
+    wav = wav[0]
+    a = int(start_s * SR)
+    b = int((start_s + dur_s) * SR)
+    return wav[a:b].contiguous()
+
+
+def load_full(path):
+    wav, sr = torchaudio.load(path)
+    if sr != SR:
+        wav = torchaudio.functional.resample(wav, sr, SR)
+    return wav[0].contiguous()
+
+
+def fixed_frames(feat, n):
+    T = feat.shape[0]
+    if T >= n:
+        return feat[:n]
+    return torch.cat([feat, torch.zeros(n - T, feat.shape[1])], dim=0)
+
+
+def cosine(a, b):
+    a = a.flatten().astype(np.float64)
+    b = b.flatten().astype(np.float64)
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-12))
+
+
+def dirsize(p):
+    if os.path.isfile(p):
+        return os.path.getsize(p) / (1024 * 1024)
+    return sum(os.path.getsize(os.path.join(d, f))
+               for d, _, fs in os.walk(p) for f in fs) / (1024 * 1024)
+
+
+def emb_full_eager(model, path):
+    """Full-length embedding (no fixed crop) for speaker sanity check."""
+    feat = fbank_from_audio(load_full(path)).unsqueeze(0)
+    with torch.no_grad():
+        return model(feat).numpy()[0]
+
+
+def main():
+    import coremltools as ct
+    print(f"[info] torch {torch.__version__}, coremltools {ct.__version__}")
+
+    # Reference model: NO relu patch (pristine), for parity reference + BN probe.
+    print("[step] loading PRETRAINED ERes2Net (pristine) ...")
+    ref_model = build_torch_model(apply_relu_patch=False)
+
+    # ---- BN running_var probe (the CAM++ failure signature) ----
+    bn_mins = []
+    for name, mod in ref_model.named_modules():
+        if isinstance(mod, (nn.BatchNorm1d, nn.BatchNorm2d)):
+            rv = mod.running_var.detach().numpy()
+            bn_mins.append((name, float(rv.min()), float(rv.max()), mod.eps))
+    global_min = min(b[1] for b in bn_mins)
+    worst = min(bn_mins, key=lambda b: b[1])
+    print(f"[bn] {len(bn_mins)} BatchNorm layers")
+    print(f"[bn] global min running_var = {global_min:.3e}  "
+          f"(worst layer: {worst[0]}, 1/sqrt(var+eps) = "
+          f"{1.0/np.sqrt(worst[1]+worst[3]):.1f}x)")
+    print(f"[bn] CAM++ comparison: CAM++ min was 4.7e-6 (~260x) -> caused FAIL")
+
+    # ---- PyTorch speaker sanity ----
+    print("[step] PyTorch speaker sanity (example clips + AMI) ...")
+    w1 = os.path.join(EXAMPLES, "speaker1_a_en_16k.wav")
+    w2 = os.path.join(EXAMPLES, "speaker1_b_en_16k.wav")
+    w3 = os.path.join(EXAMPLES, "speaker2_a_en_16k.wav")
+    have_examples = all(os.path.exists(w) for w in (w1, w2, w3))
+    if have_examples:
+        e1 = emb_full_eager(ref_model, w1)
+        e2 = emb_full_eager(ref_model, w2)
+        e3 = emb_full_eager(ref_model, w3)
+        print(f"[sanity] example spk1_a vs spk1_b (SAME): {cosine(e1,e2):.4f}")
+        print(f"[sanity] example spk1_a vs spk2_a (DIFF): {cosine(e1,e3):.4f}")
+    # AMI same-vs-diff: two clips from the same recording's early region tend to
+    # share dominant speaker; just report a couple cross-segment cosines.
+    a = emb_full_eager(ref_model, AMI_WAV)
+    seg_a = fbank_from_audio(load_segment(AMI_WAV, 60.0, 4.0)).unsqueeze(0)
+    with torch.no_grad():
+        ea = ref_model(seg_a).numpy()[0]
+    print(f"[sanity] AMI full vs AMI 60s+4s segment: {cosine(a,ea):.4f}")
+
+    # ---- Build patched model for CoreML, verify patch is output-neutral ----
+    print("[step] applying ReLU patch + verifying output-neutral ...")
+    patched = build_torch_model(apply_relu_patch=True)
+    example = torch.randn(1, N_FRAMES, FEAT_DIM)
+    with torch.no_grad():
+        ref_out = ref_model(example).numpy()
+        patched_out = patched(example).numpy()
+    patch_cos = cosine(ref_out, patched_out)
+    print(f"[info] patched vs pristine PyTorch cosine: {patch_cos:.6f} "
+          f"(should be ~1.0; cap@20 rarely fires)")
+
+    # ---- Trace + convert ----
+    print("[step] torch.jit.trace + coremltools.convert (mlprogram) ...")
+    traced = torch.jit.trace(patched, example)
+    traced.eval()
+    mlmodel = ct.convert(
+        traced,
+        inputs=[ct.TensorType(name="fbank", shape=(1, N_FRAMES, FEAT_DIM),
+                              dtype=np.float32)],
+        outputs=[ct.TensorType(name="embedding", dtype=np.float32)],
+        convert_to="mlprogram",
+        compute_units=ct.ComputeUnit.ALL,
+        minimum_deployment_target=ct.target.macOS13,
+    )
+    mlmodel.save(MLPACKAGE)
+    sz = dirsize(MLPACKAGE)
+    print(f"[ok] saved {MLPACKAGE}  ({sz:.2f} MB)")
+
+    # ---- Parity on real AMI clips ----
+    print("[step] parity on real AMI clips (PyTorch vs CoreML, identical fbank) ...")
+    segments = [(60.0, 4.0), (120.0, 3.5), (200.0, 5.0), (300.0, 4.0),
+                (450.0, 3.0), (600.0, 4.5)]
+    cosines = []
+    for i, (st, du) in enumerate(segments):
+        feat = fixed_frames(fbank_from_audio(load_segment(AMI_WAV, st, du)),
+                            N_FRAMES).unsqueeze(0)
+        # PyTorch reference uses the PRISTINE model (patch is output-neutral, but
+        # be strict and compare CoreML against the unmodified model).
+        with torch.no_grad():
+            pt = ref_model(feat).numpy()
+        out = mlmodel.predict({"fbank": feat.numpy().astype(np.float32)})
+        k = "embedding" if "embedding" in out else list(out.keys())[0]
+        cm = np.asarray(out[k])
+        c = cosine(pt, cm)
+        maxabs = float(np.max(np.abs(pt.flatten() - cm.flatten())))
+        cosines.append(c)
+        print(f"  seg{i} [{st:.0f}s+{du:.1f}s]: cosine={c:.6f} maxabsdiff={maxabs:.5f}")
+
+    mn, mean = min(cosines), float(np.mean(cosines))
+    print(f"\n[summary] cosine over {len(cosines)} segs: min={mn:.6f} mean={mean:.6f}")
+    verdict = "PASS" if mn > 0.99 else ("PARTIAL" if mn > 0.90 else "FAIL")
+    print(f"[verdict] {verdict} | min cosine {mn:.6f} | mean {mean:.6f} | "
+          f"size {sz:.2f} MB | BN min running_var {global_min:.3e} | "
+          f"compute_units=ALL")
+    return verdict, mn, mean, sz, global_min
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        import traceback
+        traceback.print_exc()
+        print(f"\n[verdict] FAIL — conversion/parity blocked: {type(e).__name__}: {e}")
+        sys.exit(1)

--- a/scripts/csv2rttm.py
+++ b/scripts/csv2rttm.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Turn a simple speaker-label CSV into the RTTM the eval expects.
+CSV columns (header required): start,end,speaker   (seconds; speaker = any stable name/id)
+  e.g.   0.0,4.2,alice
+         4.2,9.8,bob
+Usage: python3 scripts/csv2rttm.py labels.csv NAME > ground_truth.rttm
+"""
+import csv, sys
+
+if len(sys.argv) < 3:
+    sys.exit("usage: csv2rttm.py <labels.csv> <recording_name>")
+name = sys.argv[2]
+for r in csv.DictReader(open(sys.argv[1])):
+    s, e, spk = float(r["start"]), float(r["end"]), r["speaker"].strip()
+    print(f"SPEAKER {name} 1 {s:.3f} {e - s:.3f} <NA> <NA> {spk} <NA> <NA>")

--- a/scripts/dev/run_online_centering_sweep.sh
+++ b/scripts/dev/run_online_centering_sweep.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Online-centering estimator sweep (measurement only — additive, no app code touched).
+# Q2: does a better ONLINE/causal centering approach the oracle 'global'?
+# For opus12k & opus8k: running EMA at alpha in {0.005,0.01,0.02} + frozen-warmup.
+# center -> replay (match 0.55/0.60/0.65) -> score -> bands. Outputs to a tmp tree.
+set -uo pipefail
+ROOT="/Users/redbars/transcripted/.claude/worktrees/objective-noyce-06bac2"
+BIN="$ROOT/Tools/SpeakerEvalHarness/.build/release/speaker-eval-harness"
+RTTM="$ROOT/data/ami/rttm"
+TMP="$ROOT/data/eval/_online_sweep"
+ARMS="opus12k opus8k"
+MATCH="0.55 0.60 0.65"
+
+run_cfg () {
+  local arm="$1" label="$2" mode="$3" alpha="$4"
+  local IN="$ROOT/data/eval/ami_$arm/dumps"
+  local OUT="$TMP/${arm}__${label}"
+  mkdir -p "$OUT/dumps" "$OUT/results" "$OUT/reports"
+  echo "############ $arm / $label (mode=$mode alpha=$alpha) ############"
+  if [ "$mode" = "running" ]; then
+    python3 "$ROOT/scripts/center_dumps.py" --in-dumps "$IN" --out-dumps "$OUT/dumps" --mode running --alpha "$alpha" || { echo "center failed"; return; }
+  else
+    python3 "$ROOT/scripts/center_dumps.py" --in-dumps "$IN" --out-dumps "$OUT/dumps" --mode "$mode" || { echo "center failed"; return; }
+  fi
+  local INPUTS
+  INPUTS="$(ls "$OUT"/dumps/*.json | sort | tr '\n' ',' | sed 's/,$//')"
+  for mt in $MATCH; do
+    "$BIN" replay --inputs "$INPUTS" --consolidation none --match "$mt" \
+      --out "$OUT/results/match_$mt.json" 2>&1 | grep -vE "\.pcm|while processing" | tail -1
+    python3 "$ROOT/scripts/score_speaker_eval.py" --result "$OUT/results/match_$mt.json" \
+      --rttm-dir "$RTTM" --out-json "$OUT/reports/cons_none_match_$mt.json" >/dev/null 2>&1
+  done
+  python3 "$ROOT/scripts/analyze_ami_codec_bands.py" --dumps "$OUT/dumps" --rttm-dir "$RTTM" \
+    --tag "${arm}_${label}" --out-json "$OUT/reports/bands.json" >/dev/null 2>&1
+  echo "### $arm/$label done"
+}
+
+for arm in $ARMS; do
+  run_cfg "$arm" "running_a0.005" running 0.005
+  run_cfg "$arm" "running_a0.01"  running 0.01
+  run_cfg "$arm" "running_a0.02"  running 0.02
+  run_cfg "$arm" "frozen"         frozen  0
+done
+echo "### ONLINE CENTERING SWEEP DONE"

--- a/scripts/download_ami.sh
+++ b/scripts/download_ami.sh
@@ -1,20 +1,69 @@
 #!/bin/bash
-# Download AMI ES2002 scenario series (a/b/c/d) — Mix-Headset audio + ground-truth RTTMs.
+# Download AMI Meeting Corpus subsets — Mix-Headset audio + ground-truth RTTMs.
+#
 # AMI Meeting Corpus: research-use license (https://groups.inf.ed.ac.uk/ami/corpus/).
-# Internal eval only — NOT redistributed. Everything lands under data/ami/ (gitignored).
+# Ground-truth RTTMs: pyannote/AMI-diarization-setup `only_words` set
+# (https://github.com/pyannote/AMI-diarization-setup, MIT-licensed tooling over the
+# AMI annotations). Internal eval only — NOT redistributed. Everything lands under
+# data/ami/ (gitignored).
+#
+# AMI speaker IDs are GLOBALLY UNIQUE per real person (FEE005, MEE006, ...). Within a
+# scenario series the same 4 people recur across sessions a–d; different series are
+# different people. So a multi-series pull yields many distinct *recurring* identities
+# — ideal for the cross-meeting re-ID / false-positive test.
+#
+# Usage:
+#   scripts/download_ami.sh                 # default: ES2002 a–d  (4 meetings, 1 group)
+#   scripts/download_ami.sh scale           # 8 scenario series   (~32 meetings, ~32 ids)
+#   scripts/download_ami.sh full            # ALL scenario+non-scenario (~170 meetings, ~100h)
+#   scripts/download_ami.sh ES2002a ES2003a # explicit meeting ids
+#   AMI_SET=scale scripts/download_ami.sh   # same via env
+#
+# Compute/footprint guide (Mix-Headset 16 kHz mono ≈ 1.7 MB/audio-min):
+#   default  4 meetings  ~230 MB   download minutes
+#   scale   32 meetings  ~1.8 GB   download ~tens of min on the Edinburgh mirror
+#   full   ~170 meetings ~9–10 GB  download HOURS — gated heavy tier, do not run blind
 set -euo pipefail
 cd "$(dirname "$0")/.."
 DEST="data/ami"
 mkdir -p "$DEST/audio" "$DEST/rttm"
-SERIES="${1:-ES2002a ES2002b ES2002c ES2002d}"
+
 AUDIO_BASE="http://groups.inf.ed.ac.uk/ami/AMICorpusMirror/amicorpus"
-RTTM_BASE="https://raw.githubusercontent.com/pyannote/AMI-diarization-setup/main/only_words/rttms/train"
-for m in $SERIES; do
-  echo "[ami] $m audio..."
-  curl -fsSL --retry 3 -o "$DEST/audio/$m.Mix-Headset.wav" "$AUDIO_BASE/$m/audio/$m.Mix-Headset.wav"
-  echo "[ami] $m rttm..."
-  curl -fsSL --retry 3 -o "$DEST/rttm/$m.rttm" "$RTTM_BASE/$m.rttm" \
-    || curl -fsSL --retry 3 -o "$DEST/rttm/$m.rttm" "${RTTM_BASE/train/dev}/$m.rttm"
+RTTM_BASE="https://raw.githubusercontent.com/pyannote/AMI-diarization-setup/main/only_words/rttms"
+LIST_BASE="https://raw.githubusercontent.com/pyannote/AMI-diarization-setup/main/lists"
+
+# ---- resolve the meeting set ---------------------------------------------------------
+expand_series() { for s in "$@"; do for x in a b c d; do printf '%s%s ' "$s" "$x"; done; done; }
+
+ARG="${1:-${AMI_SET:-es2002}}"
+case "$ARG" in
+  es2002)  MEETINGS="ES2002a ES2002b ES2002c ES2002d" ;;
+  # 8 train-split scenario series, 4 disjoint people each -> ~32 distinct recurring ids.
+  scale)   MEETINGS="$(expand_series ES2002 ES2003 ES2005 ES2006 ES2007 ES2008 ES2009 ES2010)" ;;
+  # Everything pyannote ships RTTMs for (train+dev+test), scenario + non-scenario.
+  full)    MEETINGS="$(for sp in train dev test; do \
+              curl -fsSL "$LIST_BASE/$sp.meetings.txt"; done | tr '\n' ' ')" ;;
+  *)       MEETINGS="$*" ;;   # explicit meeting ids
+esac
+
+echo "[ami] set='$ARG' -> $(echo "$MEETINGS" | wc -w | tr -d ' ') meeting(s)"
+
+# ---- fetch -----------------------------------------------------------------------------
+for m in $MEETINGS; do
+  wav="$DEST/audio/$m.Mix-Headset.wav"
+  rttm="$DEST/rttm/$m.rttm"
+  if [ ! -s "$wav" ]; then
+    echo "[ami] $m audio..."
+    curl -fsSL --retry 3 -o "$wav" "$AUDIO_BASE/$m/audio/$m.Mix-Headset.wav" \
+      || { echo "[ami] !! audio fetch failed for $m" >&2; rm -f "$wav"; }
+  fi
+  if [ ! -s "$rttm" ]; then
+    echo "[ami] $m rttm..."
+    fetched=0
+    for sp in train dev test; do
+      if curl -fsSL --retry 3 -o "$rttm" "$RTTM_BASE/$sp/$m.rttm" 2>/dev/null; then fetched=1; break; fi
+    done
+    [ "$fetched" = 1 ] || { echo "[ami] !! rttm not found for $m in train/dev/test" >&2; rm -f "$rttm"; }
+  fi
 done
-echo "[ami] done."
-ls -la "$DEST/audio" "$DEST/rttm"
+echo "[ami] done: $(ls "$DEST/audio" | wc -l | tr -d ' ') audio, $(ls "$DEST/rttm" | wc -l | tr -d ' ') rttm under $DEST"

--- a/scripts/download_icsi.sh
+++ b/scripts/download_icsi.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Download ICSI Meeting Corpus subsets — interaction-mix audio + ground-truth RTTMs.
+#
+# ICSI Meeting Corpus: research-use license (https://groups.inf.ed.ac.uk/ami/icsi/,
+# license at .../icsi/license.shtml). 75 meetings of the same lab's research groups, so
+# speakers RECUR heavily across meetings (global IDs like mn005/fe008) — a strong
+# cross-meeting re-ID surface with real, varied identities. NOT redistributed.
+# Everything lands under data/icsi/ (gitignored).
+#
+#   - Audio : Edinburgh ICSIsignals mirror, beamformed interaction mix (no auth).
+#             https://groups.inf.ed.ac.uk/ami/ICSIsignals/NXT/<MTG>.interaction.wav
+#   - RTTMs : HF dataset `diarizers-community/icsi` (diarization-ready ground truth).
+#             GATED: needs `huggingface-cli login` + accepting the dataset terms, plus
+#             `pip install datasets soundfile`. Materialized to loose <MTG>.rttm by
+#             scripts/icsi_rttm_from_hf.py.
+#
+# GATED HEAVY TIER — interaction WAVs are ~70–190 MB each (long meetings). Wire it,
+# don't run it blind. One-liners:
+#   scripts/download_icsi.sh                       # default 6-meeting sample
+#   ICSI_SET="Bmr001 Bmr002 Bmr005 Bro003 Bro004"  scripts/download_icsi.sh
+#   ICSI_SET=full scripts/download_icsi.sh         # all 75 meetings (~10 GB)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+DEST="data/icsi"
+mkdir -p "$DEST/audio" "$DEST/rttm"
+
+AUDIO_BASE="https://groups.inf.ed.ac.uk/ami/ICSIsignals/NXT"
+
+# Default sample: two Bmr-series + Bro/Bed/Bns/Btr meetings — overlapping attendee pools
+# so the same researchers recur across recordings.
+DEFAULT_SAMPLE="Bmr001 Bmr002 Bro003 Bed002 Bns001 Btr001"
+# The 75-meeting ICSI list (Bdb/Bed/Bmr/Bns/Bro/Bsr/Btr/Buw families).
+FULL_LIST="Bdb001 Bed002 Bed003 Bed004 Bed005 Bed006 Bed008 Bed009 Bed010 Bed011 Bed012 \
+Bed013 Bed014 Bed015 Bed016 Bed017 Bmr001 Bmr002 Bmr003 Bmr005 Bmr006 Bmr007 Bmr008 Bmr009 \
+Bmr010 Bmr011 Bmr012 Bmr013 Bmr014 Bmr015 Bmr016 Bmr018 Bmr019 Bmr020 Bmr021 Bmr022 Bmr023 \
+Bmr024 Bmr025 Bmr026 Bmr027 Bmr029 Bmr030 Bmr031 Bns001 Bns002 Bns003 Bro003 Bro004 Bro005 \
+Bro007 Bro008 Bro010 Bro011 Bro012 Bro013 Bro014 Bro015 Bro016 Bro017 Bro018 Bro019 Bro021 \
+Bro022 Bro023 Bro024 Bro025 Bro026 Bro027 Bro028 Bsr001 Btr001 Btr002 Buw001"
+
+ARG="${1:-${ICSI_SET:-sample}}"
+case "$ARG" in
+  sample) MEETINGS="$DEFAULT_SAMPLE" ;;
+  full)   MEETINGS="$FULL_LIST" ;;
+  *)      MEETINGS="$*" ;;
+esac
+echo "[icsi] set='$ARG' -> $(echo "$MEETINGS" | wc -w | tr -d ' ') meeting(s)"
+
+for m in $MEETINGS; do
+  wav="$DEST/audio/$m.wav"
+  if [ ! -s "$wav" ]; then
+    echo "[icsi] $m audio..."
+    curl -fsSL --retry 3 -o "$wav" "$AUDIO_BASE/$m.interaction.wav" \
+      || { echo "[icsi] !! audio fetch failed for $m" >&2; rm -f "$wav"; }
+  fi
+done
+
+echo "[icsi] materializing RTTMs from HF diarizers-community/icsi (needs HF auth + datasets)..."
+python3 scripts/icsi_rttm_from_hf.py --out-dir "$DEST/rttm" --meetings "$MEETINGS" \
+  || echo "[icsi] !! RTTM step skipped/failed — see scripts/icsi_rttm_from_hf.py header for auth setup" >&2
+
+echo "[icsi] done: $(ls "$DEST/audio" 2>/dev/null | wc -l | tr -d ' ') audio, $(ls "$DEST/rttm" 2>/dev/null | wc -l | tr -d ' ') rttm under $DEST"

--- a/scripts/download_voxceleb_sample.sh
+++ b/scripts/download_voxceleb_sample.sh
@@ -1,40 +1,53 @@
 #!/bin/bash
-# SAMPLE-ONLY VoxCeleb1 fetch + synthetic multi-identity session build.
+# SAMPLE-ONLY VoxCeleb1 fetch + multi-identity "session" build for the speaker-DB test.
 #
 # VoxCeleb1: CC-BY-SA 4.0 (https://www.robots.ox.ac.uk/~vgg/data/voxceleb/). ~1200
-# identities — we NEVER pull all of it. This streams a HF mirror and stops at a HARD CAP
-# of distinct identities, then stitches them into conversational sessions with exact RTTMs
-# for the cross-recording re-ID / false-positive test. Everything under data/voxceleb/
-# (gitignored).
+# identities — we NEVER pull all of it. This STREAMS a HF mirror and stops at a HARD CAP
+# of distinct identities. Default mirror `s3prl/mini_voxceleb1` is PUBLIC (no HF login);
+# point VOXCELEB_DATASET at a larger/gated mirror to exceed mini's identity count.
+# Everything under data/voxceleb/ (gitignored).
 #
-# GATED TIER — VoxCeleb on HF is access-gated: `huggingface-cli login` (or HF_TOKEN) +
-# accept terms, and `pip install datasets soundfile`. Footprint is bounded by the cap
-# (default 300 ids × 10 clips ≈ a few GB streamed, NOT the full ~30 GB corpus).
+# Needs `pip install datasets` + `ffmpeg` (audio read via fsspec, transcoded by ffmpeg —
+# no torch/soundfile). Footprint bounded by the cap, NOT the full ~30 GB corpus.
+#
+# MODE (why singles is the default): `singles` makes each clip its own single-speaker
+# "meeting", so the diarizer trivially sees one clean voice and the eval isolates the DB
+# MATCHER (cross-recording re-ID / false-positive). `sessions` stitches clips into
+# multi-speaker recordings — more realistic, but it routes through the diarizer, whose
+# under-segmentation then dominates the metric (measured: it collapses 4 voices to 1–2
+# clusters), re-introducing the AMI confound. Use singles to test the matcher; sessions
+# to stress the whole pipeline.
 #
 # Env knobs:
 #   VOXCELEB_IDENTITY_CAP   distinct identities to sample (default 300; HARD CAP, max 1211)
 #   VOXCELEB_CLIPS_PER_ID   clips kept per identity (default 10)
-#   VOXCELEB_SESSIONS       synthetic sessions to build (default 20)
-#   VOXCELEB_SPK_PER_SESS   identities per session (default 4)
+#   VOXCELEB_DATASET        HF mirror (default s3prl/mini_voxceleb1, public)
+#   VOXCELEB_MODE           singles | sessions (default singles)
+#   VOXCELEB_SESSIONS       sessions-mode: # sessions to build (default 20)
+#   VOXCELEB_SPK_PER_SESS   sessions-mode: identities per session (default 4)
 #
 # One-liner:
-#   scripts/download_voxceleb_sample.sh
-#   VOXCELEB_IDENTITY_CAP=50 scripts/download_voxceleb_sample.sh   # tiny smoke sample
+#   scripts/download_voxceleb_sample.sh                              # 300-cap, singles
+#   VOXCELEB_IDENTITY_CAP=6 scripts/download_voxceleb_sample.sh      # tiny smoke sample
+#   VOXCELEB_MODE=sessions scripts/download_voxceleb_sample.sh       # multi-speaker sessions
 set -euo pipefail
 cd "$(dirname "$0")/.."
 DEST="data/voxceleb"
 RAW="$DEST/raw"
 CAP="${VOXCELEB_IDENTITY_CAP:-300}"
 CLIPS="${VOXCELEB_CLIPS_PER_ID:-10}"
+DATASET="${VOXCELEB_DATASET:-s3prl/mini_voxceleb1}"
+MODE="${VOXCELEB_MODE:-singles}"
 SESSIONS="${VOXCELEB_SESSIONS:-20}"
 SPK="${VOXCELEB_SPK_PER_SESS:-4}"
 
-echo "[voxceleb] HARD CAP = $CAP identities × $CLIPS clips (sample-only; never the full corpus)"
+echo "[voxceleb] HARD CAP = $CAP identities × $CLIPS clips from $DATASET (sample-only; never the full corpus)"
 python3 scripts/voxceleb_sample.py --out-dir "$RAW" \
-  --identity-cap "$CAP" --clips-per-id "$CLIPS"
+  --identity-cap "$CAP" --clips-per-id "$CLIPS" --dataset "$DATASET"
 
-echo "[voxceleb] building $SESSIONS synthetic sessions ($SPK identities each)..."
+echo "[voxceleb] building '$MODE' meetings..."
 python3 scripts/build_voxceleb_sessions.py --raw-dir "$RAW" \
-  --out-dir "$DEST/sessions" --num-sessions "$SESSIONS" --speakers-per-session "$SPK"
+  --out-dir "$DEST/sessions" --mode "$MODE" \
+  --num-sessions "$SESSIONS" --speakers-per-session "$SPK"
 
-echo "[voxceleb] done: sessions under $DEST/sessions (audio/ + rttm/)"
+echo "[voxceleb] done: meetings under $DEST/sessions (audio/ + rttm/). Run: CORPUS=voxceleb scripts/run_speaker_eval.sh"

--- a/scripts/download_voxceleb_sample.sh
+++ b/scripts/download_voxceleb_sample.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# SAMPLE-ONLY VoxCeleb1 fetch + synthetic multi-identity session build.
+#
+# VoxCeleb1: CC-BY-SA 4.0 (https://www.robots.ox.ac.uk/~vgg/data/voxceleb/). ~1200
+# identities — we NEVER pull all of it. This streams a HF mirror and stops at a HARD CAP
+# of distinct identities, then stitches them into conversational sessions with exact RTTMs
+# for the cross-recording re-ID / false-positive test. Everything under data/voxceleb/
+# (gitignored).
+#
+# GATED TIER — VoxCeleb on HF is access-gated: `huggingface-cli login` (or HF_TOKEN) +
+# accept terms, and `pip install datasets soundfile`. Footprint is bounded by the cap
+# (default 300 ids × 10 clips ≈ a few GB streamed, NOT the full ~30 GB corpus).
+#
+# Env knobs:
+#   VOXCELEB_IDENTITY_CAP   distinct identities to sample (default 300; HARD CAP, max 1211)
+#   VOXCELEB_CLIPS_PER_ID   clips kept per identity (default 10)
+#   VOXCELEB_SESSIONS       synthetic sessions to build (default 20)
+#   VOXCELEB_SPK_PER_SESS   identities per session (default 4)
+#
+# One-liner:
+#   scripts/download_voxceleb_sample.sh
+#   VOXCELEB_IDENTITY_CAP=50 scripts/download_voxceleb_sample.sh   # tiny smoke sample
+set -euo pipefail
+cd "$(dirname "$0")/.."
+DEST="data/voxceleb"
+RAW="$DEST/raw"
+CAP="${VOXCELEB_IDENTITY_CAP:-300}"
+CLIPS="${VOXCELEB_CLIPS_PER_ID:-10}"
+SESSIONS="${VOXCELEB_SESSIONS:-20}"
+SPK="${VOXCELEB_SPK_PER_SESS:-4}"
+
+echo "[voxceleb] HARD CAP = $CAP identities × $CLIPS clips (sample-only; never the full corpus)"
+python3 scripts/voxceleb_sample.py --out-dir "$RAW" \
+  --identity-cap "$CAP" --clips-per-id "$CLIPS"
+
+echo "[voxceleb] building $SESSIONS synthetic sessions ($SPK identities each)..."
+python3 scripts/build_voxceleb_sessions.py --raw-dir "$RAW" \
+  --out-dir "$DEST/sessions" --num-sessions "$SESSIONS" --speakers-per-session "$SPK"
+
+echo "[voxceleb] done: sessions under $DEST/sessions (audio/ + rttm/)"

--- a/scripts/download_voxconverse.sh
+++ b/scripts/download_voxconverse.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Download VoxConverse (in-the-wild multi-speaker diarization) — audio + ground-truth RTTMs.
+#
+# VoxConverse: CC-BY 4.0 (https://www.robots.ox.ac.uk/~vgg/data/voxconverse/).
+#   - Audio  : official KAIST mirror, dev + test WAV zips.
+#   - RTTMs  : github.com/joonson/voxconverse (dev/ + test/ .rttm).
+# In-the-wild YouTube audio: overlapping speech, varied recording conditions, unknown
+# speaker counts — the hardest diarizer stress + a clean re-ID/false-positive surface.
+# Everything lands under data/voxconverse/ (gitignored).
+#
+# GATED HEAVY TIER — ~4 GB download. Wire it, don't run it blind. One-liner:
+#   scripts/download_voxconverse.sh            # dev (216 files) + test (232 files)
+#   VOXCONVERSE_SPLITS="dev" scripts/download_voxconverse.sh   # dev only (~2 GB)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+DEST="data/voxconverse"
+mkdir -p "$DEST/audio" "$DEST/rttm" "$DEST/_tmp"
+
+SPLITS="${VOXCONVERSE_SPLITS:-dev test}"
+AUDIO_BASE="https://mm.kaist.ac.kr/datasets/voxconverse/data"
+RTTM_TARBALL="https://github.com/joonson/voxconverse/archive/refs/heads/master.tar.gz"
+
+echo "[vox] fetching ground-truth RTTMs (joonson/voxconverse)..."
+curl -fsSL --retry 3 -o "$DEST/_tmp/vc.tar.gz" "$RTTM_TARBALL"
+tar -xzf "$DEST/_tmp/vc.tar.gz" -C "$DEST/_tmp"
+for sp in $SPLITS; do
+  if [ -d "$DEST/_tmp/voxconverse-master/$sp" ]; then
+    cp "$DEST/_tmp/voxconverse-master/$sp"/*.rttm "$DEST/rttm/" 2>/dev/null || true
+  fi
+done
+echo "[vox] rttm files: $(ls "$DEST/rttm" | wc -l | tr -d ' ')"
+
+for sp in $SPLITS; do
+  zip="$DEST/_tmp/voxconverse_${sp}_wav.zip"
+  echo "[vox] $sp audio zip..."
+  curl -fsSL --retry 3 -o "$zip" "$AUDIO_BASE/voxconverse_${sp}_wav.zip"
+  echo "[vox] $sp extracting..."
+  unzip -oq "$zip" -d "$DEST/_tmp/${sp}_extract"
+  # zips extract to .../audio/<id>.wav — flatten into data/voxconverse/audio/
+  find "$DEST/_tmp/${sp}_extract" -name '*.wav' -exec cp {} "$DEST/audio/" \;
+done
+
+rm -rf "$DEST/_tmp"
+echo "[vox] done: $(ls "$DEST/audio" | wc -l | tr -d ' ') audio, $(ls "$DEST/rttm" | wc -l | tr -d ' ') rttm under $DEST"

--- a/scripts/download_voxconverse.sh
+++ b/scripts/download_voxconverse.sh
@@ -32,8 +32,18 @@ echo "[vox] rttm files: $(ls "$DEST/rttm" | wc -l | tr -d ' ')"
 
 for sp in $SPLITS; do
   zip="$DEST/_tmp/voxconverse_${sp}_wav.zip"
-  echo "[vox] $sp audio zip..."
-  curl -fsSL --retry 3 -o "$zip" "$AUDIO_BASE/voxconverse_${sp}_wav.zip"
+  url="$AUDIO_BASE/voxconverse_${sp}_wav.zip"
+  echo "[vox] $sp audio zip (resumable; KAIST mirror drops mid-transfer)..."
+  # The mirror frequently closes the connection mid-stream (curl exit 18). Resume the
+  # partial with -C - until the local size reaches the server's Content-Length.
+  target="$(curl -fsSLI "$url" 2>/dev/null | awk 'tolower($1)=="content-length:"{print $2}' | tr -d '\r' | tail -1)"
+  for _ in $(seq 1 60); do
+    have=$(stat -f%z "$zip" 2>/dev/null || stat -c%s "$zip" 2>/dev/null || echo 0)
+    if [ -n "$target" ] && [ "$have" -ge "$target" ] 2>/dev/null; then break; fi
+    curl -fsSL -C - --retry 8 --retry-delay 3 --connect-timeout 30 --speed-time 60 --speed-limit 1024 \
+         -o "$zip" "$url" && [ -z "$target" ] && break
+    sleep 2
+  done
   echo "[vox] $sp extracting..."
   unzip -oq "$zip" -d "$DEST/_tmp/${sp}_extract"
   # zips extract to .../audio/<id>.wav — flatten into data/voxconverse/audio/

--- a/scripts/extract_embeddings.py
+++ b/scripts/extract_embeddings.py
@@ -123,6 +123,7 @@ def main():
                     help="ecapa|xvect|resnet|wavlm|unisat|redimnet[_b6]|campplus|eres2net")
     ap.add_argument("--base-dumps", default=None, help="dumps for segment timings (default data/eval/ami_<arm>/dumps)")
     ap.add_argument("--clean-audio", default="data/ami/audio")
+    ap.add_argument("--audio", default=None, help="use this wav directly for ALL base dumps (generic/Zoom mode; skips AMI codec regen)")
     ap.add_argument("--out-dir", default=None)
     ap.add_argument("--max-sec", type=float, default=20.0)
     ap.add_argument("--batch", type=int, default=24)
@@ -142,13 +143,16 @@ def main():
             if os.path.exists(outf):
                 continue
             d = json.load(open(f))
-            clean = os.path.join(args.clean_audio, f"{m}.Mix-Headset.wav")
-            wavp = regen_audio(args.arm, clean, os.path.join(td, f"{m}.wav"))
+            if args.audio:                       # generic mode: use the given wav directly
+                wavp = args.audio
+            else:
+                clean = os.path.join(args.clean_audio, f"{m}.Mix-Headset.wav")
+                wavp = regen_audio(args.arm, clean, os.path.join(td, f"{m}.wav"))
             audio, sr = sf.read(wavp)
             if audio.ndim > 1:
                 audio = audio.mean(axis=1)
             audio = audio.astype(np.float32)
-            if args.arm != "clean":
+            if not args.audio and args.arm != "clean":
                 os.remove(wavp)
             segs = d["segments"]
             clips = []

--- a/scripts/extract_embeddings.py
+++ b/scripts/extract_embeddings.py
@@ -70,16 +70,15 @@ class Embedder:
             mn = model.split("_", 1)[1] if "_" in model else "b6"
             self.net = torch.hub.load("IDRnD/ReDimNet", "ReDimNet", model_name=mn,
                                       train_type="ft_lm", dataset="vox2", verbose=False).to(device).eval()
-        elif model.startswith("campplus") or model.startswith("eres2net") or model.startswith("wspk"):
-            self.kind = "wespeaker"; self.device = device
-            import wespeaker
-            preset = {"campplus": "campplus", "eres2net": "eres2net"}.get(model.split("_")[0], "campplus")
-            # wespeaker hub names; fall back to english ResNet if preset missing
-            try:
-                self.ws = wespeaker.load_model_local(f".venv_emb/wespeaker_{model}")
-            except Exception:
-                self.ws = wespeaker.load_model("english")
-            self.ws.set_device(device)
+        elif model in ("campplus", "eres2net", "eres2netv2"):
+            # 3D-Speaker (Alibaba) models via modelscope — handles the kaldi-fbank front-end
+            # correctly (hand-rolling it risks garbage embeddings). Runs on CPU.
+            self.kind = "modelscope"; self.device = "cpu"
+            from modelscope.pipelines import pipeline
+            mid = {"campplus": "iic/speech_campplus_sv_en_voxceleb_16k",
+                   "eres2net": "iic/speech_eres2net_sv_en_voxceleb_16k",
+                   "eres2netv2": "iic/speech_eres2netv2_sv_en_voxceleb_16k"}[model]
+            self.sv = pipeline(task="speaker-verification", model=mid)
         else:
             raise SystemExit(f"unknown model {model}")
 
@@ -104,12 +103,15 @@ class Embedder:
             emb = self.net(batch.to(self.device))
             if isinstance(emb, (tuple, list)):
                 emb = emb[0]
-        elif self.kind == "wespeaker":
-            embs = []
-            for w in wavs:
-                t = torch.from_numpy(w).unsqueeze(0)
-                embs.append(torch.as_tensor(self.ws.extract_embedding_from_pcm(t, SR)))
-            emb = torch.stack(embs)
+        elif self.kind == "modelscope":
+            wl = [w.astype("float32") for w in wavs]
+            try:
+                arr = np.array(self.sv(wl, output_emb=True)["embs"])
+                if arr.shape[0] != len(wl):
+                    raise ValueError("batch size mismatch")
+            except Exception:
+                arr = np.array([self.sv([w], output_emb=True)["embs"][0] for w in wl])
+            emb = torch.from_numpy(arr).float()
         emb = torch.nn.functional.normalize(emb, dim=-1)
         return emb.detach().cpu().float().numpy()
 

--- a/scripts/extract_embeddings.py
+++ b/scripts/extract_embeddings.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+"""Re-extract speaker embeddings for the EXACT AMI dump segments with an alternative model
+(measurement only — runs in the .venv_emb venv; writes drop-in dumps the existing analysis
+scripts consume unchanged). Tests whether a stronger / codec-robust embedding model breaks
+the within-meeting separability floor that WeSpeaker hits.
+
+For an arm it regenerates the codec-degraded audio from the clean AMI wav (same ffmpeg
+recipe as run_ami_codec_sweep.sh), slices at each baseline dump segment's [start,end], runs
+the chosen model, and writes data/eval/ami_<arm>__<model>/dumps/<meeting>.json with the SAME
+schema (speakerId/start/end/quality preserved; only `embedding` swapped). Same segmentation,
+same time spans -> a clean apples-to-apples embedding-model comparison.
+
+Models (public, non-gated):
+  ecapa  speechbrain/spkrec-ecapa-voxceleb           (192-d ECAPA-TDNN)
+  xvect  speechbrain/spkrec-xvect-voxceleb           (512-d x-vector; weaker control)
+  resnet speechbrain/spkrec-resnet-voxceleb          (256-d ResNet)
+  wavlm  microsoft/wavlm-base-plus-sv (transformers) (512-d SSL XVector head; robustness candidate)
+"""
+import argparse, glob, json, os, subprocess, sys, tempfile
+import numpy as np
+import soundfile as sf
+import torch
+
+SR = 16000
+FF = ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y"]
+
+
+def regen_audio(arm, clean_wav, out_wav):
+    if arm == "clean":
+        return clean_wav
+    if arm.startswith("opus"):
+        br = arm[len("opus"):]
+        tmp = out_wav + ".opus"
+        subprocess.run(FF + ["-i", clean_wav, "-c:a", "libopus", "-b:a", br, "-ar", "16000", "-ac", "1", tmp], check=True)
+        subprocess.run(FF + ["-i", tmp, "-ar", "16000", "-ac", "1", "-c:a", "pcm_s16le", out_wav], check=True)
+        os.remove(tmp)
+    elif arm == "g711u":
+        tmp = out_wav + ".mu.wav"
+        subprocess.run(FF + ["-i", clean_wav, "-ar", "8000", "-ac", "1", "-c:a", "pcm_mulaw", tmp], check=True)
+        subprocess.run(FF + ["-i", tmp, "-ar", "16000", "-ac", "1", "-c:a", "pcm_s16le", out_wav], check=True)
+        os.remove(tmp)
+    else:
+        raise SystemExit(f"unknown arm {arm}")
+    return out_wav
+
+
+class Embedder:
+    def __init__(self, model, device):
+        self.model = model
+        if model in ("ecapa", "xvect", "resnet"):
+            # speechbrain 1.1.0 has a run_opts device bug; load on CPU (default) instead.
+            self.kind = "speechbrain"; self.device = "cpu"
+            from speechbrain.inference.speaker import EncoderClassifier
+            src = {"ecapa": "speechbrain/spkrec-ecapa-voxceleb",
+                   "xvect": "speechbrain/spkrec-xvect-voxceleb",
+                   "resnet": "speechbrain/spkrec-resnet-voxceleb"}[model]
+            self.enc = EncoderClassifier.from_hparams(source=src, savedir=f".venv_emb/sb_{model}")
+        elif model in ("wavlm", "unisat"):
+            self.kind = "hf_xvector"; self.device = device
+            from transformers import Wav2Vec2FeatureExtractor
+            src = {"wavlm": "microsoft/wavlm-base-plus-sv", "unisat": "microsoft/unispeech-sat-base-plus-sv"}[model]
+            self.fe = Wav2Vec2FeatureExtractor.from_pretrained(src)
+            if model == "wavlm":
+                from transformers import WavLMForXVector as XV
+            else:
+                from transformers import UniSpeechSatForXVector as XV
+            self.net = XV.from_pretrained(src).to(device).eval()
+        elif model.startswith("redimnet"):  # redimnet or redimnet_b6 / _b3 ...
+            self.kind = "raw_wave"; self.device = device
+            mn = model.split("_", 1)[1] if "_" in model else "b6"
+            self.net = torch.hub.load("IDRnD/ReDimNet", "ReDimNet", model_name=mn,
+                                      train_type="ft_lm", dataset="vox2", verbose=False).to(device).eval()
+        elif model.startswith("campplus") or model.startswith("eres2net") or model.startswith("wspk"):
+            self.kind = "wespeaker"; self.device = device
+            import wespeaker
+            preset = {"campplus": "campplus", "eres2net": "eres2net"}.get(model.split("_")[0], "campplus")
+            # wespeaker hub names; fall back to english ResNet if preset missing
+            try:
+                self.ws = wespeaker.load_model_local(f".venv_emb/wespeaker_{model}")
+            except Exception:
+                self.ws = wespeaker.load_model("english")
+            self.ws.set_device(device)
+        else:
+            raise SystemExit(f"unknown model {model}")
+
+    @torch.no_grad()
+    def embed_batch(self, wavs):
+        # wavs: list of 1-D float32 np arrays at 16k. Returns [n, dim] L2-normalized float32.
+        lens = [len(w) for w in wavs]; mx = max(lens)
+        if self.kind == "speechbrain":
+            batch = torch.zeros(len(wavs), mx, dtype=torch.float32)
+            for i, w in enumerate(wavs):
+                batch[i, :len(w)] = torch.from_numpy(w)
+            wav_lens = torch.tensor([l / mx for l in lens], dtype=torch.float32)
+            emb = self.enc.encode_batch(batch.to(self.device), wav_lens.to(self.device)).squeeze(1)
+        elif self.kind == "hf_xvector":
+            inp = self.fe([w for w in wavs], sampling_rate=SR, return_tensors="pt", padding=True)
+            inp = {k: v.to(self.device) for k, v in inp.items()}
+            emb = self.net(**inp).embeddings
+        elif self.kind == "raw_wave":
+            batch = torch.zeros(len(wavs), mx, dtype=torch.float32)
+            for i, w in enumerate(wavs):
+                batch[i, :len(w)] = torch.from_numpy(w)
+            emb = self.net(batch.to(self.device))
+            if isinstance(emb, (tuple, list)):
+                emb = emb[0]
+        elif self.kind == "wespeaker":
+            embs = []
+            for w in wavs:
+                t = torch.from_numpy(w).unsqueeze(0)
+                embs.append(torch.as_tensor(self.ws.extract_embedding_from_pcm(t, SR)))
+            emb = torch.stack(embs)
+        emb = torch.nn.functional.normalize(emb, dim=-1)
+        return emb.detach().cpu().float().numpy()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--arm", required=True)
+    ap.add_argument("--model", required=True,
+                    help="ecapa|xvect|resnet|wavlm|unisat|redimnet[_b6]|campplus|eres2net")
+    ap.add_argument("--base-dumps", default=None, help="dumps for segment timings (default data/eval/ami_<arm>/dumps)")
+    ap.add_argument("--clean-audio", default="data/ami/audio")
+    ap.add_argument("--out-dir", default=None)
+    ap.add_argument("--max-sec", type=float, default=20.0)
+    ap.add_argument("--batch", type=int, default=24)
+    args = ap.parse_args()
+    base = args.base_dumps or f"data/eval/ami_{args.arm}/dumps"
+    out = args.out_dir or f"data/eval/ami_{args.arm}__{args.model}/dumps"
+    os.makedirs(out, exist_ok=True)
+    device = "mps" if torch.backends.mps.is_available() else "cpu"
+    print(f"[embed] arm={args.arm} model={args.model} device={device} -> {out}", flush=True)
+    emb = Embedder(args.model, device)
+
+    files = sorted(glob.glob(os.path.join(base, "*.json")))
+    with tempfile.TemporaryDirectory() as td:
+        for fi, f in enumerate(files):
+            m = os.path.basename(f)[:-5]
+            outf = os.path.join(out, m + ".json")
+            if os.path.exists(outf):
+                continue
+            d = json.load(open(f))
+            clean = os.path.join(args.clean_audio, f"{m}.Mix-Headset.wav")
+            wavp = regen_audio(args.arm, clean, os.path.join(td, f"{m}.wav"))
+            audio, sr = sf.read(wavp)
+            if audio.ndim > 1:
+                audio = audio.mean(axis=1)
+            audio = audio.astype(np.float32)
+            if args.arm != "clean":
+                os.remove(wavp)
+            segs = d["segments"]
+            clips = []
+            for s in segs:
+                a = int(s["start"] * SR); b = min(int(s["end"] * SR), a + int(args.max_sec * SR), len(audio))
+                w = audio[a:b]
+                if len(w) < SR // 2:  # pad very short clips to 0.5s
+                    w = np.pad(w, (0, SR // 2 - len(w)))
+                clips.append(w)
+            # batch by similar length to limit padding
+            order = sorted(range(len(clips)), key=lambda i: len(clips[i]))
+            embs = [None] * len(clips)
+            for i in range(0, len(order), args.batch):
+                idx = order[i:i + args.batch]
+                vecs = emb.embed_batch([clips[j] for j in idx])
+                for j, v in zip(idx, vecs):
+                    embs[j] = [round(float(x), 6) for x in v]
+            for s, v in zip(segs, embs):
+                s["embedding"] = v
+            d["embModel"] = args.model
+            json.dump(d, open(outf, "w"))
+            print(f"[embed] {args.arm}/{args.model} {m} ({fi+1}/{len(files)}) {len(segs)} segs", flush=True)
+    print(f"[embed] done arm={args.arm} model={args.model}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/icsi_rttm_from_hf.py
+++ b/scripts/icsi_rttm_from_hf.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Materialize loose per-meeting ICSI RTTMs from the HF `diarizers-community/icsi` dataset.
+
+GATED: requires accepting the dataset terms on HuggingFace and authenticating
+(`huggingface-cli login`, or HF_TOKEN env), plus `pip install datasets`.
+
+The diarizers-community speaker-diarization datasets expose, per row (one meeting):
+  - `timestamps_start` : list[float]
+  - `timestamps_end`   : list[float]
+  - `speakers`         : list[str]   (global ICSI speaker ids, recurring across meetings)
+plus an `audio` column (which we ignore — audio comes from the Edinburgh mirror).
+
+We emit standard SPEAKER-line RTTMs keyed by meeting id, matching the AMI scorer's
+expectations (score_speaker_eval.py reads cols 4=start, 5=dur, 8=speaker).
+
+Usage:
+  python3 scripts/icsi_rttm_from_hf.py --out-dir data/icsi/rttm --meetings "Bmr001 Bro003"
+  python3 scripts/icsi_rttm_from_hf.py --out-dir data/icsi/rttm   # all meetings in the dataset
+"""
+import argparse, os, sys
+
+
+def meeting_id_of(row):
+    """Best-effort meeting id from a dataset row (id/meeting/file/audio path)."""
+    for k in ("id", "meeting_id", "meeting", "file", "filename", "name"):
+        v = row.get(k)
+        if isinstance(v, str) and v:
+            return os.path.splitext(os.path.basename(v))[0]
+    a = row.get("audio")
+    if isinstance(a, dict) and a.get("path"):
+        return os.path.splitext(os.path.basename(a["path"]))[0]
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--meetings", default="", help="space-separated meeting ids; empty = all")
+    ap.add_argument("--dataset", default="diarizers-community/icsi")
+    ap.add_argument("--splits", default="train,validation,test")
+    args = ap.parse_args()
+
+    try:
+        from datasets import load_dataset
+    except Exception as e:
+        print(f"error: `datasets` not installed ({e}); pip install datasets", file=sys.stderr)
+        sys.exit(2)
+
+    wanted = set(args.meetings.split()) if args.meetings.strip() else None
+    os.makedirs(args.out_dir, exist_ok=True)
+    written = 0
+
+    for split in args.splits.split(","):
+        split = split.strip()
+        if not split:
+            continue
+        try:
+            ds = load_dataset(args.dataset, split=split)
+        except Exception as e:
+            print(f"warn: split '{split}' unavailable ({e})", file=sys.stderr)
+            continue
+        # Avoid decoding audio bytes — we only need the timing columns.
+        try:
+            ds = ds.remove_columns([c for c in ds.column_names if c == "audio"])
+        except Exception:
+            pass
+        for row in ds:
+            mid = meeting_id_of(row)
+            if mid is None:
+                continue
+            if wanted is not None and mid not in wanted:
+                continue
+            starts = row.get("timestamps_start") or []
+            ends = row.get("timestamps_end") or []
+            spks = row.get("speakers") or []
+            n = min(len(starts), len(ends), len(spks))
+            if n == 0:
+                continue
+            path = os.path.join(args.out_dir, f"{mid}.rttm")
+            with open(path, "w") as f:
+                for i in range(n):
+                    s, e, spk = float(starts[i]), float(ends[i]), str(spks[i])
+                    if e > s:
+                        f.write(f"SPEAKER {mid} 1 {s:.3f} {e - s:.3f} <NA> <NA> {spk} <NA> <NA>\n")
+            written += 1
+            print(f"[icsi-rttm] {mid}: {n} segments -> {path}")
+
+    print(f"[icsi-rttm] wrote {written} RTTM file(s) to {args.out_dir}")
+    if written == 0:
+        print("[icsi-rttm] nothing written — check HF auth/terms and meeting ids", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/jackknife_series_bands.py
+++ b/scripts/jackknife_series_bands.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Leave-one-series-out (LOSO) jackknife of the AMI cross-meeting embedding bands.
+
+Recomputes, from raw dumps + RTTM ground truth, the SAME-speaker band, the
+DIFFERENT-speaker band, and their separation (same.mean - diff.mean), exactly the
+way scripts/analyze_ami_codec_bands.py does (same quality/duration filters, same
+per-meeting per-true-speaker mean embedding, same cross-meeting pairing rule).
+
+Then it jackknifes by SERIES: there are 8 AMI series (ES2002..ES2010), each with
+4 meetings and 4 recurring participants that appear in NO other series. Dropping a
+series removes those 4 speakers and every pair that touches them. We report, per arm:
+  - full-sample point estimate of same/diff/separation
+  - the 8 LOSO leave-one-out values
+  - jackknife mean and jackknife SE (sqrt((n-1)/n * sum (xi - xbar)^2))
+  - which single series, when DROPPED, moves the separation the most
+and checks whether ordering clean > opus12k > opus8k holds across all 8 leave-outs.
+"""
+import glob, json, os, statistics as st
+from collections import defaultdict
+
+Q_MIN, DUR_MIN = 0.3, 1.0
+ROOT = "/Users/redbars/transcripted/.claude/worktrees/objective-noyce-06bac2/data"
+RTTM_DIR = os.path.join(ROOT, "ami", "rttm")
+
+
+def parse_rttm(path):
+    out = []
+    for ln in open(path):
+        p = ln.split()
+        if len(p) >= 8 and p[0] == "SPEAKER":
+            s, d = float(p[3]), float(p[4]); out.append((s, s + d, p[7]))
+    return out
+
+
+def true_for(s, e, ref):
+    best, bov = None, 0.0
+    for (rs, re, t) in ref:
+        ov = max(0.0, min(e, re) - max(s, rs))
+        if ov > bov: best, bov = t, ov
+    return best
+
+
+def l2(v):
+    n = sum(x * x for x in v) ** 0.5
+    return [x / n for x in v] if n else v
+
+
+def mean_emb(es):
+    if not es: return None
+    d = len(es[0]); return l2([sum(e[i] for e in es) / len(es) for i in range(d)])
+
+
+def cos(a, b): return sum(x * y for x, y in zip(a, b))
+
+
+def load_arm(arm):
+    """Return mean_by: (meeting, speaker) -> mean embedding, restricted to meetings
+    that have an RTTM. Series is meeting[:6]."""
+    dumps = os.path.join(ROOT, "eval", f"ami_{arm}", "dumps")
+    mean_by = {}
+    for dp in sorted(glob.glob(os.path.join(dumps, "*.json"))):
+        m = os.path.basename(dp)[:-5]
+        rp = os.path.join(RTTM_DIR, m + ".rttm")
+        if not os.path.exists(rp): continue
+        d = json.load(open(dp)); ref = parse_rttm(rp)
+        by = defaultdict(list)
+        for s in d["segments"]:
+            emb = s.get("embedding")
+            if not emb or s.get("quality", 1.0) < Q_MIN or (s["end"] - s["start"]) < DUR_MIN:
+                continue
+            t = true_for(s["start"], s["end"], ref)
+            if t is not None: by[t].append(l2(emb))
+        for t, es in by.items():
+            me = mean_emb(es)
+            if me: mean_by[(m, t)] = me
+    return mean_by
+
+
+def build_pairs(mean_by):
+    """Reproduce analyze_ami_codec_bands pairing. Returns:
+       same: list of (series, cosine) for same-speaker cross-meeting pairs
+       diff: list of (seriesA, seriesB, cosine) for different-speaker cross-meeting pairs
+    All deterministic and exhaustive (the eval used the full diff set; n=7744 < 300k cap)."""
+    by_spk = defaultdict(dict)
+    for (m, t), me in mean_by.items():
+        by_spk[t][m] = me
+    same = []
+    for spk, mm in by_spk.items():
+        ms = sorted(mm)
+        series = None  # speaker is series-pure; derive from any meeting
+        for i in range(len(ms)):
+            si = ms[i][:6]
+            for j in range(i + 1, len(ms)):
+                same.append((si, cos(mm[ms[i]], mm[ms[j]])))
+    flat = [(m, t, me) for (m, t), me in mean_by.items()]
+    n = len(flat)
+    diff = []
+    for i in range(n):
+        for j in range(i + 1, n):
+            if flat[i][1] != flat[j][1] and flat[i][0] != flat[j][0]:
+                diff.append((flat[i][0][:6], flat[j][0][:6], cos(flat[i][2], flat[j][2])))
+    return same, diff
+
+
+def bands_for_subset(same, diff, drop_series=None):
+    """Compute (same_mean, diff_mean, separation) over the subset that excludes drop_series."""
+    s_vals = [c for (ser, c) in same if ser != drop_series]
+    d_vals = [c for (sa, sb, c) in diff if sa != drop_series and sb != drop_series]
+    sm = st.mean(s_vals); dm = st.mean(d_vals)
+    return sm, dm, sm - dm, len(s_vals), len(d_vals)
+
+
+def jackknife_se(loo_values):
+    """Standard delete-1 jackknife SE from the n leave-one-out estimates."""
+    n = len(loo_values)
+    xbar = st.mean(loo_values)
+    return (((n - 1) / n) * sum((x - xbar) ** 2 for x in loo_values)) ** 0.5, xbar
+
+
+SERIES = ["ES2002", "ES2003", "ES2005", "ES2006", "ES2007", "ES2008", "ES2009", "ES2010"]
+ARMS = ["clean", "opus24k", "opus16k", "opus12k", "opus8k", "g711u"]
+
+
+def main():
+    results = {}
+    for arm in ARMS:
+        mb = load_arm(arm)
+        same, diff = build_pairs(mb)
+        full = bands_for_subset(same, diff)  # no drop
+        loo = {}
+        for ser in SERIES:
+            loo[ser] = bands_for_subset(same, diff, drop_series=ser)
+        results[arm] = {"full": full, "loo": loo, "n_speakers": len(set(s for s in
+                        set(t for (m, t) in mb)))}
+
+    # ---- print full point estimates (verify vs lead) ----
+    print("=" * 78)
+    print("FULL-SAMPLE BAND POINT ESTIMATES (recomputed from dumps)")
+    print("=" * 78)
+    print(f"{'arm':8} {'same':>8} {'diff':>8} {'separation':>11} {'n_same':>7} {'n_diff':>7}")
+    for arm in ARMS:
+        sm, dm, sep, ns, nd = results[arm]["full"]
+        print(f"{arm:8} {sm:8.4f} {dm:8.4f} {sep:11.4f} {ns:7d} {nd:7d}")
+
+    # ---- jackknife each band, each arm ----
+    print()
+    print("=" * 78)
+    print("LEAVE-ONE-SERIES-OUT JACKKNIFE (8 series)")
+    print("=" * 78)
+    for arm in ARMS:
+        sep_loo = [results[arm]["loo"][s][2] for s in SERIES]
+        same_loo = [results[arm]["loo"][s][0] for s in SERIES]
+        diff_loo = [results[arm]["loo"][s][1] for s in SERIES]
+        se_sep, jk_sep = jackknife_se(sep_loo)
+        se_same, jk_same = jackknife_se(same_loo)
+        se_diff, jk_diff = jackknife_se(diff_loo)
+        full_sep = results[arm]["full"][2]
+        print(f"\n[{arm}]  full separation = {full_sep:.4f}")
+        print(f"   same:  jk_mean={jk_same:.4f}  jk_SE={se_same:.4f}")
+        print(f"   diff:  jk_mean={jk_diff:.4f}  jk_SE={se_diff:.4f}")
+        print(f"   SEP :  jk_mean={jk_sep:.4f}  jk_SE={se_sep:.4f}   "
+              f"approx 95% = [{full_sep-1.96*se_sep:.4f}, {full_sep+1.96*se_sep:.4f}]")
+        print(f"   LOO separations (drop each series):")
+        for s in SERIES:
+            ds = results[arm]["loo"][s][2]
+            print(f"      drop {s}: sep={ds:.4f}  (delta vs full {ds-full_sep:+.4f})")
+        # series with max influence on separation
+        infl = sorted(((abs(results[arm]['loo'][s][2]-full_sep), s) for s in SERIES), reverse=True)
+        print(f"   most-influential series on SEPARATION: {infl[0][1]} "
+              f"(|delta|={infl[0][0]:.4f}), next {infl[1][1]} (|delta|={infl[1][0]:.4f})")
+
+    # ---- ordering robustness: clean > opus12k > opus8k under every leave-out ----
+    print()
+    print("=" * 78)
+    print("ORDERING ROBUSTNESS: separation  clean > opus12k > opus8k")
+    print("=" * 78)
+    target = ["clean", "opus12k", "opus8k"]
+    print(f"{'drop':8} {'clean':>9} {'opus12k':>9} {'opus8k':>9}  {'cl>12k':>7} {'12k>8k':>7} {'all':>5}")
+    full_ok = True
+    a, b, c = (results[t]["full"][2] for t in target)
+    print(f"{'<none>':8} {a:9.4f} {b:9.4f} {c:9.4f}  {str(a>b):>7} {str(b>c):>7} {str(a>b>c):>5}")
+    all_hold = a > b > c
+    margins_clean_12 = [a - b]
+    margins_12_8 = [b - c]
+    for ser in SERIES:
+        ca = results["clean"]["loo"][ser][2]
+        cb = results["opus12k"]["loo"][ser][2]
+        cc = results["opus8k"]["loo"][ser][2]
+        ok1, ok2 = ca > cb, cb > cc
+        hold = ok1 and ok2
+        all_hold = all_hold and hold
+        margins_clean_12.append(ca - cb)
+        margins_12_8.append(cb - cc)
+        print(f"{('drop '+ser):8} {ca:9.4f} {cb:9.4f} {cc:9.4f}  {str(ok1):>7} {str(ok2):>7} {str(hold):>5}")
+    print(f"\nordering clean>opus12k>opus8k holds in ALL leave-outs: {all_hold}")
+    print(f"clean-vs-opus12k separation gap: min={min(margins_clean_12):.4f} "
+          f"max={max(margins_clean_12):.4f} (full={margins_clean_12[0]:.4f})")
+    print(f"opus12k-vs-opus8k separation gap: min={min(margins_12_8):.4f} "
+          f"max={max(margins_12_8):.4f} (full={margins_12_8[0]:.4f})")
+
+    # also report the raw per-series structure for the same-speaker band (the fragile one)
+    print()
+    print("=" * 78)
+    print("PER-SERIES SAME-SPEAKER MEAN (the small-N / fragile band), clean arm")
+    print("=" * 78)
+    mb = load_arm("clean"); same, _ = build_pairs(mb)
+    per = defaultdict(list)
+    for ser, c in same:
+        per[ser].append(c)
+    for s in SERIES:
+        v = per[s]
+        print(f"  {s}: n={len(v):3d} same-mean={st.mean(v):.4f} "
+              f"min={min(v):.4f} max={max(v):.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/master_table.py
+++ b/scripts/master_table.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Assemble the master embedding-model scorecard from data/eval/scorecards/*.json into
+clean grids: within-meeting coverage, error (DER), and cross-call separability (AUC),
+for every model x codec arm. The "all models, all numbers" view."""
+import glob, json, os
+
+ARMS = ["clean", "opus24k", "opus16k", "opus12k", "opus8k", "g711u"]
+MODEL_ORDER = ["wespeaker", "ecapa", "xvect", "wavlm", "unisat", "redimnet_b6", "campplus", "eres2net"]
+LABEL = {"wespeaker": "WeSpeaker (current)", "ecapa": "ECAPA-TDNN", "xvect": "x-vector (control)",
+         "wavlm": "WavLM-SV", "unisat": "UniSpeech-SAT", "redimnet_b6": "ReDimNet-b6",
+         "campplus": "CAM++", "eres2net": "ERes2Net"}
+
+cards = {}
+for f in glob.glob("data/eval/scorecards/*.json"):
+    d = json.load(open(f)); cards[(d["model"], d["arm"])] = d
+
+models = [m for m in MODEL_ORDER if any((m, a) in cards for a in ARMS)]
+dims = {m: next((cards[(m, a)]["dim"] for a in ARMS if (m, a) in cards), "?") for m in models}
+
+
+def grid(title, getter, fmt="{:.3f}"):
+    out = [f"\n### {title}\n"]
+    out.append("| model | dim | " + " | ".join(ARMS) + " |")
+    out.append("|" + "---|" * (len(ARMS) + 2))
+    for m in models:
+        cells = []
+        for a in ARMS:
+            c = cards.get((m, a))
+            cells.append(fmt.format(getter(c)) if c else "·")
+        out.append(f"| {LABEL[m]} | {dims[m]} | " + " | ".join(cells) + " |")
+    return "\n".join(out)
+
+
+lines = ["# Master embedding scorecard — all models × all codec arms\n",
+         "Within-meeting = how well speakers are separated inside a meeting (oracle-k). "
+         "Cross-call AUC = threshold-free same-vs-different separability (1.0 = perfect). "
+         "Coverage/AUC higher = better; DER lower = better. `·` = not run."]
+lines.append(grid("Within-meeting coverage — speakers correctly separated (higher better)",
+                  lambda c: c["within"]["coverage_frac"]))
+lines.append(grid("Within-meeting error — DER (lower better)",
+                  lambda c: c["within"]["mean_der"]))
+lines.append(grid("Within-meeting purity (higher better)",
+                  lambda c: c["within"]["mean_purity"]))
+lines.append(grid("Cross-call separability — AUC (higher better, 1.0=perfect)",
+                  lambda c: c["cross_meeting"]["auc_raw"], "{:.4f}"))
+lines.append(grid("Cross-call raw separation — same minus different cosine (higher=less anisotropic)",
+                  lambda c: c["cross_meeting"]["sep_raw"]))
+
+md = "\n".join(lines)
+print(md)
+open("data/eval/MASTER_SCORECARD.md", "w").write(md)

--- a/scripts/mixed_segment_diag.py
+++ b/scripts/mixed_segment_diag.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Task B - mixed-segment diagnosis: segmentation vs embeddings.
+
+A clustering ceiling can come from SEGMENTATION rather than embeddings/clustering:
+if a single dump segment's time span covers >=2 true speakers (overlap or coarse
+boundaries), its WeSpeaker embedding is a blend that NO clustering can split. This
+script measures how much of the ceiling is mixed-segments.
+
+For each quality-filtered dump segment (quality>=0.3, dur>=1s, same filter as
+recluster_eval.py), we compute how much of its time span each TRUE speaker occupies
+(summing per-speaker active time within the span, from the RTTM, accounting for
+overlap), then the dominant speaker's share. A segment is 'mixed' if dominant < 0.8.
+
+Denominator choice: we report dominant share against the UNION of all true-speaker
+speech time inside the span (i.e. fraction of actual speech in the span owned by the
+dominant speaker). Pure silence inside a span is excluded from the denominator so a
+segment is not flagged mixed merely for containing gaps. Segments with zero ref
+speech in their span are excluded from the mixed/clean split (counted separately).
+
+Per arm we report:
+  - % mixed segments (count) and time-weighted speech share in mixed segments
+  - oracle-k coverage (agglo_oraclek, center=none) from recluster_eval, recomputed
+  - correlation across the 6 arms: mixed-rate vs oracle-k coverage shortfall, and
+    codec severity vs mixed-rate.
+
+Measurement only. Reads dumps + RTTMs; no app code, no re-diarization.
+"""
+import glob
+import json
+import os
+import statistics as st
+from collections import defaultdict
+
+ARMS = ["clean", "opus24k", "opus16k", "opus12k", "opus8k", "g711u"]
+QUAL_MIN = 0.3
+DUR_MIN = 1.0
+MIXED_THRESH = 0.8  # dominant share below this => mixed
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def parse_rttm(p):
+    o = []
+    for ln in open(p):
+        x = ln.split()
+        if len(x) >= 8 and x[0] == "SPEAKER":
+            s, d = float(x[3]), float(x[4])
+            o.append((s, s + d, x[7]))
+    return o
+
+
+def merge_intervals(ivs):
+    """Union length of a list of (start,end) intervals (handles overlap)."""
+    if not ivs:
+        return 0.0
+    ivs = sorted(ivs)
+    tot = 0.0
+    cs, ce = ivs[0]
+    for s, e in ivs[1:]:
+        if s > ce:
+            tot += ce - cs
+            cs, ce = s, e
+        else:
+            ce = max(ce, e)
+    tot += ce - cs
+    return tot
+
+
+def span_speaker_times(s, e, ref):
+    """For span [s,e], return dict speaker -> active (union) seconds within the span,
+    and the union of ALL speech (any speaker) within the span."""
+    per = defaultdict(list)
+    allivs = []
+    for rs, re, t in ref:
+        os_, oe = max(s, rs), min(e, re)
+        if oe > os_:
+            per[t].append((os_, oe))
+            allivs.append((os_, oe))
+    per_time = {t: merge_intervals(iv) for t, iv in per.items()}
+    union_speech = merge_intervals(allivs)
+    return per_time, union_speech
+
+
+def diagnose_arm(arm, rttm_dir):
+    dumps = os.path.join(ROOT, f"data/eval/ami_{arm}/dumps")
+    files = sorted(glob.glob(os.path.join(dumps, "*.json")))
+    total_segs = 0
+    mixed_segs = 0
+    nospeech_segs = 0
+    speech_in_mixed = 0.0
+    speech_in_clean = 0.0
+    dom_shares = []  # dominant share per (speech-bearing) segment
+    per_meeting = []
+    for f in files:
+        m = os.path.basename(f)[:-5]
+        rp = os.path.join(rttm_dir, m + ".rttm")
+        if not os.path.exists(rp):
+            continue
+        d = json.load(open(f))
+        ref = parse_rttm(rp)
+        segs = [s for s in d["segments"]
+                if s.get("embedding") and s["quality"] >= QUAL_MIN and s["end"] - s["start"] >= DUR_MIN]
+        mt, mm, mns = 0, 0, 0
+        msp_mixed, msp_clean = 0.0, 0.0
+        for s in segs:
+            per_time, union_speech = span_speaker_times(s["start"], s["end"], ref)
+            if union_speech <= 0 or not per_time:
+                nospeech_segs += 1
+                mns += 1
+                continue
+            dom = max(per_time.values())
+            share = dom / union_speech
+            dom_shares.append(share)
+            total_segs += 1
+            mt += 1
+            if share < MIXED_THRESH:
+                mixed_segs += 1
+                mm += 1
+                speech_in_mixed += union_speech
+                msp_mixed += union_speech
+            else:
+                speech_in_clean += union_speech
+                msp_clean += union_speech
+        tot_speech = msp_mixed + msp_clean
+        per_meeting.append({
+            "m": m, "segs": mt, "mixed": mm, "nospeech": mns,
+            "pct_mixed": round(100 * mm / mt, 1) if mt else None,
+            "speech_share_mixed": round(msp_mixed / tot_speech, 4) if tot_speech else None,
+        })
+    return {
+        "arm": arm,
+        "n_meetings": len(per_meeting),
+        "total_segs": total_segs,
+        "nospeech_segs": nospeech_segs,
+        "mixed_segs": mixed_segs,
+        "pct_mixed": round(100 * mixed_segs / total_segs, 2) if total_segs else None,
+        "speech_share_mixed": round(speech_in_mixed / (speech_in_mixed + speech_in_clean), 4)
+        if (speech_in_mixed + speech_in_clean) else None,
+        "median_dom_share": round(st.median(dom_shares), 4) if dom_shares else None,
+        "mean_dom_share": round(st.mean(dom_shares), 4) if dom_shares else None,
+        "per_meeting": per_meeting,
+    }
+
+
+def pearson(xs, ys):
+    n = len(xs)
+    if n < 2:
+        return None
+    mx, my = st.mean(xs), st.mean(ys)
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    dx = sum((x - mx) ** 2 for x in xs) ** 0.5
+    dy = sum((y - my) ** 2 for y in ys) ** 0.5
+    if dx == 0 or dy == 0:
+        return None
+    return num / (dx * dy)
+
+
+if __name__ == "__main__":
+    rttm_dir = os.path.join(ROOT, "data/ami/rttm")
+    out = {}
+    for arm in ARMS:
+        out[arm] = diagnose_arm(arm, rttm_dir)
+    json.dump(out, open(os.path.join(ROOT, "scripts/_mixed_seg_diag.json"), "w"), indent=2)
+    # compact stdout
+    for arm in ARMS:
+        o = out[arm]
+        print(f"{arm:8s} segs={o['total_segs']:5d} nospeech={o['nospeech_segs']:4d} "
+              f"pct_mixed={o['pct_mixed']:.2f}%  speech_share_mixed={o['speech_share_mixed']:.4f}  "
+              f"median_dom={o['median_dom_share']:.4f}")

--- a/scripts/model_scorecard.py
+++ b/scripts/model_scorecard.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Per-embedding-model scorecard on an AMI codec arm (measurement only). Compares a
+candidate speaker-embedding model against the shipping WeSpeaker on the metrics that
+decide on-device speaker accuracy, evaluated FAIRLY (threshold-free where it matters so
+an anisotropic model like WavLM isn't unfairly penalized):
+
+  WITHIN-MEETING (the diarizer floor):
+    - oracle-k coverage  : distinct true speakers recovered as some cluster's dominant id
+    - purity, DER        : pyannote optimal-mapping confusion on the same filtered segments
+  CROSS-MEETING (the matcher fitness — can it tell if two appearances are the same person):
+    - AUC                : ROC-AUC of same-vs-different cross-meeting pairs by cosine.
+                           THRESHOLD-FREE -> immune to anisotropy/scale; the fair "how well
+                           does this model separate speakers" number. 0.5=chance, 1.0=perfect.
+    - sep_raw            : same_mean - diff_mean on raw cosine
+    - sep_centered       : same - diff after subtracting the per-arm global mean (whitening
+                           the shared/anisotropy direction) -> the deployable-with-whitening view
+    - eer                : equal error rate of the same/different verification task
+
+Reads data/eval/ami_<arm>/dumps (WeSpeaker) or data/eval/ami_<arm>__<model>/dumps.
+"""
+import argparse, glob, json, os, statistics as st
+from collections import defaultdict
+import numpy as np
+from sklearn.metrics import roc_auc_score
+import sys
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from recluster_eval import parse_rttm, unit, true_for, ann, cluster  # reuse
+from pyannote.metrics.diarization import DiarizationErrorRate
+
+Q, D = 0.3, 1.0
+
+
+def eer_from(scores, labels):
+    order = np.argsort(-scores)
+    labels = np.asarray(labels)[order]
+    P = labels.sum(); N = len(labels) - P
+    if P == 0 or N == 0:
+        return None
+    tp = np.cumsum(labels); fp = np.cumsum(1 - labels)
+    fnr = 1 - tp / P; fpr = fp / N
+    i = np.argmin(np.abs(fnr - fpr))
+    return float((fnr[i] + fpr[i]) / 2)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--arm", required=True)
+    ap.add_argument("--model", default="", help="'' = WeSpeaker baseline; else ecapa/wavlm/unisat/redimnet_b6/...")
+    ap.add_argument("--rttm-dir", default="data/ami/rttm")
+    ap.add_argument("--max-pairs", type=int, default=400000)
+    ap.add_argument("--out-json")
+    args = ap.parse_args()
+    dumps = f"data/eval/ami_{args.arm}/dumps" if not args.model else f"data/eval/ami_{args.arm}__{args.model}/dumps"
+    der_metric = DiarizationErrorRate(collar=0.25, skip_overlap=False)
+
+    per = []
+    mean_by = {}   # (meeting, spk) -> mean emb
+    for f in sorted(glob.glob(os.path.join(dumps, "*.json"))):
+        m = os.path.basename(f)[:-5]
+        rp = os.path.join(args.rttm_dir, m + ".rttm")
+        if not os.path.exists(rp):
+            continue
+        d = json.load(open(f)); ref = parse_rttm(rp)
+        segs = [s for s in d["segments"] if s.get("embedding") and s["quality"] >= Q and s["end"] - s["start"] >= D]
+        if len(segs) < 2:
+            continue
+        E = unit([s["embedding"] for s in segs])
+        spans = [(s["start"], s["end"]) for s in segs]
+        tids = [true_for(s["start"], s["end"], ref) for s in segs]
+        ktrue = len(set(t for t in tids if t))
+        labels = list(cluster(E, "agglo_oraclek", ktrue, 0.7))
+        der = der_metric(ann(spans, tids), ann(spans, labels), detailed=True); tot = der["total"] or 1.0
+        byc = defaultdict(lambda: defaultdict(float))
+        for (s0, s1), lab, t in zip(spans, labels, tids):
+            if t is not None:
+                byc[lab][t] += s1 - s0
+        dom = {c: max(v, key=v.get) for c, v in byc.items()}
+        cov = len(set(dom.values()))
+        pur = [max(v.values()) / sum(v.values()) for v in byc.values() if sum(v.values())]
+        per.append({"ktrue": ktrue, "cov": cov, "der": der["diarization error rate"],
+                    "conf": der["confusion"] / tot, "purity": st.mean(pur) if pur else 0})
+        # per (meeting,speaker) mean for cross-meeting
+        bt = defaultdict(list)
+        for e, t in zip(E, tids):
+            if t is not None:
+                bt[t].append(e)
+        for t, es in bt.items():
+            mean_by[(m, t)] = unit([np.mean(es, axis=0)])[0]
+
+    # cross-meeting pairs (different meetings)
+    keys = list(mean_by); V = np.array([mean_by[k] for k in keys])
+    gmean = V.mean(axis=0)
+    Vc = unit(V - gmean)
+    rng = np.random.RandomState(0)
+    n = len(keys)
+    allpairs = [(i, j) for i in range(n) for j in range(i + 1, n) if keys[i][0] != keys[j][0]]
+    rng.shuffle(allpairs)
+    allpairs = allpairs[:args.max_pairs]
+    sc_raw, sc_ctr, lab = [], [], []
+    for i, j in allpairs:
+        sc_raw.append(float(V[i] @ V[j])); sc_ctr.append(float(Vc[i] @ Vc[j]))
+        lab.append(1 if keys[i][1] == keys[j][1] else 0)
+    sc_raw = np.array(sc_raw); sc_ctr = np.array(sc_ctr); lab = np.array(lab)
+    same_r = sc_raw[lab == 1]; diff_r = sc_raw[lab == 0]
+    same_c = sc_ctr[lab == 1]; diff_c = sc_ctr[lab == 0]
+
+    out = {
+        "arm": args.arm, "model": args.model or "wespeaker", "n_meetings": len(per),
+        "dim": int(V.shape[1]),
+        "within": {
+            "coverage_frac": round(sum(p["cov"] for p in per) / max(1, sum(p["ktrue"] for p in per)), 4),
+            "mean_purity": round(st.mean(p["purity"] for p in per), 4),
+            "mean_der": round(st.mean(p["der"] for p in per), 4),
+            "mean_conf": round(st.mean(p["conf"] for p in per), 4),
+        },
+        "cross_meeting": {
+            "n_pairs": len(lab), "n_same": int(lab.sum()),
+            "auc_raw": round(float(roc_auc_score(lab, sc_raw)), 4),
+            "auc_centered": round(float(roc_auc_score(lab, sc_ctr)), 4),
+            "eer_raw": round(eer_from(sc_raw, lab), 4) if eer_from(sc_raw, lab) is not None else None,
+            "eer_centered": round(eer_from(sc_ctr, lab), 4) if eer_from(sc_ctr, lab) is not None else None,
+            "same_mean_raw": round(float(same_r.mean()), 4), "diff_mean_raw": round(float(diff_r.mean()), 4),
+            "sep_raw": round(float(same_r.mean() - diff_r.mean()), 4),
+            "sep_centered": round(float(same_c.mean() - diff_c.mean()), 4),
+        },
+    }
+    print(json.dumps(out, indent=2))
+    if args.out_json:
+        json.dump(out, open(args.out_json, "w"), indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/model_scorecard.py
+++ b/scripts/model_scorecard.py
@@ -47,10 +47,11 @@ def main():
     ap.add_argument("--arm", required=True)
     ap.add_argument("--model", default="", help="'' = WeSpeaker baseline; else ecapa/wavlm/unisat/redimnet_b6/...")
     ap.add_argument("--rttm-dir", default="data/ami/rttm")
+    ap.add_argument("--dumps", default=None, help="explicit dumps dir (overrides the ami_<arm> path; for Zoom/generic)")
     ap.add_argument("--max-pairs", type=int, default=400000)
     ap.add_argument("--out-json")
     args = ap.parse_args()
-    dumps = f"data/eval/ami_{args.arm}/dumps" if not args.model else f"data/eval/ami_{args.arm}__{args.model}/dumps"
+    dumps = args.dumps or (f"data/eval/ami_{args.arm}/dumps" if not args.model else f"data/eval/ami_{args.arm}__{args.model}/dumps")
     der_metric = DiarizationErrorRate(collar=0.25, skip_overlap=False)
 
     per = []
@@ -101,8 +102,31 @@ def main():
         sc_raw.append(float(V[i] @ V[j])); sc_ctr.append(float(Vc[i] @ Vc[j]))
         lab.append(1 if keys[i][1] == keys[j][1] else 0)
     sc_raw = np.array(sc_raw); sc_ctr = np.array(sc_ctr); lab = np.array(lab)
-    same_r = sc_raw[lab == 1]; diff_r = sc_raw[lab == 0]
-    same_c = sc_ctr[lab == 1]; diff_c = sc_ctr[lab == 0]
+    # cross-call metrics need pairs from >=2 recordings with both same- and different-speaker pairs.
+    # A single recording (e.g. one Zoom call) has none -> report cross_meeting as N/A; within-meeting stands.
+    cross_ok = len(lab) > 0 and 0 < int(lab.sum()) < len(lab)
+
+    def m_(x):
+        return round(float(x.mean()), 4) if len(x) else None
+
+    if cross_ok:
+        same_r = sc_raw[lab == 1]; diff_r = sc_raw[lab == 0]
+        same_c = sc_ctr[lab == 1]; diff_c = sc_ctr[lab == 0]
+        cross = {
+            "n_pairs": int(len(lab)), "n_same": int(lab.sum()),
+            "auc_raw": round(float(roc_auc_score(lab, sc_raw)), 4),
+            "auc_centered": round(float(roc_auc_score(lab, sc_ctr)), 4),
+            "eer_raw": round(eer_from(sc_raw, lab), 4) if eer_from(sc_raw, lab) is not None else None,
+            "eer_centered": round(eer_from(sc_ctr, lab), 4) if eer_from(sc_ctr, lab) is not None else None,
+            "same_mean_raw": m_(same_r), "diff_mean_raw": m_(diff_r),
+            "sep_raw": round(m_(same_r) - m_(diff_r), 4),
+            "sep_centered": round(m_(same_c) - m_(diff_c), 4),
+        }
+    else:
+        cross = {"n_pairs": int(len(lab)), "n_same": int(lab.sum()), "auc_raw": None,
+                 "auc_centered": None, "eer_raw": None, "eer_centered": None,
+                 "same_mean_raw": None, "diff_mean_raw": None, "sep_raw": None, "sep_centered": None,
+                 "note": "single recording — cross-call metrics need >=2 recordings with recurring speakers"}
 
     out = {
         "arm": args.arm, "model": args.model or "wespeaker", "n_meetings": len(per),
@@ -113,15 +137,7 @@ def main():
             "mean_der": round(st.mean(p["der"] for p in per), 4),
             "mean_conf": round(st.mean(p["conf"] for p in per), 4),
         },
-        "cross_meeting": {
-            "n_pairs": len(lab), "n_same": int(lab.sum()),
-            "auc_raw": round(float(roc_auc_score(lab, sc_raw)), 4),
-            "auc_centered": round(float(roc_auc_score(lab, sc_ctr)), 4),
-            "eer_raw": round(eer_from(sc_raw, lab), 4) if eer_from(sc_raw, lab) is not None else None,
-            "eer_centered": round(eer_from(sc_ctr, lab), 4) if eer_from(sc_ctr, lab) is not None else None,
-            "same_mean_raw": round(float(same_r.mean()), 4), "diff_mean_raw": round(float(diff_r.mean()), 4),
-            "sep_raw": round(float(same_r.mean() - diff_r.mean()), 4),
-            "sep_centered": round(float(same_c.mean() - diff_c.mean()), 4),
+        "cross_meeting": {**cross,
         },
     }
     print(json.dumps(out, indent=2))

--- a/scripts/onnx_block_bisect.py
+++ b/scripts/onnx_block_bisect.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Trace is faithful (1.0) but ONNX & CoreML both diverge (0.40) -> a converter
+op-lowering bug, NOT a tracer/model bug. Bisect through ONNX (fast) to find the
+first module whose ONNX output diverges from eager. Then inspect that module's
+ops.
+"""
+import os, numpy as np, torch, torch.nn as nn, warnings
+warnings.filterwarnings("ignore")
+import onnxruntime as ort
+
+MODEL_DIR = os.path.expanduser(
+    "~/.cache/modelscope/hub/models/iic/speech_campplus_sv_en_voxceleb_16k")
+BIN = os.path.join(MODEL_DIR, "campplus_voxceleb.bin")
+OUT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "out")
+FEAT_DIM, EMB_SIZE, N_FRAMES = 80, 512, 300
+
+def cosine(a,b):
+    a=a.flatten().astype(np.float64); b=b.flatten().astype(np.float64)
+    return float(np.dot(a,b)/(np.linalg.norm(a)*np.linalg.norm(b)+1e-12))
+
+from modelscope.models.audio.sv.DTDNN import CAMPPlus
+full = CAMPPlus(feat_dim=FEAT_DIM, embedding_size=EMB_SIZE, output_level='frame')
+full.load_state_dict(torch.load(BIN, map_location="cpu"), strict=False); full.eval()
+
+class Truncated(nn.Module):
+    def __init__(self, base, k): super().__init__(); self.base=base; self.k=k
+    def forward(self, x):
+        x = x.permute(0,2,1)
+        x = self.base.head(x)
+        for i, mod in enumerate(self.base.xvector):
+            if i >= self.k: break
+            x = mod(x)
+        return x
+
+names = list(dict(full.xvector.named_children()).keys())
+rnd = torch.randn(1, N_FRAMES, FEAT_DIM)
+
+def onnx_cos(mod, x):
+    with torch.no_grad(): pt = mod(x).numpy()
+    p = os.path.join(OUT, "bisect.onnx")
+    torch.onnx.export(mod, x, p, input_names=["i"], output_names=["o"], opset_version=14)
+    s = ort.InferenceSession(p, providers=["CPUExecutionProvider"])
+    o = s.run(["o"], {"i": x.numpy().astype(np.float32)})[0]
+    return cosine(pt, o), float(np.max(np.abs(pt-o)))
+
+# head only
+class HeadOnly(nn.Module):
+    def __init__(self, base): super().__init__(); self.base=base
+    def forward(self, x):
+        x = x.permute(0,2,1); return self.base.head(x)
+c,d = onnx_cos(HeadOnly(full), rnd)
+print(f"head only            : cosine={c:.6f} maxabsdiff={d:.4f}")
+
+for k in range(1, len(names)+1):
+    c,d = onnx_cos(Truncated(full,k), rnd)
+    print(f"up to [{k-1}] {names[k-1]:13s}: cosine={c:.6f} maxabsdiff={d:.4f}")

--- a/scripts/onnx_crosscheck.py
+++ b/scripts/onnx_crosscheck.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Cross-check: export the SAME bare CAMPPlus to ONNX and run via onnxruntime.
+If ONNX matches PyTorch (cosine ~1.0) but CoreML does not, the divergence is a
+coremltools graph-conversion problem (not model fragility). This tells us whether
+a different export path (ONNX -> CoreML, or staying on ONNX) would work.
+"""
+import os, numpy as np, torch, warnings
+warnings.filterwarnings("ignore")
+import torchaudio, torchaudio.compliance.kaldi as Kaldi
+
+MODEL_DIR = os.path.expanduser(
+    "~/.cache/modelscope/hub/models/iic/speech_campplus_sv_en_voxceleb_16k")
+BIN = os.path.join(MODEL_DIR, "campplus_voxceleb.bin")
+AMI_WAV = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                       "data","ami","audio","ES2002a.Mix-Headset.wav")
+OUT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "out")
+os.makedirs(OUT, exist_ok=True)
+ONNX = os.path.join(OUT, "campplus.onnx")
+FEAT_DIM, EMB_SIZE, N_FRAMES, SR = 80, 512, 300, 16000
+
+def cosine(a,b):
+    a=a.flatten().astype(np.float64); b=b.flatten().astype(np.float64)
+    return float(np.dot(a,b)/(np.linalg.norm(a)*np.linalg.norm(b)+1e-12))
+
+from modelscope.models.audio.sv.DTDNN import CAMPPlus
+m = CAMPPlus(feat_dim=FEAT_DIM, embedding_size=EMB_SIZE)
+m.load_state_dict(torch.load(BIN, map_location="cpu"), strict=True); m.eval()
+
+def fbank(wav):
+    f = Kaldi.fbank(wav.unsqueeze(0), num_mel_bins=FEAT_DIM)
+    return f - f.mean(dim=0, keepdim=True)
+def seg(p, st, du):
+    w,sr = torchaudio.load(p)
+    if sr!=SR: w = torchaudio.functional.resample(w, sr, SR)
+    w=w[0]; return w[int(st*SR):int((st+du)*SR)].contiguous()
+def fixed(f,n):
+    if f.shape[0]>=n: return f[:n]
+    return torch.cat([f, torch.zeros(n-f.shape[0], f.shape[1])],0)
+
+# Export ONNX (dynamic-shape friendly so the host can vary frame count)
+dummy = torch.randn(1, N_FRAMES, FEAT_DIM)
+torch.onnx.export(
+    m, dummy, ONNX,
+    input_names=["fbank"], output_names=["embedding"],
+    dynamic_axes={"fbank": {1: "T"}},
+    opset_version=14)
+sz = os.path.getsize(ONNX)/(1024*1024)
+print(f"[ok] ONNX exported: {ONNX} ({sz:.2f} MB)")
+
+import onnxruntime as ort
+sess = ort.InferenceSession(ONNX, providers=["CPUExecutionProvider"])
+
+segs = [(60.0,4.0),(120.0,3.5),(200.0,5.0),(300.0,4.0)]
+print("\nseg : pytorch-vs-onnx cosine (want ~1.0)")
+for i,(st,du) in enumerate(segs):
+    feat = fixed(fbank(seg(AMI_WAV, st, du)), N_FRAMES).unsqueeze(0)
+    with torch.no_grad():
+        pt = m(feat).numpy()
+    onx = sess.run(["embedding"], {"fbank": feat.numpy().astype(np.float32)})[0]
+    print(f"  seg{i}: {cosine(pt, onx):.6f}")

--- a/scripts/oraclek_dumps.py
+++ b/scripts/oraclek_dumps.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Task D dump rewriter: replace each segment's speakerId with an ORACLE-K agglomerative
+re-clustering label, so the better (finer) clustering can be replayed through the REAL
+matcher (EmbeddingClusterer.postProcess + cross-meeting match). Measurement only — every
+other dump field (embedding, start, end, quality) is preserved verbatim.
+
+The re-clustering mirrors recluster_eval.py's `agglo_oraclek`:
+  * per meeting, average-linkage agglomerative on cosine distance (1 - cos) of the
+    L2-normalized embeddings, n_clusters = the TRUE number of AMI speakers (from the RTTM).
+  * clustering is FIT on the quality-filtered segments (quality>=0.3, dur>=1s) — identical
+    to the recluster_eval ceiling — so the labels we hand the matcher are exactly the
+    oracle-k clusters that experiment scored.
+  * segments that fail the quality filter still need a label (the harness replays every
+    segment), so they are assigned to the nearest oracle-cluster mean embedding. They are a
+    small minority and do not participate in the ceiling metric; nearest-centroid keeps the
+    dump complete without inventing new clusters.
+
+speakerId is rewritten to a small contiguous int per meeting (0..k-1), matching the dump's
+int speakerId type. Output dumps are byte-compatible with the harness RawDump decoder.
+"""
+import argparse, glob, json, os
+import numpy as np
+from sklearn.cluster import AgglomerativeClustering
+
+
+def parse_rttm(p):
+    o = []
+    for ln in open(p):
+        x = ln.split()
+        if len(x) >= 8 and x[0] == "SPEAKER":
+            s, d = float(x[3]), float(x[4]); o.append((s, s + d, x[7]))
+    return o
+
+
+def unit(M):
+    M = np.nan_to_num(np.asarray(M, dtype=np.float64))
+    n = np.linalg.norm(M, axis=1, keepdims=True); n[n == 0] = 1.0
+    return M / n
+
+
+def true_for(s, e, ref):
+    best, bo = None, 0.0
+    for rs, re, t in ref:
+        ov = max(0.0, min(e, re) - max(s, rs))
+        if ov > bo:
+            best, bo = t, ov
+    return best
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in-dumps", required=True)
+    ap.add_argument("--out-dumps", required=True)
+    ap.add_argument("--rttm-dir", default="data/ami/rttm")
+    args = ap.parse_args()
+    os.makedirs(args.out_dumps, exist_ok=True)
+
+    files = sorted(glob.glob(os.path.join(args.in_dumps, "*.json")))
+    n_written = 0
+    for f in files:
+        d = json.load(open(f))
+        m = os.path.basename(f)[:-5]
+        rp = os.path.join(args.rttm_dir, m + ".rttm")
+        segs = d["segments"]
+        # which segments have a usable embedding at all
+        has_emb = [bool(s.get("embedding")) for s in segs]
+
+        if not os.path.exists(rp):
+            # no ground truth -> cannot pick oracle k; passthrough unchanged
+            json.dump(d, open(os.path.join(args.out_dumps, os.path.basename(f)), "w"))
+            n_written += 1
+            continue
+        ref = parse_rttm(rp)
+
+        # ceiling segment set: identical filter to recluster_eval.py
+        idx_fit = [i for i, s in enumerate(segs)
+                   if s.get("embedding") and s["quality"] >= 0.3 and s["end"] - s["start"] >= 1.0]
+        # oracle k from the true number of distinct AMI speakers among the fit segments
+        tids = [true_for(segs[i]["start"], segs[i]["end"], ref) for i in idx_fit]
+        ktrue = len(set(t for t in tids if t is not None))
+
+        if len(idx_fit) < 2 or ktrue < 1:
+            # not enough to cluster -> leave speakerId as-is
+            json.dump(d, open(os.path.join(args.out_dumps, os.path.basename(f)), "w"))
+            n_written += 1
+            continue
+
+        Efit = unit([segs[i]["embedding"] for i in idx_fit])
+        k = max(1, min(ktrue, len(idx_fit)))
+        sim = np.clip(Efit @ Efit.T, -1.0, 1.0)
+        D = 1.0 - sim
+        np.fill_diagonal(D, 0.0)
+        labels = AgglomerativeClustering(n_clusters=k, metric="precomputed",
+                                         linkage="average").fit(D).labels_
+        # cluster mean embeddings (unit) for nearest-centroid assignment of off-set segments
+        cents = []
+        for c in range(k):
+            members = Efit[labels == c]
+            cents.append(members.mean(axis=0) if len(members) else np.zeros(Efit.shape[1]))
+        cents = unit(cents)
+
+        new_id = {}
+        for j, i in enumerate(idx_fit):
+            new_id[i] = int(labels[j])
+        # assign every other embedded segment to nearest oracle centroid
+        for i, s in enumerate(segs):
+            if i in new_id:
+                continue
+            if s.get("embedding"):
+                e = unit([s["embedding"]])[0]
+                new_id[i] = int(np.argmax(cents @ e))
+            else:
+                new_id[i] = 0  # no embedding: drop into cluster 0 (matcher skips empty embs)
+
+        out_segs = []
+        for i, s in enumerate(segs):
+            ns = dict(s)
+            ns["speakerId"] = new_id[i]
+            out_segs.append(ns)
+        d["segments"] = out_segs
+        d["diarizerSpeakerCount"] = len(set(new_id.values()))
+        json.dump(d, open(os.path.join(args.out_dumps, os.path.basename(f)), "w"))
+        n_written += 1
+    print(f"[oraclek] wrote {n_written} dumps -> {args.out_dumps}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pure_segment_separability.py
+++ b/scripts/pure_segment_separability.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""TASK C — pure-segment embedding separability (sharpest diagnosis of the diarizer floor).
+
+Question: is the within-meeting under-segmentation a CLUSTERING problem, an EMBEDDING
+problem, or a SEGMENTATION (mixed/overlap) problem?
+
+Method: restrict to PURE segments only — a segment whose time span overlaps ONE true
+RTTM speaker for >= PURITY_THRESH (default 0.90) of the segment's duration (so it carries
+essentially one speaker's voice, not a mix/overlap). Then cluster THOSE embeddings with
+oracle-k (true # speakers among the pure segments) using agglo + spectral, +/- global
+centering, and measure coverage_frac and time-weighted purity per arm.
+
+Logic:
+- If PURE segments STILL fail to separate at oracle-k on compressed audio (coverage << 1.0),
+  the embedding MODEL is the floor: the codec has destroyed within-meeting speaker info, and
+  no clustering/segmentation change can help — you need codec-robust embeddings.
+- If PURE segments DO separate cleanly (coverage ~ 1.0) while ALL segments do not, the ceiling
+  is the mixed/overlap segments: finer segmentation is the lever.
+
+Reuses helpers from recluster_eval.py (parse_rttm, unit, ann, cluster). Adds per-segment
+true-id overlap-fraction to identify pure segments. Same quality filter (quality>=0.3,
+dur>=1s) as the all-segment baseline so the comparison is apples-to-apples.
+
+Measurement only: reads cached dumps + RTTMs; no app code, no re-diarization.
+"""
+import argparse, glob, json, os, statistics as st
+from collections import defaultdict
+import numpy as np
+
+import sys
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from recluster_eval import parse_rttm, unit, ann, cluster
+
+from pyannote.metrics.diarization import DiarizationErrorRate
+
+
+def true_overlap_fracs(s, e, ref):
+    """Return {true_id: fraction of [s,e] covered by that true id}. Fractions are over the
+    segment duration; they need not sum to 1 (gaps with no speaker), and overlapped true
+    speech can push a single id's frac high while others are nonzero too."""
+    dur = e - s
+    if dur <= 0:
+        return {}
+    acc = defaultdict(float)
+    for rs, re, t in ref:
+        ov = max(0.0, min(e, re) - max(s, rs))
+        if ov > 0:
+            acc[t] += ov
+    return {t: v / dur for t, v in acc.items()}
+
+
+def dominant_frac(s, e, ref):
+    fr = true_overlap_fracs(s, e, ref)
+    if not fr:
+        return None, 0.0
+    t, v = max(fr.items(), key=lambda kv: kv[1])
+    return t, v
+
+
+def eval_set(segs, ref, method, center, gcent, der_metric):
+    """Cluster a chosen segment set at oracle-k and return per-meeting metrics, or None if
+    fewer than 2 segments / fewer than 1 true speaker present."""
+    if len(segs) < 2:
+        return None
+    E = unit([s["embedding"] for s in segs])
+    if center == "global" and gcent is not None:
+        E = unit(E - gcent)
+    spans = [(s["start"], s["end"]) for s in segs]
+    # dominant true id per segment (for coverage/purity bookkeeping + DER reference)
+    tids = [dominant_frac(s0, s1, ref)[0] for (s0, s1) in spans]
+    ktrue = len(set(t for t in tids if t is not None))
+    if ktrue < 1:
+        return None
+    labels = list(cluster(E, method, ktrue, 0.7))
+    der = der_metric(ann(spans, tids), ann(spans, labels), detailed=True)
+    tot = der["total"] or 1.0
+    byc = defaultdict(lambda: defaultdict(float))
+    for (s0, s1), lab, t in zip(spans, labels, tids):
+        if t is not None:
+            byc[lab][t] += (s1 - s0)
+    dom = {c: max(v.items(), key=lambda kv: kv[1])[0] for c, v in byc.items()}
+    covered = len(set(dom.values()))
+    pur = []
+    for c, v in byc.items():
+        tt = sum(v.values())
+        pur.append(max(v.values()) / tt if tt else 0)
+    return {
+        "ktrue": ktrue, "nseg": len(segs), "nclusters": len(set(labels)),
+        "covered": covered, "trapped": ktrue - covered,
+        "der": der["diarization error rate"], "conf": der["confusion"] / tot,
+        "purity": st.mean(pur) if pur else None,
+    }
+
+
+def aggregate(per):
+    if not per:
+        return {"n_meetings": 0}
+    return {
+        "n_meetings": len(per),
+        "total_true": sum(p["ktrue"] for p in per),
+        "total_covered": sum(p["covered"] for p in per),
+        "total_trapped": sum(p["trapped"] for p in per),
+        "coverage_frac": round(sum(p["covered"] for p in per) / max(1, sum(p["ktrue"] for p in per)), 4),
+        "mean_purity": round(st.mean(p["purity"] for p in per if p["purity"] is not None), 4),
+        "mean_der": round(st.mean(p["der"] for p in per), 4),
+        "mean_conf": round(st.mean(p["conf"] for p in per), 4),
+        "mean_clusters_per_true": round(st.mean(p["nclusters"] / p["ktrue"] for p in per if p["ktrue"]), 3),
+        "mean_seg_per_meeting": round(st.mean(p["nseg"] for p in per), 1),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--arms", nargs="+", default=["clean", "opus12k", "opus8k", "g711u"])
+    ap.add_argument("--methods", nargs="+", default=["agglo_oraclek", "spectral_oraclek"])
+    ap.add_argument("--centers", nargs="+", default=["none", "global"])
+    ap.add_argument("--purity-thresh", type=float, default=0.90)
+    ap.add_argument("--eval-root", default="data/eval")
+    ap.add_argument("--rttm-dir", default="data/ami/rttm")
+    ap.add_argument("--out-json")
+    args = ap.parse_args()
+
+    der_metric = DiarizationErrorRate(collar=0.25, skip_overlap=False)
+    results = {}
+
+    for arm in args.arms:
+        dumps = os.path.join(args.eval_root, f"ami_{arm}", "dumps")
+
+        # global centroid over the (quality-filtered) ALL-segment set for this arm,
+        # matching recluster_eval's global-centering definition
+        allv = []
+        for f in glob.glob(os.path.join(dumps, "*.json")):
+            for s in json.load(open(f))["segments"]:
+                if s.get("embedding") and s["quality"] >= 0.3 and s["end"] - s["start"] >= 1.0:
+                    allv.append(s["embedding"])
+        gcent = unit(allv).mean(axis=0) if allv else None
+
+        # accumulate per-meeting metrics keyed by (variant -> method,center)
+        bins = defaultdict(lambda: {"all": [], "pure": []})
+        # purity-of-segments diagnostics
+        pure_counts, all_counts = [], []
+
+        for f in sorted(glob.glob(os.path.join(dumps, "*.json"))):
+            m = os.path.basename(f)[:-5]
+            rp = os.path.join(args.rttm_dir, m + ".rttm")
+            if not os.path.exists(rp):
+                continue
+            ref = parse_rttm(rp)
+            d = json.load(open(f))
+            qsegs = [s for s in d["segments"]
+                     if s.get("embedding") and s["quality"] >= 0.3 and s["end"] - s["start"] >= 1.0]
+            psegs = [s for s in qsegs
+                     if dominant_frac(s["start"], s["end"], ref)[1] >= args.purity_thresh]
+            all_counts.append(len(qsegs))
+            pure_counts.append(len(psegs))
+
+            for method in args.methods:
+                for center in args.centers:
+                    key = (method, center)
+                    ra = eval_set(qsegs, ref, method, center, gcent, der_metric)
+                    rp_ = eval_set(psegs, ref, method, center, gcent, der_metric)
+                    if ra:
+                        bins[key]["all"].append(ra)
+                    if rp_:
+                        bins[key]["pure"].append(rp_)
+
+        arm_out = {
+            "n_meetings": len([f for f in glob.glob(os.path.join(dumps, "*.json"))
+                               if os.path.exists(os.path.join(args.rttm_dir, os.path.basename(f)[:-5] + ".rttm"))]),
+            "purity_thresh": args.purity_thresh,
+            "mean_all_seg_per_meeting": round(st.mean(all_counts), 1) if all_counts else None,
+            "mean_pure_seg_per_meeting": round(st.mean(pure_counts), 1) if pure_counts else None,
+            "pure_seg_retained_frac": round(sum(pure_counts) / max(1, sum(all_counts)), 4),
+            "variants": {},
+        }
+        for (method, center), v in bins.items():
+            arm_out["variants"][f"{method}|center={center}"] = {
+                "all_segments": aggregate(v["all"]),
+                "pure_segments": aggregate(v["pure"]),
+            }
+        results[arm] = arm_out
+
+    # ---- pretty report ----
+    print("=" * 96)
+    print(f"TASK C: pure-segment embedding separability at oracle-k (pure = dominant true id covers >= {args.purity_thresh:.0%} of segment span)")
+    print("=" * 96)
+    for arm in args.arms:
+        if arm not in results:
+            continue
+        a = results[arm]
+        print(f"\n### ARM: {arm}   ({a['n_meetings']} meetings)   "
+              f"pure segs retained: {a['pure_seg_retained_frac']:.0%} "
+              f"({a['mean_pure_seg_per_meeting']}/{a['mean_all_seg_per_meeting']} per meeting)")
+        hdr = f"  {'method|center':<28} {'set':<5} {'cov':>6} {'purity':>7} {'DER':>6} {'conf':>6} {'cl/true':>8}"
+        print(hdr)
+        print("  " + "-" * (len(hdr) - 2))
+        for vk in sorted(a["variants"].keys()):
+            v = a["variants"][vk]
+            for setname in ("all_segments", "pure_segments"):
+                g = v[setname]
+                if not g.get("n_meetings"):
+                    print(f"  {vk:<28} {setname[:4]:<5} {'--':>6}")
+                    continue
+                tag = "all" if setname == "all_segments" else "pure"
+                print(f"  {vk:<28} {tag:<5} {g['coverage_frac']:>6.3f} {g['mean_purity']:>7.3f} "
+                      f"{g['mean_der']:>6.3f} {g['mean_conf']:>6.3f} {g['mean_clusters_per_true']:>8.3f}")
+
+    if args.out_json:
+        json.dump(results, open(args.out_json, "w"), indent=2)
+        print(f"\nwrote {args.out_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/q3_attribution.py
+++ b/scripts/q3_attribution.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Q3 attribution: within-meeting (diarizer) vs cross-meeting (matcher) false merges.
+
+For each arm we use:
+  - dumps/*.json   : raw diarizer clusters (meeting, speakerId) + segment time spans
+  - data/ami/rttm/ : ground-truth global recurring speaker ids + time spans
+  - reports/cons_none_match_M.json : false_merge.profiles {pid:[trueids]} + reid_detail
+
+A diarizer cluster = (meeting, speakerId). We overlap each cluster's segment spans
+against the RTTM to compute, per cluster, the duration mass landing on each true id.
+A cluster is 'mixed' if >=2 true ids each hold >= MIX_FRAC of the cluster's matched mass.
+
+Attribution of a false-merge profile P (fuses trueids T = {t1..tk}, k>=2):
+  - Look at every diarizer cluster assigned (dominant) to P.
+  - WITHIN-MEETING pair (ti,tj): there exists a single cluster (one meeting) whose
+    mixed-true-id set contains both ti and tj  -> diarizer fused them upstream.
+  - CROSS-MEETING pair (ti,tj): ti and tj each reach P only via clusters that are
+    each (near-)pure for one of them, in different meetings -> matcher fused them.
+We classify each unordered fused pair, and also classify each profile.
+"""
+import json, glob, os, sys
+from collections import defaultdict
+
+ROOT = '/Users/redbars/transcripted/.claude/worktrees/objective-noyce-06bac2'
+RTTM_DIR = os.path.join(ROOT, 'data/ami/rttm')
+MIX_FRAC = 0.20   # a true id must hold >=20% of a cluster's matched mass to count as "in" it
+
+# ---- load RTTM: meeting -> list of (start,end,trueid) ----
+def load_rttm():
+    rttm = defaultdict(list)
+    for f in glob.glob(os.path.join(RTTM_DIR, '*.rttm')):
+        m = os.path.basename(f)[:-5]
+        for line in open(f):
+            p = line.split()
+            if p and p[0] == 'SPEAKER':
+                st = float(p[3]); dur = float(p[4]); tid = p[7]
+                rttm[m].append((st, st + dur, tid))
+    return rttm
+
+RTTM = load_rttm()
+
+def overlap(a0, a1, b0, b1):
+    return max(0.0, min(a1, b1) - max(a0, b0))
+
+def cluster_true_mass(meeting, segs):
+    """For one diarizer cluster's segments, return {trueid: overlapped_seconds}."""
+    ref = RTTM[meeting]
+    mass = defaultdict(float)
+    for s0, s1 in segs:
+        for r0, r1, tid in ref:
+            ov = overlap(s0, s1, r0, r1)
+            if ov > 0:
+                mass[tid] += ov
+    return mass
+
+def analyze_arm(arm):
+    dumpdir = os.path.join(ROOT, 'data/eval', arm, 'dumps')
+    # cluster -> list of (start,end); cluster key = (meeting, speakerId)
+    clusters = defaultdict(list)
+    for f in glob.glob(os.path.join(dumpdir, '*.json')):
+        d = json.load(open(f))
+        meeting = d['meeting']
+        for seg in d['segments']:
+            clusters[(meeting, seg['speakerId'])].append((seg['start'], seg['end']))
+    # per cluster: matched mass per true id, dominant true id, mixed-true-id set
+    cl_info = {}
+    for (meeting, sid), segs in clusters.items():
+        mass = cluster_true_mass(meeting, segs)
+        tot = sum(mass.values())
+        if tot <= 0:
+            cl_info[(meeting, sid)] = dict(dominant=None, mixed=set(), mass=mass, tot=0.0)
+            continue
+        dominant = max(mass, key=mass.get)
+        mixed = {t for t, v in mass.items() if v / tot >= MIX_FRAC}
+        cl_info[(meeting, sid)] = dict(dominant=dominant, mixed=mixed, mass=mass, tot=tot)
+    return clusters, cl_info
+
+# ---- diarizer over/under segmentation (matcher-independent) ----
+def diarizer_seg_stats(arm):
+    clusters, cl_info = analyze_arm(arm)
+    # group clusters by meeting
+    by_meeting = defaultdict(list)
+    for (meeting, sid) in clusters:
+        by_meeting[meeting].append(sid)
+    ref_speakers_per_meeting = {m: len(set(t for _,_,t in RTTM[m])) for m in RTTM}
+    over = under = exact = 0
+    n_clusters_total = 0
+    n_mixed_clusters = 0          # clusters covering >=2 true ids (under-seg: merged speakers)
+    # per true speaker per meeting: how many distinct clusters hold >=MIX_FRAC of THAT cluster
+    # over-seg: one true speaker split across multiple clusters within a meeting
+    split_count = 0   # (meeting,trueid) appearances split across >1 cluster
+    appear_total = 0
+    for m, sids in by_meeting.items():
+        nhyp = len(sids); nref = ref_speakers_per_meeting[m]
+        n_clusters_total += nhyp
+        if nhyp > nref: over += 1
+        elif nhyp < nref: under += 1
+        else: exact += 1
+        # mixed clusters
+        for sid in sids:
+            if len(cl_info[(m, sid)]['mixed']) >= 2:
+                n_mixed_clusters += 1
+        # over-seg per true id: count clusters whose dominant==tid
+        dom_count = defaultdict(int)
+        for sid in sids:
+            dom = cl_info[(m, sid)]['dominant']
+            if dom is not None:
+                dom_count[dom] += 1
+        for tid in set(t for _,_,t in RTTM[m]):
+            appear_total += 1
+            if dom_count.get(tid, 0) > 1:
+                split_count += 1
+    return dict(meetings=len(by_meeting), clusters=n_clusters_total,
+                mean_clusters_per_meeting=round(n_clusters_total/len(by_meeting),2),
+                over_seg_meetings=over, under_seg_meetings=under, exact_meetings=exact,
+                mixed_clusters=n_mixed_clusters,
+                appearances_split=split_count, appearances_total=appear_total)
+
+# ---- false-merge attribution using reid_detail (appearance->profile) ----
+def attribute_arm(arm, match):
+    clusters, cl_info = analyze_arm(arm)
+    rep = json.load(open(os.path.join(ROOT,'data/eval',arm,'reports',f'cons_none_match_{match:.2f}.json')))
+    fm = rep['false_merge']['profiles']        # pid -> [trueids]
+    reid = rep['reid_detail']                  # rows: meeting,true,appearance,anchor,dominant,reid_accuracy
+
+    # map profile -> list of (meeting, true) appearances assigned to it (dominant)
+    prof_appearances = defaultdict(list)
+    for r in reid:
+        prof_appearances[r['dominant']].append((r['meeting'], r['true']))
+
+    # Build, per meeting, the within-meeting mixed-pairs the DIARIZER created
+    # (independent of matcher): pairs (ti,tj) that share a single diarizer cluster.
+    diar_within_pairs = set()   # frozenset({ti,tj}) globally (these CAN ONLY come from diarizer)
+    diar_within_by_meeting = defaultdict(set)
+    for (m, sid), info in cl_info.items():
+        mx = sorted(info['mixed'])
+        for i in range(len(mx)):
+            for j in range(i+1, len(mx)):
+                pr = frozenset((mx[i], mx[j]))
+                diar_within_pairs.add(pr)
+                diar_within_by_meeting[m].add(pr)
+
+    per_profile = []
+    pair_within = set()
+    pair_cross = set()
+    profiles_with_any_within = 0
+    profiles_pure_cross = 0
+
+    for pid, tids in fm.items():
+        tids = sorted(set(tids))
+        # all unordered pairs fused in this profile
+        pairs = [(tids[i], tids[j]) for i in range(len(tids)) for j in range(i+1, len(tids))]
+        within_pairs_here = []
+        cross_pairs_here = []
+        for (a, b) in pairs:
+            pr = frozenset((a, b))
+            if pr in diar_within_pairs:
+                within_pairs_here.append((a, b)); pair_within.add(pr)
+            else:
+                cross_pairs_here.append((a, b)); pair_cross.add(pr)
+        has_within = len(within_pairs_here) > 0
+        if has_within: profiles_with_any_within += 1
+        else: profiles_pure_cross += 1
+        per_profile.append(dict(pid=pid, tids=tids,
+                                within=within_pairs_here, cross=cross_pairs_here))
+
+    return dict(arm=arm, match=match,
+                profiles_end=rep['profiles_at_end'],
+                fm_count=len(fm),
+                fused_pairs_total=len(pair_within)+len(pair_cross),
+                pairs_within_diarizer=len(pair_within),
+                pairs_cross_matcher=len(pair_cross),
+                profiles_with_within=profiles_with_any_within,
+                profiles_pure_cross=profiles_pure_cross,
+                per_profile=per_profile,
+                diar_within_pairs=sorted(['|'.join(sorted(p)) for p in diar_within_pairs]))
+
+if __name__ == '__main__':
+    arms = sys.argv[1].split(',') if len(sys.argv) > 1 else ['ami_clean']
+    match = float(sys.argv[2]) if len(sys.argv) > 2 else 0.60
+    out = {}
+    for arm in arms:
+        out[arm] = dict(diarizer=diarizer_seg_stats(arm),
+                        attribution=attribute_arm(arm, match))
+    print(json.dumps(out, indent=1))

--- a/scripts/q3_floor.py
+++ b/scripts/q3_floor.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Independent diarizer floor: with a PERFECT matcher (zero cross-meeting fusion),
+how many speakers are STILL trapped purely because the diarizer mixed them inside a
+single meeting's cluster?
+
+Method (matcher-free, dumps+RTTM only):
+  - For each diarizer cluster (meeting,speakerId), compute true-id mass via RTTM overlap.
+  - 'Mixed' cluster: >=2 true ids each hold >= MIX_FRAC of the cluster's matched mass.
+  - A perfect matcher assigns each cluster to its dominant true id, but a MIXED cluster
+    physically contains >=2 speakers' audio, so every true id holding >=10% of that
+    cluster is trapped together regardless of matcher quality.
+  - Floor people-trapped = distinct true ids that appear (>=10% of some cluster's mass)
+    in any mixed cluster alongside another such true id.
+Reports per arm; identical for baseline/global since clusters are byte-identical.
+"""
+import json, glob, os, sys
+from collections import defaultdict
+
+ROOT = '/Users/redbars/transcripted/.claude/worktrees/objective-noyce-06bac2'
+RTTM_DIR = os.path.join(ROOT, 'data/ami/rttm')
+MIX_FRAC = 0.10   # match the people-trapped >=10% mass threshold
+
+def load_rttm():
+    rttm = defaultdict(list)
+    for f in glob.glob(os.path.join(RTTM_DIR, '*.rttm')):
+        m = os.path.basename(f)[:-5]
+        for line in open(f):
+            p = line.split()
+            if p and p[0] == 'SPEAKER':
+                st = float(p[3]); dur = float(p[4]); rttm[m].append((st, st+dur, p[7]))
+    return rttm
+RTTM = load_rttm()
+
+def ov(a0,a1,b0,b1): return max(0.0, min(a1,b1)-max(a0,b0))
+
+def floor(arm):
+    dumpdir = os.path.join(ROOT,'data/eval',arm,'dumps')
+    clusters = defaultdict(list)
+    for f in glob.glob(os.path.join(dumpdir,'*.json')):
+        d=json.load(open(f)); m=d['meeting']
+        for s in d['segments']:
+            clusters[(m,s['speakerId'])].append((s['start'],s['end']))
+    trapped=set(); mixed_clusters=0
+    for (m,sid),segs in clusters.items():
+        mass=defaultdict(float)
+        for s0,s1 in segs:
+            for r0,r1,t in RTTM[m]:
+                o=ov(s0,s1,r0,r1)
+                if o>0: mass[t]+=o
+        tot=sum(mass.values())
+        if tot<=0: continue
+        inside={t for t,v in mass.items() if v/tot>=MIX_FRAC}
+        if len(inside)>=2:
+            mixed_clusters+=1
+            trapped|=inside
+    return dict(arm=arm, mixed_clusters=mixed_clusters,
+                floor_people_trapped=len(trapped),
+                floor_ids=sorted(trapped))
+
+if __name__=='__main__':
+    arms=sys.argv[1].split(',')
+    print(json.dumps([floor(a) for a in arms], indent=1))

--- a/scripts/q3_trapped.py
+++ b/scripts/q3_trapped.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Recompute people-trapped per the stated definition and decompose by cause.
+
+people-trapped := number of distinct true ids that have >=10% of THEIR appearances'
+mass inside a profile that is shared by >=2 such true ids (a >=2-person profile).
+
+We approximate "appearance mass in a profile" via reid_detail: each (meeting,true)
+appearance has a 'dominant' profile = where most of its mass landed, and a
+reid_accuracy. We count a true id t as trapped if t is one of the >=2 true ids that
+the false_merge.profiles map lists for some profile pid (these ARE the >=2-person
+profiles by construction), i.e. t participates in a multi-true-id profile.
+
+Then we split trapped speakers into:
+  - reachable-by-within (diarizer): t shares at least one WITHIN-MEETING diarizer pair
+    with another speaker in its profile -> would be trapped even with a perfect matcher.
+  - matcher-only: t is in a multi-id profile but ALL its fused pairs are cross-meeting.
+"""
+import json, os, sys
+from collections import defaultdict
+
+ROOT = '/Users/redbars/transcripted/.claude/worktrees/objective-noyce-06bac2'
+sys.path.insert(0, os.path.join(ROOT, 'scripts'))
+from q3_attribution import attribute_arm
+
+def trapped_decomp(arm, match):
+    att = attribute_arm(arm, match)
+    diar_within = set()
+    for p in att['diar_within_pairs']:
+        a, b = p.split('|'); diar_within.add(frozenset((a, b)))
+
+    trapped = set()                  # all true ids in any multi-id profile
+    trapped_within = set()           # those sharing a within-meeting pair inside their profile
+    for prof in att['per_profile']:
+        tids = prof['tids']
+        if len(tids) < 2:
+            continue
+        for t in tids:
+            trapped.add(t)
+        # for each speaker, does it share a within-meeting pair with a co-member?
+        for t in tids:
+            for u in tids:
+                if t == u:
+                    continue
+                if frozenset((t, u)) in diar_within:
+                    trapped_within.add(t)
+                    break
+    trapped_matcher_only = trapped - trapped_within
+    return dict(arm=arm, match=match,
+                profiles_end=att['profiles_end'],
+                fm_count=att['fm_count'],
+                trapped_total=len(trapped),
+                trapped_within_diarizer=len(trapped_within),
+                trapped_matcher_only=len(trapped_matcher_only),
+                trapped_matcher_only_ids=sorted(trapped_matcher_only))
+
+if __name__ == '__main__':
+    arms = sys.argv[1].split(',')
+    match = float(sys.argv[2]) if len(sys.argv) > 2 else 0.60
+    res = [trapped_decomp(a, match) for a in arms]
+    print(json.dumps(res, indent=1))

--- a/scripts/recluster_eval.py
+++ b/scripts/recluster_eval.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Diarizer-arm experiment: re-cluster the dump's per-segment WeSpeaker embeddings with
+alternative methods and measure whether better clustering reduces within-meeting speaker
+merging (the floor that the matcher-side levers could not move). Measurement only — reads
+the cached dumps + RTTMs; never touches app code or re-runs diarization.
+
+The sharp diagnostic is the ORACLE-K ceiling: if we hand the clusterer the true number of
+speakers and it still cannot separate them, the limit is the EMBEDDINGS/segmentation, not
+the clustering threshold — so tuning the clusterer cannot help and the lever is a better
+segmenter / codec-robust embeddings.
+
+All methods are evaluated on the SAME quality-filtered segment set (quality>=0.3, dur>=1s)
+so the comparison is apples-to-apples (the 'app' method = the dump's own speakerId on that
+set). DER uses pyannote optimal label mapping (isolates clustering quality).
+
+Methods: app | agglo_thresh | agglo_oraclek | ward_oraclek | spectral_oraclek | kmeans_oraclek
+Centering of segment embeddings before clustering: none | global | per_meeting
+"""
+import argparse, glob, json, os, statistics as st
+from collections import defaultdict, Counter
+import numpy as np
+
+from pyannote.core import Annotation, Segment
+from pyannote.metrics.diarization import DiarizationErrorRate
+
+
+def parse_rttm(p):
+    o = []
+    for ln in open(p):
+        x = ln.split()
+        if len(x) >= 8 and x[0] == "SPEAKER":
+            s, d = float(x[3]), float(x[4]); o.append((s, s + d, x[7]))
+    return o
+
+
+def unit(M):
+    M = np.nan_to_num(np.asarray(M, dtype=np.float64))
+    n = np.linalg.norm(M, axis=1, keepdims=True); n[n == 0] = 1.0
+    return M / n
+
+
+def true_for(s, e, ref):
+    best, bo = None, 0.0
+    for rs, re, t in ref:
+        ov = max(0.0, min(e, re) - max(s, rs))
+        if ov > bo:
+            best, bo = t, ov
+    return best
+
+
+def ann(spans, labels):
+    a = Annotation()
+    for i, ((s, e), lab) in enumerate(zip(spans, labels)):
+        if e > s:
+            a[Segment(s, e), i] = str(lab)
+    return a
+
+
+def cluster(embs, method, k, threshold):
+    from sklearn.cluster import AgglomerativeClustering, SpectralClustering, KMeans
+    n = len(embs)
+    if n <= 1:
+        return np.zeros(n, dtype=int)
+    sim = np.clip(embs @ embs.T, -1.0, 1.0)
+    D = 1.0 - sim
+    np.fill_diagonal(D, 0.0)
+    if method == "agglo_thresh":
+        return AgglomerativeClustering(n_clusters=None, distance_threshold=1.0 - threshold,
+                                       metric="precomputed", linkage="average").fit(D).labels_
+    k = max(1, min(k, n))
+    if method == "agglo_oraclek":
+        return AgglomerativeClustering(n_clusters=k, metric="precomputed", linkage="average").fit(D).labels_
+    if method == "ward_oraclek":
+        return AgglomerativeClustering(n_clusters=k, linkage="ward").fit(embs).labels_
+    if method == "spectral_oraclek":
+        A = np.clip((sim + 1) / 2, 0, 1)
+        return SpectralClustering(n_clusters=k, affinity="precomputed",
+                                  assign_labels="discretize", random_state=0).fit(A).labels_
+    if method == "kmeans_oraclek":
+        return KMeans(n_clusters=k, n_init=10, random_state=0).fit(embs).labels_
+    raise SystemExit(f"bad method {method}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--arm", required=True)
+    ap.add_argument("--method", required=True)
+    ap.add_argument("--center", default="none", choices=["none", "global", "per_meeting"])
+    ap.add_argument("--threshold", type=float, default=0.7)
+    ap.add_argument("--dumps")
+    ap.add_argument("--rttm-dir", default="data/ami/rttm")
+    ap.add_argument("--out-json")
+    args = ap.parse_args()
+    dumps = args.dumps or f"data/eval/ami_{args.arm}/dumps"
+    der_metric = DiarizationErrorRate(collar=0.25, skip_overlap=False)
+
+    # global centroid across the arm if requested
+    gcent = None
+    if args.center == "global":
+        allv = []
+        for f in glob.glob(os.path.join(dumps, "*.json")):
+            for s in json.load(open(f))["segments"]:
+                if s.get("embedding") and s["quality"] >= 0.3 and s["end"] - s["start"] >= 1.0:
+                    allv.append(s["embedding"])
+        U = unit(allv); gcent = U.mean(axis=0)
+
+    per = []
+    for f in sorted(glob.glob(os.path.join(dumps, "*.json"))):
+        m = os.path.basename(f)[:-5]
+        rp = os.path.join(args.rttm_dir, m + ".rttm")
+        if not os.path.exists(rp):
+            continue
+        d = json.load(open(f)); ref = parse_rttm(rp)
+        segs = [s for s in d["segments"] if s.get("embedding") and s["quality"] >= 0.3 and s["end"] - s["start"] >= 1.0]
+        if len(segs) < 2:
+            continue
+        E = unit([s["embedding"] for s in segs])
+        if args.center == "global" and gcent is not None:
+            E = unit(E - gcent)
+        elif args.center == "per_meeting":
+            E = unit(E - E.mean(axis=0))
+        spans = [(s["start"], s["end"]) for s in segs]
+        tids = [true_for(s["start"], s["end"], ref) for s in segs]
+        ktrue = len(set(t for t in tids if t is not None))
+        if args.method == "app":
+            labels = [s["speakerId"] for s in segs]
+        else:
+            labels = list(cluster(E, args.method, ktrue, args.threshold))
+        # metrics
+        der = der_metric(ann(spans, tids), ann(spans, labels), detailed=True)
+        tot = der["total"] or 1.0
+        # coverage: distinct true ids that are the dominant (time-weighted) true id of some cluster
+        byc = defaultdict(lambda: defaultdict(float))
+        for (s0, s1), lab, t in zip(spans, labels, tids):
+            if t is not None:
+                byc[lab][t] += (s1 - s0)
+        dom = {c: max(v.items(), key=lambda kv: kv[1])[0] for c, v in byc.items()}
+        covered = len(set(dom.values()))
+        # within-meeting trapped: true ids that never get a cluster they dominate (folded into another's)
+        trapped = ktrue - covered
+        # cluster purity: time-weighted fraction of each cluster that is its dominant speaker
+        pur = []
+        for c, v in byc.items():
+            tt = sum(v.values()); pur.append(max(v.values()) / tt if tt else 0)
+        per.append({"m": m, "ktrue": ktrue, "nclusters": len(set(labels)),
+                    "der": der["diarization error rate"], "conf": der["confusion"] / tot,
+                    "miss": der["missed detection"] / tot, "fa": der["false alarm"] / tot,
+                    "covered": covered, "trapped": trapped,
+                    "purity": round(st.mean(pur), 4) if pur else None})
+
+    agg = {
+        "arm": args.arm, "method": args.method, "center": args.center,
+        "threshold": args.threshold if args.method == "agglo_thresh" else None,
+        "n_meetings": len(per),
+        "mean_der": round(st.mean(p["der"] for p in per), 4) if per else None,
+        "mean_conf": round(st.mean(p["conf"] for p in per), 4) if per else None,
+        "mean_clusters_per_true": round(st.mean(p["nclusters"] / p["ktrue"] for p in per if p["ktrue"]), 3) if per else None,
+        "mean_purity": round(st.mean(p["purity"] for p in per if p["purity"] is not None), 4) if per else None,
+        "total_true": sum(p["ktrue"] for p in per),
+        "total_covered": sum(p["covered"] for p in per),
+        "total_trapped": sum(p["trapped"] for p in per),
+        "coverage_frac": round(sum(p["covered"] for p in per) / max(1, sum(p["ktrue"] for p in per)), 4),
+        "per_meeting": per,
+    }
+    print(json.dumps({k: v for k, v in agg.items() if k != "per_meeting"}, indent=2))
+    if args.out_json:
+        json.dump(agg, open(args.out_json, "w"), indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/recompute_bands_verify.py
+++ b/scripts/recompute_bands_verify.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""INDEPENDENT recomputation of embedding similarity bands from raw dumps + RTTMs.
+
+Does NOT read bands.json. Builds per-(meeting,true-speaker) mean embeddings by assigning
+each dump segment to its true AMI speaker via RTTM time overlap, then computes:
+  (a) SAME speaker, different meetings  cosine band
+  (b) DIFFERENT speakers, different meetings cosine band
+  separation = same_mean - diff_mean
+
+Then tests the shared-coloration MECHANISM: subtract per-arm global mean embedding from
+every per-(meeting,speaker) mean, re-normalize, recompute the different-speaker band.
+"""
+import glob, json, os, math, statistics as st
+from collections import defaultdict
+
+Q_MIN, DUR_MIN = 0.3, 1.0
+ROOT = "/Users/redbars/transcripted/.claude/worktrees/objective-noyce-06bac2"
+RTTM_DIR = f"{ROOT}/data/ami/rttm"
+ARMS = ["clean", "opus24k", "opus16k", "opus12k", "opus8k", "g711u"]
+
+
+def parse_rttm(path):
+    out = []
+    for ln in open(path):
+        p = ln.split()
+        if len(p) >= 8 and p[0] == "SPEAKER":
+            s, d = float(p[3]), float(p[4])
+            out.append((s, s + d, p[7]))
+    return out
+
+
+def true_for(s, e, ref):
+    best, bov = None, 0.0
+    for (rs, re, t) in ref:
+        ov = max(0.0, min(e, re) - max(s, rs))
+        if ov > bov:
+            best, bov = t, ov
+    return best
+
+
+def l2(v):
+    n = math.sqrt(sum(x * x for x in v))
+    return [x / n for x in v] if n else v
+
+
+def mean_emb(es):
+    if not es:
+        return None
+    d = len(es[0])
+    return [sum(e[i] for e in es) / len(es) for i in range(d)]  # NOT renormalized here
+
+
+def cos(a, b):
+    return sum(x * y for x, y in zip(a, b))
+
+
+def series_of(meeting):
+    # ES2002a -> ES2002 ; series shares the 4 recurring speakers
+    return meeting[:-1]
+
+
+def pct(xs, ps=(5, 25, 50, 75, 95)):
+    if not xs:
+        return {}
+    xs = sorted(xs)
+    return {p: round(xs[min(len(xs) - 1, int(p / 100 * len(xs)))], 4) for p in ps}
+
+
+def frac_ge(xs, t):
+    return round(sum(1 for x in xs if x >= t) / len(xs), 4) if xs else None
+
+
+def build_means(arm):
+    """Return dict (meeting, true_speaker) -> L2-normalized mean embedding."""
+    dumps = f"{ROOT}/data/eval/ami_{arm}/dumps"
+    mean_by = {}
+    for dp in sorted(glob.glob(os.path.join(dumps, "*.json"))):
+        m = os.path.basename(dp)[:-5]
+        rp = os.path.join(RTTM_DIR, m + ".rttm")
+        if not os.path.exists(rp):
+            continue
+        d = json.load(open(dp))
+        ref = parse_rttm(rp)
+        by = defaultdict(list)
+        for s in d["segments"]:
+            emb = s.get("embedding")
+            if not emb or s.get("quality", 1.0) < Q_MIN or (s["end"] - s["start"]) < DUR_MIN:
+                continue
+            t = true_for(s["start"], s["end"], ref)
+            if t is not None:
+                by[t].append(l2(emb))  # L2-normalize each segment embedding first
+        for t, es in by.items():
+            me = mean_emb(es)
+            if me:
+                mean_by[(m, t)] = l2(me)  # L2-normalize the per-(meeting,speaker) mean
+    return mean_by
+
+
+def bands(mean_by):
+    """Compute same-speaker (cross-meeting) and different-speaker (cross-meeting) cosine lists.
+    different-speaker = different true speaker AND different meeting (true strangers across
+    series, plus within-series different participants in different meetings)."""
+    by_spk = defaultdict(dict)
+    for (m, t), me in mean_by.items():
+        by_spk[t][m] = me
+
+    same = []
+    for spk, mm in by_spk.items():
+        ms = sorted(mm)
+        for i in range(len(ms)):
+            for j in range(i + 1, len(ms)):
+                same.append(cos(mm[ms[i]], mm[ms[j]]))
+
+    flat = [(m, t, me) for (m, t), me in mean_by.items()]
+    n = len(flat)
+    diff = []
+    diff_crossseries = []  # strict strangers: also different series
+    for i in range(n):
+        for j in range(i + 1, n):
+            if flat[i][1] != flat[j][1] and flat[i][0] != flat[j][0]:
+                c = cos(flat[i][2], flat[j][2])
+                diff.append(c)
+                if series_of(flat[i][0]) != series_of(flat[j][0]):
+                    diff_crossseries.append(c)
+    return same, diff, diff_crossseries
+
+
+def center(mean_by):
+    """Subtract per-arm global mean embedding (centroid of all per-(meeting,speaker) means),
+    then re-normalize."""
+    vals = list(mean_by.values())
+    d = len(vals[0])
+    g = [sum(v[i] for v in vals) / len(vals) for i in range(d)]
+    out = {}
+    for k, v in mean_by.items():
+        c = [v[i] - g[i] for i in range(d)]
+        out[k] = l2(c)
+    gnorm = math.sqrt(sum(x * x for x in g))
+    return out, gnorm
+
+
+def summarize(same, diff):
+    sm = st.mean(same) if same else None
+    dm = st.mean(diff) if diff else None
+    return {
+        "same_mean": round(sm, 4) if sm is not None else None,
+        "same_pct": pct(same),
+        "same_n": len(same),
+        "diff_mean": round(dm, 4) if dm is not None else None,
+        "diff_pct": pct(diff),
+        "diff_n": len(diff),
+        "separation": round(sm - dm, 4) if (sm is not None and dm is not None) else None,
+        "false_merge_0.60": frac_ge(diff, 0.60),
+        "reid_recall_0.60": frac_ge(same, 0.60),
+    }
+
+
+def main():
+    results = {}
+    for arm in ARMS:
+        mb = build_means(arm)
+        same, diff, diff_cs = bands(mb)
+        raw = summarize(same, diff)
+        raw["diff_crossseries_mean"] = round(st.mean(diff_cs), 4) if diff_cs else None
+        raw["n_means"] = len(mb)
+
+        # Mechanism test: mean-center
+        mbc, gnorm = center(mb)
+        same_c, diff_c, diff_cs_c = bands(mbc)
+        cen = summarize(same_c, diff_c)
+        cen["global_mean_norm"] = round(gnorm, 4)
+
+        results[arm] = {"raw": raw, "centered": cen}
+
+    print(json.dumps(results, indent=2))
+
+    # Compact tables
+    print("\n=== RAW BANDS (uncentered) ===")
+    print(f"{'arm':<9} {'same':>7} {'diff':>7} {'sep':>7} {'diff_xS':>8} {'fm@.60':>7} {'reid@.60':>8} {'nmeans':>6}")
+    for arm in ARMS:
+        r = results[arm]["raw"]
+        print(f"{arm:<9} {r['same_mean']:>7} {r['diff_mean']:>7} {r['separation']:>7} "
+              f"{r['diff_crossseries_mean']:>8} {r['false_merge_0.60']:>7} {r['reid_recall_0.60']:>8} {r['n_means']:>6}")
+
+    print("\n=== CENTERED (per-arm global mean subtracted, renormalized) ===")
+    print(f"{'arm':<9} {'same_c':>7} {'diff_c':>7} {'sep_c':>7} {'gmean_norm':>10} {'sep_raw':>8} {'sep_gain':>8}")
+    for arm in ARMS:
+        r = results[arm]["raw"]
+        c = results[arm]["centered"]
+        gain = round(c["separation"] - r["separation"], 4)
+        print(f"{arm:<9} {c['same_mean']:>7} {c['diff_mean']:>7} {c['separation']:>7} "
+              f"{c['global_mean_norm']:>10} {r['separation']:>8} {gain:>+8}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_all_codec_arms.sh
+++ b/scripts/run_all_codec_arms.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Drive all AMI codec arms end to end (measurement only). Sequential by design — one
+# diarizer process at a time avoids Neural-Engine contention; the per-arm dumps cache,
+# so re-runs are cheap. Brackets real usage: clean -> Opus wideband (Zoom/Meet) ->
+# narrowband telephone (G.711). ~1.5-2h cold for 32 meetings x 6 arms.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+export MATCH="${MATCH:-0.40 0.45 0.50 0.55 0.60 0.65 0.70}"
+export CONS="${CONS:-none}"
+
+# tag        mode    bitrate   (real-world analogue)
+ARMS=(
+  "clean    clean   -"        # control: pristine 16 kHz headset
+  "opus24k  opus    24k"      # Zoom/Meet typical wideband
+  "opus16k  opus    16k"      # Zoom low / Meet
+  "opus12k  opus    12k"      # aggressive VoIP (the BASELINE point)
+  "opus8k   opus    8k"       # very aggressive VoIP
+  "g711u    g711u   -"        # PSTN / narrowband telephone (8 kHz mu-law)
+)
+
+echo "### codec arms run start | match='$MATCH' cons='$CONS'"
+for row in "${ARMS[@]}"; do
+  set -- $row; tag="$1"; mode="$2"; br="$3"
+  echo; echo "############ ARM $tag (mode=$mode br=$br) ############"
+  if bash scripts/run_ami_codec_sweep.sh "$tag" "$mode" "$br"; then
+    echo "### ARM $tag OK"
+  else
+    echo "### ARM $tag FAILED (continuing)"
+  fi
+done
+echo; echo "### ALL ARMS DONE"
+ls -d data/eval/ami_*/reports/SWEEP.md 2>/dev/null

--- a/scripts/run_ami_codec_sweep.sh
+++ b/scripts/run_ami_codec_sweep.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# AMI codec re-ID sweep — one compression arm, end to end (measurement only).
+#
+# Encodes the AMI scale set through a VoIP/telephone codec, diarizes the degraded
+# audio with the app's real pipeline, then sweeps the cross-meeting MATCH threshold
+# with re-ID scoring (AMI participant ids recur across a meeting series, so re-ID and
+# cross-series false-merge are both measurable). The whole point: find the match
+# threshold X that best re-identifies a returning speaker WITHOUT fusing strangers,
+# and watch how X moves as compression degrades the embeddings.
+#
+# Usage:
+#   scripts/run_ami_codec_sweep.sh <tag> <mode> [bitrate]
+#     <tag>     output namespace, e.g. clean, opus24k, opus12k, g711u
+#     <mode>    clean | opus | g711u
+#     [bitrate] opus bitrate (e.g. 24k, 12k); ignored for clean/g711u
+#   MEETINGS="ES2002a ES2002b ..."  subset (default = all RTTMs)
+#   MATCH="0.40 0.45 ..."           match grid (default fine 0.40-0.70)
+#   CONS="none"                     consolidation grid (default none; 0.88 known inert)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+ROOT="$(pwd)"
+
+TAG="${1:?tag}"; MODE="${2:?mode: clean|opus|g711u}"; BR="${3:-}"
+CLEAN="$ROOT/data/ami/audio"; RTTM="$ROOT/data/ami/rttm"
+AUD="$ROOT/data/ami_codec/$TAG/audio"
+DUMPS="$ROOT/data/eval/ami_$TAG/dumps"
+RESULTS="$ROOT/data/eval/ami_$TAG/results"
+REPORTS="$ROOT/data/eval/ami_$TAG/reports"
+BIN="$ROOT/Tools/SpeakerEvalHarness/.build/release/speaker-eval-harness"
+mkdir -p "$AUD" "$DUMPS" "$RESULTS" "$REPORTS"
+
+MEETINGS="${MEETINGS:-$(ls "$RTTM" | sed 's/\.rttm$//' | sort | tr '\n' ' ')}"
+MATCH="${MATCH:-0.40 0.45 0.50 0.55 0.60 0.65 0.70}"
+CONS="${CONS:-none}"
+FF="ffmpeg -hide_banner -loglevel error -y"
+
+echo "==> [$TAG] mode=$MODE br=${BR:-n/a} meetings=$(echo $MEETINGS|wc -w|tr -d ' ')  match='$MATCH'"
+
+encode() {  # $1=clean src wav  $2=dest 16k mono wav
+  local src="$1" dst="$2" tmp
+  case "$MODE" in
+    clean) cp -c "$src" "$dst" 2>/dev/null || cp "$src" "$dst" ;;
+    opus)  tmp="$AUD/.tmp.opus"
+           $FF -i "$src" -c:a libopus -b:a "$BR" -ar 16000 -ac 1 "$tmp"
+           $FF -i "$tmp" -ar 16000 -ac 1 -c:a pcm_s16le "$dst"; rm -f "$tmp" ;;
+    g711u) tmp="$AUD/.tmp.mulaw.wav"
+           $FF -i "$src" -ar 8000 -ac 1 -c:a pcm_mulaw "$tmp"          # narrowband telephone
+           $FF -i "$tmp" -ar 16000 -ac 1 -c:a pcm_s16le "$dst"; rm -f "$tmp" ;;
+    *) echo "bad mode $MODE"; exit 2 ;;
+  esac
+}
+
+echo "==> [$TAG] encode + diarize (cached)"
+INPUTS=""
+for m in $MEETINGS; do
+  dump="$DUMPS/$m.json"
+  if [ ! -s "$dump" ]; then
+    src="$CLEAN/$m.Mix-Headset.wav"
+    [ -s "$src" ] || { echo "   !! missing clean $src — skip $m" >&2; continue; }
+    wav="$AUD/$m.wav"
+    [ -s "$wav" ] || encode "$src" "$wav"
+    "$BIN" dump --audio "$wav" --meeting "$m" --out "$dump" 2>&1 | grep -E "^\[dump\] $m:" || true
+    # keep dumps (small); drop the decoded wav to save disk (clean keeps originals elsewhere)
+    [ -s "$dump" ] && [ "$MODE" != clean ] && rm -f "$wav"
+  fi
+  [ -s "$dump" ] && INPUTS="${INPUTS:+$INPUTS,}$dump"
+done
+[ -n "$INPUTS" ] || { echo "[$TAG] no dumps produced"; exit 1; }
+
+echo "==> [$TAG] match sweep (re-ID on; AMI global ids — no --per-file-ids)"
+SCORES=""
+for cons in $CONS; do
+  for mt in $MATCH; do
+    tag="cons_${cons}_match_${mt}"
+    "$BIN" replay --inputs "$INPUTS" --consolidation "$cons" --match "$mt" \
+      --out "$RESULTS/$tag.json" 2>&1 | grep -vE "\.pcm|while processing" | tail -1
+    python3 "$ROOT/scripts/score_speaker_eval.py" --result "$RESULTS/$tag.json" \
+      --rttm-dir "$RTTM" --out-json "$REPORTS/$tag.json" >/dev/null
+    SCORES="${SCORES:+$SCORES,}$REPORTS/$tag.json"
+  done
+done
+
+echo "==> [$TAG] aggregate + bands"
+python3 "$ROOT/scripts/aggregate_sweep.py" --scores "$SCORES" --corpus "ami_$TAG" --out-md "$REPORTS/SWEEP.md" >/dev/null
+python3 "$ROOT/scripts/analyze_ami_codec_bands.py" --dumps "$DUMPS" --rttm-dir "$RTTM" --tag "$TAG" --out-json "$REPORTS/bands.json" >/dev/null
+echo "==> [$TAG] done -> $REPORTS/SWEEP.md , bands.json"

--- a/scripts/run_centering_experiment.sh
+++ b/scripts/run_centering_experiment.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Mean-centering matcher experiment (measurement only — no app code touched).
+# For each codec arm and centering mode: transform the cached dump embeddings, replay them
+# through the REAL clusterer + DB matcher, score vs AMI RTTMs, aggregate. Re-uses the
+# already-diarized dumps (no re-encode / re-diarize), so this is fast.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+ROOT="$(pwd)"
+BIN="$ROOT/Tools/SpeakerEvalHarness/.build/release/speaker-eval-harness"
+RTTM="$ROOT/data/ami/rttm"
+ARMS="${ARMS:-clean opus24k opus16k opus12k opus8k g711u}"
+MODES="${MODES:-normonly global running}"
+MATCH="${MATCH:-0.40 0.45 0.50 0.55 0.60 0.65 0.70}"
+
+for arm in $ARMS; do
+  IN="$ROOT/data/eval/ami_$arm/dumps"
+  [ -d "$IN" ] || { echo "!! missing baseline dumps for $arm ($IN)"; continue; }
+  for mode in $MODES; do
+    OUT="$ROOT/data/eval/ami_${arm}_${mode}"
+    mkdir -p "$OUT/dumps" "$OUT/results" "$OUT/reports"
+    echo "############ $arm / $mode ############"
+    python3 "$ROOT/scripts/center_dumps.py" --in-dumps "$IN" --out-dumps "$OUT/dumps" --mode "$mode" || { echo "center failed"; continue; }
+    INPUTS="$(ls "$OUT"/dumps/*.json | sort | tr '\n' ',' | sed 's/,$//')"
+    SCORES=""
+    for mt in $MATCH; do
+      "$BIN" replay --inputs "$INPUTS" --consolidation none --match "$mt" \
+        --out "$OUT/results/match_$mt.json" 2>&1 | grep -vE "\.pcm|while processing" | tail -1
+      python3 "$ROOT/scripts/score_speaker_eval.py" --result "$OUT/results/match_$mt.json" \
+        --rttm-dir "$RTTM" --out-json "$OUT/reports/cons_none_match_$mt.json" >/dev/null
+      SCORES="${SCORES:+$SCORES,}$OUT/reports/cons_none_match_$mt.json"
+    done
+    python3 "$ROOT/scripts/aggregate_sweep.py" --scores "$SCORES" --corpus "ami_${arm}_${mode}" --out-md "$OUT/reports/SWEEP.md" >/dev/null
+    python3 "$ROOT/scripts/analyze_ami_codec_bands.py" --dumps "$OUT/dumps" --rttm-dir "$RTTM" --tag "${arm}_${mode}" --out-json "$OUT/reports/bands.json" >/dev/null
+    echo "### $arm/$mode done"
+  done
+done
+echo "### CENTERING EXPERIMENT DONE"

--- a/scripts/run_embed_bakeoff.sh
+++ b/scripts/run_embed_bakeoff.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Embedding bake-off: re-extract embeddings for the AMI dump segments with alternative
+# models, all 6 codec arms (measurement only; venv .venv_emb). Idempotent (skips arms
+# already at 32 dumps). Writes data/eval/ami_<arm>__<model>/dumps/.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+. .venv_emb/bin/activate
+MODELS="${MODELS:-ecapa wavlm xvect}"
+ARMS="${ARMS:-clean opus24k opus16k opus12k opus8k g711u}"
+echo "### bakeoff start | models='$MODELS' arms='$ARMS'"
+for model in $MODELS; do
+  for arm in $ARMS; do
+    out="data/eval/ami_${arm}__${model}/dumps"
+    n=$(ls "$out"/*.json 2>/dev/null | wc -l | tr -d ' ')
+    if [ "${n:-0}" -ge 32 ]; then echo "### skip $arm/$model (have $n)"; continue; fi
+    echo "### extract $arm / $model"
+    python scripts/extract_embeddings.py --arm "$arm" --model "$model" 2>&1 \
+      | grep -vE "Warning|warn|deprecat|backend|NotOpenSSL|urllib3|Fetching|Downloading" | tail -1
+  done
+done
+echo "### BAKEOFF DONE (models=$MODELS)"

--- a/scripts/run_model_endtoend.sh
+++ b/scripts/run_model_endtoend.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# End-to-end: replay a candidate model's dumps through the REAL clusterer + DB matcher and
+# score vs AMI RTTM, sweeping the cross-meeting match threshold (each embedding has its own
+# cosine scale, so don't inherit WeSpeaker's 0.60). Measurement only.
+#   scripts/run_model_endtoend.sh <model>   [ARMS="clean opus8k g711u"] [MATCH="0.3 .. 0.7"]
+set -uo pipefail
+cd "$(dirname "$0")/.."
+ROOT="$(pwd)"; BIN="$ROOT/Tools/SpeakerEvalHarness/.build/release/speaker-eval-harness"
+MODEL="${1:?model}"; ARMS="${ARMS:-clean opus12k opus8k g711u}"
+MATCH="${MATCH:-0.30 0.40 0.45 0.50 0.55 0.60 0.65 0.70}"
+for arm in $ARMS; do
+  D="$ROOT/data/eval/ami_${arm}__${MODEL}"
+  [ -d "$D/dumps" ] || { echo "no dumps for $arm/$MODEL"; continue; }
+  INPUTS="$(ls "$D"/dumps/*.json | sort | tr '\n' ',' | sed 's/,$//')"
+  mkdir -p "$D/results" "$D/reports"
+  echo "### $arm/$MODEL"
+  for m in $MATCH; do
+    "$BIN" replay --inputs "$INPUTS" --consolidation none --match "$m" --out "$D/results/e2e_$m.json" 2>&1 | grep -vE "\.pcm|while proc" | tail -1
+    python3 "$ROOT/scripts/score_speaker_eval.py" --result "$D/results/e2e_$m.json" --rttm-dir "$ROOT/data/ami/rttm" --out-json "$D/reports/e2e_$m.json" >/dev/null 2>&1
+  done
+done
+echo "### E2E DONE ($MODEL)"

--- a/scripts/run_speaker_eval.sh
+++ b/scripts/run_speaker_eval.sh
@@ -37,6 +37,12 @@ case "$CORPUS" in
   *) echo "unknown CORPUS='$CORPUS' (ami|icsi|voxconverse|voxceleb)"; exit 2 ;;
 esac
 
+# VoxConverse RTTM labels (spk00, spk01, ...) are PER-FILE and reused across files —
+# namespace true ids by file so the cross-file overlap matrix doesn't conflate distinct
+# people. AMI/ICSI use globally-recurring participant ids; VoxCeleb sessions are built
+# with globally-unique ids — those leave it off so cross-meeting re-ID stays meaningful.
+PERFILE=""; [ "$CORPUS" = "voxconverse" ] && PERFILE="--per-file-ids"
+
 # Meeting list: explicit SERIES, else every meeting that has an RTTM (sorted -> stable
 # replay order; for AMI this keeps each series' a–d consecutive).
 if [ -n "${SERIES:-}" ]; then
@@ -89,7 +95,7 @@ for cons in $CONSOLIDATION; do
     "$BIN" replay --inputs "$INPUTS" --consolidation "$cons" --match "$mt" --out "$res" \
       2>&1 | grep -vE "\.pcm|while processing" | tail -1
     python3 "$ROOT/scripts/score_speaker_eval.py" --result "$res" --rttm-dir "$ROOT/$RTTM_DIR" \
-      --collar "$COLLAR" --out-json "$score" >/dev/null
+      --collar "$COLLAR" $PERFILE --out-json "$score" >/dev/null
     SWEEP_JSONS="${SWEEP_JSONS:+$SWEEP_JSONS,}$score"
   done
 done

--- a/scripts/run_speaker_eval.sh
+++ b/scripts/run_speaker_eval.sh
@@ -1,48 +1,83 @@
 #!/bin/bash
-# Re-runnable speaker-naming eval against AMI ground truth.
+# Re-runnable speaker-naming eval against ground-truth RTTMs — ANY corpus, one driver.
 #
 #   1. build the harness (reuses prebuilt deps under deps-libs/ etc.)
-#   2. dump-diarize each AMI session once (cached in data/eval/dumps/)
-#   3. replay the session series IN ORDER through the real clusterer + DB matcher
+#   2. dump-diarize each session once (cached in data/eval/<CORPUS>/dumps/)
+#   3. replay the sessions IN ORDER through the real clusterer + DB matcher
 #      for every (consolidation × match) threshold combo
-#   4. score each combo vs the AMI RTTMs and aggregate a sweep table
+#   4. score each combo vs the RTTMs (DER, fragmentation, false-merge, re-ID curve)
+#      and aggregate a sweep table
+#
+# The CORPUS env var selects the dataset; everything else (dump -> sweep -> score) is shared.
+# Each corpus just needs WAVs in its audio dir and matching <meeting>.rttm in its rttm dir,
+# fetched by the per-corpus downloader (download_ami.sh / download_icsi.sh /
+# download_voxconverse.sh / download_voxceleb_sample.sh).
 #
 # Usage:
-#   scripts/run_speaker_eval.sh                 # full sweep on the default ES2002 series
-#   SERIES="ES2002a ES2002b ES2002c ES2002d" scripts/run_speaker_eval.sh
+#   scripts/run_speaker_eval.sh                              # CORPUS=ami, all downloaded RTTMs
+#   CORPUS=ami SERIES="ES2002a ES2002b ES2002c ES2002d" scripts/run_speaker_eval.sh
+#   CORPUS=voxconverse scripts/run_speaker_eval.sh
+#   CORPUS=voxceleb scripts/run_speaker_eval.sh             # synthetic re-ID/false-positive sessions
 #   CONSOLIDATION="none 0.85 0.88" MATCH="0.55 0.6 0.65" scripts/run_speaker_eval.sh
+#
+# Env knobs: CORPUS, SERIES (subset; default = all meetings with RTTMs), CONSOLIDATION,
+#            MATCH, COLLAR.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 ROOT="$(pwd)"
 
-SERIES="${SERIES:-ES2002a ES2002b ES2002c ES2002d}"
+CORPUS="${CORPUS:-ami}"
+
+# ---- per-corpus layout: audio dir, rttm dir, audio filename suffix ----
+case "$CORPUS" in
+  ami)         AUDIO_DIR="data/ami/audio";              RTTM_DIR="data/ami/rttm";              SUFFIX=".Mix-Headset.wav" ;;
+  icsi)        AUDIO_DIR="data/icsi/audio";             RTTM_DIR="data/icsi/rttm";             SUFFIX=".wav" ;;
+  voxconverse) AUDIO_DIR="data/voxconverse/audio";      RTTM_DIR="data/voxconverse/rttm";      SUFFIX=".wav" ;;
+  voxceleb)    AUDIO_DIR="data/voxceleb/sessions/audio"; RTTM_DIR="data/voxceleb/sessions/rttm"; SUFFIX=".wav" ;;
+  *) echo "unknown CORPUS='$CORPUS' (ami|icsi|voxconverse|voxceleb)"; exit 2 ;;
+esac
+
+# Meeting list: explicit SERIES, else every meeting that has an RTTM (sorted -> stable
+# replay order; for AMI this keeps each series' a–d consecutive).
+if [ -n "${SERIES:-}" ]; then
+  MEETINGS="$SERIES"
+else
+  MEETINGS="$(ls "$ROOT/$RTTM_DIR" 2>/dev/null | sed 's/\.rttm$//' | sort | tr '\n' ' ')"
+fi
+[ -n "${MEETINGS// /}" ] || { echo "no meetings found for CORPUS=$CORPUS (run the downloader first; looked in $RTTM_DIR)"; exit 1; }
+
 # Sweep grids — consolidation around the 0.88 same-voice bar, match around 0.6.
 CONSOLIDATION="${CONSOLIDATION:-none 0.82 0.85 0.88 0.91}"
 MATCH="${MATCH:-0.50 0.55 0.60 0.65 0.70}"
 COLLAR="${COLLAR:-0.25}"
 
 BIN="$ROOT/Tools/SpeakerEvalHarness/.build/release/speaker-eval-harness"
-DUMPS="$ROOT/data/eval/dumps"
-RESULTS="$ROOT/data/eval/results"
-REPORTS="$ROOT/data/eval/reports"
+DUMPS="$ROOT/data/eval/$CORPUS/dumps"
+RESULTS="$ROOT/data/eval/$CORPUS/results"
+REPORTS="$ROOT/data/eval/$CORPUS/reports"
 mkdir -p "$DUMPS" "$RESULTS" "$REPORTS"
+
+echo "==> CORPUS=$CORPUS  meetings=$(echo "$MEETINGS" | wc -w | tr -d ' ')  (audio=$AUDIO_DIR rttm=$RTTM_DIR)"
 
 echo "==> build harness"
 ( cd "$ROOT/Tools/SpeakerEvalHarness" && swift build -c release 2>&1 | grep -vE "\.pcm|while processing" | tail -1 )
 
 echo "==> dump-diarize sessions (cached)"
 INPUTS=""
-for m in $SERIES; do
+for m in $MEETINGS; do
   dump="$DUMPS/$m.json"
+  audio="$ROOT/$AUDIO_DIR/$m$SUFFIX"
   if [ ! -s "$dump" ]; then
+    if [ ! -s "$audio" ]; then echo "    !! missing audio $audio — skipping $m" >&2; continue; fi
     echo "    diarizing $m ..."
-    "$BIN" dump --audio "$ROOT/data/ami/audio/$m.Mix-Headset.wav" --meeting "$m" --out "$dump" \
+    "$BIN" dump --audio "$audio" --meeting "$m" --out "$dump" \
       2>&1 | grep -E "^\[dump\] $m:" | grep -v processing || true
   else
     echo "    cached $m"
   fi
-  INPUTS="${INPUTS:+$INPUTS,}$dump"
+  [ -s "$dump" ] && INPUTS="${INPUTS:+$INPUTS,}$dump"
 done
+[ -n "$INPUTS" ] || { echo "no dumps produced — check audio files"; exit 1; }
 
 echo "==> threshold sweep (consolidation × match)"
 SWEEP_JSONS=""
@@ -53,12 +88,13 @@ for cons in $CONSOLIDATION; do
     score="$REPORTS/$tag.json"
     "$BIN" replay --inputs "$INPUTS" --consolidation "$cons" --match "$mt" --out "$res" \
       2>&1 | grep -vE "\.pcm|while processing" | tail -1
-    python3 "$ROOT/scripts/score_speaker_eval.py" --result "$res" --rttm-dir "$ROOT/data/ami/rttm" \
+    python3 "$ROOT/scripts/score_speaker_eval.py" --result "$res" --rttm-dir "$ROOT/$RTTM_DIR" \
       --collar "$COLLAR" --out-json "$score" >/dev/null
     SWEEP_JSONS="${SWEEP_JSONS:+$SWEEP_JSONS,}$score"
   done
 done
 
 echo "==> aggregate"
-python3 "$ROOT/scripts/aggregate_sweep.py" --scores "$SWEEP_JSONS" --out-md "$REPORTS/SWEEP.md"
+python3 "$ROOT/scripts/aggregate_sweep.py" --scores "$SWEEP_JSONS" --corpus "$CORPUS" \
+  --out-md "$REPORTS/SWEEP.md"
 echo "==> wrote $REPORTS/SWEEP.md"

--- a/scripts/run_zoom_eval.sh
+++ b/scripts/run_zoom_eval.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Validate embedding models on a REAL recording (Zoom/Meet/phone) vs ground-truth labels —
+# closes the AMI->real-audio domain gap. Same metrics as the AMI bench (within-meeting
+# coverage/DER + cross-call AUC). Measurement only.
+#
+#   scripts/run_zoom_eval.sh <recording.wav> <ground_truth.rttm> [name] ["model1 model2 ..."]
+#
+# - recording.wav: any wav (resampled to 16k mono internally). Ideally the SAME captured
+#   "system audio" Transcripted records, with 2+ known speakers.
+# - ground_truth.rttm: who-spoke-when (see scripts/csv2rttm.py to build it from a CSV).
+# - models: default "campplus" (WeSpeaker baseline is always included). e.g. "campplus eres2net ecapa".
+set -uo pipefail
+cd "$(dirname "$0")/.."
+WAV="${1:?recording.wav}"; RTTM="${2:?ground_truth.rttm}"; NAME="${3:-zoom}"; MODELS="${4:-campplus}"
+BIN="Tools/SpeakerEvalHarness/.build/release/speaker-eval-harness"
+VENV=".venv_emb/bin/python"
+RTTMDIR="$(mktemp -d)"; cp "$RTTM" "$RTTMDIR/$NAME.rttm"
+
+BASE="data/eval/zoom_${NAME}/dumps"; mkdir -p "$BASE"
+echo "==> diarize $WAV (WeSpeaker baseline)"
+[ -s "$BASE/$NAME.json" ] || "$BIN" dump --audio "$WAV" --meeting "$NAME" --out "$BASE/$NAME.json" 2>&1 | grep -E "^\[dump\]" || true
+echo; echo "### WeSpeaker (current) on $NAME:"
+python3 scripts/model_scorecard.py --arm "$NAME" --dumps "$BASE" --rttm-dir "$RTTMDIR" 2>/dev/null \
+  | python3 -c "import json,sys;d=json.load(sys.stdin);w=d['within'];c=d['cross_meeting'];print(f\"  coverage={w['coverage_frac']} DER={w['mean_der']} purity={w['mean_purity']} cross-call-AUC={c['auc_raw']}\")"
+
+for model in $MODELS; do
+  OUT="data/eval/zoom_${NAME}_${model}/dumps"; mkdir -p "$OUT"
+  echo; echo "==> extract $model embeddings"
+  "$VENV" scripts/extract_embeddings.py --arm "$NAME" --model "$model" --base-dumps "$BASE" --audio "$WAV" --out-dir "$OUT" 2>&1 | grep -E "^\[embed\] done" || true
+  echo "### $model on $NAME:"
+  python3 scripts/model_scorecard.py --arm "$NAME" --dumps "$OUT" --rttm-dir "$RTTMDIR" 2>/dev/null \
+    | python3 -c "import json,sys;d=json.load(sys.stdin);w=d['within'];c=d['cross_meeting'];print(f\"  coverage={w['coverage_frac']} DER={w['mean_der']} purity={w['mean_purity']} cross-call-AUC={c['auc_raw']}\")"
+done
+echo; echo "### done — compare each model's DER/coverage/AUC vs WeSpeaker on YOUR real recording."

--- a/scripts/score_speaker_eval.py
+++ b/scripts/score_speaker_eval.py
@@ -26,8 +26,15 @@ except Exception as e:  # pragma: no cover
     print(f"error: pyannote.metrics required ({e})", file=sys.stderr); sys.exit(2)
 
 
-def parse_rttm(path):
-    """Return list of (start, end, speaker_global_id)."""
+def parse_rttm(path, meeting=None, per_file=False):
+    """Return list of (start, end, speaker_global_id).
+
+    With per_file=True the speaker label is namespaced by `meeting`
+    (``meeting␟spk00``). Corpora whose RTTM labels are PER-FILE and reused
+    across files (e.g. VoxConverse: every file has its own ``spk00``) MUST use
+    this, or the cross-file overlap matrix conflates distinct people. Corpora
+    with globally-recurring ids (AMI ``FEE005``...) leave it off so the
+    cross-meeting re-ID curve still sees the same identity across meetings."""
     out = []
     with open(path) as f:
         for line in f:
@@ -35,6 +42,8 @@ def parse_rttm(path):
             if not p or p[0] != "SPEAKER":
                 continue
             start, dur, spk = float(p[3]), float(p[4]), p[7]
+            if per_file and meeting is not None:
+                spk = f"{meeting}␟{spk}"
             out.append((start, start + dur, spk))
     return out
 
@@ -72,6 +81,10 @@ def main():
     ap.add_argument("--rttm-dir", required=True)
     ap.add_argument("--collar", type=float, default=0.25,
                     help="DER forgiveness collar in seconds (AMI convention: 0.25)")
+    ap.add_argument("--per-file-ids", action="store_true",
+                    help="Namespace RTTM speaker ids by file. Required for corpora with "
+                         "per-file labels reused across files (VoxConverse). Leave off for "
+                         "globally-recurring ids (AMI) so cross-meeting re-ID stays meaningful.")
     ap.add_argument("--out-json")
     ap.add_argument("--out-md")
     args = ap.parse_args()
@@ -92,7 +105,7 @@ def main():
     for mr in result["meetings"]:
         meeting = mr["meeting"]
         meeting_order.append(meeting)
-        ref = parse_rttm(f"{args.rttm_dir}/{meeting}.rttm")
+        ref = parse_rttm(f"{args.rttm_dir}/{meeting}.rttm", meeting, args.per_file_ids)
         hyp = [(a["start"], a["end"], a["dbProfile"]) for a in mr["assignments"]]
 
         der = der_metric(annotation_from(ref), annotation_from(hyp), detailed=True)
@@ -164,7 +177,7 @@ def main():
                 first_anchor[tid] = dom_pid
             anchor = first_anchor.get(tid)
             # fraction of this session's speech assigned to the anchor profile
-            covered = sec_assigned(result, meeting, tid, anchor, args.rttm_dir)
+            covered = sec_assigned(result, meeting, tid, anchor, args.rttm_dir, args.per_file_ids)
             acc = covered / ref_sec if ref_sec else 0.0
             reid_by_appearance[k].append(acc)
             reid_detail.append({"meeting": meeting, "true": tid, "appearance": k,
@@ -202,12 +215,12 @@ def main():
         open(args.out_md, "w").write(format_md(summary))
 
 
-def sec_assigned(result, meeting, tid, anchor_pid, rttm_dir):
+def sec_assigned(result, meeting, tid, anchor_pid, rttm_dir, per_file=False):
     """Seconds of true speaker `tid`'s reference speech in `meeting` that overlap
     hypothesis segments labeled `anchor_pid`."""
     if anchor_pid is None:
         return 0.0
-    ref = parse_rttm(f"{rttm_dir}/{meeting}.rttm")
+    ref = parse_rttm(f"{rttm_dir}/{meeting}.rttm", meeting, per_file)
     ref = [(s, e) for (s, e, t) in ref if t == tid]
     mr = next(m for m in result["meetings"] if m["meeting"] == meeting)
     hyp = sorted([(a["start"], a["end"]) for a in mr["assignments"] if a["dbProfile"] == anchor_pid])

--- a/scripts/summarize_endtoend.py
+++ b/scripts/summarize_endtoend.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Summarize a model's end-to-end matcher sweep vs the WeSpeaker baseline. Picks the
+candidate's best operating point (profiles_end nearest the true count, then fewest people
+trapped) and compares to WeSpeaker at its shipping 0.60 and at its best-reachable point."""
+import argparse, glob, json, os, statistics as st
+
+NTRUE = 32
+
+
+def people_trapped(s):
+    return len({t for ids in s["false_merge"]["profiles"].values() for t in ids})
+
+
+def reid_later(s):
+    c = s["reid_curve_by_appearance"]; v = [x for k, x in c.items() if int(k) >= 2]
+    return round(sum(v) / len(v), 3) if v else None
+
+
+def row(s, m):
+    pm = s["der"]["per_meeting"]
+    return {"m": m, "pe": s["profiles_at_end"], "fm": s["false_merge"]["count"],
+            "trap": people_trapped(s), "reid": reid_later(s),
+            "der": round(st.mean(p["der"] for p in pm), 3)}
+
+
+def main():
+    ap = argparse.ArgumentParser(); ap.add_argument("--model", required=True)
+    ap.add_argument("--arms", default="clean opus12k opus8k g711u"); a = ap.parse_args()
+    for arm in a.arms.split():
+        D = f"data/eval/ami_{arm}__{a.model}/reports"
+        cand = []
+        for f in sorted(glob.glob(f"{D}/e2e_*.json")):
+            m = os.path.basename(f)[4:-5]
+            cand.append(row(json.load(open(f)), m))
+        if not cand:
+            print(f"\n[{arm}] no e2e reports"); continue
+        best = sorted(cand, key=lambda r: (abs(r["pe"] - NTRUE), r["trap"], float(r["m"])))[0]
+        # WeSpeaker baseline
+        wsdir = f"data/eval/ami_{arm}/reports"
+        ws60 = json.load(open(f"{wsdir}/cons_none_match_0.60.json")) if os.path.exists(f"{wsdir}/cons_none_match_0.60.json") else None
+        wsall = [row(json.load(open(f)), os.path.basename(f).split("match_")[1][:-5])
+                 for f in glob.glob(f"{wsdir}/cons_none_match_*.json")]
+        wsbest = sorted(wsall, key=lambda r: (abs(r["pe"] - NTRUE), r["trap"], float(r["m"]))) [0] if wsall else None
+        print(f"\n=== {arm}  (ideal profiles = {NTRUE}) ===")
+        print(f"  {a.model} sweep (m: pe/fm/trapped/reID/DER):")
+        for r in cand:
+            star = " <== best" if r["m"] == best["m"] else ""
+            print(f"    {r['m']}: {r['pe']}/{r['fm']}/{r['trap']}/{r['reid']}/{r['der']}{star}")
+        if ws60:
+            w = row(ws60, "0.60"); print(f"  WeSpeaker @0.60 (shipping): {w['pe']}/{w['fm']}/{w['trap']}/{w['reid']}/{w['der']}")
+        if wsbest:
+            print(f"  WeSpeaker best-reachable @{wsbest['m']}: {wsbest['pe']}/{wsbest['fm']}/{wsbest['trap']}/{wsbest['reid']}/{wsbest['der']}")
+        print(f"  -> {a.model} BEST @{best['m']}: profiles {best['pe']} (vs ideal 32), trapped {best['trap']}, DER {best['der']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/trace_vs_eager_direct.py
+++ b/scripts/trace_vs_eager_direct.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Direct test: does torch.jit.trace(m) match eager m on the SAME real-fbank
+input? Earlier we only compared trace-vs-eager on a random tensor (got 1.0).
+Now test on the EXPORT random tensor AND real fbank. If trace != eager, the
+TorchScript tracer itself is the culprit (in-place op / checkpoint), independent
+of ONNX/CoreML.
+
+Also try torch.jit.script (not trace) and torch.export as alternatives.
+"""
+import os, numpy as np, torch, warnings
+warnings.filterwarnings("ignore")
+import torchaudio, torchaudio.compliance.kaldi as Kaldi
+
+MODEL_DIR = os.path.expanduser(
+    "~/.cache/modelscope/hub/models/iic/speech_campplus_sv_en_voxceleb_16k")
+BIN = os.path.join(MODEL_DIR, "campplus_voxceleb.bin")
+AMI_WAV = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                       "data","ami","audio","ES2002a.Mix-Headset.wav")
+FEAT_DIM, EMB_SIZE, N_FRAMES, SR = 80, 512, 300, 16000
+
+def cosine(a,b):
+    a=a.flatten().astype(np.float64); b=b.flatten().astype(np.float64)
+    return float(np.dot(a,b)/(np.linalg.norm(a)*np.linalg.norm(b)+1e-12))
+
+from modelscope.models.audio.sv.DTDNN import CAMPPlus
+m = CAMPPlus(feat_dim=FEAT_DIM, embedding_size=EMB_SIZE)
+m.load_state_dict(torch.load(BIN, map_location="cpu"), strict=True); m.eval()
+
+def fbank(wav):
+    f = Kaldi.fbank(wav.unsqueeze(0), num_mel_bins=FEAT_DIM)
+    return f - f.mean(dim=0, keepdim=True)
+def seg(p, st, du):
+    w,sr = torchaudio.load(p)
+    if sr!=SR: w = torchaudio.functional.resample(w, sr, SR)
+    w=w[0]; return w[int(st*SR):int((st+du)*SR)].contiguous()
+def fixed(f,n):
+    if f.shape[0]>=n: return f[:n]
+    return torch.cat([f, torch.zeros(n-f.shape[0], f.shape[1])],0)
+
+rnd = torch.randn(1, N_FRAMES, FEAT_DIM)
+real = fixed(fbank(seg(AMI_WAV,60,4)), N_FRAMES).unsqueeze(0)
+
+with torch.no_grad():
+    e_rnd  = m(rnd).numpy()
+    e_real = m(real).numpy()
+
+# Trace on RANDOM, eval on both
+tr_rnd = torch.jit.trace(m, rnd); tr_rnd.eval()
+with torch.no_grad():
+    t_rnd_on_rnd  = tr_rnd(rnd).numpy()
+    t_rnd_on_real = tr_rnd(real).numpy()
+print("trace(on rnd) vs eager  @rnd :", f"{cosine(e_rnd,  t_rnd_on_rnd):.6f}")
+print("trace(on rnd) vs eager  @real:", f"{cosine(e_real, t_rnd_on_real):.6f}")
+
+# Trace on REAL, eval on real
+tr_real = torch.jit.trace(m, real); tr_real.eval()
+with torch.no_grad():
+    t_real_on_real = tr_real(real).numpy()
+print("trace(on real) vs eager @real:", f"{cosine(e_real, t_real_on_real):.6f}")
+
+# Does re-running eager AFTER trace change BN running stats? (trace may update them)
+with torch.no_grad():
+    e_real_after = m(real).numpy()
+print("eager @real BEFORE vs AFTER tracing:", f"{cosine(e_real, e_real_after):.6f}")

--- a/scripts/verify_bakeoff.py
+++ b/scripts/verify_bakeoff.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""TASK A independent adversarial verification of the embedding bake-off.
+Recomputes everything FROM THE DUMPS, does not read any scorecard JSON.
+Keeps PER-MEETING results for a paired sign test. Reimplements coverage/purity
+directly; uses pyannote DER (standard lib) and sklearn agglomerative (standard lib).
+"""
+import glob, json, os, sys, math
+from collections import defaultdict
+import numpy as np
+from sklearn.cluster import AgglomerativeClustering
+from sklearn.metrics import roc_auc_score
+from pyannote.core import Annotation, Segment
+from pyannote.metrics.diarization import DiarizationErrorRate
+
+Q, DUR = 0.3, 1.0
+RTTM = "data/ami/rttm"
+
+
+def parse_rttm(p):
+    o = []
+    for ln in open(p):
+        x = ln.split()
+        if len(x) >= 8 and x[0] == "SPEAKER":
+            s, d = float(x[3]), float(x[4])
+            o.append((s, s + d, x[7]))
+    return o
+
+
+def unit(M):
+    M = np.nan_to_num(np.asarray(M, dtype=np.float64))
+    n = np.linalg.norm(M, axis=1, keepdims=True)
+    n[n == 0] = 1.0
+    return M / n
+
+
+def true_for(s, e, ref):
+    best, bo = None, 0.0
+    for rs, re, t in ref:
+        ov = max(0.0, min(e, re) - max(s, rs))
+        if ov > bo:
+            best, bo = t, ov
+    return best
+
+
+def ann(spans, labels):
+    a = Annotation()
+    for i, ((s, e), lab) in enumerate(zip(spans, labels)):
+        if e > s:
+            a[Segment(s, e), i] = str(lab)
+    return a
+
+
+def oracle_k_labels(E, k):
+    n = len(E)
+    if n <= 1:
+        return np.zeros(n, dtype=int)
+    sim = np.clip(E @ E.T, -1.0, 1.0)
+    D = 1.0 - sim
+    np.fill_diagonal(D, 0.0)
+    k = max(1, min(k, n))
+    return AgglomerativeClustering(n_clusters=k, metric="precomputed",
+                                   linkage="average").fit(D).labels_
+
+
+def eval_arm_model(arm, model):
+    d = f"data/eval/ami_{arm}" + (f"__{model}" if model else "") + "/dumps"
+    der_metric = DiarizationErrorRate(collar=0.25, skip_overlap=False)
+    per = []
+    mean_by = {}  # (meeting, spk) -> mean unit emb
+    dim = None
+    for f in sorted(glob.glob(os.path.join(d, "*.json"))):
+        m = os.path.basename(f)[:-5]
+        rp = os.path.join(RTTM, m + ".rttm")
+        if not os.path.exists(rp):
+            continue
+        data = json.load(open(f))
+        ref = parse_rttm(rp)
+        segs = [s for s in data["segments"]
+                if s.get("embedding") and s["quality"] >= Q and s["end"] - s["start"] >= DUR]
+        if len(segs) < 2:
+            continue
+        E = unit([s["embedding"] for s in segs])
+        dim = E.shape[1]
+        spans = [(s["start"], s["end"]) for s in segs]
+        tids = [true_for(s["start"], s["end"], ref) for s in segs]
+        ktrue = len(set(t for t in tids if t is not None))
+        labels = list(oracle_k_labels(E, ktrue))
+        der = der_metric(ann(spans, tids), ann(spans, labels), detailed=True)
+        tot = der["total"] or 1.0
+        # coverage + purity, time-weighted, computed independently
+        byc = defaultdict(lambda: defaultdict(float))
+        for (s0, s1), lab, t in zip(spans, labels, tids):
+            if t is not None:
+                byc[lab][t] += (s1 - s0)
+        dom = {c: max(v, key=v.get) for c, v in byc.items()}
+        covered = len(set(dom.values()))
+        purs = [max(v.values()) / sum(v.values()) for v in byc.values() if sum(v.values())]
+        per.append({
+            "m": m, "ktrue": ktrue, "covered": covered,
+            "cov_frac": covered / ktrue if ktrue else 0.0,
+            "der": der["diarization error rate"],
+            "conf": der["confusion"] / tot,
+            "purity": float(np.mean(purs)) if purs else 0.0,
+        })
+        # cross-meeting per-(meeting,speaker) means
+        bt = defaultdict(list)
+        for e, t in zip(E, tids):
+            if t is not None:
+                bt[t].append(e)
+        for t, es in bt.items():
+            mean_by[(m, t)] = unit([np.mean(es, axis=0)])[0]
+    # cross-meeting verification
+    keys = list(mean_by)
+    V = np.array([mean_by[k] for k in keys])
+    n = len(keys)
+    pairs = [(i, j) for i in range(n) for j in range(i + 1, n) if keys[i][0] != keys[j][0]]
+    same_s, diff_s = [], []
+    sc, lab = [], []
+    for i, j in pairs:
+        c = float(V[i] @ V[j])
+        sc.append(c)
+        same = 1 if keys[i][1] == keys[j][1] else 0
+        lab.append(same)
+        (same_s if same else diff_s).append(c)
+    sc = np.array(sc); lab = np.array(lab)
+    auc = float(roc_auc_score(lab, sc)) if lab.sum() and (len(lab) - lab.sum()) else None
+    return {
+        "arm": arm, "model": model or "wespeaker", "dim": dim,
+        "n_meetings": len(per),
+        "agg_cov_frac": sum(p["covered"] for p in per) / max(1, sum(p["ktrue"] for p in per)),
+        "mean_der": float(np.mean([p["der"] for p in per])),
+        "mean_conf": float(np.mean([p["conf"] for p in per])),
+        "mean_purity": float(np.mean([p["purity"] for p in per])),
+        "per": per,
+        "xm_auc": auc,
+        "xm_n_same": int(lab.sum()), "xm_n_diff": int(len(lab) - lab.sum()),
+        "xm_same_mean": float(np.mean(same_s)) if same_s else None,
+        "xm_diff_mean": float(np.mean(diff_s)) if diff_s else None,
+        "xm_sep": float(np.mean(same_s) - np.mean(diff_s)) if same_s and diff_s else None,
+    }
+
+
+def sign_test_p(wins, losses):
+    """two-sided exact binomial p under H0=0.5 on decisive (non-tie) meetings."""
+    n = wins + losses
+    if n == 0:
+        return 1.0
+    k = min(wins, losses)
+    from math import comb
+    tail = sum(comb(n, i) for i in range(0, k + 1))
+    p = 2 * tail / (2 ** n)
+    return min(1.0, p)
+
+
+def paired(base, cand, key, lower_better=True):
+    """Return (wins, losses, ties, mean_delta) for cand vs base on per-meeting `key`."""
+    bm = {p["m"]: p for p in base["per"]}
+    wins = losses = ties = 0
+    deltas = []
+    for p in cand["per"]:
+        if p["m"] not in bm:
+            continue
+        b = bm[p["m"]][key]
+        c = p[key]
+        deltas.append(c - b)
+        if abs(c - b) < 1e-9:
+            ties += 1
+        elif (c < b) == lower_better:
+            wins += 1
+        else:
+            losses += 1
+    return wins, losses, ties, float(np.mean(deltas)) if deltas else 0.0
+
+
+if __name__ == "__main__":
+    arms = ["clean", "opus8k", "g711u", "opus12k"]
+    models = ["", "ecapa", "redimnet_b6"]
+    results = {}
+    for arm in arms:
+        for model in models:
+            d = f"data/eval/ami_{arm}" + (f"__{model}" if model else "") + "/dumps"
+            ndump = len(glob.glob(os.path.join(d, "*.json")))
+            if ndump < 32:
+                print(f"SKIP {arm}__{model or 'wespeaker'}: only {ndump} dumps", file=sys.stderr)
+                continue
+            r = eval_arm_model(arm, model)
+            results[(arm, model or "wespeaker")] = r
+            print(f"DONE {arm:8s} {model or 'wespeaker':12s} "
+                  f"cov={r['agg_cov_frac']:.3f} der={r['mean_der']:.3f} "
+                  f"pur={r['mean_purity']:.3f} auc={r['xm_auc']:.4f} "
+                  f"sep={r['xm_sep']:.3f} nm={r['n_meetings']}", file=sys.stderr)
+    json.dump({f"{a}__{m}": v for (a, m), v in results.items()},
+              open("/tmp/bakeoff_verify.json", "w"))
+    # paired comparisons
+    print("\n=== PAIRED (cand vs wespeaker), DER lower better ===", file=sys.stderr)
+    for arm in arms:
+        base = results.get((arm, "wespeaker"))
+        if not base:
+            continue
+        for model in ["ecapa", "redimnet_b6"]:
+            cand = results.get((arm, model))
+            if not cand:
+                continue
+            w, l, t, md = paired(base, cand, "der", lower_better=True)
+            wc, lc, tc, mc = paired(base, cand, "cov_frac", lower_better=False)
+            p = sign_test_p(w, l)
+            print(f"{arm:8s} {model:12s} DER wins={w:2d} losses={l:2d} ties={t} "
+                  f"meanΔ={md:+.3f} signtest_p={p:.4g} | COV wins={wc:2d} losses={lc:2d} meanΔ={mc:+.3f}",
+                  file=sys.stderr)

--- a/scripts/verify_static.py
+++ b/scripts/verify_static.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""ROOT CAUSE confirmed: dynamic time-axis breaks strided Conv1d in export.
+Verify the FIX end-to-end on real AMI audio for BOTH:
+  (a) ONNX with fully static shape (no dynamic_axes)
+  (b) CoreML with fully static shape
+Both must hit cosine >0.99 vs eager PyTorch.
+Report final model sizes.
+"""
+import os, numpy as np, torch, warnings
+warnings.filterwarnings("ignore")
+import torchaudio, torchaudio.compliance.kaldi as Kaldi
+import onnxruntime as ort
+import coremltools as ct
+
+MODEL_DIR = os.path.expanduser(
+    "~/.cache/modelscope/hub/models/iic/speech_campplus_sv_en_voxceleb_16k")
+BIN = os.path.join(MODEL_DIR, "campplus_voxceleb.bin")
+AMI_WAV = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                       "data","ami","audio","ES2002a.Mix-Headset.wav")
+OUT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "out")
+os.makedirs(OUT, exist_ok=True)
+FEAT_DIM, EMB_SIZE, N_FRAMES, SR = 80, 512, 300, 16000
+
+def cosine(a,b):
+    a=a.flatten().astype(np.float64); b=b.flatten().astype(np.float64)
+    return float(np.dot(a,b)/(np.linalg.norm(a)*np.linalg.norm(b)+1e-12))
+def dirsize(p):
+    if os.path.isfile(p): return os.path.getsize(p)/(1024*1024)
+    return sum(os.path.getsize(os.path.join(d,f)) for d,_,fs in os.walk(p) for f in fs)/(1024*1024)
+
+from modelscope.models.audio.sv.DTDNN import CAMPPlus
+m = CAMPPlus(feat_dim=FEAT_DIM, embedding_size=EMB_SIZE); m.eval()
+m.load_state_dict(torch.load(BIN, map_location="cpu"), strict=True)
+
+def fbank(wav):
+    f = Kaldi.fbank(wav.unsqueeze(0), num_mel_bins=FEAT_DIM)
+    return f - f.mean(dim=0, keepdim=True)
+def seg(p, st, du):
+    w,sr = torchaudio.load(p)
+    if sr!=SR: w = torchaudio.functional.resample(w, sr, SR)
+    w=w[0]; return w[int(st*SR):int((st+du)*SR)].contiguous()
+def fixed(f,n):
+    if f.shape[0]>=n: return f[:n]
+    return torch.cat([f, torch.zeros(n-f.shape[0], f.shape[1])],0)
+
+segs = [(60.0,4.0),(120.0,3.5),(200.0,5.0),(300.0,4.0),(450.0,3.0)]
+feats = [fixed(fbank(seg(AMI_WAV,st,du)), N_FRAMES).unsqueeze(0) for st,du in segs]
+ref = []
+for f in feats:
+    with torch.no_grad():
+        ref.append(m(f).numpy())
+
+dummy = torch.randn(1, N_FRAMES, FEAT_DIM)
+
+# (a) ONNX static
+onnx_static = os.path.join(OUT, "campplus_static.onnx")
+torch.onnx.export(m, dummy, onnx_static, input_names=["fbank"],
+                  output_names=["embedding"], opset_version=14)  # NO dynamic_axes
+s = ort.InferenceSession(onnx_static, providers=["CPUExecutionProvider"])
+print("== ONNX (static shape) vs eager ==")
+onnx_cos = []
+for i,f in enumerate(feats):
+    o = s.run(["embedding"], {"fbank": f.numpy().astype(np.float32)})[0]
+    c = cosine(ref[i], o); onnx_cos.append(c)
+    print(f"  seg{i}: cosine={c:.6f}")
+print(f"  min ONNX cosine: {min(onnx_cos):.6f}  size={dirsize(onnx_static):.2f} MB")
+
+# (b) CoreML static
+traced = torch.jit.trace(m, dummy); traced.eval()
+mlpkg = os.path.join(OUT, "campplus_static.mlpackage")
+ml = ct.convert(
+    traced,
+    inputs=[ct.TensorType(name="fbank", shape=(1,N_FRAMES,FEAT_DIM), dtype=np.float32)],
+    outputs=[ct.TensorType(name="embedding", dtype=np.float32)],
+    convert_to="mlprogram", compute_units=ct.ComputeUnit.ALL,
+    minimum_deployment_target=ct.target.macOS13)
+ml.save(mlpkg)
+print("\n== CoreML (static shape, FLOAT16/ALL) vs eager ==")
+cm_cos = []
+for i,f in enumerate(feats):
+    o = ml.predict({"fbank": f.numpy().astype(np.float32)})
+    k = "embedding" if "embedding" in o else list(o.keys())[0]
+    c = cosine(ref[i], np.asarray(o[k])); cm_cos.append(c)
+    print(f"  seg{i}: cosine={c:.6f}")
+print(f"  min CoreML cosine: {min(cm_cos):.6f}  size={dirsize(mlpkg):.2f} MB")
+
+# (c) CoreML static FLOAT32 CPU (precision ceiling)
+ml32 = ct.convert(
+    traced,
+    inputs=[ct.TensorType(name="fbank", shape=(1,N_FRAMES,FEAT_DIM), dtype=np.float32)],
+    outputs=[ct.TensorType(name="embedding", dtype=np.float32)],
+    convert_to="mlprogram", compute_units=ct.ComputeUnit.CPU_ONLY,
+    compute_precision=ct.precision.FLOAT32,
+    minimum_deployment_target=ct.target.macOS13)
+print("\n== CoreML (static, FLOAT32/CPU) vs eager ==")
+cm32 = []
+for i,f in enumerate(feats):
+    o = ml32.predict({"fbank": f.numpy().astype(np.float32)})
+    k = "embedding" if "embedding" in o else list(o.keys())[0]
+    c = cosine(ref[i], np.asarray(o[k])); cm32.append(c)
+    print(f"  seg{i}: cosine={c:.6f}")
+print(f"  min CoreML-f32 cosine: {min(cm32):.6f}")
+
+print("\n========= VERDICT =========")
+mn = min(min(cm_cos), min(onnx_cos))
+v = "PASS" if min(cm_cos) > 0.99 else ("PARTIAL" if min(cm_cos) > 0.9 else "FAIL")
+print(f"CoreML(f16/ALL) min cosine = {min(cm_cos):.6f} -> {v}")
+print(f"ONNX(static)    min cosine = {min(onnx_cos):.6f}")
+print(f"CoreML mlpackage size = {dirsize(mlpkg):.2f} MB")

--- a/scripts/voxceleb_sample.py
+++ b/scripts/voxceleb_sample.py
@@ -119,9 +119,22 @@ def main():
             if tmp:
                 os.unlink(tmp.name)
 
-    kept = {}            # speaker -> count kept
+    # Resume: seed counts from clips already on disk so repeated calls (e.g. one per split)
+    # ACCUMULATE clips per identity instead of overwriting. clips-per-id / identity-cap then
+    # apply to the running totals.
+    kept = {}            # speaker -> count kept (existing + new)
     os.makedirs(args.out_dir, exist_ok=True)
+    for spk in os.listdir(args.out_dir):
+        d = os.path.join(args.out_dir, spk)
+        if os.path.isdir(d):
+            n = len([f for f in os.listdir(d) if f.endswith(".wav")])
+            if n:
+                kept[spk] = n
+    if kept:
+        print(f"[voxceleb] resuming: {len(kept)} ids already on disk "
+              f"({sum(kept.values())} clips)")
     total = 0
+    failed = 0
     for row in ds:
         audio = row.get(audio_col) if audio_col else None
         spk = speaker_of(row, audio)
@@ -138,6 +151,7 @@ def main():
         os.makedirs(d, exist_ok=True)
         idx = kept.get(spk, 0)
         if not write_clip(row.get(audio_col), os.path.join(d, f"{idx:03d}.wav"), args.sr):
+            failed += 1
             continue
         kept[spk] = idx + 1
         total += 1
@@ -145,6 +159,12 @@ def main():
             print(f"[voxceleb] {len(kept)} ids, {total} clips...")
 
     print(f"[voxceleb] done: {len(kept)} identities, {total} clips -> {args.out_dir}")
+    if failed:
+        # Silent read failures are usually unauthenticated HF rate-limiting on bulk per-clip
+        # fetches — surface it instead of mysteriously yielding too few clips.
+        print(f"[voxceleb] WARNING: {failed} clip read(s) failed — likely HF rate-limiting. "
+              "Set HF_TOKEN / `huggingface-cli login` for higher limits and re-run "
+              "(resume picks up where this left off).", file=sys.stderr)
     if not kept:
         print("[voxceleb] nothing sampled — check HF auth/terms and dataset schema", file=sys.stderr)
         sys.exit(1)

--- a/scripts/voxceleb_sample.py
+++ b/scripts/voxceleb_sample.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""SAMPLE-ONLY VoxCeleb1 identity sampler with a HARD CAP.
+
+VoxCeleb1 (CC-BY-SA 4.0, https://www.robots.ox.ac.uk/~vgg/data/voxceleb/) is huge
+(~1200 identities / ~150k clips / ~30 GB). We NEVER pull all of it. Instead we STREAM a
+HuggingFace VoxCeleb1 mirror and stop as soon as we have `--identity-cap` distinct
+speakers, each with up to `--clips-per-id` clips. Streaming means the wire footprint is
+bounded by (cap × clips × ~clip-size), not the full corpus.
+
+GATED: VoxCeleb on HF is usually access-gated — needs `huggingface-cli login` (or HF_TOKEN)
+and accepting the dataset terms, plus `pip install datasets soundfile`.
+
+Output layout (16 kHz mono WAV, the app's target rate):
+  data/voxceleb/raw/<speaker_id>/<clip_index>.wav
+
+Usage:
+  python3 scripts/voxceleb_sample.py --out-dir data/voxceleb/raw \
+      --identity-cap 300 --clips-per-id 10
+"""
+import argparse, os, sys
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--identity-cap", type=int, default=300,
+                    help="HARD CAP on distinct identities (default 300). Never pull all of VoxCeleb.")
+    ap.add_argument("--clips-per-id", type=int, default=10, help="max clips kept per identity")
+    ap.add_argument("--dataset", default="confit/voxceleb1",
+                    help="HF VoxCeleb1 mirror exposing per-clip audio + speaker label")
+    ap.add_argument("--split", default="train")
+    ap.add_argument("--sr", type=int, default=16000)
+    args = ap.parse_args()
+
+    if args.identity_cap <= 0 or args.identity_cap > 1211:
+        print(f"refusing identity-cap={args.identity_cap}: must be 1..1211 (VoxCeleb1 size). "
+              "This is a SAMPLE-only tool.", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        from datasets import load_dataset
+        import soundfile as sf
+        import numpy as np
+    except Exception as e:
+        print(f"error: needs `datasets` + `soundfile` ({e}); pip install datasets soundfile",
+              file=sys.stderr)
+        sys.exit(2)
+
+    print(f"[voxceleb] STREAMING {args.dataset}:{args.split} — cap {args.identity_cap} ids "
+          f"× {args.clips_per_id} clips (hard cap; not pulling the full corpus)")
+    ds = load_dataset(args.dataset, split=args.split, streaming=True)
+
+    def speaker_of(row):
+        for k in ("speaker", "speaker_id", "label", "id", "client_id"):
+            v = row.get(k)
+            if v is not None:
+                return str(v)
+        return None
+
+    kept = {}            # speaker -> count kept
+    os.makedirs(args.out_dir, exist_ok=True)
+    total = 0
+    for row in ds:
+        spk = speaker_of(row)
+        if spk is None:
+            continue
+        if spk not in kept and len(kept) >= args.identity_cap:
+            # cap reached for new identities; only top up identities we already have
+            if all(c >= args.clips_per_id for c in kept.values()):
+                break
+            continue
+        if kept.get(spk, 0) >= args.clips_per_id:
+            continue
+        audio = row.get("audio")
+        if not isinstance(audio, dict) or "array" not in audio:
+            continue
+        arr = np.asarray(audio["array"], dtype="float32")
+        sr = int(audio.get("sampling_rate", args.sr))
+        d = os.path.join(args.out_dir, spk)
+        os.makedirs(d, exist_ok=True)
+        idx = kept.get(spk, 0)
+        sf.write(os.path.join(d, f"{idx:03d}.wav"), arr, sr)
+        kept[spk] = idx + 1
+        total += 1
+        if total % 100 == 0:
+            print(f"[voxceleb] {len(kept)} ids, {total} clips...")
+
+    print(f"[voxceleb] done: {len(kept)} identities, {total} clips -> {args.out_dir}")
+    if not kept:
+        print("[voxceleb] nothing sampled — check HF auth/terms and dataset schema", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/voxceleb_sample.py
+++ b/scripts/voxceleb_sample.py
@@ -7,15 +7,20 @@ HuggingFace VoxCeleb1 mirror and stop as soon as we have `--identity-cap` distin
 speakers, each with up to `--clips-per-id` clips. Streaming means the wire footprint is
 bounded by (cap × clips × ~clip-size), not the full corpus.
 
-GATED: VoxCeleb on HF is usually access-gated — needs `huggingface-cli login` (or HF_TOKEN)
-and accepting the dataset terms, plus `pip install datasets soundfile`.
+Needs `pip install datasets` + `ffmpeg` on PATH (audio is read via fsspec and transcoded
+by ffmpeg — no torch/soundfile/torchcodec needed). The default mirror `s3prl/mini_voxceleb1`
+is PUBLIC (no HF login). Larger mirrors may be access-gated (`huggingface-cli login` /
+HF_TOKEN + accept terms); point `--dataset` at one to scale past mini's identity count.
+
+Speaker id comes from the dataset's speaker column if populated, else from the VoxCeleb
+filename convention (`id10012-<video>-00001.wav` -> `id10012`).
 
 Output layout (16 kHz mono WAV, the app's target rate):
   data/voxceleb/raw/<speaker_id>/<clip_index>.wav
 
 Usage:
   python3 scripts/voxceleb_sample.py --out-dir data/voxceleb/raw \
-      --identity-cap 300 --clips-per-id 10
+      --identity-cap 300 --clips-per-id 10 --dataset s3prl/mini_voxceleb1
 """
 import argparse, os, sys
 
@@ -26,8 +31,9 @@ def main():
     ap.add_argument("--identity-cap", type=int, default=300,
                     help="HARD CAP on distinct identities (default 300). Never pull all of VoxCeleb.")
     ap.add_argument("--clips-per-id", type=int, default=10, help="max clips kept per identity")
-    ap.add_argument("--dataset", default="confit/voxceleb1",
-                    help="HF VoxCeleb1 mirror exposing per-clip audio + speaker label")
+    ap.add_argument("--dataset", default="s3prl/mini_voxceleb1",
+                    help="HF VoxCeleb1 mirror exposing per-clip audio (public default; "
+                         "swap for a larger/gated mirror to exceed mini's identity count)")
     ap.add_argument("--split", default="train")
     ap.add_argument("--sr", type=int, default=16000)
     args = ap.parse_args()
@@ -38,30 +44,87 @@ def main():
         sys.exit(2)
 
     try:
-        from datasets import load_dataset
-        import soundfile as sf
-        import numpy as np
+        from datasets import load_dataset, Audio
     except Exception as e:
-        print(f"error: needs `datasets` + `soundfile` ({e}); pip install datasets soundfile",
-              file=sys.stderr)
+        print(f"error: needs `datasets` ({e}); pip install datasets", file=sys.stderr)
+        sys.exit(2)
+    import shutil, subprocess, tempfile
+    if not shutil.which("ffmpeg"):
+        print("error: ffmpeg required to transcode clips", file=sys.stderr)
         sys.exit(2)
 
     print(f"[voxceleb] STREAMING {args.dataset}:{args.split} — cap {args.identity_cap} ids "
           f"× {args.clips_per_id} clips (hard cap; not pulling the full corpus)")
     ds = load_dataset(args.dataset, split=args.split, streaming=True)
+    # Disable HF audio decoding (datasets 4.x needs torchcodec to decode arrays). We grab
+    # the raw encoded bytes/path instead and let ffmpeg transcode to 16 kHz mono — no
+    # torch/soundfile dependency, and robust across mirrors.
+    audio_col = "audio" if "audio" in (ds.column_names or []) else None
+    if audio_col:
+        ds = ds.cast_column(audio_col, Audio(decode=False))
 
-    def speaker_of(row):
-        for k in ("speaker", "speaker_id", "label", "id", "client_id"):
+    import re
+    try:
+        import fsspec
+    except Exception:
+        fsspec = None
+
+    def speaker_of(row, audio):
+        # 1) an explicit speaker column, if populated
+        for k in ("speaker", "speaker_id", "client_id", "speaker_label", "label", "id"):
             v = row.get(k)
-            if v is not None:
+            if v is not None and str(v) != "":
                 return str(v)
+        # 2) VoxCeleb encodes the speaker in the filename: id10012-<video>-00001.wav
+        path = audio.get("path") if isinstance(audio, dict) else None
+        if path:
+            base = os.path.basename(path)
+            m = re.match(r"(id\d+)", base)
+            if m:
+                return m.group(1)
+            # else fall back to the leading path segment
+            parts = base.split("-")
+            if parts:
+                return parts[0]
         return None
+
+    def write_clip(audio, dst, sr):
+        """audio is {'bytes':..,'path':..} (decode=False). Read bytes (local, or hf://
+        via fsspec) and transcode to 16 kHz mono WAV with ffmpeg."""
+        src, tmp = None, None
+        if isinstance(audio, dict):
+            data = audio.get("bytes")
+            path = audio.get("path")
+            if not data and path and "://" in path and fsspec is not None:
+                try:
+                    with fsspec.open(path, "rb") as f:
+                        data = f.read()
+                except Exception:
+                    data = None
+            if data:
+                tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".bin")
+                tmp.write(data); tmp.close(); src = tmp.name
+            elif path and "://" not in path:
+                src = path
+        if not src:
+            return False
+        try:
+            subprocess.check_call(["ffmpeg", "-v", "error", "-y", "-i", src, "-ac", "1",
+                                   "-ar", str(sr), "-c:a", "pcm_s16le", dst],
+                                  stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            return True
+        except subprocess.CalledProcessError:
+            return False
+        finally:
+            if tmp:
+                os.unlink(tmp.name)
 
     kept = {}            # speaker -> count kept
     os.makedirs(args.out_dir, exist_ok=True)
     total = 0
     for row in ds:
-        spk = speaker_of(row)
+        audio = row.get(audio_col) if audio_col else None
+        spk = speaker_of(row, audio)
         if spk is None:
             continue
         if spk not in kept and len(kept) >= args.identity_cap:
@@ -71,15 +134,11 @@ def main():
             continue
         if kept.get(spk, 0) >= args.clips_per_id:
             continue
-        audio = row.get("audio")
-        if not isinstance(audio, dict) or "array" not in audio:
-            continue
-        arr = np.asarray(audio["array"], dtype="float32")
-        sr = int(audio.get("sampling_rate", args.sr))
         d = os.path.join(args.out_dir, spk)
         os.makedirs(d, exist_ok=True)
         idx = kept.get(spk, 0)
-        sf.write(os.path.join(d, f"{idx:03d}.wav"), arr, sr)
+        if not write_clip(row.get(audio_col), os.path.join(d, f"{idx:03d}.wav"), args.sr):
+            continue
         kept[spk] = idx + 1
         total += 1
         if total % 100 == 0:


### PR DESCRIPTION
**Measurement only — no app behavior changed.** Two research reports + supporting eval tooling. App code (`Sources/`) untouched; all `data/` artifacts gitignored. Built on the corpus-mix harness (`eval/corpus-mix-scaleup`).

## The question this answers
"Does compressed/remote audio (Zoom/Meet/phone) want a *lower* speaker-match threshold (~0.50) than AMI's 0.60, to get fewer false positives?" Two complementary experiments:

---
## Report 1 — VoxConverse (in-the-wild YouTube) · `Tools/SpeakerEvalHarness/VOXCONVERSE_REPORT.md`
216 files, 972 true speakers. **Optimal match does NOT drop toward 0.50.** Bands are well-separated (same 0.93 / cross-file diff 0.14); the diarizer **under-segments** (0.81 clusters/true); 0.88 consolidation is inert. VoxConverse is in-the-wild but **not codec-compressed** — the wrong proxy for the remote-audio question. Required a scoring-correctness fix (`--per-file-ids`) since VoxConverse labels are per-file (without it `n_true` collapses to ~20 and the recommender chases the lowest threshold — the wrong, dangerous conclusion). Clean/AMI scoring byte-identical.

## Report 2 — AMI codec re-ID sweep · `Tools/SpeakerEvalHarness/AMI_CODEC_REID_REPORT.md`
The *right* testbed: AMI's 32 recurring speakers (8 series × 4 meetings) re-encoded through 6 codecs (clean → Opus 24k/16k/12k/8k → G.711 telephone), match sweep 0.40–0.70 with re-ID on. **Clean control reproduces the SCALEUP baseline exactly** (0.60 → 32 profiles, fm 22, reID 0.532).

**Headline — the hypothesis is refuted (adversarially verified; all numbers recomputed from raw data by 5 verifier passes):**
- **Optimal match threshold does NOT drop to 0.50 — it holds ~0.60 or rises.** Compression inflates the *different-speaker* band (strangers look alike: 0.28 → 0.60) while same-speaker stays flat, so band separation collapses (0.544 clean → 0.287 opus8k). **Lowering the threshold would *increase* false positives.** Opus 8k can't recover 32 identities at any threshold (caps at 10); G.711 caps at 27.
- **Key new finding: the collapse is *removable* shared codec coloration, not lost identity.** `‖shared centroid‖²` tracks the diff-band rise ~1:1; **mean-centering embeddings before matching restores separation to 0.77–0.81 on every arm** (opus8k 0.287 → 0.770, ties clean) — a near-free fix, no retraining.
- **Diarizer is the bottleneck** (confusion ≈ 100% upstream; under-segments worse under compression: opus8k 0.66 clusters/true). The "1 person → 9" over-split never appears (over-seg = 0 at opus8k/g711u).
- **Significance:** ordering clean > opus12k > opus8k holds 8/8 leave-one-series-out folds and 0/5000 paired bootstrap resamples.

**Recommendation (Zoom-wideband Opus ≥16k):** keep match **0.60** (raise to 0.65–0.70 on narrowband; **never lower**). Invest in (0) mean-centering embeddings before matching, (1) codec-augmented embeddings, (2) a multi-party/compression-tuned diarizer — not the threshold.

---
## Files
- `Tools/SpeakerEvalHarness/{VOXCONVERSE_REPORT.md, AMI_CODEC_REID_REPORT.md}`
- scorer fix `scripts/score_speaker_eval.py` (`--per-file-ids`, default off → AMI byte-identical); `scripts/run_speaker_eval.sh`; `scripts/download_voxconverse.sh` (auto-resume)
- codec eval: `scripts/{run_ami_codec_sweep.sh, run_all_codec_arms.sh, analyze_ami_codec_bands.py, aggregate_codec_arms.py}`
- verification: `scripts/{recompute_bands_verify.py, jackknife_series_bands.py, bootstrap_series_bands.py}`, `scripts/analyze_voxconverse_bands.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)