### PR TITLE
Apply tabular digits to UI counters

### DIFF
--- a/Sources/UI/Settings/AgentConnectionSettingsPage.swift
+++ b/Sources/UI/Settings/AgentConnectionSettingsPage.swift
@@ -136,6 +136,7 @@ struct AgentConnectionSettingsPage: View {
             if agent == .claudeDesktop, let claudeDesktopSelfTest {
                 Text("\(claudeDesktopSelfTest.meetingFileCount) meetings, \(claudeDesktopSelfTest.dictationFileCount) dictation files visible.")
                     .font(.caption)
+                    .monospacedDigit()
                     .foregroundStyle(.secondary)
             }
         }

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -652,6 +652,7 @@ private struct HomeStatsDetailMetric: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(stat.value)
                     .font(.system(size: 20, weight: .semibold))
+                    .monospacedDigit()
                     .foregroundStyle(Color.primary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -769,6 +769,7 @@ private struct SpeakerVoiceToNameRow: View {
 
                     Text(metaLine)
                         .font(.caption)
+                        .monospacedDigit()
                         .foregroundStyle(.secondary)
                         .lineLimit(2)
                 }
@@ -1014,6 +1015,7 @@ private struct SpeakerDuplicateCandidateRow: View {
 
                 Text(candidate.summaryLine)
                     .font(.caption)
+                    .monospacedDigit()
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -1162,6 +1164,7 @@ private struct SpeakerPersonRow: View {
 
                     Text(metadataLine)
                         .font(.caption)
+                        .monospacedDigit()
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }


### PR DESCRIPTION
## Summary
- Applies tabular digit rendering to prominent Home stats values.
- Applies tabular digit rendering to count-led Agent Connection self-test text.
- Applies tabular digit rendering to speaker metadata/count summary rows.

## Interface Feel Better Proof
| Principle | Before | After |
| --- | --- | --- |
| Tabular numbers for dynamic counters/stats/durations | Count and stat labels could use proportional digit widths, causing subtle visual shimmer as values change. | Home stats, Agent Connection self-test counts, and speaker metadata summaries now use SwiftUI `.monospacedDigit()` where the content is count-led or stat-led. |
| Tasteful native adaptation | A broader first pass tried applying tabular digits to generic settings rows too. | Claude review caught that generic rows often show prose like model names or status words, so those modifiers were removed before commit. |

## Tests
- `git diff --check`
- `bash run-tests.sh --filter testHomeStatsPresentation` — 4 passed
- `bash build.sh --no-open` — passed, including signature, launch smoke, performance budget
- `bash run-tests.sh` — 10508 passed, 0 failed

## Independent Review
- Claude review via Maestro: `/Users/redbars/.codex/maestro/runs/20260622T013150Z-tabular-digits-code-review-claude`
- Finding addressed before commit: removed `.monospacedDigit()` from generic shared settings rows because most values are non-numeric prose.

## Audit Matrix
- Canonical sheet: https://docs.google.com/spreadsheets/d/1EAIVrLGERtxp9ApO4tHSuUpecFReOoKQVafS3wLE4KQ/edit
- Rows to update after PR creation: Home stats row, Agent/MCP visible-count row, speaker metadata/count rows, dynamic counter sweep row.

No merge, release, tag, notarization, appcast, Homebrew, or deploy work performed.