### PR TITLE
Add workflow recovery telemetry

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -104,6 +104,15 @@ final class MeetingSessionController: ObservableObject {
                 return nil
             }
         }
+
+        var artifactRetained: Bool {
+            switch kind {
+            case .recorded:
+                return true
+            case .imported:
+                return false
+            }
+        }
     }
 
     private enum TerminalTranscriptionOutcome: Equatable {
@@ -352,6 +361,16 @@ final class MeetingSessionController: ObservableObject {
             return
         }
 
+        let modelPreparationStartedAt = CFAbsoluteTimeGetCurrent()
+        let retrySource = showLoadingUI ? "warmup" : "background_warmup"
+        let surface = showLoadingUI ? "meeting" : "runtime"
+        WorkflowRecoveryTelemetry.attempted(
+            workflowKind: "model_preparation",
+            failureKind: "models_not_ready",
+            retrySource: retrySource,
+            surface: surface,
+            artifactRetained: false
+        )
         let task = Task<Result<Void, Error>, Never> { [downloader] in
             do {
                 try await downloader.ensureModelsReady()
@@ -366,6 +385,12 @@ final class MeetingSessionController: ObservableObject {
         modelPreparationTask?.cancel()
         modelPreparationTask = nil
         applyModelPreparationResult(result, showLoadingUI: showLoadingUI)
+        trackModelPreparationRecoveryFinished(
+            result,
+            retrySource: retrySource,
+            elapsedSeconds: CFAbsoluteTimeGetCurrent() - modelPreparationStartedAt,
+            surface: surface
+        )
     }
 
     /// Begin a new meeting recording. Safe to call from UI buttons. If a prior
@@ -1104,6 +1129,14 @@ final class MeetingSessionController: ObservableObject {
             context: baseDiagnosticsContext(extra: ["trigger": StartTrigger.fileImport.rawValue])
         )
         Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "file_import_requested")
+        let importStartedAt = CFAbsoluteTimeGetCurrent()
+        WorkflowRecoveryTelemetry.attempted(
+            workflowKind: "meeting_import",
+            failureKind: "external_recording",
+            retrySource: "file_import",
+            surface: "menu",
+            artifactRetained: false
+        )
 
         if case .idle = state {
             await prepareModels()
@@ -1121,6 +1154,15 @@ final class MeetingSessionController: ObservableObject {
             break
         default:
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "models_unavailable")
+            WorkflowRecoveryTelemetry.finished(
+                workflowKind: "meeting_import",
+                failureKind: "models_not_ready",
+                retrySource: "file_import",
+                result: "failed",
+                elapsedSeconds: CFAbsoluteTimeGetCurrent() - importStartedAt,
+                surface: "menu",
+                artifactRetained: false
+            )
             return false
         }
 
@@ -1151,6 +1193,15 @@ final class MeetingSessionController: ObservableObject {
                     "failure_kind": failureKind,
                     "import_stage": "preparation",
                 ]
+            )
+            WorkflowRecoveryTelemetry.finished(
+                workflowKind: "meeting_import",
+                failureKind: failureKind,
+                retrySource: "file_import",
+                result: "failed",
+                elapsedSeconds: CFAbsoluteTimeGetCurrent() - importStartedAt,
+                surface: "menu",
+                artifactRetained: false
             )
             state = .error(displayMessage)
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "file_import_failed")
@@ -1184,6 +1235,15 @@ final class MeetingSessionController: ObservableObject {
             properties: [
                 "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(queuedTranscriptionJobs.count),
             ]
+        )
+        WorkflowRecoveryTelemetry.finished(
+            workflowKind: "meeting_import",
+            failureKind: "external_recording",
+            retrySource: "file_import",
+            result: "success",
+            elapsedSeconds: CFAbsoluteTimeGetCurrent() - importStartedAt,
+            surface: "menu",
+            artifactRetained: false
         )
         Self.runtimeDiagnosticsRecorder?.recordSession(kind: "meeting", stage: "transcribing")
         return true
@@ -1386,6 +1446,14 @@ final class MeetingSessionController: ObservableObject {
         retryingFailedMeetingIDs.insert(id)
         activeTranscriptionTrigger = .unknown
         refreshFailedMeetings()
+        let retryStartedAt = CFAbsoluteTimeGetCurrent()
+        WorkflowRecoveryTelemetry.attempted(
+            workflowKind: "meeting_transcription",
+            failureKind: "failed_meeting",
+            retrySource: "failed_meeting_retry",
+            surface: "home",
+            artifactRetained: true
+        )
 
         Task { [weak self] in
             guard let self else { return }
@@ -1400,15 +1468,33 @@ final class MeetingSessionController: ObservableObject {
                 )
                 self.retryingFailedMeetingIDs.remove(id)
                 self.refreshFailedMeetings()
+                WorkflowRecoveryTelemetry.finished(
+                    workflowKind: "meeting_transcription",
+                    failureKind: "failed_meeting",
+                    retrySource: "failed_meeting_retry",
+                    result: "failed",
+                    elapsedSeconds: CFAbsoluteTimeGetCurrent() - retryStartedAt,
+                    surface: "home",
+                    artifactRetained: true
+                )
                 return
             }
 
-            _ = await self.taskManager.retryFailedTranscription(
+            let retryPublished = await self.taskManager.retryFailedTranscription(
                 failedId: id,
                 outputFolder: MeetingStoragePaths.transcriptsFolder
             )
             self.retryingFailedMeetingIDs.remove(id)
             self.refreshFailedMeetings()
+            WorkflowRecoveryTelemetry.finished(
+                workflowKind: "meeting_transcription",
+                failureKind: "failed_meeting",
+                retrySource: "failed_meeting_retry",
+                result: retryPublished ? "success" : "failed",
+                elapsedSeconds: CFAbsoluteTimeGetCurrent() - retryStartedAt,
+                surface: "home",
+                artifactRetained: true
+            )
         }
         return true
     }
@@ -1456,6 +1542,13 @@ final class MeetingSessionController: ObservableObject {
                 "trigger": StartTrigger.savedMeetingRetranscription.rawValue
             ]
         )
+        WorkflowRecoveryTelemetry.attempted(
+            workflowKind: "meeting_transcription",
+            failureKind: "saved_recording",
+            retrySource: "saved_meeting_retranscription",
+            surface: "home",
+            artifactRetained: true
+        )
 
         if case .idle = state {
             await prepareModels()
@@ -1469,6 +1562,14 @@ final class MeetingSessionController: ObservableObject {
         }
 
         guard case .ready = state else {
+            WorkflowRecoveryTelemetry.finished(
+                workflowKind: "meeting_transcription",
+                failureKind: "models_not_ready",
+                retrySource: "saved_meeting_retranscription",
+                result: "failed",
+                surface: "home",
+                artifactRetained: true
+            )
             return false
         }
 
@@ -2113,6 +2214,30 @@ final class MeetingSessionController: ObservableObject {
         refreshWarmupStatus()
     }
 
+    private func trackModelPreparationRecoveryFinished(
+        _ result: Result<Void, Error>,
+        retrySource: String,
+        elapsedSeconds: TimeInterval,
+        surface: String
+    ) {
+        let recoveryResult: String
+        switch result {
+        case .success:
+            recoveryResult = "success"
+        case .failure:
+            recoveryResult = "failed"
+        }
+        WorkflowRecoveryTelemetry.finished(
+            workflowKind: "model_preparation",
+            failureKind: "models_not_ready",
+            retrySource: retrySource,
+            result: recoveryResult,
+            elapsedSeconds: elapsedSeconds,
+            surface: surface,
+            artifactRetained: false
+        )
+    }
+
     private func resetPreparedSpeechModelIfNeeded() {
         let preparedEngine = sttAdapter.transcriptionEngineDescriptor.identifier
         let selectedEngine = sttRouter.selectedModel.transcriptionEngineIdentifier
@@ -2305,6 +2430,14 @@ final class MeetingSessionController: ObservableObject {
                 ]
             )
         )
+        let modelRecoveryStartedAt = CFAbsoluteTimeGetCurrent()
+        WorkflowRecoveryTelemetry.attempted(
+            workflowKind: "model_preparation",
+            failureKind: "models_not_ready",
+            retrySource: "queued_transcription",
+            surface: "meeting",
+            artifactRetained: job.artifactRetained
+        )
 
         do {
             try await downloader.ensureModelsReady(sttModel: job.sttModel)
@@ -2322,6 +2455,15 @@ final class MeetingSessionController: ObservableObject {
                         "queued_stt_model": job.sttModel.rawValue
                     ]
                 )
+            )
+            WorkflowRecoveryTelemetry.finished(
+                workflowKind: "model_preparation",
+                failureKind: "models_not_ready",
+                retrySource: "queued_transcription",
+                result: "failed",
+                elapsedSeconds: CFAbsoluteTimeGetCurrent() - modelRecoveryStartedAt,
+                surface: "meeting",
+                artifactRetained: job.artifactRetained
             )
             return false
         }
@@ -2341,6 +2483,16 @@ final class MeetingSessionController: ObservableObject {
                 )
             )
         }
+
+        WorkflowRecoveryTelemetry.finished(
+            workflowKind: "model_preparation",
+            failureKind: "models_not_ready",
+            retrySource: "queued_transcription",
+            result: ready ? "success" : "failed",
+            elapsedSeconds: CFAbsoluteTimeGetCurrent() - modelRecoveryStartedAt,
+            surface: "meeting",
+            artifactRetained: job.artifactRetained
+        )
 
         return ready
     }
@@ -2544,6 +2696,10 @@ final class MeetingSessionController: ObservableObject {
                     "trigger": transcriptionTrigger.rawValue,
                 ]
             )
+            trackSavedMeetingRetranscriptionRecoveryFinishedIfNeeded(
+                trigger: transcriptionTrigger,
+                result: "success"
+            )
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "transcript_saved")
             AppSoundPlayer.shared.play(.meetingTranscriptComplete)
             activeQueuedTranscriptionJobID = nil
@@ -2615,6 +2771,19 @@ final class MeetingSessionController: ObservableObject {
                         "trigger": transcriptionTrigger.rawValue,
                     ]
                 )
+                WorkflowRecoveryTelemetry.finished(
+                    workflowKind: "speaker_review",
+                    failureKind: failureKind.rawValue,
+                    retrySource: "review_submission",
+                    result: "failed",
+                    surface: "meeting",
+                    artifactRetained: true
+                )
+                trackSavedMeetingRetranscriptionRecoveryFinishedIfNeeded(
+                    trigger: transcriptionTrigger,
+                    result: "failed",
+                    failureKind: failureKind.rawValue
+                )
                 activeTranscriptionCaptureDiagnostics = nil
                 Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "speaker_finalization_failed")
                 finalizeBackgroundTranscriptionStateIfNeeded()
@@ -2647,6 +2816,11 @@ final class MeetingSessionController: ObservableObject {
             AnalyticsReporter.track(
                 "meeting_transcript_failed",
                 properties: failureTelemetryContext
+            )
+            trackSavedMeetingRetranscriptionRecoveryFinishedIfNeeded(
+                trigger: transcriptionTrigger,
+                result: "failed",
+                failureKind: failureKind.rawValue
             )
             activeTranscriptionCaptureDiagnostics = nil
             Self.runtimeDiagnosticsRecorder?.clearSession(kind: "meeting", outcome: "transcript_failed")
@@ -2840,6 +3014,22 @@ final class MeetingSessionController: ObservableObject {
                 )
             }
         }
+    }
+
+    private func trackSavedMeetingRetranscriptionRecoveryFinishedIfNeeded(
+        trigger: StartTrigger,
+        result: String,
+        failureKind: String = "saved_recording"
+    ) {
+        guard trigger == .savedMeetingRetranscription else { return }
+        WorkflowRecoveryTelemetry.finished(
+            workflowKind: "meeting_transcription",
+            failureKind: failureKind,
+            retrySource: "saved_meeting_retranscription",
+            result: result,
+            surface: "home",
+            artifactRetained: true
+        )
     }
 
     nonisolated private static func savedTranscriptAnalyticsProperties(transcriptURL: URL?) -> [String: String] {

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -163,6 +163,17 @@ struct AnalyticsEventPolicy: Equatable {
         "source",
     ]
 
+    private static let workflowRecoveryProperties: Set<String> = [
+        "artifact_retained",
+        "attempt_bucket",
+        "elapsed_bucket",
+        "failure_kind",
+        "result",
+        "retry_source",
+        "surface",
+        "workflow_kind",
+    ]
+
     private static let allowedPolicies: [String: AnalyticsEventPolicy] = [
         "app_launched": .init(
             name: "app_launched",
@@ -338,6 +349,14 @@ struct AnalyticsEventPolicy: Equatable {
         "activation_return_proxy_observed": .init(
             name: "activation_return_proxy_observed",
             allowedProperties: activationReturnProxyProperties
+        ),
+        "workflow_recovery_attempted": .init(
+            name: "workflow_recovery_attempted",
+            allowedProperties: workflowRecoveryProperties.subtracting(["elapsed_bucket", "result"])
+        ),
+        "workflow_recovery_finished": .init(
+            name: "workflow_recovery_finished",
+            allowedProperties: workflowRecoveryProperties
         ),
         "menu_bar_opened": .init(
             name: "menu_bar_opened",

--- a/Sources/Observability/WorkflowRecoveryTelemetry.swift
+++ b/Sources/Observability/WorkflowRecoveryTelemetry.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+enum WorkflowRecoveryTelemetry {
+    static func attempted(
+        workflowKind: String,
+        failureKind: String,
+        retrySource: String,
+        attempt: Int = 1,
+        surface: String,
+        artifactRetained: Bool
+    ) {
+        AnalyticsReporter.track(
+            "workflow_recovery_attempted",
+            properties: baseProperties(
+                workflowKind: workflowKind,
+                failureKind: failureKind,
+                retrySource: retrySource,
+                attempt: attempt,
+                surface: surface,
+                artifactRetained: artifactRetained
+            )
+        )
+    }
+
+    static func finished(
+        workflowKind: String,
+        failureKind: String,
+        retrySource: String,
+        attempt: Int = 1,
+        result: String,
+        elapsedSeconds: TimeInterval? = nil,
+        surface: String,
+        artifactRetained: Bool
+    ) {
+        var properties = baseProperties(
+            workflowKind: workflowKind,
+            failureKind: failureKind,
+            retrySource: retrySource,
+            attempt: attempt,
+            surface: surface,
+            artifactRetained: artifactRetained
+        )
+        properties["result"] = result
+        if let elapsedSeconds {
+            properties["elapsed_bucket"] = AnalyticsReporter.durationBucket(seconds: elapsedSeconds)
+        }
+
+        AnalyticsReporter.track(
+            "workflow_recovery_finished",
+            properties: properties
+        )
+    }
+
+    private static func baseProperties(
+        workflowKind: String,
+        failureKind: String,
+        retrySource: String,
+        attempt: Int,
+        surface: String,
+        artifactRetained: Bool
+    ) -> [String: String] {
+        [
+            "workflow_kind": workflowKind,
+            "failure_kind": failureKind,
+            "retry_source": retrySource,
+            "attempt_bucket": AnalyticsReporter.countBucket(attempt),
+            "surface": surface,
+            "artifact_retained": artifactRetained ? "true" : "false",
+        ]
+    }
+}

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -917,6 +917,13 @@ class ParakeetEngine: ObservableObject {
         configChangeWasRecording = false
         let myGeneration = recoveryState.generation
         let recoveryStartedAt = CFAbsoluteTimeGetCurrent()
+        WorkflowRecoveryTelemetry.attempted(
+            workflowKind: "dictation",
+            failureKind: "route_changed",
+            retrySource: "audio_route_recovery",
+            surface: "runtime",
+            artifactRetained: shouldRestartRecording
+        )
 
         configRecoveryTask = Task { @MainActor [weak self] in
             // Wait for CoreAudio to finish settling the new device graph.
@@ -983,7 +990,6 @@ class ParakeetEngine: ObservableObject {
                         ]
                     )
                 )
-
                 // If we were recording, try to restart on the new device.
                 // The watchdog (via isRecoveryAttempt=false) catches silent
                 // failures where the device looks functional but produces no
@@ -1004,6 +1010,15 @@ class ParakeetEngine: ObservableObject {
                                     "sample_rate": "\(self.safeNativeSampleRate())",
                                     "attempts": "\(attempt)"
                                 ])
+                            WorkflowRecoveryTelemetry.finished(
+                                workflowKind: "dictation",
+                                failureKind: "route_changed",
+                                retrySource: "audio_route_recovery",
+                                result: "success",
+                                elapsedSeconds: CFAbsoluteTimeGetCurrent() - recoveryStartedAt,
+                                surface: "runtime",
+                                artifactRetained: true
+                            )
                             break
                         }
                         // BT format negotiation can take ~1-2s; wait between attempts.
@@ -1023,7 +1038,26 @@ class ParakeetEngine: ObservableObject {
                                     "reason": "recording_restart_budget_exhausted"
                                 ]
                             ))
+                        WorkflowRecoveryTelemetry.finished(
+                            workflowKind: "dictation",
+                            failureKind: "route_changed",
+                            retrySource: "audio_route_recovery",
+                            result: "gave_up",
+                            elapsedSeconds: CFAbsoluteTimeGetCurrent() - recoveryStartedAt,
+                            surface: "runtime",
+                            artifactRetained: false
+                        )
                     }
