### PR TITLE
fix: analytics-taxonomy merge cascade — union the docs, document the Swift trap + durable fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,22 @@
 
 # Large binaries - mark for tracking awareness
 fluidaudio-libs/** binary
+
+# --- Append-only analytics taxonomy docs (union merge) ---
+# Every privacy-reviewed telemetry PR appends an event to the same anchor in a
+# set of lockstep files, so any single merge dirties every other open PR. Union
+# merge is applied ONLY to the line-oriented markdown registries below, where
+# each event is a self-contained single line (`- \`event_name\``) and the union
+# of two inserts is always a valid superset.
+#
+# It is deliberately NOT applied to Sources/Observability/AnalyticsEventPolicy.swift
+# or Tests/AnalyticsEventPolicyTests.swift: those entries are multi-line, brace-
+# balanced blocks whose trailing `]`/`)` aligns as shared context, so a union
+# merge SILENTLY produces unbalanced, non-compiling Swift (git reports a clean
+# auto-merge; only Swift CI catches the breakage). Those files still need a
+# taxonomy-aware merge driver or the single-source refactor described in
+# docs/analytics-taxonomy-merge.md.
+docs/privacy-first-observability.md merge=union
+docs/posthog-product-learning-plan.md merge=union
+docs/install-attribution-map.md merge=union
+docs/activation-lane.md merge=union

--- a/docs/analytics-taxonomy-merge.md
+++ b/docs/analytics-taxonomy-merge.md
@@ -1,0 +1,77 @@
+# Analytics Taxonomy Merge Cascade — root cause & fix
+
+## Symptom
+
+Dozens of auto-generated telemetry PRs sit `DIRTY` at once. Merging any one of
+them instantly re-conflicts all the others, faster than they can be rebased.
+
+## Root cause
+
+Every privacy-reviewed telemetry PR adds one or more analytics events, and each
+new event is appended at the **same anchor** in a set of lockstep files:
+
+- `Sources/Observability/AnalyticsEventPolicy.swift` — the `allowedPolicies`
+  dictionary (plus a `…Properties` set above it)
+- `Tests/AnalyticsEventPolicyTests.swift` — an additive `runSuite(…)` block
+- `docs/privacy-first-observability.md` — the `## Allowlisted analytics events`
+  list (and sibling planning docs)
+- `scripts/ops/generate-nightly-digest.py`,
+  `scripts/ops/posthog-activation-funnel.py` — per-line event tuples
+- `scripts/ops/health-probe.sh` — the event list as a **single-line string**
+
+Because every PR edits the identical anchor, one merge dirties all the rest.
+
+## What works: union merge on the line-oriented docs
+
+The markdown registries list one event per self-contained line
+(`` - `event_name` ``). A union merge of two such inserts is always a valid
+superset, and the docs↔source parity test sorts before comparing, so order is
+irrelevant. `.gitattributes` therefore sets `merge=union` on those docs only.
+
+## What does NOT work: union merge on the Swift policy (verified trap)
+
+It is tempting to also `merge=union` `AnalyticsEventPolicy.swift`. **Do not.**
+The dictionary entries and `…Properties` sets are multi-line, brace-balanced
+blocks, and when two PRs insert at the same anchor git aligns the shared trailing
+`]` / `)` as common context. A union merge then emits *both* opening blocks but
+only *one* closing delimiter:
+
+```swift
+private static let workflowAbandonedProperties: Set<String> = [
+    ...
+    "workflow_kind",
+private static let productFrictionProperties: Set<String> = [   // ← previous set never closed
+    ...
+    "surface",
+]
+```
+
+Git reports a **clean auto-merge** (no conflict markers); the file is silently
+unbalanced and will not compile. Reproduced on `#1210` ⊕ `#1222`: the result had
+`[` 74/`]` 73 and `(` 105/`)` 104. Only Swift CI catches it — a conflict that
+*looks* resolved is worse than one that doesn't. The same applies to the test
+file's `runSuite { … }` blocks.
+
+So the Swift policy + its test are intentionally left to normal (conflicting)
+merges until the durable fix below lands.
+
+## Durable fix (recommended — needs a scope decision)
+
+Single-source the taxonomy so the brace-balanced Swift is **generated**, never
+hand-merged:
+
+1. Move the allowlist to one line-oriented data file — e.g.
+   `analytics-events.psv`: `event_name|prop_a,prop_b,…`, one event per line.
+   This file is safely `merge=union` (each line independent) + a trivial
+   normalizer (`sort -u`) keeps it canonical and dedups.
+2. Generate (or load at runtime) `AnalyticsEventPolicy`, the doc list, and the
+   ops-script event tuples from that single source. The duplicate-event guard
+   stays in `Tests/AnalyticsEventPolicyTests.swift`.
+3. Make `scripts/ops/health-probe.sh` read the same file instead of hard-coding
+   a single-line copy (its current shape can't be union-merged at all).
+
+That removes every hand-merge point and makes the taxonomy single-sourced.
+
+Until then: rebasing a telemetry PR needs only a trivial keep-both resolution of
+the Swift policy/test conflict (add the missing closing `]`/`)` so both events
+remain). The doc/script conflicts auto-resolve via the union attribute above.


### PR DESCRIPTION
## Root cause

~23 open PRs are stuck `DIRTY`. The driver is the **append-only analytics taxonomy**: every privacy-reviewed telemetry PR adds an event at the **same anchor** in a set of lockstep files (`AnalyticsEventPolicy.swift` + its test, `docs/privacy-first-observability.md` + sibling docs, the `scripts/ops/*` event lists). The moment one merges, every other open telemetry PR conflicts; the auto-generated PR loop makes it cascade faster than hand-rebasing.

## What this PR does (safe, partial mitigation)

`merge=union` on the **line-oriented markdown registries only**, where each event is a self-contained line (`` - `event_name` ``) so the union of two inserts is always a valid superset. The parity test sorts before comparing, so order is irrelevant.

## What this PR deliberately does NOT do (verified trap)

It does **not** union `AnalyticsEventPolicy.swift` / its test. Those entries are multi-line, brace-balanced blocks; when two PRs insert at the same anchor, git aligns the shared trailing `]`/`)` as common context, so a union merge silently emits both opening blocks but only one closing delimiter — **git reports a clean auto-merge but the file won't compile.** Reproduced on #1210 ⊕ #1222: result had `[` 74/73 and `(` 105/104. A conflict that *looks* resolved is worse than one that doesn't, so these are left to normal merges.

## Durable fix (recommended — needs a scope decision)

Single-source the taxonomy into one line-oriented data file (`analytics-events.psv`, one event per line — safely `merge=union` + `sort -u` normalizer) and **generate** the Swift policy, the doc list, and the ops-script/health-probe event lists from it. That removes every hand-merge point. Details in `docs/analytics-taxonomy-merge.md`.

## Impact

The doc collisions auto-resolve once this is on `main`. The Swift policy/test still need a trivial keep-both resolution per rebase (add the missing closing `]`/`)`) until the single-source refactor lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)