### PR TITLE
Clarify PostHog live proof reporting

### DIFF
--- a/docs/activation-lane.md
+++ b/docs/activation-lane.md
@@ -81,6 +81,10 @@ adoption signal, under-discovered feature, release regression watch, and top
 three PR/task candidates. It has fixture and self-test modes so CI can check
 the ranking logic without PostHog credentials.
 
+If strict first-artifact proof or live `agent_capture_query_observed` proof is
+zero, treat it as a source-vs-live delivery, config, no-eligible-use, or
+regression question before creating another instrumentation task.
+
 ## PostHog Product Context Pack
 
 Use this when an agent needs the short decision context, not the full funnel:

--- a/docs/posthog-100-wau-dashboard.md
+++ b/docs/posthog-100-wau-dashboard.md
@@ -20,7 +20,7 @@ proof. Treat those as point-in-time inputs, not timeless product truth.
   last 7 days: `activation_first_artifact_saved`, `dictation_completed`,
   `meeting_transcript_saved`, `activation_artifact_action_clicked`,
   `activation_agent_prompt_action_clicked`, `activation_return_proxy_observed`,
-  or future `agent_capture_query_observed`.
+  or live `agent_capture_query_observed` rows.
 - **Strict activation:** launch -> permission/onboarding ready -> first saved
   Markdown -> agent-use proof -> return.
 - **Proxy activation:** launch -> saved Markdown or dictation completion ->
@@ -32,12 +32,12 @@ Do not collapse launch, proxy activation, and strict activation into one number.
 
 | Dashboard | Product question | Existing events to use | Missing events needed |
 | --- | --- | --- | --- |
-| 100 WAU operating dashboard | Are weekly active devices growing toward 100, and are they getting value? | `app_launched`, `activation_first_artifact_saved`, `dictation_completed`, `meeting_transcript_saved`, `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_return_proxy_observed`; group by default `app_version`, `build_version`, `os_major` | `agent_capture_query_observed`; optional `weekly_value_summary_observed` only if it stays aggregate and bucketed |
-| Activation funnel | Where does first value leak? | `app_launched`, `onboarding_shown`, `onboarding_step_viewed`, `onboarding_permission_status_changed`, `onboarding_completed`, `onboarding_first_dictation_started`, `onboarding_first_dictation_saved`, `activation_first_artifact_saved`, `meeting_transcript_saved`, `dictation_completed`, `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_agent_setup_cta_clicked`, `onboarding_agent_cta_clicked`, `activation_return_proxy_observed` | `agent_capture_query_observed`; general dictation saved-artifact event if `dictation_completed` proves too loose |
+| 100 WAU operating dashboard | Are weekly active devices growing toward 100, and are they getting value? | `app_launched`, `activation_first_artifact_saved`, `dictation_completed`, `meeting_transcript_saved`, `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_return_proxy_observed`, `agent_capture_query_observed`; group by default `app_version`, `build_version`, `os_major` | Verify live delivery/config if `agent_capture_query_observed` is zero; optional `weekly_value_summary_observed` only if it stays aggregate and bucketed |
+| Activation funnel | Where does first value leak? | `app_launched`, `onboarding_shown`, `onboarding_step_viewed`, `onboarding_permission_status_changed`, `onboarding_completed`, `onboarding_first_dictation_started`, `onboarding_first_dictation_saved`, `activation_first_artifact_saved`, `meeting_transcript_saved`, `dictation_completed`, `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_agent_setup_cta_clicked`, `onboarding_agent_cta_clicked`, `activation_return_proxy_observed`, `agent_capture_query_observed` | Verify source-vs-live delivery if strict first-artifact or true-agent rows are zero; general dictation saved-artifact event if `dictation_completed` proves too loose |
 | Dictation reliability funnel | Do users who start dictation reach usable text without painful recovery? | `dictation_started`, `dictation_start_failed`, `dictation_completed`, `dictation_stop_latency_measured`, `dictation_cancelled`, `dictation_no_speech`, `dictation_audio_route_changed`, `dictation_audio_route_recovery_finished`, `dictation_audio_route_recovery_timeout` | Dedicated `dictation_saved_markdown` only if needed to separate completion from persisted artifact |
 | Meeting reliability funnel | Do meeting captures start, retain audio, transcribe, and save? | `meeting_prompt_shown`, `meeting_prompt_record_selected`, `meeting_prompt_dismissed`, `meeting_prompt_suppressed`, `meeting_recording_started`, `meeting_recording_start_failed`, `meeting_recording_stopped`, `meeting_capture_health_snapshot`, `meeting_transcript_saved`, `meeting_transcript_failed`, `meeting_transcript_skipped`, `meeting_saved_audio_retranscription_requested`, `meeting_mic_boost_prompt_shown`, `meeting_mic_boost_prompt_actioned`, `meeting_file_imported`, `meeting_file_import_failed`, `meeting_speaker_finalization_failed` | `meeting_opened_after_save` if Home/open behavior needs stricter proof than artifact-action clicks |
 | Local summary beta funnel | Are beta summaries discoverable, prepared, run, and useful? | `settings_page_viewed`, `settings_action_clicked`, `settings_toggle_changed`; filter `page_id = 'beta'` and action/setting ids such as local summary prepare actions | `local_summary_requested`, `local_summary_started`, `local_summary_completed`, `local_summary_failed`, `local_summary_opened`; keep model/provider/status/failure as enums only |
