### PR TITLE
Improve dictation stop button target

### DIFF
--- a/Sources/UI/Overlay/OverlayHeaderView.swift
+++ b/Sources/UI/Overlay/OverlayHeaderView.swift
@@ -52,6 +52,8 @@ private final class OverlayPrimaryButton: NSButton {
     }
 
     private func updateLayerAppearance() {
+        let shouldScale = isHighlighted && !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        layer?.transform = shouldScale ? CATransform3DMakeScale(0.97, 0.97, 1) : CATransform3DIdentity
         layer?.backgroundColor = (isHighlighted
             ? NSColor.white.withAlphaComponent(0.78)
             : NSColor.white.withAlphaComponent(0.94)
@@ -77,6 +79,19 @@ final class OverlayHeaderView: NSView {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError() }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        if !stopButton.isHidden, stopButton.isEnabled, stopButton.alphaValue > 0 {
+            let stopPoint = convert(point, to: stopButton)
+            let widthInset = min(0, (stopButton.bounds.width - OverlayTokens.minimumHitTarget) / 2)
+            let heightInset = min(0, (stopButton.bounds.height - OverlayTokens.minimumHitTarget) / 2)
+            if stopButton.bounds.insetBy(dx: widthInset, dy: heightInset).contains(stopPoint) {
+                return stopButton
+            }
+        }
+
+        return super.hitTest(point)
+    }
 
     private func setupViews() {
         // Mode label

--- a/Sources/UI/Overlay/OverlayTokens.swift
+++ b/Sources/UI/Overlay/OverlayTokens.swift
@@ -25,6 +25,7 @@ enum OverlayTokens {
     static let cornerRadius: CGFloat   = 12
     static let panelCursorMiniCornerRadius: CGFloat = 17
     static let contentPadding: CGFloat = 12
+    static let minimumHitTarget: CGFloat = 40
 
     // Header
     static let headerHeight: CGFloat = 32

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -1892,6 +1892,19 @@ func testRepoCommandContract() {
             "mini cursor dictation should never leak the stop button into the tiny pill"
         )
         assertTrue(
+            headerContents.contains("override func hitTest(_ point: NSPoint) -> NSView?")
+                && headerContents.contains("OverlayTokens.minimumHitTarget")
+                && headerContents.contains("convert(point, to: stopButton)")
+                && headerContents.contains("stopButton.bounds.insetBy"),
+            "dictation overlay stop control should keep a 40pt hit target without enlarging the compact header"
+        )
+        assertTrue(
+            headerContents.contains("CATransform3DMakeScale(0.97, 0.97, 1)")
+                && headerContents.contains("isHighlighted")
+                && headerContents.contains("accessibilityDisplayShouldReduceMotion"),
+            "dictation overlay stop control should keep tactile pressed feedback that respects Reduce Motion"
+        )
+        assertTrue(
             headerContents.contains("setAccessibilityLabel(accessibilityLabel(for: state))")
                 && headerContents.contains("Dictation listening")
                 && headerContents.contains("Press Escape or your dictation shortcut"),
@@ -1902,6 +1915,11 @@ func testRepoCommandContract() {
         assertTrue(
             rootContents.contains("showsQuietStartupWaveform: state == .starting && isMiniCursorMode"),
             "mini cursor dictation should show a flat quiet waveform during startup"
+        )
+        let tokensContents = readRepoTextFile("Sources/UI/Overlay/OverlayTokens.swift")
+        assertTrue(
+            tokensContents.contains("static let minimumHitTarget: CGFloat = 40"),
+            "overlay controls should keep a shared 40pt minimum hit target token"
         )
 
         let contents = readRepoTextFile("Sources/UI/Overlay/DictationSessionController.swift")


### PR DESCRIPTION
## Summary
- Adds a shared 40pt overlay hit-target token.
- Expands the dictation overlay Stop button hit area from the parent header without enlarging the compact visual layout.
- Adds subtle pressed scale feedback gated by macOS Reduce Motion.
- Pins the behavior in repo contract tests.

## Interface Feel Better Table
| Principle | Before | After |
| --- | --- | --- |
| Minimum hit area | Stop was visually compact and its effective target followed the small text button frame. | Stop keeps the compact visual size while the parent header routes a 40pt interactive target to it. |
| Scale on press | Press feedback was only color/highlight. | Press now adds a subtle 0.97 scale when Reduce Motion allows it. |
| Reduced motion | Press motion was not part of the control state. | Motion feedback is skipped when macOS Reduce Motion is enabled. |
| No overlapping hit areas | Enlarging the visual button would crowd the compact overlay. | Hit target expands through AppKit hit testing, leaving the layout unchanged. |

## Verification
- `git diff --check`
- `bash run-tests.sh --filter RepoCommandContract` — 614 passed
- `bash build.sh --no-open`
- `bash run-tests.sh` — 10636 passed
- Claude final review PASS: `/Users/redbars/.codex/maestro/runs/20260622T033252Z-dictation-stop-control-final-review-claude`

## Manual Proof
- Manual/live click-target proof still needed before RETEST PASS.

lanes used: Codex=implemented, built, tested, pushed PR; Claude=final AppKit review PASS at /Users/redbars/.codex/maestro/runs/20260622T033252Z-dictation-stop-control-final-review-claude; Local=skipped; Windows=skipped