### PR TITLE
Polish dictation microphone timeout copy

### DIFF
--- a/Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift
+++ b/Sources/UI/Overlay/DictationRecordingStartOverlayPolicy.swift
@@ -71,14 +71,14 @@ struct DictationMicrophoneTimeoutPresentationPolicy {
         routeContext: [String: String] = [:]
     ) -> String {
         if isBluetoothFallbackRoute(routeContext) {
-            return "Couldn't start the built-in microphone while Bluetooth audio was active. Try again, or choose a different input in System Settings."
+            return "Bluetooth audio blocked the mic. Try again."
         }
 
         if startAttempts > 0, inputFormatReady {
-            return "Couldn't start the microphone. Try again, or choose a different input in System Settings."
+            return "Mic didn't start. Try again or choose another input."
         }
 
-        return "Couldn't reach \(deviceName). Try selecting a different input in System Settings."
+        return "Selected mic unavailable. Choose another input."
     }
 
     private static func isBluetoothFallbackRoute(_ context: [String: String]) -> Bool {

--- a/Tests/DictationRecordingStartOverlayPolicyTests.swift
+++ b/Tests/DictationRecordingStartOverlayPolicyTests.swift
@@ -158,7 +158,7 @@ func testDictationRecordingStartOverlayPolicy() {
 
         assertEqual(
             message,
-            "Couldn't start the built-in microphone while Bluetooth audio was active. Try again, or choose a different input in System Settings.",
+            "Bluetooth audio blocked the mic. Try again.",
             "Bluetooth fallback timeouts should tell users what changed instead of blaming only the selected mic"
         )
     }
@@ -179,7 +179,7 @@ func testDictationRecordingStartOverlayPolicy() {
 
         assertEqual(
             message,
-            "Couldn't start the built-in microphone while Bluetooth audio was active. Try again, or choose a different input in System Settings.",
+            "Bluetooth audio blocked the mic. Try again.",
             "Bluetooth fallback start failures should not fall through to generic microphone copy"
         )
     }
@@ -193,8 +193,22 @@ func testDictationRecordingStartOverlayPolicy() {
 
         assertEqual(
             message,
-            "Couldn't reach Studio Display Microphone. Try selecting a different input in System Settings.",
-            "non-Bluetooth route failures should keep the existing device-specific guidance"
+            "Selected mic unavailable. Choose another input.",
+            "non-Bluetooth route failures should keep a short input-change path"
+        )
+    }
+
+    runSuite("DictationMicrophoneTimeoutPresentationPolicy keeps generic retry copy short") {
+        let message = DictationMicrophoneTimeoutPresentationPolicy.message(
+            deviceName: "MacBook Pro Microphone",
+            startAttempts: 1,
+            inputFormatReady: true
+        )
+
+        assertEqual(
+            message,
+            "Mic didn't start. Try again or choose another input.",
+            "generic start failures should keep one visible retry path"
         )
     }
 


### PR DESCRIPTION
## Summary
- Shortens microphone timeout overlay copy so every route fits the one-line error label.
- Keeps Bluetooth fallback, generic retry, and selected-input unavailable states distinct.
- Adds focused coverage for the generic retry branch.

## Interface Feel Better Table
| Principle | Before | After |
| --- | --- | --- |
| Text wrapping / fit | Bluetooth timeout copy was far wider than the 336pt one-line overlay label and would truncate. | Bluetooth copy fits the measured label budget: `Bluetooth audio blocked the mic. Try again.` |
| Clear recovery affordance | Generic mic-start failures used a long System Settings sentence. | Generic retry copy fits and gives one clear path: `Mic didn't start. Try again or choose another input.` |
| Optical clarity in compact error states | Unreachable device copy could include long device names and overflow. | Unavailable-input copy stays stable: `Selected mic unavailable. Choose another input.` |

## Verification
- `git diff --check`
- AppKit width check against 336pt label budget — all final strings passed
- `bash run-tests.sh --filter DictationRecordingStartOverlayPolicy` — 31 passed
- `bash build.sh --no-open`
- `bash run-tests.sh` — 10634 passed
- Claude review PASS with measured width proof: `/Users/redbars/.codex/maestro/runs/20260622T035131Z-dictation-mic-timeout-copy-review-claude`

## Manual Proof
- Manual microphone-timeout/Bluetooth-fallback overlay screenshot still needed before RETEST PASS.

lanes used: Codex=implemented, built, tested, pushed PR; Claude=copy/layout review PASS at /Users/redbars/.codex/maestro/runs/20260622T035131Z-dictation-mic-timeout-copy-review-claude; Local=measurement done via AppKit in review; Windows=skipped