### PR TITLE
Fix UI contract test duplicate binding

### DIFF
--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -199,7 +199,6 @@ func testUIAutomationSurfaceContract() {
         let settingsRowsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsRows.swift")
         let settingsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let homeSource = readUIAutomationContractFile("Sources/UI/Settings/HomeView.swift")
-        let settingsRowsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsRows.swift")
         let meetingAudioPlaybackSource = readUIAutomationContractFile("Sources/UI/Shared/MeetingAudioPlayback.swift")
         let onboardingSource = readUIAutomationContractFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
         let speakerReviewSource = readUIAutomationContractFile("Sources/UI/Settings/SpeakerNamingSheet.swift")


### PR DESCRIPTION
## Summary\n- remove a duplicate local binding in UIAutomationSurfaceContractTests introduced by the clean-draft UI stack merge\n\n## Checks\n- git diff --check\n- bash scripts/dev/agent-preflight.sh\n- bash build.sh --no-open (passed before this test-file-only cleanup)\n- bash run-tests.sh (10787 passed)