### PR TITLE
Raise menu bar row hit targets

### DIFF
--- a/Sources/UI/MenuBar/MenuBarActionRowView.swift
+++ b/Sources/UI/MenuBar/MenuBarActionRowView.swift
@@ -205,14 +205,15 @@ final class MenuBarActionRowView: NSControl {
             titleLabel.frame = NSRect(x: textX, y: centeredY, width: textWidth, height: 16)
             detailLabel.frame = .zero
         } else {
-            let titleY: CGFloat = 1
+            let contentHeight: CGFloat = 30
+            let titleY = floor((bounds.height - contentHeight) / 2)
             titleLabel.frame = NSRect(x: textX, y: titleY, width: textWidth, height: 16)
             detailLabel.frame = NSRect(x: textX, y: titleLabel.frame.maxY + 1, width: textWidth, height: 13)
         }
 
         if trailingWidth > 0 {
             let trailingX = bounds.width - padX - trailingWidth
-            let trailingY = hasDetail ? 2 : (bounds.height - 14) / 2
+            let trailingY = floor((bounds.height - 14) / 2)
             trailingLabel.frame = NSRect(x: trailingX, y: trailingY, width: trailingWidth, height: 14)
         }
     }
@@ -234,9 +235,9 @@ final class MenuBarActionRowView: NSControl {
         let hasDetail = !detailLabel.stringValue.isEmpty
         switch rowSize {
         case .primary:
-            return hasDetail ? MenuTokens.compactActionRowHeight : 24
+            return hasDetail ? MenuTokens.actionRowHeight : MenuTokens.minimumActionHitTarget
         case .utility:
-            return hasDetail ? 28 : 24
+            return hasDetail ? MenuTokens.compactActionRowHeight : MenuTokens.minimumActionHitTarget
         }
     }
 

--- a/Sources/UI/MenuBar/MenuTokens.swift
+++ b/Sources/UI/MenuBar/MenuTokens.swift
@@ -63,14 +63,15 @@ enum MenuTokens {
 
     // Layout
     static let panelWidth: CGFloat = 304
-    static let panelHeight: CGFloat = 320
+    static let panelHeight: CGFloat = 480
     static let onboardingWindowWidth: CGFloat = 720
     static let onboardingWindowHeight: CGFloat = 740
     static let innerPadding: CGFloat = 10
     static let sectionSpacing: CGFloat = 7
     static let surfaceCornerRadius: CGFloat = 14
     static let cardCornerRadius: CGFloat = 8
-    static let compactActionRowHeight: CGFloat = 30
+    static let minimumActionHitTarget: CGFloat = 40
+    static let compactActionRowHeight: CGFloat = 40
     static let actionRowHeight: CGFloat = 46
     static let savedRowHeight: CGFloat = 54
     static let badgeHeight: CGFloat = 22

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -9,6 +9,7 @@ func testUIAutomationSurfaceContract() {
     runSuite("UI automation surface contract - menubar controls expose stable identifiers") {
         let appSource = readUIAutomationContractFile("Sources/TranscriptedApp.swift")
         let actionRowSource = readUIAutomationContractFile("Sources/UI/MenuBar/MenuBarActionRowView.swift")
+        let menuTokensSource = readUIAutomationContractFile("Sources/UI/MenuBar/MenuTokens.swift")
         let primarySource = readUIAutomationContractFile("Sources/UI/MenuBar/MenuBarPrimaryActionsView.swift")
         let utilitySource = readUIAutomationContractFile("Sources/UI/MenuBar/MenuBarUtilityActionsView.swift")
         let smokeScript = readUIAutomationContractFile("scripts/entrypoints/build.sh")
@@ -29,6 +30,15 @@ func testUIAutomationSurfaceContract() {
                 && actionRowSource.contains("guard isEnabled else { return false }")
                 && actionRowSource.contains("accessibilityIdentifier()"),
             "menubar smoke snapshots should carry the same accessibility identifier and AXPress path AppKit automation sees"
+        )
+
+        assertTrue(
+            menuTokensSource.contains("static let minimumActionHitTarget: CGFloat = 40")
+                && menuTokensSource.contains("static let panelHeight: CGFloat = 480")
+                && actionRowSource.contains("MenuTokens.minimumActionHitTarget")
+                && actionRowSource.contains("MenuTokens.actionRowHeight")
+                && actionRowSource.contains("MenuTokens.compactActionRowHeight"),
+            "menubar action rows should keep a real 40pt hit-target floor and a panel height that keeps default rows visible"
         )
 
         for identifier in [


### PR DESCRIPTION
## Summary
- Raises menu-bar action rows to a 40pt minimum hit-target floor.
- Keeps primary two-line rows at 46pt and vertically centers the icon/text/trailing shortcut content.
- Raises the menu popover height cap to 480pt so default Settings/Quit rows remain visible after taller targets.
- Adds a source contract for the 40pt hit-target floor and panel-height guard.

## Interface Feel Better Proof
| Principle | Before | After |
| --- | --- | --- |
| Minimum hit area | Menu bar action controls could be 24-30pt tall, below the 40pt floor for reliable pointer and accessibility targeting. | Action rows now resolve to at least 40pt; primary detail rows are 46pt. |
| Optical alignment | Two-line rows were top-pinned inside the old compact target. | Two-line content and trailing shortcut labels are vertically centered inside the taller native AppKit control. |
| Safe native adaptation | First pass made rows taller but left the 320pt panel cap, which would have hidden Settings/Quit below scroll. | Claude review caught the overflow; the panel cap is now 480pt and pinned in a source contract. |

## Tests
- `git diff --check`
- `bash run-tests.sh --filter testUIAutomationSurfaceContract` — 234 passed
- `bash build.sh --no-open` — passed, including signature, launch smoke, performance budget
- `bash run-tests.sh` — 10509 passed, 0 failed

## Independent Review
- Claude review via Maestro: `/Users/redbars/.codex/maestro/runs/20260622T014230Z-menu-hit-targets-code-review-claude`
- Finding addressed before commit: raising row heights without raising `panelHeight` would have pushed Settings/Quit below the fold.

## Audit Matrix
- Canonical sheet: https://docs.google.com/spreadsheets/d/1EAIVrLGERtxp9ApO4tHSuUpecFReOoKQVafS3wLE4KQ/edit
- Rows to update after PR creation: menu bar popover/action rows and cross-cutting icon/hit-target sweep.

No merge, release, tag, notarization, appcast, Homebrew, or deploy work performed.