### PR TITLE
Expand activity card hit targets

### DIFF
--- a/Sources/UI/Settings/TranscriptedSettingsComponents.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsComponents.swift
@@ -652,7 +652,7 @@ struct SettingsActivityCard: View {
                         Image(systemName: "xmark")
                             .font(.system(size: 10, weight: .bold))
                             .foregroundStyle(.secondary)
-                            .frame(width: 22, height: 22)
+                            .frame(width: 40, height: 40)
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(SettingsHoverButtonStyle(cornerRadius: 7))
@@ -694,6 +694,8 @@ struct SettingsActivityCard: View {
                     normalFill: tintColor.opacity(0.08),
                     normalStroke: tintColor.opacity(0.14)
                 ))
+                .frame(minHeight: 40)
+                .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
             }
         }
         .padding(18)

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -241,6 +241,13 @@ func testUIAutomationSurfaceContract() {
             homeSource.contains("representedObject = item.id"),
             "Home row menus should not depend on unstable SwiftUI-generated menu item IDs"
         )
+        assertTrue(
+            settingsComponentsSource.contains(".frame(width: 40, height: 40)")
+                && settingsComponentsSource.contains(".accessibilityIdentifier(\"transcripted.settings.activity-card.dismiss\")")
+                && settingsComponentsSource.contains(".frame(minHeight: 40)")
+                && settingsComponentsSource.contains(".contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))"),
+            "activity cards should keep 40pt action and dismiss hit targets for Home progress/notice cards"
+        )
 
         // Regression guards for fix/home-delete-confirmation-menu-loop. The Home
         // recent-meeting "Delete meeting" confirmation silently no-op'd because of


### PR DESCRIPTION
## Summary
- expands Home/local-summary activity card dismiss affordances from 22pt to a 40pt hit target
- gives activity card action buttons a 40pt minimum hit target without changing the visible visual language
- adds a UI automation contract guard so the 40pt affordances do not regress silently

## Make Interfaces Feel Better polish table
| Principle | Before | After |
| --- | --- | --- |
| Minimum hit area | Activity card dismiss used a compact 22x22 icon hit target. | Dismiss uses a 40x40 hit region while preserving the same compact xmark styling. |
| Minimum hit area | Activity card actions depended on compact button content height. | Actions keep the existing style but gain `minHeight: 40` and a rounded content shape for reliable clicking. |
| Accessibility / proof | No contract pinned the small activity-card affordances. | `UIAutomationSurfaceContract` now asserts the 40pt dismiss/action hooks and stable dismiss identifier. |

## Matrix rows
- Row 101: Summary success notice — FIXED
- Row 103: Summary failure notice — FIXED
- Row 104: Dismiss notice — FIXED

## Verification
- `git diff --check`
- `bash run-tests.sh --filter UIAutomationSurfaceContract` — 234 passed
- `bash run-tests.sh --filter HomeMeetingSummaryBetaPresentationPolicy` — 42 passed
- `bash build.sh --no-open` — passed
- `bash run-tests.sh` — 10634 passed, 0 failed
- Claude blocker review: PASS — `/Users/redbars/.codex/maestro/runs/20260622T052630Z-activity-card-hit-targets-claude-review-claude`
- Local lane attempted but output was not counted as review quality — `/Users/redbars/.codex/maestro/runs/20260622T052620Z-activity-card-hit-targets-local-review-local`

## Manual proof still needed
- Real app smoke of local-summary success notice, failure/retry notice, and dismiss target in the Home surface.

lanes used: Codex=implemented, tested, pushed, opened draft PR; Claude=blocker review PASS; Local=attempted review but not counted; Windows=skipped, small focused local UI patch
