### PR TITLE
Balance onboarding headings + harden Home greeting wrap

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -435,6 +435,9 @@ struct HomeCanvasHeader: View {
             Text(greeting)
                 .font(.system(size: 28, weight: .light))
                 .tracking(0.2)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+                .fixedSize(horizontal: false, vertical: true)
 
             Button(action: { onViewStats() }) {
                 HStack(spacing: 9) {

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -1132,6 +1132,10 @@ private struct Headline: View {
     var emphasis: String?
     var size: CGFloat = 58
     var alignment: TextAlignment = .center
+    // Cap the line measure so long headings wrap onto balanced lines instead of
+    // running nearly edge-to-edge (CenterStage is 800pt, SplitStage's column is
+    // full width) and leaving an orphan word on the last line.
+    var measure: CGFloat = 640
 
     var body: some View {
         VStack(alignment: alignment == .leading ? .leading : .center, spacing: 2) {
@@ -1147,6 +1151,7 @@ private struct Headline: View {
         .multilineTextAlignment(alignment)
         .lineLimit(nil)
         .minimumScaleFactor(0.92)
+        .frame(maxWidth: measure, alignment: alignment == .leading ? .leading : .center)
         .fixedSize(horizontal: false, vertical: true)
     }
 }


### PR DESCRIPTION
## What

Small text/layout polish from the UI-polish tracker rows:
- **Onboarding :: Read welcome copy and primary CTA**
- **Home :: Read greeting on Home**

### Onboarding headings (`PermissionsOnboardingView.swift`)
The shared `Headline` view had no measure cap, so long heading copy could run nearly edge-to-edge — `CenterStage` allows up to 800pt and `SplitStage`'s left column is full width — and wrap with an orphan word on the last line. Added a `measure` cap (640pt default) via `.frame(maxWidth:alignment:)` so headings wrap onto balanced lines. Existing `multilineTextAlignment`, `lineLimit(nil)`, `minimumScaleFactor`, and `fixedSize` behavior is unchanged. Supporting `Lede`/`BodyCopy` copy was already measure-constrained.

### Home greeting (`HomeView.swift`)
Kept the greeting on a single line with a `minimumScaleFactor(0.8)` floor and `fixedSize(horizontal: false, vertical: true)`, so a longer `Good afternoon, <name>` scales down cleanly instead of truncating or cramping the stats line below it.

## Scope
Text/layout only. No copy, logic, or behavior changes. Foundation-pure helpers (`HomeCanvasGreeting`, `FirstRunExperience` copy) untouched, so existing unit tests are unaffected.

## Proof
Visual wrap proof is Justin's (manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFSeB2fV3HFCMtk4AuMiuY)_