### PR TITLE
Dedupe cross-boundary and in-file copy-paste from code audit

### DIFF
--- a/Sources/Meeting/MeetingAudioStorageManager.swift
+++ b/Sources/Meeting/MeetingAudioStorageManager.swift
@@ -729,29 +729,78 @@ enum MeetingAudioStorageManager {
                 continue
             }
 
-            let tempURL = audioDirectory
-                .appendingPathComponent(".\(sourceURL.deletingPathExtension().lastPathComponent)-\(UUID().uuidString)")
-                .appendingPathExtension("m4a")
-
-            do {
-                try await converter.convertWAVToM4A(sourceURL: sourceURL, destinationURL: tempURL)
-                guard validator.isUsableAudioFile(at: tempURL, fileManager: fileManager) else {
-                    throw MeetingAudioStorageError.emptyConvertedFile
-                }
-                if fileManager.fileExists(atPath: destinationURL.path) {
-                    try fileManager.removeItem(at: destinationURL)
-                }
-                try fileManager.moveItem(at: tempURL, to: destinationURL)
-                fileManager.restrictFileToOwnerOnly(at: destinationURL)
-                try fileManager.removeItem(at: sourceURL)
+            switch await convertWAVToM4AAtomically(
+                sourceURL: sourceURL,
+                destinationURL: destinationURL,
+                in: audioDirectory,
+                checkingCancellation: false,
+                fileManager: fileManager,
+                converter: converter,
+                validator: validator
+            ) {
+            case .converted:
+                try? fileManager.removeItem(at: sourceURL)
                 convertedCount += 1
-            } catch {
-                try? fileManager.removeItem(at: tempURL)
+            case .cancelled, .failed:
                 continue
             }
         }
 
         return convertedCount
+    }
+
+    /// Outcome of an atomic WAV → M4A conversion attempt.
+    private enum WAVToM4AConversionOutcome {
+        /// `destinationURL` now holds a validated M4A and any existing file
+        /// there was replaced.
+        case converted
+        /// The task was cancelled mid-flight; nothing was moved into place.
+        case cancelled
+        /// Conversion or validation failed; nothing was moved into place.
+        case failed
+    }
+
+    /// Convert `sourceURL` (a WAV) into `destinationURL` (an `.m4a`) atomically:
+    /// write to a hidden temp file in `audioDirectory`, validate it, replace any
+    /// existing destination, move it into place, and restrict it to the owner.
+    /// The temp file is always removed on cancellation or failure. The caller
+    /// owns whether to delete or retain `sourceURL`.
+    ///
+    /// This is the single implementation shared by retained-audio compression
+    /// and failed-meeting audio promotion, which previously duplicated the whole
+    /// temp/convert/validate/move/cleanup flow.
+    private static func convertWAVToM4AAtomically(
+        sourceURL: URL,
+        destinationURL: URL,
+        in audioDirectory: URL,
+        checkingCancellation: Bool,
+        fileManager: FileManager,
+        converter: MeetingAudioFileConverting,
+        validator: MeetingAudioFileValidating
+    ) async -> WAVToM4AConversionOutcome {
+        let tempURL = audioDirectory
+            .appendingPathComponent(".\(sourceURL.deletingPathExtension().lastPathComponent)-\(UUID().uuidString)")
+            .appendingPathExtension("m4a")
+
+        do {
+            try await converter.convertWAVToM4A(sourceURL: sourceURL, destinationURL: tempURL)
+            if checkingCancellation, Task.isCancelled {
+                try? fileManager.removeItem(at: tempURL)
+                return .cancelled
+            }
+            guard validator.isUsableAudioFile(at: tempURL, fileManager: fileManager) else {
+                throw MeetingAudioStorageError.emptyConvertedFile
+            }
+            if fileManager.fileExists(atPath: destinationURL.path) {
+                try fileManager.removeItem(at: destinationURL)
+            }
+            try fileManager.moveItem(at: tempURL, to: destinationURL)
+            fileManager.restrictFileToOwnerOnly(at: destinationURL)
+            return .converted
+        } catch {
+            try? fileManager.removeItem(at: tempURL)
+            return .failed
+        }
     }
 
     @discardableResult
@@ -1093,24 +1142,16 @@ enum MeetingAudioStorageManager {
             )
         }
 
