### PR TITLE
Add workflow completion analytics

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -461,6 +461,13 @@ final class MeetingSessionController: ObservableObject {
                 "meeting_recording_start_failed",
                 properties: failureProperties
             )
+            WorkflowTelemetry.trackFinished(
+                workflowKind: .meeting,
+                result: .failed,
+                stage: "start",
+                trigger: trigger.rawValue,
+                failureKind: meetingStartFailureKind(from: failureMessage)
+            )
             state = .error(failureMessage)
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "start_failed")
             return false
@@ -487,6 +494,11 @@ final class MeetingSessionController: ObservableObject {
                 ["trigger": trigger.rawValue],
                 uniquingKeysWith: { _, new in new }
             )
+        )
+        WorkflowTelemetry.trackStarted(
+            workflowKind: .meeting,
+            entrypoint: trigger.rawValue,
+            trigger: trigger.rawValue
         )
         return true
     }
@@ -1152,6 +1164,13 @@ final class MeetingSessionController: ObservableObject {
                     "import_stage": "preparation",
                 ]
             )
+            WorkflowTelemetry.trackFinished(
+                workflowKind: .meeting,
+                result: .failed,
+                stage: "import",
+                trigger: StartTrigger.fileImport.rawValue,
+                failureKind: failureKind
+            )
             state = .error(displayMessage)
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "file_import_failed")
             return false
@@ -1184,6 +1203,11 @@ final class MeetingSessionController: ObservableObject {
             properties: [
                 "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
             ]
+        )
+        WorkflowTelemetry.trackStarted(
+            workflowKind: .meeting,
+            entrypoint: StartTrigger.fileImport.rawValue,
+            trigger: StartTrigger.fileImport.rawValue
         )
         Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "transcribing")
         return true
@@ -1455,6 +1479,16 @@ final class MeetingSessionController: ObservableObject {
                 "mic_stream_present": boolString(micAudioURL != nil),
                 "trigger": StartTrigger.savedMeetingRetranscription.rawValue
             ]
+        )
+        WorkflowTelemetry.trackRecoveryAttempted(
+            workflowKind: .meeting,
+            recoveryKind: "saved_audio_retranscription",
+            trigger: StartTrigger.savedMeetingRetranscription.rawValue
+        )
+        WorkflowTelemetry.trackStarted(
+            workflowKind: .meeting,
+            entrypoint: StartTrigger.savedMeetingRetranscription.rawValue,
+            trigger: StartTrigger.savedMeetingRetranscription.rawValue
         )
 
         if case .idle = state {
@@ -2544,6 +2578,12 @@ final class MeetingSessionController: ObservableObject {
                     "trigger": transcriptionTrigger.rawValue,
                 ]
             )
+            WorkflowTelemetry.trackFinished(
+                workflowKind: .meeting,
+                result: .success,
+                stage: "transcript_save",
+                trigger: transcriptionTrigger.rawValue
+            )
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "transcript_saved")
             AppSoundPlayer.shared.play(.meetingTranscriptComplete)
             activeQueuedTranscriptionJobID = nil
@@ -2577,6 +2617,13 @@ final class MeetingSessionController: ObservableObject {
                 AnalyticsReporter.track(
                     "meeting_transcript_skipped",
                     properties: failureTelemetryContext
+                )
+                WorkflowTelemetry.trackFinished(
+                    workflowKind: .meeting,
+                    result: .failed,
+                    stage: "transcription",
+                    trigger: transcriptionTrigger.rawValue,
+                    failureKind: failureKind.rawValue
                 )
                 activeTranscriptionCaptureDiagnostics = nil
                 Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: failureKind.rawValue)
@@ -2615,6 +2662,13 @@ final class MeetingSessionController: ObservableObject {
                         "trigger": transcriptionTrigger.rawValue,
                     ]
                 )
