### PR TITLE
[codex] make Home failures actionable

### DIFF
--- a/Sources/UI/Settings/HomeRootAlertPolicy.swift
+++ b/Sources/UI/Settings/HomeRootAlertPolicy.swift
@@ -38,3 +38,26 @@ enum HomeRootAlertPolicy {
         return nil
     }
 }
+
+enum HomeActionFailureCopy {
+    static let retryTitle = "Try again"
+    static let detailsTitle = "Copy Details"
+
+    static func message(forFailureTitle title: String) -> String {
+        let normalized = title.lowercased()
+
+        if normalized.contains("rename") {
+            return "Transcripted couldn't rename this meeting. Check that the file is still in your capture folder, then try again."
+        }
+
+        if normalized.contains("delete dictation") {
+            return "Transcripted couldn't remove this dictation. Check that your dictation file is available, then try again."
+        }
+
+        if normalized.contains("delete") || normalized.contains("dismiss") || normalized.contains("remove") {
+            return "Transcripted couldn't remove this item. Check that your capture folder is available, then try again."
+        }
+
+        return "Transcripted couldn't finish that action. Check that your capture folder is available, then try again."
+    }
+}

--- a/Sources/UI/Settings/HomeView.swift
+++ b/Sources/UI/Settings/HomeView.swift
@@ -285,6 +285,23 @@ struct HomeDeleteFailure: Identifiable {
     let id = UUID()
     let title: String
     let message: String
+    let retryTitle: String
+    let details: String?
+    let retry: () -> Void
+
+    init(
+        title: String,
+        message: String,
+        retryTitle: String = HomeActionFailureCopy.retryTitle,
+        details: String? = nil,
+        retry: @escaping () -> Void
+    ) {
+        self.title = title
+        self.message = message
+        self.retryTitle = retryTitle
+        self.details = details
+        self.retry = retry
+    }
 }
 
 // MARK: - Stats summary

