### PR TITLE
Expand Home compact control hit targets

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -559,6 +559,8 @@ private struct HomeAttentionPill: View {
             .contentShape(Capsule(style: .continuous))
         }
         .buttonStyle(.plain)
+        .frame(minHeight: 40)
+        .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .animation(.easeOut(duration: 0.12), value: isHovering)
         .help(issue.detail)
@@ -716,6 +718,11 @@ struct HomeArtifactStatus: Equatable {
 
 // MARK: - Row action buttons
 
+private enum HomeControlMetrics {
+    static let minimumHitArea: CGFloat = 40
+    static let compactVisualSize: CGFloat = 26
+}
+
 struct HomeRowMenuItem: Identifiable {
     let id = UUID()
     let title: String
@@ -760,7 +767,7 @@ struct HomeRowActionButtons: View {
 
             if !menuItems.isEmpty {
                 HomeRowMoreMenuButton(items: menuItems)
-                    .frame(width: 26, height: 26)
+                    .frame(width: HomeControlMetrics.minimumHitArea, height: HomeControlMetrics.minimumHitArea)
                     .help("More options")
             }
         }
@@ -771,10 +778,12 @@ struct HomeRowActionButtons: View {
             Image(systemName: systemName)
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.secondary)
-                .frame(width: 26, height: 26)
+                .frame(width: HomeControlMetrics.compactVisualSize, height: HomeControlMetrics.compactVisualSize)
                 .contentShape(Rectangle())
         }
         .buttonStyle(SettingsHoverButtonStyle(cornerRadius: 7))
+        .frame(width: HomeControlMetrics.minimumHitArea, height: HomeControlMetrics.minimumHitArea)
+        .contentShape(Rectangle())
         .help(help)
         .accessibilityLabel(Text(help))
         .accessibilityIdentifier("transcripted.home.row.copy")
@@ -793,6 +802,7 @@ struct HomeRowMoreMenuButton: NSViewRepresentable {
         let button = HoverMenuButton()
         button.isBordered = false
         button.imagePosition = .imageOnly
+        button.imageScaling = .scaleNone
         button.image = NSImage(
             systemSymbolName: "ellipsis",
             accessibilityDescription: "More options"
@@ -1148,6 +1158,8 @@ struct HomeDictationRow: View {
                     }
                     .buttonStyle(.plain)
                     .help("Open Markdown")
+                    .frame(minHeight: HomeControlMetrics.minimumHitArea, alignment: .leading)
+                    .contentShape(Rectangle())
                     .accessibilityIdentifier("transcripted.home.dictation.open-markdown")
                 }
 
@@ -1404,6 +1416,8 @@ struct HomeFailedMeetingInlineRow: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
+                .frame(minHeight: HomeControlMetrics.minimumHitArea)
+                .contentShape(Rectangle())
                 .help("Show saved audio in Finder")
                 .accessibilityIdentifier("transcripted.home.failed-meeting.show-audio")
             }
@@ -1426,7 +1440,7 @@ struct HomeFailedMeetingInlineRow: View {
                     action: onClear
                 )
             ], automationIdentifier: "transcripted.home.failed-meeting.more")
-            .frame(width: 26, height: 26)
+            .frame(width: HomeControlMetrics.minimumHitArea, height: HomeControlMetrics.minimumHitArea)
             .help("More options")
         }
     }
@@ -1524,6 +1538,8 @@ private struct HomeAttentionActionButton: View {
         }
         .buttonStyle(.plain)
         .disabled(isDisabled)
+        .frame(minHeight: HomeControlMetrics.minimumHitArea)
+        .contentShape(Rectangle())
         .onHover { isHovering = $0 }
         .homeAutomationIdentifier(automationIdentifier)
     }
@@ -1781,6 +1797,8 @@ struct HomeMeetingSearchField: View {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 12))
                         .foregroundStyle(.secondary)
+                        .frame(width: HomeControlMetrics.minimumHitArea, height: HomeControlMetrics.minimumHitArea)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .help("Clear filter")
@@ -1788,7 +1806,8 @@ struct HomeMeetingSearchField: View {
             }
         }
         .padding(.horizontal, 10)
-        .padding(.vertical, 7)
+        .padding(.vertical, 0)
+        .frame(minHeight: HomeControlMetrics.minimumHitArea)
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(Color.primary.opacity(0.04))
@@ -2495,6 +2514,8 @@ private struct HomeTranscriptFindBar: View {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 12))
                         .foregroundStyle(.secondary)
+                        .frame(width: HomeControlMetrics.minimumHitArea, height: HomeControlMetrics.minimumHitArea)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .help("Clear find")
@@ -2502,7 +2523,8 @@ private struct HomeTranscriptFindBar: View {
             }
         }
         .padding(.horizontal, 10)
