### PR TITLE
Make real Gemma summary proof executable

### DIFF
--- a/Sources/Meeting/LocalMeetingSummarizer.swift
+++ b/Sources/Meeting/LocalMeetingSummarizer.swift
@@ -818,6 +818,7 @@ struct LocalGemmaSummaryRuntime: @unchecked Sendable {
             "HF_HUB_CACHE",
             "TRANSFORMERS_CACHE",
             "UV_CACHE_DIR",
+            "UV_PYTHON",
         ]
         var sanitized: [String: String] = [:]
         for key in allowedParentKeys {

--- a/Tests/LocalMeetingSummarizerTests.swift
+++ b/Tests/LocalMeetingSummarizerTests.swift
@@ -149,6 +149,7 @@ func testLocalMeetingSummarizer() async {
                 "HOME": "/Users/example",
                 "TMPDIR": "/tmp/example",
                 "HF_HOME": "/tmp/hf-cache",
+                "UV_PYTHON": "/opt/homebrew/bin/python3.12",
                 "SENTRY_DSN": "https://secret@example.invalid/1",
                 "POSTHOG_API_KEY": "phc_secret",
                 "OPENAI_API_KEY": "sk-secret",
@@ -162,6 +163,7 @@ func testLocalMeetingSummarizer() async {
         assertEqual(env["PATH"], "/usr/bin", "safe executable lookup should be preserved")
         assertEqual(env["HOME"], "/Users/example", "safe home path should be preserved for cache resolution")
         assertEqual(env["HF_HOME"], "/tmp/hf-cache", "explicit local Hugging Face cache should be preserved")
+        assertEqual(env["UV_PYTHON"], "/opt/homebrew/bin/python3.12", "uv Python selection should be preserved for mlx-vlm's Python floor")
         assertEqual(env["OMP_NUM_THREADS"], "2", "thread cap should be forwarded")
         assertEqual(env["TOKENIZERS_PARALLELISM"], "false", "tokenizer helper threads should stay disabled")
         assertNil(env["SENTRY_DSN"], "Sentry DSNs should not reach local model subprocesses")

--- a/docs/qa-test-bench.md
+++ b/docs/qa-test-bench.md
@@ -31,6 +31,18 @@ or TCC prompts. The local summary fixture also proves the Gemma summary app path
 can start, finish, and rewrite a saved synthetic meeting into the expected
 Markdown shape without private meeting content or a model download.
 
+For real local Gemma/MLX proof on the synthetic fixture, run:
+
+```bash
+bash scripts/ops/run-local-summary-fixture.sh --real-gemma
+```
+
+That path uses `uv run --with mlx-vlm==0.6.1` and the bundled
+`Resources/LocalSummarizer/gemma4_mlx_prompt_runner.py`. It may download the
+MLX runtime/model on first run. Missing `uv`, missing Python 3.10+ for `uv`,
+insufficient RAM, runtime install failure, or model execution failure is a real
+host blocker, not a green fixture.
+
 ## Pasteback Synthetic Run
 
 ```bash
@@ -117,6 +129,17 @@ runs `deep`, then adds:
 
 - deterministic release-health fixture checks
 - a local Gemma meeting-summary dry-run plan when eligible local transcripts are present
+
+To make the Gemma rows execute instead of planning only:
+
+```bash
+bash scripts/ops/transcripted-qa-bench.sh --mode full --gemma-execute
+```
+
+`--gemma-execute` also makes quick/deep/full run the real synthetic Gemma
+fixture. In full mode, the local transcript autoeval only runs when eligible
+local transcripts are present; otherwise the synthetic fixture remains the real
+runtime proof.
 
 The report includes a compact operator verdict:
 

--- a/scripts/ops/run-local-summary-fixture.sh
+++ b/scripts/ops/run-local-summary-fixture.sh
@@ -8,7 +8,47 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 OUT_ROOT="${TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_OUT:-${REPO_ROOT}/build/local-summary-fixture}"
 RUN_ID="${TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_RUN_ID:-fixture-$(date +%Y%m%d-%H%M%S)}"
-TIMEOUT_SECONDS="${TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_TIMEOUT:-10}"
+REAL_GEMMA="${TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_REAL_GEMMA:-0}"
+
+usage() {
+  cat <<'USAGE'
+Usage: bash scripts/ops/run-local-summary-fixture.sh [--real-gemma]
+
+Runs the deterministic local-summary fixture by default.
+
+Options:
+  --real-gemma  Run the real Gemma MLX runtime on the synthetic fixture.
+                Requires uv plus the pinned mlx-vlm runtime/model prerequisites.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --real-gemma)
+      REAL_GEMMA=1
+      shift
+      ;;
+    --mock|--deterministic)
+      REAL_GEMMA=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "${REAL_GEMMA}" == "1" ]]; then
+  TIMEOUT_SECONDS="${TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_TIMEOUT:-1200}"
+else
+  TIMEOUT_SECONDS="${TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_TIMEOUT:-10}"
+fi
 RUN_ROOT="${OUT_ROOT}/${RUN_ID}"
 BUILD_DIR="${RUN_ROOT}/build"
 FAKE_HOME="${RUN_ROOT}/home"
@@ -39,14 +79,19 @@ struct LocalSummaryFixture {
                 fileURLWithPath: ProcessInfo.processInfo.environment["TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_RUN_ROOT"]!,
                 isDirectory: true
             )
-            try await run(in: runRoot)
+            let repoRoot = URL(
+                fileURLWithPath: ProcessInfo.processInfo.environment["TRANSCRIPTED_REPO_ROOT"]!,
+                isDirectory: true
+            )
+            let realGemma = ProcessInfo.processInfo.environment["TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_REAL_GEMMA"] == "1"
+            try await run(in: runRoot, repoRoot: repoRoot, realGemma: realGemma)
         } catch {
             fputs("[local-summary-fixture] FAIL: \(error)\n", stderr)
             exit(1)
         }
     }
 
-    private static func run(in runRoot: URL) async throws {
+    private static func run(in runRoot: URL, repoRoot: URL, realGemma: Bool) async throws {
         let fileManager = FileManager.default
         try fileManager.createDirectory(at: runRoot, withIntermediateDirectories: true)
 
@@ -54,18 +99,28 @@ struct LocalSummaryFixture {
         let promptCaptureURL = runRoot.appendingPathComponent("captured-prompt.txt")
         try fixtureTranscript.write(to: transcriptURL, atomically: true, encoding: .utf8)
 
-        let configuration = fixtureConfiguration()
-        let runtime = LocalGemmaSummaryRuntime(
-            configuration: configuration,
-            generateBatchOverride: { prompts, _ in
-                guard prompts.count == 1 else {
-                    throw FixtureError.failed("expected direct one-prompt fixture, got \(prompts.count)")
+        let configuration = realGemma ? LocalGemmaSummaryConfiguration.m1Optimized() : fixtureConfiguration()
+        let runtime: LocalGemmaSummaryRuntime
+        if realGemma {
+            try configuration.validateHardware()
+            let runnerURL = repoRoot.appendingPathComponent("Resources/LocalSummarizer/gemma4_mlx_prompt_runner.py")
+            try expect(fileManager.fileExists(atPath: runnerURL.path), "bundled Gemma MLX runner should exist")
+            var realRuntime = LocalGemmaSummaryRuntime(configuration: configuration)
+            realRuntime.runnerURLOverride = runnerURL
+            runtime = realRuntime
+        } else {
+            runtime = LocalGemmaSummaryRuntime(
+                configuration: configuration,
+                generateBatchOverride: { prompts, _ in
+                    guard prompts.count == 1 else {
+                        throw FixtureError.failed("expected direct one-prompt fixture, got \(prompts.count)")
+                    }
+                    let promptText = prompts.map(\.prompt).joined(separator: "\n---\n")
+                    try promptText.write(to: promptCaptureURL, atomically: true, encoding: .utf8)
+                    return [fixtureModelOutput]
                 }
-                let promptText = prompts.map(\.prompt).joined(separator: "\n---\n")
-                try promptText.write(to: promptCaptureURL, atomically: true, encoding: .utf8)
-                return [fixtureModelOutput]
-            }
-        )
+            )
+        }
 
         let result = try await LocalMeetingSummarizer(
             configuration: configuration,
@@ -77,28 +132,41 @@ struct LocalSummaryFixture {
         )
 
         let updatedMarkdown = try String(contentsOf: transcriptURL, encoding: .utf8)
-        let capturedPrompt = try String(contentsOf: promptCaptureURL, encoding: .utf8)
 
         try expect(result.chunkCount == 1, "fixture should use the direct summary path")
-        try expect(result.profileName == "fixture", "fixture profile should be reported")
-        try expect(capturedPrompt.contains("summary fixture stays local"), "prompt should include synthetic transcript text")
-        try expect(!capturedPrompt.contains("fixture-secret"), "prompt should exclude non-transcript notes")
+        try expect(result.profileName == configuration.profileName, "fixture profile should be reported")
         try expect(updatedMarkdown.contains("local_summary_version: \"1\""), "frontmatter should include local summary version")
         try expect(updatedMarkdown.contains("local_summary_source_transcript: \"Synthetic Summary Fixture.md\""), "frontmatter should backlink the source transcript")
-        try expect(updatedMarkdown.contains("local_summary_title: \"Fixture Summary Review\""), "frontmatter should include generated title")
         try expect(updatedMarkdown.contains("local_summary_chunk_count: \"1\""), "frontmatter should include chunk count")
         try expect(updatedMarkdown.contains("local_summary_participants: \"- Alex | - Riley\""), "frontmatter should include transcript participants")
+        try expect(updatedMarkdown.contains("local_summary_model: \"\(configuration.modelID)\""), "frontmatter should include the model id")
+        try expect(updatedMarkdown.contains("local_summary_runtime: \"\(configuration.runtimePackage)\""), "frontmatter should include the runtime package")
+        try expect(updatedMarkdown.contains("local_summary_profile: \"\(configuration.profileName)\""), "frontmatter should include the runtime profile")
         try expect(updatedMarkdown.contains("local_summary_next_steps:"), "frontmatter should include agent next steps")
         try expect(updatedMarkdown.contains("local_summary_commitments:"), "frontmatter should include commitment aliases")
         try expect(updatedMarkdown.contains(LocalMeetingSummaryMarkdownUpdater.startMarker), "managed summary start marker should be present")
         try expect(updatedMarkdown.contains("## Local Gemma Summary"), "managed summary heading should be present")
         try expect(updatedMarkdown.contains("Source transcript: `Synthetic Summary Fixture.md`"), "managed summary should backlink the source transcript")
-        try expect(updatedMarkdown.contains("### Summary\nThe fixture proves local summary generation can finish and rewrite the saved meeting."), "summary body should be written")
-        try expect(updatedMarkdown.contains("### Next Steps\nQA should keep this fixture in the bench.\nThe release gate should not treat fixture output as quality proof."), "next steps body should be written")
+        try expect(updatedMarkdown.contains("### Summary\n"), "summary body should be written")
+        try expect(updatedMarkdown.contains("### Next Steps\n"), "next steps body should be written")
         try expect(updatedMarkdown.contains("### Participants\n- Alex\n- Riley"), "participants body should be written")
-        try expect(updatedMarkdown.contains("### Action Items\nQA should keep this fixture in the bench."), "action item body should be written")
+        try expect(updatedMarkdown.contains("### Action Items\n"), "action item body should be written")
         try expect(updatedMarkdown.contains(LocalMeetingSummaryMarkdownUpdater.endMarker), "managed summary end marker should be present")
         try expect(!fileManager.fileExists(atPath: LocalMeetingSummaryStore.summaryURL(for: transcriptURL).path), "fixture should not create a sibling summary sidecar")
+
+        if realGemma {
+            print("[local-summary-fixture] PASS: generated real Gemma local summary fixture")
+            print("[local-summary-fixture] Transcript: \(transcriptURL.path)")
+            return
+        }
+
+        let capturedPrompt = try String(contentsOf: promptCaptureURL, encoding: .utf8)
+        try expect(capturedPrompt.contains("summary fixture stays local"), "prompt should include synthetic transcript text")
+        try expect(!capturedPrompt.contains("fixture-secret"), "prompt should exclude non-transcript notes")
+        try expect(updatedMarkdown.contains("local_summary_title: \"Fixture Summary Review\""), "frontmatter should include generated title")
+        try expect(updatedMarkdown.contains("### Summary\nThe fixture proves local summary generation can finish and rewrite the saved meeting."), "summary body should be written")
+        try expect(updatedMarkdown.contains("### Next Steps\nQA should keep this fixture in the bench.\nThe release gate should not treat fixture output as quality proof."), "next steps body should be written")
+        try expect(updatedMarkdown.contains("### Action Items\nQA should keep this fixture in the bench."), "action item body should be written")
 
         print("[local-summary-fixture] PASS: generated deterministic local summary fixture")
         print("[local-summary-fixture] Transcript: \(transcriptURL.path)")
@@ -336,8 +404,30 @@ run_with_timeout() {
 }
 
 echo "[local-summary-fixture] Run root: ${RUN_ROOT}"
+if [[ "${REAL_GEMMA}" == "1" ]]; then
+  echo "[local-summary-fixture] Real Gemma mode: requires uv plus mlx-vlm/model availability through uv."
+  if [[ -z "${TRANSCRIPTED_UV_PATH:-}" ]]; then
+    RESOLVED_UV="$(command -v uv || true)"
+    if [[ -n "${RESOLVED_UV}" ]]; then
+      export TRANSCRIPTED_UV_PATH="${RESOLVED_UV}"
+    fi
+  fi
+  if [[ -z "${UV_PYTHON:-}" ]]; then
+    for PYTHON_CANDIDATE in python3.14 python3.13 python3.12 python3.11 python3.10; do
+      RESOLVED_PYTHON="$(command -v "${PYTHON_CANDIDATE}" || true)"
+      if [[ -n "${RESOLVED_PYTHON}" ]]; then
+        export UV_PYTHON="${RESOLVED_PYTHON}"
+        break
+      fi
+    done
+  fi
+else
+  echo "[local-summary-fixture] Deterministic mode: mocked model output, no mlx runtime required."
+fi
 export CFFIXED_USER_HOME="${FAKE_HOME}"
 export HOME="${FAKE_HOME}"
 export TRANSCRIPTED_DISABLE_FILE_LOGGER=1
+export TRANSCRIPTED_REPO_ROOT="${REPO_ROOT}"
 export TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_RUN_ROOT="${RUN_ROOT}"
+export TRANSCRIPTED_LOCAL_SUMMARY_FIXTURE_REAL_GEMMA="${REAL_GEMMA}"
 run_with_timeout "${BIN}"

--- a/scripts/ops/transcripted-qa-bench.sh
+++ b/scripts/ops/transcripted-qa-bench.sh
@@ -12,6 +12,7 @@ OUT_ROOT="${TRANSCRIPTED_QA_BENCH_OUT:-/tmp/transcripted-qa-bench}"
 RUN_ID="${TRANSCRIPTED_QA_BENCH_RUN_ID:-qa-$(date +%Y%m%d-%H%M%S)}"
 SKIP_BUILD=0
 STRICT_ARTIFACTS=0
+GEMMA_EXECUTE="${TRANSCRIPTED_QA_GEMMA_EXECUTE:-0}"
 LIVE_DURATION="${TRANSCRIPTED_QA_LIVE_DURATION:-2.0}"
 CORPUS_ROOT="${TRANSCRIPTED_QA_CORPUS_ROOT:-${HOME}/Downloads/meeting-corpus}"
 CORPUS_IDS="${TRANSCRIPTED_QA_CORPUS_IDS:-}"
@@ -53,6 +54,8 @@ Modes:
 Options:
   --skip-build          Do not run build.sh in quick/deep/live modes.
   --strict-artifacts    Make live artifact validation blocking in deep/full/live mode.
+  --gemma-execute       Run real Gemma/MLX proof where the bench has local inputs.
+                       Equivalent to TRANSCRIPTED_QA_GEMMA_EXECUTE=1.
   --duration seconds    Live capture duration. Default: 2.0
   --corpus-root path    Meeting corpus root. Default: ~/Downloads/meeting-corpus
   --corpus-ids ids      Comma-separated meeting ids to validate.
@@ -87,6 +90,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --strict-artifacts)
       STRICT_ARTIFACTS=1
+      shift
+      ;;
+    --gemma-execute)
+      GEMMA_EXECUTE=1
       shift
       ;;
     --duration)
@@ -673,8 +680,13 @@ run_quick() {
   run_step "02-fast-tests" "Fast tests" "yes" "bash run-tests.sh"
   run_step "03-e2e-smoke" "Deterministic E2E smoke" "yes" "bash run-e2e-smoke.sh"
   run_pasteback_synthetic
-  run_step "05-local-summary-fixture" "Local Gemma summary fixture smoke" "yes" \
-    "bash scripts/ops/run-local-summary-fixture.sh"
+  if [[ "${GEMMA_EXECUTE}" == "1" ]]; then
+    run_step "05-local-summary-fixture" "Real Gemma summary fixture smoke" "yes" \
+      "bash scripts/ops/run-local-summary-fixture.sh --real-gemma"
+  else
+    run_step "05-local-summary-fixture" "Local Gemma summary fixture smoke" "yes" \
+      "bash scripts/ops/run-local-summary-fixture.sh"
+  fi
 }
 
 run_pasteback_synthetic() {
@@ -785,8 +797,15 @@ run_gemma_summary_plan() {
     return "${candidate_status}"
   fi
 
-  run_step "61-gemma-summary-plan" "Local Gemma summary dry-run plan" "no" \
-    "python3 scripts/ops/local-gemma-summary-autoeval.py --out-root $(shell_quote "${OUT}/local-gemma-summary") --run-id plan --limit 1 --include-longest 1 --sample-count 0 --repeats 1"
+  local execute_arg=""
+  local title="Local Gemma summary dry-run plan"
+  if [[ "${GEMMA_EXECUTE}" == "1" ]]; then
+    execute_arg=" --execute"
+    title="Local Gemma summary executable proof"
+  fi
+
+  run_step "61-gemma-summary-plan" "${title}" "no" \
+    "python3 scripts/ops/local-gemma-summary-autoeval.py --out-root $(shell_quote "${OUT}/local-gemma-summary") --run-id plan --limit 1 --include-longest 1 --sample-count 0 --repeats 1${execute_arg}"
 }
 
 run_full_tail() {


### PR DESCRIPTION
## Summary
- add `--real-gemma` to `run-local-summary-fixture.sh` so the synthetic fixture can execute the real Gemma/MLX runtime instead of only mocked output
- add `--gemma-execute` / `TRANSCRIPTED_QA_GEMMA_EXECUTE=1` to the QA bench so the Gemma row can run real proof
- preserve `UV_PYTHON` through the local Gemma runtime env so `uv` can select Python >=3.10 for `mlx-vlm==0.6.1`

## Proof
- `bash build-deps.sh --force`
- `bash scripts/ops/run-local-summary-fixture.sh --real-gemma`
- `bash scripts/ops/transcripted-qa-bench.sh --mode quick --gemma-execute` -> PASS 6/6, report: `/tmp/transcripted-qa-bench/qa-20260622-061900/qa-report.md`
- `bash run-integration-smoke.sh`
- `swift test --package-path Tools/TranscriptedQA`
- `python3 -m py_compile scripts/ops/validate-meeting-corpus.py`
- `python3 -m py_compile scripts/ops/compare-meeting-corpus.py`

lanes used: Codex=implemented, ran local Gemma proof and mapped checks; Claude=skipped, narrow local runtime/tooling fix; Local=skipped, no sensitive summarization/classification needed; Windows=skipped, Mac MLX/runtime proof required