### PR TITLE
Add WS2.3 cross-meeting MCP receipt tools

### DIFF
--- a/Sources/UI/Shared/AgentConnectionGuide.swift
+++ b/Sources/UI/Shared/AgentConnectionGuide.swift
@@ -100,6 +100,10 @@ enum AgentConnectionGuide {
         "search",
         "who_is",
         "recap",
+        "decisions",
+        "commitments",
+        "open_questions",
+        "search_meetings",
     ]
 
     static func skillFileURL(for skill: AgentConnectionStarterSkill) -> URL {

--- a/Tests/AgentConnectionGuideTests.swift
+++ b/Tests/AgentConnectionGuideTests.swift
@@ -27,7 +27,7 @@ func testAgentConnectionGuide() {
             "prompt should tell local agents to use direct tools when available"
         )
         assertTrue(
-            AgentConnectionGuide.directToolNames.count == 9,
+            AgentConnectionGuide.directToolNames.count == 13,
             "prompt should track the full Transcripted MCP direct tool set"
         )
         for toolName in AgentConnectionGuide.directToolNames {
@@ -48,6 +48,10 @@ func testAgentConnectionGuide() {
                 "search",
                 "who_is",
                 "recap",
+                "decisions",
+                "commitments",
+                "open_questions",
+                "search_meetings",
             ]),
             "direct tool list should mirror Tools/TranscriptedMCP tool registration"
         )

--- a/Tools/TranscriptedMCP/CLAUDE.md
+++ b/Tools/TranscriptedMCP/CLAUDE.md
@@ -86,10 +86,15 @@ All tools are read-only.
 | `list_action_items` | Roll up action items across meetings; filter by owner / status / query / date |
 | `list_decisions` | Roll up decisions across meetings; filter by query / date |
 | `digest` | Cross-meeting summary (decisions + action items + open questions) for a window |
+| `decisions` | WS2.3 receipt API for local decision lookup by topic/range |
+| `commitments` | WS2.3 receipt API for local action-item lookup by person/range |
+| `open_questions` | WS2.3 receipt API for local open-question lookup by project/range |
+| `search_meetings` | WS2.3 receipt API for local keyword search over meeting utterances |
 
-The last three are cross-meeting rollups over the structured summary fields and
-query the same `meeting_summary_items` index populated from saved meeting
-Markdown during reconcile.
+The rollup and WS2.3 tools are cross-meeting reads over local structured summary
+fields and raw utterance FTS. They query the same `meeting_summary_items` index
+populated from saved meeting Markdown during reconcile. They do not use
+embeddings, cloud calls, or LLM synthesis.
 
 ## Common Agent Retrieval Shapes
 

--- a/Tools/TranscriptedMCP/README.md
+++ b/Tools/TranscriptedMCP/README.md
@@ -49,3 +49,17 @@ If `TRANSCRIPTED_DATA_DIR` points at a shared root with `meetings/` and
 `dictations/` subfolders, `transcripted-mcp` uses those subfolders
 automatically and stores its SQLite index in that shared root unless
 `TRANSCRIPTED_INDEX_DIR` is also set.
+
+## Cross-Meeting Receipt Tools
+
+WS2.3 adds local structured retrieval tools for agents:
+
+- `decisions(topic, range)`
+- `commitments(person, range)`
+- `open_questions(project, range)`
+- `search_meetings(query, range)`
+
+Each returns JSON receipts shaped around `meetingId`, `timestamp`, and `quote`.
+Summary-derived receipts have `timestamp: null` until exact audio anchors are
+available; raw utterance search includes the transcript timestamp. These tools
+use only the local SQLite index and saved summary/parser output.

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Models.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/Models.swift
@@ -442,6 +442,27 @@ struct DigestResult: Codable {
     }
 }
 
