### PR TITLE
Track MCP orientation query telemetry

### DIFF
--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/AgentCaptureQueryTelemetry.swift
@@ -149,7 +149,7 @@ enum AgentCaptureQueryTelemetryPolicy {
         "agent_target": ["mcp_client"],
         "artifact_kind": ["dictation", "meeting", "mixed"],
         "capture_age_bucket": ["lt_12h", "12_24h", "24_48h", "2_7d", "older", "unknown"],
-        "query_kind": ["read", "recap", "search", "speaker_lookup"],
+        "query_kind": ["list", "read", "recap", "recent", "search", "speaker_lookup"],
         "result": ["success"],
         "return_window_bucket": ["same_day", "18_36h", "36_72h", "3_7d", "older", "unknown"],
         "source_count_bucket": ["0", "1", "2_3", "4_9", "10_plus", "unknown"],
@@ -272,6 +272,10 @@ struct AgentCaptureQueryTelemetryConfiguration {
     }
 }
 
+protocol AgentCaptureQueryTelemetryRecording: AnyObject {
+    func track(_ observation: AgentCaptureQueryObservation)
+}
+
 final class AgentCaptureQueryTelemetry {
     static let shared = AgentCaptureQueryTelemetry()
     private static let isoDateFormatter = ISO8601DateFormatter()
@@ -328,13 +332,19 @@ final class AgentCaptureQueryTelemetry {
     }
 }
 
