### PR TITLE
Add PostHog decision/outcome telemetry

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -1422,10 +1422,30 @@ final class MeetingSessionController: ObservableObject {
 
     @discardableResult
     func retryFailedMeeting(id: UUID) -> Bool {
-        guard !isRecording, !hasBackgroundTranscriptionWork, !isSpeakerReviewPending else { return false }
-        guard !retryingFailedMeetingIDs.contains(id) else { return false }
+        let failureKind = failedManager.failedTranscriptions
+            .first(where: { $0.id == id })
+            .map { MeetingFailureKind.classify(message: $0.errorMessage).rawValue }
+            ?? "unknown"
+        func trackOutcome(_ outcome: ProductDecisionTelemetry.RetryOutcome) {
+            ProductDecisionTelemetry.trackFailedCaptureRetryOutcome(
+                captureKind: .meeting,
+                failureKind: failureKind,
+                retryAction: .retry,
+                outcome: outcome
+            )
+        }
+
+        guard !isRecording, !hasBackgroundTranscriptionWork, !isSpeakerReviewPending else {
+            trackOutcome(.blocked)
+            return false
+        }
+        guard !retryingFailedMeetingIDs.contains(id) else {
+            trackOutcome(.blocked)
+            return false
+        }
         guard failedManager.failedTranscriptions.contains(where: { $0.id == id }) else {
             refreshFailedMeetings()
+            trackOutcome(.blocked)
             return false
         }
 
@@ -1447,15 +1467,27 @@ final class MeetingSessionController: ObservableObject {
                 )
                 self.retryingFailedMeetingIDs.remove(id)
                 self.refreshFailedMeetings()
+                ProductDecisionTelemetry.trackFailedCaptureRetryOutcome(
+                    captureKind: .meeting,
+                    failureKind: failureKind,
+                    retryAction: .retry,
+                    outcome: .blocked
+                )
                 return
             }
 
-            _ = await self.taskManager.retryFailedTranscription(
+            let didRetry = await self.taskManager.retryFailedTranscription(
                 failedId: id,
                 outputFolder: MeetingStoragePaths.transcriptsFolder
             )
             self.retryingFailedMeetingIDs.remove(id)
             self.refreshFailedMeetings()
+            ProductDecisionTelemetry.trackFailedCaptureRetryOutcome(
+                captureKind: .meeting,
+                failureKind: failureKind,
+                retryAction: .retry,
+                outcome: didRetry ? .recovered : .failed
+            )
         }
         return true
     }
@@ -1470,18 +1502,42 @@ final class MeetingSessionController: ObservableObject {
     ) async -> Bool {
         guard !(sttRouter.isRecording || sttRouter.isTranscribing) else {
             state = .error("Wait for the current dictation to finish before re-transcribing saved audio.")
+            ProductDecisionTelemetry.trackFailedCaptureRetryOutcome(
+                captureKind: .savedAudio,
+                failureKind: "dictation_active",
+                retryAction: .retranscribe,
+                outcome: .blocked
+            )
             return false
         }
         guard !isCaptureSessionActive else {
             state = .error("Stop the current meeting before re-transcribing saved audio.")
+            ProductDecisionTelemetry.trackFailedCaptureRetryOutcome(
+                captureKind: .savedAudio,
+                failureKind: "meeting_active",
+                retryAction: .retranscribe,
+                outcome: .blocked
+            )
             return false
         }
         guard !hasBackgroundTranscriptionWork else {
             state = .error("Wait for the current meeting to finish saving or transcribing before re-transcribing saved audio.")
+            ProductDecisionTelemetry.trackFailedCaptureRetryOutcome(
+                captureKind: .savedAudio,
+                failureKind: "pipeline_busy",
+                retryAction: .retranscribe,
+                outcome: .blocked
+            )
             return false
         }
         guard !isSpeakerReviewPending else {
             state = .error("Finish the speaker review window before re-transcribing saved audio.")
+            ProductDecisionTelemetry.trackFailedCaptureRetryOutcome(
+                captureKind: .savedAudio,
+                failureKind: "speaker_review_pending",
+                retryAction: .retranscribe,
+                outcome: .blocked
+            )
             return false
         }
 
@@ -1522,6 +1578,12 @@ final class MeetingSessionController: ObservableObject {
         }
 
         guard case .ready = state else {
+            ProductDecisionTelemetry.trackFailedCaptureRetryOutcome(
+                captureKind: .savedAudio,
+                failureKind: "model_not_ready",
+                retryAction: .retranscribe,
+                outcome: .blocked
+            )
             return false
         }
 
@@ -1544,6 +1606,12 @@ final class MeetingSessionController: ObservableObject {
     }
 
     private func handleReplacementTranscriptCommitted(for transcriptURL: URL) {
+        ProductDecisionTelemetry.trackFailedCaptureRetryOutcome(
+            captureKind: .savedAudio,
+            failureKind: "unknown",
+            retryAction: .retranscribe,
+            outcome: .recovered
+        )
         clearGeneratedSummaryAfterReplacementRetranscription(for: transcriptURL)
         savedMeetingReplacementCommitCount &+= 1
     }

--- a/Sources/Observability/ActivationTelemetry.swift
+++ b/Sources/Observability/ActivationTelemetry.swift
@@ -129,6 +129,13 @@ enum ActivationTelemetry {
                 "surface": surface.rawValue,
             ]
         )
