### PR TITLE
Docs: disclose the MCP helper's anonymous usage ping

### DIFF
--- a/Tools/TranscriptedMCP/README.md
+++ b/Tools/TranscriptedMCP/README.md
@@ -49,3 +49,21 @@ If `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
 `dictations/` subfolders, `transcripted-mcp` uses those subfolders
 automatically and stores its SQLite index in that shared root unless
 `TRANSCRIPTED_INDEX_DIR` is also set.
+
+## Telemetry
+
+The server can emit one anonymous PostHog event per successful tool call
+(`agent_capture_query_observed`, see `AgentCaptureQueryTelemetry.swift`). The
+payload is bucketed metadata only — query kind, artifact kind, capture-age
+bucket, source-count bucket — validated against an allow-list; transcript
+text, query strings, titles, speaker names, and file paths are never sent.
+
+It is gated twice:
+
+- it honors the app's anonymous-analytics toggle
+  (`observability-anonymous-analytics-enabled`; off means nothing is sent)
+- it no-ops entirely unless a PostHog API key and HTTPS host are configured
+  via `POSTHOG_API_KEY`/`POSTHOG_HOST`, a local override, or the bundle's
+  `TranscriptedPostHogAPIKey` — source builds have none by default
+
+Transcripts and audio never leave the Mac in any mode.

--- a/docs/agent-connect.md
+++ b/docs/agent-connect.md
@@ -81,6 +81,19 @@ that have a saved summary — see `docs/cross-meeting-tools.md`.
 These tools are read-only, but they are not redacted. `read_meeting` and
 `read_dictation` can return local transcript text to the agent you connected.
 
+### Anonymous usage ping
+
+Like the app, the MCP helper can send one anonymous analytics event per
+successful tool call (`agent_capture_query_observed`) so we can tell whether
+the agent connection gets used. It carries only bucketed metadata — which kind
+of tool ran, meeting vs dictation, rough capture age, rough source count.
+It never includes transcript text, queries, titles, speaker names, or file
+paths, and your captures still never leave your Mac.
+
+It follows the same anonymous-analytics switch as the app: turn off analytics
+in Settings → Privacy and the helper sends nothing. Source builds send nothing
+by default because they ship without an analytics key.
+
 ## Local Coding Agents
 
 Claude Code, Codex, and Cursor get the same one-click `Connect` as Claude


### PR DESCRIPTION
## Why

`transcripted-mcp` sends one anonymous PostHog event per successful tool call (`agent_capture_query_observed` in `AgentCaptureQueryTelemetry.swift`). It's well-gated in code — allow-list scrubbing, honors the app analytics toggle, no-ops without an API key — but it was disclosed nowhere a user would look. For a product whose pitch is "read-only, nothing leaves your Mac," an undocumented outbound call per agent query is a trust problem even when the payload is clean.

## Product Impact

- Affects: `docs only`
- Lane: `agent workflow`
- Why this matters: privacy-first is the product's core differentiator; disclosure has to be as visible as the feature.

## What changed

- `docs/agent-connect.md`: new "Anonymous usage ping" subsection right under the tool list — plain-language description of what's sent (bucketed metadata only), what's never sent (transcript text, queries, titles, names, paths), and that the app's Settings → Privacy analytics switch turns it off.
- `Tools/TranscriptedMCP/README.md`: new "Telemetry" section with the technical detail — event name, payload buckets, the double gate (analytics toggle + API-key/HTTPS-host requirement), and that source builds send nothing by default.

All claims verified against `AgentCaptureQueryTelemetry.swift` (`analyticsEnabled`, `observability-anonymous-analytics-enabled`, `POSTHOG_API_KEY`/`POSTHOG_HOST`/`TranscriptedPostHogAPIKey` resolution, HTTPS-only host check, allow-list policy).

## How I checked it

- [x] `scripts/dev/agent-preflight.sh`
- [x] Selected checks from `.agents/test-matrix.yml` (docs rule → preflight)
- [ ] `bash build.sh --no-open` — n/a, docs only
- [ ] `bash run-tests.sh` — n/a, docs only
- [ ] Performance budget — n/a
- [ ] `bash run-integration-smoke.sh` — n/a
- [ ] `swift test` — n/a, no code changed
- [x] Manual check: each gating claim traced to the exact code path before writing it down.

## Risk Review

- [x] Privacy / local-first behavior reviewed — this PR is the privacy disclosure itself
- [x] Storage path or migration impact reviewed — none
- [x] Public-facing copy stays concrete and matches current product scope
- [x] Release/update impact reviewed — none
- [x] Agent PRs link the issue/workpad and stay draft until human review
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence — n/a
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

## Notes

Stacked on #1356 (base is that branch because both edit adjacent text in `agent-connect.md`) — merge #1356 first, then retarget this to `main` (GitHub does this automatically on base-branch merge). Part of the agent-surface audit series.

## Agent handoff

`COORD_DONE: GREEN | (this PR) | telemetry disclosure in 2 docs | retarget to main after #1356 merges | none | agent-preflight.sh | review + merge after #1356`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuGZaFRmNrqfGPpqf7WH4n

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuGZaFRmNrqfGPpqf7WH4n)_