### PR TITLE
security: harden dictation, telemetry, tools, file perms, and supply chain

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -95,6 +95,40 @@ Practical implications for users:
 If a future version of the ML stack supports team-id-consistent signing for all
 embedded dylibs, the `disable-library-validation` entitlement will be removed.
 
+`com.apple.security.cs.disable-library-validation` is also enabled in the shipped
+distribution entitlements for the same reason — the bundled ML stack
+(MLX, WhisperKit, CoreML) is not Team-ID-consistent, so strict library validation
+refuses to load it. In the shipped build this is mitigated by Developer-ID signing
+plus notarization of the whole app bundle, and it is tracked for removal once the ML
+stack signs consistently.
+
+## Permissions and TCC prompts
+
+Screen Recording (`NSScreenCaptureUsageDescription`) is requested **only** to capture
+system audio through ScreenCaptureKit during meeting capture. macOS conflates system-audio
+capture and screen capture under a single Screen Recording TCC prompt, so the permission
+dialog mentions screen recording even though the app does not capture screen pixels. No
+screenshots or screen frames are read, stored, or transmitted.
+
+## Companion MCP server trust model
+
+The companion MCP server (`Tools/TranscriptedMCP`) is a read-only stdio binary. It performs
+no per-caller authentication: any local process that can launch the binary gets full READ
+access to every saved transcript, dictation, and sidecar under the capture library. There is
+no separate authorization step. Treat launching the MCP server (for example, wiring it into
+an agent or editor) as equivalent to granting that caller read access to all saved
+transcripts, and only configure it for clients you trust with that data.
+
+## Update feed (Sparkle appcast) integrity
+
+The Sparkle appcast is hosted on a raw GitHub branch
+(`raw.githubusercontent.com/.../main/docs/appcast.xml`). Update integrity does not rest on
+that hosting path: each update is verified by EdDSA signature against the public key embedded
+in the app, so a tampered feed cannot deliver an unsigned or wrong-key build. The trust roots
+are therefore the private signing key and the GitHub account/branch that backs the feed. Keep
+hardware-key 2FA and branch protection enabled on the account hosting the feed so the
+published appcast and signed artifacts cannot be silently replaced.
+
 ## Supported Versions
 
 | Version | Supported |

