### PR TITLE
Distinguish telemetry build channels

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -89,6 +89,8 @@ struct AnalyticsEventPolicy: Equatable {
 
     private static let runtimeDiagnosticProperties: Set<String> = [
         "app_version",
+        "build_channel",
+        "build_revision",
         "build_version",
         "duration_bucket",
         "format_ready",

--- a/Sources/Observability/AnalyticsReporter.swift
+++ b/Sources/Observability/AnalyticsReporter.swift
@@ -19,6 +19,10 @@ private struct AnalyticsCaptureRequest: Encodable {
 enum AnalyticsRuntimeConfiguration {
     static let apiKeyInfoKey = "TranscriptedPostHogAPIKey"
     static let hostInfoKey = "TranscriptedPostHogHost"
+    static let buildChannelInfoKey = "TranscriptedBuildChannel"
+    static let buildRevisionInfoKey = "TranscriptedBuildRevision"
+    static let buildChannelEnvironmentKey = "TRANSCRIPTED_ANALYTICS_BUILD_CHANNEL"
+    static let buildRevisionEnvironmentKey = "TRANSCRIPTED_ANALYTICS_BUILD_REVISION"
     private static let localOverridesFileName = "observability-overrides.plist"
 
     static func apiKey() -> String? {
@@ -35,6 +39,26 @@ enum AnalyticsRuntimeConfiguration {
             localOverrideValue(forKey: hostInfoKey),
             Bundle.main.object(forInfoDictionaryKey: hostInfoKey) as? String
         )
+    }
+
+    static func buildChannel(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        infoDictionary: [String: Any]? = Bundle.main.infoDictionary
+    ) -> String {
+        firstSafeBuildMetadata(
+            environment[buildChannelEnvironmentKey],
+            infoDictionary?[buildChannelInfoKey] as? String
+        ) ?? "unknown"
+    }
+
+    static func buildRevision(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        infoDictionary: [String: Any]? = Bundle.main.infoDictionary
+    ) -> String {
+        firstSafeBuildMetadata(
+            environment[buildRevisionEnvironmentKey],
+            infoDictionary?[buildRevisionInfoKey] as? String
+        ) ?? "unknown"
     }
 
     static func localOverrideValue(forKey key: String) -> String? {
@@ -76,6 +100,22 @@ enum AnalyticsRuntimeConfiguration {
         candidates
             .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
             .first(where: { !$0.isEmpty })
+    }
+
+    private static func firstSafeBuildMetadata(_ candidates: String?...) -> String? {
+        candidates
+            .compactMap { value -> String? in
+                guard let trimmed = firstNonEmpty(value),
+                      trimmed.count <= 80,
+                      trimmed.allSatisfy({ character in
+                          character.isLetter || character.isNumber || character == "." || character == "_" || character == "-"
+                      }),
+                      AnalyticsPayloadSanitizer.sanitizeText(trimmed) == trimmed else {
+                    return nil
+                }
+                return trimmed
+            }
+            .first
     }
 }
 
@@ -179,6 +219,8 @@ final class AnalyticsReporter {
             "distinct_id": distinctID,
             "app_version": infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown",
             "build_version": infoDictionary?["CFBundleVersion"] as? String ?? "unknown",
+            "build_channel": AnalyticsRuntimeConfiguration.buildChannel(infoDictionary: infoDictionary),
+            "build_revision": AnalyticsRuntimeConfiguration.buildRevision(infoDictionary: infoDictionary),
             "os_major": "\(operatingSystemVersion.majorVersion)",
         ]
 

--- a/Sources/Observability/RuntimeDiagnostics.swift
+++ b/Sources/Observability/RuntimeDiagnostics.swift
@@ -36,6 +36,8 @@ final class RuntimeDiagnostics {
         marker = RuntimeDiagnosticsStore.makeLaunchMarker(
             appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown",
             buildVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown",
+            buildChannel: AnalyticsRuntimeConfiguration.buildChannel(),
+            buildRevision: AnalyticsRuntimeConfiguration.buildRevision(),
             osMajor: ProcessInfo.processInfo.operatingSystemVersion.majorVersion
         )
         persist(event: "app_launched")

--- a/Sources/Observability/RuntimeDiagnosticsStore.swift
+++ b/Sources/Observability/RuntimeDiagnosticsStore.swift
@@ -4,6 +4,8 @@ struct RuntimeDiagnosticsMarker: Codable, Equatable {
     var launchID: String
     var appVersion: String
     var buildVersion: String
+    var buildChannel: String?
+    var buildRevision: String?
     var osMajor: Int
     var cleanShutdown: Bool
     var startedAt: Date
@@ -26,6 +28,8 @@ enum RuntimeDiagnosticsStore {
         launchID: String = UUID().uuidString,
         appVersion: String,
         buildVersion: String,
+        buildChannel: String? = nil,
+        buildRevision: String? = nil,
         osMajor: Int,
         now: Date = Date()
     ) -> RuntimeDiagnosticsMarker {
@@ -33,6 +37,8 @@ enum RuntimeDiagnosticsStore {
             launchID: launchID,
             appVersion: appVersion,
             buildVersion: buildVersion,
+            buildChannel: buildChannel,
+            buildRevision: buildRevision,
             osMajor: osMajor,
             cleanShutdown: false,
             startedAt: now,
@@ -118,7 +124,7 @@ enum RuntimeDiagnosticsStore {
         for marker: RuntimeDiagnosticsMarker,
         now: Date
     ) -> [String: String] {
-        [
+        var context = [
             "app_version": marker.appVersion,
             "build_version": marker.buildVersion,
             "heartbeat_age_bucket": heartbeatAgeBucket(previousUpdate: marker.updatedAt, now: now),
@@ -129,6 +135,15 @@ enum RuntimeDiagnosticsStore {
             "session_kind": marker.sessionKind,
             "session_stage": marker.sessionStage,
         ]
+
+        if let buildChannel = marker.buildChannel, !buildChannel.isEmpty {
+            context["build_channel"] = buildChannel
+        }
+        if let buildRevision = marker.buildRevision, !buildRevision.isEmpty {
+            context["build_revision"] = buildRevision
+        }
+
+        return context
     }
 
     static func shouldReportUncleanShutdown(

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -71,6 +71,8 @@ func testAnalyticsEventPolicy() {
             "automatic_downloads_enabled",
             "available",
             "backoff_kind",
+            "build_channel",
+            "build_revision",
             "build_version",
             "calendar_confidence",
             "calendar_status",

--- a/Tests/AnalyticsReporterTests.swift
+++ b/Tests/AnalyticsReporterTests.swift
@@ -64,6 +64,8 @@ func testAnalyticsReporter() {
             infoDictionary: [
                 "CFBundleShortVersionString": "1.2.3",
                 "CFBundleVersion": "456",
+                AnalyticsRuntimeConfiguration.buildChannelInfoKey: "local",
+                AnalyticsRuntimeConfiguration.buildRevisionInfoKey: "abc123def456",
             ],
             operatingSystemVersion: OperatingSystemVersion(majorVersion: 15, minorVersion: 4, patchVersion: 0)
         )
@@ -71,8 +73,54 @@ func testAnalyticsReporter() {
         assertEqual(properties["distinct_id"], "anonymous-device", "distinct id should be included")
         assertEqual(properties["app_version"], "1.2.3", "app version should be included")
         assertEqual(properties["build_version"], "456", "build version should be included")
+        assertEqual(properties["build_channel"], "local", "build channel should distinguish local builds from shipped builds")
+        assertEqual(properties["build_revision"], "abc123def456", "build revision should distinguish same-version main builds")
         assertEqual(properties["os_major"], "15", "OS major version should be included")
         assertEqual(properties["session_id"], "session-1", "sanitized session id should be included")
+    }
+
+    runSuite("AnalyticsRuntimeConfiguration accepts safe local build metadata overrides") {
+        let info: [String: Any] = [
+            AnalyticsRuntimeConfiguration.buildChannelInfoKey: "release",
+            AnalyticsRuntimeConfiguration.buildRevisionInfoKey: "abc123def456",
+        ]
+        let environment = [
+            AnalyticsRuntimeConfiguration.buildChannelEnvironmentKey: "local",
+            AnalyticsRuntimeConfiguration.buildRevisionEnvironmentKey: "main.20260619",
+        ]
+
+        assertEqual(
+            AnalyticsRuntimeConfiguration.buildChannel(environment: environment, infoDictionary: info),
+            "local",
+            "local analytics build channel override should win"
+        )
+        assertEqual(
+            AnalyticsRuntimeConfiguration.buildRevision(environment: environment, infoDictionary: info),
+            "main.20260619",
+            "local analytics build revision override should win"
+        )
+    }
+
+    runSuite("AnalyticsRuntimeConfiguration rejects unsafe build metadata") {
+        let info: [String: Any] = [
+            AnalyticsRuntimeConfiguration.buildChannelInfoKey: "/Users/jane/build",
+            AnalyticsRuntimeConfiguration.buildRevisionInfoKey: "person@example.com",
+        ]
+        let environment = [
+            AnalyticsRuntimeConfiguration.buildChannelEnvironmentKey: "release\nbeta",
+            AnalyticsRuntimeConfiguration.buildRevisionEnvironmentKey: "sk-private",
+        ]
+
+        assertEqual(
+            AnalyticsRuntimeConfiguration.buildChannel(environment: environment, infoDictionary: info),
+            "unknown",
+            "unsafe build channels should not become analytics metadata"
+        )
+        assertEqual(
+            AnalyticsRuntimeConfiguration.buildRevision(environment: environment, infoDictionary: info),
+            "unknown",
+            "unsafe build revisions should not become analytics metadata"
+        )
     }
 
     runSuite("AnalyticsReporter keeps caller build metadata over current defaults") {
@@ -106,6 +154,8 @@ func testAnalyticsReporter() {
 
         assertEqual(properties["app_version"], "unknown", "missing app version should not remove default metadata")
         assertEqual(properties["build_version"], "unknown", "missing build version should not remove default metadata")
+        assertEqual(properties["build_channel"], "unknown", "missing build channel should not remove default metadata")
+        assertEqual(properties["build_revision"], "unknown", "missing build revision should not remove default metadata")
         assertEqual(properties["os_major"], "15", "OS major version should still be present")
     }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1191,6 +1191,11 @@ func testRepoCommandContract() {
             "local builds should not clobber exported Sentry runtime overrides before launch smoke"
         )
         assertTrue(
+            localBuildScript.contains("TranscriptedBuildChannel local")
+                && localBuildScript.contains("TranscriptedBuildRevision"),
+            "local builds should stamp analytics metadata so same-version main builds do not look shipped"
+        )
+        assertTrue(
             betaBuildScript.contains("sentry-release-metadata.py --format shell Info.plist")
                 && betaBuildScript.contains("REGISTER_SENTRY_RELEASE")
                 && betaBuildScript.contains("APP_DSYM")
@@ -1203,6 +1208,11 @@ func testRepoCommandContract() {
                 && betaBuildScript.contains("SENTRY_REQUIRE_DEBUG_FILES")
                 && betaBuildScript.contains("register-sentry-release.sh \"$APP_VERSION\""),
             "distribution builds should surface the Sentry release/dist, generate dSYMs, and support explicit registration"
+        )
+        assertTrue(
+            betaBuildScript.contains("TranscriptedBuildChannel release")
+                && betaBuildScript.contains("TranscriptedBuildRevision"),
+            "distribution builds should stamp release-channel analytics metadata without changing Sparkle versioning"
         )
     }
 

--- a/Tests/RuntimeDiagnosticsStoreTests.swift
+++ b/Tests/RuntimeDiagnosticsStoreTests.swift
@@ -6,6 +6,8 @@ func testRuntimeDiagnosticsStore() {
             launchID: "launch-1",
             appVersion: "1.2.3",
             buildVersion: "456",
+            buildChannel: "local",
+            buildRevision: "abc123def456",
             osMajor: 26,
             cleanShutdown: false,
             startedAt: Date(timeIntervalSince1970: 1_000),
@@ -23,6 +25,8 @@ func testRuntimeDiagnosticsStore() {
 
         assertEqual(context["app_version"], "1.2.3", "context should keep app version")
         assertEqual(context["build_version"], "456", "context should keep build version")
+        assertEqual(context["build_channel"], "local", "context should keep build channel")
+        assertEqual(context["build_revision"], "abc123def456", "context should keep build revision")
         assertEqual(context["heartbeat_age_bucket"], "1_4m", "context should bucket heartbeat age")
         assertEqual(context["last_event"], "dictation_recording", "context should keep last runtime event")
         assertEqual(context["session_active"], "true", "context should keep whether a session was active")
@@ -33,6 +37,8 @@ func testRuntimeDiagnosticsStore() {
             Set(context.keys),
             [
                 "app_version",
+                "build_channel",
+                "build_revision",
                 "build_version",
                 "heartbeat_age_bucket",
                 "last_event",
@@ -55,6 +61,8 @@ func testRuntimeDiagnosticsStore() {
             launchID: "launch-2",
             appVersion: "1.2.4",
             buildVersion: "457",
+            buildChannel: "release",
+            buildRevision: "def456abc123",
             osMajor: 26,
             cleanShutdown: false,
             startedAt: Date(timeIntervalSince1970: 2_000),
@@ -72,6 +80,8 @@ func testRuntimeDiagnosticsStore() {
 
         assertEqual(context["app_version"], "1.2.4", "context should keep app version")
         assertEqual(context["build_version"], "457", "context should keep build version")
+        assertEqual(context["build_channel"], "release", "context should keep build channel")
+        assertEqual(context["build_revision"], "def456abc123", "context should keep build revision")
         assertEqual(context["heartbeat_age_bucket"], "15_59s", "context should bucket heartbeat age")
         assertEqual(context["last_event"], "meeting_transcribing", "context should keep last runtime event")
         assertEqual(context["previous_clean_shutdown"], "false", "context should keep current marker clean flag")
@@ -86,6 +96,8 @@ func testRuntimeDiagnosticsStore() {
             launchID: "launch-secret",
             appVersion: "1.2.5",
             buildVersion: "458",
+            buildChannel: "release",
+            buildRevision: "abc123def456",
             osMajor: 26,
             cleanShutdown: true,
             startedAt: Date(timeIntervalSince1970: 3_000),
@@ -105,6 +117,8 @@ func testRuntimeDiagnosticsStore() {
             Set(context.keys),
             [
                 "app_version",
+                "build_channel",
+                "build_revision",
                 "build_version",
                 "heartbeat_age_bucket",
                 "last_event",

--- a/scripts/entrypoints/build-beta.sh
+++ b/scripts/entrypoints/build-beta.sh
@@ -441,6 +441,11 @@ fi
 
 # Copy Info.plist
 cp Info.plist "$APP_BUNDLE/Contents/"
+/usr/libexec/PlistBuddy -c "Set :TranscriptedBuildChannel release" "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null \
+    || /usr/libexec/PlistBuddy -c "Add :TranscriptedBuildChannel string release" "$APP_BUNDLE/Contents/Info.plist"
+BUILD_REVISION="$(git rev-parse --short=12 HEAD 2>/dev/null || printf 'unknown')"
+/usr/libexec/PlistBuddy -c "Set :TranscriptedBuildRevision $BUILD_REVISION" "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null \
+    || /usr/libexec/PlistBuddy -c "Add :TranscriptedBuildRevision string $BUILD_REVISION" "$APP_BUNDLE/Contents/Info.plist"
 
 # Copy bundled app resources (custom sounds, etc.) when present
 if [ -d "Resources" ]; then

--- a/scripts/entrypoints/build.sh
+++ b/scripts/entrypoints/build.sh
@@ -430,6 +430,11 @@ fi
 
 # Copy Info.plist
 cp Info.plist "$APP_BUNDLE/Contents/"
+/usr/libexec/PlistBuddy -c "Set :TranscriptedBuildChannel local" "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null \
+    || /usr/libexec/PlistBuddy -c "Add :TranscriptedBuildChannel string local" "$APP_BUNDLE/Contents/Info.plist"
+BUILD_REVISION="$(git rev-parse --short=12 HEAD 2>/dev/null || printf 'unknown')"
+/usr/libexec/PlistBuddy -c "Set :TranscriptedBuildRevision $BUILD_REVISION" "$APP_BUNDLE/Contents/Info.plist" 2>/dev/null \
+    || /usr/libexec/PlistBuddy -c "Add :TranscriptedBuildRevision string $BUILD_REVISION" "$APP_BUNDLE/Contents/Info.plist"
 
 # Copy bundled app resources (custom sounds, etc.) when present
 if [ -d "Resources" ]; then


### PR DESCRIPTION
## Summary
- stamp copied app bundles with `TranscriptedBuildChannel` and `TranscriptedBuildRevision` during local and beta/distribution builds
- include `build_channel` and `build_revision` in default PostHog properties so current-main/local telemetry is separable from shipped `1.1.48`
- persist the same build metadata in runtime diagnostics markers so previous-session diagnostic analytics keep the right build identity

## Release-surface safety
- Did not change committed `Info.plist` version fields, `docs/appcast.xml`, Homebrew cask, tags, GitHub releases, notarization, or deployment.
- `build.sh --no-open` printed Sentry metadata `transcripted@1.1.48` / dist `1.1.48`.
- `SKIP_NOTARIZATION=1 bash build-beta.sh '' Codex` produced only a local unnotarized DMG and left Sparkle/Homebrew untouched.
- Built local app plist proof: `CFBundleShortVersionString=1.1.48`, `TranscriptedBuildChannel=local`, `TranscriptedBuildRevision=4ad53b9bd7ae`.
- Packaged app plist proof: `CFBundleShortVersionString=1.1.48`, `TranscriptedBuildChannel=release`, `TranscriptedBuildRevision=4ad53b9bd7ae`.

## Tests / checks
- `git fetch origin main --prune`
- Read required docs: `AGENT_START.md`, `AGENTS.md`, `Sources/Observability/CLAUDE.md`, `docs/release-packaging.md`, `docs/sparkle-updates.md`, `.agents/test-matrix.yml`
- `bash -n build.sh`
- `bash -n scripts/entrypoints/build.sh`
- `bash -n build-beta.sh`
- `bash -n scripts/entrypoints/build-beta.sh`
- `scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (5721 passed, 0 failed)
- `SKIP_NOTARIZATION=1 bash build-beta.sh '' Codex`
- `python3 scripts/ops/nightly-security-check.py --strict --live-release-surfaces` (100/100)
- `python3 scripts/ops/nightly-security-check.py --strict --require-sentry-release-health` (100/100)
- `git diff --check`

## Review note
- `codex review --uncommitted` was attempted. The first pass exited 0 but emitted no clean final verdict; the partial trace highlighted that runtime diagnostics did not carry the new build metadata, which this PR fixed. A second captured pass hung and was terminated; no additional findings were produced.
