### PR TITLE
Extract meeting capture health telemetry policy

### DIFF
--- a/Sources/Meeting/MeetingCaptureHealthTelemetry.swift
+++ b/Sources/Meeting/MeetingCaptureHealthTelemetry.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+enum MeetingCaptureHealthTelemetry {
+    struct HealthFacts {
+        let captureQuality: String
+        let audioGaps: Int
+        let deviceSwitches: Int
+    }
+
+    struct SnapshotInput {
+        let captureDiagnostics: [String: String]
+        let health: HealthFacts
+        let trigger: String
+        let reason: String
+        let durationSeconds: Double
+        let systemStreamPresent: Bool
+        let stopTimedOut: Bool
+    }
+
+    struct DegradedReportInput {
+        let captureDiagnostics: [String: String]
+        let health: HealthFacts
+        let trigger: String
+        let reason: String
+        let durationSeconds: Double
+        let micFileAvailable: Bool
+        let systemStreamPresent: Bool
+        let stopTimedOut: Bool
+        let systemFailed: Bool
+        let systemStatus: String
+    }
+
+    static func snapshotProperties(_ input: SnapshotInput) -> [String: String] {
+        input.captureDiagnostics.merging(
+            sharedProperties(
+                health: input.health,
+                trigger: input.trigger,
+                reason: input.reason,
+                durationSeconds: input.durationSeconds,
+                systemStreamPresent: input.systemStreamPresent,
+                stopTimedOut: input.stopTimedOut
+            ),
+            uniquingKeysWith: { _, new in new }
+        )
+    }
+
+    static func shouldReportDegraded(_ input: DegradedReportInput) -> Bool {
+        input.stopTimedOut
+            || !input.micFileAvailable
+            || input.health.captureQuality == "degraded"
+            || input.systemFailed
+            || input.systemStatus == "failed"
+    }
+
+    static func degradedDiagnosticsContext(_ input: DegradedReportInput) -> [String: String]? {
+        guard shouldReportDegraded(input) else { return nil }
+
+        var context = input.captureDiagnostics
+        context.removeValue(forKey: "gap_count")
+        context.removeValue(forKey: "route_change_count")
+        context.merge(
+            sharedProperties(
+                health: input.health,
+                trigger: input.trigger,
+                reason: input.reason,
+                durationSeconds: input.durationSeconds,
+                systemStreamPresent: input.systemStreamPresent,
+                stopTimedOut: input.stopTimedOut
+            ),
+            uniquingKeysWith: { _, new in new }
+        )
+        context["mic_file_available"] = boolString(input.micFileAvailable)
+        return context
+    }
+
+    private static func sharedProperties(
+        health: HealthFacts,
+        trigger: String,
+        reason: String,
+        durationSeconds: Double,
+        systemStreamPresent: Bool,
+        stopTimedOut: Bool
+    ) -> [String: String] {
+        [
+            "capture_quality": health.captureQuality,
+            "duration_bucket": AnalyticsReporter.durationBucket(seconds: durationSeconds),
+            "gap_count_bucket": AnalyticsReporter.countBucket(health.audioGaps),
+            "reason": reason,
+            "route_change_count_bucket": AnalyticsReporter.countBucket(health.deviceSwitches),
+            "system_stream_present": boolString(systemStreamPresent),
+            "stop_timed_out": boolString(stopTimedOut),
+            "trigger": trigger,
+        ]
+    }
+
+    private static func boolString(_ value: Bool) -> String {
+        value ? "true" : "false"
+    }
+}

