### PR TITLE
Add PostHog product task report

### DIFF
--- a/.agents/test-matrix.yml
+++ b/.agents/test-matrix.yml
@@ -98,6 +98,15 @@ rules:
       - "bash -n scripts/ops/health-probe.sh"
 
   - paths:
+      - "scripts/ops/posthog-product-dashboard-summary.py"
+      - "Tests/Fixtures/posthog-product-dashboard-summary.json"
+    checks:
+      - "scripts/dev/agent-preflight.sh"
+      - "python3 -m py_compile scripts/ops/posthog-product-dashboard-summary.py"
+      - "python3 scripts/ops/posthog-product-dashboard-summary.py --self-test"
+      - "python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json --json-only"
+
+  - paths:
       - "scripts/dev/onboarding.sh"
     checks:
       - "scripts/dev/agent-preflight.sh"

--- a/Tests/Fixtures/posthog-product-dashboard-summary.json
+++ b/Tests/Fixtures/posthog-product-dashboard-summary.json
@@ -1,0 +1,170 @@
+{
+  "app_version": null,
+  "generated_at": "2026-06-19T00:00:00+00:00",
+  "results": {
+    "adoption_breakdown": [
+      {
+        "action_kind": "open_markdown",
+        "agent_target": null,
+        "artifact_kind": "dictation",
+        "devices": 7,
+        "event": "activation_artifact_action_clicked",
+        "events": 8,
+        "page_id": null
+      },
+      {
+        "action_kind": "copy_prompt",
+        "agent_target": "claude",
+        "artifact_kind": "dictation",
+        "devices": 3,
+        "event": "activation_agent_prompt_action_clicked",
+        "events": 3,
+        "page_id": null
+      },
+      {
+        "action_kind": null,
+        "agent_target": null,
+        "artifact_kind": null,
+        "devices": 1,
+        "event": "meeting_file_imported",
+        "events": 1,
+        "page_id": null
+      }
+    ],
+    "daily_active": [
+      {
+        "active_devices": 8,
+        "day": "2026-06-17"
+      },
+      {
+        "active_devices": 9,
+        "day": "2026-06-18"
+      },
+      {
+        "active_devices": 7,
+        "day": "2026-06-19"
+      }
+    ],
+    "event_counts": [
+      {
+        "devices": 42,
+        "event": "app_launched",
+        "events": 140
+      },
+      {
+        "devices": 28,
+        "event": "onboarding_shown",
+        "events": 70
+      },
+      {
+        "devices": 30,
+        "event": "onboarding_step_viewed",
+        "events": 95
+      },
+      {
+        "devices": 18,
+        "event": "onboarding_completed",
+        "events": 24
+      },
+      {
+        "devices": 20,
+        "event": "dictation_started",
+        "events": 60
+      },
+      {
+        "devices": 16,
+        "event": "dictation_completed",
+        "events": 44
+      },
+      {
+        "devices": 12,
+        "event": "activation_first_artifact_saved",
+        "events": 18
+      },
+      {
+        "devices": 8,
+        "event": "activation_artifact_action_clicked",
+        "events": 10
+      },
+      {
+        "devices": 3,
+        "event": "activation_agent_prompt_action_clicked",
+        "events": 3
+      },
+      {
+        "devices": 1,
+        "event": "activation_agent_setup_cta_clicked",
+        "events": 1
+      },
+      {
+        "devices": 2,
+        "event": "activation_return_proxy_observed",
+        "events": 2
+      },
+      {
+        "devices": 0,
+        "event": "agent_capture_query_observed",
+        "events": 0
+      },
+      {
+        "devices": 7,
+        "event": "meeting_recording_started",
+        "events": 11
+      },
+      {
+        "devices": 4,
+        "event": "meeting_transcript_saved",
+        "events": 5
+      },
+      {
+        "devices": 5,
+        "event": "meeting_transcript_failed",
+        "events": 7
+      },
+      {
+        "devices": 1,
+        "event": "meeting_file_imported",
+        "events": 1
+      }
+    ],
+    "release_breakdown": [
+      {
+        "app_version": "1.1.48",
+        "failure_devices": 5,
+        "failure_events": 7,
+        "last_seen": "2026-06-19T00:00:00",
+        "launch_devices": 34,
+        "success_devices": 14
+      },
+      {
+        "app_version": "1.1.47",
+        "failure_devices": 0,
+        "failure_events": 0,
+        "last_seen": "2026-06-18T00:00:00",
+        "launch_devices": 8,
+        "success_devices": 5
+      }
+    ],
+    "reliability_breakdown": [
+      {
+        "devices": 4,
+        "event": "meeting_transcript_failed",
+        "events": 5,
+        "failure_kind": "decoder_start",
+        "trigger": "menu"
+      },
+      {
+        "devices": 2,
+        "event": "dictation_no_speech",
+        "events": 2,
+        "failure_kind": "quiet_input",
+        "trigger": "hotkey"
+      }
+    ]
+  },
+  "source": {
+    "kind": "fixture",
+    "privacy": "aggregate fixture counts only"
+  },
+  "window_days": 30
+}

--- a/docs/activation-lane.md
+++ b/docs/activation-lane.md
@@ -58,6 +58,19 @@ aggregate-only and separates strict saved-Markdown proof from proxy rows like
 For the full product-learning telemetry map, current event taxonomy, blind
 spots, and dashboard plan, see `docs/posthog-product-learning-plan.md`.
 
+For the dashboard-to-product-task loop, use:
+
+```bash
+python3 scripts/ops/posthog-product-dashboard-summary.py --days 30
+```
+
+That script reads the five dashboard families (`100 WAU Operating`,
+`Activation`, `Reliability`, `Feature Adoption`, and `Release Health`) and
+outputs the biggest activation leak, biggest reliability leak, strongest
+adoption signal, under-discovered feature, release regression watch, and top
+three PR/task candidates. It has fixture and self-test modes so CI can check
+the ranking logic without PostHog credentials.
+
 ## Guardrails
 
 - Do not add transcript text, meeting titles, speaker names, file paths, source

