### PR TITLE
[codex] Add privacy-safe meeting prompt analytics

### DIFF
--- a/Sources/Meeting/MeetingPromptDetector.swift
+++ b/Sources/Meeting/MeetingPromptDetector.swift
@@ -24,6 +24,7 @@ final class MeetingPromptDetector {
     }
 
     var onPromptRequest: ((Candidate) -> Bool)?
+    var onPromptSuppressed: ((MeetingPromptSuppression) -> Void)?
     var shouldSkipPromptEvaluation: (() -> Bool)?
 
     /// Returns true while Transcripted itself holds the mic (meeting recording or
@@ -31,6 +32,8 @@ final class MeetingPromptDetector {
     /// own capture — belt-and-suspenders with `MicActivityMonitor`'s own-bundle
     /// filter. Wired in `TranscriptedApp`.
     var isOwnCaptureActive: (() -> Bool)?
+    /// Optional richer shape for the same gate, used only for coarse analytics.
+    var ownCaptureActivity: (() -> MeetingPromptOwnCaptureActivity)?
     /// Returns false when the Settings toggle is off. This keeps late monitor
     /// callbacks quiet after the user disables auto call detection.
     var isMicInputPromptEnabled: (() -> Bool)?
@@ -49,11 +52,15 @@ final class MeetingPromptDetector {
     private var pendingUntil: [String: Date] = [:]
     private var recentNativeActivity: [MeetingPromptProvider: Date] = [:]
     private var runtimeSuppressedUntil: [MeetingPromptProvider: Date] = [:]
+    private var cooldownReasons: [String: String] = [:]
+    private var runtimeSuppressionReasons: [MeetingPromptProvider: String] = [:]
+    private var suppressionTelemetryUntil: [String: Date] = [:]
     // Bundle IDs currently holding the mic input, pushed by MicActivityMonitor.
     private var micActiveBundleIDs: Set<String> = []
 
     private let defaultSnoozeInterval: TimeInterval = 30 * 60
     private let pendingCooldown: TimeInterval = 90
+    private let suppressionTelemetryCooldown: TimeInterval = 90
     private let pollIntervalNanoseconds: UInt64 = 20_000_000_000
     // Single fetch window covering both the near-term prompt window and the
     // farthest lookahead used for runtime-dismiss resume dates.
@@ -108,9 +115,10 @@ final class MeetingPromptDetector {
             kind: MeetingPromptHeuristics.remindSoonBackoffKind(for: candidate.source),
             until: until
         )
-        suppressRuntimePrompts(for: candidate.provider, until: until)
+        suppressRuntimePrompts(for: candidate.provider, until: until, reason: decision.kind.rawValue)
         snoozedUntil[candidate.id] = until
         pendingUntil[candidate.id] = until
+        cooldownReasons[candidate.id] = decision.kind.rawValue
         return decision
     }
 
@@ -142,7 +150,7 @@ final class MeetingPromptDetector {
                 kind: MeetingPromptHeuristics.backoffKind(for: candidate.provider, source: .calendarEvent),
                 until: until
             )
-            suppressRuntimePrompts(for: candidate.provider, until: until)
+            suppressRuntimePrompts(for: candidate.provider, until: until, reason: decision.kind.rawValue)
         case .runtimeApp:
             if let resumeDate = nextRuntimePromptResumeDate(for: candidate.provider, now: now) {
                 until = resumeDate
@@ -161,10 +169,11 @@ final class MeetingPromptDetector {
                     until: until
                 )
             }
-            suppressRuntimePrompts(for: candidate.provider, until: until)
+            suppressRuntimePrompts(for: candidate.provider, until: until, reason: decision.kind.rawValue)
         }
         snoozedUntil[candidate.id] = until
         pendingUntil[candidate.id] = until
+        cooldownReasons[candidate.id] = decision.kind.rawValue
         return decision
     }
 
@@ -177,14 +186,15 @@ final class MeetingPromptDetector {
                 now.addingTimeInterval(defaultSnoozeInterval),
                 candidate.endDate.addingTimeInterval(MeetingPromptHeuristics.calendarReminderPostStartGrace)
             )
-            suppressRuntimePrompts(for: candidate.provider, until: until)
+            suppressRuntimePrompts(for: candidate.provider, until: until, reason: "record_selected")
         case .runtimeApp:
             until = runtimeSuppressionEndDate(for: candidate.provider, now: now)
                 ?? now.addingTimeInterval(defaultSnoozeInterval)
-            suppressRuntimePrompts(for: candidate.provider, until: until)
+            suppressRuntimePrompts(for: candidate.provider, until: until, reason: "record_selected")
         }
         snoozedUntil[candidate.id] = until
         pendingUntil[candidate.id] = until
