### PR TITLE
Document install attribution map

### DIFF
--- a/docs/install-attribution-map.md
+++ b/docs/install-attribution-map.md
@@ -1,0 +1,80 @@
+# Install Attribution Map
+
+Use this when checking the anonymous path from public interest to first value:
+
+`website pageview -> download intent -> GitHub/Sparkle download -> first app launch -> first useful local Markdown artifact`
+
+The goal is directional attribution, not person-level tracking. Keep the lanes
+aggregate, bucketed, and privacy-safe.
+
+## Privacy Boundary
+
+Do not add any user-level join keys between the website and the app.
+
+Do not send raw referrers, URLs, IPs, transcript text, audio references,
+meeting titles, speaker names, emails, tokens, absolute file paths, source app
+names, or raw device names to PostHog or Sentry.
+
+Allowed signals are coarse counts and bucketed app events that already pass
+through `AnalyticsEventPolicy` and `AnalyticsPayloadSanitizer`.
+
+## Current Signal Map
+
+| Funnel stage | Signal | Source | Notes |
+| --- | --- | --- | --- |
+| Website interest | Page views, requests, deployment freshness | Cloudflare Pages and Web Analytics for `transcripted.app` | Directional only. Cloudflare can show public-site demand, but it should not be joined to app devices. |
+| Download intent | `/download` page loads and `/download/latest.dmg` redirect health | Live site plus Cloudflare | Good for checking the handoff works. Path-level counts depend on Cloudflare analytics access. |
+| Release download | GitHub release asset download count | GitHub Releases | Counts public DMG downloads, including repeat downloads and automation. |
+| In-app update download | `update_check_finished`, `update_download_started`, `update_download_finished`, `update_ready_to_install`, `update_relaunching`, `update_installed` | PostHog | App-side update funnel. Use version-scoped aggregate counts. |
+| First launch | `app_launched` with `app_version` and `build_version` default properties | PostHog | Anonymous device/session signal only. |
+| First useful artifact | `onboarding_first_dictation_saved`, `dictation_completed`, `meeting_transcript_saved` | PostHog | Shows local Markdown value without inspecting content. |
+| Agent payoff | `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_agent_setup_cta_clicked`, `activation_return_proxy_observed` | PostHog | Coarse proof of opening artifacts, copying/using agent prompts, setup CTAs, and later return via Home. |
+| Reliability filter | Release-scoped issues and allowed non-fatal events | Sentry | Use to avoid mistaking broken first-run paths for weak demand. |
+
+## Standard Read-Only Checks
+
+Load ops credentials only in your shell and do not print them:
+
+```bash
+set -a
+[ -f "$HOME/.hermes/.env" ] && source "$HOME/.hermes/.env"
+[ -f "$HOME/.zprofile" ] && source "$HOME/.zprofile" >/dev/null 2>&1 || true
+set +a
+```
+
+Then run the aggregate probes:
+
+```bash
+bash scripts/ops/health-probe.sh all
+python3 scripts/ops/release-health-card.py --version "$(plutil -extract CFBundleShortVersionString raw Info.plist)" --hours 168
+curl -sSIL https://transcripted.app/download/latest.dmg
+curl -sSL https://transcripted.app/appcast.xml | head -40
+```
+
+For the attribution story, report:
+
+- Cloudflare 7-day page views and whether the live download page has the
+  analytics beacon
+- GitHub latest-release DMG download count and asset size
+- live `/download/latest.dmg`, live appcast, and `llms-full.txt` release parity
+- PostHog 7-day app launches, update events, dictation completions, meeting
+  transcript saves, activation agent/artifact events, and return-proxy events
+- Sentry release blockers that could suppress launch or first value
+
+## Missing Signals To Keep Explicit
+
+- There is no privacy-safe identity join from a website visitor to a GitHub
+  download to an app device. Treat that as intentional.
+- GitHub release downloads are not installs. They can include repeat downloads,
+  bots, failed installs, or users saving the DMG for later.
+- Cloudflare page views are not download completions unless a path-level
+  analytics read proves the specific `/download` or `/download/latest.dmg`
+  route.
+- `app_launched` does not prove a first useful artifact. Use
+  `dictation_completed`, `onboarding_first_dictation_saved`, and
+  `meeting_transcript_saved` for value.
+- Artifact events do not prove agent answer quality. The closest safe proxy is
+  `activation_agent_prompt_action_clicked` plus `activation_return_proxy_observed`.
+
+If the story is still fuzzy after these checks, prefer adding a coarse
+allowlisted event or aggregate script output over adding tracking IDs.

