### PR TITLE
Fail closed on partial speaker eval corpora

### DIFF
--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -473,6 +473,23 @@ func testRepoCommandContract() {
         }
     }
 
+    runSuite("Repo command contract - speaker eval refuses partial corpora by default") {
+        let runner = readRepoTextFile("scripts/run_speaker_eval.sh")
+
+        assertTrue(
+            runner.contains("ALLOW_PARTIAL_CORPUS")
+                && runner.contains("Partial corpus refused")
+                && runner.contains("missing_inputs+=")
+                && runner.contains("[ ! -s \"$audio\" ]")
+                && runner.contains("[ ! -s \"$rttm\" ]"),
+            "speaker eval should fail closed when audio or RTTM inputs are missing, with an explicit local-only partial-corpus override"
+        )
+        assertFalse(
+            runner.contains("missing audio $audio — skipping $m"),
+            "speaker eval should not silently skip missing audio and then score a partial corpus"
+        )
+    }
+
     runSuite("Repo command contract - release gate report composes QA, telemetry, release, and logs") {
         let report = readRepoTextFile("scripts/ops/release-gate-report.py")
         let docs = readRepoTextFile("docs/qa-test-bench.md")

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -479,10 +479,12 @@ func testRepoCommandContract() {
         assertTrue(
             runner.contains("ALLOW_PARTIAL_CORPUS")
                 && runner.contains("Partial corpus refused")
+                && runner.contains("Partial corpus refused after dump failures")
                 && runner.contains("missing_inputs+=")
+                && runner.contains("dump_failures+=")
                 && runner.contains("[ ! -s \"$audio\" ]")
                 && runner.contains("[ ! -s \"$rttm\" ]"),
-            "speaker eval should fail closed when audio or RTTM inputs are missing, with an explicit local-only partial-corpus override"
+            "speaker eval should fail closed when audio, RTTM, or dump outputs are missing, with an explicit local-only partial-corpus override"
         )
         assertFalse(
             runner.contains("missing audio $audio — skipping $m"),

--- a/scripts/run_speaker_eval.sh
+++ b/scripts/run_speaker_eval.sh
@@ -91,6 +91,7 @@ echo "==> build harness"
 
 echo "==> dump-diarize sessions (cached)"
 INPUTS=""
+dump_failures=()
 for m in "${usable_meetings[@]}"; do
   dump="$DUMPS/$m.json"
   audio="$ROOT/$AUDIO_DIR/$m$SUFFIX"
@@ -101,8 +102,20 @@ for m in "${usable_meetings[@]}"; do
   else
     echo "    cached $m"
   fi
-  [ -s "$dump" ] && INPUTS="${INPUTS:+$INPUTS,}$dump"
+  if [ -s "$dump" ]; then
+    INPUTS="${INPUTS:+$INPUTS,}$dump"
+  else
+    dump_failures+=("dump failed or produced empty output for $m")
+  fi
 done
+if [ "${#dump_failures[@]}" -gt 0 ]; then
+  printf '    !! %s\n' "${dump_failures[@]}" >&2
+  if [ "$ALLOW_PARTIAL_CORPUS" != "1" ]; then
+    echo "Partial corpus refused after dump failures. Fix the dump errors or rerun with ALLOW_PARTIAL_CORPUS=1 for local iteration only." >&2
+    exit 1
+  fi
+  echo "    !! continuing after dump failures because ALLOW_PARTIAL_CORPUS=1" >&2
+fi
 [ -n "$INPUTS" ] || { echo "no dumps produced — check audio files"; exit 1; }
 
 echo "==> threshold sweep (consolidation × match)"

--- a/scripts/run_speaker_eval.sh
+++ b/scripts/run_speaker_eval.sh
@@ -21,7 +21,7 @@
 #   CONSOLIDATION="none 0.85 0.88" MATCH="0.55 0.6 0.65" scripts/run_speaker_eval.sh
 #
 # Env knobs: CORPUS, SERIES (subset; default = all meetings with RTTMs), CONSOLIDATION,
-#            MATCH, COLLAR.
+#            MATCH, COLLAR, ALLOW_PARTIAL_CORPUS=1.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 ROOT="$(pwd)"
@@ -50,6 +50,7 @@ fi
 CONSOLIDATION="${CONSOLIDATION:-none 0.82 0.85 0.88 0.91}"
 MATCH="${MATCH:-0.50 0.55 0.60 0.65 0.70}"
 COLLAR="${COLLAR:-0.25}"
+ALLOW_PARTIAL_CORPUS="${ALLOW_PARTIAL_CORPUS:-0}"
 
 BIN="$ROOT/Tools/SpeakerEvalHarness/.build/release/speaker-eval-harness"
 DUMPS="$ROOT/data/eval/$CORPUS/dumps"
@@ -59,16 +60,41 @@ mkdir -p "$DUMPS" "$RESULTS" "$REPORTS"
 
 echo "==> CORPUS=$CORPUS  meetings=$(echo "$MEETINGS" | wc -w | tr -d ' ')  (audio=$AUDIO_DIR rttm=$RTTM_DIR)"
 
+usable_meetings=()
+missing_inputs=()
+for m in $MEETINGS; do
+  audio="$ROOT/$AUDIO_DIR/$m$SUFFIX"
+  rttm="$ROOT/$RTTM_DIR/$m.rttm"
+  if [ ! -s "$rttm" ]; then
+    missing_inputs+=("missing RTTM $rttm")
+    continue
+  fi
+  if [ ! -s "$audio" ]; then
+    missing_inputs+=("missing audio $audio")
+    continue
+  fi
+  usable_meetings+=("$m")
+done
+
+if [ "${#missing_inputs[@]}" -gt 0 ]; then
+  printf '    !! %s\n' "${missing_inputs[@]}" >&2
+  if [ "$ALLOW_PARTIAL_CORPUS" != "1" ]; then
+    echo "Partial corpus refused. Fetch the missing inputs or rerun with ALLOW_PARTIAL_CORPUS=1 for local iteration only." >&2
+    exit 1
+  fi
+  echo "    !! continuing with partial corpus because ALLOW_PARTIAL_CORPUS=1" >&2
+fi
+[ "${#usable_meetings[@]}" -gt 0 ] || { echo "no complete audio+RTTM meetings found for CORPUS=$CORPUS"; exit 1; }
+
 echo "==> build harness"
 ( cd "$ROOT/Tools/SpeakerEvalHarness" && swift build -c release 2>&1 | grep -vE "\.pcm|while processing" | tail -1 )
 
 echo "==> dump-diarize sessions (cached)"
 INPUTS=""
-for m in $MEETINGS; do
+for m in "${usable_meetings[@]}"; do
   dump="$DUMPS/$m.json"
   audio="$ROOT/$AUDIO_DIR/$m$SUFFIX"
   if [ ! -s "$dump" ]; then
-    if [ ! -s "$audio" ]; then echo "    !! missing audio $audio — skipping $m" >&2; continue; fi
     echo "    diarizing $m ..."
     "$BIN" dump --audio "$audio" --meeting "$m" --out "$dump" \
       2>&1 | grep -E "^\[dump\] $m:" | grep -v processing || true


### PR DESCRIPTION
## Summary
- make `scripts/run_speaker_eval.sh` refuse incomplete eval corpora by default when audio/RTTM inputs are missing
- also fail closed when diarization dump output is missing or empty after a dump attempt
- keep `ALLOW_PARTIAL_CORPUS=1` as an explicit local-only override for exploratory iteration
- add a repo contract test so the old silent `missing audio ... skipping` path does not come back

## Why
The thermo audit found a false-green eval risk: speaker-eval runs could silently skip missing audio and still score the surviving subset. That makes harness output look cleaner than the corpus actually was.

## Verification
- `bash -n scripts/run_speaker_eval.sh`
- `CORPUS=ami SERIES=__missing_meeting__ scripts/run_speaker_eval.sh` exits 1 with `Partial corpus refused`
- `bash run-tests.sh --filter RepoCommandContractTests` -> 607 passed
- `bash build-deps.sh --force` -> passed
- `bash build.sh --no-open` -> passed, including signing, launch smoke, performance budget
- `swift build --package-path Tools/SpeakerEvalHarness` -> passed
- `bash run-tests.sh` -> passed on serial rerun: 10,422 passed
- `bash run-integration-smoke.sh` -> passed
- `swift test` -> passed: 502 tests, 1 skipped, 0 failures
- `python3 scripts/dev/check-build-source-lists.py` -> passed

Note: an earlier parallel `bash run-tests.sh` run failed because it raced with `bash build.sh --no-open` over `build/FastTestRunner.<pid>.swift`; the serial rerun passed and is the counted result.

## Independent review
Claude independent final diff review verdict: PASS.

Rejected note: review said dump-failure assertions were missing, but the current contract test asserts both `dump_failures+=` and `Partial corpus refused after dump failures`.

Maestro proof paths:
- `/Users/redbars/.codex/maestro/runs/20260620T115911Z-thermo-tests-ci-release-claude-claude`
- `/Users/redbars/.codex/maestro/runs/20260620T122603Z-speaker-eval-partial-corpus-final-review-claude`

Lanes used: Codex=implementation/final verification/PR; Claude=structural audit + independent diff review; Local=attempted triage, unusable generic output; Windows=skipped, local proof was cheaper and sufficient.
