### PR TITLE
fix(dictation): make daily transcript appends crash-safe (atomic write)

### DIFF
--- a/Sources/Dictation/DictationTranscriptWriter.swift
+++ b/Sources/Dictation/DictationTranscriptWriter.swift
@@ -216,30 +216,17 @@ enum DictationTranscriptWriter {
         return size > 0
     }
 
+    // Append by rewriting the whole day file atomically (write-temp-then-rename) rather
+    // than seeking to the end of the existing file and writing in place. A crash or
+    // interruption part way through an in-place `FileHandle` write would leave a half-written
+    // section glued onto the day's data and corrupt every earlier entry in the file. With an
+    // atomic write the prior content survives untouched until the new file is renamed into
+    // place, so a failed write can lose the in-flight section but never the existing day.
     private static func appendSection(_ section: String, to url: URL) throws {
-        guard let handle = FileHandle(forWritingAtPath: url.path) else {
-            throw NSError(
-                domain: "DictationTranscriptWriter",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "Could not open dictation transcript for appending."]
-            )
-        }
-        defer { try? handle.close() }
-
-        let separator = fileEndsWithBlankLine(url) ? "" : "\n\n"
-        guard let data = (separator + section).data(using: .utf8) else { return }
-        handle.seekToEndOfFile()
-        handle.write(data)
-    }
-
-    private static func fileEndsWithBlankLine(_ url: URL) -> Bool {
-        guard let handle = FileHandle(forReadingAtPath: url.path) else { return false }
-        defer { try? handle.close() }
-
-        let fileLength = handle.seekToEndOfFile()
-        guard fileLength >= 2 else { return false }
-        handle.seek(toFileOffset: fileLength - 2)
-        return handle.readDataToEndOfFile() == Data([0x0A, 0x0A])
+        let existing = try String(contentsOf: url, encoding: .utf8)
+        let separator = existing.hasSuffix("\n\n") ? "" : "\n\n"
+        let combined = existing + separator + section
+        try combined.write(to: url, atomically: true, encoding: .utf8)
     }
 
     private static func buildTitle(from text: String, createdAt: Date) -> String {

--- a/Tests/DictationTranscriptWriterTests.swift
+++ b/Tests/DictationTranscriptWriterTests.swift
@@ -84,6 +84,57 @@ func testDictationTranscriptWriter() {
         )
     }
 
