### PR TITLE
fix: Sparkle update prompt — versioned + unmistakably 'update available'

### DIFF
--- a/Sources/UI/MenuBar/MenuBarPanelController.swift
+++ b/Sources/UI/MenuBar/MenuBarPanelController.swift
@@ -380,8 +380,8 @@ final class MenuBarPanelController: NSViewController {
 
             return (
                 "arrow.down.circle.fill",
-                "Install \(version)",
-                "Update ready",
+                "Update available: \(version)",
+                "A new version is ready to install",
                 "Install",
                 .warning,
                 true

--- a/docs/sparkle-updates.md
+++ b/docs/sparkle-updates.md
@@ -38,6 +38,29 @@ Future agents should treat this as a release requirement:
   automatically`; if Sparkle has already downloaded an update, the primary
   action becomes `Restart to Update`
 
+## In-app update prompt surfaces (inventory)
+
+Transcripted suppresses Sparkle's own automatic pop-ups (only critical updates
+hand back to the standard Sparkle UI), so every routine "an update is available"
+prompt is native Transcripted copy. Each surface must show the version and read
+unmistakably as *an update is available to install* — never as "you're done" or
+"shipped". The surfaces are:
+
+| Surface | Where | "Update available" copy | "Ready to install" copy |
+|---------|-------|-------------------------|-------------------------|
+| Menu bar footer row | `MenuBarPanelController.menuUpdatePresentation` | title `Update available: <version>`, detail `A new version is ready to install`, trailing `Install` | title `Restart to Update`, detail `Version <version> downloaded`, trailing `Restart` |
+| Settings → About status card | `TranscriptedSettingsView.aboutUpdateStatus*` | title `Update available (<version>)`, detail `Version <version> is ready to install.` | title `Ready to restart (<version>)`, detail `Version <version> is downloaded.` |
+| Settings → About primary button | `TranscriptedSettingsView.aboutUpdateButtonTitle` | `Install <version>` | `Restart to Update` |
+| Menu bar status-item badge + tooltip | `TranscriptedApp.updateStatusItemBadge` | (badge hidden until staged) | tooltip `Transcripted - restart to update to <version>` |
+
+When automatic downloads are enabled the available/downloading states stay quiet
+(`Preparing Update` / `Downloading…`) and the only user-facing action is the
+ready-to-install restart. The failure taxonomy behind these states lives in
+`Sources/Observability/UpdateFailureKind.swift`.
+
+If you add or rename an update prompt surface, update this table in the same
+change so the inventory stays complete.
+
 ## Local tooling
 
 `bash build-deps.sh --force` now downloads Sparkle's official pinned distribution and installs:


### PR DESCRIPTION
## Problem

Native Sparkle prompt surfaces weren't inventoried with Transcripted copy, and the menu-bar update row showed **"Update ready"** as its detail for an available-but-uninstalled update — which reads as "you're done / shipped" rather than "an update is available." From the UI-polish tracker (Updates/Sparkle :: Accept or dismiss an update prompt).

## Change (copy/inventory only, atomic)

- **Menu bar update row** (`MenuBarPanelController.menuUpdatePresentation`): for an available update with auto-download off, retitle `Install <version>` / `Update ready` → **`Update available: <version>`** / **`A new version is ready to install`**. Version stays visible; the row is now unmistakably an available update, not a completion notice.
- **`docs/sparkle-updates.md`**: new **"In-app update prompt surfaces (inventory)"** table cataloging every native prompt surface (menu bar row, Settings About card + button, status-item tooltip) with its "available" vs "ready to install" copy, plus a note to keep the table in sync when surfaces change.

No behavior change. Sparkle still suppresses its own automatic pop-ups for non-critical updates.

## Verification

- `bash build.sh --no-open` ✅
- `bash run-tests.sh` ✅ (10152 passed, 0 failed)

Manual proof of the real Sparkle prompt is Justin's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)