### PR TITLE
feat(mcp): cross-meeting rollup tools (list_action_items / list_decisions / digest)

### DIFF
--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -35,11 +35,11 @@ When `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
 that mode the SQLite index also defaults to the shared root unless
 `TRANSCRIPTED_INDEX_DIR` is set.
 
-## Package Layout (16 Swift files)
+## Package Layout (17 Swift files)
 
 - `Package.swift` — Swift package manifest for the standalone MCP server
 - `Sources/TranscriptedMCP/` — 9 source files for server startup, directory resolution, path validation, indexing, and tool handlers
-- `Tests/TranscriptedMCPTests/` — 6 test files for directory resolution, index lifecycle, markdown loading, logging, name variants, and shared fixtures
+- `Tests/TranscriptedMCPTests/` — 7 test files for directory resolution, index lifecycle, markdown loading, logging, name variants, summary rollups, and shared fixtures
 
 ## File Index
 
@@ -64,6 +64,7 @@ that mode the SQLite index also defaults to the shared root unless
 | `TranscriptLoaderTests.swift` | Markdown and YAML frontmatter parsing edge cases, including path-safety checks |
 | `LoggingTests.swift` | JSON log emission coverage for MCP startup and indexing diagnostics |
 | `NameVariantsTests.swift` | Name variant matching accuracy |
+| `SummaryRollupTests.swift` | Cross-meeting rollups: action items by owner/status/date, decisions, digest, write-seam idempotency |
 | `TestHelpers.swift` | Shared fixture builders for sample transcripts and temp directories |
 
 ## MCP Tools
@@ -81,6 +82,14 @@ All tools are read-only.
 | `recent_context` | Get a mixed recent feed of meetings and dictations |
 | `who_is` | Look up a speaker profile across saved meetings |
 | `recap` | Build a structured digest for a date range |
+| `list_action_items` | Roll up action items across meetings; filter by owner / status / query / date |
+| `list_decisions` | Roll up decisions across meetings; filter by query / date |
+| `digest` | Cross-meeting summary (decisions + action items + open questions) for a window |
+
+The last three are cross-meeting rollups over the structured summary fields and
+depend on the summary-index PR ("Moat #1") to populate the
+`action_items` / `decisions` / `open_questions` tables. See
+`docs/cross-meeting-tools.md` for the dependency and merge sequencing.
 
 ## Common Agent Retrieval Shapes
 

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Models.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Models.swift
@@ -337,6 +337,126 @@ struct PersonMeetingEntry: Codable {
     let otherSpeakers: [String]
 }
 
+// MARK: - Summary-Fact Rollups (cross-meeting tools)
+
+/// One action item handed to the index write seam (`replaceSummaryFacts`).
+/// The summary-index PR builds these from parsed meeting markdown; tests build
+/// them directly.
+struct SummaryActionItem {
+    let text: String
+    let owner: String?
+    let status: String?
+    let due: String?
+
+    init(text: String, owner: String? = nil, status: String? = nil, due: String? = nil) {
+        self.text = text
+        self.owner = owner
+        self.status = status
+        self.due = due
+    }
+}
+
+/// Open/done/all filter for `list_action_items`.
+enum ActionItemStatusFilter: String {
+    case open
+    case done
+    case all
+
+    init(raw: String?) {
+        switch raw?.lowercased() {
+        case "done", "closed", "completed": self = .done
+        case "all", "any": self = .all
+        default: self = .open
+        }
+    }
+}
+
+struct ActionItemRecord: Codable {
+    let filename: String
+    var meetingTitle: String
+    let date: String
+    let datetime: String
+    let text: String
+    let owner: String?
+    let status: String?
+    let due: String?
+
+    enum CodingKeys: String, CodingKey {
+        case filename, date, datetime, text, owner, status, due
+        case meetingTitle = "meeting_title"
+    }
+}
+
+struct ActionItemsResult: Codable {
+    let owner: String?
+    let status: String
+    let count: Int
+    let truncated: Bool
+    var items: [ActionItemRecord]
+}
+
+struct DecisionRecord: Codable {
+    let filename: String
+    var meetingTitle: String
+    let date: String
+    let datetime: String
+    let text: String
+
+    enum CodingKeys: String, CodingKey {
+        case filename, date, datetime, text
+        case meetingTitle = "meeting_title"
+    }
+}
+
+struct DecisionsResult: Codable {
+    let count: Int
+    let truncated: Bool
+    var decisions: [DecisionRecord]
+}
+
+struct DigestActionItem: Codable {
+    let text: String
+    let owner: String?
+    let status: String?
+    let due: String?
+}
+
+struct DigestMeeting: Codable {
+    let filename: String
+    var title: String
+    let date: String
+    let datetime: String
+    let decisions: [String]
+    let actionItems: [DigestActionItem]
+    let openQuestions: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case filename, title, date, datetime, decisions
+        case actionItems = "action_items"
+        case openQuestions = "open_questions"
+    }
+}
+
+struct DigestResult: Codable {
+    let dateRange: String
+    let meetingCount: Int
+    let actionItemCount: Int
+    let openActionItemCount: Int
+    let decisionCount: Int
+    let openQuestionCount: Int
+    var meetings: [DigestMeeting]
+
+    enum CodingKeys: String, CodingKey {
+        case dateRange = "date_range"
+        case meetingCount = "meeting_count"
+        case actionItemCount = "action_item_count"
+        case openActionItemCount = "open_action_item_count"
+        case decisionCount = "decision_count"
+        case openQuestionCount = "open_question_count"
+        case meetings
+    }
+}
+
 // MARK: - Errors
 
 enum MCPIndexError: Error, LocalizedError {

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -233,6 +233,84 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                 ]),
                 annotations: .init(readOnlyHint: true)
             ),
+            Tool(
+                name: "list_action_items",
+                description: "Roll up action items across every meeting. Filter by owner (supports name variants: Nate finds Nate Smith), by status (open by default, or 'done'/'all'), by a free-text query, or by date range. Use this for 'every open action item assigned to me' or 'what did we commit to last week'. Depends on the meeting summary index.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "owner": .object([
+                            "type": .string("string"),
+                            "description": .string("Filter to action items assigned to this person (e.g. 'Nate')")
+                        ]),
+                        "status": .object([
+                            "type": .string("string"),
+                            "description": .string("Which items to return: 'open' (default), 'done', or 'all'")
+                        ]),
+                        "query": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional full-text filter on the action item text")
+                        ]),
+                        "date_from": .object([
+                            "type": .string("string"),
+                            "description": .string("Start date filter (YYYY-MM-DD)")
+                        ]),
+                        "date_to": .object([
+                            "type": .string("string"),
+                            "description": .string("End date filter (YYYY-MM-DD)")
+                        ]),
+                        "count": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum items to return (default: 50, max: 200)")
+                        ]),
+                    ]),
+                ]),
+                annotations: .init(readOnlyHint: true)
+            ),
+            Tool(
+                name: "list_decisions",
+                description: "Roll up decisions across every meeting. Optionally filter by a free-text query or date range. Use this for 'what did we decide about pricing' or 'all decisions this quarter'. Depends on the meeting summary index.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "query": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional full-text filter on the decision text")
+                        ]),
+                        "date_from": .object([
+                            "type": .string("string"),
+                            "description": .string("Start date filter (YYYY-MM-DD)")
+                        ]),
+                        "date_to": .object([
+                            "type": .string("string"),
+                            "description": .string("End date filter (YYYY-MM-DD)")
+                        ]),
+                        "count": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum decisions to return (default: 50, max: 200)")
+                        ]),
+                    ]),
+                ]),
+                annotations: .init(readOnlyHint: true)
+            ),
+            Tool(
+                name: "digest",
+                description: "Cross-meeting summary for a time window: every meeting in range that has structured summary facts, with its decisions, action items, and open questions, plus rolled-up counts. Use for 'what happened across all my meetings this week'. Depends on the meeting summary index.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "date_from": .object([
+                            "type": .string("string"),
+                            "description": .string("Start date (YYYY-MM-DD). Defaults to today.")
+                        ]),
+                        "date_to": .object([
+                            "type": .string("string"),
+                            "description": .string("End date (YYYY-MM-DD). Defaults to same as date_from.")
+                        ]),
+                    ]),
+                ]),
+                annotations: .init(readOnlyHint: true)
+            ),
         ])
     }
 
@@ -257,6 +335,12 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                 return try handleWhoIs(params: params, index: index)
             case "recap":
                 return try handleRecap(params: params, index: index, meetingDirs: directories.meetingDirs)
+            case "list_action_items":
+                return try handleListActionItems(params: params, index: index, meetingDirs: directories.meetingDirs)
+            case "list_decisions":
+                return try handleListDecisions(params: params, index: index, meetingDirs: directories.meetingDirs)
+            case "digest":
+                return try handleDigest(params: params, index: index, meetingDirs: directories.meetingDirs)
             default:
                 return textResult("Unknown tool: \(params.name)", isError: true)
             }
@@ -559,6 +643,76 @@ private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, me
 
     let json = try JSONEncoder.pretty.encode(result)
     return textResult(String(data: json, encoding: .utf8) ?? "[]")
+}
+
+// MARK: - list_action_items / list_decisions / digest (cross-meeting rollups)
+
+private func handleListActionItems(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+    let owner = params.arguments?["owner"]?.stringValue
+    let query = params.arguments?["query"]?.stringValue
+    let status = ActionItemStatusFilter(raw: params.arguments?["status"]?.stringValue)
+    let dateFrom = params.arguments?["date_from"]?.stringValue
+    let dateTo = params.arguments?["date_to"]?.stringValue
+    let count = params.arguments?["count"]?.intValue ?? 50
+
+    var result = try index.listActionItems(
+        owner: owner, query: query, status: status,
+        dateFrom: dateFrom, dateTo: dateTo, maxItems: count
+    )
+
+    for i in result.items.indices {
+        result.items[i].meetingTitle = meetingTitle(for: result.items[i].filename, meetingDirs: meetingDirs)
+    }
+
+    if result.items.isEmpty {
+        var msg = "No \(status == .all ? "" : status.rawValue + " ")action items found"
+        if let owner, !owner.isEmpty { msg += " for \(owner)" }
+        msg += ". Action items come from the meeting summary index; if summaries have not been indexed yet, this will be empty."
+        return textResult(msg)
+    }
+
+    let json = try JSONEncoder.pretty.encode(result)
+    return textResult(String(data: json, encoding: .utf8) ?? "{}")
+}
+
+private func handleListDecisions(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+    let query = params.arguments?["query"]?.stringValue
+    let dateFrom = params.arguments?["date_from"]?.stringValue
+    let dateTo = params.arguments?["date_to"]?.stringValue
+    let count = params.arguments?["count"]?.intValue ?? 50
+
+    var result = try index.listDecisions(query: query, dateFrom: dateFrom, dateTo: dateTo, maxItems: count)
+
+    for i in result.decisions.indices {
+        result.decisions[i].meetingTitle = meetingTitle(for: result.decisions[i].filename, meetingDirs: meetingDirs)
+    }
+
+    if result.decisions.isEmpty {
+        return textResult("No decisions found. Decisions come from the meeting summary index; if summaries have not been indexed yet, this will be empty.")
+    }
+
+    let json = try JSONEncoder.pretty.encode(result)
+    return textResult(String(data: json, encoding: .utf8) ?? "{}")
+}
+
+private func handleDigest(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+    // Default to today when no window is given, matching recap's behavior.
+    let today = DateFormatter.localYYYYMMDD.string(from: Date())
+    let dateFrom = params.arguments?["date_from"]?.stringValue ?? today
+    let dateTo = params.arguments?["date_to"]?.stringValue ?? dateFrom
+
+    var result = try index.digest(dateFrom: dateFrom, dateTo: dateTo)
+
+    for i in result.meetings.indices {
+        result.meetings[i].title = meetingTitle(for: result.meetings[i].filename, meetingDirs: meetingDirs)
+    }
+
+    if result.meetings.isEmpty {
+        return textResult("No summarized meetings found for \(result.dateRange). Digest reads the meeting summary index; if summaries have not been indexed yet, this will be empty.")
+    }
+
+    let json = try JSONEncoder.pretty.encode(result)
+    return textResult(String(data: json, encoding: .utf8) ?? "{}")
 }
 
 // MARK: - Output Types

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -166,6 +166,94 @@ final class TranscriptIndex: @unchecked Sendable {
             END
         """)
 
+        // MARK: Summary-fact tables (cross-meeting rollups)
+        //
+        // PROVISIONAL SCHEMA — owned by the summary-index PR ("Moat #1: index
+        // summary fields"). These tables hold the structured summary fields the
+        // summarizer already writes to each meeting markdown (Decisions / Action
+        // Items / Open Questions), keyed to the meeting id (filename, the PK of
+        // `meetings`). The cross-meeting tools (list_action_items / list_decisions
+        // / digest) query them; the summary-index PR owns *populating* them by
+        // parsing meeting markdown during reconcile. They are defined here, with
+        // IF NOT EXISTS, only so the tools compile and test in isolation before
+        // that PR lands. When the two branches meet, the merge-room must reconcile
+        // this block against the summary-index PR's authoritative definition and
+        // keep a single copy. See docs/cross-meeting-tools.md.
+        exec("""
+            CREATE TABLE IF NOT EXISTS action_items (
+                rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+                filename TEXT NOT NULL,
+                text TEXT NOT NULL,
+                owner TEXT,
+                status TEXT,
+                due TEXT
+            )
+        """)
+
+        exec("""
+            CREATE TABLE IF NOT EXISTS decisions (
+                rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+                filename TEXT NOT NULL,
+                text TEXT NOT NULL
+            )
+        """)
+
+        exec("""
+            CREATE TABLE IF NOT EXISTS open_questions (
+                rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+                filename TEXT NOT NULL,
+                text TEXT NOT NULL
+            )
+        """)
+
+        exec("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS action_items_fts USING fts5(
+                text, owner,
+                content='action_items', content_rowid='rowid',
+                tokenize='porter unicode61'
+            )
+        """)
+
+        exec("""
+            CREATE TRIGGER IF NOT EXISTS action_items_ai AFTER INSERT ON action_items BEGIN
+                INSERT INTO action_items_fts(rowid, text, owner)
+                VALUES (new.rowid, new.text, new.owner);
+            END
+        """)
+
+        exec("""
+            CREATE TRIGGER IF NOT EXISTS action_items_ad AFTER DELETE ON action_items BEGIN
+                INSERT INTO action_items_fts(action_items_fts, rowid, text, owner)
+                VALUES ('delete', old.rowid, old.text, old.owner);
+            END
+        """)
+
+        exec("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS decisions_fts USING fts5(
+                text,
+                content='decisions', content_rowid='rowid',
+                tokenize='porter unicode61'
+            )
+        """)
+
+        exec("""
+            CREATE TRIGGER IF NOT EXISTS decisions_ai AFTER INSERT ON decisions BEGIN
+                INSERT INTO decisions_fts(rowid, text) VALUES (new.rowid, new.text);
+            END
+        """)
+
+        exec("""
+            CREATE TRIGGER IF NOT EXISTS decisions_ad AFTER DELETE ON decisions BEGIN
+                INSERT INTO decisions_fts(decisions_fts, rowid, text)
+                VALUES ('delete', old.rowid, old.text);
+            END
+        """)
+
+        exec("CREATE INDEX IF NOT EXISTS idx_action_items_filename ON action_items(filename)")
+        exec("CREATE INDEX IF NOT EXISTS idx_action_items_owner ON action_items(owner COLLATE NOCASE)")
+        exec("CREATE INDEX IF NOT EXISTS idx_decisions_filename ON decisions(filename)")
+        exec("CREATE INDEX IF NOT EXISTS idx_open_questions_filename ON open_questions(filename)")
+
         exec("CREATE INDEX IF NOT EXISTS idx_meetings_date ON meetings(date)")
         exec("CREATE INDEX IF NOT EXISTS idx_meeting_speakers_name ON meeting_speakers(speaker_name COLLATE NOCASE)")
         exec("CREATE INDEX IF NOT EXISTS idx_meeting_speakers_persistent_id ON meeting_speakers(persistent_speaker_id)")
@@ -390,6 +478,11 @@ final class TranscriptIndex: @unchecked Sendable {
         try bindExec("DELETE FROM meetings WHERE filename = ?", bindings: [.text(filename)])
         try bindExec("DELETE FROM dictation_entries WHERE filename = ?", bindings: [.text(filename)])
         try bindExec("DELETE FROM dictation_days WHERE filename = ?", bindings: [.text(filename)])
+        // Summary facts are keyed to the meeting id; clear them alongside the meeting
+        // so a reindex of the same file does not leave stale rollup rows behind.
+        try bindExec("DELETE FROM action_items WHERE filename = ?", bindings: [.text(filename)])
+        try bindExec("DELETE FROM decisions WHERE filename = ?", bindings: [.text(filename)])
+        try bindExec("DELETE FROM open_questions WHERE filename = ?", bindings: [.text(filename)])
         try execOrThrow("COMMIT")
         committed = true
     }
@@ -1057,6 +1150,351 @@ final class TranscriptIndex: @unchecked Sendable {
                 return colText(stmt, 0)
             }
             return ""
+        }
+    }
+
+    // MARK: - Summary-fact rollups (cross-meeting tools)
+
+    /// Replace the summary facts (Decisions / Action Items / Open Questions) for
+    /// one meeting. This is the write seam the summary-index PR ("Moat #1") calls
+    /// after it parses those fields out of the meeting markdown. It lives here,
+    /// separate from the markdown-indexing path, so the cross-meeting tools have a
+    /// populated store to query and so tests can seed facts without re-deriving the
+    /// markdown parser. The summary-index PR owns wiring this into reconcile.
+    func replaceSummaryFacts(
+        filename: String,
+        decisions: [String],
+        actionItems: [SummaryActionItem],
+        openQuestions: [String]
+    ) throws {
+        try queue.sync {
+            try execOrThrow("BEGIN EXCLUSIVE")
+            var committed = false
+            defer { if !committed { exec("ROLLBACK") } }
+
+            try bindExec("DELETE FROM action_items WHERE filename = ?", bindings: [.text(filename)])
+            try bindExec("DELETE FROM decisions WHERE filename = ?", bindings: [.text(filename)])
+            try bindExec("DELETE FROM open_questions WHERE filename = ?", bindings: [.text(filename)])
+
+            for item in actionItems {
+                let text = item.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !text.isEmpty else { continue }
+                try bindExec(
+                    "INSERT INTO action_items (filename, text, owner, status, due) VALUES (?,?,?,?,?)",
+                    bindings: [
+                        .text(filename), .text(text),
+                        normalizedOptional(item.owner).map { .text($0) } ?? .null,
+                        normalizedOptional(item.status).map { .text($0) } ?? .null,
+                        normalizedOptional(item.due).map { .text($0) } ?? .null
+                    ]
+                )
+            }
+            for decision in decisions {
+                let text = decision.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !text.isEmpty else { continue }
+                try bindExec("INSERT INTO decisions (filename, text) VALUES (?,?)", bindings: [.text(filename), .text(text)])
+            }
+            for question in openQuestions {
+                let text = question.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !text.isEmpty else { continue }
+                try bindExec("INSERT INTO open_questions (filename, text) VALUES (?,?)", bindings: [.text(filename), .text(text)])
+            }
+
+            try execOrThrow("COMMIT")
+            committed = true
+        }
+    }
+
+    func listActionItems(
+        owner: String?,
+        query: String?,
+        status: ActionItemStatusFilter,
+        dateFrom: String?,
+        dateTo: String?,
+        maxItems: Int = 50
+    ) throws -> ActionItemsResult {
+        try queue.sync {
+            let limit = max(1, min(maxItems, 200))
+            var sql = """
+                SELECT a.filename, a.text, a.owner, a.status, a.due, m.date, m.datetime
+                FROM action_items a
+                JOIN meetings m ON m.filename = a.filename
+                WHERE 1=1
+            """
+            var bindings: [SQLBinding] = []
+
+            if let owner, !owner.trimmingCharacters(in: .whitespaces).isEmpty {
+                let (clause, ownerBindings) = ownerMatchClause(owner, column: "a.owner")
+                sql += " AND \(clause)"
+                bindings.append(contentsOf: ownerBindings)
+            }
+
+            switch status {
+            case .open: sql += " AND \(openStatusClause(column: "a.status"))"
+            case .done: sql += " AND NOT \(openStatusClause(column: "a.status"))"
+            case .all: break
+            }
+
+            if let dateFrom { sql += " AND m.date >= ?"; bindings.append(.text(dateFrom)) }
+            if let dateTo { sql += " AND m.date <= ?"; bindings.append(.text(dateTo)) }
+
+            if let fts = ftsQuery(from: query) {
+                sql += " AND a.rowid IN (SELECT rowid FROM action_items_fts WHERE action_items_fts MATCH ?)"
+                bindings.append(.text(fts))
+            }
+
+            sql += " ORDER BY m.datetime DESC, a.rowid ASC LIMIT ?"
+            bindings.append(.int(limit + 1))
+
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+                throw MCPIndexError.queryFailed(dbError())
+            }
+            defer { sqlite3_finalize(stmt) }
+            for (i, binding) in bindings.enumerated() { bind(stmt: stmt, index: Int32(i + 1), value: binding) }
+
+            var rows: [ActionItemRecord] = []
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let filename = colText(stmt, 0)
+                rows.append(ActionItemRecord(
+                    filename: filename,
+                    meetingTitle: filename,
+                    date: colText(stmt, 5),
+                    datetime: colText(stmt, 6),
+                    text: colText(stmt, 1),
+                    owner: colTextOptional(stmt, 2),
+                    status: colTextOptional(stmt, 3),
+                    due: colTextOptional(stmt, 4)
+                ))
+            }
+
+            let truncated = rows.count > limit
+            let items = Array(rows.prefix(limit))
+            return ActionItemsResult(
+                owner: owner,
+                status: status.rawValue,
+                count: items.count,
+                truncated: truncated,
+                items: items
+            )
+        }
+    }
+
+    func listDecisions(
+        query: String?,
+        dateFrom: String?,
+        dateTo: String?,
+        maxItems: Int = 50
+    ) throws -> DecisionsResult {
+        try queue.sync {
+            let limit = max(1, min(maxItems, 200))
+            var sql = """
+                SELECT d.filename, d.text, m.date, m.datetime
+                FROM decisions d
+                JOIN meetings m ON m.filename = d.filename
+                WHERE 1=1
+            """
+            var bindings: [SQLBinding] = []
+
+            if let dateFrom { sql += " AND m.date >= ?"; bindings.append(.text(dateFrom)) }
+            if let dateTo { sql += " AND m.date <= ?"; bindings.append(.text(dateTo)) }
+
+            if let fts = ftsQuery(from: query) {
+                sql += " AND d.rowid IN (SELECT rowid FROM decisions_fts WHERE decisions_fts MATCH ?)"
+                bindings.append(.text(fts))
+            }
+
+            sql += " ORDER BY m.datetime DESC, d.rowid ASC LIMIT ?"
+            bindings.append(.int(limit + 1))
+
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+                throw MCPIndexError.queryFailed(dbError())
+            }
+            defer { sqlite3_finalize(stmt) }
+            for (i, binding) in bindings.enumerated() { bind(stmt: stmt, index: Int32(i + 1), value: binding) }
+
+            var rows: [DecisionRecord] = []
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                let filename = colText(stmt, 0)
+                rows.append(DecisionRecord(
+                    filename: filename,
+                    meetingTitle: filename,
+                    date: colText(stmt, 2),
+                    datetime: colText(stmt, 3),
+                    text: colText(stmt, 1)
+                ))
+            }
+
+            let truncated = rows.count > limit
+            let decisions = Array(rows.prefix(limit))
+            return DecisionsResult(count: decisions.count, truncated: truncated, decisions: decisions)
+        }
+    }
+
+    /// Cross-meeting digest for a date window: every meeting in range that has any
+    /// summary facts, with its decisions, action items, and open questions, plus
+    /// rolled-up counts.
+    func digest(dateFrom: String?, dateTo: String?, maxMeetings: Int = 50) throws -> DigestResult {
+        try queue.sync {
+            let limit = max(1, min(maxMeetings, 100))
+
+            var meetingSQL = "SELECT filename, date, datetime FROM meetings WHERE 1=1"
+            var bindings: [SQLBinding] = []
+            if let dateFrom { meetingSQL += " AND date >= ?"; bindings.append(.text(dateFrom)) }
+            if let dateTo { meetingSQL += " AND date <= ?"; bindings.append(.text(dateTo)) }
+            meetingSQL += " ORDER BY datetime DESC"
+
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(db, meetingSQL, -1, &stmt, nil) == SQLITE_OK else {
+                throw MCPIndexError.queryFailed(dbError())
+            }
+            defer { sqlite3_finalize(stmt) }
+            for (i, binding) in bindings.enumerated() { bind(stmt: stmt, index: Int32(i + 1), value: binding) }
+
+            struct WindowMeeting { let filename: String; let date: String; let datetime: String }
+            var windowMeetings: [WindowMeeting] = []
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                windowMeetings.append(WindowMeeting(
+                    filename: colText(stmt, 0), date: colText(stmt, 1), datetime: colText(stmt, 2)
+                ))
+            }
+
+            guard !windowMeetings.isEmpty else {
+                return DigestResult(
+                    dateRange: digestRangeLabel(dateFrom: dateFrom, dateTo: dateTo),
+                    meetingCount: 0, actionItemCount: 0, openActionItemCount: 0,
+                    decisionCount: 0, openQuestionCount: 0, meetings: []
+                )
+            }
+
+            let filenames = windowMeetings.map(\.filename)
+            let decisionsByMeeting = try fetchTextFacts(table: "decisions", filenames: filenames)
+            let questionsByMeeting = try fetchTextFacts(table: "open_questions", filenames: filenames)
+            let actionsByMeeting = try fetchActionFacts(filenames: filenames)
+
+            var digestMeetings: [DigestMeeting] = []
+            var totalActions = 0, totalOpenActions = 0, totalDecisions = 0, totalQuestions = 0
+
+            for meeting in windowMeetings {
+                let decisions = decisionsByMeeting[meeting.filename] ?? []
+                let questions = questionsByMeeting[meeting.filename] ?? []
+                let actions = actionsByMeeting[meeting.filename] ?? []
+                guard !decisions.isEmpty || !questions.isEmpty || !actions.isEmpty else { continue }
+
+                totalDecisions += decisions.count
+                totalQuestions += questions.count
+                totalActions += actions.count
+                totalOpenActions += actions.filter { Self.isOpenStatus($0.status) }.count
+
+                digestMeetings.append(DigestMeeting(
+                    filename: meeting.filename,
+                    title: meeting.filename,
+                    date: meeting.date,
+                    datetime: meeting.datetime,
+                    decisions: decisions,
+                    actionItems: actions,
+                    openQuestions: questions
+                ))
+                if digestMeetings.count >= limit { break }
+            }
+
+            return DigestResult(
+                dateRange: digestRangeLabel(dateFrom: dateFrom, dateTo: dateTo),
+                meetingCount: digestMeetings.count,
+                actionItemCount: totalActions,
+                openActionItemCount: totalOpenActions,
+                decisionCount: totalDecisions,
+                openQuestionCount: totalQuestions,
+                meetings: digestMeetings
+            )
+        }
+    }
+
+    // MARK: - Summary-fact helpers (run inside queue.sync)
+
+    private func fetchTextFacts(table: String, filenames: [String]) throws -> [String: [String]] {
+        let placeholders = filenames.map { _ in "?" }.joined(separator: ", ")
+        let sql = "SELECT filename, text FROM \(table) WHERE filename IN (\(placeholders)) ORDER BY rowid ASC"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw MCPIndexError.queryFailed(dbError())
+        }
+        defer { sqlite3_finalize(stmt) }
+        for (i, f) in filenames.enumerated() {
+            sqlite3_bind_text(stmt, Int32(i + 1), (f as NSString).utf8String, -1, SQLITE_TRANSIENT)
+        }
+        var result: [String: [String]] = [:]
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            result[colText(stmt, 0), default: []].append(colText(stmt, 1))
+        }
+        return result
+    }
+
+    private func fetchActionFacts(filenames: [String]) throws -> [String: [DigestActionItem]] {
+        let placeholders = filenames.map { _ in "?" }.joined(separator: ", ")
+        let sql = "SELECT filename, text, owner, status, due FROM action_items WHERE filename IN (\(placeholders)) ORDER BY rowid ASC"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw MCPIndexError.queryFailed(dbError())
+        }
+        defer { sqlite3_finalize(stmt) }
+        for (i, f) in filenames.enumerated() {
+            sqlite3_bind_text(stmt, Int32(i + 1), (f as NSString).utf8String, -1, SQLITE_TRANSIENT)
+        }
+        var result: [String: [DigestActionItem]] = [:]
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            result[colText(stmt, 0), default: []].append(DigestActionItem(
+                text: colText(stmt, 1),
+                owner: colTextOptional(stmt, 2),
+                status: colTextOptional(stmt, 3),
+                due: colTextOptional(stmt, 4)
+            ))
+        }
+        return result
+    }
+
+    private func ownerMatchClause(_ owner: String, column: String) -> (String, [SQLBinding]) {
+        let names = NameVariants.expandName(owner)
+        let exact = names.map { _ in "\(column) COLLATE NOCASE = ?" }
+        let like = names.map { _ in "\(column) COLLATE NOCASE LIKE ?" }
+        let clause = "(" + (exact + like).joined(separator: " OR ") + ")"
+        let bindings = names.map { SQLBinding.text($0) } + names.map { SQLBinding.text("%\($0)%") }
+        return (clause, bindings)
+    }
+
+    /// SQL predicate that is true for action items still considered open: an
+    /// unset status, or a status that is not one of the terminal markers.
+    private func openStatusClause(column: String) -> String {
+        "(\(column) IS NULL OR lower(trim(\(column))) NOT IN ('done','complete','completed','resolved','closed','cancelled','canceled'))"
+    }
+
+    /// Swift mirror of `openStatusClause` for in-memory rollup counting.
+    static func isOpenStatus(_ status: String?) -> Bool {
+        guard let status = status?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(), !status.isEmpty else {
+            return true
+        }
+        return !["done", "complete", "completed", "resolved", "closed", "cancelled", "canceled"].contains(status)
+    }
+
+    private func ftsQuery(from query: String?) -> String? {
+        guard let query, !query.trimmingCharacters(in: .whitespaces).isEmpty else { return nil }
+        let tokens = query.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
+        guard !tokens.isEmpty else { return nil }
+        return tokens.map { "\"\($0.replacingOccurrences(of: "\"", with: ""))\"" }.joined(separator: " ")
+    }
+
+    private func normalizedOptional(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+
+    private func digestRangeLabel(dateFrom: String?, dateTo: String?) -> String {
+        switch (dateFrom, dateTo) {
+        case let (from?, to?): return from == to ? from : "\(from) to \(to)"
+        case let (from?, nil): return "since \(from)"
+        case let (nil, to?): return "through \(to)"
+        case (nil, nil): return "all time"
         }
     }
 

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SummaryRollupTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SummaryRollupTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+@testable import transcripted_mcp
+
+/// Cross-meeting summary rollup tests: list_action_items / list_decisions /
+/// digest query layer. These seed facts directly through the index write seam
+/// (`replaceSummaryFacts`) — the same seam the summary-index PR will call after
+/// it parses meeting markdown — so they exercise the query layer without
+/// depending on the (not-yet-landed) markdown extraction.
+final class SummaryRollupTests: XCTestCase {
+    var index: TranscriptIndex!
+    var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = makeTempDir()
+        index = try! TranscriptIndex(indexDir: tempDir)
+    }
+
+    override func tearDown() {
+        index = nil
+        removeTempDir(tempDir)
+        super.tearDown()
+    }
+
+    /// Index two meetings so their summary facts have a real date/datetime to join
+    /// against, then seed structured facts for each.
+    private func seedTwoMeetings() throws {
+        try writeFixture(
+            makeFixtureJSON(title: "Roadmap Sync", date: "2026-03-26T16:04:11-0500"),
+            filename: "Call_2026-03-26_16-04-11", to: tempDir
+        )
+        try writeFixture(
+            makeFixtureJSON(title: "Pricing Review", date: "2026-04-02T09:30:00-0500"),
+            filename: "Call_2026-04-02_09-30-00", to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        try index.replaceSummaryFacts(
+            filename: "Call_2026-03-26_16-04-11",
+            decisions: ["Ship the beta on April 15"],
+            actionItems: [
+                SummaryActionItem(text: "Draft the launch email", owner: "Nate Smith", status: "open"),
+                SummaryActionItem(text: "Confirm the venue", owner: "Jenny Wen", status: "done"),
+            ],
+            openQuestions: ["Who signs off on pricing?"]
+        )
+        try index.replaceSummaryFacts(
+            filename: "Call_2026-04-02_09-30-00",
+            decisions: ["Adopt usage-based pricing"],
+            actionItems: [
+                SummaryActionItem(text: "Send the pricing model to finance", owner: "Nate", status: "open"),
+                SummaryActionItem(text: "Update the deck", owner: "You", status: nil),
+            ],
+            openQuestions: []
+        )
+    }
+
+    func testEmptyIndexReturnsNoActionItems() throws {
+        let result = try index.listActionItems(owner: nil, query: nil, status: .all, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(result.count, 0)
+        XCTAssertTrue(result.items.isEmpty)
+    }
+
+    func testActionItemsFilteredByOwnerAcrossMeetings() throws {
+        try seedTwoMeetings()
+
+        // "Nate" should match both "Nate Smith" (meeting 1) and "Nate" (meeting 2)
+        // via name-variant + substring matching, spanning two meetings.
+        let result = try index.listActionItems(owner: "Nate", query: nil, status: .open, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(result.count, 2)
+        let files = Set(result.items.map(\.filename))
+        XCTAssertEqual(files, ["Call_2026-03-26_16-04-11", "Call_2026-04-02_09-30-00"])
+        XCTAssertTrue(result.items.allSatisfy { ($0.owner ?? "").localizedCaseInsensitiveContains("nate") })
+    }
+
+    func testOpenStatusFilterExcludesDoneItems() throws {
+        try seedTwoMeetings()
+
+        let open = try index.listActionItems(owner: nil, query: nil, status: .open, dateFrom: nil, dateTo: nil)
+        // Jenny's "Confirm the venue" is done; the nil-status "Update the deck" counts as open.
+        XCTAssertFalse(open.items.contains { $0.text == "Confirm the venue" })
+        XCTAssertTrue(open.items.contains { $0.text == "Update the deck" })
+
+        let done = try index.listActionItems(owner: nil, query: nil, status: .done, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(done.items.map(\.text), ["Confirm the venue"])
+
+        let all = try index.listActionItems(owner: nil, query: nil, status: .all, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(all.count, 4)
+    }
+
+    func testActionItemsDateWindowFilter() throws {
+        try seedTwoMeetings()
+
+        let result = try index.listActionItems(
+            owner: nil, query: nil, status: .all,
+            dateFrom: "2026-04-01", dateTo: "2026-04-30"
+        )
+        XCTAssertTrue(result.items.allSatisfy { $0.filename == "Call_2026-04-02_09-30-00" })
+        XCTAssertEqual(result.count, 2)
+    }
+
+    func testActionItemsFullTextQuery() throws {
+        try seedTwoMeetings()
+
+        let result = try index.listActionItems(owner: nil, query: "pricing", status: .all, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(result.items.map(\.text), ["Send the pricing model to finance"])
+    }
+
+    func testDecisionsAcrossMeetings() throws {
+        try seedTwoMeetings()
+
+        let result = try index.listDecisions(query: nil, dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(result.count, 2)
+        // Newest meeting first.
+        XCTAssertEqual(result.decisions.first?.text, "Adopt usage-based pricing")
+        XCTAssertTrue(result.decisions.contains { $0.text == "Ship the beta on April 15" })
+    }
+
+    func testDecisionsFullTextQuery() throws {
+        try seedTwoMeetings()
+
+        let result = try index.listDecisions(query: "pricing", dateFrom: nil, dateTo: nil)
+        XCTAssertEqual(result.decisions.map(\.text), ["Adopt usage-based pricing"])
+    }
+
+    func testDigestRollsUpAcrossMeetings() throws {
+        try seedTwoMeetings()
+
+        let digest = try index.digest(dateFrom: "2026-01-01", dateTo: "2026-12-31")
+        XCTAssertEqual(digest.meetingCount, 2)
+        XCTAssertEqual(digest.actionItemCount, 4)
+        XCTAssertEqual(digest.openActionItemCount, 3) // all but Jenny's done item
+        XCTAssertEqual(digest.decisionCount, 2)
+        XCTAssertEqual(digest.openQuestionCount, 1)
+
+        // Newest meeting first, with its facts grouped under it.
+        let pricing = try XCTUnwrap(digest.meetings.first)
+        XCTAssertEqual(pricing.filename, "Call_2026-04-02_09-30-00")
+        XCTAssertEqual(pricing.decisions, ["Adopt usage-based pricing"])
+        XCTAssertEqual(pricing.actionItems.count, 2)
+        XCTAssertTrue(pricing.openQuestions.isEmpty)
+    }
+
+    func testDigestExcludesMeetingsWithoutFacts() throws {
+        try seedTwoMeetings()
+        // A third meeting with no summary facts must not appear in the digest.
+        try writeFixture(
+            makeFixtureJSON(title: "Standup", date: "2026-04-03T09:00:00-0500"),
+            filename: "Call_2026-04-03_09-00-00", to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let digest = try index.digest(dateFrom: "2026-01-01", dateTo: "2026-12-31")
+        XCTAssertFalse(digest.meetings.contains { $0.filename == "Call_2026-04-03_09-00-00" })
+        XCTAssertEqual(digest.meetingCount, 2)
+    }
+
+    func testReplaceSummaryFactsIsIdempotent() throws {
+        try seedTwoMeetings()
+        // Re-seeding the same meeting should replace, not duplicate.
+        try index.replaceSummaryFacts(
+            filename: "Call_2026-04-02_09-30-00",
+            decisions: ["Adopt usage-based pricing"],
+            actionItems: [SummaryActionItem(text: "Send the pricing model to finance", owner: "Nate", status: "open")],
+            openQuestions: []
+        )
+        let result = try index.listActionItems(owner: nil, query: nil, status: .all, dateFrom: "2026-04-01", dateTo: "2026-04-30")
+        XCTAssertEqual(result.count, 1)
+    }
+
+    func testReindexClearsStaleSummaryFacts() throws {
+        try seedTwoMeetings()
+        // Rewriting the meeting markdown triggers a reindex, which must clear the
+        // summary facts that were keyed to it (they are re-derived by the
+        // summary-index PR, not preserved here).
+        try writeFixture(
+            makeFixtureJSON(title: "Pricing Review v2", date: "2026-04-02T09:30:00-0500"),
+            filename: "Call_2026-04-02_09-30-00", to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try index.listActionItems(owner: nil, query: nil, status: .all, dateFrom: "2026-04-01", dateTo: "2026-04-30")
+        XCTAssertEqual(result.count, 0)
+    }
+}

--- a/docs/NEXT_WORK.md
+++ b/docs/NEXT_WORK.md
@@ -1,0 +1,22 @@
+# Transcripted — What's Next
+
+The ~30 things in flight are converging (UI polish, speaker accuracy, data-loss, telemetry). This is what to do *after* that lands. The theme: turn the local meeting library into a thing an agent can actually answer questions over. That's the moat cloud notetakers can't copy on private data.
+
+## DO NEXT
+Ranked by impact-for-effort. Do them in order.
+
+1. **Index the summary fields (Decisions / Action Items / Open Questions) into the search DB.** The summarizer already writes these to each meeting; the search index never reads them. This one hop is the whole "ask my history" unlock. (M)
+2. **Make recap/recent_context return the real summary, not the first 15 lines of small-talk.** Today the agent's orientation tools return greetings and audio checks. The summary is already in the same file — just point at it. Cheapest high-value fix here. (S)
+3. **Make dictation saves crash-safe.** The most-used capture surface is the one place a crash mid-write can silently corrupt a whole day's entries. Everything else already writes atomically; copy that pattern. (M)
+4. **Add the cross-meeting tools: list_action_items, list_decisions, digest.** Once the fields are indexed (#1), this is the demo: "every open action item assigned to me, across every call." No cloud tool can do this on private data. (M)
+5. **Always-on cheap extraction at save time.** Right now summaries only exist if you opt into the heavy beta. Extract on every save so the moat covers 100% of meetings, not a subset. (M)
+
+## AFTER THAT
+6. **Local semantic search** — bundle a small embedding model so paraphrase queries hit ("pricing pushback" finds "they balked at the cost"). The one thing cloud RAG still beats us on. (L)
+7. **Multi-exemplar voiceprints** — store several voice samples per person instead of one averaged blob, so clean-mic and Zoom versions of the same voice both match. Land after the ERes2Net upgrade. (L)
+8. **Reversible speaker merges** — a wrong auto-merge permanently fuses two real people today, with no undo. Add provenance + un-merge before the more-aggressive merge work goes live. (L)
+9. **Negative exemplars** — when a user corrects a wrong speaker, learn "not this person" instead of just freezing the profile. Turns every correction into training signal. (M)
+10. **Index meetings for the Home list** — stop re-reading every transcript file on every Home refresh; point the list at the table that already exists. (L)
+
+## THE ONE BET
+**Index the summary fields and ship the cross-meeting tools (#1 + #4).** It's wiring, not machine learning, and it's the only thing here that gives the agent a memory cloud notetakers structurally can't match — and that moat gets stronger every meeting added.

--- a/docs/cross-meeting-tools.md
+++ b/docs/cross-meeting-tools.md
@@ -1,0 +1,62 @@
+# Cross-meeting MCP tools (list_action_items / list_decisions / digest)
+
+These three `transcripted-mcp` tools roll up the structured summary fields —
+Decisions, Action Items, Open Questions — *across* meetings, instead of one
+meeting at a time. This is NEXT_WORK item #4 ("the demo: every open action item
+assigned to me, across every call").
+
+## Tools
+
+| Tool | What it answers |
+|------|-----------------|
+| `list_action_items` | "Open action items for Nate", "what did we commit to last week". Filters: `owner` (name-variant + substring match), `status` (`open` default / `done` / `all`), `query` (FTS on text), `date_from`/`date_to`, `count`. |
+| `list_decisions` | "What did we decide about pricing", "all decisions this quarter". Filters: `query` (FTS), `date_from`/`date_to`, `count`. |
+| `digest` | "What happened across all my meetings this week" — every meeting in the window with summary facts, grouped, plus rolled-up counts. Filters: `date_from`/`date_to` (default today). |
+
+All are read-only and join the summary-fact tables to `meetings` for date/title.
+
+## HARD DEPENDENCY — summary-index PR ("Moat #1: index summary fields")
+
+> **Sequence #1 before this PR.** These tools query three tables —
+> `action_items`, `decisions`, `open_questions` — keyed to the meeting id
+> (`filename`). The **summary-index PR owns populating them** by parsing the
+> Decisions / Action Items / Open Questions that the summarizer already writes
+> into each meeting markdown (frontmatter keys `local_summary_action_items` /
+> `local_summary_decisions` / `local_summary_open_questions`, or the
+> `### Action Items` etc. sections — see
+> `Sources/UI/Shared/RecentCaptureScanners.swift`).
+
+This PR does **not** duplicate that extraction. It contributes:
+
+1. **The provisional table schema** — defined in `TranscriptIndex.createTables()`
+   with `IF NOT EXISTS`, clearly flagged. When the summary-index PR lands its
+   authoritative schema, the merge-room must reconcile that block and keep a
+   single copy.
+2. **The write seam** `TranscriptIndex.replaceSummaryFacts(filename:decisions:actionItems:openQuestions:)`
+   — the API the summary-index PR's extractor calls during reconcile. Tests call
+   it directly to seed facts.
+3. **The query layer + the three tools + tests.**
+
+Until #1 lands, the tables exist but stay empty in production, so the tools
+return a clear "summaries have not been indexed yet" message rather than wrong
+data. The tests seed facts through the write seam, so the query layer is fully
+covered in isolation.
+
+### What the merge-room needs to do
+
+1. Land the summary-index PR (#1) first.
+2. Rebase this PR on it. Expect a conflict in `TranscriptIndex.swift`
+   (`createTables` schema block, and possibly `removeFromIndex`). Keep one copy
+   of each table definition; the column set here (`action_items(filename, text,
+   owner, status, due)`, `decisions(filename, text)`, `open_questions(filename,
+   text)`) is the contract the tools depend on — if #1 chose different column
+   names, update the query layer in `TranscriptIndex.swift` to match.
+3. Wire #1's extractor to call `replaceSummaryFacts` (or fold the two write
+   paths together) so reconcile populates the tables.
+
+### Conflict note (recap-fix thread)
+
+The recap-fix thread also edits `ToolHandlers.swift`. Changes here are
+append-only (three new `Tool` entries, three new `switch` cases, three new
+handler functions) and do not touch `handleRecap`, so the conflict surface is
+small. Merge-room sequences.


### PR DESCRIPTION
## What

Three new read-only `transcripted-mcp` tools that aggregate structured summary fields **across** meetings — NEXT_WORK item #4, the hero demo: *"every open action item assigned to me, across every call."* No cloud notetaker can do this on private local data.

| Tool | Answers |
|------|---------|
| `list_action_items` | "open action items for Nate" — filter by `owner` (name-variant + substring), `status` (`open` default / `done` / `all`), `query` (FTS), date window |
| `list_decisions` | "what did we decide about pricing" — `query` (FTS), date window |
| `digest` | "what happened across all my meetings this week" — every meeting in range with its decisions / action items / open questions grouped, plus rolled-up counts |

## ⚠️ HARD DEPENDENCY — sequence after summary-index PR ("Moat #1")

This depends on the **summary-index thread** that adds the `decisions` / `action_items` / `open_questions` tables and populates them by parsing meeting markdown. **That PR must land first.**

This PR does **not** duplicate the extraction. It contributes:
1. The **provisional table schema** (`IF NOT EXISTS`, clearly flagged in `TranscriptIndex.createTables()`) so the tools compile/test in isolation.
2. The **write seam** `replaceSummaryFacts(filename:decisions:actionItems:openQuestions:)` — the API #1's extractor calls during reconcile (tests seed through it).
3. The **query layer + tools + tests**.

Until #1 lands, the tables stay empty in production and the tools return a clear *"summaries have not been indexed yet"* message rather than wrong data.

**Merge-room:** land #1, rebase this, reconcile the schema block in `TranscriptIndex.swift` (keep one copy of each table; column contract is `action_items(filename,text,owner,status,due)`, `decisions(filename,text)`, `open_questions(filename,text)`), and wire #1's extractor to `replaceSummaryFacts`. Full notes: [`docs/cross-meeting-tools.md`](docs/cross-meeting-tools.md).

**Conflict note (recap-fix thread):** changes to `ToolHandlers.swift` are append-only (3 `Tool` entries, 3 `switch` cases, 3 handlers); `handleRecap` untouched. Small conflict surface.

## Tests

New `SummaryRollupTests.swift` (11 cases): action items filtered by owner **across 2 meetings**, open/done/all status, date window, FTS query, decisions across meetings + FTS, digest rollup with counts, digest excludes fact-less meetings, write-seam idempotency, reindex clears stale facts.

- `swift test --package-path Tools/TranscriptedMCP` → **85 passed, 0 failures**
- `transcripted-mcp --self-test` → `ok: true` (new schema opens cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)