### PR TITLE
UI: tabular digits on Home inline stats line

### DIFF
--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -466,6 +466,7 @@ struct HomeCanvasHeader: View {
         HStack(spacing: 4) {
             Text(value)
                 .font(.system(size: 12.5, weight: .medium))
+                .monospacedDigit()
                 .foregroundStyle(Color.primary.opacity(0.9))
             Text(label)
                 .font(.system(size: 12.5))


### PR DESCRIPTION
## What

Add `.monospacedDigit()` to the Home greeting header's inline stats line (`stat(_:_:)` in `HomeView.swift`), so the numeric values — streak days, hours recorded, words dictated — render with tabular digits and stop shifting width as the numbers change.

## Why

From the UI-polish tracker: *"Errors/empty/loading :: Read durations, percentages, counts, saved words, queue"* — use tabular (monospaced) numbers wherever a changing width would cause jitter.

The rest of the read surface was already covered by earlier sweeps:
- detail-sheet stat metrics (`HomeStatsDetailMetric`)
- audio playback time label (`.caption.monospacedDigit()`)
- model download percent (`MenuBarModelStatusView` uses `NSFont.monospacedDigitSystemFont`)
- meeting timer (`MeetingOverlayController` uses `monospacedDigitSystemFont`)
- settings progress %, agent file counts, speaker queue/meta lines, onboarding step counter / event times (monospaced font)

The inline stats line was the remaining live-changing counter without tabular digits. Sparkle's "wait during update download" progress is rendered by Sparkle's own window, not an app `Text` view, so there's nothing to change there.

## Scope

Single-line modifier addition. Minimal and atomic per the cross-cutting-sweep coordination note — number formatting only, no other UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPbnzEufp5aA11s4JcvG2i

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPbnzEufp5aA11s4JcvG2i)_