### PR TITLE
docs: add GitHub Sponsors link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,10 @@ Start here:
 Coding agents can run `scripts/dev/agent-preflight.sh` to get a suggested
 verification map for their branch.
 
-If Transcripted is useful to you, a star helps other people find it.
+If Transcripted is useful to you, a star helps other people find it. If you
+want to help keep it maintained, you can also
+[sponsor the project](https://github.com/sponsors/r3dbars) — the app stays free,
+local, and MIT either way.
 
 ## License
 


### PR DESCRIPTION
## What

Adds a sponsor link to the existing "a star helps" support ask in the README, pointing at `https://github.com/sponsors/r3dbars`, with a note that the app stays free, local, and MIT regardless.

## Why

The repo already ships `.github/FUNDING.yml` (`github: r3dbars`), which wires the **Sponsor** button on the repo. The README never mentioned sponsoring, so this makes the donation path discoverable to people reading the project page. Framed as goodwill/sustainability, consistent with the "free forever, no pro tier" promise in the FAQ — no paywall, no trust-position change.

## Note

The repo-side config is complete. Sponsorships only go live once the GitHub Sponsors account for `r3dbars` is enrolled and approved (profile + Stripe/bank + tax forms) — that's an account-level step on github.com that can't be done from the repo.

## Verification

- Docs-only change. `scripts/dev/agent-preflight.sh` confirms README.md is the only touched path; no build/test rules triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0199rS68WXC8kPJLBXfxTTjR)_