### PR TITLE
Polish onboarding control targets

### DIFF
--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -1039,7 +1039,11 @@ private struct NavBar: View {
                 .font(.system(size: 13))
                 .buttonStyle(.plain)
                 .foregroundStyle(OnboardingTheme.muted)
-                .frame(minHeight: CGFloat(FirstRunOnboardingPolishContract.minimumHitTarget))
+                .frame(
+                    minWidth: CGFloat(FirstRunOnboardingPolishContract.minimumHitTarget),
+                    minHeight: CGFloat(FirstRunOnboardingPolishContract.minimumHitTarget)
+                )
+                .contentShape(Rectangle())
                 .accessibilityIdentifier("transcripted.onboarding.nav.skip")
             }
 
@@ -1054,10 +1058,12 @@ private struct NavBar: View {
                 .foregroundStyle(OnboardingTheme.window)
                 .padding(.horizontal, 24)
                 .padding(.vertical, 12)
+                .frame(minHeight: CGFloat(FirstRunOnboardingPolishContract.minimumHitTarget))
                 .background(
                     RoundedRectangle(cornerRadius: 10, style: .continuous)
                         .fill(primaryDisabled ? OnboardingTheme.muted.opacity(0.45) : OnboardingTheme.ink)
                 )
+                .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
             }
             .buttonStyle(.plain)
             .disabled(primaryDisabled)
@@ -1555,8 +1561,13 @@ private struct DemoPasteTarget: View {
                 .buttonStyle(.plain)
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(OnboardingTheme.muted)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 8)
+                .frame(
+                    minWidth: CGFloat(FirstRunOnboardingPolishContract.minimumHitTarget),
+                    minHeight: CGFloat(FirstRunOnboardingPolishContract.minimumHitTarget)
+                )
+                .contentShape(Rectangle())
+                .accessibilityLabel("Clear dictation test text")
+                .accessibilityIdentifier("transcripted.onboarding.dictation-test.clear")
             }
         }
     }

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -455,7 +455,9 @@ func testUIAutomationSurfaceContract() {
         let settingsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let homeSource = readUIAutomationContractFile("Sources/UI/Settings/HomeView.swift")
         let speakerPeopleSource = readUIAutomationContractFile("Sources/UI/Settings/SpeakerPeopleSettingsSection.swift")
+        let settingsComponentsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsComponents.swift")
         let onboardingSource = readUIAutomationContractFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
+        let firstRunSource = readUIAutomationContractFile("Sources/UI/Shared/FirstRunExperience.swift")
 
         for identifier in [
             "transcripted.home.stats.view",
@@ -540,6 +542,7 @@ func testUIAutomationSurfaceContract() {
             "transcripted.onboarding.nav.back",
             "transcripted.onboarding.nav.skip",
             "transcripted.onboarding.nav.primary",
+            "transcripted.onboarding.dictation-test.clear",
             "transcripted.onboarding.use-case.meetings",
             "transcripted.onboarding.use-case.dictation",
             "transcripted.onboarding.permissions.microphone",
@@ -555,6 +558,34 @@ func testUIAutomationSurfaceContract() {
         ] {
             assertTrue(onboardingSource.contains(identifier), "\(identifier) should stay attached to onboarding click-flow controls")
         }
+
+        assertTrue(
+            onboardingSource.contains("UseCaseChoiceCard(")
+                && onboardingSource.contains("transcripted.onboarding.use-case.meetings")
+                && onboardingSource.contains("transcripted.onboarding.use-case.dictation")
+                && onboardingSource.contains("selectedStateStrokeWidth")
+                && onboardingSource.contains(".contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))"),
+            "onboarding use-case cards should keep their scriptable card-button and selected-state hooks"
+        )
+
+        assertTrue(
+            firstRunSource.contains("static let minimumHitTarget: Double = 44")
+                && firstRunSource.contains("static let modelProgressLabelMinimumWidth: Double = 104")
+                && firstRunSource.contains("static let selectedStateStrokeWidth: Double = 2")
+                && onboardingSource.contains("transcripted.onboarding.nav.skip")
+                && onboardingSource.contains("transcripted.onboarding.nav.primary")
+                && onboardingSource.contains("FirstRunOnboardingPolishContract.minimumHitTarget")
+                && onboardingSource.contains(".contentShape(Rectangle())")
+                && onboardingSource.contains(".contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))"),
+            "onboarding nav and compact controls should keep pinned polish constants and hit-shape hooks"
+        )
+
+        assertTrue(
+            settingsComponentsSource.contains(".monospacedDigit()")
+                && settingsComponentsSource.contains("modelProgressLabelMinimumWidth")
+                && settingsComponentsSource.contains(".accessibilityLabel(Text(status))"),
+            "onboarding/local-model progress labels should stay stable, tabular, and accessible"
+        )
     }
 
     runSuite("UI automation surface contract - QA CLI exposes a real AX smoke") {


### PR DESCRIPTION
## Summary
- expand onboarding skip, primary, and demo clear controls to explicit 44pt hit shapes
- add a stable automation id and accessibility label for the dictation-test clear control
- strengthen source contracts for onboarding use-case cards, nav hit-shape hooks, and model progress label stability

## Interface Feel Better
#### Minimum hit area
| Before | After |
| --- | --- |
| `PermissionsOnboardingView` skip and demo-clear controls relied on text/padding size only | Skip and demo-clear now use the 44pt onboarding hit target plus explicit `contentShape(Rectangle())` |
| Primary nav button relied on label padding for height | Primary nav label now pins `minimumHitTarget` before the visible background and rounded hit shape |

#### Tabular numbers
| Before | After |
| --- | --- |
| Model progress polish was covered by component code but not guarded in the onboarding automation contract | UI contract now pins `.monospacedDigit()`, `modelProgressLabelMinimumWidth`, and progress accessibility label hooks |

#### Selected state / scriptability
| Before | After |
| --- | --- |
| Use-case cards had source behavior, but no focused automation contract for selected-state hooks | UI contract now pins the use-case card IDs, selected stroke hook, and rounded card hit shape |
| Dictation demo clear action had no stable automation id | Added `transcripted.onboarding.dictation-test.clear` |

## Verification
- `git diff --check`
- `bash run-tests.sh --filter UIAutomationSurfaceContract` — 237 passed
- `bash build.sh --no-open` — passed
- `bash run-tests.sh` — 10,637 passed

## Review
- Claude review verdict: PASS, no blockers. Minor notes addressed by moving primary min-height before background and softening source-contract wording / pinning literal constants. Proof: `/Users/redbars/.codex/maestro/runs/20260622T023503Z-onboarding-hit-targets-review-claude`

## Manual proof
- Computer-use visual smoke not run; sheet rows remain FIXED/PASS only where source + test proof is sufficient, not RETEST PASS.

lanes used: Codex=implemented, built, tested, pushed, opened PR; Claude=diff review; Local=skipped; Windows=skipped