### PR TITLE
Expand meeting overlay hit targets

### DIFF
--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -582,7 +582,7 @@ final class MeetingOverlayRootView: NSView {
     private func layoutPrompt() {
         let pad: CGFloat = 12
         let dotSize = MeetingOverlayTokens.dotSize
-        let topY = bounds.height - 22
+        let topY = bounds.height - 24
 
         statusDot.frame = NSRect(x: pad, y: topY - dotSize / 2, width: dotSize, height: dotSize)
 
@@ -606,7 +606,7 @@ final class MeetingOverlayRootView: NSView {
 
         detailLabel.frame = NSRect(
             x: pad,
-            y: 34,
+            y: 55,
             width: bounds.width - pad * 2,
             height: 16
         )
@@ -615,7 +615,7 @@ final class MeetingOverlayRootView: NSView {
         let showsRemind = !remindButton.isHidden
         let remindWidth = showsRemind ? max(118, remindButton.fittingSize.width + 18) : 0
         let primaryWidth = max(74, recordButton.fittingSize.width + 18)
-        let buttonHeight: CGFloat = 24
+        let buttonHeight = MeetingOverlayTokens.promptButtonHeight
         let buttonGap: CGFloat = 8
         let visibleGapCount: CGFloat = showsRemind ? 2 : 1
         let totalButtonWidth = secondaryWidth + remindWidth + primaryWidth + buttonGap * visibleGapCount
@@ -623,14 +623,14 @@ final class MeetingOverlayRootView: NSView {
 
         closeButton.frame = NSRect(
             x: buttonStartX,
-            y: 10,
+            y: 8,
             width: secondaryWidth,
             height: buttonHeight
         )
         if showsRemind {
             remindButton.frame = NSRect(
                 x: closeButton.frame.maxX + buttonGap,
-                y: 10,
+                y: 8,
                 width: remindWidth,
                 height: buttonHeight
             )
@@ -639,7 +639,7 @@ final class MeetingOverlayRootView: NSView {
         }
         recordButton.frame = NSRect(
             x: bounds.width - pad - primaryWidth,
-            y: 10,
+            y: 8,
             width: primaryWidth,
             height: buttonHeight
         )
@@ -1292,7 +1292,8 @@ enum MeetingOverlayTokens {
     static let condensedPillWidth: CGFloat = 120
     static let panelHeight: CGFloat = 44
     static let condensedPillHeight: CGFloat = 32
-    static let promptHeight: CGFloat = 88
+    static let promptButtonHeight: CGFloat = 40
+    static let promptHeight: CGFloat = 106
     static let warmupHeight: CGFloat = 96
     static let errorHeight: CGFloat = 72
     static let cornerRadius: CGFloat = 22
@@ -1305,9 +1306,9 @@ enum MeetingOverlayTokens {
     static let condensedGap: CGFloat = 7
     static let timerFontSize: CGFloat = 13
     static let drawerPad: CGFloat = 12
-    static let drawerBrowserButtonSize: CGFloat = 20
-    static let drawerResizeHandleHeight: CGFloat = 12
-    static let stopHeight: CGFloat  = 28
+    static let drawerBrowserButtonSize: CGFloat = 40
+    static let drawerResizeHandleHeight: CGFloat = 40
+    static let stopHeight: CGFloat  = 40
     static let recordingWaveformWidth: CGFloat = 124
     static let tooltipOffset: CGFloat = 8
     static let tooltipScreenInset: CGFloat = 6

--- a/Tests/RepoCommandContractTests.swift
+++ b/Tests/RepoCommandContractTests.swift
@@ -3101,6 +3101,31 @@ func testRepoCommandContract() {
         )
     }
 
+    runSuite("Repo command contract - meeting overlay transient controls keep 40pt hit targets") {
+        let overlayContents = readRepoTextFile("Sources/UI/Overlay/MeetingOverlayController.swift")
+        let drawerContents = readRepoTextFile("Sources/UI/Overlay/MeetingLiveTranscriptDrawerView.swift")
+        assertTrue(
+            overlayContents.contains("static let promptButtonHeight: CGFloat = 40")
+                && overlayContents.contains("let buttonHeight = MeetingOverlayTokens.promptButtonHeight"),
+            "meeting prompt primary, remind, and dismiss controls should use a named 40pt hit height"
+        )
+        assertTrue(
+            overlayContents.contains("static let stopHeight: CGFloat  = 40")
+                && overlayContents.contains("width: tokens.stopHeight,\n            height: tokens.stopHeight"),
+            "meeting recording stop control should keep a 40x40 hit area"
+        )
+        assertTrue(
+            overlayContents.contains("static let drawerBrowserButtonSize: CGFloat = 40")
+                && drawerContents.contains("width: buttonSize, height: buttonSize"),
+            "live transcript drawer copy and more actions should keep 40x40 hit areas"
+        )
+        assertTrue(
+            overlayContents.contains("static let drawerResizeHandleHeight: CGFloat = 40")
+                && drawerContents.contains("height: MeetingOverlayTokens.drawerResizeHandleHeight"),
+            "live transcript drawer resize grip should keep a 40pt drag target"
+        )
+    }
+
     runSuite("Repo command contract - Home meeting deletion hashes audio only after metadata candidates") {
         let deletionContents = readRepoTextFile("Sources/UI/Shared/HomeMeetingDeletion.swift")
         let duplicateBlock = sourceSlice(


### PR DESCRIPTION
## Summary
- expand meeting prompt dismiss/remind/record controls to a named 40pt hit height
- expand the recording stop control, live drawer copy/more controls, and live drawer resize grip to 40pt targets
- add a repo command contract so these transient overlay controls do not regress below the macOS-friendly target size

## Interface Feel Better Audit

| Principle | Before | After |
| --- | --- | --- |
| Minimum hit area | Meeting prompt actions were 24pt tall, the recording stop control was 28pt, live drawer copy/more controls were 20pt, and the resize grip was 12pt. | Prompt actions, recording stop, live drawer actions, and resize grip now use explicit 40pt tokens. |
| Visual density without overlap | The prompt was sized for compact buttons, so simply growing controls would have cramped prompt copy. | Prompt height grows modestly from 88pt to 106pt, with title/detail/buttons separated in stable vertical bands. |
| Native polish over redesign | The overlay visuals stayed unchanged except for tactile target geometry. | Same visual language, larger interaction zones, no new decoration or state-machine changes. |
| Regression protection | Hit target sizes lived as small literals in overlay layout code. | Named tokens plus repo command contract coverage protect prompt, stop, drawer actions, and resize handle. |

## Matrix Rows
- rows 67, 68, 69: meeting prompt action hit targets
- row 72: recording stop hit target
- row 75: live transcript drawer copy action hit target
- row 77: live drawer resize grip hit target
- rows 78, 79: inactivity and mic-boost prompt actions inherit the prompt hit target fix
- row 76: hit-target portion improved through the drawer action token; browser handoff/failure-copy proof still needs a separate manual/source pass

## Verification
- `git diff --check`
- `bash run-tests.sh --filter RepoCommandContract` — 615 passed
- `bash run-tests.sh --filter MeetingLiveViewAffordance` — 26 passed
- `bash run-tests.sh --filter MeetingDuration` — 12 passed
- `bash run-tests.sh --filter MeetingPillRest` — 10 passed
- `bash run-tests.sh --filter MeetingMicBoostPrompt` — 17 passed
- `bash run-tests.sh --filter MeetingAudioInactivity` — 25 passed
- `bash build.sh --no-open` — passed
- `bash run-tests.sh` — 10637 passed
- Claude static diff review: PASS, proof at `/Users/redbars/.codex/maestro/runs/20260622T045838Z-meeting-overlay-hit-targets-quick-review-claude`

## Manual Proof Still Needed
- Real meeting overlay screenshot / click smoke for prompt buttons, recording stop, drawer copy/more, and resize grip before this is called shippable UI proof.

lanes used: Codex=implementation, build/tests, PR; Claude=static diff review proof at /Users/redbars/.codex/maestro/runs/20260622T045838Z-meeting-overlay-hit-targets-quick-review-claude; Local=skipped because Claude produced proof; Windows=skipped, focused local UI geometry change