-| Agent/Markdown value loop | Does saved Markdown become a useful agent answer and later return? | `activation_first_artifact_saved`, `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_agent_setup_cta_clicked`, `onboarding_agent_cta_clicked`, `activation_return_proxy_observed`, `meeting_transcript_saved`, `dictation_completed` | `agent_capture_query_observed` as the first true sourced-agent-use proof; maybe `agent_answer_returned_observed` only if implemented through local MCP/tool invocation metadata, never content |
+| Agent/Markdown value loop | Does saved Markdown become a useful agent answer and later return? | `activation_first_artifact_saved`, `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_agent_setup_cta_clicked`, `onboarding_agent_cta_clicked`, `activation_return_proxy_observed`, `agent_capture_query_observed`, `meeting_transcript_saved`, `dictation_completed` | Maybe `agent_answer_returned_observed` only if implemented through local MCP/tool invocation metadata, never content |
 | Release health by app version | Did a release improve activation without hurting reliability? | All dashboard events grouped by default `app_version` and `build_version`; update events: `update_check_finished`, `update_download_started`, `update_download_finished`, `update_ready_to_install`, `update_relaunching`, `update_installed`; runtime events: `app_unclean_shutdown_detected`, `app_session_stall_detected` | None for the first dashboard. Add only coarse release-readiness enums if Sentry/PostHog release reviews need a stable join key later |
 
 ## PostHog Objects
@@ -55,7 +55,7 @@ Create these as saved PostHog insights, then collect them into one dashboard.
 2. **Activation funnel**
    - Funnel: `app_launched` -> onboarding touched -> `onboarding_completed` ->
      saved Markdown/proxy -> artifact action or agent prompt -> return proxy ->
-     future `agent_capture_query_observed`.
+     live `agent_capture_query_observed`.
    - Use `scripts/ops/posthog-activation-funnel.py --days 30` for the
      aggregate report and proxy-vs-proof read.
    - Show strict saved Markdown separately from dictation-completed proxy.
@@ -87,9 +87,11 @@ Create these as saved PostHog insights, then collect them into one dashboard.
 6. **Agent/Markdown value loop**
    - Trend saved artifacts, artifact actions, agent prompt/setup actions, and
      return proxies together.
-   - Primary missing proof: `agent_capture_query_observed`.
-   - Until that exists, label this dashboard as proxy evidence, not proof that
-     an agent answered from Transcripted files.
+   - Primary proof: live `agent_capture_query_observed` from the MCP/agent
+     surface.
+   - If that count is zero or absent, label this dashboard as proxy evidence and
+     check telemetry delivery/config or current-build regression before adding
+     new source events.
 
 7. **Release health by app version**
    - Compare launch WAU, value WAU, activation conversion, dictation completion,
@@ -105,7 +107,6 @@ events.
 
 | Event | Purpose | Allowed properties |
 | --- | --- | --- |