+        cooldownReasons[candidate.id] = "record_selected"
     }
 
     func currentSuggestedTranscriptTitle(now: Date = Date()) -> String? {
@@ -210,8 +220,6 @@ final class MeetingPromptDetector {
         pruneExpiredEntries(now: now)
         seedNativeActivityIfNeeded(frontmostBundleID: frontmostBundleID, now: now)
 
-        guard shouldSkipPromptEvaluation?() != true else { return }
-
         var candidates: [ScoredCandidate] = []
         if calendarAccessGranted() {
             candidates.append(contentsOf: upcomingCalendarCandidates(
@@ -230,10 +238,44 @@ final class MeetingPromptDetector {
         let sortedCandidates = candidates.sorted(by: sortCandidates)
         guard let match = preferredCandidate(from: sortedCandidates) else { return }
 
-        guard snoozedUntil[match.candidate.id] == nil, pendingUntil[match.candidate.id] == nil else { return }
+        if shouldSkipPromptEvaluation?() == true {
+            recordSuppression(
+                candidate: match.candidate,
+                reason: .presentationBlocked,
+                now: now
+            )
+            return
+        }
+
+        if let until = snoozedUntil[match.candidate.id], until > now {
+            recordSuppression(
+                candidate: match.candidate,
+                reason: .snoozedCandidate,
+                now: now,
+                cooldownReason: cooldownReasons[match.candidate.id]
+            )
+            return
+        }
+
+        if let until = pendingUntil[match.candidate.id], until > now {
+            recordSuppression(
+                candidate: match.candidate,
+                reason: .pendingCandidate,
+                now: now,
+                cooldownReason: cooldownReasons[match.candidate.id] ?? "prompt_pending"
+            )
+            return
+        }
 
         if onPromptRequest?(match.candidate) == true {
             pendingUntil[match.candidate.id] = now.addingTimeInterval(pendingCooldown)
+            cooldownReasons[match.candidate.id] = "prompt_pending"
+        } else {
+            recordSuppression(
+                candidate: match.candidate,
+                reason: .presentationBlocked,
+                now: now
+            )
         }
     }
 
@@ -303,6 +345,12 @@ final class MeetingPromptDetector {
             guard provider.supportsRuntimeOnlyPrompt else { return nil }
             guard provider.activeBundleIdentifiers.contains(where: runningBundleIDs.contains) else { return nil }
             if let suppressedUntil = runtimeSuppressedUntil[provider], suppressedUntil > now {
+                recordSuppression(
+                    candidate: runtimeCandidate(for: provider, now: now),
+                    reason: .runtimeSuppressed,
+                    now: now,
+                    cooldownReason: runtimeSuppressionReasons[provider]
+                )
                 return nil
             }
 
@@ -315,17 +363,11 @@ final class MeetingPromptDetector {
             ) else { return nil }
 
             return ScoredCandidate(
-                candidate: Candidate(
-                    id: "runtime:\(provider.rawValue)",
+                candidate: runtimeCandidate(
+                    for: provider,
+                    now: now,
                     title: presentation.title,
-                    detail: presentation.detail,
-                    provider: provider,
-                    reason: MeetingPromptHeuristics.reason(for: .runtimeApp, hasRuntimeContext: false),
-                    source: .runtimeApp,
-                    startDate: now,
-                    endDate: now.addingTimeInterval(MeetingPromptHeuristics.runtimeReminderSnoozeInterval),
-                    meetingURL: nil,
-                    suggestedTranscriptTitle: nil
+                    detail: presentation.detail
                 ),
                 score: presentation.score
             )
@@ -346,45 +388,101 @@ final class MeetingPromptDetector {
     }
 
     private func micInputCandidates(now: Date) -> [ScoredCandidate] {
-        guard isMicInputPromptEnabled?() != false else { return [] }
         guard !micActiveBundleIDs.isEmpty else { return [] }
+        let providers = micInputProviders()
+        guard !providers.isEmpty else { return [] }
+        guard isMicInputPromptEnabled?() != false else {
+            providers.forEach {
+                recordSuppression(
+                    candidate: micInputCandidate(for: $0, now: now).candidate,
+                    reason: .micInputDisabled,
+                    now: now
+                )
+            }
+            return []
+        }
         // Never prompt to record a call while we already hold the mic ourselves.
-        guard isOwnCaptureActive?() != true else { return [] }
+        let captureActivity = currentOwnCaptureActivity()
+        guard captureActivity == .none else {
+            providers.forEach {
+                recordSuppression(
+                    candidate: micInputCandidate(for: $0, now: now).candidate,
+                    reason: .ownCaptureActive,
+                    now: now,
+                    captureActivity: captureActivity
+                )
+            }
+            return []
+        }
 
         var seenProviders: Set<MeetingPromptProvider> = []
         var candidates: [ScoredCandidate] = []
-        for bundleID in micActiveBundleIDs.sorted() {
-            guard let provider = MeetingPromptProvider.micInputProvider(forBundleID: bundleID) else { continue }
+        for provider in providers {
             guard seenProviders.insert(provider).inserted else { continue }
-            if let suppressedUntil = runtimeSuppressedUntil[provider], suppressedUntil > now { continue }
-
-            // Browser calls map to .googleMeet generically (could be Meet/Zoom-web/
-            // Teams-web), so keep their title neutral instead of mislabeling them.
-            let isBrowserCall = provider == .googleMeet
-            let title = isBrowserCall
-                ? "Call detected in your browser"
-                : "\(provider.displayName) call detected"
-            let presentation = MeetingPromptHeuristics.micInputPresentation(title: title)
-
-            candidates.append(
-                ScoredCandidate(
-                    candidate: Candidate(
-                        id: micCandidateID(for: provider),
-                        title: presentation.title,
-                        detail: presentation.detail,
-                        provider: provider,
-                        reason: .micInput,
-                        source: .runtimeApp,
-                        startDate: now,
-                        endDate: now.addingTimeInterval(MeetingPromptHeuristics.runtimeReminderSnoozeInterval),
-                        meetingURL: nil,
-                        suggestedTranscriptTitle: nil
-                    ),
-                    score: presentation.score
+            if let suppressedUntil = runtimeSuppressedUntil[provider], suppressedUntil > now {
+                recordSuppression(
+                    candidate: micInputCandidate(for: provider, now: now).candidate,
+                    reason: .runtimeSuppressed,
+                    now: now,
+                    cooldownReason: runtimeSuppressionReasons[provider]
                 )
-            )
+                continue
+            }
+
+            candidates.append(micInputCandidate(for: provider, now: now))
         }
         return candidates
+    }
+
+    private func micInputProviders() -> [MeetingPromptProvider] {
+        Set(micActiveBundleIDs.compactMap(MeetingPromptProvider.micInputProvider(forBundleID:)))
+            .sorted { $0.rawValue < $1.rawValue }
+    }
+
+    private func runtimeCandidate(
+        for provider: MeetingPromptProvider,
+        now: Date,
+        title: String? = nil,
+        detail: String? = nil
+    ) -> Candidate {
+        Candidate(
+            id: "runtime:\(provider.rawValue)",
+            title: title ?? "\(provider.displayName) is active",
+            detail: detail ?? "If this is a meeting, start recording now or press Option-M anytime.",
+            provider: provider,
+            reason: MeetingPromptHeuristics.reason(for: .runtimeApp, hasRuntimeContext: false),
+            source: .runtimeApp,
+            startDate: now,
+            endDate: now.addingTimeInterval(MeetingPromptHeuristics.runtimeReminderSnoozeInterval),
+            meetingURL: nil,
+            suggestedTranscriptTitle: nil
+        )
+    }
+
+    private func micInputCandidate(for provider: MeetingPromptProvider, now: Date) -> ScoredCandidate {
+        // Browser calls map to .googleMeet generically (could be Meet/Zoom-web/
+        // Teams-web), so keep their title neutral instead of mislabeling them.
+        let isBrowserCall = provider == .googleMeet
+        let title = isBrowserCall
+            ? "Call detected in your browser"
+            : "\(provider.displayName) call detected"
+        let presentation = MeetingPromptHeuristics.micInputPresentation(title: title)
+
+        return ScoredCandidate(
+            candidate: Candidate(
+                id: micCandidateID(for: provider),
+                title: presentation.title,
+                detail: presentation.detail,
+                provider: provider,
+                reason: .micInput,
+                source: .runtimeApp,
+                startDate: now,
+                endDate: now.addingTimeInterval(MeetingPromptHeuristics.runtimeReminderSnoozeInterval),
+                meetingURL: nil,
+                suggestedTranscriptTitle: nil
+            ),
+            score: presentation.score
+        )
     }
 
     private func micCandidateID(for provider: MeetingPromptProvider) -> String {
@@ -440,8 +538,15 @@ final class MeetingPromptDetector {
     }
 
     private func suppressRuntimePrompts(for provider: MeetingPromptProvider, until: Date) {
+        suppressRuntimePrompts(for: provider, until: until, reason: nil)
+    }
+
+    private func suppressRuntimePrompts(for provider: MeetingPromptProvider, until: Date, reason: String?) {
         let existing = runtimeSuppressedUntil[provider] ?? .distantPast
         runtimeSuppressedUntil[provider] = max(existing, until)
+        if let reason {
+            runtimeSuppressionReasons[provider] = reason
+        }
     }
 
     private func nextRuntimePromptResumeDate(for provider: MeetingPromptProvider, now: Date) -> Date? {
@@ -487,9 +592,48 @@ final class MeetingPromptDetector {
         snoozedUntil = snoozedUntil.filter { $0.value > now }
         pendingUntil = pendingUntil.filter { $0.value > now }
         runtimeSuppressedUntil = runtimeSuppressedUntil.filter { $0.value > now }
+        cooldownReasons = cooldownReasons.filter { entry in
+            (snoozedUntil[entry.key] ?? pendingUntil[entry.key]) != nil
+        }
+        runtimeSuppressionReasons = runtimeSuppressionReasons.filter { entry in
+            runtimeSuppressedUntil[entry.key] != nil
+        }
+        suppressionTelemetryUntil = suppressionTelemetryUntil.filter { $0.value > now }
         recentNativeActivity = recentNativeActivity.filter {
             now.timeIntervalSince($0.value) <= MeetingPromptHeuristics.runtimeActivityFreshness
         }
+    }
+
+    private func currentOwnCaptureActivity() -> MeetingPromptOwnCaptureActivity {
+        if let activity = ownCaptureActivity?(), activity != .none {
+            return activity
+        }
+        return isOwnCaptureActive?() == true ? .unknown : .none
+    }
+
+    private func recordSuppression(
+        candidate: Candidate,
+        reason: MeetingPromptSuppressionReason,
+        now: Date,
+        cooldownReason: String? = nil,
+        captureActivity: MeetingPromptOwnCaptureActivity? = nil
+    ) {
+        let dedupeKey = [
+            reason.rawValue,
+            candidate.id,
+            cooldownReason ?? "",
+            captureActivity?.rawValue ?? ""
+        ].joined(separator: "|")
+        guard (suppressionTelemetryUntil[dedupeKey] ?? .distantPast) <= now else { return }
+        suppressionTelemetryUntil[dedupeKey] = now.addingTimeInterval(suppressionTelemetryCooldown)
+        onPromptSuppressed?(
+            MeetingPromptSuppression(
+                candidate: candidate,
+                reason: reason,
+                cooldownReason: cooldownReason,
+                captureActivity: captureActivity
+            )
+        )
     }
 }
 

--- a/Sources/Meeting/MeetingPromptHeuristics.swift
+++ b/Sources/Meeting/MeetingPromptHeuristics.swift
@@ -175,6 +175,22 @@ enum MeetingPromptBackoffKind: String, Equatable {
     case runtimeShortReminder = "runtime_short_reminder"
 }
 
+enum MeetingPromptSuppressionReason: String, Equatable {
+    case ownCaptureActive = "own_capture_active"
+    case micInputDisabled = "mic_input_disabled"
+    case runtimeSuppressed = "runtime_suppressed"
+    case snoozedCandidate = "snoozed_candidate"
+    case pendingCandidate = "pending_candidate"
+    case presentationBlocked = "presentation_blocked"
+}
+
+enum MeetingPromptOwnCaptureActivity: String, Equatable {
+    case none
+    case meetingRecording = "meeting_recording"
+    case dictation
+    case unknown
+}
+
 struct MeetingPromptBackoffDecision: Equatable {
     let kind: MeetingPromptBackoffKind
     let until: Date
@@ -395,6 +411,52 @@ struct MeetingPromptRuntimeSnapshot: Equatable {
 struct MeetingPromptScoredCandidate {
     let candidate: MeetingPromptDetector.Candidate
     let score: Int
+}
+
+@available(macOS 14.0, *)
+struct MeetingPromptSuppression: Equatable {
+    let candidate: MeetingPromptDetector.Candidate
+    let reason: MeetingPromptSuppressionReason
+    let cooldownReason: String?
+    let captureActivity: MeetingPromptOwnCaptureActivity?
+}
+
+@available(macOS 14.0, *)
+extension MeetingPromptDetector.Candidate {
+    var analyticsCalendarConfidence: String {
+        switch reason {
+        case .calendarPlusRuntimeMatch:
+            return "linked_event_runtime_match"
+        case .calendarNearby:
+            return "linked_event"
+        case .micInput, .runtimeOnly:
+            return "none"
+        }
+    }
+
+    var analyticsCallState: String {
+        switch reason {
+        case .micInput:
+            return "mic_active"
+        case .calendarPlusRuntimeMatch, .runtimeOnly:
+            return "app_active"
+        case .calendarNearby:
+            return "scheduled"
+        }
+    }
+
+    var analyticsAppSignal: String {
+        switch reason {
+        case .micInput:
+            return provider == .googleMeet ? "browser_mic" : "native_mic"
+        case .runtimeOnly:
+            return "native_runtime"
+        case .calendarPlusRuntimeMatch:
+            return provider.browserHosted ? "browser_runtime" : "native_runtime"
+        case .calendarNearby:
+            return "none"
+        }
+    }
 }
 
 enum MeetingPromptSessionPromptState: Equatable {

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -138,6 +138,17 @@ struct AnalyticsEventPolicy: Equatable {
         "surface",
     ]
 
+    private static let meetingPromptProperties: Set<String> = [
+        "app_signal",
+        "calendar_confidence",
+        "call_state",
+        "missing_permission",
+        "prompt_reason",
+        "provider",
+        "route_ready",
+        "source",
+    ]
+
     private static let allowedPolicies: [String: AnalyticsEventPolicy] = [
         "app_launched": .init(
             name: "app_launched",
@@ -531,28 +542,26 @@ struct AnalyticsEventPolicy: Equatable {
         ),
         "meeting_prompt_shown": .init(
             name: "meeting_prompt_shown",
-            allowedProperties: [
-                "prompt_reason",
-                "provider",
-                "source",
-            ]
+            allowedProperties: meetingPromptProperties
         ),
         "meeting_prompt_dismissed": .init(
             name: "meeting_prompt_dismissed",
-            allowedProperties: [
+            allowedProperties: meetingPromptProperties.union(Set([
                 "backoff_kind",
-                "prompt_reason",
-                "provider",
-                "source",
-            ]
+                "cooldown_reason",
+            ]))
         ),
         "meeting_prompt_record_selected": .init(
             name: "meeting_prompt_record_selected",
-            allowedProperties: [
-                "prompt_reason",
-                "provider",
-                "source",
-            ]
+            allowedProperties: meetingPromptProperties
+        ),
+        "meeting_prompt_suppressed": .init(
+            name: "meeting_prompt_suppressed",
+            allowedProperties: meetingPromptProperties.union(Set([
+                "capture_activity",
+                "cooldown_reason",
+                "suppression_reason",
+            ]))
         ),
         "meeting_mic_boost_prompt_shown": .init(
             name: "meeting_mic_boost_prompt_shown",

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -177,6 +177,13 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                     )
                 )
             }
+            meetingPromptDetector.onPromptSuppressed = { [weak self] suppression in
+                guard let self else { return }
+                AnalyticsReporter.track(
+                    "meeting_prompt_suppressed",
+                    properties: self.analyticsProperties(for: suppression)
+                )
+            }
             meetingPromptDetector.onPromptRequest = { [weak self] candidate in
                 guard PermissionsOnboardingPreferences.hasCompleted() else { return false }
                 guard let self else { return false }
@@ -195,6 +202,16 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             meetingPromptDetector.isOwnCaptureActive = { [weak self] in
                 guard let self else { return false }
                 return self.appState.meetingSession.isRecording || self.appState.sttRouter.isRecording
+            }
+            meetingPromptDetector.ownCaptureActivity = { [weak self] in
+                guard let self else { return .none }
+                if self.appState.meetingSession.isRecording {
+                    return .meetingRecording
+                }
+                if self.appState.sttRouter.isRecording {
+                    return .dictation
+                }
+                return .none
             }
             meetingPromptDetector.isMicInputPromptEnabled = {
                 AutoCallDetectionPreferences.isEnabled()
@@ -826,14 +843,52 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
         backoffKind: MeetingPromptBackoffKind? = nil
     ) -> [String: String] {
         var properties = [
+            "app_signal": candidate.analyticsAppSignal,
+            "calendar_confidence": candidate.analyticsCalendarConfidence,
+            "call_state": candidate.analyticsCallState,
+            "missing_permission": missingMeetingRoutePermission(),
             "prompt_reason": candidate.reason.rawValue,
             "provider": candidate.provider.rawValue,
+            "route_ready": meetingRouteReady() ? "true" : "false",
             "source": candidate.source.analyticsValue,
         ]
         if let backoffKind {
             properties["backoff_kind"] = backoffKind.rawValue
+            properties["cooldown_reason"] = backoffKind.rawValue
         }
         return properties
+    }
+
+    private func analyticsProperties(for suppression: MeetingPromptSuppression) -> [String: String] {
+        var properties = analyticsProperties(for: suppression.candidate)
+        properties["suppression_reason"] = suppression.reason.rawValue
+        if let cooldownReason = suppression.cooldownReason {
+            properties["cooldown_reason"] = cooldownReason
+        }
+        if let captureActivity = suppression.captureActivity {
+            properties["capture_activity"] = captureActivity.rawValue
+        }
+        return properties
+    }
+
+    private func meetingRouteReady() -> Bool {
+        TranscriptedPermissionAccess.isGranted(.microphone)
+            && TranscriptedPermissionAccess.isGranted(.systemAudioRecording)
+    }
+
+    private func missingMeetingRoutePermission() -> String {
+        let microphoneGranted = TranscriptedPermissionAccess.isGranted(.microphone)
+        let systemAudioGranted = TranscriptedPermissionAccess.isGranted(.systemAudioRecording)
+        switch (microphoneGranted, systemAudioGranted) {
+        case (true, true):
+            return "none"
+        case (false, false):
+            return "microphone_and_system_audio_recording"
+        case (false, true):
+            return "microphone"
+        case (true, false):
+            return "system_audio_recording"
+        }
     }
 
     // MARK: - Menu Bar Commands

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -821,22 +821,98 @@ func testAnalyticsEventPolicy() {
         let shown = AnalyticsEventPolicy.policy(forEvent: "meeting_prompt_shown")
         let dismissed = AnalyticsEventPolicy.policy(forEvent: "meeting_prompt_dismissed")
         let recorded = AnalyticsEventPolicy.policy(forEvent: "meeting_prompt_record_selected")
+        let suppressed = AnalyticsEventPolicy.policy(forEvent: "meeting_prompt_suppressed")
 
         assertEqual(shown?.allowedProperties.contains("provider"), true, "prompt shown should allow provider attribution")
         assertEqual(shown?.allowedProperties.contains("prompt_reason"), true, "prompt shown should preserve why it appeared")
+        assertEqual(shown?.allowedProperties.contains("calendar_confidence"), true, "prompt shown should keep coarse calendar confidence")
+        assertEqual(shown?.allowedProperties.contains("call_state"), true, "prompt shown should keep coarse in-call state")
+        assertEqual(shown?.allowedProperties.contains("app_signal"), true, "prompt shown should keep coarse app signal")
+        assertEqual(shown?.allowedProperties.contains("route_ready"), true, "prompt shown should preserve route readiness")
+        assertEqual(shown?.allowedProperties.contains("missing_permission"), true, "prompt shown should preserve missing-permission buckets")
         assertEqual(dismissed?.allowedProperties.contains("source"), true, "prompt dismiss should allow source attribution")
         assertEqual(dismissed?.allowedProperties.contains("backoff_kind"), true, "prompt dismiss should preserve which backoff rule fired")
+        assertEqual(dismissed?.allowedProperties.contains("cooldown_reason"), true, "prompt dismiss should preserve cooldown reason")
         assertEqual(recorded?.allowedProperties.contains("provider"), true, "prompt accept should allow provider attribution")
+        assertEqual(suppressed?.allowedProperties.contains("suppression_reason"), true, "prompt suppression should preserve why nothing appeared")
+        assertEqual(suppressed?.allowedProperties.contains("capture_activity"), true, "prompt suppression should preserve already-recording state")
+        assertEqual(suppressed?.allowedProperties.contains("cooldown_reason"), true, "prompt suppression should preserve duplicate/cooldown reason")
 
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
             [
+                "app_signal": "browser_mic",
+                "calendar_confidence": "linked_event_runtime_match",
+                "call_state": "mic_active",
+                "capture_activity": "meeting_recording",
+                "cooldown_reason": "runtime_default_fallback",
+                "missing_permission": "system_audio_recording",
                 "prompt_reason": "calendar_plus_runtime_match",
+                "provider": "googleMeet",
+                "route_ready": "false",
+                "source": "runtime_app",
+                "suppression_reason": "pending_candidate",
                 "backoff_kind": "calendar_teams_extended",
             ],
-            allowedKeys: ["prompt_reason", "backoff_kind"]
+            allowedKeys: suppressed?.allowedProperties.union(dismissed?.allowedProperties ?? []) ?? []
         )
+        assertEqual(sanitized["app_signal"], "browser_mic", "coarse app signal should survive sanitization")
+        assertEqual(sanitized["calendar_confidence"], "linked_event_runtime_match", "calendar confidence should survive sanitization")
+        assertEqual(sanitized["call_state"], "mic_active", "in-call state should survive sanitization")
+        assertEqual(sanitized["capture_activity"], "meeting_recording", "already-recording state should survive sanitization")
+        assertEqual(sanitized["cooldown_reason"], "runtime_default_fallback", "cooldown reason should survive sanitization")
+        assertEqual(sanitized["missing_permission"], "system_audio_recording", "missing permission bucket should survive sanitization")
         assertEqual(sanitized["prompt_reason"], "calendar_plus_runtime_match", "prompt reason should survive sanitization")
+        assertEqual(sanitized["provider"], "googleMeet", "provider enum should survive sanitization")
+        assertEqual(sanitized["route_ready"], "false", "route readiness should survive sanitization")
+        assertEqual(sanitized["source"], "runtime_app", "prompt source should survive sanitization")
+        assertEqual(sanitized["suppression_reason"], "pending_candidate", "suppression reason should survive sanitization")
         assertEqual(sanitized["backoff_kind"], "calendar_teams_extended", "dismiss backoff kind should survive sanitization")
+
+        let privatePromptFields = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "app_signal": "native_mic",
+                "calendar_confidence": "linked_event",
+                "call_state": "scheduled",
+                "provider": "zoom",
+                "source": "calendar_event",
+                "source_app_name": "Private Browser",
+                "source_app_bundle_id": "com.example.private",
+                "meeting_title": "Customer Roadmap",
+                "invitee_name": "Alice Customer",
+                "speaker_name": "Bob Customer",
+                "meeting_url": "https://meet.example.com/private",
+                "prompt_text": "Record Customer Roadmap?",
+                "audio_ref": "/Users/redbars/private.wav",
+                "file_path": "/Users/redbars/private.md",
+                "transcript_text": "private words",
+            ],
+            allowedKeys: (shown?.allowedProperties ?? [])
+                .union([
+                    "source_app_name",
+                    "source_app_bundle_id",
+                    "meeting_title",
+                    "invitee_name",
+                    "speaker_name",
+                    "meeting_url",
+                    "prompt_text",
+                    "audio_ref",
+                    "file_path",
+                    "transcript_text",
+                ])
+        )
+        assertEqual(privatePromptFields["app_signal"], "native_mic", "safe prompt context should survive beside private inputs")
+        assertEqual(privatePromptFields["calendar_confidence"], "linked_event", "safe calendar confidence should survive beside private inputs")
+        assertEqual(privatePromptFields["provider"], "zoom", "safe provider enum should survive beside private inputs")
+        assertNil(privatePromptFields["source_app_name"], "source app names must not be sent")
+        assertNil(privatePromptFields["source_app_bundle_id"], "source app bundle IDs must not be sent")
+        assertNil(privatePromptFields["meeting_title"], "meeting titles must not be sent")
+        assertNil(privatePromptFields["invitee_name"], "invitee names must not be sent")
+        assertNil(privatePromptFields["speaker_name"], "speaker names must not be sent")
+        assertNil(privatePromptFields["meeting_url"], "meeting URLs must not be sent")
+        assertNil(privatePromptFields["prompt_text"], "raw prompt text must not be sent")
+        assertNil(privatePromptFields["audio_ref"], "audio references must not be sent")
+        assertNil(privatePromptFields["file_path"], "file paths must not be sent")
+        assertNil(privatePromptFields["transcript_text"], "transcript text must not be sent")
     }
 
     runSuite("AnalyticsEventPolicy keeps mic boost prompt events narrow") {

--- a/Tests/MeetingPromptDetectorTests.swift
+++ b/Tests/MeetingPromptDetectorTests.swift
@@ -5,7 +5,8 @@ import Foundation
 private func makeMeetingPromptCandidate(
     id: String,
     provider: MeetingPromptProvider = .zoom,
-    source: MeetingPromptSource
+    source: MeetingPromptSource,
+    reason: MeetingPromptReason? = nil
 ) -> MeetingPromptDetector.Candidate {
     let startDate = Date(timeIntervalSince1970: 2_000)
     return MeetingPromptDetector.Candidate(
@@ -13,7 +14,7 @@ private func makeMeetingPromptCandidate(
         title: "Meeting detected",
         detail: "Design review - starting now",
         provider: provider,
-        reason: MeetingPromptHeuristics.reason(for: source, hasRuntimeContext: false),
+        reason: reason ?? MeetingPromptHeuristics.reason(for: source, hasRuntimeContext: false),
         source: source,
         startDate: startDate,
         endDate: startDate.addingTimeInterval(30 * 60),
@@ -209,6 +210,28 @@ func testMeetingPromptDetector() async {
         )
     }
 
+    runSuite("MeetingPromptDetector.Candidate analytics buckets stay coarse") {
+        let calendarRuntime = makeMeetingPromptCandidate(
+            id: "calendar:runtime",
+            provider: .googleMeet,
+            source: .calendarEvent,
+            reason: .calendarPlusRuntimeMatch
+        )
+        let mic = makeMeetingPromptCandidate(
+            id: "mic:browser",
+            provider: .googleMeet,
+            source: .runtimeApp,
+            reason: .micInput
+        )
+
+        assertEqual(calendarRuntime.analyticsCalendarConfidence, "linked_event_runtime_match", "calendar plus runtime evidence should stay a coarse confidence bucket")
+        assertEqual(calendarRuntime.analyticsCallState, "app_active", "calendar plus runtime evidence should not name the app or meeting")
+        assertEqual(calendarRuntime.analyticsAppSignal, "browser_runtime", "browser-hosted calendar matches should stay a family-level signal")
+        assertEqual(mic.analyticsCalendarConfidence, "none", "ad-hoc mic prompts should not imply calendar evidence")
+        assertEqual(mic.analyticsCallState, "mic_active", "mic prompts should preserve active-call evidence")
+        assertEqual(mic.analyticsAppSignal, "browser_mic", "browser mic prompts should stay family-level, not bundle-level")
+    }
+
     await runSuite("MeetingPromptDetector.updateMicInputUsers — a browser holding the mic prompts an ad-hoc call") {
         let detector = MeetingPromptDetector()
         detector.isOwnCaptureActive = { false }
@@ -288,6 +311,10 @@ func testMeetingPromptDetector() async {
             box.promptCount += 1
             return true
         }
+        detector.onPromptSuppressed = { suppression in
+            box.suppression = suppression
+            box.suppressionCount += 1
+        }
 
         detector.updateMicInputUsers(["com.google.Chrome.helper"])
         await waitForPromptEvaluation()
@@ -296,6 +323,9 @@ func testMeetingPromptDetector() async {
 
         assertEqual(box.promptCount, 1, "a changed browser-helper set should not spam a second mic prompt for the same call")
         assertEqual(box.candidate?.id, "mic:googleMeet", "the pending candidate id should stay stable across browser helpers")
+        assertEqual(box.suppressionCount, 1, "duplicate pending candidates should emit one suppression signal")
+        assertEqual(box.suppression?.reason, .pendingCandidate, "duplicate prompt attempts should be classified as pending")
+        assertEqual(box.suppression?.cooldownReason, "prompt_pending", "pending duplicates should keep the prompt-pending cooldown reason")
     }
 
     await runSuite("MeetingPromptDetector.updateMicInputUsers — inactive edge preserves transient pending cooldown") {
@@ -327,6 +357,10 @@ func testMeetingPromptDetector() async {
             box.promptCount += 1
             return true
         }
+        detector.onPromptSuppressed = { suppression in
+            box.suppression = suppression
+            box.suppressionCount += 1
+        }
 
         detector.updateMicInputUsers(["com.google.Chrome.helper"])
         await waitForPromptEvaluation()
@@ -339,6 +373,34 @@ func testMeetingPromptDetector() async {
         await waitForPromptEvaluation()
 
         assertEqual(box.promptCount, 1, "mute/unmute should not wipe an explicit Not now dismissal")
+        assertEqual(box.suppressionCount, 1, "dismissed mic prompts should emit a cooldown suppression signal when the call returns")
+        assertEqual(box.suppression?.reason, .runtimeSuppressed, "dismissed mic prompts should classify follow-up attempts as runtime-suppressed")
+        assertEqual(box.suppression?.cooldownReason, MeetingPromptBackoffKind.runtimeDefaultFallback.rawValue, "suppression should keep the backoff rule that caused the cooldown")
+    }
+
+    await runSuite("MeetingPromptDetector.updateMicInputUsers — already-recording suppression is reported coarsely") {
+        let detector = MeetingPromptDetector()
+        detector.ownCaptureActivity = { .meetingRecording }
+        let box = CandidateBox()
+        detector.onPromptRequest = { candidate in
+            box.candidate = candidate
+            box.promptCount += 1
+            return true
+        }
+        detector.onPromptSuppressed = { suppression in
+            box.suppression = suppression
+            box.suppressionCount += 1
+        }
+
+        detector.updateMicInputUsers(["com.google.Chrome.helper"])
+        await waitForPromptEvaluation()
+
+        assertNil(box.candidate, "we should not prompt while a meeting recording is already active")
+        assertEqual(box.promptCount, 0, "already-recording suppression should not ask the overlay to present")
+        assertEqual(box.suppressionCount, 1, "already-recording calls should emit one suppression signal")
+        assertEqual(box.suppression?.reason, .ownCaptureActive, "already-recording calls should use the own-capture suppression reason")
+        assertEqual(box.suppression?.captureActivity, .meetingRecording, "suppression should preserve meeting-vs-dictation activity without app names")
+        assertEqual(box.suppression?.candidate.provider, .googleMeet, "suppression should keep only the coarse provider enum")
     }
 
     await runSuite("MeetingPromptDetector.updateMicInputUsers — native mic candidate keeps calendar title") {
@@ -439,7 +501,9 @@ func testMeetingPromptDetector() async {
 @MainActor
 private final class CandidateBox {
     var candidate: MeetingPromptDetector.Candidate?
+    var suppression: MeetingPromptSuppression?
     var promptCount = 0
+    var suppressionCount = 0
 }
 
 // updateMicInputUsers re-evaluates on a detached @MainActor Task; yield/sleep a

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -131,6 +131,7 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `meeting_prompt_shown`
 - `meeting_prompt_dismissed`
 - `meeting_prompt_record_selected`
+- `meeting_prompt_suppressed`
 - `meeting_mic_boost_prompt_shown`
 - `meeting_mic_boost_prompt_actioned`
 - `meeting_recording_stopped`


### PR DESCRIPTION
## Why

Meeting prompts already tracked shown, dismissed, and record-selected actions, but they did not carry enough safe context to tell whether prompts are helpful, ignored, or suppressed because they would be annoying.

## Product Impact

- Affects: `meetings`
- Lane: `meeting reliability`
- Why this matters: gives product/reliability review a privacy-safe way to understand prompt helpfulness versus prompt fatigue without collecting titles, invitees, app names, URLs, paths, audio refs, transcript text, or speaker names.

## What changed

- Expanded `meeting_prompt_shown`, `meeting_prompt_dismissed`, and `meeting_prompt_record_selected` with enum-only context: provider, source, prompt reason, app signal, call state, calendar confidence, route readiness, and missing permission bucket.
- Added `meeting_prompt_suppressed` for duplicate pending prompts, cooldown/runtime suppression, presentation blocking, mic-detection-disabled suppression, and already-recording/dictation suppression.
- Preserved cooldown reasons for dismiss/remind/record-selected paths so follow-up suppressions explain why they stayed quiet.
- Updated the PostHog allowlist, privacy observability docs, and tests proving raw source app names/bundle IDs, titles, invitees/names, URLs, prompt text, audio refs, paths, and transcript text are dropped.

## How I checked it

- [x] `scripts/dev/agent-preflight.sh`
- [x] Selected checks from `.agents/test-matrix.yml` for the files changed
- [x] `bash build-deps.sh --force`
- [x] `bash build.sh --no-open`
- [x] `bash run-tests.sh --filter MeetingPromptDetector`
- [x] `bash run-tests.sh --filter AnalyticsEventPolicy`
- [x] `bash run-tests.sh`
- [x] `bash run-integration-smoke.sh`
- [x] Performance budget passed via `bash build.sh --no-open`
- [x] Codex review: `~/.codex/skills/codex-review/scripts/codex-review --mode auto` — clean, no accepted/actionable findings
- [ ] Manual check: not run; no live calendar/call/PostHog validation in this lane

## Risk Review

- [x] Privacy / local-first behavior reviewed
- [x] Storage path or migration impact reviewed: no storage/migration changes
- [x] Public-facing copy stays concrete and matches current product scope: no user-facing copy changes
- [x] Release/update impact reviewed: no release, appcast, Sparkle, or Homebrew changes
- [x] Agent PRs link the issue/workpad and stay draft until human review
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence: no UI changes
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

## Notes

This intentionally treats raw source app names and bundle IDs as forbidden. The safe replacement is `provider` plus `app_signal` (`browser_mic`, `native_mic`, `native_runtime`, `browser_runtime`, or `none`).

## Agent handoff

`COORD_DONE: GREEN | https://github.com/r3dbars/transcripted/pull/1168 | prompt shown/dismissed/record/suppressed analytics added | provider/app_signal only; sanitizer tests reject raw app names, bundle IDs, titles, invitees/names, URLs, prompt text, audio refs, paths, transcript text | preflight; build-deps; build; focused prompt/policy tests; full fast tests; integration smoke; codex-review clean | live calendar/call/PostHog validation not run | human review draft PR`