### PR TITLE
Fix agent query dashboard wording

### DIFF
--- a/docs/posthog-dashboard-query-helpers.md
+++ b/docs/posthog-dashboard-query-helpers.md
@@ -128,8 +128,9 @@ as a product analytics failure. Use `--dry-run` or `--fixture` in CI.
 keeps the operating dashboard centered on real product use.
 
 `activation` separates strict saved-Markdown proof from `dictation_completed`
-proxy rows. Agent setup/prompt rows are intent signals only; they do not prove a
-sourced answer until `agent_capture_query_observed` exists.
+proxy rows. Agent setup/prompt rows are intent signals only; the stronger proof
+is `agent_capture_query_observed`, which confirms a saved-capture MCP query but
+still does not measure answer quality.
 
 `reliability` uses coarse failure kinds and latency buckets. It does not expose
 raw error strings, device names, app names, or audio details.


### PR DESCRIPTION
## Summary
- Confirms the stale #1255 intent is already covered on live main by #1315 / a6ba99f2.
- Updates the dashboard helper docs so `agent_capture_query_observed` is described as a live MCP saved-capture query proof, not future instrumentation.
- Keeps the answer-quality blind spot explicit.

## Verification
- `scripts/dev/agent-preflight.sh`
- `python3 -m py_compile scripts/ops/posthog-dashboard-queries.py`
- `python3 scripts/ops/posthog-dashboard-queries.py --self-test`
- `swift test --package-path Tools/TranscriptedMCP --filter ToolHandlersTests` - 7 tests, 0 failures
- `swift test --package-path Tools/TranscriptedMCP --filter AgentCaptureQueryTelemetryTests` - 12 tests, 0 failures
- `git diff --check`

## Live-main proof
- `origin/main` is `58354e68`, merge PR #1315 from `codex/mcp-orientation-query-telemetry-salvage`.
- `Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift` already tracks `queryKind: "list"` for `list_meetings` and `list_dictations`, and `queryKind: "recent"` for `recent_context`.
- `Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift` covers those three flows.
- `Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/AgentCaptureQueryTelemetryTests.swift` covers orientation query kinds, opt-out/config, and forbidden payload stripping.

## Lanes
lanes used: Codex=fresh-main verification, docs patch, mapped checks, commit/push/PR; Claude=skipped, no risky reasoning after live-main proof; Local=read-only verification attempted with proof at `/Users/redbars/.codex/maestro/runs/20260623T040438Z-mcp-query-slice-live-main-check-local` but output was noisy, Codex source/tests are authoritative; Windows=skipped, no draft implementation needed.
