### PR TITLE
Add build system guardrails

### DIFF
--- a/.agents/test-matrix.yml
+++ b/.agents/test-matrix.yml
@@ -28,6 +28,7 @@ rules:
       - "run-e2e-smoke.sh"
       - "scripts/entrypoints/run-e2e-smoke.sh"
     checks:
+      - "python3 scripts/dev/check-build-source-lists.py"
       - "bash run-e2e-smoke.sh"
 
   - paths:
@@ -37,6 +38,7 @@ rules:
       - "run-slow-pasteback-smoke.sh"
       - "scripts/entrypoints/run-slow-pasteback-smoke.sh"
     checks:
+      - "python3 scripts/dev/check-build-source-lists.py"
       - "bash run-slow-pasteback-smoke.sh"
 
   - paths:
@@ -51,8 +53,10 @@ rules:
   - paths:
       - "build.sh"
       - "scripts/entrypoints/build.sh"
+      - "scripts/entrypoints/lib/swiftc-app-args.sh"
     checks:
       - "scripts/dev/agent-preflight.sh"
+      - "python3 scripts/dev/check-build-source-lists.py"
       - "bash -n build.sh"
       - "bash -n scripts/entrypoints/build.sh"
       - "bash build.sh --no-open"
@@ -63,6 +67,7 @@ rules:
       - "Tests/FastTests.manifest"
     checks:
       - "scripts/dev/agent-preflight.sh"
+      - "python3 scripts/dev/check-build-source-lists.py"
       - "bash -n run-tests.sh"
       - "bash -n scripts/entrypoints/run-tests.sh"
       - "bash run-tests.sh"
@@ -97,6 +102,13 @@ rules:
     checks:
       - "scripts/dev/agent-preflight.sh"
       - "bash -n scripts/dev/onboarding.sh"
+
+  - paths:
+      - "scripts/dev/check-build-source-lists.py"
+    checks:
+      - "scripts/dev/agent-preflight.sh"
+      - "python3 -m py_compile scripts/dev/check-build-source-lists.py"
+      - "python3 scripts/dev/check-build-source-lists.py"
 
   - paths:
       - "scripts/dev/benchmark-home-recent-captures.sh"

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -36,6 +36,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Build source-list contracts
+        shell: bash
+        run: python3 scripts/dev/check-build-source-lists.py
+
       - name: Cache prebuilt dependencies
         id: deps-cache
         uses: actions/cache@v4

