### PR TITLE
[codex] Add speaker review analytics funnel

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -209,6 +209,32 @@ struct AnalyticsEventPolicy: Equatable {
         "source",
     ]
 
+    private static let speakerReviewLifecycleProperties: Set<String> = [
+        "collapsed_local_to_you",
+        "confirmed_count_bucket",
+        "discarded_count_bucket",
+        "has_local",
+        "has_remote",
+        "has_suggestions",
+        "local_count_bucket",
+        "participant_count_bucket",
+        "remote_count_bucket",
+        "result",
+        "review_reason",
+        "suggestion_count_bucket",
+        "surface",
+        "typed_count_bucket",
+        "unknown_count_bucket",
+    ]
+
+    private static let speakerReviewSettingsActionProperties: Set<String> = [
+        "action",
+        "pending_count_bucket",
+        "result",
+        "review_reason",
+        "surface",
+    ]
+
     private static let allowedPolicies: [String: AnalyticsEventPolicy] = [
         "app_launched": .init(
             name: "app_launched",
@@ -735,6 +761,22 @@ struct AnalyticsEventPolicy: Equatable {
                 "session_stage",
                 "trigger",
             ]
+        ),
+        "speaker_review_presented": .init(
+            name: "speaker_review_presented",
+            allowedProperties: speakerReviewLifecycleProperties
+        ),
+        "speaker_review_completed": .init(
+            name: "speaker_review_completed",
+            allowedProperties: speakerReviewLifecycleProperties
+        ),
+        "speaker_review_dismissed": .init(
+            name: "speaker_review_dismissed",
+            allowedProperties: speakerReviewLifecycleProperties
+        ),
+        "speaker_review_settings_action": .init(
+            name: "speaker_review_settings_action",
+            allowedProperties: speakerReviewSettingsActionProperties
         ),
         "meeting_transcript_skipped": .init(
             name: "meeting_transcript_skipped",

--- a/Sources/UI/Settings/SpeakerNamingSheet.swift
+++ b/Sources/UI/Settings/SpeakerNamingSheet.swift
@@ -51,6 +51,7 @@ final class SpeakerNamingSheet {
         controller.showWindow(nil)
         controller.window?.center()
         controller.window?.makeKeyAndOrderFront(nil)
+        SpeakerReviewAnalytics.trackPresented(request: request)
         NSApp.activate(ignoringOtherApps: true)
     }
 
@@ -96,7 +97,7 @@ final class NamingWindowController: NSWindowController, NSWindowDelegate {
             self?.finish(with: updates)
         }
         contentView.onCancel = { [weak self] in
-            self?.finish(with: [])
+            self?.dismiss(result: .reviewLater)
         }
     }
 
@@ -105,6 +106,7 @@ final class NamingWindowController: NSWindowController, NSWindowDelegate {
 
     func windowWillClose(_ notification: Notification) {
         if !didComplete {
+            SpeakerReviewAnalytics.trackDismissed(request: request, result: .windowClosed)
             request.onComplete([])
             didComplete = true
         }
@@ -120,7 +122,16 @@ final class NamingWindowController: NSWindowController, NSWindowDelegate {
     private func finish(with updates: [SpeakerNameUpdate]) {
         guard !didComplete else { return }
         didComplete = true
+        SpeakerReviewAnalytics.trackCompleted(request: request, updates: updates)
         request.onComplete(updates)
+        close()
+    }
+
+    private func dismiss(result: SpeakerReviewAnalytics.Result) {
+        guard !didComplete else { return }
+        didComplete = true
+        SpeakerReviewAnalytics.trackDismissed(request: request, result: result)
+        request.onComplete([])
         close()
     }
 }

--- a/Sources/UI/Settings/SpeakerReviewAnalytics.swift
+++ b/Sources/UI/Settings/SpeakerReviewAnalytics.swift
@@ -1,0 +1,170 @@
+import Foundation
+#if canImport(TranscriptedCore)
+import TranscriptedCore
+#endif
+
+@available(macOS 14.0, *)
+enum SpeakerReviewAnalytics {
+    enum Surface: String {
+        case sheet = "review_sheet"
+        case home = "home"
+        case people = "people"
+    }
+
+    enum Result: String {
+        case shown
+        case saved
+        case noChanges = "no_changes"
+        case reviewLater = "review_later"
+        case windowClosed = "window_closed"
+        case opened
+    }
+
+    enum SettingsAction: String {
+        case needsAttention = "needs_attention"
+        case rowMenu = "row_menu"
+        case retranscribeBlocked = "retranscribe_blocked"
+        case unknown
+    }
+
+    enum ReviewReason: String {
+        case needsLabels = "needs_labels"
+        case confirmSuggestions = "confirm_suggestions"
+        case mixed
+        case settingsQueue = "settings_queue"
+        case unknown
+    }
+
+    static func trackPresented(request: SpeakerNamingRequest, surface: Surface = .sheet) {
+        AnalyticsReporter.track(
+            "speaker_review_presented",
+            properties: lifecycleProperties(request: request, surface: surface, result: .shown)
+        )
+    }
+
+    static func trackCompleted(
+        request: SpeakerNamingRequest,
+        updates: [SpeakerNameUpdate],
+        surface: Surface = .sheet
+    ) {
+        AnalyticsReporter.track(
+            "speaker_review_completed",
+            properties: lifecycleProperties(
+                request: request,
+                surface: surface,
+                result: updates.isEmpty ? .noChanges : .saved,
+                updates: updates
+            )
+        )
+    }
+
+    static func trackDismissed(
+        request: SpeakerNamingRequest,
+        result: Result,
+        surface: Surface = .sheet
+    ) {
+        AnalyticsReporter.track(
+            "speaker_review_dismissed",
+            properties: lifecycleProperties(request: request, surface: surface, result: result)
+        )
+    }
+
+    static func trackSettingsAction(
+        action: SettingsAction,
+        surface: Surface,
+        pendingCount: Int
+    ) {
+        AnalyticsReporter.track(
+            "speaker_review_settings_action",
+            properties: settingsActionProperties(
+                action: action,
+                surface: surface,
+                pendingCount: pendingCount
+            )
+        )
+    }
+
+    static func lifecycleProperties(
+        request: SpeakerNamingRequest,
+        surface: Surface,
+        result: Result,
+        updates: [SpeakerNameUpdate] = []
+    ) -> [String: String] {
+        let localCount = request.speakers.filter { $0.channel == .mic }.count
+        let remoteCount = request.speakers.filter { $0.channel == .system }.count
+        let suggestionCount = request.speakers.filter { $0.needsConfirmation }.count
+        let unknownCount = request.speakers.filter { $0.needsNaming }.count
+        let updateCounts = updateBuckets(updates)
+
+        return [
+            "collapsed_local_to_you": updateCounts.collapsedLocalToYou ? "true" : "false",
+            "confirmed_count_bucket": AnalyticsReporter.countBucket(updateCounts.confirmed),
+            "discarded_count_bucket": AnalyticsReporter.countBucket(updateCounts.discarded),
+            "has_local": localCount > 0 ? "true" : "false",
+            "has_remote": remoteCount > 0 ? "true" : "false",
+            "has_suggestions": suggestionCount > 0 ? "true" : "false",
+            "local_count_bucket": AnalyticsReporter.countBucket(localCount),
+            "participant_count_bucket": AnalyticsReporter.countBucket(request.speakers.count),
+            "remote_count_bucket": AnalyticsReporter.countBucket(remoteCount),
+            "result": result.rawValue,
+            "review_reason": reviewReason(for: request).rawValue,
+            "suggestion_count_bucket": AnalyticsReporter.countBucket(suggestionCount),
+            "surface": surface.rawValue,
+            "typed_count_bucket": AnalyticsReporter.countBucket(updateCounts.typed),
+            "unknown_count_bucket": AnalyticsReporter.countBucket(unknownCount),
+        ]
+    }
+
+    static func settingsActionProperties(
+        action: SettingsAction,
+        surface: Surface,
+        pendingCount: Int
+    ) -> [String: String] {
+        [
+            "action": action.rawValue,
+            "pending_count_bucket": AnalyticsReporter.countBucket(pendingCount),
+            "result": Result.opened.rawValue,
+            "review_reason": ReviewReason.settingsQueue.rawValue,
+            "surface": surface.rawValue,
+        ]
+    }
+
+    private static func reviewReason(for request: SpeakerNamingRequest) -> ReviewReason {
+        let needsLabels = request.speakers.contains { $0.needsNaming }
+        let needsConfirmation = request.speakers.contains { $0.needsConfirmation }
+        switch (needsLabels, needsConfirmation) {
+        case (true, true):
+            return .mixed
+        case (true, false):
+            return .needsLabels
+        case (false, true):
+            return .confirmSuggestions
+        case (false, false):
+            return .unknown
+        }
+    }
+
+    private struct UpdateBuckets {
+        var collapsedLocalToYou = false
+        var confirmed = 0
+        var typed = 0
+        var discarded = 0
+    }
+
+    private static func updateBuckets(_ updates: [SpeakerNameUpdate]) -> UpdateBuckets {
+        var buckets = UpdateBuckets()
+        for update in updates {
+            switch update.action {
+            case .collapsedToMe:
+                buckets.collapsedLocalToYou = true
+            case .confirmed:
+                buckets.confirmed += 1
+            case .named, .corrected, .merged:
+                buckets.typed += 1
+            case .discardedFromDatabase:
+                buckets.discarded += 1
+            }
+        }
+        return buckets
+    }
+}

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -787,10 +787,28 @@ struct TranscriptedSettingsView: View {
 
     private func openHomeSpeakerReview(actionName: String) {
         trackSettingsAction(actionName, page: navigation.selectedPage)
+        SpeakerReviewAnalytics.trackSettingsAction(
+            action: speakerReviewSettingsAction(for: actionName),
+            surface: .home,
+            pendingCount: speakerPeopleModel.pendingVoiceGroups.count
+        )
         speakerPeopleModel.refresh()
         speakerPeopleModel.searchText = ""
         navigation.selectedPage = .people
         requestSpeakerInboxFocus()
+    }
+
+    private func speakerReviewSettingsAction(for actionName: String) -> SpeakerReviewAnalytics.SettingsAction {
+        switch actionName {
+        case "open_needs_attention_speakers":
+            return .needsAttention
+        case "open_speaker_review_before_retranscribe":
+            return .retranscribeBlocked
+        case "review_meeting_speakers_row":
+            return .rowMenu
+        default:
+            return .unknown
+        }
     }
 
     private func requestSpeakerInboxFocus() {

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -121,6 +121,10 @@ func testAnalyticsEventPolicy() {
             "first_dictation_saved",
             "format_ready",
             "from_status",
+            "collapsed_local_to_you",
+            "has_local",
+            "has_remote",
+            "has_suggestions",
             "has_target",
             "hfp_suspected",
             "import_stage",
@@ -171,6 +175,7 @@ func testAnalyticsEventPolicy() {
             "required",
             "reason_kind",
             "result",
+            "review_reason",
             "route_ready",
             "route_shape",
             "sample_flow_started",
@@ -1037,6 +1042,75 @@ func testAnalyticsEventPolicy() {
         assertEqual(speakerFinalizationFailed?.allowedProperties.contains("failure_kind"), true, "speaker finalization failures should allow normalized failure kinds")
         assertEqual(meetingSkipped?.allowedProperties.contains("failure_kind"), true, "skipped meeting transcripts should allow normalized reasons")
         assertNil(unknown, "unreviewed analytics events should not be allowed")
+    }
+
+    runSuite("AnalyticsEventPolicy keeps speaker review analytics private and bucketed") {
+        let presented = AnalyticsEventPolicy.policy(forEvent: "speaker_review_presented")
+        let completed = AnalyticsEventPolicy.policy(forEvent: "speaker_review_completed")
+        let dismissed = AnalyticsEventPolicy.policy(forEvent: "speaker_review_dismissed")
+        let settingsAction = AnalyticsEventPolicy.policy(forEvent: "speaker_review_settings_action")
+
+        let lifecycleProperties: Set<String> = [
+            "collapsed_local_to_you",
+            "confirmed_count_bucket",
+            "discarded_count_bucket",
+            "has_local",
+            "has_remote",
+            "has_suggestions",
+            "local_count_bucket",
+            "participant_count_bucket",
+            "remote_count_bucket",
+            "result",
+            "review_reason",
+            "suggestion_count_bucket",
+            "surface",
+            "typed_count_bucket",
+            "unknown_count_bucket",
+        ]
+        assertEqual(presented?.allowedProperties ?? Set<String>(), lifecycleProperties, "presented review events should carry only coarse review shape")
+        assertEqual(completed?.allowedProperties ?? Set<String>(), lifecycleProperties, "completed review events should keep the same coarse shape")
+        assertEqual(dismissed?.allowedProperties ?? Set<String>(), lifecycleProperties, "dismissed review events should keep the same coarse shape")
+        assertEqual(
+            settingsAction?.allowedProperties ?? Set<String>(),
+            ["action", "pending_count_bucket", "result", "review_reason", "surface"],
+            "settings review actions should not include private labels or file context"
+        )
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "collapsed_local_to_you": "true",
+                "confirmed_count_bucket": "1",
+                "discarded_count_bucket": "0",
+                "has_local": "true",
+                "has_remote": "true",
+                "has_suggestions": "true",
+                "local_count_bucket": "1",
+                "participant_count_bucket": "2_3",
+                "remote_count_bucket": "1",
+                "result": "saved",
+                "review_reason": "mixed",
+                "suggestion_count_bucket": "1",
+                "surface": "review_sheet",
+                "typed_count_bucket": "2_3",
+                "unknown_count_bucket": "1",
+                "audio_path": "/Users/redbars/private.wav",
+                "meeting_title": "Customer call",
+                "speaker_name": "Alice",
+                "transcript_text": "private words",
+            ],
+            allowedKeys: completed?.allowedProperties ?? Set<String>()
+        )
+        assertEqual(sanitized["collapsed_local_to_you"], "true", "collapsed local state should survive as a boolean")
+        assertEqual(sanitized["confirmed_count_bucket"], "1", "confirmed counts should stay bucketed")
+        assertEqual(sanitized["local_count_bucket"], "1", "local counts should stay bucketed")
+        assertEqual(sanitized["participant_count_bucket"], "2_3", "participant counts should stay bucketed")
+        assertEqual(sanitized["review_reason"], "mixed", "review reason should be a stable enum")
+        assertEqual(sanitized["surface"], "review_sheet", "surface enum should survive")
+        assertEqual(sanitized["typed_count_bucket"], "2_3", "typed counts should stay bucketed")
+        assertNil(sanitized["audio_path"], "audio paths must not be sent")
+        assertNil(sanitized["meeting_title"], "meeting titles must not be sent")
+        assertNil(sanitized["speaker_name"], "speaker names must not be sent")
+        assertNil(sanitized["transcript_text"], "transcript text must not be sent")
     }
 
     runSuite("AnalyticsEventPolicy meeting_recording_stopped system_stream_present key is not silently filtered") {

--- a/Tests/SpeakerNamingPolicyTests.swift
+++ b/Tests/SpeakerNamingPolicyTests.swift
@@ -193,6 +193,97 @@ func testSpeakerNamingPolicy() {
             assertTrue(false, "changing a suggested match should emit .corrected")
         }
     }
+
+    runSuite("SpeakerReviewAnalytics derives only privacy-safe review lifecycle properties") {
+        let localEntry = makeSpeakerNamingPolicyEntry(
+            channel: .mic,
+            currentName: nil,
+            needsNaming: true
+        )
+        let remoteEntry = makeSpeakerNamingPolicyEntry(
+            channel: .system,
+            currentName: "Alex",
+            needsConfirmation: true
+        )
+        let request = SpeakerNamingRequest(
+            speakers: [localEntry, remoteEntry],
+            transcriptURL: URL(fileURLWithPath: "/tmp/private-meeting.md"),
+            transcriptId: UUID(),
+            systemAudioURL: URL(fileURLWithPath: "/tmp/system.wav"),
+            micAudioURL: URL(fileURLWithPath: "/tmp/mic.wav"),
+            onComplete: { _ in }
+        )
+        let updates = [
+            SpeakerNameUpdate(
+                persistentSpeakerId: localEntry.id,
+                diarizerSpeakerId: localEntry.diarizerSpeakerId,
+                channel: .mic,
+                newName: "You",
+                previousName: localEntry.currentName,
+                action: .collapsedToMe
+            ),
+            SpeakerNameUpdate(
+                persistentSpeakerId: remoteEntry.id,
+                diarizerSpeakerId: remoteEntry.diarizerSpeakerId,
+                channel: .system,
+                newName: "Alex",
+                previousName: remoteEntry.currentName,
+                action: .confirmed
+            ),
+            SpeakerNameUpdate(
+                persistentSpeakerId: UUID(),
+                diarizerSpeakerId: "discarded",
+                channel: .system,
+                newName: "",
+                previousName: nil,
+                action: .discardedFromDatabase
+            ),
+        ]
+
+        let properties = SpeakerReviewAnalytics.lifecycleProperties(
+            request: request,
+            surface: .sheet,
+            result: .saved,
+            updates: updates
+        )
+
+        assertEqual(properties["participant_count_bucket"], "2_3", "review lifecycle should bucket total participants")
+        assertEqual(properties["local_count_bucket"], "1", "review lifecycle should bucket local voices")
+        assertEqual(properties["remote_count_bucket"], "1", "review lifecycle should bucket remote voices")
+        assertEqual(properties["suggestion_count_bucket"], "1", "review lifecycle should bucket suggestions")
+        assertEqual(properties["unknown_count_bucket"], "1", "review lifecycle should bucket unknown labels")
+        assertEqual(properties["has_local"], "true", "local inventory should be boolean")
+        assertEqual(properties["has_remote"], "true", "remote inventory should be boolean")
+        assertEqual(properties["has_suggestions"], "true", "suggestion inventory should be boolean")
+        assertEqual(properties["collapsed_local_to_you"], "true", "local collapse should be boolean")
+        assertEqual(properties["confirmed_count_bucket"], "1", "confirmed rows should be bucketed")
+        assertEqual(properties["discarded_count_bucket"], "1", "discarded rows should be bucketed")
+        assertEqual(properties["typed_count_bucket"], "0", "typed rows should be bucketed")
+        assertEqual(properties["review_reason"], "mixed", "mixed review work should stay enum-only")
+        assertEqual(properties["result"], "saved", "review outcome should stay enum-only")
+        assertEqual(properties["surface"], "review_sheet", "review surface should stay enum-only")
+        assertFalse(properties.keys.contains { $0.contains("speaker") }, "property keys should avoid sanitizer-drop speaker fragments")
+        assertFalse(properties.keys.contains { $0.contains("name") }, "property keys should avoid sanitizer-drop name fragments")
+        assertFalse(properties.keys.contains { $0.contains("title") }, "property keys should avoid sanitizer-drop title fragments")
+        assertFalse(properties.keys.contains { $0.contains("transcript") }, "property keys should avoid sanitizer-drop transcript fragments")
+        assertFalse(properties.keys.contains { $0.contains("path") }, "property keys should avoid sanitizer-drop path fragments")
+    }
+
+    runSuite("SpeakerReviewAnalytics keeps settings actions separate from review lifecycle") {
+        let properties = SpeakerReviewAnalytics.settingsActionProperties(
+            action: .rowMenu,
+            surface: .home,
+            pendingCount: 4
+        )
+
+        assertEqual(properties["action"], "row_menu", "settings action should stay enum-only")
+        assertEqual(properties["pending_count_bucket"], "4_9", "pending count should be bucketed")
+        assertEqual(properties["result"], "opened", "settings action result should stay enum-only")
+        assertEqual(properties["review_reason"], "settings_queue", "settings action reason should stay enum-only")
+        assertEqual(properties["surface"], "home", "settings action surface should stay enum-only")
+        assertFalse(properties.keys.contains { $0.contains("speaker") }, "settings action keys should avoid sanitizer-drop speaker fragments")
+        assertFalse(properties.keys.contains { $0.contains("name") }, "settings action keys should avoid sanitizer-drop name fragments")
+    }
 }
 
 private func makeSpeakerNamingPolicyEntry(

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -149,6 +149,10 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `meeting_transcript_saved`
 - `meeting_transcript_failed`
 - `meeting_speaker_finalization_failed`
+- `speaker_review_presented`
+- `speaker_review_completed`
+- `speaker_review_dismissed`
+- `speaker_review_settings_action`
 - `meeting_transcript_skipped`
 - `meeting_saved_audio_retranscription_requested`
 
@@ -168,6 +172,13 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 Meeting workflow analytics should keep that same stable `trigger` enum on later
 stop/save/fail events so product and reliability reviews can attribute outcomes
 without joining against any sensitive context.
+
+Speaker review analytics should stay limited to review lifecycle and Settings
+entry actions. Use only coarse inventory buckets, booleans, stable result enums,
+and surface/reason enums: no labels, audio references, titles, transcript text,
+paths, filenames, source apps, or free-form notes. Property keys must also avoid
+`speaker`, `name`, `title`, `transcript`, and `path` because the analytics
+sanitizer intentionally treats those fragments as private.
 
 Anything richer than that should stay local unless there is a new explicit
 privacy review and a matching allowlist change.

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -373,6 +373,7 @@ APP_SOURCES=(
     "Sources/UI/Shared/HomeMeetingRename.swift"
     "Sources/UI/Settings/HomeMeetingSummaryBetaPresentationPolicy.swift"
     "Sources/UI/Settings/SpeakerVoiceRowPresentation.swift"
+    "Sources/UI/Settings/SpeakerReviewAnalytics.swift"
     "Sources/UI/Settings/HomeFailedMeetingInlinePresentation.swift"
     "Sources/UI/Settings/FailedMeetingRecoveryPresentation.swift"
     "Sources/UI/Settings/HomeMeetingPreviewFormatter.swift"


### PR DESCRIPTION
## Summary

Adds a fresh-main, narrow speaker review PostHog funnel that does not touch conflicting PR #1233.

## What changed

- Adds `speaker_review_presented`, `speaker_review_completed`, `speaker_review_dismissed`, and `speaker_review_settings_action` events.
- Routes completed-meeting speaker review sheet lifecycle through `SpeakerReviewAnalytics`.
- Tracks Settings/Home entry actions separately from review lifecycle.
- Keeps event keys explorer-aligned and sanitizer-safe: no keys containing speaker/name/title/transcript/path, and no raw labels, titles, clips, audio refs, file paths, transcript text, or source app data.
- Updates analytics allowlist, privacy doc, fast-test source list, and focused tests.

## #1233 overlap check

PR #1233 is CONFLICTING/DIRTY and includes broader analytics consolidation plus older speaker review telemetry. This branch is a clean fresh-main replacement for only the missing speaker review lifecycle shape requested by the coordinator. It does not force-push or modify #1233.

## Validation

- `git diff --check`
- `scripts/dev/agent-preflight.sh`
- `python3 scripts/dev/check-build-source-lists.py`
- `bash -n run-tests.sh`
- `bash -n scripts/entrypoints/run-tests.sh`
- `bash run-tests.sh --filter AnalyticsEventPolicy`
- `bash run-tests.sh --filter AnalyticsPayloadSanitizer`
- `bash run-tests.sh --filter SpeakerNamingPolicy`
- `bash run-tests.sh` (10868 passed)
- `bash build-deps.sh --force`
- `bash build.sh --no-open`

## Review note

Codex review was started with `~/.codex/skills/codex-review/scripts/codex-review --mode auto`, but it stalled after re-running a nested full test pass. Per coordinator instruction, it was interrupted and this PR is draft with review unavailable/stalled noted here.