### PR TITLE
[nightly-build] Fix capture broadcaster test warnings

### DIFF
--- a/Tests/CaptureLibraryChangeBroadcasterTests.swift
+++ b/Tests/CaptureLibraryChangeBroadcasterTests.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @MainActor
 func testCaptureLibraryChangeBroadcaster() async {
-    await runSuite("CaptureLibraryChangeBroadcaster coalesces a burst into one debounced notification") {
+    runSuite("CaptureLibraryChangeBroadcaster coalesces a burst into one debounced notification") {
         let center = NotificationCenter()
         var capturedIDs: [[String]] = []
         let token = center.addObserver(
@@ -48,7 +48,7 @@ func testCaptureLibraryChangeBroadcaster() async {
         )
     }
 
-    await runSuite("CaptureLibraryChangeBroadcaster reports a library-wide change as empty ids") {
+    runSuite("CaptureLibraryChangeBroadcaster reports a library-wide change as empty ids") {
         let center = NotificationCenter()
         var capturedIDs: [[String]] = []
         let token = center.addObserver(
@@ -78,7 +78,7 @@ func testCaptureLibraryChangeBroadcaster() async {
         assertEqual(capturedIDs.first, [], "a library-wide change should carry an empty id list")
     }
 
-    await runSuite("CaptureLibraryChangeBroadcaster is idempotent with nothing pending") {
+    runSuite("CaptureLibraryChangeBroadcaster is idempotent with nothing pending") {
         let center = NotificationCenter()
         var postCount = 0
         let token = center.addObserver(


### PR DESCRIPTION
## Summary
- remove unnecessary await expressions from CaptureLibraryChangeBroadcaster fast tests
- keep the MainActor async test entry point so the generated runner does not lose actor isolation

## Verification
- bash build-deps.sh --force
- bash build.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh (warning reproduced before fix)
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh (5504 tests passed after fix)
- bash run-integration-smoke.sh
- swift test (489 tests, 1 skipped)