### PR TITLE
Polish second-instance handoff alert + bring-forward

### DIFF
--- a/Sources/Support/SingleInstanceGuard.swift
+++ b/Sources/Support/SingleInstanceGuard.swift
@@ -10,6 +10,18 @@ final class SingleInstanceGuard {
 
     static let reopenNotificationName = Notification.Name("com.transcripted.single-instance.reopen")
 
+    /// Shared, user-facing copy for the duplicate-launch handoff so the running
+    /// instance (and any future surface) describes it the same way. Transcripted
+    /// is a menu-bar app, so a second launch keeps the copy that's already
+    /// running and simply brings it forward instead of silently doing nothing.
+    enum HandoffNotice {
+        static let alreadyRunningTitle = "Transcripted is already running"
+        static let alreadyRunningMessage =
+            "Transcripted lives in your menu bar. We kept the copy that's already running and brought it to the front instead of opening a second one."
+        static let openButtonTitle = "Open Transcripted"
+        static let dismissButtonTitle = "Dismiss"
+    }
+
     private let lockURL: URL
     private var lockFileDescriptor: Int32 = -1
 

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -473,14 +473,37 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
 
     private func handleSingleInstanceReopenRequest() {
         closePopover()
+        NSApp.activate(ignoringOtherApps: true)
 
         if !PermissionsOnboardingPreferences.hasCompleted() {
+            // Mid-onboarding there's no menu-bar home to fall back to yet, so put
+            // the user straight back where they left off.
             onboardingWindowController.present(entrypoint: "single_instance_reopen")
+            return
+        }
+
+        // A second launch of a menu-bar app is easy to misread as "nothing
+        // happened". Say plainly that it's already running and offer to open it
+        // rather than silently surfacing a Settings window.
+        presentAlreadyRunningNotice()
+    }
+
+    private func presentAlreadyRunningNotice() {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = SingleInstanceGuard.HandoffNotice.alreadyRunningTitle
+        alert.informativeText = SingleInstanceGuard.HandoffNotice.alreadyRunningMessage
+        alert.addButton(withTitle: SingleInstanceGuard.HandoffNotice.openButtonTitle)
+        alert.addButton(withTitle: SingleInstanceGuard.HandoffNotice.dismissButtonTitle)
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        NSApp.activate(ignoringOtherApps: true)
+        if let button = statusItem?.button, let popover = popover {
+            showMainPopover(relativeTo: button, popover: popover, entrypoint: "single_instance_reopen")
         } else {
             showSettingsWindow(page: .home, source: "single_instance_reopen")
         }
-
-        NSApp.activate(ignoringOtherApps: true)
     }
 
     @objc func togglePopover() {

--- a/Tests/SingleInstanceGuardTests.swift
+++ b/Tests/SingleInstanceGuardTests.swift
@@ -29,4 +29,24 @@ func testSingleInstanceGuard() {
         assertEqual(guardInstance.acquire(), .acquired, "first acquire should succeed")
         assertEqual(guardInstance.acquire(), .acquired, "same guard should not reject its own repeated acquire")
     }
+
+    runSuite("SingleInstanceGuard duplicate-launch handoff copy is user-ready") {
+        assertEqual(
+            SingleInstanceGuard.HandoffNotice.alreadyRunningTitle,
+            "Transcripted is already running",
+            "the handoff title should name the already-running state plainly"
+        )
+        assertTrue(
+            SingleInstanceGuard.HandoffNotice.alreadyRunningMessage.contains("menu bar"),
+            "the handoff message should explain where the running copy lives"
+        )
+        assertFalse(
+            SingleInstanceGuard.HandoffNotice.openButtonTitle.isEmpty,
+            "the handoff should offer a way to bring the running instance forward"
+        )
+        assertFalse(
+            SingleInstanceGuard.HandoffNotice.dismissButtonTitle.isEmpty,
+            "the handoff should offer a way to dismiss the notice"
+        )
+    }
 }


### PR DESCRIPTION
## What

UI-polish tracker → *macOS menus and commands :: Launch a second instance*.

Single-instance enforcement already works (file lock in `SingleInstanceGuard`, covered by fast tests), but the user-facing handoff wasn't polished. On a second launch the duplicate process terminated and the running instance silently popped open a **Settings** window — which, for a menu-bar app, reads as "nothing happened" or "why is Settings open?".

## Change (atomic)

- The running instance now surfaces a clear informational notice that **Transcripted is already running**, with an **Open Transcripted** action that brings the menu-bar popover forward (falls back to Settings home if the status item isn't available) and a **Dismiss** action.
- Handoff copy is centralized in `SingleInstanceGuard.HandoffNotice` so the running instance and tests share one source of truth.
- Mid-onboarding still routes straight back to the onboarding window (no menu-bar home to fall back to yet).

The alert mirrors the existing `confirmQuitDuringActiveMeeting` NSAlert pattern already in `TranscriptedApp.swift`.

## Files

- `Sources/Support/SingleInstanceGuard.swift` — `HandoffNotice` copy
- `Sources/TranscriptedApp.swift` — `presentAlreadyRunningNotice()` handoff
- `Tests/SingleInstanceGuardTests.swift` — covers the handoff copy

## Verification

- `python3 scripts/dev/check-build-source-lists.py` → passes (no source-list drift).
- App build + fast tests run on the `macos-26` CI runner; they can't run in this Linux sandbox (no Apple toolchain / prebuilt deps). New test case is registered via the existing manifest entry.
- Manual double-launch proof is Justin's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBoFjawmAJFcL1zQ79GWHV)_