### PR TITLE
Salvage workflow recovery telemetry

### DIFF
--- a/Sources/Meeting/MeetingSessionController.swift
+++ b/Sources/Meeting/MeetingSessionController.swift
@@ -104,6 +104,15 @@ final class MeetingSessionController: ObservableObject {
                 return nil
             }
         }
+
+        var artifactRetained: Bool {
+            switch kind {
+            case .recorded:
+                return true
+            case .imported:
+                return false
+            }
+        }
     }
 
     private enum TerminalTranscriptionOutcome: Equatable {
@@ -352,6 +361,16 @@ final class MeetingSessionController: ObservableObject {
             return
         }
 
+        let modelPreparationStartedAt = CFAbsoluteTimeGetCurrent()
+        let retrySource = showLoadingUI ? "warmup" : "background_warmup"
+        let surface = showLoadingUI ? "meeting" : "runtime"
+        WorkflowRecoveryTelemetry.attempted(
+            workflowKind: "model_preparation",
+            failureKind: "models_not_ready",
+            retrySource: retrySource,
+            surface: surface,
+            artifactRetained: false
+        )
         let task = Task<Result<Void, Error>, Never> { [downloader] in
             do {
                 try await downloader.ensureModelsReady()
@@ -366,6 +385,12 @@ final class MeetingSessionController: ObservableObject {
         modelPreparationTask?.cancel()
         modelPreparationTask = nil
         applyModelPreparationResult(result, showLoadingUI: showLoadingUI)
+        trackModelPreparationRecoveryFinished(
+            result,
+            retrySource: retrySource,
+            elapsedSeconds: CFAbsoluteTimeGetCurrent() - modelPreparationStartedAt,
+            surface: surface
+        )
     }
 
     /// Begin a new meeting recording. Safe to call from UI buttons. If a prior
@@ -1433,6 +1458,14 @@ final class MeetingSessionController: ObservableObject {
         retryingFailedMeetingIDs.insert(id)
         activeTranscriptionTrigger = .unknown
         refreshFailedMeetings()
+        let retryStartedAt = CFAbsoluteTimeGetCurrent()
+        WorkflowRecoveryTelemetry.attempted(
+            workflowKind: "meeting_transcription",
+            failureKind: "failed_meeting",
+            retrySource: "failed_meeting_retry",
+            surface: "home",
+            artifactRetained: true
+        )
 
         Task { [weak self] in
             guard let self else { return }
@@ -1447,15 +1480,33 @@ final class MeetingSessionController: ObservableObject {
                 )
                 self.retryingFailedMeetingIDs.remove(id)
                 self.refreshFailedMeetings()
+                WorkflowRecoveryTelemetry.finished(
+                    workflowKind: "meeting_transcription",
+                    failureKind: "failed_meeting",
+                    retrySource: "failed_meeting_retry",
+                    result: "failed",
+                    elapsedSeconds: CFAbsoluteTimeGetCurrent() - retryStartedAt,
+                    surface: "home",
+                    artifactRetained: true
+                )
                 return
             }
 
-            _ = await self.taskManager.retryFailedTranscription(
+            let retryPublished = await self.taskManager.retryFailedTranscription(
                 failedId: id,
                 outputFolder: MeetingStoragePaths.transcriptsFolder
             )
             self.retryingFailedMeetingIDs.remove(id)
             self.refreshFailedMeetings()
+            WorkflowRecoveryTelemetry.finished(
+                workflowKind: "meeting_transcription",
+                failureKind: "failed_meeting",
+                retrySource: "failed_meeting_retry",
+                result: retryPublished ? "success" : "failed",
+                elapsedSeconds: CFAbsoluteTimeGetCurrent() - retryStartedAt,
+                surface: "home",
+                artifactRetained: true
+            )
         }
         return true
     }
@@ -2166,6 +2217,30 @@ final class MeetingSessionController: ObservableObject {
         refreshWarmupStatus()
     }
 
+    private func trackModelPreparationRecoveryFinished(
+        _ result: Result<Void, Error>,
+        retrySource: String,
+        elapsedSeconds: TimeInterval,
+        surface: String
+    ) {
+        let recoveryResult: String
+        switch result {
+        case .success:
+            recoveryResult = "success"
+        case .failure:
+            recoveryResult = "failed"
+        }
+        WorkflowRecoveryTelemetry.finished(
+            workflowKind: "model_preparation",
+            failureKind: "models_not_ready",
+            retrySource: retrySource,
+            result: recoveryResult,
+            elapsedSeconds: elapsedSeconds,
+            surface: surface,
+            artifactRetained: false
+        )
+    }
+
     private func resetPreparedSpeechModelIfNeeded() {
         let preparedEngine = sttAdapter.transcriptionEngineDescriptor.identifier
         let selectedEngine = sttRouter.selectedModel.transcriptionEngineIdentifier
@@ -2358,6 +2433,14 @@ final class MeetingSessionController: ObservableObject {
                 ]
             )
         )
+        let modelRecoveryStartedAt = CFAbsoluteTimeGetCurrent()
+        WorkflowRecoveryTelemetry.attempted(
+            workflowKind: "model_preparation",
+            failureKind: "models_not_ready",
+            retrySource: "queued_transcription",
+            surface: "meeting",
+            artifactRetained: job.artifactRetained
+        )
 
         do {
             try await downloader.ensureModelsReady(sttModel: job.sttModel)
@@ -2375,6 +2458,15 @@ final class MeetingSessionController: ObservableObject {
                         "queued_stt_model": job.sttModel.rawValue
                     ]
                 )
+            )
+            WorkflowRecoveryTelemetry.finished(
+                workflowKind: "model_preparation",
+                failureKind: "models_not_ready",
+                retrySource: "queued_transcription",
+                result: "failed",
+                elapsedSeconds: CFAbsoluteTimeGetCurrent() - modelRecoveryStartedAt,
+                surface: "meeting",
+                artifactRetained: job.artifactRetained
             )
             return false
         }
