### PR TITLE
Polish dictation no-speech copy

### DIFF
--- a/Sources/UI/Overlay/DictationNoSpeechPresentationPolicy.swift
+++ b/Sources/UI/Overlay/DictationNoSpeechPresentationPolicy.swift
@@ -3,8 +3,8 @@ import Foundation
 enum DictationNoSpeechPresentationPolicy {
     static func message(trigger: String) -> String {
         if trigger == "physical_key" {
-            return "Transcripted didn't catch your voice. Keep holding the dictation key until you're done talking."
+            return "No speech heard. Hold the dictation key while you talk."
         }
-        return "No speech heard. Try speaking a little longer."
+        return "No speech heard. Start over and speak a little longer."
     }
 }

--- a/Tests/DictationNoSpeechPresentationPolicyTests.swift
+++ b/Tests/DictationNoSpeechPresentationPolicyTests.swift
@@ -6,18 +6,18 @@ func testDictationNoSpeechPresentationPolicy() {
 
         assertEqual(
             message,
-            "Transcripted didn't catch your voice. Keep holding the dictation key until you're done talking.",
+            "No speech heard. Hold the dictation key while you talk.",
             "physical key no-speech copy should explain the press-and-hold behavior"
         )
     }
 
-    runSuite("DictationNoSpeechPresentationPolicy keeps generic copy for menu dictation") {
+    runSuite("DictationNoSpeechPresentationPolicy gives menu users a direct retry path") {
         let message = DictationNoSpeechPresentationPolicy.message(trigger: "menu")
 
         assertEqual(
             message,
-            "No speech heard. Try speaking a little longer.",
-            "non-physical-key dictation should keep the broader no-speech guidance"
+            "No speech heard. Start over and speak a little longer.",
+            "non-physical-key dictation should explain the next retry action"
         )
     }
 }


### PR DESCRIPTION
## Summary
- Shortens no-speech overlay copy so both physical-key and generic retry guidance fit the current single-line error label.
- Makes each no-speech state name one clear recovery action.
- Updates focused policy tests for the new recovery copy.

## Interface Feel Better Table
| Principle | Before | After |
| --- | --- | --- |
| Text wrapping / fit | Physical-key no-speech copy was long enough to truncate in the one-line overlay error label. | Physical-key copy fits the measured 336pt label budget: `No speech heard. Hold the dictation key while you talk.` |
| Clear recovery affordance | Generic no-speech copy said to speak longer, but did not name restarting dictation. | Generic copy fits the same label budget and names the retry path: `No speech heard. Start over and speak a little longer.` |
| Consistent error state | Physical and generic no-speech states used different opening language. | Both start with `No speech heard.` and then give one action. |

## Verification
- `git diff --check`
- `bash run-tests.sh --filter DictationNoSpeechPresentationPolicy` — 2 passed
- `bash build.sh --no-open`
- `bash run-tests.sh` — 10633 passed
- Claude final review PASS with measured width proof: `/Users/redbars/.codex/maestro/runs/20260622T034652Z-dictation-no-speech-final-review-claude`

## Manual Proof
- Manual no-speech overlay screenshot still needed before RETEST PASS.

lanes used: Codex=implemented, built, tested, pushed PR; Claude=copy/layout review PASS at /Users/redbars/.codex/maestro/runs/20260622T034652Z-dictation-no-speech-final-review-claude; Local=used inside Claude review for width measurement; Windows=skipped