### PR TITLE
[bug-hunter] Add meeting failure capture diagnostics

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -2609,31 +2609,32 @@ final class MeetingSessionController: ObservableObject {
                 failedJobID: activeQueuedTranscriptionJobID
             )
             activeQueuedTranscriptionJobID = nil
+            let failureTelemetryContext = meetingCaptureAnalyticsProperties(snapshot: capture.pipelineDiagnosticsSnapshot()).merging(
+                [
+                    "failure_kind": failureKind.rawValue,
+                    "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
+                    "trigger": transcriptionTrigger.rawValue,
+                ],
+                uniquingKeysWith: { _, new in new }
+            )
+            let failureDiagnosticsContext = failureTelemetryContext.merging(
+                [
+                    "error": message,
+                    "diagnostic_error": diagnosticMessage,
+                    "queue_depth": "\(queuedTranscriptionJobs.count)",
+                ],
+                uniquingKeysWith: { _, new in new }
+            )
             DiagnosticsTrail.record(
                 level: .error,
                 engine: "meeting",
                 event: "meeting_transcript_failed",
                 message: "Meeting transcription failed",
-                context: baseDiagnosticsContext(
-                    extra: [
-                        "error": message,
-                        "diagnostic_error": diagnosticMessage,
-                        "failure_kind": failureKind.rawValue,
-                        "queue_depth": "\(queuedTranscriptionJobs.count)",
-                        "trigger": transcriptionTrigger.rawValue
-                    ]
-                )
+                context: baseDiagnosticsContext(extra: failureDiagnosticsContext)
             )
             AnalyticsReporter.track(
                 "meeting_transcript_failed",
-                properties: meetingCaptureAnalyticsProperties(snapshot: capture.pipelineDiagnosticsSnapshot()).merging(
-                        [
-                        "failure_kind": failureKind.rawValue,
-                        "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
-                        "trigger": transcriptionTrigger.rawValue,
-                        ],
-                    uniquingKeysWith: { _, new in new }
-                )
+                properties: failureTelemetryContext
             )
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "transcript_failed")
             finalizeBackgroundTranscriptionStateIfNeeded()

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -80,6 +80,7 @@ final class MeetingSessionController: ObservableObject {
                 micURL: URL,
                 systemURL: URL?,
                 healthInfo: RecordingHealthInfo,
+                captureDiagnostics: [String: String],
                 meetingTitle: String?,
                 recordingDate: Date
             )
