### PR TITLE
Add settings feature discovery telemetry

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -146,6 +146,12 @@ struct AnalyticsEventPolicy: Equatable {
         "surface",
     ]
 
+    private static let settingsFeatureDiscoveryProperties: Set<String> = [
+        "feature_area",
+        "page_id",
+        "source",
+    ]
+
     private static let meetingPromptProperties: Set<String> = [
         "app_signal",
         "calendar_confidence",
@@ -433,6 +439,10 @@ struct AnalyticsEventPolicy: Equatable {
                 "page_id",
                 "source",
             ]
+        ),
+        "settings_feature_discovered": .init(
+            name: "settings_feature_discovered",
+            allowedProperties: settingsFeatureDiscoveryProperties
         ),
         "settings_action_clicked": .init(
             name: "settings_action_clicked",

--- a/Sources/Observability/FeatureDiscoveryTelemetry.swift
+++ b/Sources/Observability/FeatureDiscoveryTelemetry.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+enum FeatureDiscoveryTelemetry {
+    static let trackedKeyPrefix = "settingsFeatureDiscovered."
+
+    enum FeatureArea: String, CaseIterable {
+        case agentSetup = "agent_setup"
+        case betaSummaries = "beta_summaries"
+        case captureLibrary = "capture_library"
+        case localArtifactActions = "local_artifact_actions"
+        case permissions
+        case speakerReview = "speaker_review"
+        case support
+        case updateSettings = "update_settings"
+    }
+
+    @discardableResult
+    static func trackIfNeeded(
+        featureArea: FeatureArea,
+        pageID: String,
+        source: String,
+        userDefaults: UserDefaults = .standard
+    ) -> Bool {
+        let key = trackedKeyPrefix + featureArea.rawValue
+        guard !userDefaults.bool(forKey: key) else { return false }
+
+        userDefaults.set(true, forKey: key)
+        AnalyticsReporter.track(
+            "settings_feature_discovered",
+            properties: [
+                "feature_area": featureArea.rawValue,
+                "page_id": pageID,
+                "source": source,
+            ]
+        )
+        return true
+    }
+
+    @discardableResult
+    static func markDiscoveredIfNeeded(
+        featureArea: FeatureArea,
+        userDefaults: UserDefaults = .standard
+    ) -> Bool {
+        let key = trackedKeyPrefix + featureArea.rawValue
+        guard !userDefaults.bool(forKey: key) else { return false }
+
+        userDefaults.set(true, forKey: key)
+        return true
+    }
+}

--- a/Sources/UI/Settings/TranscriptedSettingsNavigationModel.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsNavigationModel.swift
@@ -6,10 +6,12 @@ import Observation
 final class TranscriptedSettingsNavigationModel {
     var selectedPage: TranscriptedSettingsPage
     var presentedPage: TranscriptedSettingsPage
+    var presentationSource: String
     var presentationID = UUID()
 
     init(selectedPage: TranscriptedSettingsPage = .home) {
         self.selectedPage = selectedPage
         self.presentedPage = selectedPage
+        self.presentationSource = "unknown"
     }
 }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -264,7 +264,11 @@ struct TranscriptedSettingsView: View {
         .task(id: navigation.presentationID) {
             refreshState()
             expandGeneralDisclosureForPresentedPage()
-            trackSettingsPageViewed(navigation.selectedPage, source: "presentation")
+            trackSettingsPageViewed(
+                navigation.selectedPage,
+                source: navigation.presentationSource,
+                discoveredPage: navigation.presentedPage
+            )
         }
         .onChange(of: navigation.selectedPage) { oldPage, page in
             if oldPage == .people && page != .people {
@@ -277,7 +281,12 @@ struct TranscriptedSettingsView: View {
             if pageShowsAutoEnterSettings(page) {
                 refreshAutoEnterPreferences(includeCandidates: true)
             }
-            trackSettingsPageViewed(page, source: "navigation")
+            let isPresentationSelectionChange = page == navigation.presentedPage.consolidatedDestination
+            trackSettingsPageViewed(
+                page,
+                source: "navigation",
+                trackFeatureDiscovery: !isPresentationSelectionChange
+            )
         }
         .onChange(of: meetingSession.lastSavedTranscriptURL) { _, newURL in
             refreshRecentCaptures(force: true)
@@ -4202,7 +4211,12 @@ struct TranscriptedSettingsView: View {
         }
     }
 
-    private func trackSettingsPageViewed(_ page: TranscriptedSettingsPage, source: String) {
+    private func trackSettingsPageViewed(
+        _ page: TranscriptedSettingsPage,
+        source: String,
+        discoveredPage: TranscriptedSettingsPage? = nil,
+        trackFeatureDiscovery: Bool = true
+    ) {
         AnalyticsReporter.track(
             "settings_page_viewed",
             properties: [
@@ -4210,6 +4224,8 @@ struct TranscriptedSettingsView: View {
                 "source": source,
             ]
         )
+        guard trackFeatureDiscovery else { return }
+        trackSettingsFeatureDiscovery(for: discoveredPage ?? page, source: source)
     }
 
     private func trackSettingsAction(_ actionID: String, page: TranscriptedSettingsPage? = nil) {
@@ -4242,6 +4258,39 @@ struct TranscriptedSettingsView: View {
                 "prior_status": permissionStates[kind] == true ? "ready" : "pending",
             ]
         )
+    }
+
+    private func trackSettingsFeatureDiscovery(for page: TranscriptedSettingsPage, source: String) {
+        guard let featureArea = settingsDiscoveryFeatureArea(for: page) else { return }
+
+        FeatureDiscoveryTelemetry.trackIfNeeded(
+            featureArea: featureArea,
+            pageID: page.analyticsValue,
+            source: source
+        )
+    }
+
+    private func settingsDiscoveryFeatureArea(for page: TranscriptedSettingsPage) -> FeatureDiscoveryTelemetry.FeatureArea? {
+        switch page {
+        case .home, .dictations:
+            return .localArtifactActions
+        case .people:
+            return .speakerReview
+        case .storage:
+            return .captureLibrary
+        case .connectAgent:
+            return .agentSetup
+        case .beta:
+            return .betaSummaries
+        case .privacy:
+            return .permissions
+        case .support:
+            return .support
+        case .about:
+            return .updateSettings
+        case .general, .models, .shortcuts:
+            return nil
+        }
     }
 
     private func refreshPermissions() {

--- a/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsWindowController.swift
@@ -52,6 +52,7 @@ final class TranscriptedSettingsWindowController: NSWindowController, NSWindowDe
         speakerPeopleModel.refresh()
         navigationModel.presentedPage = page
         navigationModel.selectedPage = presentedPage
+        navigationModel.presentationSource = source
         navigationModel.presentationID = UUID()
         AnalyticsReporter.track(
             "settings_opened",

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -183,6 +183,7 @@ func testAnalyticsEventPolicy() {
         let menuAction = AnalyticsEventPolicy.policy(forEvent: "menu_bar_action_clicked")
         let settingsOpened = AnalyticsEventPolicy.policy(forEvent: "settings_opened")
         let settingsPage = AnalyticsEventPolicy.policy(forEvent: "settings_page_viewed")
+        let settingsFeature = AnalyticsEventPolicy.policy(forEvent: "settings_feature_discovered")
         let settingsAction = AnalyticsEventPolicy.policy(forEvent: "settings_action_clicked")
         let settingsToggle = AnalyticsEventPolicy.policy(forEvent: "settings_toggle_changed")
         let settingsPermission = AnalyticsEventPolicy.policy(forEvent: "settings_permission_cta_clicked")
@@ -195,6 +196,7 @@ func testAnalyticsEventPolicy() {
         assertEqual(menuAction?.allowedProperties.contains("action_id"), true, "menu clicks should preserve the clicked action")
         assertEqual(settingsOpened?.allowedProperties.contains("source"), true, "settings opens should preserve entry source")
         assertEqual(settingsPage?.allowedProperties.contains("page_id"), true, "settings page views should preserve page id")
+        assertEqual(settingsFeature?.allowedProperties ?? Set<String>(), ["feature_area", "page_id", "source"], "feature discovery should preserve only the area, page, and source")
         assertEqual(settingsAction?.allowedProperties.contains("action_id"), true, "settings actions should preserve action id")
         assertEqual(settingsToggle?.allowedProperties.contains("setting_id"), true, "settings toggles should preserve setting id")
         assertEqual(settingsPermission?.allowedProperties.contains("permission_kind"), true, "settings permission CTAs should preserve permission kind")
@@ -212,23 +214,44 @@ func testAnalyticsEventPolicy() {
                 "automatic_downloads_enabled": "true",
                 "failure_code": "sparkle_2003",
                 "failure_kind": "feed_unreachable",
+                "feature_area": "agent_setup",
                 "page_id": "home",
                 "setting_id": "menu_bar_start_dictation",
                 "source": "menu_bar",
                 "state": "ready_to_install",
                 "surface": "settings_about",
             ],
-            allowedKeys: ["action_id", "automatic_downloads_enabled", "failure_code", "failure_kind", "page_id", "setting_id", "source", "state", "surface"]
+            allowedKeys: ["action_id", "automatic_downloads_enabled", "failure_code", "failure_kind", "feature_area", "page_id", "setting_id", "source", "state", "surface"]
         )
         assertEqual(sanitized["action_id"], "start_dictation", "action ids should survive sanitization")
         assertEqual(sanitized["automatic_downloads_enabled"], "true", "automatic update download state should survive sanitization")
         assertEqual(sanitized["failure_code"], "sparkle_2003", "coarse update failure codes should survive sanitization")
         assertEqual(sanitized["failure_kind"], "feed_unreachable", "update failure kind should survive sanitization")
+        assertEqual(sanitized["feature_area"], "agent_setup", "feature-area enums should survive sanitization")
         assertEqual(sanitized["page_id"], "home", "page ids should survive sanitization")
         assertEqual(sanitized["setting_id"], "menu_bar_start_dictation", "setting ids should survive sanitization")
         assertEqual(sanitized["source"], "menu_bar", "source enums should survive sanitization")
         assertEqual(sanitized["state"], "ready_to_install", "update state should survive sanitization")
         assertEqual(sanitized["surface"], "settings_about", "update surface should survive sanitization")
+    }
+
+    runSuite("FeatureDiscoveryTelemetry tracks each high-leverage feature once") {
+        let suiteName = "FeatureDiscoveryTelemetryTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        assertTrue(
+            FeatureDiscoveryTelemetry.markDiscoveredIfNeeded(featureArea: .agentSetup, userDefaults: defaults),
+            "first discovery should be recorded"
+        )
+        assertFalse(
+            FeatureDiscoveryTelemetry.markDiscoveredIfNeeded(featureArea: .agentSetup, userDefaults: defaults),
+            "same feature discovery should not be recorded twice"
+        )
+        assertTrue(
+            FeatureDiscoveryTelemetry.markDiscoveredIfNeeded(featureArea: .captureLibrary, userDefaults: defaults),
+            "a different feature area should still be recorded"
+        )
     }
 
     runSuite("AnalyticsEventPolicy allows update download lifecycle attribution") {

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -114,6 +114,7 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `update_installed`
 - `settings_opened`
 - `settings_page_viewed`
+- `settings_feature_discovered`
 - `settings_action_clicked`
 - `settings_toggle_changed`
 - `settings_permission_cta_clicked`
@@ -154,6 +155,8 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - retry attempt buckets like `start_attempt_bucket`, not raw retry counts
 - normalized failure kinds like `system_audio`, `recording_too_short`, `other`
 - normalized failure-code buckets like `url_-1009`, `sparkle_2003`, `other_42`
+- feature discovery enums like `agent_setup`, `beta_summaries`,
+  `capture_library`, `permissions`, `speaker_review`, and `update_settings`
 
 Meeting workflow analytics should keep that same stable `trigger` enum on later
 stop/save/fail events so product and reliability reviews can attribute outcomes

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -324,6 +324,7 @@ APP_SOURCES=(
     "Sources/UI/MenuBar/MenuBarHeaderLayoutPolicy.swift"
     "Sources/Observability/AnalyticsReporter.swift"
     "Sources/Observability/ActivationTelemetry.swift"
+    "Sources/Observability/FeatureDiscoveryTelemetry.swift"
     "Sources/Observability/LockedFileAppender.swift"
     "Sources/Observability/JSONLWriter.swift"
     "Sources/Observability/AnalyticsEventPolicy.swift"


### PR DESCRIPTION
## Summary
- Add `settings_feature_discovered` as a once-per-feature-area discovery event for high-leverage Settings/Home surfaces.
- Track feature areas: `local_artifact_actions`, `speaker_review`, `capture_library`, `agent_setup`, `beta_summaries`, `permissions`, `support`, and `update_settings`.
- Preserve real entry source for programmatic settings opens so first discovery is not misattributed as generic navigation.

## Privacy
- Payload is limited to `feature_area`, `page_id`, and `source`.
- No raw paths, app names, people, transcript text, URLs, file IDs, meeting titles, speaker names, or free text.
- Event and properties are allowlisted in `AnalyticsEventPolicy`; docs and sanitizer coverage were updated.

## Why These Features Matter
- Agent setup: tells whether users find the path from saved Markdown to an agent that can use it.
- Beta summaries: tells whether users discover local AI summaries without tracking transcript content.
- Capture library/storage: tells whether users find where files live and how to point tools at them.
- Permissions: tells whether users find recovery/setup controls for capture and pasteback.
- Update settings: tells whether users find the in-app update controls.
- Speaker review: tells whether users find the cleanup path for who-said-what.
- Local artifact actions: tells whether users find Home/Dictations as the place to open/reveal saved files.
- Support: tells whether users find feedback/diagnostics without measuring support-message content.

## Verification
- `git fetch origin main --prune`
- `bash build-deps.sh --force`
- `bash -n run-tests.sh && bash -n scripts/entrypoints/run-tests.sh`
- `bash build.sh --no-open`
- `bash run-tests.sh` (5713 passed)
- `bash scripts/dev/agent-preflight.sh`

## Codex Review
- Ran `/Users/redbars/.codex/skills/codex-review/scripts/codex-review --full-access`.
- Accepted finding: first discovery could be attributed to `navigation` before a programmatic presentation source landed.
- Fix: presentation-target page changes skip discovery in the navigation path so the presentation task records the real source.
- Reran `bash build.sh --no-open` and `bash run-tests.sh` after the fix.
- Clean review rerun is blocked by Codex usage limit until 2:00 PM; this PR is draft until that rerun completes.
