### PR TITLE
Polish menubar interaction targets

### DIFF
--- a/Sources/UI/MenuBar/MenuBarActionRowView.swift
+++ b/Sources/UI/MenuBar/MenuBarActionRowView.swift
@@ -205,14 +205,15 @@ final class MenuBarActionRowView: NSControl {
             titleLabel.frame = NSRect(x: textX, y: centeredY, width: textWidth, height: 16)
             detailLabel.frame = .zero
         } else {
-            let titleY: CGFloat = 1
+            let textBlockHeight: CGFloat = 30
+            let titleY = floor((bounds.height - textBlockHeight) / 2)
             titleLabel.frame = NSRect(x: textX, y: titleY, width: textWidth, height: 16)
             detailLabel.frame = NSRect(x: textX, y: titleLabel.frame.maxY + 1, width: textWidth, height: 13)
         }
 
         if trailingWidth > 0 {
             let trailingX = bounds.width - padX - trailingWidth
-            let trailingY = hasDetail ? 2 : (bounds.height - 14) / 2
+            let trailingY = hasDetail ? titleLabel.frame.minY + 1 : (bounds.height - 14) / 2
             trailingLabel.frame = NSRect(x: trailingX, y: trailingY, width: trailingWidth, height: 14)
         }
     }
@@ -234,9 +235,9 @@ final class MenuBarActionRowView: NSControl {
         let hasDetail = !detailLabel.stringValue.isEmpty
         switch rowSize {
         case .primary:
-            return hasDetail ? MenuTokens.compactActionRowHeight : 24
+            return hasDetail ? MenuTokens.compactActionRowHeight : MenuTokens.minimumHitTargetSize
         case .utility:
-            return hasDetail ? 28 : 24
+            return hasDetail ? MenuTokens.utilityActionRowHeight : MenuTokens.minimumHitTargetSize
         }
     }
 

