### PR TITLE
[codex] add local MCP semantic search

### DIFF
--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -35,20 +35,23 @@ When `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
 that mode the SQLite index also defaults to the shared root unless
 `TRANSCRIPTED_INDEX_DIR` is set.
 
-## Package Layout (17 Swift files)
+## Package Layout (20 Swift files)
 
 - `Package.swift` — Swift package manifest for the standalone MCP server
-- `Sources/TranscriptedMCP/` — 9 source files for server startup, directory resolution, path validation, indexing, and tool handlers
-- `Tests/TranscriptedMCPTests/` — 8 test files for directory resolution, index lifecycle, structured-summary indexing, summary rollups, markdown loading, logging, name variants, and shared fixtures
+- `Sources/TranscriptedMCP/` — 12 source files for server startup, directory resolution, path validation, indexing, structured summaries, semantic search, and tool handlers
+- `Tests/TranscriptedMCPTests/` — 9 test files for directory resolution, index lifecycle, structured-summary indexing, summary rollups, markdown loading, logging, name variants, semantic search, and shared fixtures
 
 ## File Index
 
 | File | Purpose |
 |------|---------|
-| `Main.swift` | `@main` entry point; resolves directories, builds the index, starts file watchers, then starts the MCP stdio server |
+| `Main.swift` | `@main` entry point; resolves directories, builds the index (with an `NLEmbeddingProvider` for semantic search), starts file watchers, then starts the MCP stdio server |
 | `DataDirectories.swift` | Index-dir resolution plus a thin wrapper over `TranscriptedCaptureKit`'s shared capture-library resolver |
 | `ToolHandlers.swift` | Registers every MCP tool and routes requests to the correct loader or index method |
-| `TranscriptIndex.swift` | SQLite-backed index, incremental updates, and query methods across meetings and dictations |
+| `TranscriptIndex.swift` | SQLite-backed index, incremental updates, and query methods across meetings and dictations; routes `lexical`/`semantic`/`hybrid` search modes |
+| `EmbeddingProvider.swift` | `EmbeddingProvider` protocol, the default `NLEmbeddingProvider` (Apple NaturalLanguage, zero-bundle on-device), `SearchMode`, and `VectorMath` helpers |
+| `EmbeddingStore.swift` | Vector store on its own SQLite connection; embeds rows, stores Float32 vectors, and runs cosine semantic search over utterances and dictation entries |
+| `SemanticSearchFusion.swift` | Reciprocal-rank fusion that merges lexical (FTS) and semantic result lists for hybrid search |
 | `TranscriptLoader.swift` | Loads markdown meeting transcripts and dictation day files from disk; parsing delegates to `TranscriptedCaptureKit` |
 | `Models.swift` | Codable input/output models and `MCPIndexError` |
 | `NameVariants.swift` | Speaker-name fuzzy matching for speaker-aware queries |
@@ -66,6 +69,7 @@ that mode the SQLite index also defaults to the shared root unless
 | `LoggingTests.swift` | JSON log emission coverage for MCP startup and indexing diagnostics |
 | `NameVariantsTests.swift` | Name variant matching accuracy |
 | `SummaryRollupTests.swift` | Cross-meeting rollups: action items by owner/status/date, decisions, digest, write-seam idempotency |
+| `SemanticSearchTests.swift` | Semantic + hybrid search via a deterministic stub provider, graceful fallback, model-change re-embed, vector-math, and RRF fusion |
 | `TestHelpers.swift` | Shared fixture builders for sample transcripts and temp directories |
 
 ## MCP Tools
@@ -78,8 +82,8 @@ All tools are read-only.
 | `read_meeting` | Read one meeting transcript by filename |
 | `list_dictations` | List saved dictation day files with counts, source apps, and titles |
 | `read_dictation` | Read one dictation day or one specific dictation entry |
-| `search` | Search meeting transcript content |
-| `search_context` | Search across meetings, dictations, or both |
+| `search` | Search meeting transcript content (lexical / semantic / hybrid via `mode`, default hybrid) |
+| `search_context` | Search across meetings, dictations, or both (same `mode` options) |
 | `recent_context` | Get a mixed recent feed of meetings and dictations |
 | `who_is` | Look up a speaker profile across saved meetings |
 | `recap` | Build a structured digest for a date range |
@@ -123,6 +127,18 @@ The SQLite index keeps separate records for:
 Structured summary items are parsed via `TranscriptedCaptureKit.CaptureSummaryParser` from each meeting's inline local summary (or a `<stem>.summary.md` sidecar fallback) during `indexMeeting`. `TranscriptIndex.listSummaryItems(kind:owner:dateFrom:dateTo:)` is the cross-meeting query foundation behind `list_action_items`, `list_decisions`, and `digest`.
 
 This lets the server answer both meeting-specific queries (`who_is`, `read_meeting`) and mixed-context queries (`search_context`, `recent_context`) without touching app-owned runtime state.
+
+The semantic layer adds three additive tables on a separate connection: `embedding_meta` (model id + dimension), `utterance_vectors`, and `dictation_entry_vectors` (Float32 BLOBs keyed by the lexical rows' `rowid`). They never alter the lexical write path.
+
+## Semantic Search
+
+Local, on-device semantic search complements FTS so paraphrase queries hit (e.g. "pricing pushback" finds "they balked at the cost").
+
+- Embeddings come from Apple's `NaturalLanguage` `NLEmbedding.sentenceEmbedding` — **no bundled model, no download, negligible app-size impact**. Backend is pluggable via `EmbeddingProvider`, so a bundled CoreML model can replace it later without touching the store or search path.
+- `EmbeddingStore` embeds new/changed rows after each reconcile (lazily, keyed by `rowid`), re-embeds everything on a model-id/dimension change, and runs a streaming cosine scan with the same speaker/date filters as FTS.
+- `search` / `search_context` accept `mode`: `hybrid` (default — FTS + semantic fused with reciprocal-rank fusion, a strict superset of FTS recall), `lexical`, or `semantic`.
+- All modes degrade gracefully: if the embedding backend is unavailable (e.g. missing OS language assets), the store is never created and every mode runs lexical-only.
+- NLEmbedding's similarity floor is high, so `semantic` alone is best-effort; `hybrid` is rank-based and stays robust because exact FTS hits anchor precision.
 
 ## Build And Test
 

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingProvider.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingProvider.swift
@@ -1,0 +1,115 @@
+import Foundation
+import NaturalLanguage
+
+/// Which retrieval strategy a search runs.
+///
+/// - `lexical`  — the original SQLite FTS5 path (exact/stemmed token match).
+/// - `semantic` — vector cosine match only (paraphrase recall).
+/// - `hybrid`   — both, fused with reciprocal-rank fusion. Strict superset of
+///                lexical recall, so it never drops an FTS hit.
+enum SearchMode: String, Codable, Sendable {
+    case lexical
+    case semantic
+    case hybrid
+}
+
+/// Produces dense vector embeddings for short text spans (meeting utterances,
+/// dictation entries).
+///
+/// Pluggable on purpose: today the shipping backend is Apple's built-in
+/// `NaturalLanguage` sentence embedding — zero bundle size, no model download,
+/// fully on-device. A bundled CoreML model (e.g. a quantized MiniLM) can replace
+/// it later without touching the vector store or the search path, by conforming
+/// a new type to this protocol and wiring it in `Main.swift`.
+protocol EmbeddingProvider: Sendable {
+    /// Stable identifier for the embedding space. Changing it invalidates every
+    /// stored vector so they get re-embedded against the new model.
+    var modelID: String { get }
+
+    /// Vector dimensionality, or 0 when the backend is unavailable on this host.
+    var dimension: Int { get }
+
+    /// Whether the backend can actually produce vectors right now.
+    var isAvailable: Bool { get }
+
+    /// Embed one text span. Returns nil for empty/unembeddable input or when the
+    /// backend is unavailable. Returned vectors are L2-normalized so a dot
+    /// product equals cosine similarity.
+    func embed(_ text: String) -> [Float]?
+}
+
+extension EmbeddingProvider {
+    var isAvailable: Bool { dimension > 0 }
+}
+
+/// Default on-device backend: Apple's `NLEmbedding` sentence embedding.
+///
+/// Built into macOS (no bundled model, no download, negligible incremental app
+/// size, modest RAM). `sentenceEmbedding(for:)` returns nil when the OS has no
+/// model assets for the language (e.g. some headless/CI images) — in that case
+/// `isAvailable` is false and the index simply skips semantic indexing, leaving
+/// lexical search fully functional.
+final class NLEmbeddingProvider: EmbeddingProvider, @unchecked Sendable {
+    let modelID: String
+    private let embedding: NLEmbedding?
+    // NLEmbedding is not documented as thread-safe; serialize vector() calls.
+    private let lock = NSLock()
+
+    init(language: NLLanguage = .english) {
+        let model = NLEmbedding.sentenceEmbedding(for: language)
+        self.embedding = model
+        self.modelID = "nl.sentence.\(language.rawValue).v1"
+    }
+
+    var dimension: Int { embedding?.dimension ?? 0 }
+    var isAvailable: Bool { embedding != nil }
+
+    func embed(_ text: String) -> [Float]? {
+        guard let embedding else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        lock.lock()
+        let raw = embedding.vector(for: trimmed)
+        lock.unlock()
+        guard let raw, !raw.isEmpty else { return nil }
+        return VectorMath.normalized(raw.map { Float($0) })
+    }
+}
+
+/// Small float-vector helpers shared by the provider and the vector store.
+enum VectorMath {
+    /// L2-normalize a vector. A zero vector is returned unchanged.
+    static func normalized(_ v: [Float]) -> [Float] {
+        var sum: Float = 0
+        for x in v { sum += x * x }
+        let norm = sum.squareRoot()
+        guard norm > 0 else { return v }
+        return v.map { $0 / norm }
+    }
+
+    /// Dot product. For L2-normalized inputs this equals cosine similarity.
+    static func dot(_ a: [Float], _ b: [Float]) -> Float {
+        let n = min(a.count, b.count)
+        var sum: Float = 0
+        var i = 0
+        while i < n {
+            sum += a[i] * b[i]
+            i += 1
+        }
+        return sum
+    }
+
+    /// Pack a vector into a Float32 blob for SQLite storage.
+    static func blob(from v: [Float]) -> Data {
+        v.withUnsafeBufferPointer { Data(buffer: $0) }
+    }
+
+    /// Unpack a Float32 blob back into a vector.
+    static func vector(from data: Data) -> [Float] {
+        let count = data.count / MemoryLayout<Float>.stride
+        guard count > 0 else { return [] }
+        return data.withUnsafeBytes { raw in
+            Array(raw.bindMemory(to: Float.self).prefix(count))
+        }
+    }
+}

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingStore.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingStore.swift
@@ -1,0 +1,391 @@
+import Foundation
+import SQLite3
+
+/// On-device vector store for semantic search.
+///
+/// Owns its own SQLite connection to the *same* `mcp_index.sqlite` file the
+/// lexical `TranscriptIndex` uses, but only ever writes its own additive tables
+/// (`embedding_meta`, `utterance_vectors`, `dictation_entry_vectors`). It reads
+/// the lexical tables (`utterances`, `meetings`, `dictation_entries`,
+/// `dictation_days`) to find rows that still need embedding and to hydrate search
+/// results. Keeping it on a separate connection means the embedding work and the
+/// vector schema stay fully decoupled from the lexical index's write path.
+///
+/// Everything here is best-effort: if the embedding provider is unavailable or a
+/// write fails, lexical search keeps working untouched.
+final class EmbeddingStore: @unchecked Sendable {
+    private var db: OpaquePointer?
+    private let queue = DispatchQueue(label: "com.transcripted.mcp.vectors", qos: .utility)
+    private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+    private let provider: EmbeddingProvider
+    private let dbPath: URL
+
+    /// Minimum cosine similarity for a row to count as a semantic match.
+    /// NLEmbedding sentence vectors have a fairly high similarity floor (even
+    /// unrelated short sentences land around ~0.30), so this trims the obvious
+    /// tail rather than acting as a precise relevance cut. Hybrid mode is
+    /// rank-based and still surfaces exact FTS hits regardless of this value.
+    private let minimumSimilarity: Float = 0.30
+
+    /// Cap on candidate rows scanned per query, newest first, to bound work on
+    /// very large libraries. Personal-scale libraries stay well under this.
+    private let maxCandidateRows = 50_000
+
+    var isAvailable: Bool { provider.isAvailable }
+
+    init(dbPath: URL, provider: EmbeddingProvider) throws {
+        self.dbPath = dbPath
+        self.provider = provider
+        try queue.sync {
+            if sqlite3_open(dbPath.path, &db) != SQLITE_OK {
+                throw MCPIndexError.databaseOpenFailed(dbErrorLocked())
+            }
+            sqlite3_exec(db, "PRAGMA busy_timeout=5000", nil, nil, nil)
+            sqlite3_exec(db, "PRAGMA journal_mode=WAL", nil, nil, nil)
+            sqlite3_exec(db, "PRAGMA synchronous=NORMAL", nil, nil, nil)
+            createTablesLocked()
+        }
+    }
+
+    deinit {
+        queue.sync {
+            if let db = db { sqlite3_close(db) }
+        }
+    }
+
+    private func createTablesLocked() {
+        execLocked("""
+            CREATE TABLE IF NOT EXISTS embedding_meta (
+                id INTEGER PRIMARY KEY CHECK (id = 0),
+                model_id TEXT NOT NULL,
+                dimension INTEGER NOT NULL
+            )
+        """)
+        // rowid mirrors utterances.rowid / dictation_entries.rowid. Those rows are
+        // deleted and re-inserted on reindex, so vectors can be orphaned — the
+        // reconcile pass cleans orphans and embeds the new rows.
+        execLocked("""
+            CREATE TABLE IF NOT EXISTS utterance_vectors (
+                rowid INTEGER PRIMARY KEY,
+                vec BLOB NOT NULL
+            )
+        """)
+        execLocked("""
+            CREATE TABLE IF NOT EXISTS dictation_entry_vectors (
+                rowid INTEGER PRIMARY KEY,
+                vec BLOB NOT NULL
+            )
+        """)
+    }
+
+    // MARK: - Embedding reconciliation
+
+    /// Embed any indexed rows that don't yet have a vector, drop orphaned
+    /// vectors, and re-embed everything if the model identity changed. Safe to
+    /// call after every lexical reconcile; it only does work for new/changed rows.
+    func reconcileEmbeddings() {
+        guard provider.isAvailable else { return }
+        queue.sync {
+            invalidateOnModelChangeLocked()
+            // Drop vectors whose backing rows are gone (reindex churns rowids).
+            execLocked("DELETE FROM utterance_vectors WHERE rowid NOT IN (SELECT rowid FROM utterances)")
+            execLocked("DELETE FROM dictation_entry_vectors WHERE rowid NOT IN (SELECT rowid FROM dictation_entries)")
+
+            embedMissingLocked(
+                selectSQL: """
+                    SELECT u.rowid, u.text FROM utterances u
+                    LEFT JOIN utterance_vectors v ON v.rowid = u.rowid
+                    WHERE v.rowid IS NULL
+                """,
+                insertSQL: "INSERT OR REPLACE INTO utterance_vectors (rowid, vec) VALUES (?, ?)"
+            )
+            embedMissingLocked(
+                selectSQL: """
+                    SELECT e.rowid, e.text FROM dictation_entries e
+                    LEFT JOIN dictation_entry_vectors v ON v.rowid = e.rowid
+                    WHERE v.rowid IS NULL
+                """,
+                insertSQL: "INSERT OR REPLACE INTO dictation_entry_vectors (rowid, vec) VALUES (?, ?)"
+            )
+        }
+    }
+
+    private func invalidateOnModelChangeLocked() {
+        var storedModel: String?
+        var storedDim: Int = 0
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, "SELECT model_id, dimension FROM embedding_meta WHERE id = 0", -1, &stmt, nil) == SQLITE_OK {
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                storedModel = String(cString: sqlite3_column_text(stmt, 0))
+                storedDim = Int(sqlite3_column_int64(stmt, 1))
+            }
+        }
+        sqlite3_finalize(stmt)
+
+        if storedModel == provider.modelID, storedDim == provider.dimension { return }
+
+        if storedModel != nil {
+            log("Embedding model changed (\(storedModel ?? "?")/\(storedDim) -> \(provider.modelID)/\(provider.dimension)); re-embedding")
+            execLocked("DELETE FROM utterance_vectors")
+            execLocked("DELETE FROM dictation_entry_vectors")
+        }
+        var upsert: OpaquePointer?
+        if sqlite3_prepare_v2(db, "INSERT OR REPLACE INTO embedding_meta (id, model_id, dimension) VALUES (0, ?, ?)", -1, &upsert, nil) == SQLITE_OK {
+            sqlite3_bind_text(upsert, 1, (provider.modelID as NSString).utf8String, -1, SQLITE_TRANSIENT)
+            sqlite3_bind_int64(upsert, 2, Int64(provider.dimension))
+            sqlite3_step(upsert)
+        }
+        sqlite3_finalize(upsert)
+    }
+
+    private func embedMissingLocked(selectSQL: String, insertSQL: String) {
+        // Collect (rowid, text) first so the read cursor isn't open while we write.
+        var pending: [(rowid: Int64, text: String)] = []
+        var selectStmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, selectSQL, -1, &selectStmt, nil) == SQLITE_OK {
+            while sqlite3_step(selectStmt) == SQLITE_ROW {
+                let rowid = sqlite3_column_int64(selectStmt, 0)
+                let text = sqlite3_column_text(selectStmt, 1).map { String(cString: $0) } ?? ""
+                pending.append((rowid, text))
+            }
+        }
+        sqlite3_finalize(selectStmt)
+        guard !pending.isEmpty else { return }
+
+        sqlite3_exec(db, "BEGIN", nil, nil, nil)
+        var inserted = 0
+        for item in pending {
+            guard let vec = provider.embed(item.text) else { continue }
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(db, insertSQL, -1, &stmt, nil) == SQLITE_OK else { continue }
+            sqlite3_bind_int64(stmt, 1, item.rowid)
+            let blob = VectorMath.blob(from: vec)
+            _ = blob.withUnsafeBytes { raw in
+                sqlite3_bind_blob(stmt, 2, raw.baseAddress, Int32(blob.count), SQLITE_TRANSIENT)
+            }
+            if sqlite3_step(stmt) == SQLITE_DONE { inserted += 1 }
+            sqlite3_finalize(stmt)
+        }
+        sqlite3_exec(db, "COMMIT", nil, nil, nil)
+        if inserted > 0 { log("Embedded \(inserted) rows") }
+    }
+
+    // MARK: - Semantic search
+
+    /// Cosine-ranked meeting utterance search, grouped per meeting (same shape as
+    /// the lexical path). Returns empty when the query can't be embedded.
+    func semanticSearchUtterances(
+        query: String,
+        speaker: String?,
+        dateFrom: String?,
+        dateTo: String?,
+        maxMeetings: Int = 10,
+        snippetsPerMeeting: Int = 3
+    ) -> GroupedSearchResult {
+        guard let qvec = provider.embed(query) else {
+            return GroupedSearchResult(results: [], totalMeetingsMatched: 0, truncated: false)
+        }
+
+        return queue.sync {
+            var sql = """
+                SELECT u.filename, u.speaker_name, u.utterance_start, u.text,
+                       m.date, m.datetime, m.duration_seconds, v.vec
+                FROM utterance_vectors v
+                JOIN utterances u ON u.rowid = v.rowid
+                JOIN meetings m ON m.filename = u.filename
+                WHERE 1 = 1
+            """
+            var binders: [(OpaquePointer?, Int32) -> Void] = []
+            var nextIndex: Int32 = 1
+
+            if let speaker = speaker {
+                let names = NameVariants.expandName(speaker)
+                let exact = names.map { _ in "u.speaker_name COLLATE NOCASE = ?" }
+                let like = names.map { _ in "u.speaker_name COLLATE NOCASE LIKE ?" }
+                sql += " AND (\((exact + like).joined(separator: " OR ")))"
+                for name in names {
+                    binders.append { stmt, idx in sqlite3_bind_text(stmt, idx, (name as NSString).utf8String, -1, self.SQLITE_TRANSIENT) }
+                }
+                for name in names {
+                    let pattern = "%\(name)%"
+                    binders.append { stmt, idx in sqlite3_bind_text(stmt, idx, (pattern as NSString).utf8String, -1, self.SQLITE_TRANSIENT) }
+                }
+            }
+            if let dateFrom = dateFrom {
+                sql += " AND m.date >= ?"
+                binders.append { stmt, idx in sqlite3_bind_text(stmt, idx, (dateFrom as NSString).utf8String, -1, self.SQLITE_TRANSIENT) }
+            }
+            if let dateTo = dateTo {
+                sql += " AND m.date <= ?"
+                binders.append { stmt, idx in sqlite3_bind_text(stmt, idx, (dateTo as NSString).utf8String, -1, self.SQLITE_TRANSIENT) }
+            }
+            sql += " ORDER BY m.datetime DESC LIMIT \(maxCandidateRows)"
+
+            struct Scored {
+                let filename: String, speaker: String, start: Double, text: String
+                let date: String, datetime: String, duration: Int, score: Float
+            }
+            var scored: [Scored] = []
+
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+                return GroupedSearchResult(results: [], totalMeetingsMatched: 0, truncated: false)
+            }
+            for binder in binders { binder(stmt, nextIndex); nextIndex += 1 }
+
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                guard let blobPtr = sqlite3_column_blob(stmt, 7) else { continue }
+                let blobLen = Int(sqlite3_column_bytes(stmt, 7))
+                let vec = VectorMath.vector(from: Data(bytes: blobPtr, count: blobLen))
+                let score = VectorMath.dot(qvec, vec)
+                guard score >= minimumSimilarity else { continue }
+                scored.append(Scored(
+                    filename: colText(stmt, 0),
+                    speaker: colText(stmt, 1),
+                    start: sqlite3_column_double(stmt, 2),
+                    text: colText(stmt, 3),
+                    date: colText(stmt, 4),
+                    datetime: colText(stmt, 5),
+                    duration: Int(sqlite3_column_int64(stmt, 6)),
+                    score: score
+                ))
+            }
+            sqlite3_finalize(stmt)
+
+            scored.sort { $0.score > $1.score }
+
+            // Group by meeting, ordered by best-scoring hit (first appearance).
+            var grouped: [String: (date: String, datetime: String, snippets: [SearchSnippet])] = [:]
+            var order: [String] = []
+            for row in scored {
+                if grouped[row.filename] == nil {
+                    order.append(row.filename)
+                    grouped[row.filename] = (row.date, row.datetime, [])
+                }
+                if (grouped[row.filename]?.snippets.count ?? 0) < snippetsPerMeeting {
+                    let mins = Int(row.start) / 60
+                    let secs = Int(row.start) % 60
+                    grouped[row.filename]?.snippets.append(SearchSnippet(
+                        speaker: row.speaker,
+                        speakerId: nil,
+                        timestamp: String(format: "%d:%02d", mins, secs),
+                        text: row.text
+                    ))
+                }
+            }
+
+            let total = order.count
+            let results = order.prefix(maxMeetings).compactMap { filename -> MeetingSearchGroup? in
+                guard let g = grouped[filename] else { return nil }
+                let title = filename
+                    .replacingOccurrences(of: "Call_", with: "")
+                    .replacingOccurrences(of: "_", with: " ")
+                    .replacingOccurrences(of: "-", with: ":")
+                return MeetingSearchGroup(
+                    meetingTitle: title,
+                    meetingDate: g.date,
+                    meetingDateTime: g.datetime,
+                    filename: filename,
+                    snippets: g.snippets
+                )
+            }
+            return GroupedSearchResult(
+                results: Array(results),
+                totalMeetingsMatched: total,
+                truncated: total > maxMeetings
+            )
+        }
+    }
+
+    /// Cosine-ranked dictation entry search, one snippet per entry (same shape as
+    /// the lexical path). Returns empty when the query can't be embedded.
+    func semanticSearchDictationEntries(
+        query: String,
+        dateFrom: String?,
+        dateTo: String?,
+        maxItems: Int = 10
+    ) -> [ContextSearchGroup] {
+        guard let qvec = provider.embed(query) else { return [] }
+
+        return queue.sync {
+            var sql = """
+                SELECT e.filename, e.entry_id, e.title, e.created_at, e.text,
+                       e.source_app_name, e.delivery, d.date, v.vec
+                FROM dictation_entry_vectors v
+                JOIN dictation_entries e ON e.rowid = v.rowid
+                JOIN dictation_days d ON d.filename = e.filename
+                WHERE 1 = 1
+            """
+            var binders: [(OpaquePointer?, Int32) -> Void] = []
+            var nextIndex: Int32 = 1
+            if let dateFrom = dateFrom {
+                sql += " AND d.date >= ?"
+                binders.append { stmt, idx in sqlite3_bind_text(stmt, idx, (dateFrom as NSString).utf8String, -1, self.SQLITE_TRANSIENT) }
+            }
+            if let dateTo = dateTo {
+                sql += " AND d.date <= ?"
+                binders.append { stmt, idx in sqlite3_bind_text(stmt, idx, (dateTo as NSString).utf8String, -1, self.SQLITE_TRANSIENT) }
+            }
+            sql += " ORDER BY d.datetime DESC LIMIT \(maxCandidateRows)"
+
+            struct Scored {
+                let group: ContextSearchGroup
+                let score: Float
+            }
+            var scored: [Scored] = []
+
+            var stmt: OpaquePointer?
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { return [] }
+            for binder in binders { binder(stmt, nextIndex); nextIndex += 1 }
+
+            while sqlite3_step(stmt) == SQLITE_ROW {
+                guard let blobPtr = sqlite3_column_blob(stmt, 8) else { continue }
+                let blobLen = Int(sqlite3_column_bytes(stmt, 8))
+                let vec = VectorMath.vector(from: Data(bytes: blobPtr, count: blobLen))
+                let score = VectorMath.dot(qvec, vec)
+                guard score >= minimumSimilarity else { continue }
+                let group = ContextSearchGroup(
+                    kind: .dictation,
+                    title: colText(stmt, 2),
+                    filename: colText(stmt, 0),
+                    entryId: colText(stmt, 1),
+                    date: colText(stmt, 7),
+                    datetime: colText(stmt, 3),
+                    snippets: [
+                        ContextSearchSnippet(
+                            text: colText(stmt, 4),
+                            speaker: nil,
+                            speakerId: nil,
+                            timestamp: nil,
+                            sourceAppName: colText(stmt, 5),
+                            delivery: colText(stmt, 6)
+                        )
+                    ]
+                )
+                scored.append(Scored(group: group, score: score))
+            }
+            sqlite3_finalize(stmt)
+
+            scored.sort { $0.score > $1.score }
+            return Array(scored.prefix(maxItems).map(\.group))
+        }
+    }
+
+    // MARK: - SQLite helpers (own connection)
+
+    private func execLocked(_ sql: String) {
+        if sqlite3_exec(db, sql, nil, nil, nil) != SQLITE_OK {
+            log("Vector store SQL failed: \(dbErrorLocked()) for: \(sql)")
+        }
+    }
+
+    private func colText(_ stmt: OpaquePointer?, _ col: Int32) -> String {
+        guard let ptr = sqlite3_column_text(stmt, col) else { return "" }
+        return String(cString: ptr)
+    }
+
+    private func dbErrorLocked() -> String {
+        if let db = db { return String(cString: sqlite3_errmsg(db)) }
+        return "database not open"
+    }
+}

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Main.swift
@@ -36,7 +36,16 @@ struct TranscriptedMCP {
         // Create and populate index
         let index: TranscriptIndex
         do {
-            index = try TranscriptIndex(indexDir: directories.indexDir)
+            // On-device semantic search. NLEmbedding ships with macOS (no bundled
+            // model, no download); when its language assets are missing the
+            // provider reports unavailable and search stays lexical-only.
+            let embeddingProvider = NLEmbeddingProvider()
+            if embeddingProvider.isAvailable {
+                log("Semantic search enabled (\(embeddingProvider.modelID), dim \(embeddingProvider.dimension))")
+            } else {
+                log("Semantic search unavailable on this host; using lexical search only")
+            }
+            index = try TranscriptIndex(indexDir: directories.indexDir, embeddingProvider: embeddingProvider)
             try index.reconcile(meetingDirs: directories.meetingDirs, dictationDirs: directories.dictationDirs)
         } catch {
             log("Failed to initialize index: \(error.localizedDescription)")

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/SemanticSearchFusion.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/SemanticSearchFusion.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+/// Combines lexical (FTS) and semantic (vector) result lists using Reciprocal
+/// Rank Fusion. RRF is scale-free — it only uses each item's rank within its own
+/// list, so it merges two scores (FTS `rank`, cosine similarity) that aren't
+/// otherwise comparable without tuning weights.
+///
+/// Fusion happens at the grouped level (per meeting / per dictation entry), which
+/// is the granularity the MCP API already returns. The result is a strict
+/// superset of the lexical list's recall: any FTS hit keeps its snippets and
+/// only gets reordered, while semantic-only matches are appended by score.
+enum SemanticSearchFusion {
+    /// Standard RRF damping constant. Larger = flatter contribution from rank.
+    static let rrfK: Double = 60
+
+    private static func rrf(_ rank: Int) -> Double { 1.0 / (rrfK + Double(rank)) }
+
+    /// Fuse two meeting-grouped result sets.
+    static func fuseGrouped(
+        lexical: GroupedSearchResult,
+        semantic: GroupedSearchResult,
+        maxMeetings: Int,
+        snippetsPerMeeting: Int
+    ) -> GroupedSearchResult {
+        var score: [String: Double] = [:]
+        var lexByName: [String: MeetingSearchGroup] = [:]
+        var semByName: [String: MeetingSearchGroup] = [:]
+        var order: [String] = []
+
+        for (rank, group) in lexical.results.enumerated() {
+            score[group.filename, default: 0] += rrf(rank)
+            if lexByName[group.filename] == nil { order.append(group.filename) }
+            lexByName[group.filename] = group
+        }
+        for (rank, group) in semantic.results.enumerated() {
+            score[group.filename, default: 0] += rrf(rank)
+            if lexByName[group.filename] == nil, semByName[group.filename] == nil {
+                order.append(group.filename)
+            }
+            semByName[group.filename] = group
+        }
+
+        let ranked = order.sorted { (score[$0] ?? 0) > (score[$1] ?? 0) }
+
+        let fused: [MeetingSearchGroup] = ranked.compactMap { name in
+            let base = lexByName[name] ?? semByName[name]
+            guard let base else { return nil }
+            let lexSnippets = lexByName[name]?.snippets ?? []
+            let semSnippets = semByName[name]?.snippets ?? []
+            let snippets = mergeSnippets(lexSnippets, semSnippets, limit: snippetsPerMeeting)
+            return MeetingSearchGroup(
+                meetingTitle: base.meetingTitle,
+                meetingDate: base.meetingDate,
+                meetingDateTime: base.meetingDateTime,
+                filename: name,
+                snippets: snippets
+            )
+        }
+
+        let total = ranked.count
+        return GroupedSearchResult(
+            results: Array(fused.prefix(maxMeetings)),
+            totalMeetingsMatched: total,
+            truncated: total > maxMeetings
+        )
+    }
+
+    /// Fuse two dictation/context result lists keyed by (filename, entry).
+    static func fuseContextGroups(
+        lexical: [ContextSearchGroup],
+        semantic: [ContextSearchGroup],
+        maxItems: Int
+    ) -> [ContextSearchGroup] {
+        func key(_ g: ContextSearchGroup) -> String { "\(g.filename)\u{1}\(g.entryId ?? "")" }
+
+        var score: [String: Double] = [:]
+        var byKey: [String: ContextSearchGroup] = [:]
+        var order: [String] = []
+
+        for (rank, group) in lexical.enumerated() {
+            let k = key(group)
+            score[k, default: 0] += rrf(rank)
+            if byKey[k] == nil { order.append(k); byKey[k] = group }
+        }
+        for (rank, group) in semantic.enumerated() {
+            let k = key(group)
+            score[k, default: 0] += rrf(rank)
+            if byKey[k] == nil { order.append(k); byKey[k] = group }
+        }
+
+        let ranked = order.sorted { (score[$0] ?? 0) > (score[$1] ?? 0) }
+        let fused = ranked.compactMap { byKey[$0] }
+        return Array(fused.prefix(maxItems))
+    }
+
+    /// Lexical snippets first (they're exact matches), then any semantic snippet
+    /// not already present, capped at `limit`. Dedupe on timestamp+text.
+    private static func mergeSnippets(
+        _ lexical: [SearchSnippet],
+        _ semantic: [SearchSnippet],
+        limit: Int
+    ) -> [SearchSnippet] {
+        var seen: Set<String> = []
+        var out: [SearchSnippet] = []
+        for snippet in lexical + semantic {
+            guard out.count < limit else { break }
+            let id = "\(snippet.timestamp)\u{1}\(snippet.text)"
+            if seen.insert(id).inserted {
+                out.append(snippet)
+            }
+        }
+        return out
+    }
+}

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -95,7 +95,7 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
             ),
             Tool(
                 name: "search",
-                description: "Full-text search across all meeting transcripts. Returns matching utterances with speaker, timestamp, and meeting context. Optionally filter by speaker name (supports variants: Mike finds Michael) or date range.",
+                description: "Search meeting transcripts. Defaults to hybrid search: exact full-text matches PLUS on-device semantic matches, so paraphrases hit (e.g. 'pricing pushback' finds 'they balked at the cost'). Returns matching utterances with speaker, timestamp, and meeting context. Optionally filter by speaker name (supports variants: Mike finds Michael) or date range.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -106,6 +106,10 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                         "speaker": .object([
                             "type": .string("string"),
                             "description": .string("Filter to utterances by this speaker")
+                        ]),
+                        "mode": .object([
+                            "type": .string("string"),
+                            "description": .string("Search strategy: 'hybrid' (default — FTS + semantic), 'lexical' (exact/stemmed only), or 'semantic' (paraphrase only). Semantic and hybrid fall back to lexical when the on-device embedding model is unavailable.")
                         ]),
                         "date_from": .object([
                             "type": .string("string"),
@@ -141,7 +145,7 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
             ),
             Tool(
                 name: "search_context",
-                description: "Search across saved meetings, dictations, or both. Great for finding everything you captured about a topic, regardless of whether it came from a meeting or a quick dictated note.",
+                description: "Search across saved meetings, dictations, or both. Defaults to hybrid (full-text + on-device semantic), so paraphrases match, not just exact wording. Great for finding everything you captured about a topic, regardless of whether it came from a meeting or a quick dictated note.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
@@ -152,6 +156,10 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                         "kind": .object([
                             "type": .string("string"),
                             "description": .string("Which context to search: 'all' (default), 'meeting', or 'dictation'")
+                        ]),
+                        "mode": .object([
+                            "type": .string("string"),
+                            "description": .string("Search strategy: 'hybrid' (default — FTS + semantic), 'lexical', or 'semantic'. Falls back to lexical when the embedding model is unavailable.")
                         ]),
                         "speaker": .object([
                             "type": .string("string"),
@@ -550,8 +558,9 @@ private func handleSearch(params: CallTool.Parameters, index: TranscriptIndex, m
     let speaker = params.arguments?["speaker"]?.stringValue
     let dateFrom = params.arguments?["date_from"]?.stringValue
     let dateTo = params.arguments?["date_to"]?.stringValue
+    let mode = parseSearchMode(params.arguments?["mode"]?.stringValue)
 
-    var results = try index.searchUtterances(query: query, speaker: speaker, dateFrom: dateFrom, dateTo: dateTo)
+    var results = try index.searchUtterances(query: query, speaker: speaker, dateFrom: dateFrom, dateTo: dateTo, mode: mode)
     hydrateMeetingSearchTitles(in: &results, meetingDirs: meetingDirs)
 
     if results.results.isEmpty {
@@ -581,6 +590,7 @@ private func handleSearchContext(params: CallTool.Parameters, index: TranscriptI
     let count = max(1, min(params.arguments?["count"]?.intValue ?? 10, 50))
     let dateFrom = params.arguments?["date_from"]?.stringValue
     let dateTo = params.arguments?["date_to"]?.stringValue
+    let mode = parseSearchMode(params.arguments?["mode"]?.stringValue)
 
     var results = try index.searchContext(
         query: query,
@@ -588,7 +598,8 @@ private func handleSearchContext(params: CallTool.Parameters, index: TranscriptI
         kind: kind,
         dateFrom: dateFrom,
         dateTo: dateTo,
-        maxItems: count
+        maxItems: count,
+        mode: mode
     )
 
     hydrateMeetingTitles(in: &results.results, kind: \.kind, filename: \.filename, title: \.title, meetingDirs: meetingDirs)
@@ -832,6 +843,15 @@ private func parseContextKind(_ raw: String?) -> ContextKind {
         return .all
     }
     return kind
+}
+
+/// Default to hybrid so paraphrase matches surface without the caller opting in.
+/// Falls back to lexical automatically when no embedding backend is available.
+private func parseSearchMode(_ raw: String?) -> SearchMode {
+    guard let raw, let mode = SearchMode(rawValue: raw.lowercased()) else {
+        return .hybrid
+    }
+    return mode
 }
 
 /// Frontmatter title for a meeting markdown file, or nil when the file is

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift
@@ -7,9 +7,18 @@ final class TranscriptIndex: @unchecked Sendable {
     private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
     private let indexPath: URL
 
-    init(indexDir: URL) throws {
+    /// Optional semantic-search sidecar. Nil when no embedding provider was
+    /// supplied or the provider is unavailable on this host; in that case every
+    /// search transparently runs lexical-only. Additive: it manages its own
+    /// vector tables on a separate connection to the same database file.
+    private(set) var embeddingStore: EmbeddingStore?
+
+    init(indexDir: URL, embeddingProvider: EmbeddingProvider? = nil) throws {
         self.indexPath = indexDir.appendingPathComponent("mcp_index.sqlite")
         try queue.sync { try self.openAndSetup() }
+        if let provider = embeddingProvider, provider.isAvailable {
+            self.embeddingStore = try EmbeddingStore(dbPath: indexPath, provider: provider)
+        }
     }
 
     deinit {
@@ -291,6 +300,10 @@ final class TranscriptIndex: @unchecked Sendable {
                 try removeFromIndex(filename: filename)
             }
         }
+
+        // Best-effort: embed any newly indexed rows. Never fails the reconcile —
+        // lexical search must keep working even if embedding hits a snag.
+        embeddingStore?.reconcileEmbeddings()
     }
 
     func indexSingleFile(_ url: URL, allowedRoots: [URL]) throws {
@@ -325,6 +338,8 @@ final class TranscriptIndex: @unchecked Sendable {
 
             try removeFromIndex(filename: filename)
         }
+
+        embeddingStore?.reconcileEmbeddings()
     }
 
     private func getIndexedModDates() throws -> [String: TimeInterval] {
@@ -597,7 +612,26 @@ final class TranscriptIndex: @unchecked Sendable {
 
     // MARK: - Queries
 
-    func searchUtterances(query: String, speaker: String?, dateFrom: String?, dateTo: String?, maxMeetings: Int = 10, snippetsPerMeeting: Int = 3) throws -> GroupedSearchResult {
+    func searchUtterances(query: String, speaker: String?, dateFrom: String?, dateTo: String?, maxMeetings: Int = 10, snippetsPerMeeting: Int = 3, mode: SearchMode = .lexical) throws -> GroupedSearchResult {
+        // Semantic / hybrid routing. Falls through to lexical when no vector store
+        // is available, so these modes degrade gracefully rather than returning
+        // nothing. The lexical branch below is unchanged.
+        if mode != .lexical, let store = embeddingStore, store.isAvailable {
+            let semantic = store.semanticSearchUtterances(
+                query: query, speaker: speaker, dateFrom: dateFrom, dateTo: dateTo,
+                maxMeetings: maxMeetings, snippetsPerMeeting: snippetsPerMeeting
+            )
+            if mode == .semantic { return semantic }
+            let lexical = try searchUtterances(
+                query: query, speaker: speaker, dateFrom: dateFrom, dateTo: dateTo,
+                maxMeetings: maxMeetings, snippetsPerMeeting: snippetsPerMeeting, mode: .lexical
+            )
+            return SemanticSearchFusion.fuseGrouped(
+                lexical: lexical, semantic: semantic,
+                maxMeetings: maxMeetings, snippetsPerMeeting: snippetsPerMeeting
+            )
+        }
+
         return try queue.sync {
             let tokens = query.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
             let ftsQuery = tokens.map { "\"\($0.replacingOccurrences(of: "\"", with: ""))\"" }.joined(separator: " ")
@@ -800,7 +834,20 @@ final class TranscriptIndex: @unchecked Sendable {
         }
     }
 
-    func searchDictationEntries(query: String, dateFrom: String?, dateTo: String?, maxItems: Int = 10) throws -> [ContextSearchGroup] {
+    func searchDictationEntries(query: String, dateFrom: String?, dateTo: String?, maxItems: Int = 10, mode: SearchMode = .lexical) throws -> [ContextSearchGroup] {
+        if mode != .lexical, let store = embeddingStore, store.isAvailable {
+            let semantic = store.semanticSearchDictationEntries(
+                query: query, dateFrom: dateFrom, dateTo: dateTo, maxItems: maxItems
+            )
+            if mode == .semantic { return semantic }
+            let lexical = try searchDictationEntries(
+                query: query, dateFrom: dateFrom, dateTo: dateTo, maxItems: maxItems, mode: .lexical
+            )
+            return SemanticSearchFusion.fuseContextGroups(
+                lexical: lexical, semantic: semantic, maxItems: maxItems
+            )
+        }
+
         return try queue.sync {
             let tokens = query.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
             let ftsQuery = tokens.map { "\"\($0.replacingOccurrences(of: "\"", with: ""))\"" }.joined(separator: " ")
@@ -918,7 +965,7 @@ final class TranscriptIndex: @unchecked Sendable {
         }
     }
 
-    func searchContext(query: String, speaker: String?, kind: ContextKind, dateFrom: String?, dateTo: String?, maxItems: Int = 10) throws -> ContextSearchResult {
+    func searchContext(query: String, speaker: String?, kind: ContextKind, dateFrom: String?, dateTo: String?, maxItems: Int = 10, mode: SearchMode = .lexical) throws -> ContextSearchResult {
         var combined: [ContextSearchGroup] = []
 
         if kind != .dictation {
@@ -928,7 +975,8 @@ final class TranscriptIndex: @unchecked Sendable {
                 dateFrom: dateFrom,
                 dateTo: dateTo,
                 maxMeetings: maxItems,
-                snippetsPerMeeting: 3
+                snippetsPerMeeting: 3,
+                mode: mode
             )
             combined.append(contentsOf: meetings.results.map {
                 ContextSearchGroup(
@@ -957,7 +1005,8 @@ final class TranscriptIndex: @unchecked Sendable {
                 query: query,
                 dateFrom: dateFrom,
                 dateTo: dateTo,
-                maxItems: maxItems
+                maxItems: maxItems,
+                mode: mode
             ))
         }
 

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SemanticSearchTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/SemanticSearchTests.swift
@@ -1,0 +1,290 @@
+import XCTest
+@testable import transcripted_mcp
+
+/// Deterministic embedding provider for tests. Maps a small fixed lexicon of
+/// words to "concept" axes so paraphrases (different words, same concept) land on
+/// the same vector and unrelated text stays orthogonal. This keeps the semantic
+/// tests independent of whether the OS NLEmbedding assets are present in CI.
+private struct StubEmbeddingProvider: EmbeddingProvider {
+    let modelID: String
+    var dimension: Int { concepts.count }
+    var isAvailable: Bool { true }
+
+    /// concept index -> member words
+    private static let concepts: [[String]] = [
+        ["cost", "pricing", "price", "expensive", "balked", "pushback", "budget"],
+        ["weather", "sunny", "rain", "cloudy", "forecast"],
+        ["roadmap", "plan", "timeline", "schedule", "milestone"],
+    ]
+    private let concepts = StubEmbeddingProvider.concepts
+
+    private var lexicon: [String: Int] {
+        var map: [String: Int] = [:]
+        for (idx, words) in concepts.enumerated() {
+            for word in words { map[word] = idx }
+        }
+        return map
+    }
+
+    init(modelID: String = "stub.v1") { self.modelID = modelID }
+
+    func embed(_ text: String) -> [Float]? {
+        let lex = lexicon
+        var vec = [Float](repeating: 0, count: concepts.count)
+        var hits = 0
+        for token in text.lowercased().split(whereSeparator: { !$0.isLetter }) {
+            if let idx = lex[String(token)] {
+                vec[idx] += 1
+                hits += 1
+            }
+        }
+        guard hits > 0 else { return nil }
+        return VectorMath.normalized(vec)
+    }
+}
+
+private struct UnavailableEmbeddingProvider: EmbeddingProvider {
+    let modelID = "unavailable"
+    var dimension: Int { 0 }
+    var isAvailable: Bool { false }
+    func embed(_ text: String) -> [Float]? { nil }
+}
+
+final class SemanticSearchTests: XCTestCase {
+    var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = makeTempDir()
+    }
+
+    override func tearDown() {
+        removeTempDir(tempDir)
+        super.tearDown()
+    }
+
+    private func makeIndex(_ provider: EmbeddingProvider? = StubEmbeddingProvider()) throws -> TranscriptIndex {
+        try TranscriptIndex(indexDir: tempDir, embeddingProvider: provider)
+    }
+
+    // MARK: - The headline unlock: paraphrase queries hit
+
+    func testSemanticFindsParaphraseThatLexicalMisses() throws {
+        let index = try makeIndex()
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "Honestly they balked at the cost"),
+            ("mic_0", 5.0, 10.0, "The weather is sunny today"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        // Lexical alone misses the paraphrase: none of these words appear verbatim.
+        let lexical = try index.searchUtterances(query: "pricing pushback", speaker: nil, dateFrom: nil, dateTo: nil, mode: .lexical)
+        XCTAssertTrue(lexical.results.isEmpty)
+
+        // Semantic matches the "cost" concept utterance, not the weather one.
+        let semantic = try index.searchUtterances(query: "pricing pushback", speaker: nil, dateFrom: nil, dateTo: nil, mode: .semantic)
+        XCTAssertEqual(semantic.results.count, 1)
+        XCTAssertEqual(semantic.results[0].snippets.count, 1)
+        XCTAssertTrue(semantic.results[0].snippets[0].text.contains("balked"))
+    }
+
+    // MARK: - Hybrid is a strict superset of lexical recall
+
+    func testHybridUnionsLexicalAndSemantic() throws {
+        let index = try makeIndex()
+        // Meeting A contains the literal word "cost"; meeting B only paraphrases it.
+        try writeFixture(makeFixtureJSON(date: "2026-03-29T10:00:00-0500", utterances: [
+            ("system_0", 0.0, 5.0, "The cost was discussed at length"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try writeFixture(makeFixtureJSON(date: "2026-03-30T10:00:00-0500", utterances: [
+            ("system_0", 0.0, 5.0, "They balked at the expensive pricing"),
+        ]), filename: "Call_2026-03-30_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let lexical = try index.searchUtterances(query: "cost", speaker: nil, dateFrom: nil, dateTo: nil, mode: .lexical)
+        XCTAssertEqual(lexical.results.count, 1)
+        XCTAssertEqual(lexical.results[0].filename, "Call_2026-03-29_10-00-00")
+
+        let hybrid = try index.searchUtterances(query: "cost", speaker: nil, dateFrom: nil, dateTo: nil, mode: .hybrid)
+        let filenames = Set(hybrid.results.map(\.filename))
+        XCTAssertEqual(hybrid.results.count, 2)
+        XCTAssertTrue(filenames.contains("Call_2026-03-29_10-00-00")) // exact hit preserved
+        XCTAssertTrue(filenames.contains("Call_2026-03-30_10-00-00")) // paraphrase added
+    }
+
+    func testSemanticRespectsDateFilter() throws {
+        let index = try makeIndex()
+        try writeFixture(makeFixtureJSON(date: "2026-03-28T10:00:00-0500", utterances: [
+            ("system_0", 0.0, 5.0, "They balked at the cost"),
+        ]), filename: "Call_2026-03-28_10-00-00", to: tempDir)
+        try writeFixture(makeFixtureJSON(date: "2026-03-30T10:00:00-0500", utterances: [
+            ("system_0", 0.0, 5.0, "The pricing was too expensive"),
+        ]), filename: "Call_2026-03-30_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let semantic = try index.searchUtterances(query: "budget pushback", speaker: nil, dateFrom: "2026-03-29", dateTo: nil, mode: .semantic)
+        XCTAssertEqual(semantic.results.count, 1)
+        XCTAssertEqual(semantic.results[0].filename, "Call_2026-03-30_10-00-00")
+    }
+
+    func testSemanticDoesNotMatchUnrelatedConcept() throws {
+        let index = try makeIndex()
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "The weather forecast looks cloudy"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let semantic = try index.searchUtterances(query: "pricing pushback", speaker: nil, dateFrom: nil, dateTo: nil, mode: .semantic)
+        XCTAssertTrue(semantic.results.isEmpty)
+    }
+
+    // MARK: - Dictation semantic search
+
+    func testSemanticSearchOnDictationEntries() throws {
+        let index = try makeIndex()
+        try writeFixture(makeDictationDayJSON(entries: [
+            ("dictation-20260407-091500-000", "2026-04-07T09:15:00-0500", "Budget note", "Client balked at the pricing again", "Slack", "copied"),
+            ("dictation-20260407-181500-000", "2026-04-07T18:15:00-0500", "Weather note", "Tomorrow looks sunny and clear", "Notes", "copied"),
+        ]), filename: "Dictations_2026-04-07", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let results = try index.searchContext(query: "cost pushback", speaker: nil, kind: .dictation, dateFrom: nil, dateTo: nil, maxItems: 10, mode: .semantic)
+        XCTAssertEqual(results.results.count, 1)
+        XCTAssertEqual(results.results[0].kind, .dictation)
+        XCTAssertTrue(results.results[0].snippets[0].text.contains("balked"))
+    }
+
+    // MARK: - Graceful degradation
+
+    func testHybridFallsBackToLexicalWhenProviderUnavailable() throws {
+        let index = try makeIndex(UnavailableEmbeddingProvider())
+        XCTAssertNil(index.embeddingStore)
+
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "The cost was discussed"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        // Hybrid with no backend must behave exactly like lexical, not error.
+        let hybrid = try index.searchUtterances(query: "cost", speaker: nil, dateFrom: nil, dateTo: nil, mode: .hybrid)
+        XCTAssertEqual(hybrid.results.count, 1)
+
+        let paraphrase = try index.searchUtterances(query: "pricing pushback", speaker: nil, dateFrom: nil, dateTo: nil, mode: .hybrid)
+        XCTAssertTrue(paraphrase.results.isEmpty) // no semantic recall without a backend
+    }
+
+    func testNoProviderLeavesSemanticDisabled() throws {
+        let index = try TranscriptIndex(indexDir: tempDir) // default: no provider
+        XCTAssertNil(index.embeddingStore)
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "The cost was discussed"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let hybrid = try index.searchUtterances(query: "cost", speaker: nil, dateFrom: nil, dateTo: nil, mode: .hybrid)
+        XCTAssertEqual(hybrid.results.count, 1)
+    }
+
+    // MARK: - Re-embedding on model change
+
+    func testModelChangeReEmbeds() throws {
+        // Index once with stub v1.
+        let index1 = try makeIndex(StubEmbeddingProvider(modelID: "stub.v1"))
+        try writeFixture(makeFixtureJSON(utterances: [
+            ("system_0", 0.0, 5.0, "They balked at the cost"),
+        ]), filename: "Call_2026-03-29_10-00-00", to: tempDir)
+        try index1.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+        XCTAssertEqual(try index1.searchUtterances(query: "pricing", speaker: nil, dateFrom: nil, dateTo: nil, mode: .semantic).results.count, 1)
+
+        // Reopen with a different model id — vectors must be rebuilt, not stale.
+        let index2 = try makeIndex(StubEmbeddingProvider(modelID: "stub.v2"))
+        try index2.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+        XCTAssertEqual(try index2.searchUtterances(query: "pricing", speaker: nil, dateFrom: nil, dateTo: nil, mode: .semantic).results.count, 1)
+    }
+}
+
+// MARK: - Vector math + fusion unit tests
+
+final class VectorMathTests: XCTestCase {
+    func testBlobRoundTrip() {
+        let v: [Float] = [0.1, -2.0, 3.5, 0.0, 42.25]
+        let restored = VectorMath.vector(from: VectorMath.blob(from: v))
+        XCTAssertEqual(restored, v)
+    }
+
+    func testNormalizedIsUnitLength() {
+        let v = VectorMath.normalized([3, 4])
+        XCTAssertEqual(VectorMath.dot(v, v), 1.0, accuracy: 1e-5)
+    }
+
+    func testDotOfOrthogonalIsZero() {
+        let a = VectorMath.normalized([1, 0])
+        let b = VectorMath.normalized([0, 1])
+        XCTAssertEqual(VectorMath.dot(a, b), 0.0, accuracy: 1e-6)
+    }
+
+    func testZeroVectorNormalizeIsSafe() {
+        XCTAssertEqual(VectorMath.normalized([0, 0, 0]), [0, 0, 0])
+    }
+}
+
+final class SemanticSearchFusionTests: XCTestCase {
+    private func meetingGroup(_ filename: String, snippetText: String = "x") -> MeetingSearchGroup {
+        MeetingSearchGroup(
+            meetingTitle: filename, meetingDate: "2026-03-29", meetingDateTime: "2026-03-29T10:00:00-0500",
+            filename: filename,
+            snippets: [SearchSnippet(speaker: "You", speakerId: nil, timestamp: "0:00", text: snippetText)]
+        )
+    }
+
+    func testFusionPreservesLexicalAndAppendsSemanticOnly() {
+        let lexical = GroupedSearchResult(results: [meetingGroup("A"), meetingGroup("B")], totalMeetingsMatched: 2, truncated: false)
+        let semantic = GroupedSearchResult(results: [meetingGroup("B"), meetingGroup("C")], totalMeetingsMatched: 2, truncated: false)
+
+        let fused = SemanticSearchFusion.fuseGrouped(lexical: lexical, semantic: semantic, maxMeetings: 10, snippetsPerMeeting: 3)
+        let names = fused.results.map(\.filename)
+        XCTAssertEqual(Set(names), ["A", "B", "C"])
+        // B ranks in both lists, so it should fuse to the top.
+        XCTAssertEqual(names.first, "B")
+        XCTAssertEqual(fused.totalMeetingsMatched, 3)
+    }
+
+    func testFusionMergesSnippetsAndDedupes() {
+        let lexical = GroupedSearchResult(results: [meetingGroup("A", snippetText: "shared")], totalMeetingsMatched: 1, truncated: false)
+        let semantic = GroupedSearchResult(results: [
+            MeetingSearchGroup(
+                meetingTitle: "A", meetingDate: "2026-03-29", meetingDateTime: "2026-03-29T10:00:00-0500",
+                filename: "A",
+                snippets: [
+                    SearchSnippet(speaker: "You", speakerId: nil, timestamp: "0:00", text: "shared"),
+                    SearchSnippet(speaker: "You", speakerId: nil, timestamp: "1:00", text: "unique"),
+                ]
+            )
+        ], totalMeetingsMatched: 1, truncated: false)
+
+        let fused = SemanticSearchFusion.fuseGrouped(lexical: lexical, semantic: semantic, maxMeetings: 10, snippetsPerMeeting: 3)
+        XCTAssertEqual(fused.results.count, 1)
+        let texts = fused.results[0].snippets.map(\.text)
+        XCTAssertEqual(texts, ["shared", "unique"]) // dedup on (timestamp,text), lexical first
+    }
+
+    func testFusionRespectsSnippetCap() {
+        let many = (0..<5).map { SearchSnippet(speaker: "You", speakerId: nil, timestamp: "\($0):00", text: "s\($0)") }
+        let lexical = GroupedSearchResult(results: [
+            MeetingSearchGroup(meetingTitle: "A", meetingDate: "d", meetingDateTime: "dt", filename: "A", snippets: many)
+        ], totalMeetingsMatched: 1, truncated: false)
+        let fused = SemanticSearchFusion.fuseGrouped(lexical: lexical, semantic: GroupedSearchResult(results: [], totalMeetingsMatched: 0, truncated: false), maxMeetings: 10, snippetsPerMeeting: 2)
+        XCTAssertEqual(fused.results[0].snippets.count, 2)
+    }
+
+    func testContextFusionUnionsByEntry() {
+        func group(_ file: String, _ entry: String) -> ContextSearchGroup {
+            ContextSearchGroup(kind: .dictation, title: entry, filename: file, entryId: entry, date: "2026-04-07", datetime: "2026-04-07T09:00:00-0500", snippets: [])
+        }
+        let lexical = [group("D", "e1")]
+        let semantic = [group("D", "e1"), group("D", "e2")]
+        let fused = SemanticSearchFusion.fuseContextGroups(lexical: lexical, semantic: semantic, maxItems: 10)
+        XCTAssertEqual(fused.count, 2)
+        XCTAssertEqual(fused.first?.entryId, "e1") // appears in both -> top
+    }
+}

--- a/scripts/entrypoints/run-e2e-smoke.sh
+++ b/scripts/entrypoints/run-e2e-smoke.sh
@@ -65,6 +65,9 @@ SWIFT_SOURCES=(
     "Tools/TranscriptedMCP/Sources/TranscriptedMCP/NameVariants.swift"
     "Tools/TranscriptedMCP/Sources/TranscriptedMCP/PathSecurity.swift"
     "Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptLoader.swift"
+    "Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingProvider.swift"
+    "Tools/TranscriptedMCP/Sources/TranscriptedMCP/EmbeddingStore.swift"
+    "Tools/TranscriptedMCP/Sources/TranscriptedMCP/SemanticSearchFusion.swift"
     "Tools/TranscriptedMCP/Sources/TranscriptedMCP/TranscriptIndex.swift"
 )
 


### PR DESCRIPTION
## What

Clean replacement for dirty draft PR #1326.

Adds local semantic and hybrid search to the Transcripted MCP package using Apple NaturalLanguage sentence embeddings behind an `EmbeddingProvider`, plus vector storage, reciprocal-rank fusion, MCP `mode` routing, deterministic tests, and the missing E2E source-list entries that caused the original PR's CI failure.

## Why

The original PR was dirty against current `main` and failed Swift CI because `run-e2e-smoke.sh` did not compile the new embedding source files. This rebuild starts from current main and preserves newer MCP summary/telemetry work.

## Checks

- `swift test --package-path Tools/TranscriptedMCP` ✅ (126 passed)
- `swift build --package-path Tools/TranscriptedMCP` ✅
- `python3 scripts/dev/check-build-source-lists.py` ✅
- `bash run-e2e-smoke.sh` ✅
- `git diff --check` ✅
