### PR TITLE
Share CaptureKit frontmatter parsing with QA

### DIFF
--- a/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdownParser.swift
+++ b/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdownParser.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// YAML frontmatter values plus the Markdown body that follows it.
 public struct ParsedCaptureDocument {
+    public let frontmatter: String
     public let values: [String: String]
     public let body: String
 }
@@ -91,19 +92,75 @@ public enum CaptureMarkdownParser {
 
         let frontmatterText = String(content[content.index(content.startIndex, offsetBy: 4)..<endRange.lowerBound])
         var values: [String: String] = [:]
+        var currentListKey: String?
+        var currentListItems: [String] = []
+
+        func resetList() {
+            currentListKey = nil
+            currentListItems = []
+        }
+
+        func flushList() {
+            guard let currentListKey, !currentListItems.isEmpty else { return }
+            values[currentListKey] = currentListItems.joined(separator: ", ")
+            resetList()
+        }
 
         for line in frontmatterText.components(separatedBy: "\n") {
+            let isIndented = line.first?.isWhitespace == true
             let trimmed = line.trimmingCharacters(in: .whitespaces)
-            guard !trimmed.hasPrefix("- "),
-                  let separator = trimmed.firstIndex(of: ":") else { continue }
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
+
+            if trimmed.hasPrefix("- ") {
+                guard currentListKey != nil else { continue }
+                currentListItems.append(
+                    String(trimmed.dropFirst(2))
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                )
+                continue
+            }
+
+            guard !isIndented else { continue }
+
+            flushList()
+
+            guard let separator = trimmed.firstIndex(of: ":") else {
+                continue
+            }
+
             let key = String(trimmed[..<separator]).trimmingCharacters(in: .whitespaces)
             let value = String(trimmed[trimmed.index(after: separator)...])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            values[key] = value
-        }
 
-        return ParsedCaptureDocument(values: values, body: String(content[endRange.upperBound...]))
+            if value.isEmpty {
+                currentListKey = key
+                currentListItems = []
+                continue
+            }
+
+            if value.hasPrefix("["), value.hasSuffix("]") {
+                let inner = String(value.dropFirst().dropLast())
+                values[key] = inner
+                    .components(separatedBy: ",")
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+                    .joined(separator: ", ")
+                resetList()
+                continue
+            }
+
+            values[key] = value
+            resetList()
+        }
+        flushList()
+
+        return ParsedCaptureDocument(
+            frontmatter: frontmatterText,
+            values: values,
+            body: String(content[endRange.upperBound...])
+        )
     }
 
     // MARK: - Meetings

