### PR TITLE
Capture format: spec doc + format_version and transcript_style markers

### DIFF
--- a/Sources/Dictation/CLAUDE.md
+++ b/Sources/Dictation/CLAUDE.md
@@ -53,5 +53,6 @@ bash run-tests.sh
 ## Agent notes
 
 - If you change the markdown layout, update the tests. The `Dictations_YYYY-MM-DD.md` day-file format is also parsed by the standalone tools through `Tools/TranscriptedCaptureKit` — update its parser and tests in the same change.
+- The day-file format (frontmatter keys including `format_version`, section grammar, metadata lines) is specified in `docs/capture-format.md`. Keep that spec in sync, and keep new frontmatter keys flat.
 - Dictation artifacts are append-only by day; do not assume one file per session.
 - This directory owns dictation persistence plus the newest-saved-dictation lookup seam. Recording lifecycle changes still belong in `Sources/UI/Overlay/DictationSessionController.swift` and `Sources/Speech/`.

--- a/Sources/Dictation/DictationTranscriptWriter.swift
+++ b/Sources/Dictation/DictationTranscriptWriter.swift
@@ -173,11 +173,15 @@ enum DictationTranscriptWriter {
         let escapedTitle = "Dictations for \(dayTitleFormatter.string(from: date))"
             .replacingOccurrences(of: "\"", with: "'")
 
+        // `format_version: 1` is the capture-format contract from
+        // docs/capture-format.md — absent means the day file predates
+        // versioning and parses the same way. Keep frontmatter keys flat.
         return """
         ---
         title: "\(escapedTitle)"
         date: \(dayFilenameFormatter.string(from: date))
         capture_type: dictation_day
+        format_version: 1
         ---
 
         # Dictations for \(dayTitleFormatter.string(from: date))

--- a/Sources/Meeting/MeetingTranscriptStyler.swift
+++ b/Sources/Meeting/MeetingTranscriptStyler.swift
@@ -279,7 +279,17 @@ enum MeetingTranscriptStyler {
     }
 
     private static func renderFrontmatter(lines: [String], title: String) -> String {
-        let filtered = lines.filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("title:") }
+        // Preserve every writer key except `title:` (re-emitted first with the
+        // styled title) and `transcript_style:`. The persisted restyle rewrites
+        // the body into the styled grammar, so the style marker is replaced with
+        // `styled` — filter-then-append keeps it from duplicating on repeat
+        // passes. `format_version` passes through untouched.
+        // See docs/capture-format.md.
+        var filtered = lines.filter { line in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            return !trimmed.hasPrefix("title:") && !trimmed.hasPrefix("transcript_style:")
+        }
+        filtered.append("transcript_style: styled")
         let escapedTitle = title.replacingOccurrences(of: "\"", with: "'")
         return ([
             "---",

--- a/Sources/TranscriptedCore/CLAUDE.md
+++ b/Sources/TranscriptedCore/CLAUDE.md
@@ -60,7 +60,7 @@ The app still injects app-specific `CoreStoragePaths` for meetings so the
 capture folder follows the selected capture library rather than a hard-coded
 default path.
 
-`TranscriptSaver.saveTranscript(...)` writes a markdown transcript, including YAML speaker metadata and recording-health fields like `capture_quality`, `audio_gaps`, and `device_switches` when the host provides them.
+`TranscriptSaver.saveTranscript(...)` writes a markdown transcript, including YAML speaker metadata and recording-health fields like `capture_quality`, `audio_gaps`, and `device_switches` when the host provides them. The written Markdown (frontmatter keys, `format_version` / `transcript_style` versioning, both body grammars, and the save → summary-injection → restyle lifecycle) is specified in `docs/capture-format.md` — keep that spec in sync with formatter changes, and keep new frontmatter keys flat (the shared parser skips indented lines).
 
 The standalone CLI/MCP tools parse this same Markdown format through a dependency-free mirror in `Tools/TranscriptedCaptureKit` (it intentionally does not link Core). If `TranscriptFormatter` or `TranscriptFrontmatter` changes the written format, update the kit's parsers and tests in the same change.
 
@@ -116,6 +116,7 @@ Current direct core coverage includes:
 - `Tests/TranscriptedCoreTests/SpeakerProfileMergerTests.swift`
 - `Tests/TranscriptedCoreTests/SpeakerProvenanceTests.swift`
 - `Tests/TranscriptedCoreTests/StatsDatabaseTests.swift`
+- `Tests/TranscriptedCoreTests/TranscriptFormatVersionTests.swift`
 - `Tests/TranscriptedCoreTests/TranscriptFrontmatterTests.swift`
 - `Tests/TranscriptedCoreTests/TranscriptMetadataBuilderTests.swift`
 - `Tests/TranscriptedCoreTests/TranscriptionPipelineHelpersTests.swift`

--- a/Sources/TranscriptedCore/Storage/TranscriptFormatter.swift
+++ b/Sources/TranscriptedCore/Storage/TranscriptFormatter.swift
@@ -80,11 +80,19 @@ extension TranscriptSaver {
         let totalWordCount = result.micWordCount + result.systemWordCount
         let totalUtterances = result.micUtteranceCount + result.systemUtteranceCount
 
-        // Build YAML frontmatter
+        // Build YAML frontmatter.
+        // `format_version` / `transcript_style` are the capture-format contract
+        // documented in docs/capture-format.md. `format_version: 1` marks the
+        // current versioned format (absent means pre-versioning; parse as 1) and
+        // `transcript_style: raw` marks the save-time body grammar — the async
+        // restyle in MeetingTranscriptStyler rewrites it to `styled`. Keep both
+        // flat: TranscriptFrontmatter.values(from:) skips indented lines.
         var yaml = """
         ---
         capture_id: "\(transcriptId.uuidString)"
         capture_type: meeting
+        format_version: 1
+        transcript_style: raw
         transcript_id: "\(transcriptId.uuidString)"
         date: \(isoDate)
         time: \(timeString)

--- a/Tests/DictationTranscriptWriterTests.swift
+++ b/Tests/DictationTranscriptWriterTests.swift
@@ -35,6 +35,13 @@ func testDictationTranscriptWriter() {
 
         let contents = (try? String(contentsOf: expectedURL, encoding: .utf8)) ?? ""
         assertTrue(contents.contains("# Dictations for"), "daily file should include a single day header")
+        assertTrue(contents.contains("capture_type: dictation_day"), "day header should mark the file as a dictation day capture")
+        assertTrue(contents.contains("format_version: 1"), "day header should carry the capture format_version key")
+        assertEqual(
+            contents.components(separatedBy: "format_version:").count - 1,
+            1,
+            "appending a second dictation must not write a second day header"
+        )
         assertTrue(contents.contains("## 9:15 AM -"), "first dictation section should include time heading")
         assertTrue(contents.contains("## 4:45 PM -"), "second dictation section should include time heading")
         assertTrue(contents.contains("first note from the morning"), "first dictation text should be present")

--- a/Tests/MeetingQuickSummaryExtractorTests.swift
+++ b/Tests/MeetingQuickSummaryExtractorTests.swift
@@ -89,6 +89,8 @@ func testMeetingQuickSummaryExtractor() {
         let markdown = """
         ---
         capture_type: meeting
+        format_version: 1
+        transcript_style: raw
         title: "Weekly Sync"
         ---
 
@@ -116,6 +118,10 @@ func testMeetingQuickSummaryExtractor() {
         assertTrue(updated.contains("delay the rollout"), "extracted decision should be persisted")
         // Body preserved verbatim.
         assertTrue(updated.contains("## Transcript"), "transcript body should be preserved")
+        // Capture-format keys (docs/capture-format.md) are not managed by this
+        // writer and must survive the frontmatter rewrite untouched.
+        assertTrue(updated.contains("format_version: 1"), "format_version must survive summary injection")
+        assertTrue(updated.contains("transcript_style: raw"), "transcript_style must survive summary injection")
         assertFalse(
             updated.contains("local_summary_version"),
             "cheap extraction must not write the heavy summarizer's keys"

--- a/Tests/MeetingTranscriptStylerTests.swift
+++ b/Tests/MeetingTranscriptStylerTests.swift
@@ -21,7 +21,71 @@ func testMeetingTranscriptStyler() {
         testMeetingTranscriptStylerFailsClosedOnUnparseableBody()
         testMeetingTranscriptStylerStillRewritesGenuinelyEmptyTranscript()
         testMeetingTranscriptStylerUsesTimeOnlyFallbackTitle()
+        testMeetingTranscriptStylerRewritesTranscriptStyleMarker()
+        testMeetingTranscriptStylerLeavesLegacyFilesWithoutFormatVersion()
     }
+}
+
+private func testMeetingTranscriptStylerRewritesTranscriptStyleMarker() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Call_2026-04-07_09-14-00.md")
+    try? sampleVersionedMeetingTranscript().write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+    let styled = MeetingTranscriptStyler.restyleTranscript(at: transcriptURL)
+    let updated = (try? String(contentsOf: styled.url, encoding: .utf8)) ?? ""
+
+    assertTrue(
+        updated.contains("format_version: 1"),
+        "Restyling must preserve the format_version frontmatter key"
+    )
+    assertTrue(
+        updated.contains("transcript_style: styled"),
+        "Persisted restyles must rewrite the transcript_style marker to styled"
+    )
+    assertFalse(
+        updated.contains("transcript_style: raw"),
+        "The raw transcript_style marker must not survive a persisted restyle"
+    )
+    assertEqual(
+        updated.components(separatedBy: "transcript_style:").count - 1,
+        1,
+        "Restyling must update the transcript_style key in place, not duplicate it"
+    )
+
+    // Second pass stays idempotent: still exactly one styled marker.
+    let secondPass = MeetingTranscriptStyler.restyleTranscript(at: styled.url)
+    let secondUpdated = (try? String(contentsOf: secondPass.url, encoding: .utf8)) ?? ""
+    assertEqual(
+        secondUpdated.components(separatedBy: "transcript_style:").count - 1,
+        1,
+        "Repeated restyle passes must keep a single transcript_style key"
+    )
+    assertTrue(
+        secondUpdated.contains("format_version: 1"),
+        "Repeated restyle passes must keep the format_version key"
+    )
+}
+
+private func testMeetingTranscriptStylerLeavesLegacyFilesWithoutFormatVersion() {
+    let directory = makeTemporaryTestDirectory()
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let transcriptURL = directory.appendingPathComponent("Call_2026-04-07_09-14-00.md")
+    try? sampleMeetingTranscript().write(to: transcriptURL, atomically: true, encoding: .utf8)
+
+    let styled = MeetingTranscriptStyler.restyleTranscript(at: transcriptURL)
+    let updated = (try? String(contentsOf: styled.url, encoding: .utf8)) ?? ""
+
+    assertFalse(
+        updated.contains("format_version:"),
+        "Restyling a pre-versioning transcript must not invent a format_version"
+    )
+    assertTrue(
+        updated.contains("transcript_style: styled"),
+        "Restyled bodies always carry the styled marker so parsers can skip sniffing"
+    )
 }
 
 private func testMeetingTranscriptStylerUsesTimeOnlyFallbackTitle() {
@@ -477,6 +541,30 @@ private func sampleMeetingTranscriptLocalSummarySections() -> LocalMeetingSummar
 private func sampleMeetingTranscript() -> String {
     """
     ---
+    date: "2026-04-07"
+    time: "09:14:00"
+    duration: "12:30"
+    total_word_count: "42"
+    mic_utterances: "1"
+    system_utterances: "1"
+    ---
+
+    ## Full Transcript
+
+    **[00:00] [Mic/You]**
+    Thanks for making time today.
+
+    **[00:04] [System/Alex]**
+    Happy to help. Let's get started.
+    """
+}
+
+private func sampleVersionedMeetingTranscript() -> String {
+    """
+    ---
+    capture_type: meeting
+    format_version: 1
+    transcript_style: raw
     date: "2026-04-07"
     time: "09:14:00"
     duration: "12:30"

--- a/Tests/TranscriptedCoreTests/TranscriptFormatVersionTests.swift
+++ b/Tests/TranscriptedCoreTests/TranscriptFormatVersionTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import TranscriptedCore
+
+/// Capture-format contract (docs/capture-format.md): the formatter stamps every
+/// meeting save with flat `format_version: 1` and `transcript_style: raw`
+/// frontmatter keys. Absent keys mean a pre-versioning file, so these must be
+/// emitted on every save and stay readable through the shared flat-line parser
+/// the Home scanner uses.
+@available(macOS 14.0, *)
+final class TranscriptFormatVersionTests: XCTestCase {
+    func testMeetingSaveEmitsFlatFormatVersionAndRawStyle() {
+        let markdown = TranscriptSaver.formatTranscriptMarkdown(
+            result: makeResult(),
+            transcriptId: UUID(uuidString: "00000000-0000-0000-0000-000000000600")!,
+            date: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertTrue(markdown.contains("\nformat_version: 1\n"))
+        XCTAssertTrue(markdown.contains("\ntranscript_style: raw\n"))
+
+        // Flat-parse round-trip contract: TranscriptFrontmatter.values(from:)
+        // skips indented lines, so the keys must land at the top level.
+        let values = TranscriptFrontmatter.document(in: markdown)?.values
+        XCTAssertEqual(values?["format_version"], "1")
+        XCTAssertEqual(values?["transcript_style"], "raw")
+    }
+
+    func testFormatVersionSurvivesHealthAndSpeakerMetadata() {
+        let markdown = TranscriptSaver.formatTranscriptMarkdown(
+            result: makeResult(),
+            transcriptId: UUID(uuidString: "00000000-0000-0000-0000-000000000601")!,
+            speakerMappings: [
+                "system_0": SpeakerMapping(speakerId: "0", identifiedName: "Alex", confidence: .high)
+            ],
+            speakerSources: ["system_0": "db_scan"],
+            date: Date(timeIntervalSince1970: 0),
+            meetingTitle: "Format contract check",
+            healthInfo: RecordingHealthInfo(
+                captureQuality: .good,
+                audioGaps: 1,
+                deviceSwitches: 0,
+                gapDescriptions: ["Audio gap at 00:42 (1.5s)"],
+                micAttenuatedByCallApp: nil,
+                micBoostPrompt: nil
+            )
+        )
+
+        let values = TranscriptFrontmatter.document(in: markdown)?.values
+        XCTAssertEqual(values?["format_version"], "1")
+        XCTAssertEqual(values?["transcript_style"], "raw")
+        XCTAssertEqual(values?["capture_type"], "meeting")
+        XCTAssertEqual(values?["title"], "Format contract check")
+    }
+
+    private func makeResult() -> TranscriptionResult {
+        TranscriptionResult(
+            micUtterances: [],
+            systemUtterances: [
+                TranscriptionUtterance(
+                    start: 0,
+                    end: 2,
+                    channel: 1,
+                    speakerId: 0,
+                    persistentSpeakerId: nil,
+                    matchSimilarity: nil,
+                    transcript: "Thanks for joining."
+                )
+            ],
+            duration: 2,
+            processingTime: 0.5
+        )
+    }
+}

--- a/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdownParser.swift
+++ b/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdownParser.swift
@@ -32,6 +32,12 @@ public struct ParsedMeetingCapture {
     public let droppedSegments: Int
     public let sttEngine: String
     public let diarizationEngine: String
+    /// `format_version` frontmatter when present. Absent means the file predates
+    /// capture-format versioning and parses as version 1 (docs/capture-format.md).
+    public let formatVersion: Int?
+    /// `transcript_style` frontmatter (`raw` or `styled`) when present. Absent
+    /// means pre-versioning; the body grammar is sniffed from its heading.
+    public let transcriptStyle: String?
     public let speakers: [Speaker]
     public let utterances: [Utterance]
 }
@@ -52,6 +58,9 @@ public struct ParsedDictationDayCapture {
 
     public let captureType: String
     public let date: String
+    /// `format_version` frontmatter when present. Absent means the day file
+    /// predates capture-format versioning and parses as version 1.
+    public let formatVersion: Int?
     public let markdownFilename: String
     public let entryCount: Int
     public let wordCount: Int
@@ -266,6 +275,8 @@ public enum CaptureMarkdownParser {
             droppedSegments: Int(document.values["dropped_segments"] ?? "") ?? 0,
             sttEngine: document.values["transcription_engine"] ?? "unknown",
             diarizationEngine: document.values["diarization_engine"] ?? "unknown",
+            formatVersion: Int(document.values["format_version"] ?? ""),
+            transcriptStyle: document.values["transcript_style"],
             speakers: speakers,
             utterances: utterances
         )
@@ -283,6 +294,7 @@ public enum CaptureMarkdownParser {
         return ParsedDictationDayCapture(
             captureType: document.values["capture_type"] ?? "dictation_day",
             date: document.values["date"] ?? fallbackDate,
+            formatVersion: Int(document.values["format_version"] ?? ""),
             markdownFilename: url.lastPathComponent,
             entryCount: entries.count,
             wordCount: entries.reduce(0) { $0 + $1.wordCount },

--- a/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureMarkdownParserTests.swift
+++ b/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureMarkdownParserTests.swift
@@ -103,6 +103,8 @@ final class CaptureMarkdownParserTests: XCTestCase {
         XCTAssertEqual(parsed.droppedSegments, 2)
         XCTAssertEqual(parsed.sttEngine, "parakeet_local")
         XCTAssertEqual(parsed.diarizationEngine, "pyannote_offline")
+        XCTAssertNil(parsed.formatVersion, "pre-versioning files carry no format_version")
+        XCTAssertNil(parsed.transcriptStyle, "pre-versioning files carry no transcript_style")
         XCTAssertEqual(parsed.utterances.count, 2)
         XCTAssertEqual(parsed.utterances.map(\.speakerId), ["mic_0", "system_0"])
 
@@ -123,6 +125,8 @@ final class CaptureMarkdownParserTests: XCTestCase {
         ---
         capture_id: "2C356828-221B-43E8-B1BB-93E0C3360E2F"
         capture_type: meeting
+        format_version: 1
+        transcript_style: raw
         transcript_id: "2C356828-221B-43E8-B1BB-93E0C3360E2F"
         date: 2026-06-12
         time: 09:30:00
@@ -192,6 +196,8 @@ final class CaptureMarkdownParserTests: XCTestCase {
 
         let parsed = try XCTUnwrap(CaptureMarkdownParser.parseMeeting(from: markdown))
 
+        XCTAssertEqual(parsed.formatVersion, 1)
+        XCTAssertEqual(parsed.transcriptStyle, "raw")
         XCTAssertEqual(parsed.utterances.map(\.speakerId), ["mic_0", "system_1"])
 
         let mic = try XCTUnwrap(parsed.speakers.first(where: { $0.id == "mic_0" }))
@@ -385,10 +391,13 @@ final class CaptureMarkdownParserTests: XCTestCase {
     func testParseMeetingStyledTranscriptSection() throws {
         let markdown = """
         ---
+        title: "Meeting with Alex"
         capture_type: meeting
+        format_version: 1
         date: 2026-04-18
         time: 09:15:00
         duration: "0:18"
+        transcript_style: styled
         ---
 
         ## Transcript
@@ -402,6 +411,8 @@ final class CaptureMarkdownParserTests: XCTestCase {
 
         let parsed = try XCTUnwrap(CaptureMarkdownParser.parseMeeting(from: markdown))
 
+        XCTAssertEqual(parsed.formatVersion, 1)
+        XCTAssertEqual(parsed.transcriptStyle, "styled")
         XCTAssertEqual(parsed.utterances.count, 2)
         XCTAssertEqual(parsed.utterances.first?.text, "Styled entry text here.")
         XCTAssertEqual(parsed.utterances.first?.start, 3)
@@ -486,6 +497,7 @@ final class CaptureMarkdownParserTests: XCTestCase {
         title: "Dictations for 2026-04-07"
         date: 2026-04-07
         capture_type: dictation_day
+        format_version: 1
         ---
 
         # Dictations for 2026-04-07
@@ -517,6 +529,7 @@ final class CaptureMarkdownParserTests: XCTestCase {
 
         XCTAssertEqual(parsed.captureType, "dictation_day")
         XCTAssertEqual(parsed.date, "2026-04-07")
+        XCTAssertEqual(parsed.formatVersion, 1)
         XCTAssertEqual(parsed.markdownFilename, "Dictations_2026-04-07.md")
         XCTAssertEqual(parsed.entryCount, 2)
         XCTAssertEqual(parsed.entries.map(\.id), ["dictation-1", "dictation-2"])
@@ -546,6 +559,7 @@ final class CaptureMarkdownParserTests: XCTestCase {
         let url = URL(fileURLWithPath: "/tmp/Dictations_2026-04-08.md")
         let parsed = try XCTUnwrap(CaptureMarkdownParser.parseDictationDay(from: markdown, markdownURL: url))
         XCTAssertEqual(parsed.date, "2026-04-08")
+        XCTAssertNil(parsed.formatVersion, "pre-versioning day files carry no format_version")
     }
 
     func testExtractTitleTrimsQuotes() {

--- a/docs/capture-format.md
+++ b/docs/capture-format.md
@@ -1,0 +1,315 @@
+# Capture Markdown format
+
+This is the authoritative spec for the Markdown files Transcripted saves under
+the capture library (`<capture-library>/meetings/` and
+`<capture-library>/dictations/`). Agents and standalone tools parse these
+files, so treat this document as the contract. Writers live in
+`Sources/TranscriptedCore/Storage/TranscriptFormatter.swift`,
+`Sources/Meeting/MeetingTranscriptStyler.swift`,
+`Sources/Meeting/MeetingQuickSummaryWriter.swift`,
+`Sources/Meeting/LocalMeetingSummarizer.swift`, and
+`Sources/Dictation/DictationTranscriptWriter.swift`. Readers include the app's
+Home scanner (`TranscriptFrontmatter`), `Tools/TranscriptedCaptureKit` (used by
+the CLI and MCP tools), and `Tools/TranscriptedQA`. If you change the written
+format, update this doc, the CaptureKit parsers, and their tests in the same
+change.
+
+## Versioning
+
+Two flat frontmatter keys carry the contract:
+
+- `format_version: 1` — the capture-format version. **Absent means the file
+  predates versioning; parse it exactly like version 1.** The grammar below has
+  not changed since before the key existed — the key was added so future
+  breaking changes have somewhere to land. Bump the number only for a breaking
+  change; additive changes stay within the current version.
+- `transcript_style: raw | styled` — which meeting body grammar the file
+  currently carries (meetings only; see the lifecycle below). Absent means the
+  file predates the key: sniff the body heading instead (`## Full Transcript`
+  → raw, `## Transcript` → styled).
+
+Dictation day files carry `format_version` but no `transcript_style` (they have
+a single body grammar).
+
+## Stability rules
+
+1. **Flat `key: value` frontmatter only.** The app's own scanner
+   (`TranscriptFrontmatter.values(from:)`) skips indented lines, so nested YAML
+   is invisible to it (see the Issue #500 comment in
+   `TranscriptFormatter.swift`). New keys must be top-level. The only nested
+   blocks are the pre-existing `gap_events`, `speakers`, `tags`, `aliases`, and
+   `cssclasses`; parsers that need them re-read the raw frontmatter lines.
+2. **Parsers must ignore unknown keys.** Writers append keys over a file's
+   lifetime (`auto_summary_*`, `local_summary_*`), and future app versions will
+   add more.
+3. **Additive changes only within a version.** Never rename or remove a key, or
+   change an existing key's value format, without bumping `format_version`.
+4. Frontmatter values may be quoted or bare; parsers strip surrounding double
+   quotes. Escaping for quoted scalars follows `TranscriptSaver.escapeYAML`.
+5. Key order is not guaranteed. Match by key, not position.
+
+## Meeting file lifecycle
+
+A meeting transcript is written once and then rewritten in place up to two
+times. **Any stage after the first can be skipped** (the restyle fails closed
+on bodies it cannot parse; the app can also quit first), so all intermediate
+shapes exist in the wild:
+
+1. **Initial save** — `TranscriptFormatter.formatTranscriptMarkdown` writes the
+   raw form to `Call_<YYYY-MM-dd_HH-mm-ss>.md` (collision suffix `_<n>`), with
+   `format_version: 1` and `transcript_style: raw`.
+2. **Quick-summary injection** — `MeetingQuickSummaryWriter` appends the
+   `auto_summary_*` keys to the frontmatter. Frontmatter-only; the body is
+   preserved verbatim, and all non-`auto_summary_*` keys (including
+   `format_version` / `transcript_style`) survive. Idempotent: it never re-runs
+   once `auto_summary_version` exists.
+3. **Restyle + rename (async)** — `MeetingTranscriptStyler.restyleTranscript`
+   rewrites the body into the styled form, re-emits `title:` first, preserves
+   every other frontmatter line (including `format_version`), rewrites
+   `transcript_style` to `styled` (replacing the `raw` marker — never
+   duplicated; legacy files without the key gain it), and renames the file to
+   `<YYYY-MM-dd> <title>.md` (collision suffix ` <n>`). Retained audio
+   directories and summary sidecars follow the rename
+   (`MeetingArtifactRenamer`).
+
+Later optional writers: the heavy local summarizer (`local_summary_*` keys plus
+a managed body block) and the Home title editor (rewrites `title:` and renames
+again). All are frontmatter-preserving.
+
+## Meeting frontmatter keys
+
+Written at initial save (all flat unless noted):
+
+| Key | Example | Notes |
+|-----|---------|-------|
+| `capture_id` | `"5E9A…"` | UUID, quoted. Same value as `transcript_id`. |
+| `capture_type` | `meeting` | Discriminator; dictation day files use `dictation_day`. |
+| `format_version` | `1` | See Versioning. Absent = pre-versioning. |
+| `transcript_style` | `raw` / `styled` | See Versioning and lifecycle. |
+| `transcript_id` | `"5E9A…"` | UUID, quoted. |
+| `date` | `2026-04-07` | `yyyy-MM-dd`, local time. |
+| `time` | `09:14:00` | `HH:mm:ss`, local time. |
+| `duration` | `"12:30"` | `m:ss` (minutes may exceed 59), quoted. |
+| `processing_time` | `"41.3s"` | Seconds with one decimal + `s`, quoted. |
+| `transcription_engine` | `parakeet_local` | Engine identifier. |
+| `diarization_engine` | `pyannote_offline` | |
+| `sources` | `[mic, system_audio]` | Inline list of captured channels. |
+| `mic_utterances` | `12` | |
+| `system_utterances` | `34` | |
+| `mic_speakers` | `1` | |
+| `system_speakers` | `2` | |
+| `total_word_count` | `1204` | |
+| `title` | `"Weekly Sync"` | Optional at save (imported audio, detected meetings); the restyle always writes one. |
+
+Recording-health keys (optional, only when health info exists):
+
+| Key | Example | Notes |
+|-----|---------|-------|
+| `capture_quality` | `excellent` | `excellent` / `good` / `fair` / `degraded`. |
+| `audio_gaps` | `0` | |
+| `device_switches` | `0` | |
+| `gap_events` | — | **Nested** list of quoted strings; invisible to flat parsers. Omitted when empty. |
+| `audio_health` | `mic_attenuated_by_call_app` | Flat; omitted for healthy meetings. |
+| `mic_boost_prompt` | `"declined"` | Flat; only alongside `audio_health`. |
+
+Speaker metadata (optional, **nested** `speakers:` block — flat parsers skip
+it; CaptureKit and the app re-read the raw lines):
+
+```yaml
+speakers:
+  - id: "0"
+    channel: mic          # mic | system; older files may omit (treat as system)
+    db_id: "1111…"        # optional persistent speaker DB UUID
+    name: "Justin"
+    confidence: high      # high | medium | manual | unknown
+    source: db_scan
+```
+
+Obsidian metadata (optional, when the user enables it): nested `tags:`
+(`transcripted`, `meeting`, `speaker/<name>`), `aliases:`, `cssclasses:`
+blocks; named speakers in the body are wrapped in `[[wiki links]]`.
+
+Summary namespaces appended later (all flat, quoted values, bullet lines
+flattened with `" | "`):
+
+- `auto_summary_*` (always-on cheap extraction): `auto_summary_version`,
+  `auto_summary_generated_at`, `auto_summary_method`,
+  `auto_summary_participants`, `auto_summary`, `auto_summary_decisions`,
+  `auto_summary_action_items`, `auto_summary_open_questions`,
+  `auto_summary_risks_or_followups`, `auto_summary_accuracy_notes`.
+- `local_summary_*` (opt-in heavy summarizer): `local_summary_version`,
+  `local_summary_source_transcript`, `local_summary_title`,
+  `local_summary_generated_at`, `local_summary_provider`,
+  `local_summary_model`, `local_summary_runtime`, `local_summary_profile`,
+  `local_summary_chunk_count`, `local_summary_participants`, `local_summary`,
+  `local_summary_next_steps`, `local_summary_commitments`,
+  `local_summary_decisions`, `local_summary_action_items`,
+  `local_summary_open_questions`, `local_summary_risks_or_followups`,
+  `local_summary_accuracy_notes`.
+
+Index precedence: prefer `local_summary_*` when present, else `auto_summary_*`.
+
+## Meeting body: raw form (`transcript_style: raw`)
+
+Written at initial save. Filename `Call_<YYYY-MM-dd_HH-mm-ss>.md`.
+
+```markdown
+# Meeting Recording - Apr 7, 2026 at 9:14 AM
+
+**Duration:** 12:30 | **Words:** 42 | **Utterances:** 2
+
+---
+
+---
+
+## Channel & Speaker Analytics
+
+### Microphone (You)
+- **Utterances:** 1
+- **Words:** ~20
+- **Speaking Time:** 22s
+
+### Meeting Audio (Remote Participants)
+- **Utterances:** 1
+- **Words:** ~22
+- **Speaking Time:** 31s
+- **Speakers Detected:** 1
+
+#### Remote Speaker Breakdown
+
+- **Sarah:** 1 utterances, ~22 words, 31s
+
+---
+
+## Full Transcript
+
+[00:00] [Mic/You] Thanks for making time today.
+
+[00:04] [System/Sarah] Happy to help. Let's get started.
+
+---
+
+*Generated by Transcripted with Parakeet + PyAnnote (local) | Duration: 12:30 | 42 words | 2 speakers*
+```
+
+Transcript grammar: one entry per line under `## Full Transcript`, blank line
+between entries:
+
+```
+[<MM:SS>] [<Mic|System>/<speaker label>] <text>
+```
+
+Mic labels default to `You` (or a named speaker with local-speaker review);
+system labels default to `Speaker <n>` until named. With Obsidian metadata
+enabled, named labels are wiki-linked: `[System/[[Sarah]]]`. Multi-speaker mic
+captures add a `### Microphone (People in the Room)` heading and a
+`#### Local Speaker Breakdown` section. When mic capture is disabled the
+microphone section is omitted and `sources` reflects it.
+
+## Meeting body: styled form (`transcript_style: styled`)
+
+Produced by the async restyle. Filename `<YYYY-MM-dd> <title>.md`.
+
+```markdown
+---
+title: "Meeting with Sarah"
+capture_id: "5E9A…"
+capture_type: meeting
+format_version: 1
+transcript_id: "5E9A…"
+date: 2026-04-07
+time: 09:14:00
+…all other preserved keys…
+transcript_style: styled
+---
+
+# Meeting with Sarah
+
+Recorded Apr 7, 2026 at 9:14 AM  •  12 min, 30 sec  •  42 words  •  2 turns
+
+## Transcript
+
+**00:00**  [Mic/You]
+Thanks for making time today.
+
+**00:04**  [System/Sarah]
+Happy to help. Let's get started.
+```
+
+Details:
+
+- The detail line joins parts with `  •  ` (two spaces around a bullet):
+  `Recorded <medium date, short time>`, humanized duration, word count and turn
+  count when nonzero.
+- Transcript entries are blank-line-separated blocks: a header line
+  `**<MM:SS>**  [<Mic|System>/<label>]` (two spaces after the bold timestamp)
+  followed by the utterance text on the next line(s).
+- An empty transcript renders as `_No transcript captured._`.
+- A managed local-summary body block (between
+  `LocalMeetingSummaryMarkdownUpdater` markers), when present, is preserved
+  after the transcript.
+- The restyle fails closed: if the body carries transcript text the entry
+  parser cannot understand, the file is left byte-for-byte untouched (still
+  raw-form, still `transcript_style: raw` if it had it).
+
+## Dictation day files
+
+`Sources/Dictation/DictationTranscriptWriter.swift` appends completed
+dictations into one file per local day:
+`<capture-library>/dictations/Dictations_<YYYY-MM-dd>.md`.
+
+```markdown
+---
+title: "Dictations for April 7, 2026"
+date: 2026-04-07
+capture_type: dictation_day
+format_version: 1
+---
+
+# Dictations for April 7, 2026
+
+## 9:15 AM - first note from the morning
+
+Entry ID: `dictation-20260407-091500-123-8c…`
+Captured: 2026-04-07T09:15:00.000Z
+Source app: Slack
+Bundle ID: `com.tinyspeck.slackmacgap`
+Delivery: pasted
+Words: 5
+Characters: 27
+
+first note from the morning
+
+## 4:45 PM - second note from the afternoon
+
+…
+```
+
+Details:
+
+- The day header is written once, when the file is created; later saves append
+  sections only. Header keys are flat; `format_version` follows the same
+  convention as meetings.
+- Section heading: `## <h:mm a> - <title>` where the title is the first ~7
+  words of the text (or `Dictation <MMM d> at <h:mm a>` for very short text).
+- Metadata lines, in order: `Entry ID:` (backticked), `Captured:` (ISO 8601
+  with fractional seconds), `Source app:`, optional `Bundle ID:` (backticked,
+  omitted when unknown), `Delivery:`, `Words:`, `Characters:`. Older files may
+  carry `Timestamp:` instead of `Captured:`.
+- `Delivery` values: `pasted`, `copied`, `failed`, `saved_without_paste`.
+- The dictated text follows after a blank line and runs to the next `## `
+  heading or end of file.
+
+## Parser guidance
+
+- Detect meetings via `capture_type: meeting`; fall back to the transcript
+  headings for pre-`capture_type` files. Detect dictation day files via
+  `capture_type: dictation_day` or the `Dictations_` filename prefix.
+- Choose the meeting body grammar by `transcript_style` when present, else by
+  heading: `## Full Transcript` (raw) vs `## Transcript` (styled). Robust
+  parsers accept both grammars in either file (see
+  `Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureMarkdownParser.swift`).
+- Treat every key as optional. Missing `format_version` = version 1 semantics.
+- `Tools/TranscriptedCaptureKit` exposes `format_version` / `transcript_style`
+  as optional `formatVersion` / `transcriptStyle` fields on
+  `ParsedMeetingCapture` and `formatVersion` on `ParsedDictationDayCapture`.


### PR DESCRIPTION
## Why

The product promise is "agent-readable Markdown," but the format had no spec and no version marker — and a saved meeting actually exists in two body grammars (the save-time form and the async restyled form, since `MeetingTranscriptStyler` fails closed and can skip files). Agents had no way to detect which form they were reading, and contributors had no contract to keep the app writers and the `TranscriptedCaptureKit` mirror parser in lockstep. Found in the agent-surface audit.

## Product Impact

- Affects: `agent artifacts` / `meetings` / `dictation`
- Lane: `agent workflow`
- Why this matters: the file format *is* the API; an unversioned, unspecified format quietly breaks every external parser each time a writer changes.

## What changed

- **New `docs/capture-format.md`** (315 lines): full meeting frontmatter key reference (core, health, nested `speakers`/`gap_events`, `auto_summary_*`/`local_summary_*` namespaces, Obsidian block), both meeting body grammars with examples, the save → quick-summary injection → restyle+rename lifecycle (explicitly documenting that both forms exist in the wild), the dictation day-file format, the versioning convention, and stability rules (flat `key: value` frontmatter only — the app's own scanner skips indented lines; unknown keys must be ignored; additive-only within a version).
- **`TranscriptFormatter.swift`**: meeting saves now emit `format_version: 1` and `transcript_style: raw`.
- **`MeetingTranscriptStyler.swift`**: `renderFrontmatter` filters any existing `transcript_style:` line and appends `transcript_style: styled` — updated in place, idempotent on repeat passes; `format_version` passes through untouched.
- **`DictationTranscriptWriter.swift`**: day headers emit `format_version: 1`.
- **`TranscriptedCaptureKit`**: parsed meeting/dictation models gain optional `formatVersion`/`transcriptStyle` (additive; no public inits, and zero external references to those fields in CLI/MCP/QA, so no call sites break — those packages untouched).
- **Tests**: new `Tests/TranscriptedCoreTests/TranscriptFormatVersionTests.swift` (round-trips the new keys through the real `TranscriptFrontmatter` parser); styler tests for marker rewrite + no invented `format_version` on legacy files + single-marker idempotency; dictation header assertions incl. single-header-on-append; quick-summary regression that injection preserves the new keys; CaptureKit fixtures for versioned and pre-versioning files.
- CLAUDE.md pointers in `Sources/TranscriptedCore/` and `Sources/Dictation/` to the new spec.

Version convention: `format_version: 1`, absent = pre-versioning, parse as 1. The grammar didn't change, so claiming a new version would imply a break that never happened; body-form variation is carried by `transcript_style` (`raw`/`styled`), with heading-sniffing documented for unmarked legacy files.

## How I checked it

- [x] `scripts/dev/agent-preflight.sh`
- [x] Selected checks from `.agents/test-matrix.yml` — Core+CaptureKit union
- [x] `bash build-deps.sh` + `bash build.sh --no-open` + `bash run-tests.sh` + `bash run-integration-smoke.sh` + `swift test` + `bash run-e2e-smoke.sh` + all four Tools package tests — **all run by Swift CI on macOS at this exact head (`00eab44`), green: https://github.com/r3dbars/transcripted/actions/runs/28621531993** (the workflow executes exactly this matrix as the required merge gate)
- [x] Manual check: new keys verified flat + key-matched (not allowlisted) in every consumer checked (RecentCaptureScanners, QA validators, MeetingQuickSummaryWriter, LocalMeetingSummarizer); styler filter mirrors the existing `title:` filter.

Authoring context: written in a Linux session with no local Swift toolchain; verification is the green macOS Swift CI run above.

## Risk Review

- [x] Privacy / local-first behavior reviewed — metadata keys only, local files only
- [x] Storage path or migration impact reviewed — no paths change; old files parse exactly as before (absent keys = version 1)
- [x] Public-facing copy stays concrete and matches current product scope
- [x] Release/update impact reviewed — none
- [x] Agent PRs link the issue/workpad and stay draft until human review
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence — n/a
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

## Notes

Part of the agent-surface audit series (#1356–#1360) and step 1 of the consolidation plan in #1358. Restyled legacy files gain `transcript_style: styled` without a `format_version` — intentional, the keys are independent and the spec says so.

## Agent handoff

`COORD_DONE: GREEN | (this PR) | format spec + version/style markers in all writers | none | none | Swift CI green at head 00eab44 (full matrix) | human review + mark ready + merge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuGZaFRmNrqfGPpqf7WH4n