### PR TITLE
[operator] Cover feedback diagnostics opt out

### DIFF
--- a/Tests/FeedbackIssueBuilderTests.swift
+++ b/Tests/FeedbackIssueBuilderTests.swift
@@ -84,6 +84,30 @@ func testFeedbackIssueBuilder() {
         assertFalse(body.contains("person@example.com"), "emails in user notes should be scrubbed")
         assertFalse(body.contains("https://example.com/log"), "diagnostic URLs should be scrubbed")
     }
+
+    runSuite("FeedbackIssueBuilder honors contextual diagnostics opt out") {
+        let report = FeedbackReport(
+            sourceKind: "meeting",
+            referenceID: "meeting-abc",
+            occurredAt: Date(timeIntervalSince1970: 1_714_000_000),
+            issueKind: "Bad transcript",
+            userNotes: "Please check the transcript quality.",
+            appVersion: "Version 1.2.3",
+            includeDiagnostics: false
+        )
+        let url = FeedbackIssueBuilder.emailURL(report: report, rawLogLines: [
+            "[12:01:00.000] ERROR | wrote /Users/redbars/private.txt for person@example.com",
+            "[12:02:00.000] TOKEN | sk-test-secret via https://example.com/private-log"
+        ])
+        let body = feedbackBody(from: url)
+
+        assertTrue(body.contains("User chose not to attach diagnostics."), "opt-out feedback should state that diagnostics were not attached")
+        assertFalse(body.contains("ERROR | wrote"), "opt-out feedback should not include raw log markers")
+        assertFalse(body.contains("/Users/redbars/"), "opt-out feedback should not include file paths from raw logs")
+        assertFalse(body.contains("person@example.com"), "opt-out feedback should not include emails from raw logs")
+        assertFalse(body.contains("sk-test-secret"), "opt-out feedback should not include tokens from raw logs")
+        assertFalse(body.contains("https://example.com/private-log"), "opt-out feedback should not include URLs from raw logs")
+    }
 }
 
 private func feedbackBody(from url: URL?) -> String {


### PR DESCRIPTION
## Why

The contextual feedback path has a user-controlled `includeDiagnostics` toggle. Existing tests covered sanitized diagnostics when enabled, but not the opt-out branch.

## What changed

- Added a fast `FeedbackIssueBuilder` regression for `includeDiagnostics: false`.
- The test passes hostile raw log lines containing a path, email, token-like string, and URL.
- It asserts the email body says diagnostics were not attached and does not include raw log markers or sensitive log content.

## Safety

- Test-only.
- No app behavior, release metadata, telemetry payload, audio path, storage/deletion path, or privacy policy change.
- Checked open app and web PRs first; no current PR touches `FeedbackIssueBuilder` or its tests.

## Verification

- `bash run-tests.sh --filter FeedbackIssueBuilder` -> 34 passed
- `scripts/dev/agent-preflight.sh`
- `git diff --check -- Tests/FeedbackIssueBuilderTests.swift`