-        let tempURL = audioDirectory
-            .appendingPathComponent(".\(sourceURL.deletingPathExtension().lastPathComponent)-\(UUID().uuidString)")
-            .appendingPathExtension("m4a")
-
-        do {
-            try await converter.convertWAVToM4A(sourceURL: sourceURL, destinationURL: tempURL)
-            guard !Task.isCancelled else {
-                try? fileManager.removeItem(at: tempURL)
-                return FailedAudioCompressionResolution(updatedURL: sourceURL, promotedFile: nil)
-            }
-            guard validator.isUsableAudioFile(at: tempURL, fileManager: fileManager) else {
-                throw MeetingAudioStorageError.emptyConvertedFile
-            }
-            if fileManager.fileExists(atPath: destinationURL.path) {
-                try fileManager.removeItem(at: destinationURL)
-            }
-            try fileManager.moveItem(at: tempURL, to: destinationURL)
-            fileManager.restrictFileToOwnerOnly(at: destinationURL)
+        switch await convertWAVToM4AAtomically(
+            sourceURL: sourceURL,
+            destinationURL: destinationURL,
+            in: audioDirectory,
+            checkingCancellation: true,
+            fileManager: fileManager,
+            converter: converter,
+            validator: validator
+        ) {
+        case .converted:
             return FailedAudioCompressionResolution(
                 updatedURL: destinationURL,
                 promotedFile: FailedAudioPromotion(
@@ -1119,8 +1160,7 @@ enum MeetingAudioStorageManager {
                     wasConverted: true
                 )
             )
-        } catch {
-            try? fileManager.removeItem(at: tempURL)
+        case .cancelled, .failed:
             return FailedAudioCompressionResolution(updatedURL: sourceURL, promotedFile: nil)
         }
     }

--- a/Sources/Observability/AnalyticsPayloadSanitizer.swift
+++ b/Sources/Observability/AnalyticsPayloadSanitizer.swift
@@ -2,28 +2,9 @@ import Foundation
 
 enum AnalyticsPayloadSanitizer {
     private static let maxValueLength = 80
-    private static let sensitiveKeyFragments = [
-        "audio",
-        "authorization",
-        "bearer",
-        "bundle",
-        "credential",
-        "dsn",
-        "email",
-        "error",
-        "file",
-        "name",
-        "password",
-        "path",
-        "speaker",
-        "source_app",
-        "secret",
-        "text",
-        "title",
-        "token",
-        "transcript",
-        "url",
-    ]
+    // Analytics drops exactly the shared base fragments; see
+    // `PayloadSanitizationCore.baseSensitiveKeyFragments`.
+    private static let sensitiveKeyFragments = PayloadSanitizationCore.baseSensitiveKeyFragments
 
     static func sanitizeProperties(
         _ properties: [String: String],

--- a/Sources/Observability/PayloadSanitizationCore.swift
+++ b/Sources/Observability/PayloadSanitizationCore.swift
@@ -8,6 +8,34 @@ import Foundation
 /// sanitizer still owns its own sensitive-key list and length cap, but the
 /// mechanics live in one place.
 enum PayloadSanitizationCore {
+    /// Sensitive-key fragments shared by every off-device destination. A value
+    /// is dropped when its lowercased key contains any of these as a substring.
+    /// Both the Sentry and Analytics sanitizers start from this list and layer
+    /// their own destination-specific fragments on top, so the common floor
+    /// cannot drift between the two.
+    static let baseSensitiveKeyFragments: [String] = [
+        "audio",
+        "authorization",
+        "bearer",
+        "bundle",
+        "credential",
+        "dsn",
+        "email",
+        "error",
+        "file",
+        "name",
+        "password",
+        "path",
+        "speaker",
+        "source_app",
+        "secret",
+        "text",
+        "title",
+        "token",
+        "transcript",
+        "url",
+    ]
+
     /// Apply `ObservabilityTextRedactor.redact` and then cap the result at
     /// `maxValueLength`, appending an ellipsis when truncated. Returns an
     /// empty string when the input redacts to empty so callers can drop

--- a/Sources/Observability/SentryPayloadSanitizer.swift
+++ b/Sources/Observability/SentryPayloadSanitizer.swift
@@ -9,29 +9,11 @@ enum SentryPayloadSanitizer {
         "mic_file_available",
         "system_file_available",
     ]
-    private static let sensitiveKeyFragments = [
-        "audio",
-        "authorization",
-        "bearer",
-        "bundle",
+    // Sentry layers two extra fragments ("context", "identifier") on top of the
+    // shared base in `PayloadSanitizationCore.baseSensitiveKeyFragments`.
+    private static let sensitiveKeyFragments = PayloadSanitizationCore.baseSensitiveKeyFragments + [
         "context",
-        "credential",
-        "dsn",
-        "email",
-        "error",
-        "file",
         "identifier",
-        "name",
-        "password",
-        "path",
-        "speaker",
-        "source_app",
-        "secret",
-        "text",
-        "title",
-        "token",
-        "transcript",
-        "url",
     ]
 
     static func sanitizeTags(_ tags: [String: String]) -> [String: String] {

--- a/Sources/Speech/ParakeetModelInitDiagnostics.swift
+++ b/Sources/Speech/ParakeetModelInitDiagnostics.swift
@@ -25,22 +25,7 @@ enum ParakeetModelInitDiagnostics {
             "failure_stage": stage.rawValue,
             "load_source": loadSource.rawValue,
             "model_bundle_present": bundledModelPresent ? "true" : "false",
-            "mic_status": diagnosticName(for: microphoneStatus),
+            "mic_status": microphoneStatus.diagnosticName,
         ]
-    }
-
-    private static func diagnosticName(for status: AVAuthorizationStatus) -> String {
-        switch status {
-        case .notDetermined:
-            return "not_determined"
-        case .restricted:
-            return "restricted"
-        case .denied:
-            return "denied"
-        case .authorized:
-            return "authorized"
-        @unknown default:
-            return "unknown"
-        }
     }
 }

--- a/Sources/Speech/ParakeetPrewarmPolicy.swift
+++ b/Sources/Speech/ParakeetPrewarmPolicy.swift
@@ -21,14 +21,14 @@ enum ParakeetPrewarmPolicy {
                 level: .info,
                 event: "prewarm_permission_pending",
                 message: "Skipping speech engine prewarm until microphone permission is decided",
-                context: ["mic_status": diagnosticName(for: microphoneStatus)]
+                context: ["mic_status": microphoneStatus.diagnosticName]
             )
         case .denied, .restricted:
             return .skip(
                 level: .warning,
                 event: "prewarm_permission_unavailable",
                 message: "Skipping speech engine prewarm because microphone permission is unavailable",
-                context: ["mic_status": diagnosticName(for: microphoneStatus)]
+                context: ["mic_status": microphoneStatus.diagnosticName]
             )
         @unknown default:
             return .skip(
@@ -37,21 +37,6 @@ enum ParakeetPrewarmPolicy {
                 message: "Skipping speech engine prewarm because microphone permission is unavailable",
                 context: ["mic_status": "unknown"]
             )
-        }
-    }
-
-    private static func diagnosticName(for status: AVAuthorizationStatus) -> String {
-        switch status {
-        case .notDetermined:
-            return "not_determined"
-        case .restricted:
-            return "restricted"
-        case .denied:
-            return "denied"
-        case .authorized:
-            return "authorized"
-        @unknown default:
-            return "unknown"
         }
     }
 }

--- a/Sources/Support/TranscriptedPermissionAccess.swift
+++ b/Sources/Support/TranscriptedPermissionAccess.swift
@@ -307,3 +307,24 @@ private final class SystemAudioPermissionRequester: NSObject, SCStreamOutput {
         completion?(granted)
     }
 }
+
+extension AVAuthorizationStatus {
+    /// Stable, privacy-safe string used in analytics and diagnostics context.
+    ///
+    /// Centralized here so the mic/camera authorization mapping is defined once
+    /// instead of being re-switched in every telemetry call site.
+    var diagnosticName: String {
+        switch self {
+        case .notDetermined:
+            return "not_determined"
+        case .restricted:
+            return "restricted"
+        case .denied:
+            return "denied"
+        case .authorized:
+            return "authorized"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}

--- a/Sources/TranscriptedApp.swift
+++ b/Sources/TranscriptedApp.swift
@@ -747,7 +747,7 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
                 "entrypoint": entrypoint,
                 "has_target": lastExternalApplication == nil ? "false" : "true",
                 "meeting_recording_ready": TranscriptedPermissionAccess.isGranted(.systemAudioRecording) ? "true" : "false",
-                "mic_status": microphoneStatusAnalyticsName(TranscriptedPermissionAccess.microphoneAuthorizationStatus()),
+                "mic_status": TranscriptedPermissionAccess.microphoneAuthorizationStatus().diagnosticName,
                 "model_state": appState.sttRouter.modelDownloadState.diagnosticName,
                 "pasteback_status": TranscriptedPermissionAccess.isGranted(.accessibility) ? "granted" : "not_granted",
             ]
@@ -761,21 +761,6 @@ class TranscriptedAppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegat
             meetingRecordingActive: appState.meetingSession.isRecording,
             dictationRecordingActive: appState.sttRouter.isRecording
         )
-    }
-
-    private func microphoneStatusAnalyticsName(_ status: AVAuthorizationStatus) -> String {
-        switch status {
-        case .notDetermined:
-            return "not_determined"
-        case .restricted:
-            return "restricted"
-        case .denied:
-            return "denied"
-        case .authorized:
-            return "authorized"
-        @unknown default:
-            return "unknown"
-        }
     }
 
     private func resolvedSourceApp() -> NSRunningApplication? {

--- a/Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift
+++ b/Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift
@@ -480,10 +480,19 @@ extension SpeakerDatabase {
 
     // MARK: - Name Variant Detection
 
-    /// Common English name variants (informal -> formal and vice versa)
+    /// Common English name variants (informal -> formal and vice versa).
+    ///
+    /// This table is intentionally mirrored in
+    /// `Tools/TranscriptedMCP/.../NameVariants.swift`, which uses it for
+    /// speaker-aware search. The two cannot share a module (Core is the lower
+    /// layer and must not depend on the Tools packages, and the standalone MCP
+    /// server has no compile-time dependency on Core), so they are kept
+    /// byte-for-byte identical instead. Any edit here MUST be mirrored there,
+    /// and vice versa.
     private static let nameVariants: [String: Set<String>] = [
         "mike": ["michael", "mike", "mikey"],
         "michael": ["michael", "mike", "mikey"],
+        "mikey": ["michael", "mike", "mikey"],
         "nate": ["nate", "nathan", "nathaniel"],
         "nathan": ["nate", "nathan", "nathaniel"],
         "nathaniel": ["nate", "nathan", "nathaniel"],
@@ -503,25 +512,33 @@ extension SpeakerDatabase {
         "christina": ["chris", "christina"],
         "nick": ["nick", "nicholas", "nic"],
         "nicholas": ["nick", "nicholas", "nic"],
+        "nic": ["nick", "nicholas", "nic"],
         "rob": ["rob", "robert", "robbie", "bob", "bobby"],
         "robert": ["rob", "robert", "robbie", "bob", "bobby"],
         "bob": ["rob", "robert", "bob", "bobby"],
+        "bobby": ["rob", "robert", "bob", "bobby"],
         "ed": ["ed", "edward", "eddie"],
         "edward": ["ed", "edward", "eddie"],
+        "eddie": ["ed", "edward", "eddie"],
         "joe": ["joe", "joseph", "joey"],
         "joseph": ["joe", "joseph", "joey"],
+        "joey": ["joe", "joseph", "joey"],
         "tom": ["tom", "thomas", "tommy"],
         "thomas": ["tom", "thomas", "tommy"],
+        "tommy": ["tom", "thomas", "tommy"],
         "sam": ["sam", "samuel", "samantha"],
         "samuel": ["sam", "samuel"],
         "samantha": ["sam", "samantha"],
         "jen": ["jen", "jennifer", "jenny"],
         "jennifer": ["jen", "jennifer", "jenny"],
+        "jenny": ["jen", "jennifer", "jenny"],
         "will": ["will", "william", "bill", "billy"],
         "william": ["will", "william", "bill", "billy"],
         "bill": ["will", "william", "bill", "billy"],
+        "billy": ["will", "william", "bill", "billy"],
         "jim": ["jim", "james", "jimmy"],
         "james": ["jim", "james", "jimmy"],
+        "jimmy": ["jim", "james", "jimmy"],
         "tony": ["tony", "anthony"],
         "anthony": ["tony", "anthony"],
         "steve": ["steve", "steven", "stephen"],
@@ -529,6 +546,7 @@ extension SpeakerDatabase {
         "stephen": ["steve", "steven", "stephen"],
         "ben": ["ben", "benjamin", "benny"],
         "benjamin": ["ben", "benjamin", "benny"],
+        "benny": ["ben", "benjamin", "benny"],
         "andy": ["andy", "andrew", "drew"],
         "andrew": ["andy", "andrew", "drew"],
         "drew": ["andy", "andrew", "drew"],

--- a/Sources/UI/Overlay/DictationSessionController.swift
+++ b/Sources/UI/Overlay/DictationSessionController.swift
@@ -1998,19 +1998,5 @@ private extension TextPasteCopyReason {
     }
 }
 
-private extension AVAuthorizationStatus {
-    var diagnosticName: String {
-        switch self {
-        case .notDetermined:
-            return "not_determined"
-        case .restricted:
-            return "restricted"
-        case .denied:
-            return "denied"
-        case .authorized:
-            return "authorized"
-        @unknown default:
-            return "unknown"
-        }
-    }
-}
+// AVAuthorizationStatus.diagnosticName is defined once in
+// Sources/Support/TranscriptedPermissionAccess.swift and reused here.

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -208,7 +208,7 @@ struct TranscriptedSettingsView: View {
                     openOwnFile(
                         candidateURLs: [preview.transcriptURL],
                         failureTitle: "Could not open transcript",
-                        failureMessage: "Transcripted couldn't find this meeting's transcript on disk. It may have been moved, renamed, or deleted outside the app."
+                        failureMessage: SettingsArtifactMessage.meetingTranscriptNotFound
                     )
                 },
                 onCopyForAgent: {
@@ -585,7 +585,7 @@ struct TranscriptedSettingsView: View {
                             openOwnFile(
                                 candidateURLs: [notice.transcriptURL],
                                 failureTitle: "Could not open transcript",
-                                failureMessage: "Transcripted couldn't find this meeting's transcript on disk. It may have been moved, renamed, or deleted outside the app."
+                                failureMessage: SettingsArtifactMessage.meetingTranscriptNotFound
                             )
                         }
                     },
@@ -768,7 +768,7 @@ struct TranscriptedSettingsView: View {
                     openOwnFile(
                         candidateURLs: [entry.url],
                         failureTitle: "Could not open dictation",
-                        failureMessage: "Transcripted couldn't find this dictation's file on disk. It may have been moved, renamed, or deleted outside the app."
+                        failureMessage: SettingsArtifactMessage.dictationFileNotFound
                     )
                 },
                 onCopy: { handleCopyDictation(entry) },
@@ -865,7 +865,7 @@ struct TranscriptedSettingsView: View {
         guard let transcriptURL = OwnFileResolver.resolveExistingFile(candidateURLs: [item.transcriptURL]) else {
             presentHomeActionFailure(
                 title: "Could not copy meeting",
-                message: "Transcripted couldn't find this meeting's transcript on disk. It may have been moved, renamed, or deleted outside the app."
+                message: SettingsArtifactMessage.meetingTranscriptNotFound
             )
             return
         }
@@ -945,7 +945,7 @@ struct TranscriptedSettingsView: View {
         guard let systemURL = OwnFileResolver.resolveExistingFile(candidateURLs: [input.systemURL]) else {
             presentHomeActionFailure(
                 title: "Could not re-transcribe meeting",
-                message: "Transcripted couldn't find this meeting's retained audio on disk. It may have been moved, recompressed, or removed by the audio-retention setting."
+                message: SettingsArtifactMessage.meetingRetainedAudioNotFound
             )
             return
         }
@@ -1243,7 +1243,7 @@ struct TranscriptedSettingsView: View {
                 openOwnFile(
                     candidateURLs: [entry.url],
                     failureTitle: "Could not open dictation",
-                    failureMessage: "Transcripted couldn't find this dictation's file on disk. It may have been moved, renamed, or deleted outside the app."
+                    failureMessage: SettingsArtifactMessage.dictationFileNotFound
                 )
             },
             HomeRowMenuItem(title: "Report issue", symbolName: "flag") {
@@ -1261,7 +1261,7 @@ struct TranscriptedSettingsView: View {
                 revealOwnFile(
                     candidateURLs: [entry.url],
                     failureTitle: "Could not show dictation",
-                    failureMessage: "Transcripted couldn't find this dictation's file on disk. It may have been moved, renamed, or deleted outside the app."
+                    failureMessage: SettingsArtifactMessage.dictationFileNotFound
                 )
             },
             HomeRowMenuItem(title: "Delete dictation", symbolName: "trash", isDestructive: true) {
@@ -1331,7 +1331,7 @@ struct TranscriptedSettingsView: View {
                 revealOwnFile(
                     candidateURLs: HomeMeetingRowActionTargets.transcriptRevealURLs(for: item),
                     failureTitle: "Could not show transcript",
-                    failureMessage: "Transcripted couldn't find this meeting's transcript on disk. It may have been moved, renamed, or deleted outside the app."
+                    failureMessage: SettingsArtifactMessage.meetingTranscriptNotFound
                 )
             }
         ])
@@ -1396,7 +1396,7 @@ struct TranscriptedSettingsView: View {
                         revealOwnFile(
                             candidateURLs: audioRevealURLs,
                             failureTitle: "Could not show audio",
-                            failureMessage: "Transcripted couldn't find this meeting's retained audio on disk. It may have been moved, recompressed, or removed by the audio-retention setting."
+                            failureMessage: SettingsArtifactMessage.meetingRetainedAudioNotFound
                         )
                     }
                 )
@@ -4945,4 +4945,16 @@ struct TranscriptedSettingsView: View {
         formatter.timeStyle = .short
         return formatter
     }()
+}
+
+// User-facing copy for the "we can't find this artifact on disk" failures that
+// several Settings actions surface. Centralized so the identical strings are
+// not re-typed at each call site and can't drift apart.
+private enum SettingsArtifactMessage {
+    static let meetingTranscriptNotFound =
+        "Transcripted couldn't find this meeting's transcript on disk. It may have been moved, renamed, or deleted outside the app."
+    static let dictationFileNotFound =
+        "Transcripted couldn't find this dictation's file on disk. It may have been moved, renamed, or deleted outside the app."
+    static let meetingRetainedAudioNotFound =
+        "Transcripted couldn't find this meeting's retained audio on disk. It may have been moved, recompressed, or removed by the audio-retention setting."
 }

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/CLIPathSecurity.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/CLIPathSecurity.swift
@@ -1,42 +1,10 @@
 import Foundation
+import TranscriptedCaptureKit
 
-enum CLIPathResolutionStatus {
-    case valid(URL)
-    case missing
-    case invalid
-}
-
-enum CLIPathSecurity {
-    static func resolveReadableFile(named requestedName: String, in baseDirectory: URL) -> CLIPathResolutionStatus {
-        let candidateURL = baseDirectory
-            .appendingPathComponent(requestedName)
-            .standardizedFileURL
-        let standardizedBase = baseDirectory.standardizedFileURL
-
-        guard candidateURL.path.hasPrefix(standardizedBase.path + "/") else {
-            return .invalid
-        }
-
-        return validateExistingFile(candidateURL, under: baseDirectory)
-    }
-
-    static func validateExistingFile(_ url: URL, under baseDirectory: URL) -> CLIPathResolutionStatus {
-        guard FileManager.default.fileExists(atPath: url.path) else {
-            return .missing
-        }
-
-        guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
-              values.isRegularFile == true,
-              values.isSymbolicLink != true else {
-            return .invalid
-        }
-
-        let resolvedBase = baseDirectory.resolvingSymlinksInPath().standardizedFileURL
-        let resolvedURL = url.resolvingSymlinksInPath().standardizedFileURL
-        guard resolvedURL.path == resolvedBase.path || resolvedURL.path.hasPrefix(resolvedBase.path + "/") else {
-            return .invalid
-        }
-
-        return .valid(resolvedURL)
-    }
-}
+// Path validation is shared with TranscriptedMCP through TranscriptedCaptureKit
+// so the traversal / symlink guards live in exactly one place. These aliases
+// keep the existing `CLIPathSecurity` / `CLIPathResolutionStatus` call sites in
+// this module unchanged. Edit the rules in
+// `TranscriptedCaptureKit/CapturePathSecurity.swift`, not here.
+typealias CLIPathResolutionStatus = CapturePathResolutionStatus
+typealias CLIPathSecurity = CapturePathSecurity

--- a/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CapturePathSecurity.swift
+++ b/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CapturePathSecurity.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Result of resolving a caller-supplied filename against a trusted base
+/// directory.
+public enum CapturePathResolutionStatus: Equatable {
+    case valid(URL)
+    case missing
+    case invalid
+}
+
+/// Guards direct file reads against path traversal, symlink escapes, and
+/// out-of-root paths. Shared by `TranscriptedCLI` and `TranscriptedMCP` so the
+/// security-critical validation lives in exactly one place; both tools expose
+/// it under their own local names (`CLIPathSecurity` / `PathSecurity`).
+public enum CapturePathSecurity {
+    /// Resolve `requestedName` inside `baseDirectory`, optionally appending a
+    /// file extension when the name does not already carry it. Rejects any
+    /// candidate that would escape `baseDirectory`.
+    public static func resolveReadableFile(
+        named requestedName: String,
+        appendingExtension pathExtension: String? = nil,
+        in baseDirectory: URL
+    ) -> CapturePathResolutionStatus {
+        let candidateName: String
+        if let pathExtension, !requestedName.hasSuffix(".\(pathExtension)") {
+            candidateName = requestedName + ".\(pathExtension)"
+        } else {
+            candidateName = requestedName
+        }
+
+        let candidateURL = baseDirectory
+            .appendingPathComponent(candidateName)
+            .standardizedFileURL
+        let standardizedBase = baseDirectory.standardizedFileURL
+
+        guard candidateURL.path.hasPrefix(standardizedBase.path + "/") else {
+            return .invalid
+        }
+        guard FileManager.default.fileExists(atPath: candidateURL.path) else {
+            return .missing
+        }
+
+        return validateExistingFile(candidateURL, under: baseDirectory)
+    }
+
+    /// Validate an already-built URL: it must exist, be a regular (non-symlink)
+    /// file, and stay within `baseDirectory` after symlink resolution.
+    public static func validateExistingFile(
+        _ url: URL,
+        under baseDirectory: URL
+    ) -> CapturePathResolutionStatus {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return .missing
+        }
+
+        guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
+              values.isRegularFile == true,
+              values.isSymbolicLink != true else {
+            return .invalid
+        }
+
+        let resolvedBase = baseDirectory.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedURL = url.resolvingSymlinksInPath().standardizedFileURL
+        let resolvedBasePath = resolvedBase.path
+        let resolvedPath = resolvedURL.path
+
+        guard resolvedPath == resolvedBasePath || resolvedPath.hasPrefix(resolvedBasePath + "/") else {
+            return .invalid
+        }
+
+        return .valid(resolvedURL)
+    }
+}

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/NameVariants.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/NameVariants.swift
@@ -1,7 +1,13 @@
 import Foundation
 
 /// Name variant expansion for speaker matching.
-/// Source: SpeakerProfileMerger.swift in the main Transcripted app.
+///
+/// The `variants` table below is intentionally mirrored from
+/// `Sources/TranscriptedCore/Speaker/SpeakerProfileMerger.swift` in the main
+/// Transcripted app. The two cannot share a module (this standalone server has
+/// no compile-time dependency on Core, and Core must not depend on the Tools
+/// packages), so they are kept byte-for-byte identical instead. Any edit here
+/// MUST be mirrored there, and vice versa.
 enum NameVariants {
     private static let variants: [String: Set<String>] = [
         "mike": ["michael", "mike", "mikey"],

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/PathSecurity.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/PathSecurity.swift
@@ -1,59 +1,10 @@
 import Foundation
+import TranscriptedCaptureKit
 
-enum PathResolutionStatus {
-    case valid(URL)
-    case missing
-    case invalid
-}
-
-enum PathSecurity {
-    static func resolveReadableFile(
-        named requestedName: String,
-        appendingExtension pathExtension: String? = nil,
-        in baseDirectory: URL
-    ) -> PathResolutionStatus {
-        let candidateName: String
-        if let pathExtension, !requestedName.hasSuffix(".\(pathExtension)") {
-            candidateName = requestedName + ".\(pathExtension)"
-        } else {
-            candidateName = requestedName
-        }
-
-        let candidateURL = baseDirectory
-            .appendingPathComponent(candidateName)
-            .standardizedFileURL
-        let standardizedBase = baseDirectory.standardizedFileURL
-
-        guard candidateURL.path.hasPrefix(standardizedBase.path + "/") else {
-            return .invalid
-        }
-        guard FileManager.default.fileExists(atPath: candidateURL.path) else {
-            return .missing
-        }
-
-        return validateExistingFile(candidateURL, under: baseDirectory)
-    }
-
-    static func validateExistingFile(_ url: URL, under baseDirectory: URL) -> PathResolutionStatus {
-        guard FileManager.default.fileExists(atPath: url.path) else {
-            return .missing
-        }
-
-        guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
-              values.isRegularFile == true,
-              values.isSymbolicLink != true else {
-            return .invalid
-        }
-
-        let resolvedBase = baseDirectory.resolvingSymlinksInPath().standardizedFileURL
-        let resolvedURL = url.resolvingSymlinksInPath().standardizedFileURL
-        let resolvedBasePath = resolvedBase.path
-        let resolvedPath = resolvedURL.path
-
-        guard resolvedPath == resolvedBasePath || resolvedPath.hasPrefix(resolvedBasePath + "/") else {
-            return .invalid
-        }
-
-        return .valid(resolvedURL)
-    }
-}
+// Path validation is shared with TranscriptedCLI through TranscriptedCaptureKit
+// so the traversal / symlink guards live in exactly one place. These aliases
+// keep the existing `PathSecurity` / `PathResolutionStatus` call sites in this
+// module unchanged. Edit the rules in
+// `TranscriptedCaptureKit/CapturePathSecurity.swift`, not here.
+typealias PathResolutionStatus = CapturePathResolutionStatus
+typealias PathSecurity = CapturePathSecurity


### PR DESCRIPTION
## Why

A code-smell/duplication audit of the repo surfaced several places where the same logic is copy-pasted — most importantly across module boundaries, where there is no compiler keeping the copies in sync. One had already drifted into a real behavior discrepancy (the speaker name-variant table). This PR consolidates the highest-confidence, behavior-preserving duplications.

## Product Impact

- Affects: `meetings` / `agent artifacts` / `docs only` (no user-facing behavior change intended)
- Lane: `agent workflow` (internal consolidation / maintainability)
- Why this matters: two of these duplications are security/privacy-adjacent (path-traversal validation, off-device payload sanitization). Centralizing them removes the "fix one copy, forget the other" risk.

## What changed

- **Path traversal / symlink validation** → one shared `CapturePathSecurity` in `TranscriptedCaptureKit`. The MCP `PathSecurity` and CLI `CLIPathSecurity` are now thin typealiases to it, so call sites are unchanged and the guard exists once. (Previously two near-identical enums, `PathResolutionStatus` vs `CLIPathResolutionStatus`.)
- **Sentry/Analytics sensitive-key fragments** → shared `PayloadSanitizationCore.baseSensitiveKeyFragments`. Analytics uses the base as-is; Sentry layers its two extra fragments (`context`, `identifier`) on top. Resulting sets are identical to before.
- **Speaker name-variant maps** → `Core/SpeakerProfileMerger` and `MCP/NameVariants` synced to a byte-identical table (they had drifted: MCP had `mikey`/`bobby`/`billy`/etc. that Core lacked) with cross-reference comments. The added reverse keys do not change Core's `areNameVariants` results because it already checks both directions; this only removes the drift. A shared module is blocked by the Core↔Tools layering, so the contract is "edit both, kept identical."
- **`AVAuthorizationStatus` → String mapping** → four copies (`TranscriptedApp`, `ParakeetModelInitDiagnostics`, `ParakeetPrewarmPolicy`, `DictationSessionController`) collapsed into one `AVAuthorizationStatus.diagnosticName` extension in `TranscriptedPermissionAccess` (already in the fast-test source list).
- **Settings "couldn't find this artifact on disk" copy** → 9 duplicated strings replaced with a file-local `SettingsArtifactMessage` namespace (the 3 genuinely-distinct variants are left as-is).
- **WAV→M4A conversion** → the duplicated temp/convert/validate/move/cleanup flow in `MeetingAudioStorageManager` (retained-audio compression and failed-meeting audio promotion) extracted into one `convertWAVToM4AAtomically` helper; the differing post-steps (delete source + count vs. cancellation check + result struct) stay at the call sites.

Net ~−52 lines across 15 files.

## How I checked it

> ⚠️ This branch was prepared in a Linux environment with **no macOS Swift toolchain**, so nothing here was compiled or run. Every change is behavior-preserving by construction and was reviewed by reasoning + grep verification (call-site checks, map-equality diff, import presence, fast-test/e2e source-list membership). The boxes below still need to run on a Mac.

- [ ] `scripts/dev/agent-preflight.sh`
- [ ] Selected checks from `.agents/test-matrix.yml` for the files changed
- [ ] `bash build-deps.sh --force` (touched `Sources/TranscriptedCore/`)
- [ ] `bash build.sh --no-open`
- [ ] `bash run-tests.sh`
- [ ] `bash run-integration-smoke.sh` (touched `Sources/Meeting/` + `Sources/TranscriptedCore/`)
- [ ] `swift test` (touched the core seam)
- [ ] `swift test --package-path Tools/TranscriptedCaptureKit` + `Tools/TranscriptedCLI` + `Tools/TranscriptedMCP` (touched CaptureKit + both consumers)
- [ ] `bash run-e2e-smoke.sh` (CaptureKit + MCP source set changed)

## Risk Review

- [x] Privacy / local-first behavior reviewed — sanitizer key sets are identical to before; redaction mechanics unchanged.
- [x] Storage path or migration impact reviewed — no path changes; WAV→M4A flow is byte-for-byte equivalent (one minor, strictly-more-correct change: a converted file is now counted even if deleting the source WAV fails).
- [x] Public-facing copy stays concrete and matches current product scope — error strings moved verbatim into a constant.
- [x] Release/update impact reviewed — none.
- [x] Agent PRs link the issue/workpad and stay draft until human review.
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence — N/A (no visual change; only an error-string constant extraction).
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included.

## Notes

Deliberately **deferred** (flagged by the audit but not done here): the large god-file decompositions — `TranscriptedSettingsView.swift` (~4,948 lines), `HomeView.swift`, `PermissionsOnboardingView.swift`, `MeetingSessionController.swift` (~3,358), and the 610-line `transcribeMultichannel()` in `TranscriptionPipeline.swift`. Splitting those blind (no compiler in this environment) would very likely ship a broken branch, so they're better done incrementally on a machine with the toolchain. The cross-Core sanitizer-regex unification (`LogPrivacySanitizer` ↔ `ObservabilityTextRedactor`) is also deferred because it requires new public Core API + a deps rebuild.

## Agent handoff

`COORD_DONE: BRIEF | this PR | 6 dedup consolidations across 15 files, +1 new shared file | none | needs Mac build+test run (matrix unchecked above) | no checks run locally (no Swift toolchain) | run bash build-deps.sh --force && bash build.sh --no-open && bash run-tests.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGExo1scqor9ZfKQt7m7DJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BGExo1scqor9ZfKQt7m7DJ)_