+                } else {
+                    WorkflowRecoveryTelemetry.finished(
+                        workflowKind: "dictation",
+                        failureKind: "route_changed",
+                        retrySource: "audio_route_recovery",
+                        result: "success",
+                        elapsedSeconds: CFAbsoluteTimeGetCurrent() - recoveryStartedAt,
+                        surface: "runtime",
+                        artifactRetained: false
+                    )
                 }
             } catch {
                 guard !self.recoveryState.isStale(generation: myGeneration) else { return }
@@ -1047,6 +1081,15 @@ class ParakeetEngine: ObservableObject {
                             "was_recording": "\(shouldRestartRecording)"
                         ]
                     )
+                )
+                WorkflowRecoveryTelemetry.finished(
+                    workflowKind: "dictation",
+                    failureKind: "route_changed",
+                    retrySource: "audio_route_recovery",
+                    result: "failed",
+                    elapsedSeconds: CFAbsoluteTimeGetCurrent() - recoveryStartedAt,
+                    surface: "runtime",
+                    artifactRetained: shouldRestartRecording
                 )
                 if failureAction.markRecordingInterrupted {
                     self.interruptRecordingAndClearRecoveredTimeline()
@@ -1124,6 +1167,15 @@ class ParakeetEngine: ObservableObject {
                         "was_recording": "\(wasRecording)"
                     ]
                 )