+        ProductDecisionTelemetry.trackArtifactReusedAfterSave(
+            artifactKind: artifactKind,
+            actionKind: actionKind,
+            surface: surface,
+            artifactDate: artifactDate,
+            now: now
+        )
     }
 
     @discardableResult

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -171,6 +171,19 @@ struct AnalyticsEventPolicy: Equatable {
         "return_window_bucket",
         "source_count_bucket",
         "surface",
+        "tool_kind",
+    ]
+
+    private static let artifactReusedAfterSaveProperties: Set<String> = [
+        "action_kind",
+        "agent_target",
+        "artifact_kind",
+        "query_kind",
+        "result",
+        "return_window_bucket",
+        "source_count_bucket",
+        "surface",
+        "tool_kind",
     ]
 
     private static let settingsFeatureDiscoveryProperties: Set<String> = [
@@ -207,6 +220,36 @@ struct AnalyticsEventPolicy: Equatable {
         "provider",
         "route_ready",
         "source",
+    ]
+
+    private static let meetingPromptDecisionProperties: Set<String> = meetingPromptProperties.union(Set([
+        "decision",
+        "elapsed_bucket",
+        "outcome",
+        "prompt_origin",
+    ]))
+
+    private static let failedCaptureRetryProperties: Set<String> = [
+        "capture_kind",
+        "elapsed_bucket",
+        "failure_kind",
+        "outcome",
+        "retry_action",
+    ]
+
+    private static let localSummaryDecisionProperties: Set<String> = [
+        "chunk_count_bucket",
+        "elapsed_bucket",
+        "provider_family",
+        "result",
+        "summary_action",
+    ]
+
+    private static let speakerReviewDecisionProperties: Set<String> = [
+        "action",
+        "item_count_bucket",
+        "review_reason",
+        "suggestion_confidence_bucket",
     ]
 
     private static let allowedPolicies: [String: AnalyticsEventPolicy] = [
@@ -392,6 +435,14 @@ struct AnalyticsEventPolicy: Equatable {
         "agent_capture_query_observed": .init(
             name: "agent_capture_query_observed",
             allowedProperties: agentCaptureQueryObservedProperties
+        ),
+        "agent_artifact_query_succeeded": .init(
+            name: "agent_artifact_query_succeeded",
+            allowedProperties: agentCaptureQueryObservedProperties
+        ),
+        "artifact_reused_after_save": .init(
+            name: "artifact_reused_after_save",
+            allowedProperties: artifactReusedAfterSaveProperties
         ),
         "workflow_abandoned": .init(
             name: "workflow_abandoned",
@@ -657,6 +708,38 @@ struct AnalyticsEventPolicy: Equatable {
                 "cooldown_reason",
                 "suppression_reason",
             ]))
+        ),
+        "meeting_prompt_decision_made": .init(
+            name: "meeting_prompt_decision_made",
+            allowedProperties: meetingPromptDecisionProperties
+        ),
+        "meeting_prompt_followup_outcome": .init(
+            name: "meeting_prompt_followup_outcome",
+            allowedProperties: meetingPromptDecisionProperties
+        ),
+        "failed_capture_retry_decision": .init(
+            name: "failed_capture_retry_decision",
+            allowedProperties: failedCaptureRetryProperties
+        ),
+        "failed_capture_retry_outcome": .init(
+            name: "failed_capture_retry_outcome",
+            allowedProperties: failedCaptureRetryProperties
+        ),
+        "local_summary_feedback_given": .init(
+            name: "local_summary_feedback_given",
+            allowedProperties: localSummaryDecisionProperties
+        ),
+        "local_summary_used_after_generation": .init(
+            name: "local_summary_used_after_generation",
+            allowedProperties: localSummaryDecisionProperties
+        ),
+        "speaker_name_corrected": .init(
+            name: "speaker_name_corrected",
+            allowedProperties: speakerReviewDecisionProperties
+        ),
+        "speaker_suggestion_accepted_or_rejected": .init(
+            name: "speaker_suggestion_accepted_or_rejected",
+            allowedProperties: speakerReviewDecisionProperties
         ),
         "meeting_mic_boost_prompt_shown": .init(
             name: "meeting_mic_boost_prompt_shown",

--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -15,6 +15,7 @@ enum AnalyticsPayloadSanitizer {
         "name",
         "password",
         "path",
+        "person",
         "speaker",
         "source_app",
         "secret",

--- a/Sources/Observability/ProductDecisionTelemetry.swift
+++ b/Sources/Observability/ProductDecisionTelemetry.swift
@@ -1,0 +1,319 @@
+import Foundation
+
+enum ProductDecisionTelemetry {
+    enum MeetingPromptDecision: String {
+        case recordNow = "record_now"
+        case remindLater = "remind_later"
+        case notNow = "not_now"
+        case dismiss
+        case ignore
+        case unknown
+    }
+
+    enum MeetingPromptOutcome: String {
+        case recordingStarted = "recording_started"
+        case transcriptSaved = "transcript_saved"
+        case suppressed
+        case noAction = "no_action"
+        case failed
+        case cancelled
+        case unknown
+    }
+
+    enum CaptureKind: String {
+        case dictation
+        case meeting
+        case importedAudio = "imported_audio"
+        case savedAudio = "saved_audio"
+        case unknown
+    }
+
+    enum RetryAction: String {
+        case retry
+        case retranscribe
+        case openAudio = "open_audio"
+        case delete
+        case report
+        case none
+    }
+
+    enum RetryOutcome: String {
+        case recovered
+        case failed
+        case blocked
+        case cancelled
+        case unknown
+    }
+
+    enum SummaryAction: String {
+        case regenerate
+        case open
+        case copy
+        case run
+        case preview
+    }
+
+    enum SummaryResult: String {
+        case started
+        case success
+        case failed
+        case blocked
+        case cancelled
+        case unknown
+    }
+
+    enum SpeakerReviewAction: String {
+        case accepted
+        case rejected
+        case corrected
+        case skipped
+    }
+
+    static func trackMeetingPromptDecision(
+        baseProperties: [String: String],
+        decision: MeetingPromptDecision,
+        elapsedBucket: String = "unknown"
+    ) {
+        let properties = meetingPromptDecisionProperties(
+            baseProperties: baseProperties,
+            decision: decision,
+            elapsedBucket: elapsedBucket
+        )
+        AnalyticsReporter.track("meeting_prompt_decision_made", properties: properties)
+    }
+
+    static func trackMeetingPromptFollowupOutcome(
+        baseProperties: [String: String],
+        decision: MeetingPromptDecision,
+        outcome: MeetingPromptOutcome,
+        elapsedBucket: String = "unknown"
+    ) {
+        var properties = meetingPromptDecisionProperties(
+            baseProperties: baseProperties,
+            decision: decision,
+            elapsedBucket: elapsedBucket
+        )
+        properties["outcome"] = outcome.rawValue
+        AnalyticsReporter.track("meeting_prompt_followup_outcome", properties: properties)
+    }
+
+    static func trackFailedCaptureRetryDecision(
+        captureKind: CaptureKind,
+        failureKind: String,
+        retryAction: RetryAction,
+        elapsedBucket: String = "unknown"
+    ) {
+        AnalyticsReporter.track(
+            "failed_capture_retry_decision",
+            properties: failedCaptureRetryProperties(
+                captureKind: captureKind,
+                failureKind: failureKind,
+                retryAction: retryAction,
+                elapsedBucket: elapsedBucket
+            )
+        )
+    }
+
+    static func trackFailedCaptureRetryOutcome(
+        captureKind: CaptureKind,
+        failureKind: String,
+        retryAction: RetryAction,
+        outcome: RetryOutcome,
+        elapsedBucket: String = "unknown"
+    ) {
+        var properties = failedCaptureRetryProperties(
+            captureKind: captureKind,
+            failureKind: failureKind,
+            retryAction: retryAction,
+            elapsedBucket: elapsedBucket
+        )
+        properties["outcome"] = outcome.rawValue
+        AnalyticsReporter.track("failed_capture_retry_outcome", properties: properties)
+    }
+
+    static func trackLocalSummaryFeedback(
+        action: SummaryAction,
+        result: SummaryResult,
+        providerFamily: String,
+        chunkCount: Int? = nil,
+        elapsedBucket: String = "unknown"
+    ) {
+        AnalyticsReporter.track(
+            "local_summary_feedback_given",
+            properties: localSummaryProperties(
+                action: action,
+                result: result,
+                providerFamily: providerFamily,
+                chunkCount: chunkCount,
+                elapsedBucket: elapsedBucket
+            )
+        )
+    }
+
+    static func trackLocalSummaryUsedAfterGeneration(
+        action: SummaryAction,
+        result: SummaryResult,
+        providerFamily: String,
+        chunkCount: Int? = nil,
+        elapsedBucket: String = "unknown"
+    ) {
+        AnalyticsReporter.track(
+            "local_summary_used_after_generation",
+            properties: localSummaryProperties(
+                action: action,
+                result: result,
+                providerFamily: providerFamily,
+                chunkCount: chunkCount,
+                elapsedBucket: elapsedBucket
+            )
+        )
+    }
+
+    static func trackSpeakerNameCorrected(
+        action: SpeakerReviewAction,
+        reviewReason: String,
+        itemCount: Int,
+        suggestionConfidenceBucket: String
+    ) {
+        AnalyticsReporter.track(
+            "speaker_name_corrected",
+            properties: speakerReviewProperties(
+                action: action,
+                reviewReason: reviewReason,
+                itemCount: itemCount,
+                suggestionConfidenceBucket: suggestionConfidenceBucket
+            )
+        )
+    }
+
+    static func trackSpeakerSuggestionAcceptedOrRejected(
+        action: SpeakerReviewAction,
+        reviewReason: String,
+        itemCount: Int,
+        suggestionConfidenceBucket: String
+    ) {
+        AnalyticsReporter.track(
+            "speaker_suggestion_accepted_or_rejected",
+            properties: speakerReviewProperties(
+                action: action,
+                reviewReason: reviewReason,
+                itemCount: itemCount,
+                suggestionConfidenceBucket: suggestionConfidenceBucket
+            )
+        )
+    }
+
+    static func trackArtifactReusedAfterSave(
+        artifactKind: ActivationTelemetry.ArtifactKind,
+        actionKind: ActivationTelemetry.ArtifactActionKind,
+        surface: ActivationTelemetry.Surface,
+        artifactDate: Date?,
+        now: Date = Date()
+    ) {
+        guard let artifactDate else { return }
+        guard let returnWindowBucket = ActivationTelemetry.returnWindowBucket(since: artifactDate, now: now) else {
+            return
+        }
+
+        AnalyticsReporter.track(
+            "artifact_reused_after_save",
+            properties: [
+                "action_kind": actionKind.rawValue,
+                "artifact_kind": artifactKind.rawValue,
+                "result": "success",
+                "return_window_bucket": returnWindowBucket,
+                "surface": surface.rawValue,
+            ]
+        )
+    }
+
+    static func itemCountBucket(_ count: Int) -> String {
+        AnalyticsReporter.countBucket(count)
+    }
+
+    static func suggestionConfidenceBucket(similarity: Double?) -> String {
+        guard let similarity else { return "unknown" }
+        switch similarity {
+        case ..<0.70:
+            return "low"
+        case ..<0.85:
+            return "medium"
+        case ..<0.92:
+            return "high"
+        default:
+            return "very_high"
+        }
+    }
+
+    private static func meetingPromptDecisionProperties(
+        baseProperties: [String: String],
+        decision: MeetingPromptDecision,
+        elapsedBucket: String
+    ) -> [String: String] {
+        var properties = baseProperties
+        properties["decision"] = decision.rawValue
+        properties["elapsed_bucket"] = elapsedBucket
+        properties["prompt_origin"] = promptOrigin(from: baseProperties)
+        return properties
+    }
+
+    private static func promptOrigin(from properties: [String: String]) -> String {
+        if properties["source"] == "calendar_event" {
+            return "calendar"
+        }
+        if properties["app_signal"]?.contains("browser") == true {
+            return "browser"
+        }
+        if properties["call_state"] == "mic_active" {
+            return "mic"
+        }
+        return "unknown"
+    }
+
+    private static func failedCaptureRetryProperties(
+        captureKind: CaptureKind,
+        failureKind: String,
+        retryAction: RetryAction,
+        elapsedBucket: String
+    ) -> [String: String] {
+        [
+            "capture_kind": captureKind.rawValue,
+            "elapsed_bucket": elapsedBucket,
+            "failure_kind": failureKind,
+            "retry_action": retryAction.rawValue,
+        ]
+    }
+
+    private static func localSummaryProperties(
+        action: SummaryAction,
+        result: SummaryResult,
+        providerFamily: String,
+        chunkCount: Int?,
+        elapsedBucket: String
+    ) -> [String: String] {
+        var properties = [
+            "elapsed_bucket": elapsedBucket,
+            "provider_family": providerFamily,
+            "result": result.rawValue,
+            "summary_action": action.rawValue,
+        ]
+        if let chunkCount {
+            properties["chunk_count_bucket"] = AnalyticsReporter.countBucket(chunkCount)
+        }
+        return properties
+    }
+
+    private static func speakerReviewProperties(
+        action: SpeakerReviewAction,
+        reviewReason: String,
+        itemCount: Int,
+        suggestionConfidenceBucket: String
+    ) -> [String: String] {
+        [
+            "action": action.rawValue,
+            "item_count_bucket": itemCountBucket(itemCount),
+            "review_reason": reviewReason,
+            "suggestion_confidence_bucket": suggestionConfidenceBucket,
+        ]
+    }
+}

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -140,18 +140,28 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             meetingOverlayController.setup(meetingSession: meetingSession)
             meetingOverlayController.onPromptRecord = { [weak self] candidate in
                 guard let self else { return }
+                let promptProperties = MeetingPromptTelemetry.properties(
+                    for: candidate,
+                    readiness: self.meetingPromptTelemetryReadiness()
+                )
+                ProductDecisionTelemetry.trackMeetingPromptDecision(
+                    baseProperties: promptProperties,
+                    decision: .recordNow
+                )
                 AnalyticsReporter.track(
                     "meeting_prompt_record_selected",
-                    properties: MeetingPromptTelemetry.properties(
-                        for: candidate,
-                        readiness: self.meetingPromptTelemetryReadiness()
-                    )
+                    properties: promptProperties
                 )
                 Task { @MainActor [weak self] in
                     guard let self else { return }
                     let started = await self.appState.meetingSession.startRecording(
                         trigger: .detectedPrompt,
                         suggestedTitle: candidate.suggestedTranscriptTitle
+                    )
+                    ProductDecisionTelemetry.trackMeetingPromptFollowupOutcome(
+                        baseProperties: promptProperties,
+                        decision: .recordNow,
+                        outcome: started ? .recordingStarted : .failed
                     )
                     if started {
                         self.meetingPromptDetector.markAccepted(candidate: candidate)
@@ -161,13 +171,54 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             meetingOverlayController.onPromptDismiss = { [weak self] candidate in
                 guard let self else { return }
                 let backoffDecision = self.meetingPromptDetector.dismiss(candidate: candidate)
+                let promptProperties = MeetingPromptTelemetry.properties(
+                    for: candidate,
+                    readiness: self.meetingPromptTelemetryReadiness(),
+                    backoffKind: backoffDecision.kind
+                )
+                ProductDecisionTelemetry.trackMeetingPromptDecision(
+                    baseProperties: promptProperties,
+                    decision: .notNow
+                )
+                ProductDecisionTelemetry.trackMeetingPromptFollowupOutcome(
+                    baseProperties: promptProperties,
+                    decision: .notNow,
+                    outcome: .suppressed
+                )
                 AnalyticsReporter.track(
                     "meeting_prompt_dismissed",
-                    properties: MeetingPromptTelemetry.properties(
-                        for: candidate,
-                        readiness: self.meetingPromptTelemetryReadiness(),
-                        backoffKind: backoffDecision.kind
+                    properties: promptProperties
+                )
+                ActivationTelemetry.trackWorkflowAbandoned(
+                    workflowKind: .meetingPrompt,
+                    stage: "prompt_shown",
+                    reasonKind: .dismissed,
+                    surface: .meetingOverlay,
+                    priorReadyState: MeetingPromptTelemetry.readyState(
+                        readiness: self.meetingPromptTelemetryReadiness()
                     )
+                )
+            }
+            meetingOverlayController.onPromptIgnored = { [weak self] candidate in
+                guard let self else { return }
+                let backoffDecision = self.meetingPromptDetector.dismiss(candidate: candidate)
+                let promptProperties = MeetingPromptTelemetry.properties(
+                    for: candidate,
+                    readiness: self.meetingPromptTelemetryReadiness(),
+                    backoffKind: backoffDecision.kind
+                )
+                ProductDecisionTelemetry.trackMeetingPromptDecision(
+                    baseProperties: promptProperties,
+                    decision: .ignore
+                )
+                ProductDecisionTelemetry.trackMeetingPromptFollowupOutcome(
+                    baseProperties: promptProperties,
+                    decision: .ignore,
+                    outcome: .noAction
+                )
+                AnalyticsReporter.track(
+                    "meeting_prompt_dismissed",
+                    properties: promptProperties
                 )
                 ActivationTelemetry.trackWorkflowAbandoned(
                     workflowKind: .meetingPrompt,
@@ -182,13 +233,23 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             meetingOverlayController.onPromptRemindSoon = { [weak self] candidate in
                 guard let self else { return }
                 let backoffDecision = self.meetingPromptDetector.remindSoon(candidate: candidate)
+                let promptProperties = MeetingPromptTelemetry.properties(
+                    for: candidate,
+                    readiness: self.meetingPromptTelemetryReadiness(),
+                    backoffKind: backoffDecision.kind
+                )
+                ProductDecisionTelemetry.trackMeetingPromptDecision(
+                    baseProperties: promptProperties,
+                    decision: .remindLater
+                )
+                ProductDecisionTelemetry.trackMeetingPromptFollowupOutcome(
+                    baseProperties: promptProperties,
+                    decision: .remindLater,
+                    outcome: .suppressed
+                )
                 AnalyticsReporter.track(
                     "meeting_prompt_dismissed",
-                    properties: MeetingPromptTelemetry.properties(
-                        for: candidate,
-                        readiness: self.meetingPromptTelemetryReadiness(),
-                        backoffKind: backoffDecision.kind
-                    )
+                    properties: promptProperties
                 )
                 ActivationTelemetry.trackWorkflowAbandoned(
                     workflowKind: .meetingPrompt,

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -1401,6 +1401,7 @@ final class MeetingOverlayController: NSObject {
     weak var meetingSession: MeetingSessionController?
     var onPromptRecord: ((MeetingPromptDetector.Candidate) -> Void)?
     var onPromptDismiss: ((MeetingPromptDetector.Candidate) -> Void)?
+    var onPromptIgnored: ((MeetingPromptDetector.Candidate) -> Void)?
     var onPromptRemindSoon: ((MeetingPromptDetector.Candidate) -> Void)?
 
     // MARK: - Setup
@@ -2387,7 +2388,14 @@ final class MeetingOverlayController: NSObject {
                 await session.endRecordingFromAudioInactivityPrompt(automatic: true)
             }
         case .detectedMeeting, .none:
-            dismissPrompt(notifyDetector: true)
+            if let candidate = promptCandidate {
+                onPromptIgnored?(candidate)
+            }
+            promptCandidate = nil
+            promptKind = nil
+            currentPrompt = nil
+            state = .idle
+            hidePanel()
         }
     }
 

--- a/Sources/UI/Settings/SpeakerNamingSheet.swift
+++ b/Sources/UI/Settings/SpeakerNamingSheet.swift
@@ -105,6 +105,7 @@ final class NamingWindowController: NSWindowController, NSWindowDelegate {
 
     func windowWillClose(_ notification: Notification) {
         if !didComplete {
+            trackSpeakerReviewSkipped()
             request.onComplete([])
             didComplete = true
         }
@@ -120,8 +121,76 @@ final class NamingWindowController: NSWindowController, NSWindowDelegate {
     private func finish(with updates: [SpeakerNameUpdate]) {
         guard !didComplete else { return }
         didComplete = true
+        trackSpeakerReview(updates)
         request.onComplete(updates)
         close()
+    }
+
+    private func trackSpeakerReview(_ updates: [SpeakerNameUpdate]) {
+        guard !updates.isEmpty else {
+            trackSpeakerReviewSkipped()
+            return
+        }
+
+        for update in updates {
+            let confidenceBucket = confidenceBucket(for: update)
+            switch update.action {
+            case .corrected:
+                ProductDecisionTelemetry.trackSpeakerNameCorrected(
+                    action: .corrected,
+                    reviewReason: "post_meeting_review",
+                    itemCount: request.speakers.count,
+                    suggestionConfidenceBucket: confidenceBucket
+                )
+                ProductDecisionTelemetry.trackSpeakerSuggestionAcceptedOrRejected(
+                    action: .rejected,
+                    reviewReason: "post_meeting_review",
+                    itemCount: request.speakers.count,
+                    suggestionConfidenceBucket: confidenceBucket
+                )
+            case .confirmed, .merged:
+                ProductDecisionTelemetry.trackSpeakerSuggestionAcceptedOrRejected(
+                    action: .accepted,
+                    reviewReason: "post_meeting_review",
+                    itemCount: request.speakers.count,
+                    suggestionConfidenceBucket: confidenceBucket
+                )
+            case .discardedFromDatabase:
+                ProductDecisionTelemetry.trackSpeakerSuggestionAcceptedOrRejected(
+                    action: .rejected,
+                    reviewReason: "post_meeting_review",
+                    itemCount: request.speakers.count,
+                    suggestionConfidenceBucket: confidenceBucket
+                )
+            case .collapsedToMe:
+                ProductDecisionTelemetry.trackSpeakerSuggestionAcceptedOrRejected(
+                    action: .skipped,
+                    reviewReason: "keep_local_mic_as_you",
+                    itemCount: request.speakers.count,
+                    suggestionConfidenceBucket: confidenceBucket
+                )
+            case .named:
+                continue
+            }
+        }
+    }
+
+    private func trackSpeakerReviewSkipped() {
+        ProductDecisionTelemetry.trackSpeakerSuggestionAcceptedOrRejected(
+            action: .skipped,
+            reviewReason: "review_later",
+            itemCount: request.speakers.count,
+            suggestionConfidenceBucket: "unknown"
+        )
+    }
+
+    private func confidenceBucket(for update: SpeakerNameUpdate) -> String {
+        let entry = request.speakers.first {
+            $0.id == update.persistentSpeakerId
+                && $0.diarizerSpeakerId == update.diarizerSpeakerId
+                && $0.channel == update.channel
+        }
+        return ProductDecisionTelemetry.suggestionConfidenceBucket(similarity: entry?.matchSimilarity)
     }
 }
 

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -199,6 +199,13 @@ struct TranscriptedSettingsView: View {
                 preview: preview,
                 onOpenMarkdown: {
                     trackSettingsAction("open_recent_meeting_markdown", page: .home)
+                    if preview.summary != nil {
+                        ProductDecisionTelemetry.trackLocalSummaryUsedAfterGeneration(
+                            action: .open,
+                            result: .success,
+                            providerFamily: localMeetingSummaryProvider.rawValue
+                        )
+                    }
                     ActivationTelemetry.trackArtifactAction(
                         artifactKind: .meeting,
                         actionKind: .openMarkdown,
@@ -598,10 +605,12 @@ struct TranscriptedSettingsView: View {
                 audioAttachment: { failedMeetingAudioAttachment(for: $0) },
                 onRetry: { item in
                     trackSettingsAction("home_retry_failed_meeting", page: .home)
+                    trackFailedMeetingRetryDecision(item, action: .retry)
                     retryFailedMeeting(item)
                 },
                 onRevealAudio: { item in
                     trackSettingsAction("home_reveal_failed_meeting_audio", page: .home)
+                    trackFailedMeetingRetryDecision(item, action: .openAudio)
                     revealFailedMeetingAudio(item)
                 },
                 onClear: { item in
@@ -683,10 +692,12 @@ struct TranscriptedSettingsView: View {
                 retryUnavailableReason: failedMeetingRetryUnavailableReason,
                 onRetry: {
                     trackSettingsAction("home_retry_failed_meeting", page: navigation.selectedPage)
+                    trackFailedMeetingRetryDecision(failedMeeting, action: .retry)
                     retryFailedMeeting(failedMeeting)
                 },
                 onRevealAudio: {
                     trackSettingsAction("home_reveal_failed_meeting_audio", page: navigation.selectedPage)
+                    trackFailedMeetingRetryDecision(failedMeeting, action: .openAudio)
                     revealFailedMeetingAudio(failedMeeting)
                 },
                 onClear: { requestClearFailedMeeting(failedMeeting) }
@@ -855,6 +866,13 @@ struct TranscriptedSettingsView: View {
 
     private func handleCopyMeetingPreview(_ preview: HomeMeetingPreview) {
         trackSettingsAction("copy_meeting_preview", page: .home)
+        if preview.summary != nil {
+            ProductDecisionTelemetry.trackLocalSummaryUsedAfterGeneration(
+                action: .copy,
+                result: .success,
+                providerFamily: localMeetingSummaryProvider.rawValue
+            )
+        }
         let bundle = AgentConnectionGuide.portableMeetingBundle(
             title: preview.title,
             date: preview.date,
@@ -915,6 +933,11 @@ struct TranscriptedSettingsView: View {
         }
 
         trackSettingsAction("retranscribe_saved_meeting", page: .home)
+        ProductDecisionTelemetry.trackFailedCaptureRetryDecision(
+            captureKind: .savedAudio,
+            failureKind: item.speakerStatus.needsReview ? "speaker_review_pending" : "unknown",
+            retryAction: .retranscribe
+        )
         Task { @MainActor in
             let didStart = await meetingSession.retranscribeSavedMeeting(
                 micAudioURL: micURL,
@@ -937,6 +960,11 @@ struct TranscriptedSettingsView: View {
 
         if item.summaryPreview != nil {
             trackSettingsAction("open_local_meeting_summary", page: .home)
+            ProductDecisionTelemetry.trackLocalSummaryUsedAfterGeneration(
+                action: .open,
+                result: .success,
+                providerFamily: localMeetingSummaryProvider.rawValue
+            )
             openOwnFile(
                 candidateURLs: [item.transcriptURL],
                 failureTitle: "Could not open transcript",
@@ -974,6 +1002,13 @@ struct TranscriptedSettingsView: View {
         }
         trackSettingsAction("generate_local_meeting_summary", page: .home)
         let provider = localMeetingSummaryProvider
+        if hasExistingSummary {
+            ProductDecisionTelemetry.trackLocalSummaryFeedback(
+                action: .regenerate,
+                result: .started,
+                providerFamily: provider.rawValue
+            )
+        }
         recordLocalSummaryEvent(
             event: "local_meeting_summary_started",
             message: "\(provider.title) meeting summary started",
@@ -1031,10 +1066,25 @@ struct TranscriptedSettingsView: View {
                         "profile": result.profileName,
                     ]
                 )
+                if hasExistingSummary {
+                    ProductDecisionTelemetry.trackLocalSummaryFeedback(
+                        action: .regenerate,
+                        result: .success,
+                        providerFamily: result.provider.rawValue,
+                        chunkCount: result.chunkCount
+                    )
+                }
                 refreshRecentCapturesAfterLocalSummary()
             } catch is CancellationError {
                 if homeLocalSummaryTaskTokens[summaryID] == taskToken {
                     trackLocalSummaryAbandoned(reason: .cancelled, stage: "generate", priorReadyState: "running")
+                }
+                if hasExistingSummary {
+                    ProductDecisionTelemetry.trackLocalSummaryFeedback(
+                        action: .regenerate,
+                        result: .cancelled,
+                        providerFamily: provider.rawValue
+                    )
                 }
                 recordLocalSummaryEvent(
                     event: "local_meeting_summary_cancelled",
@@ -1047,6 +1097,13 @@ struct TranscriptedSettingsView: View {
             } catch {
                 guard localMeetingSummariesEnabled else { return }
                 trackLocalSummaryAbandoned(reason: .failed, stage: "generate", priorReadyState: "ready")
+                if hasExistingSummary {
+                    ProductDecisionTelemetry.trackLocalSummaryFeedback(
+                        action: .regenerate,
+                        result: .failed,
+                        providerFamily: provider.rawValue
+                    )
+                }
                 recordLocalSummaryEvent(
                     level: .error,
                     event: "local_meeting_summary_failed",
@@ -1536,9 +1593,11 @@ struct TranscriptedSettingsView: View {
         let didClear: Bool
         let failureTitle: String
         if !item.audioURLs.isEmpty {
+            trackFailedMeetingRetryDecision(item, action: .delete)
             didClear = meetingSession.deleteFailedMeeting(id: item.id)
             failureTitle = "Could not delete failed meeting"
         } else {
+            trackFailedMeetingRetryDecision(item, action: .none)
             didClear = meetingSession.dismissFailedMeeting(id: item.id)
             failureTitle = "Could not dismiss failed meeting"
         }
@@ -1618,6 +1677,17 @@ struct TranscriptedSettingsView: View {
                     ?? "Transcripted could not start that retry. The saved audio may already be cleared."
             )
         }
+    }
+
+    private func trackFailedMeetingRetryDecision(
+        _ item: MeetingSessionController.FailedMeetingItem,
+        action: ProductDecisionTelemetry.RetryAction
+    ) {
+        ProductDecisionTelemetry.trackFailedCaptureRetryDecision(
+            captureKind: .meeting,
+            failureKind: item.failureKind.rawValue,
+            retryAction: action
+        )
     }
 
     private var homeStatItems: [HomeStatItem] {

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -77,6 +77,7 @@ func testAnalyticsEventPolicy() {
             "calendar_confidence",
             "calendar_status",
             "call_state",
+            "capture_kind",
             "capture_activity",
             "capture_quality",
             "captured_input_volume_before",
@@ -110,6 +111,7 @@ func testAnalyticsEventPolicy() {
             "default_system_output_volume_dropped",
             "default_system_output_volume_during",
             "delivery",
+            "decision",
             "dictation_ready",
             "elapsed_bucket",
             "enabled",
@@ -158,7 +160,9 @@ func testAnalyticsEventPolicy() {
             "prior_status",
             "prompt_kind",
             "prompt_reason",
+            "prompt_origin",
             "provider",
+            "provider_family",
             "proxy_kind",
             "query_kind",
             "quiet_mic_recovered",
@@ -171,6 +175,8 @@ func testAnalyticsEventPolicy() {
             "required",
             "reason_kind",
             "result",
+            "retry_action",
+            "review_reason",
             "route_ready",
             "route_shape",
             "sample_flow_started",
@@ -194,6 +200,7 @@ func testAnalyticsEventPolicy() {
             "stop_timed_out",
             "suppression_reason",
             "surface",
+            "summary_action",
             "system_backend",
             "system_channels",
             "system_failed",
@@ -205,6 +212,7 @@ func testAnalyticsEventPolicy() {
             "system_stream_present",
             "to_status",
             "trigger",
+            "tool_kind",
             "update_state",
             "version",
             "voice_processing",
@@ -294,6 +302,8 @@ func testAnalyticsEventPolicy() {
         let prompt = AnalyticsEventPolicy.policy(forEvent: "activation_agent_prompt_action_clicked")
         let setup = AnalyticsEventPolicy.policy(forEvent: "activation_agent_setup_cta_clicked")
         let agentQuery = AnalyticsEventPolicy.policy(forEvent: "agent_capture_query_observed")
+        let agentArtifactQuery = AnalyticsEventPolicy.policy(forEvent: "agent_artifact_query_succeeded")
+        let artifactReused = AnalyticsEventPolicy.policy(forEvent: "artifact_reused_after_save")
         let returnProxy = AnalyticsEventPolicy.policy(forEvent: "activation_return_proxy_observed")
 
         assertEqual(artifact?.allowedProperties ?? Set<String>(), ["action_kind", "artifact_age_bucket", "artifact_kind", "surface"], "artifact actions should stay bucketed")
@@ -303,7 +313,9 @@ func testAnalyticsEventPolicy() {
         assertEqual(prompt?.allowedProperties ?? Set<String>(), ["action_kind", "agent_target", "artifact_kind", "prompt_kind", "result", "surface"], "agent prompt actions should stay enum-only")
         assertEqual(setup?.allowedProperties ?? Set<String>(), ["agent_target", "prior_status", "result", "setup_kind", "surface"], "setup CTAs should stay enum-only")
         assertEqual(returnProxy?.allowedProperties ?? Set<String>(), ["prior_artifact_kind", "proxy_kind", "return_window_bucket", "surface"], "return proxy should not include paths or titles")
-        assertEqual(agentQuery?.allowedProperties ?? Set<String>(), ["agent_target", "artifact_kind", "capture_age_bucket", "query_kind", "result", "return_window_bucket", "source_count_bucket", "surface"], "agent query observation should stay enum and bucket only")
+        assertEqual(agentQuery?.allowedProperties ?? Set<String>(), ["agent_target", "artifact_kind", "capture_age_bucket", "query_kind", "result", "return_window_bucket", "source_count_bucket", "surface", "tool_kind"], "agent query observation should stay enum and bucket only")
+        assertEqual(agentArtifactQuery?.allowedProperties ?? Set<String>(), agentQuery?.allowedProperties ?? Set<String>(), "agent artifact query success should mirror the safe MCP query payload")
+        assertEqual(artifactReused?.allowedProperties ?? Set<String>(), ["action_kind", "agent_target", "artifact_kind", "query_kind", "result", "return_window_bucket", "source_count_bucket", "surface", "tool_kind"], "artifact reuse should stay enum and bucket only")
         assertEqual(
             agentQuery?.allowedProperties ?? Set<String>(),
             mcpAgentCaptureQueryAllowedProperties(),
@@ -316,6 +328,8 @@ func testAnalyticsEventPolicy() {
             .union(dictationArtifact?.allowedProperties ?? Set<String>())
             .union(secondArtifact?.allowedProperties ?? Set<String>())
             .union(agentQuery?.allowedProperties ?? Set<String>())
+            .union(agentArtifactQuery?.allowedProperties ?? Set<String>())
+            .union(artifactReused?.allowedProperties ?? Set<String>())
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
             [
                 "action_kind": "open_markdown",
@@ -334,6 +348,7 @@ func testAnalyticsEventPolicy() {
                 "second_artifact_kind": "meeting",
                 "source_count_bucket": "2_3",
                 "surface": "home_preview",
+                "tool_kind": "mcp",
                 "trigger": "detected_prompt",
                 "word_count_bucket": "300_plus",
                 "first_artifact_saved_at": "2026-06-19T12:00:00Z",
@@ -368,6 +383,7 @@ func testAnalyticsEventPolicy() {
         assertEqual(sanitized["second_artifact_kind"], "meeting", "second artifact kind should survive")
         assertEqual(sanitized["source_count_bucket"], "2_3", "source count bucket should survive")
         assertEqual(sanitized["surface"], "home_preview", "surface should survive")
+        assertEqual(sanitized["tool_kind"], "mcp", "tool kind should survive")
         assertEqual(sanitized["trigger"], "detected_prompt", "trigger should survive")
         assertEqual(sanitized["word_count_bucket"], "300_plus", "word count bucket should survive")
         assertNil(sanitized["first_artifact_saved_at"], "raw first-save timestamps must not be sent")
@@ -382,6 +398,126 @@ func testAnalyticsEventPolicy() {
         assertNil(sanitized["raw_capture_id"], "raw capture IDs must not be sent")
         assertNil(sanitized["source_app_name"], "source app names must not be sent")
         assertNil(sanitized["word_count"], "raw counts should stay out of activation analytics")
+    }
+
+    runSuite("AnalyticsEventPolicy allows decision/outcome telemetry only as safe enums and buckets") {
+        let meetingDecision = AnalyticsEventPolicy.policy(forEvent: "meeting_prompt_decision_made")
+        let meetingOutcome = AnalyticsEventPolicy.policy(forEvent: "meeting_prompt_followup_outcome")
+        let retryDecision = AnalyticsEventPolicy.policy(forEvent: "failed_capture_retry_decision")
+        let retryOutcome = AnalyticsEventPolicy.policy(forEvent: "failed_capture_retry_outcome")
+        let summaryFeedback = AnalyticsEventPolicy.policy(forEvent: "local_summary_feedback_given")
+        let summaryUsed = AnalyticsEventPolicy.policy(forEvent: "local_summary_used_after_generation")
+        let speakerCorrected = AnalyticsEventPolicy.policy(forEvent: "speaker_name_corrected")
+        let speakerSuggestion = AnalyticsEventPolicy.policy(forEvent: "speaker_suggestion_accepted_or_rejected")
+
+        let meetingProperties: Set<String> = [
+            "app_signal",
+            "calendar_confidence",
+            "call_state",
+            "decision",
+            "elapsed_bucket",
+            "missing_permission",
+            "outcome",
+            "prompt_origin",
+            "prompt_reason",
+            "provider",
+            "route_ready",
+            "source",
+        ]
+        assertEqual(meetingDecision?.allowedProperties ?? Set<String>(), meetingProperties, "meeting prompt decisions should keep existing prompt context plus safe choice fields")
+        assertEqual(meetingOutcome?.allowedProperties ?? Set<String>(), meetingProperties, "meeting prompt outcomes should mirror prompt decision context")
+        assertEqual(retryDecision?.allowedProperties ?? Set<String>(), ["capture_kind", "elapsed_bucket", "failure_kind", "outcome", "retry_action"], "retry decisions should be enum/bucket only")
+        assertEqual(retryOutcome?.allowedProperties ?? Set<String>(), ["capture_kind", "elapsed_bucket", "failure_kind", "outcome", "retry_action"], "retry outcomes should mirror retry decisions")
+        assertEqual(summaryFeedback?.allowedProperties ?? Set<String>(), ["chunk_count_bucket", "elapsed_bucket", "provider_family", "result", "summary_action"], "summary feedback should not include text or model names")
+        assertEqual(summaryUsed?.allowedProperties ?? Set<String>(), ["chunk_count_bucket", "elapsed_bucket", "provider_family", "result", "summary_action"], "summary use should mirror summary feedback")
+        assertEqual(speakerCorrected?.allowedProperties ?? Set<String>(), ["action", "item_count_bucket", "review_reason", "suggestion_confidence_bucket"], "speaker correction should not include names or person ids")
+        assertEqual(speakerSuggestion?.allowedProperties ?? Set<String>(), ["action", "item_count_bucket", "review_reason", "suggestion_confidence_bucket"], "speaker suggestion decisions should not include names or person ids")
+
+        let meetingSanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "app_signal": "browser_mic",
+                "calendar_confidence": "high",
+                "call_state": "mic_active",
+                "decision": "record_now",
+                "elapsed_bucket": "lt_10s",
+                "outcome": "recording_started",
+                "prompt_origin": "browser",
+                "prompt_reason": "browser_mic",
+                "provider": "detector",
+                "route_ready": "true",
+                "source": "detector",
+                "audio_ref": "file:///private.wav",
+                "file_path": "/Users/redbars/private.md",
+                "meeting_title": "Customer Roadmap",
+                "prompt_text": "Join private meeting",
+                "source_app_name": "Safari",
+            ],
+            allowedKeys: meetingProperties
+        )
+        assertEqual(meetingSanitized["decision"], "record_now", "prompt decision should survive")
+        assertEqual(meetingSanitized["outcome"], "recording_started", "prompt outcome should survive")
+        assertEqual(meetingSanitized["prompt_origin"], "browser", "prompt origin should survive")
+        assertNil(meetingSanitized["audio_ref"], "audio refs must not be sent")
+        assertNil(meetingSanitized["file_path"], "file paths must not be sent")
+        assertNil(meetingSanitized["meeting_title"], "meeting titles must not be sent")
+        assertNil(meetingSanitized["prompt_text"], "prompt text must not be sent")
+        assertNil(meetingSanitized["source_app_name"], "source app names must not be sent")
+
+        let retrySanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "capture_kind": "meeting",
+                "elapsed_bucket": "30_119s",
+                "failure_kind": "model_not_ready",
+                "outcome": "blocked",
+                "retry_action": "retry",
+                "audio_path": "/Users/redbars/private.wav",
+                "error_message": "private raw error",
+                "retry_count": "12",
+            ],
+            allowedKeys: retryOutcome?.allowedProperties ?? []
+        )
+        assertEqual(retrySanitized["capture_kind"], "meeting", "capture kind should survive")
+        assertEqual(retrySanitized["failure_kind"], "model_not_ready", "failure kind should survive")
+        assertEqual(retrySanitized["outcome"], "blocked", "retry outcome should survive")
+        assertEqual(retrySanitized["retry_action"], "retry", "retry action should survive")
+        assertNil(retrySanitized["audio_path"], "audio paths must not be sent")
+        assertNil(retrySanitized["error_message"], "free-form errors must not be sent")
+        assertNil(retrySanitized["retry_count"], "raw retry counts must not be sent")
+
+        let summarySanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "chunk_count_bucket": "2_3",
+                "elapsed_bucket": "10_29s",
+                "provider_family": "local",
+                "result": "success",
+                "summary_action": "copy",
+                "model_name": "private-model-build",
+                "raw_path": "/Users/redbars/summary.md",
+                "summary_text": "private summary text",
+            ],
+            allowedKeys: summaryUsed?.allowedProperties ?? []
+        )
+        assertEqual(summarySanitized["summary_action"], "copy", "summary action should survive")
+        assertEqual(summarySanitized["provider_family"], "local", "provider family should survive")
+        assertNil(summarySanitized["model_name"], "raw model names must not be sent")
+        assertNil(summarySanitized["raw_path"], "raw paths must not be sent")
+        assertNil(summarySanitized["summary_text"], "summary text must not be sent")
+
+        let speakerSanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "action": "accepted",
+                "item_count_bucket": "2_3",
+                "review_reason": "suggestion_review",
+                "suggestion_confidence_bucket": "high",
+                "person_id": "person-private",
+                "speaker_name": "Alice",
+            ],
+            allowedKeys: speakerSuggestion?.allowedProperties ?? []
+        )
+        assertEqual(speakerSanitized["action"], "accepted", "speaker review action should survive")
+        assertEqual(speakerSanitized["review_reason"], "suggestion_review", "speaker review reason should survive")
+        assertNil(speakerSanitized["person_id"], "person ids must not be sent")
+        assertNil(speakerSanitized["speaker_name"], "speaker names must not be sent")
     }
 
     runSuite("ActivationTelemetry buckets artifact age, first-artifact saves, dictation artifacts, and next-day return proxy") {

--- a/Tests/AnalyticsPayloadSanitizerTests.swift
+++ b/Tests/AnalyticsPayloadSanitizerTests.swift
@@ -20,6 +20,73 @@ func testAnalyticsPayloadSanitizer() {
         assertNil(sanitized["title"], "non-allowlisted properties should be dropped")
     }
 
+    runSuite("AnalyticsPayloadSanitizer keeps decision/outcome fields but drops private context") {
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "action": "accepted",
+                "capture_kind": "meeting",
+                "decision": "record_now",
+                "failure_kind": "model_not_ready",
+                "outcome": "recovered",
+                "prompt_origin": "browser",
+                "provider_family": "local",
+                "retry_action": "retry",
+                "review_reason": "suggestion_review",
+                "summary_action": "copy",
+                "tool_kind": "mcp",
+                "audio_path": "/Users/redbars/private.wav",
+                "meeting_title": "Customer call",
+                "person_id": "private-person",
+                "query_text": "what did Alice say?",
+                "raw_url": "https://example.com/private",
+                "source_app_name": "Safari",
+                "speaker_name": "Alice",
+                "transcript_text": "private transcript words",
+            ],
+            allowedKeys: [
+                "action",
+                "audio_path",
+                "capture_kind",
+                "decision",
+                "failure_kind",
+                "meeting_title",
+                "outcome",
+                "person_id",
+                "prompt_origin",
+                "provider_family",
+                "query_text",
+                "raw_url",
+                "retry_action",
+                "review_reason",
+                "source_app_name",
+                "speaker_name",
+                "summary_action",
+                "tool_kind",
+                "transcript_text",
+            ]
+        )
+
+        assertEqual(sanitized["action"], "accepted", "review action should survive")
+        assertEqual(sanitized["capture_kind"], "meeting", "capture kind should survive")
+        assertEqual(sanitized["decision"], "record_now", "decision should survive")
+        assertEqual(sanitized["failure_kind"], "model_not_ready", "failure kind should survive")
+        assertEqual(sanitized["outcome"], "recovered", "outcome should survive")
+        assertEqual(sanitized["prompt_origin"], "browser", "prompt origin should survive")
+        assertEqual(sanitized["provider_family"], "local", "provider family should survive")
+        assertEqual(sanitized["retry_action"], "retry", "retry action should survive")
+        assertEqual(sanitized["review_reason"], "suggestion_review", "review reason should survive")
+        assertEqual(sanitized["summary_action"], "copy", "summary action should survive")
+        assertEqual(sanitized["tool_kind"], "mcp", "tool kind should survive")
+        assertNil(sanitized["audio_path"], "audio paths should be dropped even if allowlisted")
+        assertNil(sanitized["meeting_title"], "meeting titles should be dropped even if allowlisted")
+        assertNil(sanitized["person_id"], "person ids should be dropped even if allowlisted")
+        assertNil(sanitized["query_text"], "query text should be dropped even if allowlisted")
+        assertNil(sanitized["raw_url"], "raw URLs should be dropped even if allowlisted")
+        assertNil(sanitized["source_app_name"], "source app names should be dropped even if allowlisted")
+        assertNil(sanitized["speaker_name"], "speaker names should be dropped even if allowlisted")
+        assertNil(sanitized["transcript_text"], "transcript text should be dropped even if allowlisted")
+    }
+
     runSuite("AnalyticsPayloadSanitizer redacts file paths and emails from values") {
         let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
             [

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift
@@ -56,6 +56,7 @@ struct AgentCaptureQueryObservation: Equatable {
             "return_window_bucket": returnWindowBucket,
             "source_count_bucket": sourceCountBucket,
             "surface": surface,
+            "tool_kind": "mcp",
         ]
     }
 
@@ -112,6 +113,11 @@ struct AgentCaptureQueryObservation: Equatable {
 
 enum AgentCaptureQueryTelemetryPolicy {
     static let eventName = "agent_capture_query_observed"
+    static let eventNames = [
+        "agent_capture_query_observed",
+        "agent_artifact_query_succeeded",
+        "artifact_reused_after_save",
+    ]
     // This standalone MCP package cannot import the app target, so this
     // mirrors AnalyticsEventPolicy.agentCaptureQueryProperties. Keep the root
     // AnalyticsEventPolicy parity test green when changing either side.
@@ -124,6 +130,7 @@ enum AgentCaptureQueryTelemetryPolicy {
         "return_window_bucket",
         "source_count_bucket",
         "surface",
+        "tool_kind",
     ]
     private static let sensitiveKeyFragments = [
         "audio",
@@ -154,6 +161,7 @@ enum AgentCaptureQueryTelemetryPolicy {
         "return_window_bucket": ["same_day", "18_36h", "36_72h", "3_7d", "older", "unknown"],
         "source_count_bucket": ["0", "1", "2_3", "4_9", "10_plus", "unknown"],
         "surface": ["mcp"],
+        "tool_kind": ["mcp"],
     ]
 
     static func sanitize(_ properties: [String: String]) -> [String: String] {
@@ -298,33 +306,40 @@ final class AgentCaptureQueryTelemetry {
     }
 
     func track(_ observation: AgentCaptureQueryObservation) {
-        guard let request = makeRequest(for: observation) else { return }
-        session.dataTask(with: request).resume()
+        for request in makeRequests(for: observation) {
+            session.dataTask(with: request).resume()
+        }
     }
 
     func makeRequest(for observation: AgentCaptureQueryObservation, now: Date = Date()) -> URLRequest? {
-        guard let configuration = configurationProvider() else { return nil }
+        makeRequests(for: observation, now: now).first
+    }
+
+    func makeRequests(for observation: AgentCaptureQueryObservation, now: Date = Date()) -> [URLRequest] {
+        guard let configuration = configurationProvider() else { return [] }
 
         let sanitized = AgentCaptureQueryTelemetryPolicy.sanitize(observation.properties)
         guard sanitized.count == AgentCaptureQueryTelemetryPolicy.allowedProperties.count else {
-            return nil
+            return []
         }
 
-        let payload = PostHogCaptureRequest(
-            apiKey: configuration.apiKey,
-            event: AgentCaptureQueryTelemetryPolicy.eventName,
-            distinctID: configuration.distinctID,
-            timestamp: Self.isoDateFormatter.string(from: now),
-            properties: sanitized.merging(["distinct_id": configuration.distinctID]) { current, _ in current }
-        )
+        return AgentCaptureQueryTelemetryPolicy.eventNames.compactMap { eventName in
+            let payload = PostHogCaptureRequest(
+                apiKey: configuration.apiKey,
+                event: eventName,
+                distinctID: configuration.distinctID,
+                timestamp: Self.isoDateFormatter.string(from: now),
+                properties: sanitized.merging(["distinct_id": configuration.distinctID]) { current, _ in current }
+            )
 
-        guard let data = try? JSONEncoder().encode(payload) else { return nil }
+            guard let data = try? JSONEncoder().encode(payload) else { return nil }
 
-        var request = URLRequest(url: configuration.host.appendingPathComponent("capture/"))
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = data
-        return request
+            var request = URLRequest(url: configuration.host.appendingPathComponent("capture/"))
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = data
+            return request
+        }
     }
 }
 

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/AgentCaptureQueryTelemetryTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/AgentCaptureQueryTelemetryTests.swift
@@ -19,6 +19,7 @@ final class AgentCaptureQueryTelemetryTests: XCTestCase {
         XCTAssertEqual(observation.properties["artifact_kind"], "mixed")
         XCTAssertEqual(observation.properties["result"], "success")
         XCTAssertEqual(observation.properties["surface"], "mcp")
+        XCTAssertEqual(observation.properties["tool_kind"], "mcp")
         XCTAssertEqual(observation.properties["return_window_bucket"], "3_7d")
         XCTAssertEqual(observation.properties["capture_age_bucket"], "2_7d")
         XCTAssertEqual(observation.properties["source_count_bucket"], "4_9")
@@ -34,6 +35,7 @@ final class AgentCaptureQueryTelemetryTests: XCTestCase {
             "return_window_bucket": "18_36h",
             "source_count_bucket": "1",
             "surface": "mcp",
+            "tool_kind": "mcp",
             "query_text": "what did Alice say about the roadmap?",
             "transcript_text": "private transcript words",
             "speaker_name": "Alice",
@@ -53,6 +55,7 @@ final class AgentCaptureQueryTelemetryTests: XCTestCase {
         XCTAssertEqual(sanitized["return_window_bucket"], "18_36h")
         XCTAssertEqual(sanitized["source_count_bucket"], "1")
         XCTAssertEqual(sanitized["surface"], "mcp")
+        XCTAssertEqual(sanitized["tool_kind"], "mcp")
         XCTAssertNil(sanitized["query_text"])
         XCTAssertNil(sanitized["transcript_text"])
         XCTAssertNil(sanitized["speaker_name"])
@@ -74,10 +77,12 @@ final class AgentCaptureQueryTelemetryTests: XCTestCase {
             "return_window_bucket": "18_36h",
             "source_count_bucket": "1",
             "surface": "mcp",
+            "tool_kind": "raw helper name",
         ])
 
         XCTAssertNil(sanitized["agent_target"])
         XCTAssertNil(sanitized["query_kind"])
+        XCTAssertNil(sanitized["tool_kind"])
         XCTAssertEqual(sanitized["artifact_kind"], "meeting")
     }
 
@@ -110,12 +115,59 @@ final class AgentCaptureQueryTelemetryTests: XCTestCase {
         XCTAssertEqual(properties["artifact_kind"], "dictation")
         XCTAssertEqual(properties["query_kind"], "read")
         XCTAssertEqual(properties["surface"], "mcp")
+        XCTAssertEqual(properties["tool_kind"], "mcp")
         XCTAssertEqual(properties["source_count_bucket"], "1")
         XCTAssertNil(properties["query_text"])
         XCTAssertNil(properties["transcript_text"])
         XCTAssertNil(properties["file_path"])
         XCTAssertNil(properties["meeting_title"])
         XCTAssertNil(properties["source_app_name"])
+    }
+
+    func testReporterBuildsDecisionOutcomeRequestsForAgentValue() throws {
+        let configuration = AgentCaptureQueryTelemetryConfiguration(
+            apiKey: "phc_test",
+            host: URL(string: "https://us.i.posthog.com")!,
+            distinctID: "anonymous-device"
+        )
+        let reporter = AgentCaptureQueryTelemetry(configuration: configuration)
+        let requests = reporter.makeRequests(
+            for: AgentCaptureQueryObservation(
+                queryKind: "search",
+                artifactKind: "meeting",
+                captureDate: nil,
+                sourceCount: 2
+            ),
+            now: Date(timeIntervalSince1970: 1_766_102_400)
+        )
+
+        XCTAssertEqual(requests.count, 3)
+        let payloads = try requests.map { request -> [String: Any] in
+            let body = try XCTUnwrap(request.httpBody)
+            return try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        }
+        XCTAssertEqual(
+            payloads.compactMap { $0["event"] as? String },
+            [
+                "agent_capture_query_observed",
+                "agent_artifact_query_succeeded",
+                "artifact_reused_after_save",
+            ]
+        )
+
+        for payload in payloads {
+            let properties = try XCTUnwrap(payload["properties"] as? [String: String])
+            XCTAssertEqual(properties["artifact_kind"], "meeting")
+            XCTAssertEqual(properties["query_kind"], "search")
+            XCTAssertEqual(properties["result"], "success")
+            XCTAssertEqual(properties["source_count_bucket"], "2_3")
+            XCTAssertEqual(properties["tool_kind"], "mcp")
+            XCTAssertNil(properties["query_text"])
+            XCTAssertNil(properties["transcript_text"])
+            XCTAssertNil(properties["file_path"])
+            XCTAssertNil(properties["meeting_title"])
+            XCTAssertNil(properties["source_app_name"])
+        }
     }
 
     func testReporterRechecksConfigurationBeforeEachRequest() throws {

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -103,6 +103,8 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `activation_agent_prompt_action_clicked`
 - `activation_agent_setup_cta_clicked`
 - `agent_capture_query_observed`
+- `agent_artifact_query_succeeded`
+- `artifact_reused_after_save`
 - `activation_return_proxy_observed`
 - `workflow_abandoned`
 - `product_friction_observed`
@@ -136,6 +138,8 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `meeting_recording_started`
 - `meeting_recording_start_failed`
 - `meeting_prompt_shown`
+- `meeting_prompt_decision_made`
+- `meeting_prompt_followup_outcome`
 - `meeting_prompt_dismissed`
 - `meeting_prompt_record_selected`
 - `meeting_prompt_suppressed`
@@ -151,6 +155,12 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `meeting_speaker_finalization_failed`
 - `meeting_transcript_skipped`
 - `meeting_saved_audio_retranscription_requested`
+- `failed_capture_retry_decision`
+- `failed_capture_retry_outcome`
+- `local_summary_feedback_given`
+- `local_summary_used_after_generation`
+- `speaker_name_corrected`
+- `speaker_suggestion_accepted_or_rejected`
 
 ## Allowed property style
 
@@ -168,6 +178,16 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 Meeting workflow analytics should keep that same stable `trigger` enum on later
 stop/save/fail events so product and reliability reviews can attribute outcomes
 without joining against any sensitive context.
+
+## Decision/outcome taxonomy
+
+| Family | Events | Natural trigger | Safe context | Planned or blocked |
+|---|---|---|---|---|
+| Meeting prompt choice | `meeting_prompt_decision_made`, `meeting_prompt_followup_outcome` | record, remind, dismiss, timeout, or suppression from the detected-meeting prompt | `prompt_origin`, `decision`, `outcome`, existing prompt enums, elapsed bucket | no raw app names, meeting titles, invitees, calendar text, or prompt text; camera/manual origins stay `unknown` until modeled |
+| Failed capture recovery | `failed_capture_retry_decision`, `failed_capture_retry_outcome` | retry, retranscribe, reveal audio, delete, or dismiss on failed/saved meeting recovery surfaces | `capture_kind`, `failure_kind`, `retry_action`, `outcome`, elapsed bucket | dictation retry events wait for a natural failed-dictation recovery surface |
+| Local summary usefulness | `local_summary_feedback_given`, `local_summary_used_after_generation` | regenerate, open, or copy an existing local summary | `summary_action`, `result`, provider family, chunk bucket, elapsed bucket | no generated summary text, prompt text, model names, or file paths |
+| Speaker review quality | `speaker_name_corrected`, `speaker_suggestion_accepted_or_rejected` | accept, reject, correct, skip, or close the speaker naming review | `action`, `review_reason`, `item_count_bucket`, `suggestion_confidence_bucket` | no speaker names, profile IDs, person IDs, or stable speaker identifiers |
+| Agent artifact value | `agent_artifact_query_succeeded`, `artifact_reused_after_save` | read-only MCP/agent query succeeds, or a saved artifact is reused through explicit artifact actions | `artifact_kind`, `agent_target`, `tool_kind`, `query_kind`, `result`, source-count and return-window buckets | no query text, file names, paths, titles, speaker names, or source rows |
 
 Anything richer than that should stay local unless there is a new explicit
 privacy review and a matching allowlist change.

--- a/scripts/entrypoints/run-tests.sh
+++ b/scripts/entrypoints/run-tests.sh
@@ -326,6 +326,7 @@ APP_SOURCES=(
     "Sources/UI/MenuBar/MenuBarHeaderLayoutPolicy.swift"
     "Sources/Observability/AnalyticsReporter.swift"
     "Sources/Observability/ActivationTelemetry.swift"
+    "Sources/Observability/ProductDecisionTelemetry.swift"
     "Sources/Observability/FeatureDiscoveryTelemetry.swift"
     "Sources/Observability/LockedFileAppender.swift"
     "Sources/Observability/JSONLWriter.swift"

--- a/scripts/ops/posthog-dashboard-queries.py
+++ b/scripts/ops/posthog-dashboard-queries.py
@@ -33,6 +33,9 @@ ACTIVE_WORKFLOW_EVENTS = (
     "activation_agent_setup_cta_clicked",
     "activation_return_proxy_observed",
     "agent_capture_query_observed",
+    "agent_artifact_query_succeeded",
+    "artifact_reused_after_save",
+    "local_summary_used_after_generation",
 )
 
 ACTIVATION_EVENTS = (
@@ -52,6 +55,8 @@ ACTIVATION_EVENTS = (
     "activation_agent_setup_cta_clicked",
     "onboarding_agent_cta_clicked",
     "agent_capture_query_observed",
+    "agent_artifact_query_succeeded",
+    "artifact_reused_after_save",
     "activation_return_proxy_observed",
 )
 
@@ -72,6 +77,8 @@ RELIABILITY_EVENTS = (
     "meeting_transcript_failed",
     "meeting_transcript_skipped",
     "meeting_file_import_failed",
+    "failed_capture_retry_decision",
+    "failed_capture_retry_outcome",
 )
 
 FEATURE_EVENTS = (
@@ -83,9 +90,19 @@ FEATURE_EVENTS = (
     "meeting_prompt_record_selected",
     "meeting_prompt_dismissed",
     "meeting_prompt_suppressed",
+    "meeting_prompt_decision_made",
+    "meeting_prompt_followup_outcome",
     "meeting_mic_boost_prompt_shown",
     "meeting_mic_boost_prompt_actioned",
     "meeting_saved_audio_retranscription_requested",
+    "failed_capture_retry_decision",
+    "failed_capture_retry_outcome",
+    "local_summary_feedback_given",
+    "local_summary_used_after_generation",
+    "speaker_name_corrected",
+    "speaker_suggestion_accepted_or_rejected",
+    "agent_artifact_query_succeeded",
+    "artifact_reused_after_save",
     "meeting_file_imported",
     "settings_opened",
     "settings_page_viewed",
@@ -249,14 +266,14 @@ SELECT
   uniqIf(distinct_id, event IN ('activation_first_artifact_saved', 'onboarding_first_dictation_saved', 'meeting_transcript_saved', 'dictation_completed')) AS saved_markdown_or_dictation_proxy_devices,
   uniqIf(distinct_id, event = 'activation_artifact_action_clicked') AS artifact_action_devices,
   uniqIf(distinct_id, event IN ('activation_agent_prompt_action_clicked', 'activation_agent_setup_cta_clicked', 'onboarding_agent_cta_clicked')) AS agent_proxy_devices,
-  uniqIf(distinct_id, event = 'agent_capture_query_observed') AS true_agent_query_devices,
+  uniqIf(distinct_id, event IN ('agent_capture_query_observed', 'agent_artifact_query_succeeded')) AS true_agent_query_devices,
   uniqIf(distinct_id, event = 'activation_return_proxy_observed') AS return_proxy_devices
 FROM events
 WHERE timestamp >= now() - INTERVAL {days} DAY
   AND {event_filter(ACTIVATION_EVENTS)}
   {app_version_filter(app_version)}
 """,
-            notes=("Treat agent proxy counts as intent. They do not prove a sourced answer.",),
+            notes=("Treat agent proxy counts as intent. Agent query success is the stronger sourced-answer proof.",),
         ),
         QuerySpec(
             id="activation.ordered_funnel",
@@ -309,6 +326,34 @@ GROUP BY return_window_bucket, prior_artifact_kind, surface
 ORDER BY devices DESC
 LIMIT 40
 """,
+        ),
+        QuerySpec(
+            id="activation.agent_artifact_value",
+            family="activation",
+            title="Agent artifact value",
+            description="Shows whether saved artifacts become privacy-safe agent context.",
+            columns=("event", "artifact_kind", "agent_target", "tool_kind", "query_kind", "result", "source_count_bucket", "return_window_bucket", "events", "devices"),
+            sql=f"""
+SELECT
+  event,
+  properties['artifact_kind'] AS artifact_kind,
+  properties['agent_target'] AS agent_target,
+  properties['tool_kind'] AS tool_kind,
+  properties['query_kind'] AS query_kind,
+  properties['result'] AS result,
+  properties['source_count_bucket'] AS source_count_bucket,
+  properties['return_window_bucket'] AS return_window_bucket,
+  count() AS events,
+  uniq(distinct_id) AS devices
+FROM events
+WHERE timestamp >= now() - INTERVAL {days} DAY
+  AND event IN ('agent_artifact_query_succeeded', 'artifact_reused_after_save')
+  {app_version_filter(app_version)}
+GROUP BY event, artifact_kind, agent_target, tool_kind, query_kind, result, source_count_bucket, return_window_bucket
+ORDER BY devices DESC, events DESC
+LIMIT 60
+""",
+            notes=("This is aggregate proof that a saved artifact became agent context; it never outputs query text, paths, titles, or file names.",),
         ),
         QuerySpec(
             id="reliability.workflow_failure_rates",
@@ -433,6 +478,35 @@ WHERE timestamp >= now() - INTERVAL {days} DAY
   {app_version_filter(app_version)}
 GROUP BY event, provider, source, route_ready, suppression_reason, cooldown_reason
 ORDER BY events DESC
+LIMIT 80
+""",
+        ),
+        QuerySpec(
+            id="feature_adoption.decision_outcomes",
+            family="feature_adoption",
+            title="Decision and outcome signals",
+            description="Breaks key choices and follow-up outcomes into coarse product-learning buckets.",
+            columns=("event", "prompt_origin", "decision", "outcome", "capture_kind", "failure_kind", "retry_action", "summary_action", "review_action", "result", "events", "devices"),
+            sql=f"""
+SELECT
+  event,
+  properties['prompt_origin'] AS prompt_origin,
+  properties['decision'] AS decision,
+  properties['outcome'] AS outcome,
+  properties['capture_kind'] AS capture_kind,
+  properties['failure_kind'] AS failure_kind,
+  properties['retry_action'] AS retry_action,
+  properties['summary_action'] AS summary_action,
+  properties['action'] AS review_action,
+  properties['result'] AS result,
+  count() AS events,
+  uniq(distinct_id) AS devices
+FROM events
+WHERE timestamp >= now() - INTERVAL {days} DAY
+  AND event IN ('meeting_prompt_decision_made', 'meeting_prompt_followup_outcome', 'failed_capture_retry_decision', 'failed_capture_retry_outcome', 'local_summary_feedback_given', 'local_summary_used_after_generation', 'speaker_name_corrected', 'speaker_suggestion_accepted_or_rejected')
+  {app_version_filter(app_version)}
+GROUP BY event, prompt_origin, decision, outcome, capture_kind, failure_kind, retry_action, summary_action, review_action, result
+ORDER BY devices DESC, events DESC
 LIMIT 80
 """,
         ),

--- a/scripts/ops/posthog-product-context-pack.py
+++ b/scripts/ops/posthog-product-context-pack.py
@@ -35,6 +35,16 @@ SAFE_EVENTS = (
     "onboarding_agent_cta_clicked",
     "activation_return_proxy_observed",
     "agent_capture_query_observed",
+    "agent_artifact_query_succeeded",
+    "artifact_reused_after_save",
+    "meeting_prompt_decision_made",
+    "meeting_prompt_followup_outcome",
+    "failed_capture_retry_decision",
+    "failed_capture_retry_outcome",
+    "local_summary_feedback_given",
+    "local_summary_used_after_generation",
+    "speaker_name_corrected",
+    "speaker_suggestion_accepted_or_rejected",
     "update_check_finished",
     "update_download_finished",
 )
@@ -51,6 +61,9 @@ WORKFLOW_EVENTS = (
     "activation_agent_prompt_action_clicked",
     "activation_agent_setup_cta_clicked",
     "activation_return_proxy_observed",
+    "agent_artifact_query_succeeded",
+    "artifact_reused_after_save",
+    "local_summary_used_after_generation",
 )
 
 FAILURE_EVENTS = (
@@ -60,6 +73,7 @@ FAILURE_EVENTS = (
     "meeting_recording_start_failed",
     "meeting_transcript_failed",
     "meeting_transcript_skipped",
+    "failed_capture_retry_outcome",
     "update_check_finished",
     "update_download_finished",
 )
@@ -71,6 +85,7 @@ NON_UPDATE_FAILURE_EVENTS = (
     "meeting_recording_start_failed",
     "meeting_transcript_failed",
     "meeting_transcript_skipped",
+    "failed_capture_retry_outcome",
 )
 
 DISALLOWED_OUTPUT_COLUMNS = {
@@ -123,7 +138,7 @@ SELECT
   uniqIf(distinct_id, event = 'activation_first_artifact_saved') AS first_artifact_devices,
   uniqIf(distinct_id, event = 'activation_agent_prompt_action_clicked') AS agent_prompt_devices,
   uniqIf(distinct_id, event IN ('activation_agent_setup_cta_clicked', 'onboarding_agent_cta_clicked')) AS agent_setup_devices,
-  uniqIf(distinct_id, event = 'agent_capture_query_observed') AS true_agent_query_devices,
+  uniqIf(distinct_id, event IN ('agent_capture_query_observed', 'agent_artifact_query_succeeded')) AS true_agent_query_devices,
   uniqIf(distinct_id, event = 'activation_return_proxy_observed') AS return_proxy_devices,
   uniqIf(distinct_id, event = 'dictation_completed') AS dictation_completed_devices,
   uniqIf(distinct_id, event = 'meeting_transcript_saved') AS meeting_saved_devices,
@@ -153,7 +168,7 @@ SELECT
   event,
   coalesce(properties['failure_kind'], properties['failure_code'], 'unknown') AS failure_kind,
   coalesce(properties['capture_quality'], 'unknown') AS capture_quality,
-  coalesce(properties['result'], 'unknown') AS result,
+  coalesce(properties['outcome'], properties['result'], 'unknown') AS result,
   count() AS events,
   uniq(distinct_id) AS devices
 FROM events
@@ -222,9 +237,12 @@ def feature_breakdown_query(days: int, app_version: str | None) -> str:
 SELECT
   multiIf(
     event IN ('dictation_started', 'dictation_completed'), 'dictation',
-    event IN ('meeting_recording_started', 'meeting_transcript_saved'), 'meetings',
-    event IN ('activation_artifact_action_clicked', 'activation_first_artifact_saved'), 'artifact_actions',
-    event IN ('activation_agent_prompt_action_clicked', 'activation_agent_setup_cta_clicked', 'onboarding_agent_cta_clicked'), 'agent_bridge',
+    event IN ('meeting_recording_started', 'meeting_transcript_saved', 'meeting_prompt_decision_made', 'meeting_prompt_followup_outcome'), 'meetings',
+    event IN ('activation_artifact_action_clicked', 'activation_first_artifact_saved', 'artifact_reused_after_save'), 'artifact_actions',
+    event IN ('activation_agent_prompt_action_clicked', 'activation_agent_setup_cta_clicked', 'onboarding_agent_cta_clicked', 'agent_artifact_query_succeeded'), 'agent_bridge',
+    event IN ('local_summary_feedback_given', 'local_summary_used_after_generation'), 'local_summary',
+    event IN ('speaker_name_corrected', 'speaker_suggestion_accepted_or_rejected'), 'quality_review',
+    event IN ('failed_capture_retry_decision', 'failed_capture_retry_outcome'), 'retry_recovery',
     event IN ('update_check_finished', 'update_download_finished'), 'updates',
     'other'
   ) AS feature,
@@ -265,6 +283,25 @@ ORDER BY devices DESC, events DESC
 """
 
 
+def decision_outcomes_query(days: int, app_version: str | None) -> str:
+    return f"""
+SELECT
+  event,
+  coalesce(properties['decision'], properties['retry_action'], properties['summary_action'], properties['action'], 'unknown') AS choice_kind,
+  coalesce(properties['outcome'], properties['result'], 'unknown') AS result_kind,
+  coalesce(properties['prompt_origin'], properties['capture_kind'], properties['artifact_kind'], 'unknown') AS context_kind,
+  count() AS events,
+  uniq(distinct_id) AS devices
+FROM events
+WHERE timestamp >= now() - INTERVAL {int(days)} DAY
+  AND event IN ('meeting_prompt_decision_made', 'meeting_prompt_followup_outcome', 'failed_capture_retry_decision', 'failed_capture_retry_outcome', 'local_summary_feedback_given', 'local_summary_used_after_generation', 'speaker_name_corrected', 'speaker_suggestion_accepted_or_rejected', 'agent_artifact_query_succeeded', 'artifact_reused_after_save')
+  {app_version_filter(app_version)}
+GROUP BY event, choice_kind, result_kind, context_kind
+ORDER BY devices DESC, events DESC
+LIMIT 50
+"""
+
+
 def fetch_report_data(days: int, app_version: str | None, fixture_path: Path | None) -> dict[str, Any]:
     if fixture_path:
         return json.loads(fixture_path.read_text(encoding="utf-8"))
@@ -278,6 +315,7 @@ def fetch_report_data(days: int, app_version: str | None, fixture_path: Path | N
         "release_versions": release_versions_query(days, app_version),
         "feature_breakdown": feature_breakdown_query(days, app_version),
         "repeat_breakdown": repeat_breakdown_query(days, app_version),
+        "decision_outcomes": decision_outcomes_query(days, app_version),
     }
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -313,6 +351,7 @@ def unknown_data(reason: str, days: int, app_version: str | None) -> dict[str, A
             "release_versions": [],
             "feature_breakdown": [],
             "repeat_breakdown": [],
+            "decision_outcomes": [],
         },
     }
 
@@ -400,7 +439,7 @@ def build_context_pack(data: dict[str, Any]) -> dict[str, Any]:
     if launch <= 0:
         unknowns.append(UnknownReason("activation.bottleneck", "No launch devices were available for the selected window."))
     if true_agent_query == 0:
-        unknowns.append(UnknownReason("activation.true_agent_use", "`agent_capture_query_observed` is missing or zero; prompt/setup clicks are intent proxies only."))
+        unknowns.append(UnknownReason("activation.true_agent_use", "`agent_capture_query_observed` / `agent_artifact_query_succeeded` is missing or zero; prompt/setup clicks are intent proxies only."))
 
     artifact_rate = pct(first_artifact, launch)
     prompt_rate = pct(agent_prompt, first_artifact)
@@ -459,6 +498,7 @@ def build_context_pack(data: dict[str, Any]) -> dict[str, Any]:
         unknowns.append(UnknownReason("release.anomaly", "No app_version aggregate rows were returned."))
 
     feature_top = top_row(results.get("feature_breakdown", []))
+    decision_top = top_row(results.get("decision_outcomes", []))
     if feature_top:
         feature_status = "OBSERVED"
         feature_signal = f"{feature_top.get('feature')} leads adoption by active devices."
@@ -533,6 +573,11 @@ def build_context_pack(data: dict[str, Any]) -> dict[str, Any]:
             "meeting_saved_devices": meeting_saved,
             "workflow_devices": workflow_devices,
             "features": results.get("feature_breakdown", [])[:8],
+            "decision_signals": {
+                "status": "OBSERVED" if decision_top else "UNKNOWN",
+                "top_row": decision_top,
+                "rows": results.get("decision_outcomes", [])[:8],
+            },
         },
         "data_quality": {
             "source": data.get("source", {}),
@@ -576,8 +621,8 @@ def build_recommendations(
         recs.append({
             "rank": len(recs) + 1,
             "title": "Add privacy-safe sourced-agent-use proof",
-            "why": "`agent_capture_query_observed` is missing or zero, so agents still cannot tell whether saved Markdown produced a sourced answer.",
-            "suggested_pr": "Emit aggregate-only `agent_capture_query_observed` from the read-only MCP/agent surface with enum result, query kind, agent target, artifact kind, and age buckets.",
+            "why": "`agent_capture_query_observed` / `agent_artifact_query_succeeded` is missing or zero, so agents still cannot tell whether saved Markdown produced a sourced answer.",
+            "suggested_pr": "Emit aggregate-only agent artifact query success from the read-only MCP/agent surface with enum result, query kind, agent target, artifact kind, and age buckets.",
         })
     elif launch > 0 and first_artifact / launch < 0.2:
         recs.append({

--- a/scripts/ops/posthog-product-dashboard-summary.py
+++ b/scripts/ops/posthog-product-dashboard-summary.py
@@ -31,6 +31,8 @@ CORE_EVENTS = (
     "onboarding_agent_cta_clicked",
     "activation_return_proxy_observed",
     "agent_capture_query_observed",
+    "agent_artifact_query_succeeded",
+    "artifact_reused_after_save",
     "dictation_start_failed",
     "dictation_no_speech",
     "dictation_cancelled",
@@ -46,8 +48,16 @@ CORE_EVENTS = (
     "settings_action_clicked",
     "meeting_prompt_shown",
     "meeting_prompt_record_selected",
+    "meeting_prompt_decision_made",
+    "meeting_prompt_followup_outcome",
     "meeting_file_imported",
     "meeting_saved_audio_retranscription_requested",
+    "failed_capture_retry_decision",
+    "failed_capture_retry_outcome",
+    "local_summary_feedback_given",
+    "local_summary_used_after_generation",
+    "speaker_name_corrected",
+    "speaker_suggestion_accepted_or_rejected",
 )
 
 WORKFLOW_EVENTS = (
@@ -62,6 +72,9 @@ WORKFLOW_EVENTS = (
     "activation_agent_prompt_action_clicked",
     "activation_agent_setup_cta_clicked",
     "activation_return_proxy_observed",
+    "agent_artifact_query_succeeded",
+    "artifact_reused_after_save",
+    "local_summary_used_after_generation",
 )
 
 DISALLOWED_OUTPUT_COLUMNS = {
@@ -139,13 +152,14 @@ SELECT
   event,
   properties['failure_kind'] AS failure_kind,
   properties['trigger'] AS trigger,
+  properties['outcome'] AS outcome,
   count() AS events,
   uniq(distinct_id) AS devices
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
-  AND event IN ('dictation_start_failed', 'dictation_no_speech', 'meeting_recording_start_failed', 'meeting_transcript_failed', 'meeting_transcript_skipped', 'meeting_speaker_finalization_failed')
+  AND event IN ('dictation_start_failed', 'dictation_no_speech', 'meeting_recording_start_failed', 'meeting_transcript_failed', 'meeting_transcript_skipped', 'meeting_speaker_finalization_failed', 'failed_capture_retry_outcome')
   {app_version_filter(app_version)}
-GROUP BY event, failure_kind, trigger
+GROUP BY event, failure_kind, trigger, outcome
 ORDER BY events DESC
 LIMIT 30
 """
@@ -159,13 +173,19 @@ SELECT
   properties['action_kind'] AS action_kind,
   properties['agent_target'] AS agent_target,
   properties['page_id'] AS page_id,
+  properties['decision'] AS decision,
+  properties['outcome'] AS outcome,
+  properties['retry_action'] AS retry_action,
+  properties['summary_action'] AS summary_action,
+  properties['action'] AS review_action,
+  properties['query_kind'] AS query_kind,
   count() AS events,
   uniq(distinct_id) AS devices
 FROM events
 WHERE timestamp >= now() - INTERVAL {int(days)} DAY
-  AND event IN ('activation_artifact_action_clicked', 'activation_agent_prompt_action_clicked', 'activation_agent_setup_cta_clicked', 'onboarding_agent_cta_clicked', 'settings_page_viewed', 'settings_action_clicked', 'meeting_prompt_record_selected', 'meeting_file_imported', 'meeting_saved_audio_retranscription_requested')
+  AND event IN ('activation_artifact_action_clicked', 'activation_agent_prompt_action_clicked', 'activation_agent_setup_cta_clicked', 'onboarding_agent_cta_clicked', 'settings_page_viewed', 'settings_action_clicked', 'meeting_prompt_record_selected', 'meeting_file_imported', 'meeting_saved_audio_retranscription_requested', 'meeting_prompt_decision_made', 'meeting_prompt_followup_outcome', 'failed_capture_retry_decision', 'failed_capture_retry_outcome', 'local_summary_feedback_given', 'local_summary_used_after_generation', 'speaker_name_corrected', 'speaker_suggestion_accepted_or_rejected', 'agent_artifact_query_succeeded', 'artifact_reused_after_save')
   {app_version_filter(app_version)}
-GROUP BY event, artifact_kind, action_kind, agent_target, page_id
+GROUP BY event, artifact_kind, action_kind, agent_target, page_id, decision, outcome, retry_action, summary_action, review_action, query_kind
 ORDER BY devices DESC, events DESC
 LIMIT 50
 """
@@ -303,7 +323,7 @@ def build_activation_leak(data: dict[str, Any]) -> Finding:
             "Nudge users back to yesterday's saved artifact."),
         (
             "true agent query",
-            devices.get("agent_capture_query_observed", 0),
+            max(devices.get("agent_capture_query_observed", 0), devices.get("agent_artifact_query_succeeded", 0)),
             "Instrument privacy-safe sourced-agent-use before calling the loop proven.",
         ),
     ]
@@ -385,7 +405,19 @@ def build_adoption_signal(data: dict[str, Any]) -> Finding:
     if rows:
         top = max(rows, key=lambda row: (as_int(row.get("devices")), as_int(row.get("events"))))
         event = top.get("event") or "unknown"
-        detail = top.get("action_kind") or top.get("agent_target") or top.get("page_id") or top.get("artifact_kind") or "all"
+        detail = (
+            top.get("action_kind")
+            or top.get("decision")
+            or top.get("outcome")
+            or top.get("retry_action")
+            or top.get("summary_action")
+            or top.get("review_action")
+            or top.get("query_kind")
+            or top.get("agent_target")
+            or top.get("page_id")
+            or top.get("artifact_kind")
+            or "all"
+        )
         devices = as_int(top.get("devices"))
         return Finding(
             "Strongest adoption signal",
@@ -412,6 +444,10 @@ def build_under_discovered_feature(data: dict[str, Any]) -> Finding:
     candidates = [
         ("Agent setup", max(devices.get("activation_agent_setup_cta_clicked", 0), devices.get("onboarding_agent_cta_clicked", 0)), 5, "Surface Claude/MCP setup immediately after the first saved artifact."),
         ("Agent prompt copy", devices.get("activation_agent_prompt_action_clicked", 0), 4, "Put the first sourced question beside Open Markdown."),
+        ("Agent artifact success", devices.get("agent_artifact_query_succeeded", 0), 4, "Make saved artifacts easier to query through the read-only agent bridge."),
+        ("Artifact reuse", devices.get("artifact_reused_after_save", 0), 4, "Turn saved Markdown into an obvious next-day/open/copy/agent context habit."),
+        ("Local summary use", devices.get("local_summary_used_after_generation", 0), 3, "Make copied/opened local summaries more visible from the meeting preview."),
+        ("Retry recovery", devices.get("failed_capture_retry_outcome", 0), 3, "Make failed capture retry outcomes easier to complete and understand."),
         ("Meeting import", devices.get("meeting_file_imported", 0), 3, "Expose imported-audio transcription from Home for users who missed live capture."),
         ("Saved-audio retranscription", devices.get("meeting_saved_audio_retranscription_requested", 0), 2, "Make retry from retained meeting audio clearer after transcript failure."),
         ("Meeting prompt acceptance", devices.get("meeting_prompt_record_selected", 0), 2, "Clarify detected-meeting prompts and route readiness."),
@@ -563,7 +599,7 @@ def render_markdown(data: dict[str, Any], findings: dict[str, Finding]) -> str:
         "## Privacy Boundary",
         "",
         "- Aggregate only. No raw rows or user-level forensics.",
-        "- Treat agent setup, prompt copy, and return events as proxies until `agent_capture_query_observed` exists.",
+        "- Treat agent setup, prompt copy, and return events as proxies until `agent_artifact_query_succeeded` or `agent_capture_query_observed` exists.",
         "",
     ])
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Add `ProductDecisionTelemetry` for privacy-safe decision/outcome PostHog events.
- Wire natural triggers for meeting prompts, failed meeting/saved-audio retry choices and outcomes, local summary use/regeneration, speaker review decisions, and MCP/agent artifact value proof.
- Update analytics allowlists, sanitizer coverage, privacy taxonomy docs, and PostHog dashboard/context-pack/product-summary scripts.

## Natural Triggers Wired
- `meeting_prompt_decision_made`, `meeting_prompt_followup_outcome`: record now, not now, remind later, ignored timeout, and prompt follow-up start/suppression/no-action outcomes.
- `failed_capture_retry_decision`, `failed_capture_retry_outcome`: failed meeting retry/open/delete/dismiss decisions, saved-audio retranscribe decisions, and meeting/saved-audio blocked/recovered/failed outcomes.
- `local_summary_feedback_given`, `local_summary_used_after_generation`: regenerate existing summary and open/copy generated summary surfaces.
- `speaker_name_corrected`, `speaker_suggestion_accepted_or_rejected`: speaker naming save/cancel/close actions using action/reason/count/confidence buckets only.
- `agent_artifact_query_succeeded`, `artifact_reused_after_save`: read-only MCP query success plus explicit saved-artifact reuse actions.

## Planned / Blocked
- Dictation retry decision/outcome remains planned until there is a natural failed-dictation recovery UI.
- Camera/manual meeting prompt origins remain `unknown` until those origins are modeled.
- Transcript-saved follow-up from a prompt is not faked; current natural prompt outcome is recording started/failed/suppressed/no action, while existing meeting save events retain trigger attribution.
- No generic implicit summary tracking was added; summary events only fire on explicit open/copy/regenerate actions.

## Privacy Guardrails
- Enum/bucket properties only.
- No transcript text, audio refs, meeting titles, speaker names, emails, tokens, raw URLs, raw paths, raw app/source IDs, raw device names, query text, filenames, person IDs, or identity stitching.
- Added sanitizer regression for `person` keys and new decision/outcome payloads.

## Verification
- `git diff --check`
- `python3 -m py_compile scripts/ops/posthog-dashboard-queries.py scripts/ops/posthog-product-context-pack.py scripts/ops/posthog-product-dashboard-summary.py`
- `bash run-tests.sh --filter AnalyticsEventPolicy`
- `bash run-tests.sh --filter AnalyticsPayloadSanitizer`
- `swift test --package-path Tools/TranscriptedMCP`
- `python3 scripts/ops/posthog-product-context-pack.py --self-test`
- `python3 scripts/ops/posthog-dashboard-queries.py --family feature_adoption --dry-run`
- `python3 scripts/ops/posthog-product-dashboard-summary.py --self-test`
- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh`
- `bash run-integration-smoke.sh`
- `bash scripts/dev/agent-preflight.sh`
- `python3 scripts/dev/check-build-source-lists.py && bash -n run-tests.sh && bash -n scripts/entrypoints/run-tests.sh`
- `python3 scripts/ops/posthog-dashboard-queries.py --self-test`
- `python3 scripts/ops/posthog-product-context-pack.py --fixture Tests/Fixtures/posthog-product-context-pack-fixture.json --write-dir build/posthog-product-context-sample`
- `python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json --json-only`
- `codex review --base origin/main` clean: no discrete actionable bugs found.

## Lanes
lanes used: Codex=implementation, verification, codex review, draft PR; Claude=skipped, Codex review was the independent reasoning lane; Local=trigger scan attempted but could not read repo, proof `/Users/redbars/.codex/maestro/runs/20260621T140934Z-posthog-trigger-map-local`, review attempt also could not read repo, proof `/Users/redbars/.codex/maestro/runs/20260621T143811Z-review-c752-telemetry-local`; Windows=trigger scan attempted but output was not trusted, proof `/Users/redbars/.codex/maestro/runs/20260621T140934Z-posthog-trigger-map-windows`.

Do not merge yet. This is a draft for review.