### PR TITLE
Align activation first-artifact funnel

### DIFF
--- a/docs/install-attribution-map.md
+++ b/docs/install-attribution-map.md
@@ -27,7 +27,8 @@ through `AnalyticsEventPolicy` and `AnalyticsPayloadSanitizer`.
 | Release download | GitHub release asset download count | GitHub Releases | Counts public DMG downloads, including repeat downloads and automation. |
 | In-app update download | `update_check_finished`, `update_download_started`, `update_download_finished`, `update_ready_to_install`, `update_relaunching`, `update_installed` | PostHog | App-side update funnel. Use version-scoped aggregate counts. |
 | First launch | `app_launched` with `app_version` and `build_version` default properties | PostHog | Anonymous device/session signal only. |
-| First useful artifact | `onboarding_first_dictation_saved`, `dictation_completed`, `meeting_transcript_saved` | PostHog | Shows local Markdown value without inspecting content. |
+| First useful artifact | `activation_first_artifact_saved` | PostHog | Strict first saved dictation or meeting Markdown artifact, emitted once per install without inspecting content. |
+| Saved-artifact continuity | `onboarding_first_dictation_saved`, `dictation_completed`, `meeting_transcript_saved` | PostHog | Legacy/proxy row for older builds and useful-dictation volume. Do not use it as strict first-artifact proof when `activation_first_artifact_saved` is available. |
 | Agent payoff | `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_agent_setup_cta_clicked`, `activation_return_proxy_observed` | PostHog | Coarse proof of opening artifacts, copying/using agent prompts, setup CTAs, and later return via Home. |
 | Reliability filter | Release-scoped issues and allowed non-fatal events | Sentry | Use to avoid mistaking broken first-run paths for weak demand. |
 
@@ -71,8 +72,9 @@ For the attribution story, report:
   analytics read proves the specific `/download` or `/download/latest.dmg`
   route.
 - `app_launched` does not prove a first useful artifact. Use
-  `dictation_completed`, `onboarding_first_dictation_saved`, and
-  `meeting_transcript_saved` for value.
+  `activation_first_artifact_saved` for strict first saved-Markdown proof.
+  Keep `dictation_completed`, `onboarding_first_dictation_saved`, and
+  `meeting_transcript_saved` as continuity/proxy signals for older builds.
 - Artifact events do not prove agent answer quality. The closest safe proxy is
   `activation_agent_prompt_action_clicked` plus `activation_return_proxy_observed`.
 

