### PR TITLE
feat(mcp): index structured meeting-summary fields (decisions/action items/open questions)

### DIFF
--- a/Tools/TranscriptedCaptureKit/CLAUDE.md
+++ b/Tools/TranscriptedCaptureKit/CLAUDE.md
@@ -5,6 +5,7 @@
 - capture-library directory resolution (env overrides, app manifest, `transcriptSaveLocation` preference, legacy Draft / `~/Documents/Transcripted` fallback)
 - capture-Markdown detection (`looksLikeCaptureMarkdown`, directory probing, frontmatter title extraction)
 - capture-Markdown parsing (meeting transcripts and dictation day files)
+- structured meeting-summary parsing (Decisions / Action Items / Open Questions)
 
 Both `Tools/TranscriptedCLI` and `Tools/TranscriptedMCP` depend on it via a relative `.package(path: "../TranscriptedCaptureKit")` dependency. Before this package existed, that logic was duplicated nearly verbatim in both tools and had already drifted; do not re-inline it.
 
@@ -16,6 +17,7 @@ Both `Tools/TranscriptedCLI` and `Tools/TranscriptedMCP` depend on it via a rela
 | `Sources/TranscriptedCaptureKit/CaptureLibraryResolver.swift` | `CaptureLibraryResolver.resolve(...)` → `ResolvedCaptureDirectories` (meeting dirs, dictation dirs, optional shared data root) |
 | `Sources/TranscriptedCaptureKit/CaptureMarkdown.swift` | Capture-Markdown detection and frontmatter `title:` extraction |
 | `Sources/TranscriptedCaptureKit/CaptureMarkdownParser.swift` | Frontmatter, meeting transcript, and dictation day parsing into `ParsedMeetingCapture` / `ParsedDictationDayCapture` |
+| `Sources/TranscriptedCaptureKit/CaptureSummaryParser.swift` | Structured summary parsing into `ParsedMeetingSummary` (Decisions / Action Items with owner / Open Questions); understands inline transcript summaries and generated `meeting_summary` sidecars. Ports the app's `RecentMeetingSummaryPreviewParser` section logic across the module boundary |
 
 ## Test Files
 
@@ -23,6 +25,7 @@ Both `Tools/TranscriptedCLI` and `Tools/TranscriptedMCP` depend on it via a rela
 |------|---------|
 | `Tests/TranscriptedCaptureKitTests/CaptureLibraryResolverTests.swift` | Resolution precedence: shared data dir, per-kind overrides, manifest, preference, legacy fallback, symlinked legacy roots |
 | `Tests/TranscriptedCaptureKitTests/CaptureMarkdownParserTests.swift` | Legacy + styled transcript parsing, speaker metadata, durations, dictation entries, detection helpers |
+| `Tests/TranscriptedCaptureKitTests/CaptureSummaryParserTests.swift` | Inline + sidecar summary parsing, action-item owner extraction, placeholder/None-found handling, frontmatter fallback |
 
 ## Build and test
 

