### PR TITLE
[docs] Tighten agent and release guidance

### DIFF
--- a/docs/agent-onboarding.md
+++ b/docs/agent-onboarding.md
@@ -179,6 +179,8 @@ When the issue is vague, classify it before editing:
   Read-only MCP server for saved meetings and dictations.
 - `Tools/TranscriptedQA/CLAUDE.md`
   Standalone artifact validation and QA CLI.
+- `Tools/SpeakerEvalHarness/CLAUDE.md`
+  Local-only AMI speaker-naming eval harness and sweep commands.
 
 ## Historical Zones
 

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -107,18 +107,11 @@ For a thin packaging smoke that also skips notarization, keep every opt-out visi
 SKIP_NOTARIZATION=1 REQUIRE_BUNDLED_PARAKEET_MODELS=0 BUNDLE_PARAKEET_MODELS=0 REQUIRE_BUNDLED_DIARIZER_MODELS=0 BUNDLE_DIARIZER_MODELS=0 bash build-beta.sh <beta-token> <user-name>
 ```
 
-After `build-beta.sh` succeeds, run the packaged-app smoke before publishing
-anything:
-
-```bash
-python3 scripts/ops/packaged-app-smoke.py
-```
-
-That smoke checks the packaged `build/Transcripted.app`, the versioned DMG,
-Sparkle feed URL and public key, appcast coherence, signing and entitlements,
-dSYM UUID evidence, an isolated launch/menu report, and generated launch-log
-privacy. For a stricter release-candidate report after packaging, compose it
-with:
+After `build-beta.sh` succeeds, run the packaged app smoke described below
+before publishing anything. It checks the existing `build/Transcripted.app` and
+versioned DMG for Sparkle config, signing, dSYM UUID evidence, optional UI
+smoke, and local log privacy. For a stricter release-candidate report after
+packaging, compose it with:
 
 ```bash
 python3 scripts/ops/release-gate-report.py --qa-mode deep --strict-artifacts --include-packaged-app-smoke --require-release-debug-files

--- a/docs/test-automation-strategy.md
+++ b/docs/test-automation-strategy.md
@@ -30,8 +30,9 @@ As of 2026-06-06, the repo has these automated layers:
   warns when duplicate or wrong running Transcripted app instances make UI
   targeting ambiguous.
 - `bash scripts/ops/transcripted-qa-bench.sh --mode ...`: orchestrated QA
-  reports for `quick`, `deep`, `full`, `ui`, `artifact`, `audio-synthetic`,
-  `corpus`, `corpus-compare`, and `live`.
+  reports for `quick`, `deep`, `full`, `ui`, `packaged`, `artifact`,
+  `audio-synthetic`, `pasteback-synthetic`, `corpus`, `corpus-compare`,
+  `scorecard`, and `live`.
 - `.github/workflows/repo-hygiene.yml`: PR/workflow-dispatch hygiene that runs
   preflight plus shell, Ruby, and Python syntax checks.
 - BET-88 GitHub workflows: historical label-gated fixtures for the closed QA


### PR DESCRIPTION
## Summary
- add the missing SpeakerEvalHarness local guidance pointer to agent onboarding
- update the QA bench mode inventory to match the current script
- remove a stale duplicate packaged-app smoke command from release packaging guidance and point to the detailed packaged smoke section instead

## Verification
- bash scripts/dev/agent-preflight.sh
- git diff --check

Preflight suggested the full release-path build/package checks because docs/release-packaging.md changed. I did not run them because this is a wording-only docs cleanup with no release truth, appcast, Homebrew, or public download behavior change.