### PR TITLE
feat(speakers): reversible speaker merges (provenance + un-merge)

### DIFF
--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -114,6 +114,7 @@ Current direct core coverage includes:
 - `Tests/TranscriptedCoreTests/SpeakerNamingSimulationRunnerTests.swift`
 - `Tests/SpeakerPeopleReviewPolicyTests.swift`
 - `Tests/TranscriptedCoreTests/SpeakerProfileMergerTests.swift`
+- `Tests/TranscriptedCoreTests/SpeakerProvenanceTests.swift`
 - `Tests/TranscriptedCoreTests/StatsDatabaseTests.swift`
 - `Tests/TranscriptedCoreTests/TranscriptFrontmatterTests.swift`
 - `Tests/TranscriptedCoreTests/TranscriptMetadataBuilderTests.swift`

--- a/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerDatabase.swift
@@ -145,6 +145,7 @@ public final class SpeakerDatabase: @unchecked Sendable {
         executeSQL(sql)
         FileManager.default.restrictSQLiteArtifactsToOwnerOnly(atPath: dbPath.path)
         migrateSchema()
+        createProvenanceTablesImpl()
     }
 
     /// Add columns that may be missing from older databases.
@@ -280,6 +281,8 @@ public final class SpeakerDatabase: @unchecked Sendable {
 
             if !sqlSucceeded {
                 AppLogger.speakers.error("CRITICAL: speaker update was NOT persisted to database — returning stale profile", ["id": existingId.uuidString])
+            } else {
+                recordContributionImpl(profileId: existingId, embedding: embedding, kind: SpeakerProvenanceKind.contribution)
             }
 
             return SpeakerProfile(
@@ -322,6 +325,8 @@ public final class SpeakerDatabase: @unchecked Sendable {
 
             if !sqlSucceeded {
                 AppLogger.speakers.error("CRITICAL: new speaker was NOT persisted to database — profile exists only in memory", ["id": newId.uuidString])
+            } else {
+                recordContributionImpl(profileId: newId, embedding: embedding, kind: SpeakerProvenanceKind.seed)
             }
 
             AppLogger.speakers.info("Created new speaker", ["id": "\(newId)"])

--- a/Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift
@@ -158,7 +158,7 @@ extension SpeakerDatabase {
         }
     }
 
-    func mergeProfilesImpl(sourceId: UUID, into targetId: UUID) {
+    func mergeProfilesImpl(sourceId: UUID, into targetId: UUID, kind: String = SpeakerMergeKind.explicit) {
         guard let source = getSpeakerImpl(id: sourceId),
               let target = getSpeakerImpl(id: targetId) else {
             AppLogger.speakers.warning("Merge failed — profile not found", [
@@ -200,6 +200,11 @@ extension SpeakerDatabase {
 
         // Wrap UPDATE + DELETE in a transaction so a crash between them can't orphan data
         transaction {
+            // Safety net: snapshot both profiles + re-point provenance BEFORE the blend
+            // overwrites the target and the source row is deleted, so a wrong merge can
+            // be reconstructed into two distinct profiles later. Same transaction → atomic.
+            recordMergeEventImpl(source: source, target: target, kind: kind)
+
             let sql = """
             UPDATE speakers SET embedding = ?, last_seen = ?, call_count = ?, confidence = ?
             WHERE id = ?;
@@ -300,7 +305,7 @@ extension SpeakerDatabase {
                 }
 
                 // Merge via mergeProfilesImpl (blends embeddings, transfers name, deletes source)
-                mergeProfilesImpl(sourceId: absorbed.id, into: keeper.id)
+                mergeProfilesImpl(sourceId: absorbed.id, into: keeper.id, kind: SpeakerMergeKind.duplicate)
 
                 mergedIds.insert(absorbed.id)
                 mergeCount += 1
@@ -369,7 +374,7 @@ extension SpeakerDatabase {
             let keeper = sorted[0]
 
             for source in sorted.dropFirst() {
-                mergeProfilesImpl(sourceId: source.id, into: keeper.id)
+                mergeProfilesImpl(sourceId: source.id, into: keeper.id, kind: SpeakerMergeKind.byName)
                 mergeCount += 1
             }
 

--- a/Sources/TranscriptedCore/Speaker/SpeakerProfileProvenance.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerProfileProvenance.swift
@@ -1,0 +1,696 @@
+// SpeakerProfileProvenance.swift
+// Provenance + reversible-merge safety net for the speaker database.
+//
+// A wrong speaker merge used to be permanently lossy: mergeProfilesImpl L2-blends
+// the source embedding into the target and DELETEs the source row, so the original
+// embeddings were unrecoverable and there was no record of which clips built a
+// profile or what a merge fused.
+//
+// This file adds two audit tables and the un-merge / reassignment paths on top of
+// them, entirely on the concrete `SpeakerDatabase` so the `SpeakerStore` protocol
+// (the matching/merge surface other work edits) stays untouched:
+//
+//   speaker_provenance   — one row per contribution that built a profile (the mean
+//                          embedding a recording added) plus a marker row per fuse.
+//   speaker_merge_events — full pre-merge snapshots of BOTH source and target for
+//                          every merge, so an un-merge reconstructs two distinct
+//                          profiles exactly from the retained embeddings rather than
+//                          trying to arithmetically invert the (non-invertible) blend.
+//
+// Un-merge is restricted to the most-recent non-undone merge for a target (LIFO):
+// restoring a target to an older snapshot would silently drop merges layered on top
+// of it, so we refuse instead of corrupting identity a second time.
+
+import Foundation
+import SQLite3
+
+/// User-facing record of a merge that can be undone.
+public struct SpeakerMergeRecord: Identifiable, Sendable {
+    public let id: UUID
+    public let sourceId: UUID
+    public let targetId: UUID
+    public let sourceName: String?
+    public let targetName: String?
+    public let kind: String          // SpeakerMergeKind.rawValue
+    public let mergedAt: Date
+    public let isUndone: Bool
+
+    public init(
+        id: UUID,
+        sourceId: UUID,
+        targetId: UUID,
+        sourceName: String?,
+        targetName: String?,
+        kind: String,
+        mergedAt: Date,
+        isUndone: Bool
+    ) {
+        self.id = id
+        self.sourceId = sourceId
+        self.targetId = targetId
+        self.sourceName = sourceName
+        self.targetName = targetName
+        self.kind = kind
+        self.mergedAt = mergedAt
+        self.isUndone = isUndone
+    }
+}
+
+/// Audit record of a single contribution (clip/recording mean embedding, or a merge
+/// fusion marker) that built a profile.
+public struct SpeakerContribution: Identifiable, Sendable {
+    public let id: UUID
+    public let profileId: UUID
+    public let kind: String          // SpeakerProvenanceKind.rawValue
+    public let sourceProfileId: UUID? // set for `merge` fusion markers
+    public let recordedAt: Date
+    public let hasEmbedding: Bool
+
+    public init(
+        id: UUID,
+        profileId: UUID,
+        kind: String,
+        sourceProfileId: UUID?,
+        recordedAt: Date,
+        hasEmbedding: Bool
+    ) {
+        self.id = id
+        self.profileId = profileId
+        self.kind = kind
+        self.sourceProfileId = sourceProfileId
+        self.recordedAt = recordedAt
+        self.hasEmbedding = hasEmbedding
+    }
+}
+
+/// Where a provenance row came from.
+public enum SpeakerProvenanceKind {
+    public static let seed = "seed"                 // first embedding that created the profile
+    public static let contribution = "contribution" // a later recording's mean embedding
+    public static let merge = "merge"               // marker: an absorbed profile fused in here
+}
+
+/// What kind of merge produced a merge event.
+public enum SpeakerMergeKind {
+    public static let explicit = "explicit"   // user/coordinator merged two profiles
+    public static let duplicate = "duplicate" // auto duplicate-merge after a recording
+    public static let byName = "by_name"      // same-display-name fuse
+}
+
+@available(macOS 14.0, *)
+extension SpeakerDatabase {
+
+    // MARK: - Schema
+
+    /// Create the provenance + merge-event tables. Idempotent; called from createTables().
+    func createProvenanceTablesImpl() {
+        let provenance = """
+        CREATE TABLE IF NOT EXISTS speaker_provenance (
+            id TEXT PRIMARY KEY,
+            profile_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            embedding BLOB,
+            source_profile_id TEXT,
+            merge_event_id TEXT,
+            recorded_at TEXT NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+        """
+        executeSQL(provenance)
+        executeSQL("CREATE INDEX IF NOT EXISTS idx_provenance_profile ON speaker_provenance(profile_id);")
+        executeSQL("CREATE INDEX IF NOT EXISTS idx_provenance_event ON speaker_provenance(merge_event_id);")
+
+        let mergeEvents = """
+        CREATE TABLE IF NOT EXISTS speaker_merge_events (
+            id TEXT PRIMARY KEY,
+            target_id TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            source_snapshot TEXT NOT NULL,
+            target_snapshot TEXT NOT NULL,
+            moved_provenance_ids TEXT,
+            merged_at TEXT NOT NULL,
+            undone_at TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+        """
+        executeSQL(mergeEvents)
+        executeSQL("CREATE INDEX IF NOT EXISTS idx_merge_target ON speaker_merge_events(target_id);")
+    }
+
+    // MARK: - Recording (called on the serialized queue)
+
+    /// Record one contribution embedding that built a profile. Best-effort audit —
+    /// never blocks or fails the speaker write. Must be called on `queue`.
+    func recordContributionImpl(profileId: UUID, embedding: [Float], kind: String) {
+        guard isDatabaseOpen, !embedding.isEmpty else { return }
+        let sql = """
+        INSERT INTO speaker_provenance (id, profile_id, kind, embedding, source_profile_id, merge_event_id, recorded_at)
+        VALUES (?, ?, ?, ?, NULL, NULL, ?);
+        """
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+            let embeddingData = embedding.withUnsafeBufferPointer { Data(buffer: $0) }
+            let now = ISO8601DateFormatter().string(from: Date())
+            sqlite3_bind_text(statement, 1, (UUID().uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(statement, 2, (profileId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(statement, 3, (kind as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_blob(statement, 4, (embeddingData as NSData).bytes, Int32(embeddingData.count), SQLITE_TRANSIENT)
+            sqlite3_bind_text(statement, 5, (now as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            if sqlite3_step(statement) != SQLITE_DONE {
+                AppLogger.speakers.error("Failed to record speaker provenance", ["sqlite_error": dbErrorMessage(), "profileId": profileId.uuidString])
+            }
+        } else {
+            AppLogger.speakers.error("Failed to prepare provenance insert", ["sqlite_error": dbErrorMessage()])
+        }
+        sqlite3_finalize(statement)
+    }
+
+    /// Snapshot both profiles, re-point the source's provenance onto the target, and
+    /// drop a merge marker — all on the open connection so the caller can run it inside
+    /// the same transaction as the embedding blend + source delete. Must be called on
+    /// `queue`, inside a transaction. Returns the new merge-event id (nil on failure).
+    @discardableResult
+    func recordMergeEventImpl(source: SpeakerProfile, target: SpeakerProfile, kind: String) -> UUID? {
+        guard isDatabaseOpen else { return nil }
+        guard let sourceSnapshot = Self.encodeProfileSnapshot(source),
+              let targetSnapshot = Self.encodeProfileSnapshot(target) else {
+            AppLogger.speakers.error("Failed to encode merge snapshot — skipping provenance", ["sourceId": source.id.uuidString])
+            return nil
+        }
+
+        let eventId = UUID()
+        let movedIds = provenanceIdsImpl(forProfileId: source.id)
+        let movedIdsJSON = (try? JSONEncoder().encode(movedIds.map { $0.uuidString }))
+            .flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
+        let now = ISO8601DateFormatter().string(from: Date())
+
+        let insertEvent = """
+        INSERT INTO speaker_merge_events
+            (id, target_id, source_id, kind, source_snapshot, target_snapshot, moved_provenance_ids, merged_at, undone_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL);
+        """
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(db, insertEvent, -1, &statement, nil) == SQLITE_OK else {
+            AppLogger.speakers.error("Failed to prepare merge-event insert", ["sqlite_error": dbErrorMessage()])
+            sqlite3_finalize(statement)
+            return nil
+        }
+        sqlite3_bind_text(statement, 1, (eventId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 2, (target.id.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 3, (source.id.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 4, (kind as NSString).utf8String, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 5, (sourceSnapshot as NSString).utf8String, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 6, (targetSnapshot as NSString).utf8String, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 7, (movedIdsJSON as NSString).utf8String, -1, SQLITE_TRANSIENT)
+        sqlite3_bind_text(statement, 8, (now as NSString).utf8String, -1, SQLITE_TRANSIENT)
+        if sqlite3_step(statement) != SQLITE_DONE {
+            AppLogger.speakers.error("Failed to insert merge event", ["sqlite_error": dbErrorMessage()])
+            sqlite3_finalize(statement)
+            return nil
+        }
+        sqlite3_finalize(statement)
+
+        // Re-point the absorbed profile's provenance onto the keeper.
+        execBind(
+            "UPDATE speaker_provenance SET profile_id = ? WHERE profile_id = ?;",
+            [target.id.uuidString, source.id.uuidString],
+            label: "re-point provenance"
+        )
+
+        // Marker row so the keeper's history shows what fused in.
+        let marker = """
+        INSERT INTO speaker_provenance (id, profile_id, kind, embedding, source_profile_id, merge_event_id, recorded_at)
+        VALUES (?, ?, ?, NULL, ?, ?, ?);
+        """
+        var markerStmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, marker, -1, &markerStmt, nil) == SQLITE_OK {
+            sqlite3_bind_text(markerStmt, 1, (UUID().uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(markerStmt, 2, (target.id.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(markerStmt, 3, (SpeakerProvenanceKind.merge as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(markerStmt, 4, (source.id.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(markerStmt, 5, (eventId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(markerStmt, 6, (now as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            if sqlite3_step(markerStmt) != SQLITE_DONE {
+                AppLogger.speakers.error("Failed to insert merge marker", ["sqlite_error": dbErrorMessage()])
+            }
+        }
+        sqlite3_finalize(markerStmt)
+
+        return eventId
+    }
+
+    // MARK: - Public queries
+
+    /// Recent merges that can still be undone, newest first.
+    public func recentUndoableMerges(limit: Int = 25) -> [SpeakerMergeRecord] {
+        queue.sync { recentUndoableMergesImpl(limit: limit) }
+    }
+
+    /// The most recent still-undoable merge whose keeper is `targetId`, if any.
+    public func undoableMerge(forTargetId targetId: UUID) -> SpeakerMergeRecord? {
+        queue.sync {
+            recentUndoableMergesImpl(limit: 200).first { $0.targetId == targetId }
+        }
+    }
+
+    /// Audit trail of contributions that built a profile, newest first.
+    public func contributions(forProfileId profileId: UUID) -> [SpeakerContribution] {
+        queue.sync { contributionsImpl(forProfileId: profileId) }
+    }
+
+    /// Undo the most recent still-undoable merge whose keeper is `targetId`.
+    /// Returns true if a merge was reversed.
+    @discardableResult
+    public func unmergeMostRecent(forTargetId targetId: UUID) -> Bool {
+        queue.sync {
+            guard let record = recentUndoableMergesImpl(limit: 200).first(where: { $0.targetId == targetId }) else {
+                return false
+            }
+            return unmergeImpl(mergeId: record.id)
+        }
+    }
+
+    /// Undo a specific merge by event id. Refuses (returns false) if a newer non-undone
+    /// merge targets the same keeper, since restoring the older snapshot would drop it.
+    @discardableResult
+    public func unmerge(mergeId: UUID) -> Bool {
+        queue.sync { unmergeImpl(mergeId: mergeId) }
+    }
+
+    /// Move a single contribution to another profile and re-derive both profiles'
+    /// embeddings from their remaining contribution embeddings (mean → L2 normalize).
+    /// Embedding/call-count re-derivation is best-effort: it only applies to profiles
+    /// that have stored contribution embeddings (i.e. built after provenance shipped).
+    @discardableResult
+    public func reassignContribution(id contributionId: UUID, toProfileId: UUID) -> Bool {
+        queue.sync { reassignContributionImpl(id: contributionId, toProfileId: toProfileId) }
+    }
+
+    // MARK: - Impl
+
+    private func recentUndoableMergesImpl(limit: Int) -> [SpeakerMergeRecord] {
+        guard isDatabaseOpen else { return [] }
+        var records: [SpeakerMergeRecord] = []
+        // Order by rowid (monotonic insertion order) — merged_at only has second
+        // precision, so two merges in the same second would order non-deterministically.
+        let sql = """
+        SELECT id, target_id, source_id, kind, source_snapshot, target_snapshot, merged_at
+        FROM speaker_merge_events
+        WHERE undone_at IS NULL
+        ORDER BY rowid DESC
+        LIMIT ?;
+        """
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_int(statement, 1, Int32(max(0, limit)))
+            let isoFormatter = ISO8601DateFormatter()
+            while sqlite3_step(statement) == SQLITE_ROW {
+                guard let idStr = sqlite3_column_text(statement, 0).map(String.init(cString:)),
+                      let id = UUID(uuidString: idStr),
+                      let targetStr = sqlite3_column_text(statement, 1).map(String.init(cString:)),
+                      let targetId = UUID(uuidString: targetStr),
+                      let sourceStr = sqlite3_column_text(statement, 2).map(String.init(cString:)),
+                      let sourceId = UUID(uuidString: sourceStr) else { continue }
+                let kind = sqlite3_column_text(statement, 3).map(String.init(cString:)) ?? SpeakerMergeKind.explicit
+                let sourceSnapshot = sqlite3_column_text(statement, 4).map(String.init(cString:))
+                let targetSnapshot = sqlite3_column_text(statement, 5).map(String.init(cString:))
+                let mergedAtStr = sqlite3_column_text(statement, 6).map(String.init(cString:)) ?? ""
+                records.append(SpeakerMergeRecord(
+                    id: id,
+                    sourceId: sourceId,
+                    targetId: targetId,
+                    sourceName: sourceSnapshot.flatMap { Self.decodeProfileSnapshot($0)?.displayName },
+                    targetName: targetSnapshot.flatMap { Self.decodeProfileSnapshot($0)?.displayName },
+                    kind: kind,
+                    mergedAt: isoFormatter.date(from: mergedAtStr) ?? Date.distantPast,
+                    isUndone: false
+                ))
+            }
+        } else {
+            AppLogger.speakers.error("Failed to prepare recentUndoableMerges", ["sqlite_error": dbErrorMessage()])
+        }
+        sqlite3_finalize(statement)
+        return records
+    }
+
+    private func contributionsImpl(forProfileId profileId: UUID) -> [SpeakerContribution] {
+        guard isDatabaseOpen else { return [] }
+        var rows: [SpeakerContribution] = []
+        let sql = """
+        SELECT id, profile_id, kind, source_profile_id, recorded_at, (embedding IS NOT NULL)
+        FROM speaker_provenance WHERE profile_id = ? ORDER BY recorded_at DESC;
+        """
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, (profileId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            let isoFormatter = ISO8601DateFormatter()
+            while sqlite3_step(statement) == SQLITE_ROW {
+                guard let idStr = sqlite3_column_text(statement, 0).map(String.init(cString:)),
+                      let id = UUID(uuidString: idStr) else { continue }
+                let kind = sqlite3_column_text(statement, 2).map(String.init(cString:)) ?? SpeakerProvenanceKind.contribution
+                let sourceId = sqlite3_column_text(statement, 3).map(String.init(cString:)).flatMap { UUID(uuidString: $0) }
+                let recordedAtStr = sqlite3_column_text(statement, 4).map(String.init(cString:)) ?? ""
+                let hasEmbedding = sqlite3_column_int(statement, 5) != 0
+                rows.append(SpeakerContribution(
+                    id: id,
+                    profileId: profileId,
+                    kind: kind,
+                    sourceProfileId: sourceId,
+                    recordedAt: isoFormatter.date(from: recordedAtStr) ?? Date.distantPast,
+                    hasEmbedding: hasEmbedding
+                ))
+            }
+        }
+        sqlite3_finalize(statement)
+        return rows
+    }
+
+    private func unmergeImpl(mergeId: UUID) -> Bool {
+        guard isDatabaseOpen else { return false }
+        guard let event = loadMergeEventImpl(id: mergeId), event.undoneAt == nil else {
+            AppLogger.speakers.warning("Un-merge skipped — event missing or already undone", ["mergeId": mergeId.uuidString])
+            return false
+        }
+        guard let sourceSnapshot = Self.decodeProfileSnapshot(event.sourceSnapshot),
+              let targetSnapshot = Self.decodeProfileSnapshot(event.targetSnapshot) else {
+            AppLogger.speakers.error("Un-merge failed — snapshot decode error", ["mergeId": mergeId.uuidString])
+            return false
+        }
+
+        // LIFO safety: a newer non-undone merge into the same keeper means restoring the
+        // older target snapshot would silently drop the newer fuse. Refuse instead.
+        if hasNewerUndoneMergeImpl(targetId: event.targetId, afterRowid: event.rowid) {
+            AppLogger.speakers.warning("Un-merge refused — a newer merge targets the same profile; undo it first", [
+                "mergeId": mergeId.uuidString, "targetId": event.targetId.uuidString
+            ])
+            return false
+        }
+
+        var ok = true
+        transaction {
+            // Re-create the absorbed profile and restore the keeper to its pre-merge state.
+            ok = reinsertProfileSnapshotImpl(sourceSnapshot) && ok
+            ok = reinsertProfileSnapshotImpl(targetSnapshot) && ok
+
+            // Move the absorbed profile's provenance rows back.
+            if !event.movedProvenanceIds.isEmpty {
+                let placeholders = Array(repeating: "?", count: event.movedProvenanceIds.count).joined(separator: ",")
+                let sql = "UPDATE speaker_provenance SET profile_id = ? WHERE id IN (\(placeholders));"
+                var stmt: OpaquePointer?
+                if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+                    sqlite3_bind_text(stmt, 1, (event.sourceId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    for (offset, pid) in event.movedProvenanceIds.enumerated() {
+                        sqlite3_bind_text(stmt, Int32(offset + 2), (pid.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+                    }
+                    if sqlite3_step(stmt) != SQLITE_DONE {
+                        AppLogger.speakers.error("Un-merge failed to restore provenance", ["sqlite_error": dbErrorMessage()])
+                        ok = false
+                    }
+                }
+                sqlite3_finalize(stmt)
+            }
+
+            // Drop the fuse marker and mark the event undone.
+            execBind("DELETE FROM speaker_provenance WHERE merge_event_id = ? AND kind = ?;",
+                     [mergeId.uuidString, SpeakerProvenanceKind.merge], label: "delete merge marker")
+            let now = ISO8601DateFormatter().string(from: Date())
+            execBind("UPDATE speaker_merge_events SET undone_at = ? WHERE id = ?;",
+                     [now, mergeId.uuidString], label: "mark event undone")
+        }
+
+        if ok {
+            AppLogger.speakers.info("Un-merged profiles", [
+                "restoredSource": event.sourceId.uuidString,
+                "restoredTarget": event.targetId.uuidString
+            ])
+        }
+        return ok
+    }
+
+    private func reassignContributionImpl(id contributionId: UUID, toProfileId: UUID) -> Bool {
+        guard isDatabaseOpen else { return false }
+        guard let fromProfileId = contributionProfileIdImpl(contributionId) else {
+            AppLogger.speakers.warning("Reassign skipped — contribution not found", ["contributionId": contributionId.uuidString])
+            return false
+        }
+        guard fromProfileId != toProfileId else { return true }
+        guard getSpeakerImpl(id: toProfileId) != nil else {
+            AppLogger.speakers.warning("Reassign skipped — destination profile missing", ["toProfileId": toProfileId.uuidString])
+            return false
+        }
+
+        var ok = true
+        transaction {
+            execBind("UPDATE speaker_provenance SET profile_id = ? WHERE id = ?;",
+                     [toProfileId.uuidString, contributionId.uuidString], label: "reassign contribution")
+            ok = rederiveProfileFromContributionsImpl(fromProfileId) && ok
+            ok = rederiveProfileFromContributionsImpl(toProfileId) && ok
+        }
+        return ok
+    }
+
+    /// Recompute a profile's embedding and call count from its stored contribution
+    /// embeddings. No-op (returns true) for profiles without stored embeddings.
+    private func rederiveProfileFromContributionsImpl(_ profileId: UUID) -> Bool {
+        let embeddings = contributionEmbeddingsImpl(forProfileId: profileId)
+        guard !embeddings.isEmpty else { return true }
+        guard getSpeakerImpl(id: profileId) != nil else { return true }
+
+        let dim = embeddings[0].count
+        guard dim > 0, embeddings.allSatisfy({ $0.count == dim }) else { return true }
+
+        var mean = [Float](repeating: 0, count: dim)
+        for vector in embeddings {
+            for i in 0..<dim { mean[i] += vector[i] }
+        }
+        let count = Float(embeddings.count)
+        for i in 0..<dim { mean[i] /= count }
+        let normalized = l2Normalize(mean)
+
+        let now = ISO8601DateFormatter().string(from: Date())
+        let sql = "UPDATE speakers SET embedding = ?, call_count = ?, last_seen = ? WHERE id = ?;"
+        var statement: OpaquePointer?
+        var ok = false
+        if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+            let embeddingData = normalized.withUnsafeBufferPointer { Data(buffer: $0) }
+            sqlite3_bind_blob(statement, 1, (embeddingData as NSData).bytes, Int32(embeddingData.count), SQLITE_TRANSIENT)
+            sqlite3_bind_int(statement, 2, Int32(embeddings.count))
+            sqlite3_bind_text(statement, 3, (now as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(statement, 4, (profileId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            ok = sqlite3_step(statement) == SQLITE_DONE
+            if !ok {
+                AppLogger.speakers.error("Failed to re-derive profile from contributions", ["sqlite_error": dbErrorMessage(), "profileId": profileId.uuidString])
+            }
+        }
+        sqlite3_finalize(statement)
+        return ok
+    }
+
+    // MARK: - Small SQLite helpers
+
+    private struct MergeEventRow {
+        let id: UUID
+        let rowid: Int64
+        let targetId: UUID
+        let sourceId: UUID
+        let sourceSnapshot: String
+        let targetSnapshot: String
+        let movedProvenanceIds: [UUID]
+        let mergedAt: String
+        let undoneAt: String?
+    }
+
+    private func loadMergeEventImpl(id: UUID) -> MergeEventRow? {
+        let sql = """
+        SELECT rowid, target_id, source_id, source_snapshot, target_snapshot, moved_provenance_ids, merged_at, undone_at
+        FROM speaker_merge_events WHERE id = ?;
+        """
+        var statement: OpaquePointer?
+        var row: MergeEventRow?
+        if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, (id.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            if sqlite3_step(statement) == SQLITE_ROW {
+                let rowid = sqlite3_column_int64(statement, 0)
+                let targetId = sqlite3_column_text(statement, 1).map(String.init(cString:)).flatMap { UUID(uuidString: $0) }
+                let sourceId = sqlite3_column_text(statement, 2).map(String.init(cString:)).flatMap { UUID(uuidString: $0) }
+                let sourceSnapshot = sqlite3_column_text(statement, 3).map(String.init(cString:)) ?? ""
+                let targetSnapshot = sqlite3_column_text(statement, 4).map(String.init(cString:)) ?? ""
+                let movedJSON = sqlite3_column_text(statement, 5).map(String.init(cString:)) ?? "[]"
+                let mergedAt = sqlite3_column_text(statement, 6).map(String.init(cString:)) ?? ""
+                let undoneAt = sqlite3_column_text(statement, 7).map(String.init(cString:))
+                let movedIds = (movedJSON.data(using: .utf8)
+                    .flatMap { try? JSONDecoder().decode([String].self, from: $0) } ?? [])
+                    .compactMap { UUID(uuidString: $0) }
+                if let targetId, let sourceId {
+                    row = MergeEventRow(
+                        id: id, rowid: rowid, targetId: targetId, sourceId: sourceId,
+                        sourceSnapshot: sourceSnapshot, targetSnapshot: targetSnapshot,
+                        movedProvenanceIds: movedIds, mergedAt: mergedAt, undoneAt: undoneAt
+                    )
+                }
+            }
+        }
+        sqlite3_finalize(statement)
+        return row
+    }
+
+    private func hasNewerUndoneMergeImpl(targetId: UUID, afterRowid rowid: Int64) -> Bool {
+        let sql = """
+        SELECT COUNT(*) FROM speaker_merge_events
+        WHERE target_id = ? AND undone_at IS NULL AND rowid > ?;
+        """
+        var statement: OpaquePointer?
+        var count: Int32 = 0
+        if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, (targetId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_int64(statement, 2, rowid)
+            if sqlite3_step(statement) == SQLITE_ROW {
+                count = sqlite3_column_int(statement, 0)
+            }
+        }
+        sqlite3_finalize(statement)
+        return count > 0
+    }
+
+    private func provenanceIdsImpl(forProfileId profileId: UUID) -> [UUID] {
+        var ids: [UUID] = []
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, "SELECT id FROM speaker_provenance WHERE profile_id = ?;", -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, (profileId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            while sqlite3_step(statement) == SQLITE_ROW {
+                if let str = sqlite3_column_text(statement, 0).map(String.init(cString:)), let id = UUID(uuidString: str) {
+                    ids.append(id)
+                }
+            }
+        }
+        sqlite3_finalize(statement)
+        return ids
+    }
+
+    private func contributionProfileIdImpl(_ contributionId: UUID) -> UUID? {
+        var statement: OpaquePointer?
+        var result: UUID?
+        if sqlite3_prepare_v2(db, "SELECT profile_id FROM speaker_provenance WHERE id = ?;", -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, (contributionId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            if sqlite3_step(statement) == SQLITE_ROW {
+                result = sqlite3_column_text(statement, 0).map(String.init(cString:)).flatMap { UUID(uuidString: $0) }
+            }
+        }
+        sqlite3_finalize(statement)
+        return result
+    }
+
+    private func contributionEmbeddingsImpl(forProfileId profileId: UUID) -> [[Float]] {
+        var embeddings: [[Float]] = []
+        let sql = """
+        SELECT embedding FROM speaker_provenance
+        WHERE profile_id = ? AND embedding IS NOT NULL AND kind != ?;
+        """
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, (profileId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(statement, 2, (SpeakerProvenanceKind.merge as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            while sqlite3_step(statement) == SQLITE_ROW {
+                let blobPtr = sqlite3_column_blob(statement, 0)
+                let blobSize = sqlite3_column_bytes(statement, 0)
+                if let ptr = blobPtr, blobSize > 0 {
+                    let floatCount = Int(blobSize) / MemoryLayout<Float>.size
+                    embeddings.append(Array(UnsafeBufferPointer(start: ptr.assumingMemoryBound(to: Float.self), count: floatCount)))
+                }
+            }
+        }
+        sqlite3_finalize(statement)
+        return embeddings
+    }
+
+    /// INSERT OR REPLACE a profile from a decoded snapshot. Used by un-merge to both
+    /// resurrect a deleted source row and restore the keeper's pre-merge state.
+    private func reinsertProfileSnapshotImpl(_ snapshot: ProfileSnapshot) -> Bool {
+        let sql = """
+        INSERT OR REPLACE INTO speakers
+            (id, display_name, name_source, embedding, first_seen, last_seen, call_count, confidence, dispute_count)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+        """
+        var statement: OpaquePointer?
+        var ok = false
+        if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+            let embeddingData = snapshot.embedding.withUnsafeBufferPointer { Data(buffer: $0) }
+            sqlite3_bind_text(statement, 1, (snapshot.id.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            if let name = snapshot.displayName as NSString? {
+                sqlite3_bind_text(statement, 2, name.utf8String, -1, SQLITE_TRANSIENT)
+            } else {
+                sqlite3_bind_null(statement, 2)
+            }
+            if let source = snapshot.nameSource as NSString? {
+                sqlite3_bind_text(statement, 3, source.utf8String, -1, SQLITE_TRANSIENT)
+            } else {
+                sqlite3_bind_null(statement, 3)
+            }
+            sqlite3_bind_blob(statement, 4, (embeddingData as NSData).bytes, Int32(embeddingData.count), SQLITE_TRANSIENT)
+            sqlite3_bind_text(statement, 5, (snapshot.firstSeen as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_text(statement, 6, (snapshot.lastSeen as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_int(statement, 7, Int32(snapshot.callCount))
+            sqlite3_bind_double(statement, 8, snapshot.confidence)
+            sqlite3_bind_int(statement, 9, Int32(snapshot.disputeCount))
+            ok = sqlite3_step(statement) == SQLITE_DONE
+            if !ok {
+                AppLogger.speakers.error("Failed to reinsert profile snapshot", ["sqlite_error": dbErrorMessage(), "id": snapshot.id.uuidString])
+            }
+        }
+        sqlite3_finalize(statement)
+        return ok
+    }
+
+    /// Prepare/bind/step a write with text params. Best-effort; logs on failure.
+    private func execBind(_ sql: String, _ params: [String], label: String) {
+        var statement: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+            for (offset, value) in params.enumerated() {
+                sqlite3_bind_text(statement, Int32(offset + 1), (value as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            }
+            if sqlite3_step(statement) != SQLITE_DONE {
+                AppLogger.speakers.error("SQL write failed", ["label": label, "sqlite_error": dbErrorMessage()])
+            }
+        } else {
+            AppLogger.speakers.error("SQL prepare failed", ["label": label, "sqlite_error": dbErrorMessage()])
+        }
+        sqlite3_finalize(statement)
+    }
+
+    // MARK: - Snapshot coding
+
+    struct ProfileSnapshot: Codable {
+        let id: UUID
+        let displayName: String?
+        let nameSource: String?
+        let embedding: [Float]
+        let firstSeen: String
+        let lastSeen: String
+        let callCount: Int
+        let confidence: Double
+        let disputeCount: Int
+    }
+
+    static func encodeProfileSnapshot(_ profile: SpeakerProfile) -> String? {
+        let isoFormatter = ISO8601DateFormatter()
+        let snapshot = ProfileSnapshot(
+            id: profile.id,
+            displayName: profile.displayName,
+            nameSource: profile.nameSource,
+            embedding: profile.embedding,
+            firstSeen: isoFormatter.string(from: profile.firstSeen),
+            lastSeen: isoFormatter.string(from: profile.lastSeen),
+            callCount: profile.callCount,
+            confidence: profile.confidence,
+            disputeCount: profile.disputeCount
+        )
+        guard let data = try? JSONEncoder().encode(snapshot) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func decodeProfileSnapshot(_ json: String) -> ProfileSnapshot? {
+        guard let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(ProfileSnapshot.self, from: data)
+    }
+}

--- a/Sources/TranscriptedCore/Speaker/SpeakerProfileProvenance.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerProfileProvenance.swift
@@ -510,14 +510,23 @@ extension SpeakerDatabase {
         }
         let count = Float(embeddings.count)
         for i in 0..<dim { mean[i] /= count }
-        let normalized = l2Normalize(mean)
+
+        // L2-normalize in place (kept self-contained so this method has no cross-file
+        // type-inference dependency — the release WMO build choked resolving the shared
+        // l2Normalize helper from here).
+        var norm: Float = 0
+        for value in mean { norm += value * value }
+        norm = norm.squareRoot()
+        let normalized: [Float] = norm > 0 ? mean.map { $0 / norm } : mean
 
         let now = ISO8601DateFormatter().string(from: Date())
         let sql = "UPDATE speakers SET embedding = ?, call_count = ?, last_seen = ? WHERE id = ?;"
         var statement: OpaquePointer?
         var ok = false
         if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
-            let embeddingData = normalized.withUnsafeBufferPointer { Data(buffer: $0) }
+            let embeddingData = normalized.withUnsafeBufferPointer { buffer in
+                Data(bytes: buffer.baseAddress!, count: buffer.count * MemoryLayout<Float>.stride)
+            }
             sqlite3_bind_blob(statement, 1, (embeddingData as NSData).bytes, Int32(embeddingData.count), SQLITE_TRANSIENT)
             sqlite3_bind_int(statement, 2, Int32(embeddings.count))
             sqlite3_bind_text(statement, 3, (now as NSString).utf8String, -1, SQLITE_TRANSIENT)

--- a/Sources/TranscriptedCore/Speaker/SpeakerProfileProvenance.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerProfileProvenance.swift
@@ -248,10 +248,9 @@ extension SpeakerDatabase {
     }
 
     /// The most recent still-undoable merge whose keeper is `targetId`, if any.
+    /// Targeted indexed lookup — not capped by any recent-list limit.
     public func undoableMerge(forTargetId targetId: UUID) -> SpeakerMergeRecord? {
-        queue.sync {
-            recentUndoableMergesImpl(limit: 200).first { $0.targetId == targetId }
-        }
+        queue.sync { undoableMergeImpl(forTargetId: targetId) }
     }
 
     /// Audit trail of contributions that built a profile, newest first.
@@ -264,9 +263,7 @@ extension SpeakerDatabase {
     @discardableResult
     public func unmergeMostRecent(forTargetId targetId: UUID) -> Bool {
         queue.sync {
-            guard let record = recentUndoableMergesImpl(limit: 200).first(where: { $0.targetId == targetId }) else {
-                return false
-            }
+            guard let record = undoableMergeImpl(forTargetId: targetId) else { return false }
             return unmergeImpl(mergeId: record.id)
         }
     }
@@ -332,6 +329,44 @@ extension SpeakerDatabase {
         }
         sqlite3_finalize(statement)
         return records
+    }
+
+    private func undoableMergeImpl(forTargetId targetId: UUID) -> SpeakerMergeRecord? {
+        guard isDatabaseOpen else { return nil }
+        let sql = """
+        SELECT id, source_id, kind, source_snapshot, target_snapshot, merged_at
+        FROM speaker_merge_events
+        WHERE target_id = ? AND undone_at IS NULL
+        ORDER BY rowid DESC
+        LIMIT 1;
+        """
+        var statement: OpaquePointer?
+        var record: SpeakerMergeRecord?
+        if sqlite3_prepare_v2(db, sql, -1, &statement, nil) == SQLITE_OK {
+            sqlite3_bind_text(statement, 1, (targetId.uuidString as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            if sqlite3_step(statement) == SQLITE_ROW,
+               let idStr = sqlite3_column_text(statement, 0).map(String.init(cString:)),
+               let id = UUID(uuidString: idStr),
+               let sourceStr = sqlite3_column_text(statement, 1).map(String.init(cString:)),
+               let sourceId = UUID(uuidString: sourceStr) {
+                let kind = sqlite3_column_text(statement, 2).map(String.init(cString:)) ?? SpeakerMergeKind.explicit
+                let sourceSnapshot = sqlite3_column_text(statement, 3).map(String.init(cString:))
+                let targetSnapshot = sqlite3_column_text(statement, 4).map(String.init(cString:))
+                let mergedAtStr = sqlite3_column_text(statement, 5).map(String.init(cString:)) ?? ""
+                record = SpeakerMergeRecord(
+                    id: id,
+                    sourceId: sourceId,
+                    targetId: targetId,
+                    sourceName: sourceSnapshot.flatMap { Self.decodeProfileSnapshot($0)?.displayName },
+                    targetName: targetSnapshot.flatMap { Self.decodeProfileSnapshot($0)?.displayName },
+                    kind: kind,
+                    mergedAt: ISO8601DateFormatter().date(from: mergedAtStr) ?? Date.distantPast,
+                    isUndone: false
+                )
+            }
+        }
+        sqlite3_finalize(statement)
+        return record
     }
 
     private func contributionsImpl(forProfileId profileId: UUID) -> [SpeakerContribution] {
@@ -411,9 +446,18 @@ extension SpeakerDatabase {
                 sqlite3_finalize(stmt)
             }
 
-            // Drop the fuse marker and mark the event undone.
+            // Drop the fuse marker so it doesn't linger on the keeper's audit trail.
             execBind("DELETE FROM speaker_provenance WHERE merge_event_id = ? AND kind = ?;",
                      [mergeId.uuidString, SpeakerProvenanceKind.merge], label: "delete merge marker")
+
+            // Re-derive both profiles from their (now disjoint) contribution embeddings.
+            // The snapshots above are exact pre-merge state, but the keeper may have
+            // gained recordings after the merge — re-deriving from contributions keeps
+            // that post-merge learning instead of silently discarding it. No-op (keeps
+            // the snapshot) for legacy profiles that have no stored contribution rows.
+            ok = rederiveProfileFromContributionsImpl(event.sourceId) && ok
+            ok = rederiveProfileFromContributionsImpl(event.targetId) && ok
+
             let now = ISO8601DateFormatter().string(from: Date())
             execBind("UPDATE speaker_merge_events SET undone_at = ? WHERE id = ?;",
                      [now, mergeId.uuidString], label: "mark event undone")

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -78,6 +78,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
     private var duplicateCountsByProfileID: [UUID: Int] = [:]
     private var mergeTargetsByProfileID: [UUID: [SpeakerProfile]] = [:]
     private var clipURLsByProfileID: [UUID: URL] = [:]
+    private var undoableMergesByTargetID: [UUID: SpeakerMergeRecord] = [:]
     private var refreshGeneration = 0
 
     private struct Snapshot {
@@ -88,6 +89,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         let mergeTargetsByProfileID: [UUID: [SpeakerProfile]]
         let clipURLsByProfileID: [UUID: URL]
         let reviewQueueItems: [SpeakerPendingReviewItem]
+        let undoableMergesByTargetID: [UUID: SpeakerMergeRecord]
     }
 
     init(
@@ -340,6 +342,34 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         mergeTargetsByProfileID[profile.id] ?? []
     }
 
+    /// The most recent merge into this profile that can still be undone, if any.
+    func undoableMerge(for profile: SpeakerProfile) -> SpeakerMergeRecord? {
+        undoableMergesByTargetID[profile.id]
+    }
+
+    /// Reverse the most recent merge into `profile`, reconstructing the two distinct
+    /// voice profiles from the embeddings retained at merge time. Past transcripts keep
+    /// the merged name — un-merge restores future voice matching, not transcript text.
+    func unmerge(into profile: SpeakerProfile, completion: ((Bool) -> Void)? = nil) {
+        let targetId = profile.id
+        let speakerDatabase = self.speakerDatabase
+        let preferredClipsDirectory = self.preferredClipsDirectory
+        let legacyClipsDirectory = self.legacyClipsDirectory
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let didUnmerge = speakerDatabase.unmergeMostRecent(forTargetId: targetId)
+            let snapshot = Self.snapshot(
+                from: speakerDatabase,
+                preferredClipsDirectory: preferredClipsDirectory,
+                legacyClipsDirectory: legacyClipsDirectory
+            )
+            DispatchQueue.main.async {
+                self?.applySnapshot(snapshot)
+                completion?(didUnmerge)
+            }
+        }
+    }
+
     private func applySnapshot(_ snapshot: Snapshot) {
         duplicateCandidates = snapshot.duplicateCandidates
         duplicateProfileIDs = snapshot.duplicateProfileIDs
@@ -347,6 +377,7 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         mergeTargetsByProfileID = snapshot.mergeTargetsByProfileID
         clipURLsByProfileID = snapshot.clipURLsByProfileID
         reviewQueueItems = snapshot.reviewQueueItems
+        undoableMergesByTargetID = snapshot.undoableMergesByTargetID
         hasLoadedProfiles = true
         profiles = snapshot.profiles
     }
@@ -356,17 +387,24 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         preferredClipsDirectory: URL,
         legacyClipsDirectory: URL
     ) -> Snapshot {
-        snapshot(
+        // Keep only the newest still-undoable merge per keeper (records arrive newest-first).
+        var undoableMergesByTargetID: [UUID: SpeakerMergeRecord] = [:]
+        for record in speakerDatabase.recentUndoableMerges() where undoableMergesByTargetID[record.targetId] == nil {
+            undoableMergesByTargetID[record.targetId] = record
+        }
+        return snapshot(
             from: sortedProfiles(from: speakerDatabase),
             preferredClipsDirectory: preferredClipsDirectory,
-            legacyClipsDirectory: legacyClipsDirectory
+            legacyClipsDirectory: legacyClipsDirectory,
+            undoableMergesByTargetID: undoableMergesByTargetID
         )
     }
 
     nonisolated private static func snapshot(
         from profiles: [SpeakerProfile],
         preferredClipsDirectory: URL,
-        legacyClipsDirectory: URL
+        legacyClipsDirectory: URL,
+        undoableMergesByTargetID: [UUID: SpeakerMergeRecord] = [:]
     ) -> Snapshot {
         let duplicateCandidates = duplicateCandidates(from: profiles)
         var duplicateCountsByProfileID: [UUID: Int] = [:]
@@ -418,7 +456,8 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
             duplicateCountsByProfileID: duplicateCountsByProfileID,
             mergeTargetsByProfileID: mergeTargetsByProfileID,
             clipURLsByProfileID: clipURLsByProfileID,
-            reviewQueueItems: reviewQueueItems
+            reviewQueueItems: reviewQueueItems,
+            undoableMergesByTargetID: undoableMergesByTargetID
         )
     }
 
@@ -1044,7 +1083,7 @@ private struct SpeakerDuplicateCandidateRow: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This combines their history and can't be undone. Past transcripts are updated.")
+            Text("This combines their voices into one. You can undo it later from the speaker's ••• menu. Past transcripts are updated.")
         }
     }
 
@@ -1155,6 +1194,7 @@ private struct SpeakerPersonRow: View {
     @State private var showDeleteConfirmation = false
     @State private var pendingMergeTarget: SpeakerProfile?
     @State private var showMergeConfirmation = false
+    @State private var showUnmergeConfirmation = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -1221,7 +1261,15 @@ private struct SpeakerPersonRow: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: { _ in
-            Text("This combines their history and can't be undone. Past transcripts are updated.")
+            Text("This combines their voices into one. You can undo it later from this speaker's ••• menu. Past transcripts are updated.")
+        }
+        .alert(unmergeConfirmationTitle, isPresented: $showUnmergeConfirmation) {
+            Button("Undo Merge") {
+                model.unmerge(into: profile)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This splits the merged voice back into two separate profiles so future recordings match the right person. Past transcripts keep the merged name.")
         }
     }
 
@@ -1241,6 +1289,12 @@ private struct SpeakerPersonRow: View {
                             showMergeConfirmation = true
                         }
                     }
+                }
+            }
+
+            if model.undoableMerge(for: profile) != nil {
+                Button("Undo Last Merge…") {
+                    showUnmergeConfirmation = true
                 }
             }
 
@@ -1276,6 +1330,14 @@ private struct SpeakerPersonRow: View {
             return "Merge “\(source)” into another speaker?"
         }
         return "Merge “\(source)” into “\(SpeakerDuplicateCandidate.displayName(for: pendingMergeTarget))”?"
+    }
+
+    private var unmergeConfirmationTitle: String {
+        let name = SpeakerDuplicateCandidate.displayName(for: profile)
+        if let merge = model.undoableMerge(for: profile), let sourceName = merge.sourceName {
+            return "Undo merge of “\(sourceName)” into “\(name)”?"
+        }
+        return "Undo the last merge into “\(name)”?"
     }
 
     private var metadataLine: String {

--- a/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
+++ b/Sources/UI/Settings/SpeakerPeopleSettingsSection.swift
@@ -387,13 +387,17 @@ final class SpeakerPeopleSettingsViewModel: ObservableObject {
         preferredClipsDirectory: URL,
         legacyClipsDirectory: URL
     ) -> Snapshot {
-        // Keep only the newest still-undoable merge per keeper (records arrive newest-first).
+        let profiles = sortedProfiles(from: speakerDatabase)
+        // Look up each visible speaker's newest still-undoable merge directly (indexed
+        // per-target query) so undo never disappears once merge history grows past a cap.
         var undoableMergesByTargetID: [UUID: SpeakerMergeRecord] = [:]
-        for record in speakerDatabase.recentUndoableMerges() where undoableMergesByTargetID[record.targetId] == nil {
-            undoableMergesByTargetID[record.targetId] = record
+        for profile in profiles {
+            if let record = speakerDatabase.undoableMerge(forTargetId: profile.id) {
+                undoableMergesByTargetID[profile.id] = record
+            }
         }
         return snapshot(
-            from: sortedProfiles(from: speakerDatabase),
+            from: profiles,
             preferredClipsDirectory: preferredClipsDirectory,
             legacyClipsDirectory: legacyClipsDirectory,
             undoableMergesByTargetID: undoableMergesByTargetID

--- a/Tests/TranscriptedCoreTests/SpeakerProvenanceTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerProvenanceTests.swift
@@ -159,6 +159,25 @@ final class SpeakerProvenanceTests: XCTestCase {
         XCTAssertTrue(database.contributions(forProfileId: b.id).contains { $0.id == contribution.id })
     }
 
+    func testUnmergePreservesPostMergeTargetLearning() throws {
+        let source = database.addOrUpdateSpeaker(embedding: embedding(axis: 30), existingId: nil)
+        let target = database.addOrUpdateSpeaker(embedding: embedding(axis: 31), existingId: nil)
+
+        database.mergeProfiles(sourceId: source.id, into: target.id)
+
+        // The keeper picks up another recording AFTER the merge.
+        _ = database.addOrUpdateSpeaker(embedding: embedding(axis: 31), existingId: target.id)
+
+        XCTAssertTrue(database.unmergeMostRecent(forTargetId: target.id))
+
+        // Un-merge must not roll the keeper back to its single pre-merge recording —
+        // its own seed + the post-merge recording should both still count.
+        let restoredTarget = try XCTUnwrap(database.getSpeaker(id: target.id))
+        XCTAssertEqual(restoredTarget.callCount, 2, "post-merge learning must survive un-merge")
+        // The absorbed profile is back as its own distinct person.
+        XCTAssertNotNil(database.getSpeaker(id: source.id))
+    }
+
     func testUnmergeNonexistentEventIsNoop() {
         XCTAssertFalse(database.unmerge(mergeId: UUID()))
         XCTAssertFalse(database.unmergeMostRecent(forTargetId: UUID()))

--- a/Tests/TranscriptedCoreTests/SpeakerProvenanceTests.swift
+++ b/Tests/TranscriptedCoreTests/SpeakerProvenanceTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+@testable import TranscriptedCore
+
+@available(macOS 14.0, *)
+final class SpeakerProvenanceTests: XCTestCase {
+
+    private var tempDirectory: URL!
+    private var database: SpeakerDatabase!
+
+    override func setUpWithError() throws {
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SpeakerProvenanceTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        database = SpeakerDatabase(path: tempDirectory.appendingPathComponent("speakers.sqlite").path)
+    }
+
+    override func tearDownWithError() throws {
+        database = nil
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+        tempDirectory = nil
+    }
+
+    /// One-hot-ish 256-dim embedding so two speakers point in orthogonal directions.
+    private func embedding(axis: Int) -> [Float] {
+        var vector = [Float](repeating: 0.01, count: 256)
+        vector[axis] = 1.0
+        return vector
+    }
+
+    private func cosine(_ a: [Float], _ b: [Float]) -> Double {
+        var dot: Double = 0, na: Double = 0, nb: Double = 0
+        for i in 0..<min(a.count, b.count) {
+            dot += Double(a[i]) * Double(b[i])
+            na += Double(a[i]) * Double(a[i])
+            nb += Double(b[i]) * Double(b[i])
+        }
+        guard na > 0, nb > 0 else { return 0 }
+        return dot / (na.squareRoot() * nb.squareRoot())
+    }
+
+    // MARK: - Core safety net
+
+    func testUnmergeRestoresTwoDistinctProfiles() throws {
+        let source = database.addOrUpdateSpeaker(embedding: embedding(axis: 0), existingId: nil)
+        let target = database.addOrUpdateSpeaker(embedding: embedding(axis: 1), existingId: nil)
+        database.setDisplayName(id: source.id, name: "Alice", source: NameSource.userManual)
+        database.setDisplayName(id: target.id, name: "Bob", source: NameSource.userManual)
+
+        let preSource = try XCTUnwrap(database.getSpeaker(id: source.id)).embedding
+        let preTarget = try XCTUnwrap(database.getSpeaker(id: target.id)).embedding
+        // Profiles are genuinely distinct going in.
+        XCTAssertLessThan(cosine(preSource, preTarget), 0.5)
+
+        database.mergeProfiles(sourceId: source.id, into: target.id)
+
+        // Merge fused them: source is gone, only the keeper remains.
+        XCTAssertNil(database.getSpeaker(id: source.id))
+        XCTAssertNotNil(database.getSpeaker(id: target.id))
+
+        let undone = database.unmergeMostRecent(forTargetId: target.id)
+        XCTAssertTrue(undone, "un-merge should reverse the most recent merge")
+
+        // Both profiles exist again as two distinct people.
+        let restoredSource = try XCTUnwrap(database.getSpeaker(id: source.id), "absorbed profile must be reconstructed")
+        let restoredTarget = try XCTUnwrap(database.getSpeaker(id: target.id))
+
+        XCTAssertEqual(restoredSource.displayName, "Alice")
+        XCTAssertEqual(restoredTarget.displayName, "Bob")
+
+        // Embeddings restored to their exact pre-merge state, not the blend.
+        XCTAssertGreaterThan(cosine(restoredSource.embedding, preSource), 0.999)
+        XCTAssertGreaterThan(cosine(restoredTarget.embedding, preTarget), 0.999)
+        XCTAssertLessThan(cosine(restoredSource.embedding, restoredTarget.embedding), 0.5)
+    }
+
+    func testAutoDuplicateMergeIsUndoable() throws {
+        // Two near-identical voices auto-merge after a recording.
+        let a = database.addOrUpdateSpeaker(embedding: [Float](repeating: 0.25, count: 256), existingId: nil)
+        let b = database.addOrUpdateSpeaker(embedding: [Float](repeating: 0.25, count: 256), existingId: nil)
+
+        database.mergeDuplicates(threshold: 0.6)
+
+        // Exactly one survived.
+        let survivor = database.getSpeaker(id: a.id) != nil ? a.id : b.id
+        let absorbed = survivor == a.id ? b.id : a.id
+        XCTAssertNil(database.getSpeaker(id: absorbed))
+
+        let record = try XCTUnwrap(database.undoableMerge(forTargetId: survivor))
+        XCTAssertEqual(record.kind, SpeakerMergeKind.duplicate)
+
+        XCTAssertTrue(database.unmergeMostRecent(forTargetId: survivor))
+        XCTAssertNotNil(database.getSpeaker(id: absorbed), "auto-merge must be reversible")
+        XCTAssertNotNil(database.getSpeaker(id: survivor))
+    }
+
+    func testContributionsRecordedPerProfile() throws {
+        let id = UUID()
+        _ = database.addOrUpdateSpeaker(embedding: embedding(axis: 3), existingId: id)
+        _ = database.addOrUpdateSpeaker(embedding: embedding(axis: 3), existingId: id)
+        _ = database.addOrUpdateSpeaker(embedding: embedding(axis: 3), existingId: id)
+
+        let contributions = database.contributions(forProfileId: id)
+        XCTAssertGreaterThanOrEqual(contributions.count, 3, "each recording should leave a provenance row")
+        XCTAssertTrue(contributions.allSatisfy { $0.hasEmbedding })
+        XCTAssertEqual(contributions.filter { $0.kind == SpeakerProvenanceKind.seed }.count, 1)
+    }
+
+    func testMergeLeavesFuseMarkerThenUndoRemovesIt() throws {
+        let source = database.addOrUpdateSpeaker(embedding: embedding(axis: 5), existingId: nil)
+        let target = database.addOrUpdateSpeaker(embedding: embedding(axis: 6), existingId: nil)
+
+        database.mergeProfiles(sourceId: source.id, into: target.id)
+
+        let afterMerge = database.contributions(forProfileId: target.id)
+        XCTAssertTrue(
+            afterMerge.contains { $0.kind == SpeakerProvenanceKind.merge && $0.sourceProfileId == source.id },
+            "merge should leave a fuse marker on the keeper's audit trail"
+        )
+
+        XCTAssertTrue(database.unmergeMostRecent(forTargetId: target.id))
+        let afterUndo = database.contributions(forProfileId: target.id)
+        XCTAssertFalse(
+            afterUndo.contains { $0.kind == SpeakerProvenanceKind.merge },
+            "un-merge should drop the fuse marker"
+        )
+    }
+
+    func testUnmergeRefusedWhenNewerMergeTargetsSameKeeper() throws {
+        let first = database.addOrUpdateSpeaker(embedding: embedding(axis: 10), existingId: nil)
+        let second = database.addOrUpdateSpeaker(embedding: embedding(axis: 11), existingId: nil)
+        let keeper = database.addOrUpdateSpeaker(embedding: embedding(axis: 12), existingId: nil)
+
+        database.mergeProfiles(sourceId: first.id, into: keeper.id)
+        let firstEvent = try XCTUnwrap(database.undoableMerge(forTargetId: keeper.id))
+        database.mergeProfiles(sourceId: second.id, into: keeper.id)
+
+        // The older merge can't be undone while a newer merge still sits on top.
+        XCTAssertFalse(database.unmerge(mergeId: firstEvent.id))
+        XCTAssertNil(database.getSpeaker(id: first.id))
+
+        // Undo proceeds newest-first.
+        XCTAssertTrue(database.unmergeMostRecent(forTargetId: keeper.id))
+        XCTAssertNotNil(database.getSpeaker(id: second.id))
+        // Now the older one is undoable.
+        XCTAssertTrue(database.unmerge(mergeId: firstEvent.id))
+        XCTAssertNotNil(database.getSpeaker(id: first.id))
+    }
+
+    func testReassignContributionMovesAuditRow() throws {
+        let a = database.addOrUpdateSpeaker(embedding: embedding(axis: 20), existingId: nil)
+        let b = database.addOrUpdateSpeaker(embedding: embedding(axis: 21), existingId: nil)
+
+        let contribution = try XCTUnwrap(database.contributions(forProfileId: a.id).first)
+        XCTAssertTrue(database.reassignContribution(id: contribution.id, toProfileId: b.id))
+
+        XCTAssertFalse(database.contributions(forProfileId: a.id).contains { $0.id == contribution.id })
+        XCTAssertTrue(database.contributions(forProfileId: b.id).contains { $0.id == contribution.id })
+    }
+
+    func testUnmergeNonexistentEventIsNoop() {
+        XCTAssertFalse(database.unmerge(mergeId: UUID()))
+        XCTAssertFalse(database.unmergeMostRecent(forTargetId: UUID()))
+    }
+}

--- a/docs/NEXT_WORK.md
+++ b/docs/NEXT_WORK.md
@@ -1,0 +1,22 @@
+# Transcripted — What's Next
+
+The ~30 things in flight are converging (UI polish, speaker accuracy, data-loss, telemetry). This is what to do *after* that lands. The theme: turn the local meeting library into a thing an agent can actually answer questions over. That's the moat cloud notetakers can't copy on private data.
+
+## DO NEXT
+Ranked by impact-for-effort. Do them in order.
+
+1. **Index the summary fields (Decisions / Action Items / Open Questions) into the search DB.** The summarizer already writes these to each meeting; the search index never reads them. This one hop is the whole "ask my history" unlock. (M)
+2. **Make recap/recent_context return the real summary, not the first 15 lines of small-talk.** Today the agent's orientation tools return greetings and audio checks. The summary is already in the same file — just point at it. Cheapest high-value fix here. (S)
+3. **Make dictation saves crash-safe.** The most-used capture surface is the one place a crash mid-write can silently corrupt a whole day's entries. Everything else already writes atomically; copy that pattern. (M)
+4. **Add the cross-meeting tools: list_action_items, list_decisions, digest.** Once the fields are indexed (#1), this is the demo: "every open action item assigned to me, across every call." No cloud tool can do this on private data. (M)
+5. **Always-on cheap extraction at save time.** Right now summaries only exist if you opt into the heavy beta. Extract on every save so the moat covers 100% of meetings, not a subset. (M)
+
+## AFTER THAT
+6. **Local semantic search** — bundle a small embedding model so paraphrase queries hit ("pricing pushback" finds "they balked at the cost"). The one thing cloud RAG still beats us on. (L)
+7. **Multi-exemplar voiceprints** — store several voice samples per person instead of one averaged blob, so clean-mic and Zoom versions of the same voice both match. Land after the ERes2Net upgrade. (L)
+8. **Reversible speaker merges** — a wrong auto-merge permanently fuses two real people today, with no undo. Add provenance + un-merge before the more-aggressive merge work goes live. (L)
+9. **Negative exemplars** — when a user corrects a wrong speaker, learn "not this person" instead of just freezing the profile. Turns every correction into training signal. (M)
+10. **Index meetings for the Home list** — stop re-reading every transcript file on every Home refresh; point the list at the table that already exists. (L)
+
+## THE ONE BET
+**Index the summary fields and ship the cross-meeting tools (#1 + #4).** It's wiring, not machine learning, and it's the only thing here that gives the agent a memory cloud notetakers structurally can't match — and that moat gets stronger every meeting added.


### PR DESCRIPTION
## Why

A wrong speaker merge is permanently lossy today. `mergeProfilesImpl` ([SpeakerProfileMerger.swift](Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift)) L2-blends the source embedding into the target then **deletes** the source row — original embeddings are unrecoverable and there's no per-utterance provenance. Auto-merge fires after every recording (`mergeDuplicates`, threshold 0.6; `mergeProfilesByName` fuses any two profiles sharing a display name), so a wrong fuse silently corrupts speaker identity and compounds over time. The UI even told users it "can't be undone."

This is the **safety net** that should land before the more-aggressive merge work (write-time contamination gate / link-merge floor decouple) and ERes2Net (#1175) go GA.

## What

Scoped to provenance + un-merge, kept entirely on the **concrete `SpeakerDatabase`** so the `SpeakerStore` protocol — the matching/merge surface the in-flight threads edit — is **untouched** (lowest merge-conflict footprint).

- **`speaker_provenance`** — one row per contribution (a recording's mean embedding) that built a profile, plus a fuse marker per merge. Recorded in `addOrUpdateSpeakerImpl`. Answers "which clips built this profile / what fused in."
- **`speaker_merge_events`** — full pre-merge snapshots of **both** source and target for every merge (`explicit` / `duplicate` / `by_name`), written inside the existing merge transaction. The blend is non-invertible, so **un-merge reconstructs two distinct profiles from the retained snapshots** rather than trying to arithmetically undo the blend.
- **Un-merge API** — `unmerge(mergeId:)` / `unmergeMostRecent(forTargetId:)`, **LIFO-safe via `rowid`** so restoring an older snapshot can't silently drop a newer fuse layered on the same keeper. Plus `reassignContribution(id:toProfileId:)` (per-utterance reassignment, re-derives profile means from stored contribution embeddings).
- **UI** — "Undo Last Merge…" row action in [SpeakerPeopleSettingsSection.swift](Sources/UI/Settings/SpeakerPeopleSettingsSection.swift) and honest merge copy (replaces "can't be undone").
- Idempotent `CREATE TABLE IF NOT EXISTS` migration.

### Known limitation
Un-merge restores the two **voice profiles** (so future recordings match the right person again). It does not rewrite past transcript text that the merge's `retroactivelyMergeSpeaker` already renamed — the copy reflects this.

## Tests
`SpeakerProvenanceTests`: un-merge restores two distinct profiles with **exact pre-merge embeddings**; auto-duplicate-merge reversal; LIFO refusal of an older merge under a newer one; fuse-marker lifecycle; per-profile contribution audit; reassignment.

## Verification
- `bash build-deps.sh --force` + `bash build.sh --no-open` ✅
- `bash run-tests.sh` → 10152 passed ✅
- `swift test` → 503 passed ✅
- `bash run-integration-smoke.sh` ✅

## Sequencing
Land this **before** the write-time contamination gate / link-merge floor decouple and ERes2Net (#1175) merge-surface changes. Diff is deliberately additive and protocol-free; rebase-friendly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)