--- a/docs/ops-credentials.md
+++ b/docs/ops-credentials.md
@@ -61,6 +61,22 @@ proxies only; they are not proof that an agent answered from a saved artifact.
 The desired true-use event is `agent_capture_query_observed`, which should stay
 zero/unknown until that privacy-safe instrumentation exists.
 
+For the normal health lane's product-task loop, run:
+
+```bash
+python3 scripts/ops/posthog-product-dashboard-summary.py --days 30
+```
+
+`health-probe.sh posthog` runs this helper automatically when credentials are
+present. The report summarizes the five product-learning dashboard families
+and returns ranked product tasks from aggregate counts only. For CI or dry-run
+use:
+
+```bash
+python3 scripts/ops/posthog-product-dashboard-summary.py --self-test
+python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json
+```
+
 ### Cloudflare Read vs Deploy
 
 The health probe reads Pages project/deployment status and zone analytics for

--- a/docs/posthog-product-learning-plan.md
+++ b/docs/posthog-product-learning-plan.md
@@ -42,6 +42,7 @@ Operational scripts query aggregate counts only:
 
 - `scripts/ops/health-probe.sh posthog`
 - `scripts/ops/posthog-activation-funnel.py`
+- `scripts/ops/posthog-product-dashboard-summary.py`
 - `scripts/ops/release-health-card.py`
 - `scripts/ops/generate-nightly-digest.py`
 - `scripts/ops/nightly-security-check.py`
@@ -225,6 +226,15 @@ save/open a useful artifact, connect an agent, recover from failure, or return?
 - dictation completed devices and meeting transcript saved devices.
 - failure-rate tiles for dictation start, dictation no-speech, meeting start,
   meeting transcript failure, update failure.
