### PR TITLE
Add product friction analytics

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -396,6 +396,13 @@ final class MeetingSessionController: ObservableObject {
 
         let startDecision = await resolveStartRecordingPermissionDecision(trigger: trigger)
         guard startDecision.canStart else {
+            ProductFrictionTelemetry.track(
+                surface: .meeting,
+                stage: "permission_start",
+                result: .blocked,
+                failureKind: startDecision.failureReason ?? "permissions",
+                modelState: state.diagnosticName
+            )
             DiagnosticsTrail.record(
                 level: .warning,
                 engine: "meeting",
@@ -460,6 +467,13 @@ final class MeetingSessionController: ObservableObject {
             AnalyticsReporter.track(
                 "meeting_recording_start_failed",
                 properties: failureProperties
+            )
+            ProductFrictionTelemetry.track(
+                surface: .meeting,
+                stage: "meeting_start",
+                result: .failed,
+                failureKind: failureProperties["failure_kind"],
+                modelState: state.diagnosticName
             )
             state = .error(failureMessage)
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "start_failed")
@@ -560,6 +574,13 @@ final class MeetingSessionController: ObservableObject {
         case .idle, .loadingModels, .error:
             await prepareModels()
             guard case .ready = state else {
+                ProductFrictionTelemetry.track(
+                    surface: .meeting,
+                    stage: "model_warmup",
+                    result: .blocked,
+                    failureKind: "model_not_ready",
+                    modelState: state.diagnosticName
+                )
                 DiagnosticsTrail.record(
                     level: .warning,
                     engine: "meeting",
@@ -574,6 +595,13 @@ final class MeetingSessionController: ObservableObject {
             if !isSpeechModelPreparedForSelection {
                 await prepareModels()
                 guard case .ready = state else {
+                    ProductFrictionTelemetry.track(
+                        surface: .meeting,
+                        stage: "model_warmup",
+                        result: .blocked,
+                        failureKind: "speech_model_not_ready",
+                        modelState: state.diagnosticName
+                    )
                     DiagnosticsTrail.record(
                         level: .warning,
                         engine: "meeting",
@@ -1076,6 +1104,14 @@ final class MeetingSessionController: ObservableObject {
                 uniquingKeysWith: { _, new in new }
             )
         )
+        ProductFrictionTelemetry.track(
+            surface: .meeting,
+            stage: "meeting_recording",
+            result: .cancelled,
+            failureKind: reason.rawValue,
+            elapsedBucket: AnalyticsReporter.durationBucket(seconds: recordingSnapshot.durationSeconds),
+            modelState: state.diagnosticName
+        )
         AnalyticsReporter.track(
             "meeting_capture_health_snapshot",
             properties: meetingCaptureHealthSnapshotProperties(
@@ -1151,6 +1187,13 @@ final class MeetingSessionController: ObservableObject {
                     "failure_kind": failureKind,
                     "import_stage": "preparation",
                 ]
+            )
+            ProductFrictionTelemetry.track(
+                surface: .meeting,
+                stage: "imported_audio_prepare",
+                result: .failed,
+                failureKind: failureKind,
+                modelState: state.diagnosticName
             )
             state = .error(displayMessage)
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "file_import_failed")
@@ -1455,6 +1498,12 @@ final class MeetingSessionController: ObservableObject {
                 "mic_stream_present": boolString(micAudioURL != nil),
                 "trigger": StartTrigger.savedMeetingRetranscription.rawValue
             ]
+        )
+        ProductFrictionTelemetry.track(
+            surface: .meeting,
+            stage: "meeting_retry",
+            result: .started,
+            modelState: state.diagnosticName
         )
 
         if case .idle = state {
@@ -2578,6 +2627,13 @@ final class MeetingSessionController: ObservableObject {
                     "meeting_transcript_skipped",
                     properties: failureTelemetryContext
                 )
+                ProductFrictionTelemetry.track(
+                    surface: .meeting,
+                    stage: "meeting_transcription",
+                    result: .giveUp,
+                    failureKind: failureKind.rawValue,
+                    modelState: state.diagnosticName
+                )
                 activeTranscriptionCaptureDiagnostics = nil
                 Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: failureKind.rawValue)
                 finalizeBackgroundTranscriptionStateIfNeeded()
@@ -2615,6 +2671,13 @@ final class MeetingSessionController: ObservableObject {
                         "trigger": transcriptionTrigger.rawValue,
                     ]
                 )
+                ProductFrictionTelemetry.track(
+                    surface: .meeting,
+                    stage: "speaker_finalization",
+                    result: .failed,
+                    failureKind: failureKind.rawValue,
+                    modelState: state.diagnosticName
+                )
                 activeTranscriptionCaptureDiagnostics = nil
                 Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "speaker_finalization_failed")
                 finalizeBackgroundTranscriptionStateIfNeeded()
@@ -2647,6 +2710,13 @@ final class MeetingSessionController: ObservableObject {
             AnalyticsReporter.track(
                 "meeting_transcript_failed",
                 properties: failureTelemetryContext
+            )
+            ProductFrictionTelemetry.track(
+                surface: .meeting,
+                stage: "meeting_transcription",
+                result: .failed,
+                failureKind: failureKind.rawValue,
+                modelState: state.diagnosticName
             )
             activeTranscriptionCaptureDiagnostics = nil
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "transcript_failed")

--- a/Sources/Observability/ActivationTelemetry.swift
+++ b/Sources/Observability/ActivationTelemetry.swift
@@ -305,3 +305,57 @@ enum ActivationTelemetry {
         }
     }
 }
+
+enum ProductFrictionTelemetry {
+    enum Surface: String {
+        case dictation
+        case meeting
+        case update
+    }
+
+    enum Result: String {
+        case blocked
+        case cancelled
+        case completed
+        case failed
+        case fallback
+        case giveUp = "give_up"
+        case started
+    }
+
+    static func track(
+        surface: Surface,
+        stage: String,
+        result: Result,
+        failureKind: String? = nil,
+        elapsedBucket: String? = nil,
+        routeShape: String? = nil,
+        modelState: String? = nil
+    ) {
+        var properties = [
+            "result": result.rawValue,
+            "stage": stage,
+            "surface": surface.rawValue,
+        ]
+
+        if let failureKind {
+            properties["failure_kind"] = failureKind
+        }
+        if let elapsedBucket {
+            properties["elapsed_bucket"] = elapsedBucket
+        }
+        if let routeShape {
+            properties["route_shape"] = routeShape
+        }
+        if let modelState {
+            properties["model_state"] = modelState
+        }
+
+        AnalyticsReporter.track("product_friction_observed", properties: properties)
+    }
+
+    static func modelState(isReady: Bool?) -> String {
+        guard let isReady else { return "unknown" }
+        return isReady ? "ready" : "not_ready"
+    }
+}

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -161,6 +161,16 @@ struct AnalyticsEventPolicy: Equatable {
         "workflow_kind",
     ]
 
+    private static let productFrictionProperties: Set<String> = [
+        "elapsed_bucket",
+        "failure_kind",
+        "model_state",
+        "result",
+        "route_shape",
+        "stage",
+        "surface",
+    ]
+
     private static let meetingPromptProperties: Set<String> = [
         "app_signal",
         "calendar_confidence",
@@ -351,6 +361,10 @@ struct AnalyticsEventPolicy: Equatable {
         "workflow_abandoned": .init(
             name: "workflow_abandoned",
             allowedProperties: workflowAbandonedProperties
+        ),
+        "product_friction_observed": .init(
+            name: "product_friction_observed",
+            allowedProperties: productFrictionProperties
         ),
         "menu_bar_opened": .init(
             name: "menu_bar_opened",

--- a/Sources/Observability/SparkleUpdaterController.swift
+++ b/Sources/Observability/SparkleUpdaterController.swift
@@ -426,6 +426,24 @@ final class SparkleUpdaterController: NSObject, ObservableObject {
             properties["failure_kind"] = failureKind
         }
         AnalyticsReporter.track(event, properties: properties)
+
+        switch event {
+        case "update_download_started":
+            ProductFrictionTelemetry.track(
+                surface: .update,
+                stage: "update_download",
+                result: .started
+            )
+        case "update_download_finished":
+            ProductFrictionTelemetry.track(
+                surface: .update,
+                stage: "update_download",
+                result: failureKind == nil ? .completed : .failed,
+                failureKind: failureKind
+            )
+        default:
+            break
+        }
     }
 
     private func currentAppVersion() -> String {

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -190,11 +190,18 @@ class DictationSessionController: ObservableObject {
         properties["failure_kind"] = failureKind
         properties["trigger"] = currentDictationTrigger.rawValue
 
+        let analyticsProperties = dictationAnalyticsProperties(extra: properties)
         AnalyticsReporter.track(
             "dictation_start_failed",
-            properties: dictationAnalyticsProperties(
-                extra: properties
-            )
+            properties: analyticsProperties
+        )
+        ProductFrictionTelemetry.track(
+            surface: .dictation,
+            stage: "dictation_start",
+            result: .blocked,
+            failureKind: failureKind,
+            routeShape: analyticsProperties["route_shape"],
+            modelState: ProductFrictionTelemetry.modelState(isReady: appState?.sttRouter.isModelLoaded)
         )
     }
 
@@ -842,6 +849,15 @@ class DictationSessionController: ObservableObject {
                 guard appState.sttRouter.isModelLoaded else {
                     appState.logger.log("DICTATION | voice model failed to load for transcription")
                     overlayController.showError("The voice model didn't load. Please try dictating again in a moment.")
+                    ProductFrictionTelemetry.track(
+                        surface: .dictation,
+                        stage: "dictation_transcribe",
+                        result: .blocked,
+                        failureKind: "model_not_ready",
+                        elapsedBucket: AnalyticsReporter.durationBucket(seconds: CFAbsoluteTimeGetCurrent() - sessionStartTime),
+                        routeShape: self.dictationAnalyticsProperties()["route_shape"],
+                        modelState: "not_ready"
+                    )
                     isDictating = false
                     appState.runtimeDiagnostics.clearSession(kind: "dictation", outcome: "model_unavailable")
                     return
@@ -894,6 +910,15 @@ class DictationSessionController: ObservableObject {
                             "trigger": currentDictationTrigger.rawValue,
                         ]
                     )
+                )
+                ProductFrictionTelemetry.track(
+                    surface: .dictation,
+                    stage: "dictation_transcribe",
+                    result: .giveUp,
+                    failureKind: "no_speech",
+                    elapsedBucket: AnalyticsReporter.durationBucket(seconds: CFAbsoluteTimeGetCurrent() - sessionStartTime),
+                    routeShape: self.dictationAnalyticsProperties()["route_shape"],
+                    modelState: ProductFrictionTelemetry.modelState(isReady: appState.sttRouter.isModelLoaded)
                 )
                 NotificationCenter.default.post(name: .dictationNoSpeechDetected, object: nil)
                 AppSoundPlayer.shared.play(.noSpeech)
@@ -977,6 +1002,11 @@ class DictationSessionController: ObservableObject {
                 cleanupEnabled: cleanupEnabled,
                 cleanupChanged: cleanupResult?.changed ?? false,
                 saveSucceeded: saveFailureMessage == nil
+            )
+            trackDictationDeliveryFriction(
+                pasteOutcome: pasteOutcome,
+                saveSucceeded: saveFailureMessage == nil,
+                elapsedSeconds: CFAbsoluteTimeGetCurrent() - sessionStartTime
             )
             switch pasteOutcome {
             case .pasted:
@@ -1062,6 +1092,15 @@ class DictationSessionController: ObservableObject {
                     "trigger": currentDictationTrigger.rawValue,
                 ]
             )
+        )
+        ProductFrictionTelemetry.track(
+            surface: .dictation,
+            stage: "dictation_recording",
+            result: .cancelled,
+            failureKind: "user_cancelled",
+            elapsedBucket: AnalyticsReporter.durationBucket(seconds: CFAbsoluteTimeGetCurrent() - sessionStartTime),
+            routeShape: dictationAnalyticsProperties()["route_shape"],
+            modelState: ProductFrictionTelemetry.modelState(isReady: appState.sttRouter.isModelLoaded)
         )
     }
 
@@ -1541,6 +1580,45 @@ class DictationSessionController: ObservableObject {
             context: dictationContext(extra: ["error": error.localizedDescription])
         )
         return "Transcripted couldn't save a local copy of this dictation. Check your save location and available disk space."
+    }
+
+    private func trackDictationDeliveryFriction(
+        pasteOutcome: DictationPasteOutcome,
+        saveSucceeded: Bool,
+        elapsedSeconds: Double
+    ) {
+        if pasteOutcome.delivery == .failed {
+            ProductFrictionTelemetry.track(
+                surface: .dictation,
+                stage: "pasteback",
+                result: .failed,
+                failureKind: "pasteback_failed",
+                elapsedBucket: AnalyticsReporter.durationBucket(seconds: elapsedSeconds),
+                routeShape: dictationAnalyticsProperties()["route_shape"],
+                modelState: ProductFrictionTelemetry.modelState(isReady: appState?.sttRouter.isModelLoaded)
+            )
+        } else if let copyReason = pasteOutcome.copyReason {
+            ProductFrictionTelemetry.track(
+                surface: .dictation,
+                stage: "pasteback",
+                result: .fallback,
+                failureKind: "pasteback_\(copyReason.diagnosticName)",
+                elapsedBucket: AnalyticsReporter.durationBucket(seconds: elapsedSeconds),
+                routeShape: dictationAnalyticsProperties()["route_shape"],
+                modelState: ProductFrictionTelemetry.modelState(isReady: appState?.sttRouter.isModelLoaded)
+            )
+        }
+
+        guard !saveSucceeded else { return }
+        ProductFrictionTelemetry.track(
+            surface: .dictation,
+            stage: "artifact_save",
+            result: .failed,
+            failureKind: "dictation_save_failed",
+            elapsedBucket: AnalyticsReporter.durationBucket(seconds: elapsedSeconds),
+            routeShape: dictationAnalyticsProperties()["route_shape"],
+            modelState: ProductFrictionTelemetry.modelState(isReady: appState?.sttRouter.isModelLoaded)
+        )
     }
 
     private func recordDictationStopLatency(

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -420,6 +420,50 @@ func testAnalyticsEventPolicy() {
         assertNil(sanitized["url"], "raw URLs must not be sent")
     }
 
+    runSuite("AnalyticsEventPolicy allows product friction only as coarse enums and buckets") {
+        let friction = AnalyticsEventPolicy.policy(forEvent: "product_friction_observed")
+        assertEqual(
+            friction?.allowedProperties ?? Set<String>(),
+            ["elapsed_bucket", "failure_kind", "model_state", "result", "route_shape", "stage", "surface"],
+            "product friction should stay narrowly scoped"
+        )
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "elapsed_bucket": "10_29s",
+                "failure_kind": "pasteback_failed",
+                "model_state": "ready",
+                "result": "failed",
+                "route_shape": "built_in_input_to_bluetooth_output",
+                "stage": "pasteback",
+                "surface": "dictation",
+                "error_message": "private raw error",
+                "audio_path": "/Users/jane/private.wav",
+                "file_path": "/Users/jane/private.md",
+                "meeting_title": "Customer roadmap",
+                "source_app_bundle": "com.example.Private",
+                "transcript_text": "private transcript",
+                "retry_count": "7",
+            ],
+            allowedKeys: friction?.allowedProperties ?? []
+        )
+
+        assertEqual(sanitized["elapsed_bucket"], "10_29s", "elapsed time should survive only as a bucket")
+        assertEqual(sanitized["failure_kind"], "pasteback_failed", "failure kind should survive as a normalized enum")
+        assertEqual(sanitized["model_state"], "ready", "model state should survive as a coarse enum")
+        assertEqual(sanitized["result"], "failed", "result should survive as a coarse enum")
+        assertEqual(sanitized["route_shape"], "built_in_input_to_bluetooth_output", "route shape should survive as a coarse enum")
+        assertEqual(sanitized["stage"], "pasteback", "stage should survive as a coarse enum")
+        assertEqual(sanitized["surface"], "dictation", "surface should survive as a coarse enum")
+        assertNil(sanitized["error_message"], "raw error strings should stay out of friction analytics")
+        assertNil(sanitized["audio_path"], "audio paths should stay out of friction analytics")
+        assertNil(sanitized["file_path"], "file paths should stay out of friction analytics")
+        assertNil(sanitized["meeting_title"], "meeting titles should stay out of friction analytics")
+        assertNil(sanitized["source_app_bundle"], "source app bundle IDs should stay out of friction analytics")
+        assertNil(sanitized["transcript_text"], "transcript text should stay out of friction analytics")
+        assertNil(sanitized["retry_count"], "raw retry counts should stay out of friction analytics")
+    }
+
     runSuite("AnalyticsEventPolicy allows menu and settings behavior events") {
         let menuOpened = AnalyticsEventPolicy.policy(forEvent: "menu_bar_opened")
         let menuAction = AnalyticsEventPolicy.policy(forEvent: "menu_bar_action_clicked")

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -103,6 +103,7 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `activation_agent_setup_cta_clicked`
 - `activation_return_proxy_observed`
 - `workflow_abandoned`
+- `product_friction_observed`
 - `menu_bar_opened`
 - `menu_bar_action_clicked`
 - `update_action_clicked`
@@ -155,6 +156,8 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - retry attempt buckets like `start_attempt_bucket`, not raw retry counts
 - normalized failure kinds like `system_audio`, `recording_too_short`, `other`
 - normalized failure-code buckets like `url_-1009`, `sparkle_2003`, `other_42`
+- product friction fields limited to `surface`, `stage`, `result`,
+  `failure_kind`, `elapsed_bucket`, `route_shape`, and `model_state`
 
 Meeting workflow analytics should keep that same stable `trigger` enum on later
 stop/save/fail events so product and reliability reviews can attribute outcomes


### PR DESCRIPTION
## Summary
- add a central `product_friction_observed` PostHog event for coarse friction signals across dictation, meetings, and update downloads
- wire high-signal blockers/failures: permission blocked, model not ready, download started/completed/failed, no speech, mic/start unavailable, system-audio permission unavailable, pasteback fallback/failed, retry started, cancel/give-up, import/transcript/speaker failures
- update analytics allowlist, sanitizer coverage, and privacy docs so payload stays limited to `surface`, `stage`, `result`, `failure_kind`, `elapsed_bucket`, `route_shape`, and `model_state`

## Open PR audit
- Existing telemetry drafts overlap nearby but not this central friction surface: #1193 dictation retry, #1196 taxonomy guardrails, #1202 build-channel telemetry, #1187/#1194 activation artifact telemetry.
- #1203 appears to own the current base build break / restore-green lane.

## Privacy
- No raw error strings, transcript text, audio refs, file paths, source app names/bundles, meeting titles, speaker names, URLs, tokens, or raw retry counts.
- Friction fields are enum/bucket only and covered by `AnalyticsEventPolicyTests`.

## Tests
- PASS: `bash run-tests.sh --filter AnalyticsEventPolicy` (366 passed)
- PASS: `git diff --check`
- PASS: `bash run-tests.sh` (5742 passed)
- BLOCKED: `bash build-deps.sh --force` fails twice in pre-existing `Sources/TranscriptedCore/Audio/Audio.swift` / copied temp Core: `sleepWakeNotifications` is not initialized before `wireSystemAudioStatusPublisher(...)`; this matches the open restore-green PR #1203 lane.
- BLOCKED: `bash build.sh --no-open` cannot start because the failed `build-deps --force` left deps missing/stale and asks to rerun `bash build-deps.sh --force`.
- SKIPPED: `bash run-integration-smoke.sh` because rebuilt deps are unavailable after the same base failure.
- ATTEMPTED: `codex review --uncommitted`; CLI produced plugin/tool logs only and no review verdict after 3+ minutes, so I stopped the stalled process.

## Smallest next action
Merge or apply the #1203 restore-green fix, rerun `bash build-deps.sh --force`, then run `bash build.sh --no-open` and `bash run-integration-smoke.sh` on this PR.