### PR TITLE
MCP: bounded reads with offset/limit pagination for read_meeting and read_dictation

### DIFF
--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -67,7 +67,7 @@ that mode the SQLite index also defaults to the shared root unless
 | `LoggingTests.swift` | JSON log emission coverage for MCP startup and indexing diagnostics |
 | `NameVariantsTests.swift` | Name variant matching accuracy |
 | `SummaryRollupTests.swift` | Cross-meeting rollups: action items by owner/status/date, decisions, digest, write-seam idempotency |
-| `ToolHandlersTests.swift` | Handler-level coverage: title hydration, telemetry, status tool payload, self-describing empty results, done-filter error |
+| `ToolHandlersTests.swift` | Handler-level coverage: title hydration, telemetry, status tool payload, self-describing empty results, done-filter error, read pagination windows and size guard |
 | `AgentCaptureQueryTelemetryTests.swift` | Bucketing and payload coverage for agent capture-query telemetry |
 | `TestHelpers.swift` | Shared fixture builders for sample transcripts and temp directories |
 
@@ -78,9 +78,9 @@ All tools are read-only.
 | Tool | Description |
 |------|-------------|
 | `list_meetings` | List saved meetings with metadata and optional date filters |
-| `read_meeting` | Read one meeting transcript by filename |
+| `read_meeting` | Read one meeting transcript by filename; `section` (`full`/`transcript`/`speakers`) plus optional `offset`/`limit` utterance paging |
 | `list_dictations` | List saved dictation day files with counts, source apps, and titles |
-| `read_dictation` | Read one dictation day or one specific dictation entry |
+| `read_dictation` | Read one dictation day, one specific entry by `entry_id`, or a paged window of entries via `offset`/`limit` |
 | `search` | Search meeting transcript content |
 | `search_context` | Search across meetings, dictations, or both |
 | `recent_context` | Get a mixed recent feed of meetings and dictations |
@@ -188,4 +188,5 @@ The in-app Claude Desktop installer copies that helper into:
 - `recent_context` is intentionally mixed; for the latest meeting specifically, prefer `list_meetings` or `recent_context` with `kind: "meeting"`
 - zero-result queries return a self-describing JSON payload (`searched_directories`, indexed counts, `hint`) instead of a bare "not found" string; call `status` to see the full resolution + index picture
 - `read_meeting` and `read_dictation` read markdown directly from disk, not from the SQLite index
+- both read tools carry a size guard: raw dumps larger than `maxUnpaginatedReadCharacters` (~30k chars) — or any call passing `offset`/`limit` — come back as a paginated JSON window (`total_utterances`/`total_entries`, `offset`, `returned`, `truncated`, `next_offset`, `hint`) instead of the full markdown; small unpaginated reads stay byte-identical raw markdown, and `entry_id` reads are unaffected
 - source builds can run the server standalone, but shipped app builds bundle the helper for the one-click Claude Desktop installer

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Models.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Models.swift
@@ -390,6 +390,63 @@ struct EmptyQueryResult: Codable {
     }
 }
 
+// MARK: - Bounded Reads (read_meeting / read_dictation pagination)
+
+/// Paginated window over a meeting transcript, returned when the caller asks
+/// for one (offset/limit) or when the raw markdown would exceed the read
+/// character budget. Frontmatter metadata is preserved; the dialogue is
+/// bounded to the requested utterance window.
+struct MeetingTranscriptPage: Codable {
+    let filename: String
+    let frontmatter: String?
+    let totalUtterances: Int
+    let offset: Int
+    let returned: Int
+    let truncated: Bool
+    let nextOffset: Int?
+    let hint: String
+    let utterances: [MeetingTranscriptPageUtterance]
+
+    enum CodingKeys: String, CodingKey {
+        case filename, frontmatter, offset, returned, truncated, hint, utterances
+        case totalUtterances = "total_utterances"
+        case nextOffset = "next_offset"
+    }
+}
+
+struct MeetingTranscriptPageUtterance: Codable {
+    let start: Double
+    let end: Double
+    let speaker: String
+    let speakerId: String
+    let text: String
+
+    enum CodingKeys: String, CodingKey {
+        case start, end, speaker, text
+        case speakerId = "speaker_id"
+    }
+}
+
+/// Paginated window over a dictation day's entries, mirroring
+/// `MeetingTranscriptPage` for `read_dictation` reads without an entry_id.
+struct DictationDayPage: Codable {
+    let filename: String
+    let date: String
+    let totalEntries: Int
+    let offset: Int
+    let returned: Int
+    let truncated: Bool
+    let nextOffset: Int?
+    let hint: String
+    let entries: [AgentDictationEntry]
+
+    enum CodingKeys: String, CodingKey {
+        case filename, date, offset, returned, truncated, hint, entries
+        case totalEntries = "total_entries"
+        case nextOffset = "next_offset"
+    }
+}
+
 // MARK: - Summary-Fact Rollups (cross-meeting tools)
 
 /// Open/all filter for `list_action_items`.

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -19,6 +19,32 @@ private func textResult(_ text: String, isError: Bool = false) -> CallTool.Resul
     .init(content: [.text(text: text, annotations: nil, _meta: nil)], isError: isError)
 }
 