+// MARK: - WS2.3 Cross-Meeting Retrieval
+
+struct CrossMeetingReceipt: Codable {
+    let meetingId: String
+    var meetingTitle: String
+    let timestamp: String?
+    let quote: String
+    let date: String
+    let datetime: String
+    let kind: String?
+    let person: String?
+}
+
+struct CrossMeetingToolResult: Codable {
+    let query: String?
+    let range: String?
+    let count: Int
+    let truncated: Bool
+    var results: [CrossMeetingReceipt]
+}
+
 // MARK: - Errors
 
 enum MCPIndexError: Error, LocalizedError {

--- a/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
+++ b/Tools/TranscriptedMCP/Sources/TranscriptedMCP/ToolHandlers.swift
@@ -311,6 +311,95 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                 ]),
                 annotations: .init(readOnlyHint: true)
             ),
+            Tool(
+                name: "decisions",
+                description: "Find decisions across meeting summaries. Returns local structured receipts with meetingId, timestamp when available, and quote. No semantic embeddings or LLM synthesis.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "topic": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional topic filter, e.g. pricing")
+                        ]),
+                        "range": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional date range: YYYY-MM-DD, YYYY-MM-DD..YYYY-MM-DD, today, or all")
+                        ]),
+                        "count": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum receipts to return (default: 20, max: 100)")
+                        ]),
+                    ]),
+                ]),
+                annotations: .init(readOnlyHint: true)
+            ),
+            Tool(
+                name: "commitments",
+                description: "Find action-item commitments across meeting summaries. Filter by person and date range. Returns local structured receipts with meetingId, timestamp when available, and quote.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "person": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional person/owner filter, e.g. Sarah")
+                        ]),
+                        "range": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional date range: YYYY-MM-DD, YYYY-MM-DD..YYYY-MM-DD, today, or all")
+                        ]),
+                        "count": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum receipts to return (default: 20, max: 100)")
+                        ]),
+                    ]),
+                ]),
+                annotations: .init(readOnlyHint: true)
+            ),
+            Tool(
+                name: "open_questions",
+                description: "Find open questions across meeting summaries for a project/topic. Returns local structured receipts with meetingId, timestamp when available, and quote.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "project": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional project/topic filter")
+                        ]),
+                        "range": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional date range: YYYY-MM-DD, YYYY-MM-DD..YYYY-MM-DD, today, or all")
+                        ]),
+                        "count": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum receipts to return (default: 20, max: 100)")
+                        ]),
+                    ]),
+                ]),
+                annotations: .init(readOnlyHint: true)
+            ),
+            Tool(
+                name: "search_meetings",
+                description: "Keyword search over local meeting transcript utterances. Returns structured receipts with meetingId, timestamp, and quote. This is not semantic search.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "query": .object([
+                            "type": .string("string"),
+                            "description": .string("Keyword query")
+                        ]),
+                        "range": .object([
+                            "type": .string("string"),
+                            "description": .string("Optional date range: YYYY-MM-DD, YYYY-MM-DD..YYYY-MM-DD, today, or all")
+                        ]),
+                        "count": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum receipts to return (default: 20, max: 100)")
+                        ]),
+                    ]),
+                    "required": .array([.string("query")]),
+                ]),
+                annotations: .init(readOnlyHint: true)
+            ),
         ])
     }
 
@@ -341,6 +430,14 @@ func registerToolHandlers(server: Server, index: TranscriptIndex, directories: T
                 return try handleListDecisions(params: params, index: index, meetingDirs: directories.meetingDirs)
             case "digest":
                 return try handleDigest(params: params, index: index, meetingDirs: directories.meetingDirs)
+            case "decisions":
+                return try handleDecisions(params: params, index: index, meetingDirs: directories.meetingDirs)
+            case "commitments":
+                return try handleCommitments(params: params, index: index, meetingDirs: directories.meetingDirs)
+            case "open_questions":
+                return try handleOpenQuestions(params: params, index: index, meetingDirs: directories.meetingDirs)
+            case "search_meetings":
+                return try handleSearchMeetings(params: params, index: index, meetingDirs: directories.meetingDirs)
             default:
                 return textResult("Unknown tool: \(params.name)", isError: true)
             }
