### PR TITLE
Expand meeting prompt synthetic simulator

### DIFF
--- a/Sources/Meeting/MeetingPromptHeuristics.swift
+++ b/Sources/Meeting/MeetingPromptHeuristics.swift
@@ -395,6 +395,27 @@ struct MeetingPromptRuntimeSnapshot: Equatable {
     let frontmostBundleID: String?
     let recentNativeActivity: [MeetingPromptProvider: Date]
     let runtimeSuppressedUntil: [MeetingPromptProvider: Date]
+    let micActiveBundleIDs: Set<String>
+    let isOwnCaptureActive: Bool
+    let isMicInputPromptEnabled: Bool
+
+    init(
+        runningBundleIDs: Set<String>,
+        frontmostBundleID: String?,
+        recentNativeActivity: [MeetingPromptProvider: Date],
+        runtimeSuppressedUntil: [MeetingPromptProvider: Date],
+        micActiveBundleIDs: Set<String> = [],
+        isOwnCaptureActive: Bool = false,
+        isMicInputPromptEnabled: Bool = true
+    ) {
+        self.runningBundleIDs = runningBundleIDs
+        self.frontmostBundleID = frontmostBundleID
+        self.recentNativeActivity = recentNativeActivity
+        self.runtimeSuppressedUntil = runtimeSuppressedUntil
+        self.micActiveBundleIDs = micActiveBundleIDs
+        self.isOwnCaptureActive = isOwnCaptureActive
+        self.isMicInputPromptEnabled = isMicInputPromptEnabled
+    }
 
     static let browserBundleIdentifiers: Set<String> = [
         "com.apple.Safari",
@@ -514,6 +535,9 @@ enum MeetingPromptSyntheticSuppressionReason: String, Equatable {
     case snoozedCandidate = "snoozed_candidate"
     case pendingCandidate = "pending_candidate"
     case presentationBlocked = "presentation_blocked"
+    case ownCaptureActive = "own_capture_active"
+    case micInputDisabled = "mic_input_disabled"
+    case runtimeSuppressed = "runtime_suppressed"
 }
 
 @available(macOS 14.0, *)
@@ -555,9 +579,20 @@ enum MeetingPromptSyntheticEvaluator {
             ))
         }
         candidates.append(contentsOf: runtimeCandidates(from: runtimeSnapshot, now: now))
+        let micSuppression = micInputSuppression(from: runtimeSnapshot, now: now)
+        candidates.append(contentsOf: micInputCandidates(from: runtimeSnapshot, now: now))
 
