### PR TITLE
[codex] Add analytics taxonomy guardrails

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -14,6 +14,12 @@ struct AnalyticsEventPolicy: Equatable {
         allowedPolicies.keys.sorted()
     }
 
+    /// All allowlisted analytics properties keyed by event name. Tests use this
+    /// to enforce taxonomy-wide privacy rules as new events are added.
+    static var allAllowedPropertiesByEvent: [String: Set<String>] {
+        allowedPolicies.mapValues(\.allowedProperties)
+    }
+
     private static let meetingCaptureDiagnosticProperties: Set<String> = [
         "attenuation_kind",
         "buffer_success_bucket",

--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -15,6 +15,7 @@ enum AnalyticsPayloadSanitizer {
         "name",
         "password",
         "path",
+        "raw_device",
         "speaker",
         "source_app",
         "secret",

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -14,6 +14,125 @@ func testAnalyticsEventPolicy() {
         )
     }
 
+    runSuite("AnalyticsEventPolicy keeps property names privacy-safe across the whole taxonomy") {
+        let forbiddenPropertyFragments = [
+            "app_bundle",
+            "app_name",
+            "audio_file",
+            "audio_path",
+            "audio_ref",
+            "audio_url",
+            "bundle_id",
+            "device_name",
+            "email",
+            "file_name",
+            "filename",
+            "invitee",
+            "meeting_title",
+            "participant_name",
+            "path",
+            "prompt_text",
+            "raw_device",
+            "raw_text",
+            "source_app",
+            "speaker",
+            "text",
+            "title",
+            "token",
+            "transcript",
+            "url",
+        ]
+        let reviewedExceptions: Set<String> = [
+            "mic_raw_peak",
+        ]
+
+        for (event, properties) in AnalyticsEventPolicy.allAllowedPropertiesByEvent {
+            assertTrue(
+                event.range(of: #"^[a-z][a-z0-9_]*$"#, options: .regularExpression) != nil,
+                "\(event) should use stable snake_case event names"
+            )
+
+            for property in properties {
+                assertTrue(
+                    property.range(of: #"^[a-z][a-z0-9_]*$"#, options: .regularExpression) != nil,
+                    "\(event).\(property) should use stable snake_case property names"
+                )
+                guard !reviewedExceptions.contains(property) else { continue }
+
+                let normalized = property.lowercased()
+                for fragment in forbiddenPropertyFragments {
+                    assertFalse(
+                        normalized.contains(fragment),
+                        "\(event).\(property) must not add raw content, identity, source-app, path, URL, token, or raw-device fields"
+                    )
+                }
+            }
+        }
+    }
+
+    runSuite("AnalyticsEventPolicy keeps raw counts and timings bucketed across the taxonomy") {
+        let allowedRawNumericProperties: Set<String> = [
+            "captured_input_volume_before",
+            "captured_input_volume_changed",
+            "captured_input_volume_dropped",
+            "captured_input_volume_during",
+            "default_input_volume_after",
+            "default_input_volume_before",
+            "default_input_volume_changed",
+            "default_input_volume_dropped",
+            "default_input_volume_during",
+            "default_output_volume_after",
+            "default_output_volume_before",
+            "default_output_volume_changed",
+            "default_output_volume_dropped",
+            "default_output_volume_during",
+            "default_system_output_volume_after",
+            "default_system_output_volume_before",
+            "default_system_output_volume_changed",
+            "default_system_output_volume_dropped",
+            "default_system_output_volume_during",
+            "input_channels",
+            "input_rate_hz",
+            "mic_processed_peak",
+            "mic_raw_peak",
+            "os_major",
+            "output_channels",
+            "output_rate_hz",
+            "system_channels",
+            "system_output_rate_hz",
+            "system_peak",
+            "system_rate_hz",
+        ]
+        let rawShapeFragments = [
+            "_count",
+            "_duration",
+            "_latency",
+            "_ms",
+            "_seconds",
+            "attempts",
+            "duration_seconds",
+            "duration_ms",
+            "latency_ms",
+            "queue_depth",
+            "retry_count",
+            "word_count",
+        ]
+
+        for (event, properties) in AnalyticsEventPolicy.allAllowedPropertiesByEvent {
+            for property in properties {
+                guard !property.hasSuffix("_bucket") else { continue }
+                guard !allowedRawNumericProperties.contains(property) else { continue }
+
+                for fragment in rawShapeFragments {
+                    assertFalse(
+                        property.contains(fragment),
+                        "\(event).\(property) should use a coarse *_bucket property instead of raw numeric shape"
+                    )
+                }
+            }
+        }
+    }
+
     runSuite("AnalyticsEventPolicy allows explicit onboarding funnel events") {
         let shown = AnalyticsEventPolicy.policy(forEvent: "onboarding_shown")
         let stepViewed = AnalyticsEventPolicy.policy(forEvent: "onboarding_step_viewed")

--- a/Tests/AnalyticsPayloadSanitizerTests.swift
+++ b/Tests/AnalyticsPayloadSanitizerTests.swift
@@ -67,6 +67,56 @@ func testAnalyticsPayloadSanitizer() {
         assertEqual(sanitized["duration_bucket"], "10_29s", "unrelated coarse properties should remain")
     }
 
+    runSuite("AnalyticsPayloadSanitizer rejects risky taxonomy names even if allowlisted") {
+        let riskyProperties = [
+            "app_bundle_id": "com.example.private",
+            "app_name": "Private Browser",
+            "audio_file": "customer.wav",
+            "audio_path": "/Users/redbars/customer.wav",
+            "audio_ref": "/Users/redbars/customer.wav",
+            "audio_url": "https://example.com/customer.wav",
+            "device_name": "Desk Microphone",
+            "email": "person@example.com",
+            "file_name": "customer.md",
+            "file_path": "/Users/redbars/customer.md",
+            "invitee_name": "Alice",
+            "meeting_title": "Customer Roadmap",
+            "participant_name": "Bob",
+            "prompt_text": "Summarize my meeting",
+            "raw_device": "Private AirPods",
+            "raw_text": "private words",
+            "source_app": "Safari",
+            "source_app_bundle": "com.apple.Safari",
+            "speaker_label": "Speaker 1",
+            "speaker_name": "Alice",
+            "text": "private words",
+            "title": "Customer Roadmap",
+            "token": "sk-private",
+            "transcript": "private words",
+            "transcript_text": "private words",
+            "url": "https://example.com/private",
+        ]
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            riskyProperties.merging(
+                [
+                    "duration_bucket": "10_29m",
+                    "trigger": "hotkey",
+                    "word_count_bucket": "300_plus",
+                ],
+                uniquingKeysWith: { _, new in new }
+            ),
+            allowedKeys: Set(riskyProperties.keys).union(["duration_bucket", "trigger", "word_count_bucket"])
+        )
+
+        assertEqual(sanitized["duration_bucket"], "10_29m", "coarse duration bucket should survive beside rejected risky fields")
+        assertEqual(sanitized["trigger"], "hotkey", "trigger enum should survive beside rejected risky fields")
+        assertEqual(sanitized["word_count_bucket"], "300_plus", "coarse word count bucket should survive beside rejected risky fields")
+        for key in riskyProperties.keys {
+            assertNil(sanitized[key], "\(key) should be dropped even when mistakenly included in allowedKeys")
+        }
+    }
+
     runSuite("AnalyticsPayloadSanitizer scrubs support-facing diagnostic context") {
         let sanitized = AnalyticsPayloadSanitizer.sanitizeDiagnosticContextForDisplay([
             "audio_device": "Private AirPods",

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -162,6 +162,12 @@ without joining against any sensitive context.
 Anything richer than that should stay local unless there is a new explicit
 privacy review and a matching allowlist change.
 
+`Tests/AnalyticsEventPolicyTests.swift` enforces this taxonomy across every
+allowlisted PostHog property. New properties must stay snake_case, coarse, and
+free of raw transcript/audio/title/speaker/email/path/source-app/raw-device/URL/token
+fields. `Tests/AnalyticsPayloadSanitizerTests.swift` also rejects those risky
+property names even if a caller accidentally includes them in an allowlist.
+
 ## Nightly guardrail sweep
 
 The nightly security automation should start with the deterministic checker:


### PR DESCRIPTION
## Summary
- Exposes the compiled analytics event/property allowlist to tests.
- Adds taxonomy-wide tests that reject sensitive PostHog property names and raw numeric/timing shapes.
- Tightens the analytics sanitizer to drop `raw_device` keys even when a caller accidentally allowlists them.
- Documents the guardrail contract in `docs/privacy-first-observability.md`.

Note: `docs/posthog-product-learning-plan.md` from PR #1183 is not present on live `main`, so this is based on the merged `AnalyticsEventPolicy`, `AnalyticsPayloadSanitizer`, and `docs/privacy-first-observability.md` surfaces.

## Validation
- `git fetch origin main --prune`
- `bash run-tests.sh --filter AnalyticsEventPolicyTests`
- `bash run-tests.sh --filter AnalyticsPayloadSanitizerTests`
- `bash run-tests.sh`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `scripts/dev/agent-preflight.sh`
- `codex review --base origin/main` - no actionable correctness issues
