### PR TITLE
Clarify PostHog agent query proof

### DIFF
--- a/docs/posthog-100-wau-dashboard.md
+++ b/docs/posthog-100-wau-dashboard.md
@@ -20,7 +20,7 @@ proof. Treat those as point-in-time inputs, not timeless product truth.
   last 7 days: `activation_first_artifact_saved`, `dictation_completed`,
   `meeting_transcript_saved`, `activation_artifact_action_clicked`,
   `activation_agent_prompt_action_clicked`, `activation_return_proxy_observed`,
-  or future `agent_capture_query_observed`.
+  or `agent_capture_query_observed`.
 - **Strict activation:** launch -> permission/onboarding ready -> first saved
   Markdown -> agent-use proof -> return.
 - **Proxy activation:** launch -> saved Markdown or dictation completion ->
@@ -32,12 +32,12 @@ Do not collapse launch, proxy activation, and strict activation into one number.
 
 | Dashboard | Product question | Existing events to use | Missing events needed |
 | --- | --- | --- | --- |
-| 100 WAU operating dashboard | Are weekly active devices growing toward 100, and are they getting value? | `app_launched`, `activation_first_artifact_saved`, `dictation_completed`, `meeting_transcript_saved`, `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_return_proxy_observed`; group by default `app_version`, `build_version`, `os_major` | `agent_capture_query_observed`; optional `weekly_value_summary_observed` only if it stays aggregate and bucketed |
-| Activation funnel | Where does first value leak? | `app_launched`, `onboarding_shown`, `onboarding_step_viewed`, `onboarding_permission_status_changed`, `onboarding_completed`, `onboarding_first_dictation_started`, `onboarding_first_dictation_saved`, `activation_first_artifact_saved`, `meeting_transcript_saved`, `dictation_completed`, `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_agent_setup_cta_clicked`, `onboarding_agent_cta_clicked`, `activation_return_proxy_observed` | `agent_capture_query_observed`; general dictation saved-artifact event if `dictation_completed` proves too loose |
+| 100 WAU operating dashboard | Are weekly active devices growing toward 100, and are they getting value? | `app_launched`, `activation_first_artifact_saved`, `dictation_completed`, `meeting_transcript_saved`, `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_return_proxy_observed`, `agent_capture_query_observed`; group by default `app_version`, `build_version`, `os_major` | optional `weekly_value_summary_observed` only if it stays aggregate and bucketed |
+| Activation funnel | Where does first value leak? | `app_launched`, `onboarding_shown`, `onboarding_step_viewed`, `onboarding_permission_status_changed`, `onboarding_completed`, `onboarding_first_dictation_started`, `onboarding_first_dictation_saved`, `activation_first_artifact_saved`, `meeting_transcript_saved`, `dictation_completed`, `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_agent_setup_cta_clicked`, `onboarding_agent_cta_clicked`, `activation_return_proxy_observed`, `agent_capture_query_observed` | general dictation saved-artifact event if `dictation_completed` proves too loose |
 | Dictation reliability funnel | Do users who start dictation reach usable text without painful recovery? | `dictation_started`, `dictation_start_failed`, `dictation_completed`, `dictation_stop_latency_measured`, `dictation_cancelled`, `dictation_no_speech`, `dictation_audio_route_changed`, `dictation_audio_route_recovery_finished`, `dictation_audio_route_recovery_timeout` | Dedicated `dictation_saved_markdown` only if needed to separate completion from persisted artifact |
 | Meeting reliability funnel | Do meeting captures start, retain audio, transcribe, and save? | `meeting_prompt_shown`, `meeting_prompt_record_selected`, `meeting_prompt_dismissed`, `meeting_prompt_suppressed`, `meeting_recording_started`, `meeting_recording_start_failed`, `meeting_recording_stopped`, `meeting_capture_health_snapshot`, `meeting_transcript_saved`, `meeting_transcript_failed`, `meeting_transcript_skipped`, `meeting_saved_audio_retranscription_requested`, `meeting_mic_boost_prompt_shown`, `meeting_mic_boost_prompt_actioned`, `meeting_file_imported`, `meeting_file_import_failed`, `meeting_speaker_finalization_failed` | `meeting_opened_after_save` if Home/open behavior needs stricter proof than artifact-action clicks |
 | Local summary beta funnel | Are beta summaries discoverable, prepared, run, and useful? | `settings_page_viewed`, `settings_action_clicked`, `settings_toggle_changed`; filter `page_id = 'beta'` and action/setting ids such as local summary prepare actions | `local_summary_requested`, `local_summary_started`, `local_summary_completed`, `local_summary_failed`, `local_summary_opened`; keep model/provider/status/failure as enums only |
