### PR TITLE
Deduplicate PostHog ops helpers

### DIFF
--- a/scripts/ops/posthog-activation-funnel.py
+++ b/scripts/ops/posthog-activation-funnel.py
@@ -5,30 +5,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
-import urllib.error
-import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
-TRUSTED_POSTHOG_HOSTS = {
-    "https://app.posthog.com",
-    "https://eu.posthog.com",
-    "https://posthog.com",
-    "https://us.posthog.com",
-}
-
-ENV_PATHS = (
-    Path.cwd() / ".env.local",
-    Path.cwd() / ".env",
-    Path.home() / ".transcripted-ops.env",
-    Path.home() / ".hermes" / ".env",
-    Path.home() / ".hermes" / "profiles" / "ops" / ".env",
-)
+import posthog_common as posthog
 
 RELEVANT_EVENTS = (
     "app_launched",
@@ -209,109 +192,22 @@ class PostHogReportError(RuntimeError):
     pass
 
 
-def load_env() -> None:
-    for path in ENV_PATHS:
-        if not path.is_file():
-            continue
-        for raw_line in path.read_text(encoding="utf-8").splitlines():
-            line = raw_line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            key, value = line.split("=", 1)
-            key = key.strip().removeprefix("export ").strip()
-            value = value.strip().strip('"').strip("'")
-            if key and value and key not in os.environ:
-                os.environ[key] = value
-
-
-def normalize_posthog_host(raw: str) -> str:
-    host = raw.strip().rstrip("/")
-    if host == "https://us.i.posthog.com":
-        return "https://us.posthog.com"
-    if host == "https://eu.i.posthog.com":
-        return "https://eu.posthog.com"
-    return host
+load_env = posthog.load_env
+sql_quote = posthog.sql_quote
+sql_list = posthog.sql_list
+app_version_filter = posthog.app_version_filter
 
 
 def posthog_config() -> tuple[str, str, str]:
-    token = os.environ.get("POSTHOG_PERSONAL_API_KEY")
-    project_id = os.environ.get("POSTHOG_PROJECT_ID")
-    host = normalize_posthog_host(
-        os.environ.get("POSTHOG_APP_HOST")
-        or os.environ.get("POSTHOG_HOST")
-        or "https://us.posthog.com"
-    )
-
-    missing = []
-    if not token:
-        missing.append("POSTHOG_PERSONAL_API_KEY")
-    if not project_id:
-        missing.append("POSTHOG_PROJECT_ID")
-    if missing:
-        raise PostHogReportError("missing " + ", ".join(missing))
-
-    if not host.startswith("https://"):
-        raise PostHogReportError(f"refusing non-HTTPS PostHog host: {host}")
-    if host not in TRUSTED_POSTHOG_HOSTS and os.environ.get("POSTHOG_ALLOW_UNTRUSTED_HOST") != "1":
-        raise PostHogReportError(
-            f"refusing untrusted PostHog host: {host}; set POSTHOG_ALLOW_UNTRUSTED_HOST=1 only for trusted self-hosted PostHog"
-        )
-
-    return host, project_id, token
-
-
-def sql_quote(value: str) -> str:
-    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
-
-
-def sql_list(values: tuple[str, ...]) -> str:
-    return ", ".join(sql_quote(value) for value in values)
-
-
-def app_version_filter(app_version: str | None) -> str:
-    if not app_version:
-        return ""
-    return f"AND properties['app_version'] = {sql_quote(app_version)}"
+    return posthog.posthog_config(PostHogReportError)
 
 
 def run_hogql(host: str, project_id: str, token: str, query: str) -> dict[str, Any]:
-    payload = {
-        "query": {"kind": "HogQLQuery", "query": query},
-        "refresh": "blocking",
-    }
-    request = urllib.request.Request(
-        f"{host}/api/projects/{project_id}/query/",
-        data=json.dumps(payload).encode("utf-8"),
-        method="POST",
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        },
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=30) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as exc:
-        body = exc.read().decode("utf-8", errors="replace")
-        raise PostHogReportError(f"PostHog query failed with HTTP {exc.code}: {body}") from exc
-    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
-        raise PostHogReportError(f"PostHog query failed: {exc}") from exc
+    return posthog.run_hogql(host, project_id, token, query, PostHogReportError)
 
 
 def rows_as_dicts(response: dict[str, Any]) -> list[dict[str, Any]]:
-    columns = response.get("columns") or []
-    rows = response.get("results") or response.get("data") or []
-    unsafe = [
-        str(column)
-        for column in columns
-        if any(fragment in str(column).lower() for fragment in DISALLOWED_OUTPUT_COLUMNS)
-    ]
-    if unsafe:
-        raise PostHogReportError(f"query attempted to expose unsafe output columns: {', '.join(unsafe)}")
-    return [
-        {str(column): row[index] if index < len(row) else None for index, column in enumerate(columns)}
-        for row in rows
-    ]
+    return posthog.rows_as_dicts(response, DISALLOWED_OUTPUT_COLUMNS, PostHogReportError)
 
 
 def reach_query(days: int, app_version: str | None) -> str:

--- a/scripts/ops/posthog-dashboard-queries.py
+++ b/scripts/ops/posthog-dashboard-queries.py
@@ -5,30 +5,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
-import urllib.error
-import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
-TRUSTED_POSTHOG_HOSTS = {
-    "https://app.posthog.com",
-    "https://eu.posthog.com",
-    "https://posthog.com",
-    "https://us.posthog.com",
-}
-
-ENV_PATHS = (
-    Path.cwd() / ".env.local",
-    Path.cwd() / ".env",
-    Path.home() / ".transcripted-ops.env",
-    Path.home() / ".hermes" / ".env",
-    Path.home() / ".hermes" / "profiles" / "ops" / ".env",
-)
+import posthog_common as posthog
 
 FAMILIES = (
     "100_wau",
@@ -159,79 +142,16 @@ class PostHogDashboardError(RuntimeError):
     pass
 
 
-def load_env() -> None:
-    for path in ENV_PATHS:
-        if not path.is_file():
-            continue
-        for raw_line in path.read_text(encoding="utf-8").splitlines():
-            line = raw_line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            key, value = line.split("=", 1)
-            key = key.strip().removeprefix("export ").strip()
-            value = value.strip().strip('"').strip("'")
-            if key and value and key not in os.environ:
-                os.environ[key] = value
-
-
-def normalize_posthog_host(raw: str) -> str:
-    host = raw.strip().rstrip("/")
-    if host == "https://us.i.posthog.com":
-        return "https://us.posthog.com"
-    if host == "https://eu.i.posthog.com":
-        return "https://eu.posthog.com"
-    return host
+load_env = posthog.load_env
+sql_quote = posthog.sql_quote
+sql_list = posthog.sql_list
+event_filter = posthog.event_filter
+app_version_filter = posthog.app_version_filter
+version_or_app_version_filter = posthog.version_or_app_version_filter
 
 
 def posthog_config() -> tuple[str, str, str]:
-    token = os.environ.get("POSTHOG_PERSONAL_API_KEY")
-    project_id = os.environ.get("POSTHOG_PROJECT_ID")
-    host = normalize_posthog_host(
-        os.environ.get("POSTHOG_APP_HOST")
-        or os.environ.get("POSTHOG_HOST")
-        or "https://us.posthog.com"
-    )
-
-    missing = []
-    if not token:
-        missing.append("POSTHOG_PERSONAL_API_KEY")
-    if not project_id:
-        missing.append("POSTHOG_PROJECT_ID")
-    if missing:
-        raise PostHogDashboardError("missing " + ", ".join(missing))
-
-    if not host.startswith("https://"):
-        raise PostHogDashboardError(f"refusing non-HTTPS PostHog host: {host}")
-    if host not in TRUSTED_POSTHOG_HOSTS and os.environ.get("POSTHOG_ALLOW_UNTRUSTED_HOST") != "1":
-        raise PostHogDashboardError(
-            f"refusing untrusted PostHog host: {host}; set POSTHOG_ALLOW_UNTRUSTED_HOST=1 only for trusted self-hosted PostHog"
-        )
-    return host, project_id, token
-
-
-def sql_quote(value: str) -> str:
-    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
-
-
-def sql_list(values: tuple[str, ...]) -> str:
-    return ", ".join(sql_quote(value) for value in values)
-
-
-def event_filter(events: tuple[str, ...]) -> str:
-    return f"event IN ({sql_list(events)})"
-
-
-def app_version_filter(app_version: str | None) -> str:
-    if not app_version:
-        return ""
-    return f"AND properties['app_version'] = {sql_quote(app_version)}"
-
-
-def version_or_app_version_filter(app_version: str | None) -> str:
-    if not app_version:
-        return ""
-    quoted = sql_quote(app_version)
-    return f"AND (properties['app_version'] = {quoted} OR properties['version'] = {quoted})"
+    return posthog.posthog_config(PostHogDashboardError)
 
 
 def query_specs(days: int, app_version: str | None) -> list[QuerySpec]:
@@ -598,39 +518,23 @@ def selected_specs(family: str, days: int, app_version: str | None) -> list[Quer
 
 
 def run_hogql(host: str, project_id: str, token: str, query: str) -> dict[str, Any]:
-    payload = {
-        "query": {"kind": "HogQLQuery", "query": query},
-        "refresh": "blocking",
-    }
-    request = urllib.request.Request(
-        f"{host}/api/projects/{project_id}/query/",
-        data=json.dumps(payload).encode("utf-8"),
-        method="POST",
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        },
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=30) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as exc:
-        body = exc.read().decode("utf-8", errors="replace")
-        raise PostHogDashboardError(f"PostHog query failed with HTTP {exc.code}: {body}") from exc
-    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
-        raise PostHogDashboardError(f"PostHog query failed: {exc}") from exc
+    return posthog.run_hogql(host, project_id, token, query, PostHogDashboardError)
 
 
 def rows_as_dicts(response: dict[str, Any], spec: QuerySpec) -> list[dict[str, Any]]:
-    columns = [str(column) for column in (response.get("columns") or spec.columns)]
-    unsafe = unsafe_columns(columns)
-    if unsafe:
-        raise PostHogDashboardError(f"{spec.id} attempted to expose unsafe output columns: {', '.join(unsafe)}")
-    rows = response.get("results") or response.get("data") or []
-    return [
-        {column: row[index] if index < len(row) else None for index, column in enumerate(columns)}
-        for row in rows
-    ]
+    try:
+        return posthog.rows_as_dicts(
+            response,
+            DISALLOWED_OUTPUT_FRAGMENTS,
+            PostHogDashboardError,
+            declared_columns=spec.columns,
+        )
+    except PostHogDashboardError as exc:
+        message = str(exc)
+        prefix = "query attempted to expose unsafe output columns: "
+        if message.startswith(prefix):
+            raise PostHogDashboardError(f"{spec.id} attempted to expose unsafe output columns: {message.removeprefix(prefix)}") from exc
+        raise
 
 
 def unsafe_columns(columns: list[str] | tuple[str, ...]) -> list[str]:
@@ -840,6 +744,14 @@ def run_self_test() -> int:
     except PostHogDashboardError as exc:
         errors.append(str(exc))
         payload = {"queries": []}
+    fallback_rows = posthog.rows_as_dicts(
+        {"results": [["2026-06-18", 24]]},
+        DISALLOWED_OUTPUT_FRAGMENTS,
+        PostHogDashboardError,
+        declared_columns=("day", "active_devices"),
+    )
+    if fallback_rows != [{"day": "2026-06-18", "active_devices": 24}]:
+        errors.append("column-less response fallback did not use declared columns")
     rendered = render_markdown(payload)
     required = (
         "wau.active_devices_by_week",

--- a/scripts/ops/posthog-product-context-pack.py
+++ b/scripts/ops/posthog-product-context-pack.py
@@ -5,30 +5,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
-import urllib.error
-import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
-TRUSTED_POSTHOG_HOSTS = {
-    "https://app.posthog.com",
-    "https://eu.posthog.com",
-    "https://posthog.com",
-    "https://us.posthog.com",
-}
-
-ENV_PATHS = (
-    Path.cwd() / ".env.local",
-    Path.cwd() / ".env",
-    Path.home() / ".transcripted-ops.env",
-    Path.home() / ".hermes" / ".env",
-    Path.home() / ".hermes" / "profiles" / "ops" / ".env",
-)
+import posthog_common as posthog
 
 SAFE_EVENTS = (
     "app_launched",
@@ -115,107 +98,22 @@ class UnknownReason:
     reason: str
 
 
-def load_env() -> None:
-    for path in ENV_PATHS:
-        if not path.is_file():
-            continue
-        for raw_line in path.read_text(encoding="utf-8").splitlines():
-            line = raw_line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            key, value = line.split("=", 1)
-            key = key.strip().removeprefix("export ").strip()
-            value = value.strip().strip('"').strip("'")
-            if key and value and key not in os.environ:
-                os.environ[key] = value
-
-
-def normalize_posthog_host(raw: str) -> str:
-    host = raw.strip().rstrip("/")
-    if host == "https://us.i.posthog.com":
-        return "https://us.posthog.com"
-    if host == "https://eu.i.posthog.com":
-        return "https://eu.posthog.com"
-    return host
+load_env = posthog.load_env
+sql_quote = posthog.sql_quote
+sql_list = posthog.sql_list
+app_version_filter = posthog.app_version_filter
 
 
 def posthog_config() -> tuple[str, str, str]:
-    token = os.environ.get("POSTHOG_PERSONAL_API_KEY")
-    project_id = os.environ.get("POSTHOG_PROJECT_ID")
-    host = normalize_posthog_host(
-        os.environ.get("POSTHOG_APP_HOST")
-        or os.environ.get("POSTHOG_HOST")
-        or "https://us.posthog.com"
-    )
-
-    missing = []
-    if not token:
-        missing.append("POSTHOG_PERSONAL_API_KEY")
-    if not project_id:
-        missing.append("POSTHOG_PROJECT_ID")
-    if missing:
-        raise ContextPackError("missing " + ", ".join(missing))
-    if not host.startswith("https://"):
-        raise ContextPackError(f"refusing non-HTTPS PostHog host: {host}")
-    if host not in TRUSTED_POSTHOG_HOSTS and os.environ.get("POSTHOG_ALLOW_UNTRUSTED_HOST") != "1":
-        raise ContextPackError(
-            f"refusing untrusted PostHog host: {host}; set POSTHOG_ALLOW_UNTRUSTED_HOST=1 only for trusted self-hosted PostHog"
-        )
-    return host, project_id, token
-
-
-def sql_quote(value: str) -> str:
-    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
-
-
-def sql_list(values: tuple[str, ...]) -> str:
-    return ", ".join(sql_quote(value) for value in values)
-
-
-def app_version_filter(app_version: str | None) -> str:
-    if not app_version:
-        return ""
-    return f"AND properties['app_version'] = {sql_quote(app_version)}"
+    return posthog.posthog_config(ContextPackError)
 
 
 def run_hogql(host: str, project_id: str, token: str, query: str) -> dict[str, Any]:
-    payload = {
-        "query": {"kind": "HogQLQuery", "query": query},
-        "refresh": "blocking",
-    }
-    request = urllib.request.Request(
-        f"{host}/api/projects/{project_id}/query/",
-        data=json.dumps(payload).encode("utf-8"),
-        method="POST",
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        },
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=30) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as exc:
-        body = exc.read().decode("utf-8", errors="replace")
-        raise ContextPackError(f"PostHog query failed with HTTP {exc.code}: {body}") from exc
-    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
-        raise ContextPackError(f"PostHog query failed: {exc}") from exc
+    return posthog.run_hogql(host, project_id, token, query, ContextPackError)
 
 
 def rows_as_dicts(response: dict[str, Any]) -> list[dict[str, Any]]:
-    columns = response.get("columns") or []
-    rows = response.get("results") or response.get("data") or []
-    unsafe = [
-        str(column)
-        for column in columns
-        if any(fragment in str(column).lower() for fragment in DISALLOWED_OUTPUT_COLUMNS)
-    ]
-    if unsafe:
-        raise ContextPackError(f"query attempted to expose unsafe output columns: {', '.join(unsafe)}")
-    return [
-        {str(column): row[index] if index < len(row) else None for index, column in enumerate(columns)}
-        for row in rows
-    ]
+    return posthog.rows_as_dicts(response, DISALLOWED_OUTPUT_COLUMNS, ContextPackError)
 
 
 def overview_query(days: int, app_version: str | None) -> str:

--- a/scripts/ops/posthog-product-dashboard-summary.py
+++ b/scripts/ops/posthog-product-dashboard-summary.py
@@ -5,30 +5,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
-import urllib.error
-import urllib.request
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-
-TRUSTED_POSTHOG_HOSTS = {
-    "https://app.posthog.com",
-    "https://eu.posthog.com",
-    "https://posthog.com",
-    "https://us.posthog.com",
-}
-
-ENV_PATHS = (
-    Path.cwd() / ".env.local",
-    Path.cwd() / ".env",
-    Path.home() / ".transcripted-ops.env",
-    Path.home() / ".hermes" / ".env",
-    Path.home() / ".hermes" / "profiles" / "ops" / ".env",
-)
+import posthog_common as posthog
 
 CORE_EVENTS = (
     "app_launched",
@@ -108,103 +91,22 @@ class Finding:
     score: float
 
 
-def load_env() -> None:
-    for path in ENV_PATHS:
-        if not path.is_file():
-            continue
-        for raw_line in path.read_text(encoding="utf-8").splitlines():
-            line = raw_line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            key, value = line.split("=", 1)
-            key = key.strip().removeprefix("export ").strip()
-            value = value.strip().strip('"').strip("'")
-            if key and value and key not in os.environ:
-                os.environ[key] = value
-
-
-def normalize_posthog_host(raw: str) -> str:
-    host = raw.strip().rstrip("/")
-    if host == "https://us.i.posthog.com":
-        return "https://us.posthog.com"
-    if host == "https://eu.i.posthog.com":
-        return "https://eu.posthog.com"
-    return host
+load_env = posthog.load_env
+sql_quote = posthog.sql_quote
+sql_list = posthog.sql_list
+app_version_filter = posthog.app_version_filter
 
 
 def posthog_config() -> tuple[str, str, str]:
-    token = os.environ.get("POSTHOG_PERSONAL_API_KEY")
-    project_id = os.environ.get("POSTHOG_PROJECT_ID")
-    host = normalize_posthog_host(
-        os.environ.get("POSTHOG_APP_HOST")
-        or os.environ.get("POSTHOG_HOST")
-        or "https://us.posthog.com"
-    )
-    missing = []
-    if not token:
-        missing.append("POSTHOG_PERSONAL_API_KEY")
-    if not project_id:
-        missing.append("POSTHOG_PROJECT_ID")
-    if missing:
-        raise ProductTaskReportError("missing " + ", ".join(missing))
-    if not host.startswith("https://"):
-        raise ProductTaskReportError(f"refusing non-HTTPS PostHog host: {host}")
-    if host not in TRUSTED_POSTHOG_HOSTS and os.environ.get("POSTHOG_ALLOW_UNTRUSTED_HOST") != "1":
-        raise ProductTaskReportError(
-            f"refusing untrusted PostHog host: {host}; set POSTHOG_ALLOW_UNTRUSTED_HOST=1 only for trusted self-hosted PostHog"
-        )
-    return host, project_id, token
-
-
-def sql_quote(value: str) -> str:
-    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
-
-
-def sql_list(values: tuple[str, ...]) -> str:
-    return ", ".join(sql_quote(value) for value in values)
-
-
-def app_version_filter(app_version: str | None) -> str:
-    if not app_version:
-        return ""
-    return f"AND properties['app_version'] = {sql_quote(app_version)}"
+    return posthog.posthog_config(ProductTaskReportError)
 
 
 def run_hogql(host: str, project_id: str, token: str, query: str) -> dict[str, Any]:
-    payload = {"query": {"kind": "HogQLQuery", "query": query}, "refresh": "blocking"}
-    request = urllib.request.Request(
-        f"{host}/api/projects/{project_id}/query/",
-        data=json.dumps(payload).encode("utf-8"),
-        method="POST",
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        },
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=30) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as exc:
-        body = exc.read().decode("utf-8", errors="replace")
-        raise ProductTaskReportError(f"PostHog query failed with HTTP {exc.code}: {body}") from exc
-    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
-        raise ProductTaskReportError(f"PostHog query failed: {exc}") from exc
+    return posthog.run_hogql(host, project_id, token, query, ProductTaskReportError)
 
 
 def rows_as_dicts(response: dict[str, Any]) -> list[dict[str, Any]]:
-    columns = response.get("columns") or []
-    unsafe = [
-        str(column)
-        for column in columns
-        if any(fragment in str(column).lower() for fragment in DISALLOWED_OUTPUT_COLUMNS)
-    ]
-    if unsafe:
-        raise ProductTaskReportError(f"query attempted to expose unsafe output columns: {', '.join(unsafe)}")
-    rows = response.get("results") or response.get("data") or []
-    return [
-        {str(column): row[index] if index < len(row) else None for index, column in enumerate(columns)}
-        for row in rows
-    ]
+    return posthog.rows_as_dicts(response, DISALLOWED_OUTPUT_COLUMNS, ProductTaskReportError)
 
 
 def event_counts_query(days: int, app_version: str | None) -> str:

--- a/scripts/ops/posthog_common.py
+++ b/scripts/ops/posthog_common.py
@@ -1,0 +1,152 @@
+"""Shared privacy-safe PostHog script helpers for Transcripted ops tools."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+TRUSTED_POSTHOG_HOSTS = {
+    "https://app.posthog.com",
+    "https://eu.posthog.com",
+    "https://posthog.com",
+    "https://us.posthog.com",
+}
+
+ENV_PATHS = (
+    Path.cwd() / ".env.local",
+    Path.cwd() / ".env",
+    Path.home() / ".transcripted-ops.env",
+    Path.home() / ".hermes" / ".env",
+    Path.home() / ".hermes" / "profiles" / "ops" / ".env",
+)
+
+
+def load_env() -> None:
+    for path in ENV_PATHS:
+        if not path.is_file():
+            continue
+        for raw_line in path.read_text(encoding="utf-8").splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            key = key.strip().removeprefix("export ").strip()
+            value = value.strip().strip('"').strip("'")
+            if key and value and key not in os.environ:
+                os.environ[key] = value
+
+
+def normalize_posthog_host(raw: str) -> str:
+    host = raw.strip().rstrip("/")
+    if host == "https://us.i.posthog.com":
+        return "https://us.posthog.com"
+    if host == "https://eu.i.posthog.com":
+        return "https://eu.posthog.com"
+    return host
+
+
+def posthog_config(error_cls: type[Exception]) -> tuple[str, str, str]:
+    token = os.environ.get("POSTHOG_PERSONAL_API_KEY")
+    project_id = os.environ.get("POSTHOG_PROJECT_ID")
+    host = normalize_posthog_host(
+        os.environ.get("POSTHOG_APP_HOST")
+        or os.environ.get("POSTHOG_HOST")
+        or "https://us.posthog.com"
+    )
+
+    missing = []
+    if not token:
+        missing.append("POSTHOG_PERSONAL_API_KEY")
+    if not project_id:
+        missing.append("POSTHOG_PROJECT_ID")
+    if missing:
+        raise error_cls("missing " + ", ".join(missing))
+
+    if not host.startswith("https://"):
+        raise error_cls(f"refusing non-HTTPS PostHog host: {host}")
+    if host not in TRUSTED_POSTHOG_HOSTS and os.environ.get("POSTHOG_ALLOW_UNTRUSTED_HOST") != "1":
+        raise error_cls(
+            f"refusing untrusted PostHog host: {host}; set POSTHOG_ALLOW_UNTRUSTED_HOST=1 only for trusted self-hosted PostHog"
+        )
+    return host, project_id, token
+
+
+def sql_quote(value: str) -> str:
+    return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def sql_list(values: tuple[str, ...]) -> str:
+    return ", ".join(sql_quote(value) for value in values)
+
+
+def event_filter(events: tuple[str, ...]) -> str:
+    return f"event IN ({sql_list(events)})"
+
+
+def app_version_filter(app_version: str | None) -> str:
+    if not app_version:
+        return ""
+    return f"AND properties['app_version'] = {sql_quote(app_version)}"
+
+
+def version_or_app_version_filter(app_version: str | None) -> str:
+    if not app_version:
+        return ""
+    quoted = sql_quote(app_version)
+    return f"AND (properties['app_version'] = {quoted} OR properties['version'] = {quoted})"
+
+
+def run_hogql(host: str, project_id: str, token: str, query: str, error_cls: type[Exception]) -> dict[str, Any]:
+    payload = {
+        "query": {"kind": "HogQLQuery", "query": query},
+        "refresh": "blocking",
+    }
+    request = urllib.request.Request(
+        f"{host}/api/projects/{project_id}/query/",
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise error_cls(f"PostHog query failed with HTTP {exc.code}: {body}") from exc
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise error_cls(f"PostHog query failed: {exc}") from exc
+
+
+def rows_as_dicts(
+    response: dict[str, Any],
+    disallowed_fragments: set[str] | tuple[str, ...],
+    error_cls: type[Exception],
+    declared_columns: tuple[str, ...] | None = None,
+) -> list[dict[str, Any]]:
+    response_columns = tuple(str(column) for column in (response.get("columns") or []))
+    declared_column_names = tuple(str(column) for column in (declared_columns or ()))
+    columns = response_columns or declared_column_names
+    columns_to_check = response_columns
+    if declared_column_names:
+        columns_to_check = response_columns + declared_column_names
+    unsafe = [
+        str(column)
+        for column in columns_to_check
+        if any(fragment in str(column).lower() for fragment in disallowed_fragments)
+    ]
+    if unsafe:
+        raise error_cls(f"query attempted to expose unsafe output columns: {', '.join(unsafe)}")
+
+    rows = response.get("results") or response.get("data") or []
+    return [
+        {str(column): row[index] if index < len(row) else None for index, column in enumerate(columns)}
+        for row in rows
+    ]


### PR DESCRIPTION
## Summary
- Add shared `scripts/ops/posthog_common.py` for PostHog env loading, host validation, HogQL requests, SQL helpers, and privacy-safe row conversion.
- Update activation funnel, dashboard queries, product context pack, and product dashboard summary scripts to use the shared helper without changing event/query semantics.
- Add dashboard self-test coverage for PostHog responses that omit column metadata but use declared safe columns.

## Thermo Audit Notes
- Top structural findings: duplicated PostHog ops plumbing, repeated privacy denylist patterns, duplicated diagnostic/tag vocabularies, and event taxonomy drift risk.
- This PR only takes the safe cleanup: shared PostHog ops plumbing. Larger Swift sanitizer/taxonomy single-sourcing should be a follow-up.

## Verification
- `python3 -m py_compile scripts/ops/posthog_common.py scripts/ops/posthog-activation-funnel.py scripts/ops/posthog-dashboard-queries.py scripts/ops/posthog-product-context-pack.py scripts/ops/posthog-product-dashboard-summary.py`
- `python3 scripts/ops/posthog-activation-funnel.py --self-test`
- `python3 scripts/ops/posthog-dashboard-queries.py --self-test`
- `python3 scripts/ops/posthog-product-context-pack.py --self-test`
- `python3 scripts/ops/posthog-product-dashboard-summary.py --self-test`
- `python3 scripts/ops/posthog-dashboard-queries.py --dry-run --json-only`
- `python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json --json-only`
- `python3 scripts/ops/posthog-product-context-pack.py --fixture Tests/Fixtures/posthog-product-context-pack-fixture.json --write-dir build/posthog-product-context-sample-3`
- `scripts/dev/agent-preflight.sh`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (10420/10420 passed)
- `codex review --base origin/main` and rerun against exact base: no concrete regression found

## Lanes Used
- Codex: audit, edit, tests, final review, PR
- Claude: thermo architecture review, proof `/Users/redbars/.codex/maestro/runs/20260620T115918Z-observability-thermo-claude-claude`
- Local: attempted; output was non-evidence/refusal-ish, proofs `/Users/redbars/.codex/maestro/runs/20260620T115918Z-observability-thermo-local-local`, `/Users/redbars/.codex/maestro/runs/20260620T122736Z-review-posthog-common-local`, `/Users/redbars/.codex/maestro/runs/20260620T122831Z-posthog-refactor-review-local`
- Windows: attempted; output referenced nonexistent paths, proof `/Users/redbars/.codex/maestro/runs/20260620T115918Z-observability-thermo-windows-windows`

No merge or release performed.