### PR TITLE
a11y: stable identifiers for speaker-review icon buttons

### DIFF
--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -1043,6 +1043,7 @@ private struct SpeakerPlayClipButton: View {
         .disabled(!hasClip)
         .help(SpeakerClipPlaybackPresentation.helpText(hasClip: hasClip, isPlaying: isPlaying))
         .accessibilityLabel(SpeakerClipPlaybackPresentation.accessibilityLabel(isPlaying: isPlaying))
+        .accessibilityIdentifier("transcripted.speakers.voice-to-name.play")
     }
 
     private var isActive: Bool {
@@ -1194,6 +1195,7 @@ private struct SpeakerSearchRow: View {
             .buttonStyle(.plain)
             .help("Refresh the speaker list")
             .accessibilityLabel("Refresh speakers")
+            .accessibilityIdentifier("transcripted.speakers.refresh")
         }
     }
 }
@@ -1251,6 +1253,7 @@ private struct SpeakerPersonRow: View {
                     .buttonStyle(.plain)
                     .help(isPlaying ? "Pause this voice" : "Play this voice")
                     .accessibilityLabel(isPlaying ? "Pause voice sample" : "Play voice sample")
+                    .accessibilityIdentifier("transcripted.speakers.person.play")
                 }
 
                 rowMenu
@@ -1320,6 +1323,7 @@ private struct SpeakerPersonRow: View {
         .fixedSize()
         .help("Rename, merge, or delete this speaker")
         .accessibilityLabel("Speaker actions")
+        .accessibilityIdentifier("transcripted.speakers.person.menu")
     }
 
     private var displayName: String {

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -199,7 +199,6 @@ func testUIAutomationSurfaceContract() {
         let settingsRowsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsRows.swift")
         let settingsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsView.swift")
         let homeSource = readUIAutomationContractFile("Sources/UI/Settings/HomeView.swift")
-        let settingsRowsSource = readUIAutomationContractFile("Sources/UI/Settings/TranscriptedSettingsRows.swift")
         let meetingAudioPlaybackSource = readUIAutomationContractFile("Sources/UI/Shared/MeetingAudioPlayback.swift")
         let onboardingSource = readUIAutomationContractFile("Sources/UI/Settings/PermissionsOnboardingView.swift")
         let speakerReviewSource = readUIAutomationContractFile("Sources/UI/Settings/SpeakerNamingSheet.swift")

--- a/Tests/UIAutomationSurfaceContractTests.swift
+++ b/Tests/UIAutomationSurfaceContractTests.swift
@@ -649,6 +649,19 @@ func testUIAutomationSurfaceContract() {
             "speaker refresh, all-speakers play, and overflow icon controls should use the compact 40pt hit-target label"
         )
 
+        for identifier in [
+            "transcripted.speakers.voice-to-name.play",
+            "transcripted.speakers.voice-to-name.menu",
+            "transcripted.speakers.refresh",
+            "transcripted.speakers.person.play",
+            "transcripted.speakers.person.menu",
+        ] {
+            assertTrue(
+                speakerPeopleSource.contains(identifier),
+                "\(identifier) should keep the speakers surface's icon-only controls scriptable without using speaker names"
+            )
+        }
+
         assertTrue(
             homeSource.contains("HomeAttentionPillsRow")
                 && homeSource.contains(".accessibilityHint(issue.detail)")


### PR DESCRIPTION
## What

Small, atomic a11y fix from the UI-polish tracker (rows: "Hover/focus/click every tiny icon button" + "Navigate major surfaces with VoiceOver").

The Speakers settings surface (`SpeakerPeopleSettingsSection`) had four icon-only controls that already carried VoiceOver labels and tooltips (`.accessibilityLabel` + `.help`) and 40pt hit targets, but **no stable accessibility identifiers** — so contract/UI-automation tests couldn't target them without leaning on speaker names. The post-meeting speaker *review sheet* (`SpeakerNamingSheet`) already had full identifier coverage; this brings the settings-side speakers surface in line.

## Changes

Attach `transcripted.speakers.*` identifiers to:
- `transcripted.speakers.voice-to-name.play` — voice-to-name row play/pause clip button
- `transcripted.speakers.refresh` — all-speakers refresh button
- `transcripted.speakers.person.play` — per-person play/pause sample button
- `transcripted.speakers.person.menu` — per-person overflow menu

And extend the existing speaker-settings block in `UIAutomationSurfaceContractTests` to assert all five icon-control identifiers stay wired up (including the already-present `transcripted.speakers.voice-to-name.menu`).

## Scope notes

- **a11y-only, additive, no behavior change.** Kept deliberately minimal to stay merge-friendly with the parallel UI sweeps (tabular-numbers, reduced-motion, destructive-styling, focus-order, contrast) on the same `Sources/UI` files.
- Audited the other named surfaces (Home rows, dictation/meeting overlays, settings) — those icon-only buttons already have labels + tooltips + 40pt targets from earlier merged work (the meeting overlay/drawer use a deliberate custom tracking-area tooltip because native NSToolTips don't render on the non-activating panel). This PR fills the one genuine remaining identifier gap.

## Verification

Touched `Sources/**/*.swift` + root `Tests/*.swift` → rule calls for `bash build.sh --no-open` + `bash run-tests.sh`. The build is macOS-only (AppKit + prebuilt frameworks), so it's left to CI; changes are additive SwiftUI modifiers + a test loop mirroring the existing pattern in the same suite. Manual VoiceOver pass is Justin's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011gdfnahLCgG4aCwCC92QkE)_