### PR TITLE
CLI: empty-result diagnostics, documented count clamp, structured JSON reads

### DIFF
--- a/Tools/TranscriptedCLI/CLAUDE.md
+++ b/Tools/TranscriptedCLI/CLAUDE.md
@@ -35,6 +35,13 @@ They also honor:
 - `TRANSCRIPTED_MEETINGS_DIR`
 - `TRANSCRIPTED_DICTATIONS_DIR`
 
+### Output Shapes
+
+- `context-recent`, `context-search`, and `list-dictations` print a bare JSON array with `--json` when there are results; with zero results they emit `{"results": [], "searched_directories": [...], "hint": "..."}` instead, and in text mode print `No results. Searched: <dirs>` to stderr
+- `context-search --speaker` with `--kind all` or `--kind dictation` skips dictations by design; text mode prints a one-line note to stderr, `--json` wraps the results as `{"results": [...], "notes": [...]}`
+- `--count` values are clamped to 1-50
+- `read-meeting --json` includes `recording`, `speakers`, and `utterances` (parsed transcript structure) alongside the raw `markdown`; `read-dictation --json` includes `date` and `entries` (entry id, captured timestamp, source app, title, text) alongside `markdown`
+
 ### Offline Audio
 
 - `transcripted-cli diarize <audio>` — diarize one file, output RTTM or JSON
@@ -120,5 +127,6 @@ with `TRANSCRIPTEDCLI_ENABLE_DIARIZATION=1` when diarization is needed.
 - the default context resolver prefers the app-selected capture library when Transcripted has one, then falls back to the current Transcripted capture folders, then Draft-era exports, then `~/Documents/Transcripted/`
 - when the user moved the capture library in Transcripted Settings, the CLI should follow that app-selected path before defaulting back to `~/Library/Application Support/Transcripted/captures`
 - `context-recent` is intentionally a mixed feed; if the user asks for the latest meeting specifically, add `--kind meeting`
+- diagnostics (empty-result and speaker-filter notes) go to stderr in text mode so piped stdout stays parseable; keep it that way
 - changes here should be verified independently from the app build
 - directory resolution and capture-Markdown parsing live in `Tools/TranscriptedCaptureKit` and are shared with `Tools/TranscriptedMCP`; change them there, not by re-inlining logic into `ContextStore.swift`

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextCommands.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextCommands.swift
@@ -18,21 +18,26 @@ struct ContextRecent: ParsableCommand {
     @Option(name: .long, help: "End date filter (YYYY-MM-DD).")
     var dateTo: String?
 
-    @Option(name: .shortAndLong, help: "Number of items to return.")
+    @Option(name: .shortAndLong, help: "Number of items to return (valid range 1-50; values outside are clamped).")
     var count: Int = 10
 
     @Flag(name: .long, help: "Output JSON instead of text.")
     var json: Bool = false
 
     func run() throws {
+        let directories = paths.resolved
         let items = CLIContextStore.recent(
-            in: paths.resolved,
+            in: directories,
             kind: kind,
             count: max(1, min(count, 50)),
             dateFrom: dateFrom,
             dateTo: dateTo
         )
-        try printContextItems(items, asJSON: json)
+        try printContextItems(
+            items,
+            asJSON: json,
+            searchedDirectories: searchedDirectoryPaths(in: directories, kind: kind)
+        )
     }
 }
 
@@ -59,23 +64,33 @@ struct ContextSearch: ParsableCommand {
     @Option(name: .long, help: "End date filter (YYYY-MM-DD).")
     var dateTo: String?
 
-    @Option(name: .shortAndLong, help: "Number of results to return.")
+    @Option(name: .shortAndLong, help: "Number of results to return (valid range 1-50; values outside are clamped).")
     var count: Int = 10
 
     @Flag(name: .long, help: "Output JSON instead of text.")
     var json: Bool = false
 
     func run() throws {
+        let directories = paths.resolved
+        var notes: [String] = []
+        if speaker != nil, kind != .meeting {
+            notes.append("Note: --speaker only matches meetings; dictations skipped.")
+        }
         let items = CLIContextStore.search(
             query: query,
             speaker: speaker,
-            in: paths.resolved,
+            in: directories,
             kind: kind,
             count: max(1, min(count, 50)),
             dateFrom: dateFrom,
             dateTo: dateTo
         )
-        try printContextItems(items, asJSON: json)
+        try printContextItems(
+            items,
+            asJSON: json,
+            searchedDirectories: searchedDirectoryPaths(in: directories, kind: kind),
+            notes: notes
+        )
     }
 }
 
