### PR TITLE
Add onboarding abandonment telemetry

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -157,6 +157,13 @@ struct AnalyticsEventPolicy: Equatable {
         "source",
     ]
 
+    private static let workflowAbandonedProperties: Set<String> = [
+        "elapsed_bucket",
+        "reason_kind",
+        "stage",
+        "workflow_kind",
+    ]
+
     private static let allowedPolicies: [String: AnalyticsEventPolicy] = [
         "app_launched": .init(
             name: "app_launched",
@@ -332,6 +339,10 @@ struct AnalyticsEventPolicy: Equatable {
         "activation_return_proxy_observed": .init(
             name: "activation_return_proxy_observed",
             allowedProperties: activationReturnProxyProperties
+        ),
+        "workflow_abandoned": .init(
+            name: "workflow_abandoned",
+            allowedProperties: workflowAbandonedProperties
         ),
         "menu_bar_opened": .init(
             name: "menu_bar_opened",

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -50,6 +50,7 @@ struct PermissionsOnboardingView: View {
     @State private var flowStartedAt: CFAbsoluteTime?
     @State private var stepStartedAt: CFAbsoluteTime?
     @State private var didTrackCompletion = false
+    @State private var didTrackAbandonment = false
     @State private var lastPermissionStatuses: [TranscriptedPermissionKind: String] = [:]
     @FocusState private var demoEditorFocused: Bool
 
@@ -119,6 +120,7 @@ struct PermissionsOnboardingView: View {
         .onDisappear {
             stopPolling()
             copiedResetTask?.cancel()
+            trackAbandonmentIfNeeded(reasonKind: "window_closed")
         }
     }
 
@@ -609,6 +611,23 @@ struct PermissionsOnboardingView: View {
                 firstDictationSaved: PermissionsOnboardingPreferences.hasTrackedFirstDictationSaved(),
                 anonymousUsageEnabled: AnalyticsPreferences.isEnabled(),
                 crashReportingEnabled: CrashReportingPreferences.isEnabled(),
+                elapsedSeconds: flowStartedAt.map { CFAbsoluteTimeGetCurrent() - $0 }
+            )
+        )
+    }
+
+    private func trackAbandonmentIfNeeded(reasonKind: String) {
+        guard !didTrackCompletion else { return }
+        guard !didTrackAbandonment else { return }
+        guard flowStartedAt != nil else { return }
+        didTrackAbandonment = true
+
+        AnalyticsReporter.track(
+            "workflow_abandoned",
+            properties: FirstRunExperience.workflowAbandonedAnalyticsProperties(
+                workflowKind: "onboarding",
+                stage: currentStep.kind.analyticsID,
+                reasonKind: reasonKind,
                 elapsedSeconds: flowStartedAt.map { CFAbsoluteTimeGetCurrent() - $0 }
             )
         )

--- a/Sources/UI/Shared/FirstRunExperience.swift
+++ b/Sources/UI/Shared/FirstRunExperience.swift
@@ -268,6 +268,25 @@ enum FirstRunExperience {
         return properties
     }
 
+    static func workflowAbandonedAnalyticsProperties(
+        workflowKind: String,
+        stage: String,
+        reasonKind: String,
+        elapsedSeconds: Double?
+    ) -> [String: String] {
+        var properties: [String: String] = [
+            "reason_kind": reasonKind,
+            "stage": stage,
+            "workflow_kind": workflowKind,
+        ]
+
+        if let elapsedSeconds {
+            properties["elapsed_bucket"] = AnalyticsReporter.durationBucket(seconds: elapsedSeconds)
+        }
+
+        return properties
+    }
+
     static func primaryAction(
         hasRequiredPermissions: Bool,
         hasPasteTarget: Bool,

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -138,6 +138,51 @@ func testAnalyticsEventPolicy() {
         assertNil(sanitized["word_count"], "raw counts should stay out of activation analytics")
     }
 
+    runSuite("AnalyticsEventPolicy allows only narrow workflow abandonment fields") {
+        let abandoned = AnalyticsEventPolicy.policy(forEvent: "workflow_abandoned")
+
+        assertEqual(
+            abandoned?.allowedProperties ?? Set<String>(),
+            ["elapsed_bucket", "reason_kind", "stage", "workflow_kind"],
+            "workflow abandonment should stay limited to coarse lifecycle fields"
+        )
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "workflow_kind": "onboarding",
+                "stage": "permissions",
+                "reason_kind": "window_closed",
+                "elapsed_bucket": "30_119s",
+                "transcript": "private words",
+                "prompt_text": "Ask my agent this",
+                "meeting_title": "Customer call",
+                "speaker_name": "Alice",
+                "source_app_name": "Safari",
+                "source_app_bundle": "com.apple.Safari",
+                "file_path": "/Users/redbars/private.md",
+                "audio_path": "/Users/redbars/private.wav",
+                "meeting_url": "https://example.com/private",
+                "user_id": "private-user",
+            ],
+            allowedKeys: abandoned?.allowedProperties ?? []
+        )
+
+        assertEqual(sanitized["workflow_kind"], "onboarding", "workflow kind should survive")
+        assertEqual(sanitized["stage"], "permissions", "stage should survive")
+        assertEqual(sanitized["reason_kind"], "window_closed", "reason kind should survive")
+        assertEqual(sanitized["elapsed_bucket"], "30_119s", "elapsed bucket should survive")
+        assertNil(sanitized["transcript"], "raw transcript text must not be sent")
+        assertNil(sanitized["prompt_text"], "raw prompt text must not be sent")
+        assertNil(sanitized["meeting_title"], "meeting titles must not be sent")
+        assertNil(sanitized["speaker_name"], "speaker names must not be sent")
+        assertNil(sanitized["source_app_name"], "source app names must not be sent")
+        assertNil(sanitized["source_app_bundle"], "source app bundle IDs must not be sent")
+        assertNil(sanitized["file_path"], "file paths must not be sent")
+        assertNil(sanitized["audio_path"], "audio paths must not be sent")
+        assertNil(sanitized["meeting_url"], "raw URLs must not be sent")
+        assertNil(sanitized["user_id"], "identifiers must not be sent")
+    }
+
     runSuite("ActivationTelemetry buckets artifact age, first-artifact saves, and next-day return proxy") {
         let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
         let suiteName = "ActivationTelemetryTests.first-artifact.\(UUID().uuidString)"

--- a/Tests/FirstRunExperienceTests.swift
+++ b/Tests/FirstRunExperienceTests.swift
@@ -170,6 +170,32 @@ func testFirstRunExperience() {
         assertNil(properties["flow_elapsed_bucket"], "missing elapsed time should not invent a duration bucket")
     }
 
+    runSuite("FirstRunExperience.workflowAbandonedAnalyticsProperties — keeps abandonment generic and bucketed") {
+        let properties = FirstRunExperience.workflowAbandonedAnalyticsProperties(
+            workflowKind: "onboarding",
+            stage: "permissions",
+            reasonKind: "window_closed",
+            elapsedSeconds: 75
+        )
+
+        assertEqual(properties["workflow_kind"], "onboarding", "workflow kind should stay enum-like")
+        assertEqual(properties["stage"], "permissions", "stage should stay a coarse funnel stage")
+        assertEqual(properties["reason_kind"], "window_closed", "reason should stay normalized")
+        assertEqual(properties["elapsed_bucket"], "30_119s", "elapsed time should be bucketed")
+        assertNil(properties["transcript"], "abandonment should not include spoken content")
+        assertNil(properties["meeting_title"], "abandonment should not include meeting titles")
+        assertNil(properties["file_path"], "abandonment should not include local paths")
+
+        let untimed = FirstRunExperience.workflowAbandonedAnalyticsProperties(
+            workflowKind: "onboarding",
+            stage: "welcome",
+            reasonKind: "window_closed",
+            elapsedSeconds: nil
+        )
+
+        assertNil(untimed["elapsed_bucket"], "missing elapsed time should not invent a duration bucket")
+    }
+
     runSuite("FirstRunExperience.meetingAction — switches menu copy while recording") {
         let idle = FirstRunExperience.meetingAction(
             dictationReady: true,

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -102,6 +102,7 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `activation_agent_prompt_action_clicked`
 - `activation_agent_setup_cta_clicked`
 - `activation_return_proxy_observed`
+- `workflow_abandoned`
 - `menu_bar_opened`
 - `menu_bar_action_clicked`
 - `update_action_clicked`
@@ -158,6 +159,11 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 Meeting workflow analytics should keep that same stable `trigger` enum on later
 stop/save/fail events so product and reliability reviews can attribute outcomes
 without joining against any sensitive context.
+
+`workflow_abandoned` is only for flows where the app can confidently infer
+abandonment without content. The first implementation is onboarding window close
+before completion, with only `workflow_kind`, `stage`, `reason_kind`, and
+`elapsed_bucket`.
 
 Anything richer than that should stay local unless there is a new explicit
 privacy review and a matching allowlist change.


### PR DESCRIPTION
## Summary
- add allowlisted `workflow_abandoned` analytics event with only workflow_kind, stage, reason_kind, elapsed_bucket
- emit it for first-run onboarding window close before completion
- document the guardrail and add policy/helper tests for privacy-safe payload shape

## Chosen flow
Onboarding window close before completion. This is the safest high-value abandonment signal because the app already knows the current onboarding stage and completion state without inspecting content.

## Privacy
No raw text, prompt text, titles, paths, app names, bundle IDs, names, URLs, or identifiers. The event is allowlist-only and uses coarse enum/bucket properties.

## Verification
- `scripts/dev/agent-preflight.sh`
- `bash run-tests.sh --filter AnalyticsEventPolicyTests`
- `bash run-tests.sh --filter FirstRunExperienceTests`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `codex review --uncommitted` exited 0 with no actionable findings reported; local plugin/MCP warnings only

## Notes
- No release publishing performed.