### PR TITLE
Add onboarding exit telemetry

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -313,6 +313,14 @@ struct AnalyticsEventPolicy: Equatable {
                 "step_index",
             ]
         ),
+        "onboarding_exited": .init(
+            name: "onboarding_exited",
+            allowedProperties: [
+                "elapsed_bucket",
+                "last_step_id",
+                "permission_readiness",
+            ]
+        ),
         "activation_artifact_action_clicked": .init(
             name: "activation_artifact_action_clicked",
             allowedProperties: activationArtifactActionProperties

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -50,6 +50,7 @@ struct PermissionsOnboardingView: View {
     @State private var flowStartedAt: CFAbsoluteTime?
     @State private var stepStartedAt: CFAbsoluteTime?
     @State private var didTrackCompletion = false
+    @State private var didTrackExit = false
     @State private var lastPermissionStatuses: [TranscriptedPermissionKind: String] = [:]
     @FocusState private var demoEditorFocused: Bool
 
@@ -117,6 +118,7 @@ struct PermissionsOnboardingView: View {
             trackCurrentStepViewed()
         }
         .onDisappear {
+            trackExitIfNeeded()
             stopPolling()
             copiedResetTask?.cancel()
         }
@@ -614,6 +616,21 @@ struct PermissionsOnboardingView: View {
         )
     }
 
+    private func trackExitIfNeeded() {
+        guard !didTrackCompletion, !didTrackExit else { return }
+        didTrackExit = true
+
+        let now = CFAbsoluteTimeGetCurrent()
+        AnalyticsReporter.track(
+            "onboarding_exited",
+            properties: [
+                "elapsed_bucket": flowElapsedBucket(now: now),
+                "last_step_id": currentStep.kind.analyticsID,
+                "permission_readiness": onboardingPermissionReadiness,
+            ]
+        )
+    }
+
     private func requestPermission(_ kind: TranscriptedPermissionKind, required: Bool) {
         AnalyticsReporter.track(
             "onboarding_permission_cta_clicked",
@@ -708,6 +725,10 @@ struct PermissionsOnboardingView: View {
 
     private func permissionStatus(for kind: TranscriptedPermissionKind) -> String {
         currentPermissionStatuses()[kind] ?? "unknown"
+    }
+
+    private var onboardingPermissionReadiness: String {
+        hasRequiredPermissions ? "required_ready" : "missing_required"
     }
 
     static var hasCompleted: Bool {

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -24,6 +24,7 @@ func testAnalyticsEventPolicy() {
         let agentClicked = AnalyticsEventPolicy.policy(forEvent: "onboarding_agent_cta_clicked")
         let completed = AnalyticsEventPolicy.policy(forEvent: "onboarding_completed")
         let dismissed = AnalyticsEventPolicy.policy(forEvent: "onboarding_dismissed")
+        let exited = AnalyticsEventPolicy.policy(forEvent: "onboarding_exited")
 
         assertEqual(shown?.allowedProperties.contains("meeting_recording_ready"), true, "onboarding shown should preserve meeting-readiness attribution")
         assertEqual(stepViewed?.allowedProperties.contains("flow_elapsed_bucket"), true, "step views should preserve coarse elapsed time")
@@ -36,25 +37,39 @@ func testAnalyticsEventPolicy() {
         assertEqual(completed?.allowedProperties.contains("first_dictation_saved"), true, "completion should preserve whether first value happened")
         assertEqual(completed?.allowedProperties.contains("flow_elapsed_bucket"), true, "completion should preserve coarse time to finish")
         assertEqual(dismissed?.allowedProperties.contains("step_index"), true, "dismissal should preserve where users dropped")
+        assertEqual(exited?.allowedProperties ?? Set<String>(), ["elapsed_bucket", "last_step_id", "permission_readiness"], "exit telemetry should stay limited to step, elapsed bucket, and coarse permission readiness")
 
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
             [
+                "elapsed_bucket": "30_119s",
+                "last_step_id": "permissions",
                 "meeting_recording_ready": "true",
+                "permission_readiness": "missing_required",
                 "permission_kind": "system_recording",
                 "flow_elapsed_bucket": "30_119s",
                 "step_id": "meeting_setup",
+                "microphone_ready": "false",
+                "permission_detail": "Microphone denied in System Settings",
             ],
             allowedKeys: [
+                "elapsed_bucket",
                 "flow_elapsed_bucket",
+                "last_step_id",
                 "meeting_recording_ready",
+                "permission_readiness",
                 "permission_kind",
                 "step_id",
             ]
         )
+        assertEqual(sanitized["elapsed_bucket"], "30_119s", "exit elapsed bucket should survive sanitization")
+        assertEqual(sanitized["last_step_id"], "permissions", "exit last step should survive sanitization")
+        assertEqual(sanitized["permission_readiness"], "missing_required", "coarse permission readiness should survive sanitization")
         assertEqual(sanitized["meeting_recording_ready"], "true", "meeting_recording_ready should avoid the audio-key sanitizer drop")
         assertEqual(sanitized["permission_kind"], "system_recording", "permission kind should survive as a coarse enum")
         assertEqual(sanitized["flow_elapsed_bucket"], "30_119s", "coarse elapsed buckets should survive sanitization")
         assertEqual(sanitized["step_id"], "meeting_setup", "step id should survive sanitization")
+        assertNil(sanitized["microphone_ready"], "exit telemetry should not allow per-permission readiness keys")
+        assertNil(sanitized["permission_detail"], "exit telemetry should not allow raw permission details")
     }
 
     runSuite("AnalyticsEventPolicy pins active onboarding activation events") {

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -97,6 +97,7 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `onboarding_reporting_toggle_changed`
 - `onboarding_completed`
 - `onboarding_dismissed`
+- `onboarding_exited`
 - `activation_artifact_action_clicked`
 - `activation_first_artifact_saved`
 - `activation_agent_prompt_action_clicked`


### PR DESCRIPTION
## Summary
- add privacy-safe onboarding_exited telemetry when onboarding closes before completion
- keep payload limited to last_step_id, elapsed_bucket, and coarse permission_readiness
- allowlist the event, update sanitizer/policy coverage, and document the event in privacy-first observability

## Privacy
- no names, emails, paths, transcript text, titles, raw permission details, or per-permission readiness fields
- policy test pins the exact property set and sanitizer drops non-allowlisted permission detail fields

## Verification
- git fetch origin main
- bash run-tests.sh --filter AnalyticsEventPolicyTests
- bash run-tests.sh
- bash build-deps.sh --force
- bash build.sh --no-open
- bash scripts/dev/agent-preflight.sh
- codex-review: /Users/redbars/.codex/skills/codex-review/scripts/codex-review --mode local -> clean, no accepted/actionable findings

No release was cut or published.