-| Agent/Markdown value loop | Does saved Markdown become a useful agent answer and later return? | `activation_first_artifact_saved`, `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_agent_setup_cta_clicked`, `onboarding_agent_cta_clicked`, `activation_return_proxy_observed`, `meeting_transcript_saved`, `dictation_completed` | `agent_capture_query_observed` as the first true sourced-agent-use proof; maybe `agent_answer_returned_observed` only if implemented through local MCP/tool invocation metadata, never content |
+| Agent/Markdown value loop | Does saved Markdown become a useful agent answer and later return? | `activation_first_artifact_saved`, `activation_artifact_action_clicked`, `activation_agent_prompt_action_clicked`, `activation_agent_setup_cta_clicked`, `onboarding_agent_cta_clicked`, `activation_return_proxy_observed`, `agent_capture_query_observed`, `meeting_transcript_saved`, `dictation_completed` | maybe `agent_answer_returned_observed` only if implemented through local MCP/tool invocation metadata, never content |
 | Release health by app version | Did a release improve activation without hurting reliability? | All dashboard events grouped by default `app_version` and `build_version`; update events: `update_check_finished`, `update_download_started`, `update_download_finished`, `update_ready_to_install`, `update_relaunching`, `update_installed`; runtime events: `app_unclean_shutdown_detected`, `app_session_stall_detected` | None for the first dashboard. Add only coarse release-readiness enums if Sentry/PostHog release reviews need a stable join key later |
 
 ## PostHog Objects
@@ -55,7 +55,7 @@ Create these as saved PostHog insights, then collect them into one dashboard.
 2. **Activation funnel**
    - Funnel: `app_launched` -> onboarding touched -> `onboarding_completed` ->
      saved Markdown/proxy -> artifact action or agent prompt -> return proxy ->
-     future `agent_capture_query_observed`.
+     `agent_capture_query_observed`.
    - Use `scripts/ops/posthog-activation-funnel.py --days 30` for the
      aggregate report and proxy-vs-proof read.
    - Show strict saved Markdown separately from dictation-completed proxy.
@@ -87,9 +87,9 @@ Create these as saved PostHog insights, then collect them into one dashboard.
 6. **Agent/Markdown value loop**
    - Trend saved artifacts, artifact actions, agent prompt/setup actions, and
      return proxies together.
-   - Primary missing proof: `agent_capture_query_observed`.
-   - Until that exists, label this dashboard as proxy evidence, not proof that
-     an agent answered from Transcripted files.
+   - Primary proof: `agent_capture_query_observed`.
+   - Label setup/prompt clicks as proxy evidence; even agent-query rows prove a
+     saved-capture read/search, not answer quality.
 
 7. **Release health by app version**
    - Compare launch WAU, value WAU, activation conversion, dictation completion,
@@ -105,7 +105,6 @@ events.
 
 | Event | Purpose | Allowed properties |
 | --- | --- | --- |
-| `agent_capture_query_observed` | Prove the first sourced agent query against saved captures. | `agent_target`, `artifact_kind`, `surface`, `result`, `query_age_bucket`, `source_count_bucket` |
 | `local_summary_requested` | Count user intent to summarize a meeting. | `surface`, `provider`, `transcript_age_bucket`, `duration_bucket`, `word_count_bucket` |
 | `local_summary_started` | Separate queued/prep friction from generation failures. | `surface`, `provider`, `runtime`, `profile`, `transcript_age_bucket`, `duration_bucket`, `word_count_bucket` |
 | `local_summary_completed` | Count successful local summary artifacts. | `surface`, `provider`, `runtime`, `profile`, `duration_bucket`, `word_count_bucket`, `summary_latency_bucket` |
