### PR TITLE
[operator] Cover agent bundle source labels

### DIFF
--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -353,6 +353,14 @@ func testAgentConnectionGuide() {
         assertTrue(text.contains("transcripted-search-memory"), "bundle should embed the Search Memory skill")
         assertTrue(text.contains("Source file: \(meetingURL.lastPathComponent)"), "bundle should include source filename")
         assertTrue(
+            text.contains("Recorded at: 2025-12-17T18:00:00.000Z"),
+            "bundle should include the source meeting timestamp"
+        )
+        assertTrue(
+            text.contains("**00:00**  [Speaker 1]"),
+            "bundle should preserve transcript timestamps and speaker labels"
+        )
+        assertTrue(
             text.contains("We decided to ship the agent setup and copy for agent flow."),
             "bundle should include the meeting transcript body"
         )
@@ -384,4 +392,3 @@ private func readAgentConnectionGuideSource() -> String {
         .appendingPathComponent("Sources/UI/Shared/AgentConnectionGuide.swift")
     return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
 }
-


### PR DESCRIPTION

## Summary

Adds a narrow regression to `AgentConnectionGuide.portableMeetingBundle` so the portable meeting bundle keeps the source timestamp plus transcript timestamp/speaker label visible in the pasted bundle.

This protects the first-value loop: saved Markdown -> pasted/agent-readable bundle -> sourced agent answer with file/date/timestamp/speaker evidence.

## Why this lane

- Test-only change.
- Avoids open PR files and risky runtime surfaces.
- No telemetry payloads, audio behavior, storage behavior, release metadata, or user-facing positioning changed.

## Verification

- `scripts/dev/agent-preflight.sh`
- `git diff --check -- Tests/AgentConnectionGuideTests.swift`
- `bash run-tests.sh --filter AgentConnectionGuide` -> 108 passed
- `bash run-tests.sh` -> 5506 passed

## Notes

Full fast-test compile still prints existing `CaptureLibraryChangeBroadcasterTests` async warnings; this PR does not touch that file.
