### PR TITLE
Restore Core audio boundary with initializer fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -66,7 +66,6 @@ let package = Package(
                 .linkedFramework("CoreML"),
                 .linkedFramework("CoreAudio"),
                 .linkedFramework("AVFoundation"),
-                .linkedFramework("AppKit"),
                 .linkedFramework("Network"),
                 .linkedFramework("ScreenCaptureKit"),
             ]
@@ -105,7 +104,6 @@ let package = Package(
                 .linkedFramework("CoreML"),
                 .linkedFramework("CoreAudio"),
                 .linkedFramework("AVFoundation"),
-                .linkedFramework("AppKit"),
                 .linkedFramework("Network"),
                 .linkedFramework("ScreenCaptureKit"),
             ]

--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -46,8 +46,14 @@ final class MeetingCaptureBridge: ObservableObject {
     private let startAttempt = MeetingCaptureAttempt<Bool>()
     private var timedOutStopCompletionHandler: ((CaptureStopResult) -> Void)?
 
-    init(audio: Audio = Audio()) {
-        self.audio = audio
+    init(audio: Audio? = nil) {
+        self.audio = audio ?? Audio(
+            sleepWakeNotifications: AudioSleepWakeNotifications(
+                center: NSWorkspace.shared.notificationCenter,
+                willSleepName: Notification.Name("NSWorkspaceWillSleepNotification"),
+                didWakeName: Notification.Name("NSWorkspaceDidWakeNotification")
+            )
+        )
         wireCallbacks()
         wireSubscriptions()
     }

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -711,9 +711,11 @@ public class Audio: ObservableObject, @unchecked Sendable {
 
     init(
         paths: CoreStoragePaths = .default,
-        systemAudioCaptureForTesting systemAudioCapture: (any SystemAudioCaptureEngine & Sendable)?
+        systemAudioCaptureForTesting systemAudioCapture: (any SystemAudioCaptureEngine & Sendable)?,
+        sleepWakeNotifications: AudioSleepWakeNotifications = .macOSWorkspace
     ) {
         self.paths = paths
+        self.sleepWakeNotifications = sleepWakeNotifications
         self.recordingJournal = MeetingRecordingJournalStore(directory: paths.audioCaptures)
         self.systemAudioCapture = systemAudioCapture
         if let systemAudioCapture {

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -1,7 +1,6 @@
 import Foundation
 import QuartzCore
 @preconcurrency import AVFoundation
-import AppKit
 import CoreAudio
 import Combine
 
@@ -129,6 +128,31 @@ public enum AudioInputTapTeardownPolicy {
             ? [.stopEngine, .waitForStoppedInputCallbacks, .removeInputTap]
             : [.removeInputTap]
     }
+}
+
+/// Host-provided sleep/wake notifications for recording gap tracking.
+///
+/// The default uses macOS workspace notification names without importing
+/// AppKit, so `TranscriptedCore` stays a reusable library boundary.
+public struct AudioSleepWakeNotifications: Sendable {
+    public let center: NotificationCenter
+    public let willSleepName: Notification.Name
+    public let didWakeName: Notification.Name
+
+    public init(
+        center: NotificationCenter = .default,
+        willSleepName: Notification.Name,
+        didWakeName: Notification.Name
+    ) {
+        self.center = center
+        self.willSleepName = willSleepName
+        self.didWakeName = didWakeName
+    }
+
+    public static let macOSWorkspace = AudioSleepWakeNotifications(
+        willSleepName: Notification.Name("NSWorkspaceWillSleepNotification"),
+        didWakeName: Notification.Name("NSWorkspaceDidWakeNotification")
+    )
 }
 
 /// Main audio recording class that captures microphone and system audio
@@ -669,14 +693,19 @@ public class Audio: ObservableObject, @unchecked Sendable {
     /// Filesystem layout used for writing raw mic/system WAV captures.
     /// Embedders can redirect captures by passing a custom `CoreStoragePaths` at init.
     let paths: CoreStoragePaths
+    private let sleepWakeNotifications: AudioSleepWakeNotifications
 
     /// Durable record of the in-flight recording for crash recovery. Lives
     /// next to the scratch audio; cleared once the meeting reaches a durable
     /// state (transcript saved or failed-queue entry persisted).
     let recordingJournal: MeetingRecordingJournalStore
 
-    public init(paths: CoreStoragePaths = .default) {
+    public init(
+        paths: CoreStoragePaths = .default,
+        sleepWakeNotifications: AudioSleepWakeNotifications = .macOSWorkspace
+    ) {
         self.paths = paths
+        self.sleepWakeNotifications = sleepWakeNotifications
         self.recordingJournal = MeetingRecordingJournalStore(directory: paths.audioCaptures)
     }
 
@@ -717,8 +746,8 @@ public class Audio: ObservableObject, @unchecked Sendable {
         // MARK: - Sleep/Wake Observers (Phase 1: Invisible Reliability)
         // Handle macOS sleep/wake to prevent AVAudioEngine crashes and log gaps
 
-        sleepObserver = NotificationCenter.default.addObserver(
-            forName: NSWorkspace.willSleepNotification,
+        sleepObserver = sleepWakeNotifications.center.addObserver(
+            forName: sleepWakeNotifications.willSleepName,
             object: nil,
             queue: .main
         ) { [weak self] _ in
@@ -727,8 +756,8 @@ public class Audio: ObservableObject, @unchecked Sendable {
             self.sleepTimestamp = Date()
         }
 
-        wakeObserver = NotificationCenter.default.addObserver(
-            forName: NSWorkspace.didWakeNotification,
+        wakeObserver = sleepWakeNotifications.center.addObserver(
+            forName: sleepWakeNotifications.didWakeName,
             object: nil,
             queue: .main
         ) { [weak self] _ in
@@ -1358,10 +1387,10 @@ public class Audio: ObservableObject, @unchecked Sendable {
     deinit {
         // Remove sleep/wake observers to prevent leaks
         if let observer = sleepObserver {
-            NotificationCenter.default.removeObserver(observer)
+            sleepWakeNotifications.center.removeObserver(observer)
         }
         if let observer = wakeObserver {
-            NotificationCenter.default.removeObserver(observer)
+            sleepWakeNotifications.center.removeObserver(observer)
         }
         timer?.invalidate()
         watchdogTimer?.invalidate()

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -559,6 +559,45 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - TranscriptedCore stays free of app UI frameworks") {
+        let disallowedImports = [
+            "import AppKit",
+            "import SwiftUI",
+            "import Cocoa",
+            "import UIKit"
+        ]
+        let matches = repoTextFiles(relativeTo: repoRootURL())
+            .filter { $0.hasPrefix("Sources/TranscriptedCore/") && $0.hasSuffix(".swift") }
+            .flatMap { file -> [String] in
+                let contents = readRepoTextFile(file)
+                return contents
+                    .split(separator: "\n", omittingEmptySubsequences: false)
+                    .enumerated()
+                    .compactMap { index, line in
+                        let trimmed = line.trimmingCharacters(in: .whitespaces)
+                        return disallowedImports.contains(trimmed) ? "\(file):\(index + 1)" : nil
+                    }
+            }
+
+        assertEqual(matches, [], "TranscriptedCore should not import app UI frameworks")
+
+        let packageManifest = readRepoTextFile("Package.swift")
+        assertFalse(
+            packageManifest.contains(".linkedFramework(\"AppKit\")"),
+            "TranscriptedCore package should not link AppKit"
+        )
+    }
+
+    runSuite("Repo command contract - app bridge injects workspace sleep wake notifications") {
+        let bridge = readRepoTextFile("Sources/Meeting/MeetingCaptureBridge.swift")
+        assertTrue(
+            bridge.contains("center: NSWorkspace.shared.notificationCenter")
+                && bridge.contains("willSleepName: Notification.Name(\"NSWorkspaceWillSleepNotification\")")
+                && bridge.contains("didWakeName: Notification.Name(\"NSWorkspaceDidWakeNotification\")"),
+            "app-side meeting bridge should keep NSWorkspace notification center ownership out of TranscriptedCore"
+        )
+    }
+
     runSuite("Repo command contract - microphone permission callback cannot start after cancellation") {
         let contents = readRepoTextFile("Sources/TranscriptedCore/Audio/Audio.swift")
         assertTrue(


### PR DESCRIPTION
This repairs the race from #1203: the emergency revert landed before the narrow fix branch update was recognized by GitHub.\n\nChanges:\n- restore the #1189 Core/AppKit boundary work\n- keep TranscriptedCore free of AppKit\n- initialize AudioSleepWakeNotifications in the injected Audio test initializer before any self method call\n\nLocal verification:\n- bash build-deps.sh --force\n- bash build.sh --no-open\n- bash run-tests.sh\n- bash run-integration-smoke.sh\n- swift test