### PR TITLE
feat(speaker): conservative auto-name gate (bar 0.92 + best-vs-second margin)

### DIFF
--- a/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
+++ b/Sources/TranscriptedCore/Models/TranscriptionTypes.swift
@@ -339,17 +339,22 @@ public struct ChannelSpeakerContext: Sendable {
     public let sessionEmbedding: [Float]?
     public let matchedProfileSnapshot: SpeakerProfile?
     public let matchSimilarity: Double?
+    /// Similarity of the next-closest profile that cleared the match floor (the runner-up),
+    /// or nil if unknown / no runner-up. Feeds `SpeakerNamingPolicy`'s auto-accept margin guard.
+    public let matchSecondSimilarity: Double?
 
     public init(
         persistentSpeakerId: UUID,
         sessionEmbedding: [Float]?,
         matchedProfileSnapshot: SpeakerProfile?,
-        matchSimilarity: Double?
+        matchSimilarity: Double?,
+        matchSecondSimilarity: Double? = nil
     ) {
         self.persistentSpeakerId = persistentSpeakerId
         self.sessionEmbedding = sessionEmbedding
         self.matchedProfileSnapshot = matchedProfileSnapshot
         self.matchSimilarity = matchSimilarity
+        self.matchSecondSimilarity = matchSecondSimilarity
     }
 }
 

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -243,7 +243,7 @@ extension Transcription {
 
             // Match each speaker's mean embedding against the DB once
             // (existingProfiles was already snapshotted above for post-processing)
-            var speakerMatchResults: [Int: (persistentId: UUID, similarity: Double)] = [:]
+            var speakerMatchResults: [Int: (persistentId: UUID, similarity: Double, secondSimilarity: Double)] = [:]
             var speakerNewProfiles: [Int: UUID] = [:]
             var speakerIdRemap: [Int: Int] = [:]
 
@@ -305,7 +305,7 @@ extension Transcription {
 
                 // Match only against profiles that existed BEFORE this recording
                 if let matchResult = Self.matchAgainstProfiles(meanEmbedding, profiles: existingProfiles, threshold: adaptiveThreshold) {
-                    speakerMatchResults[speakerId] = (matchResult.profileId, matchResult.similarity)
+                    speakerMatchResults[speakerId] = (matchResult.profileId, matchResult.similarity, matchResult.secondBestSimilarity)
                     _ = speakerDB.addOrUpdateSpeaker(embedding: meanEmbedding, existingId: matchResult.profileId)
                     let matchedProfile = existingProfiles.first(where: { $0.id == matchResult.profileId })
                     AppLogger.transcription.info("Speaker matched DB profile", [
@@ -374,7 +374,8 @@ extension Transcription {
                     persistentSpeakerId: persistentId,
                     sessionEmbedding: sessionEmbedding,
                     matchedProfileSnapshot: matchedProfileSnapshot,
-                    matchSimilarity: speakerMatchResults[effectiveSpeakerId]?.similarity
+                    matchSimilarity: speakerMatchResults[effectiveSpeakerId]?.similarity,
+                    matchSecondSimilarity: speakerMatchResults[effectiveSpeakerId]?.secondSimilarity
                 )
             }
 
@@ -689,7 +690,7 @@ extension Transcription {
             }
         }
 
-        var speakerMatchResults: [Int: (persistentId: UUID, similarity: Double)] = [:]
+        var speakerMatchResults: [Int: (persistentId: UUID, similarity: Double, secondSimilarity: Double)] = [:]
         var speakerNewProfiles: [Int: UUID] = [:]
         var speakerIdRemap: [Int: Int] = [:]
         var newlyCreatedProfileIds: Set<UUID> = []
@@ -726,7 +727,7 @@ extension Transcription {
             }
 
             if let matchResult = Self.matchAgainstProfiles(meanEmbedding, profiles: existingProfiles, threshold: adaptiveThreshold) {
-                speakerMatchResults[speakerId] = (matchResult.profileId, matchResult.similarity)
+                speakerMatchResults[speakerId] = (matchResult.profileId, matchResult.similarity, matchResult.secondBestSimilarity)
                 _ = speakerDB.addOrUpdateSpeaker(embedding: meanEmbedding, existingId: matchResult.profileId)
             } else {
                 let newProfile = speakerDB.addOrUpdateSpeaker(embedding: meanEmbedding, existingId: nil)
@@ -766,7 +767,8 @@ extension Transcription {
                 persistentSpeakerId: persistentId,
                 sessionEmbedding: sessionEmbedding,
                 matchedProfileSnapshot: matchedProfileSnapshot,
-                matchSimilarity: speakerMatchResults[effectiveSpeakerId]?.similarity
+                matchSimilarity: speakerMatchResults[effectiveSpeakerId]?.similarity,
+                matchSecondSimilarity: speakerMatchResults[effectiveSpeakerId]?.secondSimilarity
             )
         }
 

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipelineRunner.swift
@@ -9,6 +9,9 @@ extension TranscriptionTaskManager {
         let speakerId: String
         let profile: SpeakerProfile
         let similarity: Double
+        /// Runner-up similarity for the auto-accept margin guard; nil when unknown (the
+        /// utterance fallback path), which `shouldAutoAccept` treats as "confirm, don't auto".
+        let secondSimilarity: Double?
     }
 
     nonisolated static func speakerClassificationKnowledge(
@@ -27,7 +30,8 @@ extension TranscriptionTaskManager {
                 knowledge.append(SpeakerClassificationKnowledge(
                     speakerId: sid,
                     profile: snapshot,
-                    similarity: similarity
+                    similarity: similarity,
+                    secondSimilarity: context.matchSecondSimilarity
                 ))
                 continue
             }
@@ -39,7 +43,8 @@ extension TranscriptionTaskManager {
                 knowledge.append(SpeakerClassificationKnowledge(
                     speakerId: sid,
                     profile: profile,
-                    similarity: similarity
+                    similarity: similarity,
+                    secondSimilarity: nil   // runner-up not carried on the utterance fallback
                 ))
             }
         }
@@ -186,7 +191,8 @@ extension TranscriptionTaskManager {
             if let entry = dbKnowledge.first(where: { $0.speakerId == sid }) {
                 let canAutoAccept = SpeakerNamingPolicy.shouldAutoAccept(
                     profile: entry.profile,
-                    similarity: entry.similarity
+                    similarity: entry.similarity,
+                    secondBestSimilarity: entry.secondSimilarity
                 )
                 if canAutoAccept {
                     autoAcceptedIds.insert(sid)
@@ -211,7 +217,8 @@ extension TranscriptionTaskManager {
             let mapping = SpeakerNamingPolicy.initialMapping(
                 speakerId: entry.speakerId,
                 profile: entry.profile,
-                similarity: entry.similarity
+                similarity: entry.similarity,
+                secondBestSimilarity: entry.secondSimilarity
             )
             speakerMappings[key] = mapping
             speakerSources[key] = autoAcceptedIds.contains(entry.speakerId) ? "db" : "db_pending"
@@ -254,7 +261,8 @@ extension TranscriptionTaskManager {
                 if let entry = micDbKnowledge.first(where: { $0.speakerId == sid }) {
                     let canAutoAccept = SpeakerNamingPolicy.shouldAutoAccept(
                         profile: entry.profile,
-                        similarity: entry.similarity
+                        similarity: entry.similarity,
+                        secondBestSimilarity: entry.secondSimilarity
                     )
                     if canAutoAccept {
                         micAutoAcceptedIds.insert(sid)
@@ -276,7 +284,8 @@ extension TranscriptionTaskManager {
                 let mapping = SpeakerNamingPolicy.initialMapping(
                     speakerId: entry.speakerId,
                     profile: entry.profile,
-                    similarity: entry.similarity
+                    similarity: entry.similarity,
+                    secondBestSimilarity: entry.secondSimilarity
                 )
                 speakerMappings[key] = mapping
                 speakerSources["mic_\(entry.speakerId)"] = micAutoAcceptedIds.contains(entry.speakerId) ? "db" : "db_pending"

--- a/Sources/TranscriptedCore/Speaker/EmbeddingClusterer.swift
+++ b/Sources/TranscriptedCore/Speaker/EmbeddingClusterer.swift
@@ -26,13 +26,15 @@ import Accelerate
 
 public enum EmbeddingClusterer {
 
-    /// Cosine-similarity bar for the same-voice consolidation pass. Must equal
-    /// `SpeakerNamingPolicy.autoAcceptSimilarityThreshold` (0.88): consolidation
-    /// should only collapse two clusters into one person when they are at least as
-    /// similar as we'd demand to silently auto-accept them as the same known person.
-    /// `EmbeddingClustererTests.testConsolidationThresholdMatchesAutoAcceptBar`
-    /// asserts the two stay equal, so changing one without the other fails CI
-    /// instead of silently drifting.
+    /// Cosine-similarity bar for the same-voice consolidation pass (within a single meeting).
+    /// Kept at 0.88 even though `SpeakerNamingPolicy.autoAcceptSimilarityThreshold` was raised
+    /// to 0.92: within-meeting consolidation has temporal/contextual evidence that two clusters
+    /// are one speaker, so it may legitimately merge at a *lower* bar than the stricter
+    /// cross-meeting silent-naming decision. The guarded invariant is therefore
+    /// `sameVoiceConsolidationThreshold <= autoAcceptSimilarityThreshold`
+    /// (`EmbeddingClustererTests.testConsolidationThresholdNotAboveAutoAcceptBar`), so the merge
+    /// bar can never exceed — i.e. consolidation never merges two clusters we would NOT also
+    /// auto-accept as one another.
     public static let sameVoiceConsolidationThreshold: Float = 0.88
 
     /// Lower bar used only to detect "these centroids may belong to different

--- a/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
@@ -9,6 +9,10 @@ extension Transcription {
     struct SnapshotMatchResult {
         let profileId: UUID
         let similarity: Double
+        /// Similarity of the next-closest non-disputed profile that cleared the floor, or -1
+        /// if there was no runner-up. Used by `SpeakerNamingPolicy.shouldAutoAccept` as the
+        /// "clear winner" margin guard.
+        let secondBestSimilarity: Double
     }
 
     // MARK: - Embedding Utilities
@@ -108,7 +112,8 @@ extension Transcription {
             return nil
         }
 
-        return SnapshotMatchResult(profileId: matched.id, similarity: bestSimilarity)
+        return SnapshotMatchResult(profileId: matched.id, similarity: bestSimilarity,
+                                   secondBestSimilarity: secondBestSimilarity)
     }
 
     /// Compute L2-normalized weighted mean of multiple embeddings.

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingPolicy.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingPolicy.swift
@@ -2,17 +2,46 @@ import Foundation
 
 public enum SpeakerNamingPolicy {
     /// Cosine-similarity bar above which a returning known speaker is auto-accepted
-    /// as the same person without asking the user to confirm. This is the canonical
-    /// "same known person" threshold; `EmbeddingClusterer.sameVoiceConsolidationThreshold`
-    /// is tied to it (guarded by `EmbeddingClustererTests`) so same-voice consolidation
-    /// never merges two clusters we would not also auto-accept as one another.
-    public static let autoAcceptSimilarityThreshold: Double = 0.88
+    /// (silently named) without asking the user to confirm.
+    ///
+    /// Raised 0.88 → 0.92 and decoupled from `EmbeddingClusterer.sameVoiceConsolidationThreshold`
+    /// (which stays 0.88). The multi-meeting × audio-quality eval (SpeakerEvalHarness
+    /// LADDER_SWEEP_REPORT §11) showed the old 0.88 bar silently mislabels 8–72% of auto-names
+    /// on compressed/telephone/noisy audio; a higher bar + the margin guard below holds
+    /// false-auto near 0 across all tested qualities (AMI-full N=175: 148 autos, 0 wrong).
+    /// Within-meeting consolidation legitimately uses a *lower* bar (0.88) — it has
+    /// temporal/contextual evidence two same-meeting clusters are one speaker — so the
+    /// invariant is now `sameVoiceConsolidationThreshold <= autoAcceptSimilarityThreshold`.
+    public static let autoAcceptSimilarityThreshold: Double = 0.92
 
-    public static func shouldAutoAccept(profile: SpeakerProfile, similarity: Double) -> Bool {
-        profile.displayName != nil
+    /// Minimum required gap between the best and second-best profile similarity before a
+    /// returning speaker is auto-accepted. Degraded audio inflates the top similarity but
+    /// rarely the *gap* to the runner-up, so this "clear winner" margin is the primary guard
+    /// against silently naming the wrong person. A nil/absent runner-up (only one candidate
+    /// cleared the match floor) is treated as unambiguous and passes.
+    public static let autoAcceptMarginMin: Double = 0.12
+
+    public static func shouldAutoAccept(
+        profile: SpeakerProfile,
+        similarity: Double,
+        secondBestSimilarity: Double?
+    ) -> Bool {
+        let marginOK: Bool
+        switch secondBestSimilarity {
+        case .none:
+            // Runner-up unknown (e.g. a fallback path that didn't carry it) — be conservative
+            // and route to confirm rather than silently auto-name.
+            marginOK = false
+        case .some(let second) where second < 0:
+            marginOK = true   // no confusable runner-up cleared the match floor
+        case .some(let second):
+            marginOK = (similarity - second) >= autoAcceptMarginMin
+        }
+        return profile.displayName != nil
             && profile.disputeCount == 0
             && similarity > autoAcceptSimilarityThreshold
             && profile.callCount > 4
+            && marginOK
     }
 
     public static func confidence(similarity: Double, callCount: Int) -> SpeakerConfidence {
@@ -22,9 +51,10 @@ public enum SpeakerNamingPolicy {
     public static func initialMapping(
         speakerId: String,
         profile: SpeakerProfile,
-        similarity: Double
+        similarity: Double,
+        secondBestSimilarity: Double?
     ) -> SpeakerMapping {
-        guard shouldAutoAccept(profile: profile, similarity: similarity),
+        guard shouldAutoAccept(profile: profile, similarity: similarity, secondBestSimilarity: secondBestSimilarity),
               let name = profile.displayName,
               !name.isEmpty else {
             return SpeakerMapping(speakerId: speakerId)

--- a/Sources/TranscriptedCore/Speaker/SpeakerNamingSimulationRunner.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerNamingSimulationRunner.swift
@@ -626,7 +626,8 @@ public final class SpeakerNamingSimulationRunner {
                     persistentSpeakerId: match.profileId,
                     sessionEmbedding: meanEmbedding,
                     matchedProfileSnapshot: snapshot,
-                    matchSimilarity: match.similarity
+                    matchSimilarity: match.similarity,
+                    matchSecondSimilarity: match.secondBestSimilarity
                 )
             } else {
                 let profile = speakerDB.addOrUpdateSpeaker(embedding: meanEmbedding, existingId: nil)
@@ -759,12 +760,14 @@ public final class SpeakerNamingSimulationRunner {
                let similarity = context.matchSimilarity {
                 let canAutoAccept = SpeakerNamingPolicy.shouldAutoAccept(
                     profile: snapshot,
-                    similarity: similarity
+                    similarity: similarity,
+                    secondBestSimilarity: context.matchSecondSimilarity
                 )
                 speakerMappings[key] = SpeakerNamingPolicy.initialMapping(
                     speakerId: speakerId,
                     profile: snapshot,
-                    similarity: similarity
+                    similarity: similarity,
+                    secondBestSimilarity: context.matchSecondSimilarity
                 )
                 speakerSources[key] = canAutoAccept ? "db" : "db_pending"
             } else {

--- a/Tests/SpeakerNamingPolicyTests.swift
+++ b/Tests/SpeakerNamingPolicyTests.swift
@@ -17,7 +17,8 @@ func testSpeakerNamingPolicy() {
         let mapping = SpeakerNamingPolicy.initialMapping(
             speakerId: "0",
             profile: profile,
-            similarity: 0.97
+            similarity: 0.97,
+            secondBestSimilarity: -1
         )
 
         assertNil(mapping.identifiedName, "tentative matches should stay generic until the user confirms them")
@@ -40,12 +41,61 @@ func testSpeakerNamingPolicy() {
         let mapping = SpeakerNamingPolicy.initialMapping(
             speakerId: "0",
             profile: profile,
-            similarity: 0.91
+            similarity: 0.95,            // above the raised 0.92 auto-accept bar
+            secondBestSimilarity: -1     // no confusable runner-up -> margin satisfied
         )
 
         assertEqual(mapping.identifiedName, "Alex", "strong repeated matches should still auto-apply")
         assertEqual(mapping.displayName, "Alex", "auto-applied names should render without a tentative suffix")
         assertEqual(mapping.confidence, .high, "strong repeated matches should be marked high confidence")
+    }
+
+    runSuite("SpeakerNamingPolicy.initialMapping confirms (does not auto-apply) when a runner-up is close") {
+        let profile = SpeakerProfile(
+            id: UUID(),
+            displayName: "Alex",
+            nameSource: NameSource.userManual,
+            embedding: [0.1, 0.2, 0.3],
+            firstSeen: Date(),
+            lastSeen: Date(),
+            callCount: 8,
+            confidence: 0.9,
+            disputeCount: 0
+        )
+
+        // sim 0.94 clears the 0.92 bar, but the runner-up at 0.90 is only 0.04 away
+        // (< 0.12 margin) — ambiguous, so route to confirm rather than silently name.
+        let ambiguous = SpeakerNamingPolicy.initialMapping(
+            speakerId: "0", profile: profile, similarity: 0.94, secondBestSimilarity: 0.90
+        )
+        assertNil(ambiguous.identifiedName, "a close runner-up should block silent auto-naming (confirm instead)")
+
+        // same match with a clear gap (runner-up 0.78) auto-applies.
+        let clear = SpeakerNamingPolicy.initialMapping(
+            speakerId: "0", profile: profile, similarity: 0.94, secondBestSimilarity: 0.78
+        )
+        assertEqual(clear.identifiedName, "Alex", "a clear-winner match should still auto-apply")
+    }
+
+    runSuite("SpeakerNamingPolicy.initialMapping no longer auto-applies between 0.88 and 0.92") {
+        let profile = SpeakerProfile(
+            id: UUID(),
+            displayName: "Alex",
+            nameSource: NameSource.userManual,
+            embedding: [0.1, 0.2, 0.3],
+            firstSeen: Date(),
+            lastSeen: Date(),
+            callCount: 8,
+            confidence: 0.9,
+            disputeCount: 0
+        )
+
+        // 0.90 would have auto-applied under the old 0.88 bar; with the raised 0.92 bar it
+        // must drop to a confirm.
+        let mapping = SpeakerNamingPolicy.initialMapping(
+            speakerId: "0", profile: profile, similarity: 0.90, secondBestSimilarity: -1
+        )
+        assertNil(mapping.identifiedName, "matches between the old and new bar should confirm, not auto-apply")
     }
 
     runSuite("SpeakerNamingPolicy.initialMapping keeps disputed profiles generic") {
@@ -64,7 +114,8 @@ func testSpeakerNamingPolicy() {
         let mapping = SpeakerNamingPolicy.initialMapping(
             speakerId: "0",
             profile: profile,
-            similarity: 0.95
+            similarity: 0.95,
+            secondBestSimilarity: -1
         )
 
         assertNil(mapping.identifiedName, "disputed profiles should not auto-apply")

--- a/Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift
+++ b/Tests/TranscriptedCoreTests/EmbeddingClustererTests.swift
@@ -157,17 +157,15 @@ final class EmbeddingClustererTests: XCTestCase {
         XCTAssertEqual(Set(kept.map(\.speakerId)).count, 2)
     }
 
-    func testConsolidationThresholdMatchesAutoAcceptBar() {
-        // Drift guard: same-voice consolidation must never merge two clusters we
-        // would not also auto-accept as the same known person. If a future change
-        // moves SpeakerNamingPolicy.autoAcceptSimilarityThreshold (or the
-        // consolidation bar) without the other, this fails instead of silently
-        // letting the two diverge.
-        XCTAssertEqual(
+    func testConsolidationThresholdNotAboveAutoAcceptBar() {
+        // Drift guard: within-meeting same-voice consolidation must never merge two clusters
+        // we would not also auto-accept as the same known person across meetings. The auto bar
+        // (0.92) is now stricter than the consolidation bar (0.88) — consolidation may merge at
+        // a lower bar (it has within-meeting evidence), but it must never EXCEED the auto bar.
+        XCTAssertLessThanOrEqual(
             EmbeddingClusterer.sameVoiceConsolidationThreshold,
             Float(SpeakerNamingPolicy.autoAcceptSimilarityThreshold),
-            accuracy: 1e-6,
-            "Consolidation threshold must equal SpeakerNamingPolicy.autoAcceptSimilarityThreshold"
+            "Consolidation threshold must not exceed SpeakerNamingPolicy.autoAcceptSimilarityThreshold"
         )
     }
 

--- a/Tests/TranscriptedCoreTests/TranscriptionPipelineStateTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionPipelineStateTests.swift
@@ -173,33 +173,44 @@ final class TranscriptionPipelineStateTests: XCTestCase {
 
     func testNamingPolicyAutoAcceptsHighConfidenceMatureNamedProfile() {
         let profile = speakerProfile(displayName: "Nate", callCount: 6, disputeCount: 0)
-        XCTAssertTrue(SpeakerNamingPolicy.shouldAutoAccept(profile: profile, similarity: 0.92))
+        XCTAssertTrue(SpeakerNamingPolicy.shouldAutoAccept(profile: profile, similarity: 0.95, secondBestSimilarity: -1))
     }
 
     func testNamingPolicyRejectsUnnamedProfileEvenWhenMature() {
         let profile = speakerProfile(displayName: nil, callCount: 20, disputeCount: 0)
-        XCTAssertFalse(SpeakerNamingPolicy.shouldAutoAccept(profile: profile, similarity: 0.99))
+        XCTAssertFalse(SpeakerNamingPolicy.shouldAutoAccept(profile: profile, similarity: 0.99, secondBestSimilarity: -1))
     }
 
     func testNamingPolicyRejectsDisputedProfile() {
         let profile = speakerProfile(displayName: "Travis", callCount: 10, disputeCount: 1)
-        XCTAssertFalse(SpeakerNamingPolicy.shouldAutoAccept(profile: profile, similarity: 0.92))
+        XCTAssertFalse(SpeakerNamingPolicy.shouldAutoAccept(profile: profile, similarity: 0.95, secondBestSimilarity: -1))
     }
 
     func testNamingPolicyRejectsLowSimilarityAtBoundary() {
-        // Threshold is strictly > 0.88.
+        // Auto-accept bar is strictly > 0.92 (raised from 0.88).
         let profile = speakerProfile(displayName: "Sara", callCount: 6, disputeCount: 0)
-        XCTAssertFalse(SpeakerNamingPolicy.shouldAutoAccept(profile: profile, similarity: 0.88))
-        XCTAssertTrue(SpeakerNamingPolicy.shouldAutoAccept(profile: profile, similarity: 0.881))
+        XCTAssertFalse(SpeakerNamingPolicy.shouldAutoAccept(profile: profile, similarity: 0.92, secondBestSimilarity: -1))
+        XCTAssertTrue(SpeakerNamingPolicy.shouldAutoAccept(profile: profile, similarity: 0.921, secondBestSimilarity: -1))
+        // Old bar (0.90) no longer auto-accepts.
+        XCTAssertFalse(SpeakerNamingPolicy.shouldAutoAccept(profile: profile, similarity: 0.90, secondBestSimilarity: -1))
+    }
+
+    func testNamingPolicyRejectsAmbiguousMatchBelowMargin() {
+        // Clears the 0.92 bar but the runner-up is within the 0.12 margin -> not auto-accepted.
+        let profile = speakerProfile(displayName: "Sara", callCount: 6, disputeCount: 0)
+        XCTAssertFalse(SpeakerNamingPolicy.shouldAutoAccept(profile: profile, similarity: 0.95, secondBestSimilarity: 0.90))
+        XCTAssertTrue(SpeakerNamingPolicy.shouldAutoAccept(profile: profile, similarity: 0.95, secondBestSimilarity: 0.80))
+        // Unknown runner-up (nil) is treated conservatively -> confirm, not auto.
+        XCTAssertFalse(SpeakerNamingPolicy.shouldAutoAccept(profile: profile, similarity: 0.95, secondBestSimilarity: nil))
     }
 
     func testNamingPolicyRejectsImmatureProfileAtBoundary() {
         // callCount must be strictly > 4.
         let profile4 = speakerProfile(displayName: "Sara", callCount: 4, disputeCount: 0)
-        XCTAssertFalse(SpeakerNamingPolicy.shouldAutoAccept(profile: profile4, similarity: 0.95))
+        XCTAssertFalse(SpeakerNamingPolicy.shouldAutoAccept(profile: profile4, similarity: 0.95, secondBestSimilarity: -1))
 
         let profile5 = speakerProfile(displayName: "Sara", callCount: 5, disputeCount: 0)
-        XCTAssertTrue(SpeakerNamingPolicy.shouldAutoAccept(profile: profile5, similarity: 0.95))
+        XCTAssertTrue(SpeakerNamingPolicy.shouldAutoAccept(profile: profile5, similarity: 0.95, secondBestSimilarity: -1))
     }
 
     func testSpeakerClassificationUsesPreMeetingSnapshotForAutoAcceptMaturity() throws {
@@ -249,7 +260,8 @@ final class TranscriptionPipelineStateTests: XCTestCase {
         XCTAssertFalse(
             SpeakerNamingPolicy.shouldAutoAccept(
                 profile: knowledge[0].profile,
-                similarity: knowledge[0].similarity
+                similarity: knowledge[0].similarity,
+                secondBestSimilarity: knowledge[0].secondSimilarity
             ),
             "A profile that only became mature during this meeting should still require speaker review."
         )
@@ -326,7 +338,8 @@ final class TranscriptionPipelineStateTests: XCTestCase {
         let mapping = SpeakerNamingPolicy.initialMapping(
             speakerId: "7",
             profile: profile,
-            similarity: 0.99
+            similarity: 0.99,
+            secondBestSimilarity: -1
         )
 
         XCTAssertEqual(mapping.speakerId, "7")
@@ -340,7 +353,8 @@ final class TranscriptionPipelineStateTests: XCTestCase {
         let mapping = SpeakerNamingPolicy.initialMapping(
             speakerId: "2",
             profile: profile,
-            similarity: 0.95
+            similarity: 0.95,
+            secondBestSimilarity: -1
         )
 
         XCTAssertEqual(mapping.identifiedName, "Maya")
@@ -356,7 +370,8 @@ final class TranscriptionPipelineStateTests: XCTestCase {
         let mapping = SpeakerNamingPolicy.initialMapping(
             speakerId: "3",
             profile: profile,
-            similarity: 0.95
+            similarity: 0.95,
+            secondBestSimilarity: -1
         )
 
         XCTAssertNil(mapping.identifiedName)


### PR DESCRIPTION
## What

Makes returning-speaker **silent auto-naming more conservative** and routes borderline matches
to an **"Is this X?" confirm** instead of either silently (sometimes wrongly) naming them or
making the user type. Implements the operating point chosen from the eval in #1177.

- **Auto-name bar 0.88 → 0.92** (`SpeakerNamingPolicy.autoAcceptSimilarityThreshold`).
- **New "clear winner" margin (`autoAcceptMarginMin` = 0.12):** the top profile must beat the
  runner-up by ≥ 0.12 before auto-accepting. This was the single biggest false-positive lever
  under degraded audio. An *unknown* runner-up (the utterance fallback path) is treated
  conservatively → confirm, don't auto-name.
- Threads `secondBestSimilarity` from `matchAgainstProfiles` → `SnapshotMatchResult` →
  `speakerMatchResults` → `ChannelSpeakerContext` → `SpeakerClassificationKnowledge` →
  `shouldAutoAccept` / `initialMapping`.
- **Decouples** the auto-accept bar from `EmbeddingClusterer.sameVoiceConsolidationThreshold`
  (stays 0.88 — within-meeting consolidation legitimately merges at a lower bar). The guarded
  invariant is relaxed to `consolidation ≤ autoAccept`; the drift-guard test is updated.

## Why (data)

The multi-meeting × audio-quality eval (#1177, `SpeakerEvalHarness/LADDER_SWEEP_REPORT.md` §11)
showed the old 0.88 bar looks safe on clean audio (0% false-auto) but **silently mislabels
8–72% of auto-names on compressed / telephone / noisy audio**. A higher bar + the margin guard
holds false-auto near zero across all tested qualities.

**High-N validation (AMI-full, 175 speakers × audio-quality matrix):** `auto 0.92 + margin
0.12` produced **148 silent auto-names with 0 wrong** across orig→opus_8k→noise→reverb.

## Net effect for users

Fewer silent names, and the ones that happen are far safer; the cases that used to silently
(and sometimes wrongly) auto-name now show a one-tap "Is this X?" confirm. No extra typing.

## Tests

`swift test` (TranscriptedCore): **496 tests, 0 failures**. Added/updated coverage for the
0.92 bar, the margin gate, and nil-runner-up handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
