### PR TITLE
[test-generator] Cover menu command shortcut contract

### DIFF
--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -59,6 +59,103 @@ func testUIAutomationSurfaceContract() {
 
     }
 
+    runSuite("UI automation surface contract - app commands expose capture shortcuts") {
+        let commandsSource = readUIAutomationContractFile("Sources/TranscriptedMenuCommands.swift")
+
+        for requiredCommandHook in [
+            "CommandMenu(\"Capture\")",
+            "Button(\"Start Dictation\")",
+            "appDelegate.menuStartDictation()",
+            ".keyboardShortcut(\"d\", modifiers: .command)",
+            "Button(\"Start / Stop Meeting Recording\")",
+            "appDelegate.menuToggleMeetingRecording()",
+            ".keyboardShortcut(\"r\", modifiers: .command)",
+            "Button(\"Transcribe Audio File",
+            "appDelegate.menuImportAudio()",
+            ".keyboardShortcut(\"o\", modifiers: .command)",
+        ] {
+            assertTrue(commandsSource.contains(requiredCommandHook), "\(requiredCommandHook) should stay pinned in the app command menu")
+        }
+    }
+
+    runSuite("UI automation surface contract - app commands expose primary Go shortcuts") {
+        let commandsSource = readUIAutomationContractFile("Sources/TranscriptedMenuCommands.swift")
+        let pagesSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsPage.swift")
+
+        for requiredCommandHook in [
+            "CommandMenu(\"Go\")",
+            "Button(\"Home\")",
+            "appDelegate.menuOpenPage(.home)",
+            ".keyboardShortcut(\"1\", modifiers: .command)",
+            "Button(\"Dictations\")",
+            "appDelegate.menuOpenPage(.dictations)",
+            ".keyboardShortcut(\"2\", modifiers: .command)",
+            "Button(\"Speakers\")",
+            "appDelegate.menuOpenPage(.people)",
+            ".keyboardShortcut(\"3\", modifiers: .command)",
+            "Button(\"Agent\")",
+            "appDelegate.menuOpenPage(.connectAgent)",
+            ".keyboardShortcut(\"4\", modifiers: .command)",
+            "Button(\"Find Speaker",
+            "appDelegate.menuFindSpeaker()",
+            ".keyboardShortcut(\"f\", modifiers: .command)",
+        ] {
+            assertTrue(commandsSource.contains(requiredCommandHook), "\(requiredCommandHook) should stay pinned in the Go command menu")
+        }
+
+        for requiredPageHook in [
+            "case .home: return \"1\"",
+            "case .dictations: return \"2\"",
+            "case .people: return \"3\"",
+            "case .connectAgent: return \"4\"",
+            "return \"\\(title)  ⌘\\(key)\"",
+        ] {
+            assertTrue(pagesSource.contains(requiredPageHook), "\(requiredPageHook) should keep sidebar help aligned with Go shortcuts")
+        }
+    }
+
+    runSuite("UI automation surface contract - app commands route through existing delegate entry points") {
+        let appSource = readUIAutomationContractFile("Sources/TranscriptedApp.swift")
+
+        for requiredAppHook in [
+            "TranscriptedMenuCommands(appDelegate: appDelegate)",
+            "func menuStartDictation()",
+            "startDictationFromSettings()",
+            "func menuToggleMeetingRecording()",
+            "meetingOverlayController.toggleFromHotkey()",
+            "func menuImportAudio()",
+            "importAudioFileFromSettings()",
+            "func menuOpenPage(_ page: TranscriptedSettingsPage)",
+            "showSettingsWindow(page: page, source: \"menu_command\")",
+            "func menuFindSpeaker()",
+            "settingsWindowController.focusSpeakerSearch(source: \"menu_command\")",
+        ] {
+            assertTrue(appSource.contains(requiredAppHook), "\(requiredAppHook) should keep app commands wired through existing app-delegate actions")
+        }
+    }
+
+    runSuite("UI automation surface contract - app commands do not remap global trigger preferences") {
+        let commandsSource = readUIAutomationContractFile("Sources/TranscriptedMenuCommands.swift")
+
+        for forbiddenTriggerHook in [
+            "PhysicalDictationTriggerPreferences",
+            "HotkeyPreferences",
+            "RegisterEventHotKey",
+            "pushToTalk",
+            "handsFree",
+            ".keyboardShortcut(\"m\"",
+            "modifiers: .option",
+            "modifiers: [.option",
+            "modifiers: .control",
+            "modifiers: [.control",
+        ] {
+            assertFalse(
+                commandsSource.contains(forbiddenTriggerHook),
+                "app-active commands must not remap or shadow global recordable trigger preferences (\(forbiddenTriggerHook))"
+            )
+        }
+    }
+
     runSuite("UI automation surface contract - major settings and Home flows stay mapped") {
         let pagesSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsPage.swift")
         let settingsSidebarSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsSidebar.swift")


### PR DESCRIPTION
## Missing coverage

Recent app command work added active-app menu shortcuts for capture actions and primary Settings navigation, but the fast suite did not pin the command-to-action mapping, sidebar help alignment, or the guardrail that these commands do not remap the user's recordable global trigger preferences.

## Tests added

- Pins Capture menu shortcuts for Start Dictation, Start / Stop Meeting Recording, and Transcribe Audio File.
- Pins Go menu shortcuts for Home, Dictations, Speakers, Agent, and Find Speaker.
- Verifies app commands route through the existing app-delegate entry points.
- Guards against app-active commands referencing or shadowing global trigger preference machinery.

## Checks run

- `bash run-tests.sh --filter UIAutomationSurfaceContract`
- `bash scripts/dev/agent-preflight.sh`
- `bash build.sh --no-open`
- `bash run-tests.sh`