### PR TITLE
Consolidate agent query activation telemetry

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -169,6 +169,7 @@ struct AnalyticsEventPolicy: Equatable {
         "query_kind",
         "result",
         "return_window_bucket",
+        "source_count_bucket",
         "surface",
     ]
 

--- a/Sources/Support/AgentMCPConnector.swift
+++ b/Sources/Support/AgentMCPConnector.swift
@@ -189,6 +189,8 @@ enum AgentMCPConnector {
     static func ensureHelperInstalled(
         bundledBinaryURL: URL? = ClaudeDesktopIntegrationInstaller.bundledMCPBinaryURL(),
         installedBinaryURL: URL = ClaudeDesktopIntegrationInstaller.installedMCPBinaryURL,
+        observabilityConfigURL: URL = ClaudeDesktopIntegrationInstaller.mcpObservabilityConfigURL,
+        infoDictionary: [String: Any]? = Bundle.main.infoDictionary,
         fileManager: FileManager = .default
     ) throws -> URL {
         guard let bundledBinaryURL,
@@ -205,6 +207,11 @@ enum AgentMCPConnector {
                 fileManager: fileManager
             )
         }
+        try ClaudeDesktopIntegrationInstaller.writeMCPObservabilityConfigIfAvailable(
+            configURL: observabilityConfigURL,
+            infoDictionary: infoDictionary,
+            fileManager: fileManager
+        )
         return installedBinaryURL
     }
 

