### PR TITLE
Polish onboarding agent connect cards

### DIFF
--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -2110,7 +2110,10 @@ private struct ConnectAgentStage: View {
                     glyph: "◆",
                     color: OnboardingTheme.claude,
                     buttonTitle: claudeDesktopButtonTitle,
-                    automationIdentifier: "transcripted.onboarding.agent.connect-claude-desktop"
+                    automationIdentifier: "transcripted.onboarding.agent.connect-claude-desktop",
+                    accessibilityLabel: claudeDesktopAccessibilityLabel,
+                    accessibilityValue: claudeDesktopAccessibilityValue,
+                    isDisabled: connectPhase == .connecting || connectPhase == .connected
                 ) {
                     onConnectClaudeDesktop()
                 }
@@ -2122,7 +2125,9 @@ private struct ConnectAgentStage: View {
                     glyph: "●",
                     color: OnboardingTheme.codex,
                     buttonTitle: copiedItem == .localAgentPrompt ? "Copied" : "Copy prompt",
-                    automationIdentifier: "transcripted.onboarding.agent.copy-local-agent-prompt"
+                    automationIdentifier: "transcripted.onboarding.agent.copy-local-agent-prompt",
+                    accessibilityLabel: "Copy local agent prompt",
+                    accessibilityValue: copiedItem == .localAgentPrompt ? "Copied" : "Ready"
                 ) {
                     onCopy(.localAgentPrompt)
                 }
@@ -2164,6 +2169,32 @@ private struct ConnectAgentStage: View {
             return "Try again"
         }
     }