+/// Character budget for read_meeting / read_dictation raw markdown responses.
+/// Anything larger switches to a paginated window even when the caller did not
+/// pass offset/limit, so one 90-minute transcript cannot blow out an agent's
+/// context window. ~30k characters is roughly 7-8k tokens — big enough that
+/// typical meetings and dictation days pass through byte-identical, small
+/// enough that a runaway dump stays readable.
+let maxUnpaginatedReadCharacters = 30_000
+
+/// Rough per-item JSON encoding overhead (keys, timestamps, speaker names)
+/// used when auto-sizing a pagination window against the character budget.
+private let paginationItemOverheadCharacters = 80
+
+/// Index one past the last item that fits the character budget starting at
+/// `start`. Always advances by at least one item when any remain, so an
+/// oversized single item still makes progress.
+private func autoWindowEnd<T>(items: [T], start: Int, cost: (T) -> Int) -> Int {
+    var end = start
+    var used = 0
+    while end < items.count {
+        used += cost(items[end])
+        if used > maxUnpaginatedReadCharacters, end > start { break }
+        end += 1
+    }
+    return end
+}
+
 /// Which artifact population a tool reads; drives which indexed counts and
 /// hint an empty response carries.
 private enum EmptyResultScope {
@@ -128,7 +154,7 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
             ),
             Tool(
                 name: "read_meeting",
-                description: "Read the full transcript of a specific meeting. Returns the complete dialogue with speaker names and timestamps. Use list_meetings first to get the filename.",
+                description: "Read a meeting transcript by filename (from list_meetings). Long meetings are token-heavy: pass offset/limit to page through utterances, or section 'speakers' for metadata and analytics without dialogue. Full or transcript responses over ~30k characters are automatically truncated to a bounded window with total_utterances, next_offset, and a continuation hint.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -138,7 +164,15 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                         ]),
                         "section": .object([
                             "type": .string("string"),
-                            "description": .string("Which section to return: 'full' (default — complete transcript), 'transcript' (dialogue only), or 'speakers' (analytics only)")
+                            "description": .string("Which section to return: 'full' (default — complete transcript), 'transcript' (dialogue only), or 'speakers' (frontmatter + analytics, cheapest for long meetings)")
+                        ]),
+                        "offset": .object([
+                            "type": .string("integer"),
+                            "description": .string("0-based utterance index to start the transcript window at (default: 0). Applies to sections 'full' and 'transcript'.")
+                        ]),
+                        "limit": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum utterances to return. Setting this (or exceeding the size guard) switches the response to a paginated JSON window with total_utterances, next_offset, and a hint.")
                         ]),
                     ]),
                     "required": .array([.string("filename")]),
@@ -200,7 +234,7 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
             ),
             Tool(
                 name: "read_dictation",
-                description: "Read a saved dictation day or one specific dictation entry by ID. Use list_dictations or recent_context first to find the filename or entry_id you need.",
+                description: "Read a saved dictation day, one specific entry by ID, or a bounded window of entries. Use list_dictations or recent_context first to find the filename or entry_id you need. Prefer entry_id for a single entry. Without entry_id, pass offset/limit to page through entries; day files over ~30k characters are automatically truncated to a window with total_entries, next_offset, and a continuation hint.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -211,6 +245,14 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                         "entry_id": .object([
                             "type": .string("string"),
                             "description": .string("Optional entry ID from recent_context or search_context to return one dictation entry")
+                        ]),
+                        "offset": .object([
+                            "type": .string("integer"),
+                            "description": .string("0-based entry index to start the window at (default: 0). Ignored when entry_id is set.")
+                        ]),
+                        "limit": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum entries to return. Setting this (or exceeding the size guard) switches the response to a paginated JSON window with total_entries, next_offset, and a hint. Ignored when entry_id is set.")
                         ]),
                     ]),
                     "required": .array([.string("filename")]),