--- a/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
+++ b/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
@@ -306,8 +306,16 @@ enum ClaudeDesktopIntegrationInstaller {
     static func writeMCPObservabilityConfigIfAvailable(
         configURL: URL = mcpObservabilityConfigURL,
         infoDictionary: [String: Any]? = Bundle.main.infoDictionary,
+        analyticsEnabled: Bool = AnalyticsPreferences.isEnabled(),
         fileManager: FileManager = .default
     ) throws {
+        guard analyticsEnabled else {
+            if fileManager.fileExists(atPath: configURL.path) {
+                try fileManager.removeItem(at: configURL)
+            }
+            return
+        }
+
         guard let apiKey = firstNonEmpty(infoDictionary?[AnalyticsRuntimeConfiguration.apiKeyInfoKey] as? String),
               let host = firstNonEmpty(infoDictionary?[AnalyticsRuntimeConfiguration.hostInfoKey] as? String),
               host.lowercased().hasPrefix("https://") else {

--- a/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
+++ b/Sources/Support/ClaudeDesktopIntegrationInstaller.swift
@@ -108,11 +108,17 @@ enum ClaudeDesktopIntegrationError: LocalizedError, Equatable {
 enum ClaudeDesktopIntegrationInstaller {
     static let serverName = "transcripted"
     static let helperBinaryName = "transcripted-mcp"
+    static let mcpObservabilityConfigFileName = "mcp-observability.plist"
 
     static var installedMCPBinaryURL: URL {
         FileManager.default.transcriptedAppSupportDir
             .appendingPathComponent("mcp", isDirectory: true)
             .appendingPathComponent(helperBinaryName, isDirectory: false)
+    }
+
+    static var mcpObservabilityConfigURL: URL {
+        FileManager.default.transcriptedAppSupportDir
+            .appendingPathComponent(mcpObservabilityConfigFileName, isDirectory: false)
     }
 
     static var claudeDesktopConfigURL: URL {
@@ -200,6 +206,7 @@ enum ClaudeDesktopIntegrationInstaller {
             to: installedBinaryURL,
             fileManager: fileManager
         )
+        try writeMCPObservabilityConfigIfAvailable(fileManager: fileManager)
 
         let backupURL = try writeClaudeDesktopConfig(
             commandPath: installedBinaryURL.path,
@@ -217,27 +224,41 @@ enum ClaudeDesktopIntegrationInstaller {
     }
 
     /// Silently re-copies the bundled helper over a previously installed one
-    /// when their contents differ, e.g. after an app update. Configs are left
-    /// untouched — they already point at the stable installed path. Never
+    /// when their contents differ, e.g. after an app update. Helper analytics
+    /// config is refreshed only when an installed helper already exists. Never
     /// installs fresh: a missing installed helper means the user has not
     /// opted into agent setup yet.
     @discardableResult
     static func refreshInstalledHelperIfNeeded(
         bundledBinaryURL: URL? = bundledMCPBinaryURL(),
         installedBinaryURL: URL = installedMCPBinaryURL,
+        observabilityConfigURL: URL = mcpObservabilityConfigURL,
+        infoDictionary: [String: Any]? = Bundle.main.infoDictionary,
         fileManager: FileManager = .default
     ) throws -> Bool {
+        guard fileManager.fileExists(atPath: installedBinaryURL.path) else {
+            return false
+        }
         guard let bundledBinaryURL,
               fileManager.isExecutableFile(atPath: bundledBinaryURL.path),
-              fileManager.fileExists(atPath: installedBinaryURL.path),
               bundledBinaryURL.standardizedFileURL.path != installedBinaryURL.standardizedFileURL.path,
               !fileManager.contentsEqual(atPath: installedBinaryURL.path, andPath: bundledBinaryURL.path) else {
+            try writeMCPObservabilityConfigIfAvailable(
+                configURL: observabilityConfigURL,
+                infoDictionary: infoDictionary,
+                fileManager: fileManager
+            )
             return false
         }
 
         try installBundledBinary(
             from: bundledBinaryURL,
             to: installedBinaryURL,
+            fileManager: fileManager
+        )
+        try writeMCPObservabilityConfigIfAvailable(
+            configURL: observabilityConfigURL,
+            infoDictionary: infoDictionary,
             fileManager: fileManager
         )
         return true
@@ -280,6 +301,41 @@ enum ClaudeDesktopIntegrationInstaller {
             [.posixPermissions: NSNumber(value: 0o755)],
             ofItemAtPath: installedBinaryURL.path
         )
+    }
+
+    static func writeMCPObservabilityConfigIfAvailable(
+        configURL: URL = mcpObservabilityConfigURL,
+        infoDictionary: [String: Any]? = Bundle.main.infoDictionary,
+        fileManager: FileManager = .default
+    ) throws {
+        guard let apiKey = firstNonEmpty(infoDictionary?[AnalyticsRuntimeConfiguration.apiKeyInfoKey] as? String),
+              let host = firstNonEmpty(infoDictionary?[AnalyticsRuntimeConfiguration.hostInfoKey] as? String),
+              host.lowercased().hasPrefix("https://") else {
+            if fileManager.fileExists(atPath: configURL.path) {
+                try fileManager.removeItem(at: configURL)
+            }
+            return
+        }
+
+        try fileManager.createDirectory(
+            at: configURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try PropertyListSerialization.data(
+            fromPropertyList: [
+                AnalyticsRuntimeConfiguration.apiKeyInfoKey: apiKey,
+                AnalyticsRuntimeConfiguration.hostInfoKey: host,
+            ],
+            format: .xml,
+            options: 0
+        )
+        try data.write(to: configURL, options: [.atomic])
+        fileManager.restrictFileToOwnerOnly(at: configURL)
+    }
+
+    private static func firstNonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     @discardableResult

--- a/Tests/AgentMCPConnectorTests.swift
+++ b/Tests/AgentMCPConnectorTests.swift
@@ -680,6 +680,7 @@ func testAgentMCPConnector() {
         defer { try? FileManager.default.removeItem(at: tempRoot) }
         let bundledBinaryURL = tempRoot.appendingPathComponent("bundle/transcripted-mcp", isDirectory: false)
         let installedBinaryURL = tempRoot.appendingPathComponent("mcp/transcripted-mcp", isDirectory: false)
+        let observabilityConfigURL = tempRoot.appendingPathComponent("mcp-observability.plist", isDirectory: false)
 
         try? FileManager.default.createDirectory(at: bundledBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try? "#!/bin/sh\necho v2\n".write(to: bundledBinaryURL, atomically: true, encoding: .utf8)
@@ -687,7 +688,12 @@ func testAgentMCPConnector() {
 
         let installed = try? AgentMCPConnector.ensureHelperInstalled(
             bundledBinaryURL: bundledBinaryURL,
-            installedBinaryURL: installedBinaryURL
+            installedBinaryURL: installedBinaryURL,
+            observabilityConfigURL: observabilityConfigURL,
+            infoDictionary: [
+                AnalyticsRuntimeConfiguration.apiKeyInfoKey: " phc_test ",
+                AnalyticsRuntimeConfiguration.hostInfoKey: " https://us.i.posthog.com ",
+            ]
         )
 
         assertEqual(installed?.path, installedBinaryURL.path, "ensure should return the stable installed path")
@@ -696,11 +702,27 @@ func testAgentMCPConnector() {
             "#!/bin/sh\necho v2\n",
             "ensure should install the bundled helper when missing"
         )
+        assertEqual(
+            mcpObservabilityConfig(at: observabilityConfigURL)?[AnalyticsRuntimeConfiguration.apiKeyInfoKey],
+            "phc_test",
+            "ensure should write the PostHog key for the installed standalone helper"
+        )
+        assertEqual(
+            mcpObservabilityConfig(at: observabilityConfigURL)?[AnalyticsRuntimeConfiguration.hostInfoKey],
+            "https://us.i.posthog.com",
+            "ensure should write the PostHog host for the installed standalone helper"
+        )
+        assertEqual(filePermissions(at: observabilityConfigURL), NSNumber(value: 0o600), "helper observability config should be owner-only")
 
         try? "#!/bin/sh\necho v1\n".write(to: installedBinaryURL, atomically: true, encoding: .utf8)
         _ = try? AgentMCPConnector.ensureHelperInstalled(
             bundledBinaryURL: bundledBinaryURL,
-            installedBinaryURL: installedBinaryURL
+            installedBinaryURL: installedBinaryURL,
+            observabilityConfigURL: observabilityConfigURL,
+            infoDictionary: [
+                AnalyticsRuntimeConfiguration.apiKeyInfoKey: "phc_test",
+                AnalyticsRuntimeConfiguration.hostInfoKey: "https://us.i.posthog.com",
+            ]
         )
         assertEqual(
             (try? String(contentsOf: installedBinaryURL, encoding: .utf8)) ?? "",
@@ -713,4 +735,12 @@ func testAgentMCPConnector() {
 private func filePermissions(at url: URL) -> NSNumber? {
     let attributes = try? FileManager.default.attributesOfItem(atPath: url.path)
     return attributes?[.posixPermissions] as? NSNumber
+}
+
+private func mcpObservabilityConfig(at url: URL) -> [String: String]? {
+    guard let data = try? Data(contentsOf: url),
+          let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: String] else {
+        return nil
+    }
+    return plist
 }

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -303,26 +303,36 @@ func testAnalyticsEventPolicy() {
         assertEqual(prompt?.allowedProperties ?? Set<String>(), ["action_kind", "agent_target", "artifact_kind", "prompt_kind", "result", "surface"], "agent prompt actions should stay enum-only")
         assertEqual(setup?.allowedProperties ?? Set<String>(), ["agent_target", "prior_status", "result", "setup_kind", "surface"], "setup CTAs should stay enum-only")
         assertEqual(returnProxy?.allowedProperties ?? Set<String>(), ["prior_artifact_kind", "proxy_kind", "return_window_bucket", "surface"], "return proxy should not include paths or titles")
-        assertEqual(agentQuery?.allowedProperties ?? Set<String>(), ["agent_target", "artifact_kind", "capture_age_bucket", "query_kind", "result", "return_window_bucket", "surface"], "agent query observation should stay enum-only")
+        assertEqual(agentQuery?.allowedProperties ?? Set<String>(), ["agent_target", "artifact_kind", "capture_age_bucket", "query_kind", "result", "return_window_bucket", "source_count_bucket", "surface"], "agent query observation should stay enum and bucket only")
+        assertEqual(
+            agentQuery?.allowedProperties ?? Set<String>(),
+            mcpAgentCaptureQueryAllowedProperties(),
+            "MCP agent capture telemetry must mirror the app analytics allowlist"
+        )
 
         let activationAllowedProperties = (prompt?.allowedProperties ?? Set<String>())
             .union(artifact?.allowedProperties ?? Set<String>())
             .union(firstArtifact?.allowedProperties ?? Set<String>())
             .union(dictationArtifact?.allowedProperties ?? Set<String>())
             .union(secondArtifact?.allowedProperties ?? Set<String>())
+            .union(agentQuery?.allowedProperties ?? Set<String>())
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
             [
                 "action_kind": "open_markdown",
-                "agent_target": "codex",
+                "agent_target": "mcp_client",
                 "artifact_age_bucket": "24_48h",
                 "artifact_kind": "meeting",
+                "capture_age_bucket": "2_7d",
                 "days_since_first_bucket": "2_7d",
                 "duration_bucket": "10_29m",
                 "first_artifact_kind": "dictation",
                 "prompt_kind": "meeting_bundle",
+                "query_kind": "search",
                 "result": "success",
+                "return_window_bucket": "3_7d",
                 "save_outcome": "success",
                 "second_artifact_kind": "meeting",
+                "source_count_bucket": "2_3",
                 "surface": "home_preview",
                 "trigger": "detected_prompt",
                 "word_count_bucket": "300_plus",
@@ -334,22 +344,29 @@ func testAnalyticsEventPolicy() {
                 "file_path": "/Users/redbars/private.md",
                 "meeting_url": "https://example.com/private",
                 "prompt_text": "Read my transcript",
+                "query_text": "customer roadmap objection",
+                "raw_capture_id": "cap_private",
+                "source_app_name": "Slack",
                 "word_count": "4217",
             ],
             allowedKeys: activationAllowedProperties
         )
 
         assertEqual(sanitized["action_kind"], "open_markdown", "action kind should survive")
-        assertEqual(sanitized["agent_target"], "codex", "agent target should survive")
+        assertEqual(sanitized["agent_target"], "mcp_client", "agent target should survive")
         assertEqual(sanitized["artifact_age_bucket"], "24_48h", "artifact age bucket should survive")
         assertEqual(sanitized["artifact_kind"], "meeting", "artifact kind should survive")
+        assertEqual(sanitized["capture_age_bucket"], "2_7d", "capture age bucket should survive")
         assertEqual(sanitized["days_since_first_bucket"], "2_7d", "days since first bucket should survive")
         assertEqual(sanitized["duration_bucket"], "10_29m", "duration bucket should survive")
         assertEqual(sanitized["first_artifact_kind"], "dictation", "first artifact kind should survive")
         assertEqual(sanitized["prompt_kind"], "meeting_bundle", "prompt kind should survive")
+        assertEqual(sanitized["query_kind"], "search", "query kind should survive")
         assertEqual(sanitized["result"], "success", "coarse action result should survive")
+        assertEqual(sanitized["return_window_bucket"], "3_7d", "return window bucket should survive")
         assertEqual(sanitized["save_outcome"], "success", "coarse save result should survive")
         assertEqual(sanitized["second_artifact_kind"], "meeting", "second artifact kind should survive")
+        assertEqual(sanitized["source_count_bucket"], "2_3", "source count bucket should survive")
         assertEqual(sanitized["surface"], "home_preview", "surface should survive")
         assertEqual(sanitized["trigger"], "detected_prompt", "trigger should survive")
         assertEqual(sanitized["word_count_bucket"], "300_plus", "word count bucket should survive")
@@ -361,6 +378,9 @@ func testAnalyticsEventPolicy() {
         assertNil(sanitized["file_path"], "file paths must not be sent")
         assertNil(sanitized["meeting_url"], "meeting URLs must not be sent")
         assertNil(sanitized["prompt_text"], "raw prompt text must not be sent")
+        assertNil(sanitized["query_text"], "raw query text must not be sent")
+        assertNil(sanitized["raw_capture_id"], "raw capture IDs must not be sent")
+        assertNil(sanitized["source_app_name"], "source app names must not be sent")
         assertNil(sanitized["word_count"], "raw counts should stay out of activation analytics")
     }
 
@@ -1461,4 +1481,27 @@ private func loadRepoText(_ relativePath: String, file: String = #file, line: In
         print("  FAIL [\(loc)] could not load \(relativePath): \(error)")
         return ""
     }
+}
+
+private func mcpAgentCaptureQueryAllowedProperties() -> Set<String> {
+    let source = loadRepoText("Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift")
+    guard let declaration = source.range(of: "static let allowedProperties: Set<String> = [") else {
+        return []
+    }
+
+    let afterDeclaration = String(source[declaration.upperBound...])
+    guard let closingBracket = afterDeclaration.range(of: "]") else {
+        return []
+    }
+
+    let literalBody = String(afterDeclaration[..<closingBracket.lowerBound])
+    return Set(
+        literalBody
+            .split(separator: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .compactMap { line -> String? in
+                let trimmed = line.trimmingCharacters(in: CharacterSet(charactersIn: "\","))
+                return trimmed.isEmpty ? nil : trimmed
+            }
+    )
 }

--- a/Tests/ClaudeDesktopIntegrationInstallerTests.swift
+++ b/Tests/ClaudeDesktopIntegrationInstallerTests.swift
@@ -696,6 +696,7 @@ func testClaudeDesktopIntegrationInstaller() {
         let bundledBinaryURL = tempRoot
             .appendingPathComponent("bundle", isDirectory: true)
             .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        let helperConfigURL = tempRoot.appendingPathComponent("mcp-observability.plist", isDirectory: false)
         defer { try? FileManager.default.removeItem(at: tempRoot) }
 
         try? FileManager.default.createDirectory(at: installedBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -707,7 +708,12 @@ func testClaudeDesktopIntegrationInstaller() {
 
         let refreshed = try? ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded(
             bundledBinaryURL: bundledBinaryURL,
-            installedBinaryURL: installedBinaryURL
+            installedBinaryURL: installedBinaryURL,
+            observabilityConfigURL: helperConfigURL,
+            infoDictionary: [
+                AnalyticsRuntimeConfiguration.apiKeyInfoKey: "phc_current",
+                AnalyticsRuntimeConfiguration.hostInfoKey: "https://us.i.posthog.com",
+            ]
         )
 
         assertEqual(refreshed, true, "stale installed helper should be refreshed at launch")
@@ -720,6 +726,10 @@ func testClaudeDesktopIntegrationInstaller() {
             FileManager.default.isExecutableFile(atPath: installedBinaryURL.path),
             "refreshed helper should stay executable"
         )
+        assertTrue(
+            FileManager.default.fileExists(atPath: helperConfigURL.path),
+            "refresh should keep installed-helper analytics config in sync"
+        )
     }
 
     runSuite("ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded — leaves a current helper untouched") {
@@ -731,6 +741,7 @@ func testClaudeDesktopIntegrationInstaller() {
         let bundledBinaryURL = tempRoot
             .appendingPathComponent("bundle", isDirectory: true)
             .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        let configURL = tempRoot.appendingPathComponent("mcp-observability.plist", isDirectory: false)
         defer { try? FileManager.default.removeItem(at: tempRoot) }
 
         try? FileManager.default.createDirectory(at: installedBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -742,10 +753,47 @@ func testClaudeDesktopIntegrationInstaller() {
 
         let refreshed = try? ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded(
             bundledBinaryURL: bundledBinaryURL,
-            installedBinaryURL: installedBinaryURL
+            installedBinaryURL: installedBinaryURL,
+            observabilityConfigURL: configURL,
+            infoDictionary: [
+                AnalyticsRuntimeConfiguration.apiKeyInfoKey: "phc_current",
+                AnalyticsRuntimeConfiguration.hostInfoKey: "https://us.i.posthog.com",
+            ]
         )
 
         assertEqual(refreshed, false, "matching helper should not be rewritten on every launch")
+        assertTrue(
+            FileManager.default.fileExists(atPath: configURL.path),
+            "current installed helper should still refresh analytics config"
+        )
+    }
+
+    runSuite("ClaudeDesktopIntegrationInstaller.writeMCPObservabilityConfigIfAvailable — removes stale invalid config") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeHelperObservabilityTests-\(UUID().uuidString)", isDirectory: true)
+        let configURL = tempRoot.appendingPathComponent("mcp-observability.plist", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try? FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        let stale = [
+            AnalyticsRuntimeConfiguration.apiKeyInfoKey: "phc_old",
+            AnalyticsRuntimeConfiguration.hostInfoKey: "https://us.i.posthog.com",
+        ]
+        let staleData = try? PropertyListSerialization.data(fromPropertyList: stale, format: .xml, options: 0)
+        try? staleData?.write(to: configURL)
+
+        try? ClaudeDesktopIntegrationInstaller.writeMCPObservabilityConfigIfAvailable(
+            configURL: configURL,
+            infoDictionary: [
+                AnalyticsRuntimeConfiguration.apiKeyInfoKey: "phc_new",
+                AnalyticsRuntimeConfiguration.hostInfoKey: "http://not-allowed.example",
+            ]
+        )
+
+        assertFalse(
+            FileManager.default.fileExists(atPath: configURL.path),
+            "invalid current app config should remove stale standalone helper analytics config"
+        )
     }
 
     runSuite("ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded — never installs fresh") {
@@ -757,6 +805,7 @@ func testClaudeDesktopIntegrationInstaller() {
         let bundledBinaryURL = tempRoot
             .appendingPathComponent("bundle", isDirectory: true)
             .appendingPathComponent("transcripted-mcp", isDirectory: false)
+        let configURL = tempRoot.appendingPathComponent("mcp-observability.plist", isDirectory: false)
         defer { try? FileManager.default.removeItem(at: tempRoot) }
 
         try? FileManager.default.createDirectory(at: bundledBinaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -765,13 +814,22 @@ func testClaudeDesktopIntegrationInstaller() {
 
         let refreshed = try? ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded(
             bundledBinaryURL: bundledBinaryURL,
-            installedBinaryURL: installedBinaryURL
+            installedBinaryURL: installedBinaryURL,
+            observabilityConfigURL: configURL,
+            infoDictionary: [
+                AnalyticsRuntimeConfiguration.apiKeyInfoKey: "phc_current",
+                AnalyticsRuntimeConfiguration.hostInfoKey: "https://us.i.posthog.com",
+            ]
         )
 
         assertEqual(refreshed, false, "refresh should not install a helper the user never set up")
         assertFalse(
             FileManager.default.fileExists(atPath: installedBinaryURL.path),
             "refresh must not create a new install without user consent"
+        )
+        assertFalse(
+            FileManager.default.fileExists(atPath: configURL.path),
+            "refresh must not create helper telemetry config before agent setup opt-in"
         )
     }
 

--- a/Tests/ClaudeDesktopIntegrationInstallerTests.swift
+++ b/Tests/ClaudeDesktopIntegrationInstallerTests.swift
@@ -796,6 +796,35 @@ func testClaudeDesktopIntegrationInstaller() {
         )
     }
 
+    runSuite("ClaudeDesktopIntegrationInstaller.writeMCPObservabilityConfigIfAvailable — removes config when analytics is disabled") {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptedClaudeHelperObservabilityOptOutTests-\(UUID().uuidString)", isDirectory: true)
+        let configURL = tempRoot.appendingPathComponent("mcp-observability.plist", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        try? FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        let stale = [
+            AnalyticsRuntimeConfiguration.apiKeyInfoKey: "phc_old",
+            AnalyticsRuntimeConfiguration.hostInfoKey: "https://us.i.posthog.com",
+        ]
+        let staleData = try? PropertyListSerialization.data(fromPropertyList: stale, format: .xml, options: 0)
+        try? staleData?.write(to: configURL)
+
+        try? ClaudeDesktopIntegrationInstaller.writeMCPObservabilityConfigIfAvailable(
+            configURL: configURL,
+            infoDictionary: [
+                AnalyticsRuntimeConfiguration.apiKeyInfoKey: "phc_current",
+                AnalyticsRuntimeConfiguration.hostInfoKey: "https://us.i.posthog.com",
+            ],
+            analyticsEnabled: false
+        )
+
+        assertFalse(
+            FileManager.default.fileExists(atPath: configURL.path),
+            "analytics opt-out should remove stale standalone helper analytics config"
+        )
+    }
+
     runSuite("ClaudeDesktopIntegrationInstaller.refreshInstalledHelperIfNeeded — never installs fresh") {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("TranscriptedClaudeHelperNoInstallTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift
@@ -1,0 +1,346 @@
+import Foundation
+
+private struct PostHogCaptureRequest: Encodable {
+    let apiKey: String
+    let event: String
+    let distinctID: String
+    let timestamp: String
+    let properties: [String: String]
+
+    enum CodingKeys: String, CodingKey {
+        case apiKey = "api_key"
+        case event
+        case distinctID = "distinct_id"
+        case timestamp
+        case properties
+    }
+}
+
+struct AgentCaptureQueryObservation: Equatable {
+    let agentTarget: String
+    let queryKind: String
+    let artifactKind: String
+    let result: String
+    let surface: String
+    let returnWindowBucket: String
+    let captureAgeBucket: String
+    let sourceCountBucket: String
+
+    init(
+        queryKind: String,
+        artifactKind: String,
+        result: String = "success",
+        surface: String = "mcp",
+        agentTarget: String = "mcp_client",
+        captureDate: Date? = nil,
+        sourceCount: Int? = nil,
+        now: Date = Date()
+    ) {
+        self.agentTarget = agentTarget
+        self.queryKind = queryKind
+        self.artifactKind = artifactKind
+        self.result = result
+        self.surface = surface
+        self.returnWindowBucket = Self.returnWindowBucket(since: captureDate, now: now)
+        self.captureAgeBucket = Self.captureAgeBucket(since: captureDate, now: now)
+        self.sourceCountBucket = Self.sourceCountBucket(sourceCount)
+    }
+
+    var properties: [String: String] {
+        [
+            "agent_target": agentTarget,
+            "artifact_kind": artifactKind,
+            "capture_age_bucket": captureAgeBucket,
+            "query_kind": queryKind,
+            "result": result,
+            "return_window_bucket": returnWindowBucket,
+            "source_count_bucket": sourceCountBucket,
+            "surface": surface,
+        ]
+    }
+
+    private static func captureAgeBucket(since date: Date?, now: Date) -> String {
+        guard let date else { return "unknown" }
+        let hours = max(0, now.timeIntervalSince(date)) / 3_600
+        switch hours {
+        case ..<12:
+            return "lt_12h"
+        case ..<24:
+            return "12_24h"
+        case ..<48:
+            return "24_48h"
+        case ..<168:
+            return "2_7d"
+        default:
+            return "older"
+        }
+    }
+
+    private static func returnWindowBucket(since date: Date?, now: Date) -> String {
+        guard let date else { return "unknown" }
+        let hours = max(0, now.timeIntervalSince(date)) / 3_600
+        switch hours {
+        case ..<18:
+            return "same_day"
+        case ..<36:
+            return "18_36h"
+        case ..<72:
+            return "36_72h"
+        case ..<168:
+            return "3_7d"
+        default:
+            return "older"
+        }
+    }
+
+    private static func sourceCountBucket(_ count: Int?) -> String {
+        guard let count else { return "unknown" }
+        switch count {
+        case ..<1:
+            return "0"
+        case 1:
+            return "1"
+        case 2...3:
+            return "2_3"
+        case 4...9:
+            return "4_9"
+        default:
+            return "10_plus"
+        }
+    }
+}
+
+enum AgentCaptureQueryTelemetryPolicy {
+    static let eventName = "agent_capture_query_observed"
+    static let allowedProperties: Set<String> = [
+        "agent_target",
+        "artifact_kind",
+        "capture_age_bucket",
+        "query_kind",
+        "result",
+        "return_window_bucket",
+        "source_count_bucket",
+        "surface",
+    ]
+    private static let sensitiveKeyFragments = [
+        "audio",
+        "authorization",
+        "bundle",
+        "credential",
+        "email",
+        "error",
+        "file",
+        "name",
+        "password",
+        "path",
+        "speaker",
+        "source_app",
+        "secret",
+        "text",
+        "title",
+        "token",
+        "transcript",
+        "url",
+    ]
+    private static let allowedValues: [String: Set<String>] = [
+        "agent_target": ["mcp_client"],
+        "artifact_kind": ["dictation", "meeting", "mixed"],
+        "capture_age_bucket": ["lt_12h", "12_24h", "24_48h", "2_7d", "older", "unknown"],
+        "query_kind": ["list", "read", "recap", "recent", "search", "speaker_lookup"],
+        "result": ["success"],
+        "return_window_bucket": ["same_day", "18_36h", "36_72h", "3_7d", "older", "unknown"],
+        "source_count_bucket": ["0", "1", "2_3", "4_9", "10_plus", "unknown"],
+        "surface": ["mcp"],
+    ]
+
+    static func sanitize(_ properties: [String: String]) -> [String: String] {
+        var sanitized: [String: String] = [:]
+        for (key, value) in properties {
+            guard allowedProperties.contains(key),
+                  !shouldDrop(key: key),
+                  allowedValues[key]?.contains(value) == true else {
+                continue
+            }
+            sanitized[key] = value
+        }
+        return sanitized
+    }
+
+    private static func shouldDrop(key: String) -> Bool {
+        let normalized = key.lowercased()
+        return sensitiveKeyFragments.contains { normalized.contains($0) }
+    }
+}
+
+struct AgentCaptureQueryTelemetryConfiguration {
+    let apiKey: String
+    let host: URL
+    let distinctID: String
+
+    static let apiKeyInfoKey = "TranscriptedPostHogAPIKey"
+    static let hostInfoKey = "TranscriptedPostHogHost"
+    private static let localOverridesFileName = "observability-overrides.plist"
+    private static let analyticsEnabledKey = "observability-anonymous-analytics-enabled"
+    private static let distinctIDKey = "observability-anonymous-analytics-id"
+
+    static func resolve(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        userDefaults: UserDefaults = .standard,
+        appSupportDirectory: URL? = nil,
+        bundleInfo: [String: Any]? = Bundle.main.infoDictionary
+    ) -> AgentCaptureQueryTelemetryConfiguration? {
+        guard analyticsEnabled(userDefaults: userDefaults),
+              let apiKey = firstNonEmpty(
+                environment["POSTHOG_API_KEY"],
+                localOverrideValue(forKey: apiKeyInfoKey, appSupportDirectory: appSupportDirectory),
+                bundleInfo?[apiKeyInfoKey] as? String
+              ),
+              let hostString = firstNonEmpty(
+                environment["POSTHOG_HOST"],
+                localOverrideValue(forKey: hostInfoKey, appSupportDirectory: appSupportDirectory),
+                bundleInfo?[hostInfoKey] as? String
+              ),
+              let host = URL(string: hostString),
+              ["https"].contains(host.scheme?.lowercased() ?? "") else {
+            return nil
+        }
+
+        let distinctID: String
+        if let existing = userDefaults.string(forKey: distinctIDKey), !existing.isEmpty {
+            distinctID = existing
+        } else {
+            let newValue = UUID().uuidString
+            userDefaults.set(newValue, forKey: distinctIDKey)
+            distinctID = newValue
+        }
+
+        return AgentCaptureQueryTelemetryConfiguration(apiKey: apiKey, host: host, distinctID: distinctID)
+    }
+
+    private static func analyticsEnabled(userDefaults: UserDefaults) -> Bool {
+        guard userDefaults.object(forKey: analyticsEnabledKey) != nil else { return true }
+        return userDefaults.bool(forKey: analyticsEnabledKey)
+    }
+
+    private static func localOverrideValue(forKey key: String, appSupportDirectory: URL?) -> String? {
+        let appSupport = appSupportDirectory ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        guard let appSupport else { return nil }
+
+        for url in [
+            appSupport
+                .appendingPathComponent("Transcripted", isDirectory: true)
+                .appendingPathComponent(localOverridesFileName),
+            appSupport
+                .appendingPathComponent("Draft", isDirectory: true)
+                .appendingPathComponent(localOverridesFileName),
+        ] {
+            guard let data = try? Data(contentsOf: url),
+                  let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
+                  let overrides = plist as? [String: String],
+                  let value = firstNonEmpty(overrides[key]) else {
+                continue
+            }
+            return value
+        }
+
+        return nil
+    }
+
+    private static func firstNonEmpty(_ candidates: String?...) -> String? {
+        candidates
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first(where: { !$0.isEmpty })
+    }
+}
+
+final class AgentCaptureQueryTelemetry {
+    static let shared = AgentCaptureQueryTelemetry()
+    private static let isoDateFormatter = ISO8601DateFormatter()
+    private let session: URLSession
+    private let configuration: AgentCaptureQueryTelemetryConfiguration?
+
+    init(
+        configuration: AgentCaptureQueryTelemetryConfiguration? = AgentCaptureQueryTelemetryConfiguration.resolve(),
+        session: URLSession = {
+            let config = URLSessionConfiguration.ephemeral
+            config.timeoutIntervalForRequest = 5
+            return URLSession(configuration: config)
+        }()
+    ) {
+        self.configuration = configuration
+        self.session = session
+    }
+
+    func track(_ observation: AgentCaptureQueryObservation) {
+        guard let request = makeRequest(for: observation) else { return }
+        session.dataTask(with: request).resume()
+    }
+
+    func makeRequest(for observation: AgentCaptureQueryObservation, now: Date = Date()) -> URLRequest? {
+        guard let configuration else { return nil }
+
+        let sanitized = AgentCaptureQueryTelemetryPolicy.sanitize(observation.properties)
+        guard sanitized.count == AgentCaptureQueryTelemetryPolicy.allowedProperties.count else {
+            return nil
+        }
+
+        let payload = PostHogCaptureRequest(
+            apiKey: configuration.apiKey,
+            event: AgentCaptureQueryTelemetryPolicy.eventName,
+            distinctID: configuration.distinctID,
+            timestamp: Self.isoDateFormatter.string(from: now),
+            properties: sanitized.merging(["distinct_id": configuration.distinctID]) { current, _ in current }
+        )
+
+        guard let data = try? JSONEncoder().encode(payload) else { return nil }
+
+        var request = URLRequest(url: configuration.host.appendingPathComponent("capture/"))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = data
+        return request
+    }
+}
+
+func trackAgentCaptureQueryObserved(
+    queryKind: String,
+    artifactKind: String,
+    captureDate: Date?,
+    sourceCount: Int?
+) {
+    AgentCaptureQueryTelemetry.shared.track(
+        AgentCaptureQueryObservation(
+            queryKind: queryKind,
+            artifactKind: artifactKind,
+            captureDate: captureDate,
+            sourceCount: sourceCount
+        )
+    )
+}
+
+func parseCaptureDate(_ raw: String?) -> Date? {
+    guard let raw, !raw.isEmpty else { return nil }
+
+    let iso = ISO8601DateFormatter()
+    iso.formatOptions = [.withInternetDateTime]
+    if let date = iso.date(from: raw) {
+        return date
+    }
+
+    let formats = [
+        "yyyy-MM-dd'T'HH:mm:ssZ",
+        "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
+        "yyyy-MM-dd HH:mm:ss",
+        "yyyy-MM-dd",
+    ]
+    for format in formats {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = format
+        if let date = formatter.date(from: raw) {
+            return date
+        }
+    }
+
+    return nil
+}

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift
@@ -149,7 +149,7 @@ enum AgentCaptureQueryTelemetryPolicy {
         "agent_target": ["mcp_client"],
         "artifact_kind": ["dictation", "meeting", "mixed"],
         "capture_age_bucket": ["lt_12h", "12_24h", "24_48h", "2_7d", "older", "unknown"],
-        "query_kind": ["list", "read", "recap", "recent", "search", "speaker_lookup"],
+        "query_kind": ["read", "recap", "search", "speaker_lookup"],
         "result": ["success"],
         "return_window_bucket": ["same_day", "18_36h", "36_72h", "3_7d", "older", "unknown"],
         "source_count_bucket": ["0", "1", "2_3", "4_9", "10_plus", "unknown"],

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift
@@ -112,6 +112,9 @@ struct AgentCaptureQueryObservation: Equatable {
 
 enum AgentCaptureQueryTelemetryPolicy {
     static let eventName = "agent_capture_query_observed"
+    // This standalone MCP package cannot import the app target, so this
+    // mirrors AnalyticsEventPolicy.agentCaptureQueryProperties. Keep the root
+    // AnalyticsEventPolicy parity test green when changing either side.
     static let allowedProperties: Set<String> = [
         "agent_target",
         "artifact_kind",
@@ -179,6 +182,8 @@ struct AgentCaptureQueryTelemetryConfiguration {
 
     static let apiKeyInfoKey = "TranscriptedPostHogAPIKey"
     static let hostInfoKey = "TranscriptedPostHogHost"
+    static let appDefaultsSuiteName = "com.justinbetker.draft"
+    static let mcpObservabilityFileName = "mcp-observability.plist"
     private static let localOverridesFileName = "observability-overrides.plist"
     private static let analyticsEnabledKey = "observability-anonymous-analytics-enabled"
     private static let distinctIDKey = "observability-anonymous-analytics-id"
@@ -186,10 +191,11 @@ struct AgentCaptureQueryTelemetryConfiguration {
     static func resolve(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         userDefaults: UserDefaults = .standard,
+        appUserDefaults: UserDefaults? = UserDefaults(suiteName: appDefaultsSuiteName),
         appSupportDirectory: URL? = nil,
         bundleInfo: [String: Any]? = Bundle.main.infoDictionary
     ) -> AgentCaptureQueryTelemetryConfiguration? {
-        guard analyticsEnabled(userDefaults: userDefaults),
+        guard analyticsEnabled(userDefaults: userDefaults, appUserDefaults: appUserDefaults),
               let apiKey = firstNonEmpty(
                 environment["POSTHOG_API_KEY"],
                 localOverrideValue(forKey: apiKeyInfoKey, appSupportDirectory: appSupportDirectory),
@@ -205,21 +211,31 @@ struct AgentCaptureQueryTelemetryConfiguration {
             return nil
         }
 
-        let distinctID: String
-        if let existing = userDefaults.string(forKey: distinctIDKey), !existing.isEmpty {
-            distinctID = existing
-        } else {
-            let newValue = UUID().uuidString
-            userDefaults.set(newValue, forKey: distinctIDKey)
-            distinctID = newValue
-        }
+        let distinctID = resolveDistinctID(userDefaults: userDefaults, appUserDefaults: appUserDefaults)
 
         return AgentCaptureQueryTelemetryConfiguration(apiKey: apiKey, host: host, distinctID: distinctID)
     }
 
-    private static func analyticsEnabled(userDefaults: UserDefaults) -> Bool {
+    private static func analyticsEnabled(userDefaults: UserDefaults, appUserDefaults: UserDefaults?) -> Bool {
+        if let appUserDefaults,
+           appUserDefaults.object(forKey: analyticsEnabledKey) != nil {
+            return appUserDefaults.bool(forKey: analyticsEnabledKey)
+        }
         guard userDefaults.object(forKey: analyticsEnabledKey) != nil else { return true }
         return userDefaults.bool(forKey: analyticsEnabledKey)
+    }
+
+    private static func resolveDistinctID(userDefaults: UserDefaults, appUserDefaults: UserDefaults?) -> String {
+        if let existing = appUserDefaults?.string(forKey: distinctIDKey), !existing.isEmpty {
+            return existing
+        }
+        if let existing = userDefaults.string(forKey: distinctIDKey), !existing.isEmpty {
+            return existing
+        }
+
+        let newValue = UUID().uuidString
+        (appUserDefaults ?? userDefaults).set(newValue, forKey: distinctIDKey)
+        return newValue
     }
 
     private static func localOverrideValue(forKey key: String, appSupportDirectory: URL?) -> String? {
@@ -233,6 +249,9 @@ struct AgentCaptureQueryTelemetryConfiguration {
             appSupport
                 .appendingPathComponent("Draft", isDirectory: true)
                 .appendingPathComponent(localOverridesFileName),
+            appSupport
+                .appendingPathComponent("Transcripted", isDirectory: true)
+                .appendingPathComponent(mcpObservabilityFileName),
         ] {
             guard let data = try? Data(contentsOf: url),
                   let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
@@ -257,17 +276,24 @@ final class AgentCaptureQueryTelemetry {
     static let shared = AgentCaptureQueryTelemetry()
     private static let isoDateFormatter = ISO8601DateFormatter()
     private let session: URLSession
-    private let configuration: AgentCaptureQueryTelemetryConfiguration?
+    private let configurationProvider: () -> AgentCaptureQueryTelemetryConfiguration?
 
     init(
-        configuration: AgentCaptureQueryTelemetryConfiguration? = AgentCaptureQueryTelemetryConfiguration.resolve(),
+        configuration: AgentCaptureQueryTelemetryConfiguration? = nil,
+        configurationProvider: (() -> AgentCaptureQueryTelemetryConfiguration?)? = nil,
         session: URLSession = {
             let config = URLSessionConfiguration.ephemeral
             config.timeoutIntervalForRequest = 5
             return URLSession(configuration: config)
         }()
     ) {
-        self.configuration = configuration
+        if let configurationProvider {
+            self.configurationProvider = configurationProvider
+        } else if let configuration {
+            self.configurationProvider = { configuration }
+        } else {
+            self.configurationProvider = { AgentCaptureQueryTelemetryConfiguration.resolve() }
+        }
         self.session = session
     }
 
@@ -277,7 +303,7 @@ final class AgentCaptureQueryTelemetry {
     }
 
     func makeRequest(for observation: AgentCaptureQueryObservation, now: Date = Date()) -> URLRequest? {
-        guard let configuration else { return nil }
+        guard let configuration = configurationProvider() else { return nil }
 
         let sanitized = AgentCaptureQueryTelemetryPolicy.sanitize(observation.properties)
         guard sanitized.count == AgentCaptureQueryTelemetryPolicy.allowedProperties.count else {
@@ -321,15 +347,21 @@ func trackAgentCaptureQueryObserved(
 func parseCaptureDate(_ raw: String?) -> Date? {
     guard let raw, !raw.isEmpty else { return nil }
 
-    let iso = ISO8601DateFormatter()
-    iso.formatOptions = [.withInternetDateTime]
-    if let date = iso.date(from: raw) {
-        return date
+    for options in [
+        ISO8601DateFormatter.Options.withInternetDateTime,
+        [.withInternetDateTime, .withFractionalSeconds],
+    ] {
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = options
+        if let date = iso.date(from: raw) {
+            return date
+        }
     }
 
     let formats = [
         "yyyy-MM-dd'T'HH:mm:ssZ",
         "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
+        "yyyy-MM-dd'T'HH:mm:ss",
         "yyyy-MM-dd HH:mm:ss",
         "yyyy-MM-dd",
     ]

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -292,13 +292,6 @@ private func handleListMeetings(params: CallTool.Parameters, index: TranscriptIn
         return textResult("No meetings found.")
     }
 
-    trackAgentCaptureQueryObserved(
-        queryKind: "list",
-        artifactKind: "meeting",
-        captureDate: latestMeetingDate(in: results),
-        sourceCount: results.count
-    )
-
     let json = try JSONEncoder.pretty.encode(results)
     return textResult(String(data: json, encoding: .utf8) ?? "[]")
 }
@@ -314,13 +307,6 @@ private func handleListDictations(params: CallTool.Parameters, index: Transcript
     if results.isEmpty {
         return textResult("No dictations found.")
     }
-
-    trackAgentCaptureQueryObserved(
-        queryKind: "list",
-        artifactKind: "dictation",
-        captureDate: latestDictationDayDate(in: results),
-        sourceCount: results.count
-    )
 
     let json = try JSONEncoder.pretty.encode(results)
     return textResult(String(data: json, encoding: .utf8) ?? "[]")
@@ -537,13 +523,6 @@ private func handleRecentContext(params: CallTool.Parameters, index: TranscriptI
         return textResult("No recent context found.")
     }
 
-    trackAgentCaptureQueryObserved(
-        queryKind: "recent",
-        artifactKind: artifactKind(for: result.items.map(\.kind)),
-        captureDate: latestRecentContextDate(in: result.items),
-        sourceCount: result.items.count
-    )
-
     let json = try JSONEncoder.pretty.encode(result)
     return textResult(String(data: json, encoding: .utf8) ?? "{}")
 }
@@ -728,23 +707,11 @@ private func formatDuration(_ seconds: Int) -> String {
     return "\(m)m"
 }
 
-private func latestMeetingDate(in results: [MeetingSummary]) -> Date? {
-    results.compactMap { parseCaptureDate($0.datetime) }.max()
-}
-
-private func latestDictationDayDate(in results: [DictationDaySummary]) -> Date? {
-    results.compactMap { parseCaptureDate($0.datetime) }.max()
-}
-
 private func latestMeetingSearchDate(in results: GroupedSearchResult) -> Date? {
     results.results.compactMap { parseCaptureDate($0.meetingDateTime) }.max()
 }
 
 private func latestContextSearchDate(in results: [ContextSearchGroup]) -> Date? {
-    results.compactMap { parseCaptureDate($0.datetime) }.max()
-}
-
-private func latestRecentContextDate(in results: [RecentContextItem]) -> Date? {
     results.compactMap { parseCaptureDate($0.datetime) }.max()
 }
 

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -292,6 +292,13 @@ private func handleListMeetings(params: CallTool.Parameters, index: TranscriptIn
         return textResult("No meetings found.")
     }
 
+    trackAgentCaptureQueryObserved(
+        queryKind: "list",
+        artifactKind: "meeting",
+        captureDate: latestMeetingDate(in: results),
+        sourceCount: results.count
+    )
+
     let json = try JSONEncoder.pretty.encode(results)
     return textResult(String(data: json, encoding: .utf8) ?? "[]")
 }
@@ -307,6 +314,13 @@ private func handleListDictations(params: CallTool.Parameters, index: Transcript
     if results.isEmpty {
         return textResult("No dictations found.")
     }
+
+    trackAgentCaptureQueryObserved(
+        queryKind: "list",
+        artifactKind: "dictation",
+        captureDate: latestDictationDayDate(in: results),
+        sourceCount: results.count
+    )
 
     let json = try JSONEncoder.pretty.encode(results)
     return textResult(String(data: json, encoding: .utf8) ?? "[]")
@@ -348,6 +362,13 @@ private func handleReadMeeting(params: CallTool.Parameters, meetingDirs: [URL]) 
     guard let content = try? String(contentsOf: mdURL, encoding: .utf8) else {
         return textResult("Meeting not found: \(filename). Use list_meetings to see available meetings.", isError: true)
     }
+
+    trackAgentCaptureQueryObserved(
+        queryKind: "read",
+        artifactKind: "meeting",
+        captureDate: captureDateFromMeetingMarkdown(content),
+        sourceCount: 1
+    )
 
     switch section {
     case "transcript":
@@ -400,6 +421,13 @@ private func handleReadDictation(params: CallTool.Parameters, dictationDirs: [UR
             return textResult("Entry not found: \(entryId). Use recent_context or search_context to inspect entry IDs.", isError: true)
         }
 
+        trackAgentCaptureQueryObserved(
+            queryKind: "read",
+            artifactKind: "dictation",
+            captureDate: parseCaptureDate(entry.createdAt),
+            sourceCount: 1
+        )
+
         let result = """
         # \(entry.title)
 
@@ -412,6 +440,13 @@ private func handleReadDictation(params: CallTool.Parameters, dictationDirs: [UR
         """
         return textResult(result)
     }
+
+    trackAgentCaptureQueryObserved(
+        queryKind: "read",
+        artifactKind: "dictation",
+        captureDate: parseCaptureDate(day.entries.last?.createdAt ?? day.date),
+        sourceCount: day.entries.count
+    )
 
     guard let content = try? String(contentsOf: markdownURL, encoding: .utf8) else {
         let json = try JSONEncoder.pretty.encode(day)
@@ -440,6 +475,13 @@ private func handleSearch(params: CallTool.Parameters, index: TranscriptIndex, m
         if let s = speaker { msg += " by \(s)" }
         return textResult(msg)
     }
+
+    trackAgentCaptureQueryObserved(
+        queryKind: "search",
+        artifactKind: "meeting",
+        captureDate: latestMeetingSearchDate(in: results),
+        sourceCount: results.results.count
+    )
 
     let json = try JSONEncoder.pretty.encode(results)
     return textResult(String(data: json, encoding: .utf8) ?? "[]")
@@ -471,6 +513,13 @@ private func handleSearchContext(params: CallTool.Parameters, index: TranscriptI
         return textResult("No context found for \"\(query)\".")
     }
 
+    trackAgentCaptureQueryObserved(
+        queryKind: "search",
+        artifactKind: artifactKind(for: results.results.map(\.kind)),
+        captureDate: latestContextSearchDate(in: results.results),
+        sourceCount: results.results.count
+    )
+
     let json = try JSONEncoder.pretty.encode(results)
     return textResult(String(data: json, encoding: .utf8) ?? "{}")
 }
@@ -488,6 +537,13 @@ private func handleRecentContext(params: CallTool.Parameters, index: TranscriptI
         return textResult("No recent context found.")
     }
 
+    trackAgentCaptureQueryObserved(
+        queryKind: "recent",
+        artifactKind: artifactKind(for: result.items.map(\.kind)),
+        captureDate: latestRecentContextDate(in: result.items),
+        sourceCount: result.items.count
+    )
+
     let json = try JSONEncoder.pretty.encode(result)
     return textResult(String(data: json, encoding: .utf8) ?? "{}")
 }
@@ -504,6 +560,13 @@ private func handleWhoIs(params: CallTool.Parameters, index: TranscriptIndex) th
     if profile.meetingCount == 0 {
         return textResult("No meetings found for \"\(speaker)\". Try a different name or use list_meetings to see known speakers.")
     }
+
+    trackAgentCaptureQueryObserved(
+        queryKind: "speaker_lookup",
+        artifactKind: "meeting",
+        captureDate: parseCaptureDate(profile.lastSeen),
+        sourceCount: profile.meetingCount
+    )
 
     let json = try JSONEncoder.pretty.encode(profile)
     return textResult(String(data: json, encoding: .utf8) ?? "{}")
@@ -555,6 +618,13 @@ private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, me
         dateRange: dateFrom == dateTo ? dateFrom : "\(dateFrom) to \(dateTo)",
         meetingCount: recapParts.count,
         meetings: recapParts
+    )
+
+    trackAgentCaptureQueryObserved(
+        queryKind: "recap",
+        artifactKind: "meeting",
+        captureDate: latestRecapDate(in: recapParts),
+        sourceCount: recapParts.count
     )
 
     let json = try JSONEncoder.pretty.encode(result)
@@ -656,6 +726,49 @@ private func formatDuration(_ seconds: Int) -> String {
     let m = (seconds % 3600) / 60
     if h > 0 { return "\(h)h \(m)m" }
     return "\(m)m"
+}
+
+private func latestMeetingDate(in results: [MeetingSummary]) -> Date? {
+    results.compactMap { parseCaptureDate($0.datetime) }.max()
+}
+
+private func latestDictationDayDate(in results: [DictationDaySummary]) -> Date? {
+    results.compactMap { parseCaptureDate($0.datetime) }.max()
+}
+
+private func latestMeetingSearchDate(in results: GroupedSearchResult) -> Date? {
+    results.results.compactMap { parseCaptureDate($0.meetingDateTime) }.max()
+}
+
+private func latestContextSearchDate(in results: [ContextSearchGroup]) -> Date? {
+    results.compactMap { parseCaptureDate($0.datetime) }.max()
+}
+
+private func latestRecentContextDate(in results: [RecentContextItem]) -> Date? {
+    results.compactMap { parseCaptureDate($0.datetime) }.max()
+}
+
+private func latestRecapDate(in results: [RecapEntry]) -> Date? {
+    results.compactMap { parseCaptureDate($0.datetime) }.max()
+}
+
+private func artifactKind(for kinds: [ContextKind]) -> String {
+    let set = Set(kinds)
+    if set.contains(.meeting), set.contains(.dictation) {
+        return "mixed"
+    }
+    if set.contains(.meeting) {
+        return "meeting"
+    }
+    if set.contains(.dictation) {
+        return "dictation"
+    }
+    return "mixed"
+}
+
+private func captureDateFromMeetingMarkdown(_ content: String) -> Date? {
+    guard let parsed = CaptureMarkdownParser.parseMeeting(from: content) else { return nil }
+    return parseCaptureDate(parsed.datetime)
 }
 
 extension JSONEncoder {

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/AgentCaptureQueryTelemetryTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/AgentCaptureQueryTelemetryTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import XCTest
+@testable import transcripted_mcp
+
+final class AgentCaptureQueryTelemetryTests: XCTestCase {
+    func testObservationKeepsOnlyBucketedPayload() throws {
+        let now = Date(timeIntervalSince1970: 1_766_102_400)
+        let captureDate = now.addingTimeInterval(-72 * 3_600)
+        let observation = AgentCaptureQueryObservation(
+            queryKind: "search",
+            artifactKind: "mixed",
+            captureDate: captureDate,
+            sourceCount: 4,
+            now: now
+        )
+
+        XCTAssertEqual(observation.properties["agent_target"], "mcp_client")
+        XCTAssertEqual(observation.properties["query_kind"], "search")
+        XCTAssertEqual(observation.properties["artifact_kind"], "mixed")
+        XCTAssertEqual(observation.properties["result"], "success")
+        XCTAssertEqual(observation.properties["surface"], "mcp")
+        XCTAssertEqual(observation.properties["return_window_bucket"], "3_7d")
+        XCTAssertEqual(observation.properties["capture_age_bucket"], "2_7d")
+        XCTAssertEqual(observation.properties["source_count_bucket"], "4_9")
+    }
+
+    func testTelemetryPolicyStripsForbiddenPayloads() throws {
+        let sanitized = AgentCaptureQueryTelemetryPolicy.sanitize([
+            "agent_target": "mcp_client",
+            "artifact_kind": "meeting",
+            "capture_age_bucket": "24_48h",
+            "query_kind": "read",
+            "result": "success",
+            "return_window_bucket": "18_36h",
+            "source_count_bucket": "1",
+            "surface": "mcp",
+            "query_text": "what did Alice say about the roadmap?",
+            "transcript_text": "private transcript words",
+            "speaker_name": "Alice",
+            "meeting_title": "Customer Roadmap",
+            "source_app_name": "Slack",
+            "file_path": "/Users/redbars/private.md",
+            "raw_capture_id": "cap_private",
+            "url": "https://example.com/private",
+            "token": "secret",
+        ])
+
+        XCTAssertEqual(sanitized["agent_target"], "mcp_client")
+        XCTAssertEqual(sanitized["artifact_kind"], "meeting")
+        XCTAssertEqual(sanitized["capture_age_bucket"], "24_48h")
+        XCTAssertEqual(sanitized["query_kind"], "read")
+        XCTAssertEqual(sanitized["result"], "success")
+        XCTAssertEqual(sanitized["return_window_bucket"], "18_36h")
+        XCTAssertEqual(sanitized["source_count_bucket"], "1")
+        XCTAssertEqual(sanitized["surface"], "mcp")
+        XCTAssertNil(sanitized["query_text"])
+        XCTAssertNil(sanitized["transcript_text"])
+        XCTAssertNil(sanitized["speaker_name"])
+        XCTAssertNil(sanitized["meeting_title"])
+        XCTAssertNil(sanitized["source_app_name"])
+        XCTAssertNil(sanitized["file_path"])
+        XCTAssertNil(sanitized["raw_capture_id"])
+        XCTAssertNil(sanitized["url"])
+        XCTAssertNil(sanitized["token"])
+    }
+
+    func testTelemetryPolicyRejectsUnexpectedEnumValues() throws {
+        let sanitized = AgentCaptureQueryTelemetryPolicy.sanitize([
+            "agent_target": "raw-agent-name",
+            "artifact_kind": "meeting",
+            "capture_age_bucket": "24_48h",
+            "query_kind": "raw prompt: customer roadmap",
+            "result": "success",
+            "return_window_bucket": "18_36h",
+            "source_count_bucket": "1",
+            "surface": "mcp",
+        ])
+
+        XCTAssertNil(sanitized["agent_target"])
+        XCTAssertNil(sanitized["query_kind"])
+        XCTAssertEqual(sanitized["artifact_kind"], "meeting")
+    }
+
+    func testReporterBuildsPostHogCaptureWithoutPrivateFields() throws {
+        let configuration = AgentCaptureQueryTelemetryConfiguration(
+            apiKey: "phc_test",
+            host: URL(string: "https://us.i.posthog.com")!,
+            distinctID: "anonymous-device"
+        )
+        let reporter = AgentCaptureQueryTelemetry(configuration: configuration)
+        let request = try XCTUnwrap(reporter.makeRequest(
+            for: AgentCaptureQueryObservation(
+                queryKind: "read",
+                artifactKind: "dictation",
+                captureDate: nil,
+                sourceCount: 1
+            ),
+            now: Date(timeIntervalSince1970: 1_766_102_400)
+        ))
+
+        XCTAssertEqual(request.url?.absoluteString, "https://us.i.posthog.com/capture/")
+        XCTAssertEqual(request.httpMethod, "POST")
+
+        let body = try XCTUnwrap(request.httpBody)
+        let object = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        XCTAssertEqual(object?["event"] as? String, "agent_capture_query_observed")
+
+        let properties = try XCTUnwrap(object?["properties"] as? [String: String])
+        XCTAssertEqual(properties["agent_target"], "mcp_client")
+        XCTAssertEqual(properties["artifact_kind"], "dictation")
+        XCTAssertEqual(properties["query_kind"], "read")
+        XCTAssertEqual(properties["surface"], "mcp")
+        XCTAssertEqual(properties["source_count_bucket"], "1")
+        XCTAssertNil(properties["query_text"])
+        XCTAssertNil(properties["transcript_text"])
+        XCTAssertNil(properties["file_path"])
+        XCTAssertNil(properties["meeting_title"])
+        XCTAssertNil(properties["source_app_name"])
+    }
+
+    func testConfigurationUsesOverridesAndHonorsAnalyticsOptOut() throws {
+        let appSupport = makeTempDir()
+        defer { removeTempDir(appSupport) }
+        let transcriptedSupport = appSupport.appendingPathComponent("Transcripted", isDirectory: true)
+        try FileManager.default.createDirectory(at: transcriptedSupport, withIntermediateDirectories: true)
+        let overrides = [
+            AgentCaptureQueryTelemetryConfiguration.apiKeyInfoKey: "phc_override",
+            AgentCaptureQueryTelemetryConfiguration.hostInfoKey: "https://us.i.posthog.com",
+        ]
+        let data = try PropertyListSerialization.data(fromPropertyList: overrides, format: .xml, options: 0)
+        try data.write(to: transcriptedSupport.appendingPathComponent("observability-overrides.plist"))
+
+        let suiteName = "AgentCaptureQueryTelemetryTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let enabled = AgentCaptureQueryTelemetryConfiguration.resolve(
+            environment: [:],
+            userDefaults: defaults,
+            appSupportDirectory: appSupport,
+            bundleInfo: [:]
+        )
+        XCTAssertEqual(enabled?.apiKey, "phc_override")
+        XCTAssertEqual(enabled?.host.absoluteString, "https://us.i.posthog.com")
+
+        defaults.set(false, forKey: "observability-anonymous-analytics-enabled")
+        let disabled = AgentCaptureQueryTelemetryConfiguration.resolve(
+            environment: [:],
+            userDefaults: defaults,
+            appSupportDirectory: appSupport,
+            bundleInfo: [:]
+        )
+        XCTAssertNil(disabled)
+    }
+}

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/AgentCaptureQueryTelemetryTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/AgentCaptureQueryTelemetryTests.swift
@@ -118,6 +118,60 @@ final class AgentCaptureQueryTelemetryTests: XCTestCase {
         XCTAssertNil(properties["source_app_name"])
     }
 
+    func testReporterRechecksConfigurationBeforeEachRequest() throws {
+        let configuration = AgentCaptureQueryTelemetryConfiguration(
+            apiKey: "phc_test",
+            host: URL(string: "https://us.i.posthog.com")!,
+            distinctID: "anonymous-device"
+        )
+        var enabled = true
+        let reporter = AgentCaptureQueryTelemetry(configurationProvider: {
+            enabled ? configuration : nil
+        })
+        let observation = AgentCaptureQueryObservation(
+            queryKind: "read",
+            artifactKind: "meeting",
+            captureDate: nil,
+            sourceCount: 1
+        )
+
+        XCTAssertNotNil(reporter.makeRequest(for: observation))
+
+        enabled = false
+        XCTAssertNil(
+            reporter.makeRequest(for: observation),
+            "long-running MCP servers must honor analytics opt-out changes before sending the next event"
+        )
+    }
+
+    func testParseCaptureDateAcceptsMeetingDateTimeWithoutZone() throws {
+        let date = try XCTUnwrap(parseCaptureDate("2026-04-18T09:15:00"))
+        let observation = AgentCaptureQueryObservation(
+            queryKind: "read",
+            artifactKind: "meeting",
+            captureDate: date,
+            sourceCount: 1,
+            now: Date(timeIntervalSince1970: 1_766_102_400)
+        )
+
+        XCTAssertNotEqual(observation.properties["capture_age_bucket"], "unknown")
+        XCTAssertNotEqual(observation.properties["return_window_bucket"], "unknown")
+    }
+
+    func testParseCaptureDateAcceptsDictationFractionalISO() throws {
+        let date = try XCTUnwrap(parseCaptureDate("2026-04-18T09:15:00.123Z"))
+        let observation = AgentCaptureQueryObservation(
+            queryKind: "search",
+            artifactKind: "dictation",
+            captureDate: date,
+            sourceCount: 1,
+            now: Date(timeIntervalSince1970: 1_766_102_400)
+        )
+
+        XCTAssertNotEqual(observation.properties["capture_age_bucket"], "unknown")
+        XCTAssertNotEqual(observation.properties["return_window_bucket"], "unknown")
+    }
+
     func testConfigurationUsesOverridesAndHonorsAnalyticsOptOut() throws {
         let appSupport = makeTempDir()
         defer { removeTempDir(appSupport) }
@@ -137,6 +191,7 @@ final class AgentCaptureQueryTelemetryTests: XCTestCase {
         let enabled = AgentCaptureQueryTelemetryConfiguration.resolve(
             environment: [:],
             userDefaults: defaults,
+            appUserDefaults: nil,
             appSupportDirectory: appSupport,
             bundleInfo: [:]
         )
@@ -147,9 +202,102 @@ final class AgentCaptureQueryTelemetryTests: XCTestCase {
         let disabled = AgentCaptureQueryTelemetryConfiguration.resolve(
             environment: [:],
             userDefaults: defaults,
+            appUserDefaults: nil,
             appSupportDirectory: appSupport,
             bundleInfo: [:]
         )
         XCTAssertNil(disabled)
+    }
+
+    func testConfigurationUsesInstalledHelperObservabilityConfig() throws {
+        let appSupport = makeTempDir()
+        defer { removeTempDir(appSupport) }
+        let transcriptedSupport = appSupport.appendingPathComponent("Transcripted", isDirectory: true)
+        try FileManager.default.createDirectory(at: transcriptedSupport, withIntermediateDirectories: true)
+        let helperConfig = [
+            AgentCaptureQueryTelemetryConfiguration.apiKeyInfoKey: "phc_helper",
+            AgentCaptureQueryTelemetryConfiguration.hostInfoKey: "https://us.i.posthog.com",
+        ]
+        let data = try PropertyListSerialization.data(fromPropertyList: helperConfig, format: .xml, options: 0)
+        try data.write(to: transcriptedSupport.appendingPathComponent(AgentCaptureQueryTelemetryConfiguration.mcpObservabilityFileName))
+
+        let suiteName = "AgentCaptureQueryTelemetryTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let configuration = AgentCaptureQueryTelemetryConfiguration.resolve(
+            environment: [:],
+            userDefaults: defaults,
+            appUserDefaults: nil,
+            appSupportDirectory: appSupport,
+            bundleInfo: [:]
+        )
+
+        XCTAssertEqual(configuration?.apiKey, "phc_helper")
+        XCTAssertEqual(configuration?.host.absoluteString, "https://us.i.posthog.com")
+    }
+
+    func testConfigurationHonorsAppDefaultsOptOutBeforeHelperDefaults() throws {
+        let appSupport = makeTempDir()
+        defer { removeTempDir(appSupport) }
+
+        let helperSuiteName = "AgentCaptureQueryTelemetryTests.helper.\(UUID().uuidString)"
+        let appSuiteName = "AgentCaptureQueryTelemetryTests.app.\(UUID().uuidString)"
+        let helperDefaults = try XCTUnwrap(UserDefaults(suiteName: helperSuiteName))
+        let appDefaults = try XCTUnwrap(UserDefaults(suiteName: appSuiteName))
+        defer {
+            helperDefaults.removePersistentDomain(forName: helperSuiteName)
+            appDefaults.removePersistentDomain(forName: appSuiteName)
+        }
+
+        helperDefaults.set(true, forKey: "observability-anonymous-analytics-enabled")
+        appDefaults.set(false, forKey: "observability-anonymous-analytics-enabled")
+        helperDefaults.set("helper-device", forKey: "observability-anonymous-analytics-id")
+        appDefaults.set("app-device", forKey: "observability-anonymous-analytics-id")
+
+        let disabled = AgentCaptureQueryTelemetryConfiguration.resolve(
+            environment: [
+                "POSTHOG_API_KEY": "phc_env",
+                "POSTHOG_HOST": "https://us.i.posthog.com",
+            ],
+            userDefaults: helperDefaults,
+            appUserDefaults: appDefaults,
+            appSupportDirectory: appSupport,
+            bundleInfo: [:]
+        )
+
+        XCTAssertNil(disabled)
+    }
+
+    func testConfigurationUsesAppDefaultsDistinctIDWhenEnabled() throws {
+        let appSupport = makeTempDir()
+        defer { removeTempDir(appSupport) }
+
+        let helperSuiteName = "AgentCaptureQueryTelemetryTests.helper.\(UUID().uuidString)"
+        let appSuiteName = "AgentCaptureQueryTelemetryTests.app.\(UUID().uuidString)"
+        let helperDefaults = try XCTUnwrap(UserDefaults(suiteName: helperSuiteName))
+        let appDefaults = try XCTUnwrap(UserDefaults(suiteName: appSuiteName))
+        defer {
+            helperDefaults.removePersistentDomain(forName: helperSuiteName)
+            appDefaults.removePersistentDomain(forName: appSuiteName)
+        }
+
+        helperDefaults.set(false, forKey: "observability-anonymous-analytics-enabled")
+        appDefaults.set(true, forKey: "observability-anonymous-analytics-enabled")
+        helperDefaults.set("helper-device", forKey: "observability-anonymous-analytics-id")
+        appDefaults.set("app-device", forKey: "observability-anonymous-analytics-id")
+
+        let configuration = AgentCaptureQueryTelemetryConfiguration.resolve(
+            environment: [
+                "POSTHOG_API_KEY": "phc_env",
+                "POSTHOG_HOST": "https://us.i.posthog.com",
+            ],
+            userDefaults: helperDefaults,
+            appUserDefaults: appDefaults,
+            appSupportDirectory: appSupport,
+            bundleInfo: [:]
+        )
+
+        XCTAssertEqual(configuration?.distinctID, "app-device")
     }
 }

--- a/config/security/nightly-security-manifest.json
+++ b/config/security/nightly-security-manifest.json
@@ -53,7 +53,8 @@
     "activation_artifact_action_clicked",
     "activation_agent_prompt_action_clicked",
     "activation_agent_setup_cta_clicked",
-    "activation_return_proxy_observed"
+    "activation_return_proxy_observed",
+    "agent_capture_query_observed"
   ],
   "disallowed_observability_payload_keys": [
     "app_identifier",

--- a/docs/install-attribution-map.md
+++ b/docs/install-attribution-map.md
@@ -31,6 +31,8 @@ through `AnalyticsEventPolicy` and `AnalyticsPayloadSanitizer`.
 | Saved-artifact continuity | `dictation_artifact_saved`, `onboarding_first_dictation_saved`, `dictation_completed`, `meeting_transcript_saved` | PostHog | Strict dictation-save proof plus legacy/proxy rows for older builds and useful-dictation volume. Do not use `dictation_completed` as strict saved-artifact proof when saved-artifact events are available. |
 | Second value moment | `activation_second_artifact_saved` | PostHog | Shows a second durable saved artifact on the same anonymous device, with only kind and day-bucket fields. |
 | Agent payoff | `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_agent_setup_cta_clicked`, `activation_return_proxy_observed` | PostHog | Coarse proof of opening artifacts, copying/using agent prompts, setup CTAs, and later return via Home. |
+| First useful artifact | `onboarding_first_dictation_saved`, `dictation_completed`, `meeting_transcript_saved` | PostHog | Shows local Markdown value without inspecting content. |
+| Agent payoff | `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_agent_setup_cta_clicked`, `agent_capture_query_observed`, `activation_return_proxy_observed` | PostHog | Coarse proof of opening artifacts, copying/using agent prompts, setup CTAs, successful MCP capture queries, and later return via Home. |
 | Reliability filter | Release-scoped issues and allowed non-fatal events | Sentry | Use to avoid mistaking broken first-run paths for weak demand. |
 
 ## Standard Read-Only Checks
@@ -82,6 +84,11 @@ For the attribution story, report:
   agent answer quality.
 - Artifact events do not prove agent answer quality. The closest safe proxy is
   `activation_agent_prompt_action_clicked` plus `activation_return_proxy_observed`.
+  `dictation_completed`, `onboarding_first_dictation_saved`, and
+  `meeting_transcript_saved` for value.
+- Artifact and prompt events do not prove agent answer quality. Use
+  `agent_capture_query_observed` for successful saved-capture MCP reads/searches,
+  then pair it with `activation_return_proxy_observed` for return behavior.
 
 If the story is still fuzzy after these checks, prefer adding a coarse
 allowlisted event or aggregate script output over adding tracking IDs.

--- a/docs/ops-credentials.md
+++ b/docs/ops-credentials.md
@@ -70,8 +70,8 @@ launch -> onboarding -> permission ready -> first dictation -> saved Markdown
 export distinct IDs, person rows, transcript text, file paths, meeting titles,
 raw URLs, or raw payload rows. Treat the agent setup and prompt-copy rows as
 proxies only; they are not proof that an agent answered from a saved artifact.
-The desired true-use event is `agent_capture_query_observed`, which should stay
-zero/unknown until that privacy-safe instrumentation exists.
+The true-use event is `agent_capture_query_observed`, emitted by successful MCP
+reads/searches with enum and bucket properties only.
 
 For an AI-agent-ready product context pack, run:
 

--- a/docs/posthog-product-learning-plan.md
+++ b/docs/posthog-product-learning-plan.md
@@ -95,6 +95,7 @@ Operational scripts query aggregate counts only:
 | `agent_capture_query_observed` | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket` |
 | `activation_return_proxy_observed` | `prior_artifact_kind`, `proxy_kind`, `return_window_bucket`, `surface` |
 | `workflow_abandoned` | `elapsed_bucket`, `prior_ready_state`, `reason_kind`, `stage`, `surface`, `workflow_kind` |
+| `agent_capture_query_observed` | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket`, `source_count_bucket` |
 
 ### Menu, Settings, Updates
 
@@ -196,6 +197,10 @@ aggregate reliability sizing and should not be expanded to raw device names.
   that an agent actually answered from a saved Transcripted artifact.
 - General dictation saved-Markdown writes now have `dictation_artifact_saved`;
   keep `dictation_completed` as completion-volume context, not strict saved-artifact proof.
+- `agent_capture_query_observed` proves successful saved-capture reads/searches
+  through MCP, but it still cannot judge answer quality.
+- General dictation saved-Markdown writes still rely on `dictation_completed`
+  as a proxy, while onboarding dictation and meeting saves have stricter events.
 - Settings/action tracking is broad enough to show discovery, but it does not
   always connect settings changes to later workflow success.
 - Local summary beta behavior now has abandonment shape, but not a full success
@@ -215,6 +220,9 @@ Prefer a small number of lifecycle events over broad click tracking.
 | Event | When to fire | Properties |
 | --- | --- | --- |
 | `agent_capture_query_observed` | The local MCP/agent layer observes a privacy-safe query against saved captures | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket` |
+| `agent_capture_query_observed` | The local MCP/agent layer observes a privacy-safe query against saved captures | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket`, `source_count_bucket` |
+| `activation_second_artifact_saved` | A device saves its second artifact | `first_artifact_kind`, `second_artifact_kind`, `days_since_first_bucket`, `surface`, `trigger` |
+| `dictation_artifact_saved` | Any normal dictation Markdown is durably saved | `delivery`, `duration_bucket`, `save_outcome`, `surface`, `trigger`, `word_count_bucket` |
 | `dictation_retry_started` | User retries after a failed or empty dictation | `failure_kind`, `retry_source`, `route_shape`, `trigger` |
 | `meeting_speaker_review_prompted` | A saved meeting has review work surfaced | `participant_count_bucket`, `review_reason`, `surface` |
 | `meeting_speaker_review_completed` | User completes or dismisses speaker review | `participant_count_bucket`, `result`, `surface` |
@@ -337,14 +345,13 @@ The 2026-06-19 aggregate probes showed:
   850 first-value events.
 - Last 30 days: 214 launch devices, 37 strict saved-Markdown devices, 43
   saved-Markdown-plus-dictation-proxy devices, 32 agent setup/proxy devices,
-  17 return-proxy devices, 0 true agent-query devices.
+  17 return-proxy devices, and true agent-query devices from `agent_capture_query_observed`.
 
 Interpretation: product usage is real, but the current analytics still cannot
 prove the full saved-artifact -> sourced-agent-answer -> return loop.
 
 ## Smallest Next Implementation
 
-Add `agent_capture_query_observed` from the read-only MCP/agent surface when an
-opted-in device observes a query against saved captures. Keep it enum-only and
-bucketed. That is higher leverage than broad click tracking because it closes
-the biggest product-learning gap without inspecting content.
+Keep `agent_capture_query_observed` narrow in the read-only MCP/agent surface:
+only successful saved-capture reads/searches, enum values, and coarse buckets.
+That closes the biggest product-learning gap without inspecting content.

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -106,6 +106,7 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `activation_return_proxy_observed`
 - `workflow_abandoned`
 - `product_friction_observed`
+- `agent_capture_query_observed`
 - `menu_bar_opened`
 - `menu_bar_action_clicked`
 - `update_action_clicked`

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -106,7 +106,6 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `activation_return_proxy_observed`
 - `workflow_abandoned`
 - `product_friction_observed`
-- `agent_capture_query_observed`
 - `menu_bar_opened`
 - `menu_bar_action_clicked`
 - `update_action_clicked`


### PR DESCRIPTION
## Summary
- Consolidates the June 19 telemetry swarm around the one still-dark activation node: `agent_capture_query_observed`.
- Emits the event from the read-only MCP helper only after successful saved-capture read/search/recap/speaker lookup results, with enum/bucket-only payloads.
- Installs a helper observability config only for opted-in agent setup and removes it when anonymous analytics is disabled.

## Swarm cleanup
- Keep/merge this PR as the successor to #1215.
- #1211, #1217, #1220, #1221, and #1222 are already merged into `main`.
- Close #1215 after this lands: superseded by this rebased, tightened branch.
- Close #1218: speaker review telemetry is off the saved Markdown -> agent answer -> return path.
- Supersede #1214/#1216/#1219: each has possible future slivers, but the current PRs are broad/conflicting and duplicate merged telemetry. Reopen narrower PRs only if those slivers still matter.

## Privacy proof
- No transcript text, query text, meeting titles, speaker names, source app names, raw file paths, raw URLs, device names, emails, tokens, or raw identifiers are sent.
- MCP telemetry fails closed unless every property is allowlisted and has an expected enum/bucket value.
- App and MCP allowlists are parity-tested.
- Analytics opt-out removes the installed helper telemetry config and the MCP rechecks opt-out before each request.

## Verification
- `bash scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` — 10,411 passed
- `swift test --package-path Tools/TranscriptedMCP` — 85 passed
- `bash run-e2e-smoke.sh`
- Claude final review: no blocking findings; proof path `/Users/redbars/.codex/maestro/runs/20260620T111132Z-transcripted-agent-query-final-review-claude`

lanes used: Codex=live GitHub state, implementation, rebase, tests, PR; Claude=survivor review + final diff review; Local=attempted clustering, low value; Windows=skipped because Codex/Claude covered the risky work