--- a/Sources/Dictation/DictationStopBenchmarkRunner.swift
+++ b/Sources/Dictation/DictationStopBenchmarkRunner.swift
@@ -306,7 +306,11 @@ enum DictationStopBenchmarkRunner {
     private static func appendJSONLine(_ payload: [String: Any], to url: URL) throws {
         let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
         if !FileManager.default.fileExists(atPath: url.path) {
-            FileManager.default.createFile(atPath: url.path, contents: nil)
+            FileManager.default.createFile(
+                atPath: url.path,
+                contents: nil,
+                attributes: [.posixPermissions: 0o600]
+            )
         }
         let handle = try FileHandle(forWritingTo: url)
         try handle.seekToEnd()

--- a/Sources/Meeting/MeetingArtifactRenamer.swift
+++ b/Sources/Meeting/MeetingArtifactRenamer.swift
@@ -50,7 +50,14 @@ enum MeetingArtifactRenamer {
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         let limited = String(collapsedWhitespace.prefix(80)).trimmingCharacters(in: .whitespacesAndNewlines)
-        return limited.isEmpty ? fallback : limited
+
+        // Strip leading dots so a title can never produce a hidden/dot-prefixed fragment,
+        // and treat an all-dots (or now-empty) result as needing the fallback. The final
+        // stem is always date-prefixed today, so this is defense-in-depth rather than a
+        // live exploit, but it keeps the fragment a plain, visible name.
+        let stripped = String(limited.drop(while: { $0 == "." }))
+        let safe = stripped.trimmingCharacters(in: .whitespacesAndNewlines)
+        return safe.isEmpty ? fallback : safe
     }
 
     // MARK: - Artifact paths

--- a/Sources/Meeting/MeetingImportedAudioPreparer.swift
+++ b/Sources/Meeting/MeetingImportedAudioPreparer.swift
@@ -393,7 +393,13 @@ enum MeetingImportedAudioPreparer {
         let readHandle = try FileHandle(forReadingFrom: sourceURL)
         defer { try? readHandle.close() }
 
-        guard fileManager.createFile(atPath: destinationURL.path, contents: nil) else {
+        // Create the scratch copy owner-only from the start so imported audio
+        // never exists at the umask default before chunks are streamed in.
+        guard fileManager.createFile(
+            atPath: destinationURL.path,
+            contents: nil,
+            attributes: [.posixPermissions: 0o600]
+        ) else {
             throw MeetingImportedAudioPreparationError.copyFailed
         }
 

--- a/Sources/Observability/AppLogger.swift
+++ b/Sources/Observability/AppLogger.swift
@@ -35,7 +35,7 @@ private actor AppLogFileWriter {
             }
             // File exists and is either small enough or just rotated — open for append
         } else {
-            fm.createFile(atPath: path, contents: nil)
+            fm.createFile(atPath: path, contents: nil, attributes: [.posixPermissions: 0o600])
         }
 
         fm.restrictFileToOwnerOnly(at: URL(fileURLWithPath: path))

--- a/Sources/Observability/CrashReporter.swift
+++ b/Sources/Observability/CrashReporter.swift
@@ -77,31 +77,24 @@ final class CrashReporter {
         previousUncaughtHandler?(exception)
     }
 
+    // `capture(error:)` and `capture(message:)` forwarded arbitrary
+    // error/message text to Sentry gated only by text sanitization, with no
+    // positive event allowlist (unlike `captureObservabilityEvent`). They have
+    // no callers anywhere in the app target, so rather than keep an
+    // allowlist-bypassing path alive we make them inert no-ops. If a real need
+    // for ad-hoc error capture returns, route it through `SentryEventPolicy`
+    // like `captureObservabilityEvent` instead of re-enabling these.
+    @available(*, deprecated, message: "Unused; allowlist-bypassing. Route new error capture through captureObservabilityEvent + SentryEventPolicy.")
     func capture(error: Error, context: String = "") {
-        var extra: [String: String] = [:]
-        if !context.isEmpty {
-            // Keyed "detail", not "context": "context" is a sensitive-key fragment in
-            // SentryPayloadSanitizer, so that key would be dropped before send.
-            extra["detail"] = context
-        }
-
-        _ = captureMessageEvent(
-            level: .error,
-            title: String(describing: type(of: error)),
-            message: "Swift error captured",
-            tags: ["source": "swift_error"],
-            extra: extra
-        )
+        _ = error
+        _ = context
     }
 
+    @available(*, deprecated, message: "Unused; allowlist-bypassing. Route new message capture through captureObservabilityEvent + SentryEventPolicy.")
     func capture(message: String, level: String = "warning", extra: [String: String] = [:]) {
-        _ = captureMessageEvent(
-            level: sentryLevel(for: level),
-            title: message,
-            message: message,
-            tags: ["source": "manual_message"],
-            extra: extra
-        )
+        _ = message
+        _ = level
+        _ = extra
     }
 
     static func setRuntimeDiagnosticsContext(_ context: [String: String]) {
@@ -121,6 +114,15 @@ final class CrashReporter {
 
     @discardableResult
     func captureSupportDiagnosticEvent(extra: [String: String]) -> String? {
+        // Support-diagnostic extras are built from app state and can pick up
+        // free-text values under innocuous-looking keys (e.g. the
+        // `latest_reliability_packet` blob, interpolated `route_*`/`runtime_*`/
+        // `storage_*` keys that the sensitive-key fragment list does not catch).
+        // The off-device contract is positive-allowlist gated like
+        // `captureObservabilityEvent`, not just key-drop + redaction, so we
+        // filter to the known-safe key set owned by `SupportDiagnosticsBundle`
+        // before send. Surviving values still pass through the text redactor
+        // inside `captureMessageEvent` as defense-in-depth.
         captureMessageEvent(
             level: .warning,
             title: "support_diagnostic_event",
@@ -130,7 +132,7 @@ final class CrashReporter {
                 "engine": "support",
                 "event": "diagnostic_event",
             ],
-            extra: extra,
+            extra: SupportDiagnosticsBundle.allowlistedSentryContext(extra),
             fingerprint: ["support", "diagnostic_event"]
         )
     }
@@ -309,19 +311,6 @@ final class CrashReporter {
             return .warning
         case .info:
             return .info
-        }
-    }
-
-    private func sentryLevel(for level: String) -> SentryLevel {
-        switch level.lowercased() {
-        case "fatal":
-            return .fatal
-        case "error":
-            return .error
-        case "info":
-            return .info
-        default:
-            return .warning
         }
     }
 }

--- a/Sources/Observability/EventReporter.swift
+++ b/Sources/Observability/EventReporter.swift
@@ -133,7 +133,11 @@ private actor EventFileWriter {
         }
 
         if !FileManager.default.fileExists(atPath: fileURL.path) {
-            FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+            FileManager.default.createFile(
+                atPath: fileURL.path,
+                contents: nil,
+                attributes: [.posixPermissions: 0o600]
+            )
             print("📊 EVENT | created events.jsonl")
         }
         FileManager.default.restrictFileToOwnerOnly(at: fileURL)

--- a/Sources/Observability/JSONLWriter.swift
+++ b/Sources/Observability/JSONLWriter.swift
@@ -27,7 +27,11 @@ actor JSONLWriter {
         }
 
         if !FileManager.default.fileExists(atPath: fileURL.path) {
-            FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+            FileManager.default.createFile(
+                atPath: fileURL.path,
+                contents: nil,
+                attributes: [.posixPermissions: 0o600]
+            )
         }
 
         if handle == nil {

--- a/Sources/Observability/ReliabilityPacketRecorder.swift
+++ b/Sources/Observability/ReliabilityPacketRecorder.swift
@@ -153,7 +153,11 @@ enum ReliabilityPacketRecorder {
         )
 
         if !FileManager.default.fileExists(atPath: fileURL.path) {
-            FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+            FileManager.default.createFile(
+                atPath: fileURL.path,
+                contents: nil,
+                attributes: [.posixPermissions: 0o600]
+            )
         }
         FileManager.default.restrictFileToOwnerOnly(at: fileURL)
 

--- a/Sources/Observability/SentryEventPolicy.swift
+++ b/Sources/Observability/SentryEventPolicy.swift
@@ -21,8 +21,25 @@ struct SentryEventPolicy: Equatable {
             tags["wait_bucket"] = waitBucket
         }
 
+        // `reason` is allowlisted because callers usually set it to a short
+        // enum-style value (e.g. "preferred_built_in_for_bluetooth_headset"),
+        // but some producers pass free-text error strings. The redactor in
+        // `sanitizeTags` strips obvious paths/emails/secrets, yet a hard length
+        // cap is the cheaper backstop against an accidental free-text blob
+        // riding off-device under a "safe" key. We keep `reason` (it carries
+        // diagnostic signal `failure_kind` does not always duplicate) but bound
+        // it tightly; enum-style values fit well under the cap.
+        if let reason = tags["reason"], reason.count > maxReasonTagLength {
+            tags["reason"] = String(reason.prefix(maxReasonTagLength)) + "..."
+        }
+
         return SentryPayloadSanitizer.sanitizeTags(tags)
     }
+
+    /// Hard cap for the free-text-capable `reason` diagnostic tag. Enum-style
+    /// reason values stay well below this; anything longer is truncated before
+    /// redaction so a stray error message cannot ship a large blob to Sentry.
+    static let maxReasonTagLength = 80
 
     private static let allowedDiagnosticTagKeys: Set<String> = [
         "attenuation_kind",

--- a/Sources/Support/ClipboardRestoringTextPaster.swift
+++ b/Sources/Support/ClipboardRestoringTextPaster.swift
@@ -72,8 +72,12 @@ extension NSPasteboard: ClipboardPasteboard {
 }
 
 private func postClipboardPasteShortcut() -> Bool {
-    guard let vDown = CGEvent(keyboardEventSource: nil, virtualKey: 0x09, keyDown: true),
-          let vUp = CGEvent(keyboardEventSource: nil, virtualKey: 0x09, keyDown: false) else {
+    // Use a private event source so the synthetic Cmd+V does not inherit ambient
+    // modifier state (e.g. a physically held push-to-talk modifier) that could
+    // otherwise combine with the synthetic Command flag.
+    let source = CGEventSource(stateID: .privateState)
+    guard let vDown = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: true),
+          let vUp = CGEvent(keyboardEventSource: source, virtualKey: 0x09, keyDown: false) else {
         return false
     }
 
@@ -437,6 +441,17 @@ final class ClipboardRestoringTextPaster {
     ) {
         guard pasteboard.changeCount == temporaryChangeCount,
               pasteboard.string(forType: .string) == temporaryString else {
+            // The normal restore path is gated on the pasteboard still being the exact
+            // dictation string we borrowed it for. If another process (e.g. a clipboard
+            // manager) bumped the changeCount, that guard fails and we cannot safely
+            // restore the user's original clipboard. But if the borrowed dictation text
+            // is still resident, leaving it there leaks possibly-sensitive dictation onto
+            // the clipboard. Best-effort clear it — but only when the current string still
+            // equals the dictated text, so we never clobber unrelated content the user
+            // copied after us.
+            if pasteboard.string(forType: .string) == temporaryString {
+                pasteboard.clearContents()
+            }
             return
         }
 

--- a/Sources/Support/DictationAutoSendPreferences.swift
+++ b/Sources/Support/DictationAutoSendPreferences.swift
@@ -127,8 +127,12 @@ final class DictationAutoSender {
             return .failed("Accessibility is off, so Transcripted could not send automatically.")
         }
 
-        guard let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Return), keyDown: true),
-              let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(kVK_Return), keyDown: false) else {
+        // Use a private event source so the synthetic Return (optionally Cmd+Return)
+        // does not inherit ambient modifier state from a physically held key such as
+        // a push-to-talk modifier.
+        let source = CGEventSource(stateID: .privateState)
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: CGKeyCode(kVK_Return), keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: CGKeyCode(kVK_Return), keyDown: false) else {
             return .failed("Transcripted could not create the auto-send key event.")
         }
 

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -14,6 +14,19 @@ import UniformTypeIdentifiers
 struct TranscriptedApp: App {
     @NSApplicationDelegateAdaptor(TranscriptedAppDelegate.self) var appDelegate
 
+    init() {
+        // Security: set the process file-creation mask as early as possible so
+        // every file the app creates is owner-only (0600) by default, with no
+        // brief window at the umask default (often 0644) between creation and a
+        // later chmod. This closes the file-permission TOCTOU window for the
+        // `Data.write(.atomic)` temp files too, which we cannot pass explicit
+        // attributes to. The existing explicit `restrictToOwnerOnly`/chmod and
+        // `createFile(attributes:)` calls remain as belt-and-suspenders. App
+        // struct `init` runs before `applicationDidFinishLaunching`, so this is
+        // the earliest deterministic point in startup. `umask` comes from Darwin.
+        umask(0o077)
+    }
+
     var body: some Scene {
         Settings { EmptyView() }
             .commands {

--- a/Sources/TranscriptedCore/Logging/FileLogger.swift
+++ b/Sources/TranscriptedCore/Logging/FileLogger.swift
@@ -45,7 +45,11 @@ final class FileLogger: @unchecked Sendable {
 
         // Create file if it doesn't exist
         if !FileManager.default.fileExists(atPath: logFileURL.path) {
-            FileManager.default.createFile(atPath: logFileURL.path, contents: nil)
+            FileManager.default.createFile(
+                atPath: logFileURL.path,
+                contents: nil,
+                attributes: [.posixPermissions: 0o600]
+            )
         }
 
         FileManager.default.restrictToOwnerOnly(atPath: logFileURL.path)
@@ -144,7 +148,11 @@ final class FileLogger: @unchecked Sendable {
         fileHandle = try? FileHandle(forWritingTo: logFileURL)
         if fileHandle == nil {
             // File may have been deleted during atomic write — recreate and retry
-            FileManager.default.createFile(atPath: logFileURL.path, contents: nil)
+            FileManager.default.createFile(
+                atPath: logFileURL.path,
+                contents: nil,
+                attributes: [.posixPermissions: 0o600]
+            )
             FileManager.default.restrictToOwnerOnly(atPath: logFileURL.path)
             fileHandle = try? FileHandle(forWritingTo: logFileURL)
         }

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -1604,6 +1604,28 @@ class DictationSessionController: ObservableObject {
             await textPaster.waitForClipboardReadyForAutoEnter()
         }
         guard !Task.isCancelled else { return .disabled }
+
+        // The Cmd+V paste verified the target was frontmost, but the auto-enter delay and
+        // clipboard-readiness wait above give focus a chance to drift. Re-verify the paste
+        // target is still frontmost so a stray Return is never submitted into whatever app
+        // is now in front. Skip and log (char-count / bundle-id only, never the text).
+        if let sessionPasteTarget, !sessionPasteTarget.matchesCurrentFrontmostApp() {
+            EventReporter.shared.capture(
+                level: .warning,
+                engine: "overlay",
+                event: "dictation_auto_enter_target_changed",
+                message: "Focus changed before dictation auto-enter",
+                context: dictationContext(
+                    extra: [
+                        "char_count": "\(text.count)",
+                        "frontmost_bundle_id": NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? "unknown"
+                    ]
+                )
+            )
+            appState?.logger.log("DICTATION | focus changed before auto-enter, skipping Return")
+            return .disabled
+        }
+
         return autoSender.send(DictationAutoSendPreferences.sendKey())
     }
 

--- a/Sources/UI/Shared/SupportDiagnosticsBundle.swift
+++ b/Sources/UI/Shared/SupportDiagnosticsBundle.swift
@@ -128,6 +128,55 @@ enum SupportDiagnosticsBundle {
         return context
     }
 
+    /// Static positive key allowlist for the support-diagnostic extras that
+    /// reach Sentry. `sentryContext` builds a fixed set of coarse keys plus
+    /// interpolated `route_*` / `runtime_*` / `storage_*` keys and (previously)
+    /// a free-text `latest_reliability_packet` blob. The off-device contract is
+    /// allowlist-gated, not just key-drop + redaction, so anything not on this
+    /// allowlist or matching a bucketed prefix is dropped before send. The
+    /// free-text `latest_reliability_packet` is intentionally excluded —
+    /// `reliability_packet_count` already carries the coarse signal. Surviving
+    /// values still pass through `SentryPayloadSanitizer` (fragment drop + text
+    /// redaction) at the call site as defense-in-depth, so a prefixed key whose
+    /// suffix is sensitive (e.g. `runtime_file_path`, `route_raw_url`) is also
+    /// dropped downstream. Keep in sync with `sentryContext` above.
+    static let sentryContextAllowedKeys: Set<String> = [
+        "analytics_available",
+        "analytics_enabled",
+        "app_version",
+        "build_version",
+        "calendar_granted",
+        "crash_reporting_available",
+        "crash_reporting_enabled",
+        "meeting_display_status",
+        "meeting_duration_bucket",
+        "meeting_recording",
+        "meeting_review_pending",
+        "meeting_shortcut",
+        "meeting_state",
+        "microphone_status",
+        "pasteback_granted",
+        "queued_meeting_count",
+        "reliability_packet_count",
+        "system_recording_granted",
+    ]
+
+    static let sentryContextAllowedKeyPrefixes: [String] = [
+        "route_",
+        "runtime_",
+        "storage_",
+    ]
+
+    /// Apply the positive key allowlist to a `sentryContext` dictionary,
+    /// dropping any key (notably the free-text `latest_reliability_packet`)
+    /// that is neither explicitly allowlisted nor a bucketed prefix key.
+    static func allowlistedSentryContext(_ context: [String: String]) -> [String: String] {
+        context.filter { key, _ in
+            sentryContextAllowedKeys.contains(key)
+                || sentryContextAllowedKeyPrefixes.contains(where: { key.hasPrefix($0) })
+        }
+    }
+
     private static func render(_ values: [String: String]) -> String {
         let sanitized = AnalyticsPayloadSanitizer.sanitizeDiagnosticContextForDisplay(values)
         guard !sanitized.isEmpty else { return "Unavailable" }

--- a/Sources/UI/Shared/SupportDiagnosticsBundle.swift
+++ b/Sources/UI/Shared/SupportDiagnosticsBundle.swift
@@ -109,9 +109,11 @@ enum SupportDiagnosticsBundle {
             "reliability_packet_count": "\(min(snapshot.reliabilityPackets.count, maxReliabilityPackets))",
             "system_recording_granted": bool(snapshot.systemAudioRecordingGranted),
         ]
-        if let latest = snapshot.reliabilityPackets.last {
-            context["latest_reliability_packet"] = latest
-        }
+        // The free-text `latest_reliability_packet` blob is intentionally not
+        // emitted here: it can carry paths / free text, and
+        // `reliability_packet_count` already gives the coarse signal that reaches
+        // Sentry. (The human-readable diagnostics text, built separately, still
+        // summarizes recent reliability packets for copied support bundles.)
 
         for (key, value) in snapshot.audioRoute {
             context["route_\(key)"] = value

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -29,11 +29,20 @@ reproduced verbatim from the pinned upstream revision.
 - **License:** GNU General Public License v3.0 or later (GPL-3.0-or-later)
 
 eSpeak NG is released under the GPL version 3 or later. The complete GPL-3.0 text below is
-reproduced from the upstream `COPYING` file at release 1.52.0. Corresponding source code for
-eSpeak NG is available from the upstream repository at https://github.com/espeak-ng/espeak-ng,
-and the prebuilt framework artifact is distributed with FluidAudio's releases and package
-checkouts at https://github.com/FluidInference/FluidAudio. (Upstream also notes that
-`getopt.c` carries a 2-clause BSD license for Windows compatibility.)
+reproduced from the upstream `COPYING` file at release 1.52.0. `ESpeakNG.framework` is a
+dynamic library loaded at runtime by the otherwise proprietary Transcripted binary; it is not
+statically linked, and the app remains a separate work that links to it.
+
+**Written offer / corresponding source.** The complete corresponding source for the bundled
+eSpeak NG (version 1.52.3) is available at no charge from the upstream repository:
+https://github.com/espeak-ng/espeak-ng (tag/release `1.52.3`). The prebuilt framework artifact
+Transcripted bundles is taken unmodified from FluidAudio v0.7.9, which vendors it under
+`Sources/FluidAudio/Frameworks/ESpeakNG.xcframework`
+(https://github.com/FluidInference/FluidAudio). For three years from the date you received this
+build, the maintainer will, on request via the contact path in `SECURITY.md`, provide a copy of
+the corresponding source for the bundled version on a durable medium for no more than the cost
+of physically performing the conveyance. (Upstream also notes that `getopt.c` carries a 2-clause
+BSD license for Windows compatibility.)
 
 ### License text
 

--- a/Tests/ClipboardRestoringTextPasterTests.swift
+++ b/Tests/ClipboardRestoringTextPasterTests.swift
@@ -106,6 +106,118 @@ func testClipboardRestoringTextPaster() async {
             )
         }
 
+        runSuite("ClipboardRestoringTextPaster.restorePasteboardItems — clears resident dictation text when restore guard fails") {
+            let pasteboard = NSPasteboard(name: NSPasteboard.Name("TranscriptedClipboardTest-\(UUID().uuidString)"))
+            let paster = ClipboardRestoringTextPaster()
+            let original = "original clipboard"
+            let temporary = "temporary dictation"
+
+            pasteboard.clearContents()
+            pasteboard.setString(original, forType: .string)
+            let snapshot = paster.snapshotPasteboardItems(from: pasteboard)
+
+            pasteboard.clearContents()
+            pasteboard.setString(temporary, forType: .string)
+            let temporaryChangeCount = pasteboard.changeCount
+
+            // Simulate another process (e.g. a clipboard manager) bumping the changeCount
+            // while leaving the borrowed dictation string resident: re-write the same text
+            // so the string still equals the temporary but the changeCount no longer matches.
+            pasteboard.clearContents()
+            pasteboard.setString(temporary, forType: .string)
+            assertFalse(
+                pasteboard.changeCount == temporaryChangeCount,
+                "test setup should advance the changeCount past the recorded temporary value"
+            )
+
+            paster.restorePasteboardItems(
+                snapshot,
+                temporaryString: temporary,
+                temporaryChangeCount: temporaryChangeCount,
+                to: pasteboard
+            )
+
+            assertNil(
+                pasteboard.string(forType: .string),
+                "a failed restore guard should still clear resident dictation text from the clipboard"
+            )
+        }
+
+        runSuite("ClipboardRestoringTextPaster.restorePasteboardItems — failed guard preserves unrelated new clipboard content") {
+            let pasteboard = NSPasteboard(name: NSPasteboard.Name("TranscriptedClipboardTest-\(UUID().uuidString)"))
+            let paster = ClipboardRestoringTextPaster()
+            let original = "original clipboard"
+            let temporary = "temporary dictation"
+            let userCopy = "user copied something new"
+
+            pasteboard.clearContents()
+            pasteboard.setString(original, forType: .string)
+            let snapshot = paster.snapshotPasteboardItems(from: pasteboard)
+
+            pasteboard.clearContents()
+            pasteboard.setString(temporary, forType: .string)
+            let temporaryChangeCount = pasteboard.changeCount
+
+            // The user copied unrelated content after paste started: the guard fails and the
+            // best-effort clear must NOT clobber it, because it is no longer the dictation text.
+            pasteboard.clearContents()
+            pasteboard.setString(userCopy, forType: .string)
+
+            paster.restorePasteboardItems(
+                snapshot,
+                temporaryString: temporary,
+                temporaryChangeCount: temporaryChangeCount,
+                to: pasteboard
+            )
+
+            assertEqual(
+                pasteboard.string(forType: .string),
+                userCopy,
+                "a failed restore guard should never clear content the user copied after paste started"
+            )
+        }
+
+        runSuite("MeetingArtifactRenamer.sanitizedTitleStem — keeps normal titles unchanged") {
+            assertEqual(
+                MeetingArtifactRenamer.sanitizedTitleStem(for: "Weekly Sync", fallback: "Meeting"),
+                "Weekly Sync",
+                "a normal title should pass through unchanged"
+            )
+            assertEqual(
+                MeetingArtifactRenamer.sanitizedTitleStem(for: "Budget / Q3 review", fallback: "Meeting"),
+                "Budget Q3 review",
+                "invalid path characters should be collapsed into spaces"
+            )
+        }
+
+        runSuite("MeetingArtifactRenamer.sanitizedTitleStem — strips leading dots and rejects all-dots") {
+            assertEqual(
+                MeetingArtifactRenamer.sanitizedTitleStem(for: "...hidden", fallback: "Meeting"),
+                "hidden",
+                "leading dots should be stripped so the fragment is never dot-prefixed"
+            )
+            assertEqual(
+                MeetingArtifactRenamer.sanitizedTitleStem(for: "..", fallback: "Meeting"),
+                "Meeting",
+                "an all-dots title should fall back instead of producing a traversal-like fragment"
+            )
+            assertEqual(
+                MeetingArtifactRenamer.sanitizedTitleStem(for: ".", fallback: "Meeting"),
+                "Meeting",
+                "a single dot should fall back to the provided default"
+            )
+            assertEqual(
+                MeetingArtifactRenamer.sanitizedTitleStem(for: "", fallback: "Meeting"),
+                "Meeting",
+                "an empty title should fall back to the provided default"
+            )
+            assertEqual(
+                MeetingArtifactRenamer.sanitizedTitleStem(for: ". leading dot then text", fallback: "Meeting"),
+                "leading dot then text",
+                "leading dot plus whitespace should be stripped down to the visible text"
+            )
+        }
+
         runSuite("ClipboardRestoringTextPaster.paste — dispatches after dictation text is on the pasteboard") {
             let pasteboard = FakeClipboardPasteboard(initialString: "synthetic existing clipboard")
             let paster = ClipboardRestoringTextPaster()

--- a/Tests/SentryEventPolicyTests.swift
+++ b/Tests/SentryEventPolicyTests.swift
@@ -303,4 +303,31 @@ func testSentryEventPolicy() {
 
         assertTrue(tags.isEmpty, "local-only events should not get Sentry diagnostic tags")
     }
+
+    runSuite("SentryEventPolicy diagnosticTags hard-caps the free-text reason tag") {
+        let enumReason = "preferred_built_in_for_bluetooth_headset"
+        let shortTags = SentryEventPolicy.diagnosticTags(
+            forEngine: "meeting",
+            event: "recording_capture_degraded",
+            context: ["reason": enumReason]
+        )
+        assertEqual(shortTags["reason"], enumReason, "short enum-style reasons should pass through untruncated")
+
+        let freeText = String(repeating: "a", count: 400)
+        let cappedTags = SentryEventPolicy.diagnosticTags(
+            forEngine: "meeting",
+            event: "recording_capture_degraded",
+            context: ["reason": freeText]
+        )
+        let cappedReason = cappedTags["reason"]
+        assertTrue(cappedReason != nil, "reason should still be forwarded after capping")
+        assertTrue(
+            (cappedReason?.count ?? 0) <= SentryEventPolicy.maxReasonTagLength + 3,
+            "an oversized free-text reason should be truncated to the hard cap plus ellipsis"
+        )
+        assertTrue(
+            cappedReason?.hasSuffix("...") ?? false,
+            "a truncated reason should be marked with an ellipsis"
+        )
+    }
 }

--- a/Tests/SupportDiagnosticsBundleTests.swift
+++ b/Tests/SupportDiagnosticsBundleTests.swift
@@ -119,4 +119,109 @@ func testSupportDiagnosticsBundle() {
         assertNil(sanitized["system_audio_recording_granted"], "support diagnostics should avoid audio-prefixed permission keys")
         assertNil(sanitized["audio_input_device_class"], "support diagnostics should not use audio-prefixed Sentry keys")
     }
+
+    runSuite("SupportDiagnosticsBundle Sentry context is positive-allowlist gated") {
+        let snapshot = SupportDiagnosticsSnapshot(
+            appVersion: "1.2.3",
+            buildVersion: "456",
+            osVersion: "Version 26.0",
+            crashReportingAvailable: true,
+            crashReportingEnabled: true,
+            analyticsAvailable: true,
+            analyticsEnabled: true,
+            microphoneStatus: "authorized",
+            systemAudioRecordingGranted: true,
+            pastebackGranted: true,
+            calendarGranted: true,
+            // Adversarial injection: each entry hides a sensitive value behind a
+            // route_/runtime_/storage_ prefix or an off-allowlist key.
+            audioRoute: [
+                "input_device_class": "bluetooth",
+                "raw_url": "https://meet.example.com/private-room",
+                "audio_device": "MacBook Pro Microphone",
+            ],
+            runtime: [
+                "session_stage": "recording",
+                "file_path": "/Users/redbars/private-runtime.json",
+                "transcript_title": "Private Customer Call",
+                "speaker_name": "Alice Customer",
+                "email": "person@example.com",
+            ],
+            storage: [
+                "known_stale_model_count": "1",
+            ],
+            meetingState: "recording",
+            meetingRecording: true,
+            meetingDurationBucket: "2_9m",
+            meetingDisplayStatus: "transcribing",
+            speakerReviewPending: false,
+            queuedMeetingCount: 2,
+            meetingShortcut: "⌥M",
+            // The latest reliability packet is a free-text blob with a path — it
+            // must never ride to Sentry as `latest_reliability_packet`.
+            reliabilityPackets: [
+                "2026-05-03T01:15:11Z meeting.stop recovered path=/Users/redbars/private.txt"
+            ],
+            recentLogLines: []
+        )
+
+        let rawContext = SupportDiagnosticsBundle.sentryContext(snapshot: snapshot)
+        // Mirror the real send path: positive allowlist, then the Sentry
+        // payload sanitizer (fragment drop + redaction) as defense-in-depth.
+        let allowlisted = SupportDiagnosticsBundle.allowlistedSentryContext(rawContext)
+        let sent = SentryPayloadSanitizer.sanitizeContext(allowlisted)
+
+        // Known-safe coarse keys survive.
+        assertEqual(sent["app_version"], "1.2.3", "coarse app version should survive the allowlist")
+        assertEqual(sent["meeting_state"], "recording", "coarse meeting state should survive the allowlist")
+        assertEqual(sent["route_input_device_class"], "bluetooth", "coarse route facts should survive the allowlist")
+        assertEqual(sent["runtime_session_stage"], "recording", "coarse runtime session stage should survive the allowlist")
+        assertEqual(sent["storage_known_stale_model_count"], "1", "coarse storage facts should survive the allowlist")
+        assertEqual(sent["reliability_packet_count"], "1", "the coarse packet count should survive the allowlist")
+
+        // The free-text reliability packet blob must never leave under its key.
+        assertNil(rawContext["latest_reliability_packet"], "sentryContext should no longer emit the free-text reliability packet blob")
+        assertNil(allowlisted["latest_reliability_packet"], "the allowlist should drop the free-text reliability packet blob")
+        assertNil(sent["latest_reliability_packet"], "the free-text reliability packet blob must not reach Sentry")
+
+        // Sensitive values hidden behind prefixed keys must be dropped by the
+        // downstream fragment-drop sanitizer.
+        assertNil(sent["route_raw_url"], "raw route URLs must not reach Sentry even behind a route_ prefix")
+        assertNil(sent["route_audio_device"], "raw device names must not reach Sentry even behind a route_ prefix")
+        assertNil(sent["runtime_file_path"], "runtime file paths must not reach Sentry even behind a runtime_ prefix")
+        assertNil(sent["runtime_transcript_title"], "runtime transcript titles must not reach Sentry even behind a runtime_ prefix")
+        assertNil(sent["runtime_speaker_name"], "runtime speaker names must not reach Sentry even behind a runtime_ prefix")
+        assertNil(sent["runtime_email"], "runtime emails must not reach Sentry even behind a runtime_ prefix")
+
+        // Defense-in-depth: any value that still slipped through must not carry
+        // the raw injected secrets.
+        for value in sent.values {
+            assertFalse(value.contains("/Users/redbars"), "no allowlisted value should retain a home path")
+            assertFalse(value.contains("person@example.com"), "no allowlisted value should retain an email")
+            assertFalse(value.contains("Private Customer Call"), "no allowlisted value should retain a meeting title")
+            assertFalse(value.contains("https://meet.example.com"), "no allowlisted value should retain a raw URL")
+        }
+    }
+
+    runSuite("SupportDiagnosticsBundle allowlist drops unknown off-allowlist keys") {
+        let injected = [
+            "app_version": "1.2.3",
+            "route_input_device_class": "bluetooth",
+            "latest_reliability_packet": "free text with /Users/redbars/private.txt",
+            "device_name": "Justin's MacBook Pro",
+            "meeting_title": "Private Customer Call",
+            "operator_email": "person@example.com",
+            "arbitrary_blob": "anything not on the allowlist",
+        ]
+
+        let allowlisted = SupportDiagnosticsBundle.allowlistedSentryContext(injected)
+
+        assertEqual(allowlisted["app_version"], "1.2.3", "static allowlisted keys should survive")
+        assertEqual(allowlisted["route_input_device_class"], "bluetooth", "bucketed prefix keys should survive")
+        assertNil(allowlisted["latest_reliability_packet"], "free-text reliability blob should be dropped")
+        assertNil(allowlisted["device_name"], "off-allowlist device keys should be dropped")
+        assertNil(allowlisted["meeting_title"], "off-allowlist title keys should be dropped")
+        assertNil(allowlisted["operator_email"], "off-allowlist email keys should be dropped")
+        assertNil(allowlisted["arbitrary_blob"], "arbitrary off-allowlist keys should be dropped")
+    }
 }

--- a/Tools/TranscriptedCLI/Package.swift
+++ b/Tools/TranscriptedCLI/Package.swift
@@ -67,7 +67,10 @@ let package = Package(
         ),
         .testTarget(
             name: "TranscriptedCLITests",
-            dependencies: ["transcripted-cli"],
+            dependencies: [
+                "transcripted-cli",
+                .product(name: "TranscriptedCaptureKit", package: "TranscriptedCaptureKit"),
+            ],
             path: "Tests/TranscriptedCLITests",
             swiftSettings: hasDiarizationDeps ? [
                 .define("TRANSCRIPTEDCLI_WITH_DIARIZATION"),

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -212,7 +212,7 @@ enum CLIContextStore {
         }
 
         guard let markdownURL,
-              let content = try? String(contentsOf: markdownURL, encoding: .utf8),
+              let content = CaptureMarkdown.readBoundedContents(of: markdownURL),
               CaptureMarkdown.looksLikeCaptureMarkdown(markdownURL),
               !markdownURL.deletingPathExtension().lastPathComponent.hasPrefix("Dictations_") else {
             throw ValidationError("Meeting not found: \(filename)")
@@ -266,7 +266,7 @@ enum CLIContextStore {
             """
         }
 
-        if let content = try? String(contentsOf: markdownURL, encoding: .utf8) {
+        if let content = CaptureMarkdown.readBoundedContents(of: markdownURL) {
             return content
         }
 
@@ -386,7 +386,7 @@ enum CLIContextStore {
     }
 
     private static func loadMeeting(at url: URL) -> CLIAgentTranscript? {
-        guard let content = try? String(contentsOf: url, encoding: .utf8),
+        guard let content = CaptureMarkdown.readBoundedContents(of: url),
               let parsed = CaptureMarkdownParser.parseMeeting(from: content) else { return nil }
 
         return CLIAgentTranscript(
@@ -415,7 +415,7 @@ enum CLIContextStore {
     }
 
     private static func loadDictationDay(at url: URL) -> (payload: CLIAgentDictationDay, entries: [CLIClientDictationEntry])? {
-        guard let content = try? String(contentsOf: url, encoding: .utf8),
+        guard let content = CaptureMarkdown.readBoundedContents(of: url),
               let parsed = CaptureMarkdownParser.parseDictationDay(from: content, markdownURL: url) else { return nil }
 
         let entries = parsed.entries.map { entry in
@@ -446,7 +446,7 @@ enum CLIContextStore {
 
     private static func readMeetingTitle(filename: String, from directory: URL) -> String {
         let mdURL = directory.appendingPathComponent(filename + ".md")
-        guard let content = try? String(contentsOf: mdURL, encoding: .utf8) else {
+        guard let content = CaptureMarkdown.readBoundedContents(of: mdURL) else {
             return filename
         }
         return CaptureMarkdown.extractTitle(from: content) ?? filename

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Darwin
+import TranscriptedCaptureKit
 @testable import transcripted_cli
 
 final class ContextStoreTests: XCTestCase {
@@ -532,6 +533,39 @@ final class ContextStoreTests: XCTestCase {
         )
 
         XCTAssertEqual(content, markdown)
+    }
+
+    func testReadMeetingRefusesOversizedFile() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let (meetingsDir, dictationsDir) = try makeContextDirs(in: root)
+
+        // Otherwise-valid meeting padded past the byte cap. readMeeting must
+        // refuse it (local-DoS guard) with the same "not found" contract.
+        let body = String(repeating: "x", count: CaptureFileLimits.maxTranscriptBytes)
+        let markdown = makeMeetingMarkdown(title: "Oversized", date: "2026-04-18", body: body)
+        try markdown.write(
+            to: meetingsDir.appendingPathComponent("Oversized.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let dirs = CLIContextDirectories(meetingsDir: meetingsDir, dictationsDir: dictationsDir)
+        XCTAssertThrowsError(try CLIContextStore.readMeeting(filename: "Oversized", in: dirs))
+
+        // The oversized meeting is also skipped from the recent feed.
+        let items = CLIContextStore.recent(in: dirs, kind: .meeting, count: 5, dateFrom: nil, dateTo: nil)
+        XCTAssertTrue(items.isEmpty)
+
+        // A normal-sized meeting still reads back unchanged.
+        let normal = makeMeetingMarkdown(title: "Normal", date: "2026-04-18", body: "[00:03] [Mic/You] Hi.")
+        try normal.write(
+            to: meetingsDir.appendingPathComponent("Normal.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+        XCTAssertEqual(try CLIContextStore.readMeeting(filename: "Normal", in: dirs), normal)
     }
 
     func testReadMeetingCommandAcceptsJSONFlag() throws {

--- a/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdown.swift
+++ b/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdown.swift
@@ -1,8 +1,34 @@
 import Foundation
 
+/// Shared size guards for reading capture Markdown from disk. The standalone
+/// tools (CLI, MCP) and this kit all read transcript files into memory with
+/// `String(contentsOf:)`, and the parser then builds several derived copies, so
+/// an oversized file dropped into a watched capture directory could exhaust
+/// memory (local availability concern). All read/detection paths stat the file
+/// first and refuse anything larger than this cap.
+public enum CaptureFileLimits {
+    /// Maximum byte size for a capture Markdown file we will read into memory.
+    /// 16 MB is far larger than any realistic transcript or dictation day file
+    /// (a multi-hour meeting transcript is well under 1 MB of text) while still
+    /// bounding worst-case allocation from a hostile or corrupt file.
+    public static let maxTranscriptBytes = 16 * 1024 * 1024
+}
+
 /// Detection helpers for Transcripted capture Markdown artifacts (meetings and
 /// dictation day files). Shared by TranscriptedCLI and TranscriptedMCP.
 public enum CaptureMarkdown {
+    /// Read a capture Markdown file as UTF-8, refusing files larger than
+    /// `CaptureFileLimits.maxTranscriptBytes`. Returns nil on a missing file, a
+    /// read error, or an over-cap file so callers can fall back to their normal
+    /// "not found"/"not a capture" contract without ever loading the bytes.
+    public static func readBoundedContents(of url: URL) -> String? {
+        guard let size = try? FileManager.default.attributesOfItem(atPath: url.path)[.size] as? Int,
+              size <= CaptureFileLimits.maxTranscriptBytes else {
+            return nil
+        }
+        return try? String(contentsOf: url, encoding: .utf8)
+    }
+
     /// Whether a Markdown file looks like a Transcripted capture artifact:
     /// either a dictation day file by name, or a file with YAML frontmatter.
     public static func looksLikeCaptureMarkdown(_ url: URL) -> Bool {
@@ -11,7 +37,7 @@ public enum CaptureMarkdown {
             return true
         }
 
-        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+        guard let content = readBoundedContents(of: url) else {
             return false
         }
 

--- a/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureMarkdownParserTests.swift
+++ b/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureMarkdownParserTests.swift
@@ -599,4 +599,27 @@ final class CaptureMarkdownParserTests: XCTestCase {
 
         XCTAssertTrue(CaptureMarkdown.directoryHasCaptureMarkdownFiles(tempDir))
     }
+
+    func testLooksLikeCaptureMarkdownRefusesOversizedFile() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // Valid capture frontmatter, but padded past the byte cap. Detection must
+        // refuse it without loading the bytes (local-DoS guard), so a non
+        // Dictations_ filename forces the content-read branch.
+        let oversized = tempDir.appendingPathComponent("Call_oversized.md")
+        let header = "---\ndate: 2026-04-18\n---\n\n"
+        let padding = String(repeating: "x", count: CaptureFileLimits.maxTranscriptBytes + 1)
+        try (header + padding).write(to: oversized, atomically: true, encoding: .utf8)
+
+        XCTAssertFalse(CaptureMarkdown.looksLikeCaptureMarkdown(oversized))
+        XCTAssertNil(CaptureMarkdown.readBoundedContents(of: oversized))
+
+        // A normal-sized capture file still reads and is detected.
+        let normal = tempDir.appendingPathComponent("Call_normal.md")
+        try (header + "body").write(to: normal, atomically: true, encoding: .utf8)
+        XCTAssertTrue(CaptureMarkdown.looksLikeCaptureMarkdown(normal))
+        XCTAssertNotNil(CaptureMarkdown.readBoundedContents(of: normal))
+    }
 }

--- a/Tools/TranscriptedMCP/Package.swift
+++ b/Tools/TranscriptedMCP/Package.swift
@@ -20,7 +20,10 @@ let package = Package(
         ),
         .testTarget(
             name: "TranscriptedMCPTests",
-            dependencies: ["transcripted-mcp"],
+            dependencies: [
+                "transcripted-mcp",
+                .product(name: "TranscriptedCaptureKit", package: "TranscriptedCaptureKit"),
+            ],
             path: "Tests/TranscriptedMCPTests",
             linkerSettings: [.linkedLibrary("sqlite3")]
         ),

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -367,7 +367,7 @@ func handleListMeetings(params: CallTool.Parameters, index: TranscriptIndex, mee
             appendingExtension: "md",
             in: meetingDirs
         ) else { continue }
-        if let content = try? String(contentsOf: mdURL, encoding: .utf8) {
+        if let content = CaptureMarkdown.readBoundedContents(of: mdURL) {
             results[i].title = extractTitle(from: content) ?? results[i].filename
         }
     }
@@ -443,7 +443,7 @@ private func handleReadMeeting(params: CallTool.Parameters, meetingDirs: [URL]) 
         return textResult("Invalid filename: \(filename)", isError: true)
     }
 
-    guard let content = try? String(contentsOf: mdURL, encoding: .utf8) else {
+    guard let content = CaptureMarkdown.readBoundedContents(of: mdURL) else {
         return textResult("Meeting not found: \(filename). Use list_meetings to see available meetings.", isError: true)
     }
 
@@ -532,7 +532,7 @@ private func handleReadDictation(params: CallTool.Parameters, dictationDirs: [UR
         sourceCount: day.entries.count
     )
 
-    guard let content = try? String(contentsOf: markdownURL, encoding: .utf8) else {
+    guard let content = CaptureMarkdown.readBoundedContents(of: markdownURL) else {
         let json = try JSONEncoder.pretty.encode(day)
         return textResult(String(data: json, encoding: .utf8) ?? "{}")
     }
@@ -681,7 +681,7 @@ private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, me
         ) else { continue }
         var preview = ""
         var title = meeting.filename
-        if let content = try? String(contentsOf: mdURL, encoding: .utf8) {
+        if let content = CaptureMarkdown.readBoundedContents(of: mdURL) {
             title = extractTitle(from: content) ?? meeting.filename
             preview = extractDialogueLines(from: content).prefix(15).joined(separator: "\n")
         }
@@ -842,7 +842,7 @@ private func frontmatterMeetingTitle(for filename: String, meetingDirs: [URL]) -
         appendingExtension: "md",
         in: meetingDirs
     ),
-    let content = try? String(contentsOf: mdURL, encoding: .utf8) else {
+    let content = CaptureMarkdown.readBoundedContents(of: mdURL) else {
         return nil
     }
     return extractTitle(from: content)

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift
@@ -21,7 +21,7 @@ enum TranscriptLoader {
     }
 
     static func loadMeeting(_ url: URL) -> AgentTranscript? {
-        guard let content = try? String(contentsOf: url, encoding: .utf8),
+        guard let content = CaptureMarkdown.readBoundedContents(of: url),
               let parsed = CaptureMarkdownParser.parseMeeting(from: content) else {
             log("Cannot read markdown meeting: \(url.lastPathComponent)")
             return nil
@@ -70,13 +70,13 @@ enum TranscriptLoader {
     /// isolation does not bump the parent transcript's mtime, so its items only
     /// refresh on the next reindex of the transcript itself.
     static func loadMeetingSummary(forTranscript url: URL) -> ParsedMeetingSummary? {
-        if let content = try? String(contentsOf: url, encoding: .utf8),
+        if let content = CaptureMarkdown.readBoundedContents(of: url),
            let summary = CaptureSummaryParser.parse(from: content) {
             return summary
         }
 
         let sidecarURL = summarySidecarURL(forTranscript: url)
-        if let content = try? String(contentsOf: sidecarURL, encoding: .utf8),
+        if let content = CaptureMarkdown.readBoundedContents(of: sidecarURL),
            let summary = CaptureSummaryParser.parse(from: content) {
             return summary
         }
@@ -95,7 +95,7 @@ enum TranscriptLoader {
     }
 
     static func loadDictationDay(_ url: URL) -> AgentDictationDay? {
-        guard let content = try? String(contentsOf: url, encoding: .utf8),
+        guard let content = CaptureMarkdown.readBoundedContents(of: url),
               let parsed = CaptureMarkdownParser.parseDictationDay(from: content, markdownURL: url) else {
             log("Cannot read markdown dictation day: \(url.lastPathComponent)")
             return nil

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptLoaderTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TranscriptLoaderTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import TranscriptedCaptureKit
 @testable import transcripted_mcp
 
 final class TranscriptLoaderTests: XCTestCase {
@@ -108,6 +109,31 @@ final class TranscriptLoaderTests: XCTestCase {
     func testLoadMissingFileReturnsNil() {
         let transcript = TranscriptLoader.load(tempDir.appendingPathComponent("Call_missing.md"))
         XCTAssertNil(transcript)
+    }
+
+    func testLoadMeetingRefusesOversizedFile() throws {
+        // Otherwise-valid meeting markdown padded past the byte cap. The loader
+        // must skip it (local-DoS guard) and return nil rather than reading it.
+        let url = tempDir.appendingPathComponent("Call_oversized.md")
+        let padded = makeFixtureJSON() + "\n" + String(repeating: "x", count: CaptureFileLimits.maxTranscriptBytes)
+        try padded.write(to: url, atomically: true, encoding: .utf8)
+
+        XCTAssertNil(TranscriptLoader.loadMeeting(url))
+
+        // A normal-sized meeting still loads.
+        try writeFixture(makeFixtureJSON(), filename: "Call_normal", to: tempDir)
+        XCTAssertNotNil(TranscriptLoader.loadMeeting(tempDir.appendingPathComponent("Call_normal.md")))
+    }
+
+    func testLoadDictationDayRefusesOversizedFile() throws {
+        let url = tempDir.appendingPathComponent("Dictations_2026-04-07.md")
+        let padded = makeDictationDayJSON() + "\n" + String(repeating: "x", count: CaptureFileLimits.maxTranscriptBytes)
+        try padded.write(to: url, atomically: true, encoding: .utf8)
+
+        XCTAssertNil(TranscriptLoader.loadDictationDay(url))
+
+        try writeFixture(makeDictationDayJSON(), filename: "Dictations_2026-04-08", to: tempDir)
+        XCTAssertNotNil(TranscriptLoader.loadDictationDay(tempDir.appendingPathComponent("Dictations_2026-04-08.md")))
     }
 
     func testEnumerateArtifacts() throws {

--- a/scripts/entrypoints/build-deps.sh
+++ b/scripts/entrypoints/build-deps.sh
@@ -254,6 +254,61 @@ fetch_argmax_whisperkit_sources() {
     done
 }
 
+assert_mlx_swift_lm_revision() {
+    # mlx-swift-lm is pinned to a bare commit (MLX_SWIFT_LM_REVISION). Unlike the
+    # vendored WhisperKit clone, SwiftPM resolves it transparently, so nothing
+    # otherwise verifies that the revision SwiftPM actually checked out matches
+    # the pin. Assert it post-resolve, the same way fetch_argmax_whisperkit_sources
+    # asserts the WhisperKit clone revision. Prefer Package.resolved (the
+    # authoritative record SwiftPM just wrote); fall back to git rev-parse on the
+    # checkout if for some reason it is absent.
+    local resolved_file="Package.resolved"
+    local checkout="$DEPS_BUILD/.build/checkouts/mlx-swift-lm"
+    local resolved_revision=""
+    local source=""
+
+    if [ -f "$resolved_file" ]; then
+        # Find the mlx-swift-lm pin block and pull its "revision" field. Matches
+        # both Package.resolved v1 ("repositoryURL"/"identity") and v2 ("location").
+        resolved_revision="$(awk '
+            /mlx-swift-lm/ { in_pin = 1 }
+            in_pin && /"revision"[[:space:]]*:/ {
+                line = $0
+                sub(/.*"revision"[[:space:]]*:[[:space:]]*"/, "", line)
+                sub(/".*/, "", line)
+                print line
+                exit
+            }
+        ' "$resolved_file")"
+        [ -n "$resolved_revision" ] && source="$resolved_file"
+    fi
+
+    if [ -z "$resolved_revision" ] && [ -d "$checkout/.git" ]; then
+        resolved_revision="$(git -C "$checkout" rev-parse HEAD 2>/dev/null || true)"
+        [ -n "$resolved_revision" ] && source="git -C $checkout rev-parse HEAD"
+    fi
+
+    if [ -z "$resolved_revision" ]; then
+        echo "[build-deps] ERROR: could not determine resolved mlx-swift-lm revision"
+        echo "[build-deps]        checked Package.resolved and $checkout"
+        echo "[build-deps]        expected: $MLX_SWIFT_LM_REVISION"
+        exit 1
+    fi
+
+    # The pin is an abbreviated commit (e.g. 25b00d4); the resolved revision is a
+    # full SHA. Match by prefix so the short pin verifies against the full hash.
+    case "$resolved_revision" in
+        "$MLX_SWIFT_LM_REVISION"*) ;;
+        *)
+            echo "[build-deps] ERROR: mlx-swift-lm revision mismatch (from $source)"
+            echo "[build-deps]   expected (pin): $MLX_SWIFT_LM_REVISION"
+            echo "[build-deps]   resolved:       $resolved_revision"
+            exit 1
+            ;;
+    esac
+    echo "[build-deps] Verified mlx-swift-lm resolved revision $resolved_revision matches pin $MLX_SWIFT_LM_REVISION (from $source)"
+}
+
 resolve_package_graph() {
     local resolve_cmd=("swift" "package" "resolve" "--disable-dependency-cache")
 
@@ -264,12 +319,14 @@ resolve_package_graph() {
     echo "  Argmax WhisperKit:  $ARGMAX_OSS_SWIFT_VERSION ($ARGMAX_OSS_SWIFT_REVISION)"
 
     if "${resolve_cmd[@]}"; then
+        assert_mlx_swift_lm_revision
         return 0
     fi
 
     echo "[build-deps] WARNING: initial resolve failed; retrying from a clean SwiftPM state"
     rm -rf .build Package.resolved
     "${resolve_cmd[@]}"
+    assert_mlx_swift_lm_revision
 }
 
 ensure_mlx_swift_submodules() {


### PR DESCRIPTION
## Why

A deep security audit of the app surfaced a set of defensive gaps — none critical, but worth closing. This PR fixes the actionable findings from that audit. The app's security posture was already strong (local-first, owner-only files, Sparkle EdDSA, HTTPS-only telemetry with allowlists, mature nightly checks); these are hardening changes on top of that.

## Product Impact

- Affects: `dictation` / `meetings` / `agent artifacts` / `docs only` (all four, defensively)
- Lane: `dictation reliability` + `release ops` + `agent workflow`
- Why this matters: prevents dictation Enter landing in the wrong window, tightens what can ride off-device to Sentry, removes an unbounded-read DoS in the companion tools, and closes a file-permission TOCTOU window for custom save locations on shared volumes.

## What changed

**Dictation / paste**
- **HIGH** — Auto Enter re-verifies the paste target is still frontmost immediately before posting Return, so a stray Enter is never submitted into a window that stole focus during the auto-enter delay (`DictationSessionController.performAutoEnterIfNeeded`). Skips and logs counts/bundle-id only.
- Clipboard restore now best-effort clears resident dictation text when the restore guard fails, instead of leaving it on the pasteboard (only when the current pasteboard still equals the dictated text, so it never clobbers content copied afterward).
- Synthetic Cmd+V / Return now use a private `CGEventSource` so they don't inherit physically-held modifiers.
- Meeting-title filename sanitizer hardened (strips leading dots / all-dots).

**Telemetry (Sentry)**
- Support-diagnostic extras now route through a positive key allowlist owned by `SupportDiagnosticsBundle`, dropping the free-text reliability blob and interpolated `route_*`/`runtime_*`/`storage_*` keys the sensitive-key fragment list didn't catch — matching the `captureObservabilityEvent` contract instead of relying on key-drop + regex alone.
- Hard length cap (80) on the free-text-capable `reason` diagnostic tag before redaction.
- Unused, allowlist-bypassing `capture(error:)` / `capture(message:)` made inert no-ops (no callers in the tree).

**Companion tools**
- Cap full-file transcript reads at a shared 16 MB `CaptureFileLimits.maxTranscriptBytes` across MCP, CLI, and CaptureKit, removing an unbounded `String(contentsOf:)` local-DoS. Each call site honors its existing not-found/empty/throw contract on over-cap.

**File permissions**
- `umask(0o077)` at app `init` so every created file is owner-only by default, closing the write-then-chmod TOCTOU window (covers `Data.write(.atomic)` temp files too); added `posixPermissions: 0o600` to explicit `createFile` sites as belt-and-suspenders. Existing `restrictToOwnerOnly`/chmod calls retained.

**Supply chain / docs**
- `build-deps.sh` now asserts the resolved `mlx-swift-lm` revision matches the pin (mirrors the WhisperKit revision check), failing loudly on drift.
- `THIRD_PARTY_LICENSES.md`: explicit eSpeak NG GPL-3.0-or-later corresponding-source offer.
- `SECURITY.md`: documented the MCP trust model (launch == full read), appcast hosting/trust roots, screen-capture audio-only intent, and the `disable-library-validation` rationale + removal tracking.

## How I checked it

- [x] `python3 scripts/ops/privacy-leak-sweep.py` → **PASS** (all leak classes, 0 findings)
- [x] `python3 scripts/ops/nightly-security-check.py` → **98/100** (secret_scan 25/25, observability_privacy 25/25, release_integrity 20/20, entitlements_and_signing 15/15; the only finding is a pre-existing, unrelated missing local `automation.toml`)
- [x] `bash -n scripts/entrypoints/build-deps.sh` → OK
- [x] Confirmed no disallowed observability payload keys were introduced into the policy sources (scanned against `config/security/nightly-security-manifest.json`)
- [x] Verified the headline fix against real APIs (`EventReporter.capture`, `DictationPasteTarget.matchesCurrentFrontmostApp`, `dictationContext(extra:)`) and that the Tools `Package.swift` test-target product references resolve
- [ ] `bash build.sh --no-open` / `bash run-tests.sh` / `bash run-integration-smoke.sh` / `swift test` — **not runnable here**: this environment is Linux with no Swift toolchain and the targets are macOS-only (`platforms: [.macOS(.v14)]`). **These need to run in macOS CI before merge.**

## Risk Review

- [x] Privacy / local-first behavior reviewed — changes reduce off-device exposure; no new network paths
- [x] Storage path or migration impact reviewed — umask + perms are additive; no path/layout changes
- [x] Release/update impact reviewed — `build-deps.sh` assertion is additive; no version/appcast changes
- [x] Agent PR is draft pending human review
- [x] No private transcripts, audio, tokens, personal paths, or customer data included

## Notes

Tests were added/extended in existing registered files (`ClipboardRestoringTextPasterTests`, `SentryEventPolicyTests`, `SupportDiagnosticsBundleTests`) and the Tools package test targets — no `Tests/FastTests.manifest` changes were required.

**Out of scope / deliberately not changed** (flagged in the audit, not code-fixable here):
- `disable-library-validation` + sandbox-off remain (required by the MLX/WhisperKit/CoreML stack; mitigated by Developer-ID + notarization) — now documented and tracked.
- Legacy bundle id `com.justinbetker.draft` left as-is (changing it has signing/TCC/Sparkle-identity consequences).
- Committed Sentry DSN / PostHog key are client-embeddable ingest keys by design.
- Appcast-on-GitHub-branch and MCP-no-auth are trust-model trade-offs — documented rather than changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXiZDoQn4mmK2mKuz7R4w7

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXiZDoQn4mmK2mKuz7R4w7)_