### PR TITLE
Fix UI automation contract duplicate source read

### DIFF
--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -199,7 +199,6 @@ func testUIAutomationSurfaceContract() {
         let settingsRowsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsRows.swift")
         let settingsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let homeSource = readUIAutomationContractFile("Sources/UI/Settings/HomeView.swift")
-        let settingsRowsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsRows.swift")
         let meetingAudioPlaybackSource = readUIAutomationContractFile("Sources/UI/Shared/MeetingAudioPlayback.swift")
         let onboardingSource = readUIAutomationContractFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
         let speakerReviewSource = readUIAutomationContractFile("Sources/UI/Settings/SpeakerNamingSheet.swift")


### PR DESCRIPTION
## Summary
- removes the duplicate settingsRowsSource declaration introduced by overlapping UI-polish contract merges
- restores fast-test compilation on the final merged UI-polish main tip

## Verification
- git diff --check
- bash run-tests.sh --filter UIAutomationSurfaceContract — 255 passed
- bash build.sh --no-open — passed
- bash run-tests.sh — 10787 passed, 0 failed

No release, tag, notarization, appcast, Homebrew, or deploy work performed.