+            )
+            WorkflowRecoveryTelemetry.finished(
+                workflowKind: "dictation",
+                failureKind: "route_changed",
+                retrySource: "audio_route_recovery",
+                result: "gave_up",
+                elapsedSeconds: Double(TranscriptedConstants.audioDeviceRecoveryTimeout) / 1_000_000_000,
+                surface: "runtime",
+                artifactRetained: wasRecording
             )
             let diagnosticsEvent = failureAction.reportSentryFailure
                 ? "device_change_recovery_timeout"

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -912,6 +912,11 @@ class DictationSessionController: ObservableObject {
             stopTiming.pasteStartedAt = CFAbsoluteTimeGetCurrent()
             let pasteOutcome = self.pasteWithClipboardRestore(text)
             stopTiming.pastedAt = CFAbsoluteTimeGetCurrent()
+            self.trackPastebackRecoveryIfNeeded(
+                pasteOutcome,
+                elapsedSeconds: (stopTiming.pastedAt ?? CFAbsoluteTimeGetCurrent())
+                    - (stopTiming.pasteStartedAt ?? CFAbsoluteTimeGetCurrent())
+            )
             let autoSendOutcome: DictationAutoSendOutcome
             let saveFailureMessage: String?
             switch DictationStopFinalizationPolicy.order {
@@ -1631,6 +1636,41 @@ class DictationSessionController: ObservableObject {
         AnalyticsReporter.track(
             "dictation_stop_latency_measured",
             properties: analyticsProperties
+        )
+    }
+
+    private func trackPastebackRecoveryIfNeeded(
+        _ pasteOutcome: DictationPasteOutcome,
+        elapsedSeconds: TimeInterval
+    ) {
+        let failureKind: String
+        let result: String
+        switch pasteOutcome {
+        case .pasted:
+            return
+        case .copied(_, reason: let reason):
+            failureKind = reason.diagnosticName
+            result = "success"
+        case .failed:
+            failureKind = "pasteback_unavailable"
+            result = "gave_up"
+        }
+
+        WorkflowRecoveryTelemetry.attempted(
+            workflowKind: "pasteback",
+            failureKind: failureKind,
+            retrySource: "clipboard_fallback",
+            surface: "dictation",
+            artifactRetained: true
+        )
+        WorkflowRecoveryTelemetry.finished(
+            workflowKind: "pasteback",
+            failureKind: failureKind,
+            retrySource: "clipboard_fallback",
+            result: result,
+            elapsedSeconds: elapsedSeconds,
+            surface: "dictation",
+            artifactRetained: true
         )
     }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -960,6 +960,14 @@ struct TranscriptedSettingsView: View {
                 "setup_profile": selectedLocalSummaryProviderProfileName,
             ]
         )
+        let localSummaryStartedAt = CFAbsoluteTimeGetCurrent()
+        WorkflowRecoveryTelemetry.attempted(
+            workflowKind: "local_summary",
+            failureKind: hasExistingSummary ? "regenerate_requested" : "summary_missing",
+            retrySource: "home_summary_action",
+            surface: "home",
+            artifactRetained: true
+        )
         clearHomeLocalSummaryNotice()
         homeLocalSummaryJobIDs.insert(summaryID)
 
@@ -1007,6 +1015,15 @@ struct TranscriptedSettingsView: View {
                         "profile": result.profileName,
                     ]
                 )
+                WorkflowRecoveryTelemetry.finished(
+                    workflowKind: "local_summary",
+                    failureKind: hasExistingSummary ? "regenerate_requested" : "summary_missing",
+                    retrySource: "home_summary_action",
+                    result: "success",
+                    elapsedSeconds: CFAbsoluteTimeGetCurrent() - localSummaryStartedAt,
+                    surface: "home",
+                    artifactRetained: true
+                )
                 refreshRecentCapturesAfterLocalSummary()
             } catch is CancellationError {
                 recordLocalSummaryEvent(
@@ -1015,6 +1032,15 @@ struct TranscriptedSettingsView: View {
                     context: [
                         "provider": provider.rawValue,
                     ]
+                )
+                WorkflowRecoveryTelemetry.finished(
+                    workflowKind: "local_summary",
+                    failureKind: hasExistingSummary ? "regenerate_requested" : "summary_missing",
+                    retrySource: "home_summary_action",
+                    result: "gave_up",
+                    elapsedSeconds: CFAbsoluteTimeGetCurrent() - localSummaryStartedAt,
+                    surface: "home",
+                    artifactRetained: true
                 )
                 return
             } catch {
@@ -1027,6 +1053,15 @@ struct TranscriptedSettingsView: View {
                         "provider": provider.rawValue,
                         "error": error.localizedDescription,
                     ]
+                )
+                WorkflowRecoveryTelemetry.finished(
+                    workflowKind: "local_summary",
+                    failureKind: localSummaryFailureKind(for: error),
+                    retrySource: "home_summary_action",
+                    result: "failed",
+                    elapsedSeconds: CFAbsoluteTimeGetCurrent() - localSummaryStartedAt,
+                    surface: "home",
+                    artifactRetained: true
                 )
                 NSSound.beep()
                 presentHomeLocalSummaryNotice(
@@ -3244,6 +3279,14 @@ struct TranscriptedSettingsView: View {
                 "setup_profile": selectedLocalSummaryProviderProfileName,
             ]
         )
+        let modelPreparationStartedAt = CFAbsoluteTimeGetCurrent()
+        WorkflowRecoveryTelemetry.attempted(
+            workflowKind: "model_preparation",
+            failureKind: "summary_model_not_ready",
+            retrySource: "summary_model_prepare",
+            surface: "settings",
+            artifactRetained: false
+        )
 
         let taskToken = UUID()
         let task = Task.detached(priority: .utility) {
@@ -3274,6 +3317,15 @@ struct TranscriptedSettingsView: View {
                         "profile": profile,
                     ]
                 )
+                WorkflowRecoveryTelemetry.finished(
+                    workflowKind: "model_preparation",
+                    failureKind: "summary_model_not_ready",
+                    retrySource: "summary_model_prepare",
+                    result: "success",
+                    elapsedSeconds: CFAbsoluteTimeGetCurrent() - modelPreparationStartedAt,
+                    surface: "settings",
+                    artifactRetained: false
+                )
             } catch is CancellationError {
                 guard localSummaryModelPreparationToken == taskToken else { return }
                 isLocalSummaryModelPreparing = false
@@ -3286,6 +3338,15 @@ struct TranscriptedSettingsView: View {
                     context: [
                         "provider": provider.rawValue,
                     ]
+                )
+                WorkflowRecoveryTelemetry.finished(
+                    workflowKind: "model_preparation",
+                    failureKind: "summary_model_not_ready",
+                    retrySource: "summary_model_prepare",
+                    result: "gave_up",
+                    elapsedSeconds: CFAbsoluteTimeGetCurrent() - modelPreparationStartedAt,
+                    surface: "settings",
+                    artifactRetained: false
                 )
             } catch {
                 guard localSummaryModelPreparationToken == taskToken else { return }
@@ -3302,6 +3363,15 @@ struct TranscriptedSettingsView: View {
                         "provider": provider.rawValue,
                         "error": error.localizedDescription,
                     ]
+                )
+                WorkflowRecoveryTelemetry.finished(
+                    workflowKind: "model_preparation",
+                    failureKind: localSummaryFailureKind(for: error),
+                    retrySource: "summary_model_prepare",
+                    result: "failed",
+                    elapsedSeconds: CFAbsoluteTimeGetCurrent() - modelPreparationStartedAt,
+                    surface: "settings",
+                    artifactRetained: false
                 )
             }
         }
