### PR TITLE
docs(agents): ultracode + workflow as the default orchestration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,3 +207,7 @@ under `~/Library/Application Support/Transcripted/`.
 Historic `Draft` paths still exist for migration and standalone-tool fallback.
 
 See `docs/storage-paths.md` for the canonical storage map, including legacy fallbacks and `TranscriptedCore` standalone defaults.
+
+## Default orchestration: ultracode + workflows
+
+For substantive work — research, audits, multi-file or cross-cutting changes, design, and reviews — default to authoring and running a **Workflow** that fans out parallel agents and adversarially verifies findings, rather than working solo. Reserve solo execution for trivial mechanical edits and conversational replies. Spawned worker threads inherit this default: a thread doing real work should itself orchestrate with a workflow wherever breadth or independent verification helps. Token cost is not the constraint here — correctness and coverage are. This is "ultracode" as the standing default for this repo.


### PR DESCRIPTION
Appends one standing directive to the end of `AGENTS.md`: make **ultracode + Workflow orchestration** the repo default for substantive work (research, audits, multi-file/cross-cutting changes, design, reviews), reserving solo execution for trivial mechanical edits and conversational replies. Spawned worker threads inherit the default.

Doc-only — only `AGENTS.md` changed (+4 lines). New top-level `##` section appended in the repo's existing heading style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)