--- a/Sources/UI/MenuBar/MenuBarModelStatusView.swift
+++ b/Sources/UI/MenuBar/MenuBarModelStatusView.swift
@@ -25,6 +25,9 @@ final class MenuBarModelStatusView: NSControl {
     override var isFlipped: Bool { true }
 
     private func setupViews() {
+        setAccessibilityElement(true)
+        setAccessibilityRole(.button)
+
         wantsLayer = true
         layer?.cornerRadius = 8
         layer?.backgroundColor = NSColor.clear.cgColor
@@ -33,7 +36,7 @@ final class MenuBarModelStatusView: NSControl {
         statusDot.layer?.cornerRadius = MenuTokens.statusDotSize / 2
         addSubview(statusDot)
 
-        label.font = NSFont.systemFont(ofSize: 11, weight: .medium)
+        label.font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .medium)
         label.textColor = MenuTokens.textSecondaryNS
         label.lineBreakMode = .byTruncatingTail
         label.cell?.usesSingleLineMode = true
@@ -87,6 +90,7 @@ final class MenuBarModelStatusView: NSControl {
         currentState = state
         applyState()
         needsLayout = true
+        window?.invalidateCursorRects(for: self)
     }
 
     private func applyState() {
@@ -118,6 +122,14 @@ final class MenuBarModelStatusView: NSControl {
             label.stringValue = "Parakeet TDT V3 · Needs retry"
             toolTip = "Local model failed. Open Models settings to retry the download."
         }
+        setAccessibilityLabel("Local model status")
+        setAccessibilityValue(label.stringValue)
+        setAccessibilityHelp(toolTip)
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        addCursorRect(bounds, cursor: .pointingHand)
     }
 
     override func mouseEntered(with event: NSEvent) {
@@ -141,7 +153,12 @@ final class MenuBarModelStatusView: NSControl {
         }
     }
 
-    var intrinsicHeight: CGFloat { 26 }
+    var intrinsicHeight: CGFloat { MenuTokens.minimumHitTargetSize }
 
     override var acceptsFirstResponder: Bool { true }
+
+    override func accessibilityPerformPress() -> Bool {
+        onOpenSettings?()
+        return true
+    }
 }

--- a/Sources/UI/MenuBar/MenuIconButton.swift
+++ b/Sources/UI/MenuBar/MenuIconButton.swift
@@ -91,8 +91,23 @@ final class MenuIconButton: NSButton {
 
         layer?.backgroundColor = backgroundColor.cgColor
         layer?.borderColor = borderColor.cgColor
+        layer?.transform = isPressing
+            ? CATransform3DMakeScale(0.96, 0.96, 1)
+            : CATransform3DIdentity
         contentTintColor = iconTint
         alphaValue = isEnabled ? 1.0 : 0.55
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard isEnabled, !isHidden, alphaValue > 0.01 else { return nil }
+        let localPoint = convert(point, from: superview)
+        return minimumHitBounds.contains(localPoint) ? self : nil
+    }
+
+    private var minimumHitBounds: NSRect {
+        let horizontalInset = max(0, (MenuTokens.minimumHitTargetSize - bounds.width) / 2)
+        let verticalInset = max(0, (MenuTokens.minimumHitTargetSize - bounds.height) / 2)
+        return bounds.insetBy(dx: -horizontalInset, dy: -verticalInset)
     }
 
     override func updateTrackingAreas() {
@@ -121,7 +136,23 @@ final class MenuIconButton: NSButton {
     override func mouseDown(with event: NSEvent) {
         guard isEnabled else { return }
         isPressing = true
-        super.mouseDown(with: event)
+        let shouldPerformClick = trackPressInMinimumHitBounds()
         isPressing = false
+        if shouldPerformClick, let action {
+            NSApp.sendAction(action, to: target, from: self)
+        }
+    }
+
+    private func trackPressInMinimumHitBounds() -> Bool {
+        while let nextEvent = window?.nextEvent(matching: [.leftMouseDragged, .leftMouseUp]) {
+            let point = convert(nextEvent.locationInWindow, from: nil)
+            let isInside = minimumHitBounds.contains(point)
+            isPressing = isInside
+
+            if nextEvent.type == .leftMouseUp {
+                return isInside
+            }
+        }
+        return false
     }
 }

--- a/Sources/UI/MenuBar/MenuOutlineButton.swift
+++ b/Sources/UI/MenuBar/MenuOutlineButton.swift
@@ -143,9 +143,24 @@ final class MenuOutlineButton: NSButton {
 
         layer?.backgroundColor = backgroundColor.cgColor
         layer?.borderColor = borderColor.cgColor
+        layer?.transform = isPressing
+            ? CATransform3DMakeScale(0.96, 0.96, 1)
+            : CATransform3DIdentity
         contentTintColor = contentColor
         alphaValue = isEnabled ? 1.0 : 0.55
         updateTitleAppearance(contentColor: contentColor)
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard isEnabled, !isHidden, alphaValue > 0.01 else { return nil }
+        let localPoint = convert(point, from: superview)
+        return minimumHitBounds.contains(localPoint) ? self : nil
+    }
+
+    private var minimumHitBounds: NSRect {
+        let horizontalInset = max(0, (MenuTokens.minimumHitTargetSize - bounds.width) / 2)
+        let verticalInset = max(0, (MenuTokens.minimumHitTargetSize - bounds.height) / 2)
+        return bounds.insetBy(dx: -horizontalInset, dy: -verticalInset)
     }
 
     override func updateTrackingAreas() {
@@ -174,7 +189,23 @@ final class MenuOutlineButton: NSButton {
     override func mouseDown(with event: NSEvent) {
         guard isEnabled else { return }
         isPressing = true
-        super.mouseDown(with: event)
+        let shouldPerformClick = trackPressInMinimumHitBounds()
         isPressing = false
+        if shouldPerformClick, let action {
+            NSApp.sendAction(action, to: target, from: self)
+        }
+    }
+
+    private func trackPressInMinimumHitBounds() -> Bool {
+        while let nextEvent = window?.nextEvent(matching: [.leftMouseDragged, .leftMouseUp]) {
+            let point = convert(nextEvent.locationInWindow, from: nil)
+            let isInside = minimumHitBounds.contains(point)
+            isPressing = isInside
+
+            if nextEvent.type == .leftMouseUp {
+                return isInside
+            }
+        }
+        return false
     }
 }

--- a/Sources/UI/MenuBar/MenuTokens.swift
+++ b/Sources/UI/MenuBar/MenuTokens.swift
@@ -70,12 +70,14 @@ enum MenuTokens {
     static let sectionSpacing: CGFloat = 7
     static let surfaceCornerRadius: CGFloat = 14
     static let cardCornerRadius: CGFloat = 8
-    static let compactActionRowHeight: CGFloat = 30
+    static let minimumHitTargetSize: CGFloat = 40
+    static let compactActionRowHeight: CGFloat = 42
+    static let utilityActionRowHeight: CGFloat = 40
     static let actionRowHeight: CGFloat = 46
     static let savedRowHeight: CGFloat = 54
     static let badgeHeight: CGFloat = 22
-    static let secondaryButtonSize: CGFloat = 28
-    static let secondaryButtonCornerRadius: CGFloat = 8
+    static let secondaryButtonSize: CGFloat = 32
+    static let secondaryButtonCornerRadius: CGFloat = 10
     static let secondaryButtonIconPointSize: CGFloat = 11
     static let symbolWellSize: CGFloat = 26
     static let statusDotSize: CGFloat = 6

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -59,6 +59,41 @@ func testUIAutomationSurfaceContract() {
 
     }
 
+    runSuite("UI automation surface contract - menubar controls keep polished hit targets") {
+        let tokenSource = readUIAutomationContractFile("Sources/UI/MenuBar/MenuTokens.swift")
+        let actionRowSource = readUIAutomationContractFile("Sources/UI/MenuBar/MenuBarActionRowView.swift")
+        let iconButtonSource = readUIAutomationContractFile("Sources/UI/MenuBar/MenuIconButton.swift")
+        let outlineButtonSource = readUIAutomationContractFile("Sources/UI/MenuBar/MenuOutlineButton.swift")
+        let modelStatusSource = readUIAutomationContractFile("Sources/UI/MenuBar/MenuBarModelStatusView.swift")
+
+        assertTrue(
+            tokenSource.contains("minimumHitTargetSize: CGFloat = 40")
+                && actionRowSource.contains("MenuTokens.minimumHitTargetSize"),
+            "menubar rows should stay at or above the 40px minimum hit target"
+        )
+
+        for source in [iconButtonSource, outlineButtonSource] {
+            assertTrue(
+                source.contains("override func hitTest(_ point: NSPoint)")
+                    && source.contains("let localPoint = convert(point, from: superview)")
+                    && source.contains("minimumHitBounds.contains(localPoint)")
+                    && source.contains("trackPressInMinimumHitBounds()")
+                    && source.contains("NSApp.sendAction(action, to: target, from: self)")
+                    && source.contains("CATransform3DMakeScale(0.96, 0.96, 1)"),
+                "small menubar buttons should keep expanded hit testing and subtle 0.96 press feedback"
+            )
+        }
+
+        assertTrue(
+            modelStatusSource.contains("NSFont.monospacedDigitSystemFont")
+                && modelStatusSource.contains("setAccessibilityRole(.button)")
+                && modelStatusSource.contains("setAccessibilityValue(label.stringValue)")
+                && modelStatusSource.contains("override func resetCursorRects()")
+                && modelStatusSource.contains("override func accessibilityPerformPress()"),
+            "menubar model status should keep tabular progress digits and a real AX button contract"
+        )
+    }
+
     runSuite("UI automation surface contract - app commands expose capture shortcuts") {
         let commandsSource = readUIAutomationContractFile("Sources/TranscriptedMenuCommands.swift")
 


### PR DESCRIPTION
## Summary
- Raise menubar row and secondary control targets to the 40px minimum from the interface polish audit.
- Add real expanded hit testing plus subtle 0.96 press feedback for compact menubar icon/outline buttons.
- Give the local model status badge tabular progress digits and a real AX button contract.

## Audit Matrix
- Canonical Sheet: https://docs.google.com/spreadsheets/d/1EAIVrLGERtxp9ApO4tHSuUpecFReOoKQVafS3wLE4KQ/edit
- 167 interactions inventoried across onboarding, menu bar, dictation, Home, meetings, speaker review, local summary beta, settings, storage, updates, observability, support, and cross-cutting states.

## Verification
- git diff --check
- bash build-deps.sh --force (dependency recovery earlier in run)
- bash build.sh --no-open
- bash run-tests.sh --filter testUIAutomationSurfaceContract
- bash run-tests.sh (10,512 passed)
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa permission-state --mode computer-use (11 pass, 1 warning: System Events automation OSStatus -600; screenshot/click proof remains manual)

## Review / lanes
- Codex review helper: first pass found the dead-halo hit-test issue; final retry hung in plugin startup and was terminated without a clean verdict.
- Claude design critique: /Users/redbars/.codex/maestro/runs/20260621T201730Z-interface-design-critique-claude
- Claude independent code review: /Users/redbars/.codex/maestro/runs/20260621T204709Z-menubar-polish-code-review-claude
- Claude re-review after fix: /Users/redbars/.codex/maestro/runs/20260621T205356Z-menubar-polish-code-rereview-claude
- Local clustering attempt: /Users/redbars/.codex/maestro/runs/20260621T201730Z-interface-cluster-local (low-signal, not trusted)
- Windows inventory attempt: /Users/redbars/.codex/maestro/runs/20260621T201730Z-interface-inventory-windows (low-signal, not trusted)

## Release
- No release, tag, notarization, appcast/Homebrew, web deploy, or merge actions.