### PR TITLE
Polish onboarding first-run controls

### DIFF
--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -1023,6 +1023,7 @@ private struct NavBar: View {
                 Text("← Back")
                     .font(.system(size: 13))
                     .foregroundStyle(OnboardingTheme.muted)
+                    .frame(minWidth: CGFloat(FirstRunOnboardingPolishContract.minimumHitTarget), minHeight: CGFloat(FirstRunOnboardingPolishContract.minimumHitTarget))
             }
             .buttonStyle(.plain)
             .opacity(canGoBack ? 1 : 0)
@@ -1038,6 +1039,7 @@ private struct NavBar: View {
                 .font(.system(size: 13))
                 .buttonStyle(.plain)
                 .foregroundStyle(OnboardingTheme.muted)
+                .frame(minHeight: CGFloat(FirstRunOnboardingPolishContract.minimumHitTarget))
                 .accessibilityIdentifier("transcripted.onboarding.nav.skip")
             }
 
@@ -1146,6 +1148,7 @@ private struct Headline: View {
         .foregroundStyle(OnboardingTheme.ink)
         .multilineTextAlignment(alignment)
         .lineLimit(nil)
+        .minimumScaleFactor(0.92)
         .fixedSize(horizontal: false, vertical: true)
     }
 }
@@ -1166,6 +1169,8 @@ private struct Lede: View {
             .foregroundStyle(OnboardingTheme.body)
             .multilineTextAlignment(.center)
             .frame(maxWidth: maxWidth)
+            .lineLimit(FirstRunOnboardingPolishContract.bodyCopyLineLimit)
+            .minimumScaleFactor(0.94)
             .fixedSize(horizontal: false, vertical: true)
     }
 }
@@ -1185,6 +1190,8 @@ private struct BodyCopy: View {
             .lineSpacing(3)
             .foregroundStyle(OnboardingTheme.body)
             .frame(maxWidth: maxWidth, alignment: .leading)
+            .lineLimit(FirstRunOnboardingPolishContract.bodyCopyLineLimit)
+            .minimumScaleFactor(0.94)
             .fixedSize(horizontal: false, vertical: true)
     }
 }
@@ -1285,6 +1292,7 @@ private struct PermissionGrantRow: View {
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 16)
+        .frame(minHeight: CGFloat(FirstRunOnboardingPolishContract.minimumHitTarget))
         .background(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(granted ? OnboardingTheme.ink : OnboardingTheme.card)
@@ -1335,10 +1343,14 @@ private struct UseCaseChoiceCard: View {
                         .font(.system(size: 13.5))
                         .foregroundStyle(OnboardingTheme.body)
                         .lineSpacing(2)
+                        .lineLimit(3)
+                        .minimumScaleFactor(0.94)
                         .fixedSize(horizontal: false, vertical: true)
                     Text(footnote)
                         .font(.system(size: 11.5, weight: .medium))
                         .foregroundStyle(OnboardingTheme.muted)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 Spacer(minLength: 0)
@@ -1349,12 +1361,16 @@ private struct UseCaseChoiceCard: View {
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(isSelected ? OnboardingTheme.ink.opacity(0.45) : OnboardingTheme.border, lineWidth: isSelected ? 1.4 : 1)
+                    .stroke(
+                        isSelected ? OnboardingTheme.ink.opacity(0.62) : OnboardingTheme.border,
+                        lineWidth: isSelected ? CGFloat(FirstRunOnboardingPolishContract.selectedStateStrokeWidth) : 1
+                    )
             )
             .shadow(color: .black.opacity(isSelected ? 0.08 : 0.03), radius: isSelected ? 16 : 8, y: 8)
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier(automationIdentifier)
+        .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 }
 
@@ -1368,6 +1384,8 @@ private struct InkButtonStyle: ButtonStyle {
             .foregroundStyle(isSubtle ? OnboardingTheme.ink : OnboardingTheme.window)
             .padding(.horizontal, compact ? 14 : 22)
             .padding(.vertical, compact ? 8 : 12)
+            .frame(minWidth: CGFloat(compact ? FirstRunOnboardingPolishContract.minimumCompactButtonHeight : FirstRunOnboardingPolishContract.minimumHitTarget))
+            .frame(minHeight: CGFloat(compact ? FirstRunOnboardingPolishContract.minimumCompactButtonHeight : FirstRunOnboardingPolishContract.minimumHitTarget))
             .background(
                 RoundedRectangle(cornerRadius: compact ? 8 : 10, style: .continuous)
                     .fill(isSubtle ? Color.clear : OnboardingTheme.ink)
@@ -1377,6 +1395,8 @@ private struct InkButtonStyle: ButtonStyle {
                     .stroke(isSubtle ? OnboardingTheme.border : Color.clear, lineWidth: 1)
             )
             .opacity(configuration.isPressed ? 0.72 : 1)
+            .scaleEffect(configuration.isPressed ? 0.96 : 1)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
     }
 }
 
@@ -1398,6 +1418,9 @@ private struct BulletList: View {
                     Text(item)
                         .font(.system(size: 13.5))
                         .foregroundStyle(OnboardingTheme.body)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.95)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }
