### PR TITLE
Add PostHog analytics delivery retry buffer

### DIFF
--- a/Sources/Observability/AnalyticsReporter.swift
+++ b/Sources/Observability/AnalyticsReporter.swift
@@ -16,6 +16,146 @@ private struct AnalyticsCaptureRequest: Encodable {
     }
 }
 
+struct PendingAnalyticsCapture: Codable, Equatable {
+    let id: String
+    let event: String
+    let distinctID: String
+    let timestamp: String
+    let enqueuedAt: TimeInterval
+    var attemptCount: Int
+    var nextRetryAt: TimeInterval?
+    let properties: [String: String]
+}
+
+struct AnalyticsDeliveryBufferStore {
+    private struct BufferFile: Codable {
+        let version: Int
+        let records: [PendingAnalyticsCapture]
+    }
+
+    static let fileName = "analytics-delivery-buffer.json"
+    static let defaultMaxRecordCount = 100
+    static let defaultMaxFileBytes = 64 * 1024
+    static let defaultTTL: TimeInterval = 24 * 60 * 60
+
+    let fileURL: URL
+    let fileManager: FileManager
+    let maxRecordCount: Int
+    let maxFileBytes: Int
+    let ttl: TimeInterval
+
+    init(
+        fileURL: URL,
+        fileManager: FileManager = .default,
+        maxRecordCount: Int = Self.defaultMaxRecordCount,
+        maxFileBytes: Int = Self.defaultMaxFileBytes,
+        ttl: TimeInterval = Self.defaultTTL
+    ) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+        self.maxRecordCount = maxRecordCount
+        self.maxFileBytes = maxFileBytes
+        self.ttl = ttl
+    }
+
+    static func defaultFileURL(fileManager: FileManager = .default) -> URL {
+        fileManager.transcriptedStateDir.appendingPathComponent(fileName, isDirectory: false)
+    }
+
+    func load(now: Date = Date()) -> [PendingAnalyticsCapture] {
+        guard let data = try? Data(contentsOf: fileURL) else { return [] }
+
+        do {
+            let file = try JSONDecoder().decode(BufferFile.self, from: data)
+            return cappedRecords(file.records, now: now)
+        } catch {
+            remove()
+            return []
+        }
+    }
+
+    func save(_ records: [PendingAnalyticsCapture], now: Date = Date()) {
+        let capped = cappedRecords(records, now: now)
+        guard !capped.isEmpty else {
+            remove()
+            return
+        }
+
+        do {
+            try fileManager.createPrivateDirectory(at: fileURL.deletingLastPathComponent())
+            let data = try JSONEncoder().encode(BufferFile(version: 1, records: capped))
+            try data.write(to: fileURL, options: [.atomic])
+            fileManager.restrictFileToOwnerOnly(at: fileURL)
+        } catch {
+            return
+        }
+    }
+
+    func remove() {
+        try? fileManager.removeItem(at: fileURL)
+    }
+
+    func cappedRecords(_ records: [PendingAnalyticsCapture], now: Date = Date()) -> [PendingAnalyticsCapture] {
+        let cutoff = now.timeIntervalSince1970 - ttl
+        var capped = records
+            .filter { $0.enqueuedAt >= cutoff }
+            .sorted { lhs, rhs in
+                if lhs.enqueuedAt == rhs.enqueuedAt {
+                    return lhs.id < rhs.id
+                }
+                return lhs.enqueuedAt < rhs.enqueuedAt
+            }
+
+        if capped.count > maxRecordCount {
+            capped = Array(capped.suffix(maxRecordCount))
+        }
+
+        while !capped.isEmpty && encodedByteCount(capped) > maxFileBytes {
+            capped.removeFirst()
+        }
+
+        return capped
+    }
+
+    private func encodedByteCount(_ records: [PendingAnalyticsCapture]) -> Int {
+        (try? JSONEncoder().encode(BufferFile(version: 1, records: records)).count) ?? Int.max
+    }
+}
+
+private enum AnalyticsDeliveryResult {
+    case delivered
+    case retry
+    case drop
+}
+
+enum AnalyticsDeliveryPolicy {
+    fileprivate static func result(response: URLResponse?, error: Error?) -> AnalyticsDeliveryResult {
+        if error != nil {
+            return .retry
+        }
+
+        guard let response = response as? HTTPURLResponse else {
+            return .retry
+        }
+
+        switch response.statusCode {
+        case 200..<300:
+            return .delivered
+        case 429, 500..<600:
+            return .retry
+        case 400..<500:
+            return .drop
+        default:
+            return .retry
+        }
+    }
+
+    static func retryDelay(afterAttempt attempt: Int) -> TimeInterval {
+        let exponent = min(max(attempt - 1, 0), 5)
+        return min(pow(2.0, Double(exponent)), 60)
+    }
+}
+
 enum AnalyticsRuntimeConfiguration {
     static let apiKeyInfoKey = "TranscriptedPostHogAPIKey"
     static let hostInfoKey = "TranscriptedPostHogHost"
@@ -253,34 +393,104 @@ final class AnalyticsReporter {
         return eventProperties
     }
 
-    private init() {}
+    private convenience init() {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 5
+        self.init(
+            apiKey: AnalyticsRuntimeConfiguration.apiKey(),
+            captureHost: AnalyticsRuntimeConfiguration.host(),
+            session: URLSession(configuration: configuration),
+            bufferStore: AnalyticsDeliveryBufferStore(
+                fileURL: AnalyticsDeliveryBufferStore.defaultFileURL()
+            ),
+            userDefaults: .standard,
+            observePreferenceChanges: true
+        )
+    }
+
+    init(
+        apiKey: String?,
+        captureHost: String?,
+        session: URLSession,
+        bufferStore: AnalyticsDeliveryBufferStore,
+        userDefaults: UserDefaults = .standard,
+        currentDate: @escaping () -> Date = Date.init,
+        retryDelay: @escaping (Int) -> TimeInterval = AnalyticsDeliveryPolicy.retryDelay(afterAttempt:),
+        analyticsEnabled: (() -> Bool)? = nil,
+        observePreferenceChanges: Bool = false
+    ) {
+        self.apiKey = apiKey
+        self.captureHost = captureHost
+        self.session = session
+        self.bufferStore = bufferStore
+        self.userDefaults = userDefaults
+        self.currentDate = currentDate
+        self.retryDelay = retryDelay
+        self.analyticsEnabled = analyticsEnabled ?? { AnalyticsPreferences.isEnabled(userDefaults: userDefaults) }
+        deliveryQueue.setSpecific(key: Self.deliveryQueueSpecificKey, value: true)
+
+        if observePreferenceChanges {
+            preferenceObserver = NotificationCenter.default.addObserver(
+                forName: UserDefaults.didChangeNotification,
+                object: userDefaults,
+                queue: nil
+            ) { [weak self] _ in
+                guard let self else { return }
+                if !self.analyticsEnabled() {
+                    self.clearPendingCaptures()
+                }
+            }
+        }
+
+        if self.analyticsEnabled() {
+            flushPendingCaptures()
+        } else {
+            clearPendingCaptures()
+        }
+    }
+
+    deinit {
+        if let preferenceObserver {
+            NotificationCenter.default.removeObserver(preferenceObserver)
+        }
+    }
 
     // Config is read once from env/plist/overrides file and cached for the app lifetime.
-    private let apiKey: String? = AnalyticsRuntimeConfiguration.apiKey()
-    private let captureHost: String? = AnalyticsRuntimeConfiguration.host()
+    private let apiKey: String?
+    private let captureHost: String?
     private static let isoDateFormatter = ISO8601DateFormatter()
     private let storageKey = "observability-anonymous-analytics-id"
     private let sessionID = UUID().uuidString
-    private let session: URLSession = {
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.timeoutIntervalForRequest = 5
-        return URLSession(configuration: configuration)
-    }()
+    private let session: URLSession
+    private let bufferStore: AnalyticsDeliveryBufferStore
+    private let userDefaults: UserDefaults
+    private let currentDate: () -> Date
+    private let retryDelay: (Int) -> TimeInterval
+    private let analyticsEnabled: () -> Bool
+    private static let deliveryQueueSpecificKey = DispatchSpecificKey<Bool>()
+    private let deliveryQueue = DispatchQueue(label: "com.transcripted.analytics.delivery-buffer")
+    private var inFlightCaptureIDs: Set<String> = []
+    private var preferenceObserver: NSObjectProtocol?
 
     private lazy var distinctID: String = {
-        if let existing = UserDefaults.standard.string(forKey: storageKey) {
+        if let existing = userDefaults.string(forKey: storageKey) {
             return existing
         }
 
         let newValue = UUID().uuidString
-        UserDefaults.standard.set(newValue, forKey: storageKey)
+        userDefaults.set(newValue, forKey: storageKey)
         return newValue
     }()
 
-    private func trackEvent(_ event: String, properties: [String: String]) {
-        guard AnalyticsPreferences.isEnabled() else { return }
-        guard let apiKey,
+    func trackEvent(_ event: String, properties: [String: String] = [:]) {
+        guard analyticsEnabled() else {
+            clearPendingCaptures()
+            return
+        }
+
+        guard apiKey != nil,
               let captureHost,
+              normalizedCaptureURL(from: captureHost) != nil,
               let policy = AnalyticsEventPolicy.policy(forEvent: event) else {
             return
         }
@@ -296,17 +506,99 @@ final class AnalyticsReporter {
             sessionID: sessionID
         )
 
-        let payload = AnalyticsCaptureRequest(
-            apiKey: apiKey,
+        let now = currentDate()
+        let capture = PendingAnalyticsCapture(
+            id: UUID().uuidString,
             event: policy.name,
             distinctID: distinctID,
-            timestamp: Self.isoDateFormatter.string(from: Date()),
+            timestamp: Self.isoDateFormatter.string(from: now),
+            enqueuedAt: now.timeIntervalSince1970,
+            attemptCount: 0,
+            nextRetryAt: nil,
             properties: eventProperties
         )
 
-        guard let data = try? JSONEncoder().encode(payload),
+        enqueue(capture)
+    }
+
+    func flushPendingCapturesForTesting() {
+        flushPendingCaptures()
+    }
+
+    private func enqueue(_ capture: PendingAnalyticsCapture) {
+        syncOnDeliveryQueue {
+            guard self.analyticsEnabled() else {
+                self.bufferStore.remove()
+                return
+            }
+
+            let now = self.currentDate()
+            var records = self.bufferStore.load(now: now)
+            records.append(capture)
+            self.bufferStore.save(records, now: now)
+            self.flushPendingCapturesLocked()
+        }
+    }
+
+    private func flushPendingCaptures() {
+        deliveryQueue.async {
+            self.flushPendingCapturesLocked()
+        }
+    }
+
+    private func clearPendingCaptures() {
+        syncOnDeliveryQueue {
+            self.inFlightCaptureIDs.removeAll()
+            self.bufferStore.remove()
+        }
+    }
+
+    private func syncOnDeliveryQueue(_ work: () -> Void) {
+        if DispatchQueue.getSpecific(key: Self.deliveryQueueSpecificKey) == true {
+            work()
+        } else {
+            deliveryQueue.sync(execute: work)
+        }
+    }
+
+    private func flushPendingCapturesLocked() {
+        guard analyticsEnabled() else {
+            inFlightCaptureIDs.removeAll()
+            bufferStore.remove()
+            return
+        }
+
+        guard let apiKey,
+              let captureHost,
               let urlString = normalizedCaptureURL(from: captureHost),
               let url = URL(string: urlString) else {
+            return
+        }
+
+        let now = currentDate()
+        let records = bufferStore.load(now: now)
+        bufferStore.save(records, now: now)
+
+        for capture in records {
+            guard capture.nextRetryAt.map({ $0 <= now.timeIntervalSince1970 }) ?? true else { continue }
+            guard !inFlightCaptureIDs.contains(capture.id) else { continue }
+
+            inFlightCaptureIDs.insert(capture.id)
+            send(capture, apiKey: apiKey, url: url)
+        }
+    }
+
+    private func send(_ capture: PendingAnalyticsCapture, apiKey: String, url: URL) {
+        let payload = AnalyticsCaptureRequest(
+            apiKey: apiKey,
+            event: capture.event,
+            distinctID: capture.distinctID,
+            timestamp: capture.timestamp,
+            properties: capture.properties
+        )
+
+        guard let data = try? JSONEncoder().encode(payload) else {
+            completeDelivery(for: capture, result: .drop)
             return
         }
 
@@ -315,7 +607,44 @@ final class AnalyticsReporter {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = data
 
-        session.dataTask(with: request).resume()
+        session.dataTask(with: request) { [weak self] _, response, error in
+            let result = AnalyticsDeliveryPolicy.result(response: response, error: error)
+            self?.deliveryQueue.async {
+                self?.completeDeliveryLocked(for: capture, result: result)
+            }
+        }.resume()
+    }
+
+    private func completeDelivery(for capture: PendingAnalyticsCapture, result: AnalyticsDeliveryResult) {
+        deliveryQueue.async {
+            self.completeDeliveryLocked(for: capture, result: result)
+        }
+    }
+
+    private func completeDeliveryLocked(for capture: PendingAnalyticsCapture, result: AnalyticsDeliveryResult) {
+        defer { inFlightCaptureIDs.remove(capture.id) }
+
+        guard analyticsEnabled() else {
+            inFlightCaptureIDs.removeAll()
+            bufferStore.remove()
+            return
+        }
+
+        let now = currentDate()
+        var records = bufferStore.load(now: now)
+        guard let index = records.firstIndex(where: { $0.id == capture.id }) else { return }
+
+        switch result {
+        case .delivered, .drop:
+            records.remove(at: index)
+        case .retry:
+            var retryCapture = records[index]
+            retryCapture.attemptCount += 1
+            retryCapture.nextRetryAt = now.addingTimeInterval(retryDelay(retryCapture.attemptCount)).timeIntervalSince1970
+            records[index] = retryCapture
+        }
+
+        bufferStore.save(records, now: now)
     }
 
     private func normalizedCaptureURL(from host: String) -> String? {

--- a/Tests/AnalyticsReporterTests.swift
+++ b/Tests/AnalyticsReporterTests.swift
@@ -373,4 +373,415 @@ func testAnalyticsReporter() {
             "invalid negative timings should fail closed to the smallest latency bucket"
         )
     }
+
+    runSuite("AnalyticsReporter persists only sanitized allowlisted retry records") {
+        let fixture = makeAnalyticsReporterFixture(responses: [.networkFailure])
+        defer { fixture.cleanup() }
+
+        fixture.reporter.trackEvent(
+            "dictation_completed",
+            properties: [
+                "trigger": "hotkey",
+                "duration_bucket": "30_119s",
+                "word_count_bucket": "50_149",
+                "audio_path": "/Users/jane/private.wav",
+                "meeting_title": "Secret roadmap",
+                "speaker_name": "Jane",
+                "transcript_text": "private words",
+            ]
+        )
+
+        assertTrue(
+            waitUntil { AnalyticsReporterTestURLProtocol.requestCount() == 1 && loadBufferedAnalyticsCaptures(from: fixture.bufferURL).first?.attemptCount == 1 },
+            "failed delivery should leave one persisted retry record"
+        )
+
+        let captures = loadBufferedAnalyticsCaptures(from: fixture.bufferURL)
+        assertEqual(captures.count, 1, "one failed capture should remain buffered")
+        assertEqual(captures.first?.event, "dictation_completed", "buffer should persist the reviewed event name")
+        assertEqual(captures.first?.properties["trigger"], "hotkey", "allowlisted properties should survive persistence")
+        assertEqual(captures.first?.properties["duration_bucket"], "30_119s", "allowlisted buckets should survive persistence")
+        assertNil(captures.first?.properties["audio_path"], "audio paths should never be persisted")
+        assertNil(captures.first?.properties["meeting_title"], "meeting titles should never be persisted")
+        assertNil(captures.first?.properties["speaker_name"], "speaker names should never be persisted")
+        assertNil(captures.first?.properties["transcript_text"], "transcript text should never be persisted")
+
+        let diskJSON = readStringIfPresent(fixture.bufferURL) ?? ""
+        assertFalse(diskJSON.contains("test-api-key"), "retry buffer must not persist the PostHog API key")
+        assertFalse(diskJSON.contains("posthog.example.com"), "retry buffer must not persist the PostHog host")
+        assertFalse(diskJSON.contains("api_key"), "retry buffer must not persist capture request secrets")
+        assertFalse(diskJSON.contains("Content-Type"), "retry buffer must not persist HTTP headers")
+        assertFalse(diskJSON.contains("/Users/jane/private.wav"), "retry buffer must not persist raw local paths")
+        assertFalse(diskJSON.contains("Secret roadmap"), "retry buffer must not persist raw titles")
+        assertFalse(diskJSON.contains("private words"), "retry buffer must not persist transcript text")
+    }
+
+    runSuite("AnalyticsReporter retries transient failures and deletes after success") {
+        let fixture = makeAnalyticsReporterFixture(
+            responses: [.status(503), .status(200)],
+            retryDelay: { _ in 0 }
+        )
+        defer { fixture.cleanup() }
+
+        fixture.reporter.trackEvent("app_launched")
+
+        assertTrue(
+            waitUntil { AnalyticsReporterTestURLProtocol.requestCount() == 1 && loadBufferedAnalyticsCaptures(from: fixture.bufferURL).first?.attemptCount == 1 },
+            "5xx delivery should leave the capture ready for retry"
+        )
+
+        fixture.reporter.flushPendingCapturesForTesting()
+
+        assertTrue(
+            waitUntil { AnalyticsReporterTestURLProtocol.requestCount() == 2 && !FileManager.default.fileExists(atPath: fixture.bufferURL.path) },
+            "successful retry should delete the persisted capture"
+        )
+    }
+
+    runSuite("AnalyticsReporter drops non-429 4xx responses and retains 429 responses") {
+        let badRequest = makeAnalyticsReporterFixture(responses: [.status(400)])
+        defer { badRequest.cleanup() }
+
+        badRequest.reporter.trackEvent("app_launched")
+
+        assertTrue(
+            waitUntil { AnalyticsReporterTestURLProtocol.requestCount() == 1 && !FileManager.default.fileExists(atPath: badRequest.bufferURL.path) },
+            "400 responses should drop the persisted capture"
+        )
+
+        let retryAfter429 = makeAnalyticsReporterFixture(
+            responses: [.status(429)],
+            now: Date(timeIntervalSince1970: 1_000),
+            retryDelay: { _ in 30 }
+        )
+        defer { retryAfter429.cleanup() }
+
+        retryAfter429.reporter.trackEvent("app_launched")
+
+        assertTrue(
+            waitUntil { AnalyticsReporterTestURLProtocol.requestCount() == 1 && loadBufferedAnalyticsCaptures(from: retryAfter429.bufferURL).first?.attemptCount == 1 },
+            "429 responses should retain the capture"
+        )
+
+        let captures = loadBufferedAnalyticsCaptures(from: retryAfter429.bufferURL)
+        assertEqual(captures.count, 1, "429 capture should stay buffered")
+        assertEqual(captures.first?.nextRetryAt, Optional(1_030.0), "429 capture should honor retry backoff")
+
+        retryAfter429.reporter.flushPendingCapturesForTesting()
+        Thread.sleep(forTimeInterval: 0.05)
+        assertEqual(AnalyticsReporterTestURLProtocol.requestCount(), 1, "backoff should prevent an immediate retry")
+    }
+
+    runSuite("AnalyticsReporter flushes persisted launch captures on reporter initialization") {
+        let fixture = makeAnalyticsReporterFixture(responses: [.status(200)], autostart: false)
+        defer { fixture.cleanup() }
+
+        fixture.store.save([
+            makePendingAnalyticsCapture(event: "app_launched", enqueuedAt: 1_000),
+        ], now: Date(timeIntervalSince1970: 1_000))
+
+        fixture.start()
+
+        assertTrue(
+            waitUntil { AnalyticsReporterTestURLProtocol.requestCount() == 1 && !FileManager.default.fileExists(atPath: fixture.bufferURL.path) },
+            "reporter startup should flush pending launch captures"
+        )
+    }
+
+    runSuite("AnalyticsReporter opt-out wipes the retry buffer and prevents delivery") {
+        let fixture = makeAnalyticsReporterFixture(responses: [.networkFailure], observePreferenceChanges: true)
+        defer { fixture.cleanup() }
+
+        fixture.reporter.trackEvent("app_launched")
+
+        assertTrue(
+            waitUntil { AnalyticsReporterTestURLProtocol.requestCount() == 1 && loadBufferedAnalyticsCaptures(from: fixture.bufferURL).count == 1 },
+            "failed delivery should create a retry file before opt-out"
+        )
+
+        AnalyticsPreferences.setEnabled(false, userDefaults: fixture.userDefaults)
+
+        assertTrue(
+            waitUntil { !FileManager.default.fileExists(atPath: fixture.bufferURL.path) },
+            "analytics opt-out notification should delete the retry file"
+        )
+
+        fixture.reporter.trackEvent("app_launched")
+
+        assertTrue(
+            waitUntil { !FileManager.default.fileExists(atPath: fixture.bufferURL.path) },
+            "analytics opt-out should delete the retry file"
+        )
+        assertEqual(AnalyticsReporterTestURLProtocol.requestCount(), 1, "opt-out should prevent new delivery attempts")
+    }
+
+    runSuite("AnalyticsReporter refuses non-HTTPS PostHog hosts before buffering") {
+        let fixture = makeAnalyticsReporterFixture(
+            responses: [.status(200)],
+            captureHost: "http://posthog.example.com"
+        )
+        defer { fixture.cleanup() }
+
+        fixture.reporter.trackEvent("app_launched")
+
+        assertEqual(AnalyticsReporterTestURLProtocol.requestCount(), 0, "non-HTTPS hosts should not be contacted")
+        assertFalse(FileManager.default.fileExists(atPath: fixture.bufferURL.path), "non-HTTPS hosts should not create retry records")
+    }
+
+    runSuite("AnalyticsDeliveryBufferStore caps records, expires stale captures, and recovers from corrupt JSON") {
+        let fixture = makeAnalyticsReporterFixture(responses: [], autostart: false)
+        defer { fixture.cleanup() }
+
+        let defaultStore = AnalyticsDeliveryBufferStore(fileURL: fixture.bufferURL)
+        let records = (0..<105).map { index in
+            makePendingAnalyticsCapture(id: "capture-\(index)", enqueuedAt: TimeInterval(index))
+        }
+        defaultStore.save(records, now: Date(timeIntervalSince1970: 200))
+
+        let capped = defaultStore.load(now: Date(timeIntervalSince1970: 200))
+        assertEqual(capped.count, 100, "buffer should cap persisted captures near one hundred records")
+        assertEqual(capped.first?.id, "capture-5", "record cap should drop the oldest captures first")
+
+        let tinyStore = AnalyticsDeliveryBufferStore(
+            fileURL: fixture.bufferURL,
+            maxRecordCount: 100,
+            maxFileBytes: 1_200,
+            ttl: AnalyticsDeliveryBufferStore.defaultTTL
+        )
+        tinyStore.save(records, now: Date(timeIntervalSince1970: 200))
+        let byteCapped = tinyStore.load(now: Date(timeIntervalSince1970: 200))
+        assertTrue(byteCapped.count < 100, "byte cap should drop old records until the JSON file is small")
+        assertTrue((try? Data(contentsOf: fixture.bufferURL).count) ?? Int.max <= 1_200, "retry file should stay under the configured byte cap")
+
+        let ttlStore = AnalyticsDeliveryBufferStore(
+            fileURL: fixture.bufferURL,
+            maxRecordCount: 100,
+            maxFileBytes: AnalyticsDeliveryBufferStore.defaultMaxFileBytes,
+            ttl: 10
+        )
+        ttlStore.save([
+            makePendingAnalyticsCapture(id: "old", enqueuedAt: 1_000),
+            makePendingAnalyticsCapture(id: "fresh", enqueuedAt: 1_016),
+        ], now: Date(timeIntervalSince1970: 1_020))
+        let ttlCaptures = ttlStore.load(now: Date(timeIntervalSince1970: 1_020))
+        assertEqual(ttlCaptures.map(\.id), ["fresh"], "TTL should drop records older than one day in production")
+
+        try? Data("not-json".utf8).write(to: fixture.bufferURL, options: [.atomic])
+        assertEqual(defaultStore.load().count, 0, "corrupt retry files should recover as an empty buffer")
+        assertFalse(FileManager.default.fileExists(atPath: fixture.bufferURL.path), "corrupt retry files should be deleted")
+    }
+}
+
+private final class AnalyticsReporterFixture {
+    let directory: URL
+    let bufferURL: URL
+    let store: AnalyticsDeliveryBufferStore
+    let userDefaults: UserDefaults
+    private let makeReporter: () -> AnalyticsReporter
+    private let suiteName: String
+    private var startedReporter: AnalyticsReporter?
+
+    var reporter: AnalyticsReporter {
+        if let startedReporter {
+            return startedReporter
+        }
+        let reporter = makeReporter()
+        startedReporter = reporter
+        return reporter
+    }
+
+    init(
+        directory: URL,
+        bufferURL: URL,
+        store: AnalyticsDeliveryBufferStore,
+        userDefaults: UserDefaults,
+        suiteName: String,
+        makeReporter: @escaping () -> AnalyticsReporter,
+        startedReporter: AnalyticsReporter? = nil
+    ) {
+        self.directory = directory
+        self.bufferURL = bufferURL
+        self.store = store
+        self.userDefaults = userDefaults
+        self.suiteName = suiteName
+        self.makeReporter = makeReporter
+        self.startedReporter = startedReporter
+    }
+
+    func start() {
+        _ = reporter
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: directory)
+        userDefaults.removePersistentDomain(forName: suiteName)
+    }
+}
+
+private enum AnalyticsReporterTestResponse {
+    case status(Int)
+    case networkFailure
+}
+
+private func makeAnalyticsReporterFixture(
+    responses: [AnalyticsReporterTestResponse],
+    captureHost: String = "https://posthog.example.com",
+    now: Date = Date(timeIntervalSince1970: 2_000),
+    retryDelay: @escaping (Int) -> TimeInterval = { _ in 1 },
+    analyticsEnabled: (() -> Bool)? = nil,
+    observePreferenceChanges: Bool = false,
+    autostart: Bool = true
+) -> AnalyticsReporterFixture {
+    AnalyticsReporterTestURLProtocol.reset(responses: responses)
+
+    let directory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("AnalyticsReporterTests-\(UUID().uuidString)", isDirectory: true)
+    try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let bufferURL = directory.appendingPathComponent(AnalyticsDeliveryBufferStore.fileName)
+    let store = AnalyticsDeliveryBufferStore(fileURL: bufferURL)
+    let suiteName = "AnalyticsReporterTests.\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.protocolClasses = [AnalyticsReporterTestURLProtocol.self]
+    let session = URLSession(configuration: configuration)
+
+    let fixture = AnalyticsReporterFixture(
+        directory: directory,
+        bufferURL: bufferURL,
+        store: store,
+        userDefaults: defaults,
+        suiteName: suiteName,
+        makeReporter: {
+            AnalyticsReporter(
+                apiKey: "test-api-key",
+                captureHost: captureHost,
+                session: session,
+                bufferStore: store,
+                userDefaults: defaults,
+                currentDate: { now },
+                retryDelay: retryDelay,
+                analyticsEnabled: analyticsEnabled,
+                observePreferenceChanges: observePreferenceChanges
+            )
+        }
+    )
+
+    if autostart {
+        fixture.start()
+    }
+
+    return fixture
+}
+
+private func makePendingAnalyticsCapture(
+    id: String = UUID().uuidString,
+    event: String = "app_launched",
+    enqueuedAt: TimeInterval = 1_000,
+    nextRetryAt: TimeInterval? = nil
+) -> PendingAnalyticsCapture {
+    PendingAnalyticsCapture(
+        id: id,
+        event: event,
+        distinctID: "anonymous-device",
+        timestamp: "2026-06-20T12:00:00Z",
+        enqueuedAt: enqueuedAt,
+        attemptCount: 0,
+        nextRetryAt: nextRetryAt,
+        properties: [
+            "distinct_id": "anonymous-device",
+            "app_version": "1.0",
+            "build_version": "1",
+            "build_channel": "test",
+            "build_revision": "abc123",
+            "os_major": "26",
+            "session_id": "session-1",
+        ]
+    )
+}
+
+private struct AnalyticsReporterTestBufferFile: Decodable {
+    let version: Int
+    let records: [PendingAnalyticsCapture]
+}
+
+private func loadBufferedAnalyticsCaptures(from url: URL) -> [PendingAnalyticsCapture] {
+    guard let data = try? Data(contentsOf: url),
+          let file = try? JSONDecoder().decode(AnalyticsReporterTestBufferFile.self, from: data) else {
+        return []
+    }
+    return file.records
+}
+
+private func readStringIfPresent(_ url: URL) -> String? {
+    guard let data = try? Data(contentsOf: url) else { return nil }
+    return String(data: data, encoding: .utf8)
+}
+
+private func waitUntil(timeout: TimeInterval = 2, condition: () -> Bool) -> Bool {
+    let deadline = Date().addingTimeInterval(timeout)
+    while Date() < deadline {
+        if condition() {
+            return true
+        }
+        Thread.sleep(forTimeInterval: 0.01)
+    }
+    return condition()
+}
+
+private final class AnalyticsReporterTestURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private static var responses: [AnalyticsReporterTestResponse] = []
+    private static var requests: [URLRequest] = []
+
+    static func reset(responses: [AnalyticsReporterTestResponse]) {
+        lock.lock()
+        self.responses = responses
+        self.requests = []
+        lock.unlock()
+    }
+
+    static func requestCount() -> Int {
+        lock.lock()
+        let count = requests.count
+        lock.unlock()
+        return count
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        let response = Self.nextResponse(recording: request)
+        switch response {
+        case .networkFailure:
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+        case .status(let status):
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: status,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: Data("{}".utf8))
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+
+    override func stopLoading() {}
+
+    private static func nextResponse(recording request: URLRequest) -> AnalyticsReporterTestResponse {
+        lock.lock()
+        requests.append(request)
+        let response = responses.isEmpty ? .status(200) : responses.removeFirst()
+        lock.unlock()
+        return response
+    }
 }


### PR DESCRIPTION
## Summary
- Add a small persistent PostHog delivery buffer under app-owned state.
- Persist only already-sanitized allowlisted capture records; no API key, host, headers, errors, or raw private content are written to disk.
- Flush on reporter startup and after new events; delete on 2xx, drop 4xx except 429, retry network/429/5xx with backoff.
- Wipe pending captures on analytics opt-out and enforce the existing HTTPS-only host gate before buffering.

## Verification
- ✅ `bash run-tests.sh --filter AnalyticsReporter`
- ✅ `bash run-tests.sh --filter AnalyticsEventPolicy`
- ✅ `bash run-tests.sh --filter AnalyticsPayloadSanitizer`
- ✅ `bash build-deps.sh --force`
- ✅ `bash build.sh --no-open`
- ✅ `bash run-tests.sh`
- ✅ `bash scripts/dev/agent-preflight.sh`
- ✅ `git diff --check`

## Review notes
- Local Maestro review was attempted but not treated as a blocking verdict because the output was low quality. Proof: `/Users/redbars/.codex/maestro/runs/20260620T172502Z-analytics-buffer-diff-review-local`
- Claude Maestro risk review was attempted and stopped after no output, so no Claude verdict is claimed. Proof: `/Users/redbars/.codex/maestro/runs/20260620T172519Z-analytics-buffer-risk-review-claude`
