### PR TITLE
[nightly-review] Refresh Home after playback-mix backfill

### DIFF
--- a/Sources/Meeting/MeetingAudioStorageManager.swift
+++ b/Sources/Meeting/MeetingAudioStorageManager.swift
@@ -433,6 +433,23 @@ struct MeetingAudioStorageMaintenanceResult: Equatable {
     let scannedDirectories: Int
     let convertedFiles: Int
     let prunedDirectories: Int
+    let createdPlaybackMixes: Int
+
+    init(
+        scannedDirectories: Int,
+        convertedFiles: Int,
+        prunedDirectories: Int,
+        createdPlaybackMixes: Int = 0
+    ) {
+        self.scannedDirectories = scannedDirectories
+        self.convertedFiles = convertedFiles
+        self.prunedDirectories = prunedDirectories
+        self.createdPlaybackMixes = createdPlaybackMixes
+    }
+
+    var changedArtifacts: Bool {
+        convertedFiles > 0 || prunedDirectories > 0 || createdPlaybackMixes > 0
+    }
 }
 
 struct FailedMeetingAudioCompressionCandidate: Equatable {
@@ -481,14 +498,17 @@ enum MeetingAudioStorageManager {
         )
 
         var convertedFiles = 0
+        var createdPlaybackMixes = 0
         for directory in directories {
-            await createPlaybackMixIfNeeded(
+            if await createPlaybackMixIfNeeded(
                 in: directory,
                 now: now,
                 fileManager: fileManager,
                 validator: validator,
                 playbackMixer: playbackMixer
-            )
+            ) {
+                createdPlaybackMixes += 1
+            }
             convertedFiles += await compressWAVAudio(
                 in: directory,
                 now: now,
@@ -501,7 +521,8 @@ enum MeetingAudioStorageManager {
         return MeetingAudioStorageMaintenanceResult(
             scannedDirectories: directories.count,
             convertedFiles: convertedFiles,
-            prunedDirectories: prunedDirectories
+            prunedDirectories: prunedDirectories,
+            createdPlaybackMixes: createdPlaybackMixes
         )
     }
 

--- a/Sources/TranscriptedAppState.swift
+++ b/Sources/TranscriptedAppState.swift
@@ -341,9 +341,9 @@ class TranscriptedAppState: ObservableObject {
             let result = await MeetingAudioStorageManager.processExistingRetainedAudio(
                 in: MeetingStoragePaths.transcriptsFolder
             )
-            // Launch backfill can recompress/prune many meetings' audio; if it
+            // Launch backfill can create/recompress/prune many meetings' audio; if it
             // changed anything, tell Home so cached audio URLs re-resolve.
-            if result.convertedFiles > 0 || result.prunedDirectories > 0 {
+            if result.changedArtifacts {
                 await MainActor.run {
                     CaptureLibraryChangeBroadcaster.shared.noteLibraryWideChange()
                 }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -4339,9 +4339,9 @@ struct TranscriptedSettingsView: View {
                 in: MeetingStoragePaths.transcriptsFolder,
                 retentionWindow: window
             )
-            // A retention change can recompress/prune retained audio across the
+            // A retention change can create/recompress/prune retained audio across the
             // library; signal Home so cached audio URLs re-resolve from disk.
-            if result.convertedFiles > 0 || result.prunedDirectories > 0 {
+            if result.changedArtifacts {
                 await MainActor.run {
                     CaptureLibraryChangeBroadcaster.shared.noteLibraryWideChange()
                 }

--- a/Tests/MeetingAudioStorageManagerTests.swift
+++ b/Tests/MeetingAudioStorageManagerTests.swift
@@ -178,6 +178,44 @@ func testMeetingAudioStorageManager() async {
         assertFalse(FileManager.default.fileExists(atPath: systemWAV.path), "raw system WAV should still follow normal compression")
     }
 
+    await runSuite("MeetingAudioStorageManager reports uncompressed playback mix backfills") {
+        let directory = makeMeetingAudioStorageTestDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let transcriptURL = try! makeTranscript(named: "Compressed Split Backfill", in: directory, ageDays: 1)
+        let audioDirectory = makeAudioDirectory(for: transcriptURL)
+        try! Data("m4a".utf8).write(to: audioDirectory.appendingPathComponent("microphone.m4a"))
+        try! Data("m4a".utf8).write(to: audioDirectory.appendingPathComponent("system_audio.m4a"))
+
+        let result = await MeetingAudioStorageManager.processExistingRetainedAudio(
+            in: directory,
+            retentionWindow: .never,
+            converter: FakeMeetingAudioConverter(shouldFail: true),
+            validator: FakeMeetingAudioValidator(),
+            playbackMixer: FakeMeetingAudioPlaybackMixer()
+        )
+
+        assertEqual(
+            result,
+            MeetingAudioStorageMaintenanceResult(
+                scannedDirectories: 1,
+                convertedFiles: 0,
+                prunedDirectories: 0,
+                createdPlaybackMixes: 1
+            ),
+            "backfill should report playback mix creation even when later M4A compression fails"
+        )
+        assertTrue(result.changedArtifacts, "playback mix creation should trigger Home cache refresh")
+        assertTrue(
+            FileManager.default.fileExists(atPath: audioDirectory.appendingPathComponent("playback.wav").path),
+            "created playback WAV should remain usable when compression fails"
+        )
+        assertFalse(
+            FileManager.default.fileExists(atPath: audioDirectory.appendingPathComponent("playback.m4a").path),
+            "failed compression should not leave a fake M4A playback file"
+        )
+    }
+
     await runSuite("MeetingAudioStorageManager falls back to usable compressed split audio for playback mix") {
         let directory = makeMeetingAudioStorageTestDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }


### PR DESCRIPTION
## Nightly review

Live evidence checked on 2026-06-17:
- `origin/main` at `a5f9ea04` with last-24h PRs #1114, #1135, #1136, #1137, #1139, #1141, #1142, #1143, #1145.
- Open nightly PR search found no `[nightly-review]` or `[nightly-regression]` drafts before this patch.
- Sentry 24h top unresolved current-release risk: `APPLE-MACOS-1W`, fatal `EXC_BREAKPOINT` in `TdtDecoderV3.runJointPrepared`, release `transcripted@1.1.48`.
- Sentry `APPLE-MACOS-1B` meeting capture degraded latest sampled event was older release `transcripted@1.1.41`; still worth watching but not a current-code fix.
- PostHog 7d from health probe: devices=143, workflow_events=2437, onboarding_events=724, first_value_events=938.

Ranked risks:
1. Fresh `APPLE-MACOS-1W` TdtDecoder fatal on 1.1.48 is the highest live production risk, but open draft #1146 already owns residual fatal-crash triage and currently defers this as likely upstream/vendored memory corruption.
2. Home audio attachment drift after #1139: launch/settings maintenance can create a `playback.wav` mix, fail later M4A compression, and report no artifact change, leaving cached Home audio URLs stale.
3. Audio lifecycle/device-change rewarm from #1145 remains high-risk, but the landed policy path has focused fast coverage for blocked engine queue abandonment.

Chosen nightly action: small code fix for risk #2.

## Changes

- Count `createdPlaybackMixes` in `MeetingAudioStorageMaintenanceResult`.
- Add `changedArtifacts` so callers use one artifact-change signal.
- Broadcast Home library refresh after launch/settings maintenance when playback-mix creation is the only successful change.
- Add a registered fast regression where playback mix creation succeeds but M4A compression fails.

## Verification

- `scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` — 5508 passed
- `bash run-integration-smoke.sh`
- `/Users/redbars/.codex/skills/codex-review/scripts/codex-review --mode auto --output /tmp/transcripted-nightly-review-codex-review.txt` — clean, no accepted/actionable findings

Known noise: `CaptureLibraryChangeBroadcasterTests` async warnings are already covered by open draft #1154.
