### PR TITLE
Polish onboarding model failure recovery copy

### DIFF
--- a/Sources/UI/Shared/FirstRunExperience.swift
+++ b/Sources/UI/Shared/FirstRunExperience.swift
@@ -135,6 +135,8 @@ struct FirstRunOnboardingCopy {
 }
 
 enum FirstRunExperience {
+    private static let failedModelSetupDetail = "Local voice setup needs another try. Retry Download will try the same one-time local model setup again."
+
     static func modelPersistenceDetail(for model: TranscriptionModelChoice) -> String {
         "One-time \(model.approximateDownloadSize) download. The model is saved on this Mac outside the app bundle, so normal Transcripted updates do not download it again."
     }
@@ -387,10 +389,10 @@ enum FirstRunExperience {
                 progress: 1.0,
                 tone: .ready
             )
-        case .failed(let message):
+        case .failed:
             return FirstRunModelCardState(
                 title: "Couldn't load \(model.title)",
-                detail: "\(message) Retry Download will try the same one-time local model setup again.",
+                detail: failedModelSetupDetail,
                 status: "Retry needed",
                 progress: nil,
                 tone: .failed

--- a/Tests/FirstRunExperienceTests.swift
+++ b/Tests/FirstRunExperienceTests.swift
@@ -398,6 +398,29 @@ func testFirstRunExperience() {
         assertNil(card.progress, "cached files should not show fake download progress")
     }
 
+    runSuite("FirstRunExperience.modelCard — failed setup stays concise and retryable") {
+        let card = FirstRunExperience.modelCard(
+            for: .failed("CoreML failed while reading /Users/example/Library/Application Support/Transcripted/private-model-file")
+        )
+
+        assertEqual(card.title, "Couldn't load Parakeet TDT V3", "failed model card should name the affected model")
+        assertEqual(card.status, "Retry needed", "failed model card should make the recovery state clear")
+        assertEqual(card.tone, .failed, "failed model card should keep the visual failure tone")
+        assertNil(card.progress, "failed model setup should not show fake download progress")
+        assertTrue(
+            card.detail.contains("Local voice setup needs another try"),
+            "failed model card should lead with a plain-language recovery cue"
+        )
+        assertTrue(
+            card.detail.contains("Retry Download"),
+            "failed model card should name the retry action"
+        )
+        assertFalse(
+            card.detail.contains("/Users/example"),
+            "failed model card should not expose raw local diagnostic paths in onboarding"
+        )
+    }
+
     runSuite("FirstRunExperience.modelCard — names Whisper when it is selected") {
         let card = FirstRunExperience.modelCard(
             for: .downloading(progress: 0.25),


### PR DESCRIPTION
## Summary
- Replaces raw local-model failure diagnostics in first-run onboarding with stable recovery copy.
- Adds a fast-test contract proving the failed model card stays concise, retryable, and does not expose local paths.

## Interface Feel Better Table
| Principle | Before | After |
| --- | --- | --- |
| Privacy-safe error states | Failed setup pasted the raw model error into onboarding, which could include local paths or long diagnostics. | Failed setup leads with a short recovery cue and names the retry action without exposing raw diagnostics. |
| Text wrapping / concise descriptions | Variable-length error strings could overflow the model card copy area. | Fixed two-sentence copy fits the existing first-run card line limits. |
| Clear recovery affordance | Error detail depended on the underlying technical message. | Error detail consistently points to Retry Download as the next action. |

## Verification
- `git diff --check`
- `bash run-tests.sh --filter FirstRunExperience` — 108 passed
- `bash build.sh --no-open`
- `bash run-tests.sh` — 10640 passed
- Claude review PASS: `/Users/redbars/.codex/maestro/runs/20260622T031611Z-onboarding-error-state-review-claude`

## Manual Proof
- Manual visual/TCC/model-failure UI proof still needed; this PR is code/test verified only.

lanes used: Codex=implemented, built, tested, pushed PR; Claude=diff review PASS at /Users/redbars/.codex/maestro/runs/20260622T031611Z-onboarding-error-state-review-claude; Local=skipped; Windows=skipped