### PR TITLE
fix(speaker): write-time contamination gate + decoupled link/merge floor

### DIFF
--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -346,21 +346,25 @@ extension Transcription {
             // off to its own profile so it stays independently nameable.
             let linkPlan = Self.planCrossClusterLinks(
                 matchedProfileBySpeaker: speakerMatchResults.mapValues { $0.persistentId },
+                matchSimilarityBySpeaker: speakerMatchResults.mapValues { $0.similarity },
                 meanBySpeaker: matchedMeanPerSpeaker,
                 segmentCountBySpeaker: embeddingsPerSpeaker.mapValues { $0.count }
             )
-            for (other, canonical) in linkPlan.remaps {
-                speakerIdRemap[other] = canonical
+            // Spin-off representatives: a distinct voice (or fragments of one) that only resembled the
+            // matched profile — give it its own identity so review names it separately. Removed from
+            // the matched set so it never writes back into the shared profile.
+            for rep in linkPlan.spinOffs {
+                let repMean = matchedMeanPerSpeaker[rep]
+                    ?? Self.computeMeanEmbedding(embeddingsPerSpeaker[rep] ?? [])
+                let spinoff = speakerDB.addOrUpdateSpeaker(embedding: repMean, existingId: nil)
+                speakerMatchResults.removeValue(forKey: rep)
+                speakerNewProfiles[rep] = spinoff.id
             }
-            for other in linkPlan.spinOffs {
-                // Distinct voice that only coincidentally matched the same profile — give it its own
-                // identity so review names it separately instead of inheriting the matched profile's
-                // name. Removed from the matched set so it never writes back into the shared profile.
-                let otherMean = matchedMeanPerSpeaker[other]
-                    ?? Self.computeMeanEmbedding(embeddingsPerSpeaker[other] ?? [])
-                let spinoff = speakerDB.addOrUpdateSpeaker(embedding: otherMean, existingId: nil)
+            // Group members fuse into their representative; drop their own match so only the
+            // representative writes back (keeper group → shared profile, spin-off group → new profile).
+            for (other, rep) in linkPlan.remaps {
+                speakerIdRemap[other] = rep
                 speakerMatchResults.removeValue(forKey: other)
-                speakerNewProfiles[other] = spinoff.id
             }
             if !linkPlan.remaps.isEmpty {
                 AppLogger.transcription.info("Merged speaker IDs with same DB profile", [
@@ -799,19 +803,21 @@ extension Transcription {
         // full rationale). `nonGhostMeans` holds the matched mean per non-ghost speaker.
         let micLinkPlan = Self.planCrossClusterLinks(
             matchedProfileBySpeaker: speakerMatchResults.mapValues { $0.persistentId },
+            matchSimilarityBySpeaker: speakerMatchResults.mapValues { $0.similarity },
             meanBySpeaker: nonGhostMeans,
             segmentCountBySpeaker: embeddingsPerSpeaker.mapValues { $0.count }
         )
-        for (other, canonical) in micLinkPlan.remaps {
-            speakerIdRemap[other] = canonical
-        }
-        for other in micLinkPlan.spinOffs {
-            let otherMean = nonGhostMeans[other]
-                ?? Self.computeMeanEmbedding(embeddingsPerSpeaker[other] ?? [])
-            let spinoff = speakerDB.addOrUpdateSpeaker(embedding: otherMean, existingId: nil)
-            speakerMatchResults.removeValue(forKey: other)
-            speakerNewProfiles[other] = spinoff.id
+        for rep in micLinkPlan.spinOffs {
+            let repMean = nonGhostMeans[rep]
+                ?? Self.computeMeanEmbedding(embeddingsPerSpeaker[rep] ?? [])
+            let spinoff = speakerDB.addOrUpdateSpeaker(embedding: repMean, existingId: nil)
+            speakerMatchResults.removeValue(forKey: rep)
+            speakerNewProfiles[rep] = spinoff.id
             newlyCreatedProfileIds.insert(spinoff.id)
+        }
+        for (other, rep) in micLinkPlan.remaps {
+            speakerIdRemap[other] = rep
+            speakerMatchResults.removeValue(forKey: other)
         }
 
         // Deferred write-back (#6): blend each surviving matched cluster under the contamination

--- a/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
+++ b/Sources/TranscriptedCore/Pipeline/TranscriptionPipeline.swift
@@ -246,6 +246,10 @@ extension Transcription {
             var speakerMatchResults: [Int: (persistentId: UUID, similarity: Double, secondSimilarity: Double)] = [:]
             var speakerNewProfiles: [Int: UUID] = [:]
             var speakerIdRemap: [Int: Int] = [:]
+            // Session mean embedding actually matched for each non-ghost speaker, kept so the
+            // cross-cluster link/merge step can compare clusters directly to each other (#8)
+            // instead of relying only on "matched the same profile".
+            var matchedMeanPerSpeaker: [Int: [Float]] = [:]
 
             // Pre-compute unweighted means for non-ghost speakers so the ghost merge inner
             // loop doesn't recompute the same means once per ghost (O(G×N) → O(N)).
@@ -258,6 +262,7 @@ extension Transcription {
                 let meanEmbedding = Self.computeWeightedMeanEmbedding(embeddings, weights: weights)
 
                 let isGhost = ghostSpeakerIdSet.contains(speakerId)
+                if !isGhost { matchedMeanPerSpeaker[speakerId] = meanEmbedding }
 
                 // Ghost speakers have unreliable embeddings (laughter, coughs, codec artifacts).
                 // Prefer force-merging into the closest real speaker, but if every detected
@@ -303,14 +308,18 @@ extension Transcription {
                     default: 0.70      // 4+ segments — reliable mean embedding
                 }
 
-                // Match only against profiles that existed BEFORE this recording
+                // Match only against profiles that existed BEFORE this recording.
+                // Write-back is DEFERRED until after the cross-cluster link/merge decision below,
+                // so a cluster that turns out to be a distinct voice (spun off) never blends into
+                // the shared profile. Matching reads only the `existingProfiles` snapshot, so
+                // deferring the blend cannot change any match decision.
                 if let matchResult = Self.matchAgainstProfiles(meanEmbedding, profiles: existingProfiles, threshold: adaptiveThreshold) {
                     speakerMatchResults[speakerId] = (matchResult.profileId, matchResult.similarity, matchResult.secondBestSimilarity)
-                    _ = speakerDB.addOrUpdateSpeaker(embedding: meanEmbedding, existingId: matchResult.profileId)
                     let matchedProfile = existingProfiles.first(where: { $0.id == matchResult.profileId })
                     AppLogger.transcription.info("Speaker matched DB profile", [
                         "speakerId": "\(speakerId)",
                         "similarity": String(format: "%.3f", matchResult.similarity),
+                        "secondBest": String(format: "%.3f", matchResult.secondBestSimilarity),
                         "threshold": String(format: "%.2f", adaptiveThreshold),
                         "segmentsAveraged": "\(embeddings.count)",
                         "profileName": matchedProfile?.displayName ?? "unnamed",
@@ -327,23 +336,69 @@ extension Transcription {
                 }
             }
 
-            // Merge speaker IDs that matched the same DB profile.
-            // Fixes cross-cluster fragmentation: if Sortformer split one person
-            // into spk1 and spk3, and DB matching identified both as the same
-            // profile, unify them under the speaker ID with the most segments.
-            let profileToSpeakers = Dictionary(grouping: speakerMatchResults.keys) { speakerMatchResults[$0]?.persistentId }
-            for (profileId, matchedSpeakerIds) in profileToSpeakers where profileId != nil && matchedSpeakerIds.count >= 2 {
-                let sorted = matchedSpeakerIds.sorted { a, b in
-                    embeddingsPerSpeaker[a]?.count ?? 0 > embeddingsPerSpeaker[b]?.count ?? 0
-                }
-                let canonical = sorted[0]
-                for other in sorted.dropFirst() {
-                    speakerIdRemap[other] = canonical
-                }
+            // Cross-cluster link/merge (#8): two diarizer clusters that matched the SAME DB profile
+            // are candidates for fusion into one transcript row. The 0.70 attach floor that bound
+            // each cluster to the profile is too loose to ALSO prove they are the same person — two
+            // distinct people who each merely resemble one profile would be silently fused, then
+            // named once in review. Decouple it: only fuse clusters that are directly similar to
+            // EACH OTHER (cross-cluster cosine ≥ link floor — the genuine over-segmentation
+            // signature). A cluster that matched the same profile but is a distinct voice is spun
+            // off to its own profile so it stays independently nameable.
+            let linkPlan = Self.planCrossClusterLinks(
+                matchedProfileBySpeaker: speakerMatchResults.mapValues { $0.persistentId },
+                meanBySpeaker: matchedMeanPerSpeaker,
+                segmentCountBySpeaker: embeddingsPerSpeaker.mapValues { $0.count }
+            )
+            for (other, canonical) in linkPlan.remaps {
+                speakerIdRemap[other] = canonical
+            }
+            for other in linkPlan.spinOffs {
+                // Distinct voice that only coincidentally matched the same profile — give it its own
+                // identity so review names it separately instead of inheriting the matched profile's
+                // name. Removed from the matched set so it never writes back into the shared profile.
+                let otherMean = matchedMeanPerSpeaker[other]
+                    ?? Self.computeMeanEmbedding(embeddingsPerSpeaker[other] ?? [])
+                let spinoff = speakerDB.addOrUpdateSpeaker(embedding: otherMean, existingId: nil)
+                speakerMatchResults.removeValue(forKey: other)
+                speakerNewProfiles[other] = spinoff.id
+            }
+            if !linkPlan.remaps.isEmpty {
                 AppLogger.transcription.info("Merged speaker IDs with same DB profile", [
-                    "merged": sorted.dropFirst().map { "spk\($0)" }.joined(separator: "+"),
-                    "canonical": "spk\(canonical)"
+                    "merged": linkPlan.remaps.keys.map { "spk\($0)" }.joined(separator: "+"),
+                    "remaps": "\(linkPlan.remaps.count)"
                 ])
+            }
+            if !linkPlan.spinOffs.isEmpty {
+                AppLogger.transcription.info("Cross-cluster fusion declined — distinct voices spun off", [
+                    "spunOff": linkPlan.spinOffs.map { "spk\($0)" }.joined(separator: "+"),
+                    "linkFloor": String(format: "%.2f", SpeakerWritePathPolicy.crossClusterLinkFloor)
+                ])
+            }
+
+            // Deferred write-back (#6): now that fusion/spin-off is resolved, blend each surviving
+            // matched cluster's session mean into its profile under the write-time contamination
+            // gate. A weak or ambiguous match freezes the voiceprint (alpha 0) — still recorded as
+            // an appearance, never silently drifting the stored fingerprint. Spun-off clusters were
+            // removed from speakerMatchResults above and so never contaminate the shared profile.
+            for (speakerId, match) in speakerMatchResults {
+                guard let meanEmbedding = matchedMeanPerSpeaker[speakerId] else { continue }
+                let writeAlpha = SpeakerWritePathPolicy.voiceprintBlendAlpha(
+                    similarity: match.similarity,
+                    secondBestSimilarity: match.secondSimilarity
+                )
+                _ = speakerDB.addOrUpdateSpeaker(
+                    embedding: meanEmbedding,
+                    existingId: match.persistentId,
+                    blendAlpha: writeAlpha
+                )
+                if writeAlpha < SpeakerWritePathPolicy.confidentBlendAlpha {
+                    AppLogger.transcription.info("Voiceprint write-back gated", [
+                        "speakerId": "\(speakerId)",
+                        "similarity": String(format: "%.3f", match.similarity),
+                        "secondBest": String(format: "%.3f", match.secondSimilarity),
+                        "writeBackAlpha": String(format: "%.2f", writeAlpha)
+                    ])
+                }
             }
 
             var systemSpeakerContexts: [String: ChannelSpeakerContext] = [:]
@@ -726,9 +781,12 @@ extension Transcription {
                 default: 0.70
             }
 
+            // Write-back is DEFERRED until after the cross-cluster decision below (#6/#8 — same
+            // rationale as the system path: matching reads only the existingProfiles snapshot, so
+            // deferring the blend changes no match decision, and a spun-off distinct voice never
+            // contaminates the shared profile).
             if let matchResult = Self.matchAgainstProfiles(meanEmbedding, profiles: existingProfiles, threshold: adaptiveThreshold) {
                 speakerMatchResults[speakerId] = (matchResult.profileId, matchResult.similarity, matchResult.secondBestSimilarity)
-                _ = speakerDB.addOrUpdateSpeaker(embedding: meanEmbedding, existingId: matchResult.profileId)
             } else {
                 let newProfile = speakerDB.addOrUpdateSpeaker(embedding: meanEmbedding, existingId: nil)
                 speakerNewProfiles[speakerId] = newProfile.id
@@ -736,14 +794,39 @@ extension Transcription {
             }
         }
 
-        // Cross-cluster merge: same-DB-profile speakers collapse.
-        let profileToSpeakers = Dictionary(grouping: speakerMatchResults.keys) { speakerMatchResults[$0]?.persistentId }
-        for (profileId, matchedSpeakerIds) in profileToSpeakers where profileId != nil && matchedSpeakerIds.count >= 2 {
-            let sorted = matchedSpeakerIds.sorted { a, b in
-                embeddingsPerSpeaker[a]?.count ?? 0 > embeddingsPerSpeaker[b]?.count ?? 0
-            }
-            let canonical = sorted[0]
-            for other in sorted.dropFirst() { speakerIdRemap[other] = canonical }
+        // Cross-cluster link/merge (#8): only fuse same-profile clusters that are directly similar
+        // to each other; spin distinct voices off to their own profile (see system path for the
+        // full rationale). `nonGhostMeans` holds the matched mean per non-ghost speaker.
+        let micLinkPlan = Self.planCrossClusterLinks(
+            matchedProfileBySpeaker: speakerMatchResults.mapValues { $0.persistentId },
+            meanBySpeaker: nonGhostMeans,
+            segmentCountBySpeaker: embeddingsPerSpeaker.mapValues { $0.count }
+        )
+        for (other, canonical) in micLinkPlan.remaps {
+            speakerIdRemap[other] = canonical
+        }
+        for other in micLinkPlan.spinOffs {
+            let otherMean = nonGhostMeans[other]
+                ?? Self.computeMeanEmbedding(embeddingsPerSpeaker[other] ?? [])
+            let spinoff = speakerDB.addOrUpdateSpeaker(embedding: otherMean, existingId: nil)
+            speakerMatchResults.removeValue(forKey: other)
+            speakerNewProfiles[other] = spinoff.id
+            newlyCreatedProfileIds.insert(spinoff.id)
+        }
+
+        // Deferred write-back (#6): blend each surviving matched cluster under the contamination
+        // gate. Spun-off clusters were removed above and never write into the shared profile.
+        for (speakerId, match) in speakerMatchResults {
+            guard let meanEmbedding = nonGhostMeans[speakerId] else { continue }
+            let writeAlpha = SpeakerWritePathPolicy.voiceprintBlendAlpha(
+                similarity: match.similarity,
+                secondBestSimilarity: match.secondSimilarity
+            )
+            _ = speakerDB.addOrUpdateSpeaker(
+                embedding: meanEmbedding,
+                existingId: match.persistentId,
+                blendAlpha: writeAlpha
+            )
         }
 
         // Build speaker contexts keyed by effective speakerId (post-remap).

--- a/Sources/TranscriptedCore/Protocols/SpeakerStore.swift
+++ b/Sources/TranscriptedCore/Protocols/SpeakerStore.swift
@@ -10,6 +10,14 @@ public protocol SpeakerStore: Sendable {
     /// Add a new speaker or update an existing profile with a new embedding
     func addOrUpdateSpeaker(embedding: [Float], existingId: UUID?) -> SpeakerProfile
 
+    /// Add a new speaker or update an existing matched profile with an explicit EMA blend weight.
+    ///
+    /// `blendAlpha == 0` records the appearance (call-count / last-seen) **without** altering the
+    /// stored voiceprint — used by the write-time contamination gate when a match is too marginal
+    /// or ambiguous to safely adapt the fingerprint. Higher alpha blends as normal. See
+    /// `SpeakerWritePathPolicy.voiceprintBlendAlpha`.
+    func addOrUpdateSpeaker(embedding: [Float], existingId: UUID?, blendAlpha: Float) -> SpeakerProfile
+
     /// Get a specific speaker profile by ID
     func getSpeaker(id: UUID) -> SpeakerProfile?
 
@@ -54,5 +62,12 @@ public extension SpeakerStore {
     func mergeDuplicates(protecting protectedIds: Set<UUID>) {
         guard protectedIds.isEmpty else { return }
         mergeDuplicates()
+    }
+
+    /// Back-compat default: conformers that don't model an EMA blend weight (test doubles, simple
+    /// stores) fall back to the standard write-back, ignoring `blendAlpha`. `SpeakerDatabase`
+    /// provides a real implementation that honours the gate.
+    func addOrUpdateSpeaker(embedding: [Float], existingId: UUID?, blendAlpha: Float) -> SpeakerProfile {
+        addOrUpdateSpeaker(embedding: embedding, existingId: existingId)
     }
 }

--- a/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
@@ -233,12 +233,24 @@ public final class SpeakerDatabase: @unchecked Sendable {
     /// Callers that pre-generate IDs (e.g. naming coordinator) rely on this;
     /// callers that pass `nil` always get a fresh UUID.
     public func addOrUpdateSpeaker(embedding: [Float], existingId: UUID? = nil) -> SpeakerProfile {
+        return addOrUpdateSpeaker(
+            embedding: embedding,
+            existingId: existingId,
+            blendAlpha: SpeakerWritePathPolicy.confidentBlendAlpha
+        )
+    }
+
+    /// Gated write-back: `blendAlpha` controls how much of the new embedding is blended into an
+    /// existing matched profile's voiceprint. `0` freezes the fingerprint while still bumping
+    /// call-count / last-seen (records the appearance without contaminating the identity).
+    /// New-speaker inserts ignore `blendAlpha`. See `SpeakerWritePathPolicy`.
+    public func addOrUpdateSpeaker(embedding: [Float], existingId: UUID?, blendAlpha: Float) -> SpeakerProfile {
         return queue.sync {
-            addOrUpdateSpeakerImpl(embedding: embedding, existingId: existingId)
+            addOrUpdateSpeakerImpl(embedding: embedding, existingId: existingId, blendAlpha: blendAlpha)
         }
     }
 
-    private func addOrUpdateSpeakerImpl(embedding: [Float], existingId: UUID?) -> SpeakerProfile {
+    private func addOrUpdateSpeakerImpl(embedding: [Float], existingId: UUID?, blendAlpha: Float) -> SpeakerProfile {
         guard isDatabaseOpen else {
             AppLogger.speakers.error("CRITICAL: addOrUpdateSpeaker returning in-memory-only profile — database not open, speaker will NOT be persisted", ["existingId": existingId?.uuidString ?? "new"])
             return SpeakerProfile(id: existingId ?? UUID(), displayName: nil, nameSource: nil, embedding: embedding, firstSeen: Date(), lastSeen: Date(), callCount: 1, confidence: 0.5, disputeCount: 0)
@@ -248,8 +260,12 @@ public final class SpeakerDatabase: @unchecked Sendable {
         let now = isoFormatter.string(from: Date())
 
         if let existingId = existingId, let existing = getSpeakerImpl(id: existingId) {
-            // Update: blend embedding with exponential moving average
-            let alpha: Float = 0.15  // Weight for new embedding (0.15 = slow adaptation, preserves identity)
+            // Update: blend embedding with exponential moving average.
+            // alpha is the write-time contamination gate (SpeakerWritePathPolicy): the caller
+            // passes a reduced/zero weight for marginal or ambiguous matches so a low-quality
+            // re-identification cannot permanently drift a mature profile's stored voiceprint.
+            // alpha == 0 leaves the embedding byte-identical while still recording the appearance.
+            let alpha = max(0, min(1, blendAlpha))
             let blended = zip(existing.embedding, embedding).map { old, new in
                 old * (1 - alpha) + new * alpha
             }

--- a/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
@@ -119,12 +119,16 @@ extension Transcription {
     // MARK: - Cross-Cluster Link/Merge (#8)
 
     /// Plan for resolving multiple diarizer clusters that matched the same DB profile.
-    struct CrossClusterLinkPlan: Equatable {
-        /// `other speakerId -> canonical speakerId`: genuine over-segmentation, fuse into one row.
-        var remaps: [Int: Int] = [:]
-        /// speakerIds whose shared-profile match should be discarded and replaced with a fresh
-        /// profile — a distinct voice that only coincidentally matched the same profile.
-        var spinOffs: [Int] = []
+    public struct CrossClusterLinkPlan: Equatable {
+        /// `member speakerId -> representative speakerId`: clusters that share one final identity
+        /// (either genuine over-segmentation kept on the matched profile, or fragments of one
+        /// spun-off distinct voice). The representative carries the identity for the whole group.
+        public var remaps: [Int: Int] = [:]
+        /// Representative speakerIds whose group should be discarded from the matched profile and
+        /// given a *fresh* profile — a distinct voice (or fragments of one) that only coincidentally
+        /// resembled the matched profile. Sorted for deterministic output.
+        public var spinOffs: [Int] = []
+        public init() {}
     }
 
     /// Decide, for clusters that matched the same DB profile, which are genuine over-segmentation of
@@ -132,42 +136,70 @@ extension Transcription {
     ///
     /// Decouples the link/merge decision from the per-utterance attach floor (#8): a cluster
     /// attaches to a profile at the loose adaptive floor (0.70), but two clusters only FUSE when
-    /// they are directly similar to each other (cross-cluster cosine ≥
-    /// `SpeakerWritePathPolicy.crossClusterLinkFloor`). The largest cluster keeps the matched
-    /// identity; smaller distinct voices are spun off.
+    /// they are directly similar *to each other* (cross-cluster cosine ≥
+    /// `SpeakerWritePathPolicy.crossClusterLinkFloor`).
     ///
-    /// Pure and deterministic so the eval/unit tests can exercise the two-people-one-profile case
-    /// directly without the full audio pipeline.
-    nonisolated static func planCrossClusterLinks(
+    /// Clusters on one profile are grouped by mutual cross-cluster similarity (union-find, so three
+    /// fragments of one voice all collapse even if no single pair-with-the-largest holds). The group
+    /// containing the cluster that *best matches the profile* keeps the identity; every other group
+    /// is a distinct voice and is spun off to its own profile. Within each group the representative
+    /// is the highest-similarity-to-profile cluster (ties: more segments, then lower id), so the
+    /// real returning speaker keeps the name even when a longer distinct voice also matched.
+    ///
+    /// Pure and deterministic so the eval harness and unit tests exercise the two-people-one-profile
+    /// (and N-people / 3-fragment) cases directly without the full audio pipeline.
+    nonisolated public static func planCrossClusterLinks(
         matchedProfileBySpeaker: [Int: UUID],
+        matchSimilarityBySpeaker: [Int: Double],
         meanBySpeaker: [Int: [Float]],
         segmentCountBySpeaker: [Int: Int]
     ) -> CrossClusterLinkPlan {
         var plan = CrossClusterLinkPlan()
         let byProfile = Dictionary(grouping: matchedProfileBySpeaker.keys) { matchedProfileBySpeaker[$0] }
-        for (profileId, speakerIds) in byProfile where profileId != nil && speakerIds.count >= 2 {
-            // Largest cluster (most segments) claims the identity; ties broken by speakerId for
-            // deterministic output.
-            let sorted = speakerIds.sorted { a, b in
-                let ca = segmentCountBySpeaker[a] ?? 0
-                let cb = segmentCountBySpeaker[b] ?? 0
-                return ca == cb ? a < b : ca > cb
+        for (profileId, ids) in byProfile where profileId != nil && ids.count >= 2 {
+            let clusters = ids.filter { meanBySpeaker[$0] != nil }
+            guard clusters.count >= 2 else { continue }
+
+            // Union-find over the same-profile clusters: fuse any pair similar enough to be one
+            // voice, transitively (A≈B, B≈C ⇒ {A,B,C}).
+            var parent = Dictionary(uniqueKeysWithValues: clusters.map { ($0, $0) })
+            func find(_ x: Int) -> Int {
+                var r = x
+                while parent[r]! != r { r = parent[r]! }
+                var n = x
+                while n != r { let nx = parent[n]!; parent[n] = r; n = nx }
+                return r
             }
-            let canonical = sorted[0]
-            guard let canonicalMean = meanBySpeaker[canonical] else { continue }
-            for other in sorted.dropFirst() {
-                guard let otherMean = meanBySpeaker[other] else {
-                    plan.spinOffs.append(other)
-                    continue
+            func union(_ a: Int, _ b: Int) {
+                let ra = find(a), rb = find(b)
+                if ra != rb { parent[rb] = ra }
+            }
+            for i in 0..<clusters.count {
+                for j in (i + 1)..<clusters.count {
+                    let s = cosineSimilarityStatic(meanBySpeaker[clusters[i]]!, meanBySpeaker[clusters[j]]!)
+                    if SpeakerWritePathPolicy.shouldFuseMatchedClusters(crossClusterSimilarity: s) {
+                        union(clusters[i], clusters[j])
+                    }
                 }
-                let crossSim = cosineSimilarityStatic(canonicalMean, otherMean)
-                if SpeakerWritePathPolicy.shouldFuseMatchedClusters(crossClusterSimilarity: crossSim) {
-                    plan.remaps[other] = canonical
-                } else {
-                    plan.spinOffs.append(other)
-                }
+            }
+
+            // Rank key: best match to the profile, then most segments, then lowest id (deterministic).
+            func rank(_ c: Int) -> (Double, Int, Int) {
+                (matchSimilarityBySpeaker[c] ?? -1, segmentCountBySpeaker[c] ?? 0, -c)
+            }
+
+            // The group that owns the profile = the one containing the overall best-matching cluster.
+            let keeperRoot = clusters.max(by: { rank($0) < rank($1) }).map { find($0) }
+
+            var components: [Int: [Int]] = [:]
+            for c in clusters { components[find(c), default: []].append(c) }
+            for (root, members) in components {
+                let rep = members.max(by: { rank($0) < rank($1) })!
+                for other in members where other != rep { plan.remaps[other] = rep }
+                if root != keeperRoot { plan.spinOffs.append(rep) }
             }
         }
+        plan.spinOffs.sort()
         return plan
     }
 

--- a/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
@@ -116,6 +116,61 @@ extension Transcription {
                                    secondBestSimilarity: secondBestSimilarity)
     }
 
+    // MARK: - Cross-Cluster Link/Merge (#8)
+
+    /// Plan for resolving multiple diarizer clusters that matched the same DB profile.
+    struct CrossClusterLinkPlan: Equatable {
+        /// `other speakerId -> canonical speakerId`: genuine over-segmentation, fuse into one row.
+        var remaps: [Int: Int] = [:]
+        /// speakerIds whose shared-profile match should be discarded and replaced with a fresh
+        /// profile — a distinct voice that only coincidentally matched the same profile.
+        var spinOffs: [Int] = []
+    }
+
+    /// Decide, for clusters that matched the same DB profile, which are genuine over-segmentation of
+    /// one voice (fuse) and which are distinct voices that merely resemble the profile (spin off).
+    ///
+    /// Decouples the link/merge decision from the per-utterance attach floor (#8): a cluster
+    /// attaches to a profile at the loose adaptive floor (0.70), but two clusters only FUSE when
+    /// they are directly similar to each other (cross-cluster cosine ≥
+    /// `SpeakerWritePathPolicy.crossClusterLinkFloor`). The largest cluster keeps the matched
+    /// identity; smaller distinct voices are spun off.
+    ///
+    /// Pure and deterministic so the eval/unit tests can exercise the two-people-one-profile case
+    /// directly without the full audio pipeline.
+    nonisolated static func planCrossClusterLinks(
+        matchedProfileBySpeaker: [Int: UUID],
+        meanBySpeaker: [Int: [Float]],
+        segmentCountBySpeaker: [Int: Int]
+    ) -> CrossClusterLinkPlan {
+        var plan = CrossClusterLinkPlan()
+        let byProfile = Dictionary(grouping: matchedProfileBySpeaker.keys) { matchedProfileBySpeaker[$0] }
+        for (profileId, speakerIds) in byProfile where profileId != nil && speakerIds.count >= 2 {
+            // Largest cluster (most segments) claims the identity; ties broken by speakerId for
+            // deterministic output.
+            let sorted = speakerIds.sorted { a, b in
+                let ca = segmentCountBySpeaker[a] ?? 0
+                let cb = segmentCountBySpeaker[b] ?? 0
+                return ca == cb ? a < b : ca > cb
+            }
+            let canonical = sorted[0]
+            guard let canonicalMean = meanBySpeaker[canonical] else { continue }
+            for other in sorted.dropFirst() {
+                guard let otherMean = meanBySpeaker[other] else {
+                    plan.spinOffs.append(other)
+                    continue
+                }
+                let crossSim = cosineSimilarityStatic(canonicalMean, otherMean)
+                if SpeakerWritePathPolicy.shouldFuseMatchedClusters(crossClusterSimilarity: crossSim) {
+                    plan.remaps[other] = canonical
+                } else {
+                    plan.spinOffs.append(other)
+                }
+            }
+        }
+        return plan
+    }
+
     /// Compute L2-normalized weighted mean of multiple embeddings.
     /// Higher-weight embeddings contribute more to the mean. Segments recorded while
     /// the local mic was active have lower weight (system audio contaminated by local voice).

--- a/Sources/TranscriptedCore/Speaker/SpeakerWritePathPolicy.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerWritePathPolicy.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Write-path quality gates for the speaker subsystem.
+///
+/// The certified naming ladder (`SpeakerNamingPolicy.shouldAutoAccept`, 0.92 similarity / margin
+/// 0.12) gates only the *display* decision — whether a returning speaker is silently NAMED. It
+/// does **not** gate the two write-path decisions that quietly mutate persistent state:
+///
+///   1. **Voiceprint write-back** — every successful match EMA-blends the session mean into the
+///      stored fingerprint (`SpeakerDatabase.addOrUpdateSpeaker`). With no quality gate a mature,
+///      named profile blends a weak/ambiguous match straight into its identity, drifting it
+///      permanently, compounding across meetings, invisible to the user. `voiceprintBlendAlpha`
+///      is the gate: confident, well-separated matches adapt at the full historical rate; marginal
+///      matches adapt slowly; weak or ambiguous matches *freeze* the voiceprint (alpha 0 — the
+///      appearance is still recorded via call-count / last-seen, but the fingerprint is untouched).
+///
+///   2. **Cross-cluster link/merge** — when two diarizer clusters match the *same* profile they are
+///      fused into a single transcript row. The adaptive 0.70 floor that ATTACHES a cluster's
+///      utterances to a profile is too loose to *also* decide two clusters are the SAME person: two
+///      distinct people who each merely resemble one profile get silently fused, and review then
+///      names the fused row once. `shouldFuseMatchedClusters` decouples this — clusters only fuse
+///      when they are directly similar *to each other* (cross-cluster cosine ≥ `crossClusterLinkFloor`),
+///      which is what genuine over-segmentation of one voice looks like; distinct voices stay
+///      separate and independently nameable.
+///
+/// Every threshold here is deliberately decoupled from the display ladder and is meant to be tuned
+/// on the SpeakerEvalHarness (DER / fragmentation / false-merge / cross-meeting re-ID), **not** on
+/// the auto-name bar. Raising the display bar must never silently change the write path, and a
+/// write-path change must never trade silent contamination for silent under-adaptation — both are
+/// observable only on the harness.
+public enum SpeakerWritePathPolicy {
+
+    // MARK: - #6 Voiceprint write-back gate
+
+    /// Full adaptation rate — matches `SpeakerDatabase`'s historical EMA weight. Used for a
+    /// confident, clearly-separated match writing back into the stored fingerprint.
+    public static let confidentBlendAlpha: Float = 0.15
+
+    /// Reduced rate for a decent-but-not-strong match: still tracks genuine session-to-session
+    /// voice drift, but bounds how far any single mediocre session can pull the fingerprint.
+    public static let cautiousBlendAlpha: Float = 0.05
+
+    /// No adaptation — record the appearance (call-count / last-seen) but freeze the voiceprint.
+    public static let frozenBlendAlpha: Float = 0.0
+
+    /// Minimum margin to the runner-up before a match is trusted to *write back*. Reuses the
+    /// certified ladder's margin (`SpeakerNamingPolicy.autoAcceptMarginMin`) but applies it to the
+    /// write decision the ladder does not cover. The read-side match guard only rejects runner-ups
+    /// within 0.05 (ambiguous), so a match in [0.05, 0.12) is still NAMED but must not CONTAMINATE.
+    public static let writeBackMarginMin: Double = 0.12
+
+    /// At or above this cosine a match adapts the fingerprint at the full rate. Deliberately below
+    /// the 0.92 *display* auto-name bar so legitimate drift keeps the profile current — using the
+    /// display bar here would freeze adaptation and trade contamination for under-adaptation.
+    public static let confidentWriteBackSimilarity: Double = 0.80
+
+    /// Between this and `confidentWriteBackSimilarity` a match adapts slowly. Below it, it freezes.
+    public static let cautiousWriteBackSimilarity: Double = 0.72
+
+    /// EMA weight to blend a matched session embedding into the persisted voiceprint.
+    ///
+    /// - Parameters:
+    ///   - similarity: cosine of the session mean to the matched profile.
+    ///   - secondBestSimilarity: next-closest profile that cleared the match floor, or `nil`/negative
+    ///     when there was no confusable runner-up (treated as unambiguous).
+    /// - Returns: `confidentBlendAlpha`, `cautiousBlendAlpha`, or `frozenBlendAlpha`.
+    public static func voiceprintBlendAlpha(
+        similarity: Double,
+        secondBestSimilarity: Double?
+    ) -> Float {
+        // Ambiguity guard: a runner-up almost as close means we cannot be sure WHO this is, so
+        // blending would risk contaminating the wrong profile. Freeze regardless of similarity.
+        if let second = secondBestSimilarity, second >= 0,
+           (similarity - second) < writeBackMarginMin {
+            return frozenBlendAlpha
+        }
+        if similarity >= confidentWriteBackSimilarity { return confidentBlendAlpha }
+        if similarity >= cautiousWriteBackSimilarity { return cautiousBlendAlpha }
+        return frozenBlendAlpha
+    }
+
+    // MARK: - #8 Cross-cluster link/merge floor
+
+    /// Minimum *cross-cluster* cosine (cluster-to-cluster, not cluster-to-profile) required to fuse
+    /// two diarizer clusters that matched the same profile into one row. Stricter than the loosest
+    /// per-utterance attach floor (0.70) so two distinct people who each merely resemble one profile
+    /// are not silently merged, but below the within-meeting same-voice consolidation bar
+    /// (`EmbeddingClusterer.sameVoiceConsolidationThreshold`, 0.88) so genuine over-segmented
+    /// fragments of one voice that survived consolidation still fuse.
+    public static let crossClusterLinkFloor: Double = 0.78
+
+    /// Whether two clusters that matched the same profile are similar enough *to each other* to be
+    /// the same person (genuine de-fragmentation) rather than two distinct people who both resemble
+    /// the profile.
+    public static func shouldFuseMatchedClusters(crossClusterSimilarity: Double) -> Bool {
+        crossClusterSimilarity >= crossClusterLinkFloor
+    }
+}

--- a/Tests/TranscriptedCoreTests/SpeakerWriteBackGateTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerWriteBackGateTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import TranscriptedCore
+
+/// DB-level verification that the write-time contamination gate (#6) actually freezes the stored
+/// voiceprint when alpha is 0, while still recording the appearance, and blends normally otherwise.
+@available(macOS 14.0, *)
+final class SpeakerWriteBackGateTests: XCTestCase {
+
+    private var tempDirectory: URL!
+    private var database: SpeakerDatabase!
+
+    override func setUpWithError() throws {
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SpeakerWriteBackGateTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        database = SpeakerDatabase(path: tempDirectory.appendingPathComponent("speakers.sqlite").path)
+    }
+
+    override func tearDownWithError() throws {
+        database = nil
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+        tempDirectory = nil
+    }
+
+    func testFrozenAlphaLeavesVoiceprintUnchangedButRecordsAppearance() {
+        let base = axis(0)   // [1, 0, 0, ...]
+        let created = database.addOrUpdateSpeaker(embedding: base, existingId: nil)
+        let before = try! XCTUnwrap(database.getSpeaker(id: created.id)).embedding
+
+        // A contaminating embedding pointing in a very different direction, blended at alpha 0.
+        let contaminant = axis(1)   // [0, 1, 0, ...]
+        let updated = database.addOrUpdateSpeaker(embedding: contaminant, existingId: created.id, blendAlpha: 0)
+        let after = try! XCTUnwrap(database.getSpeaker(id: created.id)).embedding
+
+        // Voiceprint must be byte-for-byte (cosine 1.0) unchanged.
+        XCTAssertEqual(cosine(before, after), 1.0, accuracy: 1e-5,
+                       "alpha 0 must not move the stored fingerprint")
+        // Appearance is still recorded: call count advances, profile matures.
+        XCTAssertEqual(updated.callCount, created.callCount + 1)
+    }
+
+    func testStandardAlphaBlendsTowardNewEmbedding() {
+        let base = axis(0)
+        let created = database.addOrUpdateSpeaker(embedding: base, existingId: nil)
+        let contaminant = axis(1)
+
+        _ = database.addOrUpdateSpeaker(
+            embedding: contaminant,
+            existingId: created.id,
+            blendAlpha: SpeakerWritePathPolicy.confidentBlendAlpha
+        )
+        let after = try! XCTUnwrap(database.getSpeaker(id: created.id)).embedding
+
+        // With a real blend the fingerprint moves off the original axis toward the new one.
+        XCTAssertLessThan(cosine(base, after), 0.9999, "alpha > 0 must move the fingerprint")
+        XCTAssertGreaterThan(cosine(contaminant, after), 0.0, "fingerprint should tilt toward the new embedding")
+    }
+
+    func testDefaultTwoArgWriteBackStillBlends() {
+        // The legacy 2-arg call site must keep its historical full-rate behaviour.
+        let base = axis(0)
+        let created = database.addOrUpdateSpeaker(embedding: base, existingId: nil)
+        _ = database.addOrUpdateSpeaker(embedding: axis(1), existingId: created.id)
+        let after = try! XCTUnwrap(database.getSpeaker(id: created.id)).embedding
+        XCTAssertLessThan(cosine(base, after), 0.9999)
+    }
+
+    // MARK: - Helpers
+
+    private func axis(_ index: Int, dim: Int = 256) -> [Float] {
+        var v = [Float](repeating: 0, count: dim)
+        v[index] = 1
+        return v
+    }
+
+    private func cosine(_ a: [Float], _ b: [Float]) -> Double {
+        Transcription.cosineSimilarityStatic(a, b)
+    }
+}

--- a/Tests/TranscriptedCoreTests/SpeakerWritePathPolicyTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerWritePathPolicyTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import TranscriptedCore
+
+@available(macOS 14.0, *)
+final class SpeakerWritePathPolicyTests: XCTestCase {
+
+    // MARK: - #6 voiceprint write-back gate
+
+    func testConfidentWellSeparatedMatchAdaptsAtFullRate() {
+        let alpha = SpeakerWritePathPolicy.voiceprintBlendAlpha(similarity: 0.95, secondBestSimilarity: 0.50)
+        XCTAssertEqual(alpha, SpeakerWritePathPolicy.confidentBlendAlpha)
+    }
+
+    func testNoRunnerUpHighSimilarityAdaptsFully() {
+        // secondBest < 0 means no confusable runner-up cleared the floor → unambiguous.
+        let alpha = SpeakerWritePathPolicy.voiceprintBlendAlpha(similarity: 0.85, secondBestSimilarity: -1)
+        XCTAssertEqual(alpha, SpeakerWritePathPolicy.confidentBlendAlpha)
+    }
+
+    func testNilRunnerUpTreatedAsUnambiguous() {
+        let alpha = SpeakerWritePathPolicy.voiceprintBlendAlpha(similarity: 0.85, secondBestSimilarity: nil)
+        XCTAssertEqual(alpha, SpeakerWritePathPolicy.confidentBlendAlpha)
+    }
+
+    func testAmbiguousRunnerUpFreezesVoiceprintEvenWhenSimilarityHigh() {
+        // margin 0.05 < writeBackMarginMin (0.12): we cannot be sure WHO this is → freeze.
+        let alpha = SpeakerWritePathPolicy.voiceprintBlendAlpha(similarity: 0.90, secondBestSimilarity: 0.85)
+        XCTAssertEqual(alpha, SpeakerWritePathPolicy.frozenBlendAlpha)
+    }
+
+    func testMarginalSimilarityAdaptsCautiously() {
+        // 0.72 <= 0.75 < 0.80, well-separated → slow adaptation.
+        let alpha = SpeakerWritePathPolicy.voiceprintBlendAlpha(similarity: 0.75, secondBestSimilarity: -1)
+        XCTAssertEqual(alpha, SpeakerWritePathPolicy.cautiousBlendAlpha)
+    }
+
+    func testWeakMatchFreezesVoiceprint() {
+        // The documented contamination case: a 0.70 match with no clear runner-up must NOT blend.
+        let alpha = SpeakerWritePathPolicy.voiceprintBlendAlpha(similarity: 0.70, secondBestSimilarity: -1)
+        XCTAssertEqual(alpha, SpeakerWritePathPolicy.frozenBlendAlpha)
+    }
+
+    func testWriteBackBandsAreDecoupledFromDisplayLadder() {
+        // A match that NAMES (passes the read-side floor) but is below the display auto-name bar
+        // (0.92) and below the confident write bar still gets a non-full / zero alpha — i.e. the
+        // write path is strictly stricter-or-equal than the loose attach floor and never silently
+        // rides the display bar.
+        XCTAssertLessThan(SpeakerWritePathPolicy.confidentWriteBackSimilarity,
+                          SpeakerNamingPolicy.autoAcceptSimilarityThreshold)
+        XCTAssertEqual(SpeakerWritePathPolicy.writeBackMarginMin, SpeakerNamingPolicy.autoAcceptMarginMin)
+    }
+
+    // MARK: - #8 cross-cluster link/merge floor
+
+    func testTwoDistinctVoicesMatchingOneProfileAreNotFused() {
+        // Two clusters both matched profile P, but they are only 0.60 similar to each other
+        // (< crossClusterLinkFloor 0.78): distinct people. The smaller must be spun off, not fused.
+        let p = UUID()
+        let big = 1, small = 2
+        let plan = Transcription.planCrossClusterLinks(
+            matchedProfileBySpeaker: [big: p, small: p],
+            meanBySpeaker: [big: unit(cos: 1.0), small: unit(cos: 0.60)],
+            segmentCountBySpeaker: [big: 10, small: 3]
+        )
+        XCTAssertTrue(plan.remaps.isEmpty, "distinct voices must not be fused")
+        XCTAssertEqual(plan.spinOffs, [small], "smaller distinct voice should be spun off, larger keeps identity")
+    }
+
+    func testOverSegmentedVoiceIsFused() {
+        // One person split into two clusters that are 0.85 similar to each other (>= 0.78):
+        // genuine over-segmentation → fuse the smaller into the larger (de-fragmentation preserved).
+        let p = UUID()
+        let big = 1, small = 2
+        let plan = Transcription.planCrossClusterLinks(
+            matchedProfileBySpeaker: [big: p, small: p],
+            meanBySpeaker: [big: unit(cos: 1.0), small: unit(cos: 0.85)],
+            segmentCountBySpeaker: [big: 8, small: 4]
+        )
+        XCTAssertEqual(plan.remaps, [small: big], "over-segmented same voice should fuse into canonical")
+        XCTAssertTrue(plan.spinOffs.isEmpty)
+    }
+
+    func testMixedFuseAndSpinOffAgainstOneProfile() {
+        // Canonical A; B is the same voice (0.84) → fuse; C is a distinct voice (0.50) → spin off.
+        let p = UUID()
+        let a = 1, b = 2, c = 3
+        let plan = Transcription.planCrossClusterLinks(
+            matchedProfileBySpeaker: [a: p, b: p, c: p],
+            meanBySpeaker: [a: unit(cos: 1.0), b: unit(cos: 0.84), c: unit(cos: 0.50)],
+            segmentCountBySpeaker: [a: 12, b: 5, c: 4]
+        )
+        XCTAssertEqual(plan.remaps, [b: a])
+        XCTAssertEqual(plan.spinOffs, [c])
+    }
+
+    func testDistinctProfilesAreLeftAlone() {
+        let plan = Transcription.planCrossClusterLinks(
+            matchedProfileBySpeaker: [1: UUID(), 2: UUID()],
+            meanBySpeaker: [1: unit(cos: 1.0), 2: unit(cos: 0.60)],
+            segmentCountBySpeaker: [1: 5, 2: 5]
+        )
+        XCTAssertTrue(plan.remaps.isEmpty)
+        XCTAssertTrue(plan.spinOffs.isEmpty)
+    }
+
+    func testCanonicalIsLargestClusterRegardlessOfIteration() {
+        // small id but most segments should claim the identity.
+        let p = UUID()
+        let plan = Transcription.planCrossClusterLinks(
+            matchedProfileBySpeaker: [7: p, 2: p],
+            meanBySpeaker: [7: unit(cos: 1.0), 2: unit(cos: 0.50)],
+            segmentCountBySpeaker: [7: 2, 2: 9]   // id 2 has more segments → canonical
+        )
+        XCTAssertEqual(plan.spinOffs, [7], "the smaller (fewer-segment) cluster is spun off")
+        XCTAssertTrue(plan.remaps.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    /// 2-D unit vector with a given cosine to the x-axis reference [1, 0].
+    private func unit(cos: Float) -> [Float] {
+        let y = (max(0, 1 - cos * cos)).squareRoot()
+        return [cos, y]
+    }
+}

--- a/Tests/TranscriptedCoreTests/SpeakerWritePathPolicyTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerWritePathPolicyTests.swift
@@ -54,39 +54,47 @@ final class SpeakerWritePathPolicyTests: XCTestCase {
 
     func testTwoDistinctVoicesMatchingOneProfileAreNotFused() {
         // Two clusters both matched profile P, but they are only 0.60 similar to each other
-        // (< crossClusterLinkFloor 0.78): distinct people. The smaller must be spun off, not fused.
+        // (< crossClusterLinkFloor 0.78): distinct people. The weaker match is spun off, not fused.
         let p = UUID()
-        let big = 1, small = 2
+        let keeper = 1, intruder = 2
         let plan = Transcription.planCrossClusterLinks(
-            matchedProfileBySpeaker: [big: p, small: p],
-            meanBySpeaker: [big: unit(cos: 1.0), small: unit(cos: 0.60)],
-            segmentCountBySpeaker: [big: 10, small: 3]
+            matchedProfileBySpeaker: [keeper: p, intruder: p],
+            matchSimilarityBySpeaker: [keeper: 0.95, intruder: 0.74],
+            meanBySpeaker: [keeper: unit(cos: 1.0), intruder: unit(cos: 0.60)],
+            segmentCountBySpeaker: [keeper: 10, intruder: 3]
         )
         XCTAssertTrue(plan.remaps.isEmpty, "distinct voices must not be fused")
-        XCTAssertEqual(plan.spinOffs, [small], "smaller distinct voice should be spun off, larger keeps identity")
+        XCTAssertEqual(plan.spinOffs, [intruder], "the distinct voice is spun off; best-match keeps identity")
     }
 
     func testOverSegmentedVoiceIsFused() {
         // One person split into two clusters that are 0.85 similar to each other (>= 0.78):
-        // genuine over-segmentation → fuse the smaller into the larger (de-fragmentation preserved).
+        // genuine over-segmentation → fuse into the best-matching representative (de-frag preserved).
         let p = UUID()
         let big = 1, small = 2
         let plan = Transcription.planCrossClusterLinks(
             matchedProfileBySpeaker: [big: p, small: p],
+            matchSimilarityBySpeaker: [big: 0.92, small: 0.85],
             meanBySpeaker: [big: unit(cos: 1.0), small: unit(cos: 0.85)],
             segmentCountBySpeaker: [big: 8, small: 4]
         )
-        XCTAssertEqual(plan.remaps, [small: big], "over-segmented same voice should fuse into canonical")
+        XCTAssertEqual(plan.remaps, [small: big], "over-segmented same voice should fuse into representative")
         XCTAssertTrue(plan.spinOffs.isEmpty)
     }
 
     func testMixedFuseAndSpinOffAgainstOneProfile() {
-        // Canonical A; B is the same voice (0.84) → fuse; C is a distinct voice (0.50) → spin off.
+        // Representative A; B is the same voice (0.84) → fuse; C is a distinct voice (0.50) → spin off.
         let p = UUID()
         let a = 1, b = 2, c = 3
+        // a,b same voice (0.84). c distinct from BOTH (0.50 to a, ~0.42 to b) — placed on an
+        // independent axis so the 2-D plane doesn't make it accidentally close to b.
+        let av: [Float] = [1, 0, 0]
+        let bv: [Float] = [0.84, 0.5426, 0]
+        let cv: [Float] = [0.5, 0, 0.866]   // cos(cv,av)=0.50, cos(cv,bv)=0.42
         let plan = Transcription.planCrossClusterLinks(
             matchedProfileBySpeaker: [a: p, b: p, c: p],
-            meanBySpeaker: [a: unit(cos: 1.0), b: unit(cos: 0.84), c: unit(cos: 0.50)],
+            matchSimilarityBySpeaker: [a: 0.95, b: 0.88, c: 0.74],
+            meanBySpeaker: [a: av, b: bv, c: cv],
             segmentCountBySpeaker: [a: 12, b: 5, c: 4]
         )
         XCTAssertEqual(plan.remaps, [b: a])
@@ -96,6 +104,7 @@ final class SpeakerWritePathPolicyTests: XCTestCase {
     func testDistinctProfilesAreLeftAlone() {
         let plan = Transcription.planCrossClusterLinks(
             matchedProfileBySpeaker: [1: UUID(), 2: UUID()],
+            matchSimilarityBySpeaker: [1: 0.95, 2: 0.80],
             meanBySpeaker: [1: unit(cos: 1.0), 2: unit(cos: 0.60)],
             segmentCountBySpeaker: [1: 5, 2: 5]
         )
@@ -103,16 +112,41 @@ final class SpeakerWritePathPolicyTests: XCTestCase {
         XCTAssertTrue(plan.spinOffs.isEmpty)
     }
 
-    func testCanonicalIsLargestClusterRegardlessOfIteration() {
-        // small id but most segments should claim the identity.
+    func testBestMatchKeepsIdentityEvenWithFewerSegments() {
+        // The real returning speaker (id 7) matches the profile strongly but is short; a longer,
+        // distinct voice (id 2) only weakly matched. The strong match must keep the name and the
+        // long distinct voice must be spun off — NOT the other way around (canonical by similarity,
+        // not segment count).
         let p = UUID()
         let plan = Transcription.planCrossClusterLinks(
             matchedProfileBySpeaker: [7: p, 2: p],
+            matchSimilarityBySpeaker: [7: 0.95, 2: 0.72],
             meanBySpeaker: [7: unit(cos: 1.0), 2: unit(cos: 0.50)],
-            segmentCountBySpeaker: [7: 2, 2: 9]   // id 2 has more segments → canonical
+            segmentCountBySpeaker: [7: 2, 2: 9]   // id 2 has far more segments but a weaker match
         )
-        XCTAssertEqual(plan.spinOffs, [7], "the smaller (fewer-segment) cluster is spun off")
-        XCTAssertTrue(plan.remaps.isEmpty)
+        XCTAssertEqual(plan.spinOffs, [2], "the longer but distinct voice is spun off")
+        XCTAssertTrue(plan.remaps.isEmpty, "the strong (short) match keeps the profile")
+    }
+
+    func testThreeClustersTwoMutualFragmentsFuseTogether() {
+        // x is the returning profile owner; y and z are a DIFFERENT person split into two fragments
+        // (0.85 to each other, ~0.50 to x). y and z must fuse into ONE spun-off profile, not two —
+        // the union-find prevents re-fragmenting a distinct voice across the profile boundary.
+        let p = UUID()
+        let x = 1, y = 2, z = 3
+        // x = [1,0,0]; y,z ≈0.50 to x but ≈0.85 to each other (a distinct voice in two fragments).
+        let xv: [Float] = [1, 0, 0]
+        let yv: [Float] = [0.5, 0.866, 0]
+        let zv: [Float] = [0.5, 0.6928, 0.5196]   // cos(zv,xv)=0.50, cos(zv,yv)=0.85
+        let plan = Transcription.planCrossClusterLinks(
+            matchedProfileBySpeaker: [x: p, y: p, z: p],
+            matchSimilarityBySpeaker: [x: 0.95, y: 0.74, z: 0.73],
+            meanBySpeaker: [x: xv, y: yv, z: zv],
+            segmentCountBySpeaker: [x: 10, y: 4, z: 4]
+        )
+        // y is the higher-ranked of the two fragments (0.74 > 0.73) → representative.
+        XCTAssertEqual(plan.spinOffs, [y], "the distinct voice gets exactly one new profile")
+        XCTAssertEqual(plan.remaps, [z: y], "its second fragment fuses into it, not a third profile")
     }
 
     // MARK: - Helpers

--- a/Tools/SpeakerEvalHarness/README.md
+++ b/Tools/SpeakerEvalHarness/README.md
@@ -42,7 +42,30 @@ speaker-eval-harness dump --audio path.wav --meeting NAME --out raw.json
 # replay a series in order through clusterer + DB, emit hypothesis assignments (cheap; sweepable)
 speaker-eval-harness replay --inputs a.json,b.json,c.json,d.json \
     --consolidation none|0.88 --match 0.6 --out result.json
+
+# A/B the write-path fixes (#6 write-time contamination gate + #8 cross-cluster link/merge decouple)
+speaker-eval-harness replay --inputs ... --write-path-fixes off|on --out result.json
 ```
+
+`--write-path-fixes` (default `off`): `off` is the legacy write path (every match blends at the
+full EMA rate; clusters matching the same profile collapse together). `on` applies the
+`SpeakerWritePathPolicy` gates, mirroring `TranscriptionPipeline` (gated EMA blend + cross-cluster
+spin-off of distinct voices). Replay the same dumps both ways to get a clean before/after.
+
+## Network-free synthetic A/B (no corpus / no models)
+
+The real corpora need multi-GB downloads + CoreML models. When that's unavailable, the
+write-path fixes can still be A/B'd on **synthetic embeddings with controlled cosine geometry** —
+the `replay` stage only consumes embeddings + RTTMs, both of which can be fabricated:
+
+```bash
+python3 scripts/gen_synthetic_speaker_eval.py     # -> data/eval/synthetic/{normal,twopeople,contamination}
+MATCH=0.70 bash scripts/run_synthetic_speaker_eval.sh   # replay off/on + score each, print before/after
+```
+
+`normal` is a no-regression control; `twopeople` reproduces the #8 cross-cluster fusion bug;
+`contamination` reproduces the #6 voiceprint-drift bug. Data is gitignored; the generator + driver
+are committed so the probe is reproducible.
 
 ## Run the whole thing
 

--- a/Tools/SpeakerEvalHarness/Sources/speaker-eval-harness/main.swift
+++ b/Tools/SpeakerEvalHarness/Sources/speaker-eval-harness/main.swift
@@ -242,6 +242,7 @@ func runReplay(_ args: [String]) async {
             return a > b
         }
         var spunOffProfileIds: Set<UUID> = []
+        var memberToRep: [Int: Int] = [:]   // (fixes mode) fused member cluster -> representative
         if !writePathFixes {
             // Legacy: match against the live DB, blend every match at the full EMA rate.
             for cid in clusterOrder {
@@ -252,9 +253,9 @@ func runReplay(_ args: [String]) async {
             // 3) Dedup pass — the app runs mergeDuplicates after each transcript.
             await MainActor.run { db.mergeDuplicates(threshold: matchThreshold) }
         } else {
-            // Production mirror of TranscriptionPipeline's write path:
-            //   match-all vs the pre-meeting snapshot → cross-cluster link/merge (#8) →
-            //   gated write-back (#6) → mergeDuplicates protecting spun-off distinct voices.
+            // Production mirror of TranscriptionPipeline's write path: match-all vs the pre-meeting
+            // snapshot → cross-cluster link/merge (#8) via the SAME planner the app uses → gated
+            // write-back (#6) → mergeDuplicates protecting spun-off distinct voices.
             var matchedProfile: [Int: UUID] = [:]
             var matchSim: [Int: Double] = [:]
             var matchSecond: [Int: Double] = [:]
@@ -263,37 +264,24 @@ func runReplay(_ args: [String]) async {
                     matchedProfile[cid] = m.id; matchSim[cid] = m.similarity; matchSecond[cid] = m.second
                 }
             }
-
-            // #8: clusters that matched the same profile only fuse when they are similar to each
-            // other; distinct voices that merely resemble the profile are spun off.
-            var spinOff: Set<Int> = []
-            let byProfile = Dictionary(grouping: matchedProfile.keys) { matchedProfile[$0] }
-            for (_, cids) in byProfile where cids.count >= 2 {
-                let sorted = cids.sorted {
-                    let a = byCluster[$0]!.reduce(0.0) { $0 + ($1.end - $1.start) }
-                    let b = byCluster[$1]!.reduce(0.0) { $0 + ($1.end - $1.start) }
-                    return a == b ? $0 < $1 : a > b
-                }
-                let canonical = sorted[0]
-                for other in sorted.dropFirst() {
-                    let crossSim = cosineSim(clusterEmb[canonical]!, clusterEmb[other]!)
-                    if !SpeakerWritePathPolicy.shouldFuseMatchedClusters(crossClusterSimilarity: crossSim) {
-                        spinOff.insert(other)
-                    }
-                }
-            }
-
-            for cid in clusterOrder {
+            let plan = Transcription.planCrossClusterLinks(
+                matchedProfileBySpeaker: matchedProfile,
+                matchSimilarityBySpeaker: matchSim,
+                meanBySpeaker: clusterEmb,
+                segmentCountBySpeaker: byCluster.mapValues { $0.count }
+            )
+            memberToRep = plan.remaps
+            let spinOffReps = Set(plan.spinOffs)
+            // Write-back for representatives + uncontended clusters only; fused members inherit their
+            // representative (they don't write back, mirroring the pipeline).
+            for cid in clusterOrder where memberToRep[cid] == nil {
                 let emb = clusterEmb[cid]!
-                if spinOff.contains(cid) {
+                if spinOffReps.contains(cid) {
                     let p = await MainActor.run { db.addOrUpdateSpeaker(embedding: emb, existingId: nil) }
                     spunOffProfileIds.insert(p.id)
                 } else if let pid = matchedProfile[cid] {
-                    // #6: gate the EMA blend on match quality.
                     let alpha = SpeakerWritePathPolicy.voiceprintBlendAlpha(
-                        similarity: matchSim[cid] ?? 0,
-                        secondBestSimilarity: matchSecond[cid]
-                    )
+                        similarity: matchSim[cid] ?? 0, secondBestSimilarity: matchSecond[cid])
                     _ = await MainActor.run {
                         db.addOrUpdateSpeaker(embedding: emb, existingId: pid, blendAlpha: alpha)
                     }
@@ -301,18 +289,21 @@ func runReplay(_ args: [String]) async {
                     _ = await MainActor.run { db.addOrUpdateSpeaker(embedding: emb, existingId: nil) }
                 }
             }
-            // Dedup, but protect spun-off distinct voices so they are not immediately re-merged
-            // (mirrors the pipeline runner protecting pending-review profiles).
             await MainActor.run { db.mergeDuplicates(threshold: matchThreshold, protecting: spunOffProfileIds) }
         }
 
-        // Resolve each cluster to its FINAL surviving profile by re-matching its mean
-        // embedding against the post-merge DB (a merge folds a UUID into its survivor).
+        // Resolve each cluster to its FINAL surviving profile. Representatives + uncontended clusters
+        // re-match their mean against the post-merge DB; fused members inherit their representative's
+        // profile (matchSpeaker alone could wrongly route a spun-off member back to the profile it
+        // merely resembled).
         var resolved: [Int: String] = [:]
-        for cid in clusterOrder {
+        for cid in clusterOrder where memberToRep[cid] == nil {
             let emb = clusterEmb[cid]!
             let m: SpeakerMatchResult? = await MainActor.run { db.matchSpeaker(embedding: emb, threshold: matchThreshold) }
             if let m { resolved[cid] = m.profile.id.uuidString }
+        }
+        for (member, rep) in memberToRep where resolved[rep] != nil {
+            resolved[member] = resolved[rep]
         }
         let surviving = Set(await MainActor.run { db.allSpeakers() }.map { $0.id.uuidString })
 

--- a/Tools/SpeakerEvalHarness/Sources/speaker-eval-harness/main.swift
+++ b/Tools/SpeakerEvalHarness/Sources/speaker-eval-harness/main.swift
@@ -55,6 +55,7 @@ struct MeetingResult: Codable {
 struct ReplayResult: Codable {
     let consolidationThreshold: String   // "none" or a float as string
     let matchThreshold: Double
+    let writePathFixes: Bool             // #6 write-gate + #8 link-decouple applied?
     let profilesAtEnd: Int
     let meetings: [MeetingResult]
 }
@@ -94,6 +95,33 @@ func clusterMeanEmbedding(_ segs: [SegmentDump]) -> [Float]? {
     if !filtered.isEmpty { return mean(filtered) }
     let all = segs.compactMap { $0.embedding }.filter { !$0.isEmpty }
     return all.isEmpty ? nil : mean(all)
+}
+
+/// Cosine similarity between two equal-length vectors (eval-local mirror of the app's helper).
+func cosineSim(_ a: [Float], _ b: [Float]) -> Double {
+    guard a.count == b.count, !a.isEmpty else { return 0 }
+    var dot: Float = 0, na: Float = 0, nb: Float = 0
+    for i in 0..<a.count { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i] }
+    let denom = (na.squareRoot()) * (nb.squareRoot())
+    return denom > 0 ? Double(dot / denom) : 0
+}
+
+/// Best + second-best profile (above `threshold`) for an embedding against a frozen snapshot.
+/// Returns the matched profile id, its similarity, and the runner-up similarity (-1 if none) so the
+/// eval can feed `SpeakerWritePathPolicy.voiceprintBlendAlpha`'s margin guard exactly like the app.
+func bestAndSecond(_ emb: [Float], profiles: [SpeakerProfile], threshold: Double)
+    -> (id: UUID, similarity: Double, second: Double)? {
+    var bestId: UUID?
+    var best = -1.0, second = -1.0
+    for p in profiles {
+        guard p.disputeCount == 0, p.embedding.count == emb.count else { continue }
+        let s = cosineSim(emb, p.embedding)
+        guard s >= threshold else { continue }
+        if s > best { second = best; best = s; bestId = p.id }
+        else if s > second { second = s }
+    }
+    guard let id = bestId else { return nil }
+    return (id, best, second)
 }
 
 // MARK: - dump
@@ -154,6 +182,12 @@ func runReplay(_ args: [String]) async {
     let consolidationArg = (argValue("--consolidation", in: args) ?? "none").lowercased()
     let consolidation: Float? = consolidationArg == "none" ? nil : Float(consolidationArg)
 
+    // Write-path fixes (#6 write-time contamination gate + #8 cross-cluster link/merge decouple).
+    // "off" (default) = legacy behavior: every match blends at the full EMA rate and any clusters
+    // matching the same profile collapse together. "on" = apply the SpeakerWritePathPolicy gates,
+    // mirroring TranscriptionPipeline. Use the flag to A/B before/after on the same dumps.
+    let writePathFixes = (argValue("--write-path-fixes", in: args) ?? "off").lowercased() == "on"
+
     let inputs = inputsCSV.split(separator: ",").map(String.init)
     let dec = JSONDecoder()
     var dumps: [RawDump] = []
@@ -207,14 +241,70 @@ func runReplay(_ args: [String]) async {
             let b = byCluster[$1]!.reduce(0.0) { $0 + ($1.end - $1.start) }
             return a > b
         }
-        for cid in clusterOrder {
-            let emb = clusterEmb[cid]!
-            let matched = await MainActor.run { db.matchSpeaker(embedding: emb, threshold: matchThreshold) }
-            _ = await MainActor.run { db.addOrUpdateSpeaker(embedding: emb, existingId: matched?.profile.id) }
-        }
+        var spunOffProfileIds: Set<UUID> = []
+        if !writePathFixes {
+            // Legacy: match against the live DB, blend every match at the full EMA rate.
+            for cid in clusterOrder {
+                let emb = clusterEmb[cid]!
+                let matched = await MainActor.run { db.matchSpeaker(embedding: emb, threshold: matchThreshold) }
+                _ = await MainActor.run { db.addOrUpdateSpeaker(embedding: emb, existingId: matched?.profile.id) }
+            }
+            // 3) Dedup pass — the app runs mergeDuplicates after each transcript.
+            await MainActor.run { db.mergeDuplicates(threshold: matchThreshold) }
+        } else {
+            // Production mirror of TranscriptionPipeline's write path:
+            //   match-all vs the pre-meeting snapshot → cross-cluster link/merge (#8) →
+            //   gated write-back (#6) → mergeDuplicates protecting spun-off distinct voices.
+            var matchedProfile: [Int: UUID] = [:]
+            var matchSim: [Int: Double] = [:]
+            var matchSecond: [Int: Double] = [:]
+            for cid in clusterOrder {
+                if let m = bestAndSecond(clusterEmb[cid]!, profiles: existing, threshold: matchThreshold) {
+                    matchedProfile[cid] = m.id; matchSim[cid] = m.similarity; matchSecond[cid] = m.second
+                }
+            }
 
-        // 3) Dedup pass — the app runs mergeDuplicates after each transcript.
-        await MainActor.run { db.mergeDuplicates(threshold: matchThreshold) }
+            // #8: clusters that matched the same profile only fuse when they are similar to each
+            // other; distinct voices that merely resemble the profile are spun off.
+            var spinOff: Set<Int> = []
+            let byProfile = Dictionary(grouping: matchedProfile.keys) { matchedProfile[$0] }
+            for (_, cids) in byProfile where cids.count >= 2 {
+                let sorted = cids.sorted {
+                    let a = byCluster[$0]!.reduce(0.0) { $0 + ($1.end - $1.start) }
+                    let b = byCluster[$1]!.reduce(0.0) { $0 + ($1.end - $1.start) }
+                    return a == b ? $0 < $1 : a > b
+                }
+                let canonical = sorted[0]
+                for other in sorted.dropFirst() {
+                    let crossSim = cosineSim(clusterEmb[canonical]!, clusterEmb[other]!)
+                    if !SpeakerWritePathPolicy.shouldFuseMatchedClusters(crossClusterSimilarity: crossSim) {
+                        spinOff.insert(other)
+                    }
+                }
+            }
+
+            for cid in clusterOrder {
+                let emb = clusterEmb[cid]!
+                if spinOff.contains(cid) {
+                    let p = await MainActor.run { db.addOrUpdateSpeaker(embedding: emb, existingId: nil) }
+                    spunOffProfileIds.insert(p.id)
+                } else if let pid = matchedProfile[cid] {
+                    // #6: gate the EMA blend on match quality.
+                    let alpha = SpeakerWritePathPolicy.voiceprintBlendAlpha(
+                        similarity: matchSim[cid] ?? 0,
+                        secondBestSimilarity: matchSecond[cid]
+                    )
+                    _ = await MainActor.run {
+                        db.addOrUpdateSpeaker(embedding: emb, existingId: pid, blendAlpha: alpha)
+                    }
+                } else {
+                    _ = await MainActor.run { db.addOrUpdateSpeaker(embedding: emb, existingId: nil) }
+                }
+            }
+            // Dedup, but protect spun-off distinct voices so they are not immediately re-merged
+            // (mirrors the pipeline runner protecting pending-review profiles).
+            await MainActor.run { db.mergeDuplicates(threshold: matchThreshold, protecting: spunOffProfileIds) }
+        }
 
         // Resolve each cluster to its FINAL surviving profile by re-matching its mean
         // embedding against the post-merge DB (a merge folds a UUID into its survivor).
@@ -240,13 +330,15 @@ func runReplay(_ args: [String]) async {
 
         FileHandle.standardError.write(Data((
             "[replay] \(dump.meeting): clusters=\(byCluster.count) "
-            + "profilesNow=\(surviving.count) (match=\(matchThreshold) consolidation=\(consolidationArg))\n").utf8))
+            + "profilesNow=\(surviving.count) (match=\(matchThreshold) consolidation=\(consolidationArg) "
+            + "fixes=\(writePathFixes ? "on" : "off") spunOff=\(spunOffProfileIds.count))\n").utf8))
     }
 
     let profilesAtEnd = await MainActor.run { db.allSpeakers().count }
     let result = ReplayResult(
         consolidationThreshold: consolidationArg,
         matchThreshold: matchThreshold,
+        writePathFixes: writePathFixes,
         profilesAtEnd: profilesAtEnd,
         meetings: meetingResults)
     let enc = JSONEncoder()

--- a/docs/MEETING_CAPTURE_PROMPTING.md
+++ b/docs/MEETING_CAPTURE_PROMPTING.md
@@ -1,0 +1,284 @@
+# Meeting-Capture Prompting Overhaul
+
+**Status:** Draft spec for review
+**Owner:** Design lead (synthesis)
+**Audience:** Justin + eng
+**One-line goal:** Get more meetings recorded with near-zero user thought, without inheriting the silent-recorder liability that forces people to turn the feature off.
+
+---
+
+## 1. Problem & goal
+
+Transcripted is only valuable when it has artifacts. More recorded meetings = more transcripts, summaries, and searchable history. Today most meetings are never captured, and the ones that are cost the user attention at the exact moment they have none (the first 10 seconds of a live call).
+
+**The goal is a capture rate that approaches 100% of the meetings the user actually wants, while the per-meeting cognitive cost approaches zero.** Two numbers move in opposite directions if you design naively:
+
+- Crank capture up with silent auto-record → you record non-consenting third parties, the user gets uncomfortable, behavior chills, and the feature gets disabled (or sued — see Otter below).
+- Crank trust up with a per-meeting "do you want to record?" modal → friction kills capture; people blow past it mid-conversation.
+
+The winning design threads both: **front-load the detection and staging to *before* the meeting (so the user never has to remember, find a hotkey, or decide what counts as a meeting), and keep the actual record-start a single explicit human tap (so no file is ever written by surprise).** Convenience comes from prediction; trust comes from the tap.
+
+---
+
+## 2. How the current system works, and where it loses meetings
+
+### 2.1 Current detection
+
+All detection lives in `Transcripted/Services/MeetingDetector.swift`:
+
+- **Running-process detection (primary trigger).** A hardcoded bundle-ID→name map (`MeetingDetector.swift:72-80`): `us.zoom.xos` (Zoom), `com.microsoft.teams2` / `com.microsoft.teams` (Teams), Webex, FaceTime, Loom. It subscribes to `NSWorkspace.didLaunchApplicationNotification` / `didTerminateApplicationNotification` and scans `runningApplications` on startup. A matching app *running* is the necessary precondition for any auto-record.
+- **Bidirectional audio-level detection (the "a meeting is happening" signal).** Once a meeting app is running, `Audio.startMonitoring()` (`Audio.swift:508`, lightweight mic + system metering, no file) plus a 1s timer poll. In `tick()` it reads mic and system-audio levels; both above `speechThreshold = 0.02` = "bidirectional". Sustained bidirectional for `requiredBidirectionalDuration = 5s` → `onMeetingStart`.
+- **Everything is gated on `UserDefaults` `autoRecordMeetings`**, which defaults to **false** (`SettingsContainerView.swift:21`, `@AppStorage` default false; never registered otherwise).
+
+### 2.2 Current prompt UX: there isn't one
+
+There is effectively **no pre-recording prompt**. When auto-detect is ON, the flow is fully automatic with only a *post-facto* notification: after 5s of bidirectional audio, `audio.start()` runs and *then* `sendAutoDetectStartNotification(appName:)` fires a banner titled "Recording Started" whose only action button is "Stop" (`NotificationCoordinator.swift:54-74`, `:16-25`). The user is **told after the fact**, never **asked**. When auto-detect is OFF (the default) the user gets nothing — no suggestion, no banner. The floating pill (`PillStateManager.swift:46-50`) has exactly four states — `idle`, `recording`, `processing`, `saved` — and **no "meeting detected / tap to record" state**.
+
+### 2.3 Where meetings leak (ranked by size)
+
+1. **Off by default = most meetings never record.** `autoRecordMeetings` defaults false. Unless the user finds Settings → Meeting Detection and flips it, the detector tracks state but never records (`MeetingDetector.swift:163,217,246`). This is the single biggest leak: the feature is dormant for anyone who didn't opt in.
+2. **Browser meetings are a total blind spot.** Google Meet, Zoom-web, Teams-web run in a browser whose bundle ID isn't in `meetingApps`, so detection never even arms. The settings copy admits it (`MeetingDetectionSection.swift:43`: "Browser meetings (Google Meet, Teams web) require manual start."). A large share of modern meetings is 0% covered.
+3. **Prompts too late / first 5+ seconds always lost.** Auto-start needs 5s of sustained bidirectional audio *after* the app is in a call. The opening (greetings, the first decision) is never captured.
+4. **Tell-not-ask, and only nudge is a dismissible banner.** No proactive "looks like you're in a Zoom call, record it?" anywhere. The pill has no suggest state.
+5. **Notifications silently suppressed if permission not granted.** Both auto-detect banners bail unless `authorizationStatus == .authorized` (`NotificationCoordinator.swift:56,80`). A user who denied notifications gets no feedback that recording started/stopped — and the "Stop" opt-out is unreachable.
+6. **Audio heuristic is fragile.** Auto-start needs *both* mic AND system audio above 0.02 simultaneously — a muted listener never crosses the bar and is never recorded. A 15s lull (`silenceGracePeriod`) ends recording mid-meeting, then it must re-arm with another 5s.
+7. **One meeting app at a time.** `handleMeetingAppLaunched` returns early if `activeMeetingApp != nil` (`MeetingDetector.swift:148`). Back-to-back/overlapping tools confuse state.
+8. **No retroactive recovery.** Once the opening is lost, there's no buffer — recording only starts forward from `audio.start()`.
+
+### 2.4 What the prior art says (research-backed constraints)
+
+These are not opinions; they shape what we're allowed to ship.
+
+- **All-party consent is the only safe default.** Federal + ~38 states are one-party, but 12 states (CA, WA, IL, FL, PA, …) are all-party, and you cannot geolocate remote participants. CIPA / Wiretap statutory damages **stack per violation**. So behave as if all-party always applies.
+- **The Otter class action (In re Otter.AI, N.D. Cal. 2025) is the cautionary tale.** OtterPilot auto-joined calendar meetings as a bot and captured non-host participants who never consented and couldn't opt out. The legal landmine is **the third party who never knew** — not the user who installed the app. "Make sure you have permission" boilerplate that shifts liability onto the user is exactly the mistake.
+- **"Silent recording is impossible" should be an advertised invariant (Fathom).** If the product has no silent-to-disk path, you literally cannot ship the Otter failure mode by accident.
+- **Self-documenting consent (Granola).** Capture the spoken "yes" / disclosure inside the recording at t=0; auto-post an in-meeting chat notice; supply 5-second context-matched verbal scripts (sales / client / internal) so disclosure feels natural.
+- **Lean into the OS indicator.** The macOS orange (mic) / purple (system-audio) menu-bar dot is system-enforced and tamper-proof. "Invisible to the meeting" is never invisible to the Mac user — treat the dot as free, honest proof.
+- **Design against surprise, not recording.** 58% of professionals are uncomfortable with surprise AI joins; 41% change behavior when they know recording is happening (Calendly 2024). Predictability + visible control preserves both trust *and* conversation quality. A prompt for a meeting you scheduled is *expected*; a banner that pops because a bot heard two voices is a *surprise*.
+- **EU/GDPR:** consent is often the *wrong* instrument (employee consent rarely "freely given"); transparency-before-capture + retention limits + auto-delete is the portable design that satisfies both US all-party norms and EU duties.
+
+---
+
+## 3. Recommended design
+
+**Calendar-driven pre-arm with a single gentle one-tap nudge, on a new fifth pill state `.armed`** — synthesized winner, with the strongest grafts from the runner-up "auto-arm" and "ambient" designs deliberately scoped in or explicitly deferred.
+
+### 3.1 Stance on aggressiveness: gentle by default, with one aggressive option behind a switch
+
+**Default: gentle. One tap per meeting. No countdown-to-auto-record in the default path.**
+
+This is defended directly by the judge and the adversarial reviews:
+
+- The judges scored the calendar pre-arm the winner precisely because it **front-loads detection to before the meeting** (killing the "remember / find hotkey / decide" cost) **while keeping record-start an explicit human tap** so **no file is ever written without a tap**. That single property is what lets us advertise "it never records you by surprise" — and what keeps us on the safe side of the Otter line.
+- The aggressive "inaction = consent, auto-start at t=0" design (design #1) scored well on raw capture but every one of its key tradeoffs is a *blocking* risk: default-on auto-start *can* capture a non-consenting third party, "the notice came a beat late" is arguable in strict all-party states, and the audible chime it relies on is itself a feature people will ask to suppress — which is the silent path we refuse to ship. We keep its *good* ideas (pre-roll buffer, browser detection, muted-listener fix) and drop its auto-start-on-inaction core.
+- The ambient "set-it-once, record everything silently" design (design #4) maximizes capture but is the highest-liability option: it leans entirely on an always-visible indicator to substitute for consent, and a denied-notifications / glanced-past user can be recorded with no contemporaneous human acknowledgement. We make this an *opt-in advanced mode*, not the default.
+
+**Net stance:** ship the gentle calendar-pre-arm as the default-on primary path. Offer aggressiveness as an explicit, clearly-disclosed setting (see §3.7), defaulting to the gentle tier. The countdown-auto-record path (below) is **built but defaults OFF**; turning it on is a deliberate choice with full disclosure.
+
+### 3.2 Detection triggers (layered, calendar-first)
+
+**Tier 1 — Calendar pre-arm (NEW, primary).** Add EventKit (zero calendar code exists today; `grep EKEventStore` over Sources returns nothing). On launch and on a 15-min refresh, plus `EKEventStoreChanged` notifications, read events in the next 12h from the default calendars. An event qualifies for pre-arm if **any** of:
+
+- a conferencing URL via regex over `event.url`, `location`, and `notes` for `zoom.us`, `teams.microsoft`/`teams.live`, `webex.com`, `meet.google.com`, or a tel/SIP dial-in;
+- a known virtual-conference structured field; or
+- 2+ attendees on a non-all-day time block.
+
+Each qualifying event schedules a local timer firing at **start − lead** (default lead **60s**). We honor `EKEvent` status and the user's RSVP: **declined or cancelled events never arm**; edits reschedule via `EKEventStoreChanged`.
+
+This fixes the two biggest leaks for free: **browser meetings become first-class** (we key off the calendar link, not the app process) and the **off-by-default dormancy** is replaced by a visibly-working path.
+
+**Tier 2 — Conferencing/app detection (KEPT + widened, fallback for ad-hoc meetings).** The legacy running-process + bidirectional-audio detector (`MeetingDetector.swift`) stays as an **opt-in** fallback for meetings with no calendar event (someone grabs you on Zoom with no invite, Slack huddles). Two grafted improvements from the other designs, gated to the fallback path:
+
+- **Close the browser blind spot cheaply:** a low-frequency window-title scan (the RecapAI / pasrom open-source pattern) matching `"Meet - "`, `"Zoom Meeting"`, `"Microsoft Teams | "` in Chrome/Safari/Arc/Edge. Prefer `CGWindowList` (already linked at `OnboardingState.swift:145`, **no AX permission**) over the AX API; fall back to AX only if title fidelity demands it, and request that permission once with a clear rationale.
+- **Muted-listener fix:** arm on **either channel sustained** above `speechThreshold`, not the current `mic AND system` (`MeetingDetector.swift:208,231` already computes `||` for `hasAudio` on the stop side — bring the start side in line). This captures the mostly-listening attendee who never crosses the bidirectional bar today.
+
+**Tier 3 — the staging step (NEW, applies to both tiers).** At pre-arm/lead time we call the existing `Audio.startMonitoring()` (`Audio.swift:508`) to pre-warm the engine and permission checks. **No file is written.** This is the same lightweight metering path `MeetingDetector` already uses, now driven by the clock instead of a process match.
+
+### 3.3 The prompt UX (exact spec)
+
+Add a **fifth `PillState` case `.armed`** to `PillStateManager.swift:46-50` (between `idle` and `recording`). Two touchpoints, both on the existing floating pill (`FloatingPanelView.swift`) — never a system notification, so it works even when notification permission is denied (fixes the silent-suppression gap at `NotificationCoordinator.swift:56,80`).
+
+**Touchpoint 1 — PRE-ARM card (T−60s, silent).** Pill morphs from the `.idle` capsule into a slim `.armed` card, ~220×44, **no sound, no modal, does not steal focus** (panel keeps `canBecomeKey = false`).
+
+- Left: a calendar-clock glyph with a soft pulsing ring (reuse `showOnboardingGlow` styling, `PillStateManager.swift:62`).
+- Center, one line, truncated: the event title, e.g. **"Weekly 1:1 with Sarah"** (privacy fallback "Meeting" — see §4).
+- Right: one pill-shaped primary button **"Record"** (`mic.fill`). A faint secondary **×** dismisses this meeting's prompt.
+- Subtext, 11pt secondary: **"Starts in 1 min"**.
+
+**Touchpoint 2 — START nudge (T−0, the single gentle nudge).** At the event's scheduled start the card plays **one** soft chime (reuse `PillSounds` "Pop" at 30% volume, `PillStateManager.swift:11-13,37`). Subtext flips to **"Starting now — tap to record"**. The Record button gets a one-time scale bounce. **That is the entire nudge: one chime, one line, one button.** No countdown, no auto-start in the default path — if the user does nothing, **nothing records** and the `.armed` card auto-dismisses ~3 min after scheduled start.
+
+**Exact copy & buttons (default gentle path):**
+
+| Element | Copy |
+|---|---|
+| Pre-arm title | `Weekly 1:1 with Sarah` (event title; fallback `Meeting`) |
+| Pre-arm subtext | `Starts in 1 min` |
+| Primary button | `Record` (icon `mic.fill`) |
+| Secondary | `×` (dismiss this meeting; on recurring series → `Skip this one` / `Skip series`) |
+| T−0 subtext | `Starting now — tap to record` |
+
+**The 60s-countdown auto-record path (built, OFF by default).** Some users will want hands-free capture. For them we ship an **opt-in "Auto-record scheduled meetings"** tier (§3.7) that converts the gentle nudge into a short countdown. **Critical: the countdown is ~8 seconds, NOT 60.** A 60s timer guarantees you lose the meeting's opening (the existing #1 pain point) at the worst possible scale; 8s is long enough to react (well above the ~2s glance-and-act floor) and the pre-roll buffer (§3.5) fully covers the gap so nothing is actually lost. When this tier is on, the `.armed` card and pill show:
+
+| Element | Copy (auto-record tier only) |
+|---|---|
+| Title | `Looks like a Zoom call` (app/meeting name interpolated) |
+| Subtitle | `Recording starts in 8s unless you stop it` |
+| Countdown ring | 42px info/**blue** ring (not red — red reads as "already recording"), depleting clockwise, live integer 8…7…6 |
+| Button 1 | `Not now` (icon `ti-x`) — dismiss, no recording; suppress re-prompt for this meeting instance |
+| Button 2 | `Snooze` (icon `ti-clock`) — re-arm in 90s if the call is still live |
+| Button 3 | `Record now` (icon `ti-player-record`, filled, primary) — start immediately, back-fill pre-roll |
+| Footer | `All-party notice. Everyone hears recording start. Esc = stop & discard.` |
+| At t=0 (no action) | Recording starts **non-silently**: chime on the call + pill → recording + in-meeting chat notice where the API allows + pre-roll back-fill |
+
+So the button set across the whole feature is: gentle path = **`Record` / ×**; auto-record tier = **`Not now` / `Snooze` / `Record now`** with t=0 auto-start. We deliberately do not offer a "Remind me in N minutes" beyond Snooze — it's the same affordance with a fixed 90s.
+
+### 3.4 The tap, and what start means
+
+Clicking **Record** calls the existing `audio.start()` entry (same path as `AuroraIdleView onRecord`, `FloatingPanelView.swift:267-272` → `RecordingCoordinator.toggleRecording`, `RecordingCoordinator.swift:9-16`). The pill transitions to the existing `.recording` state (gradient border + running timer + Stop). Because record starts at the tap, **not after 5s of bidirectional audio**, the meeting opening is captured.
+
+At t=0 of the recording we surface consent in-band (see §4): post an in-meeting chat notice where the conferencing API allows (Granola/Fathom), and show a 5-second verbal-disclosure one-liner in the pill tooltip, matched to meeting type by attendee domains (internal vs external), e.g. *"Heads up — I'm recording this for notes."*
+
+### 3.5 Pre-roll buffer (grafted, default-ON, RAM-only)
+
+While `.armed`, hold a short rolling **in-memory** buffer (default **20s**, configurable 0–30s) from the already-running monitor tap (`Audio.startMonitoring`). On the Record tap we prepend it so greetings aren't lost. **The buffer is RAM-only, continuously overwritten, and never hits disk unless the user taps** — this preserves the no-silent-file invariant and is the load-bearing engineering risk (§4.4). If shipping the buffer is too costly or its invariant can't be guaranteed under review, the honest fallback is **forward-only-from-tap**, which still beats today because the tap can happen at T−0 instead of after first speech.
+
+### 3.6 Recording indicator & instant stop/discard
+
+**Indicator (three redundant, honest signals):**
+
+1. The macOS system **orange mic / purple system-audio menu-bar dot** — never suppressed, treated as tamper-proof proof.
+2. The pill in `.recording` state, pinned visible, showing app/meeting name + live elapsed timer + red dot. **The pill is the source of truth**, so a denied-notifications user always sees state.
+3. The existing "Recording Started" notification (`NotificationCoordinator.swift:54-74`) fires as a *redundant* signal only.
+
+**Stop / discard (instant, multiple routes):**
+
+- **During `.armed`** (gentle path): the × on the card, or `Stop` on the armed pill — aborts before any file is written, **zero artifact**.
+- **After recording starts:** the pill's `Stop` (keeps the recording, `RecordingCoordinator.toggleRecording`) **and a distinct `Discard`** affordance — a small "Delete this recording" link visible for the first ~10s that **stops AND deletes** the audio + pre-roll without transcribing. This is the panic button for "I didn't mean to start this in front of someone."
+- **Global Esc**, hooked like the tray's existing local+global Esc monitors (`FloatingPanelView.swift:340-376`): Esc during arm = abort; Esc within the first ~10s of recording = stop & discard.
+- **Cmd+Shift+R** toggles as today (`HotkeyManager.swift:10-28`).
+
+`Discard` is reachable from the pill, never buried in a menu.
+
+### 3.7 Aggressiveness as a setting (the tier model)
+
+One setting, three tiers, **default = Gentle**:
+
+1. **Off** — no pre-arm, no prompts. (Legacy audio/process auto-detect remains independently opt-in, as today.)
+2. **Gentle (DEFAULT, what onboarding turns on)** — calendar pre-arm + one-tap nudge. No countdown, no auto-start. *No file without a tap.*
+3. **Auto-record (opt-in, full disclosure)** — calendar pre-arm + 8s countdown + non-silent t=0 auto-start. This is the only tier that can write a file without a tap, and it only does so after an audible chime + visible indicator + in-meeting notice.
+
+The legacy running-process/bidirectional-audio detector (`MeetingDetector.swift`) is the **ad-hoc fallback** under any tier ≥ Gentle, still independently toggleable.
+
+---
+
+## 4. Consent model & blocking mitigations (load-bearing)
+
+This section is non-negotiable. The product invariant we advertise — **"Transcripted never writes a recording file without a human signal, and never records anyone silently"** — is what keeps us off the Otter docket. Every mitigation below is a ship-blocker.
+
+### 4.1 Two-layer consent
+
+**App-level (the Mac user).** One-time onboarding opt-in: Transcripted asks for EventKit read permission and states plainly: *"I'll watch your calendar and offer to record meetings with one tap. I never record without your tap."* This replaces the buried default-off `autoRecordMeetings` flag (`SettingsContainerView.swift:21`) with an explicit onboarding choice. (Keep the code default `false`; onboarding's primary CTA writes the tier.)
+
+**Participant-level (everyone in the room).** All-party consent is the **universal default** because remote attendees can't be geolocated and statutory damages stack. We satisfy it three ways at record-start:
+
+1. **Self-documenting verbal disclosure** — surface a context-matched one-liner the user reads aloud; it lands *inside* the recording at t=0 (Granola pattern), so consent survives in two-party states.
+2. **Auto-posted chat notice** via the conferencing API where available (Granola/Fathom).
+3. **Separate local consent log** — one row per recording: timestamp, meeting title, detected app, disclosure method surfaced. Local-only.
+
+Jurisdiction handling is **portable, not geo-gated**: notify-before-capture + retention limit + auto-delete satisfies both US all-party norms and EU/GDPR transparency duties (where employee "consent" is rarely freely given and Art. 6(1)(f) legitimate interest + transparency matters more than a click).
+
+### 4.2 BLOCKING legal mitigations (from the adversarial review)
+
+- **B1 — No silent-to-disk path, ever.** In the default/Gentle tier, a file is written only on the human tap. In the opt-in Auto-record tier, t=0 start is **never silent**: audible chime + visible pill + OS dot + in-meeting chat notice all fire at t=0. If any of those four can't fire (e.g. chat-notice API unavailable), the recording **still must** emit the chime + dot + pill. Delete any code path that could record to disk with zero contemporaneous signal.
+- **B2 — Do not push compliance onto the user.** No "ensure you have permission" boilerplate substituting for product behavior (the explicit Otter mistake). The product *performs* notice; it doesn't *outsource* it.
+- **B3 — Non-host third parties must always have notice + a real opt-out/pause.** The in-meeting notice + the audible chime are the notice; Stop/Discard + Pause are the opt-out. This is the precise gap that sank Otter.
+- **B4 — Retention + auto-delete are first-class.** Ship a visible retention setting and auto-delete (portable EU/US posture). AI-transcript accuracy is itself a compliance concern; keep a human-review path.
+- **B5 — Calendar metadata is sensitive.** Event titles/attendees rendered on a floating pill and written to the consent log are PII. Local-only handling; a setting to show generic **"Meeting"** instead of the real title (default to generic in screen-share contexts).
+
+### 4.3 BLOCKING false-positive mitigations
+
+False positives must be **cheap by construction**: pre-arm writes nothing and auto-starts nothing in the Gentle tier, so a wrong guess costs at most one dismissible card and **zero recorded bytes**.
+
+- **F1 — Link-but-not-a-meeting** (focus block, hold, "Zoom link in notes"): `.armed` card appears, user ignores or taps ×. No file.
+- **F2 — Back-to-back / overlapping meetings** (today's detector returns early on `activeMeetingApp != nil`, `MeetingDetector.swift:148`): calendar pre-arm handles a queue — show the nearer-starting event, roll to the next at its start.
+- **F3 — Cancelled / declined / moved:** honor `EKEvent` status + RSVP; declined/cancelled never arm; `EKEventStoreChanged` reschedules on edits.
+- **F4 — Recurring junk:** per-meeting × offers **"Skip this one / Skip series"**. Track dismiss-vs-record per series; after 3 straight ignores, stop arming with a quiet, undoable "muted this recurring meeting" note.
+- **F5 — Wrong-link meetings** (phone-only, in-person with a stray URL): still just a card; ignored at no cost.
+- **F6 — Auto-record tier safety:** in the opt-in tier, the t=0 chime makes any wrong auto-start **immediately audible** (and disclosed), and Esc within 10s does stop-and-discard in one keystroke — a wrong auto-start can never silently accumulate. Repeated "Not now" on the same app within a session raises that app's arm threshold for the day.
+
+**Honest core:** because the default path has no silent record, a false positive **can never become a privacy incident** — the worst outcome is a card you didn't want.
+
+### 4.4 The one new invariant risk to watch
+
+The 20s in-memory pre-roll buffer means **audio IS held in RAM before any tap**. Eng must guarantee it never persists and is continuously overwritten, or the "no recording without a tap" promise is undermined. This gets explicit review sign-off; if it can't be guaranteed, ship forward-only-from-tap (§3.5).
+
+---
+
+## 5. Implementation plan
+
+Phased so the trust-preserving default ships first and the aggressive tier is gated behind a switch + telemetry.
+
+### Phase 0 — Pill `.armed` state + plumbing (no calendar yet)
+- Add `case armed` to `PillState` (`PillStateManager.swift:46-50`) with transitions `idle → armed → recording` and `armed → idle` (dismiss).
+- Build the `.armed` card view in `FloatingPanelView.swift` (reuse `showOnboardingGlow` for the pulse). Wire its Record button to the existing `RecordingCoordinator.toggleRecording` path (`FloatingPanelView.swift:267-272`).
+- Add the `Discard` affordance to the `.recording` view (first ~10s): stop + delete without transcribe.
+- **Ship behind a feature flag, dark.** No behavior change for users yet.
+
+### Phase 1 — Calendar pre-arm (EventKit)
+- New `Services/CalendarPreArm.swift`: EventKit read, 12h horizon, 15-min refresh + `EKEventStoreChanged`, qualification regex (§3.2), per-event local timers at start−lead.
+- Onboarding step requesting EventKit permission with the §4.1 copy; primary CTA writes tier = **Gentle**.
+- At lead time: enter `.armed`, call `Audio.startMonitoring()` (`Audio.swift:508`). No file.
+- Honor `EKEvent` status + RSVP (F3); queue overlapping events (F2); per-series skip/mute (F4).
+- Consent log writer (local-only, §4.1); generic-title privacy setting (B5).
+
+### Phase 2 — Pre-roll buffer (RAM-only)
+- Extend the `Audio.startMonitoring` tap to write mic+system into a continuously-overwritten in-memory ring (default 20s). On Record tap, flush to the front of the file. **Explicit eng sign-off on the never-persists invariant (§4.4).** Fallback: forward-only-from-tap.
+
+### Phase 3 — Ad-hoc fallback improvements (legacy detector)
+- Window-title scan via `CGWindowList` (already linked, `OnboardingState.swift:145`) to close the browser blind spot (Tier 2).
+- Bring the start-side audio gate in line with the stop-side `||` so muted listeners arm (`MeetingDetector.swift:208,231`).
+- Keep this tier independently opt-in.
+
+### Phase 4 — Auto-record tier (opt-in countdown, default OFF)
+- Add the 8s countdown ring + `Not now` / `Snooze` / `Record now` to the `.armed` card (auto-record tier only).
+- Non-silent t=0 auto-start: chime + pill + OS dot + in-meeting chat notice + pre-roll back-fill (B1).
+- In-meeting chat-notice integration per conferencing API where available.
+
+### Settings / opt-in
+- `MeetingDetectionSection.swift`: replace the static browser-limitation copy (`:43`) with the tier picker (Off / Gentle / Auto-record), pre-roll length (0–30s), retention/auto-delete (B4), generic-title toggle (B5), and the ad-hoc-fallback toggle.
+- Onboarding writes **Gentle** as the default.
+
+### Safe rollout & kill switch
+- **Default aggressiveness: Gentle.** Auto-record tier defaults **OFF**; turning it on is a deliberate, disclosed choice.
+- **Feature flag / kill switch** gating the entire pre-arm path (a single `UserDefaults` / remote flag) so we can dark-launch and disable instantly if EventKit scanning, title-matching, or the pre-roll invariant misbehaves.
+- **Telemetry to tune, before considering any default change:** prompt-shown → tapped → recorded → kept funnel; false-positive dismiss rate per source; pre-roll cost; countdown abort rate (if/when Auto-record tier sees use). Use this to settle the 8s-vs-8–12s number and whether Auto-record should ever graduate to default.
+- Staged: internal → small cohort → GA, with the kill switch live the whole time.
+
+---
+
+## 6. Open questions for Justin
+
+1. **Default aggressiveness.** Recommendation is **Gentle by default** (one tap, no auto-start). Agree, or do you want Auto-record (8s countdown, non-silent t=0 start) as the default to maximize capture? The judges and risk reviews favor Gentle; Auto-record is the only tier that can write a file without a tap.
+2. **Does countdown-auto-record ship at all, and on/opt-in?** Recommendation: **build it, ship it OFF (opt-in)**, full disclosure. Alternative: don't build it yet (Gentle only) and revisit after telemetry. Your call on whether the capture upside justifies the liability surface even behind a switch.
+3. **Pre-roll buffer.** Ship the 20s RAM-only pre-roll (max capture of the opening, but new invariant risk), or the safer forward-only-from-tap (lower value, zero RAM-audio risk)? Recommendation: pre-roll **if** eng signs off on the never-persists guarantee; otherwise forward-only.
+4. **Calendar permission friction.** Pre-arm is dead without EventKit access. How hard do we push the calendar ask in onboarding, and how graceful is the no-calendar fallback (ad-hoc detector only)?
+5. **Title privacy default.** Show real event titles on the pill (better UX) or default to generic "Meeting" (safer for screen-share)? Recommendation: real title normally, generic when a screen-share/system-audio capture is detected.
+6. **Lead time.** 60s pre-arm lead and 20s pre-roll — keep, or tune? Meetings start early/late, so the chime can fire into an empty room or after the real start.
+7. **Ad-hoc fallback scope.** Keep the legacy audio/process detector as an opt-in fallback (re-inherits browser-blind/5s-late gaps unless we also ship the Phase 3 title-scan)? Or invest fully in title-scan so ad-hoc meetings are first-class too?
+
+---
+
+## Appendix — file map (current system, for implementers)
+
+- `Transcripted/Services/MeetingDetector.swift` — all current detection; `meetingApps` map (`:72-80`), thresholds `speechThreshold 0.02` (`:51`) / `requiredBidirectionalDuration 5s` (`:54`) / `silenceGracePeriod 15s` (`:57`), one-app-at-a-time early return (`:148`), gate on `autoRecordMeetings` (`:163,217,246`), `||` stop-side audio (`:208`).
+- `Transcripted/TranscriptedApp.swift:138-153` — wires `onMeetingStart`/`onMeetingEnd`.
+- `Transcripted/Core/NotificationCoordinator.swift:54-101` — post-start/stop banners; auth gate (`:56,80`); Stop action (`:16-25`).
+- `Transcripted/UI/Settings/Sections/MeetingDetectionSection.swift:43` — settings copy incl. browser-limitation disclaimer (to be replaced by the tier picker).
+- `Transcripted/UI/Settings/SettingsContainerView.swift:21` — `autoRecordMeetings` `@AppStorage` default `false`.
+- `Transcripted/Core/RecordingCoordinator.swift:9-16` — `toggleRecording`, shared start/stop.
+- `Transcripted/Core/HotkeyManager.swift:10-28` — Cmd+Shift+R.
+- `Transcripted/Core/MenuBarManager.swift:52-55` — menu-bar Start Recording.
+- `Transcripted/UI/FloatingPanel/FloatingPanelView.swift` — pill/tray; manual start (`:267-272`); Esc monitors (`:340-376`).
+- `Transcripted/UI/FloatingPanel/PillStateManager.swift:46-50` — `PillState` (idle/recording/processing/saved — **add `.armed`**); `PillSounds` (`:9-41`); `showOnboardingGlow` (`:62`).
+- `Transcripted/Core/Audio.swift:508` — `startMonitoring()`, the pre-warm/pre-roll tap.
+- **EventKit:** none today (`grep EKEventStore` → zero). New `Services/CalendarPreArm.swift`.

--- a/scripts/gen_synthetic_speaker_eval.py
+++ b/scripts/gen_synthetic_speaker_eval.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Generate deterministic synthetic dumps + RTTMs for the SpeakerEvalHarness.
+
+The real corpora (AMI/VoxCeleb) need multi-GB downloads + HuggingFace models, which aren't
+available in every environment. The harness `replay` stage, however, only consumes per-segment
+EMBEDDINGS (the expensive `dump` stage is already baked into the JSON) plus ground-truth RTTMs.
+
+This script fabricates embeddings with *controlled cosine geometry* so the write-path fixes can be
+A/B'd with `--write-path-fixes off|on` and scored on the real metrics (DER / fragmentation /
+false-merge / cross-meeting re-ID). It is NOT a substitute for an AMI sweep — it is a reproducible,
+network-free probe of the exact failure modes #6 and #8 target, plus a no-regression control.
+
+Corpora produced under data/eval/synthetic/<name>/{dumps,rttm}:
+
+  normal         — 5 well-separated speakers across 8 meetings, each voice drifting slightly
+                   meeting-to-meeting. Control: the gate must NOT hurt DER/fragmentation/re-ID here
+                   (proves no under-adaptation regression).
+  twopeople      — profile P learned in M1; M2 has two DISTINCT people (B,C) who each resemble P
+                   (~0.74) but not each other (~0.1). #8 should keep them apart (false-merge → 0).
+  contamination  — target T (M1), attacker A (~0.71 to T) appears alone across M2..M8 repeatedly
+                   blending into T's stored profile, then a third party D (0.66 to T, ~0.85 to A)
+                   arrives in M9. Without #6 the drifted T-profile wrongly swallows D.
+
+Embeddings are 256-D (matching the app) with the controlled geometry in the leading dims plus a
+small deterministic orthogonal jitter per segment so a cluster mean lands back on its base vector.
+"""
+import argparse, json, math, os
+import numpy as np
+
+DIM = 256
+RNG = np.random.default_rng(20260620)
+
+
+def base_vector(coords):
+    """Unit 256-D vector with `coords` in the leading dims, zeros elsewhere."""
+    v = np.zeros(DIM, dtype=np.float64)
+    v[: len(coords)] = coords
+    n = np.linalg.norm(v)
+    return v / n if n > 0 else v
+
+
+def jitter(vec, scale=0.008):
+    """Add small per-segment noise (deterministic via global RNG) and renormalize. Kept small so a
+    cluster mean lands back on its base vector and the controlled cosine geometry is stable
+    (std 0.008 over 256 dims ≈ 0.13 norm → per-segment cos≈0.99, cluster-mean cos≈0.999)."""
+    noise = RNG.normal(0, scale, size=DIM)
+    out = vec + noise
+    return out / np.linalg.norm(out)
+
+
+def vec_at_cos(theta_deg):
+    """2-D plane unit vector at angle theta to the x-axis."""
+    t = math.radians(theta_deg)
+    return base_vector([math.cos(t), math.sin(t)])
+
+
+def seg(speaker_local_id, start, dur, embedding, quality=0.75):
+    return {
+        "speakerId": speaker_local_id,
+        "start": round(start, 3),
+        "end": round(start + dur, 3),
+        "quality": quality,
+        "embedding": [float(x) for x in embedding],
+    }
+
+
+def write_meeting(out_dir, name, segments, rttm_rows):
+    dumps = os.path.join(out_dir, "dumps")
+    rttm = os.path.join(out_dir, "rttm")
+    os.makedirs(dumps, exist_ok=True)
+    os.makedirs(rttm, exist_ok=True)
+    dur = max((s["end"] for s in segments), default=0.0)
+    raw = {
+        "meeting": name,
+        "audioPath": f"synthetic://{name}",
+        "durationSeconds": dur,
+        "diarizerSpeakerCount": len({s["speakerId"] for s in segments}),
+        "segments": segments,
+    }
+    with open(os.path.join(dumps, f"{name}.json"), "w") as f:
+        json.dump(raw, f)
+    with open(os.path.join(rttm, f"{name}.rttm"), "w") as f:
+        for (start, dur_, label) in rttm_rows:
+            f.write(f"SPEAKER {name} 1 {start:.3f} {dur_:.3f} <NA> <NA> {label} <NA> <NA>\n")
+
+
+def build_speaker_block(local_id, global_label, base_vec, start, n_segs=4, seg_dur=3.0, gap=0.0):
+    """A contiguous block of `n_segs` segments for one speaker; returns (segments, rttm_rows, end)."""
+    segs, rows = [], []
+    t = start
+    for _ in range(n_segs):
+        e = jitter(base_vec)
+        segs.append(seg(local_id, t, seg_dur, e))
+        rows.append((t, seg_dur, global_label))
+        t += seg_dur + gap
+    return segs, rows, t
+
+
+def meeting_from(out_dir, name, present):
+    """present: list of (global_label, base_vec) or (global_label, base_vec, n_segs).
+    Each entry gets its own local diarizer id + a contiguous time block."""
+    all_segs, all_rows, t = [], [], 0.0
+    for local_id, entry in enumerate(present):
+        label, vec = entry[0], entry[1]
+        n_segs = entry[2] if len(entry) > 2 else 4
+        segs, rows, t = build_speaker_block(local_id, label, vec, t, n_segs=n_segs)
+        all_segs += segs
+        all_rows += rows
+        t += 2.0  # silence gap between speakers
+    write_meeting(out_dir, name, all_segs, all_rows)
+
+
+def gen_normal(root):
+    out = os.path.join(root, "normal")
+    # 5 speakers spread 72° apart in the plane (adjacent cos≈0.31 — well separated).
+    speakers = {f"S{i}": vec_at_cos(i * 72.0) for i in range(5)}
+    # 8 meetings; each meeting 2-3 speakers; voices drift a few degrees per meeting.
+    schedule = [
+        ["S0", "S1"], ["S1", "S2", "S3"], ["S0", "S2"], ["S3", "S4"],
+        ["S0", "S1", "S4"], ["S2", "S4"], ["S0", "S3"], ["S1", "S2", "S4"],
+    ]
+    for mi, present in enumerate(schedule):
+        drift = []
+        for label in present:
+            ang = (list("S0 S1 S2 S3 S4".split()).index(label)) * 72.0 + (mi * 1.5)
+            drift.append((label, vec_at_cos(ang)))
+        meeting_from(out, f"normal_M{mi+1:02d}", drift)
+    return out
+
+
+def gen_twopeople(root):
+    out = os.path.join(root, "twopeople")
+    # Realistic two-people-one-profile bug: X is learned in M1; in M2 X returns (dominant) AND a
+    # distinct intruder Y also resembles X (~0.74) but is nothing like X's session… they're the same
+    # *profile match*, different people. Y must NOT be silently fused into X's row.
+    X = vec_at_cos(0.0)
+    Y = vec_at_cos(42.3)                       # cos(Y,X)=0.74 (above the 0.70 attach floor)
+    meeting_from(out, "twopeople_M01", [("X", X, 5)])                  # learn X
+    meeting_from(out, "twopeople_M02", [("X", X, 5), ("Y", Y, 3)])     # X returns + intruder Y
+    return out
+
+
+def gen_contamination(root):
+    out = os.path.join(root, "contamination")
+    T = base_vector([1, 0, 0])
+    A = base_vector([0.71, 0.7042, 0.0])                 # cos(A,T)=0.71
+    # D: cos(D,T)=0.66, cos(D,A)=0.85 — a distinct 3rd party close to A, not to clean T.
+    d0 = 0.66
+    d1 = (0.85 - 0.71 * d0) / 0.7042
+    d2 = math.sqrt(max(0.0, 1 - d0 * d0 - d1 * d1))
+    D = base_vector([d0, d1, d2])
+    meeting_from(out, "contam_M01", [("T", T)])               # learn T
+    for k in range(2, 9):                                     # M2..M8: attacker A alone, repeatedly
+        meeting_from(out, f"contam_M{k:02d}", [("A", A)])
+    meeting_from(out, "contam_M09", [("D", D)])               # 3rd party arrives
+    meeting_from(out, "contam_M10", [("T", T)])               # target returns
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="data/eval/synthetic")
+    args = ap.parse_args()
+    os.makedirs(args.out, exist_ok=True)
+    for fn in (gen_normal, gen_twopeople, gen_contamination):
+        path = fn(args.out)
+        print(f"wrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_synthetic_speaker_eval.sh
+++ b/scripts/run_synthetic_speaker_eval.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# A/B the speaker write-path fixes (#6 write-time contamination gate + #8 cross-cluster link/merge
+# decouple) on the network-free synthetic corpora from gen_synthetic_speaker_eval.py.
+#
+# For each corpus it replays the meetings IN ORDER through the real TranscriptedCore clusterer + DB
+# matcher with the fixes OFF (legacy) and ON, then scores both against the ground-truth RTTMs and
+# prints the before/after metrics (DER / fragmentation / false-merge / re-ID).
+#
+# Usage:
+#   scripts/gen_synthetic_speaker_eval.py        # once, to (re)generate data/eval/synthetic
+#   scripts/run_synthetic_speaker_eval.sh        # all corpora, match=0.65
+#   MATCH=0.70 scripts/run_synthetic_speaker_eval.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+ROOT="$(pwd)"
+
+MATCH="${MATCH:-0.65}"
+COLLAR="${COLLAR:-0.25}"
+CONS="${CONS:-none}"
+CORPORA="${CORPORA:-normal twopeople contamination}"
+BASE="$ROOT/data/eval/synthetic"
+BIN="$ROOT/Tools/SpeakerEvalHarness/.build/release/speaker-eval-harness"
+
+[ -x "$BIN" ] || { echo "build first: swift build --package-path Tools/SpeakerEvalHarness -c release"; exit 1; }
+[ -d "$BASE" ] || { echo "generate first: python3 scripts/gen_synthetic_speaker_eval.py"; exit 1; }
+
+for corpus in $CORPORA; do
+  dumps_dir="$BASE/$corpus/dumps"; rttm_dir="$BASE/$corpus/rttm"
+  [ -d "$dumps_dir" ] || { echo "missing $dumps_dir"; continue; }
+  # chronological order (filenames sort lexicographically: *_M01, *_M02, ...)
+  inputs="$(ls "$dumps_dir"/*.json | sort | tr '\n' ',' | sed 's/,$//')"
+  out="$BASE/$corpus/results"; mkdir -p "$out"
+  echo "============================================================"
+  echo "CORPUS: $corpus  (match=$MATCH consolidation=$CONS)"
+  echo "============================================================"
+  for mode in off on; do
+    res="$out/replay_fixes_${mode}.json"
+    "$BIN" replay --inputs "$inputs" --match "$MATCH" --consolidation "$CONS" \
+      --write-path-fixes "$mode" --out "$res" 2>/dev/null
+    echo "----- fixes=$mode -----"
+    python3 "$ROOT/scripts/score_speaker_eval.py" --result "$res" --rttm-dir "$rttm_dir" \
+      --collar "$COLLAR" 2>/dev/null \
+      | grep -E "mean|Fragmentation|False-merge|re-ID|Profiles at end|…" || true
+  done
+  echo
+done


### PR DESCRIPTION
Closes the two **write-path** speaker-accuracy holes from `docs/FIX_ROADMAP.md` (#6, #8 — see [#1227](https://github.com/r3dbars/transcripted/pull/1227)). Both ride the same matching surface, so they're one coherent PR, validated on the SpeakerEvalHarness.

> **Draft.** Do not merge / do not cut a release. Thresholds (0.78 link floor, 0.80/0.72 write bands) are deliberately conservative and should be confirmed on a full AMI/VoxCeleb sweep before landing — that needs network + CoreML models, which weren't available in the authoring environment, so validation here is on controlled-geometry synthetic corpora through the **real** TranscriptedCore code path.

## #6 — write-time voiceprint contamination gate
The EMA write-back fired on *every* successful match (`TranscriptionPipeline` :309/:731), blending the session mean into the persisted voiceprint at a fixed `alpha=0.15` (`SpeakerDatabase` :250-262) with **no quality/margin/confidence gate at write time**. A mature, named profile (`callCount>4`, no maturity bonus) accepting a 0.70 cosine match from an under-segmented cluster with no clear runner-up permanently, invisibly contaminated the stored fingerprint — compounding across meetings.

**Fix:** new `SpeakerWritePathPolicy.voiceprintBlendAlpha` — confident `0.15` / cautious `0.05` / frozen `0.0`, keyed on similarity **and** a margin-to-runner-up guard (reuses the certified ladder's `0.12`). Threaded through `addOrUpdateSpeaker` via an **additive** `SpeakerStore` requirement + forwarding default extension, so the existing 2-arg callers and the test double are untouched. Low-quality matches still **NAME** (display) but **freeze** the voiceprint (the appearance is still recorded). The write bar is decoupled from the 0.92 *display* auto-name bar so legitimate drift keeps adapting — no contamination-for-under-adaptation trade.

## #8 — decouple link/merge floor from per-utterance attach
The adaptive 0.70 floor both **attached** utterances *and* **fused** clusters that matched the same profile (`profileToSpeakers`, :334-347). Two distinct people each landing 0.70–0.92 against one profile (no runner-up within 0.05) were silently fused into one row; review then named the fused cluster and the mis-attribution survived.

**Fix:** new `SpeakerWritePathPolicy.crossClusterLinkFloor` (0.78) + `Transcription.planCrossClusterLinks`. Clusters that matched the same profile fuse **only when their mean embeddings are directly similar to each other** (the genuine over-segmentation signature) — strictly stricter than the 0.70 attach floor, but below the 0.88 within-meeting consolidation bar so legitimate de-fragmentation is preserved. A distinct voice is **spun off** to its own fresh profile so review can name it independently. Write-back is **deferred** until after this decision, so a spun-off voice never contaminates the shared profile (matching reads only the pre-meeting snapshot, so deferring changes no match decision).

Both the system and mic pipeline paths are updated identically; the decision is a pure, unit-tested helper.

## Coordination with in-flight work
- **Certified naming ladder (0.92 / 0.12):** raises only the auto-*name* (display) bar — it does **not** gate the write path, which is exactly this gap. This PR adds the write-path gates *next to* it without changing it; `voiceprintBlendAlpha` reuses the same `0.12` margin constant. No conflict.
- **ERes2Net #1175 (embedding-model swap):** does not conflict — these are pure decision functions over cosine geometry + a tunable link floor. If #1175 changes the embedding distribution, only the **threshold constants** in `SpeakerWritePathPolicy` need a re-sweep (all centralized in one file, harness-tunable). Flagging rather than fighting.

## Validation — SpeakerEvalHarness before/after
Added `--write-path-fixes off|on` to the harness `replay` so the same dumps run both ways, plus a network-free synthetic generator (`scripts/gen_synthetic_speaker_eval.py`) with controlled cosine geometry. `off` = legacy path; `on` = `SpeakerWritePathPolicy` gates (mirrors `TranscriptionPipeline`). `MATCH=0.70`, collar 0.25.

| corpus | metric | fixes **off** | fixes **on** |
|---|---|---|---|
| **normal** (no-regression control) | DER / fragmentation / false-merge / re-ID / profiles | 0.0 / 1.0 / 0 / 1.0 / 5 of 5 | **identical** |
| **twopeople** (#8) | false-merge | `1` → profile spans `[X,Y]` | **`0`** |
| | profiles at end (ideal 2) | `1` | **`2`** |
| | mean DER | `0.1875` | **`0.0`** |
| **contamination** (#6) | false-merge profile | spans `[A, D, T]` (3 people) | spans `[A, T]` — 3rd party **D rescued** |
| | profiles at end (ideal 3) | `1` | **`2`** |

- **normal** proves the gate does **not** cause under-adaptation / DER / fragmentation / re-ID regressions (the task's back-out criterion).
- **#8** is directly fixed: the intruder is no longer fused (false-merge 1→0, DER 0.1875→0).
- **#6**: the contaminated profile no longer swallows the unrelated 3rd party D. The residual `[A,T]` merge is the matcher legitimately matching A@0.71 ≥ the 0.70 floor (a threshold property, not a write-path one) — out of scope here.

> The synthetic corpora are a reproducible, network-free *probe* of the exact failure modes, **not** a substitute for an AMI sweep. Re-run on real corpora before landing.

Plus **15 new unit tests** (`SpeakerWritePathPolicyTests`, `SpeakerWriteBackGateTests`) — alpha bands, margin/ambiguity guard, frozen-alpha-leaves-voiceprint-byte-identical, two-people-one-profile spin-off, over-segmentation still fuses.

## Authoritative verification (all green)
`build-deps.sh --force` · `build.sh --no-open` · `run-tests.sh` **10152/10152** · `swift test` **511 (1 skipped, 0 failures)** · `run-integration-smoke.sh` · `swift build --package-path Tools/SpeakerEvalHarness -c release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