+    runSuite("DictationTranscriptWriter.save — a failed append leaves the existing day intact") {
+        let fm = FileManager.default
+        let tempRoot = temporaryDictationWriterTestRoot(fileManager: fm)
+        let outputDir = tempRoot.appendingPathComponent("dictations", isDirectory: true)
+        try? fm.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        defer {
+            try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: outputDir.path)
+            try? fm.removeItem(at: tempRoot)
+        }
+
+        let firstDate = localDate(year: 2026, month: 4, day: 7, hour: 9, minute: 15)
+        let firstSaved = try? DictationTranscriptWriter.save(
+            text: "first note that must survive a crash",
+            sourceApp: nil,
+            delivery: .pasted,
+            createdAt: firstDate,
+            directory: outputDir
+        )
+
+        guard let dayFile = firstSaved?.url else {
+            assertionFailure("Expected first dictation to save")
+            return
+        }
+
+        let before = (try? String(contentsOf: dayFile, encoding: .utf8)) ?? ""
+        assertTrue(before.contains("first note that must survive a crash"), "first dictation should be on disk")
+
+        // Simulate an interrupted/failed write: make the day folder read-only so the atomic
+        // write (write-temp-then-rename) cannot create its temp file and throws mid-append.
+        try? fm.setAttributes([.posixPermissions: 0o500], ofItemAtPath: outputDir.path)
+
+        let secondSaved = try? DictationTranscriptWriter.save(
+            text: "second note from a doomed write",
+            sourceApp: nil,
+            delivery: .copied,
+            createdAt: localDate(year: 2026, month: 4, day: 7, hour: 16, minute: 45),
+            directory: outputDir
+        )
+        assertTrue(secondSaved == nil, "append into a read-only folder should fail rather than succeed")
+
+        // Restore access and confirm the original day file is byte-for-byte intact: the
+        // failed second write must not have truncated, partially overwritten, or appended
+        // garbage to the existing entries.
+        try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: outputDir.path)
+
+        let after = (try? String(contentsOf: dayFile, encoding: .utf8)) ?? ""
+        assertEqual(after, before, "existing day file must be unchanged after a failed append")
+        assertTrue(after.contains("first note that must survive a crash"), "first dictation must survive")
+        assertTrue(!after.contains("second note from a doomed write"), "no partial second entry should leak in")
+    }
+
     runSuite("DictationTranscriptWriter.save — separates different days") {
         let fm = FileManager.default
         let tempRoot = temporaryDictationWriterTestRoot(fileManager: fm)

--- a/docs/NEXT_WORK.md
+++ b/docs/NEXT_WORK.md
@@ -1,0 +1,22 @@
+# Transcripted — What's Next
+
+The ~30 things in flight are converging (UI polish, speaker accuracy, data-loss, telemetry). This is what to do *after* that lands. The theme: turn the local meeting library into a thing an agent can actually answer questions over. That's the moat cloud notetakers can't copy on private data.
+
+## DO NEXT
+Ranked by impact-for-effort. Do them in order.
+
+1. **Index the summary fields (Decisions / Action Items / Open Questions) into the search DB.** The summarizer already writes these to each meeting; the search index never reads them. This one hop is the whole "ask my history" unlock. (M)
+2. **Make recap/recent_context return the real summary, not the first 15 lines of small-talk.** Today the agent's orientation tools return greetings and audio checks. The summary is already in the same file — just point at it. Cheapest high-value fix here. (S)
+3. **Make dictation saves crash-safe.** The most-used capture surface is the one place a crash mid-write can silently corrupt a whole day's entries. Everything else already writes atomically; copy that pattern. (M)
+4. **Add the cross-meeting tools: list_action_items, list_decisions, digest.** Once the fields are indexed (#1), this is the demo: "every open action item assigned to me, across every call." No cloud tool can do this on private data. (M)
+5. **Always-on cheap extraction at save time.** Right now summaries only exist if you opt into the heavy beta. Extract on every save so the moat covers 100% of meetings, not a subset. (M)
+
+## AFTER THAT
+6. **Local semantic search** — bundle a small embedding model so paraphrase queries hit ("pricing pushback" finds "they balked at the cost"). The one thing cloud RAG still beats us on. (L)
+7. **Multi-exemplar voiceprints** — store several voice samples per person instead of one averaged blob, so clean-mic and Zoom versions of the same voice both match. Land after the ERes2Net upgrade. (L)
+8. **Reversible speaker merges** — a wrong auto-merge permanently fuses two real people today, with no undo. Add provenance + un-merge before the more-aggressive merge work goes live. (L)
+9. **Negative exemplars** — when a user corrects a wrong speaker, learn "not this person" instead of just freezing the profile. Turns every correction into training signal. (M)
+10. **Index meetings for the Home list** — stop re-reading every transcript file on every Home refresh; point the list at the table that already exists. (L)
+
+## THE ONE BET
+**Index the summary fields and ship the cross-meeting tools (#1 + #4).** It's wiring, not machine learning, and it's the only thing here that gives the agent a memory cloud notetakers structurally can't match — and that moat gets stronger every meeting added.


### PR DESCRIPTION
## Why

Dictation is the highest-frequency capture surface, and its day-file save was the **one capture write that wasn't atomic**. Everything else (meeting artifacts, journals, JSON state) already uses `Data.write(options: .atomic)` / `String.write(atomically: true)`. Dictation appends did not.

`DictationTranscriptWriter.appendSection` opened the existing `Dictations_YYYY-MM-DD.md` with a `FileHandle`, seeked to the end, and wrote the new section **in place**. A crash, power loss, or interruption part way through that write would leave a half-written section glued onto the file and corrupt **every earlier entry for that day**.

## What changed

- `Sources/Dictation/DictationTranscriptWriter.swift` — `appendSection` now reads the existing day file, concatenates the new section, and writes the whole file atomically via `String.write(atomically: true)` (write-temp-then-rename) — the same safe-write pattern the rest of the app uses. The prior content survives untouched until the new file is renamed into place, so a failed write can lose only the in-flight section, never the existing day. Removed the now-unused `fileEndsWithBlankLine` byte-probe helper (replaced by a `hasSuffix("\n\n")` check on the in-memory string).
- New-file creation (`String.write(atomically: true)`) and the delete-rebuild path (`DictationTranscriptStore`) were already atomic — this closes the last gap.

Markdown layout is unchanged (same `\n\n` separator and section shape), so the `TranscriptedCaptureKit` day-file parser needs no change.

## Test

Added a regression suite in `Tests/DictationTranscriptWriterTests.swift`: it saves a first entry, then simulates an **interrupted/failed append** by making the day folder read-only so the atomic temp write throws mid-write, and asserts the existing day file is **byte-for-byte intact** with the second (doomed) entry never leaking in.

## Verification

- `bash build.sh --no-open` ✅
- `bash run-tests.sh` ✅ (10157 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)