### PR TITLE
Simplify recovery diagnostics plumbing

### DIFF
--- a/Sources/Capture/ContextCaptureEngine.swift
+++ b/Sources/Capture/ContextCaptureEngine.swift
@@ -2,22 +2,16 @@
 // Orchestrates the active capture flows: meeting hotkey + dictation tap handling.
 
 import AppKit
-import Carbon
 import CoreGraphics
 
-// MARK: - Carbon Hotkey Handler (C-level callback)
+// MARK: - Shared Hotkey Routing
 
-// Global reference so the C callback can reach the dictation controller
+// Global reference so physical shortcut callbacks can reach the dictation controller.
 private weak var _sharedSessionController: DictationSessionController?
 
-// Global callback for meeting hotkey (id 3). Separate from the session
-// controller so meeting UI can be wired independently of draft/dictation.
-// Stored on the MainActor and invoked from the Carbon callback via Task.
-private var _sharedMeetingToggle: (() -> Void)?
-
-// Carbon hotkeys can fire back-to-back before Transcripted finishes updating its
-// session state. Ignore rapid repeats so start/stop/cancel transitions stay
-// single-shot and predictable.
+// Global shortcut events can fire back-to-back before Transcripted finishes
+// updating its session state. Ignore rapid repeats so start/stop/cancel
+// transitions stay single-shot and predictable.
 // Use systemUptime (monotonic) instead of CFAbsoluteTimeGetCurrent (wall clock)
 // so NTP adjustments, manual time changes, or DST transitions can't make a
 // backward clock jump silently drop all subsequent hotkey presses.
@@ -76,51 +70,9 @@ private func overlayStateName(_ state: FloatingOverlayController.OverlayState?) 
     }
 }
 
-private func hotkeyHandler(
-    nextHandler: EventHandlerCallRef?,
-    event: EventRef?,
-    userData: UnsafeMutableRawPointer?
-)-> OSStatus {
-    // Extract which hotkey fired.
-    guard let event = event else { return noErr }
-    var hotkeyID = EventHotKeyID()
-    let status = GetEventParameter(
-        event,
-        EventParamName(kEventParamDirectObject),
-        EventParamType(typeEventHotKeyID),
-        nil,
-        MemoryLayout<EventHotKeyID>.size,
-        nil,
-        &hotkeyID
-    )
-    guard status == noErr else { return noErr }
-
-    guard shouldAcceptHotkeyAction("carbon_meeting_toggle") else {
-        Task { @MainActor in
-            EventReporter.shared.capture(
-                level: .info,
-                engine: "capture",
-                event: "hotkey_repeat_ignored",
-                message: "Ignored rapid repeat hotkey press",
-                context: ["hotkey_id": "\(hotkeyID.id)"]
-            )
-        }
-        return noErr
-    }
-
-    if hotkeyID.id == 3 {
-        // ⌥M — Meeting mode: toggle meeting recording.
-        // No screenshot, no cross-mode switching with draft/dictation.
-        Task { @MainActor in
-            _sharedMeetingToggle?()
-        }
-    }
-    return noErr
-}
-
 // PhysicalShortcutAction and PhysicalShortcutBinding live in
 // PhysicalShortcutMatcher.swift so the pure chord-resolution precedence can be