@@ -515,12 +557,15 @@ private func extractDialogueLines(from content: String) -> [String] {
 
 // MARK: - read_meeting
 
-private func handleReadMeeting(params: CallTool.Parameters, meetingDirs: [URL]) throws -> CallTool.Result {
+func handleReadMeeting(params: CallTool.Parameters, meetingDirs: [URL]) throws -> CallTool.Result {
     guard let filename = params.arguments?["filename"]?.stringValue, !filename.isEmpty else {
         return textResult("Missing required parameter: filename", isError: true)
     }
 
     let section = params.arguments?["section"]?.stringValue ?? "full"
+    let offset = max(0, params.arguments?["offset"]?.intValue ?? 0)
+    let limit = params.arguments?["limit"]?.intValue
+    let paginationRequested = limit != nil || offset > 0
 
     let mdURL: URL
     switch PathSecurity.resolveReadableFile(named: filename, appendingExtension: "md", in: meetingDirs) {
@@ -536,24 +581,32 @@ private func handleReadMeeting(params: CallTool.Parameters, meetingDirs: [URL]) 
         return textResult("Meeting not found: \(filename). Use list_meetings to see available meetings.", isError: true)
     }
 
+    let parsed = CaptureMarkdownParser.parseMeeting(from: content)
+
     trackAgentCaptureQueryObserved(
         queryKind: "read",
         artifactKind: "meeting",
-        captureDate: captureDateFromMeetingMarkdown(content),
+        captureDate: parsed.flatMap { parseCaptureDate($0.datetime) },
         sourceCount: 1
     )
 
     switch section {
     case "transcript":
         let dialogue = extractDialogueLines(from: content).joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-        return textResult(dialogue.isEmpty ? content : dialogue)
+        let raw = dialogue.isEmpty ? content : dialogue
+        if !paginationRequested, raw.count <= maxUnpaginatedReadCharacters {
+            return textResult(raw)
+        }
+        return try meetingTranscriptPageResult(
+            parsed: parsed, content: content, filename: filename,
+            offset: offset, limit: limit, includeFrontmatter: false, rawFallback: raw
+        )
 
     case "speakers":
         // Return YAML frontmatter + speaker analytics section
         var result = ""
-        if content.count >= 8, content.hasPrefix("---"),
-           let endRange = content.range(of: "\n---\n", range: content.index(content.startIndex, offsetBy: 3)..<content.endIndex) {
-            result += String(content[content.startIndex...endRange.upperBound])
+        if let frontmatter = frontmatterBlock(of: content) {
+            result += frontmatter
         }
         if let analyticsRange = content.range(of: "## Channel & Speaker Analytics") {
             if let transcriptRange = content.range(of: "## Full Transcript") {
@@ -565,11 +618,95 @@ private func handleReadMeeting(params: CallTool.Parameters, meetingDirs: [URL]) 
         return textResult(result.isEmpty ? content : result)
 
     default: // "full"
-        return textResult(content)
+        if !paginationRequested, content.count <= maxUnpaginatedReadCharacters {
+            return textResult(content)
+        }
+        return try meetingTranscriptPageResult(
+            parsed: parsed, content: content, filename: filename,
+            offset: offset, limit: limit, includeFrontmatter: true, rawFallback: content
+        )
     }
 }
 
-private func handleReadDictation(params: CallTool.Parameters, dictationDirs: [URL]) throws -> CallTool.Result {
+/// Bounded transcript read: frontmatter metadata plus one utterance window and
+/// explicit pagination fields, so a long meeting never comes back as an
+/// unbounded dump. Falls back to the raw markdown when the file does not parse
+/// as a windowable transcript — we can only page what the parser understands.
+private func meetingTranscriptPageResult(
+    parsed: ParsedMeetingCapture?,
+    content: String,
+    filename: String,
+    offset: Int,
+    limit: Int?,
+    includeFrontmatter: Bool,
+    rawFallback: String
+) throws -> CallTool.Result {
+    guard let parsed, !parsed.utterances.isEmpty else {
+        return textResult(rawFallback)
+    }
+
+    let total = parsed.utterances.count
+    let start = min(offset, total)
+    let end: Int
+    if let limit {
+        end = min(start + max(1, limit), total)
+    } else {
+        end = autoWindowEnd(items: parsed.utterances, start: start) {
+            $0.text.count + paginationItemOverheadCharacters
+        }
+    }
+
+    let speakerNames = Dictionary(uniqueKeysWithValues: parsed.speakers.map { ($0.id, $0.name) })
+    let utterances = parsed.utterances[start..<end].map { utterance in
+        MeetingTranscriptPageUtterance(
+            start: utterance.start,
+            end: utterance.end,
+            speaker: speakerNames[utterance.speakerId] ?? utterance.speakerId,
+            speakerId: utterance.speakerId,
+            text: utterance.text
+        )
+    }
+
+    let returned = utterances.count
+    let truncated = start + returned < total
+    let nextOffset = truncated ? start + returned : nil
+
+    let hint: String
+    if offset >= total {
+        hint = "offset \(offset) is past the end — this transcript has \(total) utterances. Retry with a smaller offset."
+    } else if let nextOffset {
+        hint = "Showing utterances \(start)-\(end - 1) of \(total). Call read_meeting again with offset=\(nextOffset) to continue, or use section \"speakers\" for the overview without dialogue."
+    } else {
+        hint = "End of transcript — all remaining utterances included."
+    }
+
+    let page = MeetingTranscriptPage(
+        filename: filename,
+        frontmatter: includeFrontmatter ? frontmatterBlock(of: content) : nil,
+        totalUtterances: total,
+        offset: offset,
+        returned: returned,
+        truncated: truncated,
+        nextOffset: nextOffset,
+        hint: hint,
+        utterances: utterances
+    )
+
+    let json = try JSONEncoder.pretty.encode(page)
+    return textResult(String(data: json, encoding: .utf8) ?? "{}")
+}
+
+/// Raw YAML frontmatter block, matching the exact slice the speakers section
+/// has always returned (both fences plus the character after the closing one).
+private func frontmatterBlock(of content: String) -> String? {
+    guard content.count >= 8, content.hasPrefix("---"),
+          let endRange = content.range(of: "\n---\n", range: content.index(content.startIndex, offsetBy: 3)..<content.endIndex) else {
+        return nil
+    }
+    return String(content[content.startIndex...endRange.upperBound])
+}
+
+func handleReadDictation(params: CallTool.Parameters, dictationDirs: [URL]) throws -> CallTool.Result {
     guard let filename = params.arguments?["filename"]?.stringValue, !filename.isEmpty else {
         return textResult("Missing required parameter: filename", isError: true)
     }
@@ -621,12 +758,66 @@ private func handleReadDictation(params: CallTool.Parameters, dictationDirs: [UR
         sourceCount: day.entries.count
     )
 
+    let offset = max(0, params.arguments?["offset"]?.intValue ?? 0)
+    let limit = params.arguments?["limit"]?.intValue
+    let paginationRequested = limit != nil || offset > 0
+
     guard let content = try? String(contentsOf: markdownURL, encoding: .utf8) else {
         let json = try JSONEncoder.pretty.encode(day)
         return textResult(String(data: json, encoding: .utf8) ?? "{}")
     }
 
-    return textResult(content)
+    if !paginationRequested, content.count <= maxUnpaginatedReadCharacters {
+        return textResult(content)
+    }
+
+    return try dictationDayPageResult(day: day, filename: filename, offset: offset, limit: limit)
+}
+
+/// Bounded dictation-day read: day metadata plus one entry window and explicit
+/// pagination fields, mirroring the meeting transcript window.
+private func dictationDayPageResult(day: AgentDictationDay, filename: String, offset: Int, limit: Int?) throws -> CallTool.Result {
+    let total = day.entries.count
+    let start = min(offset, total)
+    let end: Int
+    if let limit {
+        end = min(start + max(1, limit), total)
+    } else {
+        end = autoWindowEnd(items: day.entries, start: start) {
+            $0.text.count + $0.title.count + paginationItemOverheadCharacters * 3
+        }
+    }
+
+    let entries = Array(day.entries[start..<end])
+    let returned = entries.count
+    let truncated = start + returned < total
+    let nextOffset = truncated ? start + returned : nil
+
+    let hint: String
+    if total == 0 {
+        hint = "This dictation day has no entries."
+    } else if offset >= total {
+        hint = "offset \(offset) is past the end — this day has \(total) entries. Retry with a smaller offset."
+    } else if let nextOffset {
+        hint = "Showing entries \(start)-\(end - 1) of \(total). Call read_dictation again with offset=\(nextOffset) to continue, or pass entry_id for one specific entry."
+    } else {
+        hint = "End of day — all remaining entries included."
+    }
+
+    let page = DictationDayPage(
+        filename: filename,
+        date: day.date,
+        totalEntries: total,
+        offset: offset,
+        returned: returned,
+        truncated: truncated,
+        nextOffset: nextOffset,
+        hint: hint,
+        entries: entries
+    )
+
+    let json = try JSONEncoder.pretty.encode(page)
+    return textResult(String(data: json, encoding: .utf8) ?? "{}")
 }
 
 // MARK: - search
@@ -1035,11 +1226,6 @@ private func artifactKind(for kinds: [ContextKind]) -> String {
         return "dictation"
     }
     return "mixed"
-}
-
-private func captureDateFromMeetingMarkdown(_ content: String) -> Date? {
-    guard let parsed = CaptureMarkdownParser.parseMeeting(from: content) else { return nil }
-    return parseCaptureDate(parsed.datetime)
 }
 
 extension JSONEncoder {

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TestHelpers.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/TestHelpers.swift
@@ -1,6 +1,22 @@
 import Foundation
 @testable import transcripted_mcp
 
+/// Sequential system-channel utterances for pagination fixtures. Built with a
+/// loop: mapping to labeled tuples with inline Double math makes the type
+/// checker time out on CI.
+func makeSequentialUtterances(
+    count: Int,
+    text: (Int) -> String
+) -> [(speakerId: String, start: Double, end: Double, text: String)] {
+    var utterances: [(speakerId: String, start: Double, end: Double, text: String)] = []
+    for index in 0..<count {
+        let start = Double(index * 10)
+        let end = Double(index * 10 + 5)
+        utterances.append((speakerId: "system_0", start: start, end: end, text: text(index)))
+    }
+    return utterances
+}
+
 func makeFixtureJSON(
     title: String? = nil,
     date: String = "2026-03-29T10:00:00-0500",

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
@@ -269,6 +269,198 @@ final class ToolHandlersTests: XCTestCase {
         XCTAssertTrue(payload.hint.contains("No structured summaries are indexed"))
     }
 
+    func testReadMeetingSmallFullReadStaysByteIdenticalRawMarkdown() throws {
+        let content = makeFixtureJSON(title: "Roadmap Sync", date: "2026-03-26T16:04:11-0500")
+        try writeFixture(content, filename: "Call_2026-03-26_16-04-11", to: tempDir)
+
+        let result = try handleReadMeeting(
+            params: CallTool.Parameters(name: "read_meeting", arguments: ["filename": .string("Call_2026-03-26_16-04-11")]),
+            meetingDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        XCTAssertEqual(try resultText(result), content)
+    }
+
+    func testReadMeetingWindowedReadReturnsRequestedUtterances() throws {
+        let utterances: [(speakerId: String, start: Double, end: Double, text: String)] = (0..<6).map {
+            ("system_0", Double($0 * 10), Double($0 * 10 + 5), "Utterance number \($0)")
+        }
+        try writeFixture(
+            makeFixtureJSON(title: "Roadmap Sync", date: "2026-03-26T16:04:11-0500", utterances: utterances),
+            filename: "Call_2026-03-26_16-04-11",
+            to: tempDir
+        )
+
+        let result = try handleReadMeeting(
+            params: CallTool.Parameters(name: "read_meeting", arguments: [
+                "filename": .string("Call_2026-03-26_16-04-11"),
+                "offset": .int(2),
+                "limit": .int(2),
+            ]),
+            meetingDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        let page = try JSONDecoder().decode(MeetingTranscriptPage.self, from: Data(resultText(result).utf8))
+        XCTAssertEqual(page.totalUtterances, 6)
+        XCTAssertEqual(page.offset, 2)
+        XCTAssertEqual(page.returned, 2)
+        XCTAssertTrue(page.truncated)
+        XCTAssertEqual(page.nextOffset, 4)
+        XCTAssertEqual(page.utterances.map(\.text), ["Utterance number 2", "Utterance number 3"])
+        XCTAssertEqual(page.utterances.first?.speaker, "Jenny Wen")
+        // Full-section pages keep the frontmatter metadata.
+        let frontmatter = try XCTUnwrap(page.frontmatter)
+        XCTAssertTrue(frontmatter.contains("title: \"Roadmap Sync\""))
+        XCTAssertTrue(page.hint.contains("offset=4"))
+    }
+
+    func testReadMeetingTranscriptSectionWindowOmitsFrontmatter() throws {
+        let utterances: [(speakerId: String, start: Double, end: Double, text: String)] = (0..<6).map {
+            ("system_0", Double($0 * 10), Double($0 * 10 + 5), "Utterance number \($0)")
+        }
+        try writeFixture(
+            makeFixtureJSON(date: "2026-03-26T16:04:11-0500", utterances: utterances),
+            filename: "Call_2026-03-26_16-04-11",
+            to: tempDir
+        )
+
+        let result = try handleReadMeeting(
+            params: CallTool.Parameters(name: "read_meeting", arguments: [
+                "filename": .string("Call_2026-03-26_16-04-11"),
+                "section": .string("transcript"),
+                "limit": .int(3),
+            ]),
+            meetingDirs: [tempDir]
+        )
+
+        let page = try JSONDecoder().decode(MeetingTranscriptPage.self, from: Data(resultText(result).utf8))
+        XCTAssertNil(page.frontmatter)
+        XCTAssertEqual(page.totalUtterances, 6)
+        XCTAssertEqual(page.offset, 0)
+        XCTAssertEqual(page.returned, 3)
+        XCTAssertEqual(page.nextOffset, 3)
+    }
+
+    func testReadMeetingOffsetBeyondEndReturnsEmptyWindowWithTotals() throws {
+        try writeFixture(
+            makeFixtureJSON(date: "2026-03-26T16:04:11-0500"),
+            filename: "Call_2026-03-26_16-04-11",
+            to: tempDir
+        )
+
+        let result = try handleReadMeeting(
+            params: CallTool.Parameters(name: "read_meeting", arguments: [
+                "filename": .string("Call_2026-03-26_16-04-11"),
+                "offset": .int(50),
+                "limit": .int(5),
+            ]),
+            meetingDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        let page = try JSONDecoder().decode(MeetingTranscriptPage.self, from: Data(resultText(result).utf8))
+        // Default fixture has 2 utterances.
+        XCTAssertEqual(page.totalUtterances, 2)
+        XCTAssertEqual(page.offset, 50)
+        XCTAssertEqual(page.returned, 0)
+        XCTAssertTrue(page.utterances.isEmpty)
+        XCTAssertFalse(page.truncated)
+        XCTAssertNil(page.nextOffset)
+        XCTAssertTrue(page.hint.contains("past the end"))
+    }
+
+    func testReadMeetingOversizedTranscriptAutoTruncatesWithNextOffset() throws {
+        let filler = String(repeating: "budget planning detail ", count: 14)
+        let utterances: [(speakerId: String, start: Double, end: Double, text: String)] = (0..<200).map {
+            ("system_0", Double($0 * 10), Double($0 * 10 + 5), "Utterance \($0): \(filler)")
+        }
+        try writeFixture(
+            makeFixtureJSON(date: "2026-03-26T16:04:11-0500", utterances: utterances),
+            filename: "Call_2026-03-26_16-04-11",
+            to: tempDir
+        )
+
+        // No offset/limit — the size guard alone must trigger pagination.
+        let result = try handleReadMeeting(
+            params: CallTool.Parameters(name: "read_meeting", arguments: ["filename": .string("Call_2026-03-26_16-04-11")]),
+            meetingDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        let page = try JSONDecoder().decode(MeetingTranscriptPage.self, from: Data(resultText(result).utf8))
+        XCTAssertEqual(page.totalUtterances, 200)
+        XCTAssertEqual(page.offset, 0)
+        XCTAssertTrue(page.truncated)
+        XCTAssertGreaterThan(page.returned, 0)
+        XCTAssertLessThan(page.returned, 200)
+        let nextOffset = try XCTUnwrap(page.nextOffset)
+        XCTAssertEqual(nextOffset, page.returned)
+        XCTAssertTrue(page.hint.contains("offset=\(nextOffset)"))
+    }
+
+    func testReadDictationSmallDayFullReadStaysByteIdenticalRawMarkdown() throws {
+        let content = makeDictationDayJSON()
+        try writeFixture(content, filename: "Dictations_2026-04-07", to: tempDir)
+
+        let result = try handleReadDictation(
+            params: CallTool.Parameters(name: "read_dictation", arguments: ["filename": .string("Dictations_2026-04-07")]),
+            dictationDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        XCTAssertEqual(try resultText(result), content)
+    }
+
+    func testReadDictationEntryWindowing() throws {
+        let entries: [(id: String, createdAt: String, title: String, text: String, sourceAppName: String, delivery: String)] = [
+            ("dictation-20260407-091500-000", "2026-04-07T09:15:00-0500", "First note", "Alpha text for the morning", "Slack", "copied"),
+            ("dictation-20260407-120000-000", "2026-04-07T12:00:00-0500", "Second note", "Beta text for midday", "Mail", "pasted"),
+            ("dictation-20260407-183000-000", "2026-04-07T18:30:00-0500", "Third note", "Gamma text for the evening", "Notes", "copied"),
+        ]
+        try writeFixture(makeDictationDayJSON(entries: entries), filename: "Dictations_2026-04-07", to: tempDir)
+
+        let result = try handleReadDictation(
+            params: CallTool.Parameters(name: "read_dictation", arguments: [
+                "filename": .string("Dictations_2026-04-07"),
+                "offset": .int(1),
+                "limit": .int(1),
+            ]),
+            dictationDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        let page = try JSONDecoder().decode(DictationDayPage.self, from: Data(resultText(result).utf8))
+        XCTAssertEqual(page.totalEntries, 3)
+        XCTAssertEqual(page.offset, 1)
+        XCTAssertEqual(page.returned, 1)
+        XCTAssertTrue(page.truncated)
+        XCTAssertEqual(page.nextOffset, 2)
+        XCTAssertEqual(page.entries.map(\.title), ["Second note"])
+        XCTAssertTrue(page.hint.contains("offset=2"))
+    }
+
+    func testReadDictationEntryIdBehaviorUnchangedByPaginationParams() throws {
+        try writeFixture(makeDictationDayJSON(), filename: "Dictations_2026-04-07", to: tempDir)
+
+        let result = try handleReadDictation(
+            params: CallTool.Parameters(name: "read_dictation", arguments: [
+                "filename": .string("Dictations_2026-04-07"),
+                "entry_id": .string("dictation-20260407-091500-000"),
+                "offset": .int(1),
+                "limit": .int(1),
+            ]),
+            dictationDirs: [tempDir]
+        )
+
+        XCTAssertNotEqual(result.isError, true)
+        let text = try resultText(result)
+        XCTAssertTrue(text.hasPrefix("# Morning note"))
+        XCTAssertTrue(text.contains("Ship the follow-up note to product today"))
+        XCTAssertFalse(text.contains("total_entries"))
+    }
+
     func testListActionItemsDoneStatusReturnsExplicitError() throws {
         let result = try handleListActionItems(
             params: CallTool.Parameters(name: "list_action_items", arguments: ["status": .string("done")]),

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
@@ -283,9 +283,7 @@ final class ToolHandlersTests: XCTestCase {
     }
 
     func testReadMeetingWindowedReadReturnsRequestedUtterances() throws {
-        let utterances: [(speakerId: String, start: Double, end: Double, text: String)] = (0..<6).map {
-            ("system_0", Double($0 * 10), Double($0 * 10 + 5), "Utterance number \($0)")
-        }
+        let utterances = makeSequentialUtterances(count: 6) { "Utterance number \($0)" }
         try writeFixture(
             makeFixtureJSON(title: "Roadmap Sync", date: "2026-03-26T16:04:11-0500", utterances: utterances),
             filename: "Call_2026-03-26_16-04-11",
@@ -317,9 +315,7 @@ final class ToolHandlersTests: XCTestCase {
     }
 
     func testReadMeetingTranscriptSectionWindowOmitsFrontmatter() throws {
-        let utterances: [(speakerId: String, start: Double, end: Double, text: String)] = (0..<6).map {
-            ("system_0", Double($0 * 10), Double($0 * 10 + 5), "Utterance number \($0)")
-        }
+        let utterances = makeSequentialUtterances(count: 6) { "Utterance number \($0)" }
         try writeFixture(
             makeFixtureJSON(date: "2026-03-26T16:04:11-0500", utterances: utterances),
             filename: "Call_2026-03-26_16-04-11",
@@ -373,9 +369,7 @@ final class ToolHandlersTests: XCTestCase {
 
     func testReadMeetingOversizedTranscriptAutoTruncatesWithNextOffset() throws {
         let filler = String(repeating: "budget planning detail ", count: 14)
-        let utterances: [(speakerId: String, start: Double, end: Double, text: String)] = (0..<200).map {
-            ("system_0", Double($0 * 10), Double($0 * 10 + 5), "Utterance \($0): \(filler)")
-        }
+        let utterances = makeSequentialUtterances(count: 200) { "Utterance \($0): \(filler)" }
         try writeFixture(
             makeFixtureJSON(date: "2026-03-26T16:04:11-0500", utterances: utterances),
             filename: "Call_2026-03-26_16-04-11",


### PR DESCRIPTION
## Why

`read_meeting` (default `section:"full"`) and `read_dictation` (no `entry_id`) dump entire files — a 90-minute meeting is a massive token bill for the connected agent, and there was no way to page through a transcript or fetch a bounded slice. These are exactly the tools an agent reaches for right after any `list_*` call. From the agent-surface audit.

## Product Impact

- Affects: `agent artifacts`
- Lane: `agent workflow`
- Why this matters: read-path token cost is the biggest practical constraint on "ask Claude about your meetings" working well for long meetings.

## What changed

- **`read_meeting`**: new optional `offset` (0-based utterance index) and `limit` params. Explicit paging — or a raw dump that would exceed a size guard — returns a structured page instead: frontmatter preserved, dialogue bounded to the window, plus `total_utterances`, `offset`, `returned`, `truncated`, `next_offset` (null when done), and a `hint` telling the agent how to continue or use `section:"speakers"`.
- **`read_dictation`**: same shape over entries (`total_entries`, …) when no `entry_id` is given; `entry_id` behavior unchanged.
- **Size guard**: `maxUnpaginatedReadCharacters = 30_000` (~7–8k tokens) — typical files pass through untouched; a long transcript auto-truncates with continuation info instead of dumping. Auto-windows fill to the budget with per-item overhead estimates and always advance at least one item.
- **Backward compatible**: no offset/limit and under budget → byte-identical raw markdown (tested for both tools); `section:"speakers"` unchanged; unparseable markdown falls back to the raw dump rather than erroring.
- Tool descriptions/inputSchemas updated so agents discover the cheap paths; `Tools/TranscriptedMCP/CLAUDE.md` rows + size-guard gotcha; 8 new handler tests (windowing, offset-past-end totals, oversized auto-truncation, byte-identical small reads, entry_id precedence).

## How I checked it

- [x] `scripts/dev/agent-preflight.sh`
- [x] Selected checks from `.agents/test-matrix.yml` identified
- [x] `swift test --package-path Tools/TranscriptedMCP` + stacked union (CaptureKit/CLI package tests, e2e smoke) — **run by Swift CI on macOS at this exact head (`f918b61`), green: https://github.com/r3dbars/transcripted/actions/runs/28622792834** (the workflow runs the full matrix as the required merge gate)
- [x] Manual check: new models and handler paths reviewed hunk-by-hunk; pagination fields verified against the response builders.

CI history: the first run failed on a Swift type-check timeout in three new test fixtures (labeled tuples with inline `Double` math in `.map` closures); fixed in `f918b61` by a loop-based `makeSequentialUtterances` helper in TestHelpers, after which the full run passed.

Authoring context: written in a Linux session with no local Swift toolchain; verification is the green macOS Swift CI run above.

## Risk Review

- [x] Privacy / local-first behavior reviewed — same local trust boundary; no new data exposure
- [x] Storage path or migration impact reviewed — none
- [x] Public-facing copy stays concrete and matches current product scope
- [x] Release/update impact reviewed — bundled helper picks this up on next app build
- [x] Agent PRs link the issue/workpad and stay draft until human review
- [ ] UI changes include sanitized `.agent-review/visuals/` evidence — n/a
- [x] No private transcripts, audio, tokens, personal paths, or customer data are included

## Notes

**Stacked on #1362** (both modify `ToolHandlers.swift`/`Models.swift`) — merge that first; GitHub will retarget this to `main` automatically. Part of the agent-surface audit series (#1356–#1362). Design choice worth flagging: files the parser can't window bypass the size guard via the raw fallback (documented in a comment) — erroring there would break reads of legacy/odd files entirely.

## Agent handoff

`COORD_DONE: GREEN | (this PR) | bounded reads + pagination on both read tools | retarget after #1362 merges | none | Swift CI green at head f918b61 (full matrix) | merge #1362, retarget, human review + merge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GuGZaFRmNrqfGPpqf7WH4n