### PR TITLE
fix(audio): fail system-audio capture when the tap never streams

### DIFF
--- a/Sources/Meeting/MeetingCaptureBridge.swift
+++ b/Sources/Meeting/MeetingCaptureBridge.swift
@@ -184,6 +184,7 @@ final class MeetingCaptureBridge: ObservableObject {
         switch AudioCaptureStartState.meetingCaptureOutcome(
             isRecording: audio.isRecording,
             systemAudioFileURL: audio.systemAudioFileURL,
+            systemAudioStreaming: audio.systemAudioStreaming,
             errorMessage: errorMessage
         ) {
         case .waiting:
@@ -280,6 +281,11 @@ final class MeetingCaptureBridge: ObservableObject {
 
         sinkStartAttemptTriggers(from: audio.$isRecording)
         sinkStartAttemptTriggers(from: audio.$systemAudioFileURL)
+        // A tap can install (file URL assigned, isRecording true) yet never
+        // stream. Re-evaluate readiness when the first system buffer arrives so
+        // a silent-death tap stays `.waiting` and fails the start deadline
+        // instead of being reported as recording.
+        sinkStartAttemptTriggers(from: audio.$systemAudioStreaming)
     }
 
     private func currentStopResult(didTimeOut: Bool = false) -> CaptureStopResult {

--- a/Sources/TranscriptedCore/Audio/Audio.swift
+++ b/Sources/TranscriptedCore/Audio/Audio.swift
@@ -184,6 +184,16 @@ public class Audio: ObservableObject, @unchecked Sendable {
     @Published public var micAudioFileURL: URL?
     @Published public var systemAudioFileURL: URL?
 
+    /// True once the system-audio tap has actually delivered its first buffer
+    /// for the current recording. Meeting-capture readiness
+    /// (`AudioCaptureStartState`) must not promote `.waiting` → `.ready` on
+    /// "I/O proc started + file URL assigned" alone: a tap can install, get a
+    /// file URL, and then silently never stream, losing the entire remote side
+    /// of a call. The setter is module-internal; the flag is flipped from the
+    /// system buffer callback via `markSystemAudioStreamingIfCurrent` and reset
+    /// at each start in `prepareForNewRecordingStart`.
+    @Published public internal(set) var systemAudioStreaming: Bool = false
+
     // Base mic URL set at recording start. If recovery creates additional mic WAV
     // segments, this remains the anchor used to name any merged output passed to
     // the pipeline on stop.
@@ -919,6 +929,7 @@ public class Audio: ObservableObject, @unchecked Sendable {
         error = nil
         isMicRecovering = false
         systemBufferCount = 0  // Reset debug counter (lock-protected)
+        systemAudioStreaming = false  // Re-gate readiness on a fresh first buffer
         resetSignalDiagnostics()
         // Fresh instance = clean one-shot latch per recording.
         quietMicAttenuationDetector = QuietMicAttenuationDetector()
@@ -1105,6 +1116,21 @@ public class Audio: ObservableObject, @unchecked Sendable {
         systemAudioFileURL = fileURL
         recordingJournal.recordSystemAudio(fileURL, session: journalSession)
         restoreSystemAudioHealthyStatusAfterSuccessfulStart()
+    }
+
+    /// Records that the system-audio tap has started streaming for this
+    /// recording. Called from the system buffer callback on its first buffer
+    /// (on a CoreAudio dispatch thread), so it hops to main to publish
+    /// `systemAudioStreaming`. Generation-guarded so a late buffer from a
+    /// finished session cannot re-arm readiness. This is the signal that
+    /// promotes meeting-capture readiness (`AudioCaptureStartState`) from
+    /// `.waiting` to `.ready`: a tap that installs but never streams never sets
+    /// it, so the start deadline fails it instead of reporting "recording".
+    func markSystemAudioStreamingIfCurrent(sessionGeneration: UInt64) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.recordingSessionGeneration == sessionGeneration else { return }
+            self.systemAudioStreaming = true
+        }
     }
 
     // MARK: - Stop Recording

--- a/Sources/TranscriptedCore/Audio/AudioCaptureStartState.swift
+++ b/Sources/TranscriptedCore/Audio/AudioCaptureStartState.swift
@@ -2,9 +2,16 @@ import Foundation
 
 /// Start-state policy for meeting capture.
 ///
-/// Meeting recordings are only valid once the mic is running AND the system-audio
-/// file has been created. Returning success earlier can leave a long mic-only
-/// recording that later fails in the multichannel pipeline.
+/// Meeting recordings are only valid once the mic is running, the system-audio
+/// file has been created, AND the system-audio tap has actually delivered its
+/// first buffer. Returning success on "I/O proc started + file URL assigned"
+/// alone can leave a long mic-only recording that later fails in the
+/// multichannel pipeline — or, worse, mark a tap that silently never streams as
+/// "recording," losing the entire remote side of a call with no recovery (the
+/// device-change watchdog is gated on the first buffer and never fires). Gating
+/// readiness on `systemAudioStreaming` makes a never-streaming tap stay
+/// `.waiting` so it misses the start deadline and fails (the existing
+/// start-timeout teardown then stops it) instead of masquerading as recording.
 public enum AudioCaptureStartState {
     public enum Outcome: Equatable {
         case waiting
@@ -15,13 +22,14 @@ public enum AudioCaptureStartState {
     public static func meetingCaptureOutcome(
         isRecording: Bool,
         systemAudioFileURL: URL?,
+        systemAudioStreaming: Bool,
         errorMessage: String?
     ) -> Outcome {
         if let errorMessage, !errorMessage.isEmpty {
             return .failed(errorMessage)
         }
 
-        if isRecording, systemAudioFileURL != nil {
+        if isRecording, systemAudioFileURL != nil, systemAudioStreaming {
             return .ready
         }
 

--- a/Sources/TranscriptedCore/Audio/AudioFileManager.swift
+++ b/Sources/TranscriptedCore/Audio/AudioFileManager.swift
@@ -167,6 +167,12 @@ extension Audio {
 
                         self.systemBufferCount += 1
                         let currentBufferCount = self.systemBufferCount
+                        if currentBufferCount == 1 {
+                            // First real buffer: the tap is actually streaming
+                            // (not just installed with a file URL). Promote
+                            // meeting-capture readiness past `.waiting`.
+                            self.markSystemAudioStreamingIfCurrent(sessionGeneration: sessionGeneration)
+                        }
 
                         // Calculate system audio level synchronously (fast, no I/O)
                         self.calculateSystemLevel(buffer: systemBuffer)

--- a/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
+++ b/Tests/TranscriptedCoreTests/AudioInitializationTests.swift
@@ -477,6 +477,55 @@ final class AudioInitializationTests: XCTestCase {
             "when the async file URL arrives after the start finish callback, it should complete the status repair"
         )
     }
+
+    func testSystemAudioStreamingDefaultsFalseAndResetsOnNewStart() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioInitializationTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let audio = Audio(paths: makeCoreStoragePaths(root: root))
+        XCTAssertFalse(
+            audio.systemAudioStreaming,
+            "a fresh Audio must not claim the system-audio tap is streaming before any buffer arrives"
+        )
+
+        audio.systemAudioStreaming = true
+        audio.prepareForNewRecordingStart()
+        XCTAssertFalse(
+            audio.systemAudioStreaming,
+            "each new recording must re-gate readiness on a fresh first system-audio buffer"
+        )
+    }
+
+    func testMarkSystemAudioStreamingOnlyArmsForTheCurrentSession() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioInitializationTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let audio = Audio(paths: makeCoreStoragePaths(root: root))
+        audio.prepareForNewRecordingStart()
+        let currentGeneration = audio.recordingSessionGeneration
+
+        // A buffer tagged with a finished session must not re-arm readiness.
+        let staleHandled = expectation(description: "stale streaming mark drained")
+        audio.markSystemAudioStreamingIfCurrent(sessionGeneration: currentGeneration &- 1)
+        DispatchQueue.main.async { staleHandled.fulfill() }
+        wait(for: [staleHandled], timeout: 1.0)
+        XCTAssertFalse(
+            audio.systemAudioStreaming,
+            "a first buffer from a previous session must not mark the new session as streaming"
+        )
+
+        // The current session's first buffer marks the tap as streaming.
+        let currentHandled = expectation(description: "current streaming mark drained")
+        audio.markSystemAudioStreamingIfCurrent(sessionGeneration: currentGeneration)
+        DispatchQueue.main.async { currentHandled.fulfill() }
+        wait(for: [currentHandled], timeout: 1.0)
+        XCTAssertTrue(
+            audio.systemAudioStreaming,
+            "the current session's first system-audio buffer must mark the tap as streaming"
+        )
+    }
 }
 
 @available(macOS 14.0, *)

--- a/Tests/TranscriptedCoreTests/LiveCaptureSmokeTests.swift
+++ b/Tests/TranscriptedCoreTests/LiveCaptureSmokeTests.swift
@@ -128,6 +128,7 @@ final class LiveCaptureSmokeTests: XCTestCase {
             let outcome = AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: audio.isRecording,
                 systemAudioFileURL: audio.systemAudioFileURL,
+                systemAudioStreaming: audio.systemAudioStreaming,
                 errorMessage: audio.error
             )
 

--- a/Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift
@@ -20,6 +20,7 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
             AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: true,
                 systemAudioFileURL: nil,
+                systemAudioStreaming: true,
                 errorMessage: nil
             ),
             .waiting
@@ -29,6 +30,7 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
             AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: true,
                 systemAudioFileURL: readyURL,
+                systemAudioStreaming: true,
                 errorMessage: nil
             ),
             .ready
@@ -38,9 +40,26 @@ final class TranscriptionPipelineHelpersTests: XCTestCase {
             AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: true,
                 systemAudioFileURL: readyURL,
+                systemAudioStreaming: true,
                 errorMessage: "System audio unavailable"
             ),
             .failed("System audio unavailable")
+        )
+    }
+
+    func testAudioCaptureStartStateWaitsWhenTapHasNotStreamedYet() {
+        // The silent-death case: the I/O proc started and a file URL was
+        // assigned, but the tap never delivered a buffer. Readiness must stay
+        // `.waiting` so the start deadline fails it instead of reporting a tap
+        // that is silently writing nothing as "recording".
+        XCTAssertEqual(
+            AudioCaptureStartState.meetingCaptureOutcome(
+                isRecording: true,
+                systemAudioFileURL: URL(fileURLWithPath: "/tmp/system.wav"),
+                systemAudioStreaming: false,
+                errorMessage: nil
+            ),
+            .waiting
         )
     }
 

--- a/Tests/TranscriptedCoreTests/TranscriptionPipelineStateTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptionPipelineStateTests.swift
@@ -95,6 +95,23 @@ final class TranscriptionPipelineStateTests: XCTestCase {
             AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: false,
                 systemAudioFileURL: url,
+                systemAudioStreaming: true,
+                errorMessage: nil
+            ),
+            .waiting
+        )
+    }
+
+    func testMeetingCaptureOutcomeWaitsUntilSystemAudioTapStreams() {
+        // The silent-death tap: recording flag set, file URL assigned, but the
+        // tap has not delivered its first buffer. Must stay `.waiting` so the
+        // start deadline fails it instead of reporting a tap that is silently
+        // writing nothing as ready/recording.
+        XCTAssertEqual(
+            AudioCaptureStartState.meetingCaptureOutcome(
+                isRecording: true,
+                systemAudioFileURL: URL(fileURLWithPath: "/tmp/system.wav"),
+                systemAudioStreaming: false,
                 errorMessage: nil
             ),
             .waiting
@@ -108,6 +125,7 @@ final class TranscriptionPipelineStateTests: XCTestCase {
             AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: true,
                 systemAudioFileURL: URL(fileURLWithPath: "/tmp/system.wav"),
+                systemAudioStreaming: true,
                 errorMessage: ""
             ),
             .ready
@@ -120,6 +138,7 @@ final class TranscriptionPipelineStateTests: XCTestCase {
             AudioCaptureStartState.meetingCaptureOutcome(
                 isRecording: true,
                 systemAudioFileURL: URL(fileURLWithPath: "/tmp/system.wav"),
+                systemAudioStreaming: true,
                 errorMessage: "permission denied"
             ),
             .failed("permission denied")


### PR DESCRIPTION
## Problem

Meeting capture reported **recording** the moment the system-audio I/O proc started and a file URL was assigned — not when the tap actually delivered audio. A tap that installs but silently never streams (the narrower sibling of the hard-permission-failure case, which already throws cleanly) was therefore marked as recording while writing nothing, **losing the entire remote side of a call** with no recovery. The only feedback was a passive `.silent` badge after 10s.

- `AudioCaptureStartState.meetingCaptureOutcome` returned `.ready` on `isRecording && systemAudioFileURL != nil`; the URL is assigned right after `capture.start{}` returns (`AudioFileManager.swift`).
- The device-change watchdog can't recover it — it is gated on `hasReceivedFirstBuffer` (`SystemAudioBufferWriter.swift`) and so never fires for a tap that never streamed.

## Fix

Gate the start outcome on a first-buffer-arrival signal:

- `Audio.systemAudioStreaming` (`@Published`, module-internal setter) flips true on the **first** system-audio buffer via `markSystemAudioStreamingIfCurrent` (generation-guarded, hops to main); reset each start in `prepareForNewRecordingStart`.
- `meetingCaptureOutcome` now also requires `systemAudioStreaming` for `.ready`.
- `MeetingCaptureBridge` passes the live signal and re-evaluates readiness when it flips.

A never-streaming tap now stays `.waiting`, misses the existing 5s `meetingStartTimeout`, and is **failed + stopped by the existing start-timeout teardown** instead of masquerading as recording. Hard permission failures still throw cleanly. Normal starts are unaffected: the system tap streams continuously (including silence), so the first buffer lands within ~100–200 ms — far inside the 5s deadline.

## Tests

- Policy: `.waiting` when `systemAudioStreaming == false` even with `isRecording` + file URL (`testMeetingCaptureOutcomeWaitsUntilSystemAudioTapStreams`, `testAudioCaptureStartStateWaitsWhenTapHasNotStreamedYet`). Existing `.ready`/`.failed` cases updated to pass the new signal.
- Behavioral: `systemAudioStreaming` defaults false and resets on new start; `markSystemAudioStreamingIfCurrent` only arms the current session (generation-guarded).

## Verification

- `swift test` (Core) — green
- `bash build-deps.sh --force` + `bash build.sh --no-open` + `bash run-tests.sh` + `bash run-integration-smoke.sh` — all green

## Manual proof still recommended

The never-streams path is hard to reproduce deterministically without a silent-death tap. Unit tests cover the readiness gate and the buffer→flag wiring; a live check (start a meeting, confirm `.ready` only fires once audio flows, and simulate a dead tap to confirm it now fails the start instead of reporting "recording") would be the final hardware confirmation.

From `docs/FIX_ROADMAP.md` item #4 (draft PR #1227). Draft — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)