--- a/Sources/UI/Settings/TranscriptedSettingsView.swift
+++ b/Sources/UI/Settings/TranscriptedSettingsView.swift
@@ -254,7 +254,14 @@ struct TranscriptedSettingsView: View {
                 return Alert(
                     title: Text(failure.title),
                     message: Text(failure.message),
-                    dismissButton: .default(Text("OK"))
+                    primaryButton: .default(Text(failure.retryTitle)) {
+                        failure.retry()
+                    },
+                    secondaryButton: .cancel(Text(failure.details == nil ? "Dismiss" : HomeActionFailureCopy.detailsTitle)) {
+                        if let details = failure.details {
+                            copyHomeFailureDetails(details)
+                        }
+                    }
                 )
             case .audioRetention(let window):
                 return Alert(
@@ -867,7 +874,10 @@ struct TranscriptedSettingsView: View {
         guard let transcriptURL = OwnFileResolver.resolveExistingFile(candidateURLs: [item.transcriptURL]) else {
             presentHomeActionFailure(
                 title: "Could not copy meeting",
-                message: "Transcripted couldn't find this meeting's transcript on disk. It may have been moved, renamed, or deleted outside the app."
+                message: "Transcripted couldn't find this meeting's transcript on disk. It may have been moved, renamed, or deleted outside the app.",
+                retry: {
+                    handleCopyMeeting(item)
+                }
             )
             return
         }
@@ -884,7 +894,10 @@ struct TranscriptedSettingsView: View {
         } else {
             presentHomeActionFailure(
                 title: "Could not copy meeting",
-                message: "Transcripted found this meeting's transcript but couldn't read it. The file may be open exclusively elsewhere or corrupted."
+                message: "Transcripted found this meeting's transcript but couldn't read it. The file may be open exclusively elsewhere or corrupted.",
+                retry: {
+                    handleCopyMeeting(item)
+                }
             )
             return
         }
@@ -934,7 +947,10 @@ struct TranscriptedSettingsView: View {
         guard let input = item.audio?.retranscriptionInput else {
             presentHomeActionFailure(
                 title: "Could not re-transcribe meeting",
-                message: "Transcripted couldn't find the retained audio for this meeting. It may have been recompressed or removed by the audio-retention setting."
+                message: "Transcripted couldn't find the retained audio for this meeting. It may have been recompressed or removed by the audio-retention setting.",
+                retry: {
+                    handleRetranscribeMeeting(item)
+                }
             )
             return
         }
@@ -947,7 +963,10 @@ struct TranscriptedSettingsView: View {
         guard let systemURL = OwnFileResolver.resolveExistingFile(candidateURLs: [input.systemURL]) else {
             presentHomeActionFailure(
                 title: "Could not re-transcribe meeting",
-                message: "Transcripted couldn't find this meeting's retained audio on disk. It may have been moved, recompressed, or removed by the audio-retention setting."
+                message: "Transcripted couldn't find this meeting's retained audio on disk. It may have been moved, recompressed, or removed by the audio-retention setting.",
+                retry: {
+                    handleRetranscribeMeeting(item)
+                }
             )
             return
         }
@@ -964,7 +983,10 @@ struct TranscriptedSettingsView: View {
             if !didStart {
                 presentHomeActionFailure(
                     title: "Could not re-transcribe meeting",
-                    message: "Transcripted couldn't start re-transcription from the retained audio. The saved files may be incomplete or already in use."
+                    message: "Transcripted couldn't start re-transcription from the retained audio. The saved files may be incomplete or already in use.",
+                    retry: {
+                        handleRetranscribeMeeting(item)
+                    }
                 )
             }
         }
@@ -1006,7 +1028,14 @@ struct TranscriptedSettingsView: View {
             trackLocalSummaryAbandoned(reason: .blocked, stage: "start", priorReadyState: "not_ready")
             homeDeleteFailure = HomeDeleteFailure(
                 title: "Could not summarize meeting",
-                message: unavailableReason
+                message: unavailableReason,
+                retry: {
+                    generateLocalSummary(
+                        transcriptURL: transcriptURL,
+                        title: title,
+                        hasExistingSummary: hasExistingSummary
+                    )
+                }
             )
             return
         }
@@ -1279,7 +1308,20 @@ struct TranscriptedSettingsView: View {
                     } catch {
                         presentHomeDeleteFailure(
                             title: "Could not delete dictation",
-                            error: error
+                            error: error,
+                            retry: {
+                                trackSettingsAction("delete_dictation_retry", page: .home)
+                                do {
+                                    try DictationTranscriptStore.deleteEntry(entry)
+                                    refreshRecentCaptures(force: true)
+                                } catch {
+                                    presentHomeDeleteFailure(
+                                        title: "Could not delete dictation",
+                                        error: error,
+                                        retry: { refreshRecentCaptures(force: true) }
+                                    )
+                                }
+                            }
                         )
                     }
                 }
@@ -1513,14 +1555,20 @@ struct TranscriptedSettingsView: View {
                    FileManager.default.fileExists(atPath: item.transcriptURL.path) {
                     presentHomeActionFailure(
                         title: "Could not delete meeting",
-                        message: "Transcripted couldn't remove this meeting's files. They may have been moved or renamed outside the app — reopen Settings and try again."
+                        message: "Transcripted couldn't remove this meeting's files. They may have been moved or renamed outside the app. Reopen Settings, then try again.",
+                        retry: {
+                            deleteMeeting(item)
+                        }
                     )
                 }
             } catch {
                 refreshRecentCaptures(force: true)
                 presentHomeDeleteFailure(
                     title: "Could not delete meeting",
-                    error: error
+                    error: error,
+                    retry: {
+                        deleteMeeting(item)
+                    }
                 )
             }
         }
@@ -1559,7 +1607,10 @@ struct TranscriptedSettingsView: View {
                 refreshRecentCaptures(force: true)
                 presentHomeDeleteFailure(
                     title: "Could not rename meeting",
-                    error: error
+                    error: error,
+                    retry: {
+                        renameMeetingPreview(preview, to: rawTitle)
+                    }
                 )
             }
         }
@@ -1617,7 +1668,10 @@ struct TranscriptedSettingsView: View {
         if !didClear {
             presentHomeActionFailure(
                 title: failureTitle,
-                message: "Transcripted couldn't remove this meeting. Check that your capture folder is available, then try again."
+                message: "Transcripted couldn't remove this meeting. Check that your capture folder is available, then try again.",
+                retry: {
+                    clearFailedMeeting(item)
+                }
             )
         } else {
             ActivationTelemetry.trackWorkflowAbandoned(
@@ -1643,7 +1697,17 @@ struct TranscriptedSettingsView: View {
         case .reveal(let urls):
             NSWorkspace.shared.activateFileViewerSelecting(urls)
         case .unavailable:
-            presentHomeActionFailure(title: failureTitle, message: failureMessage)
+            presentHomeActionFailure(
+                title: failureTitle,
+                message: failureMessage,
+                retry: {
+                    revealOwnFile(
+                        candidateURLs: candidateURLs,
+                        failureTitle: failureTitle,
+                        failureMessage: failureMessage
+                    )
+                }
+            )
         }
     }
 
@@ -1658,26 +1722,61 @@ struct TranscriptedSettingsView: View {
         failureMessage: String
     ) -> Bool {
         guard let url = OwnFileResolver.resolveExistingFile(candidateURLs: candidateURLs) else {
-            presentHomeActionFailure(title: failureTitle, message: failureMessage)
+            presentHomeActionFailure(
+                title: failureTitle,
+                message: failureMessage,
+                retry: {
+                    _ = openOwnFile(
+                        candidateURLs: candidateURLs,
+                        failureTitle: failureTitle,
+                        failureMessage: failureMessage
+                    )
+                }
+            )
             return false
         }
         NSWorkspace.shared.open(url)
         return true
     }
 
-    private func presentHomeDeleteFailure(title: String, error: Error) {
-        presentHomeActionFailure(title: title, message: error.localizedDescription)
+    private func presentHomeDeleteFailure(
+        title: String,
+        error: Error,
+        retry: @escaping () -> Void
+    ) {
+        presentHomeActionFailure(
+            title: title,
+            message: HomeActionFailureCopy.message(forFailureTitle: title),
+            details: error.localizedDescription,
+            retry: retry
+        )
     }
 
-    private func presentHomeActionFailure(title: String, message: String) {
+    private func presentHomeActionFailure(
+        title: String,
+        message: String,
+        details: String? = nil,
+        retry: @escaping () -> Void
+    ) {
         NSSound.beep()
         // Defer to the next runloop turn so a failure raised synchronously inside
         // an alert's confirm action lands after that alert finishes dismissing.
         // SwiftUI won't present a second alert during the first one's dismissal,
         // and the shared binding clears the dismissed alert on the same turn.
         DispatchQueue.main.async {
-            homeDeleteFailure = HomeDeleteFailure(title: title, message: message)
+            homeDeleteFailure = HomeDeleteFailure(
+                title: title,
+                message: message,
+                details: details,
+                retry: retry
+            )
         }
+    }
+
+    private func copyHomeFailureDetails(_ details: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(details, forType: .string)
     }
 
     private func retryFailedMeeting(_ item: MeetingSessionController.FailedMeetingItem) {
@@ -1686,7 +1785,10 @@ struct TranscriptedSettingsView: View {
             presentHomeActionFailure(
                 title: "Could not retry meeting",
                 message: failedMeetingRetryUnavailableReason
-                    ?? "Transcripted could not start that retry. The saved audio may already be cleared."
+                    ?? "Transcripted could not start that retry. The saved audio may already be cleared.",
+                retry: {
+                    retryFailedMeeting(item)
+                }
             )
         }
     }

--- a/Tests/HomeRootAlertPolicyTests.swift
+++ b/Tests/HomeRootAlertPolicyTests.swift
@@ -64,4 +64,27 @@ func testHomeRootAlertPolicy() {
             "failure outranks audio retention"
         )
     }
+
+    runSuite("HomeActionFailureCopy normalizes raw delete and rename errors") {
+        assertEqual(
+            HomeActionFailureCopy.retryTitle,
+            "Try again",
+            "Home failure alerts should expose a retry action"
+        )
+        assertEqual(
+            HomeActionFailureCopy.detailsTitle,
+            "Copy Details",
+            "technical details should be behind an explicit affordance"
+        )
+        assertEqual(
+            HomeActionFailureCopy.message(forFailureTitle: "Could not delete meeting"),
+            "Transcripted couldn't remove this item. Check that your capture folder is available, then try again.",
+            "delete failures should not show raw filesystem errors"
+        )
+        assertEqual(
+            HomeActionFailureCopy.message(forFailureTitle: "Could not rename meeting"),
+            "Transcripted couldn't rename this meeting. Check that the file is still in your capture folder, then try again.",
+            "rename failures should explain the action without exposing raw NSError text"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Converts Home failure alerts from OK-only messages into actionable alerts with a primary `Try again` action.
- Normalizes delete/rename failure copy so raw `Error.localizedDescription` does not appear in the user-facing message.
- Keeps technical error text behind an explicit `Copy Details` affordance when an underlying error exists.
- Adds fast coverage for the Home failure copy contract.

## Surfaces Fixed
- Home root failure alert path for copy/open/reveal/re-transcribe/delete/rename/failed-meeting cleanup failures.

## Surfaces Held
- Agent connection setup errors, paste-last feedback, dictation overlay messages, and meeting overlay alerts are still separate WS4.3 candidates.

## Checks
- `bash run-tests.sh --filter HomeRootAlertPolicy` — 11 passed.
- `bash run-tests.sh` — 11221 passed.
- `bash build-deps.sh --force` — passed.
- `bash build.sh --no-open` — app compiled and signed, then failed at launch smoke with `_LSOpenURLsWithCompletionHandler() failed with error -10810`; treated as local launch-smoke YELLOW, not a code compile failure.

## Maestro Lanes
lanes used: Codex=implemented, built, tested, committed, pushed, opened draft PR; Claude=skipped, scope was small and local; Local=surface ranking via `/Users/redbars/.codex/maestro/runs/20260703T001713Z-ws43-error-surface-ranking-local`; Windows=skipped, no long-running draft implementation needed.
