### PR TITLE
Reduce dictation loading retry flicker

### DIFF
--- a/Sources/UI/Overlay/DictationMicrophoneLoadingPresentationPolicy.swift
+++ b/Sources/UI/Overlay/DictationMicrophoneLoadingPresentationPolicy.swift
@@ -22,7 +22,7 @@ struct DictationMicrophoneLoadingPresentationPolicy {
             ? "Connecting to the new audio device."
             : "Opening the selected audio input."
         let status: String?
-        if startAttempts > 1 {
+        if startAttempts > 1 && elapsed >= switchingCopyDelay {
             status = "Retrying \(deviceName)"
         } else if elapsed > 1.5 {
             status = "Still connecting to \(deviceName)\u{2026}"

--- a/Tests/DictationMicrophoneLoadingPresentationPolicyTests.swift
+++ b/Tests/DictationMicrophoneLoadingPresentationPolicyTests.swift
@@ -28,6 +28,34 @@ func testDictationMicrophoneLoadingPresentationPolicy() {
         assertEqual(copy.detail, "Connecting to the new audio device.", "real recovery should keep recovery detail")
     }
 
+    runSuite("DictationMicrophoneLoadingPresentationPolicy suppresses brief retry flicker") {
+        let copy = DictationMicrophoneLoadingPresentationPolicy.copy(
+            elapsed: 0.2,
+            deviceName: "MacBook Pro Microphone",
+            isRecovering: true,
+            inputFormatReady: false,
+            startAttempts: 2
+        )
+
+        assertEqual(copy.title, "Starting microphone", "brief route churn should keep the initial title stable")
+        assertEqual(copy.detail, "Opening the selected audio input.", "brief route churn should avoid flashing switching copy")
+        assertNil(copy.status, "brief retry attempts should not flash a retry status before the switching delay")
+    }
+
+    runSuite("DictationMicrophoneLoadingPresentationPolicy shows retry at the switching boundary") {
+        let copy = DictationMicrophoneLoadingPresentationPolicy.copy(
+            elapsed: DictationMicrophoneLoadingPresentationPolicy.switchingCopyDelay,
+            deviceName: "MacBook Pro Microphone",
+            isRecovering: true,
+            inputFormatReady: false,
+            startAttempts: 2
+        )
+
+        assertEqual(copy.title, "Switching microphone", "visible recovery should name the route change")
+        assertEqual(copy.detail, "Connecting to the new audio device.", "visible recovery should explain the wait")
+        assertEqual(copy.status, "Retrying MacBook Pro Microphone", "retry status should arrive with the switching copy")
+    }
+
     runSuite("DictationMicrophoneLoadingPresentationPolicy keeps retry status") {
         let copy = DictationMicrophoneLoadingPresentationPolicy.copy(
             elapsed: 2.0,


### PR DESCRIPTION
## Summary
- Suppresses the transient `Retrying <device>` status until the microphone loading overlay has crossed the same 0.6s switching-copy delay.
- Adds focused policy tests for brief retry flicker, the exact switching boundary, and long retry behavior.

## Interface Feel Better Table
| Principle | Before | After |
| --- | --- | --- |
| Interruptible/stable state changes | A brief retry attempt could show `Retrying <device>` while the overlay still said `Starting microphone`. | Retry status appears only when the overlay also switches to `Switching microphone`, so the state changes as one coherent unit. |
| Text stability | Loading copy could flicker during fast route churn. | The first 0.6s keeps the initial copy stable, then reveals route recovery if the wait is real. |
| Precise status copy | Retry detail could appear before the UI had committed to a recovery state. | Retry detail is aligned with the visible recovery threshold and still names the device on sustained retry. |

## Verification
- `git diff --check`
- `bash run-tests.sh --filter DictationMicrophoneLoadingPresentationPolicy` — 13 passed
- `bash run-tests.sh --filter DictationRecordingStartOverlayPolicy` — 30 passed
- `bash build.sh --no-open`
- `bash run-tests.sh` — 10639 passed
- Claude final review PASS: `/Users/redbars/.codex/maestro/runs/20260622T032551Z-dictation-loading-overlay-final-review-claude`

## Manual Proof
- Manual/live dictation route-churn proof still needed before RETEST PASS.

lanes used: Codex=implemented, built, tested, pushed PR; Claude=final diff review PASS at /Users/redbars/.codex/maestro/runs/20260622T032551Z-dictation-loading-overlay-final-review-claude; Local=skipped; Windows=skipped