### PR TITLE
Track MCP orientation query telemetry

### DIFF
--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift
@@ -149,7 +149,7 @@ enum AgentCaptureQueryTelemetryPolicy {
         "agent_target": ["mcp_client"],
         "artifact_kind": ["dictation", "meeting", "mixed"],
         "capture_age_bucket": ["lt_12h", "12_24h", "24_48h", "2_7d", "older", "unknown"],
-        "query_kind": ["read", "recap", "search", "speaker_lookup"],
+        "query_kind": ["list", "read", "recap", "recent", "search", "speaker_lookup"],
         "result": ["success"],
         "return_window_bucket": ["same_day", "18_36h", "36_72h", "3_7d", "older", "unknown"],
         "source_count_bucket": ["0", "1", "2_3", "4_9", "10_plus", "unknown"],
@@ -272,6 +272,10 @@ struct AgentCaptureQueryTelemetryConfiguration {
     }
 }
 
+protocol AgentCaptureQueryTelemetryRecording: AnyObject {
+    func track(_ observation: AgentCaptureQueryObservation)
+}
+
 final class AgentCaptureQueryTelemetry {
     static let shared = AgentCaptureQueryTelemetry()
     private static let isoDateFormatter = ISO8601DateFormatter()
@@ -328,13 +332,19 @@ final class AgentCaptureQueryTelemetry {
     }
 }
 