--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -716,14 +716,16 @@ final class MeetingSessionController: ObservableObject {
         )
         AnalyticsReporter.track(
             "meeting_capture_health_snapshot",
-            properties: meetingCaptureHealthSnapshotProperties(
-                captureDiagnostics: stopCaptureDiagnostics,
-                healthInfo: recordingSnapshot.healthInfo,
-                trigger: recordingSnapshot.trigger.rawValue,
-                reason: reason.rawValue,
-                durationSeconds: recordingSnapshot.durationSeconds,
-                systemStreamPresent: files.systemURL != nil,
-                stopTimedOut: stopResult.didTimeOut
+            properties: MeetingCaptureHealthTelemetry.snapshotProperties(
+                .init(
+                    captureDiagnostics: stopCaptureDiagnostics,
+                    health: captureHealthFacts(from: recordingSnapshot.healthInfo),
+                    trigger: recordingSnapshot.trigger.rawValue,
+                    reason: reason.rawValue,
+                    durationSeconds: recordingSnapshot.durationSeconds,
+                    systemStreamPresent: files.systemURL != nil,
+                    stopTimedOut: stopResult.didTimeOut
+                )
             )
         )
         reportCaptureHealthIfNeeded(
@@ -1114,14 +1116,16 @@ final class MeetingSessionController: ObservableObject {
         )
         AnalyticsReporter.track(
             "meeting_capture_health_snapshot",
-            properties: meetingCaptureHealthSnapshotProperties(
-                captureDiagnostics: cancelCaptureDiagnostics,
-                healthInfo: recordingSnapshot.healthInfo,
-                trigger: recordingSnapshot.trigger.rawValue,
-                reason: reason.rawValue,
-                durationSeconds: recordingSnapshot.durationSeconds,
-                systemStreamPresent: files.systemURL != nil,
-                stopTimedOut: stopResult.didTimeOut
+            properties: MeetingCaptureHealthTelemetry.snapshotProperties(
+                .init(
+                    captureDiagnostics: cancelCaptureDiagnostics,
+                    health: captureHealthFacts(from: recordingSnapshot.healthInfo),
+                    trigger: recordingSnapshot.trigger.rawValue,
+                    reason: reason.rawValue,
+                    durationSeconds: recordingSnapshot.durationSeconds,
+                    systemStreamPresent: files.systemURL != nil,
+                    stopTimedOut: stopResult.didTimeOut
+                )
             )
         )
     }
@@ -2814,30 +2818,6 @@ final class MeetingSessionController: ObservableObject {
         )
     }
 
-    private func meetingCaptureHealthSnapshotProperties(
-        captureDiagnostics: [String: String],
-        healthInfo: RecordingHealthInfo,
-        trigger: String,
-        reason: String,
-        durationSeconds: Double,
-        systemStreamPresent: Bool,
-        stopTimedOut: Bool
-    ) -> [String: String] {
-        captureDiagnostics.merging(
-            [
-                "capture_quality": healthInfo.captureQuality.rawValue,
-                "duration_bucket": AnalyticsReporter.durationBucket(seconds: durationSeconds),
-                "gap_count_bucket": AnalyticsReporter.countBucket(healthInfo.audioGaps),
-                "reason": reason,
-                "route_change_count_bucket": AnalyticsReporter.countBucket(healthInfo.deviceSwitches),
-                "system_stream_present": boolString(systemStreamPresent),
-                "stop_timed_out": boolString(stopTimedOut),
-                "trigger": trigger,
-            ],
-            uniquingKeysWith: { _, new in new }
-        )
-    }
-
     private func reportCaptureHealthIfNeeded(
         snapshot: AudioPipelineDiagnosticsSnapshot,
         captureDiagnostics: [String: String],
@@ -2848,26 +2828,20 @@ final class MeetingSessionController: ObservableObject {
         files: (micURL: URL?, systemURL: URL?),
         stopTimedOut: Bool
     ) {
-        let shouldReport =
-            stopTimedOut ||
-            files.micURL == nil ||
-            healthInfo.captureQuality == .degraded ||
-            snapshot.systemFailed ||
-            snapshot.systemStatus == "failed"
-        guard shouldReport else { return }
-
-        var context = captureDiagnostics
-        context.removeValue(forKey: "gap_count")
-        context.removeValue(forKey: "route_change_count")
-        context["capture_quality"] = healthInfo.captureQuality.rawValue
-        context["duration_bucket"] = AnalyticsReporter.durationBucket(seconds: durationSeconds)
-        context["gap_count_bucket"] = AnalyticsReporter.countBucket(healthInfo.audioGaps)
-        context["mic_file_available"] = boolString(files.micURL != nil)
-        context["reason"] = reason.rawValue
-        context["route_change_count_bucket"] = AnalyticsReporter.countBucket(healthInfo.deviceSwitches)
-        context["stop_timed_out"] = boolString(stopTimedOut)
-        context["system_stream_present"] = boolString(files.systemURL != nil)
-        context["trigger"] = trigger.rawValue
+        guard let context = MeetingCaptureHealthTelemetry.degradedDiagnosticsContext(
+            .init(
+                captureDiagnostics: captureDiagnostics,
+                health: captureHealthFacts(from: healthInfo),
+                trigger: trigger.rawValue,
+                reason: reason.rawValue,
+                durationSeconds: durationSeconds,
+                micFileAvailable: files.micURL != nil,
+                systemStreamPresent: files.systemURL != nil,
+                stopTimedOut: stopTimedOut,
+                systemFailed: snapshot.systemFailed,
+                systemStatus: snapshot.systemStatus
+            )
+        ) else { return }
 
         DiagnosticsTrail.record(
             level: .error,
@@ -2875,6 +2849,14 @@ final class MeetingSessionController: ObservableObject {
             event: "recording_capture_degraded",
             message: "Meeting capture health degraded",
             context: baseDiagnosticsContext(extra: context)
+        )
+    }
+
+    private func captureHealthFacts(from healthInfo: RecordingHealthInfo) -> MeetingCaptureHealthTelemetry.HealthFacts {
+        .init(
+            captureQuality: healthInfo.captureQuality.rawValue,
+            audioGaps: healthInfo.audioGaps,
+            deviceSwitches: healthInfo.deviceSwitches
         )
     }
 

--- a/Tests/MeetingCaptureVolumeDiagnosticsTests.swift
+++ b/Tests/MeetingCaptureVolumeDiagnosticsTests.swift
@@ -387,4 +387,92 @@ func testMeetingCaptureVolumeDiagnostics() {
             "an empty context should never surface the hint"
         )
     }
+
+    runSuite("MeetingCaptureHealthTelemetry builds shared capture health payloads") {
+        let properties = MeetingCaptureHealthTelemetry.snapshotProperties(
+            .init(
+                captureDiagnostics: [
+                    "system_status": "healthy",
+                    "gap_count": "raw",
+                    "route_change_count": "raw",
+                ],
+                health: .init(
+                    captureQuality: "fair",
+                    audioGaps: 3,
+                    deviceSwitches: 2
+                ),
+                trigger: "manual",
+                reason: "user",
+                durationSeconds: 122,
+                systemStreamPresent: true,
+                stopTimedOut: false
+            )
+        )
+
+        assertEqual(properties["system_status"], "healthy", "snapshot payload should keep diagnostics")
+        assertEqual(properties["capture_quality"], "fair", "snapshot payload should include capture quality")
+        assertEqual(properties["gap_count_bucket"], "2_3", "snapshot payload should bucket audio gaps")
+        assertEqual(properties["route_change_count_bucket"], "2_3", "snapshot payload should bucket route switches")
+        assertEqual(properties["system_stream_present"], "true", "snapshot payload should expose system stream presence")
+        assertEqual(properties["stop_timed_out"], "false", "snapshot payload should expose stop timeout")
+    }
+
+    runSuite("MeetingCaptureHealthTelemetry emits degraded context only for real capture risks") {
+        let healthyInput = MeetingCaptureHealthTelemetry.DegradedReportInput(
+            captureDiagnostics: [
+                "gap_count": "raw",
+                "route_change_count": "raw",
+                "system_status": "healthy",
+            ],
+            health: .init(
+                captureQuality: "excellent",
+                audioGaps: 0,
+                deviceSwitches: 0
+            ),
+            trigger: "manual",
+            reason: "user",
+            durationSeconds: 45,
+            micFileAvailable: true,
+            systemStreamPresent: true,
+            stopTimedOut: false,
+            systemFailed: false,
+            systemStatus: "healthy"
+        )
+
+        assertNil(
+            MeetingCaptureHealthTelemetry.degradedDiagnosticsContext(healthyInput),
+            "healthy captures should not emit degraded diagnostics"
+        )
+
+        let degradedInput = MeetingCaptureHealthTelemetry.DegradedReportInput(
+            captureDiagnostics: [
+                "gap_count": "raw",
+                "route_change_count": "raw",
+                "system_status": "failed",
+            ],
+            health: .init(
+                captureQuality: "degraded",
+                audioGaps: 4,
+                deviceSwitches: 1
+            ),
+            trigger: "detected_prompt",
+            reason: "timeout",
+            durationSeconds: 301,
+            micFileAvailable: false,
+            systemStreamPresent: false,
+            stopTimedOut: true,
+            systemFailed: true,
+            systemStatus: "failed"
+        )
+
+        let context = MeetingCaptureHealthTelemetry.degradedDiagnosticsContext(degradedInput)
+        assertEqual(context?["system_status"], "failed", "degraded context should preserve status")
+        assertEqual(context?["gap_count"], nil, "degraded context should drop raw gap counts")
+        assertEqual(context?["route_change_count"], nil, "degraded context should drop raw route counts")
+        assertEqual(context?["capture_quality"], "degraded", "degraded context should include capture quality")
+        assertEqual(context?["gap_count_bucket"], "4_9", "degraded context should include gap bucket")
+        assertEqual(context?["mic_file_available"], "false", "degraded context should include mic file availability")
+        assertEqual(context?["system_stream_present"], "false", "degraded context should include system stream presence")
+        assertEqual(context?["stop_timed_out"], "true", "degraded context should include timeout")
+    }
 }

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1988,19 +1988,29 @@ func testRepoCommandContract() {
     }
 
     runSuite("Repo command contract - degraded meeting Sentry context stays bucketed") {
-        let contents = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let controller = readRepoTextFile("Sources/Meeting/MeetingSessionController.swift")
+        let contents = readRepoTextFile("Sources/Meeting/MeetingCaptureHealthTelemetry.swift")
+        assertTrue(
+            controller.contains("MeetingCaptureHealthTelemetry.degradedDiagnosticsContext"),
+            "degraded meeting Sentry context should stay behind the dedicated capture-health helper"
+        )
         let reportBlock = sourceSlice(
             contents,
-            from: "private func reportCaptureHealthIfNeeded(",
-            to: "private func trackSavedTranscriptAnalyticsInBackground("
+            from: "static func degradedDiagnosticsContext(",
+            to: "private static func sharedProperties("
+        )
+        let sharedPropertiesBlock = sourceSlice(
+            contents,
+            from: "private static func sharedProperties(",
+            to: "private static func boolString("
         )
 
         assertTrue(
-            reportBlock.contains("context[\"gap_count_bucket\"] = AnalyticsReporter.countBucket(healthInfo.audioGaps)"),
+            sharedPropertiesBlock.contains("\"gap_count_bucket\": AnalyticsReporter.countBucket(health.audioGaps)"),
             "degraded meeting Sentry events should preserve coarse gap counts"
         )
         assertTrue(
-            reportBlock.contains("context[\"route_change_count_bucket\"] = AnalyticsReporter.countBucket(healthInfo.deviceSwitches)"),
+            sharedPropertiesBlock.contains("\"route_change_count_bucket\": AnalyticsReporter.countBucket(health.deviceSwitches)"),
             "degraded meeting Sentry events should preserve coarse route-change counts"
         )
         assertTrue(

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -301,6 +301,7 @@ APP_SOURCES=(
     "Sources/Speech/DictationAudioLevelMeter.swift"
     "Sources/Meeting/MeetingRecordingStartGate.swift"
     "Sources/Meeting/MeetingCaptureSupport.swift"
+    "Sources/Meeting/MeetingCaptureHealthTelemetry.swift"
     "Sources/Meeting/MeetingFailureExplanation.swift"
     "Sources/Meeting/MeetingFailureCopy.swift"
     "Sources/Meeting/MeetingFailureKind.swift"


### PR DESCRIPTION
## Summary
- Extract meeting capture health snapshot/degraded-report payload construction out of MeetingSessionController into a pure MeetingCaptureHealthTelemetry helper.
- Keep stop/cancel telemetry behavior intact while sharing bucketed capture-health keys in one place.
- Add focused fast-test coverage and update the source-list/contract tests for the new ownership boundary.

## Review
- Independent Claude review: PASS, no behavior/telemetry/privacy drift found.
- MAESTRO_PROOF=/Users/redbars/.codex/maestro/runs/20260620T120558Z-thermo-meeting-capture-health-review-claude

## Verification
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh --filter MeetingCaptureVolumeDiagnosticsTests
- bash run-tests.sh --filter RepoCommandContractTests
- bash run-tests.sh
- bash run-integration-smoke.sh
- swift test
- bash scripts/dev/agent-preflight.sh
- python3 scripts/dev/check-build-source-lists.py
- bash -n run-tests.sh
- bash -n scripts/entrypoints/run-tests.sh

## Risk / holds
- Behavior-preserving pure telemetry extraction only; no capture-thread, hardware, or audio routing code changed.
- Hardware/live audio proof remains UNKNOWN, not claimed.