+                WorkflowTelemetry.trackFinished(
+                    workflowKind: .meeting,
+                    result: .partialSuccess,
+                    stage: "speaker_finalization",
+                    trigger: transcriptionTrigger.rawValue,
+                    failureKind: failureKind.rawValue
+                )
                 activeTranscriptionCaptureDiagnostics = nil
                 Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "speaker_finalization_failed")
                 finalizeBackgroundTranscriptionStateIfNeeded()
@@ -2647,6 +2701,13 @@ final class MeetingSessionController: ObservableObject {
             AnalyticsReporter.track(
                 "meeting_transcript_failed",
                 properties: failureTelemetryContext
+            )
+            WorkflowTelemetry.trackFinished(
+                workflowKind: .meeting,
+                result: .failed,
+                stage: "transcription",
+                trigger: transcriptionTrigger.rawValue,
+                failureKind: failureKind.rawValue
             )
             activeTranscriptionCaptureDiagnostics = nil
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "transcript_failed")

--- a/Sources/Observability/ActivationTelemetry.swift
+++ b/Sources/Observability/ActivationTelemetry.swift
@@ -170,6 +170,18 @@ enum ActivationTelemetry {
         priorStatus: AgentSetupPriorStatus = .unknown,
         result: AgentSetupResult = .success
     ) {
+        WorkflowTelemetry.trackStarted(
+            workflowKind: .agentSetup,
+            entrypoint: setupKind.rawValue,
+            trigger: surface.rawValue
+        )
+        WorkflowTelemetry.trackFinished(
+            workflowKind: .agentSetup,
+            result: result.workflowResult,
+            stage: "setup_cta",
+            trigger: surface.rawValue,
+            failureKind: result.workflowFailureKind
+        )
         AnalyticsReporter.track(
             "activation_agent_setup_cta_clicked",
             properties: [
@@ -238,5 +250,111 @@ enum ActivationTelemetry {
         default:
             return "older"
         }
+    }
+}
+
+private extension ActivationTelemetry.AgentSetupResult {
+    var workflowResult: WorkflowTelemetry.Result {
+        switch self {
+        case .success:
+            return .success
+        case .fallbackCopied:
+            return .partialSuccess
+        case .failed:
+            return .failed
+        }
+    }
+
+    var workflowFailureKind: String? {
+        switch self {
+        case .success:
+            return nil
+        case .fallbackCopied:
+            return "fallback_copied"
+        case .failed:
+            return "setup_failed"
+        }
+    }
+}
+
+enum WorkflowTelemetry {
+    enum WorkflowKind: String {
+        case agentSetup = "agent_setup"
+        case dictation
+        case localSummary = "local_summary"
+        case meeting
+    }
+
+    enum Result: String {
+        case abandoned
+        case failed
+        case partialSuccess = "partial_success"
+        case success
+    }
+
+    static func trackStarted(
+        workflowKind: WorkflowKind,
+        entrypoint: String,
+        trigger: String? = nil
+    ) {
+        var properties = [
+            "entrypoint": entrypoint,
+            "workflow_kind": workflowKind.rawValue,
+        ]
+        if let trigger {
+            properties["trigger"] = trigger
+        }
+
+        AnalyticsReporter.track("workflow_started", properties: properties)
+    }
+
+    static func trackFinished(
+        workflowKind: WorkflowKind,
+        result: Result,
+        stage: String,
+        trigger: String? = nil,
+        failureKind: String? = nil,
+        durationBucket: String? = nil,
+        wordCountBucket: String? = nil
+    ) {
+        var properties = [
+            "result": result.rawValue,
+            "stage": stage,
+            "workflow_kind": workflowKind.rawValue,
+        ]
+        if let trigger {
+            properties["trigger"] = trigger
+        }
+        if let failureKind {
+            properties["failure_kind"] = failureKind
+        }
+        if let durationBucket {
+            properties["duration_bucket"] = durationBucket
+        }
+        if let wordCountBucket {
+            properties["word_count_bucket"] = wordCountBucket
+        }
+
+        AnalyticsReporter.track("workflow_finished", properties: properties)
+    }
+
+    static func trackRecoveryAttempted(
+        workflowKind: WorkflowKind,
+        recoveryKind: String,
+        trigger: String? = nil,
+        priorFailureKind: String? = nil
+    ) {
+        var properties = [
+            "recovery_kind": recoveryKind,
+            "workflow_kind": workflowKind.rawValue,
+        ]
+        if let trigger {
+            properties["trigger"] = trigger
+        }
+        if let priorFailureKind {
+            properties["prior_failure_kind"] = priorFailureKind
+        }
+
+        AnalyticsReporter.track("workflow_recovery_attempted", properties: properties)
     }
 }

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -146,6 +146,24 @@ struct AnalyticsEventPolicy: Equatable {
         "surface",
     ]
 
+    private static let workflowLifecycleProperties: Set<String> = [
+        "duration_bucket",
+        "entrypoint",
+        "failure_kind",
+        "result",
+        "stage",
+        "trigger",
+        "word_count_bucket",
+        "workflow_kind",
+    ]
+
+    private static let workflowRecoveryProperties: Set<String> = [
+        "prior_failure_kind",
+        "recovery_kind",
+        "trigger",
+        "workflow_kind",
+    ]
+
     private static let meetingPromptProperties: Set<String> = [
         "app_signal",
         "calendar_confidence",
@@ -332,6 +350,18 @@ struct AnalyticsEventPolicy: Equatable {
         "activation_return_proxy_observed": .init(
             name: "activation_return_proxy_observed",
             allowedProperties: activationReturnProxyProperties
+        ),
+        "workflow_started": .init(
+            name: "workflow_started",
+            allowedProperties: workflowLifecycleProperties
+        ),
+        "workflow_finished": .init(
+            name: "workflow_finished",
+            allowedProperties: workflowLifecycleProperties
+        ),
+        "workflow_recovery_attempted": .init(
+            name: "workflow_recovery_attempted",
+            allowedProperties: workflowRecoveryProperties
         ),
         "menu_bar_opened": .init(
             name: "menu_bar_opened",

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -180,6 +180,11 @@ class DictationSessionController: ObservableObject {
                 ]
             )
         )
+        WorkflowTelemetry.trackStarted(
+            workflowKind: .dictation,
+            entrypoint: trigger.rawValue,
+            trigger: trigger.rawValue
+        )
     }
 
     private func trackDictationStartFailed(
@@ -195,6 +200,13 @@ class DictationSessionController: ObservableObject {
             properties: dictationAnalyticsProperties(
                 extra: properties
             )
+        )
+        WorkflowTelemetry.trackFinished(
+            workflowKind: .dictation,
+            result: .failed,
+            stage: "start",
+            trigger: currentDictationTrigger.rawValue,
+            failureKind: failureKind
         )
     }
 
@@ -895,6 +907,14 @@ class DictationSessionController: ObservableObject {
                         ]
                     )
                 )
