### PR TITLE
Fix UI automation contract duplicate source binding

### DIFF
--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -164,7 +164,6 @@ func testUIAutomationSurfaceContract() {
         let settingsRowsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsRows.swift")
         let settingsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let homeSource = readUIAutomationContractFile("Sources/UI/Settings/HomeView.swift")
-        let settingsRowsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsRows.swift")
         let meetingAudioPlaybackSource = readUIAutomationContractFile("Sources/UI/Shared/MeetingAudioPlayback.swift")
         let onboardingSource = readUIAutomationContractFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
         let speakerReviewSource = readUIAutomationContractFile("Sources/UI/Settings/SpeakerNamingSheet.swift")


### PR DESCRIPTION
## Summary
- remove the duplicate settingsRowsSource binding introduced by the merged UI hit-target stack
- restores fast-test compilation on current main

## Verification
- git diff --check
- bash run-tests.sh — 10749 tests passed

## Lanes used
Codex=repair, tests, PR; Claude=skipped, one-line compile repair; Local=skipped; Windows=skipped

No release, tag, notarization, appcast, Homebrew, or deploy work performed.