-// fast-tested independently of this Carbon/CGEventTap engine.
+// fast-tested independently of this CGEventTap engine.
 
 private enum PhysicalShortcutPhase {
     case press
@@ -406,11 +358,8 @@ private final class PhysicalShortcutDetector {
 
 @MainActor
 class ContextCaptureEngine: ObservableObject {
-    private var meetingHotkeyRef: EventHotKeyRef?
-    private var eventHandlerRef: EventHandlerRef?
     private var hotkeyChangeObserver: NSObjectProtocol?
     private let physicalShortcutDetector = PhysicalShortcutDetector()
-    private var carbonHotkeyError: String?
     private var physicalTriggerError: String?
 
     /// Human-readable display strings for current shortcuts (drives MenuBarPanel pills + overlay hints)
@@ -429,14 +378,10 @@ class ContextCaptureEngine: ObservableObject {
         }
     }
 
-    /// Closure invoked when ⌥M (hotkey id 3) fires. Wired by TranscriptedAppDelegate
+    /// Closure invoked when the meeting physical trigger fires. Wired by TranscriptedAppDelegate
     /// to `MeetingSessionController.toggleMeeting()` (or equivalent). Nil when
     /// the meeting subsystem is unavailable — the hotkey simply does nothing.
-    var onMeetingToggle: (() -> Void)? {
-        didSet {
-            _sharedMeetingToggle = onMeetingToggle
-        }
-    }
+    var onMeetingToggle: (() -> Void)?
 
     var onPasteLastDictation: (() -> Void)?
 
@@ -447,10 +392,9 @@ class ContextCaptureEngine: ObservableObject {
             return
         }
 
-        // Restore C-callback routing after temporary unregister/re-register cycles
+        // Restore dictation routing after temporary unregister/re-register cycles
         // such as wake recovery.
         _sharedSessionController = sessionController
-        _sharedMeetingToggle = onMeetingToggle
 
         refreshShortcutDisplays()
         configurePhysicalShortcutDetector()
@@ -476,7 +420,6 @@ class ContextCaptureEngine: ObservableObject {
     }
 
     private func refreshShortcutDisplays() {
-        carbonHotkeyError = nil
         dictationShortcutDisplay = Self.currentDictationShortcutDisplay()
         meetingShortcutDisplay = PhysicalDictationTriggerPreferences.displayString(
             for: PhysicalDictationTriggerPreferences.meetingBinding()
@@ -571,7 +514,6 @@ class ContextCaptureEngine: ObservableObject {
 
     private func updateHotkeyError() {
         let errors = [
-            carbonHotkeyError,
             physicalTriggerError,
             HotkeyPreferences.dictationShortcutsEnabled()
                 ? PhysicalDictationTriggerPreferences.functionKeyConflictWarning(
@@ -710,8 +652,6 @@ class ContextCaptureEngine: ObservableObject {
     }
 
     deinit {
-        if let ref = meetingHotkeyRef { UnregisterEventHotKey(ref) }
-        if let ref = eventHandlerRef { RemoveEventHandler(ref) }
         if let observer = hotkeyChangeObserver {
             NotificationCenter.default.removeObserver(observer)
         }
@@ -719,20 +659,11 @@ class ContextCaptureEngine: ObservableObject {
     }
 
     func unregisterHotkey() {
-        if let ref = meetingHotkeyRef {
-            UnregisterEventHotKey(ref)
-            meetingHotkeyRef = nil
-        }
-        if let ref = eventHandlerRef {
-            RemoveEventHandler(ref)
-            eventHandlerRef = nil
-        }
         if let observer = hotkeyChangeObserver {
             NotificationCenter.default.removeObserver(observer)
             hotkeyChangeObserver = nil
         }
         physicalShortcutDetector.remove()
         _sharedSessionController = nil
-        _sharedMeetingToggle = nil
     }
 }

--- a/Sources/Observability/EventReporter.swift
+++ b/Sources/Observability/EventReporter.swift
@@ -254,6 +254,7 @@ final class EventReporter {
             }
         }
         await writer.flushForShutdown()
+        await ReliabilityPacketRecorder.flushForShutdown()
     }
 
     private func markAppendTaskFinished(_ id: Int) {

--- a/Sources/Observability/ReliabilityPacketRecorder.swift
+++ b/Sources/Observability/ReliabilityPacketRecorder.swift
@@ -40,11 +40,17 @@ private actor ReliabilityPacketFileWriter {
             approximateSize += UInt64(lineData.count)
             if approximateSize > TranscriptedConstants.jsonlLogRotationThreshold {
                 // Close so the next append re-prepares, which rotates the file.
+                handle.synchronizeFile()
                 try? handle.close()
                 self.handle = nil
                 isPrepared = false
             }
         }
+    }
+
+    func flushForShutdown() {
+        guard isPrepared, let handle else { return }
+        handle.synchronizeFile()
     }
 
     private func prepareIfNeeded() -> Bool {
@@ -71,16 +77,42 @@ enum ReliabilityPacketRecorder {
 
     private static let writer = ReliabilityPacketFileWriter()
     private static let decoder = JSONDecoder()
+    @MainActor private static var pendingRecordTasks: [Int: Task<Void, Never>] = [:]
+    @MainActor private static var nextRecordTaskID = 0
 
     static func defaultFileURL() -> URL {
         FileManager.default.transcriptedLogsDirURL.appendingPathComponent(fileName)
     }
 
+    @MainActor
     static func record(event: ObservabilityEvent) {
         guard let packet = packet(from: event) else { return }
-        Task.detached(priority: .utility) {
+        let recordTaskID = nextRecordTaskID
+        nextRecordTaskID += 1
+        let recordTask = Task.detached(priority: .utility) {
             await writer.append(packet)
+            await MainActor.run {
+                ReliabilityPacketRecorder.markRecordTaskFinished(recordTaskID)
+            }
         }
+        pendingRecordTasks[recordTaskID] = recordTask
+    }
+
+    @MainActor
+    static func flushForShutdown() async {
+        while !pendingRecordTasks.isEmpty {
+            let tasks = Array(pendingRecordTasks.values)
+            pendingRecordTasks.removeAll(keepingCapacity: true)
+            for task in tasks {
+                await task.value
+            }
+        }
+        await writer.flushForShutdown()
+    }
+
+    @MainActor
+    private static func markRecordTaskFinished(_ id: Int) {
+        pendingRecordTasks[id] = nil
     }
 
     // MARK: - Shared append primitives

--- a/Tests/ContextCaptureEnginePolicyTests.swift
+++ b/Tests/ContextCaptureEnginePolicyTests.swift
@@ -4,7 +4,7 @@
 // the default binding set that feeds bindingProvider, and the conflict-warning
 // text that flows into the engine's hotkeyError pipeline.
 //
-// NOTE: ContextCaptureEngine itself is @MainActor and wired to AppKit, Carbon,
+// NOTE: ContextCaptureEngine itself is @MainActor and wired to AppKit,
 // NSWorkspace, DictationSessionController, FloatingOverlayController,
 // EventReporter, and DiagnosticsTrail. Its remaining internal seams
 // (shouldAcceptHotkeyAction, routeDictationToggle, PhysicalShortcutDetector)
@@ -189,9 +189,9 @@ func testContextCaptureEnginePolicy() {
     }
 
     // MARK: - hotkeyError pipeline inputs
-    // ContextCaptureEngine.updateHotkeyError() joins carbonHotkeyError,
-    // physicalTriggerError, and (when dictation shortcuts are enabled) the
-    // function-key conflict warning. Pin the conflict-warning text since it
+    // ContextCaptureEngine.updateHotkeyError() joins physicalTriggerError and
+    // (when dictation shortcuts are enabled) the function-key conflict warning.
+    // Pin the conflict-warning text since it
     // surfaces verbatim in the MenuBarPanel banner.
 
     runSuite("PhysicalDictationTriggerPreferences.functionKeyConflictWarning — silent when binding isn't bare Fn") {

--- a/Tests/ObservabilityLogWriterTests.swift
+++ b/Tests/ObservabilityLogWriterTests.swift
@@ -33,11 +33,20 @@ func testObservabilityLogWriter() {
 
     runSuite("EventReporter exposes shutdown flushing for buffered info events") {
         let reporterSource = readObservabilityTestRepoTextFile("Sources/Observability/EventReporter.swift")
+        let reliabilityRecorderSource = readObservabilityTestRepoTextFile("Sources/Observability/ReliabilityPacketRecorder.swift")
         let appSource = readObservabilityTestRepoTextFile("Sources/TranscriptedApp.swift")
 
         assertTrue(
             reporterSource.contains("func flushLocalEventsForShutdown() async"),
             "buffered local info events should have an explicit shutdown flush path"
+        )
+        assertTrue(
+            reliabilityRecorderSource.contains("static func flushForShutdown() async"),
+            "reliability packet writes should also have an explicit shutdown flush path"
+        )
+        assertTrue(
+            reporterSource.contains("await ReliabilityPacketRecorder.flushForShutdown()"),
+            "the shared local-event shutdown flush should drain reliability packet writes too"
         )
         assertTrue(
             appSource.contains("await EventReporter.shared.flushLocalEventsForShutdown()"),


### PR DESCRIPTION
## Summary

- Remove the dead Carbon meeting-hotkey callback path from `ContextCaptureEngine`; the physical shortcut detector is now the only hotkey recovery surface there.
- Track and flush reliability-packet write tasks during the existing local event shutdown flush.
- Sync `reliability.jsonl` before rotation close so support diagnostics do not lose the tail of a packet batch.

## Thermo audit notes

- Claude architecture audit recommended not unifying the wake/audio/zombie watchdog state machines: their retry budgets, cooldowns, generation guards, and suspension-point checks are intentionally different.
- Independent diff review found a stale `_sharedMeetingToggle` global after the Carbon removal; fixed before commit.
- Local lane output was discarded as unreliable because it hallucinated non-repo paths.

Proof paths:

- `MAESTRO_PROOF=/Users/redbars/.codex/maestro/runs/20260620T120003Z-reliability-thermo-architecture-claude`
- `MAESTRO_PROOF=/Users/redbars/.codex/maestro/runs/20260620T122000Z-reliability-pr-diff-review-claude`
- local lane discarded: `/Users/redbars/.codex/maestro/runs/20260620T120003Z-reliability-thermo-pattern-scan-local`

## Verification

- `bash build-deps.sh --force` PASS
- `bash run-tests.sh --filter ContextCaptureEnginePolicy` PASS, 63 tests
- `bash run-tests.sh --filter ObservabilityLogWriter` PASS, 44 tests
- `bash run-tests.sh --filter ReliabilityPacketRecorder` PASS, 78 tests
- `bash build.sh --no-open` PASS
- `bash run-tests.sh` PASS, 10,422 tests
- `bash run-integration-smoke.sh` PASS, including wake recovery smoke and MicRecordingFileMerger package tests
- `TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa permission-state --mode computer-use --format json` WARN, exit 3: duplicate/wrong running Transcripted app instance and Automation OSStatus -600. Treat UI/computer-use proof as incomplete, not green.

No merge or release performed.