+extension AgentCaptureQueryTelemetry: AgentCaptureQueryTelemetryRecording {}
+
+enum AgentCaptureQueryTelemetryRuntime {
+    static var recorder: AgentCaptureQueryTelemetryRecording = AgentCaptureQueryTelemetry.shared
+}
+
 func trackAgentCaptureQueryObserved(
     queryKind: String,
     artifactKind: String,
     captureDate: Date?,
     sourceCount: Int?
 ) {
-    AgentCaptureQueryTelemetry.shared.track(
+    AgentCaptureQueryTelemetryRuntime.recorder.track(
         AgentCaptureQueryObservation(
             queryKind: queryKind,
             artifactKind: artifactKind,

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -268,7 +268,7 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
 
 // MARK: - list_meetings
 
-private func handleListMeetings(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+func handleListMeetings(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
     let count = params.arguments?["count"]?.intValue ?? 10
     let date = params.arguments?["date"]?.stringValue
     let dateFrom = params.arguments?["date_from"]?.stringValue ?? date
@@ -292,11 +292,18 @@ private func handleListMeetings(params: CallTool.Parameters, index: TranscriptIn
         return textResult("No meetings found.")
     }
 
+    trackAgentCaptureQueryObserved(
+        queryKind: "list",
+        artifactKind: "meeting",
+        captureDate: latestMeetingDate(in: results),
+        sourceCount: results.count
+    )
+
     let json = try JSONEncoder.pretty.encode(results)
     return textResult(String(data: json, encoding: .utf8) ?? "[]")
 }
 
-private func handleListDictations(params: CallTool.Parameters, index: TranscriptIndex) throws -> CallTool.Result {
+func handleListDictations(params: CallTool.Parameters, index: TranscriptIndex) throws -> CallTool.Result {
     let count = params.arguments?["count"]?.intValue ?? 10
     let date = params.arguments?["date"]?.stringValue
     let dateFrom = params.arguments?["date_from"]?.stringValue ?? date
@@ -307,6 +314,13 @@ private func handleListDictations(params: CallTool.Parameters, index: Transcript
     if results.isEmpty {
         return textResult("No dictations found.")
     }
+
+    trackAgentCaptureQueryObserved(
+        queryKind: "list",
+        artifactKind: "dictation",
+        captureDate: latestDictationDayDate(in: results),
+        sourceCount: results.count
+    )
 
     let json = try JSONEncoder.pretty.encode(results)
     return textResult(String(data: json, encoding: .utf8) ?? "[]")
@@ -510,7 +524,7 @@ private func handleSearchContext(params: CallTool.Parameters, index: TranscriptI
     return textResult(String(data: json, encoding: .utf8) ?? "{}")
 }
 
-private func handleRecentContext(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+func handleRecentContext(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
     let kind = parseContextKind(params.arguments?["kind"]?.stringValue)
     let count = max(1, min(params.arguments?["count"]?.intValue ?? 10, 50))
     let dateFrom = params.arguments?["date_from"]?.stringValue
@@ -522,6 +536,13 @@ private func handleRecentContext(params: CallTool.Parameters, index: TranscriptI
     if result.items.isEmpty {
         return textResult("No recent context found.")
     }
+
+    trackAgentCaptureQueryObserved(
+        queryKind: "recent",
+        artifactKind: artifactKind(for: result.items.map(\.kind)),
+        captureDate: latestRecentContextDate(in: result.items),
+        sourceCount: result.items.count
+    )
 
     let json = try JSONEncoder.pretty.encode(result)
     return textResult(String(data: json, encoding: .utf8) ?? "{}")
@@ -707,11 +728,23 @@ private func formatDuration(_ seconds: Int) -> String {
     return "\(m)m"
 }
 
+private func latestMeetingDate(in results: [MeetingSummary]) -> Date? {
+    results.compactMap { parseCaptureDate($0.datetime) }.max()
+}
+
+private func latestDictationDayDate(in results: [DictationDaySummary]) -> Date? {
+    results.compactMap { parseCaptureDate($0.datetime) }.max()
+}
+
 private func latestMeetingSearchDate(in results: GroupedSearchResult) -> Date? {
     results.results.compactMap { parseCaptureDate($0.meetingDateTime) }.max()
 }
 
 private func latestContextSearchDate(in results: [ContextSearchGroup]) -> Date? {
+    results.compactMap { parseCaptureDate($0.datetime) }.max()
+}
+
+private func latestRecentContextDate(in results: [RecentContextItem]) -> Date? {
     results.compactMap { parseCaptureDate($0.datetime) }.max()
 }
 

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/AgentCaptureQueryTelemetryTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/AgentCaptureQueryTelemetryTests.swift
@@ -64,6 +64,23 @@ final class AgentCaptureQueryTelemetryTests: XCTestCase {
         XCTAssertNil(sanitized["token"])
     }
 
+    func testTelemetryPolicyAllowsOrientationQueryKinds() throws {
+        for queryKind in ["list", "recent"] {
+            let sanitized = AgentCaptureQueryTelemetryPolicy.sanitize([
+                "agent_target": "mcp_client",
+                "artifact_kind": "meeting",
+                "capture_age_bucket": "lt_12h",
+                "query_kind": queryKind,
+                "result": "success",
+                "return_window_bucket": "same_day",
+                "source_count_bucket": "1",
+                "surface": "mcp",
+            ])
+
+            XCTAssertEqual(sanitized["query_kind"], queryKind)
+        }
+    }
+
     func testTelemetryPolicyRejectsUnexpectedEnumValues() throws {
         let sanitized = AgentCaptureQueryTelemetryPolicy.sanitize([
             "agent_target": "raw-agent-name",

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
@@ -1,17 +1,23 @@
+import MCP
 import XCTest
 @testable import transcripted_mcp
 
 final class ToolHandlersTests: XCTestCase {
     var index: TranscriptIndex!
     var tempDir: URL!
+    private var telemetry: RecordingAgentCaptureQueryTelemetry!
 
     override func setUp() {
         super.setUp()
         tempDir = makeTempDir()
         index = try! TranscriptIndex(indexDir: tempDir)
+        telemetry = RecordingAgentCaptureQueryTelemetry()
+        AgentCaptureQueryTelemetryRuntime.recorder = telemetry
     }
 
     override func tearDown() {
+        AgentCaptureQueryTelemetryRuntime.recorder = AgentCaptureQueryTelemetry.shared
+        telemetry = nil
         index = nil
         removeTempDir(tempDir)
         super.tearDown()
@@ -69,5 +75,82 @@ final class ToolHandlersTests: XCTestCase {
         hydrateMeetingSearchTitles(in: &results, meetingDirs: [emptyDir])
 
         XCTAssertEqual(results.results[0].meetingTitle, "2026:03:26 16:04:11")
+    }
+
+    func testListMeetingsTracksBucketedAgentQueryTelemetry() throws {
+        try writeFixture(
+            makeFixtureJSON(title: "Roadmap Sync", date: "2026-03-26T16:04:11-0500"),
+            filename: "Call_2026-03-26_16-04-11",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        _ = try handleListMeetings(
+            params: CallTool.Parameters(name: "list_meetings", arguments: ["count": .int(10)]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let observation = try XCTUnwrap(telemetry.observations.last)
+        XCTAssertEqual(observation.queryKind, "list")
+        XCTAssertEqual(observation.artifactKind, "meeting")
+        XCTAssertEqual(observation.sourceCountBucket, "1")
+        XCTAssertNotEqual(observation.captureAgeBucket, "unknown")
+    }
+
+    func testListDictationsTracksBucketedAgentQueryTelemetry() throws {
+        try writeFixture(makeDictationDayJSON(), filename: "Dictations_2026-04-07", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        _ = try handleListDictations(
+            params: CallTool.Parameters(name: "list_dictations", arguments: ["count": .int(10)]),
+            index: index
+        )
+
+        let observation = try XCTUnwrap(telemetry.observations.last)
+        XCTAssertEqual(observation.queryKind, "list")
+        XCTAssertEqual(observation.artifactKind, "dictation")
+        XCTAssertEqual(observation.sourceCountBucket, "1")
+        XCTAssertNotEqual(observation.captureAgeBucket, "unknown")
+    }
+
+    func testRecentContextTracksMixedAgentQueryTelemetry() throws {
+        try writeFixture(
+            makeFixtureJSON(date: "2026-03-29T10:00:00-0500"),
+            filename: "Call_2026-03-29_10-00-00",
+            to: tempDir
+        )
+        try writeFixture(makeDictationDayJSON(), filename: "Dictations_2026-04-07", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        _ = try handleRecentContext(
+            params: CallTool.Parameters(name: "recent_context", arguments: ["count": .int(10)]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let observation = try XCTUnwrap(telemetry.observations.last)
+        XCTAssertEqual(observation.queryKind, "recent")
+        XCTAssertEqual(observation.artifactKind, "mixed")
+        XCTAssertEqual(observation.sourceCountBucket, "2_3")
+        XCTAssertNotEqual(observation.captureAgeBucket, "unknown")
+    }
+
+    func testEmptyListDoesNotTrackAgentQueryTelemetry() throws {
+        _ = try handleListMeetings(
+            params: CallTool.Parameters(name: "list_meetings", arguments: ["count": .int(10)]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        XCTAssertTrue(telemetry.observations.isEmpty)
+    }
+}
+
+private final class RecordingAgentCaptureQueryTelemetry: AgentCaptureQueryTelemetryRecording {
+    private(set) var observations: [AgentCaptureQueryObservation] = []
+
+    func track(_ observation: AgentCaptureQueryObservation) {
+        observations.append(observation)
     }
 }


### PR DESCRIPTION
## Summary
- Salvages the narrow useful slice from stale PR #1255: privacy-safe `agent_capture_query_observed` telemetry for successful MCP orientation calls.
- Tracks `list_meetings`, `list_dictations`, and `recent_context` only after non-empty results, using existing bucketed `artifact_kind`, `capture_age_bucket`, `return_window_bucket`, and `source_count_bucket` fields.
- Expands the standalone MCP query-kind sanitizer to allow only `list` and `recent`; no raw query text, titles, paths, speaker labels, source apps, tokens, or IDs are sent.

## Stale analytics dedupe
- #1259: mostly superseded by current main decision/outcome, activation, workflow, and speaker-review telemetry; broad stale branch not safe to salvage wholesale.
- #1256: superseded by #1314 / current `meeting_speaker_review_shown` and `meeting_speaker_review_submitted` funnel.
- #1255: one narrow safe slice preserved here; remaining docs wording is stale/superseded.
- #1212: dropped/deferred; current main already has `workflow_abandoned`, `product_friction_observed`, and `settings_feature_discovered`, and the stale branch adds broad UX/session inference risk.
- #1208: superseded by current `workflow_recovery_attempted` / `workflow_recovery_finished` plus current activation/workflow events; stale `workflow_started/finished` family not preserved.
- #1169: dropped from this analytics lane because it touches speaker identity/pipeline behavior and overlaps #1314; any confidence-bucket idea needs a fresh product decision.

## Verification
- `scripts/dev/agent-preflight.sh`
- `python3 scripts/dev/check-build-source-lists.py`
- `python3 scripts/ops/normalize-analytics-taxonomy.py --check`
- `swift test` in `Tools/TranscriptedMCP` (90 tests, 0 failures)
- `bash run-e2e-smoke.sh`
- `bash build-deps.sh --force`
- `bash run-tests.sh` (11,178 tests, 0 failures)
- `bash build.sh --no-open` compiled/signed but local LaunchServices smoke failed with `_LSOpenURLsWithCompletionHandler() failed with error -10810`
- `TRANSCRIPTED_SKIP_LAUNCH_SMOKE=1 bash build.sh --no-open` passed compile/sign/performance proof; launch smoke remains unverified
- `codex review --base origin/main`: no actionable correctness issues

## Lane notes
- Codex: final diff, tests, review, PR.
- Claude: taxonomy/privacy second opinion recommended dropping all stale PRs; Codex disagreed only on this narrow already-guarded #1255 slice after code inspection. Proof: `/Users/redbars/.codex/maestro/runs/20260622T215852Z-stale-analytics-privacy-second-opinion-claude`.
- Local: initial title-only inventory was low signal; not used as truth. Proof: `/Users/redbars/.codex/maestro/runs/20260622T215852Z-stale-analytics-inventory-local`.
- Windows: smoke reachable only; skipped for truth.