### PR TITLE
Consolidate speaker vector math

### DIFF
--- a/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
@@ -253,7 +253,7 @@ public final class SpeakerDatabase: @unchecked Sendable {
             let blended = zip(existing.embedding, embedding).map { old, new in
                 old * (1 - alpha) + new * alpha
             }
-            let normalized = l2Normalize(blended)
+            let normalized = SpeakerVectorMath.l2Normalize(blended)
             let newConfidence = min(1.0, existing.confidence + 0.1)
 
             var sqlSucceeded = false
@@ -296,7 +296,7 @@ public final class SpeakerDatabase: @unchecked Sendable {
         } else {
             // New speaker
             let newId = existingId ?? UUID()
-            let normalized = l2Normalize(embedding)
+            let normalized = SpeakerVectorMath.l2Normalize(embedding)
             let embeddingData = normalized.withUnsafeBufferPointer { Data(buffer: $0) }
 
             var sqlSucceeded = false

--- a/Sources/TranscriptedCore/Speaker/SpeakerEmbeddingMatcher.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerEmbeddingMatcher.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Accelerate
 
 // MARK: - Speaker Matching
 
@@ -22,7 +21,7 @@ extension SpeakerDatabase {
         var bestSimilarity: Double = -1
 
         for speaker in allSpeakers {
-            let similarity = cosineSimilarity(embedding, speaker.embedding)
+            let similarity = SpeakerVectorMath.cosineSimilarity(embedding, speaker.embedding)
             if similarity > bestSimilarity && similarity >= threshold {
                 bestSimilarity = similarity
                 bestMatch = speaker
@@ -35,38 +34,5 @@ extension SpeakerDatabase {
         }
 
         return nil
-    }
-
-    // MARK: - Math Utilities
-
-    /// Cosine similarity between two vectors
-    func cosineSimilarity(_ a: [Float], _ b: [Float]) -> Double {
-        guard a.count == b.count, !a.isEmpty else { return 0 }
-
-        var dotProduct: Float = 0
-        var normA: Float = 0
-        var normB: Float = 0
-
-        vDSP_dotpr(a, 1, b, 1, &dotProduct, vDSP_Length(a.count))
-        vDSP_dotpr(a, 1, a, 1, &normA, vDSP_Length(a.count))
-        vDSP_dotpr(b, 1, b, 1, &normB, vDSP_Length(b.count))
-
-        let denom = sqrt(normA) * sqrt(normB)
-        guard denom > 0 else { return 0 }
-
-        return Double(dotProduct / denom)
-    }
-
-    /// L2 normalize a vector
-    func l2Normalize(_ v: [Float]) -> [Float] {
-        var norm: Float = 0
-        vDSP_dotpr(v, 1, v, 1, &norm, vDSP_Length(v.count))
-        norm = sqrt(norm)
-        guard norm > 0 else { return v }
-
-        var result = [Float](repeating: 0, count: v.count)
-        var divisor = norm
-        vDSP_vsdiv(v, 1, &divisor, &result, 1, vDSP_Length(v.count))
-        return result
     }
 }

--- a/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerMatchingService.swift
@@ -36,15 +36,7 @@ extension Transcription {
         var mean = sum
         var scale = Float(embeddings.count)
         vDSP_vsdiv(mean, 1, &scale, &mean, 1, vDSP_Length(mean.count))
-
-        // L2 normalize
-        var norm: Float = 0
-        vDSP_dotpr(mean, 1, mean, 1, &norm, vDSP_Length(mean.count))
-        norm = sqrt(norm)
-        if norm > 0 {
-            vDSP_vsdiv(mean, 1, &norm, &mean, 1, vDSP_Length(mean.count))
-        }
-        return mean
+        return SpeakerVectorMath.l2Normalize(mean)
     }
 
     /// Match an embedding against a frozen snapshot of speaker profiles.
@@ -137,32 +129,11 @@ extension Transcription {
         var mean = sum
         var scale = totalWeight
         vDSP_vsdiv(mean, 1, &scale, &mean, 1, vDSP_Length(mean.count))
-
-        // L2 normalize
-        var norm: Float = 0
-        vDSP_dotpr(mean, 1, mean, 1, &norm, vDSP_Length(mean.count))
-        norm = sqrt(norm)
-        if norm > 0 {
-            vDSP_vsdiv(mean, 1, &norm, &mean, 1, vDSP_Length(mean.count))
-        }
-        return mean
+        return SpeakerVectorMath.l2Normalize(mean)
     }
 
     /// Static cosine similarity (no instance needed — used in nonisolated static context)
     nonisolated static func cosineSimilarityStatic(_ a: [Float], _ b: [Float]) -> Double {
-        guard a.count == b.count, !a.isEmpty else { return 0 }
-
-        var dotProduct: Float = 0
-        var normA: Float = 0
-        var normB: Float = 0
-
-        vDSP_dotpr(a, 1, b, 1, &dotProduct, vDSP_Length(a.count))
-        vDSP_dotpr(a, 1, a, 1, &normA, vDSP_Length(a.count))
-        vDSP_dotpr(b, 1, b, 1, &normB, vDSP_Length(b.count))
-
-        let denom = sqrt(normA) * sqrt(normB)
-        guard denom > 0 else { return 0 }
-
-        return Double(dotProduct / denom)
+        SpeakerVectorMath.cosineSimilarity(a, b)
     }
 }

--- a/Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift
@@ -185,7 +185,7 @@ extension SpeakerDatabase {
         let blended = zip(source.embedding, target.embedding).map { s, t in
             s * sourceWeight + t * targetWeight
         }
-        let normalized = l2Normalize(blended)
+        let normalized = SpeakerVectorMath.l2Normalize(blended)
 
         // Transfer name from source if target has none
         if target.displayName == nil, let name = source.displayName {
@@ -285,7 +285,7 @@ extension SpeakerDatabase {
                 guard !protectedIds.contains(speakers[j].id) else { continue }
                 guard !shouldSkipDuplicateMerge(speakers[i], speakers[j]) else { continue }
 
-                let similarity = cosineSimilarity(speakers[i].embedding, speakers[j].embedding)
+                let similarity = SpeakerVectorMath.cosineSimilarity(speakers[i].embedding, speakers[j].embedding)
                 guard similarity >= threshold else { continue }
 
                 // Determine which profile to keep (more calls = better data)

--- a/Sources/TranscriptedCore/Speaker/SpeakerVectorMath.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerVectorMath.swift
@@ -1,0 +1,33 @@
+import Accelerate
+import Foundation
+
+public enum SpeakerVectorMath {
+    public static func cosineSimilarity(_ lhs: [Float], _ rhs: [Float]) -> Double {
+        guard lhs.count == rhs.count, !lhs.isEmpty else { return 0 }
+
+        var dotProduct: Float = 0
+        var lhsNorm: Float = 0
+        var rhsNorm: Float = 0
+
+        vDSP_dotpr(lhs, 1, rhs, 1, &dotProduct, vDSP_Length(lhs.count))
+        vDSP_dotpr(lhs, 1, lhs, 1, &lhsNorm, vDSP_Length(lhs.count))
+        vDSP_dotpr(rhs, 1, rhs, 1, &rhsNorm, vDSP_Length(rhs.count))
+
+        let denominator = sqrt(lhsNorm) * sqrt(rhsNorm)
+        guard denominator > 0 else { return 0 }
+
+        return Double(dotProduct / denominator)
+    }
+
+    public static func l2Normalize(_ values: [Float]) -> [Float] {
+        var norm: Float = 0
+        vDSP_dotpr(values, 1, values, 1, &norm, vDSP_Length(values.count))
+        norm = sqrt(norm)
+        guard norm > 0 else { return values }
+
+        var result = [Float](repeating: 0, count: values.count)
+        var divisor = norm
+        vDSP_vsdiv(values, 1, &divisor, &result, 1, vDSP_Length(values.count))
+        return result
+    }
+}

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -573,20 +573,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
 
     nonisolated private static func cosineSimilarity(_ lhs: [Float], _ rhs: [Float]) -> Double? {
         guard lhs.count == rhs.count, !lhs.isEmpty else { return nil }
-
-        var dotProduct: Float = 0
-        var lhsNorm: Float = 0
-        var rhsNorm: Float = 0
-
-        for (left, right) in zip(lhs, rhs) {
-            dotProduct += left * right
-            lhsNorm += left * left
-            rhsNorm += right * right
-        }
-
-        let denominator = sqrt(lhsNorm) * sqrt(rhsNorm)
-        guard denominator > 0 else { return nil }
-        return Double(dotProduct / denominator)
+        return SpeakerVectorMath.cosineSimilarity(lhs, rhs)
     }
 
     nonisolated private static func clipURL(

--- a/Tests/TranscriptedCoreTests/SpeakerEmbeddingMatcherTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerEmbeddingMatcherTests.swift
@@ -89,41 +89,34 @@ final class SpeakerEmbeddingMatcherTests: XCTestCase {
     // MARK: - cosineSimilarity
 
     func testCosineSimilarityIdenticalVectorsIsOne() {
-        let (db, _) = makeDatabase()
-        XCTAssertEqual(db.cosineSimilarity([1, 2, 3], [1, 2, 3]), 1.0, accuracy: 0.000_1)
+        XCTAssertEqual(SpeakerVectorMath.cosineSimilarity([1, 2, 3], [1, 2, 3]), 1.0, accuracy: 0.000_1)
     }
 
     func testCosineSimilarityOrthogonalVectorsIsZero() {
-        let (db, _) = makeDatabase()
-        XCTAssertEqual(db.cosineSimilarity([1, 0], [0, 1]), 0.0, accuracy: 0.000_1)
+        XCTAssertEqual(SpeakerVectorMath.cosineSimilarity([1, 0], [0, 1]), 0.0, accuracy: 0.000_1)
     }
 
     func testCosineSimilarityOppositeVectorsIsNegativeOne() {
-        let (db, _) = makeDatabase()
-        XCTAssertEqual(db.cosineSimilarity([1, 0], [-1, 0]), -1.0, accuracy: 0.000_1)
+        XCTAssertEqual(SpeakerVectorMath.cosineSimilarity([1, 0], [-1, 0]), -1.0, accuracy: 0.000_1)
     }
 
     func testCosineSimilarityMismatchedLengthIsZero() {
-        let (db, _) = makeDatabase()
-        XCTAssertEqual(db.cosineSimilarity([1, 0, 0], [1, 0]), 0.0)
+        XCTAssertEqual(SpeakerVectorMath.cosineSimilarity([1, 0, 0], [1, 0]), 0.0)
     }
 
     func testCosineSimilarityEmptyVectorsIsZero() {
-        let (db, _) = makeDatabase()
-        XCTAssertEqual(db.cosineSimilarity([], []), 0.0)
+        XCTAssertEqual(SpeakerVectorMath.cosineSimilarity([], []), 0.0)
     }
 
     func testCosineSimilarityZeroVectorIsZero() {
-        let (db, _) = makeDatabase()
         // A zero-magnitude vector makes the denominator zero — guarded to 0.
-        XCTAssertEqual(db.cosineSimilarity([0, 0], [1, 0]), 0.0)
+        XCTAssertEqual(SpeakerVectorMath.cosineSimilarity([0, 0], [1, 0]), 0.0)
     }
 
     // MARK: - l2Normalize
 
     func testL2NormalizeProducesUnitVector() {
-        let (db, _) = makeDatabase()
-        let normalized = db.l2Normalize([3, 4])
+        let normalized = SpeakerVectorMath.l2Normalize([3, 4])
 
         XCTAssertEqual(magnitude(normalized), 1.0, accuracy: 0.000_1)
         XCTAssertEqual(normalized[0], 0.6, accuracy: 0.000_1)
@@ -131,17 +124,15 @@ final class SpeakerEmbeddingMatcherTests: XCTestCase {
     }
 
     func testL2NormalizeLeavesAlreadyUnitVectorUnchanged() {
-        let (db, _) = makeDatabase()
-        let normalized = db.l2Normalize([1, 0, 0])
+        let normalized = SpeakerVectorMath.l2Normalize([1, 0, 0])
 
         XCTAssertEqual(magnitude(normalized), 1.0, accuracy: 0.000_1)
         XCTAssertEqual(normalized, [1, 0, 0])
     }
 
     func testL2NormalizeNoOpsZeroVector() {
-        let (db, _) = makeDatabase()
         // Zero magnitude — guarded to return the input untouched.
-        XCTAssertEqual(db.l2Normalize([0, 0, 0]), [0, 0, 0])
+        XCTAssertEqual(SpeakerVectorMath.l2Normalize([0, 0, 0]), [0, 0, 0])
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
- Add `SpeakerVectorMath` as the shared cosine/L2 helper for speaker embeddings.
- Route database matching, in-memory matching, profile merge, and People duplicate scoring through it.
- Update embedding math tests to target the shared helper directly.

## Thermo audit notes
The larger speaker-review risks are still separate PRs:
- Split `SpeakerNamingCoordinator.handleNamingComplete` into action planning vs apply/persist/rewrite.
- Move People duplicate/merge identity policy out of `SpeakerPeopleSettingsViewModel`.
- Centralize name normalization so Core, coordinator, and settings use the same folding rules.
- Collapse or clearly label the weaker matcher path vs the guarded production matching path.
- Hoist simulator thresholds/apply rules so simulator proof cannot drift from production.
- Add privacy-safe speaker-review shown/submitted/finalized telemetry without names, audio, transcript text, or paths.

## Verification
- `bash build-deps.sh --force`
- `bash run-tests.sh --filter Speaker`
- `swift test --filter Speaker`
- `python3 -m py_compile scripts/ops/speaker-naming-simulator.py && scripts/ops/speaker-naming-simulator.py`
- `scripts/ops/speaker-naming-simulator.py --sweep`
- `swift build --package-path Tools/SpeakerEvalHarness`
- `bash build.sh --no-open`
- `bash scripts/dev/agent-preflight.sh`
- `bash run-tests.sh` — 10420 passed
- `bash run-integration-smoke.sh`
- `swift test` — 502 passed, 1 skipped
- `git diff --cached --check`
- `codex review --base origin/main` — first pass caught unstaged helper; rerun clean after staging

## Lanes
- Codex: repo audit, patch, verification, PR
- Claude: structural audit proof `/Users/redbars/.codex/maestro/runs/20260620T120027Z-speaker-thermo-audit-claude`
- Local: first-pass audit rejected as hallucinated, proof `/Users/redbars/.codex/maestro/runs/20260620T120011Z-speaker-thermo-audit-local`
- Windows: smoke reachable, skipped for this small deterministic cleanup
