### PR TITLE
Expand Home icon hit targets

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -759,7 +759,7 @@ struct HomeRowActionButtons: View {
 
             if !menuItems.isEmpty {
                 HomeRowMoreMenuButton(items: menuItems)
-                    .frame(width: 26, height: 26)
+                    .frame(width: HomeHitTarget.minimum, height: HomeHitTarget.minimum)
                     .help("More options")
             }
         }
@@ -770,10 +770,8 @@ struct HomeRowActionButtons: View {
             Image(systemName: systemName)
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.secondary)
-                .frame(width: 26, height: 26)
-                .contentShape(Rectangle())
         }
-        .buttonStyle(SettingsHoverButtonStyle(cornerRadius: 7))
+        .buttonStyle(HomeCompactIconButtonStyle())
         .help(help)
         .accessibilityLabel(Text(help))
         .accessibilityIdentifier("transcripted.home.row.copy")
@@ -897,6 +895,7 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
     final class HoverMenuButton: NSButton {
         var retainedActionTarget: AnyObject?
         private var trackingAreaRef: NSTrackingArea?
+        private var hoverBackgroundLayer: CALayer?
         private var isHovering = false {
             didSet { updateAppearance() }
         }
@@ -924,6 +923,11 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
             trackingAreaRef = area
         }
 
+        override func layout() {
+            super.layout()
+            layoutHoverBackgroundLayer()
+        }
+
         override func mouseEntered(with event: NSEvent) {
             guard isEnabled else { return }
             isHovering = true
@@ -934,8 +938,10 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
         }
 
         private func updateAppearance() {
+            layoutHoverBackgroundLayer()
             guard isEnabled else {
                 layer?.backgroundColor = NSColor.clear.cgColor
+                hoverBackgroundLayer?.backgroundColor = NSColor.clear.cgColor
                 alphaValue = 0.55
                 return
             }
@@ -949,7 +955,30 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
             } else {
                 color = .clear
             }
-            layer?.backgroundColor = color.cgColor
+            layer?.backgroundColor = NSColor.clear.cgColor
+            hoverBackgroundLayer?.backgroundColor = color.cgColor
+        }
+
+        private func layoutHoverBackgroundLayer() {
+            guard wantsLayer, let layer else { return }
+            let backgroundLayer: CALayer
+            if let hoverBackgroundLayer {
+                backgroundLayer = hoverBackgroundLayer
+            } else {
+                let createdLayer = CALayer()
+                createdLayer.cornerRadius = 7
+                layer.insertSublayer(createdLayer, at: 0)
+                hoverBackgroundLayer = createdLayer
+                backgroundLayer = createdLayer
+            }
+
+            let size = HomeHitTarget.compactVisibleSize
+            backgroundLayer.frame = CGRect(
+                x: floor((bounds.width - size) / 2),
+                y: floor((bounds.height - size) / 2),
+                width: size,
+                height: size
+            )
         }
     }
 }
@@ -1425,7 +1454,7 @@ struct HomeFailedMeetingInlineRow: View {
                     action: onClear
                 )
             ], automationIdentifier: "transcripted.home.failed-meeting.more")
-            .frame(width: 26, height: 26)
+            .frame(width: HomeHitTarget.minimum, height: HomeHitTarget.minimum)
             .help("More options")
         }
     }
@@ -1547,32 +1576,51 @@ private struct HomeAttentionActionButton: View {
     }
 }
 