-        guard let match = candidates.sorted(by: sortCandidates).first else {
-            return MeetingPromptSyntheticEvaluation(candidate: nil, suppressionReason: .noCandidate)
+        let sortedCandidates = candidates.sorted(by: sortCandidates)
+        guard let match = preferredCandidate(
+            from: sortedCandidates,
+            snoozedUntil: snoozedUntil,
+            pendingUntil: pendingUntil,
+            now: now
+        ) else {
+            return MeetingPromptSyntheticEvaluation(
+                candidate: nil,
+                suppressionReason: micSuppression ?? .noCandidate
+            )
         }
 
         if let until = snoozedUntil[match.candidate.id], until > now {
@@ -569,6 +604,121 @@ enum MeetingPromptSyntheticEvaluator {
         }
 
         return MeetingPromptSyntheticEvaluation(candidate: match.candidate, suppressionReason: nil)
+    }
+
+    static func micInputCandidates(
+        from snapshot: MeetingPromptRuntimeSnapshot,
+        now: Date
+    ) -> [MeetingPromptScoredCandidate] {
+        guard micInputSuppression(from: snapshot, now: now) == nil else { return [] }
+
+        var seenProviders: Set<MeetingPromptProvider> = []
+        return micInputProviders(from: snapshot).compactMap { provider in
+            guard seenProviders.insert(provider).inserted else { return nil }
+            if let suppressedUntil = snapshot.runtimeSuppressedUntil[provider], suppressedUntil > now {
+                return nil
+            }
+            return micInputCandidate(for: provider, now: now)
+        }
+    }
+
+    private static func micInputProviders(
+        from snapshot: MeetingPromptRuntimeSnapshot
+    ) -> [MeetingPromptProvider] {
+        Set(snapshot.micActiveBundleIDs.compactMap(MeetingPromptProvider.micInputProvider(forBundleID:)))
+            .sorted { $0.rawValue < $1.rawValue }
+    }
+
+    private static func micInputSuppression(
+        from snapshot: MeetingPromptRuntimeSnapshot,
+        now: Date
+    ) -> MeetingPromptSyntheticSuppressionReason? {
+        let providers = micInputProviders(from: snapshot)
+        guard !providers.isEmpty else { return nil }
+
+        if !snapshot.isMicInputPromptEnabled {
+            return .micInputDisabled
+        }
+        if snapshot.isOwnCaptureActive {
+            return .ownCaptureActive
+        }
+        if providers.allSatisfy({ provider in
+            (snapshot.runtimeSuppressedUntil[provider] ?? .distantPast) > now
+        }) {
+            return .runtimeSuppressed
+        }
+
+        return nil
+    }
+
+    private static func micInputCandidate(
+        for provider: MeetingPromptProvider,
+        now: Date
+    ) -> MeetingPromptScoredCandidate {
+        let title = provider == .googleMeet
+            ? "Call detected in your browser"
+            : "\(provider.displayName) call detected"
+        let presentation = MeetingPromptHeuristics.micInputPresentation(title: title)
+
+        return MeetingPromptScoredCandidate(
+            candidate: MeetingPromptDetector.Candidate(
+                id: "mic:\(provider.rawValue)",
+                title: presentation.title,
+                detail: presentation.detail,
+                provider: provider,
+                reason: .micInput,
+                source: .runtimeApp,
+                startDate: now,
+                endDate: now.addingTimeInterval(MeetingPromptHeuristics.runtimeReminderSnoozeInterval),
+                meetingURL: nil,
+                suggestedTranscriptTitle: nil
+            ),
+            score: presentation.score
+        )
+    }
+
+    private static func preferredCandidate(
+        from sortedCandidates: [MeetingPromptScoredCandidate],
+        snoozedUntil: [String: Date],
+        pendingUntil: [String: Date],
+        now: Date
+    ) -> MeetingPromptScoredCandidate? {
+        guard let first = sortedCandidates.first else { return nil }
+        guard first.candidate.reason == .micInput else { return first }
+
+        let calendarCandidate = sortedCandidates.first {
+            $0.candidate.source == .calendarEvent &&
+                $0.candidate.provider == first.candidate.provider
+        }
+        guard first.candidate.provider == .googleMeet else {
+            return calendarCandidate ?? first
+        }
+
+        return sortedCandidates.first {
+            $0.candidate.source == .calendarEvent &&
+                $0.candidate.provider == first.candidate.provider &&
+                hasActiveCooldown(
+                    for: $0.candidate.id,
+                    snoozedUntil: snoozedUntil,
+                    pendingUntil: pendingUntil,
+                    now: now
+                )
+        } ?? first
+    }
+
+    private static func hasActiveCooldown(
+        for candidateID: String,
+        snoozedUntil: [String: Date],
+        pendingUntil: [String: Date],
+        now: Date
+    ) -> Bool {
+        if let until = pendingUntil[candidateID], until > now {
+            return true
+        }
+        if let until = snoozedUntil[candidateID], until > now {
+            return true
+        }
+        return false
     }
 
     static func runtimeCandidates(

--- a/Tests/SyntheticMeetingPromptTests.swift
+++ b/Tests/SyntheticMeetingPromptTests.swift
@@ -8,13 +8,19 @@ private func syntheticRuntimeSnapshot(
     runningBundleIDs: Set<String> = [],
     frontmostBundleID: String? = nil,
     recentNativeActivity: [MeetingPromptProvider: Date] = [:],
-    runtimeSuppressedUntil: [MeetingPromptProvider: Date] = [:]
+    runtimeSuppressedUntil: [MeetingPromptProvider: Date] = [:],
+    micActiveBundleIDs: Set<String> = [],
+    isOwnCaptureActive: Bool = false,
+    isMicInputPromptEnabled: Bool = true
 ) -> MeetingPromptRuntimeSnapshot {
     MeetingPromptRuntimeSnapshot(
         runningBundleIDs: runningBundleIDs,
         frontmostBundleID: frontmostBundleID,
         recentNativeActivity: recentNativeActivity,
-        runtimeSuppressedUntil: runtimeSuppressedUntil
+        runtimeSuppressedUntil: runtimeSuppressedUntil,
+        micActiveBundleIDs: micActiveBundleIDs,
+        isOwnCaptureActive: isOwnCaptureActive,
+        isMicInputPromptEnabled: isMicInputPromptEnabled
     )
 }
 
@@ -159,6 +165,140 @@ func testSyntheticMeetingPrompts() {
         )
 
         assertEqual(result.suppressionReason, .noCandidate, "a browser alone is not enough evidence for a prompt")
+    }
+
+    runSuite("SyntheticMeetingPrompts — browser WebRTC mic activity prompts without Calendar") {
+        let result = evaluateSyntheticPrompt(
+            calendarAccessGranted: false,
+            calendarEvents: [],
+            runtimeSnapshot: syntheticRuntimeSnapshot(
+                micActiveBundleIDs: [
+                    "com.google.Chrome.helper",
+                    "com.apple.WebKit.GPU"
+                ]
+            )
+        )
+
+        assertTrue(result.shouldPrompt, "a browser process holding the mic is strong enough for an ad-hoc call prompt")
+        assertEqual(result.candidate?.id, "mic:googleMeet", "browser helper noise should collapse to one stable browser-call candidate")
+        assertEqual(result.candidate?.title, "Call detected in your browser", "browser WebRTC copy should stay provider-neutral")
+        assertEqual(result.candidate?.reason, .micInput, "mic activity should keep its own analytics reason")
+        assertNil(result.candidate?.suggestedTranscriptTitle, "ad-hoc browser calls should not invent a calendar title")
+    }
+
+    runSuite("SyntheticMeetingPrompts — native Zoom mic plus Calendar keeps the scheduled prompt") {
+        let result = evaluateSyntheticPrompt(
+            calendarEvents: [
+                syntheticCalendarEvent(id: "zoom-native-mic", startsIn: 20)
+            ],
+            runtimeSnapshot: syntheticRuntimeSnapshot(
+                micActiveBundleIDs: ["us.zoom.xos"]
+            )
+        )
+
+        assertEqual(result.candidate?.id, "calendar:zoom-native-mic", "native Zoom mic evidence should not replace a matching calendar prompt")
+        assertEqual(result.candidate?.source, .calendarEvent, "the prompt should keep calendar context for title handoff")
+        assertEqual(result.candidate?.suggestedTranscriptTitle, "Design review", "calendar-backed native calls should keep the meeting title hint")
+    }
+
+    runSuite("SyntheticMeetingPrompts — browser mic stays neutral unless a calendar prompt is already pending") {
+        let activeBrowserCall = evaluateSyntheticPrompt(
+            calendarEvents: [
+                syntheticCalendarEvent(
+                    id: "meet-calendar",
+                    startsIn: 20,
+                    url: URL(string: "https://meet.google.com/abc-defg-hij")
+                )
+            ],
+            runtimeSnapshot: syntheticRuntimeSnapshot(
+                micActiveBundleIDs: ["com.google.Chrome.helper"]
+            )
+        )
+        let pendingCalendar = evaluateSyntheticPrompt(
+            calendarEvents: [
+                syntheticCalendarEvent(
+                    id: "meet-calendar",
+                    startsIn: 20,
+                    url: URL(string: "https://meet.google.com/abc-defg-hij")
+                )
+            ],
+            runtimeSnapshot: syntheticRuntimeSnapshot(
+                micActiveBundleIDs: ["com.google.Chrome.helper"]
+            ),
+            pendingUntil: ["calendar:meet-calendar": syntheticPromptNow.addingTimeInterval(60)]
+        )
+        let expiredCalendarCooldown = evaluateSyntheticPrompt(
+            calendarEvents: [
+                syntheticCalendarEvent(
+                    id: "meet-calendar",
+                    startsIn: 20,
+                    url: URL(string: "https://meet.google.com/abc-defg-hij")
+                )
+            ],
+            runtimeSnapshot: syntheticRuntimeSnapshot(
+                micActiveBundleIDs: ["com.google.Chrome.helper"]
+            ),
+            snoozedUntil: ["calendar:meet-calendar": syntheticPromptNow.addingTimeInterval(-1)],
+            pendingUntil: ["calendar:meet-calendar": syntheticPromptNow.addingTimeInterval(-1)]
+        )
+
+        assertEqual(activeBrowserCall.candidate?.id, "mic:googleMeet", "generic browser calls should not borrow a possibly unrelated calendar title")
+        assertNil(activeBrowserCall.candidate?.suggestedTranscriptTitle, "browser calls may be Meet, Zoom web, or Teams web")
+        assertFalse(pendingCalendar.shouldPrompt, "browser mic should not bypass a visible scheduled prompt")
+        assertEqual(pendingCalendar.suppressionReason, .pendingCandidate, "pending calendar prompt should explain the quiet repeat")
+        assertEqual(expiredCalendarCooldown.candidate?.id, "mic:googleMeet", "expired calendar cooldowns should not steal a live browser mic prompt")
+    }
+
+    runSuite("SyntheticMeetingPrompts — mic app flags suppress stale callbacks") {
+        let disabled = evaluateSyntheticPrompt(
+            calendarAccessGranted: false,
+            calendarEvents: [],
+            runtimeSnapshot: syntheticRuntimeSnapshot(
+                micActiveBundleIDs: ["com.google.Chrome.helper"],
+                isMicInputPromptEnabled: false
+            )
+        )
+        let ownCapture = evaluateSyntheticPrompt(
+            calendarAccessGranted: false,
+            calendarEvents: [],
+            runtimeSnapshot: syntheticRuntimeSnapshot(
+                micActiveBundleIDs: ["com.google.Chrome.helper"],
+                isOwnCaptureActive: true
+            )
+        )
+
+        assertEqual(disabled.suppressionReason, .micInputDisabled, "disabled auto-call detection should suppress late mic callbacks")
+        assertEqual(ownCapture.suppressionReason, .ownCaptureActive, "our own recording or dictation should suppress mic prompts")
+    }
+
+    runSuite("SyntheticMeetingPrompts — duplicate mic route noise respects pending cooldown") {
+        let firstPass = evaluateSyntheticPrompt(
+            calendarAccessGranted: false,
+            calendarEvents: [],
+            runtimeSnapshot: syntheticRuntimeSnapshot(
+                micActiveBundleIDs: [
+                    "com.google.Chrome.helper",
+                    "com.google.Chrome.helper.audio",
+                    "com.apple.WebKit.GPU"
+                ]
+            )
+        )
+        let repeatPass = evaluateSyntheticPrompt(
+            calendarAccessGranted: false,
+            calendarEvents: [],
+            runtimeSnapshot: syntheticRuntimeSnapshot(
+                micActiveBundleIDs: [
+                    "com.google.Chrome.helper",
+                    "com.google.Chrome.helper.audio",
+                    "com.apple.WebKit.GPU"
+                ]
+            ),
+            pendingUntil: ["mic:googleMeet": syntheticPromptNow.addingTimeInterval(60)]
+        )
+
+        assertEqual(firstPass.candidate?.id, "mic:googleMeet", "noisy browser helpers should still produce one candidate id")
+        assertFalse(repeatPass.shouldPrompt, "pending mic prompts should not repeat while helper processes churn")
+        assertEqual(repeatPass.suppressionReason, .pendingCandidate, "repeat mic route noise should classify as pending")
     }
 
     runSuite("SyntheticMeetingPrompts — native runtime prompts are provider-limited") {


### PR DESCRIPTION
## Summary
- Extend `MeetingPromptSyntheticEvaluator` with deterministic mic/WebRTC input fixtures.
- Model browser helper mic activity, native Zoom mic routes, auto-call detection off, own-capture suppression, runtime suppression, and pending/snoozed duplicate prevention.
- Add synthetic regressions for neutral browser call prompts, calendar title preservation for native scheduled calls, noisy helper churn, and expired cooldown handling.

## What the simulator covers
- Calendar-backed Zoom/Meet/Teams/Webex prompts, URL extraction from event URL/location/notes, lead/grace windows, all-day/expired/lookalike rejection.
- Runtime app prompts for supported native app-only routes and suppression for Zoom/Teams app-open-only noise.
- Mic/WebRTC routes from browser helpers and native conferencing apps.
- Presentation gates for already recording, loading/preparing, existing prompt, and other busy overlay states.
- Pending, snoozed, dismissed, runtime-suppressed, disabled, and own-capture duplicate/noisy-repeat cases.

## Manual gaps
- Real Calendar permission/EventKit polling behavior remains manual or integration-level.
- Live Zoom/Google Meet/Teams/WebRTC process behavior and TCC/system-audio route proof remain manual.
- UI rendering/click behavior of the actual popup is not covered by this pure simulator.

## Review
- `~/.codex/skills/codex-review/scripts/codex-review` first found an expired-cooldown synthetic preference edge; accepted and fixed.
- Final rerun: `codex-review clean: no accepted/actionable findings reported`.

## Tests
- `scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force`
- `bash run-tests.sh --filter SyntheticMeetingPrompt` (71 passed)
- `bash run-tests.sh --filter MeetingPrompt` (186 passed)
- `~/.codex/skills/codex-review/scripts/codex-review` (clean final rerun)
- `bash build.sh --no-open`
- `bash run-tests.sh` (5686 passed)
- `bash run-integration-smoke.sh`
