### PR TITLE
Warm up System Events for permission-state proof

### DIFF
--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -164,7 +164,6 @@ func testUIAutomationSurfaceContract() {
         let settingsRowsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsRows.swift")
         let settingsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let homeSource = readUIAutomationContractFile("Sources/UI/Settings/HomeView.swift")
-        let settingsRowsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsRows.swift")
         let meetingAudioPlaybackSource = readUIAutomationContractFile("Sources/UI/Shared/MeetingAudioPlayback.swift")
         let onboardingSource = readUIAutomationContractFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
         let speakerReviewSource = readUIAutomationContractFile("Sources/UI/Settings/SpeakerNamingSheet.swift")

--- a/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PermissionState.swift
+++ b/Tools/TranscriptedQA/Sources/TranscriptedQA/Commands/PermissionState.swift
@@ -344,6 +344,26 @@ struct PermissionStateProbe {
     }
 
     static func determineAutomationStatus(targetBundleID: String) -> AutomationStatus {
+        automationStatus(
+            targetBundleID: targetBundleID,
+            permissionStatusProvider: { automationPermissionStatus(targetBundleID: targetBundleID) },
+            warmUpTargetProvider: { warmUpAutomationTargetIfNeeded(targetBundleID: $0) }
+        )
+    }
+
+    static func automationStatus(
+        targetBundleID: String,
+        permissionStatusProvider: () -> OSStatus,
+        warmUpTargetProvider: (String) -> Bool
+    ) -> AutomationStatus {
+        let status = permissionStatusProvider()
+        if status == OSStatus(procNotFound), warmUpTargetProvider(targetBundleID) {
+            return mapAutomationPermissionStatus(permissionStatusProvider())
+        }
+        return mapAutomationPermissionStatus(status)
+    }
+
+    private static func automationPermissionStatus(targetBundleID: String) -> OSStatus {
         var target = AEAddressDesc()
         let createStatus = OSStatus(targetBundleID.withCString { pointer in
             AECreateDesc(
@@ -354,16 +374,19 @@ struct PermissionStateProbe {
             )
         })
         guard createStatus == noErr else {
-            return .unavailable(createStatus)
+            return createStatus
         }
         defer { AEDisposeDesc(&target) }
 
-        let status = AEDeterminePermissionToAutomateTarget(
+        return AEDeterminePermissionToAutomateTarget(
             &target,
             typeWildCard,
             typeWildCard,
             false
         )
+    }
+
+    private static func mapAutomationPermissionStatus(_ status: OSStatus) -> AutomationStatus {
         if status == noErr {
             return .allowed
         }
@@ -374,6 +397,25 @@ struct PermissionStateProbe {
             return .denied
         }
         return .unavailable(status)
+    }
+
+    private static func warmUpAutomationTargetIfNeeded(targetBundleID: String) -> Bool {
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: targetBundleID) else {
+            return false
+        }
+
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = false
+        configuration.addsToRecentItems = false
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var didLaunch = false
+        NSWorkspace.shared.openApplication(at: url, configuration: configuration) { app, error in
+            didLaunch = app != nil && error == nil
+            semaphore.signal()
+        }
+        _ = semaphore.wait(timeout: .now() + 2)
+        return didLaunch
     }
 
     private static func bundleIdentifier(atPath path: String) -> String? {

--- a/Tools/TranscriptedQA/Tests/TranscriptedQATests/PermissionStateProbeTests.swift
+++ b/Tools/TranscriptedQA/Tests/TranscriptedQATests/PermissionStateProbeTests.swift
@@ -101,6 +101,34 @@ final class PermissionStateProbeTests: XCTestCase {
         XCTAssertTrue(result?.detail?.contains("OSStatus -1743") == true)
     }
 
+    func testAutomationStatusRetriesOnceWhenTargetIsNotRunning() {
+        var statuses = [OSStatus(procNotFound), noErr]
+        var warmedTargets: [String] = []
+
+        let status = PermissionStateProbe.automationStatus(
+            targetBundleID: "com.apple.systemevents",
+            permissionStatusProvider: { statuses.removeFirst() },
+            warmUpTargetProvider: {
+                warmedTargets.append($0)
+                return true
+            }
+        )
+
+        XCTAssertEqual(status, .allowed)
+        XCTAssertEqual(warmedTargets, ["com.apple.systemevents"])
+        XCTAssertTrue(statuses.isEmpty, "the permission check should retry exactly once after warming the target")
+    }
+
+    func testAutomationStatusKeepsProcNotFoundWhenWarmupFails() {
+        let status = PermissionStateProbe.automationStatus(
+            targetBundleID: "com.apple.systemevents",
+            permissionStatusProvider: { OSStatus(procNotFound) },
+            warmUpTargetProvider: { _ in false }
+        )
+
+        XCTAssertEqual(status, .unavailable(OSStatus(procNotFound)))
+    }
+
     func testLiveCaptureModeWarnsWhenTranscriptedDefaultsDomainCannotOpen() {
         let results = makeProbe(mode: .liveCapture, defaults: nil).validate()
         let result = results.first { $0.check == "permissions/app/system-audio-cache" }


### PR DESCRIPTION
## Summary
- Retries the permission-state Apple Events probe after warming the target app when macOS returns procNotFound (-600).
- Fixes the false System Events warning that made computer-use / feature-wide UI proof look blocked when System Events simply was not running.
- Adds package tests for the retry and failed-warmup paths.

## Verification
- git diff --check
- swift test --package-path Tools/TranscriptedQA (41 passed)
- bash run-tests.sh --filter PermissionStateHarnessContract (8 passed)
- TRANSCRIPTED_DISABLE_FILE_LOGGER=1 swift run --package-path Tools/TranscriptedQA transcripted-qa permission-state --mode computer-use --app-bundle /Users/redbars/transcripted-latest/build/Transcripted.app --format json (PASS, 12 passed, 0 warnings)

## Notes
- This is QA tooling only; it does not change Transcripted runtime UI behavior.
- The permission-state command still correctly warns if the wrong Transcripted app is running; pass --app-bundle for the app under test or launch the intended build before UI proof.

No merge, release, appcast, Homebrew, notarization, or deploy work performed.