@@ -2394,6 +2486,16 @@ final class MeetingSessionController: ObservableObject {
                 )
             )
         }
+
+        WorkflowRecoveryTelemetry.finished(
+            workflowKind: "model_preparation",
+            failureKind: "models_not_ready",
+            retrySource: "queued_transcription",
+            result: ready ? "success" : "failed",
+            elapsedSeconds: CFAbsoluteTimeGetCurrent() - modelRecoveryStartedAt,
+            surface: "meeting",
+            artifactRetained: job.artifactRetained
+        )
 
         return ready
     }

--- a/Sources/Observability/AnalyticsEventPolicy.swift
+++ b/Sources/Observability/AnalyticsEventPolicy.swift
@@ -188,6 +188,17 @@ struct AnalyticsEventPolicy: Equatable {
         "workflow_kind",
     ]
 
+    private static let workflowRecoveryProperties: Set<String> = [
+        "artifact_retained",
+        "attempt_bucket",
+        "elapsed_bucket",
+        "failure_kind",
+        "result",
+        "retry_source",
+        "surface",
+        "workflow_kind",
+    ]
+
     private static let productFrictionProperties: Set<String> = [
         "elapsed_bucket",
         "failure_kind",
@@ -396,6 +407,14 @@ struct AnalyticsEventPolicy: Equatable {
         "workflow_abandoned": .init(
             name: "workflow_abandoned",
             allowedProperties: workflowAbandonedProperties
+        ),
+        "workflow_recovery_attempted": .init(
+            name: "workflow_recovery_attempted",
+            allowedProperties: workflowRecoveryProperties.subtracting(["elapsed_bucket", "result"])
+        ),
+        "workflow_recovery_finished": .init(
+            name: "workflow_recovery_finished",
+            allowedProperties: workflowRecoveryProperties
         ),
         "product_friction_observed": .init(
             name: "product_friction_observed",

--- a/Sources/Observability/WorkflowRecoveryTelemetry.swift
+++ b/Sources/Observability/WorkflowRecoveryTelemetry.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+enum WorkflowRecoveryTelemetry {
+    static func attempted(
+        workflowKind: String,
+        failureKind: String,
+        retrySource: String,
+        attempt: Int = 1,
+        surface: String,
+        artifactRetained: Bool
+    ) {
+        AnalyticsReporter.track(
+            "workflow_recovery_attempted",
+            properties: baseProperties(
+                workflowKind: workflowKind,
+                failureKind: failureKind,
+                retrySource: retrySource,
+                attempt: attempt,
+                surface: surface,
+                artifactRetained: artifactRetained
+            )
+        )
+    }
+
+    static func finished(
+        workflowKind: String,
+        failureKind: String,
+        retrySource: String,
+        attempt: Int = 1,
+        result: String,
+        elapsedSeconds: TimeInterval? = nil,
+        surface: String,
+        artifactRetained: Bool
+    ) {
+        var properties = baseProperties(
+            workflowKind: workflowKind,
+            failureKind: failureKind,
+            retrySource: retrySource,
+            attempt: attempt,
+            surface: surface,
+            artifactRetained: artifactRetained
+        )
+        properties["result"] = result
+        if let elapsedSeconds {
+            properties["elapsed_bucket"] = AnalyticsReporter.durationBucket(seconds: elapsedSeconds)
+        }
+
+        AnalyticsReporter.track(
+            "workflow_recovery_finished",
+            properties: properties
+        )
+    }
+
+    private static func baseProperties(
+        workflowKind: String,
+        failureKind: String,
+        retrySource: String,
+        attempt: Int,
+        surface: String,
+        artifactRetained: Bool
+    ) -> [String: String] {
+        [
+            "workflow_kind": workflowKind,
+            "failure_kind": failureKind,
+            "retry_source": retrySource,
+            "attempt_bucket": AnalyticsReporter.countBucket(attempt),
+            "surface": surface,
+            "artifact_retained": artifactRetained ? "true" : "false",
+        ]
+    }
+}

--- a/Sources/Speech/ParakeetEngine.swift
+++ b/Sources/Speech/ParakeetEngine.swift
@@ -923,6 +923,33 @@ class ParakeetEngine: ObservableObject {
             try? await Task.sleep(nanoseconds: TranscriptedConstants.audioRecoveryDelay)
             guard !Task.isCancelled, let self = self else { return }
             guard !self.recoveryState.isStale(generation: myGeneration) else { return }
+            var workflowRecoveryFinished = false
+            func finishWorkflowRecovery(result: String, artifactRetained: Bool) {
+                guard !workflowRecoveryFinished else { return }
+                workflowRecoveryFinished = true
+                WorkflowRecoveryTelemetry.finished(
+                    workflowKind: "dictation",
+                    failureKind: "route_changed",
+                    retrySource: "audio_route_recovery",
+                    result: result,
+                    elapsedSeconds: CFAbsoluteTimeGetCurrent() - recoveryStartedAt,
+                    surface: "runtime",
+                    artifactRetained: artifactRetained
+                )
+            }
+            defer {
+                finishWorkflowRecovery(
+                    result: Task.isCancelled ? "cancelled" : "superseded",
+                    artifactRetained: shouldRestartRecording
+                )
+            }
+            WorkflowRecoveryTelemetry.attempted(
+                workflowKind: "dictation",
+                failureKind: "route_changed",
+                retrySource: "audio_route_recovery",
+                surface: "runtime",
+                artifactRetained: shouldRestartRecording
+            )
             do {
                 var recoveryAttempt = 0
                 var readySnapshot: ParakeetAudioInputSnapshot?
@@ -1004,6 +1031,7 @@ class ParakeetEngine: ObservableObject {
                                     "sample_rate": "\(self.safeNativeSampleRate())",
                                     "attempts": "\(attempt)"
                                 ])
+                            finishWorkflowRecovery(result: "success", artifactRetained: true)
                             break
                         }
                         // BT format negotiation can take ~1-2s; wait between attempts.
@@ -1023,7 +1051,10 @@ class ParakeetEngine: ObservableObject {
                                     "reason": "recording_restart_budget_exhausted"
                                 ]
                             ))
+                        finishWorkflowRecovery(result: "gave_up", artifactRetained: false)
                     }
