### PR TITLE
Add forbidden entitlement privacy guardrail

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,6 +75,13 @@ WhisperKit, CoreML model bundles) currently ships dylibs that do not all carry
 the same team-id signing as the app, so strict library validation refuses to
 load them. We treat that as a known cost of running ML locally on macOS today.
 
+The entitlement contract is intentionally narrow even while the app is not
+sandboxed. `config/security/nightly-security-manifest.json` forbids broad OS
+entitlements such as user-selected file read/write access, Apple Events
+automation, camera, location, contacts, photos, media-library, and network
+server access; `scripts/ops/nightly-security-check.py` fails if those appear in
+the local, beta, or built-app entitlement set.
+
 Practical implications for users:
 
 - install Transcripted from a trusted source (the signed DMG from GitHub

--- a/Tests/NightlySecurityContractTests.swift
+++ b/Tests/NightlySecurityContractTests.swift
@@ -75,6 +75,43 @@ func testNightlySecurityContract() {
         )
     }
 
+    runSuite("Nightly security manifest forbids broad OS entitlements") {
+        let manifest = loadJSONFixture("config/security/nightly-security-manifest.json", as: [String: AnyDecodable].self)
+        let forbidden = Set(manifest["forbidden_entitlements"]?.arrayValue?.compactMap(\.stringValue) ?? [])
+        let localEntitlements = Set(loadPlistDictionary("config/entitlements/local.plist").keys)
+        let betaEntitlements = Set(loadPlistDictionary("config/entitlements/beta.plist").keys)
+        let checker = (try? String(contentsOf: repoFixtureURL("scripts/ops/nightly-security-check.py"), encoding: .utf8)) ?? ""
+
+        assertTrue(
+            forbidden.contains("com.apple.security.files.user-selected.read-write"),
+            "privacy contract should explicitly forbid broad user-selected file write access"
+        )
+        assertTrue(
+            forbidden.contains("com.apple.security.automation.apple-events"),
+            "privacy contract should explicitly forbid broad Apple Events automation"
+        )
+        assertTrue(
+            forbidden.contains("com.apple.security.network.server"),
+            "privacy contract should explicitly forbid listening network-server entitlement"
+        )
+        assertTrue(
+            localEntitlements.isDisjoint(with: forbidden),
+            "local entitlements should not include forbidden broad OS permissions"
+        )
+        assertTrue(
+            betaEntitlements.isDisjoint(with: forbidden),
+            "beta entitlements should not include forbidden broad OS permissions"
+        )
+        assertTrue(
+            checker.contains("forbidden_entitlements"),
+            "nightly checker should enforce the forbidden-entitlements contract"
+        )
+        assertTrue(
+            checker.contains("built-forbidden-entitlements"),
+            "built app verification should reject forbidden entitlements too"
+        )
+    }
+
     runSuite("Nightly security sanitizer corpus stays shared and non-empty") {
         let corpus = loadJSONFixture("Tests/Fixtures/ObservabilitySanitizerCorpus.json", as: ObservabilitySanitizerCorpus.self)
         let ids = corpus.cases.map(\.id)

--- a/config/security/nightly-security-manifest.json
+++ b/config/security/nightly-security-manifest.json
@@ -114,6 +114,27 @@
       "com.apple.security.network.client": true
     }
   },
