### PR TITLE
Expand speaker naming sheet hit targets

### DIFF
--- a/Sources/UI/Settings/SpeakerNamingSheet.swift
+++ b/Sources/UI/Settings/SpeakerNamingSheet.swift
@@ -13,6 +13,14 @@ import AppKit
 import Combine
 import TranscriptedCore
 
+enum SpeakerNamingHitTargets {
+    static let minimum: CGFloat = 40
+    static let rowHeight: CGFloat = 136
+    static let rowSpacing: CGFloat = 12
+    static let sectionHeaderHeight: CGFloat = 40
+    static let sectionHeaderGap: CGFloat = 10
+}
+
 @available(macOS 14.0, *)
 @MainActor
 final class SpeakerNamingSheet {
@@ -207,7 +215,6 @@ final class SpeakerNamingContentView: NSView {
         remoteSectionLabel.textColor = NSColor.labelColor
 
         keepAsYouButton.bezelStyle = .rounded
-        keepAsYouButton.controlSize = .small
         keepAsYouButton.font = NSFont.systemFont(ofSize: 12, weight: .medium)
         keepAsYouButton.toolTip = "Use one \"You\" label for everyone picked up by the local microphone"
         keepAsYouButton.target = self
@@ -274,7 +281,7 @@ final class SpeakerNamingContentView: NSView {
         )
 
         // Buttons at bottom-right.
-        let btnH: CGFloat = 28
+        let btnH = SpeakerNamingHitTargets.minimum
         let saveSize = saveButton.fittingSize
         let cancelSize = cancelButton.fittingSize
         saveButton.frame = NSRect(
@@ -303,10 +310,10 @@ final class SpeakerNamingContentView: NSView {
 
         // Layout rows + section headers inside the document view. Flipped coordinates:
         // rows stack top-down visually, laid out with bottom-up math.
-        let rowHeight: CGFloat = 104
-        let rowSpacing: CGFloat = 12
-        let headerHeight: CGFloat = 24
-        let headerGap: CGFloat = 10
+        let rowHeight = SpeakerNamingHitTargets.rowHeight
+        let rowSpacing = SpeakerNamingHitTargets.rowSpacing
+        let headerHeight = SpeakerNamingHitTargets.sectionHeaderHeight
+        let headerGap = SpeakerNamingHitTargets.sectionHeaderGap
 
         let micCount = micRows.count
         let systemCount = systemRows.count
@@ -339,13 +346,13 @@ final class SpeakerNamingContentView: NSView {
             let btnW = max(110, btnSize.width + 12)
             localSectionLabel.frame = NSRect(
                 x: 0,
-                y: y + 2,
+                y: y + 10,
                 width: docInnerWidth - btnW - 8,
-                height: headerHeight - 2
+                height: 20
             )
             keepAsYouButton.frame = NSRect(
                 x: docInnerWidth - btnW,
-                y: y + 1,
+                y: y,
                 width: btnW,
                 height: headerHeight
             )
@@ -362,7 +369,7 @@ final class SpeakerNamingContentView: NSView {
         if hasSystemSection {
             if hasMicSection {
                 y -= headerHeight
-                remoteSectionLabel.frame = NSRect(x: 0, y: y + 2, width: docInnerWidth, height: headerHeight - 2)
+                remoteSectionLabel.frame = NSRect(x: 0, y: y + 10, width: docInnerWidth, height: 20)
                 y -= headerGap
             }
             for row in systemRows {
@@ -615,11 +622,12 @@ final class SpeakerRowView: NSView {
             width: max(120, w - playSize.width - 8),
             height: 18
         )
+        let hitTarget = SpeakerNamingHitTargets.minimum
         playButton.frame = NSRect(
             x: bounds.width - pad - max(92, playSize.width),
-            y: bounds.height - pad - 22,
+            y: bounds.height - pad - hitTarget,
             width: max(92, playSize.width),
-            height: 22
+            height: hitTarget
         )
         evidenceField.frame = NSRect(
             x: pad,
@@ -634,7 +642,7 @@ final class SpeakerRowView: NSView {
             height: 26
         )
 
-        let fieldH: CGFloat = 22
+        let fieldH = SpeakerNamingHitTargets.minimum
         let discardSize = discardButton.fittingSize
         let discardW = max(72, discardSize.width + 8)
         discardButton.frame = NSRect(

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -390,6 +390,19 @@ func testUIAutomationSurfaceContract() {
                 "\(identifier) should keep speaker review scriptable without using speaker names"
             )
         }
+        assertTrue(
+            speakerReviewSource.contains("static let minimum: CGFloat = 40")
+                && speakerReviewSource.contains("let btnH = SpeakerNamingHitTargets.minimum")
+                && speakerReviewSource.contains("let fieldH = SpeakerNamingHitTargets.minimum")
+                && speakerReviewSource.contains("let hitTarget = SpeakerNamingHitTargets.minimum"),
+            "speaker review save/cancel/name/play/confirm/discard controls should keep a 40pt hit floor"
+        )
+        assertTrue(
+            speakerReviewSource.contains("static let sectionHeaderHeight: CGFloat = 40")
+                && speakerReviewSource.contains("let headerHeight = SpeakerNamingHitTargets.sectionHeaderHeight")
+                && speakerReviewSource.contains("keepAsYouButton.frame = NSRect("),
+            "speaker review Keep Local Mic as You should keep a 40pt section-header hit floor"
+        )
 
         for requiredAgentHook in [
             "transcripted.settings.agent.connect.\\(agent.rawValue)",


### PR DESCRIPTION
## Summary
- add named speaker-review hit target tokens for the AppKit naming sheet
- expand Save Names / Review Later, Keep Local Mic as You, Play sample, name field, Confirm Match, and Discard Voice to 40pt hit targets
- increase row/header spacing enough to avoid overlap while keeping the dense sheet layout
- add UI automation surface contract coverage for the new 40pt hooks

## Interface Feel Better Audit

### Minimum hit area
| Before | After |
| --- | --- |
| `SpeakerNamingSheet.swift` used 28pt footer buttons for Save Names / Review Later. | Footer buttons now use `SpeakerNamingHitTargets.minimum = 40`. |
| The Keep Local Mic as You header action used a 24pt section header and `.small` control sizing. | The section header action now gets a 40pt header hit area and normal control sizing. |
| Row controls used 22pt frames for Play sample, Confirm Match, Discard Voice, and the name combo box. | Row controls now use the shared 40pt minimum token. |

### Layout stability
| Before | After |
| --- | --- |
| Growing row controls directly would overlap sample text and lower actions inside the 104pt row. | Row height is now 136pt, preserving separate bands for title/evidence/sample/actions. |
| Section label text was vertically tied to the old 24pt header. | Section labels are optically centered in the taller 40pt header band. |

### Regression protection
| Before | After |
| --- | --- |
| Hit sizes were local literals (`28`, `24`, `22`) with no source contract. | `UIAutomationSurfaceContract` asserts the 40pt token and its use for footer, row, and Keep as You controls. |

## Matrix Rows
- row 88: Speaker naming sheet
- row 89: Owner mapping / Keep as You
- row 91: Confirm suggested match

## Verification
- `git diff --check`
- `bash run-tests.sh --filter UIAutomationSurfaceContract` — 235 passed
- `bash run-tests.sh --filter SpeakerNaming` — 18 passed
- `bash build.sh --no-open` — passed
- `bash run-tests.sh` — 10635 passed
- local independent review: PASS, proof at `/Users/redbars/.codex/maestro/runs/20260622T051915Z-speaker-naming-hit-targets-local-review-local`
- Claude review attempt stalled with no output and does not count as proof

## Manual Proof Still Needed
- Real completed-meeting speaker review sheet screenshot/click smoke for Save Names, Review Later, Keep Local Mic as You, Play sample, Confirm Match, Discard Voice, and the name field before RETEST PASS.

lanes used: Codex=implementation, build/tests, PR; Claude=attempted but stalled/no output, not counted; Local=review proof at /Users/redbars/.codex/maestro/runs/20260622T051915Z-speaker-naming-hit-targets-local-review-local; Windows=skipped, focused local AppKit layout change