--- a/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureSummaryParser.swift
+++ b/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureSummaryParser.swift
@@ -1,0 +1,224 @@
+import Foundation
+
+/// Structured meeting-summary fields extracted from a saved capture. Carries the
+/// rollup-friendly subset the index needs (decisions, action items, open
+/// questions); each item is one bullet so cross-meeting tools can aggregate.
+public struct ParsedMeetingSummary: Equatable {
+    public struct ActionItem: Equatable {
+        /// Named owner if the bullet led with one (`Owner: do thing`); nil means
+        /// unassigned. Generic placeholders ("unassigned", "TBD", ...) normalize
+        /// to nil so rollups don't treat them as a person.
+        public let owner: String?
+        public let text: String
+
+        public init(owner: String?, text: String) {
+            self.owner = owner
+            self.text = text
+        }
+    }
+
+    public let title: String?
+    public let decisions: [String]
+    public let actionItems: [ActionItem]
+    public let openQuestions: [String]
+
+    public init(
+        title: String?,
+        decisions: [String],
+        actionItems: [ActionItem],
+        openQuestions: [String]
+    ) {
+        self.title = title
+        self.decisions = decisions
+        self.actionItems = actionItems
+        self.openQuestions = openQuestions
+    }
+
+    public var isEmpty: Bool {
+        decisions.isEmpty && actionItems.isEmpty && openQuestions.isEmpty
+    }
+}
+
+/// Parses the structured summary sections (Decisions / Action Items / Open
+/// Questions) out of a Transcripted capture.
+///
+/// This mirrors the section-parsing logic the app uses for the Home preview
+/// (`RecentMeetingSummaryPreviewParser` in `Sources/UI/Shared/RecentCaptureScanners.swift`).
+/// The app target's parser can't be imported by the standalone tools, so the
+/// proven string logic lives here in the shared kit. It understands both shapes:
+///
+/// - inline summary written into the meeting transcript: frontmatter
+///   `local_summary_version` plus a `## Local Summary` body block with `###`
+///   subsections (and a pipe-joined `local_summary_*` frontmatter fallback).
+/// - a generated `meeting_summary` sidecar file with `#` sections.
+public enum CaptureSummaryParser {
+    private static let startMarker = "<!-- transcripted:local-summary:start v=1 -->"
+    private static let endMarker = "<!-- transcripted:local-summary:end -->"
+    private static let placeholder = "None found."
+
+    /// Returns nil when the content carries no structured summary, or when every
+    /// indexable section is empty.
+    public static func parse(from content: String) -> ParsedMeetingSummary? {
+        guard let document = CaptureMarkdownParser.parseFrontmatter(from: content) else {
+            return nil
+        }
+        let values = document.values
+        let body = document.body
+
+        if values["capture_type"] == "meeting_summary" {
+            return assemble(
+                title: cleanTitle(values["summary_title"]),
+                decisions: bulletItems(section("# Decisions", in: body, headingLevel: "#")),
+                actions: bulletItems(section("# Action Items", in: body, headingLevel: "#")),
+                questions: bulletItems(section("# Open Questions", in: body, headingLevel: "#"))
+            )
+        }
+
+        guard values["local_summary_version"] != nil else { return nil }
+
+        let block = localSummaryBlock(in: body) ?? body
+        return assemble(
+            title: cleanTitle(values["local_summary_title"]),
+            decisions: inlineItems("### Decisions", in: block, fallback: values["local_summary_decisions"]),
+            actions: inlineItems("### Action Items", in: block, fallback: values["local_summary_action_items"]),
+            questions: inlineItems("### Open Questions", in: block, fallback: values["local_summary_open_questions"])
+        )
+    }
+
+    // MARK: - Assembly
+
+    private static func assemble(
+        title: String?,
+        decisions: [String],
+        actions: [String],
+        questions: [String]
+    ) -> ParsedMeetingSummary? {
+        let summary = ParsedMeetingSummary(
+            title: title,
+            decisions: decisions,
+            actionItems: actions.map(actionItem(from:)),
+            openQuestions: questions
+        )
+        return summary.isEmpty ? nil : summary
+    }
+
+    /// Body `### Heading` wins; falls back to the pipe-joined `local_summary_*`
+    /// frontmatter value when the body block is missing the heading entirely.
+    private static func inlineItems(_ heading: String, in block: String, fallback: String?) -> [String] {
+        if let raw = section(heading, in: block, headingLevel: "###") {
+            return bulletItems(raw)
+        }
+        return frontmatterItems(fallback)
+    }
+
+    private static let placeholderOwners: Set<String> = [
+        "unassigned", "tbd", "n/a", "na", "none", "unknown", "everyone", "all", "team"
+    ]
+
+    private static func actionItem(from text: String) -> ParsedMeetingSummary.ActionItem {
+        // The summarizer prompts action bullets as "<Owner if named: follow-up>".
+        // Treat a short leading segment before the first ": " as the owner only
+        // when it reads like a name/team — a Title-Case noun phrase. Sentence
+        // fragments ("Discuss the new API: ...") carry lowercase function words,
+        // so we keep them as plain text instead of shredding a fake owner out.
+        if let colon = text.range(of: ": ") {
+            let owner = String(text[..<colon.lowerBound]).trimmingCharacters(in: .whitespaces)
+            let rest = String(text[colon.upperBound...]).trimmingCharacters(in: .whitespaces)
+            if !rest.isEmpty, looksLikeOwner(owner) {
+                let normalized = placeholderOwners.contains(owner.lowercased()) ? nil : owner
+                return ParsedMeetingSummary.ActionItem(owner: normalized, text: rest)
+            }
+        }
+        return ParsedMeetingSummary.ActionItem(owner: nil, text: text)
+    }
+
+    private static func looksLikeOwner(_ candidate: String) -> Bool {
+        guard !candidate.isEmpty, candidate.count <= 24, !candidate.contains(".") else { return false }
+        let words = candidate.split(separator: " ")
+        guard (1...3).contains(words.count) else { return false }
+        // Every word must lead with an uppercase letter (or a non-letter, e.g.
+        // initials like "JW"). A lowercase function word ("the", "and") marks a
+        // sentence fragment, not a name.
+        return words.allSatisfy { word in
+            guard let first = word.first else { return false }
+            return !first.isLowercase
+        }
+    }
+
+    // MARK: - Section extraction (ported from the app's preview parser)
+
+    /// Returns the raw text under `heading` up to the next same-level heading, or
+    /// nil when the heading is absent. Local-summary HTML markers are stripped so
+    /// the start/end comment lines never bound a section.
+    private static func section(_ heading: String, in body: String, headingLevel: String) -> String? {
+        let stripped = body
+            .replacingOccurrences(of: startMarker, with: "")
+            .replacingOccurrences(of: endMarker, with: "")
+        let lines = stripped.components(separatedBy: .newlines)
+        guard let startIndex = lines.firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines) == heading
+        }) else {
+            return nil
+        }
+
+        var endIndex = lines.endIndex
+        for index in lines.index(after: startIndex)..<lines.endIndex {
+            let trimmed = lines[index].trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.hasPrefix("\(headingLevel) "), trimmed != heading {
+                endIndex = index
+                break
+            }
+        }
+
+        return lines[lines.index(after: startIndex)..<endIndex]
+            .joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func localSummaryBlock(in body: String) -> String? {
+        guard let startRange = body.range(of: startMarker),
+              let endRange = body.range(of: endMarker, range: startRange.upperBound..<body.endIndex) else {
+            return nil
+        }
+        return String(body[startRange.lowerBound..<endRange.upperBound])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - Item cleaning
+
+    private static func bulletItems(_ raw: String?) -> [String] {
+        guard let raw else { return [] }
+        return raw
+            .components(separatedBy: .newlines)
+            .map(cleanMarkdown)
+            .filter { !$0.isEmpty && $0 != placeholder }
+    }
+
+    /// Frontmatter fallback values are pipe-joined ("a | b | c").
+    private static func frontmatterItems(_ value: String?) -> [String] {
+        guard let value, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return []
+        }
+        return value
+            .components(separatedBy: " | ")
+            .map(cleanMarkdown)
+            .filter { !$0.isEmpty && $0 != placeholder }
+    }
+
+    private static func cleanTitle(_ raw: String?) -> String? {
+        let title = cleanMarkdown(raw)
+        guard !title.isEmpty, title != placeholder else { return nil }
+        return String(title.prefix(96))
+    }
+
+    private static func cleanMarkdown(_ raw: String?) -> String {
+        var text = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        for prefix in ["- ", "* "] where text.hasPrefix(prefix) {
+            text.removeFirst(prefix.count)
+        }
+        return text
+            .replacingOccurrences(of: "**", with: "")
+            .replacingOccurrences(of: "`", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureSummaryParserTests.swift
+++ b/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureSummaryParserTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+@testable import TranscriptedCaptureKit
+
+final class CaptureSummaryParserTests: XCTestCase {
+    // Inline summary mirrors LocalMeetingSummaryMarkdownUpdater: frontmatter
+    // `local_summary_*` keys plus a marker-bounded `## Local Summary` body block
+    // with `###` subsections.
+    private func inlineMeeting(
+        decisions: String = "### Decisions\n- Ship the beta on Friday\n- Cut the legacy import path",
+        actionItems: String = "### Action Items\n- Jenny: send the revised spec\n- Follow up with legal",
+        openQuestions: String = "### Open Questions\n- Do we need a migration window?"
+    ) -> String {
+        """
+        ---
+        capture_type: meeting
+        date: 2026-04-18
+        time: 09:15:00
+        duration: "30:00"
+        transcription_engine: parakeet_local
+        diarization_engine: pyannote_offline
+        local_summary_version: "1"
+        local_summary_title: "Beta launch sync"
+        local_summary_decisions: "Ship the beta on Friday | Cut the legacy import path"
+        local_summary_action_items: "Jenny: send the revised spec | Follow up with legal"
+        local_summary_open_questions: "Do we need a migration window?"
+        ---
+
+        # Meeting
+
+        ## Full Transcript
+
+        [00:00] [System/Jenny] Let's lock the launch.
+
+        <!-- transcripted:local-summary:start v=1 -->
+        ## Local Summary
+
+        ### Summary
+        - The team aligned on launch.
+
+        ### Next Steps
+        - None found.
+
+        \(decisions)
+
+        \(openQuestions)
+
+        ### Participants
+        - Jenny
+
+        \(actionItems)
+
+        ### Risks or Follow-ups
+        - None found.
+
+        ### Accuracy Notes
+        - None found.
+        <!-- transcripted:local-summary:end -->
+        """
+    }
+
+    func testParsesInlineBodyBlockSections() throws {
+        let summary = try XCTUnwrap(CaptureSummaryParser.parse(from: inlineMeeting()))
+        XCTAssertEqual(summary.title, "Beta launch sync")
+        XCTAssertEqual(summary.decisions, ["Ship the beta on Friday", "Cut the legacy import path"])
+        XCTAssertEqual(summary.openQuestions, ["Do we need a migration window?"])
+        XCTAssertEqual(summary.actionItems.count, 2)
+    }
+
+    func testExtractsActionItemOwner() throws {
+        let summary = try XCTUnwrap(CaptureSummaryParser.parse(from: inlineMeeting()))
+        XCTAssertEqual(summary.actionItems[0].owner, "Jenny")
+        XCTAssertEqual(summary.actionItems[0].text, "send the revised spec")
+        // No "Owner:" prefix → unassigned, full text retained.
+        XCTAssertNil(summary.actionItems[1].owner)
+        XCTAssertEqual(summary.actionItems[1].text, "Follow up with legal")
+    }
+
+    func testDoesNotShredSentenceColonsIntoOwner() throws {
+        let markdown = inlineMeeting(
+            actionItems: "### Action Items\n- Discuss the new API: review the public endpoints and document them"
+        )
+        let summary = try XCTUnwrap(CaptureSummaryParser.parse(from: markdown))
+        XCTAssertNil(summary.actionItems[0].owner)
+        XCTAssertEqual(summary.actionItems[0].text, "Discuss the new API: review the public endpoints and document them")
+    }
+
+    func testNormalizesPlaceholderOwnersToUnassigned() throws {
+        let markdown = inlineMeeting(actionItems: "### Action Items\n- Unassigned: triage the backlog")
+        let summary = try XCTUnwrap(CaptureSummaryParser.parse(from: markdown))
+        XCTAssertNil(summary.actionItems[0].owner)
+        XCTAssertEqual(summary.actionItems[0].text, "triage the backlog")
+    }
+
+    func testTreatsNoneFoundAsEmptySection() throws {
+        let markdown = inlineMeeting(
+            decisions: "### Decisions\n- None found.",
+            openQuestions: "### Open Questions\n- None found."
+        )
+        let summary = try XCTUnwrap(CaptureSummaryParser.parse(from: markdown))
+        XCTAssertTrue(summary.decisions.isEmpty)
+        XCTAssertTrue(summary.openQuestions.isEmpty)
+        XCTAssertEqual(summary.actionItems.count, 2)
+    }
+
+    func testFallsBackToFrontmatterWhenBodyBlockMissing() throws {
+        let markdown = """
+        ---
+        capture_type: meeting
+        date: 2026-04-18
+        time: 09:15:00
+        local_summary_version: "1"
+        local_summary_decisions: "Adopt the new schema | Freeze the old endpoint"
+        local_summary_action_items: "Sam: write the migration"
+        local_summary_open_questions: "When do we cut over?"
+        ---
+
+        # Meeting
+
+        ## Full Transcript
+
+        [00:00] [System/Sam] Body has no local-summary block.
+        """
+        let summary = try XCTUnwrap(CaptureSummaryParser.parse(from: markdown))
+        XCTAssertEqual(summary.decisions, ["Adopt the new schema", "Freeze the old endpoint"])
+        XCTAssertEqual(summary.openQuestions, ["When do we cut over?"])
+        XCTAssertEqual(summary.actionItems.first?.owner, "Sam")
+        XCTAssertEqual(summary.actionItems.first?.text, "write the migration")
+    }
+
+    func testParsesGeneratedSidecarSections() throws {
+        let sidecar = """
+        ---
+        capture_type: meeting_summary
+        source_transcript: "2026-04-18 Beta launch sync.md"
+        summary_title: "Beta launch sync"
+        ---
+
+        # Title
+        Beta launch sync
+
+        # Summary
+        - The team aligned on launch.
+
+        # Decisions
+        - Ship the beta on Friday
+
+        # Action Items
+        - Jenny: send the revised spec
+
+        # Open Questions
+        - Do we need a migration window?
+        """
+        let summary = try XCTUnwrap(CaptureSummaryParser.parse(from: sidecar))
+        XCTAssertEqual(summary.title, "Beta launch sync")
+        XCTAssertEqual(summary.decisions, ["Ship the beta on Friday"])
+        XCTAssertEqual(summary.actionItems.first?.owner, "Jenny")
+        XCTAssertEqual(summary.openQuestions, ["Do we need a migration window?"])
+    }
+
+    func testReturnsNilWhenNoSummaryPresent() {
+        let markdown = """
+        ---
+        capture_type: meeting
+        date: 2026-04-18
+        time: 09:15:00
+        ---
+
+        # Meeting
+
+        ## Full Transcript
+
+        [00:00] [System/Sam] No summary here.
+        """
+        XCTAssertNil(CaptureSummaryParser.parse(from: markdown))
+    }
+
+    func testReturnsNilWhenEverySectionEmpty() {
+        let markdown = inlineMeeting(
+            decisions: "### Decisions\n- None found.",
+            actionItems: "### Action Items\n- None found.",
+            openQuestions: "### Open Questions\n- None found."
+        )
+        XCTAssertNil(CaptureSummaryParser.parse(from: markdown))
+    }
+}

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -35,11 +35,11 @@ When `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
 that mode the SQLite index also defaults to the shared root unless
 `TRANSCRIPTED_INDEX_DIR` is set.
 
-## Package Layout (16 Swift files)
+## Package Layout (17 Swift files)
 
 - `Package.swift` — Swift package manifest for the standalone MCP server
 - `Sources/TranscriptedMCP/` — 9 source files for server startup, directory resolution, path validation, indexing, and tool handlers
-- `Tests/TranscriptedMCPTests/` — 6 test files for directory resolution, index lifecycle, markdown loading, logging, name variants, and shared fixtures
+- `Tests/TranscriptedMCPTests/` — 7 test files for directory resolution, index lifecycle, structured-summary indexing, markdown loading, logging, name variants, and shared fixtures
 
 ## File Index
 
@@ -61,6 +61,7 @@ that mode the SQLite index also defaults to the shared root unless
 |------|---------|
 | `DataDirectoriesTests.swift` | Directory-resolution coverage for current Transcripted captures vs legacy Draft fallback |
 | `TranscriptIndexTests.swift` | Full index lifecycle: reconcile, query, date filters, speaker search, and mixed-context indexing |
+| `SummaryItemIndexTests.swift` | Structured summary parse→index→query: decisions/action-items/open-questions, owner + unassigned rollup, reindex/delete, sidecar-not-a-meeting |
 | `TranscriptLoaderTests.swift` | Markdown and YAML frontmatter parsing edge cases, including path-safety checks |
 | `LoggingTests.swift` | JSON log emission coverage for MCP startup and indexing diagnostics |
 | `NameVariantsTests.swift` | Name variant matching accuracy |
@@ -107,8 +108,11 @@ The SQLite index keeps separate records for:
 
 - meetings
 - meeting speakers / utterance search rows
+- structured meeting-summary items (Decisions / Action Items with owner / Open Questions), one row per bullet in `meeting_summary_items` with a `kind` discriminator + FTS5, so cross-meeting tools can roll up across all meetings
 - dictation day files
 - dictation entry search rows
+
+Structured summary items are parsed via `TranscriptedCaptureKit.CaptureSummaryParser` from each meeting's inline local summary (or a `<stem>.summary.md` sidecar fallback) during `indexMeeting`. `TranscriptIndex.listSummaryItems(kind:owner:dateFrom:dateTo:)` is the cross-meeting query foundation; no MCP tool is wired to it yet (that is a separate thread).
 
 This lets the server answer both meeting-specific queries (`who_is`, `read_meeting`) and mixed-context queries (`search_context`, `recent_context`) without touching app-owned runtime state.
 

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -46,7 +46,39 @@ final class TranscriptIndex: @unchecked Sendable {
             sqlite3_finalize(stmt)
         }
 
+        try applySchemaVersionGate()
         createTables()
+        exec("PRAGMA user_version=\(Self.schemaVersion)")
+    }
+
+    /// Bump when the derived index shape changes so existing on-disk indexes are
+    /// rebuilt from disk on next open. v2 added `meeting_summary_items`.
+    private static let schemaVersion: Int32 = 2
+
+    /// An already-indexed meeting whose transcript mtime is unchanged is skipped
+    /// by `reconcile`, so a schema addition (new table/column) would never
+    /// populate for it. When the stored `user_version` is older than the current
+    /// schema, wipe and reopen the index so the next reconcile rebuilds every
+    /// derived table from disk. Mirrors the corruption-recovery path above.
+    /// (Old/unversioned indexes report 0, indistinguishable from a fresh DB —
+    /// rebuilding an empty fresh DB is a harmless no-op.)
+    private func applySchemaVersionGate() throws {
+        guard storedUserVersion() < Self.schemaVersion else { return }
+        sqlite3_close(db)
+        db = nil
+        try? FileManager.default.removeItem(at: indexPath)
+        log("Index schema older than v\(Self.schemaVersion), rebuilding from disk")
+        if sqlite3_open(indexPath.path, &db) != SQLITE_OK {
+            throw MCPIndexError.databaseOpenFailed(dbError())
+        }
+        configureDatabase()
+    }
+
+    private func storedUserVersion() -> Int32 {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, "PRAGMA user_version", -1, &stmt, nil) == SQLITE_OK else { return 0 }
+        defer { sqlite3_finalize(stmt) }
+        return sqlite3_step(stmt) == SQLITE_ROW ? sqlite3_column_int(stmt, 0) : 0
     }
 
     /// Apply owner-only file permissions and WAL pragmas to an already-opened database handle.
@@ -166,6 +198,45 @@ final class TranscriptIndex: @unchecked Sendable {
             END
         """)
 
+        // Structured summary fields (Decisions / Action Items / Open Questions)
+        // parsed from each meeting's local summary. One row per bullet, keyed to
+        // the meeting filename, with a `kind` discriminator so cross-meeting tools
+        // (list_action_items, open_questions roll-ups) can aggregate over all
+        // meetings without a per-category table. Mirrors the utterances + FTS5 +
+        // triggers pattern above.
+        exec("""
+            CREATE TABLE IF NOT EXISTS meeting_summary_items (
+                rowid INTEGER PRIMARY KEY AUTOINCREMENT,
+                filename TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                position INTEGER NOT NULL,
+                owner TEXT,
+                text TEXT NOT NULL
+            )
+        """)
+
+        exec("""
+            CREATE VIRTUAL TABLE IF NOT EXISTS meeting_summary_items_fts USING fts5(
+                text, owner,
+                content='meeting_summary_items', content_rowid='rowid',
+                tokenize='porter unicode61'
+            )
+        """)
+
+        exec("""
+            CREATE TRIGGER IF NOT EXISTS meeting_summary_items_ai AFTER INSERT ON meeting_summary_items BEGIN
+                INSERT INTO meeting_summary_items_fts(rowid, text, owner)
+                VALUES (new.rowid, new.text, new.owner);
+            END
+        """)
+
+        exec("""
+            CREATE TRIGGER IF NOT EXISTS meeting_summary_items_ad AFTER DELETE ON meeting_summary_items BEGIN
+                INSERT INTO meeting_summary_items_fts(meeting_summary_items_fts, rowid, text, owner)
+                VALUES ('delete', old.rowid, old.text, old.owner);
+            END
+        """)
+
         exec("CREATE INDEX IF NOT EXISTS idx_meetings_date ON meetings(date)")
         exec("CREATE INDEX IF NOT EXISTS idx_meeting_speakers_name ON meeting_speakers(speaker_name COLLATE NOCASE)")
         exec("CREATE INDEX IF NOT EXISTS idx_meeting_speakers_persistent_id ON meeting_speakers(persistent_speaker_id)")
@@ -173,6 +244,9 @@ final class TranscriptIndex: @unchecked Sendable {
         exec("CREATE INDEX IF NOT EXISTS idx_dictation_days_date ON dictation_days(date)")
         exec("CREATE INDEX IF NOT EXISTS idx_dictation_entries_filename ON dictation_entries(filename)")
         exec("CREATE INDEX IF NOT EXISTS idx_dictation_entries_created_at ON dictation_entries(created_at)")
+        exec("CREATE INDEX IF NOT EXISTS idx_summary_items_filename ON meeting_summary_items(filename)")
+        exec("CREATE INDEX IF NOT EXISTS idx_summary_items_kind ON meeting_summary_items(kind)")
+        exec("CREATE INDEX IF NOT EXISTS idx_summary_items_owner ON meeting_summary_items(owner COLLATE NOCASE)")
     }
 
     // MARK: - Reconciliation
@@ -324,9 +398,41 @@ final class TranscriptIndex: @unchecked Sendable {
             )
         }
 
+        try insertSummaryItems(forMeeting: url, filename: filename)
+
         try execOrThrow("COMMIT")
         committed = true
         log("Indexed: \(filename) (\(transcript.utterances.count) utterances)")
+    }
+
+    /// Parse the meeting's structured summary (inline transcript summary, then a
+    /// generated sidecar) and write one row per Decision / Action Item / Open
+    /// Question. Called inside the meeting index transaction. A meeting with no
+    /// summary inserts nothing.
+    private func insertSummaryItems(forMeeting url: URL, filename: String) throws {
+        guard let summary = TranscriptLoader.loadMeetingSummary(forTranscript: url) else { return }
+
+        for (position, text) in summary.decisions.enumerated() {
+            try bindExec(
+                "INSERT INTO meeting_summary_items (filename, kind, position, owner, text) VALUES (?,?,?,?,?)",
+                bindings: [.text(filename), .text(SummaryItemKind.decision), .int(position), .null, .text(text)]
+            )
+        }
+        for (position, item) in summary.actionItems.enumerated() {
+            try bindExec(
+                "INSERT INTO meeting_summary_items (filename, kind, position, owner, text) VALUES (?,?,?,?,?)",
+                bindings: [
+                    .text(filename), .text(SummaryItemKind.actionItem), .int(position),
+                    item.owner.map { .text($0) } ?? .null, .text(item.text)
+                ]
+            )
+        }
+        for (position, text) in summary.openQuestions.enumerated() {
+            try bindExec(
+                "INSERT INTO meeting_summary_items (filename, kind, position, owner, text) VALUES (?,?,?,?,?)",
+                bindings: [.text(filename), .text(SummaryItemKind.openQuestion), .int(position), .null, .text(text)]
+            )
+        }
     }
 
     private func indexDictationDay(file url: URL, filename: String, modDate: TimeInterval) throws {
@@ -386,12 +492,107 @@ final class TranscriptIndex: @unchecked Sendable {
         var committed = false
         defer { if !committed { exec("ROLLBACK") } }
         try bindExec("DELETE FROM utterances WHERE filename = ?", bindings: [.text(filename)])
+        try bindExec("DELETE FROM meeting_summary_items WHERE filename = ?", bindings: [.text(filename)])
         try bindExec("DELETE FROM meeting_speakers WHERE filename = ?", bindings: [.text(filename)])
         try bindExec("DELETE FROM meetings WHERE filename = ?", bindings: [.text(filename)])
         try bindExec("DELETE FROM dictation_entries WHERE filename = ?", bindings: [.text(filename)])
         try bindExec("DELETE FROM dictation_days WHERE filename = ?", bindings: [.text(filename)])
         try execOrThrow("COMMIT")
         committed = true
+    }
+
+    // MARK: - Structured summary queries
+
+    /// Stable `kind` discriminator values for `meeting_summary_items`.
+    enum SummaryItemKind {
+        static let decision = "decision"
+        static let actionItem = "action_item"
+        static let openQuestion = "open_question"
+    }
+
+    /// One indexed structured-summary row joined to its meeting's date metadata.
+    /// This is the foundation the separate cross-meeting tools thread (e.g.
+    /// `list_action_items`) builds on; no MCP tool is wired here yet.
+    struct IndexedSummaryItem {
+        let filename: String
+        let kind: String
+        let position: Int
+        let owner: String?
+        let text: String
+        let meetingDate: String
+        let meetingDateTime: String
+    }
+
+    /// Roll up structured summary items across meetings, newest meeting first.
+    /// `kind` and `owner` are optional filters; `owner == ""` selects unassigned
+    /// (NULL-owner) items, which is meaningful only for action items.
+    func listSummaryItems(
+        kind: String? = nil,
+        owner: String? = nil,
+        dateFrom: String? = nil,
+        dateTo: String? = nil,
+        limit: Int = 200
+    ) throws -> [IndexedSummaryItem] {
+        return try queue.sync {
+            let cappedLimit = max(1, min(limit, 1000))
+            var sql = """
+                SELECT s.filename, s.kind, s.position, s.owner, s.text, m.date, m.datetime
+                FROM meeting_summary_items s
+                JOIN meetings m ON m.filename = s.filename
+            """
+            var bindings: [SQLBinding] = []
+            var conditions: [String] = []
+
+            if let kind = kind {
+                conditions.append("s.kind = ?")
+                bindings.append(.text(kind))
+            }
+            if let owner = owner {
+                if owner.isEmpty {
+                    conditions.append("s.owner IS NULL")
+                } else {
+                    conditions.append("s.owner COLLATE NOCASE = ?")
+                    bindings.append(.text(owner))
+                }
+            }
+            if let dateFrom = dateFrom {
+                conditions.append("m.date >= ?")
+                bindings.append(.text(dateFrom))
+            }
+            if let dateTo = dateTo {
+                conditions.append("m.date <= ?")
+                bindings.append(.text(dateTo))
+            }
+
+            if !conditions.isEmpty {
+                sql += " WHERE " + conditions.joined(separator: " AND ")
+            }
+            sql += " ORDER BY m.datetime DESC, s.filename, s.kind, s.position LIMIT ?"
+            bindings.append(.int(cappedLimit))
+
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+                throw MCPIndexError.queryFailed(dbError())
+            }
+            defer { sqlite3_finalize(stmt) }
+            for (i, binding) in bindings.enumerated() {
+                bind(stmt: stmt, index: Int32(i + 1), value: binding)
+            }
+
+            var items: [IndexedSummaryItem] = []
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                items.append(IndexedSummaryItem(
+                    filename: colText(stmt, 0),
+                    kind: colText(stmt, 1),
+                    position: Int(sqlite3_column_int64(stmt, 2)),
+                    owner: colTextOptional(stmt, 3),
+                    text: colText(stmt, 4),
+                    meetingDate: colText(stmt, 5),
+                    meetingDateTime: colText(stmt, 6)
+                ))
+            }
+            return items
+        }
     }
 
     // MARK: - Queries

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
@@ -59,6 +59,41 @@ enum TranscriptLoader {
         )
     }
 
+    /// Structured summary for a saved meeting. Prefers the inline summary written
+    /// into the transcript (`local_summary_version` frontmatter + `## Local
+    /// Summary` body block), then falls back to a generated `<stem>.summary.md`
+    /// sidecar if one exists. Returns nil when neither carries a summary.
+    ///
+    /// Note: the live summarizer writes the summary *into the transcript*, so a
+    /// (re)summarize bumps the transcript mtime and `reconcile` re-indexes it.
+    /// The sidecar branch is a legacy-compat fallback; a sidecar edited in
+    /// isolation does not bump the parent transcript's mtime, so its items only
+    /// refresh on the next reindex of the transcript itself.
+    static func loadMeetingSummary(forTranscript url: URL) -> ParsedMeetingSummary? {
+        if let content = try? String(contentsOf: url, encoding: .utf8),
+           let summary = CaptureSummaryParser.parse(from: content) {
+            return summary
+        }
+
+        let sidecarURL = summarySidecarURL(forTranscript: url)
+        if let content = try? String(contentsOf: sidecarURL, encoding: .utf8),
+           let summary = CaptureSummaryParser.parse(from: content) {
+            return summary
+        }
+
+        return nil
+    }
+
+    /// Mirrors `LocalMeetingSummaryStore.summaryURL(for:)` in the app target:
+    /// `<dir>/<stem>.summary.md` next to the transcript.
+    static func summarySidecarURL(forTranscript url: URL) -> URL {
+        let base = url.deletingPathExtension()
+        return base
+            .deletingLastPathComponent()
+            .appendingPathComponent("\(base.lastPathComponent).summary")
+            .appendingPathExtension("md")
+    }
+
     static func loadDictationDay(_ url: URL) -> AgentDictationDay? {
         guard let content = try? String(contentsOf: url, encoding: .utf8),
               let parsed = CaptureMarkdownParser.parseDictationDay(from: content, markdownURL: url) else {
@@ -95,6 +130,13 @@ enum TranscriptLoader {
         let filename = url.deletingPathExtension().lastPathComponent
         if filename.hasPrefix("Dictations_") {
             return .dictationDay
+        }
+        // Generated `<stem>.summary.md` sidecars carry frontmatter too, but they
+        // are not meetings — they are read as a fallback summary source for their
+        // parent transcript (see loadMeetingSummary). Indexing them as meetings
+        // would create empty junk rows and double-index summary items.
+        if filename.hasSuffix(".summary") {
+            return nil
         }
         return .meeting
     }

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SummaryItemIndexTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SummaryItemIndexTests.swift
@@ -1,0 +1,173 @@
+import SQLite3
+import XCTest
+@testable import transcripted_mcp
+
+/// parse → index → query coverage for the structured summary fields
+/// (Decisions / Action Items / Open Questions) added to the MCP index.
+final class SummaryItemIndexTests: XCTestCase {
+    var index: TranscriptIndex!
+    var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = makeTempDir()
+        index = try! TranscriptIndex(indexDir: tempDir)
+    }
+
+    override func tearDown() {
+        index = nil
+        removeTempDir(tempDir)
+        super.tearDown()
+    }
+
+    func testIndexesInlineSummaryItems() throws {
+        try writeFixture(makeMeetingWithInlineSummary(), filename: "Call_2026-04-18_09-15-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let decisions = try index.listSummaryItems(kind: TranscriptIndex.SummaryItemKind.decision)
+        XCTAssertEqual(decisions.map(\.text), ["Ship the beta on Friday", "Cut the legacy import path"])
+        XCTAssertEqual(decisions.map(\.position), [0, 1])
+        XCTAssertEqual(decisions.first?.meetingDate, "2026-04-18")
+
+        let questions = try index.listSummaryItems(kind: TranscriptIndex.SummaryItemKind.openQuestion)
+        XCTAssertEqual(questions.map(\.text), ["Do we need a migration window?"])
+    }
+
+    func testIndexesActionItemOwnerAndUnassigned() throws {
+        try writeFixture(makeMeetingWithInlineSummary(), filename: "Call_2026-04-18_09-15-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let actions = try index.listSummaryItems(kind: TranscriptIndex.SummaryItemKind.actionItem)
+        XCTAssertEqual(actions.count, 2)
+        XCTAssertEqual(actions[0].owner, "Jenny")
+        XCTAssertEqual(actions[0].text, "send the revised spec")
+        XCTAssertNil(actions[1].owner)
+
+        // Owner filter rolls up across meetings; "" selects unassigned.
+        let jenny = try index.listSummaryItems(kind: TranscriptIndex.SummaryItemKind.actionItem, owner: "jenny")
+        XCTAssertEqual(jenny.map(\.text), ["send the revised spec"])
+        let unassigned = try index.listSummaryItems(kind: TranscriptIndex.SummaryItemKind.actionItem, owner: "")
+        XCTAssertEqual(unassigned.map(\.text), ["Follow up with legal"])
+    }
+
+    func testRollsUpAcrossMeetingsNewestFirst() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(date: "2026-04-10", decisions: ["Older decision"]),
+            filename: "Call_2026-04-10_09-15-00", to: tempDir
+        )
+        try writeFixture(
+            makeMeetingWithInlineSummary(date: "2026-04-20", decisions: ["Newer decision"]),
+            filename: "Call_2026-04-20_09-15-00", to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let decisions = try index.listSummaryItems(kind: TranscriptIndex.SummaryItemKind.decision)
+        XCTAssertEqual(decisions.map(\.text), ["Newer decision", "Older decision"])
+
+        let dated = try index.listSummaryItems(
+            kind: TranscriptIndex.SummaryItemKind.decision,
+            dateFrom: "2026-04-15"
+        )
+        XCTAssertEqual(dated.map(\.text), ["Newer decision"])
+    }
+
+    func testReindexReplacesSummaryItems() throws {
+        let filename = "Call_2026-04-18_09-15-00"
+        try writeFixture(makeMeetingWithInlineSummary(), filename: filename, to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+        XCTAssertEqual(try index.listSummaryItems(kind: TranscriptIndex.SummaryItemKind.decision).count, 2)
+
+        // Rewrite the same meeting with a single decision; reconcile should
+        // replace, not accumulate.
+        try writeFixture(
+            makeMeetingWithInlineSummary(decisions: ["Only one decision now"]),
+            filename: filename, to: tempDir
+        )
+        // Bump mtime so reconcile re-indexes.
+        let url = tempDir.appendingPathComponent("\(filename).md")
+        try FileManager.default.setAttributes([.modificationDate: Date().addingTimeInterval(5)], ofItemAtPath: url.path)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let decisions = try index.listSummaryItems(kind: TranscriptIndex.SummaryItemKind.decision)
+        XCTAssertEqual(decisions.map(\.text), ["Only one decision now"])
+    }
+
+    func testRemovingMeetingClearsSummaryItems() throws {
+        let filename = "Call_2026-04-18_09-15-00"
+        try writeFixture(makeMeetingWithInlineSummary(), filename: filename, to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+        XCTAssertFalse(try index.listSummaryItems().isEmpty)
+
+        try FileManager.default.removeItem(at: tempDir.appendingPathComponent("\(filename).md"))
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+        XCTAssertTrue(try index.listSummaryItems().isEmpty)
+    }
+
+    func testMeetingWithoutSummaryIndexesNoItems() throws {
+        try writeFixture(makeFixtureJSON(), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+        XCTAssertTrue(try index.listSummaryItems().isEmpty)
+        // The transcript itself still indexes as a meeting.
+        XCTAssertEqual(try index.listRecentMeetings(count: 10).count, 1)
+    }
+
+    func testOlderSchemaVersionForcesRebuild() throws {
+        // Simulate a pre-v2 index: index a meeting-with-summary, then stamp the
+        // on-disk DB back to an older user_version to mimic an index built before
+        // meeting_summary_items existed.
+        try writeFixture(makeMeetingWithInlineSummary(), filename: "Call_2026-04-18_09-15-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+        XCTAssertFalse(try index.listSummaryItems().isEmpty)
+        index = nil // close the handle (deinit closes the db)
+
+        let dbPath = tempDir.appendingPathComponent("mcp_index.sqlite").path
+        var raw: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(dbPath, &raw), SQLITE_OK)
+        XCTAssertEqual(sqlite3_exec(raw, "PRAGMA user_version=1", nil, nil, nil), SQLITE_OK)
+        sqlite3_close(raw)
+
+        // Reopening trips the schema gate, which wipes the stale index.
+        let reopened = try TranscriptIndex(indexDir: tempDir)
+        XCTAssertTrue(try reopened.listRecentMeetings(count: 10).isEmpty)
+
+        // A reconcile rebuilds everything, now including summary items.
+        try reopened.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+        XCTAssertEqual(try reopened.listRecentMeetings(count: 10).count, 1)
+        XCTAssertEqual(try reopened.listSummaryItems(kind: TranscriptIndex.SummaryItemKind.decision).count, 2)
+    }
+
+    func testGeneratedSidecarIsNotIndexedAsMeetingButFeedsSummary() throws {
+        // A transcript with no inline summary, plus a `<stem>.summary.md` sidecar.
+        try writeFixture(makeFixtureJSON(), filename: "2026-04-18 Beta sync", to: tempDir)
+        let sidecar = """
+        ---
+        capture_type: meeting_summary
+        source_transcript: "2026-04-18 Beta sync.md"
+        summary_title: "Beta sync"
+        ---
+
+        # Decisions
+        - Adopt the sidecar plan
+
+        # Action Items
+        - Sam: wire the rollup
+
+        # Open Questions
+        - None found.
+        """
+        try writeFixture(sidecar, filename: "2026-04-18 Beta sync.summary", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        // The sidecar must not appear as its own meeting row.
+        let meetings = try index.listRecentMeetings(count: 10)
+        XCTAssertEqual(meetings.count, 1)
+        XCTAssertEqual(meetings.first?.filename, "2026-04-18 Beta sync")
+
+        // Its summary feeds the parent transcript's summary items.
+        let decisions = try index.listSummaryItems(kind: TranscriptIndex.SummaryItemKind.decision)
+        XCTAssertEqual(decisions.map(\.text), ["Adopt the sidecar plan"])
+        XCTAssertEqual(decisions.first?.filename, "2026-04-18 Beta sync")
+        let actions = try index.listSummaryItems(kind: TranscriptIndex.SummaryItemKind.actionItem)
+        XCTAssertEqual(actions.first?.owner, "Sam")
+    }
+}

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TestHelpers.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TestHelpers.swift
@@ -137,6 +137,59 @@ func writeFixture(_ content: String, filename: String, to directory: URL) throws
     try content.write(to: path, atomically: true, encoding: .utf8)
 }
 
+/// Minimal meeting transcript carrying an inline local summary, mirroring what
+/// LocalMeetingSummaryMarkdownUpdater writes: `local_summary_*` frontmatter keys
+/// plus a marker-bounded `## Local Summary` body block with `###` subsections.
+func makeMeetingWithInlineSummary(
+    date: String = "2026-04-18",
+    time: String = "09:15:00",
+    decisions: [String] = ["Ship the beta on Friday", "Cut the legacy import path"],
+    actionItems: [String] = ["Jenny: send the revised spec", "Follow up with legal"],
+    openQuestions: [String] = ["Do we need a migration window?"]
+) -> String {
+    func block(_ heading: String, _ items: [String]) -> String {
+        let body = items.isEmpty ? "- None found." : items.map { "- \($0)" }.joined(separator: "\n")
+        return "\(heading)\n\(body)"
+    }
+    func frontmatter(_ items: [String]) -> String {
+        items.isEmpty ? "None found." : items.joined(separator: " | ")
+    }
+    return """
+    ---
+    capture_type: meeting
+    date: \(date)
+    time: \(time)
+    duration: "30:00"
+    transcription_engine: parakeet_local
+    diarization_engine: pyannote_offline
+    local_summary_version: "1"
+    local_summary_title: "Beta launch sync"
+    local_summary_decisions: "\(frontmatter(decisions))"
+    local_summary_action_items: "\(frontmatter(actionItems))"
+    local_summary_open_questions: "\(frontmatter(openQuestions))"
+    ---
+
+    # Meeting
+
+    ## Full Transcript
+
+    [00:00] [System/Jenny] Let's lock the launch.
+
+    <!-- transcripted:local-summary:start v=1 -->
+    ## Local Summary
+
+    ### Summary
+    - The team aligned on launch.
+
+    \(block("### Decisions", decisions))
+
+    \(block("### Open Questions", openQuestions))
+
+    \(block("### Action Items", actionItems))
+    <!-- transcripted:local-summary:end -->
+    """
+}
+
 func makeDictationDayJSON(
     date: String = "2026-04-07",
     markdownFilename: String = "Dictations_2026-04-07.md",

--- a/docs/NEXT_WORK.md
+++ b/docs/NEXT_WORK.md
@@ -1,0 +1,22 @@
+# Transcripted — What's Next
+
+The ~30 things in flight are converging (UI polish, speaker accuracy, data-loss, telemetry). This is what to do *after* that lands. The theme: turn the local meeting library into a thing an agent can actually answer questions over. That's the moat cloud notetakers can't copy on private data.
+
+## DO NEXT
+Ranked by impact-for-effort. Do them in order.
+
+1. **Index the summary fields (Decisions / Action Items / Open Questions) into the search DB.** The summarizer already writes these to each meeting; the search index never reads them. This one hop is the whole "ask my history" unlock. (M)
+2. **Make recap/recent_context return the real summary, not the first 15 lines of small-talk.** Today the agent's orientation tools return greetings and audio checks. The summary is already in the same file — just point at it. Cheapest high-value fix here. (S)
+3. **Make dictation saves crash-safe.** The most-used capture surface is the one place a crash mid-write can silently corrupt a whole day's entries. Everything else already writes atomically; copy that pattern. (M)
+4. **Add the cross-meeting tools: list_action_items, list_decisions, digest.** Once the fields are indexed (#1), this is the demo: "every open action item assigned to me, across every call." No cloud tool can do this on private data. (M)
+5. **Always-on cheap extraction at save time.** Right now summaries only exist if you opt into the heavy beta. Extract on every save so the moat covers 100% of meetings, not a subset. (M)
+
+## AFTER THAT
+6. **Local semantic search** — bundle a small embedding model so paraphrase queries hit ("pricing pushback" finds "they balked at the cost"). The one thing cloud RAG still beats us on. (L)
+7. **Multi-exemplar voiceprints** — store several voice samples per person instead of one averaged blob, so clean-mic and Zoom versions of the same voice both match. Land after the ERes2Net upgrade. (L)
+8. **Reversible speaker merges** — a wrong auto-merge permanently fuses two real people today, with no undo. Add provenance + un-merge before the more-aggressive merge work goes live. (L)
+9. **Negative exemplars** — when a user corrects a wrong speaker, learn "not this person" instead of just freezing the profile. Turns every correction into training signal. (M)
+10. **Index meetings for the Home list** — stop re-reading every transcript file on every Home refresh; point the list at the table that already exists. (L)
+
+## THE ONE BET
+**Index the summary fields and ship the cross-meeting tools (#1 + #4).** It's wiring, not machine learning, and it's the only thing here that gives the agent a memory cloud notetakers structurally can't match — and that moat gets stronger every meeting added.


### PR DESCRIPTION
## What

Makes the structured summary fields (**Decisions / Action Items / Open Questions**) queryable from the Transcripted MCP index. Today the summarizer extracts these into each meeting's summary, but the MCP index (`TranscriptIndex`) only builds FTS over raw utterances + dictation — it never parses the summary. There was no decisions/action_items/open_questions table anywhere.

This is the **indexing foundation only**. The cross-meeting tools (`list_action_items`, etc.) are a separate thread that builds on `listSummaryItems`.

## How

**Parser (`TranscriptedCaptureKit`)** — new `CaptureSummaryParser` → `ParsedMeetingSummary`. The app-target preview parser (`RecentMeetingSummaryPreviewParser` in `Sources/UI/Shared/RecentCaptureScanners.swift`) can't be imported across the module boundary, so the proven section logic is ported into the shared kit that the standalone tools already depend on. Handles both shapes:
- inline transcript summary (`local_summary_version` frontmatter + marker-bounded `## Local Summary` body block with `###` subsections, plus pipe-joined `local_summary_*` frontmatter fallback)
- legacy generated `meeting_summary` sidecar (`#` sections)

Action-item owner is extracted conservatively: a leading Title-Case name/team before `": "` (≤3 words, ≤24 chars, no lowercase function words), with placeholders (`unassigned`, `tbd`, `team`, …) normalized to unassigned. `Discuss the new API: …` stays plain text.

**Index (`TranscriptedMCP`)**
- One normalized `meeting_summary_items` table (`kind` discriminator + `owner` + FTS5 + AI/AD triggers, mirroring the `utterances` pattern). A single table with a `kind` column rolls up trivially across meetings — designed so the future tools thread can `GROUP BY owner` / filter by kind without a per-category table.
- Parse + insert in `indexMeeting` (inside the existing transaction); delete in `removeFromIndex`.
- `listSummaryItems(kind:owner:dateFrom:dateTo:)` is the cross-meeting query foundation (`owner: ""` selects unassigned).
- Exclude `*.summary.md` sidecars from meeting enumeration — read as a summary fallback instead of being indexed as empty junk meetings.
- Schema `user_version` gate (v2): existing on-disk indexes rebuild once on upgrade, since unchanged transcript mtimes would otherwise skip backfill. (The live path writes the summary *into* the transcript, so re-summarizing bumps its mtime and reconcile catches it; the sidecar-only staleness is a documented legacy-path limitation.)

## Tests

- `CaptureSummaryParserTests` (9) — inline/sidecar parsing, owner extraction + sentence-colon guard, placeholder normalization, None-found → empty, frontmatter fallback, nil cases.
- `SummaryItemIndexTests` (8) — parse→index→query, owner + unassigned rollup, date filter, newest-first ordering, reindex-replaces, delete-clears, sidecar-not-a-meeting, older-schema-forces-rebuild.

## Verification

Per `.agents/test-matrix.yml` (touched `TranscriptedCaptureKit/**` + MCP):

- `swift test --package-path Tools/TranscriptedCaptureKit` → 34 pass
- `swift test --package-path Tools/TranscriptedCLI` → 45 pass
- `swift test --package-path Tools/TranscriptedMCP` → 82 pass
- `bash run-e2e-smoke.sh` → OK

Independent codex review: PASS, no P1. The two P2s it raised (backfill on upgrade; sidecar-only staleness) are addressed by the schema-version gate and documented, respectively.

## Unblocks

Cross-meeting tools thread (`list_action_items`, open-questions roll-up) builds on `meeting_summary_items` + `listSummaryItems`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)