### PR TITLE
Add local summary telemetry

### DIFF
--- a/Sources/Meeting/LocalMeetingSummarizer.swift
+++ b/Sources/Meeting/LocalMeetingSummarizer.swift
@@ -94,6 +94,46 @@ struct LocalMeetingSummaryRunMetadata: Equatable, Sendable {
     }
 }
 
+enum LocalSummaryTelemetry {
+    static func modelFamily(for provider: LocalMeetingSummaryProvider) -> String {
+        switch provider {
+        case .gemmaMLX:
+            return "gemma"
+        case .appleFoundation:
+            return "apple_foundation"
+        }
+    }
+
+    static func failureKind(for error: Error) -> String {
+        if error is CancellationError {
+            return "cancelled"
+        }
+        guard let summaryError = error as? LocalMeetingSummaryError else {
+            return "unknown"
+        }
+        switch summaryError {
+        case .emptyTranscript:
+            return "empty_transcript"
+        case .insufficientMemory:
+            return "insufficient_memory"
+        case .runtimeUnavailable:
+            return "runtime_unavailable"
+        case .appleFoundationUnavailable:
+            return "apple_foundation_unavailable"
+        case .missingBundledRunner:
+            return "missing_runner"
+        case .transcriptChanged:
+            return "transcript_changed"
+        case .processTimedOut:
+            return "timeout"
+        case .processFailed:
+            return "process_failed"
+        case .outputMissing:
+            return "output_missing"
+        }
+    }
+}
+
 struct LocalGemmaSummaryConfiguration: Equatable, Sendable {
     let modelID: String
     let runtimePackage: String

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -157,6 +157,14 @@ struct AnalyticsEventPolicy: Equatable {
         "source",
     ]
 
+    private static let localSummaryProperties: Set<String> = [
+        "duration_bucket",
+        "failure_kind",
+        "model_family",
+        "provider",
+        "result",
+    ]
+
     private static let allowedPolicies: [String: AnalyticsEventPolicy] = [
         "app_launched": .init(
             name: "app_launched",
@@ -332,6 +340,18 @@ struct AnalyticsEventPolicy: Equatable {
         "activation_return_proxy_observed": .init(
             name: "activation_return_proxy_observed",
             allowedProperties: activationReturnProxyProperties
+        ),
+        "local_summary_requested": .init(
+            name: "local_summary_requested",
+            allowedProperties: localSummaryProperties
+        ),
+        "local_summary_finished": .init(
+            name: "local_summary_finished",
+            allowedProperties: localSummaryProperties
+        ),
+        "local_summary_failed": .init(
+            name: "local_summary_failed",
+            allowedProperties: localSummaryProperties
         ),
         "menu_bar_opened": .init(
             name: "menu_bar_opened",

--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -12,6 +12,7 @@ enum AnalyticsPayloadSanitizer {
         "email",
         "error",
         "file",
+        "model_id",
         "name",
         "password",
         "path",

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -950,6 +950,12 @@ struct TranscriptedSettingsView: View {
         }
         trackSettingsAction("generate_local_meeting_summary", page: .home)
         let provider = localMeetingSummaryProvider
+        let summaryStartedAt = Date()
+        trackLocalSummaryAnalytics(
+            event: "local_summary_requested",
+            provider: provider,
+            result: "requested"
+        )
         recordLocalSummaryEvent(
             event: "local_meeting_summary_started",
             message: "\(provider.title) meeting summary started",
@@ -1007,6 +1013,12 @@ struct TranscriptedSettingsView: View {
                         "profile": result.profileName,
                     ]
                 )
+                trackLocalSummaryAnalytics(
+                    event: "local_summary_finished",
+                    provider: result.provider,
+                    result: "success",
+                    duration: Date().timeIntervalSince(summaryStartedAt)
+                )
                 refreshRecentCapturesAfterLocalSummary()
             } catch is CancellationError {
                 recordLocalSummaryEvent(
@@ -1015,6 +1027,13 @@ struct TranscriptedSettingsView: View {
                     context: [
                         "provider": provider.rawValue,
                     ]
+                )
+                trackLocalSummaryAnalytics(
+                    event: "local_summary_failed",
+                    provider: provider,
+                    result: "cancelled",
+                    duration: Date().timeIntervalSince(summaryStartedAt),
+                    failureKind: "cancelled"
                 )
                 return
             } catch {
@@ -1028,6 +1047,13 @@ struct TranscriptedSettingsView: View {
                         "error": error.localizedDescription,
                     ]
                 )
+                trackLocalSummaryAnalytics(
+                    event: "local_summary_failed",
+                    provider: provider,
+                    result: "failed",
+                    duration: Date().timeIntervalSince(summaryStartedAt),
+                    failureKind: LocalSummaryTelemetry.failureKind(for: error)
+                )
                 NSSound.beep()
                 presentHomeLocalSummaryNotice(
                     HomeLocalSummaryNotice(
@@ -1038,6 +1064,27 @@ struct TranscriptedSettingsView: View {
                 )
             }
         }
+    }
+
+    private func trackLocalSummaryAnalytics(
+        event: String,
+        provider: LocalMeetingSummaryProvider,
+        result: String,
+        duration: TimeInterval? = nil,
+        failureKind: String? = nil
+    ) {
+        var properties = [
+            "model_family": LocalSummaryTelemetry.modelFamily(for: provider),
+            "provider": provider.rawValue,
+            "result": result,
+        ]
+        if let duration {
+            properties["duration_bucket"] = AnalyticsReporter.durationBucket(seconds: duration)
+        }
+        if let failureKind {
+            properties["failure_kind"] = failureKind
+        }
+        AnalyticsReporter.track(event, properties: properties)
     }
 
     private func presentHomeMeetingPreview(_ item: RecentMeetingItem) {

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -138,6 +138,52 @@ func testAnalyticsEventPolicy() {
         assertNil(sanitized["word_count"], "raw counts should stay out of activation analytics")
     }
 
+    runSuite("AnalyticsEventPolicy allows privacy-safe local summary telemetry") {
+        let requested = AnalyticsEventPolicy.policy(forEvent: "local_summary_requested")
+        let finished = AnalyticsEventPolicy.policy(forEvent: "local_summary_finished")
+        let failed = AnalyticsEventPolicy.policy(forEvent: "local_summary_failed")
+        let expected: Set<String> = [
+            "duration_bucket",
+            "failure_kind",
+            "model_family",
+            "provider",
+            "result",
+        ]
+
+        assertEqual(requested?.allowedProperties ?? Set<String>(), expected, "summary requests should use the reviewed local summary payload")
+        assertEqual(finished?.allowedProperties ?? Set<String>(), expected, "summary finishes should use the reviewed local summary payload")
+        assertEqual(failed?.allowedProperties ?? Set<String>(), expected, "summary failures should use the reviewed local summary payload")
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "provider": "gemmaMLX",
+                "model_family": "gemma",
+                "duration_bucket": "10_29m",
+                "result": "failed",
+                "failure_kind": "timeout",
+                "transcript": "private transcript text",
+                "title": "Customer roadmap call",
+                "speaker_name": "Maya",
+                "file_path": "/Users/redbars/Library/Application Support/Transcripted/captures/meetings/private.md",
+                "model_path": "/Users/redbars/.cache/huggingface/models/private",
+                "model_id": "mlx-community/gemma-4-12B-it-4bit",
+            ],
+            allowedKeys: expected.union(["transcript", "title", "speaker_name", "file_path", "model_path", "model_id"])
+        )
+
+        assertEqual(sanitized["provider"], "gemmaMLX", "provider enum should survive")
+        assertEqual(sanitized["model_family"], "gemma", "model family should survive")
+        assertEqual(sanitized["duration_bucket"], "10_29m", "duration bucket should survive")
+        assertEqual(sanitized["result"], "failed", "coarse result should survive")
+        assertEqual(sanitized["failure_kind"], "timeout", "failure taxonomy should survive")
+        assertNil(sanitized["transcript"], "raw transcript text must not be sent")
+        assertNil(sanitized["title"], "meeting titles must not be sent")
+        assertNil(sanitized["speaker_name"], "speaker names must not be sent")
+        assertNil(sanitized["file_path"], "file paths must not be sent")
+        assertNil(sanitized["model_path"], "local model paths must not be sent")
+        assertNil(sanitized["model_id"], "exact model IDs should stay out of local summary analytics")
+    }
+
     runSuite("ActivationTelemetry buckets artifact age, first-artifact saves, and next-day return proxy") {
         let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
         let suiteName = "ActivationTelemetryTests.first-artifact.\(UUID().uuidString)"

--- a/Tests/LocalMeetingSummarizerTests.swift
+++ b/Tests/LocalMeetingSummarizerTests.swift
@@ -86,6 +86,39 @@ func testLocalMeetingSummarizer() async {
         }
     }
 
+    runSuite("LocalSummaryTelemetry uses coarse model families and failure kinds") {
+        assertEqual(
+            LocalSummaryTelemetry.modelFamily(for: .gemmaMLX),
+            "gemma",
+            "Gemma summaries should report only the coarse model family"
+        )
+        assertEqual(
+            LocalSummaryTelemetry.modelFamily(for: .appleFoundation),
+            "apple_foundation",
+            "Apple summaries should report only the coarse provider family"
+        )
+        assertEqual(
+            LocalSummaryTelemetry.failureKind(for: LocalMeetingSummaryError.transcriptChanged),
+            "transcript_changed",
+            "stale transcript failures should have a stable taxonomy"
+        )
+        assertEqual(
+            LocalSummaryTelemetry.failureKind(for: LocalMeetingSummaryError.processTimedOut(label: "direct")),
+            "timeout",
+            "timeouts should not expose prompt labels or stderr"
+        )
+        assertEqual(
+            LocalSummaryTelemetry.failureKind(for: CancellationError()),
+            "cancelled",
+            "cancelled summaries should stay distinguishable from model failures"
+        )
+        assertEqual(
+            LocalSummaryTelemetry.failureKind(for: NSError(domain: "private", code: 1)),
+            "unknown",
+            "unknown errors should collapse before analytics"
+        )
+    }
+
     runSuite("LocalMeetingSummarySetupStatus reports runtime and low-memory readiness") {
         let gib = UInt64(1024 * 1024 * 1024)
         let temporaryDirectory = FileManager.default.temporaryDirectory

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -102,6 +102,9 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `activation_agent_prompt_action_clicked`
 - `activation_agent_setup_cta_clicked`
 - `activation_return_proxy_observed`
+- `local_summary_requested`
+- `local_summary_finished`
+- `local_summary_failed`
 - `menu_bar_opened`
 - `menu_bar_action_clicked`
 - `update_action_clicked`
@@ -158,6 +161,11 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 Meeting workflow analytics should keep that same stable `trigger` enum on later
 stop/save/fail events so product and reliability reviews can attribute outcomes
 without joining against any sensitive context.
+
+Local summary analytics are limited to request / finish / failure stages with
+`provider`, coarse `model_family`, `duration_bucket`, `result`, and normalized
+`failure_kind`. They must not include transcript text, meeting title, speaker
+names, file paths, local model paths, exact model IDs, prompts, or raw errors.
 
 Anything richer than that should stay local unless there is a new explicit
 privacy review and a matching allowlist change.


### PR DESCRIPTION
## Summary
- add PostHog allowlist entries for `local_summary_requested`, `local_summary_finished`, and `local_summary_failed`
- emit local summary telemetry from the Home summary flow with provider, model family, result, duration bucket, and normalized failure kind only
- tighten analytics sanitization so exact `model_id` keys fail closed, and document the local summary privacy contract

## Privacy guardrails
- no transcript text, meeting title, speaker name, file path, local model path, exact model ID, prompt, or raw error is sent
- `LocalMeetingSummarizer.swift` keeps only pure provider/failure classification so standalone fixture/E2E compiles stay local-only

## Tests / checks
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `bash run-e2e-smoke.sh`
- `bash scripts/ops/run-local-summary-fixture.sh`
- focused: `bash run-tests.sh --filter LocalMeetingSummarizer`, `bash run-tests.sh --filter AnalyticsEventPolicy`, `bash run-tests.sh --filter AnalyticsPayloadSanitizerTests`

## Codex review
- `codex-review` initially found a real standalone E2E compile gap from putting analytics directly in `LocalMeetingSummarizer.swift`; fixed by moving PostHog calls to the Home/UI flow and verified with E2E + fixture smoke.
- Final rerun was blocked by local Codex usage limit until 2:00 PM, so this PR is draft pending a clean final review rerun.