+extension AgentCaptureQueryTelemetry: AgentCaptureQueryTelemetryRecording {}
+
+enum AgentCaptureQueryTelemetryRuntime {
+    static var recorder: AgentCaptureQueryTelemetryRecording = AgentCaptureQueryTelemetry.shared
+}
+
 func trackAgentCaptureQueryObserved(
     queryKind: String,
     artifactKind: String,
     captureDate: Date?,
     sourceCount: Int?
 ) {
-    AgentCaptureQueryTelemetry.shared.track(
+    AgentCaptureQueryTelemetryRuntime.recorder.track(
         AgentCaptureQueryObservation(
             queryKind: queryKind,
             artifactKind: artifactKind,

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -268,7 +268,7 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
 
 // MARK: - list_meetings
 
-private func handleListMeetings(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+func handleListMeetings(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
     let count = params.arguments?["count"]?.intValue ?? 10
     let date = params.arguments?["date"]?.stringValue
     let dateFrom = params.arguments?["date_from"]?.stringValue ?? date
@@ -292,11 +292,18 @@ private func handleListMeetings(params: CallTool.Parameters, index: TranscriptIn
         return textResult("No meetings found.")
     }
 
+    trackAgentCaptureQueryObserved(
+        queryKind: "list",
+        artifactKind: "meeting",
+        captureDate: latestMeetingDate(in: results),
+        sourceCount: results.count
+    )
+
     let json = try JSONEncoder.pretty.encode(results)
     return textResult(String(data: json, encoding: .utf8) ?? "[]")
 }
 
-private func handleListDictations(params: CallTool.Parameters, index: TranscriptIndex) throws -> CallTool.Result {
+func handleListDictations(params: CallTool.Parameters, index: TranscriptIndex) throws -> CallTool.Result {
     let count = params.arguments?["count"]?.intValue ?? 10
     let date = params.arguments?["date"]?.stringValue
     let dateFrom = params.arguments?["date_from"]?.stringValue ?? date
@@ -307,6 +314,13 @@ private func handleListDictations(params: CallTool.Parameters, index: Transcript
     if results.isEmpty {
         return textResult("No dictations found.")
     }
+
+    trackAgentCaptureQueryObserved(
+        queryKind: "list",
+        artifactKind: "dictation",
+        captureDate: latestDictationDayDate(in: results),
+        sourceCount: results.count
+    )
 
     let json = try JSONEncoder.pretty.encode(results)
     return textResult(String(data: json, encoding: .utf8) ?? "[]")
@@ -510,7 +524,7 @@ private func handleSearchContext(params: CallTool.Parameters, index: TranscriptI
     return textResult(String(data: json, encoding: .utf8) ?? "{}")
 }
 
-private func handleRecentContext(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+func handleRecentContext(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
     let kind = parseContextKind(params.arguments?["kind"]?.stringValue)
     let count = max(1, min(params.arguments?["count"]?.intValue ?? 10, 50))
     let dateFrom = params.arguments?["date_from"]?.stringValue
@@ -522,6 +536,13 @@ private func handleRecentContext(params: CallTool.Parameters, index: TranscriptI
     if result.items.isEmpty {
         return textResult("No recent context found.")
     }
+
+    trackAgentCaptureQueryObserved(
+        queryKind: "recent",
+        artifactKind: artifactKind(for: result.items.map(\.kind)),
+        captureDate: latestRecentContextDate(in: result.items),
+        sourceCount: result.items.count
+    )
 
     let json = try JSONEncoder.pretty.encode(result)
     return textResult(String(data: json, encoding: .utf8) ?? "{}")
@@ -707,11 +728,23 @@ private func formatDuration(_ seconds: Int) -> String {
     return "\(m)m"
 }
 
+private func latestMeetingDate(in results: [MeetingSummary]) -> Date? {
+    results.compactMap { parseCaptureDate($0.datetime) }.max()
+}
+
+private func latestDictationDayDate(in results: [DictationDaySummary]) -> Date? {
+    results.compactMap { parseCaptureDate($0.datetime) }.max()
+}
+
 private func latestMeetingSearchDate(in results: GroupedSearchResult) -> Date? {
     results.results.compactMap { parseCaptureDate($0.meetingDateTime) }.max()
 }
 
 private func latestContextSearchDate(in results: [ContextSearchGroup]) -> Date? {
+    results.compactMap { parseCaptureDate($0.datetime) }.max()
+}
+
+private func latestRecentContextDate(in results: [RecentContextItem]) -> Date? {
     results.compactMap { parseCaptureDate($0.datetime) }.max()
 }
 

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/AgentCaptureQueryTelemetryTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/AgentCaptureQueryTelemetryTests.swift
@@ -64,6 +64,23 @@ final class AgentCaptureQueryTelemetryTests: XCTestCase {
         XCTAssertNil(sanitized["token"])
     }
 
+    func testTelemetryPolicyAllowsOrientationQueryKinds() throws {
+        for queryKind in ["list", "recent"] {
+            let sanitized = AgentCaptureQueryTelemetryPolicy.sanitize([
+                "agent_target": "mcp_client",
+                "artifact_kind": "meeting",
+                "capture_age_bucket": "lt_12h",
+                "query_kind": queryKind,
+                "result": "success",
+                "return_window_bucket": "same_day",
+                "source_count_bucket": "1",
+                "surface": "mcp",
+            ])
+
+            XCTAssertEqual(sanitized["query_kind"], queryKind)
+        }
+    }
+
     func testTelemetryPolicyRejectsUnexpectedEnumValues() throws {
         let sanitized = AgentCaptureQueryTelemetryPolicy.sanitize([
             "agent_target": "raw-agent-name",

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
@@ -1,17 +1,23 @@
+import MCP
 import XCTest
 @testable import transcripted_mcp
 
 final class ToolHandlersTests: XCTestCase {
     var index: TranscriptIndex!
     var tempDir: URL!
+    private var telemetry: RecordingAgentCaptureQueryTelemetry!
 
     override func setUp() {
         super.setUp()
         tempDir = makeTempDir()
         index = try! TranscriptIndex(indexDir: tempDir)
+        telemetry = RecordingAgentCaptureQueryTelemetry()
+        AgentCaptureQueryTelemetryRuntime.recorder = telemetry
     }
 
     override func tearDown() {
+        AgentCaptureQueryTelemetryRuntime.recorder = AgentCaptureQueryTelemetry.shared
+        telemetry = nil
         index = nil
         removeTempDir(tempDir)
         super.tearDown()
@@ -69,5 +75,82 @@ final class ToolHandlersTests: XCTestCase {
         hydrateMeetingSearchTitles(in: &results, meetingDirs: [emptyDir])
 
         XCTAssertEqual(results.results[0].meetingTitle, "2026:03:26 16:04:11")
+    }
+
+    func testListMeetingsTracksBucketedAgentQueryTelemetry() throws {
+        try writeFixture(
+            makeFixtureJSON(title: "Roadmap Sync", date: "2026-03-26T16:04:11-0500"),
+            filename: "Call_2026-03-26_16-04-11",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        _ = try handleListMeetings(
+            params: CallTool.Parameters(name: "list_meetings", arguments: ["count": .int(10)]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let observation = try XCTUnwrap(telemetry.observations.last)
+        XCTAssertEqual(observation.queryKind, "list")
+        XCTAssertEqual(observation.artifactKind, "meeting")
+        XCTAssertEqual(observation.sourceCountBucket, "1")
+        XCTAssertNotEqual(observation.captureAgeBucket, "unknown")
+    }
+
+    func testListDictationsTracksBucketedAgentQueryTelemetry() throws {
+        try writeFixture(makeDictationDayJSON(), filename: "Dictations_2026-04-07", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        _ = try handleListDictations(
+            params: CallTool.Parameters(name: "list_dictations", arguments: ["count": .int(10)]),
+            index: index
+        )
+
+        let observation = try XCTUnwrap(telemetry.observations.last)
+        XCTAssertEqual(observation.queryKind, "list")
+        XCTAssertEqual(observation.artifactKind, "dictation")
+        XCTAssertEqual(observation.sourceCountBucket, "1")
+        XCTAssertNotEqual(observation.captureAgeBucket, "unknown")
+    }
+
+    func testRecentContextTracksMixedAgentQueryTelemetry() throws {
+        try writeFixture(
+            makeFixtureJSON(date: "2026-03-29T10:00:00-0500"),
+            filename: "Call_2026-03-29_10-00-00",
+            to: tempDir
+        )
+        try writeFixture(makeDictationDayJSON(), filename: "Dictations_2026-04-07", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        _ = try handleRecentContext(
+            params: CallTool.Parameters(name: "recent_context", arguments: ["count": .int(10)]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let observation = try XCTUnwrap(telemetry.observations.last)
+        XCTAssertEqual(observation.queryKind, "recent")
+        XCTAssertEqual(observation.artifactKind, "mixed")
+        XCTAssertEqual(observation.sourceCountBucket, "2_3")
+        XCTAssertNotEqual(observation.captureAgeBucket, "unknown")
+    }
+
+    func testEmptyListDoesNotTrackAgentQueryTelemetry() throws {
+        _ = try handleListMeetings(
+            params: CallTool.Parameters(name: "list_meetings", arguments: ["count": .int(10)]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        XCTAssertTrue(telemetry.observations.isEmpty)
+    }
+}
+
+private final class RecordingAgentCaptureQueryTelemetry: AgentCaptureQueryTelemetryRecording {
+    private(set) var observations: [AgentCaptureQueryObservation] = []
+
+    func track(_ observation: AgentCaptureQueryObservation) {
+        observations.append(observation)
     }
 }

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -43,6 +43,18 @@ Transcripted copies the bundled `transcripted-mcp` helper into:
 ~/Library/Application Support/Transcripted/mcp/transcripted-mcp
 ```
 
+When anonymous usage statistics are enabled and the app has a valid PostHog
+host/key, Transcripted also writes the helper's local observability config:
+
+```text
+~/Library/Application Support/Transcripted/mcp-observability.plist
+```
+
+If anonymous usage statistics are turned off, or the app has no valid HTTPS
+PostHog config, that helper config is removed and the MCP helper sends no
+analytics. The helper re-checks config before each event, so opt-out takes
+effect without reinstalling the agent connection.
+
 Then it safely merges this entry into Claude Desktop's config:
 
 ```text
@@ -73,6 +85,11 @@ Current `transcripted-mcp` capabilities:
 
 These tools are read-only, but they are not redacted. `read_meeting` and
 `read_dictation` can return local transcript text to the agent you connected.
+Successful MCP list, recent, read, search, speaker lookup, and recap calls emit
+only the coarse `agent_capture_query_observed` event when anonymous usage
+statistics are enabled. Direct Markdown folder reads by agents that skip MCP are
+not observable from Transcripted without risky file/prompt monitoring, so
+analytics dashboards should label those as unknown, not zero.
 
 ## Local Coding Agents
 
@@ -99,6 +116,11 @@ connected, otherwise read the saved Markdown folders:
 ~/Library/Application Support/Transcripted/captures/meetings
 ~/Library/Application Support/Transcripted/captures/dictations
 ```
+
+The fallback saved-folder path is intentionally untracked beyond setup and
+prompt-copy intent. A safe future proof event should come from an explicit local
+tool or user action with enum/bucket fields only; do not infer direct file reads
+by watching transcript files, prompts, titles, paths, or agent output.
 
 ## Live Meeting Sidecar
 

--- a/docs/ops-credentials.md
+++ b/docs/ops-credentials.md
@@ -71,7 +71,9 @@ export distinct IDs, person rows, transcript text, file paths, meeting titles,
 raw URLs, or raw payload rows. Treat the agent setup and prompt-copy rows as
 proxies only; they are not proof that an agent answered from a saved artifact.
 The true-use event is `agent_capture_query_observed`, emitted by successful MCP
-reads/searches with enum and bucket properties only.
+list, recent, read, search, speaker lookup, and recap calls with enum and
+bucket properties only. Direct saved-folder reads by agents that do not use MCP
+remain unknown; count setup and prompt-copy rows as proxy intent, not proof.
 
 For an AI-agent-ready product context pack, run:
 

--- a/docs/posthog-product-learning-plan.md
+++ b/docs/posthog-product-learning-plan.md
@@ -1,6 +1,6 @@
 # Transcripted PostHog Product-Learning Plan
 
-Last audited: 2026-06-19 against `origin/main` at `4ad53b9b`.
+Last audited: 2026-06-20 against `origin/main` at `e8a30e99`.
 
 This is the product-learning map for opt-in PostHog analytics. It is meant to
 answer one question: are users reaching the loop that matters?
@@ -92,10 +92,9 @@ Operational scripts query aggregate counts only:
 | `activation_second_artifact_saved` | `first_artifact_kind`, `second_artifact_kind`, `days_since_first_bucket`, `surface`, `trigger` |
 | `activation_agent_prompt_action_clicked` | `action_kind`, `agent_target`, `artifact_kind`, `prompt_kind`, `result`, `surface` |
 | `activation_agent_setup_cta_clicked` | `agent_target`, `prior_status`, `result`, `setup_kind`, `surface` |
-| `agent_capture_query_observed` | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket` |
+| `agent_capture_query_observed` | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket`, `source_count_bucket` |
 | `activation_return_proxy_observed` | `prior_artifact_kind`, `proxy_kind`, `return_window_bucket`, `surface` |
 | `workflow_abandoned` | `elapsed_bucket`, `prior_ready_state`, `reason_kind`, `stage`, `surface`, `workflow_kind` |
-| `agent_capture_query_observed` | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket`, `source_count_bucket` |
 
 ### Menu, Settings, Updates
 
@@ -185,20 +184,34 @@ aggregate reliability sizing and should not be expanded to raw device names.
 - First saved artifact across dictation and meeting with coarse artifact kind,
   trigger, duration bucket, and word-count bucket.
 - Artifact open/reveal/preview actions and agent setup or prompt-copy intent.
+- Successful MCP list, recent, read, search, speaker lookup, and recap calls
+  through `agent_capture_query_observed`, when the installed helper has local
+  PostHog config and anonymous usage statistics are enabled.
 - Confident workflow abandonment for onboarding close, meeting-prompt dismissal
   or suppression, local-summary/model-prep block/cancel/fail, failed agent setup
   or artifact handoff, and failed-meeting retry dismissal/delete.
 - Return proxy when Home observes an older saved artifact.
 - Release health by app version and update lifecycle.
 
-## Biggest Blind Spots
+## Biggest Blind Spots And Runbook
 
-- `agent_capture_query_observed` does not exist yet, so PostHog cannot prove
-  that an agent actually answered from a saved Transcripted artifact.
 - General dictation saved-Markdown writes now have `dictation_artifact_saved`;
   keep `dictation_completed` as completion-volume context, not strict saved-artifact proof.
-- `agent_capture_query_observed` proves successful saved-capture reads/searches
-  through MCP, but it still cannot judge answer quality.
+- `agent_capture_query_observed` proves successful saved-capture queries through
+  MCP, but it still cannot judge answer quality or whether the answer was useful.
+- Direct saved-folder reads by Claude Code, Codex, Cursor, Obsidian, or another
+  agent are not safely observable from Transcripted. Do not watch files, prompts,
+  titles, paths, or agent output to infer those reads. Dashboard copy should say
+  "direct folder reads unknown" rather than treating zero MCP events as zero
+  agent use.
+- If live PostHog shows zero true agent-query devices, first verify the install
+  path before changing privacy posture:
+  1. The app installed `~/Library/Application Support/Transcripted/mcp/transcripted-mcp`.
+  2. The connected agent config points at that installed helper, not a source-build helper.
+  3. Anonymous usage statistics are enabled.
+  4. `~/Library/Application Support/Transcripted/mcp-observability.plist` exists
+     with `TranscriptedPostHogAPIKey` and an HTTPS `TranscriptedPostHogHost`.
+  5. The helper can resolve saved captures with `transcripted-mcp --self-test`.
 - General dictation saved-Markdown writes still rely on `dictation_completed`
   as a proxy, while onboarding dictation and meeting saves have stricter events.
 - Settings/action tracking is broad enough to show discovery, but it does not
@@ -219,8 +232,6 @@ Prefer a small number of lifecycle events over broad click tracking.
 
 | Event | When to fire | Properties |
 | --- | --- | --- |
-| `agent_capture_query_observed` | The local MCP/agent layer observes a privacy-safe query against saved captures | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket` |
-| `agent_capture_query_observed` | The local MCP/agent layer observes a privacy-safe query against saved captures | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket`, `source_count_bucket` |
 | `activation_second_artifact_saved` | A device saves its second artifact | `first_artifact_kind`, `second_artifact_kind`, `days_since_first_bucket`, `surface`, `trigger` |
 | `dictation_artifact_saved` | Any normal dictation Markdown is durably saved | `delivery`, `duration_bucket`, `save_outcome`, `surface`, `trigger`, `word_count_bucket` |
 | `dictation_retry_started` | User retries after a failed or empty dictation | `failure_kind`, `retry_source`, `route_shape`, `trigger` |
@@ -304,7 +315,8 @@ agent prompt/setup -> `agent_capture_query_observed` -> next-day return ->
 second artifact saved.
 
 This is the north-star dashboard. Treat prompt-copy and setup clicks as intent,
-not proof.
+not proof. Treat `agent_capture_query_observed` as true MCP query proof only,
+not proof of direct Markdown folder reads or answer quality.
 
 ### Agent Product Context Pack
 
@@ -353,5 +365,7 @@ prove the full saved-artifact -> sourced-agent-answer -> return loop.
 ## Smallest Next Implementation
 
 Keep `agent_capture_query_observed` narrow in the read-only MCP/agent surface:
-only successful saved-capture reads/searches, enum values, and coarse buckets.
-That closes the biggest product-learning gap without inspecting content.
+only successful saved-capture list/recent/read/search/speaker/recap calls, enum
+values, and coarse buckets. The next safe direct-agent proposal is an explicit
+local handoff/proof action with enum-only fields, not file watching or content
+inspection.


### PR DESCRIPTION
## Summary
- Track privacy-safe `agent_capture_query_observed` telemetry for MCP orientation flows: `list_meetings`, `list_dictations`, and `recent_context`.
- Allow the new `query_kind` values (`list`, `recent`) and add targeted MCP tests for bucketed, opt-in-safe capture.
- Update PostHog/agent-connect docs with the installed MCP telemetry config proof path, opt-out behavior, live-dashboard runbook, and the direct-file-read blind spot wording.

## Context
Live PostHog had zero true agent-query devices even though main already had the event. The likely missing slice was not raw transcript/file watching; it was MCP orientation/query flows and install/config proof. This keeps the event coarse: enum values, count buckets, and relative recency only. No transcript text, prompts, titles, names, emails, audio refs, or paths are sent.

PR #1233 was inspected. It is broad and currently conflicting; this PR preserves only the useful MCP list/recent telemetry intent and avoids duplicating the larger rescue lane.

## Direct-agent blind spot
Direct reads of saved Markdown folders remain unobservable from MCP and are documented as `unknown`, not zero. The safe next proposal is an explicit local action/tool event with enum/bucket fields only, not file watching or prompt/content tracking.

## Checks
- `swift test --package-path Tools/TranscriptedMCP --filter AgentCaptureQueryTelemetryTests` passed: 12 tests, 0 failures.
- `swift test --package-path Tools/TranscriptedMCP --filter ToolHandlersTests` passed: 7 tests, 0 failures.
- `swift test --package-path Tools/TranscriptedMCP` passed: 90 tests, 0 failures.
- `bash scripts/dev/agent-preflight.sh` passed.
- `git diff --check` passed.
- `bash run-e2e-smoke.sh` passed.

## Review note
Claude review was attempted but stalled/unavailable with empty output: `/Users/redbars/.codex/maestro/runs/20260620T171059Z-mcp-agent-query-review-claude`.

`codex review --uncommitted` also stalled before a final verdict. Per coordinator directive, no more review tooling was run, and this is published as a draft PR using the green mapped checks above.

## Lanes
Codex=implementation, manual diff sanity, mapped tests, commit/push/PR. Claude=attempted review but stalled/unavailable. Local=PR #1233 comparison proof at `/Users/redbars/.codex/maestro/runs/20260620T170626Z-mcp-agent-query-pr1233-check-local`. Windows=skipped; no long-running draft worker needed.

## Cleanup
If this PR lands, #1233 should either be trimmed to exclude this MCP telemetry slice or superseded for that part. It remains broad/conflicting today.