--- a/scripts/ops/posthog-activation-funnel.py
+++ b/scripts/ops/posthog-activation-funnel.py
@@ -117,16 +117,16 @@ REACH_STEPS = (
     StepDefinition(
         "strict_saved_markdown_devices",
         "Strict saved Markdown",
-        "event IN ('onboarding_first_dictation_saved', 'meeting_transcript_saved')",
+        "event = 'activation_first_artifact_saved'",
         "observed",
-        "Saved onboarding dictation Markdown or saved meeting Markdown. General saved dictation lacks a dedicated remote event.",
+        "First saved dictation or meeting Markdown artifact, emitted once per install from the successful save path.",
     ),
     StepDefinition(
         "saved_markdown_plus_dictation_proxy_devices",
         "Saved Markdown plus dictation proxy",
-        "event IN ('onboarding_first_dictation_saved', 'meeting_transcript_saved', 'dictation_completed')",
+        "event IN ('activation_first_artifact_saved', 'onboarding_first_dictation_saved', 'meeting_transcript_saved', 'dictation_completed')",
         "proxy",
-        "Adds dictation completion as a product-success proxy because general dictation save is only local diagnostics today.",
+        "Adds legacy saved-artifact events and dictation completion as product-success proxies around the strict first-artifact event.",
     ),
     StepDefinition(
         "artifact_action_devices",
@@ -172,7 +172,7 @@ SEQUENCE_STEPS = (
     ("Dictation started", "event IN ('onboarding_first_dictation_started', 'dictation_started')"),
     (
         "Saved Markdown or dictation proxy",
-        "event IN ('onboarding_first_dictation_saved', 'meeting_transcript_saved', 'dictation_completed')",
+        "event IN ('activation_first_artifact_saved', 'onboarding_first_dictation_saved', 'meeting_transcript_saved', 'dictation_completed')",
     ),
     (
         "Artifact opened or prompt copied",
@@ -552,8 +552,8 @@ def render_report(data: dict[str, Any]) -> str:
 
     limitations = [
         "`permission ready` uses `onboarding_completed` as a proxy. The app guards completion on required dictation permissions, but this does not count users who became ready outside onboarding.",
-        "`strict saved Markdown` counts onboarding first-dictation saves and meeting transcript saves. General dictation save currently has local diagnostics but no dedicated remote saved-artifact event.",
-        "`dictation_completed` is included only in the proxy saved-Markdown row. It can prove useful dictation volume, but not every general saved Markdown write.",
+        "`strict saved Markdown` counts `activation_first_artifact_saved`, emitted once per install from successful dictation and meeting Markdown save paths.",
+        "`dictation_completed`, `onboarding_first_dictation_saved`, and `meeting_transcript_saved` are included only in the proxy saved-Markdown row for legacy continuity.",
         "Agent setup and prompt-copy events prove intent. They do not prove the user asked an agent a sourced question or got a useful answer.",
         "`agent_capture_query_observed` is the desired true first-agent-use signal and is currently expected to be zero until instrumentation exists.",
     ]
@@ -564,7 +564,7 @@ def render_report(data: dict[str, Any]) -> str:
         "Artifact actions: open Markdown, preview, reveal folder, and copy-for-agent surfaces.",
         "Agent bridge: setup kind, agent target, prompt kind, result, and surface.",
         "Return loop: `activation_return_proxy_observed` by return-window bucket.",
-        "Data quality: missing true-agent-use event and general dictation saved-artifact gap.",
+        "Data quality: missing true-agent-use event and first-artifact adoption by app version.",
     ]
 
     lines = [
@@ -639,7 +639,7 @@ def render_report(data: dict[str, Any]) -> str:
         "",
         "## Next Best Action",
         "",
-        "Add one privacy-safe first-use event for `activation_first_artifact_saved` and one for `agent_capture_query_observed`, then make the dashboard's primary KPI the share of launch devices that reach true sourced-agent-use within 7 days.",
+        "Verify `activation_first_artifact_saved` reaches live PostHog for current builds, add `agent_capture_query_observed`, then make the dashboard's primary KPI the share of launch devices that reach true sourced-agent-use within 7 days.",
         "",
     ]
     return "\n".join(lines)
@@ -695,8 +695,15 @@ def run_self_test() -> int:
     if "True agent-query proof: **0 devices**" not in report:
         print("self-test failed: missing true agent-query proof limitation", file=sys.stderr)
         return 1
+    reach = reach_query(30, None)
+    if "activation_first_artifact_saved') AS strict_saved_markdown_devices" not in reach:
+        print("self-test failed: strict saved-Markdown reach must use activation_first_artifact_saved", file=sys.stderr)
+        return 1
+    if "activation_first_artifact_saved" not in sequence_query(30, None):
+        print("self-test failed: ordered saved-Markdown step must include activation_first_artifact_saved", file=sys.stderr)
+        return 1
     for query in (
-        reach_query(30, None),
+        reach,
         event_counts_query(30, None),
         daily_active_query(30, None),
         sequence_query(30, None),


### PR DESCRIPTION
## Summary
- make `activation_first_artifact_saved` the strict saved-Markdown step in the PostHog activation funnel helper
- keep legacy saved-artifact events and `dictation_completed` in the proxy/continuity row
- update install-attribution docs so operators do not use legacy events as strict first-artifact proof

## Activation proof
- App wiring already calls `ActivationTelemetry.trackFirstArtifactSavedIfNeeded` from successful dictation and meeting save paths.
- Analytics allowlist keeps `activation_first_artifact_saved` limited to `artifact_kind`, `duration_bucket`, `surface`, `trigger`, and `word_count_bucket`.
- Live aggregate PostHog helper run for last 30 days found `activation_first_artifact_saved`: 0 devices, while legacy/proxy saved-artifact row had 43 devices. So live production receipt is still unproven.

## Verification
- `python3 -m py_compile scripts/ops/posthog-activation-funnel.py`
- `python3 scripts/ops/posthog-activation-funnel.py --self-test`
- `python3 scripts/ops/posthog-activation-funnel.py --days 30`
- `scripts/dev/agent-preflight.sh`
- `bash run-tests.sh` (5707 passed)

## Codex review
Not run: docs/helper-only taxonomy alignment; no app runtime code changed.
