### PR TITLE
Add analytics taxonomy guardrails

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -14,6 +14,12 @@ struct AnalyticsEventPolicy: Equatable {
         allowedPolicies.keys.sorted()
     }
 
+    /// All allowlisted analytics policies, sorted by event name. Tests use this
+    /// to keep the public taxonomy doc in lockstep with the compiled allowlist.
+    static var allPolicies: [AnalyticsEventPolicy] {
+        allowedPolicies.keys.sorted().compactMap { allowedPolicies[$0] }
+    }
+
     private static let meetingCaptureDiagnosticProperties: Set<String> = [
         "attenuation_kind",
         "buffer_success_bucket",

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -14,6 +14,203 @@ func testAnalyticsEventPolicy() {
         )
     }
 
+    runSuite("AnalyticsEventPolicy taxonomy blocks sensitive property names") {
+        let forbiddenFragments = [
+            "audio_path",
+            "audio_ref",
+            "authorization",
+            "bundle",
+            "credential",
+            "device_id",
+            "distinct_id",
+            "email",
+            "file",
+            "filename",
+            "identity",
+            "invitee",
+            "meeting_title",
+            "person_id",
+            "raw_url",
+            "referrer",
+            "speaker",
+            "source_app",
+            "text",
+            "title",
+            "token",
+            "transcript",
+            "url",
+            "user_id",
+        ]
+        let properties = allAllowedAnalyticsPropertyNames()
+
+        for property in properties {
+            let normalized = property.lowercased()
+            for fragment in forbiddenFragments {
+                assertFalse(
+                    normalized.contains(fragment),
+                    "\(property) should not include forbidden analytics fragment \(fragment)"
+                )
+            }
+        }
+    }
+
+    runSuite("AnalyticsEventPolicy taxonomy requires reviewed non-bucket property shapes") {
+        let reviewedNonBucketProperties: Set<String> = [
+            "action",
+            "action_id",
+            "action_kind",
+            "agent_cta",
+            "agent_target",
+            "analytics_available",
+            "anonymous_usage_enabled",
+            "app_signal",
+            "app_version",
+            "artifact_kind",
+            "attenuation_kind",
+            "auto_send",
+            "automatic_downloads_enabled",
+            "available",
+            "backoff_kind",
+            "build_version",
+            "calendar_confidence",
+            "calendar_status",
+            "call_state",
+            "capture_activity",
+            "capture_quality",
+            "captured_input_volume_before",
+            "captured_input_volume_changed",
+            "captured_input_volume_dropped",
+            "captured_input_volume_during",
+            "cleanup_changed",
+            "cleanup_enabled",
+            "completion_flow",
+            "cooldown_reason",
+            "copy_reason",
+            "crash_reporting_available",
+            "crash_reporting_enabled",
+            "cta",
+            "cta_type",
+            "default_input_class",
+            "default_input_volume_after",
+            "default_input_volume_before",
+            "default_input_volume_changed",
+            "default_input_volume_dropped",
+            "default_input_volume_during",
+            "default_output_class",
+            "default_output_volume_after",
+            "default_output_volume_before",
+            "default_output_volume_changed",
+            "default_output_volume_dropped",
+            "default_output_volume_during",
+            "default_system_output_volume_after",
+            "default_system_output_volume_before",
+            "default_system_output_volume_changed",
+            "default_system_output_volume_dropped",
+            "default_system_output_volume_during",
+            "delivery",
+            "dictation_ready",
+            "enabled",
+            "entrypoint",
+            "failure_code",
+            "failure_kind",
+            "first_dictation_saved",
+            "format_ready",
+            "from_status",
+            "has_target",
+            "hfp_suspected",
+            "import_stage",
+            "input_channels",
+            "input_device_class",
+            "input_rate_hz",
+            "input_volume_scalar_available",
+            "last_event",
+            "location_type",
+            "meeting_dry_run_completed",
+            "meeting_recording_ready",
+            "mic_boost_prompt",
+            "mic_processed_peak",
+            "mic_processing",
+            "mic_raw_peak",
+            "mic_recovering",
+            "mic_status",
+            "mic_stream_present",
+            "missing_permission",
+            "model_state",
+            "os_major",
+            "outcome",
+            "output_channels",
+            "output_device_class",
+            "output_ducking_detected",
+            "output_rate_hz",
+            "page_id",
+            "paste_available",
+            "pasteback_status",
+            "permission_kind",
+            "previous_clean_shutdown",
+            "previous_version",
+            "prior_artifact_kind",
+            "prior_status",
+            "prompt_kind",
+            "prompt_reason",
+            "provider",
+            "proxy_kind",
+            "quiet_mic_recovered",
+            "quiet_mic_unrecovered",
+            "realtime_agc",
+            "reason",
+            "recent_meetings_available",
+            "recovering",
+            "reporting_kind",
+            "required",
+            "result",
+            "route_ready",
+            "route_shape",
+            "sample_flow_started",
+            "save_outcome",
+            "selected_input_class",
+            "selection_overrode_default",
+            "selection_reason",
+            "session_active",
+            "session_kind",
+            "session_stage",
+            "setting_id",
+            "setup_kind",
+            "source",
+            "stall_kind",
+            "stall_stage",
+            "state",
+            "step_id",
+            "step_index",
+            "stop_timed_out",
+            "suppression_reason",
+            "surface",
+            "system_backend",
+            "system_channels",
+            "system_failed",
+            "system_output_device_class",
+            "system_output_rate_hz",
+            "system_peak",
+            "system_rate_hz",
+            "system_status",
+            "system_stream_present",
+            "to_status",
+            "trigger",
+            "update_state",
+            "version",
+            "voice_processing",
+            "voice_processing_active",
+            "was_recording",
+        ]
+        let properties = allAllowedAnalyticsPropertyNames()
+
+        for property in properties where !property.hasSuffix("_bucket") {
+            assertTrue(
+                reviewedNonBucketProperties.contains(property),
+                "\(property) must be explicitly reviewed as an enum, boolean, public version, count, or coarse numeric diagnostic"
+            )
+        }
+    }
+
     runSuite("AnalyticsEventPolicy allows explicit onboarding funnel events") {
         let shown = AnalyticsEventPolicy.policy(forEvent: "onboarding_shown")
         let stepViewed = AnalyticsEventPolicy.policy(forEvent: "onboarding_step_viewed")
@@ -986,6 +1183,10 @@ private func documentedAnalyticsEvents() -> [String] {
 
         return String(trimmed.dropFirst(3).dropLast())
     }
+}
+
+private func allAllowedAnalyticsPropertyNames() -> [String] {
+    Set(AnalyticsEventPolicy.allPolicies.flatMap { $0.allowedProperties }).sorted()
 }
 
 private func markdownSection(named heading: String, in text: String) -> String {

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -162,6 +162,40 @@ without joining against any sensitive context.
 Anything richer than that should stay local unless there is a new explicit
 privacy review and a matching allowlist change.
 
+## Analytics taxonomy review checklist
+
+Every analytics change should update `AnalyticsEventPolicy.swift` and this doc
+in the same PR. `Tests/AnalyticsEventPolicyTests.swift` machine-checks the
+event-name list above and the compiled property taxonomy.
+
+For each new or changed event:
+
+- document the event name in "Allowlisted analytics events"
+- keep event names stable once released; add a new event instead of changing the
+  meaning of an old one
+- use enum, bucket, boolean, or count-bucket properties whenever possible
+- use raw numeric diagnostics only for reviewed audio-health shape, such as
+  sample rate, channel count, scalar volume, or peak buckets needed to debug
+  capture reliability
+- route activation and return-loop events through `ActivationTelemetry` when
+  possible so saved-artifact and agent-payoff signals stay coarse
+- verify `bash run-tests.sh --filter AnalyticsEventPolicy` and
+  `bash run-tests.sh --filter AnalyticsPayloadSanitizer`
+
+Never add analytics properties for:
+
+- transcript text or prompt text
+- audio data, audio paths, or audio references
+- meeting titles
+- speaker names or invitee names
+- absolute file paths or filenames derived from user content
+- source app names or bundle IDs
+- emails, tokens, authorization values, or credentials
+- raw URLs or referrers
+- raw device IDs, advertising IDs, person IDs, user IDs, distinct IDs, or
+  identity-stitching fields
+- free-form error strings or free-form context blobs
+
 ## Nightly guardrail sweep
 
 The nightly security automation should start with the deterministic checker:


### PR DESCRIPTION
## Summary
- expose the compiled analytics policy table to tests so taxonomy checks use source truth
- add fast-test guardrails that block forbidden analytics property names and require reviewed non-bucket property shapes
- add a privacy-first analytics taxonomy checklist for future PostHog changes

## Current risk / gaps found
- Current allowlisting and sanitizer coverage were already strong for event names and sensitive payload scrubbing.
- Gap: docs only machine-checked event names, not property taxonomy shape, so future raw properties could rely on runtime sanitizer drops instead of being caught in review.
- Gap: future analytics PRs did not have a compact review checklist tied to the test gate.

## Verification
- PASS: bash run-tests.sh --filter AnalyticsEventPolicy
- PASS: bash run-tests.sh --filter AnalyticsPayloadSanitizer
- PASS: bash run-tests.sh
- PASS: bash scripts/dev/agent-preflight.sh
- PASS: git diff --check
- PASS: codex review --uncommitted — no discrete correctness issue found; review reran AnalyticsEventPolicy focused tests
- BLOCKED: bash build.sh --no-open. It required bash build-deps.sh --force; build-deps failed twice in current TranscriptedCore state at Sources/TranscriptedCore/Audio/Audio.swift because sleepWakeNotifications is not initialized before init returns / self is used before all stored properties are initialized. This patch does not touch that file.