+
+    private var claudeDesktopAccessibilityLabel: String {
+        switch connectPhase {
+        case .idle:
+            return "Connect Claude Desktop"
+        case .connecting:
+            return "Connecting Claude Desktop"
+        case .connected:
+            return "Claude Desktop connected"
+        case .failed:
+            return "Try connecting Claude Desktop again"
+        }
+    }
+
+    private var claudeDesktopAccessibilityValue: String {
+        switch connectPhase {
+        case .idle:
+            return "Ready"
+        case .connecting:
+            return "Connecting"
+        case .connected:
+            return "Connected"
+        case .failed:
+            return "Needs attention"
+        }
+    }
 }
 
 private struct AgentOptionCard: View {
@@ -2174,7 +2205,10 @@ private struct AgentOptionCard: View {
     let color: Color
     let buttonTitle: String
     let automationIdentifier: String
+    let accessibilityLabel: String
+    let accessibilityValue: String
     var inverted = false
+    var isDisabled = false
     let action: () -> Void
 
     var body: some View {
@@ -2188,13 +2222,18 @@ private struct AgentOptionCard: View {
                 AgentGlyph(glyph: glyph, color: color)
                 Text(title)
                     .font(.system(size: 20, weight: .semibold))
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.94)
                     .fixedSize(horizontal: false, vertical: true)
+                    .layoutPriority(1)
             }
 
             Text(detail)
                 .font(.system(size: 13))
                 .lineSpacing(3)
                 .foregroundStyle(inverted ? OnboardingTheme.window.opacity(0.72) : OnboardingTheme.body)
+                .lineLimit(4)
+                .minimumScaleFactor(0.94)
                 .fixedSize(horizontal: false, vertical: true)
 
             Spacer()
@@ -2203,6 +2242,10 @@ private struct AgentOptionCard: View {
                 action()
             }
             .buttonStyle(InkButtonStyle(isSubtle: inverted))
+            .disabled(isDisabled)
+            .help(accessibilityLabel)
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityValue(accessibilityValue)
             .accessibilityIdentifier(automationIdentifier)
         }
         .foregroundStyle(inverted ? OnboardingTheme.window : OnboardingTheme.ink)

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -555,6 +555,41 @@ func testUIAutomationSurfaceContract() {
         ] {
             assertTrue(onboardingSource.contains(identifier), "\(identifier) should stay attached to onboarding click-flow controls")
         }
+
+        let connectAgentStageSource = onboardingSource
+            .components(separatedBy: "private struct ConnectAgentStage: View")
+            .dropFirst()
+            .first?
+            .components(separatedBy: "private struct AgentOptionCard: View")
+            .first ?? ""
+        let agentOptionCardSource = onboardingSource
+            .components(separatedBy: "private struct AgentOptionCard: View")
+            .dropFirst()
+            .first?
+            .components(separatedBy: "private struct AgentGlyph: View")
+            .first ?? ""
+
+        assertTrue(
+            !connectAgentStageSource.isEmpty
+                && connectAgentStageSource.contains("accessibilityLabel: claudeDesktopAccessibilityLabel")
+                && connectAgentStageSource.contains("accessibilityValue: claudeDesktopAccessibilityValue")
+                && connectAgentStageSource.contains("isDisabled: connectPhase == .connecting || connectPhase == .connected")
+                && connectAgentStageSource.contains("accessibilityLabel: \"Copy local agent prompt\"")
+                && connectAgentStageSource.contains("accessibilityValue: copiedItem == .localAgentPrompt ? \"Copied\" : \"Ready\""),
+            "onboarding agent cards should keep contextual button state instead of generic Connect/Copy labels"
+        )
+
+        assertTrue(
+            !agentOptionCardSource.isEmpty
+                && agentOptionCardSource.contains(".lineLimit(2)")
+                && agentOptionCardSource.contains(".lineLimit(4)")
+                && agentOptionCardSource.contains(".minimumScaleFactor(0.94)")
+                && agentOptionCardSource.contains(".layoutPriority(1)")
+                && agentOptionCardSource.contains(".help(accessibilityLabel)")
+                && agentOptionCardSource.contains(".accessibilityLabel(accessibilityLabel)")
+                && agentOptionCardSource.contains(".accessibilityValue(accessibilityValue)"),
+            "onboarding agent option cards should keep stable wrapping and explicit action accessibility"
+        )
     }
 
     runSuite("UI automation surface contract - QA CLI exposes a real AX smoke") {


### PR DESCRIPTION
## Summary
- Give onboarding agent-connect buttons contextual help, accessibility labels, and accessibility values instead of generic `Connect` / `Copy prompt` only.
- Disable the Claude Desktop action while it is connecting or already connected, leaving idle and failed/retry states actionable.
- Stabilize agent card title/detail wrapping and pin the contract in `UIAutomationSurfaceContractTests`.

## Interface Feel Better Changes

### Text wrapping
| Before | After |
| --- | --- |
| Agent card titles and detail copy relied on default wrapping inside a fixed-height card. | `AgentOptionCard` now caps titles to two lines and details to four lines with `.minimumScaleFactor(0.94)` and vertical fixed sizing. |
| The title sat beside a fixed glyph without claiming width explicitly. | The title gets `.layoutPriority(1)` so it wraps before crowding the glyph/button rhythm. |

### Accessibility/state clarity
| Before | After |
| Buttons exposed generic labels like `Connect` and `Copy prompt`. | Buttons now expose contextual labels/values such as `Connect Claude Desktop` + `Ready` and `Copy local agent prompt` + `Copied`. |
| The Claude Desktop button could remain actionable-looking while connecting or after reaching the connected state. | The card disables the button for `.connecting` and `.connected`, while `.failed` stays enabled for retry. |
| Hover help did not name the exact action. | Buttons now use `.help(accessibilityLabel)` so pointer users get the same contextual action name. |

### Contract proof
| Before | After |
| Onboarding only pinned the agent button automation IDs. | The UI automation surface contract now scopes to `ConnectAgentStage` and `AgentOptionCard` and asserts contextual labels/values, disabled state, wrapping caps, and help/AX hooks. |

## Verification
- `git diff --check`
- `bash run-tests.sh --filter UIAutomationSurfaceContract` — 235 passed, 0 failed
- `bash build.sh --no-open` — build, signing, launch smoke, performance budget passed
- `bash run-tests.sh` — 10635 passed, 0 failed
- Claude review: PASS, proof `/Users/redbars/.codex/maestro/runs/20260622T025752Z-onboarding-agent-connect-review-claude`

## Manual proof
- Manual first-run onboarding visual/TCC/agent-connect smoke not run; keep matrix row FIXED rather than RETEST PASS until visual proof is captured.

Lanes used: Codex=implemented, reviewed, built, tested, opened PR; Claude=reviewed diff (`/Users/redbars/.codex/maestro/runs/20260622T025752Z-onboarding-agent-connect-review-claude`); Local=skipped, not needed for narrow implementation; Windows=skipped, not needed for local macOS UI proof.