@@ -1747,9 +1770,14 @@ private struct ToggleCard: View {
                 .toggleStyle(.switch)
                 .labelsHidden()
                 .onboardingAutomationIdentifier(automationIdentifier)
+                .frame(
+                    minWidth: CGFloat(FirstRunOnboardingPolishContract.minimumHitTarget),
+                    minHeight: CGFloat(FirstRunOnboardingPolishContract.minimumHitTarget)
+                )
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 16)
+        .frame(minHeight: CGFloat(FirstRunOnboardingPolishContract.minimumHitTarget))
         .background(OnboardingTheme.card)
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay(

--- a/Sources/UI/Settings/TranscriptedSettingsComponents.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsComponents.swift
@@ -536,7 +536,12 @@ struct SettingsStatusCard: View {
 
                 Text(status)
                     .font(.caption.weight(.semibold))
+                    .monospacedDigit()
                     .foregroundStyle(tintColor)
+                    .frame(
+                        minWidth: progress == nil ? 0 : CGFloat(FirstRunOnboardingPolishContract.modelProgressLabelMinimumWidth),
+                        alignment: .trailing
+                    )
             }
 
             Text(detail)
@@ -650,7 +655,12 @@ struct SettingsActivityCard: View {
 
                     Text("\(Int(progress * 100))% complete")
                         .font(.caption2)
+                        .monospacedDigit()
                         .foregroundStyle(.secondary)
+                        .frame(
+                            minWidth: CGFloat(FirstRunOnboardingPolishContract.modelProgressLabelMinimumWidth),
+                            alignment: .leading
+                        )
                 }
             }
 

--- a/Sources/UI/Shared/FirstRunExperience.swift
+++ b/Sources/UI/Shared/FirstRunExperience.swift
@@ -30,6 +30,14 @@ struct FirstRunModelCardState: Equatable {
     let tone: Tone
 }
 
+enum FirstRunOnboardingPolishContract {
+    static let minimumHitTarget: Double = 44
+    static let minimumCompactButtonHeight: Double = 40
+    static let modelProgressLabelMinimumWidth: Double = 104
+    static let selectedStateStrokeWidth: Double = 2
+    static let bodyCopyLineLimit = 3
+}
+
 struct MenuBarPrimaryActionState: Equatable {
     let title: String
     let symbolName: String
@@ -347,10 +355,11 @@ enum FirstRunExperience {
                 tone: .working
             )
         case .downloading(let progress):
+            let percentage = max(0, min(100, Int(progress * 100)))
             return FirstRunModelCardState(
                 title: "Downloading \(model.title)",
                 detail: "\(modelPersistenceDetail(for: model)) Downloading from huggingface.co. Keep Transcripted open; if the download fails, use Retry Download.",
-                status: progress > 0 ? "\(Int(progress * 100))% complete" : "Starting download",
+                status: progress > 0 ? "\(percentage)% complete" : "Starting download",
                 progress: max(0.12, min(0.84, 0.12 + progress * 0.72)),
                 tone: .working
             )

--- a/Tests/FirstRunExperienceTests.swift
+++ b/Tests/FirstRunExperienceTests.swift
@@ -349,6 +349,14 @@ func testFirstRunExperience() {
         assertNotNil(card.progress, "model card should show a progress bar during downloads")
     }
 
+    runSuite("FirstRunExperience.modelCard — clamps displayed download progress") {
+        let belowZero = FirstRunExperience.modelCard(for: .downloading(progress: -0.2))
+        let aboveComplete = FirstRunExperience.modelCard(for: .downloading(progress: 1.3))
+
+        assertEqual(belowZero.status, "Starting download", "negative progress should not render a jumpy negative percentage")
+        assertEqual(aboveComplete.status, "100% complete", "over-complete progress should keep the label bounded")
+    }
+
     runSuite("FirstRunExperience.modelCard — names Parakeet TDT V3 in ready state") {
         let card = FirstRunExperience.modelCard(for: .ready)
 
@@ -399,5 +407,28 @@ func testFirstRunExperience() {
         assertEqual(card.title, "Downloading Whisper Large V3 Turbo", "advanced model card should name Whisper")
         assertTrue(card.detail.contains("~632 MB"), "Whisper Turbo card should show the expected model size")
         assertEqual(card.status, "25% complete", "Whisper card should keep progress behavior")
+    }
+
+    runSuite("FirstRunOnboardingPolishContract — protects first-run polish targets") {
+        assertTrue(
+            FirstRunOnboardingPolishContract.minimumHitTarget >= 40,
+            "onboarding controls should keep at least a 40px hit target"
+        )
+        assertTrue(
+            FirstRunOnboardingPolishContract.minimumCompactButtonHeight >= 40,
+            "compact permission buttons should not shrink below the requested target"
+        )
+        assertTrue(
+            FirstRunOnboardingPolishContract.modelProgressLabelMinimumWidth >= 100,
+            "download progress labels need a stable tabular slot"
+        )
+        assertTrue(
+            FirstRunOnboardingPolishContract.selectedStateStrokeWidth >= 2,
+            "selected cards need a visible state that is not just a faint border"
+        )
+        assertTrue(
+            FirstRunOnboardingPolishContract.bodyCopyLineLimit <= 3,
+            "first-run cards should keep short copy from wrapping into tall blocks"
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Add source-backed onboarding polish constants for 40px+ targets, stable model progress width, selected-state stroke, and short copy wrapping.
- Apply the contract to first-run onboarding controls: nav buttons, permission rows, use-case cards, toggles, copy blocks, and press feedback.
- Clamp displayed model download percentages and render progress labels with monospaced digits/fixed width.

## Tests
- bash run-tests.sh --filter FirstRunExperienceTests
- bash run-tests.sh
- bash build-deps.sh --force
- bash build.sh --no-open
- bash scripts/dev/agent-preflight.sh

## Maestro lanes
lanes used: Codex=implemented, tested, committed, pushed, opened PR; Claude=skipped (small UI polish pass, no risky architecture); Local=attempted scan, low-signal output, proof /Users/redbars/.codex/maestro/runs/20260622T013801Z-onboarding-polish-scan-local; Windows=skipped (Mac SwiftUI/local build proof needed)

Skipped menu bar work already covered by PR #1262.