### PR TITLE
Show live browser open failures

### DIFF
--- a/Sources/UI/Overlay/MeetingLiveTranscriptDrawerView.swift
+++ b/Sources/UI/Overlay/MeetingLiveTranscriptDrawerView.swift
@@ -26,9 +26,11 @@ final class MeetingLiveTranscriptDrawerView: NSView {
     private let resizeHandle = MeetingLiveTranscriptResizeHandle()
 
     private var statusText: String?
+    private var transientStatusText: String?
     private var hasEntries = false
     private var needsScrollToEnd = false
     private var copyFeedbackTask: Task<Void, Never>?
+    private var transientStatusTask: Task<Void, Never>?
     private var hoverTrackingArea: NSTrackingArea?
 
     var onOpenInBrowser: (() -> Void)?
@@ -123,6 +125,7 @@ final class MeetingLiveTranscriptDrawerView: NSView {
 
     deinit {
         copyFeedbackTask?.cancel()
+        transientStatusTask?.cancel()
     }
 
     private func configureHeaderButton(
@@ -188,8 +191,7 @@ final class MeetingLiveTranscriptDrawerView: NSView {
     func update(transcript: NSAttributedString, statusText: String?, hasEntries: Bool) {
         self.statusText = statusText
         self.hasEntries = hasEntries
-        statusLabel.stringValue = statusText ?? ""
-        statusLabel.isHidden = statusText == nil
+        refreshStatusLabel()
         scrollView.isHidden = !hasEntries
         copyButton.isEnabled = hasEntries
 
@@ -223,6 +225,34 @@ final class MeetingLiveTranscriptDrawerView: NSView {
             self.copyButton.image = Self.copyButtonImage()
             self.copyButton.contentTintColor = MeetingOverlayTokens.quietActionTint
         }
+    }
+
+    /// Brief user-visible feedback when macOS refuses the browser handoff.
+    func flashBrowserOpenFailure() {
+        transientStatusTask?.cancel()
+        transientStatusText = MeetingLiveViewAffordancePolicy.openInBrowserFailedStatus
+        refreshStatusLabel()
+        NSAccessibility.post(
+            element: window ?? self,
+            notification: .announcementRequested,
+            userInfo: [
+                .announcement: MeetingLiveViewAffordancePolicy.openInBrowserFailedStatus,
+                .priority: NSAccessibilityPriorityLevel.high.rawValue
+            ]
+        )
+        transientStatusTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard !Task.isCancelled, let self else { return }
+            self.transientStatusText = nil
+            self.refreshStatusLabel()
+        }
+    }
+
+    private func refreshStatusLabel() {
+        let visibleStatus = transientStatusText ?? statusText
+        statusLabel.stringValue = visibleStatus ?? ""
+        statusLabel.isHidden = visibleStatus == nil
+        needsLayout = true
     }
 
     override func layout() {

--- a/Sources/UI/Overlay/MeetingLiveViewAffordancePolicy.swift
+++ b/Sources/UI/Overlay/MeetingLiveViewAffordancePolicy.swift
@@ -27,6 +27,7 @@ enum MeetingLiveViewAffordancePolicy {
     static let openInBrowserMenuTitle = "Open Live View in Browser"
     static let keepControlsVisibleMenuTitle = "Keep Controls Visible"
     static let discardRecordingMenuTitle = "Discard Recording…"
+    static let openInBrowserFailedStatus = "Could not open Live View in your browser. Try again from the menu."
 
     struct Affordance: Equatable {
         let tooltip: String

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -346,6 +346,10 @@ final class MeetingOverlayRootView: NSView {
         transcriptDrawer.flashCopyFeedback()
     }
 
+    func flashTranscriptBrowserOpenFailure() {
+        transcriptDrawer.flashBrowserOpenFailure()
+    }
+
     override func layout() {
         super.layout()
         if currentState == .preparing {
@@ -2273,8 +2277,11 @@ final class MeetingOverlayController: NSObject {
                     agentTarget: .localAgent,
                     surface: .meetingOverlay
                 )
+            } else {
+                showLiveViewBrowserOpenFailure()
             }
         } catch {
+            showLiveViewBrowserOpenFailure()
             ActivationTelemetry.trackAgentSetupCTA(
                 setupKind: .livePreview,
                 agentTarget: .localAgent,
@@ -2289,6 +2296,19 @@ final class MeetingOverlayController: NSObject {
                 context: ["error": error.localizedDescription]
             )
         }
+    }
+
+    private func showLiveViewBrowserOpenFailure() {
+        guard state == .recording else {
+            rootView?.flashTranscriptBrowserOpenFailure()
+            return
+        }
+
+        isTranscriptExpanded = true
+        bloomFromRest()
+        flushPendingTranscriptIfNeeded()
+        pushToView()
+        rootView?.flashTranscriptBrowserOpenFailure()
     }
 
     private func dismissPrompt(notifyDetector: Bool) {

--- a/Tests/MeetingLiveViewAffordancePolicyTests.swift
+++ b/Tests/MeetingLiveViewAffordancePolicyTests.swift
@@ -88,6 +88,11 @@ func testMeetingLiveViewAffordancePolicy() {
         )
         assertEqual(MeetingLiveViewAffordancePolicy.openInBrowserMenuTitle, "Open Live View in Browser")
         assertEqual(MeetingLiveViewAffordancePolicy.copyTranscriptMenuTitle, "Copy Transcript")
+        assertEqual(
+            MeetingLiveViewAffordancePolicy.openInBrowserFailedStatus,
+            "Could not open Live View in your browser. Try again from the menu.",
+            "browser handoff failures should have visible drawer feedback, not just telemetry"
+        )
     }
 
     runSuite("MeetingLiveViewAffordancePolicy — drawer status copy follows the feed phase") {

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -427,6 +427,18 @@ func testUIAutomationSurfaceContract() {
                 && transcriptDrawerSource.contains("MeetingLiveViewAffordancePolicy.openInBrowserMenuTitle"),
             "pill context-menu and drawer overflow actions should keep policy-pinned titles for automation"
         )
+        assertTrue(
+            transcriptDrawerSource.contains("transientStatusText ?? statusText")
+                && transcriptDrawerSource.contains("openInBrowserFailedStatus")
+                && transcriptDrawerSource.contains(".announcement: MeetingLiveViewAffordancePolicy.openInBrowserFailedStatus"),
+            "browser-open failures should remain visible and announced even while transcript updates continue"
+        )
+        assertTrue(
+            meetingOverlaySource.contains("showLiveViewBrowserOpenFailure")
+                && meetingOverlaySource.contains("isTranscriptExpanded = true")
+                && meetingOverlaySource.contains("rootView?.flashTranscriptBrowserOpenFailure()"),
+            "browser-open failures from the collapsed pill menu should reveal the drawer before showing feedback"
+        )
 
         assertTrue(
             deletePolicySource.contains("Delete this meeting?")


### PR DESCRIPTION
## Summary
- Shows a visible live transcript drawer notice when macOS refuses to open the Live View browser preview.
- Reveals the drawer first when the failure comes from the collapsed meeting-pill context menu.
- Announces the failure through VoiceOver with an explicit accessibility announcement payload.

## Interface Feel Better Table

| Principle | Before | After |
| --- | --- | --- |
| Error state clarity | Open Live View failures were telemetry-only from the meeting overlay. | The live transcript drawer shows: “Could not open Live View in your browser. Try again from the menu.” |
| State feedback | The collapsed pill context menu could fail invisibly because the drawer was hidden. | The drawer opens first, then shows the failure notice for the user. |
| Accessibility | The attempted announcement had no message payload. | VoiceOver gets an announcement with the failure copy and high priority. |
| Interruptible/transient feedback | Live transcript updates could have overwritten ad hoc feedback if handled inline. | Transient status wins over normal drawer status for a short window, then restores itself. |

## Verification
- git diff --check
- bash build-deps.sh --force
- bash run-tests.sh --filter MeetingLiveViewAffordancePolicy
- bash run-tests.sh --filter UIAutomationSurfaceContract
- bash build.sh --no-open
- bash run-tests.sh (10636 passed)
- bash run-integration-smoke.sh
- Claude review: initial findings fixed, rereview PASS /Users/redbars/.codex/maestro/runs/20260622T061120Z-live-browser-failure-rereview-claude

## Manual proof still needed
- Real macOS UI smoke with Live View browser open failure forced from both the drawer overflow menu and the collapsed pill context menu.
- VoiceOver announcement delivery proof on-device.

No release, merge, appcast, Homebrew, notarization, or deploy work performed.