### PR TITLE
Expand retained audio hit targets

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -1641,6 +1641,8 @@ private struct HomeMeetingAudioControl: View {
                 normalFill: isActive ? Color.accentColor.opacity(0.14) : Color.secondary.opacity(0.08),
                 normalStroke: isActive ? Color.accentColor.opacity(0.28) : Color.primary.opacity(0.10)
             ))
+            .frame(minHeight: 40, alignment: .leading)
+            .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
             .accessibilityLabel(title)
             .accessibilityIdentifier("transcripted.home.audio.inline-toggle")
 

--- a/Sources/UI/Settings/TranscriptedSettingsComponents.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsComponents.swift
@@ -300,6 +300,8 @@ struct SettingsInlineActionButton: View {
             normalFill: normalFill,
             normalStroke: normalStroke
         ))
+        .frame(minHeight: 40)
+        .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         .settingsAutomationIdentifier(automationIdentifier)
     }
 

--- a/Sources/UI/Settings/TranscriptedSettingsRows.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsRows.swift
@@ -243,6 +243,8 @@ struct SettingsRecentMeetingAudioControl: View {
                 normalFill: background,
                 normalStroke: stroke
             ))
+            .frame(minHeight: 40, alignment: .leading)
+            .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
 
             if let scrubber {
                 scrubber

--- a/Sources/UI/Shared/MeetingAudioPlayback.swift
+++ b/Sources/UI/Shared/MeetingAudioPlayback.swift
@@ -351,6 +351,8 @@ struct MeetingAudioSourceMenu: View {
             }
             .buttonStyle(.plain)
             .fixedSize()
+            .frame(minHeight: 40)
+            .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
             .help("Choose retained meeting audio source")
         }
     }

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -163,6 +163,8 @@ func testUIAutomationSurfaceContract() {
         let generalControlsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsGeneralControls.swift")
         let settingsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let homeSource = readUIAutomationContractFile("Sources/UI/Settings/HomeView.swift")
+        let settingsRowsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsRows.swift")
+        let meetingAudioPlaybackSource = readUIAutomationContractFile("Sources/UI/Shared/MeetingAudioPlayback.swift")
         let onboardingSource = readUIAutomationContractFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
         let speakerReviewSource = readUIAutomationContractFile("Sources/UI/Settings/SpeakerNamingSheet.swift")
         let agentSettingsSource = readUIAutomationContractFile("Sources/UI/Settings/AgentConnectionSettingsPage.swift")
@@ -237,6 +239,26 @@ func testUIAutomationSurfaceContract() {
         ] {
             assertTrue(failedMeetingRecoverySource.contains(requiredFailedMeetingPolicyHook), "\(requiredFailedMeetingPolicyHook) should keep failed-meeting action policy visible")
         }
+        assertTrue(
+            settingsComponentsSource.contains(".frame(minHeight: 40)")
+                && settingsComponentsSource.contains(".contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))"),
+            "shared inline settings actions should keep a 40pt hit floor for failed-meeting recovery controls"
+        )
+        assertTrue(
+            homeSource.contains(".frame(minHeight: 40, alignment: .leading)")
+                && homeSource.contains(".accessibilityIdentifier(\"transcripted.home.audio.inline-toggle\")"),
+            "Home retained-audio play controls should keep a 40pt hit floor"
+        )
+        assertTrue(
+            settingsRowsSource.contains(".frame(minHeight: 40, alignment: .leading)")
+                && settingsRowsSource.contains("struct SettingsRecentMeetingAudioControl"),
+            "Settings retained-audio play controls should keep a 40pt hit floor"
+        )
+        assertTrue(
+            meetingAudioPlaybackSource.contains(".frame(minHeight: 40)")
+                && meetingAudioPlaybackSource.contains("struct MeetingAudioSourceMenu"),
+            "retained-audio source menus should keep a 40pt hit floor"
+        )
         assertFalse(
             homeSource.contains("representedObject = item.id"),
             "Home row menus should not depend on unstable SwiftUI-generated menu item IDs"


### PR DESCRIPTION
## Summary
- give shared inline Settings/Home action buttons a 40pt minimum hit floor
- give retained meeting-audio play controls in Home and Settings a 40pt minimum hit floor
- give the retained-audio source menu a 40pt minimum hit floor
- add UI automation surface contract hooks so these controls do not regress

## Interface Feel Better Audit

| Principle | Before | After |
| --- | --- | --- |
| Minimum hit area | Failed-meeting recovery actions and retained-audio controls used compact caption padding; one clear action was explicitly 30pt high. | Shared inline actions, Home/Settings retained-audio play controls, and source menus now reserve at least 40pt. |
| Dense native layout | The row controls were visually compact and useful, but the acquisition target was too small for repeated recovery/playback work. | The visible chrome stays compact; the clickable geometry gets safer. |
| Optical alignment | Split mic/system audio controls had small icon/text clusters with no stable touch floor. | Play controls and source menus keep their current alignment while the target rectangle matches the row action style. |
| Regression protection | The hit target was implicit in padding and easy to shrink accidentally. | UIAutomationSurfaceContract now asserts the 40pt hooks for shared inline actions, Home audio, Settings audio, and source menus. |

## Matrix Rows
- row 82: meeting failure recovery controls
- row 86: retained audio playback/source controls

## Verification
- `git diff --check`
- `bash run-tests.sh --filter UIAutomationSurfaceContract` — 237 passed
- `bash run-tests.sh --filter FailedMeetingRecoveryPresentation` — 20 passed
- `bash run-tests.sh --filter RecentCaptureScanners` — 172 passed
- `bash build.sh --no-open` — passed
- `bash run-tests.sh` — 10637 passed
- local independent review: PASS, proof at `/Users/redbars/.codex/maestro/runs/20260622T051027Z-retained-audio-hit-targets-local-review-local`
- Claude review attempt stalled with no output and does not count as proof

## Manual Proof Still Needed
- Real Home/Settings failed-meeting row screenshot/click smoke for play, source, Show Audio, Try Again, Delete/Dismiss before RETEST PASS.

lanes used: Codex=implementation, build/tests, PR; Claude=attempted but stalled/no output, not counted; Local=review proof at /Users/redbars/.codex/maestro/runs/20260622T051027Z-retained-audio-hit-targets-local-review-local; Windows=skipped, focused local UI source change