@@ -785,6 +882,152 @@ private func handleDigest(params: CallTool.Parameters, index: TranscriptIndex, m
     return textResult(String(data: json, encoding: .utf8) ?? "{}")
 }
 
+// MARK: - decisions / commitments / open_questions / search_meetings
+
+func handleDecisions(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+    let topic = params.arguments?["topic"]?.stringValue
+    let range = parseToolRange(params.arguments?["range"]?.stringValue)
+    let count = cappedCrossMeetingCount(params.arguments?["count"]?.intValue)
+    let indexed = try index.listDecisions(
+        query: topic,
+        dateFrom: range.dateFrom,
+        dateTo: range.dateTo,
+        maxItems: count + 1
+    )
+    var receipts = indexed.decisions.prefix(count).map { item in
+        CrossMeetingReceipt(
+            meetingId: item.filename,
+            meetingTitle: meetingTitle(for: item.filename, meetingDirs: meetingDirs),
+            timestamp: nil,
+            quote: item.text,
+            date: item.date,
+            datetime: item.datetime,
+            kind: "decision",
+            person: nil
+        )
+    }
+    hydrateReceiptTitles(&receipts, meetingDirs: meetingDirs)
+    let result = CrossMeetingToolResult(
+        query: topic,
+        range: range.label,
+        count: receipts.count,
+        truncated: indexed.truncated || indexed.decisions.count > count,
+        results: receipts
+    )
+    return try encodedToolResult(result)
+}
+
+func handleCommitments(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+    let person = params.arguments?["person"]?.stringValue
+    let range = parseToolRange(params.arguments?["range"]?.stringValue)
+    let count = cappedCrossMeetingCount(params.arguments?["count"]?.intValue)
+    let indexed = try index.listActionItems(
+        owner: person,
+        query: nil,
+        status: .open,
+        dateFrom: range.dateFrom,
+        dateTo: range.dateTo,
+        maxItems: count + 1
+    )
+    var receipts = indexed.items.prefix(count).map { item in
+        CrossMeetingReceipt(
+            meetingId: item.filename,
+            meetingTitle: meetingTitle(for: item.filename, meetingDirs: meetingDirs),
+            timestamp: nil,
+            quote: item.owner.map { "\($0): \(item.text)" } ?? item.text,
+            date: item.date,
+            datetime: item.datetime,
+            kind: "commitment",
+            person: item.owner
+        )
+    }
+    hydrateReceiptTitles(&receipts, meetingDirs: meetingDirs)
+    let result = CrossMeetingToolResult(
+        query: person,
+        range: range.label,
+        count: receipts.count,
+        truncated: indexed.truncated || indexed.items.count > count,
+        results: receipts
+    )
+    return try encodedToolResult(result)
+}
+
+func handleOpenQuestions(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+    let project = params.arguments?["project"]?.stringValue
+    let range = parseToolRange(params.arguments?["range"]?.stringValue)
+    let count = cappedCrossMeetingCount(params.arguments?["count"]?.intValue)
+    let fetchLimit = project?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? 1000 : count + 1
+    let indexed = try index.listSummaryItems(
+        kind: TranscriptIndex.SummaryItemKind.openQuestion,
+        dateFrom: range.dateFrom,
+        dateTo: range.dateTo,
+        limit: fetchLimit
+    )
+    let filtered = filterSummaryItems(indexed, matching: project)
+    var receipts = filtered.prefix(count).map { item in
+        CrossMeetingReceipt(
+            meetingId: item.filename,
+            meetingTitle: meetingTitle(for: item.filename, meetingDirs: meetingDirs),
+            timestamp: nil,
+            quote: item.text,
+            date: item.meetingDate,
+            datetime: item.meetingDateTime,
+            kind: "open_question",
+            person: nil
+        )
+    }
+    hydrateReceiptTitles(&receipts, meetingDirs: meetingDirs)
+    let result = CrossMeetingToolResult(
+        query: project,
+        range: range.label,
+        count: receipts.count,
+        truncated: filtered.count > count,
+        results: receipts
+    )
+    return try encodedToolResult(result)
+}
+
+func handleSearchMeetings(params: CallTool.Parameters, index: TranscriptIndex, meetingDirs: [URL]) throws -> CallTool.Result {
+    guard let query = params.arguments?["query"]?.stringValue, !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        return textResult("Missing required parameter: query", isError: true)
+    }
+
+    let range = parseToolRange(params.arguments?["range"]?.stringValue)
+    let count = cappedCrossMeetingCount(params.arguments?["count"]?.intValue)
+    var groups = try index.searchUtterances(
+        query: query,
+        speaker: nil,
+        dateFrom: range.dateFrom,
+        dateTo: range.dateTo,
+        maxMeetings: count,
+        snippetsPerMeeting: 3
+    )
+    hydrateMeetingSearchTitles(in: &groups, meetingDirs: meetingDirs)
+
+    let receipts = groups.results.flatMap { group in
+        group.snippets.map { snippet in
+            CrossMeetingReceipt(
+                meetingId: group.filename,
+                meetingTitle: group.meetingTitle,
+                timestamp: snippet.timestamp,
+                quote: snippet.text,
+                date: group.meetingDate,
+                datetime: group.meetingDateTime,
+                kind: "utterance",
+                person: snippet.speaker
+            )
+        }
+    }
+    let result = CrossMeetingToolResult(
+        query: query,
+        range: range.label,
+        count: min(receipts.count, count),
+        truncated: groups.truncated || receipts.count > count,
+        results: Array(receipts.prefix(count))
+    )
+    return try encodedToolResult(result)
+}
+
 // MARK: - Output Types
 
 struct RecapEntry: Codable {
@@ -873,6 +1116,65 @@ private func hydrateMeetingTitles<T>(
     for index in collection.indices where collection[index][keyPath: kind] == .meeting {
         collection[index][keyPath: title] = meetingTitle(for: collection[index][keyPath: filename], meetingDirs: meetingDirs)
     }
+}
+
+private func hydrateReceiptTitles(_ receipts: inout [CrossMeetingReceipt], meetingDirs: [URL]) {
+    for index in receipts.indices {
+        receipts[index].meetingTitle = meetingTitle(for: receipts[index].meetingId, meetingDirs: meetingDirs)
+    }
+}
+
+private struct ParsedToolRange {
+    let dateFrom: String?
+    let dateTo: String?
+    let label: String?
+}
+
+private func parseToolRange(_ raw: String?) -> ParsedToolRange {
+    guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+        return ParsedToolRange(dateFrom: nil, dateTo: nil, label: nil)
+    }
+    let lower = raw.lowercased()
+    if lower == "all" || lower == "all time" {
+        return ParsedToolRange(dateFrom: nil, dateTo: nil, label: raw)
+    }
+    if lower == "today" {
+        let today = DateFormatter.localYYYYMMDD.string(from: Date())
+        return ParsedToolRange(dateFrom: today, dateTo: today, label: today)
+    }
+
+    let separators = ["..", " to ", " - "]
+    for separator in separators where raw.contains(separator) {
+        let parts = raw.components(separatedBy: separator).map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        if parts.count == 2 {
+            let from = parts[0].isEmpty ? nil : parts[0]
+            let to = parts[1].isEmpty ? nil : parts[1]
+            return ParsedToolRange(dateFrom: from, dateTo: to, label: raw)
+        }
+    }
+
+    return ParsedToolRange(dateFrom: raw, dateTo: raw, label: raw)
+}
+
+private func cappedCrossMeetingCount(_ raw: Int?) -> Int {
+    max(1, min(raw ?? 20, 100))
+}
+
+private func filterSummaryItems(_ items: [TranscriptIndex.IndexedSummaryItem], matching query: String?) -> [TranscriptIndex.IndexedSummaryItem] {
+    guard let query = query?.trimmingCharacters(in: .whitespacesAndNewlines), !query.isEmpty else {
+        return items
+    }
+    let terms = query.lowercased().split(whereSeparator: \.isWhitespace).map(String.init)
+    guard !terms.isEmpty else { return items }
+    return items.filter { item in
+        let haystack = item.text.lowercased()
+        return terms.allSatisfy { haystack.contains($0) }
+    }
+}
+
+private func encodedToolResult<T: Encodable>(_ result: T) throws -> CallTool.Result {
+    let json = try JSONEncoder.pretty.encode(result)
+    return textResult(String(data: json, encoding: .utf8) ?? "{}")
 }
 
 private func formatDuration(_ seconds: Int) -> String {

--- a/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
+++ b/Tools/TranscriptedMCP/Tests/TranscriptedMCPTests/ToolHandlersTests.swift
@@ -145,6 +145,173 @@ final class ToolHandlersTests: XCTestCase {
 
         XCTAssertTrue(telemetry.observations.isEmpty)
     }
+
+    func testDecisionsToolReturnsStructuredReceipts() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                decisions: ["Keep pricing simple", "Ship the beta on Friday"]
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try handleDecisions(
+            params: CallTool.Parameters(
+                name: "decisions",
+                arguments: ["topic": .string("pricing"), "range": .string("2026-04-18")]
+            ),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let decoded = try decodeCrossMeetingResult(result)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.results.first?.meetingId, "Call_2026-04-18_09-15-00")
+        XCTAssertEqual(decoded.results.first?.timestamp, nil)
+        XCTAssertEqual(decoded.results.first?.quote, "Keep pricing simple")
+    }
+
+    func testCommitmentsToolFiltersByPerson() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                actionItems: ["Jenny: send the revised spec", "Sam: draft the launch note"]
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try handleCommitments(
+            params: CallTool.Parameters(
+                name: "commitments",
+                arguments: ["person": .string("Jenny"), "range": .string("2026-04-01..2026-04-30")]
+            ),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let decoded = try decodeCrossMeetingResult(result)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.results.first?.person, "Jenny")
+        XCTAssertEqual(decoded.results.first?.quote, "Jenny: send the revised spec")
+    }
+
+    func testOpenQuestionsToolFiltersByProject() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                openQuestions: ["Should the pricing page mention credits?", "Do we need a migration window?"]
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try handleOpenQuestions(
+            params: CallTool.Parameters(
+                name: "open_questions",
+                arguments: ["project": .string("pricing credits")]
+            ),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let decoded = try decodeCrossMeetingResult(result)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.results.first?.kind, "open_question")
+        XCTAssertEqual(decoded.results.first?.quote, "Should the pricing page mention credits?")
+    }
+
+    func testSearchMeetingsToolReturnsUtteranceReceiptsWithTimestamps() throws {
+        try writeFixture(
+            makeFixtureJSON(
+                utterances: [
+                    ("mic_0", 0.0, 5.0, "Good morning everyone"),
+                    ("system_0", 125.0, 135.0, "The pricing decision needs a receipt"),
+                ]
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try handleSearchMeetings(
+            params: CallTool.Parameters(name: "search_meetings", arguments: ["query": .string("pricing receipt")]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let decoded = try decodeCrossMeetingResult(result)
+        XCTAssertEqual(decoded.count, 1)
+        XCTAssertEqual(decoded.results.first?.meetingId, "Call_2026-04-18_09-15-00")
+        XCTAssertEqual(decoded.results.first?.timestamp, "2:05")
+        XCTAssertEqual(decoded.results.first?.quote, "The pricing decision needs a receipt")
+    }
+
+    func testCrossMeetingToolsReturnStructuredEmptyCorpusResults() throws {
+        let decisions = try decodeCrossMeetingResult(try handleDecisions(
+            params: CallTool.Parameters(name: "decisions", arguments: ["topic": .string("pricing")]),
+            index: index,
+            meetingDirs: [tempDir]
+        ))
+        let commitments = try decodeCrossMeetingResult(try handleCommitments(
+            params: CallTool.Parameters(name: "commitments", arguments: ["person": .string("Jenny")]),
+            index: index,
+            meetingDirs: [tempDir]
+        ))
+        let questions = try decodeCrossMeetingResult(try handleOpenQuestions(
+            params: CallTool.Parameters(name: "open_questions", arguments: ["project": .string("pricing")]),
+            index: index,
+            meetingDirs: [tempDir]
+        ))
+        let search = try decodeCrossMeetingResult(try handleSearchMeetings(
+            params: CallTool.Parameters(name: "search_meetings", arguments: ["query": .string("pricing")]),
+            index: index,
+            meetingDirs: [tempDir]
+        ))
+
+        XCTAssertEqual(decisions.count, 0)
+        XCTAssertEqual(commitments.count, 0)
+        XCTAssertEqual(questions.count, 0)
+        XCTAssertEqual(search.count, 0)
+    }
+
+    func testCrossMeetingToolsIgnoreMeetingsWithoutSummaries() throws {
+        try writeFixture(makeFixtureJSON(), filename: "Call_2026-04-18_09-15-00", to: tempDir)
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try handleDecisions(
+            params: CallTool.Parameters(name: "decisions", arguments: ["topic": .string("pricing")]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let decoded = try decodeCrossMeetingResult(result)
+        XCTAssertEqual(decoded.count, 0)
+        XCTAssertTrue(decoded.results.isEmpty)
+    }
+
+    func testCrossMeetingToolResultLimitsAreCappedAndTruncated() throws {
+        try writeFixture(
+            makeMeetingWithInlineSummary(
+                decisions: ["Decision one", "Decision two", "Decision three"]
+            ),
+            filename: "Call_2026-04-18_09-15-00",
+            to: tempDir
+        )
+        try index.reconcile(meetingsDir: tempDir, dictationsDir: tempDir)
+
+        let result = try handleDecisions(
+            params: CallTool.Parameters(name: "decisions", arguments: ["count": .int(2)]),
+            index: index,
+            meetingDirs: [tempDir]
+        )
+
+        let decoded = try decodeCrossMeetingResult(result)
+        XCTAssertEqual(decoded.count, 2)
+        XCTAssertTrue(decoded.truncated)
+        XCTAssertEqual(decoded.results.map(\.quote), ["Decision one", "Decision two"])
+    }
 }
 
 private final class RecordingAgentCaptureQueryTelemetry: AgentCaptureQueryTelemetryRecording {
@@ -153,4 +320,12 @@ private final class RecordingAgentCaptureQueryTelemetry: AgentCaptureQueryTeleme
     func track(_ observation: AgentCaptureQueryObservation) {
         observations.append(observation)
     }
+}
+
+private func decodeCrossMeetingResult(_ result: CallTool.Result) throws -> CrossMeetingToolResult {
+    guard case .text(let text, _, _) = result.content.first else {
+        XCTFail("Expected text tool result")
+        throw NSError(domain: "ToolHandlersTests", code: 1)
+    }
+    return try JSONDecoder().decode(CrossMeetingToolResult.self, from: Data(text.utf8))
 }


### PR DESCRIPTION
## Summary
- Add WS2.3 MCP tools: `decisions`, `commitments`, `open_questions`, and `search_meetings`.
- Return local structured JSON receipts centered on `meetingId`, `timestamp`, and `quote`.
- Reuse the existing summary item index and raw utterance FTS; no embeddings, cloud calls, or LLM synthesis.
- Sync the local agent direct-tool guide and MCP docs.

## Tests
- `swift test --package-path Tools/TranscriptedMCP` — 117 passed
- `./scripts/entrypoints/run-tests.sh --filter AgentConnectionGuideTests` — 112 passed

## Lanes used
Codex=implemented, tested, committed, pushed, opened draft PR; Claude=skipped, CLI not logged in; Local=smoke reachable but scout output unusable, proof at `/Users/redbars/.codex/maestro/runs/20260703T001526Z-ws23-mcp-scout-local`; Windows=skipped, worker not configured.