### PR TITLE
UI: explain why disabled Settings controls are disabled

### DIFF
--- a/Sources/UI/Settings/AgentConnectionSettingsPage.swift
+++ b/Sources/UI/Settings/AgentConnectionSettingsPage.swift
@@ -395,10 +395,12 @@ struct AgentConnectionSettingsPage: View {
                     )
                 }
 
+                let claudeDesktopConfigExists = FileManager.default.fileExists(atPath: ClaudeDesktopIntegrationInstaller.claudeDesktopConfigURL.path)
                 SettingsInlineActionButton(title: "Show Config", symbolName: "folder") {
                     revealClaudeDesktopConfig()
                 }
-                .disabled(!FileManager.default.fileExists(atPath: ClaudeDesktopIntegrationInstaller.claudeDesktopConfigURL.path))
+                .disabled(!claudeDesktopConfigExists)
+                .help(claudeDesktopConfigExists ? "" : "No Claude Desktop config file exists yet.")
             }
         }
     }
@@ -906,6 +908,7 @@ private struct AgentFolderRow: View {
 
             SettingsInlineActionButton(title: "Reveal", action: action)
                 .disabled(!isAvailable)
+                .help(isAvailable ? "" : "This location hasn't been created yet.")
         }
     }
 }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -1863,6 +1863,12 @@ struct TranscriptedSettingsView: View {
         savedMeetingRetranscriptionUnavailableReason == nil
     }
 
+    private var modelCacheBusyHelp: String {
+        modelCacheCleanupInProgress
+            ? "A cache cleanup is already running."
+            : "Wait for the storage scan to finish."
+    }
+
     private var failedMeetingRetryUnavailableReason: String? {
         if sttRouter.isRecording || sttRouter.isTranscribing {
             return "Wait for the current dictation to finish before retrying a failed meeting."
@@ -2349,6 +2355,9 @@ struct TranscriptedSettingsView: View {
                             updatePreferredTranscriptionModel(.parakeetTDTv3, page: .general)
                         }
                         .disabled(preferredTranscriptionModel == .parakeetTDTv3)
+                        .help(preferredTranscriptionModel == .parakeetTDTv3
+                            ? "Parakeet is already the selected transcription model."
+                            : "")
 
                         Text("Changes apply to the next capture.")
                             .font(.caption)
@@ -2686,6 +2695,7 @@ struct TranscriptedSettingsView: View {
                     clearCorrectionRows()
                 }
                 .disabled(!hasCustomDictionaryContent)
+                .help(hasCustomDictionaryContent ? "" : "No saved corrections to clear yet.")
             }
 
             DisclosureGroup("Try a phrase", isExpanded: $showCorrectionPreview) {
@@ -2804,6 +2814,9 @@ struct TranscriptedSettingsView: View {
                                 updatePreferredTranscriptionModel(.parakeetTDTv3)
                             }
                             .disabled(preferredTranscriptionModel == .parakeetTDTv3)
+                            .help(preferredTranscriptionModel == .parakeetTDTv3
+                                ? "Parakeet is already the selected transcription model."
+                                : "")
 
                             Text("Changes apply to the next capture.")
                                 .font(.caption)
@@ -2942,6 +2955,7 @@ struct TranscriptedSettingsView: View {
                             showReclaimableCacheCleanupConfirmation = true
                         }
                         .disabled(modelCacheCleanupInProgress || modelCacheLoading)
+                        .help(modelCacheCleanupInProgress || modelCacheLoading ? modelCacheBusyHelp : "")
                     }
                     ModelCacheMetricRow(
                         title: "FluidAudio models",
@@ -2961,6 +2975,9 @@ struct TranscriptedSettingsView: View {
                             showWhisperCacheCleanupConfirmation = true
                         }
                         .disabled(effectiveTranscriptionModel.isWhisper || modelCacheCleanupInProgress || modelCacheLoading)
+                        .help(effectiveTranscriptionModel.isWhisper
+                            ? "Switch back to Parakeet before removing the Whisper cache."
+                            : (modelCacheCleanupInProgress || modelCacheLoading ? modelCacheBusyHelp : ""))
 
                         if effectiveTranscriptionModel.isWhisper {
                             Text("Switch back to Parakeet before removing the Whisper cache.")
@@ -2983,6 +3000,7 @@ struct TranscriptedSettingsView: View {
                             showModelCacheCleanupConfirmation = true
                         }
                         .disabled(modelCacheCleanupInProgress || modelCacheLoading)
+                        .help(modelCacheCleanupInProgress || modelCacheLoading ? modelCacheBusyHelp : "")
                     } else {
                         Text("No known stale Parakeet model folders found.")
                             .font(.caption)
@@ -3006,6 +3024,7 @@ struct TranscriptedSettingsView: View {
                     refreshModelCacheSnapshot()
                 }
                 .disabled(modelCacheLoading)
+                .help(modelCacheLoading ? "Storage sizes are being scanned." : "")
             }
             .onAppear {
                 if modelCacheSnapshot == nil, !modelCacheLoading {
@@ -3114,6 +3133,9 @@ struct TranscriptedSettingsView: View {
                     }
                     .pickerStyle(.segmented)
                     .disabled(isLocalSummaryModelPreparing)
+                    .help(isLocalSummaryModelPreparing
+                        ? "Finish or cancel the current model setup before switching providers."
+                        : "")
 
                     Text(localMeetingSummaryProvider.detail)
                         .font(.caption)


### PR DESCRIPTION
## What

From the UI-polish tracker ("Errors/empty/loading :: Encounter unavailable model/permission/action state"). Some disabled controls didn't say *why* they were disabled. This adds a concise reason next to each via `.help()` tooltips — no behavior change.

## Audited controls + reasons added

`Sources/UI/Settings/TranscriptedSettingsView.swift`:
- **"Use Parakeet"** (General + dictation model sections) → "Parakeet is already the selected transcription model."
- **Clear-all corrections** → "No saved corrections to clear yet."
- **Remove Reclaimable / Known-Stale cache + Refresh Storage Sizes** → busy reason ("A cache cleanup is already running." / "Wait for the storage scan to finish." / "Storage sizes are being scanned.")
- **Remove Whisper cache** → keeps its existing visible "switch back to Parakeet" reason, plus the busy reason when applicable
- **Summary provider picker** (Beta) → "Finish or cancel the current model setup before switching providers."

`Sources/UI/Settings/AgentConnectionSettingsPage.swift`:
- **"Show Config"** → "No Claude Desktop config file exists yet."
- **"Reveal"** (agent folder row) → "This location hasn't been created yet."

## Notes

- Controls that already explained themselves were left alone: failed-meeting / re-transcribe retry buttons already carry `.help()` reasons; menubar Start Dictation / Start Meeting stay enabled with informative subtitles (they kick off setup on first use), and "Connecting…" already shows its state in the title.
- Tooltip strings are empty when the control is enabled, so no stray tooltips appear in the normal state.

## Verification

Tooltip-only change, no behavior change. Can't build here (Linux env; macOS/AppKit app) — relying on CI. Manual proof is Justin's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLB7pbVohTAMSmh1aS6XVi)_