-| `agent_capture_query_observed` | Prove the first sourced agent query against saved captures. | `agent_target`, `artifact_kind`, `surface`, `result`, `query_age_bucket`, `source_count_bucket` |
 | `local_summary_requested` | Count user intent to summarize a meeting. | `surface`, `provider`, `transcript_age_bucket`, `duration_bucket`, `word_count_bucket` |
 | `local_summary_started` | Separate queued/prep friction from generation failures. | `surface`, `provider`, `runtime`, `profile`, `transcript_age_bucket`, `duration_bucket`, `word_count_bucket` |
 | `local_summary_completed` | Count successful local summary artifacts. | `surface`, `provider`, `runtime`, `profile`, `duration_bucket`, `word_count_bucket`, `summary_latency_bucket` |
@@ -127,5 +128,5 @@ events.
 ## Smallest Next Action
 
 Build the PostHog dashboard from existing events first. Then add
-`agent_capture_query_observed` as the next instrumentation slice, because that
-is the biggest gap between artifact volume and true product value.
+strict first-artifact and true-agent proof checks that flag live-zero rows as
+delivery/config/regression candidates before creating more instrumentation.

--- a/docs/posthog-product-learning-plan.md
+++ b/docs/posthog-product-learning-plan.md
@@ -92,7 +92,6 @@ Operational scripts query aggregate counts only:
 | `activation_second_artifact_saved` | `first_artifact_kind`, `second_artifact_kind`, `days_since_first_bucket`, `surface`, `trigger` |
 | `activation_agent_prompt_action_clicked` | `action_kind`, `agent_target`, `artifact_kind`, `prompt_kind`, `result`, `surface` |
 | `activation_agent_setup_cta_clicked` | `agent_target`, `prior_status`, `result`, `setup_kind`, `surface` |
-| `agent_capture_query_observed` | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket` |
 | `activation_return_proxy_observed` | `prior_artifact_kind`, `proxy_kind`, `return_window_bucket`, `surface` |
 | `workflow_abandoned` | `elapsed_bucket`, `prior_ready_state`, `reason_kind`, `stage`, `surface`, `workflow_kind` |
 | `agent_capture_query_observed` | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket`, `source_count_bucket` |
@@ -193,14 +192,14 @@ aggregate reliability sizing and should not be expanded to raw device names.
 
 ## Biggest Blind Spots
 
-- `agent_capture_query_observed` does not exist yet, so PostHog cannot prove
-  that an agent actually answered from a saved Transcripted artifact.
+- `agent_capture_query_observed` is implemented in the read-only MCP/agent
+  surface and allowlisted for PostHog, but live PostHog may still show zero or
+  absent rows. Treat that as delivery, config, no-eligible-use, or regression
+  evidence to investigate, not as missing source.
 - General dictation saved-Markdown writes now have `dictation_artifact_saved`;
   keep `dictation_completed` as completion-volume context, not strict saved-artifact proof.
 - `agent_capture_query_observed` proves successful saved-capture reads/searches
-  through MCP, but it still cannot judge answer quality.
-- General dictation saved-Markdown writes still rely on `dictation_completed`
-  as a proxy, while onboarding dictation and meeting saves have stricter events.
+  through MCP, but it still cannot judge answer quality or usefulness.
 - Settings/action tracking is broad enough to show discovery, but it does not
   always connect settings changes to later workflow success.
 - Local summary beta behavior now has abandonment shape, but not a full success
@@ -213,14 +212,15 @@ aggregate reliability sizing and should not be expanded to raw device names.
 - Retention is a return proxy, not a real habit model. It needs day/week active
   cohorts and first-artifact-to-second-artifact conversion in PostHog dashboards.
 
-## A+ Event Taxonomy To Add
+## A+ Event Taxonomy To Add Or Verify
 
-Prefer a small number of lifecycle events over broad click tracking.
+Prefer a small number of lifecycle events over broad click tracking. Some rows
+below are source-implemented and need live-delivery verification rather than new
+source work.
 
 | Event | When to fire | Properties |
 | --- | --- | --- |