+                WorkflowTelemetry.trackFinished(
+                    workflowKind: .dictation,
+                    result: .failed,
+                    stage: "transcription",
+                    trigger: currentDictationTrigger.rawValue,
+                    failureKind: "no_speech",
+                    durationBucket: AnalyticsReporter.durationBucket(seconds: CFAbsoluteTimeGetCurrent() - sessionStartTime)
+                )
                 NotificationCenter.default.post(name: .dictationNoSpeechDetected, object: nil)
                 AppSoundPlayer.shared.play(.noSpeech)
                 overlayController.showNoSpeechAndDismiss(trigger: currentDictationTrigger.rawValue)
@@ -1012,6 +1032,21 @@ class DictationSessionController: ObservableObject {
                     ]
                 )
             )
+            let workflowResult: WorkflowTelemetry.Result = saveFailureMessage == nil && pasteOutcome.delivery != .failed
+                ? .success
+                : .partialSuccess
+            let workflowFailureKind: String? = saveFailureMessage != nil
+                ? "markdown_save_failed"
+                : (pasteOutcome.delivery == .failed ? "delivery_failed" : nil)
+            WorkflowTelemetry.trackFinished(
+                workflowKind: .dictation,
+                result: workflowResult,
+                stage: "delivery",
+                trigger: currentDictationTrigger.rawValue,
+                failureKind: workflowFailureKind,
+                durationBucket: AnalyticsReporter.durationBucket(seconds: CFAbsoluteTimeGetCurrent() - sessionStartTime),
+                wordCountBucket: AnalyticsReporter.wordCountBucket(wordCount)
+            )
             if saveFailureMessage == nil {
                 ActivationTelemetry.trackFirstArtifactSavedIfNeeded(
                     artifactKind: .dictation,
@@ -1062,6 +1097,14 @@ class DictationSessionController: ObservableObject {
                     "trigger": currentDictationTrigger.rawValue,
                 ]
             )
+        )
+        WorkflowTelemetry.trackFinished(
+            workflowKind: .dictation,
+            result: .abandoned,
+            stage: "recording",
+            trigger: currentDictationTrigger.rawValue,
+            failureKind: "user_cancelled",
+            durationBucket: AnalyticsReporter.durationBucket(seconds: CFAbsoluteTimeGetCurrent() - sessionStartTime)
         )
     }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -950,6 +950,11 @@ struct TranscriptedSettingsView: View {
         }
         trackSettingsAction("generate_local_meeting_summary", page: .home)
         let provider = localMeetingSummaryProvider
