### PR TITLE
Extract dictation stop finalizer

### DIFF
--- a/Sources/Dictation/DictationStopFinalizationPolicy.swift
+++ b/Sources/Dictation/DictationStopFinalizationPolicy.swift
@@ -24,3 +24,37 @@ enum DictationStopFinalizationOrder: String {
 enum DictationStopFinalizationPolicy {
     static let order: DictationStopFinalizationOrder = .saveBeforeAutoEnter
 }
+
+struct DictationStopFinalizationResult<AutoEnterOutcome, SaveFailure> {
+    let autoEnterOutcome: AutoEnterOutcome
+    let saveFailure: SaveFailure?
+}
+
+enum DictationStopFinalizer {
+    @MainActor
+    static func finalize<SaveValue, AutoEnterOutcome, SaveFailure>(
+        order: DictationStopFinalizationOrder,
+        startSaving: () -> Task<Result<SaveValue, Error>, Never>,
+        finishSaving: (Task<Result<SaveValue, Error>, Never>) async -> SaveFailure?,
+        saveSynchronously: () -> SaveFailure?,
+        performAutoEnter: () async -> AutoEnterOutcome
+    ) async -> DictationStopFinalizationResult<AutoEnterOutcome, SaveFailure> {
+        switch order {
+        case .saveAfterAutoEnter:
+            let autoEnterOutcome = await performAutoEnter()
+            let saveFailure = saveSynchronously()
+            return DictationStopFinalizationResult(
+                autoEnterOutcome: autoEnterOutcome,
+                saveFailure: saveFailure
+            )
+        case .saveBeforeAutoEnter:
+            let saveTask = startSaving()
+            let autoEnterOutcome = await performAutoEnter()
+            let saveFailure = await finishSaving(saveTask)
+            return DictationStopFinalizationResult(
+                autoEnterOutcome: autoEnterOutcome,
+                saveFailure: saveFailure
+            )
+        }
+    }
+}

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -960,37 +960,41 @@ class DictationSessionController: ObservableObject {
             stopTiming.pasteStartedAt = CFAbsoluteTimeGetCurrent()
             let pasteOutcome = self.pasteWithClipboardRestore(text)
             stopTiming.pastedAt = CFAbsoluteTimeGetCurrent()
-            let autoSendOutcome: DictationAutoSendOutcome
-            let saveFailureMessage: String?
-            switch DictationStopFinalizationPolicy.order {
-            case .saveAfterAutoEnter:
-                stopTiming.autoEnterStartedAt = CFAbsoluteTimeGetCurrent()
-                autoSendOutcome = await self.performAutoEnterIfNeeded(
-                    text: text,
-                    delivery: pasteOutcome.delivery
-                )
-                stopTiming.autoEnterFinishedAt = CFAbsoluteTimeGetCurrent()
-                stopTiming.saveStartedAt = CFAbsoluteTimeGetCurrent()
-                saveFailureMessage = self.persistDictationTranscript(text: text, delivery: pasteOutcome.delivery)
-                stopTiming.savedAt = CFAbsoluteTimeGetCurrent()
-            case .saveBeforeAutoEnter:
-                stopTiming.saveStartedAt = CFAbsoluteTimeGetCurrent()
-                let saveTask = self.startPersistingDictationTranscript(
-                    text: text,
-                    delivery: pasteOutcome.delivery
-                )
-                stopTiming.autoEnterStartedAt = CFAbsoluteTimeGetCurrent()
-                autoSendOutcome = await self.performAutoEnterIfNeeded(
-                    text: text,
-                    delivery: pasteOutcome.delivery
-                )
-                stopTiming.autoEnterFinishedAt = CFAbsoluteTimeGetCurrent()
-                saveFailureMessage = await self.finishPersistingDictationTranscript(
-                    saveTask,
-                    delivery: pasteOutcome.delivery
-                )
-                stopTiming.savedAt = CFAbsoluteTimeGetCurrent()
-            }
+            let finalization = await DictationStopFinalizer.finalize(
+                order: DictationStopFinalizationPolicy.order,
+                startSaving: {
+                    stopTiming.saveStartedAt = CFAbsoluteTimeGetCurrent()
+                    return self.startPersistingDictationTranscript(
+                        text: text,
+                        delivery: pasteOutcome.delivery
+                    )
+                },
+                finishSaving: { saveTask in
+                    let failure = await self.finishPersistingDictationTranscript(
+                        saveTask,
+                        delivery: pasteOutcome.delivery
+                    )
+                    stopTiming.savedAt = CFAbsoluteTimeGetCurrent()
+                    return failure
+                },
+                saveSynchronously: {
+                    stopTiming.saveStartedAt = CFAbsoluteTimeGetCurrent()
+                    let failure = self.persistDictationTranscript(text: text, delivery: pasteOutcome.delivery)
+                    stopTiming.savedAt = CFAbsoluteTimeGetCurrent()
+                    return failure
+                },
+                performAutoEnter: {
+                    stopTiming.autoEnterStartedAt = CFAbsoluteTimeGetCurrent()
+                    let outcome = await self.performAutoEnterIfNeeded(
+                        text: text,
+                        delivery: pasteOutcome.delivery
+                    )
+                    stopTiming.autoEnterFinishedAt = CFAbsoluteTimeGetCurrent()
+                    return outcome
+                }
+            )
+            let autoSendOutcome = finalization.autoEnterOutcome
+            let saveFailureMessage = finalization.saveFailure
             let wordCount = text.split(whereSeparator: \.isWhitespace).count
             stopTiming.completedAt = CFAbsoluteTimeGetCurrent()
             let deliveryLevel: EventLevel = pasteOutcome.delivery == .pasted ? .info : .warning

--- a/Tests/DictationStopFinalizationPolicyTests.swift
+++ b/Tests/DictationStopFinalizationPolicyTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-func testDictationStopFinalizationPolicy() {
+func testDictationStopFinalizationPolicy() async {
     runSuite("DictationStopFinalizationOrder.parse - accepts canonical raw values") {
         assertEqual(
             DictationStopFinalizationOrder.parse("saveBeforeAutoEnter"),
@@ -44,5 +44,78 @@ func testDictationStopFinalizationPolicy() {
             .saveBeforeAutoEnter,
             "the default should keep the dictation artifact save ahead of the optional Auto Enter delay"
         )
+    }
+
+    await runSuite("DictationStopFinalizer.finalize - default starts save before Auto Enter and finishes after") {
+        var events: [String] = []
+        let result: DictationStopFinalizationResult<String, String> = await DictationStopFinalizer.finalize(
+            order: .saveBeforeAutoEnter,
+            startSaving: {
+                events.append("start_save")
+                return Task { .success("saved") }
+            },
+            finishSaving: { task in
+                events.append("finish_save_started")
+                _ = await task.value
+                events.append("finish_save_finished")
+                return nil
+            },
+            saveSynchronously: {
+                events.append("save_synchronously")
+                return nil
+            },
+            performAutoEnter: {
+                events.append("auto_enter")
+                return "sent"
+            }
+        )
+
+        assertEqual(
+            events,
+            [
+                "start_save",
+                "auto_enter",
+                "finish_save_started",
+                "finish_save_finished",
+            ],
+            "save-before finalization should start saving, send Auto Enter, then await the save result"
+        )
+        assertEqual(result.autoEnterOutcome, "sent", "finalizer should preserve the Auto Enter result")
+        assertNil(result.saveFailure, "successful save should report no failure")
+    }
+
+    await runSuite("DictationStopFinalizer.finalize - legacy order keeps save after Auto Enter") {
+        var events: [String] = []
+        let result: DictationStopFinalizationResult<String, String> = await DictationStopFinalizer.finalize(
+            order: .saveAfterAutoEnter,
+            startSaving: {
+                events.append("start_save")
+                return Task { .success("saved") }
+            },
+            finishSaving: { task in
+                events.append("finish_save")
+                _ = await task.value
+                return nil
+            },
+            saveSynchronously: {
+                events.append("save_synchronously")
+                return "disk full"
+            },
+            performAutoEnter: {
+                events.append("auto_enter")
+                return "sent"
+            }
+        )
+
+        assertEqual(
+            events,
+            [
+                "auto_enter",
+                "save_synchronously",
+            ],
+            "save-after finalization should preserve the legacy Auto Enter first order"
+        )
+        assertEqual(result.autoEnterOutcome, "sent", "finalizer should preserve the Auto Enter result")
+        assertEqual(result.saveFailure, "disk full", "finalizer should preserve synchronous save failures")
     }
 }

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1629,22 +1629,76 @@ func testRepoCommandContract() {
 
     runSuite("Repo command contract - dictation Auto Enter stays after paste readiness") {
         let contents = readRepoTextFile("Sources/UI/Overlay/DictationSessionController.swift")
-        let saveBeforeAutoEnterBlock = sourceSlice(
+        let finalizerBlock = sourceSlice(
             contents,
-            from: "case .saveBeforeAutoEnter:",
-            to: "let wordCount = text.split"
+            from: "let finalization = await DictationStopFinalizer.finalize(",
+            to: "let autoSendOutcome = finalization.autoEnterOutcome"
         )
-        let saveTaskRange = saveBeforeAutoEnterBlock.range(of: "let saveTask = self.startPersistingDictationTranscript")
-        let autoEnterRange = saveBeforeAutoEnterBlock.range(of: "autoSendOutcome = await self.performAutoEnterIfNeeded")
-        let finishSaveRange = saveBeforeAutoEnterBlock.range(of: "saveFailureMessage = await self.finishPersistingDictationTranscript")
+        let startSaveClosure = sourceSlice(
+            finalizerBlock,
+            from: "startSaving: {",
+            to: "},\n                finishSaving:"
+        )
+        let finishSaveClosure = sourceSlice(
+            finalizerBlock,
+            from: "finishSaving: { saveTask in",
+            to: "},\n                saveSynchronously:"
+        )
+        let synchronousSaveClosure = sourceSlice(
+            finalizerBlock,
+            from: "saveSynchronously: {",
+            to: "},\n                performAutoEnter:"
+        )
+        let autoEnterClosure = sourceSlice(
+            finalizerBlock,
+            from: "performAutoEnter: {",
+            to: "}\n            )"
+        )
 
         assertTrue(
-            saveTaskRange != nil
-                && autoEnterRange != nil
-                && finishSaveRange != nil
-                && saveTaskRange!.lowerBound < autoEnterRange!.lowerBound
-                && autoEnterRange!.lowerBound < finishSaveRange!.lowerBound,
-            "default stop finalization should start saving, wait/send Auto Enter, then await the save result"
+            sourceOrder(
+                in: startSaveClosure,
+                needles: [
+                    "stopTiming.saveStartedAt = CFAbsoluteTimeGetCurrent()",
+                    "return self.startPersistingDictationTranscript",
+                ]
+            ),
+            "finalizer startSaving closure should timestamp save start before launching the async save"
+        )
+        assertTrue(
+            sourceOrder(
+                in: finishSaveClosure,
+                needles: [
+                    "await self.finishPersistingDictationTranscript",
+                    "stopTiming.savedAt = CFAbsoluteTimeGetCurrent()",
+                    "return failure",
+                ]
+            ),
+            "finalizer finishSaving closure should await the save result before timestamping completion"
+        )
+        assertTrue(
+            sourceOrder(
+                in: synchronousSaveClosure,
+                needles: [
+                    "stopTiming.saveStartedAt = CFAbsoluteTimeGetCurrent()",
+                    "self.persistDictationTranscript",
+                    "stopTiming.savedAt = CFAbsoluteTimeGetCurrent()",
+                    "return failure",
+                ]
+            ),
+            "legacy synchronous save closure should keep save timing around the blocking save"
+        )
+        assertTrue(
+            sourceOrder(
+                in: autoEnterClosure,
+                needles: [
+                    "stopTiming.autoEnterStartedAt = CFAbsoluteTimeGetCurrent()",
+                    "await self.performAutoEnterIfNeeded",
+                    "stopTiming.autoEnterFinishedAt = CFAbsoluteTimeGetCurrent()",
+                    "return outcome",
+                ]
+            ),
+            "finalizer Auto Enter closure should timestamp around the tested Auto Enter path"
         )
 
         let autoEnterBlock = sourceSlice(
@@ -3390,6 +3444,17 @@ private func sourceSlice(_ contents: String, from start: String, to end: String)
     }
 
     return String(contents[startRange.lowerBound..<endRange.lowerBound])
+}
+
+private func sourceOrder(in contents: String, needles: [String]) -> Bool {
+    var searchStart = contents.startIndex
+    for needle in needles {
+        guard let range = contents.range(of: needle, range: searchStart..<contents.endIndex) else {
+            return false
+        }
+        searchStart = range.upperBound
+    }
+    return true
 }
 
 private func countOccurrences(of needle: String, in haystack: String) -> Int {


### PR DESCRIPTION
## Summary
- extract dictation stop save/Auto Enter ordering into `DictationStopFinalizer`
- keep the rebased session-cap `autoPaste: false` / `finalizeWithoutPaste` rescue path intact
- replace brittle controller source-slice coverage with direct finalizer ordering tests plus stricter controller wiring contract checks

## Review evidence
- Thermo-nuclear audit identified the stop finalization switch as the safest behavior-preserving cleanup seam.
- Independent review first caught stale-base risk against PR #1234 session-cap rescue. Fixed by rebasing onto `origin/main` (`c2f8aaab`) and preserving `finalizeWithoutPaste` before paste/Auto Enter.
- Final independent review: no findings; manual pasteback feel remains UNKNOWN.

## Tests
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh --filter DictationStopFinalizationPolicy` — 13/13 passed
- `bash run-tests.sh --filter RepoCommandContract` — 608/608 passed
- `bash run-tests.sh` — 10439/10439 passed
- `bash run-slow-pasteback-smoke.sh` — 8/8 passed

## Holds
- Real-app pasteback feel remains UNKNOWN until manual app testing.
