### PR TITLE
MCP recap returns meeting summaries

### DIFF
--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -658,7 +658,7 @@ private func handleWhoIs(params: CallTool.Parameters, index: TranscriptIndex) th
 
 // MARK: - recap
 
-private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
     // Use local calendar so "today" matches transcript dates (which are stored in local time)
     let today = DateFormatter.localYYYYMMDD.string(from: Date())
     let dateFrom = params.arguments?["date_from"]?.stringValue ?? String(today)
@@ -673,7 +673,6 @@ private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, me
     var recapParts: [RecapEntry] = []
 
     for meeting in meetings {
-        // Read first ~200 words of transcript as preview
         guard case .valid(let mdURL) = PathSecurity.resolveReadableFile(
             named: meeting.filename,
             appendingExtension: "md",
@@ -681,9 +680,23 @@ private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, me
         ) else { continue }
         var preview = ""
         var title = meeting.filename
+        var decisions: [String] = []
+        var actionItems: [RecapActionItem] = []
+        var openQuestions: [String] = []
+        var summarySource = "transcript_fallback"
+
         if let content = try? String(contentsOf: mdURL, encoding: .utf8) {
             title = extractTitle(from: content) ?? meeting.filename
-            preview = extractDialogueLines(from: content).prefix(15).joined(separator: "\n")
+            if let summary = TranscriptLoader.loadMeetingSummary(forTranscript: mdURL) {
+                title = summary.title ?? title
+                decisions = summary.decisions
+                actionItems = summary.actionItems.map { RecapActionItem(owner: $0.owner, text: $0.text) }
+                openQuestions = summary.openQuestions
+                preview = summaryPreview(decisions: decisions, actionItems: actionItems, openQuestions: openQuestions)
+                summarySource = "summary"
+            } else {
+                preview = extractDialogueLines(from: content).prefix(15).joined(separator: "\n")
+            }
         }
 
         recapParts.append(RecapEntry(
@@ -694,7 +707,11 @@ private func handleRecap(params: CallTool.Parameters, index: TranscriptIndex, me
             durationFormatted: formatDuration(meeting.durationSeconds),
             speakers: meeting.speakers.map { $0.name },
             wordCount: meeting.wordCount,
-            preview: preview
+            preview: preview,
+            decisions: decisions,
+            actionItems: actionItems,
+            openQuestions: openQuestions,
+            summarySource: summarySource
         ))
     }
 
@@ -796,6 +813,15 @@ struct RecapEntry: Codable {
     let speakers: [String]
     let wordCount: Int
     let preview: String
+    let decisions: [String]
+    let actionItems: [RecapActionItem]
+    let openQuestions: [String]
+    let summarySource: String
+}
+
+struct RecapActionItem: Codable, Equatable {
+    let owner: String?
+    let text: String
 }
 
 struct RecapResult: Codable {
@@ -880,6 +906,33 @@ private func formatDuration(_ seconds: Int) -> String {
     let m = (seconds % 3600) / 60
     if h > 0 { return "\(h)h \(m)m" }
     return "\(m)m"
+}
+
+private func summaryPreview(
+    decisions: [String],
+    actionItems: [RecapActionItem],
+    openQuestions: [String]
+) -> String {
+    var sections: [String] = []
+    appendSummarySection("Decisions", decisions, to: &sections)
+    appendSummarySection(
+        "Action Items",
+        actionItems.map { item in
+            if let owner = item.owner, !owner.isEmpty {
+                return "\(owner): \(item.text)"
+            }
+            return item.text
+        },
+        to: &sections
+    )
+    appendSummarySection("Open Questions", openQuestions, to: &sections)
+    return sections.joined(separator: "\n\n")
+}
+
+private func appendSummarySection(_ title: String, _ items: [String], to sections: inout [String]) {
+    guard !items.isEmpty else { return }
+    let body = items.map { "- \($0)" }.joined(separator: "\n")
+    sections.append("## \(title)\n\(body)")
 }
 
 private func latestMeetingDate(in results: [MeetingSummary]) -> Date? {

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
@@ -136,6 +136,77 @@ final class ToolHandlersTests: XCTestCase {
         XCTAssertNotEqual(observation.captureAgeBucket, "unknown")
     }
 
+    func testRecapReturnsStructuredSummaryWhenPresent() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                date: "2026-04-18",
+                time: "09:15:00",
+                decisions: ["Ship the beta on Friday"],
+                actionItems: ["Jenny: send the revised spec"],
+                openQuestions: ["Do we need a migration window?"]
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let recap = try decodedRecap(date: "2026-04-18")
+        let meeting = try XCTUnwrap(recap.meetings.first)
+
+        XCTAssertEqual(meeting.title, "Beta launch sync")
+        XCTAssertEqual(meeting.summarySource, "summary")
+        XCTAssertEqual(meeting.decisions, ["Ship the beta on Friday"])
+        XCTAssertEqual(meeting.actionItems, [RecapActionItem(owner: "Jenny", text: "send the revised spec")])
+        XCTAssertEqual(meeting.openQuestions, ["Do we need a migration window?"])
+        XCTAssertTrue(meeting.preview.contains("## Decisions"))
+        XCTAssertFalse(meeting.preview.contains("[00:00]"), "recap should not leak raw dialogue when a summary exists")
+    }
+
+    func testRecapFallsBackToRawLinesWhenSummaryIsMissing() throws {
+        try writeFixture(
+            makeFixtureJSON(
+                title: "Fallback Sync",
+                date: "2026-04-19T10:00:00-0500",
+                utterances: [
+                    ("mic_0", 0.0, 5.0, "This raw line is only for fallback"),
+                    ("system_0", 5.0, 10.0, "Second fallback line"),
+                ]
+            ),
+            filename: "Call_2026-04-19_10-00-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let meeting = try XCTUnwrap(decodedRecap(date: "2026-04-19").meetings.first)
+        XCTAssertEqual(meeting.summarySource, "transcript_fallback")
+        XCTAssertTrue(meeting.decisions.isEmpty)
+        XCTAssertTrue(meeting.actionItems.isEmpty)
+        XCTAssertTrue(meeting.openQuestions.isEmpty)
+        XCTAssertTrue(meeting.preview.contains("This raw line is only for fallback"))
+    }
+
+    func testRecapFallsBackForMalformedEmptySummary() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                date: "2026-04-20",
+                time: "11:00:00",
+                decisions: [],
+                actionItems: [],
+                openQuestions: []
+            ),
+            filename: "Call_2026-04-20_11-00-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let meeting = try XCTUnwrap(decodedRecap(date: "2026-04-20").meetings.first)
+        XCTAssertEqual(meeting.summarySource, "transcript_fallback")
+        XCTAssertTrue(meeting.decisions.isEmpty)
+        XCTAssertTrue(meeting.actionItems.isEmpty)
+        XCTAssertTrue(meeting.openQuestions.isEmpty)
+        XCTAssertTrue(meeting.preview.contains("Let's lock the launch."))
+    }
+
     func testEmptyListDoesNotTrackAgentQueryTelemetry() throws {
         _ = try handleListMeetings(
             params: CallTool.Parameters(name: "list_meetings", arguments: ["count": .int(10)]),
@@ -145,6 +216,17 @@ final class ToolHandlersTests: XCTestCase {
 
         XCTAssertTrue(telemetry.observations.isEmpty)
     }
+
+    private func decodedRecap(date: String) throws -> RecapResult {
+        let result = try handleRecap(
+            params: CallTool.Parameters(name: "recap", arguments: ["date_from": .string(date), "date_to": .string(date)]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+        let text = try XCTUnwrap(result.textContent)
+        let data = try XCTUnwrap(text.data(using: .utf8))
+        return try JSONDecoder().decode(RecapResult.self, from: data)
+    }
 }
 
 private final class RecordingAgentCaptureQueryTelemetry: AgentCaptureQueryTelemetryRecording {
@@ -152,5 +234,15 @@ private final class RecordingAgentCaptureQueryTelemetry: AgentCaptureQueryTeleme
 
     func track(_ observation: AgentCaptureQueryObservation) {
         observations.append(observation)
+    }
+}
+
+private extension CallTool.Result {
+    var textContent: String? {
+        guard let first = content.first,
+              case .text(let text, _, _) = first else {
+            return nil
+        }
+        return text
     }
 }


### PR DESCRIPTION
## Summary
- change MCP `recap` to prefer parsed meeting summary sections over raw transcript preview lines
- add structured `decisions`, `actionItems`, `openQuestions`, and `summarySource` fields while preserving existing recap keys
- fall back to the first raw dialogue lines only when no usable summary exists

## Tests / checks
- `cd Tools/TranscriptedMCP && swift test` (113 tests, pass)
- `cd Tools/TranscriptedMCP && swift build -c release` (pass)
- `TRANSCRIPTED_DATA_DIR=<tmp> TRANSCRIPTED_INDEX_DIR=<tmp>/index ./.build/release/transcripted-mcp --self-test` (pass, `ok: true`)
- `git diff --check` (pass)
- `codex review --base origin/main` (no actionable bugs; reran `swift test`)

## Notes
- Default `./.build/release/transcripted-mcp --self-test` against this Mac's existing app cache failed with `MCPIndexError.queryFailed("no such table: dictation_days")`; temp isolated self-test passed. That looks like stale local cache/schema state, not this recap diff.

lanes used: Codex=implementation/tests/review/PR; Claude=skipped, not needed for narrow MCP handler change; Local=attempted scan via `/Users/redbars/.codex/maestro/runs/20260703T001532Z-ws22-mcp-recap-scan-local` but output was unusable/noise; Windows=skipped, not needed for local Swift package proof.