@@ -94,6 +95,15 @@ final class MeetingSessionController: ObservableObject {
         let kind: Kind
         let startTrigger: StartTrigger
         let sttModel: TranscriptionModelChoice
+
+        var captureDiagnostics: [String: String]? {
+            switch kind {
+            case .recorded(_, _, _, let captureDiagnostics, _, _):
+                return captureDiagnostics
+            case .imported:
+                return nil
+            }
+        }
     }
 
     private enum TerminalTranscriptionOutcome: Equatable {
@@ -195,6 +205,7 @@ final class MeetingSessionController: ObservableObject {
     private var queuedTranscriptionStartTask: Task<Void, Never>?
     private var queuedRuntimeDiagnosticsJobIDs: Set<UUID> = []
     private var lastTerminalTranscriptionOutcome: TerminalTranscriptionOutcome?
+    private var activeTranscriptionCaptureDiagnostics: [String: String]?
     private var activeRecordingTrigger: StartTrigger = .unknown
     private var activeRecordingIdentity: UUID?
     private var micBoostPromptRecordingIdentity: UUID?
@@ -792,6 +803,7 @@ final class MeetingSessionController: ObservableObject {
             micURL: micURL,
             systemURL: files.systemURL,
             healthInfo: healthInfoForSave,
+            captureDiagnostics: stopCaptureDiagnostics,
             meetingTitle: recordingSnapshot.suggestedTitle,
             recordingDate: recordingSnapshot.recordingStartedAt ?? Date(),
             startTrigger: recordingSnapshot.trigger
@@ -1205,10 +1217,11 @@ final class MeetingSessionController: ObservableObject {
         preparingQueuedTranscriptionJob = nil
         lastTerminalTranscriptionOutcome = nil
         activeTranscriptionTrigger = .unknown
+        activeTranscriptionCaptureDiagnostics = nil
 
         for job in queuedJobs + [preparingJob].compactMap({ $0 }) {
             switch job.kind {
-            case .recorded(let micURL, let systemURL, _, let meetingTitle, let recordingDate):
+            case .recorded(let micURL, let systemURL, _, _, let meetingTitle, let recordingDate):
                 preserveFailedMeetingForRetry(
                     micAudioURL: micURL,
                     systemAudioURL: systemURL,
@@ -1343,7 +1356,7 @@ final class MeetingSessionController: ObservableObject {
         var preservedCount = 0
         for job in jobs {
             switch job.kind {
-            case .recorded(let micURL, let systemURL, _, let meetingTitle, let recordingDate):
+            case .recorded(let micURL, let systemURL, _, _, let meetingTitle, let recordingDate):
                 if preserveFailedMeetingForRetry(
                     micAudioURL: micURL,
                     systemAudioURL: systemURL,
@@ -2179,6 +2192,7 @@ final class MeetingSessionController: ObservableObject {
         micURL: URL,
         systemURL: URL?,
         healthInfo: RecordingHealthInfo,
+        captureDiagnostics: [String: String],
         meetingTitle: String?,
         recordingDate: Date,
         startTrigger: StartTrigger
@@ -2188,6 +2202,7 @@ final class MeetingSessionController: ObservableObject {
                 micURL: micURL,
                 systemURL: systemURL,
                 healthInfo: healthInfo,
+                captureDiagnostics: captureDiagnostics,
                 meetingTitle: meetingTitle,
                 recordingDate: recordingDate
             ),
@@ -2234,6 +2249,7 @@ final class MeetingSessionController: ObservableObject {
     private func startQueuedTranscription(_ job: QueuedTranscriptionJob) {
         lastTerminalTranscriptionOutcome = nil
         activeTranscriptionTrigger = job.startTrigger
+        activeTranscriptionCaptureDiagnostics = job.captureDiagnostics
         sttAdapter.selectPreparedModel(job.sttModel)
         preparingQueuedTranscriptionJob = job
 
@@ -2335,7 +2351,7 @@ final class MeetingSessionController: ObservableObject {
         activeQueuedTranscriptionJobID = job.id
 
         switch job.kind {
-        case .recorded(let micURL, let systemURL, let healthInfo, let meetingTitle, let recordingDate):
+        case .recorded(let micURL, let systemURL, let healthInfo, _, let meetingTitle, let recordingDate):
             taskManager.startTranscription(
                 taskId: job.id,
                 micURL: micURL,
@@ -2369,7 +2385,7 @@ final class MeetingSessionController: ObservableObject {
         }
 
         switch job.kind {
-        case .recorded(let micURL, let systemURL, _, let meetingTitle, let recordingDate):
+        case .recorded(let micURL, let systemURL, _, _, let meetingTitle, let recordingDate):
             preserveFailedMeetingForRetry(
                 micAudioURL: micURL,
                 systemAudioURL: systemURL,
@@ -2531,6 +2547,7 @@ final class MeetingSessionController: ObservableObject {
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "transcript_saved")
             AppSoundPlayer.shared.play(.meetingTranscriptComplete)
             activeQueuedTranscriptionJobID = nil
+            activeTranscriptionCaptureDiagnostics = nil
         case .failed(let message):
             lastTerminalTranscriptionOutcome = .failed(message)
             let transcriptionTrigger = activeTranscriptionTrigger
@@ -2541,6 +2558,10 @@ final class MeetingSessionController: ObservableObject {
                     failedJobID: activeQueuedTranscriptionJobID
                 )
                 activeQueuedTranscriptionJobID = nil
+                let failureTelemetryContext = meetingFailureTelemetryContext(
+                    failureKind: failureKind,
+                    transcriptionTrigger: transcriptionTrigger
+                )
                 DiagnosticsTrail.record(
                     engine: "meeting",
                     event: "meeting_transcript_skipped",
@@ -2555,15 +2576,9 @@ final class MeetingSessionController: ObservableObject {
                 )
                 AnalyticsReporter.track(
                     "meeting_transcript_skipped",
-                    properties: meetingCaptureAnalyticsProperties(snapshot: capture.pipelineDiagnosticsSnapshot()).merging(
-                        [
-                            "failure_kind": failureKind.rawValue,
-                            "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
-                            "trigger": transcriptionTrigger.rawValue,
-                        ],
-                        uniquingKeysWith: { _, new in new }
-                    )
+                    properties: failureTelemetryContext
                 )
+                activeTranscriptionCaptureDiagnostics = nil
                 Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: failureKind.rawValue)
                 finalizeBackgroundTranscriptionStateIfNeeded()
                 return
@@ -2600,6 +2615,7 @@ final class MeetingSessionController: ObservableObject {
                         "trigger": transcriptionTrigger.rawValue,
                     ]
                 )
+                activeTranscriptionCaptureDiagnostics = nil
                 Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "speaker_finalization_failed")
                 finalizeBackgroundTranscriptionStateIfNeeded()
                 return
@@ -2609,13 +2625,9 @@ final class MeetingSessionController: ObservableObject {
                 failedJobID: activeQueuedTranscriptionJobID
             )
             activeQueuedTranscriptionJobID = nil
-            let failureTelemetryContext = meetingCaptureAnalyticsProperties(snapshot: capture.pipelineDiagnosticsSnapshot()).merging(
-                [
-                    "failure_kind": failureKind.rawValue,
-                    "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
-                    "trigger": transcriptionTrigger.rawValue,
-                ],
-                uniquingKeysWith: { _, new in new }
+            let failureTelemetryContext = meetingFailureTelemetryContext(
+                failureKind: failureKind,
+                transcriptionTrigger: transcriptionTrigger
             )
             let failureDiagnosticsContext = failureTelemetryContext.merging(
                 [
@@ -2636,6 +2648,7 @@ final class MeetingSessionController: ObservableObject {
                 "meeting_transcript_failed",
                 properties: failureTelemetryContext
             )
+            activeTranscriptionCaptureDiagnostics = nil
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "transcript_failed")
             finalizeBackgroundTranscriptionStateIfNeeded()
         case .gettingReady:
@@ -2715,6 +2728,20 @@ final class MeetingSessionController: ObservableObject {
         properties["route_change_count_bucket"] = AnalyticsReporter.countBucket(snapshot.routeChangeCount)
         properties["recovery_attempt_bucket"] = AnalyticsReporter.countBucket(snapshot.recoveryAttemptCount)
         return properties
+    }
+
+    private func meetingFailureTelemetryContext(
+        failureKind: MeetingFailureKind,
+        transcriptionTrigger: StartTrigger
+    ) -> [String: String] {
+        (activeTranscriptionCaptureDiagnostics ?? [:]).merging(
+            [
+                "failure_kind": failureKind.rawValue,
+                "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
+                "trigger": transcriptionTrigger.rawValue,
+            ],
+            uniquingKeysWith: { _, new in new }
+        )
     }
 
     private func meetingCaptureHealthSnapshotProperties(

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2229,8 +2229,16 @@ func testRepoCommandContract() {
         )
 
         assertTrue(
-            failureBlock.contains("let failureTelemetryContext = meetingCaptureAnalyticsProperties(snapshot: capture.pipelineDiagnosticsSnapshot()).merging("),
-            "failed meeting transcript diagnostics should include privacy-safe capture health context"
+            controllerContents.contains("activeTranscriptionCaptureDiagnostics = job.captureDiagnostics"),
+            "failed meeting transcript diagnostics should use the capture health context stored with the active queued job"
+        )
+        assertTrue(
+            failureBlock.contains("let failureTelemetryContext = meetingFailureTelemetryContext("),
+            "failed meeting transcript diagnostics should compose shared failure telemetry through the stable helper"
+        )
+        assertFalse(
+            failureBlock.contains("capture.pipelineDiagnosticsSnapshot()"),
+            "failed meeting transcript diagnostics should not sample the live capture singleton after transcription fails"
         )
         assertTrue(
             failureBlock.contains("\"queue_depth_bucket\": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count)"),

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -2220,6 +2220,32 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - failed meeting transcripts carry capture diagnostics") {
+        let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let failureBlock = sourceSlice(
+            controllerContents,
+            from: "case .failed(let message):",
+            to: "case .gettingReady:"
+        )
+
+        assertTrue(
+            failureBlock.contains("let failureTelemetryContext = meetingCaptureAnalyticsProperties(snapshot: capture.pipelineDiagnosticsSnapshot()).merging("),
+            "failed meeting transcript diagnostics should include privacy-safe capture health context"
+        )
+        assertTrue(
+            failureBlock.contains("\"queue_depth_bucket\": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count)"),
+            "failed meeting transcript diagnostics should include bucketed queue depth"
+        )
+        assertTrue(
+            failureBlock.contains("context: baseDiagnosticsContext(extra: failureDiagnosticsContext)"),
+            "failed meeting transcript Sentry context should use the enriched diagnostics context"
+        )
+        assertTrue(
+            failureBlock.contains("properties: failureTelemetryContext"),
+            "analytics and diagnostics should share the same privacy-safe failure telemetry context"
+        )
+    }
+
     runSuite("Repo command contract - shutdown preservation clears live sidecar waits") {
         let controllerContents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
         let terminationBlock = sourceSlice(


### PR DESCRIPTION
## Summary
- Add privacy-safe capture diagnostics to `meeting_transcript_failed` diagnostics context.
- Reuse the same sanitized failure telemetry context for analytics.
- Add a repo contract test so failed meeting transcript events keep capture context and bucketed queue depth.

## Why
Hourly bug scan found fresh production Sentry events on `transcripted@1.1.48`: `APPLE-MACOS-1H` (`meeting_transcript_failed`, last seen 2026-06-19T11:12:59Z) and paired `APPLE-MACOS-1B` (`recording_capture_degraded`, same trace). The failure event only carried `failure_kind=transcription_inference_failed`, while the paired capture event carried the useful safe tags like `system_status=silent`, capture quality, gap bucket, and route-change bucket. This makes repeat failures harder to triage without trace correlation.

## Validation
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (5672 passed)
- `bash run-integration-smoke.sh`