@@ -126,6 +125,7 @@ events.
 
 ## Smallest Next Action
 
-Build the PostHog dashboard from existing events first. Then add
-`agent_capture_query_observed` as the next instrumentation slice, because that
-is the biggest gap between artifact volume and true product value.
+Build the PostHog dashboard from existing events first. Then verify
+`agent_capture_query_observed` is reaching live aggregates for current builds,
+because that is now the strongest gap between artifact volume and true product
+value.

--- a/docs/posthog-product-learning-plan.md
+++ b/docs/posthog-product-learning-plan.md
@@ -92,7 +92,6 @@ Operational scripts query aggregate counts only:
 | `activation_second_artifact_saved` | `first_artifact_kind`, `second_artifact_kind`, `days_since_first_bucket`, `surface`, `trigger` |
 | `activation_agent_prompt_action_clicked` | `action_kind`, `agent_target`, `artifact_kind`, `prompt_kind`, `result`, `surface` |
 | `activation_agent_setup_cta_clicked` | `agent_target`, `prior_status`, `result`, `setup_kind`, `surface` |
-| `agent_capture_query_observed` | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket` |
 | `activation_return_proxy_observed` | `prior_artifact_kind`, `proxy_kind`, `return_window_bucket`, `surface` |
 | `workflow_abandoned` | `elapsed_bucket`, `prior_ready_state`, `reason_kind`, `stage`, `surface`, `workflow_kind` |
 | `agent_capture_query_observed` | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket`, `source_count_bucket` |
@@ -193,8 +192,8 @@ aggregate reliability sizing and should not be expanded to raw device names.
 
 ## Biggest Blind Spots
 
-- `agent_capture_query_observed` does not exist yet, so PostHog cannot prove
-  that an agent actually answered from a saved Transcripted artifact.
+- `agent_capture_query_observed` exists in the read-only MCP/agent surface, but
+  PostHog still cannot judge whether the sourced answer was useful.
 - General dictation saved-Markdown writes now have `dictation_artifact_saved`;
   keep `dictation_completed` as completion-volume context, not strict saved-artifact proof.
 - `agent_capture_query_observed` proves successful saved-capture reads/searches
@@ -219,7 +218,6 @@ Prefer a small number of lifecycle events over broad click tracking.
 
 | Event | When to fire | Properties |
 | --- | --- | --- |