-        .padding(.vertical, 7)
+        .padding(.vertical, 0)
+        .frame(minHeight: HomeControlMetrics.minimumHitArea)
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(Color.primary.opacity(0.04))
@@ -2522,7 +2544,8 @@ private struct HomeTranscriptFindBar: View {
         Button(action: action) {
             Image(systemName: symbol)
                 .font(.system(size: 11, weight: .semibold))
-                .frame(width: 22, height: 20)
+                .frame(width: HomeControlMetrics.minimumHitArea, height: HomeControlMetrics.minimumHitArea)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .help(help)
@@ -2821,6 +2844,8 @@ private struct HomeFailedMeetingRow: View {
                         ) {
                             onRevealAudio()
                         }
+                        .frame(minHeight: HomeControlMetrics.minimumHitArea)
+                        .contentShape(Rectangle())
                     } else {
                         Label("No audio kept", systemImage: "speaker.slash")
                             .font(.caption)
@@ -2852,7 +2877,7 @@ private struct HomeFailedMeetingRow: View {
                     ) {
                         onClear()
                     }
-                    .frame(width: presentation.clearIsDestructive ? 78 : 82, height: 30)
+                    .frame(width: presentation.clearIsDestructive ? 78 : 82, height: HomeControlMetrics.minimumHitArea)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -397,6 +397,8 @@ struct TranscriptedSettingsView: View {
                         .contentShape(Capsule(style: .continuous))
                 }
                 .buttonStyle(.plain)
+                .frame(minWidth: 44, minHeight: 40)
+                .contentShape(Rectangle())
                 .accessibilityIdentifier("transcripted.settings.tab.\(page.rawValue)")
             }
 

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -3101,6 +3101,25 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - Home compact controls keep 40pt hit targets") {
+        let homeContents = readRepoTextFile("Sources/UI/Settings/HomeView.swift")
+        let settingsContents = readRepoTextFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
+        assertTrue(
+            homeContents.contains("static let minimumHitArea: CGFloat = 40"),
+            "Home compact controls should keep a named 40pt minimum hit target"
+        )
+        assertTrue(
+            homeContents.contains(".frame(width: HomeControlMetrics.minimumHitArea, height: HomeControlMetrics.minimumHitArea)")
+                && homeContents.contains(".frame(minHeight: HomeControlMetrics.minimumHitArea"),
+            "Home row action buttons, search clears, and failed-meeting actions should use the minimum hit target"
+        )
+        assertTrue(
+            settingsContents.contains(".frame(minWidth: 44, minHeight: 40)")
+                && settingsContents.contains("transcripted.settings.tab.\\(page.rawValue)"),
+            "settings tab chips should keep at least a 44x40 hit area"
+        )
+    }
+
     runSuite("Repo command contract - Home meeting deletion hashes audio only after metadata candidates") {
         let deletionContents = readRepoTextFile("Sources/UI/Shared/HomeMeetingDeletion.swift")
         let duplicateBlock = sourceSlice(


### PR DESCRIPTION
## Summary
- Expand compact Home/settings controls to at least 40pt hit targets while keeping the visible controls dense.
- Cover attention pills, settings tab chips, Home row copy/more buttons, dictation open affordance, search/find clear controls, find steppers, and failed-meeting actions.
- Add a repo contract so these compact controls do not quietly shrink below the polish floor again.

## Interface Feel Better Audit
| Principle | Before | After |
| --- | --- | --- |
| Minimum hit area | Several Home controls were 22-30pt high/wide: attention pills, search clears, row copy/more, find steppers, failed-meeting actions, and settings tab chips. | Controls now keep compact visuals but expose 40pt hit frames; settings tab chips use at least 44x40. |
| Preserve density | Fix could have made Home rows visibly bulky. | Visual icon/capsule sizes remain compact; the extra area is mostly invisible whitespace/contentShape. |
| Tactile polish | Existing hover/press states worked but only over tiny controls. | Existing exact-property hover/press styles now apply over usable targets. |
| Accessibility | Labels/identifiers existed, but tiny targets were harder to acquire. | Labels/identifiers are preserved and targets are easier for mouse/assistive workflows. |

## Matrix
- Rows fixed by this PR: 50, 51, 52, 54, 56, 63
- Status target: `FIXED`

## Verification
- `git diff --check`
- `bash run-tests.sh --filter RepoCommandContract` — 614 passed
- `bash run-tests.sh --filter Home` — 203 passed
- `bash build.sh --no-open` — passed
- `bash run-tests.sh` — 10636 passed
- Claude review PASS: `/Users/redbars/.codex/maestro/runs/20260622T044340Z-home-hit-targets-review-quick-claude`

## Manual proof still needed
- Real GUI smoke/screenshot for Home visual density and hit target feel.
