### PR TITLE
Honor Reduce Motion across overlays, waveform, and onboarding

### DIFF
--- a/Sources/UI/Overlay/FloatingOverlayController.swift
+++ b/Sources/UI/Overlay/FloatingOverlayController.swift
@@ -333,7 +333,7 @@ class FloatingOverlayController {
         }
 
         NSAnimationContext.runAnimationGroup({ ctx in
-            ctx.duration = 0.2
+            ctx.duration = AccessibilityDisplayPolicy.motionDuration(0.2)
             ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
             panel.animator().alphaValue = 1.0
         })
@@ -389,7 +389,7 @@ class FloatingOverlayController {
         panel.orderOut(nil)
 
         NSAnimationContext.runAnimationGroup({ ctx in
-            ctx.duration = 0.14
+            ctx.duration = AccessibilityDisplayPolicy.motionDuration(0.14)
             ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
             panel.animator().alphaValue = 0
         }, completionHandler: { [weak self] in
@@ -416,7 +416,8 @@ class FloatingOverlayController {
         panel.ignoresMouseEvents = true
 
         let baseX = panel.frame.origin.x
-        let offsets: [CGFloat] = [7, -5, 3, -1, 0]
+        // Skip the horizontal shake under Reduce Motion; the fade below still runs.
+        let offsets: [CGFloat] = AccessibilityDisplayPolicy.reduceMotion ? [] : [7, -5, 3, -1, 0]
         let stepDuration = 0.068
 
         for (i, offset) in offsets.enumerated() {
@@ -437,7 +438,7 @@ class FloatingOverlayController {
                 return
             }
             NSAnimationContext.runAnimationGroup({ ctx in
-                ctx.duration = 0.14
+                ctx.duration = AccessibilityDisplayPolicy.motionDuration(0.14)
                 ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
                 panel.animator().alphaValue = 0
             }, completionHandler: { [weak self] in

--- a/Sources/UI/Overlay/MeetingLiveTranscriptDrawerView.swift
+++ b/Sources/UI/Overlay/MeetingLiveTranscriptDrawerView.swift
@@ -183,7 +183,7 @@ final class MeetingLiveTranscriptDrawerView: NSView {
 
     private func setHeaderRevealed(_ revealed: Bool) {
         NSAnimationContext.runAnimationGroup { ctx in
-            ctx.duration = 0.15
+            ctx.duration = AccessibilityDisplayPolicy.motionDuration(0.15)
             hoverBar.animator().alphaValue = revealed ? 1 : 0
         }
     }

--- a/Sources/UI/Overlay/MeetingOverlayController.swift
+++ b/Sources/UI/Overlay/MeetingOverlayController.swift
@@ -886,7 +886,7 @@ final class MeetingOverlayRootView: NSView {
             }
         }
         NSAnimationContext.runAnimationGroup({ ctx in
-            ctx.duration = fadeOut ? 0.12 : 0.18
+            ctx.duration = AccessibilityDisplayPolicy.motionDuration(fadeOut ? 0.12 : 0.18)
             ctx.timingFunction = CAMediaTimingFunction(name: fadeOut ? .easeIn : .easeOut)
             for view in fadeViews {
                 view.animator().alphaValue = fadeOut ? 0 : 1
@@ -935,13 +935,13 @@ final class MeetingOverlayRootView: NSView {
             transcriptDrawer.isHidden = false
             transcriptDrawer.prepareForReveal()
             NSAnimationContext.runAnimationGroup { ctx in
-                ctx.duration = 0.18
+                ctx.duration = AccessibilityDisplayPolicy.motionDuration(0.18)
                 ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
                 transcriptDrawer.animator().alphaValue = 1
             }
         } else {
             NSAnimationContext.runAnimationGroup({ ctx in
-                ctx.duration = 0.12
+                ctx.duration = AccessibilityDisplayPolicy.motionDuration(0.12)
                 ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
                 transcriptDrawer.animator().alphaValue = 0
             }, completionHandler: { [weak self] in
@@ -1014,7 +1014,8 @@ final class MeetingOverlayRootView: NSView {
     private func setStatusDotPulsing(_ pulsing: Bool) {
         let key = "transcribingPulse"
         guard let layer = statusDot.layer else { return }
-        if pulsing {
+        // Reduce Motion: keep the dot at full opacity instead of breathing.
+        if pulsing && !AccessibilityDisplayPolicy.reduceMotion {
             guard layer.animation(forKey: key) == nil else { return }
             let pulse = CABasicAnimation(keyPath: "opacity")
             pulse.fromValue = 1.0
@@ -1838,7 +1839,7 @@ final class MeetingOverlayController: NSObject {
         panel.alphaValue = 0
         panel.orderFrontRegardless()
         NSAnimationContext.runAnimationGroup { ctx in
-            ctx.duration = 0.18
+            ctx.duration = AccessibilityDisplayPolicy.motionDuration(0.18)
             ctx.timingFunction = CAMediaTimingFunction(name: .easeOut)
             panel.animator().alphaValue = 1.0
         }
@@ -1886,7 +1887,7 @@ final class MeetingOverlayController: NSObject {
         // stale hover flag would silently block resting next recording.
         isPanelHovered = false
         NSAnimationContext.runAnimationGroup({ ctx in
-            ctx.duration = 0.14
+            ctx.duration = AccessibilityDisplayPolicy.motionDuration(0.14)
             ctx.timingFunction = CAMediaTimingFunction(name: .easeIn)
             panel.animator().alphaValue = 0
         }, completionHandler: { [weak panel] in

--- a/Sources/UI/Overlay/WaveformLayer.swift
+++ b/Sources/UI/Overlay/WaveformLayer.swift
@@ -196,6 +196,8 @@ final class WaveformDrawingLayer: CALayer {
     }
 
     private func scrollingOffset(now: CFAbsoluteTime, stride: CGFloat) -> CGFloat {
+        // Reduce Motion: skip the sub-pixel glide so bars don't continuously slide.
+        guard !AccessibilityDisplayPolicy.reduceMotion else { return 0 }
         let currentElapsed = now - lastSampleTime
         let fractionalProgress = min(currentElapsed / sampleInterval, 1.0)
         return CGFloat(fractionalProgress) * stride
@@ -435,6 +437,8 @@ final class DualWaveformDrawingLayer: CALayer {
     }
 
     private func scrollingOffset(now: CFAbsoluteTime) -> CGFloat {
+        // Reduce Motion: skip the sub-pixel glide so bars don't continuously slide.
+        guard !AccessibilityDisplayPolicy.reduceMotion else { return 0 }
         let currentElapsed = now - lastSampleTime
         let fractionalProgress = min(currentElapsed / sampleInterval, 1.0)
         return CGFloat(fractionalProgress) * barStride

--- a/Sources/UI/Settings/PermissionsOnboardingView.swift
+++ b/Sources/UI/Settings/PermissionsOnboardingView.swift
@@ -32,6 +32,7 @@ struct PermissionsOnboardingView: View {
     static let preferredSize = NSSize(width: 960, height: 680)
     private static let defaultDictationShortcut = "Right Option"
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var currentStepIndex = 0
     @State private var navigationDirection: OnboardingNavigationDirection = .forward
     @State private var micGranted = false
@@ -440,7 +441,7 @@ struct PermissionsOnboardingView: View {
 
     private func goBack() {
         guard currentStepIndex > 0 else { return }
-        withAnimation(.easeInOut(duration: 0.24)) {
+        withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.24)) {
             navigationDirection = .backward
             currentStepIndex -= 1
         }
@@ -448,7 +449,7 @@ struct PermissionsOnboardingView: View {
 
     private func goNext() {
         guard currentStepIndex < steps.count - 1 else { return }
-        withAnimation(.easeInOut(duration: 0.24)) {
+        withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.24)) {
             navigationDirection = .forward
             currentStepIndex += 1
         }
@@ -892,6 +893,7 @@ private enum OnboardingTheme {
 }
 
 private struct OnboardingWindowShell<Content: View>: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let current: Int
     let total: Int
     let direction: OnboardingNavigationDirection
@@ -945,7 +947,7 @@ private struct OnboardingWindowShell<Content: View>: View {
 
                 ZStack {
                     content
-                        .transition(direction.transition)
+                        .transition(reduceMotion ? .opacity : direction.transition)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .clipped()
@@ -1195,11 +1197,13 @@ private struct BodyCopy: View {
 }
 
 private struct HeroWaveCircle: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     private let count = 26
 
     var body: some View {
         TimelineView(.animation) { timeline in
-            let t = timeline.date.timeIntervalSinceReferenceDate
+            // Reduce Motion: freeze the wave at a fixed phase instead of looping.
+            let t = reduceMotion ? 0 : timeline.date.timeIntervalSinceReferenceDate
             ZStack {
                 Circle()
                     .fill(OnboardingTheme.ink)


### PR DESCRIPTION
Small atomic UI-polish fix: gate the transient animations behind the system **Reduce Motion** setting so they go calm (instant snap / cross-fade / frozen) when it's on. Motion-gating only — no other behavior changes. Reuses the existing `AccessibilityDisplayPolicy` (`reduceMotion` / `motionDuration`) and SwiftUI's `accessibilityReduceMotion` environment value.

### Surfaces covered
- **Dictation overlay** (`FloatingOverlayController`): entrance/confirm fade durations collapse to instant; the cancel shake drops its horizontal jitter (still fades out).
- **Meeting overlay / pill rest+recede** (`MeetingOverlayController`): strip condense/bloom, drawer reveal, and panel show/hide fade durations collapse; the transcribing status-dot breathing pulse is suppressed (dot stays at full opacity).
- **Meeting live transcript drawer** (`MeetingLiveTranscriptDrawerView`): hover-bar fade duration collapses.
- **Dictation/meeting waveform meter** (`WaveformLayer`): the continuous sub-pixel scroll glide is skipped (bars stop sliding; level-driven height still renders).
- **Onboarding → Home** (`PermissionsOnboardingView`): step transition becomes a plain cross-fade, step-nav animations go instant, and the hero wave circle freezes at a fixed phase.

The panel frame-resize and overlay entrance spring were already gated; this fills the remaining gaps.

### Scope notes
Kept deliberately minimal to play nice with the parallel UI sweeps (tabular-numbers, contrast, focus-order, destructive-styling) on the same files — only motion gating, no restyling. Left the dense Settings/Home hover micro-animations alone since they're outside the named surfaces.

### Verification
The macOS app build / Swift CI runs on the CI runner (this dev environment is Linux and can't run the Apple toolchain). Manual reduce-motion toggle proof is Justin's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9AzrMYxptbJSzccPvwYPG)_