-private struct HomeAudioIconButton: View {
-    let title: String
-    let symbolName: String
-    let isActive: Bool
-    let isPlaying: Bool
-    let action: () -> Void
+private enum HomeHitTarget {
+    static let minimum: CGFloat = 40
+    static let compactVisibleSize: CGFloat = 26
+}
 
-    var body: some View {
-        Button(action: action) {
-            Image(systemName: symbolName)
-                .font(.system(size: 10, weight: .bold))
-                .foregroundStyle(isActive ? Color.white : Color.secondary)
-                .frame(width: 26, height: 26)
-                .background(Circle().fill(isActive ? Color.accentColor : Color.primary.opacity(0.08)))
-                .overlay(
-                    Circle()
-                        .stroke(isPlaying ? Color.accentColor.opacity(0.5) : Color.primary.opacity(0.06), lineWidth: 1)
+private struct HomeCompactIconButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> Body {
+        Body(configuration: configuration)
+    }
+
+    struct Body: View {
+        let configuration: Configuration
+        @Environment(\.isEnabled) private var isEnabled
+        @State private var isHovering = false
+
+        var body: some View {
+            configuration.label
+                .frame(width: HomeHitTarget.compactVisibleSize, height: HomeHitTarget.compactVisibleSize)
+                .background(
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .fill(backgroundColor)
                 )
-                .contentShape(Circle())
+                .overlay(
+                    RoundedRectangle(cornerRadius: 7, style: .continuous)
+                        .stroke(strokeColor, lineWidth: 1)
+                )
+                .frame(width: HomeHitTarget.minimum, height: HomeHitTarget.minimum)
+                .contentShape(Rectangle())
+                .opacity(isEnabled ? 1 : 0.55)
+                .onHover { isHovering = $0 }
         }
-        .buttonStyle(SettingsHoverButtonStyle(
-            tone: isActive ? .accent : .neutral,
-            cornerRadius: 7
-        ))
-        .accessibilityLabel(title)
-        .accessibilityIdentifier("transcripted.home.audio.\(isPlaying ? "pause" : "play")")
+
+        private var backgroundColor: Color {
+            if configuration.isPressed {
+                return Color.primary.opacity(0.10)
+            }
+            if isHovering {
+                return Color.primary.opacity(0.06)
+            }
+            return Color.clear
+        }
+
+        private var strokeColor: Color {
+            configuration.isPressed || isHovering ? Color.primary.opacity(0.08) : Color.clear
+        }
     }
 }
 
@@ -2415,21 +2463,28 @@ private struct HomePodcastPlayerButton: View {
     let automationIdentifier: String
     let action: () -> Void
 
+    private var hitTargetSize: CGFloat {
+        max(size, HomeHitTarget.minimum)
+    }
+
     var body: some View {
         Button(action: action) {
-            Image(systemName: symbolName)
-                .font(.system(size: size >= 40 ? 15 : 12, weight: .bold))
-                .foregroundStyle(foreground)
-                .frame(width: size, height: size)
-                .background(
-                    Circle()
-                        .fill(background)
-                )
-                .overlay(
-                    Circle()
-                        .stroke(Color.primary.opacity(isPrimary ? 0.0 : 0.08), lineWidth: 1)
-                )
-                .contentShape(Circle())
+            ZStack {
+                Circle()
+                    .fill(background)
+                    .frame(width: size, height: size)
+                    .overlay(
+                        Circle()
+                            .stroke(Color.primary.opacity(isPrimary ? 0.0 : 0.08), lineWidth: 1)
+                    )
+
+                Image(systemName: symbolName)
+                    .font(.system(size: size >= 40 ? 15 : 12, weight: .bold))
+                    .foregroundStyle(foreground)
+                    .frame(width: size, height: size)
+            }
+            .frame(width: hitTargetSize, height: hitTargetSize)
+            .contentShape(Circle())
         }
         .buttonStyle(.plain)
         .disabled(isDisabled)

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -229,6 +229,12 @@ func testUIAutomationSurfaceContract() {
         ] {
             assertTrue(homeSource.contains(requiredHomeRendererHook), "\(requiredHomeRendererHook) should keep Home action rendering visible")
         }
+        assertTrue(
+            homeSource.contains("private enum HomeHitTarget")
+                && homeSource.contains("static let minimum: CGFloat = 40")
+                && homeSource.contains("HomeHitTarget.minimum"),
+            "Home icon buttons and compact row actions should keep a shared 40pt hit-target floor"
+        )
         for requiredFailedMeetingPolicyHook in [
             "clearTitle: hasRetainedAudioFiles ? \"Delete\" : \"Dismiss\"",
             "clearSymbolName: hasRetainedAudioFiles ? \"trash\" : \"xmark\"",
@@ -485,11 +491,6 @@ func testUIAutomationSurfaceContract() {
         ] {
             assertTrue(homeSource.contains(identifier), "\(identifier) should stay attached to Home click-flow controls")
         }
-
-        assertTrue(
-            homeSource.contains("transcripted.home.audio.\\(isPlaying ?"),
-            "Home audio play/pause action should keep a stable dynamic automation ID"
-        )
 
         for identifier in [
             "transcripted.settings.footer.check-updates",


### PR DESCRIPTION
## Summary
- Adds a shared 40pt Home hit-target floor for compact icon controls.
- Keeps row copy/more hover chrome visually compact at 26pt while expanding the actual click area.
- Keeps podcast skip controls visually 34pt while giving them a 40pt hit area.
- Removes a stale unused HomeAudioIconButton and updates the automation contract to guard live Home controls.

## Interface Feel Better Proof
| Principle | Before | After |
| --- | --- | --- |
| Minimum hit area | Home row copy/more buttons and podcast skip controls had 26-34pt targets. | Shared Home hit-target floor gives compact controls at least 40pt hit areas. |
| Dense native polish | First pass enlarged visible hover fills/circles and bloated the transcript find bar. | Review fixes keep visible chrome compact: copy/more draw 26pt hover chrome, podcast skip circles stay 34pt, find bar is untouched. |
| Testable contract | Home had no shared source contract for compact hit targets, and one stale dynamic automation ID guarded dead code. | Added a source contract for `HomeHitTarget.minimum = 40`; removed the dead audio button and stale contract while preserving live identifiers. |

## Tests
- `git diff --check`
- `bash run-tests.sh --filter testUIAutomationSurfaceContract` — 233 passed
- `bash build.sh --no-open` — passed, including signature, launch smoke, performance budget
- `bash run-tests.sh` — 10508 passed, 0 failed

## Independent Review
- Initial Claude review via Maestro: `/Users/redbars/.codex/maestro/runs/20260622T015859Z-home-icon-targets-code-review-claude`
- Follow-up Claude review via Maestro: `/Users/redbars/.codex/maestro/runs/20260622T020723Z-home-icon-targets-followup-review-claude`
- Findings addressed before commit: reverted find-bar enlargement, kept compact visible chrome inside larger hit areas, removed dead HomeAudioIconButton, and made the AppKit ellipsis hover layer draw at 26pt inside the 40pt hit area.

## Audit Matrix
- Canonical sheet: https://docs.google.com/spreadsheets/d/1EAIVrLGERtxp9ApO4tHSuUpecFReOoKQVafS3wLE4KQ/edit
- Rows to update after PR creation: Home hover/actions, overflow menu, audio controls, cross-cutting icon-button sweep.

No merge, release, tag, notarization, appcast, Homebrew, or deploy work performed.