@@ -93,23 +108,34 @@ struct ListDictations: ParsableCommand {
     @Option(name: .long, help: "End date filter (YYYY-MM-DD).")
     var dateTo: String?
 
-    @Option(name: .shortAndLong, help: "Number of days to return.")
+    @Option(name: .shortAndLong, help: "Number of days to return (valid range 1-50; values outside are clamped).")
     var count: Int = 10
 
     @Flag(name: .long, help: "Output JSON instead of text.")
     var json: Bool = false
 
     func run() throws {
+        let directories = paths.resolved
         let days = CLIContextStore.listDictationDays(
-            in: paths.resolved,
+            in: directories,
             count: max(1, min(count, 50)),
             dateFrom: dateFrom,
             dateTo: dateTo
         )
+        let searchedDirectories = searchedDirectoryPaths(in: directories, kind: .dictation)
 
         if json {
+            if days.isEmpty {
+                try printEmptyResultsJSON(searchedDirectories: searchedDirectories, notes: [])
+                return
+            }
             let data = try JSONEncoder.contextPretty.encode(days)
             print(String(data: data, encoding: .utf8) ?? "[]")
+            return
+        }
+
+        if days.isEmpty {
+            printEmptyResultsToStandardError(searchedDirectories: searchedDirectories)
             return
         }
 
@@ -139,13 +165,17 @@ struct ReadMeeting: ParsableCommand {
 
     func run() throws {
         let markdown = try CLIContextStore.readMeeting(filename: filename, in: paths.resolved)
-        try printReadMarkdown(
+        let transcript = json ? CLIContextStore.meetingTranscript(fromMarkdown: markdown) : nil
+        let document = CLIReadMarkdownDocument(
             kind: .meeting,
-            filename: filename,
+            filename: normalizedMarkdownFilename(filename),
             entryId: nil,
             markdown: markdown,
-            asJSON: json
+            recording: transcript?.recording,
+            speakers: transcript?.speakers,
+            utterances: transcript?.utterances
         )
+        try printReadDocument(document, asJSON: json)
     }
 }
 
@@ -167,21 +197,54 @@ struct ReadDictation: ParsableCommand {
     var json: Bool = false
 
     func run() throws {
-        let markdown = try CLIContextStore.readDictation(filename: filename, entryId: entryId, in: paths.resolved)
-        try printReadMarkdown(
+        let read = try CLIContextStore.readDictationDocument(filename: filename, entryId: entryId, in: paths.resolved)
+        let document = CLIReadMarkdownDocument(
             kind: .dictation,
-            filename: filename,
+            filename: normalizedMarkdownFilename(filename),
             entryId: entryId,
-            markdown: markdown,
-            asJSON: json
+            markdown: read.markdown,
+            date: read.date,
+            entries: read.entries
         )
+        try printReadDocument(document, asJSON: json)
     }
 }
 
-private func printContextItems(_ items: [CLIContextItem], asJSON: Bool) throws {
+private let emptyResultsHint = "No captures matched. Check the searched directories or pass --data-dir, --meetings-dir, or --dictations-dir."
+
+private func printContextItems(
+    _ items: [CLIContextItem],
+    asJSON: Bool,
+    searchedDirectories: [String],
+    notes: [String] = []
+) throws {
     if asJSON {
+        if items.isEmpty {
+            try printEmptyResultsJSON(searchedDirectories: searchedDirectories, notes: notes)
+            return
+        }
+        if !notes.isEmpty {
+            let document = CLIContextResultsDocument(
+                results: items,
+                searchedDirectories: nil,
+                hint: nil,
+                notes: notes
+            )
+            let data = try JSONEncoder.contextPretty.encode(document)
+            print(String(data: data, encoding: .utf8) ?? "{}")
+            return
+        }
         let data = try JSONEncoder.contextPretty.encode(items)
         print(String(data: data, encoding: .utf8) ?? "[]")
+        return
+    }
+
+    for note in notes {
+        printToStandardError(note)
+    }
+
+    if items.isEmpty {
+        printEmptyResultsToStandardError(searchedDirectories: searchedDirectories)
         return
     }
 
@@ -198,26 +261,48 @@ private func printContextItems(_ items: [CLIContextItem], asJSON: Bool) throws {
     }
 }
 
-private func printReadMarkdown(
-    kind: CLIContextKind,
-    filename: String,
-    entryId: String?,
-    markdown: String,
-    asJSON: Bool
-) throws {
+private func printReadDocument(_ document: CLIReadMarkdownDocument, asJSON: Bool) throws {
     guard asJSON else {
-        print(markdown)
+        print(document.markdown)
         return
     }
 
-    let document = CLIReadMarkdownDocument(
-        kind: kind,
-        filename: normalizedMarkdownFilename(filename),
-        entryId: entryId,
-        markdown: markdown
+    let data = try JSONEncoder.contextPretty.encode(document)
+    print(String(data: data, encoding: .utf8) ?? "{}")
+}
+
+private func printEmptyResultsJSON(searchedDirectories: [String], notes: [String]) throws {
+    let document = CLIContextResultsDocument(
+        results: [],
+        searchedDirectories: searchedDirectories,
+        hint: emptyResultsHint,
+        notes: notes.isEmpty ? nil : notes
     )
     let data = try JSONEncoder.contextPretty.encode(document)
     print(String(data: data, encoding: .utf8) ?? "{}")
+}
+
+private func printEmptyResultsToStandardError(searchedDirectories: [String]) {
+    printToStandardError("No results. Searched: \(searchedDirectories.joined(separator: ", "))")
+}
+
+private func printToStandardError(_ message: String) {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+}
+
+private func searchedDirectoryPaths(in directories: CLIContextDirectories, kind: CLIContextKind) -> [String] {
+    var urls: [URL] = []
+    if kind != .dictation {
+        urls.append(contentsOf: directories.meetingDirs)
+    }
+    if kind != .meeting {
+        urls.append(contentsOf: directories.dictationDirs)
+    }
+
+    var seen: Set<String> = []
+    return urls.compactMap { url in
+        seen.insert(url.path).inserted ? url.path : nil
+    }
 }
 
 private func normalizedMarkdownFilename(_ filename: String) -> String {

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextModels.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextModels.swift
@@ -134,10 +134,49 @@ struct CLIReadMarkdownDocument: Codable {
     let filename: String
     let entryId: String?
     let markdown: String
+    let recording: CLIAgentRecording?
+    let speakers: [CLIActorSpeaker]?
+    let utterances: [CLIUtterance]?
+    let date: String?
+    let entries: [CLIClientDictationEntry]?
+
+    init(
+        kind: CLIContextKind,
+        filename: String,
+        entryId: String?,
+        markdown: String,
+        recording: CLIAgentRecording? = nil,
+        speakers: [CLIActorSpeaker]? = nil,
+        utterances: [CLIUtterance]? = nil,
+        date: String? = nil,
+        entries: [CLIClientDictationEntry]? = nil
+    ) {
+        self.kind = kind
+        self.filename = filename
+        self.entryId = entryId
+        self.markdown = markdown
+        self.recording = recording
+        self.speakers = speakers
+        self.utterances = utterances
+        self.date = date
+        self.entries = entries
+    }
 
     enum CodingKeys: String, CodingKey {
-        case kind, filename, markdown
+        case kind, filename, markdown, recording, speakers, utterances, date, entries
         case entryId = "entry_id"
+    }
+}
+
+struct CLIContextResultsDocument: Codable {
+    let results: [CLIContextItem]
+    let searchedDirectories: [String]?
+    let hint: String?
+    let notes: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case results, hint, notes
+        case searchedDirectories = "searched_directories"
     }
 }
 

--- a/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
+++ b/Tools/TranscriptedCLI/Sources/TranscriptedCLI/ContextStore.swift
@@ -221,7 +221,17 @@ enum CLIContextStore {
         return content
     }
 
+    struct DictationRead {
+        let markdown: String
+        let date: String
+        let entries: [CLIClientDictationEntry]
+    }
+
     static func readDictation(filename: String, entryId: String?, in directories: CLIContextDirectories) throws -> String {
+        try readDictationDocument(filename: filename, entryId: entryId, in: directories).markdown
+    }
+
+    static func readDictationDocument(filename: String, entryId: String?, in directories: CLIContextDirectories) throws -> DictationRead {
         let requestedName = filename.hasSuffix(".md") ? filename : filename + ".md"
         var invalidPathRequested = false
         var markdownURL: URL?
@@ -254,7 +264,7 @@ enum CLIContextStore {
                 throw ValidationError("Dictation entry not found: \(entryId)")
             }
 
-            return """
+            let markdown = """
             # \(entry.title)
 
             Captured: \(entry.createdAt)
@@ -264,14 +274,19 @@ enum CLIContextStore {
 
             \(entry.text)
             """
+            return DictationRead(markdown: markdown, date: day.payload.date, entries: [entry])
         }
 
         if let content = try? String(contentsOf: markdownURL, encoding: .utf8) {
-            return content
+            return DictationRead(markdown: content, date: day.payload.date, entries: day.entries)
         }
 
         let data = try JSONEncoder.contextPretty.encode(day.payload)
-        return String(data: data, encoding: .utf8) ?? "{}"
+        return DictationRead(
+            markdown: String(data: data, encoding: .utf8) ?? "{}",
+            date: day.payload.date,
+            entries: day.entries
+        )
     }
 
     private struct MeetingRecord {
@@ -386,8 +401,12 @@ enum CLIContextStore {
     }
 
     private static func loadMeeting(at url: URL) -> CLIAgentTranscript? {
-        guard let content = try? String(contentsOf: url, encoding: .utf8),
-              let parsed = CaptureMarkdownParser.parseMeeting(from: content) else { return nil }
+        guard let content = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+        return meetingTranscript(fromMarkdown: content)
+    }
+
+    static func meetingTranscript(fromMarkdown content: String) -> CLIAgentTranscript? {
+        guard let parsed = CaptureMarkdownParser.parseMeeting(from: content) else { return nil }
 
         return CLIAgentTranscript(
             version: "2.0",

--- a/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
+++ b/Tools/TranscriptedCLI/Tests/TranscriptedCLITests/ContextStoreTests.swift
@@ -573,6 +573,8 @@ final class ContextStoreTests: XCTestCase {
         XCTAssertTrue(json?.contains("\"kind\" : \"dictation\"") == true)
         XCTAssertTrue(json?.contains("\"entry_id\" : \"dictation-20260407-091500-000\"") == true)
         XCTAssertTrue(json?.contains("\"markdown\" :") == true)
+        XCTAssertTrue(json?.contains("\"utterances\"") == false)
+        XCTAssertTrue(json?.contains("\"entries\"") == false)
     }
 
     func testReadMeetingCommandJSONOutputsReadableDocument() throws {
@@ -902,6 +904,309 @@ final class ContextStoreTests: XCTestCase {
         XCTAssertTrue(json?.contains("\"kind\" : \"dictation\"") == true)
     }
 
+    func testContextRecentCommandEmptyTextModePrintsSearchedDirectoriesToStandardError() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let (meetingsDir, dictationsDir) = try makeContextDirs(in: root)
+        let command = try ContextRecent.parse([
+            "--meetings-dir", meetingsDir.path,
+            "--dictations-dir", dictationsDir.path,
+        ])
+
+        var stderr = ""
+        let stdout = try captureStandardOutput {
+            stderr = try captureStandardError {
+                try command.run()
+            }
+        }
+
+        XCTAssertEqual(stdout, "")
+        XCTAssertTrue(stderr.hasPrefix("No results. Searched: "))
+        XCTAssertTrue(stderr.contains(meetingsDir.path))
+        XCTAssertTrue(stderr.contains(dictationsDir.path))
+    }
+
+    func testContextRecentCommandEmptyJSONOutputsSearchedDirectoriesAndHint() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let (meetingsDir, dictationsDir) = try makeContextDirs(in: root)
+        let command = try ContextRecent.parse([
+            "--meetings-dir", meetingsDir.path,
+            "--dictations-dir", dictationsDir.path,
+            "--json",
+        ])
+        let output = try captureStandardOutput {
+            try command.run()
+        }
+        let document = try JSONDecoder().decode(CLIContextResultsDocument.self, from: XCTUnwrap(output.data(using: .utf8)))
+
+        XCTAssertTrue(document.results.isEmpty)
+        XCTAssertEqual(document.searchedDirectories, [meetingsDir.path, dictationsDir.path])
+        XCTAssertEqual(document.hint?.isEmpty, false)
+        XCTAssertNil(document.notes)
+    }
+
+    func testContextRecentCommandEmptyJSONLimitsSearchedDirectoriesToRequestedKind() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let (meetingsDir, dictationsDir) = try makeContextDirs(in: root)
+        let command = try ContextRecent.parse([
+            "--kind", "meeting",
+            "--meetings-dir", meetingsDir.path,
+            "--dictations-dir", dictationsDir.path,
+            "--json",
+        ])
+        let output = try captureStandardOutput {
+            try command.run()
+        }
+        let document = try JSONDecoder().decode(CLIContextResultsDocument.self, from: XCTUnwrap(output.data(using: .utf8)))
+
+        XCTAssertEqual(document.searchedDirectories, [meetingsDir.path])
+    }
+
+    func testListDictationsCommandEmptyJSONOutputsSearchedDirectoriesAndHint() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let (meetingsDir, dictationsDir) = try makeContextDirs(in: root)
+        let command = try ListDictations.parse([
+            "--meetings-dir", meetingsDir.path,
+            "--dictations-dir", dictationsDir.path,
+            "--json",
+        ])
+        let output = try captureStandardOutput {
+            try command.run()
+        }
+        let document = try JSONDecoder().decode(CLIContextResultsDocument.self, from: XCTUnwrap(output.data(using: .utf8)))
+
+        XCTAssertTrue(document.results.isEmpty)
+        XCTAssertEqual(document.searchedDirectories, [dictationsDir.path])
+        XCTAssertEqual(document.hint?.isEmpty, false)
+    }
+
+    func testListDictationsCommandEmptyTextModePrintsSearchedDirectoriesToStandardError() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let (meetingsDir, dictationsDir) = try makeContextDirs(in: root)
+        let command = try ListDictations.parse([
+            "--meetings-dir", meetingsDir.path,
+            "--dictations-dir", dictationsDir.path,
+        ])
+
+        var stderr = ""
+        let stdout = try captureStandardOutput {
+            stderr = try captureStandardError {
+                try command.run()
+            }
+        }
+
+        XCTAssertEqual(stdout, "")
+        XCTAssertTrue(stderr.hasPrefix("No results. Searched: "))
+        XCTAssertTrue(stderr.contains(dictationsDir.path))
+        XCTAssertFalse(stderr.contains(meetingsDir.path))
+    }
+
+    func testContextSearchCommandSpeakerWithKindAllEmitsNoteInJSON() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let (meetingsDir, dictationsDir) = try makeContextDirs(in: root)
+        try makeMeetingMarkdown(title: "Planning", date: "2026-04-06", body: "[00:03] [Mic/You] Roadmap meeting note.")
+            .write(to: meetingsDir.appendingPathComponent("Planning.md"), atomically: true, encoding: .utf8)
+
+        let command = try ContextSearch.parse([
+            "roadmap",
+            "--speaker", "You",
+            "--meetings-dir", meetingsDir.path,
+            "--dictations-dir", dictationsDir.path,
+            "--json",
+        ])
+        let output = try captureStandardOutput {
+            try command.run()
+        }
+        let document = try JSONDecoder().decode(CLIContextResultsDocument.self, from: XCTUnwrap(output.data(using: .utf8)))
+
+        XCTAssertEqual(document.results.count, 1)
+        XCTAssertEqual(document.results.first?.kind, .meeting)
+        XCTAssertEqual(document.notes, ["Note: --speaker only matches meetings; dictations skipped."])
+        XCTAssertNil(document.searchedDirectories)
+        XCTAssertNil(document.hint)
+    }
+
+    func testContextSearchCommandSpeakerWithKindAllPrintsNoteToStandardError() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let (meetingsDir, dictationsDir) = try makeContextDirs(in: root)
+        try makeMeetingMarkdown(title: "Planning", date: "2026-04-06", body: "[00:03] [Mic/You] Roadmap meeting note.")
+            .write(to: meetingsDir.appendingPathComponent("Planning.md"), atomically: true, encoding: .utf8)
+
+        let command = try ContextSearch.parse([
+            "roadmap",
+            "--speaker", "You",
+            "--meetings-dir", meetingsDir.path,
+            "--dictations-dir", dictationsDir.path,
+        ])
+
+        var stderr = ""
+        let stdout = try captureStandardOutput {
+            stderr = try captureStandardError {
+                try command.run()
+            }
+        }
+
+        XCTAssertTrue(stdout.contains("Planning"))
+        XCTAssertTrue(stderr.contains("Note: --speaker only matches meetings; dictations skipped."))
+    }
+
+    func testContextSearchCommandSpeakerWithMeetingKindKeepsBareArrayJSON() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let (meetingsDir, dictationsDir) = try makeContextDirs(in: root)
+        try makeMeetingMarkdown(title: "Planning", date: "2026-04-06", body: "[00:03] [Mic/You] Roadmap meeting note.")
+            .write(to: meetingsDir.appendingPathComponent("Planning.md"), atomically: true, encoding: .utf8)
+
+        let command = try ContextSearch.parse([
+            "roadmap",
+            "--kind", "meeting",
+            "--speaker", "You",
+            "--meetings-dir", meetingsDir.path,
+            "--dictations-dir", dictationsDir.path,
+            "--json",
+        ])
+        let output = try captureStandardOutput {
+            try command.run()
+        }
+        let items = try JSONDecoder().decode([CLIContextItem].self, from: XCTUnwrap(output.data(using: .utf8)))
+
+        XCTAssertEqual(items.count, 1)
+        XCTAssertEqual(items.first?.title, "Planning")
+    }
+
+    func testContextRecentCommandNonEmptyJSONKeepsBareArrayShape() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let (meetingsDir, dictationsDir) = try makeContextDirs(in: root)
+        try makeMeetingMarkdown(title: "Planning", date: "2026-04-06", body: "[00:03] [Mic/You] Roadmap meeting note.")
+            .write(to: meetingsDir.appendingPathComponent("Planning.md"), atomically: true, encoding: .utf8)
+
+        let command = try ContextRecent.parse([
+            "--meetings-dir", meetingsDir.path,
+            "--dictations-dir", dictationsDir.path,
+            "--json",
+        ])
+        let output = try captureStandardOutput {
+            try command.run()
+        }
+        let items = try JSONDecoder().decode([CLIContextItem].self, from: XCTUnwrap(output.data(using: .utf8)))
+
+        XCTAssertEqual(items.map(\.title), ["Planning"])
+    }
+
+    func testReadMeetingCommandJSONIncludesStructuredTranscript() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let (meetingsDir, dictationsDir) = try makeContextDirs(in: root)
+        let markdown = makeMeetingMarkdown(
+            title: "Product review",
+            date: "2026-04-18",
+            body: "[00:03] [Mic/You] Ship the agent path.\n\n[00:08] [System/Speaker 2] Agreed."
+        )
+        try markdown.write(
+            to: meetingsDir.appendingPathComponent("Product review.md"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let command = try ReadMeeting.parse([
+            "Product review",
+            "--meetings-dir", meetingsDir.path,
+            "--dictations-dir", dictationsDir.path,
+            "--json",
+        ])
+        let output = try captureStandardOutput {
+            try command.run()
+        }
+        let document = try JSONDecoder().decode(CLIReadMarkdownDocument.self, from: XCTUnwrap(output.data(using: .utf8)))
+
+        XCTAssertEqual(document.kind, .meeting)
+        XCTAssertEqual(document.markdown, markdown)
+        XCTAssertEqual(document.recording?.date.prefix(10), "2026-04-18")
+        XCTAssertEqual(document.utterances?.count, 2)
+        XCTAssertEqual(document.utterances?.first?.text, "Ship the agent path.")
+        let speakerIds = Set((document.speakers ?? []).map(\.id))
+        XCTAssertTrue(Set((document.utterances ?? []).map(\.speakerId)).isSubset(of: speakerIds))
+    }
+
+    func testReadDictationCommandJSONIncludesDayEntries() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let (meetingsDir, dictationsDir) = try makeContextDirs(in: root)
+        try makeDictationMarkdown(text: "Fixture dictation.")
+            .write(
+                to: dictationsDir.appendingPathComponent("Dictations_2026-04-07.md"),
+                atomically: true,
+                encoding: .utf8
+            )
+
+        let command = try ReadDictation.parse([
+            "Dictations_2026-04-07",
+            "--meetings-dir", meetingsDir.path,
+            "--dictations-dir", dictationsDir.path,
+            "--json",
+        ])
+        let output = try captureStandardOutput {
+            try command.run()
+        }
+        let document = try JSONDecoder().decode(CLIReadMarkdownDocument.self, from: XCTUnwrap(output.data(using: .utf8)))
+
+        XCTAssertEqual(document.kind, .dictation)
+        XCTAssertEqual(document.date, "2026-04-07")
+        XCTAssertEqual(document.entries?.count, 1)
+        XCTAssertEqual(document.entries?.first?.id, "dictation-20260407-091500-000")
+        XCTAssertEqual(document.entries?.first?.createdAt, "2026-04-07T09:15:00-0500")
+        XCTAssertEqual(document.entries?.first?.title, "Morning note")
+        XCTAssertEqual(document.entries?.first?.sourceAppName, "Slack")
+        XCTAssertEqual(document.entries?.first?.text, "Fixture dictation.")
+        XCTAssertNil(document.utterances)
+    }
+
+    func testReadDictationCommandJSONWithEntryIdLimitsEntries() throws {
+        let root = makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let (meetingsDir, dictationsDir) = try makeContextDirs(in: root)
+        try makeDictationMarkdown(text: "Fixture dictation.")
+            .write(
+                to: dictationsDir.appendingPathComponent("Dictations_2026-04-07.md"),
+                atomically: true,
+                encoding: .utf8
+            )
+
+        let command = try ReadDictation.parse([
+            "Dictations_2026-04-07",
+            "--meetings-dir", meetingsDir.path,
+            "--dictations-dir", dictationsDir.path,
+            "--entry-id", "dictation-20260407-091500-000",
+            "--json",
+        ])
+        let output = try captureStandardOutput {
+            try command.run()
+        }
+        let document = try JSONDecoder().decode(CLIReadMarkdownDocument.self, from: XCTUnwrap(output.data(using: .utf8)))
+
+        XCTAssertEqual(document.entryId, "dictation-20260407-091500-000")
+        XCTAssertEqual(document.entries?.map(\.id), ["dictation-20260407-091500-000"])
+    }
+
     private func makeTempDir() -> URL {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
@@ -936,6 +1241,32 @@ final class ContextStoreTests: XCTestCase {
             fflush(stdout)
             dup2(originalStdout, STDOUT_FILENO)
             close(originalStdout)
+            pipe.fileHandleForWriting.closeFile()
+            _ = pipe.fileHandleForReading.readDataToEndOfFile()
+            throw error
+        }
+    }
+
+    private func captureStandardError(_ body: () throws -> Void) throws -> String {
+        let pipe = Pipe()
+        let originalStderr = dup(STDERR_FILENO)
+        XCTAssertGreaterThanOrEqual(originalStderr, 0)
+
+        fflush(stderr)
+        dup2(pipe.fileHandleForWriting.fileDescriptor, STDERR_FILENO)
+
+        do {
+            try body()
+            fflush(stderr)
+            dup2(originalStderr, STDERR_FILENO)
+            close(originalStderr)
+            pipe.fileHandleForWriting.closeFile()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            return String(data: data, encoding: .utf8) ?? ""
+        } catch {
+            fflush(stderr)
+            dup2(originalStderr, STDERR_FILENO)
+            close(originalStderr)
             pipe.fileHandleForWriting.closeFile()
             _ = pipe.fileHandleForReading.readDataToEndOfFile()
             throw error


### PR DESCRIPTION
## Why

`transcripted-cli`'s context commands had three agent-hostile behaviors found in the agent-surface audit:

- `context-recent`, `context-search`, and `list-dictations` printed **nothing and exited 0** when directory resolution landed somewhere empty or wrong — an agent can't tell "no data" from "wrong folder" and confidently reports "you have no meetings".
- `--count` silently clamps to 1–50 with no mention in help.
- `--speaker` silently drops all dictation results; and `read-meeting`/`read-dictation --json` threw away the structure `ContextStore` had already parsed, returning just a raw-markdown blob an agent has to re-parse.

## Product Impact

- Affects: `agent artifacts`
- Lane: `agent workflow`
- Why this matters: silent emptiness is the main way agents give confidently wrong answers about a user's capture history.

## What changed

- `ContextCommands.swift`: empty results now say so — text mode prints `No results. Searched: <dirs>` to stderr (stdout stays clean for piping); `--json` emits `{"results": [], "searched_directories": [...], "hint": "..."}`. `context-search` with `--speaker` on non-meeting kinds emits `Note: --speaker only matches meetings; dictations skipped.` (stderr in text, `notes` array in JSON). All three `--count` helps document the 1–50 clamp. Searched-directory reporting is `--kind`-aware and deduped.
- `ContextModels.swift`: `CLIReadMarkdownDocument` gains optional `recording`/`speakers`/`utterances` (meetings) and `date`/`entries` (dictations) alongside the unchanged `markdown` field; new `CLIContextResultsDocument` wrapper for the empty/notes cases.
- `ContextStore.swift`: extracted `meetingTranscript(fromMarkdown:)` and `readDictationDocument(...)` so reads can return parsed structure; `--entry-id` narrows `entries` to the one entry.
- `ContextStoreTests.swift`: 11 new command-level tests (empty text/JSON shapes, kind-scoped searched dirs, speaker note on both streams, bare-array compatibility preserved for non-empty output, structured read JSON incl. entry narrowing) with an fd-level stderr capture helper mirroring the existing stdout one.
- `Tools/TranscriptedCLI/CLAUDE.md`: new Output Shapes section + stderr-diagnostics gotcha.

Backward compatibility: non-empty list/search output is still a bare JSON array (unless a note applies), and `markdown` is unchanged in reads.

## How I checked it

- [x] `scripts/dev/agent-preflight.sh`
- [x] Selected checks from `.agents/test-matrix.yml` — matrix rule for `Tools/TranscriptedCLI/**` is `swift test --package-path Tools/TranscriptedCLI`
- [x] `swift test --package-path Tools/TranscriptedCLI` — **run by Swift CI on macOS at this exact head (`f6e6c65`), green: https://github.com/r3dbars/transcripted/actions/runs/28621353693** (the Tools package tests step runs all four package suites)
- [x] `bash build.sh --no-open` / `bash run-tests.sh` / smokes — also executed green in the same Swift CI run (required merge gate)
- [x] Manual check: all referenced model types and store functions verified present; diff reviewed hunk-by-hunk.

Authoring context: written in a Linux session with no local Swift toolchain; verification is the green macOS Swift CI run above, which enforces the same matrix as local runs.

## Risk Review

- [x] Privacy / local-first behavior reviewed — diagnostics print local paths to the local terminal only; nothing leaves the machine
- [x] Storage path or migration impact reviewed — read-only; resolution behavior unchanged
- [x] Public-facing copy stays concrete and matches current product scope
- [x] Release/update impact reviewed — CLI is not distributed in releases
- [x] Agent PRs link the issue/workpad and stay draft until human review
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence — n/a
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

## Notes

Part of the agent-surface audit series (#1356, #1357, #1358). Deliberately does not touch `TranscriptedCaptureKit` — #1362 owns resolver changes.

## Agent handoff

`COORD_DONE: GREEN | (this PR) | CLI diagnostics + structured JSON reads | none | none | Swift CI green at head f6e6c65 (full matrix incl. CLI package tests) | human review + mark ready + merge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuGZaFRmNrqfGPpqf7WH4n