### PR TITLE
Add speaker naming identity simulator coverage

### DIFF
--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingSimulationRunner.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingSimulationRunner.swift
@@ -150,6 +150,14 @@ public struct SpeakerNamingSimulationSplitIndicator: Hashable, Sendable {
 }
 
 @available(macOS 14.0, *)
+public struct SpeakerNamingSimulationDuplicateIdentityIndicator: Hashable, Sendable {
+    public let truthSpeakerId: String
+    public let actualLabel: String
+    public let speakerIds: [String]
+    public let caseIds: [String]
+}
+
+@available(macOS 14.0, *)
 public struct SpeakerNamingSimulationCaseReport: Sendable {
     public let id: String
     public let title: String
@@ -177,6 +185,9 @@ public struct SpeakerNamingSimulationReport: Sendable {
     public let confusionPairs: [SpeakerNamingSimulationConfusionPair]
     public let falseMergeIndicators: [SpeakerNamingSimulationMergeIndicator]
     public let falseSplitIndicators: [SpeakerNamingSimulationSplitIndicator]
+    public let duplicateIdentityIndicators: [SpeakerNamingSimulationDuplicateIdentityIndicator]
+    public let identityStabilityChecks: Int
+    public let identityStabilitySuccesses: Int
     public let renamedPropagationChecks: Int
     public let renamedPropagationSuccesses: Int
     public let rollbackChecks: Int
@@ -193,6 +204,10 @@ public struct SpeakerNamingSimulationReport: Sendable {
         renamedPropagationSuccesses == renamedPropagationChecks
     }
 
+    public var identityStabilitySucceeded: Bool {
+        identityStabilitySuccesses == identityStabilityChecks
+    }
+
     public var rollbackSucceeded: Bool {
         rollbackSuccesses == rollbackChecks
     }
@@ -206,6 +221,8 @@ public struct SpeakerNamingSimulationReport: Sendable {
             && (minimumExactLabelAccuracy < 1.0 || confusionPairs.isEmpty)
             && falseMergeIndicators.isEmpty
             && falseSplitIndicators.isEmpty
+            && duplicateIdentityIndicators.isEmpty
+            && identityStabilitySucceeded
             && renamedSpeakerPropagationSucceeded
             && rollbackSucceeded
             && replacementSucceeded
@@ -221,6 +238,8 @@ public struct SpeakerNamingSimulationReport: Sendable {
         lines.append("- Confusion pairs: \(confusionPairs.isEmpty ? "none" : "\(confusionPairs.count)")")
         lines.append("- False merge indicators: \(falseMergeIndicators.isEmpty ? "none" : "\(falseMergeIndicators.count)")")
         lines.append("- False split indicators: \(falseSplitIndicators.isEmpty ? "none" : "\(falseSplitIndicators.count)")")
+        lines.append("- Duplicate identity indicators: \(duplicateIdentityIndicators.isEmpty ? "none" : "\(duplicateIdentityIndicators.count)")")
+        lines.append("- Identity stability: \(identityStabilitySuccesses)/\(identityStabilityChecks)")
         lines.append("- Renamed propagation: \(renamedPropagationSuccesses)/\(renamedPropagationChecks)")
         lines.append("- Rollback: \(rollbackSuccesses)/\(rollbackChecks)")
         lines.append("- Saved-audio retranscription: \(replacementSuccesses)/\(replacementChecks)")
@@ -254,6 +273,14 @@ public struct SpeakerNamingSimulationReport: Sendable {
             lines.append("## False Split Indicators")
             for indicator in falseSplitIndicators {
                 lines.append("- \(indicator.truthSpeakerId): actual labels \(indicator.actualLabels.joined(separator: ", "))")
+            }
+        }
+
+        if !duplicateIdentityIndicators.isEmpty {
+            lines.append("")
+            lines.append("## Duplicate Identity Indicators")
+            for indicator in duplicateIdentityIndicators {
+                lines.append("- \(indicator.truthSpeakerId) / \(indicator.actualLabel): speaker ids \(indicator.speakerIds.joined(separator: ", ")) in cases \(indicator.caseIds.joined(separator: ", "))")
             }
         }
 
@@ -297,7 +324,7 @@ public final class SpeakerNamingSimulationRunner {
         }
 
         var caseReports: [SpeakerNamingSimulationCaseReport] = []
-        var evaluated: [EvaluatedUtterance] = []
+        var evaluatedByCaseId: [String: [EvaluatedUtterance]] = [:]
         var renamedChecks = 0
         var renamedSuccesses = 0
         var rollbackChecks = 0
@@ -308,7 +335,11 @@ public final class SpeakerNamingSimulationRunner {
         for meeting in suite.meetings {
             let outcome = try runMeeting(meeting, state: &state)
             caseReports.append(outcome.caseReport)
-            evaluated.append(contentsOf: outcome.evaluatedUtterances)
+            if let replacementTargetMeetingId = meeting.replacementTargetMeetingId,
+               outcome.caseReport.replacementSucceeded == true {
+                evaluatedByCaseId.removeValue(forKey: replacementTargetMeetingId)
+            }
+            evaluatedByCaseId[meeting.id] = outcome.evaluatedUtterances
             renamedChecks += outcome.renamedChecks
             renamedSuccesses += outcome.renamedSuccesses
             if let rollbackSucceeded = outcome.caseReport.rollbackSucceeded {
@@ -321,9 +352,11 @@ public final class SpeakerNamingSimulationRunner {
             }
         }
 
+        let evaluated = suite.meetings.flatMap { evaluatedByCaseId[$0.id] ?? [] }
         let confusionPairs = aggregateConfusionPairs(evaluated)
         let falseMergeIndicators = falseMergeIndicators(evaluated)
         let falseSplitIndicators = falseSplitIndicators(evaluated)
+        let identityStability = identityStability(evaluated)
 
         return SpeakerNamingSimulationReport(
             suiteName: suite.name,
@@ -334,6 +367,9 @@ public final class SpeakerNamingSimulationRunner {
             confusionPairs: confusionPairs,
             falseMergeIndicators: falseMergeIndicators,
             falseSplitIndicators: falseSplitIndicators,
+            duplicateIdentityIndicators: identityStability.indicators,
+            identityStabilityChecks: identityStability.checks,
+            identityStabilitySuccesses: identityStability.successes,
             renamedPropagationChecks: renamedChecks,
             renamedPropagationSuccesses: renamedSuccesses,
             rollbackChecks: rollbackChecks,
@@ -485,6 +521,7 @@ public final class SpeakerNamingSimulationRunner {
         if let replacementTargetMeetingId = meeting.replacementTargetMeetingId {
             replacementSucceeded = transcriptURL == state.records[replacementTargetMeetingId]?.url
             if replacementSucceeded == true {
+                state.records[replacementTargetMeetingId] = record
                 notes.append("saved-audio retranscription replaced \(replacementTargetMeetingId)")
             } else {
                 notes.append("saved-audio retranscription did not reuse target transcript URL")
@@ -797,7 +834,8 @@ public final class SpeakerNamingSimulationRunner {
                     channel: channel,
                     newName: name,
                     previousName: context.matchedProfileSnapshot?.displayName,
-                    action: .confirmed
+                    action: .confirmed,
+                    resolvedPersistentSpeakerId: nil
                 ))
 
             case .correct(let channel, let diarizerSpeakerId, let previousName, let newName):
@@ -1067,6 +1105,9 @@ public final class SpeakerNamingSimulationRunner {
                 speakerDB.resetDisputeCount(id: resolvedId)
 
             case .confirmed:
+                if resolvedId != update.persistentSpeakerId {
+                    speakerDB.mergeProfiles(sourceId: update.persistentSpeakerId, into: resolvedId)
+                }
                 speakerDB.setDisplayName(id: resolvedId, name: update.newName, source: NameSource.userManual)
                 speakerDB.resetDisputeCount(id: resolvedId)
 
@@ -1193,7 +1234,10 @@ public final class SpeakerNamingSimulationRunner {
                 caseId: record.id,
                 truthSpeakerId: segment.fixture.truthSpeakerId,
                 expected: segment.fixture.expectedDisplayName,
-                actual: actual ?? "(missing)"
+                actual: actual ?? "(missing)",
+                speakerId: record.speakerIdsByKey[
+                    segment.fixture.channel.speakerKey(diarizerSpeakerId: String(segment.effectiveSpeakerId))
+                ]
             )
         }
     }
@@ -1319,6 +1363,51 @@ public final class SpeakerNamingSimulationRunner {
             )
         }
         .sorted { $0.truthSpeakerId < $1.truthSpeakerId }
+    }
+
+    private func identityStability(
+        _ evaluated: [EvaluatedUtterance]
+    ) -> (checks: Int, successes: Int, indicators: [SpeakerNamingSimulationDuplicateIdentityIndicator]) {
+        let rowsWithIdentity = evaluated.compactMap { row -> (row: EvaluatedUtterance, speakerId: UUID)? in
+            guard let speakerId = row.speakerId,
+                  row.actual != "(missing)" else {
+                return nil
+            }
+            return (row, speakerId)
+        }
+        let grouped = Dictionary(grouping: rowsWithIdentity) {
+            "\($0.row.truthSpeakerId)\u{1F}\($0.row.actual)"
+        }
+
+        var checks = 0
+        var successes = 0
+        var indicators: [SpeakerNamingSimulationDuplicateIdentityIndicator] = []
+        for values in grouped.values {
+            guard values.count > 1 else { continue }
+            checks += 1
+
+            let speakerIds = Set(values.map { $0.speakerId.uuidString })
+            if speakerIds.count == 1 {
+                successes += 1
+                continue
+            }
+
+            indicators.append(SpeakerNamingSimulationDuplicateIdentityIndicator(
+                truthSpeakerId: values[0].row.truthSpeakerId,
+                actualLabel: values[0].row.actual,
+                speakerIds: speakerIds.sorted(),
+                caseIds: Set(values.map { $0.row.caseId }).sorted()
+            ))
+        }
+
+        return (
+            checks,
+            successes,
+            indicators.sorted {
+                if $0.truthSpeakerId != $1.truthSpeakerId { return $0.truthSpeakerId < $1.truthSpeakerId }
+                return $0.actualLabel < $1.actualLabel
+            }
+        )
     }
 
     private func correctedTargetId(
@@ -1487,6 +1576,7 @@ public final class SpeakerNamingSimulationRunner {
         let truthSpeakerId: String
         let expected: String
         let actual: String
+        let speakerId: UUID?
 
         var isExactMatch: Bool {
             expected == actual

--- a/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerNamingCoordinatorTests.swift
@@ -300,6 +300,105 @@ final class SpeakerNamingCoordinatorTests: XCTestCase {
     }
 
     @MainActor
+    func testHandleNamingCompleteDoesNotMergeConfirmedProfileByNameAlone() async throws {
+        let harness = try makeHarness()
+        let transcriptId = UUID()
+        let confirmedSpeakerId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.31, count: 256),
+            existingId: nil
+        ).id
+        let unrelatedSameNameId = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.72, count: 256),
+            existingId: nil
+        ).id
+        _ = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.72, count: 256),
+            existingId: unrelatedSameNameId
+        )
+        _ = harness.speakerDB.addOrUpdateSpeaker(
+            embedding: [Float](repeating: 0.72, count: 256),
+            existingId: unrelatedSameNameId
+        )
+        harness.speakerDB.setDisplayName(id: confirmedSpeakerId, name: "Jordan Lee")
+        harness.speakerDB.setDisplayName(id: unrelatedSameNameId, name: "Jordan Lee")
+
+        let transcriptURL = harness.paths.transcripts.appendingPathComponent("Confirmed_Same_Name.md")
+        let micURL = harness.paths.audioCaptures.appendingPathComponent("confirmed-mic.wav")
+        let systemURL = harness.paths.audioCaptures.appendingPathComponent("confirmed-system.wav")
+        let clipURL = harness.paths.speakerClips.appendingPathComponent("confirmed-speaker.wav")
+        let speakers = [
+            MarkdownSpeaker(id: "1", persistentSpeakerId: confirmedSpeakerId, name: "Jordan Lee", confidence: "medium", source: "user_manual")
+        ]
+        let utterances = [
+            MarkdownUtterance(timestamp: "00:01", source: "System", label: "Jordan Lee", text: "Confirmed row stays on its own profile.", diarizerSpeakerId: 1)
+        ]
+
+        try sampleTranscript(
+            transcriptId: transcriptId,
+            speakers: speakers,
+            utterances: utterances,
+            breakdownEntries: [
+                BreakdownEntry(name: "Jordan Lee", utterances: 1, wordCount: 7, duration: "00:03")
+            ],
+            totalWords: 7
+        ).write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let transcriptionResult = sampleTranscriptionResult(speakers: speakers, utterances: utterances)
+        try Data().write(to: micURL)
+        try Data().write(to: systemURL)
+        try Data().write(to: clipURL)
+
+        harness.manager.speakerNamingRequest = SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            systemAudioURL: systemURL,
+            micAudioURL: micURL,
+            onComplete: { _ in }
+        )
+
+        harness.manager.handleNamingComplete(
+            updates: [
+                SpeakerNameUpdate(
+                    persistentSpeakerId: confirmedSpeakerId,
+                    diarizerSpeakerId: "1",
+                    newName: "Jordan Lee",
+                    previousName: "Jordan Lee",
+                    action: .confirmed
+                )
+            ],
+            transcriptURL: transcriptURL,
+            transcriptId: transcriptId,
+            transcriptionResult: transcriptionResult,
+            micURL: micURL,
+            systemURL: systemURL,
+            clips: [
+                SpeakerNamingEntry(
+                    id: confirmedSpeakerId,
+                    diarizerSpeakerId: "1",
+                    clipURL: clipURL,
+                    sampleText: "Confirmed row stays on its own profile.",
+                    currentName: "Jordan Lee",
+                    matchSimilarity: 0.82,
+                    needsNaming: false,
+                    needsConfirmation: true,
+                    sessionEmbedding: [Float](repeating: 0.31, count: 256)
+                )
+            ]
+        )
+
+        try await waitUntil {
+            harness.manager.speakerNamingRequest == nil
+                && harness.manager.displayStatus == .transcriptSaved
+        }
+
+        let savedTranscript = try String(contentsOf: transcriptURL, encoding: .utf8)
+        XCTAssertTrue(savedTranscript.contains(confirmedSpeakerId.uuidString), savedTranscript)
+        XCTAssertFalse(savedTranscript.contains(unrelatedSameNameId.uuidString), savedTranscript)
+        XCTAssertNotNil(harness.speakerDB.getSpeaker(id: confirmedSpeakerId))
+        XCTAssertNotNil(harness.speakerDB.getSpeaker(id: unrelatedSameNameId))
+    }
+
+    @MainActor
     func testHandleNamingCompleteAppleMacOS1RCoalescesSplitRowsAndSkipsNoDialogSpeaker() async throws {
         let harness = try makeHarness()
         let transcriptId = UUID()

--- a/Tests/TranscriptedCoreTests/SpeakerNamingSimulationRunnerTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerNamingSimulationRunnerTests.swift
@@ -44,6 +44,7 @@ final class SpeakerNamingSimulationRunnerTests: XCTestCase {
                 channelCollisionMeeting(),
                 repeatedTextMeeting(),
                 sameReviewCoalescedNameMeeting(),
+                duplicateReviewRowsSameNameMeeting(),
                 deferredReviewMeeting(),
                 renamePropagationMeeting(),
                 cancellationRollbackMeeting(),
@@ -63,6 +64,9 @@ final class SpeakerNamingSimulationRunnerTests: XCTestCase {
         XCTAssertTrue(report.confusionPairs.isEmpty, report.markdown)
         XCTAssertTrue(report.falseMergeIndicators.isEmpty, report.markdown)
         XCTAssertTrue(report.falseSplitIndicators.isEmpty, report.markdown)
+        XCTAssertTrue(report.duplicateIdentityIndicators.isEmpty, report.markdown)
+        XCTAssertEqual(report.identityStabilitySuccesses, report.identityStabilityChecks, report.markdown)
+        XCTAssertGreaterThanOrEqual(report.identityStabilityChecks, 4, report.markdown)
         XCTAssertEqual(report.renamedPropagationSuccesses, report.renamedPropagationChecks, report.markdown)
         XCTAssertGreaterThanOrEqual(report.renamedPropagationChecks, 2, report.markdown)
         XCTAssertEqual(report.rollbackSuccesses, report.rollbackChecks, report.markdown)
@@ -201,6 +205,9 @@ final class SpeakerNamingSimulationRunnerTests: XCTestCase {
             ],
             falseMergeIndicators: [],
             falseSplitIndicators: [],
+            duplicateIdentityIndicators: [],
+            identityStabilityChecks: 0,
+            identityStabilitySuccesses: 0,
             renamedPropagationChecks: 0,
             renamedPropagationSuccesses: 0,
             rollbackChecks: 0,
@@ -212,6 +219,47 @@ final class SpeakerNamingSimulationRunnerTests: XCTestCase {
         XCTAssertTrue(report.passed, report.markdown)
         XCTAssertFalse(report.confusionPairs.isEmpty)
         XCTAssertTrue(report.markdown.contains("Confusion Pairs"))
+    }
+
+    func testSimulationReportFailsWhenDuplicateIdentityIndicatorsExist() {
+        let report = SpeakerNamingSimulationReport(
+            suiteName: "duplicate-identity-report-gate",
+            minimumExactLabelAccuracy: 1.0,
+            caseReports: [],
+            totalEvaluatedUtterances: 2,
+            exactMatches: 2,
+            confusionPairs: [],
+            falseMergeIndicators: [],
+            falseSplitIndicators: [],
+            duplicateIdentityIndicators: [
+                SpeakerNamingSimulationDuplicateIdentityIndicator(
+                    truthSpeakerId: "jamie",
+                    actualLabel: "Jamie Park",
+                    speakerIds: [
+                        "00000000-0000-0000-0000-000000000001",
+                        "00000000-0000-0000-0000-000000000002",
+                    ],
+                    caseIds: ["same-name-duplicate-identities"]
+                )
+            ],
+            identityStabilityChecks: 1,
+            identityStabilitySuccesses: 0,
+            renamedPropagationChecks: 0,
+            renamedPropagationSuccesses: 0,
+            rollbackChecks: 0,
+            rollbackSuccesses: 0,
+            replacementChecks: 0,
+            replacementSuccesses: 0
+        )
+
+        XCTAssertFalse(report.passed, report.markdown)
+        XCTAssertTrue(report.confusionPairs.isEmpty, report.markdown)
+        XCTAssertTrue(report.falseMergeIndicators.isEmpty, report.markdown)
+        XCTAssertTrue(report.falseSplitIndicators.isEmpty, report.markdown)
+        XCTAssertEqual(report.identityStabilityChecks, 1, report.markdown)
+        XCTAssertEqual(report.identityStabilitySuccesses, 0, report.markdown)
+        XCTAssertEqual(report.duplicateIdentityIndicators.count, 1, report.markdown)
+        XCTAssertTrue(report.markdown.contains("Duplicate Identity Indicators"))
     }
 
     private func stableTwoSpeakerMeeting() -> SpeakerNamingSimulationMeeting {
@@ -325,6 +373,23 @@ final class SpeakerNamingSimulationRunnerTests: XCTestCase {
             ],
             postActions: [
                 .renameProfile(channel: .system, diarizerSpeakerId: 41, to: "Samuel Lee")
+            ]
+        )
+    }
+
+    private func duplicateReviewRowsSameNameMeeting() -> SpeakerNamingSimulationMeeting {
+        SpeakerNamingSimulationMeeting(
+            id: "duplicate-review-rows-same-name",
+            title: "Duplicate Review Rows Same Name",
+            segments: [
+                segment(.system, 51, truth: "lee", expected: "Lee Morgan", text: "lee first duplicated review row", start: 0, embedding: vector3D(degrees: 0)),
+                segment(.system, 52, truth: "lee", expected: "Lee Morgan", text: "lee second duplicated review row", start: 4, embedding: vector3D(degrees: 35)),
+                segment(.system, 53, truth: "rory", expected: "Rory Kim", text: "rory stays a separate speaker", start: 8, embedding: vector3D(degrees: 120))
+            ],
+            actions: [
+                .name(channel: .system, diarizerSpeakerId: 51, as: "Lee Morgan"),
+                .name(channel: .system, diarizerSpeakerId: 52, as: "Lee Morgan"),
+                .name(channel: .system, diarizerSpeakerId: 53, as: "Rory Kim")
             ]
         )
     }
@@ -536,6 +601,11 @@ final class SpeakerNamingSimulationRunnerTests: XCTestCase {
     private func vector(degrees: Float) -> [Float] {
         let radians = degrees * .pi / 180
         return [cos(radians), sin(radians)]
+    }
+
+    private func vector3D(degrees: Float) -> [Float] {
+        let radians = degrees * .pi / 180
+        return [cos(radians), sin(radians), 0]
     }
 
     private func near(_ base: [Float], degrees: Float) -> [Float] {

--- a/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionTaskManagerMetadataTests.swift
@@ -235,6 +235,48 @@ final class TranscriptionTaskManagerMetadataTests: XCTestCase {
         XCTAssertEqual(manager.pendingSpeakerNamingRequests.map(\.transcriptId), [secondId])
     }
 
+    func testDuplicateSpeakerNamingRequestsAreIgnoredForActiveAndQueuedTranscripts() {
+        let manager = makeManager()
+        let firstId = UUID()
+        let secondId = UUID()
+
+        manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: tempDirectory.appendingPathComponent("first.md"),
+            transcriptId: firstId,
+            systemAudioURL: tempDirectory.appendingPathComponent("first-system.wav"),
+            micAudioURL: nil,
+            onComplete: { _ in }
+        ))
+        manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: tempDirectory.appendingPathComponent("first-duplicate.md"),
+            transcriptId: firstId,
+            systemAudioURL: tempDirectory.appendingPathComponent("first-duplicate-system.wav"),
+            micAudioURL: nil,
+            onComplete: { _ in }
+        ))
+        manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: tempDirectory.appendingPathComponent("second.md"),
+            transcriptId: secondId,
+            systemAudioURL: tempDirectory.appendingPathComponent("second-system.wav"),
+            micAudioURL: nil,
+            onComplete: { _ in }
+        ))
+        manager.enqueueSpeakerNamingRequest(SpeakerNamingRequest(
+            speakers: [],
+            transcriptURL: tempDirectory.appendingPathComponent("second-duplicate.md"),
+            transcriptId: secondId,
+            systemAudioURL: tempDirectory.appendingPathComponent("second-duplicate-system.wav"),
+            micAudioURL: nil,
+            onComplete: { _ in }
+        ))
+
+        XCTAssertEqual(manager.speakerNamingRequest?.transcriptId, firstId)
+        XCTAssertEqual(manager.pendingSpeakerNamingRequests.map(\.transcriptId), [secondId])
+    }
+
     func testClearCompletedSpeakerNamingRequestClearsActiveReviewAndPromotesNext() {
         let manager = makeManager()
         let firstId = UUID()


### PR DESCRIPTION
## Summary
- Adds duplicate-identity and identity-stability reporting to SpeakerNamingSimulationRunner.
- Expands deterministic speaker naming coverage for known, unknown, renamed, duplicate, local/remote, bad diarization, repeated meeting, imported/saved review, and stale duplicate-review flows.
- Adds regressions for duplicate pending speaker naming requests and confirmed same-name profiles staying separate unless the user explicitly merges.

## Accuracy failure modes found
- Label accuracy can pass while one real speaker maps to multiple DB identities.
- Saved-audio replacement harness could double-count stale target rows unless superseded rows are removed.
- Codex review caught an unsafe attempted fix: merging confirmed rows by name alone could corrupt same-name people. The risky path was removed and covered with a regression.

## Review
- `~/.codex/skills/codex-review/scripts/codex-review --mode local`
- Initial review accepted one P2 same-name confirm merge risk; fixed.
- Final review clean: no accepted/actionable findings.

## Tests
- `scripts/dev/agent-preflight.sh`
- `swift test --filter SpeakerNamingSimulationRunnerTests`
- `swift test --filter SpeakerNamingCoordinatorTests/testHandleNamingCompleteDoesNotMergeConfirmedProfileByNameAlone`
- `swift test --filter TranscriptionTaskManagerMetadataTests/testDuplicateSpeakerNamingRequestsAreIgnoredForActiveAndQueuedTranscripts`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `swift test`

## Manual gaps
- No private or real audio.
- No live speaker review UI click-through.
- No manual imported-audio-from-device proof.

Draft PR only. Not merged or published.