+        WorkflowTelemetry.trackStarted(
+            workflowKind: .localSummary,
+            entrypoint: hasExistingSummary ? "regenerate" : "generate",
+            trigger: "home"
+        )
         recordLocalSummaryEvent(
             event: "local_meeting_summary_started",
             message: "\(provider.title) meeting summary started",
@@ -1007,6 +1012,12 @@ struct TranscriptedSettingsView: View {
                         "profile": result.profileName,
                     ]
                 )
+                WorkflowTelemetry.trackFinished(
+                    workflowKind: .localSummary,
+                    result: .success,
+                    stage: "summary_save",
+                    trigger: "home"
+                )
                 refreshRecentCapturesAfterLocalSummary()
             } catch is CancellationError {
                 recordLocalSummaryEvent(
@@ -1016,9 +1027,17 @@ struct TranscriptedSettingsView: View {
                         "provider": provider.rawValue,
                     ]
                 )
+                WorkflowTelemetry.trackFinished(
+                    workflowKind: .localSummary,
+                    result: .abandoned,
+                    stage: "generation",
+                    trigger: "home",
+                    failureKind: "cancelled"
+                )
                 return
             } catch {
                 guard localMeetingSummariesEnabled else { return }
+                let failureKind = localSummaryWorkflowFailureKind(for: error)
                 recordLocalSummaryEvent(
                     level: .error,
                     event: "local_meeting_summary_failed",
@@ -1027,6 +1046,13 @@ struct TranscriptedSettingsView: View {
                         "provider": provider.rawValue,
                         "error": error.localizedDescription,
                     ]
+                )
+                WorkflowTelemetry.trackFinished(
+                    workflowKind: .localSummary,
+                    result: .failed,
+                    stage: "generation",
+                    trigger: "home",
+                    failureKind: failureKind
                 )
                 NSSound.beep()
                 presentHomeLocalSummaryNotice(
@@ -3396,6 +3422,33 @@ struct TranscriptedSettingsView: View {
             message: message,
             context: context
         )
+    }
+
+    private func localSummaryWorkflowFailureKind(for error: Error) -> String {
+        guard let summaryError = error as? LocalMeetingSummaryError else {
+            return "summary_failed"
+        }
+
+        switch summaryError {
+        case .emptyTranscript:
+            return "empty_transcript"
+        case .insufficientMemory:
+            return "insufficient_memory"
+        case .runtimeUnavailable:
+            return "runtime_unavailable"
+        case .appleFoundationUnavailable:
+            return "apple_foundation_unavailable"
+        case .missingBundledRunner:
+            return "missing_bundled_runner"
+        case .transcriptChanged:
+            return "transcript_changed"
+        case .processTimedOut:
+            return "timeout"
+        case .processFailed:
+            return "process_failed"
+        case .outputMissing:
+            return "output_missing"
+        }
     }
 
     private func openUVInstallGuide() {

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -138,6 +138,71 @@ func testAnalyticsEventPolicy() {
         assertNil(sanitized["word_count"], "raw counts should stay out of activation analytics")
     }
 
+    runSuite("AnalyticsEventPolicy allows coarse workflow lifecycle events") {
+        let started = AnalyticsEventPolicy.policy(forEvent: "workflow_started")
+        let finished = AnalyticsEventPolicy.policy(forEvent: "workflow_finished")
+        let recovery = AnalyticsEventPolicy.policy(forEvent: "workflow_recovery_attempted")
+
+        assertEqual(
+            started?.allowedProperties ?? Set<String>(),
+            ["duration_bucket", "entrypoint", "failure_kind", "result", "stage", "trigger", "word_count_bucket", "workflow_kind"],
+            "workflow starts should share the narrow lifecycle property set"
+        )
+        assertEqual(
+            finished?.allowedProperties ?? Set<String>(),
+            ["duration_bucket", "entrypoint", "failure_kind", "result", "stage", "trigger", "word_count_bucket", "workflow_kind"],
+            "workflow finishes should share the narrow lifecycle property set"
+        )
+        assertEqual(
+            recovery?.allowedProperties ?? Set<String>(),
+            ["prior_failure_kind", "recovery_kind", "trigger", "workflow_kind"],
+            "workflow recovery should stay enum-only"
+        )
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "workflow_kind": "meeting",
+                "entrypoint": "hotkey",
+                "trigger": "hotkey",
+                "stage": "transcript_save",
+                "result": "success",
+                "failure_kind": "no_speech",
+                "duration_bucket": "10_29m",
+                "word_count_bucket": "300_plus",
+                "recovery_kind": "saved_audio_retranscription",
+                "prior_failure_kind": "system_audio",
+                "transcript": "private words",
+                "meeting_title": "Customer call",
+                "speaker_name": "Alice",
+                "audio_path": "/Users/redbars/private.wav",
+                "file_path": "/Users/redbars/private.md",
+                "source_app_name": "Zoom",
+                "raw_duration_seconds": "1234",
+            ],
+            allowedKeys: (started?.allowedProperties ?? [])
+                .union(finished?.allowedProperties ?? [])
+                .union(recovery?.allowedProperties ?? [])
+        )
+
+        assertEqual(sanitized["workflow_kind"], "meeting", "workflow kind should survive")
+        assertEqual(sanitized["entrypoint"], "hotkey", "entrypoint enum should survive")
+        assertEqual(sanitized["trigger"], "hotkey", "trigger enum should survive")
+        assertEqual(sanitized["stage"], "transcript_save", "stage enum should survive")
+        assertEqual(sanitized["result"], "success", "result enum should survive")
+        assertEqual(sanitized["failure_kind"], "no_speech", "normalized failure kind should survive")
+        assertEqual(sanitized["duration_bucket"], "10_29m", "duration bucket should survive")
+        assertEqual(sanitized["word_count_bucket"], "300_plus", "word count bucket should survive")
+        assertEqual(sanitized["recovery_kind"], "saved_audio_retranscription", "recovery kind should survive")
+        assertEqual(sanitized["prior_failure_kind"], "system_audio", "prior failure kind should survive")
+        assertNil(sanitized["transcript"], "raw transcript text must not be sent")
+        assertNil(sanitized["meeting_title"], "meeting titles must not be sent")
+        assertNil(sanitized["speaker_name"], "speaker names must not be sent")
+        assertNil(sanitized["audio_path"], "audio paths must not be sent")
+        assertNil(sanitized["file_path"], "file paths must not be sent")
+        assertNil(sanitized["source_app_name"], "source app names must not be sent")
+        assertNil(sanitized["raw_duration_seconds"], "raw timings should stay out of workflow analytics")
+    }
+
     runSuite("ActivationTelemetry buckets artifact age, first-artifact saves, and next-day return proxy") {
         let now = Date(timeIntervalSinceReferenceDate: 1_000_000)
         let suiteName = "ActivationTelemetryTests.first-artifact.\(UUID().uuidString)"

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -102,6 +102,9 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `activation_agent_prompt_action_clicked`
 - `activation_agent_setup_cta_clicked`
 - `activation_return_proxy_observed`
+- `workflow_started`
+- `workflow_finished`
+- `workflow_recovery_attempted`
 - `menu_bar_opened`
 - `menu_bar_action_clicked`
 - `update_action_clicked`
@@ -158,6 +161,13 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 Meeting workflow analytics should keep that same stable `trigger` enum on later
 stop/save/fail events so product and reliability reviews can attribute outcomes
 without joining against any sensitive context.
+
+Generic workflow lifecycle events are the cross-product envelope for dictation,
+meetings, local summaries, and agent setup. They should only carry
+`workflow_kind`, `entrypoint`, `trigger`, `stage`, `result`,
+`failure_kind`, `recovery_kind`, and coarse duration/word-count buckets. Do not
+add transcript text, titles, source apps, raw paths, speaker names, audio
+references, or raw counts to these events.
 
 Anything richer than that should stay local unless there is a new explicit
 privacy review and a matching allowlist change.


### PR DESCRIPTION
## Summary
- add generic privacy-safe workflow envelope events: `workflow_started`, `workflow_finished`, and `workflow_recovery_attempted`
- emit dictation start/result events for start failure, no-speech, cancel, success, and partial delivery/save success
- emit meeting start/result/recovery events for recording, imported audio, saved-audio retranscription, transcript save, transcription failures, skipped transcripts, and speaker-finalization partial success
- emit local-summary workflow start/result events and agent-setup CTA start/result events
- update analytics allowlist, sanitizer-facing tests, and privacy docs

## Audit notes for #1187-#1202
Already covered by open analytics PRs: first/second artifact taxonomy, onboarding abandonment/exit, dictation retry, dictation Markdown save, speaker-review funnel, MCP agent query proof, local summary detailed events, settings discovery, and build-channel tagging. This PR only adds the cross-workflow start/result/recovery envelope on top.

## Privacy guardrails
- payloads are enum/bucket only: workflow_kind, entrypoint, trigger, stage, result, failure_kind, recovery_kind, duration_bucket, word_count_bucket
- no transcript text, audio refs, meeting titles, speaker names, source app names, file paths, raw URLs, emails, tokens, raw counts, or raw timings
- policy test includes adversarial private fields and proves they are dropped

## Verification
- `bash run-tests.sh --filter AnalyticsEventPolicyTests` -> 371 passed
- `bash run-tests.sh` -> 5747 passed
- `bash scripts/dev/agent-preflight.sh`
- `git diff --check`
- `/Users/redbars/.codex/skills/codex-review/scripts/codex-review --mode local` -> clean, no accepted/actionable findings

## Blocked mapped checks
- `bash build-deps.sh --force` failed on current-main `Sources/TranscriptedCore/Audio.swift`: `sleepWakeNotifications` not initialized / `self` used before all stored properties initialized. This matches live PR #1203 reverting #1189.
- `bash build.sh --no-open` then failed because the dependency bundle was missing/stale after the failed deps rebuild.
- `bash run-integration-smoke.sh` was not run because it depends on the rebuilt deps bundle.

No release publishing performed.
