### PR TITLE
UI contrast pass: lift dictation overlay loading status to secondary text

### DIFF
--- a/Sources/UI/Overlay/OverlayDraftingView.swift
+++ b/Sources/UI/Overlay/OverlayDraftingView.swift
@@ -91,7 +91,11 @@ final class OverlayDraftingView: NSView {
 
         // Status text
         statusLabel.font = NSFont.systemFont(ofSize: 12)
-        statusLabel.textColor = OverlayTokens.textMuted
+        // The loading/processing status is the sole readable message in this
+        // state, so it tracks the secondary text token (matching the error and
+        // "Refining…" labels) instead of the weakest muted token, which kept it
+        // a notch under contrast on the translucent overlay over bright windows.
+        statusLabel.textColor = OverlayTokens.textSecondary
         statusLabel.isBezeled = false
         statusLabel.isEditable = false
         statusLabel.drawsBackground = false


### PR DESCRIPTION
## What

Small, atomic contrast pass on the menu-bar / popover / overlay surfaces (UI-polish tracker: "Errors/empty/loading :: use app under contrast/display variations").

**One token change:** the dictation overlay's processing/loading status label (`OverlayDraftingView.statusLabel`) moves from `OverlayTokens.textMuted` (white@0.58) to `OverlayTokens.textSecondary` (white@0.74).

## Why

The loading/processing status (the spinner's "Transcribing…", "Pasting…", etc.) is the *only* readable message shown in that state, yet it was drawn on the weakest muted token — while its sibling error label and "Refining…" label both already use `textSecondary`. The dictation overlay panel is translucent (`panelBg` = black@0.82), so over a bright app window behind it the composited background lightens and white@0.58 drops to ~5.6:1, a notch under where the rest of the state's text sits. Tracking the secondary token makes the loading state consistent with the error/refining labels and clears AA comfortably (~8:1).

## Audit notes / what I deliberately did NOT change

These are intentionally fixed dark-glass surfaces (popover `surfaceBackground` white@0.11, overlay `panelBg` near-black). The white-at-alpha text tokens largely mirror Apple's own dark-mode label alphas (`secondaryLabelColor` is white@0.55), so they hold contrast on near-black. Swapping them to adaptive semantic colors (`labelColor` etc.) would actually *break* the design, since these surfaces stay dark regardless of system appearance — so "prefer semantic colors" doesn't cleanly apply to fixed-dark glass. I kept the change to the one spot that was genuinely inconsistent and below its peers.

**For Justin (visual judgment):** the deeper "does every state pass under all display variations" check is manual visual proof in Dark Aqua. A couple of deliberately-low-alpha-but-passing tokens (e.g. the overlay header `shortcutHint` and idle status dot on `textMuted`, `MeetingOverlayTokens.textSecondary` at white@0.55) read as intentional tertiary/secondary hints and weren't touched — flag if you want any of those lifted too.

## Verification

Color/token-only change; `textSecondary` is the same `NSColor` type already used a few lines below, so it can't affect compilation. This environment is Linux and Transcripted is macOS/Apple-Silicon-only, so the authoritative `build.sh` + `run-tests.sh` run is on Swift CI. Visual contrast proof in Dark Aqua is Justin's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YPb8RUEuUUQrUAo1Wz6BDv

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPb8RUEuUUQrUAo1Wz6BDv)_