### PR TITLE
[codex] Add dictation retry telemetry

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -478,6 +478,14 @@ struct AnalyticsEventPolicy: Equatable {
                 "trigger",
             ]))
         ),
+        "dictation_retry_started": .init(
+            name: "dictation_retry_started",
+            allowedProperties: dictationRouteDiagnosticProperties.union(Set([
+                "failure_kind",
+                "retry_source",
+                "trigger",
+            ]))
+        ),
         "dictation_completed": .init(
             name: "dictation_completed",
             allowedProperties: dictationRouteDiagnosticProperties.union(Set([

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -60,6 +60,7 @@ class DictationSessionController: ObservableObject {
     private var sessionStartTime: CFAbsoluteTime = 0
     private var currentDictationTrigger: DictationTrigger = .unknown
     private var currentDictationSessionID = UUID()
+    private var pendingRetryTelemetry: PendingDictationRetryTelemetry?
 
     /// Max duration for a listening session before auto-cancel (5 minutes).
     /// Prevents stuck sessions when the user walks away from the computer.
@@ -111,6 +112,7 @@ class DictationSessionController: ObservableObject {
         currentDictationTrigger = trigger
         lastCompletedText = nil
         appState.runtimeDiagnostics.recordSession(kind: "dictation", stage: "start_requested")
+        recordDictationRetryStartedIfNeeded(trigger: trigger)
 
         switch TranscriptedPermissionAccess.microphoneAuthorizationStatus() {
         case .authorized:
@@ -186,6 +188,7 @@ class DictationSessionController: ObservableObject {
         _ failureKind: String,
         extra: [String: String] = [:]
     ) {
+        markDictationRetryCandidate(failureKind: failureKind)
         var properties = extra
         properties["failure_kind"] = failureKind
         properties["trigger"] = currentDictationTrigger.rawValue
@@ -616,6 +619,10 @@ class DictationSessionController: ObservableObject {
             actionTitle: "Try Again",
             action: { [weak self] in
                 guard let self else { return }
+                self.markDictationRetryCandidate(
+                    failureKind: cleanupPlan.outcome,
+                    retrySource: "error_action"
+                )
                 self.startDictation(sourceApp: sourceApp, trigger: self.currentDictationTrigger)
             }
         )
@@ -681,6 +688,10 @@ class DictationSessionController: ObservableObject {
                             )
                             return
                         }
+                        self.markDictationRetryCandidate(
+                            failureKind: self.dictationStartFailureKind(for: status),
+                            retrySource: "permission_action"
+                        )
                         self.startDictation(
                             sourceApp: sourceApp,
                             trigger: self.currentDictationTrigger,
@@ -690,6 +701,10 @@ class DictationSessionController: ObservableObject {
                 case .denied, .restricted:
                     TranscriptedPermissionAccess.openSettings(for: .microphone)
                 case .authorized:
+                    self.markDictationRetryCandidate(
+                        failureKind: self.dictationStartFailureKind(for: status),
+                        retrySource: "error_action"
+                    )
                     self.startDictation(
                         sourceApp: sourceApp,
                         trigger: self.currentDictationTrigger,
@@ -802,6 +817,10 @@ class DictationSessionController: ObservableObject {
                 actionTitle: "Try Again",
                 action: { [weak self] in
                     guard let self else { return }
+                    self.markDictationRetryCandidate(
+                        failureKind: failureKind,
+                        retrySource: "error_action"
+                    )
                     self.startDictation(sourceApp: self.sessionSourceApp, trigger: self.currentDictationTrigger)
                 }
             )
@@ -843,6 +862,7 @@ class DictationSessionController: ObservableObject {
                     appState.logger.log("DICTATION | voice model failed to load for transcription")
                     overlayController.showError("The voice model didn't load. Please try dictating again in a moment.")
                     isDictating = false
+                    self.markDictationRetryCandidate(failureKind: "model_unavailable")
                     appState.runtimeDiagnostics.clearSession(kind: "dictation", outcome: "model_unavailable")
                     return
                 }
@@ -895,6 +915,7 @@ class DictationSessionController: ObservableObject {
                         ]
                     )
                 )
+                self.markDictationRetryCandidate(failureKind: "no_speech")
                 NotificationCenter.default.post(name: .dictationNoSpeechDetected, object: nil)
                 AppSoundPlayer.shared.play(.noSpeech)
                 overlayController.showNoSpeechAndDismiss(trigger: currentDictationTrigger.rawValue)
@@ -1116,11 +1137,16 @@ class DictationSessionController: ObservableObject {
                 case .failed(let message):
                     self.startupTask = nil
                     self.isDictating = false
+                    self.markDictationRetryCandidate(failureKind: "model_load_failed")
                     appState.runtimeDiagnostics.clearSession(kind: "dictation", outcome: "model_failed")
                     overlayController.showError(
                         "Dictation couldn't start: \(message)",
                         actionTitle: "Retry Dictation",
                         action: { [weak self] in
+                            self?.markDictationRetryCandidate(
+                                failureKind: "model_load_failed",
+                                retrySource: "error_action"
+                            )
                             self?.startDictation(
                                 sourceApp: sourceApp,
                                 trigger: self?.currentDictationTrigger ?? .unknown,
@@ -1139,6 +1165,7 @@ class DictationSessionController: ObservableObject {
             guard !Task.isCancelled else { return }
             self.startupTask = nil
             self.isDictating = false
+            self.markDictationRetryCandidate(failureKind: "model_load_timeout")
             appState.runtimeDiagnostics.recordStall(
                 kind: "dictation",
                 stage: "model_load_timeout",
@@ -1150,6 +1177,10 @@ class DictationSessionController: ObservableObject {
                 "Dictation is still loading. Please try again in a moment.",
                 actionTitle: "Retry Dictation",
                 action: { [weak self] in
+                    self?.markDictationRetryCandidate(
+                        failureKind: "model_load_timeout",
+                        retrySource: "error_action"
+                    )
                     self?.startDictation(
                         sourceApp: sourceApp,
                         trigger: self?.currentDictationTrigger ?? .unknown,
@@ -1346,6 +1377,7 @@ class DictationSessionController: ObservableObject {
         isDictating = false
         appState?.runtimeDiagnostics.clearSession(kind: "dictation", outcome: "interrupted")
         appState?.logger.log("DICTATION | interrupted")
+        markDictationRetryCandidate(failureKind: "recording_interrupted")
         DiagnosticsTrail.record(
             logger: appState?.logger,
             level: .warning,
@@ -1363,6 +1395,10 @@ class DictationSessionController: ObservableObject {
             "Recording was interrupted. Check your microphone or audio device, then try again.",
             actionTitle: "Retry Dictation",
             action: { [weak self] in
+                self?.markDictationRetryCandidate(
+                    failureKind: "recording_interrupted",
+                    retrySource: "error_action"
+                )
                 self?.startDictation(
                     sourceApp: self?.sessionSourceApp,
                     trigger: self?.currentDictationTrigger ?? .unknown,
@@ -1658,6 +1694,36 @@ class DictationSessionController: ObservableObject {
         }
         return properties
     }
+
+    private func markDictationRetryCandidate(
+        failureKind: String,
+        retrySource: String = "manual_start_after_failure"
+    ) {
+        pendingRetryTelemetry = PendingDictationRetryTelemetry(
+            failureKind: failureKind,
+            retrySource: retrySource
+        )
+    }
+
+    private func recordDictationRetryStartedIfNeeded(trigger: DictationTrigger) {
+        guard let retry = pendingRetryTelemetry else { return }
+        pendingRetryTelemetry = nil
+        AnalyticsReporter.track(
+            "dictation_retry_started",
+            properties: dictationAnalyticsProperties(
+                extra: [
+                    "failure_kind": retry.failureKind,
+                    "retry_source": retry.retrySource,
+                    "trigger": trigger.rawValue,
+                ]
+            )
+        )
+    }
+}
+
+private struct PendingDictationRetryTelemetry {
+    let failureKind: String
+    let retrySource: String
 }
 
 @MainActor

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -428,6 +428,40 @@ func testAnalyticsEventPolicy() {
         assertEqual(sanitized["trigger"], "menu", "non-hotkey triggers should remain attributable")
     }
 
+    runSuite("AnalyticsEventPolicy allows dictation retry starts without private payloads") {
+        let retryStarted = AnalyticsEventPolicy.policy(forEvent: "dictation_retry_started")
+
+        assertEqual(retryStarted?.allowedProperties.contains("failure_kind"), true, "dictation retries should preserve the prior failure bucket")
+        assertEqual(retryStarted?.allowedProperties.contains("retry_source"), true, "dictation retries should preserve the coarse retry source")
+        assertEqual(retryStarted?.allowedProperties.contains("route_shape"), true, "dictation retries should preserve safe route shape")
+        assertEqual(retryStarted?.allowedProperties.contains("trigger"), true, "dictation retries should preserve the new start trigger")
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "audio_device": "Desk microphone",
+                "failure_kind": "no_speech",
+                "input_device_class": "built_in",
+                "raw_text": "private dictated words",
+                "retry_count": "2",
+                "retry_source": "manual_start_after_failure",
+                "route_shape": "built_in_input_to_bluetooth_output",
+                "source_app_name": "Private editor",
+                "trigger": "physical_key",
+            ],
+            allowedKeys: retryStarted?.allowedProperties ?? []
+        )
+
+        assertEqual(sanitized["failure_kind"], "no_speech", "prior failure kind should survive as an enum")
+        assertEqual(sanitized["input_device_class"], "built_in", "coarse input class should survive")
+        assertEqual(sanitized["retry_source"], "manual_start_after_failure", "coarse retry source should survive")
+        assertEqual(sanitized["route_shape"], "built_in_input_to_bluetooth_output", "safe route shape should survive")
+        assertEqual(sanitized["trigger"], "physical_key", "retry start trigger should survive")
+        assertNil(sanitized["audio_device"], "raw audio device names should stay out of retry telemetry")
+        assertNil(sanitized["raw_text"], "dictation text should stay out of retry telemetry")
+        assertNil(sanitized["retry_count"], "raw retry counts should stay out of retry telemetry")
+        assertNil(sanitized["source_app_name"], "source app names should stay out of retry telemetry")
+    }
+
     runSuite("AnalyticsEventPolicy allows dictation stop latency only as coarse buckets") {
         let stopLatency = AnalyticsEventPolicy.policy(forEvent: "dictation_stop_latency_measured")
 
@@ -556,6 +590,7 @@ func testAnalyticsEventPolicy() {
 
     runSuite("AnalyticsEventPolicy only permits reviewed analytics events") {
         let dictationStartFailed = AnalyticsEventPolicy.policy(forEvent: "dictation_start_failed")
+        let dictationRetryStarted = AnalyticsEventPolicy.policy(forEvent: "dictation_retry_started")
         let dictationCompleted = AnalyticsEventPolicy.policy(forEvent: "dictation_completed")
         let dictationStopLatency = AnalyticsEventPolicy.policy(forEvent: "dictation_stop_latency_measured")
         let dictationNoSpeech = AnalyticsEventPolicy.policy(forEvent: "dictation_no_speech")
@@ -565,6 +600,7 @@ func testAnalyticsEventPolicy() {
         let unknown = AnalyticsEventPolicy.policy(forEvent: "raw_transcript_uploaded")
 
         assertEqual(dictationStartFailed?.allowedProperties.contains("failure_kind"), true, "dictation start failures should allow normalized failure kinds")
+        assertEqual(dictationRetryStarted?.allowedProperties.contains("retry_source"), true, "dictation retry starts should allow only coarse retry source")
         assertEqual(dictationCompleted?.allowedProperties.contains("word_count_bucket"), true, "dictation completion should allow bucketed word counts")
         assertEqual(dictationStopLatency?.allowedProperties.contains("stop_to_paste_bucket"), true, "dictation stop latency should allow only bucketed stop-to-paste timing")
         assertEqual(dictationNoSpeech?.allowedProperties.contains("duration_bucket"), true, "dictation no-speech should keep a coarse duration bucket")

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -120,6 +120,7 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `settings_capture_library_changed`
 - `dictation_started`
 - `dictation_start_failed`
+- `dictation_retry_started`
 - `dictation_completed`
 - `dictation_stop_latency_measured`
 - `dictation_cancelled`


### PR DESCRIPTION
## Summary

Adds privacy-safe `dictation_retry_started` telemetry so we can tell whether users retry after failed, interrupted, model-unavailable, or empty/no-speech dictations.

## What changed

- Tracks a pending retry candidate after dictation start failure, no-speech, model load/unavailable, and interruption outcomes.
- Emits `dictation_retry_started` on the next retry start, then clears the marker to avoid double-counting.
- Uses only reviewed enum/bucket properties: `failure_kind`, `retry_source`, `trigger`, plus the existing coarse dictation route analytics context such as `route_shape`.
- Adds the event to `AnalyticsEventPolicy` and `docs/privacy-first-observability.md`.
- Adds sanitizer/policy coverage proving raw audio device names, dictation text, source app names, and raw retry counts are dropped.

## Reliability question answered

This bridges the current gap between `dictation_no_speech` / `dictation_start_failed` and a later `dictation_started`: PostHog can now count retry attempts by prior failure kind and route shape without linking to transcript content or app names.

## Privacy guardrails

- No transcript text, audio references, raw device names, source app names, bundle IDs, file paths, or counts are allowlisted.
- `retry_source` is coarse enum-like attribution: `manual_start_after_failure`, `error_action`, or `permission_action`.
- Route data reuses the existing reviewed coarse dictation route context.

## Validation

- `bash scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force` (needed after stale dependency bundle warning)
- `bash build.sh --no-open`
- `bash run-tests.sh --filter AnalyticsEventPolicy` (365 passed)
- `bash run-tests.sh` (5721 passed)
- `git diff --check`
- `codex review --uncommitted` (exit 0; no actionable findings emitted; local CLI rejected combining `--uncommitted` with `--base`, branch was created from freshly fetched `origin/main`)

No release publishing.