### PR TITLE
[nightly-telemetry] Tag crash reports with runtime last event

### DIFF
--- a/Sources/Observability/CrashReporter.swift
+++ b/Sources/Observability/CrashReporter.swift
@@ -81,9 +81,13 @@ final class CrashReporter {
 
         let sanitizedContext = SentryPayloadSanitizer.sanitizeContext(context)
         guard !sanitizedContext.isEmpty else { return }
+        let sanitizedTags = SentryPayloadSanitizer.sanitizeCrashRuntimeTags(context)
 
         SentrySDK.configureScope { scope in
             scope.setContext(value: sanitizedContext, key: "runtime")
+            if !sanitizedTags.isEmpty {
+                scope.setTags(sanitizedTags)
+            }
         }
     }
 

--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -2,6 +2,9 @@ import Foundation
 
 enum SentryPayloadSanitizer {
     private static let maxValueLength = 240
+    private static let crashRuntimeTagKeys: Set<String> = [
+        "last_event",
+    ]
     private static let explicitlySafeKeys: Set<String> = [
         "mic_file_available",
         "system_file_available",
@@ -55,6 +58,11 @@ enum SentryPayloadSanitizer {
         }
 
         return sanitized
+    }
+
+    static func sanitizeCrashRuntimeTags(_ context: [String: String]) -> [String: String] {
+        let tagCandidates = context.filter { crashRuntimeTagKeys.contains($0.key) }
+        return sanitizeTags(tagCandidates)
     }
 
     static func sanitizeAnyDictionary(_ dictionary: [String: Any]) -> [String: Any] {

--- a/Tests/SentryPayloadSanitizerTests.swift
+++ b/Tests/SentryPayloadSanitizerTests.swift
@@ -137,6 +137,19 @@ func testSentryPayloadSanitizer() {
         assertNil(sanitized["error"], "free-form runtime errors should still be dropped")
     }
 
+    runSuite("SentryPayloadSanitizer.sanitizeCrashRuntimeTags exposes only reviewed workflow state") {
+        let sanitized = SentryPayloadSanitizer.sanitizeCrashRuntimeTags([
+            "last_event": "dictation_transcribing",
+            "session_kind": "dictation",
+            "session_stage": "transcribing",
+            "transcript_path": "/Users/redbars/Library/Application Support/Transcripted/captures/meetings/private.md",
+            "error": "private raw failure",
+        ])
+
+        assertEqual(sanitized["last_event"], "dictation_transcribing", "last runtime event should be queryable as a crash tag")
+        assertEqual(Set(sanitized.keys), ["last_event"], "crash runtime tags should stay limited to one reviewed workflow dimension")
+    }
+
     runSuite("SentryPayloadSanitizer.sanitizeText redacts emails hostnames and non-home paths") {
         let input = "Contact me at person@example.com from Redbarss-MacBook-Pro.local and inspect /private/var/folders/demo/file.txt"
         let sanitized = SentryPayloadSanitizer.sanitizeText(input)


### PR DESCRIPTION
## Summary

Adds one privacy-safe Sentry crash tag from the existing runtime diagnostics context: `last_event`.

Current fatal crash events already carry runtime context in Sentry event detail, but the issue list/tags only show default crash metadata. This makes current-release crashes such as `APPLE-MACOS-1W` look like generic decoder crashes until someone opens the event detail or cross-checks PostHog restart telemetry. Tagging the coarse `last_event` value makes the issue directly filterable as workflow state, e.g. `dictation_transcribing`, without adding transcript, audio, title, app, device-name, user, URL, token, or path data.

## Evidence

- Read the required automation docs: `AGENTS.md`, `Sources/Observability/CLAUDE.md`, `Sources/UI/CLAUDE.md`, `docs/privacy-first-observability.md`, `transcripted-health/SKILL.md`, and automation memory.
- Confirmed no open `[nightly-telemetry]` or `[nightly-ux]` draft PRs before editing.
- Sentry: `APPLE-MACOS-1W` is unresolved, fatal, current-release `transcripted@1.1.48`, last seen 2026-06-16T21:10:30Z.
- Sentry event detail for that crash already has runtime context: `last_event=dictation_transcribing`, `session_kind=dictation`, `session_stage=transcribing`; the issue/event tags did not expose that workflow state.
- PostHog: `1.1.48` has 288 launches / 120 devices over 7d, 47 meeting starts, 45 meeting saves, zero current-release meeting failures, and one current-release unclean-shutdown row in dictation transcription.

## Candidate Scoring

Winner: current-release fatal crash missing issue-list workflow tag — 91/100

- User pain / workflow distortion: 24/30 — fatal crash on the shipped release.
- Debugging/confusion severity: 23/25 — event detail has the clue, but issue tags do not.
- Current-release relevance: 15/15 — latest event is `1.1.48`.
- Small-patch safety: 14/15 — one tag dimension from an existing sanitized runtime context.
- Privacy/payload confidence: 15/15 — controlled coarse runtime state only.

Why the next candidates lost:

- `APPLE-MACOS-1B` meeting capture degraded: recent but last release on the issue is `1.1.41`, and it already carries rich bucketed capture tags.
- No-speech / short dictation friction: `1.1.48` has 14 events / 4 devices over 7d, mostly physical-key `lt_10s`, but existing copy/read-window mitigation is already on `main` and volume is too low for another UI change.
- Clear progress/error-copy UX: real polish, but already owned by draft PRs #1147 and #1148.

## Patch

- `SentryPayloadSanitizer.sanitizeCrashRuntimeTags` allowlists only `last_event` for crash runtime tags.
- `CrashReporter.setRuntimeDiagnosticsContext` keeps writing the full sanitized runtime context and additionally sets the sanitized `last_event` tag.
- Added a sanitizer test that rejects `session_kind`, `session_stage`, paths, and free-form errors from crash runtime tags.

## Verification

- `git diff --check`
- `bash run-tests.sh` -> 5506 tests passed
