### PR TITLE
Add UX confusion analytics

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -146,6 +146,31 @@ struct AnalyticsEventPolicy: Equatable {
         "surface",
     ]
 
+    private static let uxConfusionProperties: Set<String> = [
+        "action_id",
+        "elapsed_bucket",
+        "failure_kind",
+        "page_id",
+        "reason_kind",
+        "retryability",
+        "signal_kind",
+        "step_id",
+        "step_index",
+        "surface",
+        "visit_count_bucket",
+    ]
+
+    private static let uxRecoveryProperties: Set<String> = [
+        "action_id",
+        "failure_kind",
+        "page_id",
+        "reason_kind",
+        "recovery_kind",
+        "result",
+        "retryability",
+        "surface",
+    ]
+
     private static let meetingPromptProperties: Set<String> = [
         "app_signal",
         "calendar_confidence",
@@ -332,6 +357,14 @@ struct AnalyticsEventPolicy: Equatable {
         "activation_return_proxy_observed": .init(
             name: "activation_return_proxy_observed",
             allowedProperties: activationReturnProxyProperties
+        ),
+        "ux_confusion_signal_observed": .init(
+            name: "ux_confusion_signal_observed",
+            allowedProperties: uxConfusionProperties
+        ),
+        "ux_recovery_action_taken": .init(
+            name: "ux_recovery_action_taken",
+            allowedProperties: uxRecoveryProperties
         ),
         "menu_bar_opened": .init(
             name: "menu_bar_opened",

--- a/Sources/Observability/UXConfusionTelemetry.swift
+++ b/Sources/Observability/UXConfusionTelemetry.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+enum UXConfusionTelemetry {
+    enum Surface: String {
+        case onboarding
+        case home
+        case homeRow = "home_row"
+        case settings
+        case support
+    }
+
+    enum SignalKind: String {
+        case onboardingExited = "onboarding_exited"
+        case setupAbandoned = "setup_abandoned"
+        case repeatedSettingsVisit = "repeated_settings_visit"
+        case disabledActionAttempted = "disabled_action_attempted"
+        case emptyStateExited = "empty_state_exited"
+        case failedMeetingDetailsOpened = "failed_meeting_details_opened"
+    }
+
+    enum RecoveryKind: String {
+        case retryFromFailure = "retry_from_failure"
+        case supportDiagnostics = "support_diagnostics"
+    }
+
+    enum Result: String {
+        case blocked
+        case copied
+        case failed
+        case queued
+        case started
+    }
+
+    static func trackSignal(
+        _ signalKind: SignalKind,
+        surface: Surface,
+        pageID: String? = nil,
+        stepID: String? = nil,
+        stepIndex: Int? = nil,
+        actionID: String? = nil,
+        failureKind: String? = nil,
+        reasonKind: String? = nil,
+        visitCountBucket: String? = nil,
+        elapsedBucket: String? = nil,
+        retryability: String? = nil
+    ) {
+        AnalyticsReporter.track(
+            "ux_confusion_signal_observed",
+            properties: properties(
+                base: [
+                    "signal_kind": signalKind.rawValue,
+                    "surface": surface.rawValue,
+                ],
+                pageID: pageID,
+                stepID: stepID,
+                stepIndex: stepIndex,
+                actionID: actionID,
+                failureKind: failureKind,
+                reasonKind: reasonKind,
+                visitCountBucket: visitCountBucket,
+                elapsedBucket: elapsedBucket,
+                retryability: retryability
+            )
+        )
+    }
+
+    static func trackRecovery(
+        _ recoveryKind: RecoveryKind,
+        surface: Surface,
+        pageID: String? = nil,
+        actionID: String? = nil,
+        failureKind: String? = nil,
+        reasonKind: String? = nil,
+        result: Result,
+        retryability: String? = nil
+    ) {
+        AnalyticsReporter.track(
+            "ux_recovery_action_taken",
+            properties: properties(
+                base: [
+                    "recovery_kind": recoveryKind.rawValue,
+                    "result": result.rawValue,
+                    "surface": surface.rawValue,
+                ],
+                pageID: pageID,
+                actionID: actionID,
+                failureKind: failureKind,
+                reasonKind: reasonKind,
+                retryability: retryability
+            )
+        )
+    }
+
+    static func visitCountBucket(_ count: Int) -> String? {
+        switch count {
+        case ..<3:
+            return nil
+        case 3...4:
+            return "3_4"
+        case 5...9:
+            return "5_9"
+        default:
+            return "10_plus"
+        }
+    }
+
+    private static func properties(
+        base: [String: String],
+        pageID: String? = nil,
+        stepID: String? = nil,
+        stepIndex: Int? = nil,
+        actionID: String? = nil,
+        failureKind: String? = nil,
+        reasonKind: String? = nil,
+        visitCountBucket: String? = nil,
+        elapsedBucket: String? = nil,
+        retryability: String? = nil
+    ) -> [String: String] {
+        var properties = base
+        properties["page_id"] = pageID
+        properties["step_id"] = stepID
+        properties["step_index"] = stepIndex.map(String.init)
+        properties["action_id"] = actionID
+        properties["failure_kind"] = failureKind
+        properties["reason_kind"] = reasonKind
+        properties["visit_count_bucket"] = visitCountBucket
+        properties["elapsed_bucket"] = elapsedBucket
+        properties["retryability"] = retryability
+        return properties
+    }
+}

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -714,6 +714,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         systemAudioCaptureForTesting systemAudioCapture: (any SystemAudioCaptureEngine & Sendable)?
     ) {
         self.paths = paths
+        self.sleepWakeNotifications = .macOSWorkspace
         self.recordingJournal = MeetingRecordingJournalStore(directory: paths.audioCaptures)
         self.systemAudioCapture = systemAudioCapture
         if let systemAudioCapture {

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -119,6 +119,7 @@ struct PermissionsOnboardingView: View {
         .onDisappear {
             stopPolling()
             copiedResetTask?.cancel()
+            trackOnboardingExitIfNeeded()
         }
     }
 
@@ -612,6 +613,30 @@ struct PermissionsOnboardingView: View {
                 elapsedSeconds: flowStartedAt.map { CFAbsoluteTimeGetCurrent() - $0 }
             )
         )
+    }
+
+    private func trackOnboardingExitIfNeeded() {
+        guard !didTrackCompletion else { return }
+        let now = CFAbsoluteTimeGetCurrent()
+        let reasonKind = hasRequiredPermissions ? "window_closed" : "missing_required_permission"
+        UXConfusionTelemetry.trackSignal(
+            .onboardingExited,
+            surface: .onboarding,
+            stepID: currentStep.kind.analyticsID,
+            stepIndex: currentStepIndex,
+            reasonKind: reasonKind,
+            elapsedBucket: flowElapsedBucket(now: now)
+        )
+        if !hasRequiredPermissions {
+            UXConfusionTelemetry.trackSignal(
+                .setupAbandoned,
+                surface: .onboarding,
+                stepID: currentStep.kind.analyticsID,
+                stepIndex: currentStepIndex,
+                reasonKind: reasonKind,
+                elapsedBucket: flowElapsedBucket(now: now)
+            )
+        }
     }
 
     private func requestPermission(_ kind: TranscriptedPermissionKind, required: Bool) {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -93,6 +93,13 @@ struct TranscriptedSettingsView: View {
     @State private var settingsColumnVisibility: NavigationSplitViewVisibility = .all
     @State private var speakerInboxScrollRequest = 0
     @State private var speakerInboxScrollAwaitingQueue = false
+    @State private var settingsPageVisitCounts: [TranscriptedSettingsPage: Int] = [:]
+    @State private var trackedSettingsVisitBuckets: Set<String> = []
+    @State private var emptyHomeSectionsSeen: Set<String> = []
+    @State private var emptyHomeSectionsResolvedByAction: Set<String> = []
+    @State private var failedMeetingDetailSignalsTracked: Set<UUID> = []
+    @State private var homeCaptureRefreshStarted = false
+    @State private var homeCaptureRefreshCompleted = false
 
     init(
         appState: TranscriptedAppState,
@@ -279,6 +286,11 @@ struct TranscriptedSettingsView: View {
             }
             trackSettingsPageViewed(page, source: "navigation")
         }
+        .onChange(of: homeViewModel.isLoading) { wasLoading, isLoading in
+            guard homeCaptureRefreshStarted, wasLoading, !isLoading else { return }
+            homeCaptureRefreshCompleted = true
+            markVisibleEmptyHomeSectionsIfNeeded()
+        }
         .onChange(of: meetingSession.lastSavedTranscriptURL) { _, newURL in
             refreshRecentCaptures(force: true)
             if SettingsSpeakerQueueRefreshPolicy.shouldRefreshAfterMeetingTranscriptSave(newURL) {
@@ -321,6 +333,7 @@ struct TranscriptedSettingsView: View {
             refreshShortcutState()
         }
         .onDisappear {
+            trackEmptyHomeExitIfNeeded()
             homeDashboardRefreshTask?.cancel()
             homeDashboardRefreshTask = nil
             homeDashboardRefreshInFlight = false
@@ -587,6 +600,9 @@ struct TranscriptedSettingsView: View {
                 },
                 onShowAll: {
                     trackSettingsAction("home_show_all_failed_meetings", page: .home)
+                    for item in allFailedMeetings {
+                        trackFailedMeetingDetailsOpened(item)
+                    }
                     homeShowsAllFailedMeetings = true
                 }
             )
@@ -616,6 +632,8 @@ struct TranscriptedSettingsView: View {
                 automationIdentifier: "transcripted.home.meetings.empty.start",
                 action: {
                     trackSettingsAction("empty_start_meeting", page: .home)
+                    emptyHomeSectionsSeen.remove("meetings")
+                    emptyHomeSectionsResolvedByAction.insert("meetings")
                     actions.startMeeting()
                 }
             ),
@@ -629,6 +647,9 @@ struct TranscriptedSettingsView: View {
             }
         ) { item in
             homeMeetingListRow(item)
+        }
+        .onAppear {
+            markVisibleEmptyHomeSectionsIfNeeded()
         }
     }
 
@@ -683,6 +704,8 @@ struct TranscriptedSettingsView: View {
                 automationIdentifier: "transcripted.home.dictations.empty.start",
                 action: {
                     trackSettingsAction("empty_start_dictation", page: .dictations)
+                    emptyHomeSectionsSeen.remove("dictations")
+                    emptyHomeSectionsResolvedByAction.insert("dictations")
                     actions.startDictation()
                 }
             ),
@@ -720,6 +743,9 @@ struct TranscriptedSettingsView: View {
                 menuItems: dictationRowMenuItems(for: entry)
             )
         }
+        .onAppear {
+            markVisibleEmptyHomeSectionsIfNeeded()
+        }
     }
 
     private var homeGreeting: String {
@@ -744,6 +770,9 @@ struct TranscriptedSettingsView: View {
         switch issue.destination {
         case .failedMeetings:
             trackSettingsAction("open_needs_attention_failed_meetings", page: .home)
+            for item in meetingSession.failedMeetings {
+                trackFailedMeetingDetailsOpened(item)
+            }
             navigation.selectedPage = .home
             homeShowsAllFailedMeetings = true
         case .speakers:
@@ -1575,6 +1604,15 @@ struct TranscriptedSettingsView: View {
 
     private func retryFailedMeeting(_ item: MeetingSessionController.FailedMeetingItem) {
         let didStart = meetingSession.retryFailedMeeting(id: item.id)
+        UXConfusionTelemetry.trackRecovery(
+            .retryFromFailure,
+            surface: .home,
+            pageID: navigation.selectedPage.analyticsValue,
+            actionID: "home_retry_failed_meeting",
+            failureKind: item.failureKind.rawValue,
+            result: didStart ? .started : .blocked,
+            retryability: item.isRetryable ? "retryable" : "not_retryable"
+        )
         if !didStart {
             presentHomeActionFailure(
                 title: "Could not retry meeting",
@@ -4210,6 +4248,7 @@ struct TranscriptedSettingsView: View {
                 "source": source,
             ]
         )
+        trackRepeatedSettingsVisit(page)
     }
 
     private func trackSettingsAction(_ actionID: String, page: TranscriptedSettingsPage? = nil) {
@@ -4230,6 +4269,70 @@ struct TranscriptedSettingsView: View {
                 "page_id": (page ?? navigation.selectedPage).analyticsValue,
                 "setting_id": settingID,
             ]
+        )
+    }
+
+    private func trackRepeatedSettingsVisit(_ page: TranscriptedSettingsPage) {
+        let count = (settingsPageVisitCounts[page] ?? 0) + 1
+        settingsPageVisitCounts[page] = count
+        guard let bucket = UXConfusionTelemetry.visitCountBucket(count) else { return }
+        let key = "\(page.analyticsValue):\(bucket)"
+        guard !trackedSettingsVisitBuckets.contains(key) else { return }
+        trackedSettingsVisitBuckets.insert(key)
+        UXConfusionTelemetry.trackSignal(
+            .repeatedSettingsVisit,
+            surface: .settings,
+            pageID: page.analyticsValue,
+            visitCountBucket: bucket
+        )
+    }
+
+    private func trackEmptyHomeExitIfNeeded() {
+        for section in emptyHomeSectionsSeen.sorted() {
+            guard !emptyHomeSectionsResolvedByAction.contains(section) else { continue }
+            guard homeSectionIsStillEmpty(section) else { continue }
+            UXConfusionTelemetry.trackSignal(
+                .emptyStateExited,
+                surface: .home,
+                pageID: section == "meetings" ? "home" : "dictations",
+                reasonKind: section
+            )
+        }
+        emptyHomeSectionsSeen.removeAll()
+        emptyHomeSectionsResolvedByAction.removeAll()
+    }
+
+    private func markVisibleEmptyHomeSectionsIfNeeded() {
+        guard homeCaptureRefreshCompleted, !homeViewModel.isLoading else { return }
+        switch navigation.selectedPage {
+        case .home where homeMeetingDaySections.isEmpty:
+            emptyHomeSectionsSeen.insert("meetings")
+        case .dictations where homeViewModel.dictationDaySections.isEmpty:
+            emptyHomeSectionsSeen.insert("dictations")
+        default:
+            break
+        }
+    }
+
+    private func homeSectionIsStillEmpty(_ section: String) -> Bool {
+        switch section {
+        case "meetings":
+            return homeMeetingDaySections.isEmpty
+        case "dictations":
+            return homeViewModel.dictationDaySections.isEmpty
+        default:
+            return false
+        }
+    }
+
+    private func trackFailedMeetingDetailsOpened(_ item: MeetingSessionController.FailedMeetingItem) {
+        guard failedMeetingDetailSignalsTracked.insert(item.id).inserted else { return }
+        UXConfusionTelemetry.trackSignal(
+            .failedMeetingDetailsOpened,
+            surface: .homeRow,
+            pageID: navigation.selectedPage.analyticsValue,
+            failureKind: item.failureKind.rawValue,
+            retryability: item.isRetryable ? "retryable" : "not_retryable"
         )
     }
 
@@ -4405,6 +4508,8 @@ struct TranscriptedSettingsView: View {
         let generation = homeDashboardRefreshGeneration
         lastHomeDashboardRefreshStartedAt = now
         homeDashboardRefreshInFlight = true
+        homeCaptureRefreshStarted = true
+        homeCaptureRefreshCompleted = false
         homeViewModel.refresh()
 
         homeDashboardRefreshTask = Task { @MainActor in
@@ -4559,20 +4664,64 @@ struct TranscriptedSettingsView: View {
 
     private func sendDiagnosticEvent() {
         guard CrashReporter.isAvailable else {
+            UXConfusionTelemetry.trackSignal(
+                .disabledActionAttempted,
+                surface: .support,
+                pageID: navigation.selectedPage.analyticsValue,
+                actionID: "send_diagnostic_event",
+                reasonKind: "crash_reporting_unavailable"
+            )
+            UXConfusionTelemetry.trackRecovery(
+                .supportDiagnostics,
+                surface: .support,
+                pageID: navigation.selectedPage.analyticsValue,
+                actionID: "send_diagnostic_event",
+                reasonKind: "crash_reporting_unavailable",
+                result: .blocked
+            )
             diagnosticsActionStatus = "Sentry is not configured in this build yet."
             return
         }
 
         guard crashReportingEnabled else {
+            UXConfusionTelemetry.trackSignal(
+                .disabledActionAttempted,
+                surface: .support,
+                pageID: navigation.selectedPage.analyticsValue,
+                actionID: "send_diagnostic_event",
+                reasonKind: "crash_reporting_disabled"
+            )
+            UXConfusionTelemetry.trackRecovery(
+                .supportDiagnostics,
+                surface: .support,
+                pageID: navigation.selectedPage.analyticsValue,
+                actionID: "send_diagnostic_event",
+                reasonKind: "crash_reporting_disabled",
+                result: .blocked
+            )
             diagnosticsActionStatus = "Turn on crash and error reports first."
             return
         }
 
         guard let eventID = actions.sendDiagnosticEvent() else {
+            UXConfusionTelemetry.trackRecovery(
+                .supportDiagnostics,
+                surface: .support,
+                pageID: navigation.selectedPage.analyticsValue,
+                actionID: "send_diagnostic_event",
+                result: .failed
+            )
             diagnosticsActionStatus = "Diagnostic event could not be queued."
             return
         }
 
+        UXConfusionTelemetry.trackRecovery(
+            .supportDiagnostics,
+            surface: .support,
+            pageID: navigation.selectedPage.analyticsValue,
+            actionID: "send_diagnostic_event",
+            result: .queued
+        )
         diagnosticsActionStatus = "Queued diagnostic event \(eventID.prefix(8))."
     }
 

--- a/Sources/UI/Shared/TranscriptedSupportActions.swift
+++ b/Sources/UI/Shared/TranscriptedSupportActions.swift
@@ -22,6 +22,12 @@ enum TranscriptedSupportActions {
         let copied = pasteboard.setString(text, forType: .string)
         if copied {
             AnalyticsReporter.track("support_diagnostics_copied")
+            UXConfusionTelemetry.trackRecovery(
+                .supportDiagnostics,
+                surface: .support,
+                actionID: "copy_diagnostics",
+                result: .copied
+            )
         }
         return copied
     }

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -231,6 +231,87 @@ func testAnalyticsEventPolicy() {
         assertEqual(sanitized["surface"], "settings_about", "update surface should survive sanitization")
     }
 
+    runSuite("AnalyticsEventPolicy allows UX confusion and recovery signals") {
+        let confusion = AnalyticsEventPolicy.policy(forEvent: "ux_confusion_signal_observed")
+        let recovery = AnalyticsEventPolicy.policy(forEvent: "ux_recovery_action_taken")
+
+        assertEqual(
+            confusion?.allowedProperties ?? Set<String>(),
+            [
+                "action_id",
+                "elapsed_bucket",
+                "failure_kind",
+                "page_id",
+                "reason_kind",
+                "retryability",
+                "signal_kind",
+                "step_id",
+                "step_index",
+                "surface",
+                "visit_count_bucket",
+            ],
+            "confusion signals should stay coarse and enum-shaped"
+        )
+        assertEqual(
+            recovery?.allowedProperties ?? Set<String>(),
+            [
+                "action_id",
+                "failure_kind",
+                "page_id",
+                "reason_kind",
+                "recovery_kind",
+                "result",
+                "retryability",
+                "surface",
+            ],
+            "recovery actions should not include private artifacts"
+        )
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "action_id": "send_diagnostic_event",
+                "elapsed_bucket": "30_119s",
+                "failure_kind": "transcription_inference_failed",
+                "page_id": "support",
+                "reason_kind": "crash_reporting_disabled",
+                "recovery_kind": "support_diagnostics",
+                "result": "blocked",
+                "retryability": "retryable",
+                "signal_kind": "disabled_action_attempted",
+                "step_id": "permissions",
+                "step_index": "3",
+                "surface": "settings",
+                "visit_count_bucket": "3_4",
+                "meeting_title": "Customer call",
+                "audio_path": "/Users/redbars/private.wav",
+                "prompt_text": "read this transcript",
+            ],
+            allowedKeys: (confusion?.allowedProperties ?? []).union(recovery?.allowedProperties ?? [])
+        )
+
+        assertEqual(sanitized["action_id"], "send_diagnostic_event", "action id should survive")
+        assertEqual(sanitized["elapsed_bucket"], "30_119s", "elapsed bucket should survive")
+        assertEqual(sanitized["failure_kind"], "transcription_inference_failed", "normalized failure kind should survive")
+        assertEqual(sanitized["page_id"], "support", "page id should survive")
+        assertEqual(sanitized["reason_kind"], "crash_reporting_disabled", "reason kind should survive")
+        assertEqual(sanitized["recovery_kind"], "support_diagnostics", "recovery kind should survive")
+        assertEqual(sanitized["result"], "blocked", "coarse result should survive")
+        assertEqual(sanitized["retryability"], "retryable", "retryability enum should survive")
+        assertEqual(sanitized["signal_kind"], "disabled_action_attempted", "signal kind should survive")
+        assertEqual(sanitized["step_id"], "permissions", "step id should survive")
+        assertEqual(sanitized["step_index"], "3", "step index should survive")
+        assertEqual(sanitized["surface"], "settings", "surface should survive")
+        assertEqual(sanitized["visit_count_bucket"], "3_4", "visit count bucket should survive")
+        assertNil(sanitized["meeting_title"], "meeting titles must not be sent")
+        assertNil(sanitized["audio_path"], "audio paths must not be sent")
+        assertNil(sanitized["prompt_text"], "prompt text must not be sent")
+
+        assertNil(UXConfusionTelemetry.visitCountBucket(2), "first two visits should not count as repeat confusion")
+        assertEqual(UXConfusionTelemetry.visitCountBucket(3), "3_4", "third visit should start repeat bucket")
+        assertEqual(UXConfusionTelemetry.visitCountBucket(7), "5_9", "mid repeat visits should stay bucketed")
+        assertEqual(UXConfusionTelemetry.visitCountBucket(10), "10_plus", "high repeat visits should stay bucketed")
+    }
+
     runSuite("AnalyticsEventPolicy allows update download lifecycle attribution") {
         let started = AnalyticsEventPolicy.policy(forEvent: "update_download_started")
         let finished = AnalyticsEventPolicy.policy(forEvent: "update_download_finished")

--- a/docs/posthog-product-learning-plan.md
+++ b/docs/posthog-product-learning-plan.md
@@ -87,6 +87,8 @@ Operational scripts query aggregate counts only:
 | `activation_agent_prompt_action_clicked` | `action_kind`, `agent_target`, `artifact_kind`, `prompt_kind`, `result`, `surface` |
 | `activation_agent_setup_cta_clicked` | `agent_target`, `prior_status`, `result`, `setup_kind`, `surface` |
 | `activation_return_proxy_observed` | `prior_artifact_kind`, `proxy_kind`, `return_window_bucket`, `surface` |
+| `ux_confusion_signal_observed` | `action_id`, `elapsed_bucket`, `failure_kind`, `page_id`, `reason_kind`, `retryability`, `signal_kind`, `step_id`, `step_index`, `surface`, `visit_count_bucket` |
+| `ux_recovery_action_taken` | `action_id`, `failure_kind`, `page_id`, `reason_kind`, `recovery_kind`, `result`, `retryability`, `surface` |
 
 ### Menu, Settings, Updates
 
@@ -175,6 +177,9 @@ aggregate reliability sizing and should not be expanded to raw device names.
 - First saved artifact across dictation and meeting with coarse artifact kind,
   trigger, duration bucket, and word-count bucket.
 - Artifact open/reveal/preview actions and agent setup or prompt-copy intent.
+- UX/CX confusion and recovery signals: onboarding exit/abandonment, repeated
+  Settings page visits, support diagnostics attempts, failed-meeting detail
+  opens, retry attempts, and empty Home exits.
 - Return proxy when Home observes an older saved artifact.
 - Release health by app version and update lifecycle.
 
@@ -214,6 +219,10 @@ Prefer a small number of lifecycle events over broad click tracking.
 Do not add generic "button clicked" for every control. Track buttons only when
 they answer a product question: did the user start capture, grant permission,
 save/open a useful artifact, connect an agent, recover from failure, or return?
+
+The current implementation covers the first confusion slice through
+`ux_confusion_signal_observed` and `ux_recovery_action_taken`. Keep using those
+for high-signal confusion and recovery moments instead of raw click tracking.
 
 ## Dashboards And Funnels
 

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -102,6 +102,8 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `activation_agent_prompt_action_clicked`
 - `activation_agent_setup_cta_clicked`
 - `activation_return_proxy_observed`
+- `ux_confusion_signal_observed`
+- `ux_recovery_action_taken`
 - `menu_bar_opened`
 - `menu_bar_action_clicked`
 - `update_action_clicked`

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -324,6 +324,7 @@ APP_SOURCES=(
     "Sources/UI/MenuBar/MenuBarHeaderLayoutPolicy.swift"
     "Sources/Observability/AnalyticsReporter.swift"
     "Sources/Observability/ActivationTelemetry.swift"
+    "Sources/Observability/UXConfusionTelemetry.swift"
     "Sources/Observability/LockedFileAppender.swift"
     "Sources/Observability/JSONLWriter.swift"
     "Sources/Observability/AnalyticsEventPolicy.swift"


### PR DESCRIPTION
## Summary
- Add `UXConfusionTelemetry` for coarse confusion/recovery events.
- Track onboarding exits/setup abandonment, repeated settings visits, empty-state exits after loaded Home state, failed-meeting recovery detail opens, retry-from-failure, disabled diagnostic actions, and support diagnostics recovery.
- Extend analytics policy, sanitizer coverage, docs, and fast-test source lists.
- Fix the injected `Audio` test initializer so rebuilt Core deps compile with the existing `sleepWakeNotifications` field.

## Product questions answered
- Where do users leave onboarding or abandon required setup?
- Which settings pages are revisited enough to suggest confusion?
- Do users see empty meeting/dictation history and leave without starting capture?
- Do users open failed meeting recovery details and retry?
- Are support/diagnostics actions blocked, copied, queued, or failed?

## Privacy guardrails
- Two event families only: `ux_confusion_signal_observed` and `ux_recovery_action_taken`.
- Enum/bucket payloads only: surfaces, page IDs, step IDs, failure kinds, retryability, visit buckets, elapsed buckets, and coarse results.
- No transcript text, audio paths, file paths, titles, speaker names, emails, device names, raw errors, or raw counts.
- Sanitizer tests verify private fields are dropped.

## Review
- `codex review --base origin/main`: initial findings fixed for tracked source file, empty-state overcount, and failed-row render overcount.
- Final `codex review --base origin/main`: no actionable correctness issues; review also reran `bash run-tests.sh` and `swift test`.

## Tests
- `python3 scripts/dev/check-build-source-lists.py`
- `bash run-tests.sh --filter AnalyticsEventPolicyTests`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `swift test`
- `bash run-integration-smoke.sh`
- `bash scripts/dev/agent-preflight.sh`
- `bash -n run-tests.sh`
- `bash -n scripts/entrypoints/run-tests.sh`
- `git diff --check`
