### PR TITLE
Remove AppKit from core audio boundary

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -66,7 +66,6 @@ let package = Package(
                 .linkedFramework("CoreML"),
                 .linkedFramework("CoreAudio"),
                 .linkedFramework("AVFoundation"),
-                .linkedFramework("AppKit"),
                 .linkedFramework("Network"),
                 .linkedFramework("ScreenCaptureKit"),
             ]
@@ -105,7 +104,6 @@ let package = Package(
                 .linkedFramework("CoreML"),
                 .linkedFramework("CoreAudio"),
                 .linkedFramework("AVFoundation"),
-                .linkedFramework("AppKit"),
                 .linkedFramework("Network"),
                 .linkedFramework("ScreenCaptureKit"),
             ]

--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -46,8 +46,14 @@ final class MeetingCaptureBridge: ObservableObject {
     private let startAttempt = MeetingCaptureAttempt<Bool>()
     private var timedOutStopCompletionHandler: ((CaptureStopResult) -> Void)?
 
-    init(audio: Audio = Audio()) {
-        self.audio = audio
+    init(audio: Audio? = nil) {
+        self.audio = audio ?? Audio(
+            sleepWakeNotifications: AudioSleepWakeNotifications(
+                center: NSWorkspace.shared.notificationCenter,
+                willSleepName: Notification.Name("NSWorkspaceWillSleepNotification"),
+                didWakeName: Notification.Name("NSWorkspaceDidWakeNotification")
+            )
+        )
         wireCallbacks()
         wireSubscriptions()
     }

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -1,7 +1,6 @@
 import Foundation
 import QuartzCore
 @preconcurrency import AVFoundation
-import AppKit
 import CoreAudio
 import Combine
 
@@ -129,6 +128,31 @@ public enum AudioInputTapTeardownPolicy {
             ? [.stopEngine, .waitForStoppedInputCallbacks, .removeInputTap]
             : [.removeInputTap]
     }
+}
+
+/// Host-provided sleep/wake notifications for recording gap tracking.
+///
+/// The default uses macOS workspace notification names without importing
+/// AppKit, so `TranscriptedCore` stays a reusable library boundary.
+public struct AudioSleepWakeNotifications: Sendable {
+    public let center: NotificationCenter
+    public let willSleepName: Notification.Name
+    public let didWakeName: Notification.Name
+
+    public init(
+        center: NotificationCenter = .default,
+        willSleepName: Notification.Name,
+        didWakeName: Notification.Name
+    ) {
+        self.center = center
+        self.willSleepName = willSleepName
+        self.didWakeName = didWakeName
+    }
+
+    public static let macOSWorkspace = AudioSleepWakeNotifications(
+        willSleepName: Notification.Name("NSWorkspaceWillSleepNotification"),
+        didWakeName: Notification.Name("NSWorkspaceDidWakeNotification")
+    )
 }
 
 /// Main audio recording class that captures microphone and system audio
@@ -669,14 +693,19 @@ public class Audio: ObservableObject, @unchecked Sendable {
     /// Filesystem layout used for writing raw mic/system WAV captures.
     /// Embedders can redirect captures by passing a custom `CoreStoragePaths` at init.
     let paths: CoreStoragePaths
+    private let sleepWakeNotifications: AudioSleepWakeNotifications
 
     /// Durable record of the in-flight recording for crash recovery. Lives
     /// next to the scratch audio; cleared once the meeting reaches a durable
     /// state (transcript saved or failed-queue entry persisted).
     let recordingJournal: MeetingRecordingJournalStore
 
-    public init(paths: CoreStoragePaths = .default) {
+    public init(
+        paths: CoreStoragePaths = .default,
+        sleepWakeNotifications: AudioSleepWakeNotifications = .macOSWorkspace
+    ) {
         self.paths = paths
+        self.sleepWakeNotifications = sleepWakeNotifications
         self.recordingJournal = MeetingRecordingJournalStore(directory: paths.audioCaptures)
     }
 
@@ -698,8 +727,8 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // MARK: - Sleep/Wake Observers (Phase 1: Invisible Reliability)
         // Handle macOS sleep/wake to prevent AVAudioEngine crashes and log gaps
 
-        sleepObserver = NotificationCenter.default.addObserver(
-            forName: NSWorkspace.willSleepNotification,
+        sleepObserver = sleepWakeNotifications.center.addObserver(
+            forName: sleepWakeNotifications.willSleepName,
             object: nil,
             queue: .main
         ) { [weak self] _ in
@@ -708,8 +737,8 @@ public class Audio: ObservableObject, @unchecked Sendable {
             self.sleepTimestamp = Date()
         }
 
-        wakeObserver = NotificationCenter.default.addObserver(
-            forName: NSWorkspace.didWakeNotification,
+        wakeObserver = sleepWakeNotifications.center.addObserver(
+            forName: sleepWakeNotifications.didWakeName,
             object: nil,
             queue: .main
         ) { [weak self] _ in
@@ -1339,10 +1368,10 @@ public class Audio: ObservableObject, @unchecked Sendable {
     deinit {
         // Remove sleep/wake observers to prevent leaks
         if let observer = sleepObserver {
-            NotificationCenter.default.removeObserver(observer)
+            sleepWakeNotifications.center.removeObserver(observer)
         }
         if let observer = wakeObserver {
-            NotificationCenter.default.removeObserver(observer)
+            sleepWakeNotifications.center.removeObserver(observer)
         }
         timer?.invalidate()
         watchdogTimer?.invalidate()

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -549,6 +549,45 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - TranscriptedCore stays free of app UI frameworks") {
+        let disallowedImports = [
+            "import AppKit",
+            "import SwiftUI",
+            "import Cocoa",
+            "import UIKit"
+        ]
+        let matches = repoTextFiles(relativeTo: repoRootURL())
+            .filter { $0.hasPrefix("Sources/TranscriptedCore/") && $0.hasSuffix(".swift") }
+            .flatMap { file -> [String] in
+                let contents = readRepoTextFile(file)
+                return contents
+                    .split(separator: "\n", omittingEmptySubsequences: false)
+                    .enumerated()
+                    .compactMap { index, line in
+                        let trimmed = line.trimmingCharacters(in: .whitespaces)
+                        return disallowedImports.contains(trimmed) ? "\(file):\(index + 1)" : nil
+                    }
+            }
+
+        assertEqual(matches, [], "TranscriptedCore should not import app UI frameworks")
+
+        let packageManifest = readRepoTextFile("Package.swift")
+        assertFalse(
+            packageManifest.contains(".linkedFramework(\"AppKit\")"),
+            "TranscriptedCore package should not link AppKit"
+        )
+    }
+
+    runSuite("Repo command contract - app bridge injects workspace sleep wake notifications") {
+        let bridge = readRepoTextFile("Sources/Meeting/MeetingCaptureBridge.swift")
+        assertTrue(
+            bridge.contains("center: NSWorkspace.shared.notificationCenter")
+                && bridge.contains("willSleepName: Notification.Name(\"NSWorkspaceWillSleepNotification\")")
+                && bridge.contains("didWakeName: Notification.Name(\"NSWorkspaceDidWakeNotification\")"),
+            "app-side meeting bridge should keep NSWorkspace notification center ownership out of TranscriptedCore"
+        )
+    }
+
     runSuite("Repo command contract - microphone permission callback cannot start after cancellation") {
         let contents = readRepoTextFile("Sources/TranscriptedCore/Audio/Audio.swift")
         assertTrue(


### PR DESCRIPTION
## Summary
- remove the AppKit import and AppKit link from TranscriptedCore
- move real NSWorkspace sleep/wake notification-center ownership to the app-side meeting bridge
- add repo-contract coverage so Core cannot regain UI framework imports or an AppKit package link quietly
- audited MCP/tool read-only behavior; no tool behavior changes

## Verification
- git fetch origin main --prune
- bash build-deps.sh --force
- bash build.sh --no-open
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh (5710 passed)
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-integration-smoke.sh
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift test (492 passed, 1 skipped)
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 bash run-tests.sh --filter RepoCommandContractTests (577 passed)
- swift test --package-path Tools/TranscriptedCaptureKit (25 passed)
- swift test --package-path Tools/TranscriptedCLI (45 passed)
- swift test --package-path Tools/TranscriptedMCP (74 passed)
- build/Transcripted.app/Contents/Helpers/transcripted-mcp --self-test with temp data/index dirs
- codex review --uncommitted: first pass found the NSWorkspace notification-center preservation issue; fixed here. Final rerun wedged in its own build subprocess after direct build/tests passed, so this remains a draft review caveat.