@@ -3396,6 +3466,32 @@ struct TranscriptedSettingsView: View {
             message: message,
             context: context
         )
+    }
+
+    private func localSummaryFailureKind(for error: Error) -> String {
+        guard let summaryError = error as? LocalMeetingSummaryError else {
+            return "unknown"
+        }
+        switch summaryError {
+        case .emptyTranscript:
+            return "empty_content"
+        case .insufficientMemory:
+            return "insufficient_memory"
+        case .runtimeUnavailable:
+            return "runtime_unavailable"
+        case .appleFoundationUnavailable:
+            return "runtime_unavailable"
+        case .missingBundledRunner:
+            return "runner_missing"
+        case .transcriptChanged:
+            return "artifact_changed"
+        case .processTimedOut:
+            return "timeout"
+        case .processFailed:
+            return "process_failed"
+        case .outputMissing:
+            return "output_missing"
+        }
     }
 
     private func openUVInstallGuide() {

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -65,6 +65,7 @@ func testAnalyticsEventPolicy() {
             "anonymous_usage_enabled",
             "app_signal",
             "app_version",
+            "artifact_retained",
             "artifact_kind",
             "attenuation_kind",
             "auto_send",
@@ -163,6 +164,7 @@ func testAnalyticsEventPolicy() {
             "reporting_kind",
             "required",
             "result",
+            "retry_source",
             "route_ready",
             "route_shape",
             "sample_flow_started",
@@ -200,6 +202,7 @@ func testAnalyticsEventPolicy() {
             "voice_processing",
             "voice_processing_active",
             "was_recording",
+            "workflow_kind",
         ]
         let properties = allAllowedAnalyticsPropertyNames()
 
@@ -749,6 +752,60 @@ func testAnalyticsEventPolicy() {
         assertEqual(sanitized["recovery_latency_bucket"], "2_9m", "route recovery latency bucket should survive sanitization")
         assertEqual(sanitized["selected_input_class"], "built_in", "selected input class should survive sanitization")
         assertEqual(sanitized["was_recording"], "true", "recording interruption state should survive sanitization")
+    }
+
+    runSuite("AnalyticsEventPolicy allows workflow recovery lifecycle events") {
+        let attempted = AnalyticsEventPolicy.policy(forEvent: "workflow_recovery_attempted")
+        let finished = AnalyticsEventPolicy.policy(forEvent: "workflow_recovery_finished")
+
+        assertEqual(
+            attempted?.allowedProperties ?? Set<String>(),
+            [
+                "artifact_retained",
+                "attempt_bucket",
+                "failure_kind",
+                "retry_source",
+                "surface",
+                "workflow_kind",
+            ],
+            "recovery attempts should carry only coarse workflow shape"
+        )
+        assertEqual(
+            finished?.allowedProperties ?? Set<String>(),
+            [
+                "artifact_retained",
+                "attempt_bucket",
+                "elapsed_bucket",
+                "failure_kind",
+                "result",
+                "retry_source",
+                "surface",
+                "workflow_kind",
+            ],
+            "recovery finishes should add result and elapsed bucket only"
+        )
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "workflow_kind": "meeting_transcription",
+                "failure_kind": "models_not_ready",
+                "retry_source": "queued_transcription",
+                "attempt_bucket": "1",
+                "result": "success",
+                "elapsed_bucket": "10_29s",
+                "surface": "meeting",
+                "artifact_retained": "true",
+                "error": "raw error",
+                "transcript_path": "/private/tmp/meeting.md",
+            ],
+            allowedKeys: finished?.allowedProperties ?? Set<String>()
+        )
+        assertEqual(sanitized["workflow_kind"], "meeting_transcription", "workflow kind should survive")
+        assertEqual(sanitized["failure_kind"], "models_not_ready", "failure kind should survive")
+        assertEqual(sanitized["retry_source"], "queued_transcription", "retry source should survive")
+        assertEqual(sanitized["result"], "success", "result should survive")
+        assertNil(sanitized["error"], "raw errors must not be sent")
+        assertNil(sanitized["transcript_path"], "transcript paths must not be sent")
     }
 
     runSuite("AnalyticsEventPolicy only permits reviewed analytics events") {

--- a/docs/posthog-product-learning-plan.md
+++ b/docs/posthog-product-learning-plan.md
@@ -203,11 +203,10 @@ Prefer a small number of lifecycle events over broad click tracking.
 | `agent_capture_query_observed` | The local MCP/agent layer observes a privacy-safe query against saved captures | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket` |
 | `activation_second_artifact_saved` | A device saves its second artifact | `first_artifact_kind`, `second_artifact_kind`, `days_since_first_bucket`, `surface`, `trigger` |
 | `dictation_artifact_saved` | Any normal dictation Markdown is durably saved | `delivery`, `duration_bucket`, `save_outcome`, `surface`, `trigger`, `word_count_bucket` |
-| `dictation_retry_started` | User retries after a failed or empty dictation | `failure_kind`, `retry_source`, `route_shape`, `trigger` |
+| `workflow_recovery_attempted` | App or user starts a recoverable failure path | `workflow_kind`, `failure_kind`, `retry_source`, `attempt_bucket`, `surface`, `artifact_retained` |
+| `workflow_recovery_finished` | The recoverable path succeeds, fails, or gives up | `workflow_kind`, `failure_kind`, `retry_source`, `attempt_bucket`, `result`, `elapsed_bucket`, `surface`, `artifact_retained` |
 | `meeting_speaker_review_prompted` | A saved meeting has review work surfaced | `participant_count_bucket`, `review_reason`, `surface` |
 | `meeting_speaker_review_completed` | User completes or dismisses speaker review | `participant_count_bucket`, `result`, `surface` |
-| `meeting_summary_requested` | User asks for a local summary | `artifact_age_bucket`, `model_state`, `surface` |
-| `meeting_summary_finished` | Summary succeeds or fails | `duration_bucket`, `failure_kind`, `latency_bucket`, `model_state`, `result`, `surface` |
 | `settings_feature_discovered` | A high-leverage feature panel is first viewed | `feature_area`, `page_id`, `source` |
 | `workflow_abandoned` | App can confidently infer abandonment without content | `workflow_kind`, `stage`, `reason_kind`, `elapsed_bucket` |
 

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -102,6 +102,8 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `activation_agent_prompt_action_clicked`
 - `activation_agent_setup_cta_clicked`
 - `activation_return_proxy_observed`
+- `workflow_recovery_attempted`
+- `workflow_recovery_finished`
 - `menu_bar_opened`
 - `menu_bar_action_clicked`
 - `update_action_clicked`

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -324,6 +324,7 @@ APP_SOURCES=(
     "Sources/UI/MenuBar/MenuBarHeaderLayoutPolicy.swift"
     "Sources/Observability/AnalyticsReporter.swift"
     "Sources/Observability/ActivationTelemetry.swift"
+    "Sources/Observability/WorkflowRecoveryTelemetry.swift"
     "Sources/Observability/LockedFileAppender.swift"
     "Sources/Observability/JSONLWriter.swift"
     "Sources/Observability/AnalyticsEventPolicy.swift"

--- a/scripts/ops/posthog-activation-funnel.py
+++ b/scripts/ops/posthog-activation-funnel.py
@@ -48,6 +48,8 @@ RELEVANT_EVENTS = (
     "activation_return_proxy_observed",
     "activation_first_artifact_saved",
     "agent_capture_query_observed",
+    "workflow_recovery_attempted",
+    "workflow_recovery_finished",
 )
 
 WORKFLOW_EVENTS = (
@@ -61,6 +63,13 @@ WORKFLOW_EVENTS = (
     "activation_agent_prompt_action_clicked",
     "activation_agent_setup_cta_clicked",
     "activation_return_proxy_observed",
+    "workflow_recovery_attempted",
+    "workflow_recovery_finished",
+)
+
+RECOVERY_EVENTS = (
+    "workflow_recovery_attempted",
+    "workflow_recovery_finished",
 )
 
 DISALLOWED_OUTPUT_COLUMNS = {
@@ -410,6 +419,28 @@ LIMIT 60
 """
 
 
+def recovery_outcomes_query(days: int, app_version: str | None) -> str:
+    return f"""
+SELECT
+  event,
+  properties['workflow_kind'] AS workflow_kind,
+  properties['failure_kind'] AS failure_kind,
+  properties['retry_source'] AS retry_source,
+  properties['result'] AS result,
+  properties['surface'] AS surface,
+  properties['artifact_retained'] AS artifact_retained,
+  count() AS events,
+  uniq(distinct_id) AS devices
+FROM events
+WHERE timestamp >= now() - INTERVAL {int(days)} DAY
+  AND event IN ({sql_list(RECOVERY_EVENTS)})
+  {app_version_filter(app_version)}
+GROUP BY event, workflow_kind, failure_kind, retry_source, result, surface, artifact_retained
+ORDER BY events DESC
+LIMIT 80
+"""
+
+
 def fetch_report_data(days: int, app_version: str | None) -> dict[str, Any]:
     load_env()
     host, project_id, token = posthog_config()
@@ -422,6 +453,7 @@ def fetch_report_data(days: int, app_version: str | None) -> dict[str, Any]:
         "onboarding_completion": onboarding_completion_query(days, app_version),
         "artifact_actions": artifact_actions_query(days, app_version),
         "agent_signals": agent_signals_query(days, app_version),
+        "recovery_outcomes": recovery_outcomes_query(days, app_version),
     }
 
     results = {
@@ -629,6 +661,11 @@ def render_report(data: dict[str, Any]) -> str:
             data["results"].get("agent_signals", []),
             ["event", "prompt_kind", "setup_kind", "agent_target", "result", "surface", "events", "devices"],
         ),
+        render_top_rows(
+            "Workflow Recovery",
+            data["results"].get("recovery_outcomes", []),
+            ["event", "workflow_kind", "failure_kind", "retry_source", "result", "surface", "artifact_retained", "events", "devices"],
+        ),
         "## Data Limitations",
         "",
         "\n".join(f"- {item}" for item in limitations),
@@ -683,6 +720,19 @@ def run_self_test() -> int:
             "onboarding_completion": [],
             "artifact_actions": [],
             "agent_signals": [],
+            "recovery_outcomes": [
+                {
+                    "event": "workflow_recovery_finished",
+                    "workflow_kind": "meeting_transcription",
+                    "failure_kind": "models_not_ready",
+                    "retry_source": "queued_transcription",
+                    "result": "success",
+                    "surface": "meeting",
+                    "artifact_retained": "true",
+                    "events": 2,
+                    "devices": 2,
+                }
+            ],
         },
     }
     report = render_report(sample)
@@ -703,6 +753,7 @@ def run_self_test() -> int:
         onboarding_completion_query(30, None),
         artifact_actions_query(30, None),
         agent_signals_query(30, None),
+        recovery_outcomes_query(30, None),
     ):
         if "SELECT *" in query.upper():
             print("self-test failed: query uses SELECT *", file=sys.stderr)


### PR DESCRIPTION
## Summary
- add normalized workflow_recovery_attempted / workflow_recovery_finished telemetry
- cover dictation route recovery, pasteback clipboard fallback, meeting import/retry/retranscription, local summary, speaker review, and model preparation
- update analytics allowlist, docs, tests, and PostHog helper queries

## Privacy proof
- allowlisted properties only: workflow_kind, failure_kind, retry_source, attempt_bucket, result, elapsed_bucket, surface, artifact_retained
- no raw errors, transcript/audio refs, paths, names, titles, URLs, source apps, or raw device identifiers
- sanitizer test verifies recovery telemetry drops raw error and transcript_path fields

## Review
- codex review --base origin/main: clean after fixing accepted P2 route-recovery result timing; accepted P1 resolved by adding the new telemetry source file to the staged patch

## Verification
- bash scripts/dev/agent-preflight.sh
- bash run-tests.sh --filter AnalyticsEventPolicy
- python3 -m py_compile scripts/ops/posthog-activation-funnel.py
- python3 scripts/ops/posthog-activation-funnel.py --self-test
- git diff --check
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-integration-smoke.sh
- python3 scripts/dev/check-build-source-lists.py
- bash -n run-tests.sh && bash -n scripts/entrypoints/run-tests.sh
- bash run-slow-pasteback-smoke.sh
- bash run-tests.sh

Note: one parallel bash run-tests.sh attempt collided with bash build.sh shared build temp files; reran run-tests.sh solo and it passed 10059/10059.