+                } else {
+                    finishWorkflowRecovery(result: "success", artifactRetained: false)
                 }
             } catch {
                 guard !self.recoveryState.isStale(generation: myGeneration) else { return }
@@ -1048,6 +1079,7 @@ class ParakeetEngine: ObservableObject {
                         ]
                     )
                 )
+                finishWorkflowRecovery(result: "failed", artifactRetained: shouldRestartRecording)
                 if failureAction.markRecordingInterrupted {
                     self.interruptRecordingAndClearRecoveredTimeline()
                     EventReporter.shared.capture(level: .error, engine: "parakeet",
@@ -1124,6 +1156,15 @@ class ParakeetEngine: ObservableObject {
                         "was_recording": "\(wasRecording)"
                     ]
                 )
+            )
+            WorkflowRecoveryTelemetry.finished(
+                workflowKind: "dictation",
+                failureKind: "route_changed",
+                retrySource: "audio_route_recovery",
+                result: "gave_up",
+                elapsedSeconds: Double(TranscriptedConstants.audioDeviceRecoveryTimeout) / 1_000_000_000,
+                surface: "runtime",
+                artifactRetained: wasRecording
             )
             let diagnosticsEvent = failureAction.reportSentryFailure
                 ? "device_change_recovery_timeout"

--- a/Tests/AnalyticsEventPolicyTests.swift
+++ b/Tests/AnalyticsEventPolicyTests.swift
@@ -65,6 +65,7 @@ func testAnalyticsEventPolicy() {
             "anonymous_usage_enabled",
             "app_signal",
             "app_version",
+            "artifact_retained",
             "artifact_kind",
             "attenuation_kind",
             "auto_send",
@@ -171,6 +172,7 @@ func testAnalyticsEventPolicy() {
             "required",
             "reason_kind",
             "result",
+            "retry_source",
             "route_ready",
             "route_shape",
             "sample_flow_started",
@@ -571,6 +573,65 @@ func testAnalyticsEventPolicy() {
         assertNil(sanitized["raw_error"], "raw errors must not be sent")
         assertNil(sanitized["source_app"], "source apps must not be sent")
         assertNil(sanitized["url"], "raw URLs must not be sent")
+    }
+
+    runSuite("AnalyticsEventPolicy allows workflow recovery lifecycle events") {
+        let attempted = AnalyticsEventPolicy.policy(forEvent: "workflow_recovery_attempted")
+        let finished = AnalyticsEventPolicy.policy(forEvent: "workflow_recovery_finished")
+
+        assertEqual(
+            attempted?.allowedProperties ?? Set<String>(),
+            [
+                "artifact_retained",
+                "attempt_bucket",
+                "failure_kind",
+                "retry_source",
+                "surface",
+                "workflow_kind",
+            ],
+            "recovery attempts should carry only coarse workflow shape"
+        )
+        assertEqual(
+            finished?.allowedProperties ?? Set<String>(),
+            [
+                "artifact_retained",
+                "attempt_bucket",
+                "elapsed_bucket",
+                "failure_kind",
+                "result",
+                "retry_source",
+                "surface",
+                "workflow_kind",
+            ],
+            "recovery finishes should add only result and elapsed bucket"
+        )
+
+        let sanitized = AnalyticsPayloadSanitizer.sanitizeProperties(
+            [
+                "workflow_kind": "meeting_transcription",
+                "failure_kind": "models_not_ready",
+                "retry_source": "queued_transcription",
+                "attempt_bucket": "1",
+                "result": "success",
+                "elapsed_bucket": "10_29s",
+                "surface": "meeting",
+                "artifact_retained": "true",
+                "error": "raw error",
+                "transcript_path": "/private/tmp/meeting.md",
+            ],
+            allowedKeys: finished?.allowedProperties ?? Set<String>()
+        )
+
+        assertEqual(sanitized["workflow_kind"], "meeting_transcription", "workflow kind should survive")
+        assertEqual(sanitized["failure_kind"], "models_not_ready", "failure kind should survive")
+        assertEqual(sanitized["retry_source"], "queued_transcription", "retry source should survive")
+        assertEqual(sanitized["attempt_bucket"], "1", "attempt bucket should survive")
+        assertEqual(sanitized["result"], "success", "result should survive")
+        assertEqual(sanitized["elapsed_bucket"], "10_29s", "elapsed bucket should survive")
+        assertEqual(sanitized["surface"], "meeting", "surface should survive")
+        assertEqual(sanitized["artifact_retained"], "true", "artifact retained state should survive")
+        assertNil(sanitized["error"], "raw errors must not be sent")
+        assertNil(sanitized["transcript_path"], "transcript paths must not be sent")
     }
 
     runSuite("AnalyticsEventPolicy allows product friction only as coarse enums and buckets") {

--- a/docs/privacy-first-observability.md
+++ b/docs/privacy-first-observability.md
@@ -105,6 +105,8 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - `agent_capture_query_observed`
 - `activation_return_proxy_observed`
 - `workflow_abandoned`
+- `workflow_recovery_attempted`
+- `workflow_recovery_finished`
 - `product_friction_observed`
 - `menu_bar_opened`
 - `menu_bar_action_clicked`
@@ -162,6 +164,9 @@ This list should match `Sources/Observability/AnalyticsEventPolicy.swift`.
 - normalized failure-code buckets like `url_-1009`, `sparkle_2003`, `other_42`
 - feature discovery enums like `agent_setup`, `beta_summaries`,
   `capture_library`, `permissions`, `speaker_review`, and `update_settings`
+- workflow recovery fields limited to `workflow_kind`, `failure_kind`,
+  `retry_source`, `attempt_bucket`, `surface`, `artifact_retained`, `result`,
+  and `elapsed_bucket`
 - product friction fields limited to `surface`, `stage`, `result`,
   `failure_kind`, `elapsed_bucket`, `route_shape`, and `model_state`
 


### PR DESCRIPTION
## Summary

- salvages only the still-useful workflow recovery telemetry slice from #1233 onto fresh `main`
- adds `workflow_recovery_attempted` / `workflow_recovery_finished` with enum/bucket allowlists, docs, and sanitizer coverage
- wires recovery attempts/results for meeting model prep, failed-meeting retry, queued transcription model prep, and dictation route recovery

## What I intentionally did not carry from #1233

- `artifact_created`, `artifact_opened`, `artifact_revealed`, `artifact_copied`: duplicate shipped/main activation artifact events
- `workflow_started`, `workflow_finished`: too generic and overlapping with existing product events
- `UXConfusionTelemetry`: broad confusion/recovery taxonomy, not crisp enough versus newer decision/outcome drafts
- speaker review, local summary, MCP query/reporting slices: covered by newer PRs #1255, #1256, #1258, #1259, #1260 or already on main

## Review notes

- Live GitHub state checked for #1233 and #1253-#1260. #1233 is open and dirty; #1253-#1260 are open drafts and clean against main.
- Independent Claude final-diff review found one medium issue in the first pass: dictation route recovery could orphan `attempted` without `finished` during route churn. Fixed before commit by moving attempt emission inside the recovery task and adding a guarded terminal finish path for cancelled/superseded exits.
- Proof paths: `/Users/redbars/.codex/maestro/runs/20260622T013836Z-pr1233-salvage-review-claude`, `/Users/redbars/.codex/maestro/runs/20260622T015814Z-workflow-recovery-final-review-claude`

## Validation

- `bash build-deps.sh --force`
- `bash build.sh --no-open`
- `bash run-tests.sh --filter AnalyticsEventPolicyTests` (5054 passed)
- `bash run-tests.sh` (10594 passed)
- `bash run-integration-smoke.sh`
- `bash scripts/dev/agent-preflight.sh`

## GitHub cleanup recommendation

Close #1233 after this PR is reviewed. The only slice I found worth saving is here; the rest is either already shipped, superseded by #1255-#1260, or too broad to revive.