### PR TITLE
Make summary saved notice dismissible

### DIFF
--- a/Sources/UI/Settings/HomeMeetingSummaryBetaPresentationPolicy.swift
+++ b/Sources/UI/Settings/HomeMeetingSummaryBetaPresentationPolicy.swift
@@ -78,6 +78,10 @@ struct HomeLocalSummaryNotice: Identifiable, Equatable {
         !isFailure
     }
 
+    var allowsManualDismiss: Bool {
+        !isFailure
+    }
+
     var isFailure: Bool {
         if case .failed = kind { return true }
         return false

--- a/Sources/UI/Settings/TranscriptedSettingsComponents.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsComponents.swift
@@ -612,6 +612,7 @@ struct SettingsActivityCard: View {
     let progress: Double?
     let actionTitle: String?
     let action: (() -> Void)?
+    var dismissAction: (() -> Void)? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -640,6 +641,20 @@ struct SettingsActivityCard: View {
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
                     .background(tintColor.opacity(0.12), in: Capsule())
+
+                if let dismissAction {
+                    Button(action: dismissAction) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 22, height: 22)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(SettingsHoverButtonStyle(cornerRadius: 7))
+                    .help("Dismiss")
+                    .accessibilityLabel("Dismiss")
+                    .accessibilityIdentifier("transcripted.settings.activity-card.dismiss")
+                }
             }
 
             if let progress {

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -559,7 +559,13 @@ struct TranscriptedSettingsView: View {
                                 failureMessage: "Transcripted couldn't find this meeting's transcript on disk. It may have been moved, renamed, or deleted outside the app."
                             )
                         }
-                    }
+                    },
+                    dismissAction: notice.allowsManualDismiss
+                        ? {
+                            trackSettingsAction("dismiss_local_meeting_summary_notice", page: .home)
+                            clearHomeLocalSummaryNotice(id: notice.id)
+                        }
+                        : nil
                 )
                 .transition(.move(edge: .top).combined(with: .opacity))
             }

--- a/Tests/HomeMeetingSummaryBetaPresentationPolicyTests.swift
+++ b/Tests/HomeMeetingSummaryBetaPresentationPolicyTests.swift
@@ -105,6 +105,7 @@ func testHomeMeetingSummaryBetaPresentationPolicy() {
         )
         assertEqual(singlePass.title, "AI summary saved", "saved notices should read as complete")
         assertTrue(singlePass.shouldAutoDismiss, "saved notices should auto-dismiss")
+        assertTrue(singlePass.allowsManualDismiss, "saved notices should also be dismissible on demand")
     }
 
     runSuite("HomeLocalSummaryNoticeDismissalPolicy clears only the scheduled notice") {
@@ -177,6 +178,7 @@ func testHomeMeetingSummaryBetaPresentationPolicy() {
         assertEqual(notice.status, "Needs retry", "failure notice should not look complete")
         assertEqual(notice.actionTitle, "Retry summary", "failure notice should offer retry")
         assertFalse(notice.shouldAutoDismiss, "failure notice should persist until the user acts")
+        assertFalse(notice.allowsManualDismiss, "failure notice should not hide behind a dismiss affordance")
         assertTrue(
             notice.detail.contains("model load failed: missing model cache"),
             "failure detail should collapse noisy line breaks into readable copy"


### PR DESCRIPTION
## Summary
- add a manual dismiss affordance for successful Home local-summary notices
- keep failed local-summary notices persistent and retry-focused
- cover the success/failure dismiss split in focused policy tests

## Bug report
Used the June 8 self-feedback email about the green “AI summary saved” popup not going away. Current code already marks success notices as auto-dismissable; this adds an immediate user-controlled escape hatch for the saved notice without adding one to failures.

## Verification
- bash run-tests.sh --filter HomeMeetingSummaryBetaPresentationPolicy
- bash scripts/dev/agent-preflight.sh
- bash build-deps.sh --force
- bash build.sh --no-open
- bash run-tests.sh
- Independent review: PASS, MAESTRO_PROOF=/Users/redbars/.codex/maestro/runs/20260622T015116Z-summary-notice-dismiss-review-claude
- Local audit lane proof: /Users/redbars/.codex/maestro/runs/20260622T013810Z-home-summary-notice-audit-local