### PR TITLE
Harden local summary stale state cleanup

### DIFF
--- a/Sources/Meeting/LocalMeetingSummarizer.swift
+++ b/Sources/Meeting/LocalMeetingSummarizer.swift
@@ -1840,27 +1840,61 @@ enum LocalMeetingSummaryMarkdownUpdater {
         guard oldFilename != newFilename else { return nil }
 
         var didChange = false
-        let updatedLines = markdown.components(separatedBy: "\n").map { line -> String in
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if frontmatterKey(in: trimmed) == "local_summary_source_transcript",
-               trimmed.contains(oldFilename) {
-                didChange = true
-                return yamlLine("local_summary_source_transcript", newFilename)
+        if let document = TranscriptFrontmatter.document(in: markdown) {
+            let updatedFrontmatter = document.lines.map { line -> String in
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if frontmatterKey(in: trimmed) == "local_summary_source_transcript",
+                   TranscriptFrontmatter.values(from: [trimmed])["local_summary_source_transcript"] == oldFilename {
+                    didChange = true
+                    return yamlLine("local_summary_source_transcript", newFilename)
+                }
+                return line
             }
-
-            let oldSourceLine = "Source transcript: `\(oldFilename)`"
-            if line.contains(oldSourceLine) {
-                didChange = true
-                return line.replacingOccurrences(
-                    of: oldSourceLine,
-                    with: "Source transcript: `\(newFilename)`"
-                )
-            }
-
-            return line
+            let updatedBody = updatingGeneratedSourceTranscriptLine(
+                in: document.body,
+                from: oldFilename,
+                to: newFilename,
+                didChange: &didChange
+            )
+            guard didChange else { return nil }
+            return "---\n\(updatedFrontmatter.joined(separator: "\n"))\n---\n\(updatedBody)"
         }
 
-        return didChange ? updatedLines.joined(separator: "\n") : nil
+        let updated = updatingGeneratedSourceTranscriptLine(
+            in: markdown,
+            from: oldFilename,
+            to: newFilename,
+            didChange: &didChange
+        )
+        return didChange ? updated : nil
+    }
+
+    private static func updatingGeneratedSourceTranscriptLine(
+        in body: String,
+        from oldFilename: String,
+        to newFilename: String,
+        didChange: inout Bool
+    ) -> String {
+        guard let startRange = body.range(of: startMarker) else { return body }
+        let replacementRange: Range<String.Index>
+        if let endRange = body.range(of: endMarker, range: startRange.upperBound..<body.endIndex) {
+            replacementRange = startRange.lowerBound..<endRange.upperBound
+        } else {
+            replacementRange = startRange.lowerBound..<body.endIndex
+        }
+
+        let oldSourceLine = "Source transcript: `\(oldFilename)`"
+        let block = String(body[replacementRange])
+        let updatedBlock = block.replacingOccurrences(
+            of: oldSourceLine,
+            with: "Source transcript: `\(newFilename)`"
+        )
+        guard updatedBlock != block else { return body }
+
+        var updated = body
+        updated.replaceSubrange(replacementRange, with: updatedBlock)
+        didChange = true
+        return updated
     }
 
     private static func frontmatterKey(in line: String) -> String? {

--- a/Sources/Meeting/LocalMeetingSummarizer.swift
+++ b/Sources/Meeting/LocalMeetingSummarizer.swift
@@ -304,14 +304,27 @@ enum LocalMeetingSummaryStore {
         for transcriptURL: URL,
         fileManager: FileManager = .default
     ) throws -> Bool {
+        var didRemove = false
         let url = summaryURL(for: transcriptURL)
-        guard fileManager.fileExists(atPath: url.path),
-              let values = try TranscriptFrontmatter.readValues(from: url),
-              values["capture_type"] == "meeting_summary",
-              values["source_transcript"] == transcriptURL.lastPathComponent else {
-            return false
+        if fileManager.fileExists(atPath: url.path),
+           let values = try TranscriptFrontmatter.readValues(from: url),
+           values["capture_type"] == "meeting_summary",
+           values["source_transcript"] == transcriptURL.lastPathComponent {
+            try fileManager.removeItem(at: url)
+            didRemove = true
         }
-        try fileManager.removeItem(at: url)
+
+        guard fileManager.fileExists(atPath: transcriptURL.path),
+              let values = try? TranscriptFrontmatter.readValues(from: transcriptURL),
+              values["capture_type"]?.lowercased() == "meeting" else {
+            return didRemove
+        }
+
+        let raw = try String(contentsOf: transcriptURL, encoding: .utf8)
+        let updated = LocalMeetingSummaryMarkdownUpdater.removingGeneratedSummary(from: raw)
+        guard updated != raw else { return didRemove }
+        try updated.write(to: transcriptURL, atomically: true, encoding: .utf8)
+        fileManager.restrictFileToOwnerOnly(at: transcriptURL)
         return true
     }
 }
@@ -1789,6 +1802,65 @@ enum LocalMeetingSummaryMarkdownUpdater {
     static func removingLocalSummaryMarkers(from body: String) -> String {
         body.replacingOccurrences(of: startMarker, with: "")
             .replacingOccurrences(of: endMarker, with: "")
+    }
+
+    static func removingGeneratedSummary(from markdown: String) -> String {
+        guard let document = TranscriptFrontmatter.document(in: markdown) else {
+            return removingLocalSummaryBlock(from: markdown)
+        }
+
+        var removedFrontmatter = false
+        let retainedFrontmatter = document.lines.filter { line in
+            guard let key = frontmatterKey(in: line) else { return true }
+            let shouldRetain = !managedFrontmatterKeys.contains(key)
+            if !shouldRetain { removedFrontmatter = true }
+            return shouldRetain
+        }
+        let untrimmedBody = removingLocalSummaryBlock(from: document.body)
+        guard removedFrontmatter || untrimmedBody != document.body else {
+            return markdown
+        }
+        let body = untrimmedBody
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return """
+        ---
+        \(retainedFrontmatter.joined(separator: "\n"))
+        ---
+
+        \(body)
+        """
+    }
+
+    static func updatingSourceTranscriptFilename(
+        in markdown: String,
+        from oldFilename: String,
+        to newFilename: String
+    ) -> String? {
+        guard oldFilename != newFilename else { return nil }
+
+        var didChange = false
+        let updatedLines = markdown.components(separatedBy: "\n").map { line -> String in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if frontmatterKey(in: trimmed) == "local_summary_source_transcript",
+               trimmed.contains(oldFilename) {
+                didChange = true
+                return yamlLine("local_summary_source_transcript", newFilename)
+            }
+
+            let oldSourceLine = "Source transcript: `\(oldFilename)`"
+            if line.contains(oldSourceLine) {
+                didChange = true
+                return line.replacingOccurrences(
+                    of: oldSourceLine,
+                    with: "Source transcript: `\(newFilename)`"
+                )
+            }
+
+            return line
+        }
+
+        return didChange ? updatedLines.joined(separator: "\n") : nil
     }
 
     private static func frontmatterKey(in line: String) -> String? {

--- a/Sources/Meeting/MeetingArtifactRenamer.swift
+++ b/Sources/Meeting/MeetingArtifactRenamer.swift
@@ -111,6 +111,13 @@ enum MeetingArtifactRenamer {
             fileManager: fileManager,
             logFailure: logFailure
         )
+        updateInlineSummarySourceIfNeeded(
+            at: targetURL,
+            from: url.lastPathComponent,
+            to: targetURL.lastPathComponent,
+            fileManager: fileManager,
+            logFailure: logFailure
+        )
         return targetURL
     }
 
@@ -219,6 +226,38 @@ enum MeetingArtifactRenamer {
                 [
                     "sourceExists": "\(fileManager.fileExists(atPath: sourceSummaryURL.path))",
                     "targetExists": "\(fileManager.fileExists(atPath: targetSummaryURL.path))",
+                    "errorType": "\(type(of: error))"
+                ]
+            )
+        }
+    }
+
+    private static func updateInlineSummarySourceIfNeeded(
+        at transcriptURL: URL,
+        from oldName: String,
+        to newName: String,
+        fileManager: FileManager,
+        logFailure: (_ event: String, _ context: [String: String]) -> Void
+    ) {
+        guard oldName != newName,
+              fileManager.fileExists(atPath: transcriptURL.path),
+              let raw = try? String(contentsOf: transcriptURL, encoding: .utf8),
+              let updated = LocalMeetingSummaryMarkdownUpdater.updatingSourceTranscriptFilename(
+                in: raw,
+                from: oldName,
+                to: newName
+              ) else {
+            return
+        }
+
+        do {
+            try updated.write(to: transcriptURL, atomically: true, encoding: .utf8)
+            fileManager.restrictFileToOwnerOnly(at: transcriptURL)
+        } catch {
+            logFailure(
+                "meeting_inline_summary_source_rename_failed",
+                [
+                    "transcriptExists": "\(fileManager.fileExists(atPath: transcriptURL.path))",
                     "errorType": "\(type(of: error))"
                 ]
             )

--- a/Tests/HomeMeetingRenameTests.swift
+++ b/Tests/HomeMeetingRenameTests.swift
@@ -8,6 +8,7 @@ func testHomeMeetingRename() {
             let audioDirectory = try writeRenameAudio(for: transcriptURL)
             let summaryURL = LocalMeetingSummaryStore.summaryURL(for: transcriptURL)
             try writeRenameSummary(summaryURL, sourceTranscript: transcriptURL.lastPathComponent)
+            try writeInlineRenameSummary(transcriptURL: transcriptURL)
 
             do {
                 let result = try HomeMeetingRename.rename(transcriptAt: transcriptURL, to: "  Launch planning  ")
@@ -25,6 +26,18 @@ func testHomeMeetingRename() {
                 assertTrue(updated.contains("title: \"Launch planning\""), "frontmatter title should be rewritten")
                 assertTrue(updated.contains("# Launch planning"), "body heading should be rewritten")
                 assertFalse(updated.contains("Quick notes"), "old title should not survive anywhere")
+                assertTrue(
+                    updated.contains("local_summary_source_transcript: \"2026-06-05 Launch planning.md\""),
+                    "inline summary metadata should repoint at the renamed transcript"
+                )
+                assertTrue(
+                    updated.contains("Source transcript: `2026-06-05 Launch planning.md`"),
+                    "managed inline summary block should show the renamed source transcript"
+                )
+                assertFalse(
+                    updated.contains("Source transcript: `Call_2026-06-05_18-39-20.md`"),
+                    "managed inline summary block should not keep the stale source filename"
+                )
 
                 let movedAudio = MeetingAudioArchiveResolver.archiveDirectory(forTranscript: result.transcriptURL)
                 assertTrue(FileManager.default.fileExists(atPath: movedAudio.path), "audio directory should follow the rename")
@@ -188,4 +201,26 @@ private func writeRenameSummary(_ url: URL, sourceTranscript: String) throws {
     Synthetic summary.
     """
     try markdown.write(to: url, atomically: true, encoding: .utf8)
+}
+
+private func writeInlineRenameSummary(transcriptURL: URL) throws {
+    let raw = try String(contentsOf: transcriptURL, encoding: .utf8)
+    let updated = LocalMeetingSummaryMarkdownUpdater.markdown(
+        byApplying: LocalMeetingSummarySections(
+            title: "Generated Summary",
+            participants: "- You",
+            summary: "Synthetic summary.",
+            decisions: "None found.",
+            actionItems: "None found.",
+            openQuestions: "None found.",
+            risksOrFollowUps: "None found.",
+            accuracyNotes: "None found."
+        ),
+        to: raw,
+        configuration: .m1Optimized(physicalMemoryBytes: 16 * 1024 * 1024 * 1024),
+        generatedAt: Date(timeIntervalSince1970: 1_780_000_000),
+        chunkCount: 1,
+        sourceTranscriptFilename: transcriptURL.lastPathComponent
+    )
+    try updated.write(to: transcriptURL, atomically: true, encoding: .utf8)
 }

--- a/Tests/LocalMeetingSummarizerTests.swift
+++ b/Tests/LocalMeetingSummarizerTests.swift
@@ -265,6 +265,92 @@ func testLocalMeetingSummarizer() async {
         try? FileManager.default.removeItem(at: root)
     }
 
+    runSuite("LocalMeetingSummaryStore removes inline generated summary state") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LocalMeetingSummaryInlineRemovalTests-\(UUID().uuidString)", isDirectory: true)
+        let transcriptURL = root.appendingPathComponent("Call.md")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        do {
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            try """
+            ---
+            capture_type: meeting
+            title: "Call"
+            local_summary_version: "1"
+            local_summary_source_transcript: "Call.md"
+            local_summary_title: "Generated Call"
+            local_summary: "Old generated summary."
+            ---
+
+            # Call
+
+            ## Transcript
+
+            **00:01** [Mic/You]
+            Keep the real transcript.
+
+            \(LocalMeetingSummaryMarkdownUpdater.startMarker)
+            ## Local Gemma Summary
+
+            Source transcript: `Call.md`
+
+            ### Summary
+            Old generated summary.
+            \(LocalMeetingSummaryMarkdownUpdater.endMarker)
+            """.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+            assertTrue(
+                try LocalMeetingSummaryStore.removeGeneratedSummary(for: transcriptURL),
+                "inline generated summary metadata should count as removed summary state"
+            )
+
+            let updated = try String(contentsOf: transcriptURL, encoding: .utf8)
+            assertTrue(updated.contains("## Transcript"), "canonical transcript should stay")
+            assertTrue(updated.contains("Keep the real transcript."), "transcript text should stay")
+            assertFalse(updated.contains("local_summary_version"), "inline summary metadata should be removed")
+            assertFalse(updated.contains("local_summary_source_transcript"), "inline source backlink should be removed")
+            assertFalse(updated.contains(LocalMeetingSummaryMarkdownUpdater.startMarker), "managed summary block should be removed")
+            assertFalse(updated.contains("Old generated summary."), "generated summary body should be removed")
+        } catch {
+            assertionFailure("inline summary removal fixture should not throw: \(error)")
+        }
+    }
+
+    runSuite("LocalMeetingSummaryStore leaves unsummarized meetings untouched") {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LocalMeetingSummaryNoopRemovalTests-\(UUID().uuidString)", isDirectory: true)
+        let transcriptURL = root.appendingPathComponent("Call.md")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        do {
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            let original = """
+            ---
+            capture_type: meeting
+            title: "Call"
+            ---
+
+            # Call
+
+            ## Transcript
+
+            **00:01** [Mic/You]
+            Keep the real transcript.
+            """
+            try original.write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+            assertFalse(
+                try LocalMeetingSummaryStore.removeGeneratedSummary(for: transcriptURL),
+                "unsummarized meeting transcripts should not be rewritten"
+            )
+            let updated = try String(contentsOf: transcriptURL, encoding: .utf8)
+            assertEqual(updated, original, "no-op cleanup should preserve exact transcript contents")
+        } catch {
+            assertionFailure("no-op summary removal fixture should not throw: \(error)")
+        }
+    }
+
     runSuite("LocalMeetingSummaryNormalizer restores missing sections") {
         let normalized = LocalMeetingSummaryNormalizer.normalized("# Summary\nUseful brief.")
         for heading in [

--- a/Tests/LocalMeetingSummarizerTests.swift
+++ b/Tests/LocalMeetingSummarizerTests.swift
@@ -580,6 +580,50 @@ func testLocalMeetingSummarizer() async {
         assertTrue(updated.contains("## Transcript"), "original transcript body should remain in the same file")
     }
 
+    runSuite("LocalMeetingSummaryMarkdownUpdater refreshes only managed source links") {
+        let markdown = """
+        ---
+        capture_type: meeting
+        title: "Quick notes"
+        local_summary_source_transcript: "Quick notes.md"
+        ---
+
+        # Quick notes
+
+        ## Transcript
+
+        **00:01** [Mic/Justin]
+        The note said Source transcript: `Quick notes.md` before we renamed it.
+
+        \(LocalMeetingSummaryMarkdownUpdater.startMarker)
+        ## Local Gemma Summary
+
+        Source transcript: `Quick notes.md`
+
+        ### Summary
+        Useful summary.
+        \(LocalMeetingSummaryMarkdownUpdater.endMarker)
+        """
+        let updated = LocalMeetingSummaryMarkdownUpdater.updatingSourceTranscriptFilename(
+            in: markdown,
+            from: "Quick notes.md",
+            to: "2026-06-05 Launch planning.md"
+        ) ?? markdown
+
+        assertTrue(
+            updated.contains("local_summary_source_transcript: \"2026-06-05 Launch planning.md\""),
+            "managed source frontmatter should refresh"
+        )
+        assertTrue(
+            updated.contains("Source transcript: `2026-06-05 Launch planning.md`"),
+            "managed summary block should refresh"
+        )
+        assertTrue(
+            updated.contains("The note said Source transcript: `Quick notes.md` before we renamed it."),
+            "ordinary transcript text should not be rewritten"
+        )
+    }
+
     runSuite("LocalMeetingSummaryMarkdownUpdater records Apple provider metadata") {
         let markdown = """
         ---


### PR DESCRIPTION
## Summary
- Clear inline local-summary metadata and managed summary blocks when generated summaries are invalidated, while keeping no-summary transcripts byte-for-byte untouched.
- Refresh inline local-summary source back-links when Home renames a meeting, matching the existing sidecar rename behavior.
- Add deterministic fixtures for inline cleanup, no-op cleanup, and rename source-link refresh.

## Bugs found/fixed
- Fixed stale inline AI-summary source state after Home meeting rename.
- Fixed generated-summary invalidation so saved-audio retranscription cleanup covers current inline summaries, not only legacy `.summary.md` sidecars.

## Proof
- `bash run-tests.sh --filter LocalMeetingSummarizerTests` — 181/181 passed.
- `bash run-tests.sh --filter HomeMeetingRenameTests` — 24/24 passed.
- `bash scripts/dev/agent-preflight.sh` — passed.
- `bash scripts/ops/run-local-summary-fixture.sh` — passed.
- `bash build-deps.sh --force` — passed.
- `bash build.sh --no-open` — passed.
- `bash run-tests.sh` — 5680/5680 passed.
- `bash run-integration-smoke.sh` — passed.
- `codex review --uncommitted` — no actionable bugs found.
- `bash scripts/ops/transcripted-qa-bench.sh --mode full` — PASS, 16/16; report: `/tmp/transcripted-qa-bench/qa-20260619-062412/qa-report.md`.

## Manual checks still needed
- Real local Gemma summary beta workflow on an actual beta machine/model cache.
- Real Zoom/WebRTC meeting route, Bluetooth/AirPods route, slow pasteback feel, and install/update proof remain manual per QA bench.

## Notes
No new network assumptions. Model download behavior remains inside the existing Gemma/uv path.