+
+`scripts/ops/posthog-product-dashboard-summary.py` is the deterministic
+dashboard-to-product-task loop. It reads aggregate PostHog signal for this
+dashboard plus Activation, Reliability, Feature Adoption, and Release Health,
+then outputs the biggest activation leak, biggest reliability leak, strongest
+adoption signal, under-discovered feature, release regression watch, and top
+three PR/task candidates. Fixture mode uses
+`Tests/Fixtures/posthog-product-dashboard-summary.json` so CI can verify the
+ranking logic without credentials.
 
 ### Activation Funnel
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -62,6 +62,11 @@ with the operational health probes at `scripts/ops/daily-audio-reliability-check
   - Release-scoped usage: `python3 scripts/ops/posthog-activation-funnel.py --days 30 --app-version 1.1.48`
   - Writes local Markdown and JSON under `/tmp/transcripted-posthog-activation-funnel/<run-id>/`
   - Self-test: `python3 scripts/ops/posthog-activation-funnel.py --self-test`
+- `scripts/ops/posthog-product-dashboard-summary.py` — turn the five PostHog product-learning dashboard families into ranked product tasks
+  - Usage: `python3 scripts/ops/posthog-product-dashboard-summary.py --days 30`
+  - Fixture usage: `python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json`
+  - Writes local Markdown and JSON under `/tmp/transcripted-posthog-product-tasks/<run-id>/`
+  - Self-test: `python3 scripts/ops/posthog-product-dashboard-summary.py --self-test`
 - `scripts/ops/daily-audio-reliability-check.sh` — interactive daily audio reliability loop for launch, wake, Bluetooth/device-change, meeting recovery, retry, and stop-race checks
   - Usage: `bash run-daily-audio-reliability.sh`
   - Synthetic-only usage: `bash run-daily-audio-reliability.sh --synthetic`

--- a/scripts/dev/agent-preflight.sh
+++ b/scripts/dev/agent-preflight.sh
@@ -148,6 +148,13 @@ if [ -n "$changed_paths" ]; then
             add_command "bash -n scripts/ops/health-probe.sh"
         fi
 
+        if matches_any "$path" "scripts/ops/posthog-product-dashboard-summary.py" "Tests/Fixtures/posthog-product-dashboard-summary.json"; then
+            add_command "scripts/dev/agent-preflight.sh"
+            add_command "python3 -m py_compile scripts/ops/posthog-product-dashboard-summary.py"
+            add_command "python3 scripts/ops/posthog-product-dashboard-summary.py --self-test"
+            add_command "python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json --json-only"
+        fi
+
         if matches_any "$path" "scripts/dev/onboarding.sh"; then
             add_command "scripts/dev/agent-preflight.sh"
             add_command "bash -n scripts/dev/onboarding.sh"

--- a/scripts/ops/health-probe.sh
+++ b/scripts/ops/health-probe.sh
@@ -172,6 +172,13 @@ probe_posthog() {
   fi
   echo "PostHog (last 7d): devices=$devices, workflow_events=$events, onboarding_events=$onboarding, first_value_events=$first_value"
   echo "PostHog daily active devices: $daily_devices"
+
+  if [[ -e "$REPO_ROOT/scripts/ops/posthog-product-dashboard-summary.py" ]]; then
+    echo "PostHog product task recommendations:"
+    if ! python3 "$REPO_ROOT/scripts/ops/posthog-product-dashboard-summary.py" --days 7 --summary-only; then
+      echo "PostHog product task recommendations: unavailable; core aggregate health probe succeeded"
+    fi
+  fi
 }
 
 probe_cloudflare() {

--- a/scripts/ops/posthog-product-dashboard-summary.py
+++ b/scripts/ops/posthog-product-dashboard-summary.py
@@ -1,0 +1,782 @@
+#!/usr/bin/env python3
+"""Turn aggregate PostHog dashboard signal into ranked Transcripted product tasks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+TRUSTED_POSTHOG_HOSTS = {
+    "https://app.posthog.com",
+    "https://eu.posthog.com",
+    "https://posthog.com",
+    "https://us.posthog.com",
+}
+
+ENV_PATHS = (
+    Path.cwd() / ".env.local",
+    Path.cwd() / ".env",
+    Path.home() / ".transcripted-ops.env",
+    Path.home() / ".hermes" / ".env",
+    Path.home() / ".hermes" / "profiles" / "ops" / ".env",
+)
+
+CORE_EVENTS = (
+    "app_launched",
+    "onboarding_shown",
+    "onboarding_step_viewed",
+    "onboarding_completed",
+    "onboarding_first_dictation_started",
+    "dictation_started",
+    "meeting_recording_started",
+    "onboarding_first_dictation_saved",
+    "activation_first_artifact_saved",
+    "dictation_completed",
+    "meeting_transcript_saved",
+    "activation_artifact_action_clicked",
+    "activation_agent_prompt_action_clicked",
+    "activation_agent_setup_cta_clicked",
+    "onboarding_agent_cta_clicked",
+    "activation_return_proxy_observed",
+    "agent_capture_query_observed",
+    "dictation_start_failed",
+    "dictation_no_speech",
+    "dictation_cancelled",
+    "meeting_recording_start_failed",
+    "meeting_transcript_failed",
+    "meeting_transcript_skipped",
+    "meeting_speaker_finalization_failed",
+    "update_check_finished",
+    "update_download_finished",
+    "update_installed",
+    "settings_opened",
+    "settings_page_viewed",
+    "settings_action_clicked",
+    "meeting_prompt_shown",
+    "meeting_prompt_record_selected",
+    "meeting_file_imported",
+    "meeting_saved_audio_retranscription_requested",
+)
+
+WORKFLOW_EVENTS = (
+    "app_launched",
+    "onboarding_completed",
+    "dictation_started",
+    "dictation_completed",
+    "meeting_recording_started",
+    "meeting_transcript_saved",
+    "activation_first_artifact_saved",
+    "activation_artifact_action_clicked",
+    "activation_agent_prompt_action_clicked",
+    "activation_agent_setup_cta_clicked",
+    "activation_return_proxy_observed",
+)
+
+DISALLOWED_OUTPUT_COLUMNS = {
+    "distinct_id",
+    "person_id",
+    "uuid",
+    "email",
+    "name",
+    "path",
+    "title",
+    "transcript",
+    "url",
+    "raw",
+}
+
+
+class ProductTaskReportError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Finding:
+    title: str
+    metric: str
+    recommendation: str
+    confidence: str
+    score: float
+
+
+def load_env() -> None:
+    for path in ENV_PATHS:
+        if not path.is_file():
+            continue
+        for raw_line in path.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            key = key.strip().removeprefix("export ").strip()
+            value = value.strip().strip('"').strip("'")
+            if key and value and key not in os.environ:
+                os.environ[key] = value
+
+
+def normalize_posthog_host(raw: str) -> str:
+    host = raw.strip().rstrip("/")
+    if host == "https://us.i.posthog.com":
+        return "https://us.posthog.com"
+    if host == "https://eu.i.posthog.com":
+        return "https://eu.posthog.com"
+    return host
+
+
+def posthog_config() -> tuple[str, str, str]:
+    token = os.environ.get("POSTHOG_PERSONAL_API_KEY")
+    project_id = os.environ.get("POSTHOG_PROJECT_ID")
+    host = normalize_posthog_host(
+        os.environ.get("POSTHOG_APP_HOST")
+        or os.environ.get("POSTHOG_HOST")
+        or "https://us.posthog.com"
+    )
+    missing = []
+    if not token:
+        missing.append("POSTHOG_PERSONAL_API_KEY")
+    if not project_id:
+        missing.append("POSTHOG_PROJECT_ID")
+    if missing:
+        raise ProductTaskReportError("missing " + ", ".join(missing))
+    if not host.startswith("https://"):
+        raise ProductTaskReportError(f"refusing non-HTTPS PostHog host: {host}")
+    if host not in TRUSTED_POSTHOG_HOSTS and os.environ.get("POSTHOG_ALLOW_UNTRUSTED_HOST") != "1":
+        raise ProductTaskReportError(
+            f"refusing untrusted PostHog host: {host}; set POSTHOG_ALLOW_UNTRUSTED_HOST=1 only for trusted self-hosted PostHog"
+        )
+    return host, project_id, token
+
+
+def sql_quote(value: str) -> str:
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def sql_list(values: tuple[str, ...]) -> str:
+    return ", ".join(sql_quote(value) for value in values)
+
+
+def app_version_filter(app_version: str | None) -> str:
+    if not app_version:
+        return ""
+    return f"AND properties['app_version'] = {sql_quote(app_version)}"
+
+
+def run_hogql(host: str, project_id: str, token: str, query: str) -> dict[str, Any]:
+    payload = {"query": {"kind": "HogQLQuery", "query": query}, "refresh": "blocking"}
+    request = urllib.request.Request(
+        f"{host}/api/projects/{project_id}/query/",
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise ProductTaskReportError(f"PostHog query failed with HTTP {exc.code}: {body}") from exc
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise ProductTaskReportError(f"PostHog query failed: {exc}") from exc
+
+
+def rows_as_dicts(response: dict[str, Any]) -> list[dict[str, Any]]:
+    columns = response.get("columns") or []
+    unsafe = [
+        str(column)
+        for column in columns
+        if any(fragment in str(column).lower() for fragment in DISALLOWED_OUTPUT_COLUMNS)
+    ]
+    if unsafe:
+        raise ProductTaskReportError(f"query attempted to expose unsafe output columns: {', '.join(unsafe)}")
+    rows = response.get("results") or response.get("data") or []
+    return [
+        {str(column): row[index] if index < len(row) else None for index, column in enumerate(columns)}
+        for row in rows
+    ]
+
+
+def event_counts_query(days: int, app_version: str | None) -> str:
+    return f"""
+SELECT event, count() AS events, uniq(distinct_id) AS devices
+FROM events
+WHERE timestamp >= now() - INTERVAL {int(days)} DAY
+  AND event IN ({sql_list(CORE_EVENTS)})
+  {app_version_filter(app_version)}
+GROUP BY event
+ORDER BY event ASC
+"""
+
+
+def daily_active_query(days: int, app_version: str | None) -> str:
+    return f"""
+SELECT toDate(timestamp) AS day, uniq(distinct_id) AS active_devices
+FROM events
+WHERE timestamp >= now() - INTERVAL {int(days)} DAY
+  AND event IN ({sql_list(WORKFLOW_EVENTS)})
+  {app_version_filter(app_version)}
+GROUP BY day
+ORDER BY day ASC
+"""
+
+
+def reliability_breakdown_query(days: int, app_version: str | None) -> str:
+    return f"""
+SELECT
+  event,
+  properties['failure_kind'] AS failure_kind,
+  properties['trigger'] AS trigger,
+  count() AS events,
+  uniq(distinct_id) AS devices
+FROM events
+WHERE timestamp >= now() - INTERVAL {int(days)} DAY
+  AND event IN ('dictation_start_failed', 'dictation_no_speech', 'meeting_recording_start_failed', 'meeting_transcript_failed', 'meeting_transcript_skipped', 'meeting_speaker_finalization_failed')
+  {app_version_filter(app_version)}
+GROUP BY event, failure_kind, trigger
+ORDER BY events DESC
+LIMIT 30
+"""
+
+
+def adoption_breakdown_query(days: int, app_version: str | None) -> str:
+    return f"""
+SELECT
+  event,
+  properties['artifact_kind'] AS artifact_kind,
+  properties['action_kind'] AS action_kind,
+  properties['agent_target'] AS agent_target,
+  properties['page_id'] AS page_id,
+  count() AS events,
+  uniq(distinct_id) AS devices
+FROM events
+WHERE timestamp >= now() - INTERVAL {int(days)} DAY
+  AND event IN ('activation_artifact_action_clicked', 'activation_agent_prompt_action_clicked', 'activation_agent_setup_cta_clicked', 'onboarding_agent_cta_clicked', 'settings_page_viewed', 'settings_action_clicked', 'meeting_prompt_record_selected', 'meeting_file_imported', 'meeting_saved_audio_retranscription_requested')
+  {app_version_filter(app_version)}
+GROUP BY event, artifact_kind, action_kind, agent_target, page_id
+ORDER BY devices DESC, events DESC
+LIMIT 50
+"""
+
+
+def release_breakdown_query(days: int) -> str:
+    return f"""
+SELECT
+  properties['app_version'] AS app_version,
+  uniqIf(distinct_id, event = 'app_launched') AS launch_devices,
+  uniqIf(distinct_id, event IN ('dictation_completed', 'meeting_transcript_saved', 'activation_first_artifact_saved')) AS success_devices,
+  countIf(event IN ('dictation_start_failed', 'meeting_recording_start_failed', 'meeting_transcript_failed', 'meeting_transcript_skipped')) AS failure_events,
+  uniqIf(distinct_id, event IN ('dictation_start_failed', 'meeting_recording_start_failed', 'meeting_transcript_failed', 'meeting_transcript_skipped')) AS failure_devices,
+  max(timestamp) AS last_seen
+FROM events
+WHERE timestamp >= now() - INTERVAL {int(days)} DAY
+  AND event IN ({sql_list(CORE_EVENTS)})
+GROUP BY app_version
+ORDER BY last_seen DESC
+LIMIT 20
+"""
+
+
+def fetch_report_data(days: int, app_version: str | None) -> dict[str, Any]:
+    load_env()
+    host, project_id, token = posthog_config()
+    queries = {
+        "event_counts": event_counts_query(days, app_version),
+        "daily_active": daily_active_query(days, app_version),
+        "reliability_breakdown": reliability_breakdown_query(days, app_version),
+        "adoption_breakdown": adoption_breakdown_query(days, app_version),
+        "release_breakdown": release_breakdown_query(days),
+    }
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "window_days": days,
+        "app_version": app_version,
+        "source": {
+            "kind": "posthog_hogql_aggregate",
+            "host": host,
+            "privacy": "aggregate counts only; no user IDs, people rows, transcript text, audio references, file paths, titles, URLs, or raw payload rows are written",
+        },
+        "results": {
+            name: rows_as_dicts(run_hogql(host, project_id, token, query))
+            for name, query in queries.items()
+        },
+    }
+
+
+def load_fixture(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProductTaskReportError(f"unable to read fixture {path}: {exc}") from exc
+    if not isinstance(data, dict) or not isinstance(data.get("results"), dict):
+        raise ProductTaskReportError("fixture must be a JSON object with a results object")
+    data.setdefault("generated_at", datetime.now(timezone.utc).isoformat())
+    data.setdefault("source", {"kind": "fixture", "privacy": "aggregate fixture counts only"})
+    data.setdefault("window_days", 30)
+    data.setdefault("app_version", None)
+    return data
+
+
+def as_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def pct(numerator: int, denominator: int) -> str:
+    if denominator <= 0:
+        return "n/a"
+    return f"{(numerator / denominator) * 100:.1f}%"
+
+
+def event_devices(data: dict[str, Any]) -> dict[str, int]:
+    return {
+        str(row.get("event")): as_int(row.get("devices"))
+        for row in data["results"].get("event_counts", [])
+    }
+
+
+def event_events(data: dict[str, Any]) -> dict[str, int]:
+    return {
+        str(row.get("event")): as_int(row.get("events"))
+        for row in data["results"].get("event_counts", [])
+    }
+
+
+def build_activation_leak(data: dict[str, Any]) -> Finding:
+    devices = event_devices(data)
+    stages = [
+        ("launch", devices.get("app_launched", 0), "Improve first-run reach and install-to-launch proof."),
+        (
+            "onboarding touched",
+            max(devices.get("onboarding_shown", 0), devices.get("onboarding_step_viewed", 0)),
+            "Make the first screen and permission path harder to miss.",
+        ),
+        ("permission ready", devices.get("onboarding_completed", 0), "Shorten the permission/model-ready path."),
+        (
+            "capture started",
+            max(
+                devices.get("onboarding_first_dictation_started", 0),
+                devices.get("dictation_started", 0),
+                devices.get("meeting_recording_started", 0),
+            ),
+            "Put the first successful capture action closer to launch."),
+        (
+            "first saved artifact",
+            max(
+                devices.get("activation_first_artifact_saved", 0),
+                devices.get("onboarding_first_dictation_saved", 0),
+                devices.get("meeting_transcript_saved", 0),
+            ),
+            "Make saved Markdown visible immediately after capture.",
+        ),
+        (
+            "artifact action",
+            devices.get("activation_artifact_action_clicked", 0),
+            "Add a stronger open/copy/reveal moment after save.",
+        ),
+        (
+            "agent signal",
+            max(
+                devices.get("activation_agent_prompt_action_clicked", 0),
+                devices.get("activation_agent_setup_cta_clicked", 0),
+                devices.get("onboarding_agent_cta_clicked", 0),
+            ),
+            "Make the first agent question explicit and copyable.",
+        ),
+        (
+            "return proxy",
+            devices.get("activation_return_proxy_observed", 0),
+            "Nudge users back to yesterday's saved artifact."),
+        (
+            "true agent query",
+            devices.get("agent_capture_query_observed", 0),
+            "Instrument privacy-safe sourced-agent-use before calling the loop proven.",
+        ),
+    ]
+    biggest = ("unknown", 0, 0, "Add more activation instrumentation.")
+    previous_label, previous_count = stages[0][0], stages[0][1]
+    for label, count, recommendation in stages[1:]:
+        drop = max(previous_count - count, 0)
+        if drop > biggest[1]:
+            biggest = (f"{previous_label} -> {label}", drop, previous_count, recommendation)
+        previous_label, previous_count = label, count
+    rate = pct(biggest[1], biggest[2])
+    return Finding(
+        "Biggest activation leak",
+        f"{biggest[0]} drops {biggest[1]} devices ({rate} of prior stage).",
+        biggest[3],
+        "high" if biggest[2] >= 10 else "medium",
+        float(biggest[1]),
+    )
+
+
+def build_reliability_leak(data: dict[str, Any]) -> Finding:
+    events = event_events(data)
+    devices = event_devices(data)
+    candidates = [
+        (
+            "Dictation start failure",
+            events.get("dictation_start_failed", 0),
+            max(events.get("dictation_started", 0) + events.get("dictation_start_failed", 0), 1),
+            "Add a clearer retry/recovery path for dictation start failures.",
+        ),
+        (
+            "Dictation no-speech",
+            events.get("dictation_no_speech", 0),
+            max(events.get("dictation_started", 0), 1),
+            "Tune no-speech guidance and route-readiness recovery.",
+        ),
+        (
+            "Meeting start failure",
+            events.get("meeting_recording_start_failed", 0),
+            max(events.get("meeting_recording_started", 0) + events.get("meeting_recording_start_failed", 0), 1),
+            "Tighten meeting permission/route preflight before start.",
+        ),
+        (
+            "Meeting transcript failure",
+            events.get("meeting_transcript_failed", 0) + events.get("meeting_transcript_skipped", 0),
+            max(
+                events.get("meeting_transcript_saved", 0)
+                + events.get("meeting_transcript_failed", 0)
+                + events.get("meeting_transcript_skipped", 0),
+                1,
+            ),
+            "Improve failed/queued meeting transcript recovery and retained-audio retry.",
+        ),
+    ]
+    title, count, base, recommendation = max(candidates, key=lambda item: (item[1] / item[2], item[1], item[0]))
+    breakdown = data["results"].get("reliability_breakdown", [])
+    top_kind = ""
+    if breakdown:
+        top = max(breakdown, key=lambda row: as_int(row.get("events")))
+        failure_kind = top.get("failure_kind") or "unknown"
+        trigger = top.get("trigger") or "any trigger"
+        top_kind = f" Top breakdown: {top.get('event')} / {failure_kind} / {trigger}."
+    return Finding(
+        "Biggest reliability leak",
+        f"{title}: {count} failure events, {pct(count, base)} of relevant attempts.{top_kind}",
+        recommendation,
+        "high" if count >= 5 else "medium" if count else "low",
+        (count / base) * 1000 + count,
+    )
+
+
+def build_adoption_signal(data: dict[str, Any]) -> Finding:
+    rows = data["results"].get("adoption_breakdown", [])
+    if rows:
+        top = max(rows, key=lambda row: (as_int(row.get("devices")), as_int(row.get("events"))))
+        event = top.get("event") or "unknown"
+        detail = top.get("action_kind") or top.get("agent_target") or top.get("page_id") or top.get("artifact_kind") or "all"
+        devices = as_int(top.get("devices"))
+        return Finding(
+            "Strongest adoption signal",
+            f"{event} / {detail}: {devices} devices.",
+            "Double down on the surface that already gets used; make its next step obvious.",
+            "high" if devices >= 10 else "medium",
+            float(devices),
+        )
+    devices = event_devices(data)
+    event = max(devices, key=devices.get) if devices else "unknown"
+    count = devices.get(event, 0)
+    return Finding(
+        "Strongest adoption signal",
+        f"{event}: {count} devices.",
+        "Use the strongest current behavior as the entry point for the next activation prompt.",
+        "medium",
+        float(count),
+    )
+
+
+def build_under_discovered_feature(data: dict[str, Any]) -> Finding:
+    devices = event_devices(data)
+    wau = devices.get("app_launched", 0)
+    candidates = [
+        ("Agent setup", max(devices.get("activation_agent_setup_cta_clicked", 0), devices.get("onboarding_agent_cta_clicked", 0)), 5, "Surface Claude/MCP setup immediately after the first saved artifact."),
+        ("Agent prompt copy", devices.get("activation_agent_prompt_action_clicked", 0), 4, "Put the first sourced question beside Open Markdown."),
+        ("Meeting import", devices.get("meeting_file_imported", 0), 3, "Expose imported-audio transcription from Home for users who missed live capture."),
+        ("Saved-audio retranscription", devices.get("meeting_saved_audio_retranscription_requested", 0), 2, "Make retry from retained meeting audio clearer after transcript failure."),
+        ("Meeting prompt acceptance", devices.get("meeting_prompt_record_selected", 0), 2, "Clarify detected-meeting prompts and route readiness."),
+    ]
+    under = [
+        item for item in candidates
+        if wau <= 0 or item[1] <= max(2, int(wau * 0.2))
+    ]
+    name, count, _, recommendation = min(under or candidates, key=lambda item: (item[1], -item[2], item[0]))
+    return Finding(
+        "Under-discovered feature",
+        f"{name}: {count} devices ({pct(count, wau)} of launch devices).",
+        recommendation,
+        "high" if wau >= 10 else "medium",
+        float(max(wau - count, 0)),
+    )
+
+
+def build_release_watch(data: dict[str, Any]) -> Finding:
+    rows = [row for row in data["results"].get("release_breakdown", []) if row.get("app_version")]
+    if not rows:
+        return Finding(
+            "Release regression watch",
+            "No app-version rows in this window.",
+            "Keep release-health UNKNOWN until PostHog app_version rows appear.",
+            "low",
+            0,
+        )
+    watched = max(
+        rows,
+        key=lambda row: (
+            as_int(row.get("failure_events")) / max(as_int(row.get("launch_devices")), 1),
+            as_int(row.get("failure_events")),
+            str(row.get("last_seen") or ""),
+        ),
+    )
+    launches = as_int(watched.get("launch_devices"))
+    successes = as_int(watched.get("success_devices"))
+    failures = as_int(watched.get("failure_events"))
+    version = watched.get("app_version")
+    if launches and successes == 0:
+        recommendation = "Watch this version for install/update friction: launch exists but no first success signal yet."
+    elif failures:
+        recommendation = "Compare this version against Sentry and recent PRs before calling the release clean."
+    else:
+        recommendation = "No release regression from aggregate PostHog counts; keep watching Sentry for sparse fatals."
+    return Finding(
+        "Release regression watch",
+        f"{version}: launches={launches}, success_devices={successes}, failure_events={failures}.",
+        recommendation,
+        "medium" if launches < 10 or failures else "high",
+        (failures / max(launches, 1)) * 1000 + max(0, launches - successes),
+    )
+
+
+def task_priority_score(finding: Finding) -> float:
+    if finding.title == "Release regression watch":
+        return min(finding.score / 50, 20)
+    if finding.title == "Under-discovered feature":
+        return min(finding.score, 20)
+    if finding.title == "Strongest adoption signal":
+        return min(finding.score / 2, 10)
+    return min(finding.score, 20)
+
+
+def task_candidates(findings: dict[str, Finding]) -> list[Finding]:
+    pinned = [findings["activation"], findings["reliability"]]
+    pool = [findings["release"], findings["under"], findings["adoption"]]
+    third = max(pool, key=lambda item: (task_priority_score(item), item.title))
+    return sorted([*pinned, third], key=lambda item: (-task_priority_score(item), item.title))
+
+
+def dashboard_lines(data: dict[str, Any], findings: dict[str, Finding]) -> list[str]:
+    devices = event_devices(data)
+    events = event_events(data)
+    wau = devices.get("app_launched", 0)
+    dau_rows = data["results"].get("daily_active", [])
+    latest_dau = as_int(dau_rows[-1].get("active_devices")) if dau_rows else 0
+    activation = findings["activation"]
+    reliability = findings["reliability"]
+    adoption = findings["adoption"]
+    under = findings["under"]
+    release = findings["release"]
+    return [
+        f"- 100 WAU Operating: {wau} active launch devices; latest DAU row is {latest_dau}.",
+        f"- Activation: {activation.metric}",
+        f"- Reliability: {reliability.metric}",
+        f"- Feature Adoption: {adoption.metric} Under-discovered: {under.metric}",
+        f"- Release Health: {release.metric}",
+        f"- Core event volume: launches={events.get('app_launched', 0)}, dictations_completed={events.get('dictation_completed', 0)}, meetings_saved={events.get('meeting_transcript_saved', 0)}.",
+    ]
+
+
+def render_json(data: dict[str, Any], findings: dict[str, Finding]) -> dict[str, Any]:
+    ordered = [
+        findings["activation"],
+        findings["reliability"],
+        findings["adoption"],
+        findings["under"],
+        findings["release"],
+    ]
+    return {
+        "generated_at": data["generated_at"],
+        "window_days": data["window_days"],
+        "app_version": data.get("app_version"),
+        "source": data.get("source", {}),
+        "dashboards": dashboard_lines(data, findings),
+        "findings": {
+            "biggest_activation_leak": findings["activation"].__dict__,
+            "biggest_reliability_leak": findings["reliability"].__dict__,
+            "strongest_adoption_signal": findings["adoption"].__dict__,
+            "under_discovered_feature": findings["under"].__dict__,
+            "release_regression_watch": findings["release"].__dict__,
+        },
+        "top_recommended_tasks": [finding.__dict__ for finding in task_candidates(findings)],
+    }
+
+
+def render_markdown(data: dict[str, Any], findings: dict[str, Finding]) -> str:
+    result = render_json(data, findings)
+    tasks = result["top_recommended_tasks"]
+    lines = [
+        "# Transcripted PostHog Product Task Report",
+        "",
+        f"Generated: {data['generated_at']}",
+        f"Window: last {data['window_days']} days, {data.get('app_version') or 'all app versions'}",
+        "",
+        "Source: aggregate PostHog signal only. This report writes counts and enum buckets, not user rows, transcript text, audio references, file paths, meeting titles, URLs, or raw payloads.",
+        "",
+        "## Dashboard Families",
+        "",
+        *result["dashboards"],
+        "",
+        "## Required Read",
+        "",
+        f"- Biggest activation leak: {findings['activation'].metric} {findings['activation'].recommendation}",
+        f"- Biggest reliability leak: {findings['reliability'].metric} {findings['reliability'].recommendation}",
+        f"- Strongest adoption signal: {findings['adoption'].metric} {findings['adoption'].recommendation}",
+        f"- Under-discovered feature: {findings['under'].metric} {findings['under'].recommendation}",
+        f"- Release regression watch: {findings['release'].metric} {findings['release'].recommendation}",
+        "",
+        "## Top 3 Recommended PR/Task Candidates",
+        "",
+    ]
+    for index, task in enumerate(tasks, start=1):
+        lines.append(f"{index}. {task['title']}: {task['recommendation']} ({task['metric']})")
+    lines.extend([
+        "",
+        "## Privacy Boundary",
+        "",
+        "- Aggregate only. No raw rows or user-level forensics.",
+        "- Treat agent setup, prompt copy, and return events as proxies until `agent_capture_query_observed` exists.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def analyze(data: dict[str, Any]) -> dict[str, Finding]:
+    return {
+        "activation": build_activation_leak(data),
+        "reliability": build_reliability_leak(data),
+        "adoption": build_adoption_signal(data),
+        "under": build_under_discovered_feature(data),
+        "release": build_release_watch(data),
+    }
+
+
+def write_outputs(data: dict[str, Any], markdown: str, summary: dict[str, Any], write_dir: Path | None) -> tuple[Path, Path]:
+    output_dir = write_dir or Path("/tmp/transcripted-posthog-product-tasks") / datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = output_dir / "product-task-report.md"
+    data_path = output_dir / "product-task-report.json"
+    report_path.write_text(markdown, encoding="utf-8")
+    data_path.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+    return report_path, data_path
+
+
+def run_self_test() -> int:
+    fixture_path = Path(__file__).resolve().parents[2] / "Tests" / "Fixtures" / "posthog-product-dashboard-summary.json"
+    if not fixture_path.is_file():
+        print(f"self-test failed: missing fixture {fixture_path}", file=sys.stderr)
+        return 1
+    data = load_fixture(fixture_path)
+    findings = analyze(data)
+    markdown = render_markdown(data, findings)
+    summary = render_json(data, findings)
+    required = (
+        "Biggest activation leak",
+        "Biggest reliability leak",
+        "Strongest adoption signal",
+        "Under-discovered feature",
+        "Release regression watch",
+        "Top 3 Recommended PR/Task Candidates",
+    )
+    missing = [item for item in required if item not in markdown]
+    if missing:
+        print(f"self-test failed: missing sections: {', '.join(missing)}", file=sys.stderr)
+        return 1
+    forbidden = ("distinct_id", "transcript_text", "audio_path", "meeting_title", "raw_url", "person_id")
+    lowered = (markdown + json.dumps(summary, sort_keys=True)).lower()
+    leaked = [fragment for fragment in forbidden if fragment in lowered]
+    if leaked:
+        print(f"self-test failed: unsafe fragment in output: {', '.join(leaked)}", file=sys.stderr)
+        return 1
+    if len(summary["top_recommended_tasks"]) != 3:
+        print("self-test failed: expected exactly three top task candidates", file=sys.stderr)
+        return 1
+    for query in (
+        event_counts_query(30, None),
+        daily_active_query(30, None),
+        reliability_breakdown_query(30, None),
+        adoption_breakdown_query(30, None),
+        release_breakdown_query(30),
+    ):
+        if "SELECT *" in query.upper():
+            print("self-test failed: query uses SELECT *", file=sys.stderr)
+            return 1
+    print("self-test passed")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--days", type=int, default=30, help="Lookback window in days.")
+    parser.add_argument("--app-version", help="Optional app_version filter for non-release queries, e.g. 1.1.48.")
+    parser.add_argument("--fixture", type=Path, help="Read aggregate fixture JSON instead of querying PostHog.")
+    parser.add_argument("--write-dir", type=Path, help="Directory for product-task-report.md and product-task-report.json.")
+    parser.add_argument("--json-only", action="store_true", help="Print the JSON summary instead of Markdown.")
+    parser.add_argument("--summary-only", action="store_true", help="Print only dashboard and top task lines.")
+    parser.add_argument("--self-test", action="store_true", help="Run offline formatting/privacy checks without PostHog access.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test:
+        return run_self_test()
+    if args.days <= 0:
+        print("ERROR: --days must be positive", file=sys.stderr)
+        return 2
+    try:
+        data = load_fixture(args.fixture) if args.fixture else fetch_report_data(args.days, args.app_version)
+        findings = analyze(data)
+        markdown = render_markdown(data, findings)
+        summary = render_json(data, findings)
+        if args.write_dir or not (args.json_only or args.summary_only):
+            report_path, data_path = write_outputs(data, markdown, summary, args.write_dir)
+        else:
+            report_path = None
+            data_path = None
+    except ProductTaskReportError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 3
+
+    if args.json_only:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    elif args.summary_only:
+        for line in summary["dashboards"]:
+            print(line)
+        print("Top recommended tasks:")
+        for index, task in enumerate(summary["top_recommended_tasks"], start=1):
+            print(f"{index}. {task['title']}: {task['recommendation']}")
+        if report_path and data_path:
+            print(f"Report written: {report_path}")
+            print(f"Data written: {data_path}")
+    else:
+        print(markdown)
+        if report_path and data_path:
+            print(f"Report written: {report_path}")
+            print(f"Data written: {data_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ops/posthog-product-dashboard-summary.py
+++ b/scripts/ops/posthog-product-dashboard-summary.py
@@ -431,18 +431,21 @@ def build_reliability_leak(data: dict[str, Any]) -> Finding:
             events.get("dictation_start_failed", 0),
             max(events.get("dictation_started", 0) + events.get("dictation_start_failed", 0), 1),
             "Add a clearer retry/recovery path for dictation start failures.",
+            ("dictation_start_failed",),
         ),
         (
             "Dictation no-speech",
             events.get("dictation_no_speech", 0),
             max(events.get("dictation_started", 0), 1),
             "Tune no-speech guidance and route-readiness recovery.",
+            ("dictation_no_speech",),
         ),
         (
             "Meeting start failure",
             events.get("meeting_recording_start_failed", 0),
             max(events.get("meeting_recording_started", 0) + events.get("meeting_recording_start_failed", 0), 1),
             "Tighten meeting permission/route preflight before start.",
+            ("meeting_recording_start_failed",),
         ),
         (
             "Meeting transcript failure",
@@ -454,13 +457,15 @@ def build_reliability_leak(data: dict[str, Any]) -> Finding:
                 1,
             ),
             "Improve failed/queued meeting transcript recovery and retained-audio retry.",
+            ("meeting_transcript_failed", "meeting_transcript_skipped"),
         ),
     ]
-    title, count, base, recommendation = max(candidates, key=lambda item: (item[1] / item[2], item[1], item[0]))
+    title, count, base, recommendation, matching_events = max(candidates, key=lambda item: (item[1] / item[2], item[1], item[0]))
     breakdown = data["results"].get("reliability_breakdown", [])
+    matching_breakdown = [row for row in breakdown if row.get("event") in matching_events]
     top_kind = ""
-    if breakdown:
-        top = max(breakdown, key=lambda row: as_int(row.get("events")))
+    if matching_breakdown:
+        top = max(matching_breakdown, key=lambda row: as_int(row.get("events")))
         failure_kind = top.get("failure_kind") or "unknown"
         trigger = top.get("trigger") or "any trigger"
         top_kind = f" Top breakdown: {top.get('event')} / {failure_kind} / {trigger}."
@@ -711,6 +716,15 @@ def run_self_test() -> int:
         return 1
     if len(summary["top_recommended_tasks"]) != 3:
         print("self-test failed: expected exactly three top task candidates", file=sys.stderr)
+        return 1
+    mismatch_data = json.loads(json.dumps(data))
+    mismatch_data["results"]["reliability_breakdown"] = [
+        {"event": "dictation_no_speech", "events": 99, "failure_kind": "quiet_input", "trigger": "hotkey"},
+        {"event": "meeting_transcript_failed", "events": 5, "failure_kind": "decoder_start", "trigger": "menu"},
+    ]
+    mismatch_metric = build_reliability_leak(mismatch_data).metric
+    if "Meeting transcript failure" not in mismatch_metric or "meeting_transcript_failed" not in mismatch_metric or "dictation_no_speech" in mismatch_metric:
+        print("self-test failed: reliability breakdown did not stay tied to selected leak", file=sys.stderr)
         return 1
     for query in (
         event_counts_query(30, None),

--- a/scripts/ops/transcripted-qa-bench.sh
+++ b/scripts/ops/transcripted-qa-bench.sh
@@ -794,6 +794,10 @@ run_full_tail() {
     "scripts/ops/nightly-security-check.py" \
     "python3 scripts/ops/nightly-security-check.py --strict --automation-toml Tests/Fixtures/nightly-security-automation.toml --github-release-json Tests/Fixtures/release-health-github-release-1.1.48.json --write-report $(shell_quote "${RAW_DIR}/release-health.json")"
 
+  run_step_when_present "62-posthog-product-tasks" "PostHog product task fixture gate" "yes" \
+    "scripts/ops/posthog-product-dashboard-summary.py" \
+    "python3 scripts/ops/posthog-product-dashboard-summary.py --self-test && python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json --json-only > $(shell_quote "${RAW_DIR}/posthog-product-tasks.json")"
+
   run_gemma_summary_plan
 }
 


### PR DESCRIPTION
## Summary
- add `posthog-product-dashboard-summary.py` to turn aggregate PostHog dashboard signal into ranked product recommendations
- cover the five dashboard families: 100 WAU, Activation, Reliability, Feature Adoption, Release Health
- wire the report into `health-probe.sh posthog`, agent preflight/test matrix, and the full QA bench fixture gate
- add a fixture/dry-run path so CI and agents can test without credentials

## Sample fixture recommendations
1. Biggest reliability leak: Improve failed/queued meeting transcript recovery and retained-audio retry.
2. Under-discovered feature: Clarify detected-meeting prompts and route readiness.
3. Biggest activation leak: Make the first screen and permission path harder to miss.

## Privacy
- aggregate PostHog counts and enum buckets only
- no raw rows, distinct IDs, people rows, transcript text, audio references, meeting titles, file paths, URLs, or raw payloads are written

## Verification
- `python3 -m py_compile scripts/ops/posthog-product-dashboard-summary.py`
- `python3 scripts/ops/posthog-product-dashboard-summary.py --self-test`
- `python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json --json-only`
- `bash -n scripts/ops/health-probe.sh`
- `bash -n scripts/ops/transcripted-qa-bench.sh`
- `bash -n scripts/ops/run-local-summary-fixture.sh`
- `bash scripts/ops/run-local-summary-fixture.sh`
- `swift test --package-path Tools/TranscriptedQA`
- `bash run-tests.sh`
- `bash build-deps.sh --force`
- `bash scripts/ops/transcripted-qa-bench.sh --mode quick` (PASS 6/6, report `/tmp/transcripted-qa-bench/qa-20260619-170414/qa-report.md`)

## Independent review
- Claude review found two medium issues before commit: health-probe gating and incomparable top-3 ranking. Both were fixed.
- Follow-up Claude review: no blocker; prior findings addressed.
