### PR TITLE
Tighten storage artifact writes

### DIFF
--- a/Sources/Dictation/DictationTranscriptWriter.swift
+++ b/Sources/Dictation/DictationTranscriptWriter.swift
@@ -217,29 +217,11 @@ enum DictationTranscriptWriter {
     }
 
     private static func appendSection(_ section: String, to url: URL) throws {
-        guard let handle = FileHandle(forWritingAtPath: url.path) else {
-            throw NSError(
-                domain: "DictationTranscriptWriter",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "Could not open dictation transcript for appending."]
-            )
-        }
-        defer { try? handle.close() }
-
-        let separator = fileEndsWithBlankLine(url) ? "" : "\n\n"
-        guard let data = (separator + section).data(using: .utf8) else { return }
-        handle.seekToEndOfFile()
-        handle.write(data)
-    }
-
-    private static func fileEndsWithBlankLine(_ url: URL) -> Bool {
-        guard let handle = FileHandle(forReadingAtPath: url.path) else { return false }
-        defer { try? handle.close() }
-
-        let fileLength = handle.seekToEndOfFile()
-        guard fileLength >= 2 else { return false }
-        handle.seek(toFileOffset: fileLength - 2)
-        return handle.readDataToEndOfFile() == Data([0x0A, 0x0A])
+        var data = try Data(contentsOf: url)
+        let separator = data.suffix(2) == Data([0x0A, 0x0A]) ? "" : "\n\n"
+        guard let appended = (separator + section).data(using: .utf8) else { return }
+        data.append(appended)
+        try data.write(to: url, options: .atomic)
     }
 
     private static func buildTitle(from text: String, createdAt: Date) -> String {

--- a/Sources/Meeting/MeetingAudioStorageManager.swift
+++ b/Sources/Meeting/MeetingAudioStorageManager.swift
@@ -907,10 +907,7 @@ enum MeetingAudioStorageManager {
     }
 
     private static func audioDirectoryURL(forTranscript transcriptURL: URL) -> URL {
-        transcriptURL
-            .deletingLastPathComponent()
-            .appendingPathComponent("audio", isDirectory: true)
-            .appendingPathComponent("\(transcriptURL.deletingPathExtension().lastPathComponent)_audio", isDirectory: true)
+        MeetingArtifactRenamer.audioDirectoryURL(for: transcriptURL)
     }
 
     private static func isAudioArchiveDirectory(_ url: URL, fileManager: FileManager) -> Bool {

--- a/Sources/UI/Shared/MeetingAudioArchiveResolver.swift
+++ b/Sources/UI/Shared/MeetingAudioArchiveResolver.swift
@@ -201,10 +201,7 @@ enum MeetingAudioArchiveResolver {
     }
 
     static func archiveDirectory(forTranscript transcriptURL: URL) -> URL {
-        transcriptURL
-            .deletingLastPathComponent()
-            .appendingPathComponent("audio", isDirectory: true)
-            .appendingPathComponent("\(transcriptURL.deletingPathExtension().lastPathComponent)_audio", isDirectory: true)
+        MeetingArtifactRenamer.audioDirectoryURL(for: transcriptURL)
     }
 
     private static func firstAudioFile(named stem: String, in urls: [URL]) -> URL? {

--- a/Tests/MeetingAudioArchiveResolverTests.swift
+++ b/Tests/MeetingAudioArchiveResolverTests.swift
@@ -2,6 +2,7 @@ import Foundation
 
 func testMeetingAudioArchiveResolver() {
     runSuite("MeetingAudioArchiveResolverTests") {
+        testResolverUsesCanonicalMeetingArtifactAudioDirectory()
         testResolverKeepsLiveMeetingAudioPairButUsesSinglePlaybackSource()
         testResolverFallsBackToMicrophonePlayback()
         testAttachmentPlaybackPrefersSystemForFailedMeetingAudio()
@@ -16,6 +17,16 @@ func testMeetingAudioArchiveResolver() {
         testRetranscriptionInputMapsLiveSplitStreams()
         testRetranscriptionInputMapsSingleRecording()
     }
+}
+
+private func testResolverUsesCanonicalMeetingArtifactAudioDirectory() {
+    let transcriptURL = URL(fileURLWithPath: "/tmp/Transcripted Meeting.md", isDirectory: false)
+
+    assertEqual(
+        MeetingAudioArchiveResolver.archiveDirectory(forTranscript: transcriptURL).path,
+        MeetingArtifactRenamer.audioDirectoryURL(for: transcriptURL).path,
+        "Retained-audio playback should use the same archive path convention as meeting renames"
+    )
 }
 
 private func testResolverKeepsLiveMeetingAudioPairButUsesSinglePlaybackSource() {


### PR DESCRIPTION
## Summary
- Rewrite dictation day-file appends through an atomic data write under the existing mutation lock.
- Route retained meeting-audio archive path resolution through the canonical MeetingArtifactRenamer helper.
- Add a drift guard so playback resolution stays aligned with meeting artifact rename paths.

## Verification
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh --filter DictationTranscriptWriter
- bash run-tests.sh
- bash run-integration-smoke.sh

Note: an initial parallel run of bash run-tests.sh collided with bash build.sh over the generated build/FastTestRunner file; rerun solo passed with 10421/10421 tests.

## Independent review
- Claude diff review: no blockers.
- Proof: /Users/redbars/.codex/maestro/runs/20260620T122048Z-storage-pr-diff-review-claude
- One irrelevant review line mentioned an enum removal not present in this diff; no action taken.

## Audit notes
- Claude storage audit also flagged QA path-resolution drift and non-atomic multi-artifact meeting rename as follow-up candidates.
- Proof: /Users/redbars/.codex/maestro/runs/20260620T120004Z-storage-architecture-audit-claude