### PR TITLE
[codex] Add speaker naming reliability telemetry

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1470,6 +1470,7 @@ final class MeetingSessionController: ObservableObject {
             splitLocalSpeakers: true,
             replacementTranscriptURL: transcriptURL,
             recordingDate: recordingDate,
+            speakerReviewSourceTrigger: StartTrigger.savedMeetingRetranscription.rawValue,
             onReplacementTranscriptCommitted: { [weak self] committedTranscriptURL in
                 self?.handleReplacementTranscriptCommitted(for: committedTranscriptURL)
             }
@@ -1622,6 +1623,13 @@ final class MeetingSessionController: ObservableObject {
                 let previousStatus = self.displayStatus
                 self.displayStatus = status
                 self.handleDisplayStatusChange(from: previousStatus, to: status)
+            }
+            .store(in: &cancellables)
+
+        taskManager.$lastSpeakerNamingFinalizationOutcome
+            .compactMap { $0 }
+            .sink { [weak self] outcome in
+                self?.trackSpeakerNamingFinalizationOutcome(outcome)
             }
             .store(in: &cancellables)
 
@@ -2344,14 +2352,16 @@ final class MeetingSessionController: ObservableObject {
                 healthInfo: healthInfo,
                 meetingTitle: meetingTitle,
                 splitLocalSpeakers: LocalSpeakerPreferences.isEnabled(),
-                recordingDate: recordingDate
+                recordingDate: recordingDate,
+                speakerReviewSourceTrigger: job.startTrigger.rawValue
             )
         case .imported(let audioURL, let suggestedTitle, let recordingDate):
             taskManager.startImportedTranscription(
                 audioURL: audioURL,
                 outputFolder: MeetingStoragePaths.transcriptsFolder,
                 meetingTitle: suggestedTitle,
-                recordingDate: recordingDate
+                recordingDate: recordingDate,
+                speakerReviewSourceTrigger: job.startTrigger.rawValue
             )
         }
     }
@@ -2713,6 +2723,44 @@ final class MeetingSessionController: ObservableObject {
         properties["gap_count_bucket"] = AnalyticsReporter.countBucket(snapshot.gapCount)
         properties["route_change_count_bucket"] = AnalyticsReporter.countBucket(snapshot.routeChangeCount)
         properties["recovery_attempt_bucket"] = AnalyticsReporter.countBucket(snapshot.recoveryAttemptCount)
+        return properties
+    }
+
+    private func trackSpeakerNamingFinalizationOutcome(_ outcome: SpeakerNamingFinalizationOutcome) {
+        var properties = Self.speakerReviewAnalyticsProperties(outcome.reviewTelemetry)
+        properties["finalize_result"] = outcome.result.rawValue
+        properties["finalize_reason"] = outcome.reason.rawValue
+        properties["queue_depth_bucket"] = AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count)
+        properties["trigger"] = outcome.sourceTrigger
+
+        AnalyticsReporter.track(
+            "meeting_speaker_finalization_completed",
+            properties: properties
+        )
+    }
+
+    nonisolated static func speakerReviewAnalyticsProperties(
+        _ review: SpeakerNamingReviewTelemetry,
+        includeOutcome: Bool = true
+    ) -> [String: String] {
+        var properties = [
+            "review_item_bucket": AnalyticsReporter.countBucket(review.reviewItemCount),
+            "local_voice_bucket": AnalyticsReporter.countBucket(review.localVoiceCount),
+            "remote_voice_bucket": AnalyticsReporter.countBucket(review.remoteVoiceCount),
+            "match_suggestion_bucket": AnalyticsReporter.countBucket(review.suggestedMatchCount),
+        ]
+        guard includeOutcome else { return properties }
+
+        properties["updates_submitted_bucket"] = AnalyticsReporter.countBucket(review.updatesSubmittedCount)
+        properties["match_accept_bucket"] = AnalyticsReporter.countBucket(review.suggestedMatchAcceptedCount)
+        properties["match_reject_bucket"] = AnalyticsReporter.countBucket(review.suggestedMatchRejectedCount)
+        properties["manual_label_bucket"] = AnalyticsReporter.countBucket(review.manualLabelCount)
+        properties["confirmed_bucket"] = AnalyticsReporter.countBucket(review.confirmedCount)
+        properties["corrected_bucket"] = AnalyticsReporter.countBucket(review.correctedCount)
+        properties["merge_bucket"] = AnalyticsReporter.countBucket(review.mergedCount)
+        properties["collapse_bucket"] = AnalyticsReporter.countBucket(review.collapsedToMeCount)
+        properties["discard_bucket"] = AnalyticsReporter.countBucket(review.discardedCount)
+        properties["deferred"] = review.didDeferReview ? "true" : "false"
         return properties
     }
 

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -138,6 +138,27 @@ struct AnalyticsEventPolicy: Equatable {
         "surface",
     ]
 