+  "forbidden_entitlements": [
+    "com.apple.security.assets.movies.read-only",
+    "com.apple.security.assets.movies.read-write",
+    "com.apple.security.assets.music.read-only",
+    "com.apple.security.assets.music.read-write",
+    "com.apple.security.assets.pictures.read-only",
+    "com.apple.security.assets.pictures.read-write",
+    "com.apple.security.automation.apple-events",
+    "com.apple.security.device.camera",
+    "com.apple.security.files.bookmarks.app-scope",
+    "com.apple.security.files.bookmarks.document-scope",
+    "com.apple.security.files.downloads.read-only",
+    "com.apple.security.files.downloads.read-write",
+    "com.apple.security.files.user-selected.executable",
+    "com.apple.security.files.user-selected.read-only",
+    "com.apple.security.files.user-selected.read-write",
+    "com.apple.security.network.server",
+    "com.apple.security.personal-information.addressbook",
+    "com.apple.security.personal-information.location",
+    "com.apple.security.personal-information.photos-library"
+  ],
   "required_build_script_substrings": {
     "scripts/entrypoints/build.sh": [
       "config/entitlements/local.plist",

--- a/scripts/ops/nightly-security-check.py
+++ b/scripts/ops/nightly-security-check.py
@@ -1280,6 +1280,7 @@ def check_entitlements(root: Path, manifest: dict) -> list[dict]:
         "local": manifest["paths"]["local_entitlements"],
         "beta": manifest["paths"]["beta_entitlements"],
     }
+    forbidden_entitlements = set(manifest.get("forbidden_entitlements", []))
 
     for label, relative_path in path_map.items():
         actual = load_plist(root / relative_path)
@@ -1292,6 +1293,18 @@ def check_entitlements(root: Path, manifest: dict) -> list[dict]:
                     f"{label}-entitlements-drift",
                     f"{label.capitalize()} entitlements drifted from the nightly manifest.",
                     f"Expected {expected!r}, got {actual!r}.",
+                    relative_path,
+                )
+            )
+        forbidden_present = sorted(forbidden_entitlements.intersection(actual.keys()))
+        if forbidden_present:
+            findings.append(
+                make_finding(
+                    "entitlements_and_signing",
+                    "high",
+                    f"{label}-forbidden-entitlements",
+                    f"{label.capitalize()} entitlements include broad OS permissions forbidden by the privacy contract.",
+                    f"Forbidden entitlement(s): {', '.join(forbidden_present)}.",
                     relative_path,
                 )
             )
@@ -1411,6 +1424,20 @@ def check_built_app(root: Path, manifest: dict, app_bundle_argument: str | None)
                 "built-entitlements-drift",
                 "Built app entitlements drifted from the expected local contract.",
                 f"Expected {expected_local!r}, got {entitlements!r}.",
+                app_bundle_argument,
+            )
+        )
+
+    forbidden_entitlements = set(manifest.get("forbidden_entitlements", []))
+    forbidden_present = sorted(forbidden_entitlements.intersection(entitlements.keys()))
+    if forbidden_present:
+        findings.append(
+            make_finding(
+                "entitlements_and_signing",
+                "high",
+                "built-forbidden-entitlements",
+                "Built app entitlements include broad OS permissions forbidden by the privacy contract.",
+                f"Forbidden entitlement(s): {', '.join(forbidden_present)}.",
                 app_bundle_argument,
             )
         )


### PR DESCRIPTION
## Summary
- add a forbidden-entitlements contract for broad OS permissions that should stay absent
- make nightly-security-check fail if local, beta, or built app entitlements include those broad permissions
- add fast contract coverage and document the OS-enforcement boundary in SECURITY.md

## OS-enforcement gaps addressed
- explicit denylist for user-selected file read/write, Downloads, media libraries, Apple Events automation, camera, contacts, location, photos, and network server entitlements
- built app entitlement verification now checks that denylist in addition to exact local entitlement drift

## Tests / checks
- python3 -m json.tool config/security/nightly-security-manifest.json >/dev/null
- python3 -m py_compile scripts/ops/nightly-security-check.py scripts/ops/privacy-leak-sweep.py
- python3 scripts/ops/nightly-security-check.py --strict --automation-toml Tests/Fixtures/nightly-security-automation.toml --github-release-json Tests/Fixtures/release-health-github-release-1.1.48.json --write-report build/nightly-security-report.json
- python3 scripts/ops/privacy-leak-sweep.py --write-report build/privacy-leak-sweep-report.json
- bash scripts/dev/agent-preflight.sh
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh
- python3 scripts/ops/nightly-security-check.py --strict --automation-toml Tests/Fixtures/nightly-security-automation.toml --github-release-json Tests/Fixtures/release-health-github-release-1.1.48.json --app-bundle build/Transcripted.app --write-report build/nightly-security-built-app-report.json

## Codex review
- attempted: codex review --base origin/main
- it independently ran/verified diff inspection, strict nightly security check, focused NightlySecurityContractTests, and git diff --check
- no actionable finding was emitted before nested codex review subprocesses hung after a stream retry; I killed only those review processes and did not claim a clean review verdict

## Remaining A+ gaps
- app is still intentionally unsandboxed because of current local ML/library-validation constraints
- non-LFS HuggingFace model files still rely on HTTPS rather than per-file pinned hashes
- this PR adds guardrails/proof, not a sandbox migration
