### PR TITLE
Expand general settings hit targets

### DIFF
--- a/Sources/UI/Settings/TranscriptedSettingsGeneralControls.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsGeneralControls.swift
@@ -61,7 +61,7 @@ struct GeneralInfoButton: View {
                     Circle()
                         .fill(Color.primary.opacity(isHovering ? 0.10 : 0.04))
                 )
-                .frame(width: 24, height: 24)
+                .frame(width: 40, height: 40)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/Sources/UI/Settings/TranscriptedSettingsRows.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsRows.swift
@@ -84,7 +84,7 @@ struct CorrectionEditorRow: View {
             Button(role: .destructive, action: onRemove) {
                 Image(systemName: "minus.circle.fill")
                     .foregroundStyle(.secondary)
-                    .frame(width: 28, height: 28)
+                    .frame(width: 40, height: 40)
             }
             .buttonStyle(SettingsHoverButtonStyle(tone: .destructive, cornerRadius: 7))
             .accessibilityLabel(Text("Remove correction"))

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -2671,6 +2671,8 @@ struct TranscriptedSettingsView: View {
                     normalFill: Color.accentColor.opacity(0.08),
                     normalStroke: Color.accentColor.opacity(0.16)
                 ))
+                .frame(minHeight: 40)
+                .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
 
                 Spacer()
 

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -161,6 +161,7 @@ func testUIAutomationSurfaceContract() {
         let settingsSidebarSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsSidebar.swift")
         let settingsComponentsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsComponents.swift")
         let generalControlsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsGeneralControls.swift")
+        let settingsRowsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsRows.swift")
         let settingsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let homeSource = readUIAutomationContractFile("Sources/UI/Settings/HomeView.swift")
         let onboardingSource = readUIAutomationContractFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
@@ -190,6 +191,23 @@ func testUIAutomationSurfaceContract() {
             pagesSource.contains("var automationIdentifier: String")
                 && settingsSidebarSource.contains(".accessibilityIdentifier(page.automationIdentifier)"),
             "settings sidebar pages should expose stable automation identifiers"
+        )
+
+        assertTrue(
+            generalControlsSource.contains(".frame(width: 40, height: 40)")
+                && generalControlsSource.contains("accessibilityIdentifier(\"transcripted.settings.general.info.\\(automationSlug(info.title))\")"),
+            "General settings info buttons should keep compact visuals with a 40pt hit target and stable AX identifiers"
+        )
+        assertTrue(
+            settingsRowsSource.contains(".frame(width: 40, height: 40)")
+                && settingsRowsSource.contains(".accessibilityLabel(Text(\"Remove correction\"))"),
+            "custom dictionary remove controls should keep a 40pt destructive hit target with a clear AX label"
+        )
+        assertTrue(
+            settingsSource.contains("Label(\"Add correction\", systemImage: \"plus\")")
+                && settingsSource.contains(".frame(minHeight: 40)")
+                && settingsSource.contains(".contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))"),
+            "custom dictionary add correction should keep a 40pt tactile action target"
         )
 
         for requiredSourceHook in [


### PR DESCRIPTION
## Summary
- expands General settings info buttons to 40pt hit targets while keeping the compact icon visual
- expands custom dictionary remove and Add correction controls to 40pt tactile targets
- adds UI automation contract guards for the General/custom-dictionary hit-target promises

## Make Interfaces Feel Better polish table
| Principle | Before | After |
| --- | --- | --- |
| Minimum hit area | General info buttons used compact 24pt hit targets beside toggle titles. | Info buttons keep compact 18pt icon chrome but expose a 40x40 hit region and stable AX identifiers. |
| Minimum hit area | Custom dictionary remove used a 28pt destructive icon target. | Remove uses a 40x40 destructive target with the existing AX label/help. |
| Minimum hit area | Add correction depended on compact label padding. | Add correction keeps the same visual style and gains a 40pt minimum action target. |
| Regression proof | No source contract pinned these small Settings controls. | `UIAutomationSurfaceContract` now guards info, remove, and add-correction hit target hooks. |

## Matrix rows
- Row 107: General toggles — FIXED
- Row 108: Dictation window mode — PASS by source audit, unchanged; cards already use large selectable card targets
- Row 112: Custom dictionary — FIXED

## Verification
- `git diff --check`
- `bash run-tests.sh --filter UIAutomationSurfaceContract` — 236 passed
- `bash build.sh --no-open` — passed
- `bash run-tests.sh` — 10636 passed, 0 failed
- Claude blocker review: PASS — `/Users/redbars/.codex/maestro/runs/20260622T053337Z-settings-general-hit-targets-claude-review-claude`

Note: one parallel test attempt hit the known generated-runner race while `build.sh` was also compiling. The full suite was rerun serially and passed.

## Manual proof still needed
- Real Settings visual/click smoke for General info buttons and Custom Dictionary add/remove controls.

lanes used: Codex=implemented, tested, pushed, opened draft PR; Claude=blocker review PASS; Local=skipped; Windows=skipped