-| `agent_capture_query_observed` | The local MCP/agent layer observes a privacy-safe query against saved captures | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket` |
 | `agent_capture_query_observed` | The local MCP/agent layer observes a privacy-safe query against saved captures | `agent_target`, `query_kind`, `artifact_kind`, `result`, `surface`, `return_window_bucket`, `capture_age_bucket`, `source_count_bucket` |
 | `activation_second_artifact_saved` | A device saves its second artifact | `first_artifact_kind`, `second_artifact_kind`, `days_since_first_bucket`, `surface`, `trigger` |
 | `dictation_artifact_saved` | Any normal dictation Markdown is durably saved | `delivery`, `duration_bucket`, `save_outcome`, `surface`, `trigger`, `word_count_bucket` |
@@ -352,6 +350,7 @@ prove the full saved-artifact -> sourced-agent-answer -> return loop.
 
 ## Smallest Next Implementation
 
-Keep `agent_capture_query_observed` narrow in the read-only MCP/agent surface:
-only successful saved-capture reads/searches, enum values, and coarse buckets.
-That closes the biggest product-learning gap without inspecting content.
+Keep `agent_capture_query_observed` live and narrow in the read-only MCP/agent
+surface: successful saved-capture reads/searches, enum values, source-count
+buckets, and coarse age/window buckets only. The next useful loop is live-proof
+verification and answer-quality UNKNOWN reporting, not richer content capture.

--- a/scripts/ops/posthog-activation-funnel.py
+++ b/scripts/ops/posthog-activation-funnel.py
@@ -156,8 +156,8 @@ REACH_STEPS = (
         "true_agent_query_devices",
         "True agent-use signal",
         "event = 'agent_capture_query_observed'",
-        "missing",
-        "Desired future privacy-safe event for the first sourced agent query/answer loop.",
+        "observed",
+        "Privacy-safe saved-capture read/search signal for the first sourced agent-use loop.",
     ),
     StepDefinition(
         "workflow_abandonment_devices",
@@ -515,7 +515,7 @@ def render_report(data: dict[str, Any]) -> str:
         "`dictation_artifact_saved`, `dictation_completed`, `onboarding_first_dictation_saved`, and `meeting_transcript_saved` are included only in the broader proxy row for dictation volume and legacy continuity.",
         "Agent setup and prompt-copy events prove intent. They do not prove the user asked an agent a sourced question or got a useful answer.",
         "`activation_second_artifact_saved` proves a second durable artifact save on the same anonymous device, but does not inspect artifact content or join identity.",
-        "`agent_capture_query_observed` is the desired true first-agent-use signal and is currently expected to be zero until instrumentation exists.",
+        "`agent_capture_query_observed` is the strongest current true-agent-use signal, but it still only proves a saved-capture read/search, not answer quality.",
         "`workflow_abandoned` is a conservative exit map. It should not be read as every possible drop-off or every click.",
     ]
 
@@ -527,7 +527,7 @@ def render_report(data: dict[str, Any]) -> str:
         "Agent bridge: setup kind, agent target, prompt kind, result, and surface.",
         "Abandonment exits: workflow kind, stage, reason kind, surface, and prior-ready state.",
         "Return loop: `activation_return_proxy_observed` by return-window bucket.",
-        "Data quality: missing true-agent-use event and the dictation completion-vs-saved-artifact split.",
+        "Data quality: true-agent-use event volume, answer-quality UNKNOWNs, and the dictation completion-vs-saved-artifact split.",
     ]
 
     lines = [
@@ -547,7 +547,7 @@ def render_report(data: dict[str, Any]) -> str:
         f"- Agent setup/proxy reach: **{agent_signal} devices** ({pct(agent_signal, launch)} of launch).",
         f"- Return proxy reach: **{return_proxy} devices** ({pct(return_proxy, launch)} of launch).",
         f"- Workflow abandonment exits: **{workflow_abandonment} devices** ({pct(workflow_abandonment, launch)} of launch).",
-        f"- True agent-query proof: **{true_agent_query} devices**. Treat this as unknown, not green, until instrumentation exists.",
+        f"- True agent-query proof: **{true_agent_query} devices**. Treat zero as no live proof in this window, not proof the loop is broken.",
         "",
         "## Funnel Reach",
         "",
@@ -614,7 +614,7 @@ def render_report(data: dict[str, Any]) -> str:
         "",
         "## Next Best Action",
         "",
-        "Verify `activation_first_artifact_saved` and `activation_second_artifact_saved` reach live PostHog for current builds, then add `agent_capture_query_observed` so the dashboard can separate repeated saved-artifact value from true sourced-agent-use.",
+        "Verify `activation_first_artifact_saved`, `activation_second_artifact_saved`, and `agent_capture_query_observed` reach live PostHog for current builds, then use the agent-query rows to separate repeated saved-artifact value from true sourced-agent-use.",
         "",
     ]
     return "\n".join(lines)

--- a/scripts/ops/posthog-product-context-pack.py
+++ b/scripts/ops/posthog-product-context-pack.py
@@ -400,7 +400,7 @@ def build_context_pack(data: dict[str, Any]) -> dict[str, Any]:
     if launch <= 0:
         unknowns.append(UnknownReason("activation.bottleneck", "No launch devices were available for the selected window."))
     if true_agent_query == 0:
-        unknowns.append(UnknownReason("activation.true_agent_use", "`agent_capture_query_observed` is missing or zero; prompt/setup clicks are intent proxies only."))
+        unknowns.append(UnknownReason("activation.true_agent_use", "`agent_capture_query_observed` is zero in this window; prompt/setup clicks are intent proxies only."))
 
     artifact_rate = pct(first_artifact, launch)
     prompt_rate = pct(agent_prompt, first_artifact)
@@ -575,9 +575,9 @@ def build_recommendations(
     elif true_agent_query == 0:
         recs.append({
             "rank": len(recs) + 1,
-            "title": "Add privacy-safe sourced-agent-use proof",
-            "why": "`agent_capture_query_observed` is missing or zero, so agents still cannot tell whether saved Markdown produced a sourced answer.",
-            "suggested_pr": "Emit aggregate-only `agent_capture_query_observed` from the read-only MCP/agent surface with enum result, query kind, agent target, artifact kind, and age buckets.",
+            "title": "Verify privacy-safe sourced-agent-use proof",
+            "why": "`agent_capture_query_observed` is zero in this window, so agents still cannot tell from live aggregates whether saved Markdown produced a sourced answer.",
+            "suggested_pr": "Verify the read-only MCP/agent surface is emitting aggregate-only `agent_capture_query_observed` rows for current builds, with enum result, query kind, agent target, artifact kind, and age buckets.",
         })
     elif launch > 0 and first_artifact / launch < 0.2:
         recs.append({
@@ -680,7 +680,7 @@ def render_markdown(pack: dict[str, Any]) -> str:
         f"- Launch devices: {pack['activation'].get('launch_devices')}",
         f"- First artifact devices: {pack['activation'].get('first_artifact_devices')} ({md_value(pack['activation'].get('first_artifact_rate_pct'))} of launch)",
         f"- Agent prompt devices: {pack['activation'].get('agent_prompt_devices')} ({md_value(pack['activation'].get('agent_prompt_per_first_artifact_pct'))} of first artifact)",
-        f"- True agent-query devices: {pack['activation'].get('true_agent_query_devices')} (UNKNOWN if zero because the event may not exist yet)",
+        f"- True agent-query devices: {pack['activation'].get('true_agent_query_devices')} (UNKNOWN if zero in this window)",
         f"- Return proxy devices: {pack['activation'].get('return_proxy_devices')} ({md_value(pack['activation'].get('return_proxy_per_first_artifact_pct'))} of first artifact)",
         "",
         "## Recommended Next PRs",

--- a/scripts/ops/posthog-product-dashboard-summary.py
+++ b/scripts/ops/posthog-product-dashboard-summary.py
@@ -563,7 +563,7 @@ def render_markdown(data: dict[str, Any], findings: dict[str, Finding]) -> str:
         "## Privacy Boundary",
         "",
         "- Aggregate only. No raw rows or user-level forensics.",
-        "- Treat agent setup, prompt copy, and return events as proxies until `agent_capture_query_observed` exists.",
+        "- Treat agent setup, prompt copy, and return events as proxies; `agent_capture_query_observed` is the stronger saved-capture query proof, but not answer-quality proof.",
         "",
     ])
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- update PostHog plan docs now that `agent_capture_query_observed` exists in the MCP/agent surface
- adjust activation funnel and product-context reports to treat zero agent-query rows as live-data UNKNOWN, not missing instrumentation
- keep answer-quality proof explicitly UNKNOWN and preserve aggregate-only privacy wording

## Checks
- `git diff --check`
- `bash scripts/dev/agent-preflight.sh`
- `python3 -m py_compile scripts/ops/posthog-activation-funnel.py scripts/ops/posthog-product-context-pack.py scripts/ops/posthog-product-dashboard-summary.py`
- `python3 scripts/ops/posthog-activation-funnel.py --self-test`
- `python3 scripts/ops/posthog-product-context-pack.py --self-test`
- `python3 scripts/ops/posthog-product-context-pack.py --fixture Tests/Fixtures/posthog-product-context-pack-fixture.json --write-dir build/posthog-product-context-sample`
- `python3 scripts/ops/posthog-product-dashboard-summary.py --self-test`
- `python3 scripts/ops/posthog-product-dashboard-summary.py --fixture Tests/Fixtures/posthog-product-dashboard-summary.json --json-only`
- stale-text scan for future/missing `agent_capture_query_observed` wording

## Notes
- Swift app code was not touched, so `bash build.sh --no-open` and `bash run-tests.sh` were not required by `.agents/test-matrix.yml`.
- Local lane proof path: `/Users/redbars/.codex/maestro/runs/20260621T202124Z-posthog-truthfulness-review-local`, but that lane returned generic guidance; Codex final review/checks are the real proof.