### PR TITLE
Docs: sync agent-surface docs with actual behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,26 +124,36 @@ A meeting:
 ```md
 # Product Review
 
-Recorded Apr 10 at 3:01 PM  -  32:14  -  4,230 words
+Recorded Apr 10, 2026 at 3:01 PM  •  32 min, 14 sec  •  4230 words  •  18 turns
 
 ## Transcript
 
-**00:00** [Sarah]
+**00:00**  [System/Sarah]
 Keep annual pricing manual for now.
 
-**00:04** [Michael]
+**00:04**  [Mic/You]
 Onboarding friction is still the blocker.
 ```
+
+(Each file also starts with a small metadata header — date, duration,
+speakers — that agents can parse. Speaker labels carry the audio channel, so
+`[Mic/You]` is you on the microphone and `[System/Sarah]` is a remote voice.)
 
 A day of dictations:
 
 ```md
 # Dictations for April 10, 2026
 
-## 9:15 AM
+## 9:15 AM - Need to test the onboarding changes
+
+Source app: Notes
+Words: 11
 
 Need to test the onboarding changes before touching pricing.
 ```
+
+(Trimmed for the README — each entry also records an entry ID, exact
+timestamp, and delivery outcome.)
 
 Everything lives in normal folders:
 

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -70,6 +70,13 @@ Current `transcripted-mcp` capabilities:
 - `search`
 - `who_is`
 - `recap`
+- `list_action_items`
+- `list_decisions`
+- `digest`
+
+The last three roll up structured summary fields (decisions, action items,
+open questions) across saved meetings. They only return rows for meetings
+that have a saved summary — see `docs/cross-meeting-tools.md`.
 
 These tools are read-only, but they are not redacted. `read_meeting` and
 `read_dictation` can return local transcript text to the agent you connected.

--- a/docs/storage-paths.md
+++ b/docs/storage-paths.md
@@ -8,10 +8,11 @@ Support root:
 - app support root: `~/Library/Application Support/Transcripted/`
 - default capture library: `~/Library/Application Support/Transcripted/captures/`
 
-Users can move the capture library in Settings via the `transcriptSaveLocation`
-preference. When that happens, meetings and dictations move under the selected
-folder, while app-owned state, cache, logs, and temp files stay under
-`~/Library/Application Support/Transcripted/`.
+Users can point the capture library at a different folder in Settings via the
+`transcriptSaveLocation` preference. Changing it only affects where *new*
+meetings and dictations are written — existing captures are not migrated and
+stay in the previous folder. App-owned state, cache, logs, and temp files
+always stay under `~/Library/Application Support/Transcripted/`.
 
 ## Dictation
 


### PR DESCRIPTION
## Why

An audit of the agent-facing surface found places where the docs describe behavior the code doesn't have (or omit behavior it does have). Agents and users reading these docs get wrong expectations: a tool list missing 3 of 12 tools, a README file example that doesn't match real output, and relocation wording that implies captures are migrated when they aren't.

## Product Impact

- Affects: `docs only`
- Lane: `agent workflow`
- Why this matters: these docs are the first things a user or agent reads when wiring Transcripted into Claude/Codex/Cursor; drift here turns directly into wrong agent behavior and support confusion.

## What changed

- `docs/agent-connect.md`: capability list now shows all 12 MCP tools — `list_action_items`, `list_decisions`, `digest` were missing — with a note that the rollup tools only return rows for meetings with saved summaries (links `docs/cross-meeting-tools.md`).
- `README.md`: the meeting example now matches `MeetingTranscriptStyler.renderBody` output (`  •  ` separators, `32 min, 14 sec` duration, no thousands separator, `turns` count, channel-qualified `[System/Sarah]` / `[Mic/You]` labels); the dictation example now matches `DictationTranscriptWriter.dailySection` (title in the `##` heading, metadata lines), marked as trimmed.
- `docs/storage-paths.md`: changing `transcriptSaveLocation` only affects where new captures are written; existing files are not migrated. The old wording said meetings and dictations "move under the selected folder", which `TranscriptedStoragePreferences.setCaptureLibraryURL` does not do. (When #1360 merges, this paragraph gains a one-line follow-up about the new copy offer.)

Rebase note: this PR originally also fixed the stale file map in `Tools/TranscriptedMCP/CLAUDE.md`; #1362 landed a fresher version of that same fix on `main`, so that hunk was dropped here during the rebase — the PR is now 3 files.

Heads-up for the merge-room: `docs/agent-connect.md` currently says "Current `transcripted-mcp` capabilities" as a 12-tool list; #1362/#1363 added the `status` tool and pagination after this PR was written, so a tiny follow-up (add `status` to the list) is queued behind this and #1357 to avoid another same-hunk conflict cascade.

## How I checked it

- [x] `scripts/dev/agent-preflight.sh`
- [x] Selected checks from `.agents/test-matrix.yml` for the files changed (docs rule → preflight)
- [x] Swift CI ran green on the original head; docs-only rebase re-runs it on the new head
- [x] Manual check: every claim verified against the writers/parsers (`MeetingTranscriptStyler.swift`, `DictationTranscriptWriter.swift`, `TranscriptedStoragePaths.swift`) before editing.

## Risk Review

- [x] Privacy / local-first behavior reviewed — wording only
- [x] Storage path or migration impact reviewed — wording only; no behavior change
- [x] Public-facing copy stays concrete and matches current product scope
- [x] Release/update impact reviewed — none
- [x] Agent PRs link the issue/workpad and stay draft until human review — marked ready by @r3dbars
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence — n/a
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

## Notes

First of the agent-surface audit series. Merge order: this, then #1357 (stacked on this branch).

## Agent handoff

`COORD_DONE: GREEN | (this PR) | synced 3 docs with verified behavior (CLAUDE.md hunk superseded by #1362) | none | none | preflight + CI on rebase | merge, then #1357`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuGZaFRmNrqfGPpqf7WH4n