### PR TITLE
MCP: status tool, self-describing empty results, explicit done-filter error

### DIFF
--- a/Tools/TranscriptedCaptureKit/CLAUDE.md
+++ b/Tools/TranscriptedCaptureKit/CLAUDE.md
@@ -14,7 +14,7 @@ Both `Tools/TranscriptedCLI` and `Tools/TranscriptedMCP` depend on it via a rela
 | File | Purpose |
 |------|---------|
 | `Package.swift` | Library-only Swift package manifest (no external dependencies) |
-| `Sources/TranscriptedCaptureKit/CaptureLibraryResolver.swift` | `CaptureLibraryResolver.resolve(...)` → `ResolvedCaptureDirectories` (meeting dirs, dictation dirs, optional shared data root) |
+| `Sources/TranscriptedCaptureKit/CaptureLibraryResolver.swift` | `CaptureLibraryResolver.resolve(...)` → `ResolvedCaptureDirectories` (meeting dirs, dictation dirs, optional shared data root, winning resolution rule + legacy-fallback flag) |
 | `Sources/TranscriptedCaptureKit/CaptureMarkdown.swift` | Capture-Markdown detection and frontmatter `title:` extraction |
 | `Sources/TranscriptedCaptureKit/CaptureMarkdownParser.swift` | Frontmatter, meeting transcript, and dictation day parsing into `ParsedMeetingCapture` / `ParsedDictationDayCapture` |
 | `Sources/TranscriptedCaptureKit/CaptureSummaryParser.swift` | Structured summary parsing into `ParsedMeetingSummary` (Decisions / Action Items with owner / Open Questions); understands inline transcript summaries and generated `meeting_summary` sidecars. Ports the app's `RecentMeetingSummaryPreviewParser` section logic across the module boundary |

--- a/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureLibraryResolver.swift
+++ b/Tools/TranscriptedCaptureKit/Sources/TranscriptedCaptureKit/CaptureLibraryResolver.swift
@@ -10,6 +10,18 @@ private struct CaptureDirectoryManifest: Decodable {
 private struct ConfiguredCaptureDirectories {
     let meetings: URL
     let dictations: URL
+    let source: CaptureLibraryResolutionSource
+}
+
+/// Which resolution rule selected the capture directories. Explicit
+/// `--data-dir` / `--meetings-dir` style arguments report the same tier as
+/// their environment-variable equivalents.
+public enum CaptureLibraryResolutionSource: String, Codable, Sendable {
+    case envDataDir = "env_data_dir"
+    case envKindDirs = "env_kind_dirs"
+    case appManifest = "app_manifest"
+    case appPreference = "app_preference"
+    case defaultCaptures = "default"
 }
 
 /// Resolved capture-library locations for meetings and dictations.
@@ -19,11 +31,24 @@ public struct ResolvedCaptureDirectories {
     /// Set when resolution used an explicit shared data directory
     /// (a `--data-dir` style argument or `TRANSCRIPTED_DATA_DIR`).
     public let sharedDataRoot: URL?
+    /// Which resolution rule selected the directories above.
+    public let resolutionSource: CaptureLibraryResolutionSource
+    /// True when legacy fallback directories (Draft exports,
+    /// `~/Documents/Transcripted`) were appended after the primary directory.
+    public let legacyFallbackAppended: Bool
 
-    public init(meetingDirs: [URL], dictationDirs: [URL], sharedDataRoot: URL? = nil) {
+    public init(
+        meetingDirs: [URL],
+        dictationDirs: [URL],
+        sharedDataRoot: URL? = nil,
+        resolutionSource: CaptureLibraryResolutionSource = .defaultCaptures,
+        legacyFallbackAppended: Bool = false
+    ) {
         self.meetingDirs = meetingDirs
         self.dictationDirs = dictationDirs
         self.sharedDataRoot = sharedDataRoot
+        self.resolutionSource = resolutionSource
+        self.legacyFallbackAppended = legacyFallbackAppended
     }
 }
 
@@ -59,13 +84,15 @@ public enum CaptureLibraryResolver {
                 return ResolvedCaptureDirectories(
                     meetingDirs: [sharedMeetings],
                     dictationDirs: [sharedDictations],
-                    sharedDataRoot: sharedURL
+                    sharedDataRoot: sharedURL,
+                    resolutionSource: .envDataDir
                 )
             }
             return ResolvedCaptureDirectories(
                 meetingDirs: [sharedURL],
                 dictationDirs: [sharedURL],
-                sharedDataRoot: sharedURL
+                sharedDataRoot: sharedURL,
+                resolutionSource: .envDataDir
             )
         }
 
@@ -128,10 +155,28 @@ public enum CaptureLibraryResolver {
                 fileManager: fileManager
             )
 
+        // When only one kind is overridden, the other still resolves through
+        // the manifest/preference/default chain; report the override tier as
+        // the winning rule since it took precedence for the kind it covers.
+        let resolutionSource: CaptureLibraryResolutionSource
+        if meetingsOverride != nil || dictationsOverride != nil {
+            resolutionSource = .envKindDirs
+        } else if let appConfigured {
+            resolutionSource = appConfigured.source
+        } else {
+            resolutionSource = .defaultCaptures
+        }
+
+        // Primary resolution always yields one directory per kind; anything
+        // extra came from the legacy candidates.
+        let legacyFallbackAppended = meetingDirs.count > 1 || dictationDirs.count > 1
+
         return ResolvedCaptureDirectories(
             meetingDirs: meetingDirs,
             dictationDirs: dictationDirs,
-            sharedDataRoot: nil
+            sharedDataRoot: nil,
+            resolutionSource: resolutionSource,
+            legacyFallbackAppended: legacyFallbackAppended
         )
     }
 
@@ -180,7 +225,7 @@ public enum CaptureLibraryResolver {
             return nil
         }
 
-        return ConfiguredCaptureDirectories(meetings: meetings, dictations: dictations)
+        return ConfiguredCaptureDirectories(meetings: meetings, dictations: dictations, source: .appManifest)
     }
 
     private static func appPreferenceCaptureDirectories(homeDirectory home: URL) -> ConfiguredCaptureDirectories? {
@@ -200,7 +245,8 @@ public enum CaptureLibraryResolver {
 
             return ConfiguredCaptureDirectories(
                 meetings: captureLibrary.appendingPathComponent("meetings", isDirectory: true),
-                dictations: captureLibrary.appendingPathComponent("dictations", isDirectory: true)
+                dictations: captureLibrary.appendingPathComponent("dictations", isDirectory: true),
+                source: .appPreference
             )
         }
 

--- a/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureLibraryResolverTests.swift
+++ b/Tools/TranscriptedCaptureKit/Tests/TranscriptedCaptureKitTests/CaptureLibraryResolverTests.swift
@@ -29,6 +29,8 @@ final class CaptureLibraryResolverTests: XCTestCase {
             legacyDraftMeetings.standardizedFileURL.path,
         ])
         XCTAssertNil(resolved.sharedDataRoot)
+        XCTAssertEqual(resolved.resolutionSource, .defaultCaptures)
+        XCTAssertTrue(resolved.legacyFallbackAppended)
     }
 
     func testResolveSkipsLegacyCandidatesWithoutCaptureMarkdown() throws {
@@ -49,6 +51,8 @@ final class CaptureLibraryResolverTests: XCTestCase {
             .contains(legacyShared.standardizedFileURL.path))
         XCTAssertFalse(resolved.dictationDirs.map(\.standardizedFileURL.path)
             .contains(legacyShared.standardizedFileURL.path))
+        XCTAssertEqual(resolved.resolutionSource, .defaultCaptures)
+        XCTAssertFalse(resolved.legacyFallbackAppended)
     }
 
     func testResolveIncludesSymlinkedLegacyDirectoryWithCaptureMarkdown() throws {
@@ -103,6 +107,8 @@ final class CaptureLibraryResolverTests: XCTestCase {
             sharedRoot.appendingPathComponent("dictations", isDirectory: true).standardizedFileURL.path,
         ])
         XCTAssertEqual(resolved.sharedDataRoot?.standardizedFileURL.path, sharedRoot.standardizedFileURL.path)
+        XCTAssertEqual(resolved.resolutionSource, .envDataDir)
+        XCTAssertFalse(resolved.legacyFallbackAppended)
     }
 
     func testResolveExplicitDataDirWinsOverEnvironment() throws {
@@ -151,6 +157,8 @@ final class CaptureLibraryResolverTests: XCTestCase {
         XCTAssertEqual(resolved.meetingDirs.map(\.standardizedFileURL.path), [
             overrideMeetings.standardizedFileURL.path,
         ])
+        XCTAssertEqual(resolved.resolutionSource, .envKindDirs)
+        XCTAssertFalse(resolved.legacyFallbackAppended)
     }
 
     func testResolveUsesAppDirectoryManifestBeforeDefaultCaptures() throws {
@@ -190,6 +198,7 @@ final class CaptureLibraryResolverTests: XCTestCase {
         XCTAssertEqual(resolved.dictationDirs.map(\.standardizedFileURL.path), [
             manifestDictations.standardizedFileURL.path,
         ])
+        XCTAssertEqual(resolved.resolutionSource, .appManifest)
     }
 
     func testResolveUsesAppCaptureLibraryPreferenceWhenManifestIsMissing() throws {
@@ -223,6 +232,7 @@ final class CaptureLibraryResolverTests: XCTestCase {
         XCTAssertEqual(resolved.dictationDirs.map(\.standardizedFileURL.path), [
             customCaptureLibrary.appendingPathComponent("dictations", isDirectory: true).standardizedFileURL.path,
         ])
+        XCTAssertEqual(resolved.resolutionSource, .appPreference)
     }
 
     private let sampleMeetingMarkdown = """

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -35,11 +35,11 @@ When `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
 that mode the SQLite index also defaults to the shared root unless
 `TRANSCRIPTED_INDEX_DIR` is set.
 
-## Package Layout (17 Swift files)
+## Package Layout (20 Swift files)
 
 - `Package.swift` — Swift package manifest for the standalone MCP server
-- `Sources/TranscriptedMCP/` — 9 source files for server startup, directory resolution, path validation, indexing, and tool handlers
-- `Tests/TranscriptedMCPTests/` — 8 test files for directory resolution, index lifecycle, structured-summary indexing, summary rollups, markdown loading, logging, name variants, and shared fixtures
+- `Sources/TranscriptedMCP/` — 10 source files for server startup, directory resolution, path validation, indexing, telemetry, and tool handlers
+- `Tests/TranscriptedMCPTests/` — 10 test files for directory resolution, index lifecycle, structured-summary indexing, summary rollups, tool handlers, markdown loading, logging, telemetry, name variants, and shared fixtures
 
 ## File Index
 
@@ -54,6 +54,7 @@ that mode the SQLite index also defaults to the shared root unless
 | `NameVariants.swift` | Speaker-name fuzzy matching for speaker-aware queries |
 | `PathSecurity.swift` | Guards direct file reads against traversal, symlinks, and out-of-root paths |
 | `FileWatcher.swift` | Watches the local transcript directories and incrementally reindexes changed files |
+| `AgentCaptureQueryTelemetry.swift` | Anonymous bucketed telemetry for agent capture queries |
 
 ## Test Files
 
@@ -66,6 +67,8 @@ that mode the SQLite index also defaults to the shared root unless
 | `LoggingTests.swift` | JSON log emission coverage for MCP startup and indexing diagnostics |
 | `NameVariantsTests.swift` | Name variant matching accuracy |
 | `SummaryRollupTests.swift` | Cross-meeting rollups: action items by owner/status/date, decisions, digest, write-seam idempotency |
+| `ToolHandlersTests.swift` | Handler-level coverage: title hydration, telemetry, status tool payload, self-describing empty results, done-filter error |
+| `AgentCaptureQueryTelemetryTests.swift` | Bucketing and payload coverage for agent capture-query telemetry |
 | `TestHelpers.swift` | Shared fixture builders for sample transcripts and temp directories |
 
 ## MCP Tools
@@ -83,9 +86,10 @@ All tools are read-only.
 | `recent_context` | Get a mixed recent feed of meetings and dictations |
 | `who_is` | Look up a speaker profile across saved meetings |
 | `recap` | Build a structured digest for a date range |
-| `list_action_items` | Roll up action items across meetings; filter by owner / status / query / date |
+| `list_action_items` | Roll up action items across meetings; filter by owner / status (`open`/`all`; `done` is rejected with an explicit error) / query / date |
 | `list_decisions` | Roll up decisions across meetings; filter by query / date |
 | `digest` | Cross-meeting summary (decisions + action items + open questions) for a window |
+| `status` | Server version, resolved capture directories and which resolution rule selected them, index location, and indexed counts |
 
 The last three are cross-meeting rollups over the structured summary fields and
 query the same `meeting_summary_items` index populated from saved meeting
@@ -182,5 +186,6 @@ The in-app Claude Desktop installer copies that helper into:
 - the server auto-creates missing data and index directories
 - the index rebuilds from disk on startup
 - `recent_context` is intentionally mixed; for the latest meeting specifically, prefer `list_meetings` or `recent_context` with `kind: "meeting"`
+- zero-result queries return a self-describing JSON payload (`searched_directories`, indexed counts, `hint`) instead of a bare "not found" string; call `status` to see the full resolution + index picture
 - `read_meeting` and `read_dictation` read markdown directly from disk, not from the SQLite index
 - source builds can run the server standalone, but shipped app builds bundle the helper for the one-click Claude Desktop installer

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/DataDirectories.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/DataDirectories.swift
@@ -5,6 +5,8 @@ struct TranscriptedDataDirectories {
     let meetingDirs: [URL]
     let dictationDirs: [URL]
     let indexDir: URL
+    let resolutionSource: CaptureLibraryResolutionSource
+    let legacyFallbackAppended: Bool
 
     var meetingsDir: URL {
         meetingDirs[0]
@@ -28,16 +30,32 @@ struct TranscriptedDataDirectories {
         return directories
     }
 
-    init(meetingsDir: URL, dictationsDir: URL, indexDir: URL) {
+    init(
+        meetingsDir: URL,
+        dictationsDir: URL,
+        indexDir: URL,
+        resolutionSource: CaptureLibraryResolutionSource = .defaultCaptures,
+        legacyFallbackAppended: Bool = false
+    ) {
         self.meetingDirs = [meetingsDir]
         self.dictationDirs = [dictationsDir]
         self.indexDir = indexDir
+        self.resolutionSource = resolutionSource
+        self.legacyFallbackAppended = legacyFallbackAppended
     }
 
-    init(meetingDirs: [URL], dictationDirs: [URL], indexDir: URL) {
+    init(
+        meetingDirs: [URL],
+        dictationDirs: [URL],
+        indexDir: URL,
+        resolutionSource: CaptureLibraryResolutionSource = .defaultCaptures,
+        legacyFallbackAppended: Bool = false
+    ) {
         self.meetingDirs = meetingDirs
         self.dictationDirs = dictationDirs
         self.indexDir = indexDir
+        self.resolutionSource = resolutionSource
+        self.legacyFallbackAppended = legacyFallbackAppended
     }
 
     static func resolve(
@@ -56,7 +74,9 @@ struct TranscriptedDataDirectories {
             return TranscriptedDataDirectories(
                 meetingDirs: resolved.meetingDirs,
                 dictationDirs: resolved.dictationDirs,
-                indexDir: indexOverride ?? sharedDataRoot
+                indexDir: indexOverride ?? sharedDataRoot,
+                resolutionSource: resolved.resolutionSource,
+                legacyFallbackAppended: resolved.legacyFallbackAppended
             )
         }
 
@@ -70,7 +90,9 @@ struct TranscriptedDataDirectories {
         return TranscriptedDataDirectories(
             meetingDirs: resolved.meetingDirs,
             dictationDirs: resolved.dictationDirs,
-            indexDir: indexOverride ?? defaultIndex
+            indexDir: indexOverride ?? defaultIndex,
+            resolutionSource: resolved.resolutionSource,
+            legacyFallbackAppended: resolved.legacyFallbackAppended
         )
     }
 }

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
@@ -3,6 +3,8 @@ import MCP
 
 @main
 struct TranscriptedMCP {
+    static let serverVersion = "1.0.0"
+
     static func main() async throws {
         if CommandLine.arguments.contains("--help") || CommandLine.arguments.contains("-h") {
             print(Self.helpText)
@@ -10,7 +12,7 @@ struct TranscriptedMCP {
         }
 
         if CommandLine.arguments.contains("--version") {
-            print("transcripted-mcp 1.0.0")
+            print("transcripted-mcp \(serverVersion)")
             return
         }
 
@@ -21,7 +23,7 @@ struct TranscriptedMCP {
 
         let directories = TranscriptedDataDirectories.resolve()
 
-        log("Starting transcripted-mcp v1.0.0")
+        log("Starting transcripted-mcp v\(serverVersion)")
         log("Meetings directories: \(directories.meetingDirs.map(\.path).joined(separator: ", "))")
         log("Dictations directories: \(directories.dictationDirs.map(\.path).joined(separator: ", "))")
         log("Index directory: \(directories.indexDir.path)")
@@ -57,7 +59,7 @@ struct TranscriptedMCP {
         // Create MCP server
         let server = Server(
             name: "transcripted",
-            version: "1.0.0",
+            version: serverVersion,
             capabilities: .init(tools: .init(listChanged: false))
         )
 

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Models.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Models.swift
@@ -337,11 +337,65 @@ struct PersonMeetingEntry: Codable {
     let otherSpeakers: [String]
 }
 
+// MARK: - Status / Empty Results
+
+struct StatusResult: Codable {
+    let serverVersion: String
+    let meetingDirectories: [String]
+    let dictationDirectories: [String]
+    let resolutionSource: String
+    let legacyFallbackAppended: Bool
+    let indexDirectory: String
+    let indexedMeetings: Int
+    let indexedDictationDays: Int
+    let indexedDictationEntries: Int
+    let indexedSummaryItems: Int
+    let summarizedMeetings: Int
+    let summariesIndexed: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case serverVersion = "server_version"
+        case meetingDirectories = "meeting_directories"
+        case dictationDirectories = "dictation_directories"
+        case resolutionSource = "resolution_source"
+        case legacyFallbackAppended = "legacy_fallback_appended"
+        case indexDirectory = "index_directory"
+        case indexedMeetings = "indexed_meetings"
+        case indexedDictationDays = "indexed_dictation_days"
+        case indexedDictationEntries = "indexed_dictation_entries"
+        case indexedSummaryItems = "indexed_summary_items"
+        case summarizedMeetings = "summarized_meetings"
+        case summariesIndexed = "summaries_indexed"
+    }
+}
+
+/// Payload returned when a query tool matches nothing: where the server
+/// looked, what is indexed, and what to try next. Only the counts relevant to
+/// the tool are populated; nil fields are omitted from the JSON.
+struct EmptyQueryResult: Codable {
+    let searchedDirectories: [String]
+    let indexedMeetings: Int?
+    let indexedDictationDays: Int?
+    let indexedDictationEntries: Int?
+    let indexedSummaryItems: Int?
+    let hint: String
+
+    enum CodingKeys: String, CodingKey {
+        case searchedDirectories = "searched_directories"
+        case indexedMeetings = "indexed_meetings"
+        case indexedDictationDays = "indexed_dictation_days"
+        case indexedDictationEntries = "indexed_dictation_entries"
+        case indexedSummaryItems = "indexed_summary_items"
+        case hint
+    }
+}
+
 // MARK: - Summary-Fact Rollups (cross-meeting tools)
 
-/// Open/done/all filter for `list_action_items`.
-/// Current saved meeting summaries do not carry done/due metadata; done is
-/// accepted as a forward-compatible filter but returns no derived rows today.
+/// Open/all filter for `list_action_items`.
+/// Current saved meeting summaries do not carry done/due metadata; the tool
+/// handler rejects "done" with an explicit error instead of returning a
+/// silent empty set.
 enum ActionItemStatusFilter: String {
     case open
     case done

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -19,6 +19,84 @@ private func textResult(_ text: String, isError: Bool = false) -> CallTool.Resul
     .init(content: [.text(text: text, annotations: nil, _meta: nil)], isError: isError)
 }
 
+/// Which artifact population a tool reads; drives which indexed counts and
+/// hint an empty response carries.
+private enum EmptyResultScope {
+    case meetings
+    case dictations
+    case mixed
+    case summaries
+}
+
+/// Self-describing zero-result response: where the server looked, what is
+/// indexed, and what to try next — so agents can tell an unindexed library
+/// apart from a query that matched nothing.
+private func emptyResult(scope: EmptyResultScope, searchedDirectories: [URL], index: TranscriptIndex) throws -> CallTool.Result {
+    let counts = try index.counts()
+    let directories = uniquePaths(searchedDirectories)
+
+    let payload: EmptyQueryResult
+    switch scope {
+    case .meetings:
+        payload = EmptyQueryResult(
+            searchedDirectories: directories,
+            indexedMeetings: counts.meetings,
+            indexedDictationDays: nil,
+            indexedDictationEntries: nil,
+            indexedSummaryItems: nil,
+            hint: counts.meetings == 0
+                ? "No meetings are indexed — check that the directories above contain capture Markdown, or call the status tool."
+                : "No meetings matched these filters — try widening the date range or changing the query."
+        )
+    case .dictations:
+        payload = EmptyQueryResult(
+            searchedDirectories: directories,
+            indexedMeetings: nil,
+            indexedDictationDays: counts.dictationDays,
+            indexedDictationEntries: counts.dictationEntries,
+            indexedSummaryItems: nil,
+            hint: counts.dictationDays == 0
+                ? "No dictations are indexed — check that the directories above contain capture Markdown, or call the status tool."
+                : "No dictations matched these filters — try widening the date range or changing the query."
+        )
+    case .mixed:
+        payload = EmptyQueryResult(
+            searchedDirectories: directories,
+            indexedMeetings: counts.meetings,
+            indexedDictationDays: counts.dictationDays,
+            indexedDictationEntries: nil,
+            indexedSummaryItems: nil,
+            hint: counts.meetings == 0 && counts.dictationDays == 0
+                ? "Nothing is indexed — check that the directories above contain capture Markdown, or call the status tool."
+                : "No items matched these filters — try widening the date range or changing the query."
+        )
+    case .summaries:
+        payload = EmptyQueryResult(
+            searchedDirectories: directories,
+            indexedMeetings: counts.meetings,
+            indexedDictationDays: nil,
+            indexedDictationEntries: nil,
+            indexedSummaryItems: counts.summaryItems,
+            hint: counts.summaryItems == 0
+                ? "No structured summaries are indexed. Rollups only cover meetings with a saved summary (Settings → Meetings → local summaries)."
+                : "No summary items matched these filters — try widening the date range or removing filters."
+        )
+    }
+
+    let json = try JSONEncoder.pretty.encode(payload)
+    return textResult(String(data: json, encoding: .utf8) ?? "{}")
+}
+
+private func uniquePaths(_ directories: [URL]) -> [String] {
+    var seen: Set<String> = []
+    var paths: [String] = []
+    for url in directories {
+        guard seen.insert(url.standardizedFileURL.path).inserted else { continue }
+        paths.append(url.path)
+    }
+    return paths
+}
+
 func registerToolHandlers(server: Server, index: TranscriptIndex, directories: TranscriptedDataDirectories) async {
     await server.withMethodHandler(ListTools.self) { _ in
         .init(tools: [
@@ -235,7 +313,7 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
             ),
             Tool(
                 name: "list_action_items",
-                description: "Roll up action items across every meeting. Filter by owner (supports name variants: Nate finds Nate Smith), by status (open by default, or 'done'/'all'), by a free-text query, or by date range. Use this for 'every open action item assigned to me' or 'what did we commit to last week'. Depends on the meeting summary index.",
+                description: "Roll up action items across every meeting. Filter by owner (supports name variants: Nate finds Nate Smith), by status ('open' by default, or 'all'), by a free-text query, or by date range. Use this for 'every open action item assigned to me' or 'what did we commit to last week'. Depends on the meeting summary index.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -245,7 +323,7 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                         ]),
                         "status": .object([
                             "type": .string("string"),
-                            "description": .string("Which items to return: 'open' (default), 'done', or 'all'")
+                            "description": .string("Which items to return: 'open' (default) or 'all'. 'done' is not supported — saved summaries do not track completion state yet.")
                         ]),
                         "query": .object([
                             "type": .string("string"),
@@ -311,6 +389,15 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                 ]),
                 annotations: .init(readOnlyHint: true)
             ),
+            Tool(
+                name: "status",
+                description: "Server status and configuration: version, resolved capture directories, which resolution rule selected them, index location, and indexed counts. Call this when other tools return empty results to see whether anything is indexed at all.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([:]),
+                ]),
+                annotations: .init(readOnlyHint: true)
+            ),
         ])
     }
 
@@ -320,7 +407,7 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
             case "list_meetings":
                 return try handleListMeetings(params: params, index: index, meetingDirs: directories.meetingDirs)
             case "list_dictations":
-                return try handleListDictations(params: params, index: index)
+                return try handleListDictations(params: params, index: index, dictationDirs: directories.dictationDirs)
             case "read_meeting":
                 return try handleReadMeeting(params: params, meetingDirs: directories.meetingDirs)
             case "read_dictation":
@@ -328,9 +415,9 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
             case "search":
                 return try handleSearch(params: params, index: index, meetingDirs: directories.meetingDirs)
             case "search_context":
-                return try handleSearchContext(params: params, index: index, meetingDirs: directories.meetingDirs)
+                return try handleSearchContext(params: params, index: index, meetingDirs: directories.meetingDirs, dictationDirs: directories.dictationDirs)
             case "recent_context":
-                return try handleRecentContext(params: params, index: index, meetingDirs: directories.meetingDirs)
+                return try handleRecentContext(params: params, index: index, meetingDirs: directories.meetingDirs, dictationDirs: directories.dictationDirs)
             case "who_is":
                 return try handleWhoIs(params: params, index: index)
             case "recap":
@@ -341,6 +428,8 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                 return try handleListDecisions(params: params, index: index, meetingDirs: directories.meetingDirs)
             case "digest":
                 return try handleDigest(params: params, index: index, meetingDirs: directories.meetingDirs)
+            case "status":
+                return try handleStatus(index: index, directories: directories)
             default:
                 return textResult("Unknown tool: \(params.name)", isError: true)
             }
@@ -373,7 +462,7 @@ func handleListMeetings(params: CallTool.Parameters, index: TranscriptIndex, mee
     }
 
     if results.isEmpty {
-        return textResult("No meetings found.")
+        return try emptyResult(scope: .meetings, searchedDirectories: meetingDirs, index: index)
     }
 
     trackAgentCaptureQueryObserved(
@@ -387,7 +476,7 @@ func handleListMeetings(params: CallTool.Parameters, index: TranscriptIndex, mee
     return textResult(String(data: json, encoding: .utf8) ?? "[]")
 }
 
-func handleListDictations(params: CallTool.Parameters, index: TranscriptIndex) throws -> CallTool.Result {
+func handleListDictations(params: CallTool.Parameters, index: TranscriptIndex, dictationDirs: [URL]) throws -> CallTool.Result {
     let count = params.arguments?["count"]?.intValue ?? 10
     let date = params.arguments?["date"]?.stringValue
     let dateFrom = params.arguments?["date_from"]?.stringValue ?? date
@@ -396,7 +485,7 @@ func handleListDictations(params: CallTool.Parameters, index: TranscriptIndex) t
     let results = try index.listDictationDays(count: count, dateFrom: dateFrom, dateTo: dateTo)
 
     if results.isEmpty {
-        return textResult("No dictations found.")
+        return try emptyResult(scope: .dictations, searchedDirectories: dictationDirs, index: index)
     }
 
     trackAgentCaptureQueryObserved(
@@ -555,9 +644,7 @@ private func handleSearch(params: CallTool.Parameters, index: TranscriptIndex, m
     hydrateMeetingSearchTitles(in: &results, meetingDirs: meetingDirs)
 
     if results.results.isEmpty {
-        var msg = "No results found for \"\(query)\""
-        if let s = speaker { msg += " by \(s)" }
-        return textResult(msg)
+        return try emptyResult(scope: .meetings, searchedDirectories: meetingDirs, index: index)
     }
 
     trackAgentCaptureQueryObserved(
@@ -571,7 +658,7 @@ private func handleSearch(params: CallTool.Parameters, index: TranscriptIndex, m
     return textResult(String(data: json, encoding: .utf8) ?? "[]")
 }
 
-private func handleSearchContext(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+private func handleSearchContext(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL], dictationDirs: [URL]) throws -> CallTool.Result {
     guard let query = params.arguments?["query"]?.stringValue, !query.isEmpty else {
         return textResult("Missing required parameter: query", isError: true)
     }
@@ -594,7 +681,7 @@ private func handleSearchContext(params: CallTool.Parameters, index: TranscriptI
     hydrateMeetingTitles(in: &results.results, kind: \.kind, filename: \.filename, title: \.title, meetingDirs: meetingDirs)
 
     if results.results.isEmpty {
-        return textResult("No context found for \"\(query)\".")
+        return try emptyResult(scope: .mixed, searchedDirectories: meetingDirs + dictationDirs, index: index)
     }
 
     trackAgentCaptureQueryObserved(
@@ -608,7 +695,7 @@ private func handleSearchContext(params: CallTool.Parameters, index: TranscriptI
     return textResult(String(data: json, encoding: .utf8) ?? "{}")
 }
 
-func handleRecentContext(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+func handleRecentContext(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL], dictationDirs: [URL]) throws -> CallTool.Result {
     let kind = parseContextKind(params.arguments?["kind"]?.stringValue)
     let count = max(1, min(params.arguments?["count"]?.intValue ?? 10, 50))
     let dateFrom = params.arguments?["date_from"]?.stringValue
@@ -618,7 +705,7 @@ func handleRecentContext(params: CallTool.Parameters, index: TranscriptIndex, me
     hydrateMeetingTitles(in: &result.items, kind: \.kind, filename: \.filename, title: \.title, meetingDirs: meetingDirs)
 
     if result.items.isEmpty {
-        return textResult("No recent context found.")
+        return try emptyResult(scope: .mixed, searchedDirectories: meetingDirs + dictationDirs, index: index)
     }
 
     trackAgentCaptureQueryObserved(
@@ -667,7 +754,7 @@ private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, me
     let meetings = try index.listMeetings(count: 50, dateFrom: dateFrom, dateTo: dateTo)
 
     if meetings.isEmpty {
-        return textResult("No meetings found from \(dateFrom) to \(dateTo).")
+        return try emptyResult(scope: .meetings, searchedDirectories: meetingDirs, index: index)
     }
 
     var recapParts: [RecapEntry] = []
@@ -717,13 +804,23 @@ private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, me
 
 // MARK: - list_action_items / list_decisions / digest (cross-meeting rollups)
 
-private func handleListActionItems(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+func handleListActionItems(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
     let owner = params.arguments?["owner"]?.stringValue
     let query = params.arguments?["query"]?.stringValue
-    let status = ActionItemStatusFilter(raw: params.arguments?["status"]?.stringValue)
+    let rawStatus = params.arguments?["status"]?.stringValue
+    let status = ActionItemStatusFilter(raw: rawStatus)
     let dateFrom = params.arguments?["date_from"]?.stringValue
     let dateTo = params.arguments?["date_to"]?.stringValue
     let count = params.arguments?["count"]?.intValue ?? 50
+
+    // Saved summaries do not track completion state, so a done filter would
+    // always be a silent empty set — fail loudly instead.
+    if status == .done {
+        return textResult(
+            "Unsupported status filter: \"\(rawStatus ?? "done")\". Saved meeting summaries do not track done/completed state yet, so this filter would always return nothing. Use status \"open\" (the default) or \"all\".",
+            isError: true
+        )
+    }
 
     var result = try index.listActionItems(
         owner: owner, query: query, status: status,
@@ -735,10 +832,7 @@ private func handleListActionItems(params: CallTool.Parameters, index: Transcrip
     }
 
     if result.items.isEmpty {
-        var msg = "No \(status == .all ? "" : status.rawValue + " ")action items found"
-        if let owner, !owner.isEmpty { msg += " for \(owner)" }
-        msg += ". Action items come from the meeting summary index; if summaries have not been indexed yet, this will be empty."
-        return textResult(msg)
+        return try emptyResult(scope: .summaries, searchedDirectories: meetingDirs, index: index)
     }
 
     let json = try JSONEncoder.pretty.encode(result)
@@ -758,7 +852,7 @@ private func handleListDecisions(params: CallTool.Parameters, index: TranscriptI
     }
 
     if result.decisions.isEmpty {
-        return textResult("No decisions found. Decisions come from the meeting summary index; if summaries have not been indexed yet, this will be empty.")
+        return try emptyResult(scope: .summaries, searchedDirectories: meetingDirs, index: index)
     }
 
     let json = try JSONEncoder.pretty.encode(result)
@@ -778,8 +872,31 @@ private func handleDigest(params: CallTool.Parameters, index: TranscriptIndex, m
     }
 
     if result.meetings.isEmpty {
-        return textResult("No summarized meetings found for \(result.dateRange). Digest reads the meeting summary index; if summaries have not been indexed yet, this will be empty.")
+        return try emptyResult(scope: .summaries, searchedDirectories: meetingDirs, index: index)
     }
+
+    let json = try JSONEncoder.pretty.encode(result)
+    return textResult(String(data: json, encoding: .utf8) ?? "{}")
+}
+
+// MARK: - status
+
+func handleStatus(index: TranscriptIndex, directories: TranscriptedDataDirectories) throws -> CallTool.Result {
+    let counts = try index.counts()
+    let result = StatusResult(
+        serverVersion: TranscriptedMCP.serverVersion,
+        meetingDirectories: directories.meetingDirs.map(\.path),
+        dictationDirectories: directories.dictationDirs.map(\.path),
+        resolutionSource: directories.resolutionSource.rawValue,
+        legacyFallbackAppended: directories.legacyFallbackAppended,
+        indexDirectory: directories.indexDir.path,
+        indexedMeetings: counts.meetings,
+        indexedDictationDays: counts.dictationDays,
+        indexedDictationEntries: counts.dictationEntries,
+        indexedSummaryItems: counts.summaryItems,
+        summarizedMeetings: counts.summarizedMeetings,
+        summariesIndexed: counts.summaryItems > 0
+    )
 
     let json = try JSONEncoder.pretty.encode(result)
     return textResult(String(data: json, encoding: .utf8) ?? "{}")

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -595,6 +595,43 @@ final class TranscriptIndex: @unchecked Sendable {
         }
     }
 
+    // MARK: - Index counts (status tool + self-describing empty results)
+
+    /// Row counts across the derived tables so agents can tell an unindexed
+    /// library apart from a query that matched nothing.
+    struct IndexCounts {
+        let meetings: Int
+        let dictationDays: Int
+        let dictationEntries: Int
+        let summaryItems: Int
+        let summarizedMeetings: Int
+    }
+
+    func counts() throws -> IndexCounts {
+        try queue.sync {
+            IndexCounts(
+                meetings: try scalarCount("SELECT COUNT(*) FROM meetings"),
+                dictationDays: try scalarCount("SELECT COUNT(*) FROM dictation_days"),
+                dictationEntries: try scalarCount("SELECT COUNT(*) FROM dictation_entries"),
+                summaryItems: try scalarCount("SELECT COUNT(*) FROM meeting_summary_items"),
+                summarizedMeetings: try scalarCount("SELECT COUNT(DISTINCT filename) FROM meeting_summary_items")
+            )
+        }
+    }
+
+    /// Single-value COUNT query. Must run inside `queue.sync`.
+    private func scalarCount(_ sql: String) throws -> Int {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            throw MCPIndexError.queryFailed(dbError())
+        }
+        defer { sqlite3_finalize(stmt) }
+        guard sqlite3_step(stmt) == SQLITE_ROW else {
+            throw MCPIndexError.queryFailed(dbError())
+        }
+        return Int(sqlite3_column_int64(stmt, 0))
+    }
+
     // MARK: - Queries
 
     func searchUtterances(query: String, speaker: String?, dateFrom: String?, dateTo: String?, maxMeetings: Int = 10, snippetsPerMeeting: Int = 3) throws -> GroupedSearchResult {

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
@@ -104,7 +104,8 @@ final class ToolHandlersTests: XCTestCase {
 
         _ = try handleListDictations(
             params: CallTool.Parameters(name: "list_dictations", arguments: ["count": .int(10)]),
-            index: index
+            index: index,
+            dictationDirs: [tempDir]
         )
 
         let observation = try XCTUnwrap(telemetry.observations.last)
@@ -126,7 +127,8 @@ final class ToolHandlersTests: XCTestCase {
         _ = try handleRecentContext(
             params: CallTool.Parameters(name: "recent_context", arguments: ["count": .int(10)]),
             index: index,
-            meetingDirs: [tempDir]
+            meetingDirs: [tempDir],
+            dictationDirs: [tempDir]
         )
 
         let observation = try XCTUnwrap(telemetry.observations.last)
@@ -144,6 +146,148 @@ final class ToolHandlersTests: XCTestCase {
         )
 
         XCTAssertTrue(telemetry.observations.isEmpty)
+    }
+
+    func testStatusToolReportsDirectoriesAndIndexCounts() throws {
+        try writeFixture(makeMeetingWithInlineSummary(), filename: "Call_2026-04-18_09-15-00", to: tempDir)
+        try writeFixture(makeDictationDayJSON(), filename: "Dictations_2026-04-07", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let directories = TranscriptedDataDirectories(meetingsDir: tempDir, dictationsDir: tempDir, indexDir: tempDir)
+        let result = try handleStatus(index: index, directories: directories)
+
+        XCTAssertNotEqual(result.isError, true)
+        let payload = try JSONDecoder().decode(StatusResult.self, from: Data(resultText(result).utf8))
+        XCTAssertEqual(payload.serverVersion, TranscriptedMCP.serverVersion)
+        XCTAssertEqual(payload.meetingDirectories, [tempDir.path])
+        XCTAssertEqual(payload.dictationDirectories, [tempDir.path])
+        XCTAssertEqual(payload.resolutionSource, "default")
+        XCTAssertFalse(payload.legacyFallbackAppended)
+        XCTAssertEqual(payload.indexDirectory, tempDir.path)
+        XCTAssertEqual(payload.indexedMeetings, 1)
+        XCTAssertEqual(payload.indexedDictationDays, 1)
+        XCTAssertEqual(payload.indexedDictationEntries, 2)
+        // Fixture summary: 2 decisions + 2 action items + 1 open question.
+        XCTAssertEqual(payload.indexedSummaryItems, 5)
+        XCTAssertEqual(payload.summarizedMeetings, 1)
+        XCTAssertTrue(payload.summariesIndexed)
+    }
+
+    func testStatusToolReportsZeroCountsOnEmptyIndex() throws {
+        let directories = TranscriptedDataDirectories(meetingsDir: tempDir, dictationsDir: tempDir, indexDir: tempDir)
+        let result = try handleStatus(index: index, directories: directories)
+
+        let payload = try JSONDecoder().decode(StatusResult.self, from: Data(resultText(result).utf8))
+        XCTAssertEqual(payload.indexedMeetings, 0)
+        XCTAssertEqual(payload.indexedDictationDays, 0)
+        XCTAssertEqual(payload.indexedSummaryItems, 0)
+        XCTAssertFalse(payload.summariesIndexed)
+    }
+
+    func testEmptyListMeetingsDescribesSearchedDirectoriesAndHint() throws {
+        let result = try handleListMeetings(
+            params: CallTool.Parameters(name: "list_meetings", arguments: ["count": .int(10)]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        let payload = try JSONDecoder().decode(EmptyQueryResult.self, from: Data(resultText(result).utf8))
+        XCTAssertEqual(payload.searchedDirectories, [tempDir.path])
+        XCTAssertEqual(payload.indexedMeetings, 0)
+        XCTAssertTrue(payload.hint.contains("No meetings are indexed"))
+        XCTAssertTrue(payload.hint.contains("status tool"))
+    }
+
+    func testEmptyListMeetingsWithIndexedDataHintsAtFilters() throws {
+        try writeFixture(
+            makeFixtureJSON(date: "2026-03-26T16:04:11-0500"),
+            filename: "Call_2026-03-26_16-04-11",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try handleListMeetings(
+            params: CallTool.Parameters(name: "list_meetings", arguments: ["date": .string("2001-01-01")]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let payload = try JSONDecoder().decode(EmptyQueryResult.self, from: Data(resultText(result).utf8))
+        XCTAssertEqual(payload.indexedMeetings, 1)
+        XCTAssertTrue(payload.hint.contains("No meetings matched"))
+    }
+
+    func testEmptyListDictationsDescribesSearchedDirectoriesAndHint() throws {
+        let result = try handleListDictations(
+            params: CallTool.Parameters(name: "list_dictations", arguments: ["count": .int(10)]),
+            index: index,
+            dictationDirs: [tempDir]
+        )
+
+        let payload = try JSONDecoder().decode(EmptyQueryResult.self, from: Data(resultText(result).utf8))
+        XCTAssertEqual(payload.searchedDirectories, [tempDir.path])
+        XCTAssertEqual(payload.indexedDictationDays, 0)
+        XCTAssertEqual(payload.indexedDictationEntries, 0)
+        XCTAssertTrue(payload.hint.contains("No dictations are indexed"))
+    }
+
+    func testEmptyRecentContextDeduplicatesSearchedDirectories() throws {
+        let result = try handleRecentContext(
+            params: CallTool.Parameters(name: "recent_context", arguments: ["count": .int(10)]),
+            index: index,
+            meetingDirs: [tempDir],
+            dictationDirs: [tempDir]
+        )
+
+        let payload = try JSONDecoder().decode(EmptyQueryResult.self, from: Data(resultText(result).utf8))
+        XCTAssertEqual(payload.searchedDirectories, [tempDir.path])
+        XCTAssertEqual(payload.indexedMeetings, 0)
+        XCTAssertEqual(payload.indexedDictationDays, 0)
+        XCTAssertTrue(payload.hint.contains("Nothing is indexed"))
+    }
+
+    func testEmptyActionItemsExplainMissingSummaries() throws {
+        // Meeting without a saved summary: indexed, but no summary rows.
+        try writeFixture(
+            makeFixtureJSON(date: "2026-03-26T16:04:11-0500"),
+            filename: "Call_2026-03-26_16-04-11",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try handleListActionItems(
+            params: CallTool.Parameters(name: "list_action_items", arguments: [:]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        let payload = try JSONDecoder().decode(EmptyQueryResult.self, from: Data(resultText(result).utf8))
+        XCTAssertEqual(payload.indexedMeetings, 1)
+        XCTAssertEqual(payload.indexedSummaryItems, 0)
+        XCTAssertTrue(payload.hint.contains("No structured summaries are indexed"))
+    }
+
+    func testListActionItemsDoneStatusReturnsExplicitError() throws {
+        let result = try handleListActionItems(
+            params: CallTool.Parameters(name: "list_action_items", arguments: ["status": .string("done")]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        XCTAssertEqual(result.isError, true)
+        let text = try resultText(result)
+        XCTAssertTrue(text.contains("done"))
+        XCTAssertTrue(text.contains("\"all\""))
+    }
+
+    private func resultText(_ result: CallTool.Result) throws -> String {
+        guard case .text(let text, _, _) = try XCTUnwrap(result.content.first) else {
+            XCTFail("Expected text content")
+            return ""
+        }
+        return text
     }
 }
 


### PR DESCRIPTION
## Why

The MCP server's dominant failure mode is silent emptiness: an agent getting `[]` can't distinguish "no data" from "wrong directory" from "index not built" from "feature needs summaries enabled" — so it confidently tells the user they have no meetings. Specific offenders from the agent-surface audit: no runtime introspection at all (the `--self-test` diagnostics are unreachable from an MCP client), rollup tools that are empty for anyone without saved summaries, and `list_action_items` `status:"done"` compiling to `AND 1=0`.

## Product Impact

- Affects: `agent artifacts`
- Lane: `agent workflow`
- Why this matters: self-describing responses are the difference between an agent that recovers ("your index has 0 meetings — check the searched folders") and one that hallucinates an answer.

## What changed

- **New `status` tool** (13th tool, read-only): server version, resolved meeting/dictation directories, which resolution rule won (`env_data_dir` / `env_kind_dirs` / `app_manifest` / `app_preference` / `default`), whether legacy fallback dirs were appended, index directory, and indexed counts (meetings, dictation days/entries, summary items, summarized meetings, `summaries_indexed`).
- **`TranscriptedCaptureKit`**: additive `CaptureLibraryResolutionSource` enum + `resolutionSource`/`legacyFallbackAppended` on `ResolvedCaptureDirectories` (new init params defaulted; the CLI call site compiles unchanged).
- **Self-describing empty results** in all 9 query tools: empty responses now carry `searched_directories`, scope-relevant indexed counts, and a `hint` that distinguishes "nothing indexed — call the status tool" from "nothing matched these filters". Rollup tools explain that they only cover meetings with saved summaries. Non-empty responses are byte-identical.
- **`status:"done"` now errors explicitly** ("not tracked in saved summaries yet; use open or all") instead of returning a silent empty set; tool schema/description updated. The defensive `AND 1=0` stays at the index layer.
- `Main.swift` now has a single `serverVersion` constant reused by `--version`, the startup log, `Server(version:)`, and `status`.
- Tests: 8 new handler tests (status shape, empty hints per scope, done error) + resolver source/fallback assertions; `TranscriptIndex.counts()` with 5 small COUNT queries.
- `Tools/TranscriptedMCP/CLAUDE.md`: `status` row, done-filter note, empty-result gotcha, refreshed file index.

## How I checked it

- [x] `scripts/dev/agent-preflight.sh`
- [x] Selected checks from `.agents/test-matrix.yml` — CaptureKit rule = package-test union + e2e smoke
- [x] `swift test --package-path Tools/TranscriptedCaptureKit` + `Tools/TranscriptedCLI` + `Tools/TranscriptedMCP` + `bash run-e2e-smoke.sh` — **all run by Swift CI on macOS at this exact head (`802ff5f`), green: https://github.com/r3dbars/transcripted/actions/runs/28621577716** (the workflow runs the full matrix: build, fast tests, Core `swift test`, integration smoke, e2e smoke, and all four Tools package suites)
- [x] Manual check: resolver changes verified additive against the CLI call site; diff reviewed hunk-by-hunk.

Authoring context: written in a Linux session with no local Swift toolchain; verification is the green macOS Swift CI run above (required merge gate, same matrix as local runs).

## Risk Review

- [x] Privacy / local-first behavior reviewed — `status` and empty-result fields expose local paths to the local MCP client only (same trust boundary as `read_meeting` returning transcript text)
- [x] Storage path or migration impact reviewed — resolution behavior unchanged; only observability added
- [x] Public-facing copy stays concrete and matches current product scope
- [x] Release/update impact reviewed — the bundled helper picks this up on the next app build; self-heal refresh covers installed copies
- [x] Agent PRs link the issue/workpad and stay draft until human review
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence — n/a
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

## Notes

Part of the agent-surface audit series (#1356–#1361) and step 2 of the consolidation plan in #1358. Known behavior change: empty responses switch from plain text ("No meetings found.") to structured JSON — intentional, that's the fix. One judgment call: with only one per-kind env override set, `resolution_source` reports `env_kind_dirs` even though the other kind resolved lower in the chain (commented in the resolver).

#1363 (read-path pagination) stacks on this branch because both touch `ToolHandlers.swift` — merge this first.

## Agent handoff

`COORD_DONE: GREEN | (this PR) | status tool + self-describing empties + done-filter error | none | none | Swift CI green at head 802ff5f (full matrix incl. all package tests + e2e) | human review + mark ready + merge, then #1363`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuGZaFRmNrqfGPpqf7WH4n