### PR TITLE
[nightly-security] Harden selector crash tags

### DIFF
--- a/Sources/Observability/CrashReporter.swift
+++ b/Sources/Observability/CrashReporter.swift
@@ -332,11 +332,12 @@ final class CrashReporter {
 /// stack-frame symbols) and then forwards to the previously-installed handler.
 private func transcriptedUnrecognizedSelectorHandler(_ exception: NSException) {
     if let parsed = UnrecognizedSelectorReason.parse(exception.reason) {
+        let tags = SentryPayloadSanitizer.sanitizeTags([
+            "unrecognized_selector": parsed.selector,
+            "unrecognized_selector_class": parsed.receiver,
+        ])
         SentrySDK.configureScope { scope in
-            scope.setTags([
-                "unrecognized_selector": parsed.selector,
-                "unrecognized_selector_class": parsed.receiver,
-            ])
+            scope.setTags(tags)
         }
     }
     CrashReporter.forwardUncaughtException(exception)

--- a/Tests/SentryPayloadSanitizerTests.swift
+++ b/Tests/SentryPayloadSanitizerTests.swift
@@ -150,6 +150,22 @@ func testSentryPayloadSanitizer() {
         assertEqual(Set(sanitized.keys), ["last_event"], "crash runtime tags should stay limited to one reviewed workflow dimension")
     }
 
+    runSuite("SentryPayloadSanitizer.sanitizeTags still scrubs selector-enrichment values") {
+        let sanitized = SentryPayloadSanitizer.sanitizeTags([
+            "unrecognized_selector": "openURL:https://example.com/private?token=abc123",
+            "unrecognized_selector_class": "/Users/redbars/PrivateWidget",
+        ])
+
+        assertFalse(
+            sanitized["unrecognized_selector"]?.contains("https://example.com") ?? true,
+            "selector crash tags should not retain raw URLs"
+        )
+        assertFalse(
+            sanitized["unrecognized_selector_class"]?.contains("/Users/redbars") ?? true,
+            "selector class crash tags should not retain absolute paths"
+        )
+    }
+
     runSuite("SentryPayloadSanitizer.sanitizeText redacts emails hostnames and non-home paths") {
         let input = "Contact me at person@example.com from Redbarss-MacBook-Pro.local and inspect /private/var/folders/demo/file.txt"
         let sanitized = SentryPayloadSanitizer.sanitizeText(input)


### PR DESCRIPTION
## Summary
- route unrecognized-selector crash enrichment tags through the shared Sentry tag sanitizer
- add regression coverage that selector-enrichment tag values do not retain raw URLs or absolute paths

## Verification
- python3 scripts/ops/nightly-security-check.py --write-report build/nightly-security-report-source.json
- python3 scripts/ops/nightly-security-check.py --app-bundle build/Transcripted.app --write-report build/nightly-security-report.json
- python3 scripts/ops/privacy-leak-sweep.py --write-report build/privacy-leak-sweep-report.json
- bash scripts/release/verify-sparkle-release.sh 1.1.48
- python3 scripts/ops/packaged-app-smoke.py --app-bundle build/Transcripted.app --expected-version 1.1.48 --write-report build/packaged-app-smoke.json --markdown-out build/packaged-app-smoke.md (WARN: local-build DMG/dSYM/entitlements only)
- bash build-deps.sh --force
- bash build.sh --no-open
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh
- bash run-integration-smoke.sh
- swift test