### PR TITLE
UI: normalize destructive confirmation sheet focus + ordering

### DIFF
--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -887,6 +887,7 @@ private struct SpeakerVoiceToNameRow: View {
                 deleteVoice()
             }
             Button("Cancel", role: .cancel) {}
+                .keyboardShortcut(.defaultAction)
         } message: {
             Text(SpeakerVoiceRowMenuPolicy.deleteConfirmationMessage)
         }
@@ -1266,6 +1267,7 @@ private struct SpeakerPersonRow: View {
                 model.delete(profile: profile)
             }
             Button("Cancel", role: .cancel) {}
+                .keyboardShortcut(.defaultAction)
         } message: {
             Text("This removes the saved voice profile and sample clip. Past transcripts stay unchanged.")
         }

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -237,13 +237,16 @@ struct TranscriptedSettingsView: View {
         .alert(item: rootAlertBinding) { alert in
             switch alert {
             case .deleteConfirmation(let confirmation):
+                // Cancel is the primary (default) button so Return lands on the
+                // safe, reversible choice; the destructive action stays a clearly
+                // marked `.destructive` secondary button.
                 return Alert(
                     title: Text(confirmation.title),
                     message: Text(confirmation.message),
-                    primaryButton: .destructive(Text(confirmation.confirmTitle)) {
+                    primaryButton: .cancel(),
+                    secondaryButton: .destructive(Text(confirmation.confirmTitle)) {
                         confirmation.perform()
-                    },
-                    secondaryButton: .cancel()
+                    }
                 )
             case .deleteFailure(let failure):
                 return Alert(
@@ -255,10 +258,10 @@ struct TranscriptedSettingsView: View {
                 return Alert(
                     title: Text("Delete old replay audio?"),
                     message: Text("Transcripted will keep your Markdown transcripts, but retained replay audio older than \(window.title) will be permanently removed now and cleaned up automatically later."),
-                    primaryButton: .destructive(Text("Delete Old Audio")) {
+                    primaryButton: .cancel(),
+                    secondaryButton: .destructive(Text("Delete Old Audio")) {
                         applyAudioRetentionWindow(window)
-                    },
-                    secondaryButton: .cancel()
+                    }
                 )
             }
         }
@@ -3017,6 +3020,7 @@ struct TranscriptedSettingsView: View {
                     removeReclaimableModelCaches()
                 }
                 Button("Cancel", role: .cancel) {}
+                    .keyboardShortcut(.defaultAction)
             } message: {
                 let includeWhisper = !effectiveTranscriptionModel.isWhisper
                 Text(includeWhisper
@@ -3028,6 +3032,7 @@ struct TranscriptedSettingsView: View {
                     removeStaleModelCaches()
                 }
                 Button("Cancel", role: .cancel) {}
+                    .keyboardShortcut(.defaultAction)
             } message: {
                 Text("Transcripted will remove only known old Parakeet folders: \(modelCacheSnapshot?.staleModelSummary ?? "none"). Active Parakeet CoreML and Whisper caches stay.")
             }
@@ -3036,6 +3041,7 @@ struct TranscriptedSettingsView: View {
                     removeWhisperModelCache()
                 }
                 Button("Cancel", role: .cancel) {}
+                    .keyboardShortcut(.defaultAction)
             } message: {
                 Text("Transcripted will remove downloaded Whisper model files. Parakeet stays available, and Whisper can download again later if you choose it.")
             }


### PR DESCRIPTION
## What

Small atomic UI-polish slice: normalize destructive/sheet button **focus + ordering** across the confirmation sheets so the safe, reversible choice is the default, while the destructive action stays clearly marked but not loud.

Per the macOS HIG, destructive alerts should focus **Cancel** as the default button so an accidental Return doesn't trigger deletion. The destructive button keeps the system `.destructive` role (red = distinct, not loud — no custom-loud styling added).

## Changes (Sources/UI only)

- **Home delete dictation/meeting** + **audio-retention** legacy `Alert`s (`TranscriptedSettingsView.swift`): `Cancel` is now the primary (default) button; the destructive action moves to the secondary slot. Pure in-API reorder — no change to the single-presenter `rootAlertBinding` routing.
- **Speaker delete-voice / delete-speaker** (`SpeakerPeopleSettingsSection.swift`) and the **three model-cache cleanup** alerts (`TranscriptedSettingsView.swift`): add `.keyboardShortcut(.defaultAction)` to `Cancel` so Return cancels.

## Left unchanged (intentional)

- **Merge** confirmations are non-destructive (Merge stays the primary/default action).
- The **discard meeting** `NSAlert` already adds "Keep Recording" first, so it already defaults to the safe choice.

## Scope / conflicts

Kept deliberately minimal (destructive/sheet focus + ordering only) — this lane runs alongside the tabular-numbers / reduced-motion / accessibility / focus-order / contrast sweeps on the same `Sources/UI` files. No conflicts hit on this push; will rebase + continue if merge-room sequences a conflict.

## Verification

This is a Linux session; the macOS app build (`build.sh`) needs prebuilt deps + AppKit and can't run here — Swift CI on macOS validates. Changes are minimal, syntactically-safe SwiftUI modifier reorderings. Manual proof is Justin's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015r4AS1jWVdPnwC6q5kQwwf)_