### PR TITLE
[codex] Add local summary PostHog funnel

### DIFF
--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -209,6 +209,30 @@ struct AnalyticsEventPolicy: Equatable {
         "source",
     ]
 
+    private static let localMeetingSummaryStartedProperties: Set<String> = [
+        "provider",
+        "queue_depth_bucket",
+        "runtime",
+        "setup_ready",
+        "summary_action",
+    ]
+
+    private static let localMeetingSummaryCompletedProperties: Set<String> = [
+        "chunk_count_bucket",
+        "duration_bucket",
+        "provider",
+        "runtime",
+        "summary_action",
+    ]
+
+    private static let localMeetingSummaryFailedProperties: Set<String> = [
+        "duration_bucket",
+        "failure_kind",
+        "provider",
+        "stage",
+        "summary_action",
+    ]
+
     private static let allowedPolicies: [String: AnalyticsEventPolicy] = [
         "app_launched": .init(
             name: "app_launched",
@@ -718,6 +742,18 @@ struct AnalyticsEventPolicy: Equatable {
                 "trigger",
                 "word_count_bucket",
             ]
+        ),
+        "local_meeting_summary_started": .init(
+            name: "local_meeting_summary_started",
+            allowedProperties: localMeetingSummaryStartedProperties
+        ),
+        "local_meeting_summary_completed": .init(
+            name: "local_meeting_summary_completed",
+            allowedProperties: localMeetingSummaryCompletedProperties
+        ),
+        "local_meeting_summary_failed": .init(
+            name: "local_meeting_summary_failed",
+            allowedProperties: localMeetingSummaryFailedProperties
         ),
         "meeting_transcript_failed": .init(
             name: "meeting_transcript_failed",

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -974,6 +974,18 @@ struct TranscriptedSettingsView: View {
         }
         trackSettingsAction("generate_local_meeting_summary", page: .home)
         let provider = localMeetingSummaryProvider
+        let summaryAction = hasExistingSummary ? "regenerate" : "generate"
+        let summaryStartedAt = CFAbsoluteTimeGetCurrent()
+        trackLocalSummaryAnalytics(
+            event: "local_meeting_summary_started",
+            properties: [
+                "provider": provider.rawValue,
+                "summary_action": summaryAction,
+                "setup_ready": selectedLocalSummaryProviderIsReady ? "true" : "false",
+                "runtime": selectedLocalSummaryProviderProfileName,
+                "queue_depth_bucket": AnalyticsReporter.queueDepthBucket(homeLocalSummaryTasks.count),
+            ]
+        )
         recordLocalSummaryEvent(
             event: "local_meeting_summary_started",
             message: "\(provider.title) meeting summary started",
@@ -1031,6 +1043,16 @@ struct TranscriptedSettingsView: View {
                         "profile": result.profileName,
                     ]
                 )
+                trackLocalSummaryAnalytics(
+                    event: "local_meeting_summary_completed",
+                    properties: [
+                        "provider": result.provider.rawValue,
+                        "summary_action": summaryAction,
+                        "chunk_count_bucket": AnalyticsReporter.countBucket(result.chunkCount),
+                        "runtime": result.profileName,
+                        "duration_bucket": localSummaryRunDurationBucket(since: summaryStartedAt),
+                    ]
+                )
                 refreshRecentCapturesAfterLocalSummary()
             } catch is CancellationError {
                 if homeLocalSummaryTaskTokens[summaryID] == taskToken {
@@ -1046,6 +1068,7 @@ struct TranscriptedSettingsView: View {
                 return
             } catch {
                 guard localMeetingSummariesEnabled else { return }
+                let failureKind = localSummaryFailureKind(error)
                 trackLocalSummaryAbandoned(reason: .failed, stage: "generate", priorReadyState: "ready")
                 recordLocalSummaryEvent(
                     level: .error,
@@ -1053,7 +1076,17 @@ struct TranscriptedSettingsView: View {
                     message: "\(provider.title) meeting summary failed",
                     context: [
                         "provider": provider.rawValue,
-                        "error": error.localizedDescription,
+                        "failure_kind": failureKind,
+                    ]
+                )
+                trackLocalSummaryAnalytics(
+                    event: "local_meeting_summary_failed",
+                    properties: [
+                        "provider": provider.rawValue,
+                        "summary_action": summaryAction,
+                        "failure_kind": failureKind,
+                        "stage": "generate",
+                        "duration_bucket": localSummaryRunDurationBucket(since: summaryStartedAt),
                     ]
                 )
                 NSSound.beep()
@@ -3476,6 +3509,42 @@ struct TranscriptedSettingsView: View {
             message: message,
             context: context
         )
+    }
+
+    private func trackLocalSummaryAnalytics(event: String, properties: [String: String]) {
+        AnalyticsReporter.track(event, properties: properties)
+    }
+
+    private func localSummaryRunDurationBucket(since start: CFAbsoluteTime) -> String {
+        AnalyticsReporter.durationBucket(seconds: max(0, CFAbsoluteTimeGetCurrent() - start))
+    }
+
+    private func localSummaryFailureKind(_ error: Error) -> String {
+        if error is CancellationError { return "cancelled" }
+        guard let summaryError = error as? LocalMeetingSummaryError else {
+            return "other"
+        }
+
+        switch summaryError {
+        case .emptyTranscript:
+            return "empty_transcript"
+        case .insufficientMemory:
+            return "insufficient_memory"
+        case .runtimeUnavailable:
+            return "runtime_unavailable"
+        case .appleFoundationUnavailable:
+            return "apple_foundation_unavailable"
+        case .missingBundledRunner:
+            return "missing_runner"
+        case .transcriptChanged:
+            return "transcript_changed"
+        case .processTimedOut:
+            return "timeout"
+        case .processFailed:
+            return "process_failed"
+        case .outputMissing:
+            return "output_missing"
+        }
     }
 
     private func trackLocalSummaryAbandoned(

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -173,6 +173,7 @@ func testAnalyticsEventPolicy() {
             "result",
             "route_ready",
             "route_shape",
+            "runtime",
             "sample_flow_started",
             "save_outcome",
             "selected_input_class",
@@ -184,6 +185,7 @@ func testAnalyticsEventPolicy() {
             "session_stage",
             "setting_id",
             "setup_kind",
+            "setup_ready",
             "source",
             "stall_kind",
             "stall_stage",
@@ -194,6 +196,7 @@ func testAnalyticsEventPolicy() {
             "stop_timed_out",
             "suppression_reason",
             "surface",
+            "summary_action",
             "system_backend",
             "system_channels",
             "system_failed",
@@ -531,6 +534,66 @@ func testAnalyticsEventPolicy() {
         )
         assertTrue(enabledResult, "first artifact after analytics opt-in should be treated as the first observable artifact")
         assertEqual(defaults.string(forKey: ActivationTelemetry.firstArtifactKindKey), "meeting", "only opted-in artifact kind should be retained")
+    }
+
+    runSuite("AnalyticsEventPolicy allows local meeting summary funnel events") {
+        let started = AnalyticsEventPolicy.policy(forEvent: "local_meeting_summary_started")
+        let completed = AnalyticsEventPolicy.policy(forEvent: "local_meeting_summary_completed")
+        let failed = AnalyticsEventPolicy.policy(forEvent: "local_meeting_summary_failed")
+
+        assertEqual(
+            started?.allowedProperties ?? Set<String>(),
+            ["provider", "queue_depth_bucket", "runtime", "setup_ready", "summary_action"],
+            "local summary starts should include only provider/setup/action and queue shape"
+        )
+        assertEqual(
+            completed?.allowedProperties ?? Set<String>(),
+            ["chunk_count_bucket", "duration_bucket", "provider", "runtime", "summary_action"],
+            "local summary completions should include only provider/runtime/action and coarse result buckets"
+        )
+        assertEqual(
+            failed?.allowedProperties ?? Set<String>(),
+            ["duration_bucket", "failure_kind", "provider", "stage", "summary_action"],
+            "local summary failures should include only provider/action/stage and coarse failure shape"
+        )
+
+        let allowed = (started?.allowedProperties ?? [])
+            .union(completed?.allowedProperties ?? [])
+            .union(failed?.allowedProperties ?? [])
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "provider": "gemmaMLX",
+                "summary_action": "generate",
+                "setup_ready": "true",
+                "runtime": "m1-low-memory",
+                "queue_depth_bucket": "1",
+                "chunk_count_bucket": "2_3",
+                "duration_bucket": "2_9m",
+                "failure_kind": "timeout",
+                "stage": "generate",
+                "transcriptURL": "/Users/redbars/private.md",
+                "title": "Customer call",
+                "summary_text": "private generated summary",
+                "filename": "Customer call.md",
+                "error": "Failed at /Users/redbars/private.md",
+            ],
+            allowedKeys: allowed.union(["transcriptURL", "title", "summary_text", "filename", "error"])
+        )
+
+        assertEqual(sanitized["provider"], "gemmaMLX", "provider enum should survive")
+        assertEqual(sanitized["summary_action"], "generate", "summary action enum should survive")
+        assertEqual(sanitized["setup_ready"], "true", "setup readiness should survive as a boolean string")
+        assertEqual(sanitized["runtime"], "m1-low-memory", "reviewed runtime enum should survive")
+        assertEqual(sanitized["queue_depth_bucket"], "1", "queue depth bucket should survive")
+        assertEqual(sanitized["chunk_count_bucket"], "2_3", "chunk count bucket should survive")
+        assertEqual(sanitized["duration_bucket"], "2_9m", "duration bucket should survive")
+        assertEqual(sanitized["failure_kind"], "timeout", "normalized failure kind should survive")
+        assertEqual(sanitized["stage"], "generate", "failure stage should survive")
+        assertNil(sanitized["transcriptURL"], "transcript URLs must not be sent")
+        assertNil(sanitized["title"], "meeting titles must not be sent")
+        assertNil(sanitized["summary_text"], "summary text must not be sent")
+        assertNil(sanitized["filename"], "filenames must not be sent")
+        assertNil(sanitized["error"], "raw error strings must not be sent")
     }
 
     runSuite("AnalyticsEventPolicy allows workflow abandonment taxonomy") {

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -147,6 +147,9 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `meeting_file_imported`
 - `meeting_file_import_failed`
 - `meeting_transcript_saved`
+- `local_meeting_summary_started`
+- `local_meeting_summary_completed`
+- `local_meeting_summary_failed`
 - `meeting_transcript_failed`
 - `meeting_speaker_finalization_failed`
 - `meeting_transcript_skipped`
@@ -164,6 +167,9 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
   `capture_library`, `permissions`, `speaker_review`, and `update_settings`
 - product friction fields limited to `surface`, `stage`, `result`,
   `failure_kind`, `elapsed_bucket`, `route_shape`, and `model_state`
+- local meeting summary analytics limited to `provider`, `summary_action`,
+  `setup_ready`, `runtime`, `queue_depth_bucket`, `chunk_count_bucket`,
+  `duration_bucket`, `failure_kind`, and `stage`
 
 Meeting workflow analytics should keep that same stable `trigger` enum on later
 stop/save/fail events so product and reliability reviews can attribute outcomes


### PR DESCRIPTION
## Summary
- Adds direct AnalyticsReporter.track funnel events for local meeting summaries: started, completed, failed.
- Allowlists only coarse privacy-safe properties and documents the new event surface.
- Adds policy/sanitizer coverage proving transcript URLs, titles, summary text, filenames, and raw errors are dropped.

## Scope / overlap
- Inspected #1233 first. It overlaps these files but uses broader/misaligned meeting_summary_* events and does not cleanly cover the requested local_meeting_summary_* direct PostHog funnel.
- This PR is intentionally narrow to the local summary funnel.
- Used `runtime` instead of `profile` because the existing sanitizer rejects keys containing `file`; this keeps the coarse profile/runtime signal without weakening file/path protections.

## Verification
- `bash run-tests.sh --filter AnalyticsEventPolicy` (5084 passed)
- `bash run-tests.sh --filter AnalyticsPayloadSanitizer` (136 passed)
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh` (10624 passed)
- `bash scripts/dev/agent-preflight.sh`
- `git diff --check`
- codex-review: clean, no actionable findings
- Local lane first-pass review proof: `/Users/redbars/.codex/maestro/runs/20260620T172225Z-local-summary-posthog-review-local`
- Extra local review proof, rejected unrelated hallucinated file findings: `/Users/redbars/.codex/maestro/runs/20260620T172641Z-transcripted-summary-analytics-review-local`

lanes used: Codex=implementation, #1233 inspection, tests, codex-review, commit/push/PR; Claude=skipped, scoped change did not need high-reasoning lane; Local=maestro first-pass privacy/review proof paths above; Windows=skipped, local verification was faster and sufficient