--- a/Tests/CIWorkflowContractTests.swift
+++ b/Tests/CIWorkflowContractTests.swift
@@ -21,6 +21,10 @@ func testCIWorkflowContract() {
     }
 
     runSuite("CI workflow contract - swift-ci runs the full suite") {
+        assertTrue(
+            swiftCI.contains("python3 scripts/dev/check-build-source-lists.py"),
+            "swift-ci should validate raw swiftc source lists before the expensive build"
+        )
         assertTrue(swiftCI.contains("bash run-tests.sh"), "swift-ci should keep running the fast tests")
         assertTrue(swiftCI.contains("swift test\n"), "swift-ci should keep running the Core package tests")
         assertTrue(swiftCI.contains("run-integration-smoke.sh"), "swift-ci should run the integration smoke")

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -267,6 +267,12 @@ func testRepoCommandContract() {
             buildDepsScript.contains("newest_dependency_input") && buildDepsScript.contains("deps_are_ready"),
             "build-deps.sh should rebuild stale TranscriptedCore artifacts instead of printing a false ready message"
         )
+        assertTrue(
+            buildDepsScript.contains("dependency_input_digest")
+                && buildDepsScript.contains("dependency_inputs_sha256")
+                && buildDepsScript.contains("Dependency input digest changed."),
+            "build-deps.sh should stamp dependency inputs by content digest, not only by filesystem mtime"
+        )
         // The dual-archive invariant — Core lives in libDraftDeps.a (app path) and is absent
         // from libExternalDeps.a (SPM path) — must stay verified at build time, not just trusted.
         // A raw `ar t | wc -l` object count cannot catch Core leaking into (or vanishing from) an
@@ -391,12 +397,14 @@ func testRepoCommandContract() {
         let expectedChecks = [
             "bash -n scripts/entrypoints/build-deps.sh",
             "bash build-deps.sh --force",
+            "python3 scripts/dev/check-build-source-lists.py",
             "bash -n scripts/entrypoints/build.sh",
             "bash -n scripts/entrypoints/run-tests.sh",
             "bash -n scripts/entrypoints/run-integration-smoke.sh",
             "bash -n scripts/ops/daily-audio-reliability-check.sh",
             "bash -n scripts/ops/health-probe.sh",
             "bash -n scripts/dev/onboarding.sh",
+            "python3 -m py_compile scripts/dev/check-build-source-lists.py",
             "bash -n scripts/dev/benchmark-home-recent-captures.sh",
             "python3 -m py_compile scripts/ops/generate-nightly-digest.py",
             "python3 scripts/ops/generate-nightly-digest.py --self-test",
@@ -505,8 +513,10 @@ func testRepoCommandContract() {
         assertTrue(
             contents.contains("newest_dependency_input")
                 && contents.contains("deps_build_stamp_info")
+                && contents.contains("dependency_input_digest")
+                && contents.contains("Dependency input digest changed.")
                 && contents.contains("Dependencies are stale for TranscriptedCore."),
-            "integration smoke should refuse stale TranscriptedCore dependency artifacts"
+            "integration smoke should refuse stale TranscriptedCore dependency artifacts by mtime or digest"
         )
     }
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -35,6 +35,7 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
 ## Active helper scripts
 
 - `scripts/dev/agent-preflight.sh` — summarize branch state, changed paths, trusted docs, and suggested checks from the agent test matrix
+- `scripts/dev/check-build-source-lists.py` — fast raw-`swiftc` guardrail for app, fast-test, and smoke source-list drift
 - `scripts/dev/benchmark-home-recent-captures.sh` — compile and run the Settings Home recent-capture loader benchmark
 - `scripts/download_ami.sh` — fetch the gitignored AMI ES2002 audio/RTTM subset used by `Tools/SpeakerEvalHarness`
 - `scripts/run_speaker_eval.sh` — build and run the AMI speaker-naming sweep, writing local reports under `data/eval/`

--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -97,10 +97,12 @@ if [ -n "$changed_paths" ]; then
         fi
 
         if matches_any "$path" "Tests/E2E/*" "run-e2e-smoke.sh" "scripts/entrypoints/run-e2e-smoke.sh"; then
+            add_command "python3 scripts/dev/check-build-source-lists.py"
             add_command "bash run-e2e-smoke.sh"
         fi
 
         if matches_any "$path" "Tests/E2E/SlowPastebackSmoke.swift" "Sources/Support/ClipboardRestoringTextPaster.swift" "Sources/Support/TranscriptedConstants.swift" "run-slow-pasteback-smoke.sh" "scripts/entrypoints/run-slow-pasteback-smoke.sh"; then
+            add_command "python3 scripts/dev/check-build-source-lists.py"
             add_command "bash run-slow-pasteback-smoke.sh"
         fi
 
@@ -111,8 +113,9 @@ if [ -n "$changed_paths" ]; then
             add_command "bash build-deps.sh --force"
         fi
 
-        if matches_any "$path" "build.sh" "scripts/entrypoints/build.sh"; then
+        if matches_any "$path" "build.sh" "scripts/entrypoints/build.sh" "scripts/entrypoints/lib/swiftc-app-args.sh"; then
             add_command "scripts/dev/agent-preflight.sh"
+            add_command "python3 scripts/dev/check-build-source-lists.py"
             add_command "bash -n build.sh"
             add_command "bash -n scripts/entrypoints/build.sh"
             add_command "bash build.sh --no-open"
@@ -120,6 +123,7 @@ if [ -n "$changed_paths" ]; then
 
         if matches_any "$path" "run-tests.sh" "scripts/entrypoints/run-tests.sh" "Tests/FastTests.manifest"; then
             add_command "scripts/dev/agent-preflight.sh"
+            add_command "python3 scripts/dev/check-build-source-lists.py"
             add_command "bash -n run-tests.sh"
             add_command "bash -n scripts/entrypoints/run-tests.sh"
             add_command "bash run-tests.sh"
@@ -147,6 +151,12 @@ if [ -n "$changed_paths" ]; then
         if matches_any "$path" "scripts/dev/onboarding.sh"; then
             add_command "scripts/dev/agent-preflight.sh"
             add_command "bash -n scripts/dev/onboarding.sh"
+        fi
+
+        if matches_any "$path" "scripts/dev/check-build-source-lists.py"; then
+            add_command "scripts/dev/agent-preflight.sh"
+            add_command "python3 -m py_compile scripts/dev/check-build-source-lists.py"
+            add_command "python3 scripts/dev/check-build-source-lists.py"
         fi
 
         if matches_any "$path" "scripts/dev/benchmark-home-recent-captures.sh" "Tests/Benchmarks/HomeRecentCaptureBenchmark.swift"; then
@@ -286,7 +296,7 @@ if [ -n "$changed_paths" ]; then
             add_command "SKIP_NOTARIZATION=1 bash build-beta.sh '' <user-name>"
         fi
 
-        if matches_any "$path" "README.md" "AGENT_START.md" "AGENTS.md" "CLAUDE.md" "CONTRIBUTING.md" "WORKFLOW.md" "docs/*" "Tests/README.md" "scripts/README.md" "Sources/CLAUDE.md" "Sources/*/CLAUDE.md" "Sources/*/*/CLAUDE.md" "Tools/README.md" "Tools/*/CLAUDE.md" "Tools/*/*/CLAUDE.md" ".agents/*" ".github/*" "scripts/dev/agent-preflight.sh"; then
+        if matches_any "$path" "README.md" "AGENT_START.md" "AGENTS.md" "CLAUDE.md" "CONTRIBUTING.md" "WORKFLOW.md" "docs/*" "Tests/README.md" "scripts/README.md" "Sources/CLAUDE.md" "Sources/*/CLAUDE.md" "Sources/*/*/CLAUDE.md" "Tools/README.md" "Tools/*/CLAUDE.md" "Tools/*/*/CLAUDE.md" ".agents/*" ".github/*" "scripts/dev/agent-preflight.sh" "scripts/dev/check-build-source-lists.py"; then
             add_command "scripts/dev/agent-preflight.sh"
         fi
     done <<< "$changed_paths"

--- a/scripts/dev/check-build-source-lists.py
+++ b/scripts/dev/check-build-source-lists.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Validate raw-swiftc source-list contracts with clear, fast failures."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def read_text(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def extract_shell_array(script_path: str, array_name: str) -> list[str]:
+    contents = read_text(script_path)
+    match = re.search(rf"^{re.escape(array_name)}=\(\n(.*?)^\)", contents, re.MULTILINE | re.DOTALL)
+    if not match:
+        raise ValueError(f"{script_path}: missing {array_name}=(...) array")
+    return re.findall(r'"([^"\n]+)"', match.group(1))
+
+
+def validate_paths(label: str, paths: list[str]) -> list[str]:
+    failures: list[str] = []
+    if not paths:
+        failures.append(f"{label}: source list is empty")
+        return failures
+    for path in paths:
+        if path.startswith(("Sources/", "Tests/", "Tools/")) and not (REPO_ROOT / path).is_file():
+            failures.append(f"{label}: missing source {path}")
+    return failures
+
+
+def app_source_files_from_shared_args() -> list[str]:
+    command = r'''
+set -euo pipefail
+source scripts/entrypoints/lib/swiftc-app-args.sh
+build_app_swiftc_args
+printf '%s\n' "${APP_SOURCE_FILES[@]}"
+'''
+    result = subprocess.run(
+        ["bash", "-lc", command],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "failed to build shared app swiftc args")
+    return sorted(line for line in result.stdout.splitlines() if line)
+
+
+def expected_app_sources() -> list[str]:
+    return sorted(
+        str(path.relative_to(REPO_ROOT))
+        for path in (REPO_ROOT / "Sources").rglob("*.swift")
+        if "Sources/TranscriptedCore/" not in str(path.relative_to(REPO_ROOT))
+    )
+
+
+def validate_fast_manifest() -> list[str]:
+    failures: list[str] = []
+    manifest = read_text("Tests/FastTests.manifest")
+    entries = [
+        line.strip()
+        for line in manifest.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    manifest_files = sorted(entry.split(":", 1)[0] for entry in entries if ":" in entry)
+    actual_files = sorted(path.name for path in (REPO_ROOT / "Tests").glob("*Tests.swift"))
+    if manifest_files != actual_files:
+        failures.append("Tests/FastTests.manifest does not match root Tests/*Tests.swift files")
+
+    for entry in entries:
+        if ":" not in entry:
+            failures.append(f"Tests/FastTests.manifest: malformed entry {entry!r}")
+            continue
+        filename, function = entry.split(":", 1)
+        test_path = REPO_ROOT / "Tests" / filename
+        if not test_path.is_file():
+            failures.append(f"Tests/FastTests.manifest: missing Tests/{filename}")
+            continue
+        if f"func {function}(" not in test_path.read_text(encoding="utf-8"):
+            failures.append(f"Tests/FastTests.manifest: missing entry function {function} in {filename}")
+    return failures
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    app_sources = app_source_files_from_shared_args()
+    expected_sources = expected_app_sources()
+    if app_sources != expected_sources:
+        failures.append("scripts/entrypoints/lib/swiftc-app-args.sh APP_SOURCE_FILES drifted from Sources/*.swift discovery")
+        missing = sorted(set(expected_sources) - set(app_sources))
+        extra = sorted(set(app_sources) - set(expected_sources))
+        failures.extend(f"  missing app source: {path}" for path in missing[:20])
+        failures.extend(f"  unexpected app source: {path}" for path in extra[:20])
+    if any(path.startswith("Sources/TranscriptedCore/") for path in app_sources):
+        failures.append("APP_SOURCE_FILES must not compile Sources/TranscriptedCore directly; Core links via libDraftDeps.a")
+
+    for script_path, array_name in [
+        ("scripts/entrypoints/run-tests.sh", "APP_SOURCES"),
+        ("scripts/entrypoints/run-e2e-smoke.sh", "SWIFT_SOURCES"),
+        ("scripts/entrypoints/run-slow-pasteback-smoke.sh", "SWIFT_SOURCES"),
+    ]:
+        try:
+            failures.extend(validate_paths(f"{script_path} {array_name}", extract_shell_array(script_path, array_name)))
+        except (RuntimeError, ValueError) as error:
+            failures.append(str(error))
+
+    failures.extend(validate_fast_manifest())
+
+    if failures:
+        print("Build source-list validation failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("Build source-list validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/entrypoints/build-deps.sh
+++ b/scripts/entrypoints/build-deps.sh
@@ -59,15 +59,26 @@ SENTRY_COCOA_VERSION="${SENTRY_COCOA_VERSION:-9.10.0}"
 SPARKLE_SHA256="${SPARKLE_SHA256:-9fec2b888e6e2940b1bfbd5d3d010b9f67076b52170923549095cbb74132403b}"
 SENTRY_COCOA_SHA256="${SENTRY_COCOA_SHA256:-1dd70512f3b5af6c74f1b8f11279531900173fb638d7d541320a7cbc00ed06bc}"
 
-dependency_input_listing() {
+dependency_input_paths() {
     {
         printf '%s\n' "Package.swift"
         printf '%s\n' "scripts/entrypoints/build-deps.sh"
         find "Sources/TranscriptedCore" -type f ! -name "CLAUDE.md"
-    } | while IFS= read -r path; do
+    } | sort
+}
+
+dependency_input_listing() {
+    dependency_input_paths | while IFS= read -r path; do
         [ -e "$path" ] || continue
         printf '%s\t%s\n' "$(stat -f '%m' "$path")" "$path"
     done
+}
+
+dependency_input_digest() {
+    dependency_input_paths | while IFS= read -r path; do
+        [ -f "$path" ] || continue
+        shasum -a 256 "$path"
+    done | shasum -a 256 | awk '{print $1}'
 }
 
 newest_dependency_input() {
@@ -80,6 +91,19 @@ deps_build_stamp_info() {
     fi
 }
 
+deps_build_stamp_digest() {
+    if [ -f "$DEPS_BUILD_STAMP" ]; then
+        awk -F= '$1 == "dependency_inputs_sha256" { print $2; exit }' "$DEPS_BUILD_STAMP"
+    fi
+}
+
+write_deps_build_stamp() {
+    {
+        printf 'dependency_inputs_sha256=%s\n' "$(dependency_input_digest)"
+        printf 'built_at_unix=%s\n' "$(date +%s)"
+    } > "$DEPS_BUILD_STAMP"
+}
+
 deps_are_ready() {
     local newest_input
     local build_stamp
@@ -87,6 +111,8 @@ deps_are_ready() {
     local newest_input_path
     local build_stamp_mtime
     local build_stamp_path
+    local current_digest
+    local stamp_digest
 
     if [ ! -f "$DEPS_LIBS/libDraftDeps.a" ] \
         || [ ! -f "$DEPS_LIBS/libExternalDeps.a" ] \
@@ -114,6 +140,16 @@ deps_are_ready() {
         echo "[build-deps]   $newest_input_path"
         echo "[build-deps] Built deps stamp:"
         echo "[build-deps]   $build_stamp_path"
+        return 1
+    fi
+
+    current_digest="$(dependency_input_digest)"
+    stamp_digest="$(deps_build_stamp_digest)"
+    if [ -z "$stamp_digest" ] || [ "$current_digest" != "$stamp_digest" ]; then
+        echo "[build-deps] Dependencies are stale for TranscriptedCore."
+        echo "[build-deps] Dependency input digest changed."
+        echo "[build-deps]   current: ${current_digest:-missing}"
+        echo "[build-deps]   stamp:   ${stamp_digest:-missing}"
         return 1
     fi
 
@@ -630,7 +666,8 @@ else
     echo "  WARNING: Cmlx source not found — cannot compile Metal shaders"
 fi
 
-touch "$DEPS_BUILD_STAMP"
+cd "$DRAFT_DIR"
+write_deps_build_stamp
 
 # Everything succeeded — swap staged artifacts into their final locations.
 # The window where old artifacts are gone is now a few renames, not the

--- a/scripts/entrypoints/build.sh
+++ b/scripts/entrypoints/build.sh
@@ -54,15 +54,26 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 
-dependency_input_listing() {
+dependency_input_paths() {
     {
         printf '%s\n' "Package.swift"
         printf '%s\n' "scripts/entrypoints/build-deps.sh"
         find "Sources/TranscriptedCore" -type f ! -name "CLAUDE.md"
-    } | while IFS= read -r path; do
+    } | sort
+}
+
+dependency_input_listing() {
+    dependency_input_paths | while IFS= read -r path; do
         [ -e "$path" ] || continue
         printf '%s\t%s\n' "$(stat -f '%m' "$path")" "$path"
     done
+}
+
+dependency_input_digest() {
+    dependency_input_paths | while IFS= read -r path; do
+        [ -f "$path" ] || continue
+        shasum -a 256 "$path"
+    done | shasum -a 256 | awk '{print $1}'
 }
 
 newest_dependency_input() {
@@ -72,6 +83,12 @@ newest_dependency_input() {
 deps_build_stamp_info() {
     if [ -f "$DEPS_BUILD_STAMP" ]; then
         printf '%s\t%s\n' "$(stat -f '%m' "$DEPS_BUILD_STAMP")" "$DEPS_BUILD_STAMP"
+    fi
+}
+
+deps_build_stamp_digest() {
+    if [ -f "$DEPS_BUILD_STAMP" ]; then
+        awk -F= '$1 == "dependency_inputs_sha256" { print $2; exit }' "$DEPS_BUILD_STAMP"
     fi
 }
 
@@ -89,6 +106,8 @@ ensure_deps_ready() {
     local newest_input_path
     local build_stamp_mtime
     local build_stamp_path
+    local current_digest
+    local stamp_digest
 
     if [ -f "$DEPS_ARCHIVE" ] && [ -f "$DEPS_BUILD_STAMP" ] && [ -d "$DEPS_MODULE_ROOT" ] && [ -f "$TRANSCRIPTED_CORE_MODULE" ] && [ -f "$ARGMAX_CORE_MODULE" ] && [ -f "$WHISPERKIT_MODULE" ] && [ -d "$ESPEAK_FRAMEWORK" ] && [ -d "$SENTRY_FRAMEWORK" ] && [ -d "$SPARKLE_FRAMEWORK" ]; then
         newest_input="$(newest_dependency_input)"
@@ -103,6 +122,18 @@ ensure_deps_ready() {
             echo "  $newest_input_path"
             echo "Built deps stamp:"
             echo "  $build_stamp_path"
+            echo ""
+            echo "Run: bash build-deps.sh --force"
+            exit 1
+        fi
+
+        current_digest="$(dependency_input_digest)"
+        stamp_digest="$(deps_build_stamp_digest)"
+        if [ -z "$stamp_digest" ] || [ "$current_digest" != "$stamp_digest" ]; then
+            echo "Dependencies are stale for TranscriptedCore."
+            echo "Dependency input digest changed."
+            echo "  current: ${current_digest:-missing}"
+            echo "  stamp:   ${stamp_digest:-missing}"
             echo ""
             echo "Run: bash build-deps.sh --force"
             exit 1

--- a/scripts/entrypoints/run-integration-smoke.sh
+++ b/scripts/entrypoints/run-integration-smoke.sh
@@ -28,15 +28,26 @@ ARGMAX_CORE_MODULE="$DEPS_MODULE_ROOT/ArgmaxCore.swiftmodule/arm64-apple-macos.s
 WHISPERKIT_MODULE="$DEPS_MODULE_ROOT/WhisperKit.swiftmodule/arm64-apple-macos.swiftmodule"
 ESPEAK_FRAMEWORK="$DEPS_FRAMEWORK_ROOT/ESpeakNG.framework"
 
-dependency_input_listing() {
+dependency_input_paths() {
     {
         printf '%s\n' "Package.swift"
         printf '%s\n' "scripts/entrypoints/build-deps.sh"
         find "Sources/TranscriptedCore" -type f ! -name "CLAUDE.md"
-    } | while IFS= read -r path; do
+    } | sort
+}
+
+dependency_input_listing() {
+    dependency_input_paths | while IFS= read -r path; do
         [ -e "$path" ] || continue
         printf '%s\t%s\n' "$(stat -f '%m' "$path")" "$path"
     done
+}
+
+dependency_input_digest() {
+    dependency_input_paths | while IFS= read -r path; do
+        [ -f "$path" ] || continue
+        shasum -a 256 "$path"
+    done | shasum -a 256 | awk '{print $1}'
 }
 
 newest_dependency_input() {
@@ -46,6 +57,12 @@ newest_dependency_input() {
 deps_build_stamp_info() {
     if [ -f "$DEPS_BUILD_STAMP" ]; then
         printf '%s\t%s\n' "$(stat -f '%m' "$DEPS_BUILD_STAMP")" "$DEPS_BUILD_STAMP"
+    fi
+}
+
+deps_build_stamp_digest() {
+    if [ -f "$DEPS_BUILD_STAMP" ]; then
+        awk -F= '$1 == "dependency_inputs_sha256" { print $2; exit }' "$DEPS_BUILD_STAMP"
     fi
 }
 
@@ -64,6 +81,18 @@ if [ -n "$newest_input_mtime" ] && [ -n "$build_stamp_mtime" ] && [ "$newest_inp
     echo "  $newest_input_path"
     echo "Built deps stamp:"
     echo "  $build_stamp_path"
+    echo ""
+    echo "Run: bash build-deps.sh --force"
+    exit 1
+fi
+
+current_digest="$(dependency_input_digest)"
+stamp_digest="$(deps_build_stamp_digest)"
+if [ -z "$stamp_digest" ] || [ "$current_digest" != "$stamp_digest" ]; then
+    echo "Dependencies are stale for TranscriptedCore."
+    echo "Dependency input digest changed."
+    echo "  current: ${current_digest:-missing}"
+    echo "  stamp:   ${stamp_digest:-missing}"
     echo ""
     echo "Run: bash build-deps.sh --force"
     exit 1


### PR DESCRIPTION
## Summary
- add content-digest dependency stamps so build.sh and integration smoke reject stale TranscriptedCore deps even when mtimes are misleading
- add a fast source-list validator for raw swiftc app, fast-test, and smoke source lists
- wire the validator into CI, agent preflight, the test matrix, and repo command contracts

## Validation
- python3 -m py_compile scripts/dev/check-build-source-lists.py
- python3 scripts/dev/check-build-source-lists.py
- bash -n scripts/entrypoints/build-deps.sh
- bash -n scripts/entrypoints/build.sh
- bash -n scripts/entrypoints/run-integration-smoke.sh
- bash -n scripts/dev/agent-preflight.sh
- scripts/dev/agent-preflight.sh
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test

## Review
- codex-review: not run yet; draft PR opened for review/CI first