-| `agent_capture_query_observed` | The local MCP/agent layer observes a privacy-safe query against saved captures | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket` |
-| `agent_capture_query_observed` | The local MCP/agent layer observes a privacy-safe query against saved captures | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket`, `source_count_bucket` |
+| `agent_capture_query_observed` | Source-implemented; verify live delivery when the local MCP/agent layer observes a privacy-safe query against saved captures | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket`, `source_count_bucket` |
 | `activation_second_artifact_saved` | A device saves its second artifact | `first_artifact_kind`, `second_artifact_kind`, `days_since_first_bucket`, `surface`, `trigger` |
 | `dictation_artifact_saved` | Any normal dictation Markdown is durably saved | `delivery`, `duration_bucket`, `save_outcome`, `surface`, `trigger`, `word_count_bucket` |
 | `dictation_retry_started` | User retries after a failed or empty dictation | `failure_kind`, `retry_source`, `route_shape`, `trigger` |
@@ -354,4 +354,5 @@ prove the full saved-artifact -> sourced-agent-answer -> return loop.
 
 Keep `agent_capture_query_observed` narrow in the read-only MCP/agent surface:
 only successful saved-capture reads/searches, enum values, and coarse buckets.
-That closes the biggest product-learning gap without inspecting content.
+If live PostHog shows zero true-agent rows, verify MCP telemetry config,
+delivery, and current-build regression before adding another source event.

--- a/scripts/ops/posthog-activation-funnel.py
+++ b/scripts/ops/posthog-activation-funnel.py
@@ -508,6 +508,17 @@ def render_report(data: dict[str, Any]) -> str:
     return_proxy = as_int(reach.get("return_proxy_devices"))
     workflow_abandonment = as_int(reach.get("workflow_abandonment_devices"))
     app_version = data.get("app_version") or "all app versions"
+    proof_checks: list[str] = []
+    if strict_saved == 0:
+        proof_checks.append(
+            "Strict first-artifact proof is zero. `activation_first_artifact_saved` is source-implemented, so check analytics config, delivery, current-build regression, or no eligible saves before adding source work."
+        )
+    if true_agent_query == 0:
+        proof_checks.append(
+            "True agent-query proof is zero. `agent_capture_query_observed` is source-implemented in the MCP/agent surface, so check MCP telemetry config, delivery, current-build regression, or no eligible agent use before adding source work."
+        )
+    if not proof_checks:
+        proof_checks.append("Strict first-artifact and true-agent proof both have nonzero live counts in this window.")
 
     limitations = [
         "`permission ready` uses `onboarding_completed` as a proxy. The app guards completion on required dictation permissions, but this does not count users who became ready outside onboarding.",
@@ -515,7 +526,7 @@ def render_report(data: dict[str, Any]) -> str:
         "`dictation_artifact_saved`, `dictation_completed`, `onboarding_first_dictation_saved`, and `meeting_transcript_saved` are included only in the broader proxy row for dictation volume and legacy continuity.",
         "Agent setup and prompt-copy events prove intent. They do not prove the user asked an agent a sourced question or got a useful answer.",
         "`activation_second_artifact_saved` proves a second durable artifact save on the same anonymous device, but does not inspect artifact content or join identity.",
-        "`agent_capture_query_observed` is the desired true first-agent-use signal and is currently expected to be zero until instrumentation exists.",
+        "`agent_capture_query_observed` is the true first-agent-use signal. Source support exists; zero live rows are a delivery/config/no-use/regression candidate, not missing source by default.",
         "`workflow_abandoned` is a conservative exit map. It should not be read as every possible drop-off or every click.",
     ]
 
@@ -527,7 +538,7 @@ def render_report(data: dict[str, Any]) -> str:
         "Agent bridge: setup kind, agent target, prompt kind, result, and surface.",
         "Abandonment exits: workflow kind, stage, reason kind, surface, and prior-ready state.",
         "Return loop: `activation_return_proxy_observed` by return-window bucket.",
-        "Data quality: missing true-agent-use event and the dictation completion-vs-saved-artifact split.",
+        "Data quality: strict first-artifact zero, true-agent zero, and the dictation completion-vs-saved-artifact split.",
     ]
 
     lines = [
@@ -547,7 +558,11 @@ def render_report(data: dict[str, Any]) -> str:
         f"- Agent setup/proxy reach: **{agent_signal} devices** ({pct(agent_signal, launch)} of launch).",
         f"- Return proxy reach: **{return_proxy} devices** ({pct(return_proxy, launch)} of launch).",
         f"- Workflow abandonment exits: **{workflow_abandonment} devices** ({pct(workflow_abandonment, launch)} of launch).",
-        f"- True agent-query proof: **{true_agent_query} devices**. Treat this as unknown, not green, until instrumentation exists.",
+        f"- True agent-query proof: **{true_agent_query} devices**. Treat zero as source-vs-live delivery/config/regression UNKNOWN, not green.",
+        "",
+        "## Proof Quality Checks",
+        "",
+        "\n".join(f"- {item}" for item in proof_checks),
         "",
         "## Funnel Reach",
         "",
@@ -614,7 +629,7 @@ def render_report(data: dict[str, Any]) -> str:
         "",
         "## Next Best Action",
         "",
-        "Verify `activation_first_artifact_saved` and `activation_second_artifact_saved` reach live PostHog for current builds, then add `agent_capture_query_observed` so the dashboard can separate repeated saved-artifact value from true sourced-agent-use.",
+        "If strict first-artifact or true-agent proof is zero, verify telemetry config, delivery, and current-build regression before creating new instrumentation work.",
         "",
     ]
     return "\n".join(lines)
@@ -681,6 +696,9 @@ def run_self_test() -> int:
         return 1
     if "True agent-query proof: **0 devices**" not in report:
         print("self-test failed: missing true agent-query proof limitation", file=sys.stderr)
+        return 1
+    if "True agent-query proof is zero" not in report or "source-implemented" not in report:
+        print("self-test failed: zero true-agent proof must point to source-vs-live triage", file=sys.stderr)
         return 1
     reach = reach_query(30, None)
     sequence = sequence_query(30, None)

--- a/scripts/ops/posthog-product-context-pack.py
+++ b/scripts/ops/posthog-product-context-pack.py
@@ -399,8 +399,10 @@ def build_context_pack(data: dict[str, Any]) -> dict[str, Any]:
         unknowns.append(UnknownReason("activation", "PostHog overview query did not return aggregate rows."))
     if launch <= 0:
         unknowns.append(UnknownReason("activation.bottleneck", "No launch devices were available for the selected window."))
+    if launch > 0 and first_artifact == 0:
+        unknowns.append(UnknownReason("activation.first_artifact", "`activation_first_artifact_saved` is source-implemented but zero in live PostHog; check delivery, config, no eligible saves, or regression."))
     if true_agent_query == 0:
-        unknowns.append(UnknownReason("activation.true_agent_use", "`agent_capture_query_observed` is missing or zero; prompt/setup clicks are intent proxies only."))
+        unknowns.append(UnknownReason("activation.true_agent_use", "`agent_capture_query_observed` is source-implemented but zero in live PostHog; prompt/setup clicks are intent proxies only until delivery/config/no-use/regression is checked."))
 
     artifact_rate = pct(first_artifact, launch)
     prompt_rate = pct(agent_prompt, first_artifact)
@@ -408,6 +410,8 @@ def build_context_pack(data: dict[str, Any]) -> dict[str, Any]:
 
     if artifact_rate is None:
         bottleneck = "UNKNOWN: missing launch denominator."
+    elif first_artifact == 0:
+        bottleneck = "No live first saved-Markdown proof; check telemetry delivery/config or current-build save regression before adding source work."
     elif artifact_rate < 20:
         bottleneck = "Too few launch devices reach first saved Markdown."
     elif true_agent_query == 0 and agent_prompt > 0:
@@ -572,12 +576,19 @@ def build_recommendations(
             "why": "PostHog aggregate data was unavailable, so the pack is intentionally UNKNOWN instead of guessing from missing rows.",
             "suggested_pr": "Wire the health lane to surface missing PostHog credentials/query failures clearly and attach the UNKNOWN context pack for agent runs.",
         })
+    elif launch > 0 and first_artifact == 0:
+        recs.append({
+            "rank": len(recs) + 1,
+            "title": "Verify first saved-Markdown telemetry delivery",
+            "why": "`activation_first_artifact_saved` is source-implemented but zero in live PostHog, so the gap may be delivery, config, no eligible saves, or a current-build regression.",
+            "suggested_pr": "Check analytics config and delivery for first-artifact saves, then inspect current save paths before adding another source event.",
+        })
     elif true_agent_query == 0:
         recs.append({
             "rank": len(recs) + 1,
-            "title": "Add privacy-safe sourced-agent-use proof",
-            "why": "`agent_capture_query_observed` is missing or zero, so agents still cannot tell whether saved Markdown produced a sourced answer.",
-            "suggested_pr": "Emit aggregate-only `agent_capture_query_observed` from the read-only MCP/agent surface with enum result, query kind, agent target, artifact kind, and age buckets.",
+            "title": "Verify sourced-agent-use telemetry delivery",
+            "why": "`agent_capture_query_observed` is source-implemented but zero in live PostHog, so the gap may be MCP telemetry config, delivery, no eligible agent use, or a current-build regression.",
+            "suggested_pr": "Check MCP telemetry config and delivery for `agent_capture_query_observed`, then inspect current agent-query paths before adding another source event.",
         })
     elif launch > 0 and first_artifact / launch < 0.2:
         recs.append({
@@ -680,7 +691,7 @@ def render_markdown(pack: dict[str, Any]) -> str:
         f"- Launch devices: {pack['activation'].get('launch_devices')}",
         f"- First artifact devices: {pack['activation'].get('first_artifact_devices')} ({md_value(pack['activation'].get('first_artifact_rate_pct'))} of launch)",
         f"- Agent prompt devices: {pack['activation'].get('agent_prompt_devices')} ({md_value(pack['activation'].get('agent_prompt_per_first_artifact_pct'))} of first artifact)",
-        f"- True agent-query devices: {pack['activation'].get('true_agent_query_devices')} (UNKNOWN if zero because the event may not exist yet)",
+        f"- True agent-query devices: {pack['activation'].get('true_agent_query_devices')} (UNKNOWN if zero; source is implemented, so check delivery/config/no-use/regression)",
         f"- Return proxy devices: {pack['activation'].get('return_proxy_devices')} ({md_value(pack['activation'].get('return_proxy_per_first_artifact_pct'))} of first artifact)",
         "",
         "## Recommended Next PRs",
@@ -724,6 +735,11 @@ def run_self_test() -> int:
         return 1
     if not pack["recommendations"] or "sourced-agent-use" not in pack["recommendations"][0]["title"]:
         print("self-test failed: first recommendation should close agent-use proof", file=sys.stderr)
+        return 1
+    stale_fragments = ("event may not exist", "missing or zero", "emit aggregate-only `agent_capture_query_observed`")
+    stale = [fragment for fragment in stale_fragments if fragment in rendered.lower()]
+    if stale:
+        print(f"self-test failed: stale source-missing wording in rendered output: {', '.join(stale)}", file=sys.stderr)
         return 1
     unknown = unknown_data("missing POSTHOG_PERSONAL_API_KEY", 30, None)
     unknown_pack = build_context_pack(unknown)

--- a/scripts/ops/posthog-product-dashboard-summary.py
+++ b/scripts/ops/posthog-product-dashboard-summary.py
@@ -281,7 +281,7 @@ def build_activation_leak(data: dict[str, Any]) -> Finding:
                 devices.get("onboarding_first_dictation_saved", 0),
                 devices.get("meeting_transcript_saved", 0),
             ),
-            "Make saved Markdown visible immediately after capture.",
+            "If strict first-artifact proof is zero, verify telemetry delivery/config or current-build save regression before treating this as pure UX.",
         ),
         (
             "artifact action",
@@ -304,7 +304,7 @@ def build_activation_leak(data: dict[str, Any]) -> Finding:
         (
             "true agent query",
             devices.get("agent_capture_query_observed", 0),
-            "Instrument privacy-safe sourced-agent-use before calling the loop proven.",
+            "If true-agent proof is zero, verify MCP telemetry delivery/config, no eligible use, or current-build regression before adding source work.",
         ),
     ]
     biggest = ("unknown", 0, 0, "Add more activation instrumentation.")
@@ -484,6 +484,20 @@ def task_candidates(findings: dict[str, Finding]) -> list[Finding]:
     return sorted([*pinned, third], key=lambda item: (-task_priority_score(item), item.title))
 
 
+def proof_quality_checks(data: dict[str, Any]) -> list[str]:
+    devices = event_devices(data)
+    checks: list[str] = []
+    if devices.get("activation_first_artifact_saved", 0) == 0:
+        checks.append(
+            "Strict first-artifact proof is zero: `activation_first_artifact_saved` is source-implemented, so check delivery, config, no eligible saves, or current-build regression."
+        )
+    if devices.get("agent_capture_query_observed", 0) == 0:
+        checks.append(
+            "True agent-query proof is zero: `agent_capture_query_observed` is source-implemented, so check MCP telemetry delivery, config, no eligible use, or current-build regression."
+        )
+    return checks or ["Strict first-artifact and true-agent proof both have nonzero live counts in this window."]
+
+
 def dashboard_lines(data: dict[str, Any], findings: dict[str, Finding]) -> list[str]:
     devices = event_devices(data)
     events = event_events(data)
@@ -519,6 +533,7 @@ def render_json(data: dict[str, Any], findings: dict[str, Finding]) -> dict[str,
         "app_version": data.get("app_version"),
         "source": data.get("source", {}),
         "dashboards": dashboard_lines(data, findings),
+        "proof_quality_checks": proof_quality_checks(data),
         "findings": {
             "biggest_activation_leak": findings["activation"].__dict__,
             "biggest_reliability_leak": findings["reliability"].__dict__,
@@ -553,6 +568,10 @@ def render_markdown(data: dict[str, Any], findings: dict[str, Finding]) -> str:
         f"- Under-discovered feature: {findings['under'].metric} {findings['under'].recommendation}",
         f"- Release regression watch: {findings['release'].metric} {findings['release'].recommendation}",
         "",
+        "## Proof Quality Checks",
+        "",
+        *[f"- {line}" for line in result["proof_quality_checks"]],
+        "",
         "## Top 3 Recommended PR/Task Candidates",
         "",
     ]
@@ -563,7 +582,7 @@ def render_markdown(data: dict[str, Any], findings: dict[str, Finding]) -> str:
         "## Privacy Boundary",
         "",
         "- Aggregate only. No raw rows or user-level forensics.",
-        "- Treat agent setup, prompt copy, and return events as proxies until `agent_capture_query_observed` exists.",
+        "- Treat agent setup, prompt copy, and return events as proxies unless `agent_capture_query_observed` has live nonzero rows.",
         "",
     ])
     return "\n".join(lines)
@@ -618,6 +637,15 @@ def run_self_test() -> int:
         return 1
     if len(summary["top_recommended_tasks"]) != 3:
         print("self-test failed: expected exactly three top task candidates", file=sys.stderr)
+        return 1
+    if "True agent-query proof is zero" not in markdown:
+        print("self-test failed: zero true-agent proof should be called out as source-vs-live triage", file=sys.stderr)
+        return 1
+    if not summary.get("proof_quality_checks"):
+        print("self-test failed: JSON summary should include proof quality checks", file=sys.stderr)
+        return 1
+    if "until `agent_capture_query_observed` exists" in markdown:
+        print("self-test failed: stale source-missing wording in product task report", file=sys.stderr)
         return 1
     mismatch_data = json.loads(json.dumps(data))
     mismatch_data["results"]["reliability_breakdown"] = [


### PR DESCRIPTION
## Summary
- Fix PostHog docs that treated `agent_capture_query_observed` as missing source instead of source-implemented/live-zero.
- Add proof-quality checks to activation funnel and dashboard summary reports for zero strict first-artifact or true-agent proof.
- Update product context recommendations so zero live proof points to delivery/config/no-use/regression triage, not duplicate instrumentation.

## Scope notes
- Built from a fresh isolated worktree at `/Users/redbars/.codex/worktrees/posthog-doc-report-cleanup-20260620` off current `origin/main`.
- Inspected PR #1233 first; this PR intentionally excludes rescue-branch conflict state and source telemetry changes.
- Claude review lane was started but cancelled after coordinator directive to publish once self-tests passed.

## Checks
- `scripts/dev/agent-preflight.sh`
- `python3 -m py_compile scripts/ops/posthog-activation-funnel.py scripts/ops/posthog-product-context-pack.py scripts/ops/posthog-product-dashboard-summary.py`
- `python3 scripts/ops/posthog-activation-funnel.py --self-test`
- `python3 scripts/ops/posthog-product-context-pack.py --self-test`
- `python3 scripts/ops/posthog-product-dashboard-summary.py --self-test`
- `python3 scripts/ops/posthog-product-context-pack.py --fixture Tests/Fixtures/posthog-product-context-pack-fixture.json --write-dir build/posthog-product-context-sample`
- `python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json --json-only`
- `git diff --check`