--- a/docs/ops-credentials.md
+++ b/docs/ops-credentials.md
@@ -40,6 +40,9 @@ Only report aggregate counts, status codes, deployment IDs, and issue titles. Fo
 
 The PostHog probe reports aggregate 7-day counts for active devices, workflow events, onboarding events, and first-value events. It also prints a 7-day daily active-device trend so operators can see whether DAU is rising, flat, or missing without inspecting user-level data. First-value events are limited to `dictation_completed`, `onboarding_first_dictation_saved`, `meeting_transcript_saved`, `onboarding_agent_cta_clicked`, `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_agent_setup_cta_clicked`, and `activation_return_proxy_observed`, so the health lane can see whether users reached successful dictation, a saved Markdown meeting artifact, or agent payoff without exposing transcript text, file paths, titles, or user identifiers.
 
+For the full anonymous website-to-first-value attribution contract, see
+[`install-attribution-map.md`](./install-attribution-map.md).
+
 If `POSTHOG_HOST` points at the app ingest host, such as `https://us.i.posthog.com`, the probe normalizes it to the matching PostHog API host before running HogQL. The probe only sends `POSTHOG_PERSONAL_API_KEY` to HTTPS PostHog API hosts by default. Set `POSTHOG_ALLOW_UNTRUSTED_HOST=1` only when using a trusted self-hosted PostHog endpoint.
 
 ### Cloudflare Read vs Deploy

--- a/docs/repo-layout.md
+++ b/docs/repo-layout.md
@@ -111,6 +111,7 @@ Use these docs for these jobs:
 - `docs/docs.md` - documentation tone, drift checks, and follow-up PR rules
 - `docs/strategy/` - point-in-time strategy synthesis and deep-dive docs for planning context
 - `docs/agent-issue-orchestration.md` - how to queue GitHub issues for the local Codex runner
+- `docs/install-attribution-map.md` — anonymous website/download/install to first-value signal map
 - `docs/live-meeting-codex-sidecar.md` — opt-in live meeting sidecar and agent workspace notes
 - `docs/ops-credentials.md` — Sentry, PostHog, GitHub, and Cloudflare credential lanes
 - `docs/storage-paths.md` — canonical storage and fallback path map


### PR DESCRIPTION
## Summary
- Add docs/install-attribution-map.md for the anonymous website/download/install to first-value signal map.
- Link the map from ops credentials and the repo docs map.
- Keep the boundary explicit: no website-to-app identity join, no raw referrers/URLs/IPs/content, aggregate signals only.

## Audit notes
- Live download/appcast/llms surfaces are aligned on 1.1.48; latest GitHub DMG has 175 downloads.
- Cloudflare read via the health helper found transcripted.app live with the Web Analytics beacon and 3,511 page views over the 2026-06-13..2026-06-19 window.
- PostHog aggregate reads are available for app launches, updates, dictation, meeting saves, onboarding, and activation events.
- Missing by design: no privacy-safe person-level join from website visitor to GitHub download to app device.

## Tests
- bash scripts/dev/agent-preflight.sh
- git diff --check
- Read-only audit probes: bash scripts/ops/health-probe.sh all; python3 scripts/ops/release-health-card.py --version 1.1.48 --hours 168; Cloudflare/PostHog/GitHub snapshot helpers

No release, tag, appcast, cask, deploy, or publish action was run.