+    private static let meetingSpeakerReviewInventoryProperties: Set<String> = [
+        "known_people_bucket",
+        "local_voice_bucket",
+        "match_suggestion_bucket",
+        "remote_voice_bucket",
+        "review_item_bucket",
+    ]
+
+    private static let meetingSpeakerReviewOutcomeProperties = meetingSpeakerReviewInventoryProperties.union(Set([
+        "collapse_bucket",
+        "confirmed_bucket",
+        "corrected_bucket",
+        "deferred",
+        "discard_bucket",
+        "manual_label_bucket",
+        "match_accept_bucket",
+        "match_reject_bucket",
+        "merge_bucket",
+        "updates_submitted_bucket",
+    ]))
+
     private static let allowedPolicies: [String: AnalyticsEventPolicy] = [
         "app_launched": .init(
             name: "app_launched",
@@ -632,6 +653,25 @@ struct AnalyticsEventPolicy: Equatable {
                 "trigger",
             ]
         ),
+        "meeting_speaker_review_shown": .init(
+            name: "meeting_speaker_review_shown",
+            allowedProperties: meetingSpeakerReviewInventoryProperties
+        ),
+        "meeting_speaker_review_submitted": .init(
+            name: "meeting_speaker_review_submitted",
+            allowedProperties: meetingSpeakerReviewOutcomeProperties.union(Set([
+                "completion_kind",
+            ]))
+        ),
+        "meeting_speaker_finalization_completed": .init(
+            name: "meeting_speaker_finalization_completed",
+            allowedProperties: meetingSpeakerReviewOutcomeProperties.union(Set([
+                "finalize_reason",
+                "finalize_result",
+                "queue_depth_bucket",
+                "trigger",
+            ]))
+        ),
         "meeting_transcript_skipped": .init(
             name: "meeting_transcript_skipped",
             allowedProperties: meetingCaptureDiagnosticProperties.union(Set([
@@ -658,6 +698,15 @@ struct AnalyticsEventPolicy: Equatable {
             allowedProperties: [
                 "failure_kind",
                 "import_stage",
+            ]
+        ),
+        "speaker_user_label_saved": .init(
+            name: "speaker_user_label_saved",
+            allowedProperties: [
+                "affected_voice_bucket",
+                "label_update_kind",
+                "result",
+                "surface",
             ]
         ),
     ]

--- a/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
+++ b/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
@@ -258,6 +258,7 @@ public struct SpeakerNamingRequest {
     public let micAudioURL: URL?
     public let shouldRemoveTemporaryAudioOnCleanup: Bool
     public let sourceFailedTranscriptionId: UUID?
+    public let sourceTrigger: String
     public let onComplete: ([SpeakerNameUpdate]) -> Void
 
     public init(
@@ -269,6 +270,7 @@ public struct SpeakerNamingRequest {
         micAudioURL: URL?,
         shouldRemoveTemporaryAudioOnCleanup: Bool = true,
         sourceFailedTranscriptionId: UUID? = nil,
+        sourceTrigger: String = "unknown",
         onComplete: @escaping ([SpeakerNameUpdate]) -> Void
     ) {
         self.speakers = speakers
@@ -279,6 +281,7 @@ public struct SpeakerNamingRequest {
         self.micAudioURL = micAudioURL
         self.shouldRemoveTemporaryAudioOnCleanup = shouldRemoveTemporaryAudioOnCleanup
         self.sourceFailedTranscriptionId = sourceFailedTranscriptionId
+        self.sourceTrigger = sourceTrigger
         self.onComplete = onComplete
     }
 
@@ -388,5 +391,178 @@ public struct SpeakerNameUpdate: Sendable {
         case merged(targetProfileId: UUID)  // user linked this speaker to an existing profile
         case collapsedToMe  // user clicked "Keep as You" — collapse this mic speaker into the single owner
         case discardedFromDatabase  // user kept this review row out of the speaker database
+    }
+}
+
+public struct SpeakerNamingReviewTelemetry: Sendable, Equatable {
+    public let reviewItemCount: Int
+    public let localVoiceCount: Int
+    public let remoteVoiceCount: Int
+    public let suggestedMatchCount: Int
+    public let updatesSubmittedCount: Int
+    public let manualLabelCount: Int
+    public let confirmedCount: Int
+    public let correctedCount: Int
+    public let mergedCount: Int
+    public let collapsedToMeCount: Int
+    public let discardedCount: Int
+    public let suggestedMatchAcceptedCount: Int
+    public let suggestedMatchRejectedCount: Int
+
+    public var didDeferReview: Bool {
+        reviewItemCount > 0 && updatesSubmittedCount == 0
+    }
+
+    public init(
+        reviewItemCount: Int,
+        localVoiceCount: Int,
+        remoteVoiceCount: Int,
+        suggestedMatchCount: Int,
+        updatesSubmittedCount: Int,
+        manualLabelCount: Int,
+        confirmedCount: Int,
+        correctedCount: Int,
+        mergedCount: Int,
+        collapsedToMeCount: Int,
+        discardedCount: Int,
+        suggestedMatchAcceptedCount: Int,
+        suggestedMatchRejectedCount: Int
+    ) {
+        self.reviewItemCount = reviewItemCount
+        self.localVoiceCount = localVoiceCount
+        self.remoteVoiceCount = remoteVoiceCount
+        self.suggestedMatchCount = suggestedMatchCount
+        self.updatesSubmittedCount = updatesSubmittedCount
+        self.manualLabelCount = manualLabelCount
+        self.confirmedCount = confirmedCount
+        self.correctedCount = correctedCount
+        self.mergedCount = mergedCount
+        self.collapsedToMeCount = collapsedToMeCount
+        self.discardedCount = discardedCount
+        self.suggestedMatchAcceptedCount = suggestedMatchAcceptedCount
+        self.suggestedMatchRejectedCount = suggestedMatchRejectedCount
+    }
+
+    public static func summarize(
+        reviewEntries entries: [SpeakerNamingEntry],
+        updates: [SpeakerNameUpdate]
+    ) -> SpeakerNamingReviewTelemetry {
+        let entriesByKey = Dictionary(
+            entries.map {
+                ($0.channel.speakerKey(diarizerSpeakerId: $0.diarizerSpeakerId), $0)
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let suggestedKeys = Set(entries.filter(isSuggestedMatch).map {
+            $0.channel.speakerKey(diarizerSpeakerId: $0.diarizerSpeakerId)
+        })
+
+        var manualLabelCount = 0
+        var confirmedCount = 0
+        var correctedCount = 0
+        var mergedCount = 0
+        var collapsedToMeCount = 0
+        var discardedCount = 0
+        var acceptedCount = 0
+        var rejectedCount = 0
+
+        for update in updates {
+            let key = update.channel.speakerKey(diarizerSpeakerId: update.diarizerSpeakerId)
+            let entry = entriesByKey[key]
+            let hadSuggestion = suggestedKeys.contains(key)
+
+            switch update.action {
+            case .named:
+                manualLabelCount += 1
+                if hadSuggestion { rejectedCount += 1 }
+
+            case .confirmed:
+                confirmedCount += 1
+                if hadSuggestion { acceptedCount += 1 }
+
+            case .corrected:
+                correctedCount += 1
+                manualLabelCount += 1
+                if hadSuggestion { rejectedCount += 1 }
+
+            case .merged(let targetProfileId):
+                mergedCount += 1
+                if hadSuggestion {
+                    if entry?.suggestedProfileId == targetProfileId || entry?.id == targetProfileId {
+                        acceptedCount += 1
+                    } else {
+                        rejectedCount += 1
+                    }
+                }
+
+            case .collapsedToMe:
+                collapsedToMeCount += 1
+                if hadSuggestion { rejectedCount += 1 }
+
+            case .discardedFromDatabase:
+                discardedCount += 1
+                if hadSuggestion { rejectedCount += 1 }
+            }
+        }
+
+        return SpeakerNamingReviewTelemetry(
+            reviewItemCount: entries.count,
+            localVoiceCount: entries.filter { $0.channel == .mic }.count,
+            remoteVoiceCount: entries.filter { $0.channel == .system }.count,
+            suggestedMatchCount: suggestedKeys.count,
+            updatesSubmittedCount: updates.count,
+            manualLabelCount: manualLabelCount,
+            confirmedCount: confirmedCount,
+            correctedCount: correctedCount,
+            mergedCount: mergedCount,
+            collapsedToMeCount: collapsedToMeCount,
+            discardedCount: discardedCount,
+            suggestedMatchAcceptedCount: acceptedCount,
+            suggestedMatchRejectedCount: rejectedCount
+        )
+    }
+
+    private static func isSuggestedMatch(_ entry: SpeakerNamingEntry) -> Bool {
+        entry.needsConfirmation
+            || entry.suggestedProfileId != nil
+            || (entry.currentName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+                && entry.matchSimilarity != nil)
+    }
+}
+
+public enum SpeakerNamingFinalizationResult: String, Sendable, Equatable {
+    case success
+    case failure
+}
+
+public enum SpeakerNamingFinalizationReason: String, Sendable, Equatable {
+    case finalized
+    case transcriptNotFound = "transcript_not_found"
+    case resolutionPlanFailed = "resolution_plan_failed"
+    case transcriptRewriteFailed = "transcript_rewrite_failed"
+    case deferredReviewWriteFailed = "deferred_review_write_failed"
+    case collapseRewriteFailed = "collapse_rewrite_failed"
+    case discardRewriteFailed = "discard_rewrite_failed"
+}
+
+public struct SpeakerNamingFinalizationOutcome: Sendable, Equatable {
+    public let transcriptId: UUID
+    public let result: SpeakerNamingFinalizationResult
+    public let reason: SpeakerNamingFinalizationReason
+    public let sourceTrigger: String
+    public let reviewTelemetry: SpeakerNamingReviewTelemetry
+
+    public init(
+        transcriptId: UUID,
+        result: SpeakerNamingFinalizationResult,
+        reason: SpeakerNamingFinalizationReason,
+        sourceTrigger: String,
+        reviewTelemetry: SpeakerNamingReviewTelemetry
+    ) {
+        self.transcriptId = transcriptId
+        self.result = result
+        self.reason = reason
+        self.sourceTrigger = sourceTrigger
+        self.reviewTelemetry = reviewTelemetry
     }
 }

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -313,7 +313,7 @@ extension Transcription {
                         "similarity": String(format: "%.3f", matchResult.similarity),
                         "threshold": String(format: "%.2f", adaptiveThreshold),
                         "segmentsAveraged": "\(embeddings.count)",
-                        "profileName": matchedProfile?.displayName ?? "unnamed",
+                        "profileId": matchResult.profileId.uuidString,
                         "profileCallCount": "\(matchedProfile?.callCount ?? 0)"
                     ])
                 } else {

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -77,7 +77,8 @@ extension TranscriptionTaskManager {
         meetingTitle: String? = nil,
         recordingDate: Date? = nil,
         sourceFailedTranscriptionId: UUID? = nil,
-        removeSourceAudioAfterArchive: Bool = true
+        removeSourceAudioAfterArchive: Bool = true,
+        speakerReviewSourceTrigger: String = "unknown"
     ) async throws -> URL {
 
         // Require system audio for multichannel transcription
@@ -95,7 +96,8 @@ extension TranscriptionTaskManager {
             meetingTitle: meetingTitle,
             recordingDate: recordingDate,
             sourceFailedTranscriptionId: sourceFailedTranscriptionId,
-            removeSourceAudioAfterArchive: removeSourceAudioAfterArchive
+            removeSourceAudioAfterArchive: removeSourceAudioAfterArchive,
+            speakerReviewSourceTrigger: speakerReviewSourceTrigger
         )
     }
 
@@ -105,7 +107,8 @@ extension TranscriptionTaskManager {
         outputFolder: URL,
         taskId: UUID,
         meetingTitle: String? = nil,
-        recordingDate: Date? = nil
+        recordingDate: Date? = nil,
+        speakerReviewSourceTrigger: String = "unknown"
     ) async throws -> URL {
         try await transcribeMultichannelPipeline(
             micURL: nil,
@@ -115,7 +118,8 @@ extension TranscriptionTaskManager {
             healthInfo: nil,
             splitLocalSpeakers: false,
             meetingTitle: meetingTitle,
-            recordingDate: recordingDate
+            recordingDate: recordingDate,
+            speakerReviewSourceTrigger: speakerReviewSourceTrigger
         )
     }
 
@@ -135,7 +139,8 @@ extension TranscriptionTaskManager {
         sourceFailedTranscriptionId: UUID? = nil,
         removeSourceAudioAfterArchive: Bool = true,
         targetTranscriptURL: URL? = nil,
-        archiveRecordingAudio: Bool = true
+        archiveRecordingAudio: Bool = true,
+        speakerReviewSourceTrigger: String = "unknown"
     ) async throws -> URL {
 
         let transcription = await MainActor.run { self.transcription }
@@ -515,6 +520,7 @@ extension TranscriptionTaskManager {
                     micAudioURL: micURL,
                     shouldRemoveTemporaryAudioOnCleanup: shouldRemoveScratchAudio && sourceFailedTranscriptionId == nil,
                     sourceFailedTranscriptionId: sourceFailedTranscriptionId,
+                    sourceTrigger: speakerReviewSourceTrigger,
                     onComplete: { [weak self] updates in
                         self?.handleNamingComplete(
                             updates: updates,
@@ -525,6 +531,7 @@ extension TranscriptionTaskManager {
                             systemURL: systemURL,
                             shouldRemoveTemporaryAudio: shouldRemoveScratchAudio,
                             sourceFailedTranscriptionId: sourceFailedTranscriptionId,
+                            sourceTrigger: speakerReviewSourceTrigger,
                             clips: capturedEntries
                         )
                     }

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionTaskManager.swift
@@ -19,6 +19,7 @@ public class TranscriptionTaskManager: ObservableObject {
     @Published public var lastSavedDuration: String? = nil
     @Published public var lastSavedSpeakerCount: Int? = nil
     @Published public private(set) var lastFailureDiagnosticMessage: String? = nil
+    @Published public internal(set) var lastSpeakerNamingFinalizationOutcome: SpeakerNamingFinalizationOutcome? = nil
 
     var lastSavedTranscriptId: UUID?
     private var savedTranscriptTaskIdsByTranscriptId: [UUID: UUID] = [:]
@@ -86,7 +87,8 @@ public class TranscriptionTaskManager: ObservableObject {
         healthInfo: RecordingHealthInfo? = nil,
         meetingTitle: String? = nil,
         splitLocalSpeakers: Bool = false,
-        recordingDate: Date? = nil
+        recordingDate: Date? = nil,
+        speakerReviewSourceTrigger: String = "unknown"
     ) {
 
         // Guard: reject concurrent pipelines to prevent model contention
@@ -211,7 +213,8 @@ public class TranscriptionTaskManager: ObservableObject {
                     healthInfo: task.healthInfo,
                     splitLocalSpeakers: task.splitLocalSpeakers,
                     meetingTitle: task.meetingTitle,
-                    recordingDate: task.recordingDate
+                    recordingDate: task.recordingDate,
+                    speakerReviewSourceTrigger: speakerReviewSourceTrigger
                 )
 
                 await MainActor.run {
@@ -258,7 +261,8 @@ public class TranscriptionTaskManager: ObservableObject {
         audioURL: URL,
         outputFolder: URL,
         meetingTitle: String? = nil,
-        recordingDate: Date? = nil
+        recordingDate: Date? = nil,
+        speakerReviewSourceTrigger: String = "unknown"
     ) {
         if !activeTasks.isEmpty {
             AppLogger.pipeline.warning("Rejecting imported transcription — another pipeline is already active", ["activeCount": "\(activeTasks.count)"])
@@ -304,7 +308,8 @@ public class TranscriptionTaskManager: ObservableObject {
                     outputFolder: outputFolder,
                     taskId: taskId,
                     meetingTitle: meetingTitle,
-                    recordingDate: recordingDate
+                    recordingDate: recordingDate,
+                    speakerReviewSourceTrigger: speakerReviewSourceTrigger
                 )
 
                 await MainActor.run {
@@ -350,6 +355,7 @@ public class TranscriptionTaskManager: ObservableObject {
         splitLocalSpeakers: Bool = false,
         replacementTranscriptURL: URL? = nil,
         recordingDate: Date? = nil,
+        speakerReviewSourceTrigger: String = "unknown",
         onReplacementTranscriptCommitted: (@MainActor @Sendable (URL) -> Void)? = nil
     ) {
         if !activeTasks.isEmpty {
@@ -411,7 +417,8 @@ public class TranscriptionTaskManager: ObservableObject {
                     recordingDate: recordingDate,
                     removeSourceAudioAfterArchive: false,
                     targetTranscriptURL: replacementTranscriptURL,
-                    archiveRecordingAudio: replacementTranscriptURL == nil
+                    archiveRecordingAudio: replacementTranscriptURL == nil,
+                    speakerReviewSourceTrigger: speakerReviewSourceTrigger
                 )
 
                 await MainActor.run {

--- a/Sources/TranscriptedCore/Speaker/EmbeddingClusterer.swift
+++ b/Sources/TranscriptedCore/Speaker/EmbeddingClusterer.swift
@@ -532,10 +532,9 @@ public enum EmbeddingClusterer {
                     }
                 }
 
-                let profileName = profiles.first(where: { $0.id == profileId })?.displayName ?? profileId.uuidString.prefix(8).description
                 AppLogger.transcription.info("DB-informed split", [
                     "originalSpkId": "spk\(speakerId)",
-                    "profile": profileName,
+                    "profileId": profileId.uuidString,
                     "assignedSpkId": "spk\(assignedSpkId)",
                     "segments": "\(segmentIndices.count)"
                 ])

--- a/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
+++ b/Sources/TranscriptedCore/Speaker/RetroactiveSpeakerUpdater.swift
@@ -103,7 +103,7 @@ extension TranscriptSaver {
 
         if updatedCount > 0 {
             AppLogger.pipeline.info("Retroactively updated speaker in transcripts",
-                ["dbId": dbIdString, "name": newName, "files": "\(updatedCount)"])
+                ["dbId": dbIdString, "files": "\(updatedCount)"])
         }
     }
 

--- a/Sources/TranscriptedCore/Speaker/SpeakerEmbeddingMatcher.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerEmbeddingMatcher.swift
@@ -30,7 +30,10 @@ extension SpeakerDatabase {
         }
 
         if let match = bestMatch {
-            AppLogger.speakers.info("Matched speaker", ["name": match.displayName ?? match.id.uuidString, "similarity": String(format: "%.3f", bestSimilarity)])
+            AppLogger.speakers.info("Matched speaker", [
+                "profileId": match.id.uuidString,
+                "similarity": String(format: "%.3f", bestSimilarity)
+            ])
             return SpeakerMatchResult(profile: match, similarity: bestSimilarity)
         }
 

--- a/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
@@ -90,7 +90,7 @@ extension Transcription {
 
         if bestSimilarity < effectiveThreshold {
             AppLogger.transcription.info("Match rejected: immature profile", [
-                "profile": matched.displayName ?? matched.id.uuidString.prefix(8).description,
+                "profileId": matched.id.uuidString,
                 "callCount": "\(matched.callCount)",
                 "similarity": String(format: "%.3f", bestSimilarity),
                 "effectiveThreshold": String(format: "%.3f", effectiveThreshold)
@@ -101,7 +101,7 @@ extension Transcription {
         // Separation check: reject if two profiles are too close (ambiguous).
         if secondBestSimilarity >= threshold && (bestSimilarity - secondBestSimilarity) < 0.05 {
             AppLogger.transcription.info("Match rejected: ambiguous (two profiles too close)", [
-                "bestProfile": matched.displayName ?? matched.id.uuidString.prefix(8).description,
+                "bestProfileId": matched.id.uuidString,
                 "bestSimilarity": String(format: "%.3f", bestSimilarity),
                 "secondBestSimilarity": String(format: "%.3f", secondBestSimilarity)
             ])

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingCoordinator.swift
@@ -40,6 +40,7 @@ extension TranscriptionTaskManager {
         systemURL: URL,
         shouldRemoveTemporaryAudio: Bool = true,
         sourceFailedTranscriptionId: UUID? = nil,
+        sourceTrigger: String = "unknown",
         clips: [SpeakerNamingEntry]
     ) {
         let speakerDB = transcription.speakerDB
@@ -47,6 +48,10 @@ extension TranscriptionTaskManager {
         let clipsBySpeakerId = Dictionary(uniqueKeysWithValues: clips.map {
             ($0.channel.speakerKey(diarizerSpeakerId: $0.diarizerSpeakerId), $0)
         })
+        let reviewTelemetry = SpeakerNamingReviewTelemetry.summarize(
+            reviewEntries: clips,
+            updates: updates
+        )
 
         // Partition updates: special actions follow different paths than regular
         // name/merge/confirm updates. We process all of them during naming completion.
@@ -90,10 +95,13 @@ extension TranscriptionTaskManager {
                 Task { @MainActor in
                     self?.finishNamingFlow(
                         didFinalizeTranscript: false,
+                        reason: .transcriptNotFound,
+                        reviewTelemetry: reviewTelemetry,
                         updatesCount: updates.count,
                         transcriptId: transcriptId,
                         resolvedURL: transcriptURL,
-                        sourceFailedTranscriptionId: sourceFailedTranscriptionId
+                        sourceFailedTranscriptionId: sourceFailedTranscriptionId,
+                        sourceTrigger: sourceTrigger
                     )
                 }
                 return
@@ -114,10 +122,13 @@ extension TranscriptionTaskManager {
                 Task { @MainActor in
                     self?.finishNamingFlow(
                         didFinalizeTranscript: false,
+                        reason: .resolutionPlanFailed,
+                        reviewTelemetry: reviewTelemetry,
                         updatesCount: updates.count,
                         transcriptId: transcriptId,
                         resolvedURL: resolvedURL,
-                        sourceFailedTranscriptionId: sourceFailedTranscriptionId
+                        sourceFailedTranscriptionId: sourceFailedTranscriptionId,
+                        sourceTrigger: sourceTrigger
                     )
                 }
                 return
@@ -130,12 +141,19 @@ extension TranscriptionTaskManager {
             let transcriptUpdates = plannedChanges.resolvedUpdates.filter {
                 Self.visibleTranscriptUtteranceCount(for: $0, in: transcriptionResult) > 0
             }
-            var didFinalizeTranscript = visibleRegularUpdates.isEmpty || TranscriptSaver.updateSpeakerNames(
-                transcriptURL: resolvedURL,
-                updates: transcriptUpdates,
-                transcriptionResult: transcriptionResult,
-                speakerStore: speakerDB
-            )
+            var didFinalizeTranscript = true
+            var finalizationReason: SpeakerNamingFinalizationReason = .finalized
+            if !visibleRegularUpdates.isEmpty {
+                didFinalizeTranscript = TranscriptSaver.updateSpeakerNames(
+                    transcriptURL: resolvedURL,
+                    updates: transcriptUpdates,
+                    transcriptionResult: transcriptionResult,
+                    speakerStore: speakerDB
+                )
+                if !didFinalizeTranscript {
+                    finalizationReason = .transcriptRewriteFailed
+                }
+            }
 
             if didFinalizeTranscript, let deferredReviewPlan {
                 didFinalizeTranscript = TranscriptSaver.markSpeakerReviewDeferred(
@@ -143,6 +161,9 @@ extension TranscriptionTaskManager {
                     entries: clips,
                     redirectedSpeakerIdsByKey: deferredReviewPlan.redirectedSpeakerIdsByKey
                 )
+                if !didFinalizeTranscript {
+                    finalizationReason = .deferredReviewWriteFailed
+                }
             }
 
             if didFinalizeTranscript && !collapsedUpdates.isEmpty {
@@ -150,6 +171,9 @@ extension TranscriptionTaskManager {
                     transcriptURL: resolvedURL,
                     collapsedUpdates: collapsedUpdates
                 )
+                if !didFinalizeTranscript {
+                    finalizationReason = .collapseRewriteFailed
+                }
             }
 
             if didFinalizeTranscript && !discardedUpdates.isEmpty {
@@ -157,6 +181,9 @@ extension TranscriptionTaskManager {
                     transcriptURL: resolvedURL,
                     discardedUpdates: discardedUpdates
                 )
+                if !didFinalizeTranscript {
+                    finalizationReason = .discardRewriteFailed
+                }
             }
 
             if didFinalizeTranscript {
@@ -206,11 +233,14 @@ extension TranscriptionTaskManager {
             Task { @MainActor in
                 self?.finishNamingFlow(
                     didFinalizeTranscript: didFinalizeTranscript,
+                    reason: didFinalizeTranscript ? .finalized : finalizationReason,
+                    reviewTelemetry: reviewTelemetry,
                     updatesCount: updates.count,
                     transcriptId: transcriptId,
                     resolvedURL: resolvedURL,
                     sourceFailedTranscriptionId: sourceFailedTranscriptionId,
-                    shouldDeleteSourceFailedAudio: shouldRemoveTemporaryAudio
+                    shouldDeleteSourceFailedAudio: shouldRemoveTemporaryAudio,
+                    sourceTrigger: sourceTrigger
                 )
             }
         }
@@ -390,7 +420,6 @@ extension TranscriptionTaskManager {
             AppLogger.speakers.info("Speaker named", [
                 "originalId": update.persistentSpeakerId.uuidString,
                 "resolvedId": resolvedPersistentSpeakerId.uuidString,
-                "name": resolvedName,
                 "action": "\(update.action)"
             ])
 
@@ -543,8 +572,7 @@ extension TranscriptionTaskManager {
             }
 
             AppLogger.speakers.error("Correction missing session embedding; refusing unsafe profile rewrite", [
-                "speakerId": update.persistentSpeakerId.uuidString,
-                "name": update.newName
+                "speakerId": update.persistentSpeakerId.uuidString
             ])
             return nil
 
@@ -737,17 +765,27 @@ extension TranscriptionTaskManager {
 
     @MainActor private func finishNamingFlow(
         didFinalizeTranscript: Bool,
+        reason: SpeakerNamingFinalizationReason,
+        reviewTelemetry: SpeakerNamingReviewTelemetry,
         updatesCount: Int,
         transcriptId: UUID,
         resolvedURL: URL,
         sourceFailedTranscriptionId: UUID? = nil,
-        shouldDeleteSourceFailedAudio: Bool = true
+        shouldDeleteSourceFailedAudio: Bool = true,
+        sourceTrigger: String = "unknown"
     ) {
         if didFinalizeTranscript {
             AppLogger.pipeline.info("Speaker naming complete", [
                 "named": "\(updatesCount)",
-                "transcript": resolvedURL.lastPathComponent
+                "transcriptId": transcriptId.uuidString
             ])
+            publishSpeakerNamingFinalizationOutcome(
+                transcriptId: transcriptId,
+                result: .success,
+                reason: reason,
+                sourceTrigger: sourceTrigger,
+                reviewTelemetry: reviewTelemetry
+            )
             if let sourceFailedTranscriptionId {
                 if shouldDeleteSourceFailedAudio {
                     failedTranscriptionManager.deleteFailedTranscription(id: sourceFailedTranscriptionId)
@@ -765,8 +803,15 @@ extension TranscriptionTaskManager {
         } else {
             AppLogger.pipeline.error("Speaker naming finalization failed", [
                 "transcriptId": transcriptId.uuidString,
-                "transcript": resolvedURL.lastPathComponent
+                "reason": reason.rawValue
             ])
+            publishSpeakerNamingFinalizationOutcome(
+                transcriptId: transcriptId,
+                result: .failure,
+                reason: reason,
+                sourceTrigger: sourceTrigger,
+                reviewTelemetry: reviewTelemetry
+            )
             if let sourceFailedTranscriptionId {
                 failedTranscriptionManager.updateFailedTranscriptionError(
                     id: sourceFailedTranscriptionId,
@@ -778,5 +823,21 @@ extension TranscriptionTaskManager {
         }
 
         clearCompletedSpeakerNamingRequest(transcriptId: transcriptId)
+    }
+
+    @MainActor private func publishSpeakerNamingFinalizationOutcome(
+        transcriptId: UUID,
+        result: SpeakerNamingFinalizationResult,
+        reason: SpeakerNamingFinalizationReason,
+        sourceTrigger: String,
+        reviewTelemetry: SpeakerNamingReviewTelemetry
+    ) {
+        lastSpeakerNamingFinalizationOutcome = SpeakerNamingFinalizationOutcome(
+            transcriptId: transcriptId,
+            result: result,
+            reason: reason,
+            sourceTrigger: sourceTrigger,
+            reviewTelemetry: reviewTelemetry
+        )
     }
 }

--- a/Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift
@@ -25,7 +25,7 @@ extension SpeakerDatabase {
 
     func setDisplayNameImpl(id: UUID, name: String, source: String) {
         guard isDatabaseOpen else {
-            AppLogger.speakers.error("setDisplayName failed — database not open", ["speakerId": id.uuidString, "name": name])
+            AppLogger.speakers.error("setDisplayName failed — database not open", ["speakerId": id.uuidString])
             return
         }
         let sql = "UPDATE speakers SET display_name = ?, name_source = ? WHERE id = ?;"
@@ -235,8 +235,8 @@ extension SpeakerDatabase {
         }
 
         AppLogger.speakers.info("Merged profiles", [
-            "source": source.displayName ?? "\(sourceId)",
-            "target": target.displayName ?? "\(targetId)",
+            "sourceId": sourceId.uuidString,
+            "targetId": targetId.uuidString,
             "newCallCount": "\(newCallCount)"
         ])
     }
@@ -304,7 +304,11 @@ extension SpeakerDatabase {
 
                 mergedIds.insert(absorbed.id)
                 mergeCount += 1
-                AppLogger.speakers.info("Merged duplicate speaker", ["absorbed": absorbed.displayName ?? "unnamed", "keeper": keeper.displayName ?? "unnamed", "similarity": String(format: "%.3f", similarity)])
+                AppLogger.speakers.info("Merged duplicate speaker", [
+                    "absorbedId": absorbed.id.uuidString,
+                    "keeperId": keeper.id.uuidString,
+                    "similarity": String(format: "%.3f", similarity)
+                ])
             }
         }
 
@@ -361,7 +365,7 @@ extension SpeakerDatabase {
         }
 
         var mergeCount = 0
-        for (name, profiles) in byName {
+        for (_, profiles) in byName {
             guard profiles.count > 1 else { continue }
 
             // Keep the profile with the highest call count (best embedding data)
@@ -374,7 +378,6 @@ extension SpeakerDatabase {
             }
 
             AppLogger.speakers.info("Merged same-name profiles", [
-                "name": name,
                 "merged": "\(sorted.count - 1)",
                 "keeperId": "\(keeper.id)"
             ])

--- a/Sources/UI/Settings/SpeakerNamingSheet.swift
+++ b/Sources/UI/Settings/SpeakerNamingSheet.swift
@@ -44,6 +44,7 @@ final class SpeakerNamingSheet {
         // Avoid stacking — if a previous sheet is still open, close it first.
         currentWindowController?.close()
 
+        trackReviewShown(request)
         let controller = NamingWindowController(request: request) { [weak self] in
             self?.currentWindowController = nil
         }
@@ -52,6 +53,22 @@ final class SpeakerNamingSheet {
         controller.window?.center()
         controller.window?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func trackReviewShown(_ request: SpeakerNamingRequest) {
+        let review = SpeakerNamingReviewTelemetry.summarize(
+            reviewEntries: request.speakers,
+            updates: []
+        )
+        var properties = MeetingSessionController.speakerReviewAnalyticsProperties(
+            review,
+            includeOutcome: false
+        )
+        properties["known_people_bucket"] = AnalyticsReporter.countBucket(request.knownPeople.count)
+        AnalyticsReporter.track(
+            "meeting_speaker_review_shown",
+            properties: properties
+        )
     }
 
     private func dismissCurrentWindowBecauseRequestCleared() {
@@ -93,10 +110,10 @@ final class NamingWindowController: NSWindowController, NSWindowDelegate {
         window.delegate = self
 
         contentView.onSave = { [weak self] updates in
-            self?.finish(with: updates)
+            self?.finish(completionKind: "save", updates: updates)
         }
         contentView.onCancel = { [weak self] in
-            self?.finish(with: [])
+            self?.finish(completionKind: "review_later", updates: [])
         }
     }
 
@@ -105,6 +122,7 @@ final class NamingWindowController: NSWindowController, NSWindowDelegate {
 
     func windowWillClose(_ notification: Notification) {
         if !didComplete {
+            trackReviewSubmitted(completionKind: "window_closed", updates: [])
             request.onComplete([])
             didComplete = true
         }
@@ -117,11 +135,32 @@ final class NamingWindowController: NSWindowController, NSWindowDelegate {
         close()
     }
 
-    private func finish(with updates: [SpeakerNameUpdate]) {
+    private func finish(
+        completionKind: String,
+        updates: [SpeakerNameUpdate]
+    ) {
         guard !didComplete else { return }
         didComplete = true
+        trackReviewSubmitted(completionKind: completionKind, updates: updates)
         request.onComplete(updates)
         close()
+    }
+
+    private func trackReviewSubmitted(
+        completionKind: String,
+        updates: [SpeakerNameUpdate]
+    ) {
+        let review = SpeakerNamingReviewTelemetry.summarize(
+            reviewEntries: request.speakers,
+            updates: updates
+        )
+        var properties = MeetingSessionController.speakerReviewAnalyticsProperties(review)
+        properties["completion_kind"] = completionKind
+        properties["known_people_bucket"] = AnalyticsReporter.countBucket(request.knownPeople.count)
+        AnalyticsReporter.track(
+            "meeting_speaker_review_submitted",
+            properties: properties
+        )
     }
 }
 

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -223,6 +223,15 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
             )
             DispatchQueue.main.async {
                 self?.applySnapshot(snapshot)
+                AnalyticsReporter.track(
+                    "speaker_user_label_saved",
+                    properties: [
+                        "affected_voice_bucket": AnalyticsReporter.countBucket(matchingReviewItems.count),
+                        "label_update_kind": "pending_review",
+                        "result": allTranscriptUpdatesSucceeded ? "success" : "failure",
+                        "surface": "people_review_queue",
+                    ]
+                )
                 completion?(allTranscriptUpdatesSucceeded)
             }
         }
@@ -233,6 +242,9 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         guard !trimmed.isEmpty else { return }
 
         let profileId = profile.id
+        let labelUpdateKind = profile.displayName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            ? "changed"
+            : "added"
         let speakerDatabase = self.speakerDatabase
         let preferredClipsDirectory = self.preferredClipsDirectory
         let legacyClipsDirectory = self.legacyClipsDirectory
@@ -247,6 +259,15 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
             )
             DispatchQueue.main.async {
                 self?.applySnapshot(snapshot)
+                AnalyticsReporter.track(
+                    "speaker_user_label_saved",
+                    properties: [
+                        "affected_voice_bucket": AnalyticsReporter.countBucket(1),
+                        "label_update_kind": labelUpdateKind,
+                        "result": "success",
+                        "surface": "people_all_voices",
+                    ]
+                )
             }
         }
     }

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -541,6 +541,8 @@ func testAnalyticsEventPolicy() {
         let dictationNoSpeech = AnalyticsEventPolicy.policy(forEvent: "dictation_no_speech")
         let meetingFailed = AnalyticsEventPolicy.policy(forEvent: "meeting_transcript_failed")
         let speakerFinalizationFailed = AnalyticsEventPolicy.policy(forEvent: "meeting_speaker_finalization_failed")
+        let speakerReviewShown = AnalyticsEventPolicy.policy(forEvent: "meeting_speaker_review_shown")
+        let speakerFinalizationCompleted = AnalyticsEventPolicy.policy(forEvent: "meeting_speaker_finalization_completed")
         let meetingSkipped = AnalyticsEventPolicy.policy(forEvent: "meeting_transcript_skipped")
         let unknown = AnalyticsEventPolicy.policy(forEvent: "raw_transcript_uploaded")
 
@@ -551,6 +553,8 @@ func testAnalyticsEventPolicy() {
         assertEqual(dictationNoSpeech?.allowedProperties.contains("trigger"), true, "dictation no-speech should preserve trigger attribution")
         assertEqual(meetingFailed?.allowedProperties.contains("failure_kind"), true, "meeting failures should allow normalized failure kinds")
         assertEqual(speakerFinalizationFailed?.allowedProperties.contains("failure_kind"), true, "speaker finalization failures should allow normalized failure kinds")
+        assertEqual(speakerReviewShown?.allowedProperties.contains("review_item_bucket"), true, "speaker review shown should allow only bucketed review counts")
+        assertEqual(speakerFinalizationCompleted?.allowedProperties.contains("finalize_reason"), true, "speaker finalization completion should allow normalized finalization reasons")
         assertEqual(meetingSkipped?.allowedProperties.contains("failure_kind"), true, "skipped meeting transcripts should allow normalized reasons")
         assertNil(unknown, "unreviewed analytics events should not be allowed")
     }
@@ -705,6 +709,116 @@ func testAnalyticsEventPolicy() {
         assertEqual(speakerFinalizationFailed?.allowedProperties.contains("queue_depth_bucket"), true, "speaker finalization failures should preserve bucketed queue depth")
         assertEqual(speakerFinalizationFailed?.allowedProperties.contains("session_stage"), true, "speaker finalization failures should keep save-stage attribution")
         assertEqual(skipped?.allowedProperties.contains("trigger"), true, "skipped meeting transcripts should preserve trigger attribution")
+    }
+
+    runSuite("AnalyticsEventPolicy keeps speaker review telemetry bucketed and nameless") {
+        let shown = AnalyticsEventPolicy.policy(forEvent: "meeting_speaker_review_shown")
+        let submitted = AnalyticsEventPolicy.policy(forEvent: "meeting_speaker_review_submitted")
+        let finalized = AnalyticsEventPolicy.policy(forEvent: "meeting_speaker_finalization_completed")
+        let userLabel = AnalyticsEventPolicy.policy(forEvent: "speaker_user_label_saved")
+
+        assertEqual(shown?.allowedProperties.contains("review_item_bucket"), true, "review shown should preserve speakers-to-name as a bucket")
+        assertEqual(shown?.allowedProperties.contains("match_suggestion_bucket"), true, "review shown should preserve suggested-match volume as a bucket")
+        assertEqual(shown?.allowedProperties.contains("deferred"), false, "review shown should not mark deferred before user action")
+        assertEqual(shown?.allowedProperties.contains("updates_submitted_bucket"), false, "review shown should not report submission volume before user action")
+        assertEqual(shown?.allowedProperties.contains("match_accept_bucket"), false, "review shown should not report accepted matches before user action")
+        assertEqual(submitted?.allowedProperties.contains("match_accept_bucket"), true, "review submitted should preserve accepted match bucket")
+        assertEqual(submitted?.allowedProperties.contains("match_reject_bucket"), true, "review submitted should preserve rejected match bucket")
+        assertEqual(submitted?.allowedProperties.contains("manual_label_bucket"), true, "review submitted should preserve manual label bucket")
+        assertEqual(submitted?.allowedProperties.contains("completion_kind"), true, "review submitted should preserve save vs later")
+        assertEqual(finalized?.allowedProperties.contains("finalize_result"), true, "finalization should preserve success/failure")
+        assertEqual(finalized?.allowedProperties.contains("finalize_reason"), true, "finalization should preserve normalized reason")
+        assertEqual(userLabel?.allowedProperties.contains("label_update_kind"), true, "People renames should preserve add/change/pending-review kind")
+
+        let privateFields = [
+            "audio_path": "/Users/jane/Private/customer.wav",
+            "meeting_title": "Customer Roadmap",
+            "speaker_name": "Alice Customer",
+            "speaker_id": "private-id",
+            "transcript_text": "private transcript words",
+        ]
+
+        let shownSanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            privateFields.merging(
+                [
+                    "deferred": "true",
+                    "known_people_bucket": "4_9",
+                    "local_voice_bucket": "1",
+                    "match_accept_bucket": "1",
+                    "match_suggestion_bucket": "2_3",
+                    "remote_voice_bucket": "2_3",
+                    "review_item_bucket": "4_9",
+                    "updates_submitted_bucket": "0",
+                ],
+                uniquingKeysWith: { _, new in new }
+            ),
+            allowedKeys: shown?.allowedProperties ?? []
+        )
+
+        assertEqual(shownSanitized["review_item_bucket"], "4_9", "review shown should keep speaker count inventory")
+        assertEqual(shownSanitized["match_suggestion_bucket"], "2_3", "review shown should keep suggestion inventory")
+        assertNil(shownSanitized["deferred"], "review shown should drop deferred because no user action happened yet")
+        assertNil(shownSanitized["updates_submitted_bucket"], "review shown should drop submitted update count")
+        assertNil(shownSanitized["match_accept_bucket"], "review shown should drop accepted match count")
+
+        let finalizedSanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            privateFields.merging(
+                [
+                    "collapse_bucket": "0",
+                    "confirmed_bucket": "1",
+                    "corrected_bucket": "1",
+                    "deferred": "false",
+                    "discard_bucket": "0",
+                    "finalize_reason": "finalized",
+                    "finalize_result": "success",
+                    "known_people_bucket": "4_9",
+                    "local_voice_bucket": "1",
+                    "manual_label_bucket": "2_3",
+                    "match_accept_bucket": "1",
+                    "match_reject_bucket": "1",
+                    "match_suggestion_bucket": "2_3",
+                    "merge_bucket": "1",
+                    "queue_depth_bucket": "0",
+                    "remote_voice_bucket": "2_3",
+                    "review_item_bucket": "4_9",
+                    "trigger": "hotkey",
+                    "updates_submitted_bucket": "4_9",
+                ],
+                uniquingKeysWith: { _, new in new }
+            ),
+            allowedKeys: finalized?.allowedProperties ?? []
+        )
+
+        assertEqual(finalizedSanitized["review_item_bucket"], "4_9", "review-item bucket should survive")
+        assertEqual(finalizedSanitized["match_accept_bucket"], "1", "accepted match bucket should survive")
+        assertEqual(finalizedSanitized["match_reject_bucket"], "1", "rejected match bucket should survive")
+        assertEqual(finalizedSanitized["manual_label_bucket"], "2_3", "manual label bucket should survive")
+        assertEqual(finalizedSanitized["finalize_result"], "success", "finalization result should survive")
+        assertEqual(finalizedSanitized["finalize_reason"], "finalized", "finalization reason should survive")
+        assertEqual(finalizedSanitized["trigger"], "hotkey", "trigger should survive")
+
+        let userLabelSanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            privateFields.merging(
+                [
+                    "affected_voice_bucket": "2_3",
+                    "label_update_kind": "pending_review",
+                    "result": "success",
+                    "surface": "people_review_queue",
+                ],
+                uniquingKeysWith: { _, new in new }
+            ),
+            allowedKeys: userLabel?.allowedProperties ?? []
+        )
+        assertEqual(userLabelSanitized["affected_voice_bucket"], "2_3", "affected voice bucket should survive")
+        assertEqual(userLabelSanitized["label_update_kind"], "pending_review", "label update kind should survive")
+        assertEqual(userLabelSanitized["result"], "success", "result enum should survive")
+        assertEqual(userLabelSanitized["surface"], "people_review_queue", "surface enum should survive")
+
+        for sanitized in [finalizedSanitized, userLabelSanitized] {
+            for key in privateFields.keys {
+                assertNil(sanitized[key], "\(key) should not be emitted for speaker review analytics")
+            }
+        }
     }
 
     runSuite("AnalyticsEventPolicy meeting outcomes drop adversarial private fields") {

--- a/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
@@ -102,6 +102,116 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: externalSystemURL.path))
     }
 
+    func testSpeakerNamingReviewTelemetryCountsSuggestionOutcomesWithoutNames() throws {
+        let suggestedProfileId = UUID()
+        let rejectedProfileId = UUID()
+        let unknownProfileId = UUID()
+        let localProfileId = UUID()
+        let entries = [
+            SpeakerNamingEntry(
+                id: suggestedProfileId,
+                suggestedProfileId: suggestedProfileId,
+                diarizerSpeakerId: "1",
+                channel: .system,
+                clipURL: tempDirectory.appendingPathComponent("suggested.wav"),
+                sampleText: "sample",
+                currentName: "Suggested Person",
+                matchSimilarity: 0.84,
+                needsNaming: false,
+                needsConfirmation: true
+            ),
+            SpeakerNamingEntry(
+                id: rejectedProfileId,
+                suggestedProfileId: rejectedProfileId,
+                diarizerSpeakerId: "2",
+                channel: .system,
+                clipURL: tempDirectory.appendingPathComponent("rejected.wav"),
+                sampleText: "sample",
+                currentName: "Rejected Person",
+                matchSimilarity: 0.82,
+                needsNaming: false,
+                needsConfirmation: true
+            ),
+            SpeakerNamingEntry(
+                id: unknownProfileId,
+                diarizerSpeakerId: "3",
+                channel: .system,
+                clipURL: tempDirectory.appendingPathComponent("unknown.wav"),
+                sampleText: "sample",
+                currentName: nil,
+                matchSimilarity: nil,
+                needsNaming: true,
+                needsConfirmation: false
+            ),
+            SpeakerNamingEntry(
+                id: localProfileId,
+                diarizerSpeakerId: "1",
+                channel: .mic,
+                clipURL: tempDirectory.appendingPathComponent("local.wav"),
+                sampleText: "sample",
+                currentName: nil,
+                matchSimilarity: nil,
+                needsNaming: true,
+                needsConfirmation: false
+            ),
+        ]
+        let updates = [
+            SpeakerNameUpdate(
+                persistentSpeakerId: suggestedProfileId,
+                diarizerSpeakerId: "1",
+                channel: .system,
+                newName: "Suggested Person",
+                action: .merged(targetProfileId: suggestedProfileId)
+            ),
+            SpeakerNameUpdate(
+                persistentSpeakerId: rejectedProfileId,
+                diarizerSpeakerId: "2",
+                channel: .system,
+                newName: "Correct Person",
+                previousName: "Rejected Person",
+                action: .corrected
+            ),
+            SpeakerNameUpdate(
+                persistentSpeakerId: unknownProfileId,
+                diarizerSpeakerId: "3",
+                channel: .system,
+                newName: "New Person",
+                action: .named
+            ),
+            SpeakerNameUpdate(
+                persistentSpeakerId: localProfileId,
+                diarizerSpeakerId: "1",
+                channel: .mic,
+                newName: "You",
+                action: .collapsedToMe
+            ),
+        ]
+
+        let summary = SpeakerNamingReviewTelemetry.summarize(
+            reviewEntries: entries,
+            updates: updates
+        )
+
+        XCTAssertEqual(summary.reviewItemCount, 4)
+        XCTAssertEqual(summary.localVoiceCount, 1)
+        XCTAssertEqual(summary.remoteVoiceCount, 3)
+        XCTAssertEqual(summary.suggestedMatchCount, 2)
+        XCTAssertEqual(summary.updatesSubmittedCount, 4)
+        XCTAssertEqual(summary.manualLabelCount, 2)
+        XCTAssertEqual(summary.mergedCount, 1)
+        XCTAssertEqual(summary.correctedCount, 1)
+        XCTAssertEqual(summary.collapsedToMeCount, 1)
+        XCTAssertEqual(summary.suggestedMatchAcceptedCount, 1)
+        XCTAssertEqual(summary.suggestedMatchRejectedCount, 1)
+        XCTAssertFalse(summary.didDeferReview)
+
+        let deferred = SpeakerNamingReviewTelemetry.summarize(
+            reviewEntries: entries,
+            updates: []
+        )
+        XCTAssertTrue(deferred.didDeferReview)
+    }
+
     @MainActor
     func testHandleNamingCompletePublishesSuccessAfterTranscriptRewrite() async throws {
         let harness = try makeHarness()
@@ -169,6 +279,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             transcriptionResult: transcriptionResult,
             micURL: micURL,
             systemURL: systemURL,
+            sourceTrigger: "hotkey",
             clips: [
                 SpeakerNamingEntry(
                     id: persistentSpeakerId,
@@ -190,6 +301,11 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
         }
 
         XCTAssertEqual(harness.manager.lastSavedTranscriptURL, transcriptURL)
+        XCTAssertEqual(harness.manager.lastSpeakerNamingFinalizationOutcome?.result, .success)
+        XCTAssertEqual(harness.manager.lastSpeakerNamingFinalizationOutcome?.reason, .finalized)
+        XCTAssertEqual(harness.manager.lastSpeakerNamingFinalizationOutcome?.sourceTrigger, "hotkey")
+        XCTAssertEqual(harness.manager.lastSpeakerNamingFinalizationOutcome?.reviewTelemetry.reviewItemCount, 1)
+        XCTAssertEqual(harness.manager.lastSpeakerNamingFinalizationOutcome?.reviewTelemetry.manualLabelCount, 1)
         let savedTranscript = try String(contentsOf: transcriptURL, encoding: .utf8)
         XCTAssertTrue(savedTranscript.contains("Sarah Graham"))
         XCTAssertFalse(FileManager.default.fileExists(atPath: clipURL.path))
@@ -1862,6 +1978,7 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             transcriptionResult: transcriptionResult,
             micURL: micURL,
             systemURL: systemURL,
+            sourceTrigger: "file_import",
             clips: [
                 SpeakerNamingEntry(
                     id: persistentSpeakerId,
@@ -1889,6 +2006,11 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
             harness.speakerDB.getSpeaker(id: persistentSpeakerId)?.displayName,
             "speaker DB should stay untouched when transcript rewrite fails"
         )
+        XCTAssertEqual(harness.manager.lastSpeakerNamingFinalizationOutcome?.result, .failure)
+        XCTAssertEqual(harness.manager.lastSpeakerNamingFinalizationOutcome?.reason, .transcriptNotFound)
+        XCTAssertEqual(harness.manager.lastSpeakerNamingFinalizationOutcome?.sourceTrigger, "file_import")
+        XCTAssertEqual(harness.manager.lastSpeakerNamingFinalizationOutcome?.reviewTelemetry.reviewItemCount, 1)
+        XCTAssertEqual(harness.manager.lastSpeakerNamingFinalizationOutcome?.reviewTelemetry.manualLabelCount, 1)
         XCTAssertFalse(FileManager.default.fileExists(atPath: clipURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: micURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path))

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -141,8 +141,12 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `meeting_transcript_saved`
 - `meeting_transcript_failed`
 - `meeting_speaker_finalization_failed`
+- `meeting_speaker_review_shown`
+- `meeting_speaker_review_submitted`
+- `meeting_speaker_finalization_completed`
 - `meeting_transcript_skipped`
 - `meeting_saved_audio_retranscription_requested`
+- `speaker_user_label_saved`
 
 ## Allowed property style
 


### PR DESCRIPTION
## Summary
- Reviewed current speaker-related PR/work: #1144 is measurement-only multi-corpus eval work, #1153 is still draft/dirty real-corpus eval work, and #1140 is a dirty/superseded same-voice branch.
- Added privacy-safe speaker review and finalization telemetry for speakers-to-name, suggested match accept/reject, finalization result/reason, and user rename actions.
- Added typed speaker finalization outcomes in Core, including normalized failure reasons and source-trigger attribution.
- Removed speaker display/name values from speaker matching, merge, embedding, and retroactive update logs.

## Privacy notes
- Analytics stays bucketed and enum-only.
- No speaker names, audio paths, transcript text, meeting titles, emails, or absolute file paths are allowed for the new events.
- `meeting_speaker_review_shown` is inventory-only; deferred/update outcome fields are only emitted after submit/close/finalization.

## Tests and review
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh --filter AnalyticsEventPolicyTests`
- `bash run-tests.sh --filter AnalyticsPayloadSanitizerTests`
- `bash run-tests.sh`
- `swift test --filter SpeakerNamingCoordinatorTests/testSpeakerNamingReviewTelemetryCountsSuggestionOutcomesWithoutNames`
- `swift test`
- `bash run-integration-smoke.sh`
- `bash scripts/dev/agent-preflight.sh`
- `git diff --check`
- `codex review --base origin/main`

Codex review first found a P2 issue where review-shown telemetry was incorrectly marked deferred before user action. Fixed by splitting inventory vs outcome properties and adding sanitizer/policy regression coverage. Final Codex review found no actionable issues; it also reran `build.sh --no-open`, `swift test`, `run-tests.sh`, and `git diff --check` clean.

## Remaining speaker risks
- Real-corpus accuracy is still mostly in the eval lane (#1144/#1153), not proven by this PR.
- Manual real-call speaker naming accuracy remains unproven here; this PR adds deterministic/funnel proof and telemetry so the next real-corpus pass has better signal.
