### PR TITLE
Polish onboarding permission rows

### DIFF
--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -1275,11 +1275,16 @@ private struct PermissionGrantRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
                     .font(.system(size: 14, weight: .semibold))
+                    .lineLimit(1)
                 Text(reason)
                     .font(.system(size: 12))
                     .foregroundStyle(OnboardingTheme.muted)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.94)
+                    .fixedSize(horizontal: false, vertical: true)
             }
             .foregroundStyle(granted ? OnboardingTheme.window : OnboardingTheme.ink)
+            .layoutPriority(1)
 
             Spacer()
 
@@ -1288,6 +1293,9 @@ private struct PermissionGrantRow: View {
             }
             .buttonStyle(InkButtonStyle(isSubtle: granted, compact: true))
             .disabled(granted)
+            .help(granted ? "\(title) permission is granted" : "\(actionTitle) \(title) permission")
+            .accessibilityLabel(granted ? title : "\(actionTitle) \(title) permission")
+            .accessibilityValue(granted ? "Granted" : "Needs permission")
             .accessibilityIdentifier(automationIdentifier)
         }
         .padding(.horizontal, 20)

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -555,6 +555,32 @@ func testUIAutomationSurfaceContract() {
         ] {
             assertTrue(onboardingSource.contains(identifier), "\(identifier) should stay attached to onboarding click-flow controls")
         }
+
+        assertTrue(
+            onboardingSource.contains("private func startPolling()")
+                && onboardingSource.contains("pollTask = Task { @MainActor in")
+                && onboardingSource.contains("checkAllPermissions(trackChanges: true)")
+                && onboardingSource.contains("try? await Task.sleep(nanoseconds: 1_000_000_000)")
+                && onboardingSource.contains("pollTask?.cancel()"),
+            "onboarding permission retry should keep polling async grants without relying on a manual refresh button"
+        )
+
+        let permissionGrantRowSource = onboardingSource
+            .components(separatedBy: "private struct PermissionGrantRow: View")
+            .dropFirst()
+            .first?
+            .components(separatedBy: "private struct UseCaseChoiceCard: View")
+            .first ?? ""
+
+        assertTrue(
+            !permissionGrantRowSource.isEmpty
+                && permissionGrantRowSource.contains(".lineLimit(2)")
+                && permissionGrantRowSource.contains(".fixedSize(horizontal: false, vertical: true)")
+                && permissionGrantRowSource.contains(".layoutPriority(1)")
+                && permissionGrantRowSource.contains(".accessibilityLabel(granted ? title : \"\\(actionTitle) \\(title) permission\")")
+                && permissionGrantRowSource.contains(".accessibilityValue(granted ? \"Granted\" : \"Needs permission\")"),
+            "onboarding permission rows should keep stable wrapping and readable state"
+        )
     }
 
     runSuite("UI automation surface contract - QA CLI exposes a real AX smoke") {


### PR DESCRIPTION
## Summary
- Tighten onboarding permission row text wrapping so permission reasons keep a stable two-line shape in narrow layouts.
- Add precise help and accessibility label/value copy for permission action buttons.
- Pin permission polling and row polish with the UI automation surface contract.

## Interface Feel Better Changes

### Text wrapping
| Before | After |
| --- | --- |
| `PermissionGrantRow` titles and descriptions relied on default wrapping, so tight layouts could compress or clip the explanation unpredictably. | `Sources/UI/Settings/PermissionsOnboardingView.swift` now keeps the title to one line and gives the reason `.lineLimit(2)`, `.minimumScaleFactor(0.94)`, and `.fixedSize(horizontal: false, vertical: true)`. |
| The text column did not explicitly claim space before the trailing permission button. | The text `VStack` now has `.layoutPriority(1)` so explanatory copy wraps before the button crowds it. |

### Accessibility/state clarity
| Before | After |
| --- | --- |
| Permission buttons exposed the visible text only, so repeated `Allow` buttons could be vague to VoiceOver and hover help. | Buttons now expose contextual `.help`, `.accessibilityLabel`, and `.accessibilityValue` such as `Allow Microphone permission` + `Needs permission`. |
| Granted buttons could only communicate their disabled/granted state through visible copy. | Granted buttons now expose label `Microphone` with value `Granted`, avoiding repeated state wording. |

### Contract proof
| Before | After |
| --- | --- |
| The async permission polling behavior was present but not pinned by the UI automation contract. | `Tests/UIAutomationSurfaceContractTests.swift` now asserts the polling loop, one-second async sleep, permission recheck, and cancellation hooks remain in place. |
| Permission row polish could regress without a source-level guard. | The contract now scopes directly to `PermissionGrantRow` and asserts its wrapping and accessibility modifiers. |

## Verification
- `git diff --check`
- `bash run-tests.sh --filter UIAutomationSurfaceContract` — 235 passed, 0 failed
- `bash build.sh --no-open` — build, signing, launch smoke, performance budget passed
- `bash run-tests.sh` — 10635 passed, 0 failed
- Claude final clean review: PASS, proof `/Users/redbars/.codex/maestro/runs/20260622T025244Z-onboarding-permissions-final-clean-review-claude`

## Manual proof
- Manual TCC/System Settings permission grant smoke not run; matrix rows should stay FIXED/PASS rather than RETEST PASS until visual/manual proof is captured.

Lanes used: Codex=implemented, reviewed, built, tested, opened PR; Claude=reviewed final clean diff (`/Users/redbars/.codex/maestro/runs/20260622T025244Z-onboarding-permissions-final-clean-review-claude`); Local=skipped, not needed for narrow implementation; Windows=skipped, not needed for local macOS UI proof.