### PR TITLE
Pin existing install onboarding skip

### DIFF
--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -726,14 +726,6 @@ struct PermissionsOnboardingView: View {
         currentPermissionStatuses()[kind] ?? "unknown"
     }
 
-    static var hasCompleted: Bool {
-        UserDefaults.standard.bool(forKey: "permissionsOnboardingCompleted")
-    }
-
-    static func markCompleted() {
-        UserDefaults.standard.set(true, forKey: "permissionsOnboardingCompleted")
-    }
-
     private static func steps(for useCase: OnboardingUseCase) -> [OnboardingStepSpec] {
         switch useCase {
         case .meetings:

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -3038,6 +3038,35 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - existing installs skip first-run onboarding") {
+        let appContents = readRepoTextFile("Sources/TranscriptedApp.swift")
+        let onboardingContents = readRepoTextFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
+        let preferencesContents = readRepoTextFile("Sources/Support/PermissionsOnboardingPreferences.swift")
+
+        assertTrue(
+            preferencesContents.contains("static func hasCompleted(userDefaults: UserDefaults = .standard) -> Bool")
+                && preferencesContents.contains("if userDefaults.bool(forKey: forceKey)")
+                && preferencesContents.contains("return userDefaults.bool(forKey: completionKey)")
+                && preferencesContents.contains("static func markCompleted(userDefaults: UserDefaults = .standard)")
+                && preferencesContents.contains("userDefaults.removeObject(forKey: forceKey)"),
+            "onboarding completion should stay centralized so existing installs skip onboarding while forced reruns still work"
+        )
+        assertTrue(
+            appContents.contains("guard !PermissionsOnboardingPreferences.hasCompleted(), !hasPresentedInitialOnboarding else { return }")
+                && appContents.contains("guard let self, !self.onboardingWindowController.isVisible, !PermissionsOnboardingPreferences.hasCompleted() else { return }")
+                && appContents.contains("onboardingWindowController.present(entrypoint: \"dock_icon\")")
+                && appContents.contains("onboardingWindowController.present(entrypoint: \"single_instance_reopen\")")
+                && appContents.contains("onboardingWindowController.present(entrypoint: \"status_item\")")
+                && appContents.contains("private func finishOnboarding()")
+                && appContents.contains("PermissionsOnboardingPreferences.markCompleted()"),
+            "all app entry points should route completed installs to Home/menu instead of reopening first-run onboarding"
+        )
+        assertFalse(
+            onboardingContents.contains("permissionsOnboardingCompleted"),
+            "the SwiftUI onboarding view should not carry a raw completion-key helper that can drift from forced-rerun behavior"
+        )
+    }
+
     runSuite("Repo command contract - onboarding funnel telemetry is wired from the active view") {
         let contents = readRepoTextFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
 


### PR DESCRIPTION
## Summary
- Remove unused raw `permissionsOnboardingCompleted` helpers from `PermissionsOnboardingView` so the UI cannot drift from forced-rerun behavior.
- Add a repo command contract proving existing installs skip first-run onboarding through `PermissionsOnboardingPreferences` while forced reruns still work.
- Pin the app entrypoints that should show onboarding only when incomplete: initial launch, status item, Dock reopen, and single-instance reopen.

## Interface Feel Better Changes

### State clarity
| Before | After |
| --- | --- |
| `PermissionsOnboardingView` carried unused raw completion helpers that read/write `permissionsOnboardingCompleted` directly. | Completion state now stays centralized through `PermissionsOnboardingPreferences`, which honors `forcePermissionsOnboarding` and clears it on completion. |
| Existing-install skip behavior was spread across app entrypoints without a focused contract. | `RepoCommandContractTests` now pins the initial launch, status item, Dock reopen, and single-instance reopen gates. |

### Contract proof
| Before | After |
| --- | --- |
| Row 16 had source inventory only. | Added a contract that completed installs route to Home/menu instead of reopening first-run onboarding, while forced reruns remain possible. |

## Verification
- `git diff --check`
- `bash run-tests.sh --filter RepoCommandContract` — 614 passed, 0 failed
- `bash run-tests.sh --filter PermissionsOnboardingPreferences` — 11 passed, 0 failed
- `bash build.sh --no-open` — build, signing, launch smoke, performance budget passed
- `bash run-tests.sh` — 10636 passed, 0 failed
- Claude review: PASS, proof `/Users/redbars/.codex/maestro/runs/20260622T030652Z-existing-install-onboarding-final-review-claude`

## Manual proof
- Manual existing-install launch/reopen smoke not run; matrix row should stay FIXED/PASS, not RETEST PASS, until app-launch proof is captured.

Lanes used: Codex=implemented, reviewed, built, tested, opened PR; Claude=reviewed diff (`/Users/redbars/.codex/maestro/runs/20260622T030652Z-existing-install-onboarding-final-review-claude`); Local=skipped, not needed for narrow contract cleanup; Windows=skipped, not needed for local macOS UI proof.