--- a/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureMarkdownParserTests.swift
+++ b/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureMarkdownParserTests.swift
@@ -2,6 +2,54 @@ import XCTest
 @testable import TranscriptedCaptureKit
 
 final class CaptureMarkdownParserTests: XCTestCase {
+    func testParseFrontmatterNormalizesInlineAndBlockLists() throws {
+        let markdown = """
+        ---
+        title: "Release QA"
+        transcription_engine: parakeet_local
+        sources:
+          - mic
+          - system_audio
+        tags: [release, qa]
+        ---
+        ## Transcript
+        Body
+        """
+
+        let document = try XCTUnwrap(CaptureMarkdownParser.parseFrontmatter(from: markdown))
+
+        XCTAssertEqual(document.values["title"], "Release QA")
+        XCTAssertEqual(document.values["sources"], "mic, system_audio")
+        XCTAssertEqual(document.values["tags"], "release, qa")
+        XCTAssertTrue(document.frontmatter.contains("transcription_engine: parakeet_local"))
+        XCTAssertTrue(document.body.contains("## Transcript"))
+    }
+
+    func testParseFrontmatterIgnoresNestedObjectFields() throws {
+        let markdown = """
+        ---
+        capture_type: meeting
+        speakers:
+          - id: "0"
+            channel: system
+            name: "Alex"
+            confidence: high
+        tags:
+          - transcripted
+        ---
+        ## Transcript
+        Body
+        """
+
+        let document = try XCTUnwrap(CaptureMarkdownParser.parseFrontmatter(from: markdown))
+
+        XCTAssertEqual(document.values["capture_type"], "meeting")
+        XCTAssertEqual(document.values["tags"], "transcripted")
+        XCTAssertNil(document.values["channel"])
+        XCTAssertNil(document.values["name"])
+        XCTAssertNil(document.values["confidence"])
+    }
+
     // Frontmatter mirrors what TranscriptFormatter.formatTranscriptMarkdown
     // actually writes: recording-health keys and gap_events before speakers,
     // channel-qualified speaker entries, and Obsidian tags/aliases after.

--- a/Tools/TranscriptedQA/Package.swift
+++ b/Tools/TranscriptedQA/Package.swift
@@ -6,12 +6,14 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+        .package(path: "../TranscriptedCaptureKit"),
     ],
     targets: [
         .executableTarget(
             name: "transcripted-qa",
             dependencies: [
-                .product(name: "ArgumentParser", package: "swift-argument-parser")
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "TranscriptedCaptureKit", package: "TranscriptedCaptureKit"),
             ],
             path: "Sources/TranscriptedQA",
             linkerSettings: [.linkedLibrary("sqlite3")]

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Utilities/YAMLParser.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Utilities/YAMLParser.swift
@@ -1,78 +1,22 @@
 import Foundation
+import TranscriptedCaptureKit
 
-/// Minimal YAML frontmatter parser (regex-based, not a full YAML parser)
+/// Minimal frontmatter adapter for QA validators.
 struct YAMLParser {
     let raw: String
     let body: String
     let fields: [String: String]
 
     init(content: String) {
-        // Split frontmatter from body
-        if content.hasPrefix("---\n"),
-           let endRange = content.range(of: "\n---\n", range: content.index(content.startIndex, offsetBy: 4)..<content.endIndex) {
-            raw = String(content[content.index(content.startIndex, offsetBy: 4)..<endRange.lowerBound])
-            body = String(content[endRange.upperBound...])
+        if let document = CaptureMarkdownParser.parseFrontmatter(from: content) {
+            raw = document.frontmatter
+            body = document.body
+            fields = document.values
         } else {
             raw = ""
             body = content
+            fields = [:]
         }
-
-        // Parse simple key: value pairs and lists
-        var parsed: [String: String] = [:]
-        var currentKey: String?
-        var listItems: [String] = []
-
-        for line in raw.components(separatedBy: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { continue }
-
-            if trimmed.hasPrefix("- ") {
-                // List item — associate with most recent key
-                let item = String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces)
-                listItems.append(item)
-                continue
-            }
-
-            // Flush any pending list items to the previous key
-            if let key = currentKey, !listItems.isEmpty {
-                parsed[key] = listItems.joined(separator: ", ")
-                listItems = []
-            }
-
-            if let colonIdx = trimmed.firstIndex(of: ":") {
-                let key = String(trimmed[trimmed.startIndex..<colonIdx]).trimmingCharacters(in: .whitespaces)
-                let value = String(trimmed[trimmed.index(after: colonIdx)...]).trimmingCharacters(in: .whitespaces)
-
-                if value.isEmpty {
-                    // Value may follow as a list
-                    currentKey = key
-                    continue
-                }
-
-                // Handle inline list syntax: key: [item1, item2]
-                if value.hasPrefix("[") && value.hasSuffix("]") {
-                    let inner = String(value.dropFirst().dropLast())
-                    let items = inner.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
-                    parsed[key] = items.joined(separator: ", ")
-                    currentKey = key
-                    continue
-                }
-
-                // Strip surrounding quotes
-                let stripped = value.hasPrefix("\"") && value.hasSuffix("\"")
-                    ? String(value.dropFirst().dropLast())
-                    : value
-                parsed[key] = stripped
-                currentKey = key
-            }
-        }
-
-        // Flush any trailing list items
-        if let key = currentKey, !listItems.isEmpty {
-            parsed[key] = listItems.joined(separator: ", ")
-        }
-
-        fields = parsed
     }
 
     var hasFrontmatter: Bool { !raw.isEmpty }


### PR DESCRIPTION
## Summary
- route TranscriptedQA frontmatter reads through CaptureKit instead of a duplicate YAMLParser implementation
- preserve the QA-facing parser API while adding shared handling for block and inline lists
- add CaptureKit coverage for normalized lists and ignored nested object fields

## Thermo audit notes
- Fixed one low-risk duplication: QA/tool frontmatter parsing now uses CaptureKit.
- Held larger audit findings for separate PRs: duplicated CLI/MCP path-security guard belongs in CaptureKit; `RecordingValidator` still reads app-shell save-location defaults from core; `MeetingSessionController` and `TranscriptionTaskManager` remain large split candidates; audio DSP in `MeetingAudioStorageManager` likely belongs behind core/library contracts.

## Verification
- `swift test --package-path Tools/TranscriptedCaptureKit`
- `swift test --package-path Tools/TranscriptedQA`
- `swift test --package-path Tools/TranscriptedMCP`
- `swift test --package-path Tools/TranscriptedCLI`
- `bash run-e2e-smoke.sh`
- `bash build-deps.sh --force`
- `swift test`
- `bash run-integration-smoke.sh`
- `bash run-tests.sh`

## Independent review
- Claude PR diff review verdict: GREEN, no blocking findings.
- Proof: `/Users/redbars/.codex/maestro/runs/20260620T122106Z-transcripted-frontmatter-pr-review-claude`
- Architecture audit proof: `/Users/redbars/.codex/maestro/runs/20260620T115959Z-transcripted-core-mcp-thermo-architecture-claude`
- Local lane proof: `/Users/redbars/.codex/maestro/runs/20260620T115959Z-transcripted-core-mcp-thermo-mechanical-local`

Do not merge/release from this lane.